### PR TITLE
Salvage novel PR-cron scripts from DO1 dangling PR #3219

### DIFF
--- a/scripts/cron-admin-bypass-requeue.sh
+++ b/scripts/cron-admin-bypass-requeue.sh
@@ -1,0 +1,742 @@
+#!/usr/bin/env bash
+# Job 3 — scan admin-bypass PRs, repair finished failures, and queue passed stack bottoms.
+#
+# Every tick:
+#   - scan open PRs carrying `admin-bypass`
+#   - collapse them into stacks
+#   - for the lowest admin-bypass PR in each stack:
+#       * if CI / PR Body is still running or absent, wait
+#       * if finished and failing, open a fresh checkout, let Codex fix it, then
+#         push or rerun failed checks
+#       * if finished and passing, verify stack order and retoggle admin-bypass on
+#         the stack bottom so Mergify re-queues it
+#   - for higher admin-bypass PRs in the same stack:
+#       * if failures are cancelled-only, rerun those checks
+#       * otherwise use the same fix path as the bottom PR
+#
+# Constraints:
+#   - bottom-up only for merge queueing
+#   - queue only the stack bottom
+#   - AI fixes run outside Invoker in a separate checkout
+set -euo pipefail
+
+# shellcheck source=scripts/cron-pr-lib.sh
+source "$(dirname "$0")/cron-pr-lib.sh"
+
+STATE_FILE="${INVOKER_PR_REQUEUE_STATE_FILE:-${HOME}/.invoker/admin-bypass-requeue.tsv}"
+WORKDIR="${INVOKER_PR_REQUEUE_WORKDIR:-${HOME}/.invoker/pr-requeue-work}"
+MAX_PER_HOUR="${INVOKER_PR_REQUEUE_MAX_ATTEMPTS_PER_HOUR:-0}"
+MAX_PER_DAY="${INVOKER_PR_REQUEUE_MAX_ATTEMPTS_PER_DAY:-0}"
+REQUEUE_TIMEOUT_SECONDS="${INVOKER_PR_REQUEUE_TIMEOUT_SECONDS:-600}"
+QUEUE_COOLDOWN_SECONDS="${INVOKER_PR_REQUEUE_QUEUE_COOLDOWN_SECONDS:-1800}"
+OMP_TIMEOUT="${INVOKER_PR_CRON_OMP_TIMEOUT:-45m}"
+OMP_COMMAND="${INVOKER_OMP_COMMAND:-omp}"
+ACTION_LIMIT="${INVOKER_PR_REQUEUE_ACTION_LIMIT:-1}"
+ACTIONS_DONE=0
+
+cron_lock
+ledger_init "$STATE_FILE"
+mkdir -p "$WORKDIR"
+
+mark_action_taken() {
+  [ "$DRY_RUN" = "1" ] && return 0
+  ACTIONS_DONE=$((ACTIONS_DONE + 1))
+}
+
+action_limit_reached() {
+  [ "$DRY_RUN" = "1" ] && return 1
+  [ "$ACTIONS_DONE" -ge "$ACTION_LIMIT" ]
+}
+
+fetch_open_pulls() {
+  if [[ -n "${INVOKER_PR_REQUEUE_PULLS_JSON_FILE:-}" ]]; then
+    cat "$INVOKER_PR_REQUEUE_PULLS_JSON_FILE"
+    return 0
+  fi
+  local raw
+  raw="$(gh_json api "repos/$TARGET_REPO/pulls?state=open&per_page=100" --paginate 2>/dev/null || true)"
+  printf '%s' "$raw" | jq -s 'add // []' 2>/dev/null || printf '[]'
+}
+
+stack_specs() {
+  python3 -c '
+import json, sys
+prs = json.load(sys.stdin)
+
+def state(pr):
+    return (pr.get("state") or "").lower()
+
+def labels(pr):
+    return {label.get("name") for label in pr.get("labels", [])}
+
+def head_ref(pr):
+    return pr.get("headRefName") or ((pr.get("head") or {}).get("ref"))
+
+def base_ref(pr):
+    return pr.get("baseRefName") or ((pr.get("base") or {}).get("ref"))
+
+open_prs = [pr for pr in prs if state(pr) == "open"]
+by_num = {pr["number"]: pr for pr in open_prs}
+by_head = {head_ref(pr): pr for pr in open_prs if head_ref(pr)}
+children = {}
+for pr in open_prs:
+    base = base_ref(pr)
+    if base:
+        children.setdefault(base, []).append(pr)
+
+targets = [pr for pr in open_prs if "admin-bypass" in labels(pr)]
+seen = set()
+for pr in sorted(targets, key=lambda item: item["number"]):
+    overall_bottom = pr
+    while base_ref(overall_bottom) in by_head:
+        overall_bottom = by_head[base_ref(overall_bottom)]
+
+    target_bottom = pr
+    while base_ref(target_bottom) in by_head:
+        parent = by_head[base_ref(target_bottom)]
+        if "admin-bypass" not in labels(parent):
+            break
+        target_bottom = parent
+
+    dedupe_key = (overall_bottom["number"], target_bottom["number"])
+    if dedupe_key in seen:
+        continue
+    seen.add(dedupe_key)
+
+    chain = [overall_bottom]
+    current = overall_bottom
+    ambiguous = False
+    while True:
+        next_children = sorted(children.get(head_ref(current), []), key=lambda item: item["number"])
+        if not next_children:
+            break
+        if len(next_children) > 1:
+            ambiguous = True
+            break
+        current = next_children[0]
+        chain.append(current)
+
+    print(json.dumps({
+        "overallBottom": overall_bottom["number"],
+        "targetBottom": target_bottom["number"],
+        "prs": [item["number"] for item in chain],
+        "ambiguous": ambiguous,
+    }))
+'
+}
+
+relevant_check_rows() {
+  jq '[.statusCheckRollup[]? | select((.workflowName // "") == "CI" or (.workflowName // "") == "PR Body")]'
+}
+
+failed_check_rows() {
+  printf '%s' "$1" | relevant_check_rows | python3 -c '
+import json, sys
+rows = json.load(sys.stdin)
+failed = []
+for row in rows:
+    conclusion = (row.get("conclusion") or row.get("state") or "").upper()
+    if conclusion in {"FAILURE", "TIMED_OUT", "ACTION_REQUIRED", "CANCELLED", "ERROR"}:
+        failed.append(row)
+print(json.dumps(failed))
+'
+}
+
+check_summary() {
+  local pr_json="$1"
+  printf '%s' "$pr_json" | relevant_check_rows | python3 -c '
+import json, sys
+rows = json.load(sys.stdin)
+active = any((row.get("status") or "").upper() != "COMPLETED" for row in rows)
+failed = any((row.get("conclusion") or row.get("state") or "").upper() in {"FAILURE", "TIMED_OUT", "ACTION_REQUIRED", "CANCELLED", "ERROR"} for row in rows)
+finished = len(rows) > 0 and not active
+passed = finished and not failed
+print(json.dumps({"active": active, "finished": finished, "failed": failed, "passed": passed, "count": len(rows)}))
+'
+}
+
+cancelled_only_failures() {
+  local failed_json="$1"
+  printf '%s' "$failed_json" | python3 -c '
+import json, sys
+rows = json.load(sys.stdin)
+print("true" if rows and all((row.get("conclusion") or row.get("state") or "").upper() == "CANCELLED" for row in rows) else "false")
+'
+}
+
+add_label() {
+  local pr="$1" label="$2"
+  gh_json api --method POST "repos/$TARGET_REPO/issues/$pr/labels" -f "labels[]=$label" >/dev/null
+}
+
+remove_label() {
+  local pr="$1" label="$2"
+  gh_json api --method DELETE "repos/$TARGET_REPO/issues/$pr/labels/$label" >/dev/null 2>&1 || true
+}
+
+attempt_key_hour() { date -u +%Y-%m-%dT%H; }
+attempt_key_day() { date -u +%Y-%m-%d; }
+
+cap_reached() {
+  local kind="$1" key="$2" label="$3"
+  local hour_key day_key
+  if [ "$MAX_PER_HOUR" -le 0 ] && [ "$MAX_PER_DAY" -le 0 ]; then
+    return 1
+  fi
+  hour_key="$(attempt_key_hour)"
+  day_key="$(attempt_key_day)"
+  if [ "$MAX_PER_HOUR" -gt 0 ] && [ "$(ledger_count "$kind-hour" "$key" "$hour_key")" -ge "$MAX_PER_HOUR" ]; then
+    log_line "$label: hourly retry cap $MAX_PER_HOUR reached; skip"
+    return 0
+  fi
+  if [ "$MAX_PER_DAY" -gt 0 ] && [ "$(ledger_count "$kind-day" "$key" "$day_key")" -ge "$MAX_PER_DAY" ]; then
+    log_line "$label: daily retry cap $MAX_PER_DAY reached; skip"
+    return 0
+  fi
+  return 1
+}
+
+record_attempt() {
+  local kind="$1" key="$2"
+  ledger_record "$kind-hour" "$key" "$(attempt_key_hour)"
+  ledger_record "$kind-day" "$key" "$(attempt_key_day)"
+}
+
+queue_cooldown_reached() {
+  local key="$1" label="$2"
+  local last_epoch now
+  if [ "$QUEUE_COOLDOWN_SECONDS" -le 0 ]; then
+    return 1
+  fi
+  last_epoch="$(ledger_max_marker "queue-epoch" "$key")"
+  [ -n "$last_epoch" ] || return 1
+  now="$(date +%s)"
+  if [ $((now - last_epoch)) -lt "$QUEUE_COOLDOWN_SECONDS" ]; then
+    log_line "$label: queued recently for the same head; cooldown active"
+    return 0
+  fi
+  return 1
+}
+
+record_queue_attempt() {
+  local key="$1"
+  record_attempt queue "$key"
+  ledger_record "queue-epoch" "$key" "$(date +%s)"
+}
+
+extract_run_id() {
+  local url="$1"
+  python3 - "$url" <<'PY'
+import re, sys
+m = re.search(r'/actions/runs/(\d+)', sys.argv[1] or '')
+print(m.group(1) if m else '')
+PY
+}
+
+prepare_checkout() {
+  local pr="$1" head_sha="$2"
+  local wt="$WORKDIR/pr-$pr"
+  local local_ref="refs/heads/cron-src/pr-$pr"
+  local branch="cron/admin-bypass-pr-$pr"
+  git -C "$REPO_ROOT" worktree remove --force "$wt" >/dev/null 2>&1 || true
+  git -C "$REPO_ROOT" update-ref -d "$local_ref" >/dev/null 2>&1 || true
+  if git -C "$REPO_ROOT" fetch --quiet origin "pull/$pr/head:$local_ref" >/dev/null 2>&1; then
+    git -C "$REPO_ROOT" worktree add -B "$branch" "$wt" "$local_ref" >/dev/null
+    printf '%s\n' "$wt"
+    return 0
+  fi
+  git -C "$REPO_ROOT" fetch --quiet origin "$head_sha" >/dev/null 2>&1 || return 1
+  git -C "$REPO_ROOT" worktree add -B "$branch" "$wt" "$head_sha" >/dev/null
+  printf '%s\n' "$wt"
+}
+
+is_generated_stack_branch() {
+  local branch="$1"
+  python3 - "$branch" <<'PY'
+import sys
+parts = (sys.argv[1] or '').split('/')
+print('1' if len(parts) >= 4 and parts[0] == 'stack' else '0')
+PY
+}
+
+derive_stack_parent_branch() {
+  local branch="$1"
+  python3 - "$branch" <<'PY'
+import sys
+parts = (sys.argv[1] or '').split('/')
+if len(parts) < 4 or parts[0] != 'stack':
+    sys.exit(1)
+print('/'.join(parts[2:-1]))
+PY
+}
+
+prepare_stack_parent_checkout() {
+  local pr="$1" head_branch="$2" head_sha="$3" base_branch="$4"
+  local parent_branch wt="$WORKDIR/pr-$pr" local_ref="refs/heads/cron-src/pr-$pr"
+  parent_branch="$(derive_stack_parent_branch "$head_branch")" || return 1
+  git -C "$REPO_ROOT" worktree remove --force "$wt" >/dev/null 2>&1 || true
+  git -C "$REPO_ROOT" update-ref -d "$local_ref" >/dev/null 2>&1 || true
+  git -C "$REPO_ROOT" fetch --quiet origin "$base_branch" >/dev/null 2>&1 || return 1
+  if ! git -C "$REPO_ROOT" fetch --quiet origin "pull/$pr/head:$local_ref" >/dev/null 2>&1; then
+    git -C "$REPO_ROOT" fetch --quiet origin "$head_sha" >/dev/null 2>&1 || return 1
+    local_ref="$head_sha"
+  fi
+  git -C "$REPO_ROOT" worktree add -B "$parent_branch" "$wt" "origin/$base_branch" >/dev/null || return 1
+  git -C "$wt" cherry-pick "$local_ref" >/dev/null || {
+    git -C "$wt" cherry-pick --abort >/dev/null 2>&1 || true
+    return 1
+  }
+  git -C "$wt" branch --set-upstream-to="origin/$base_branch" "$parent_branch" >/dev/null
+  printf '%s\n' "$wt"
+}
+
+publish_stack_checkout() {
+  local checkout_dir="$1" label="$2" push_log published_pr
+  push_log="$(mktemp "$WORKDIR/mergify-stack-push.XXXXXX.log")"
+  if ! ( cd "$checkout_dir" && mergify stack setup >/dev/null && mergify stack push --skip-rebase --keep-pull-request-title-and-body --no-verify ) >"$push_log" 2>&1; then
+    cat "$push_log" >&2
+    rm -f "$push_log"
+    return 1
+  fi
+  published_pr="$(grep -Eo 'https://github.com/[^ ]+/pull/[0-9]+' "$push_log" | sed -E 's#.*/pull/([0-9]+)#\1#' | awk 'NF { value=$0 } END { print value }')"
+  rm -f "$push_log"
+  if [ -z "$published_pr" ]; then
+    log_line "$label: mergify stack push finished without publishing a PR URL"
+    return 1
+  fi
+  printf '%s\n' "$published_pr"
+}
+
+publish_checkout_update() {
+  local pr="$1" head_branch="$2" head_sha="$3" base_branch="$4" checkout_dir="$5" label="$6"
+  local stack_pr remote_after_json remote_after_sha remote_after_state
+  if [ "$(is_generated_stack_branch "$head_branch")" = "1" ]; then
+    stack_pr="$(publish_stack_checkout "$checkout_dir" "$label")" || return 1
+    remote_after_json="$(gh_json pr view "$stack_pr" --repo "$TARGET_REPO" --json number,headRefOid,state 2>/dev/null || printf '{}')"
+    remote_after_sha="$(jq -r '.headRefOid // empty' <<<"$remote_after_json")"
+    remote_after_state="$(jq -r '.state // empty' <<<"$remote_after_json")"
+    if [ "$remote_after_state" = "OPEN" ]; then
+      add_label "$stack_pr" admin-bypass
+      remove_label "$stack_pr" dequeued
+    fi
+    printf '%s\t%s\t%s\n' "$stack_pr" "$remote_after_sha" "$remote_after_state"
+    return 0
+  fi
+
+  local local_head
+  local_head="$(git -C "$checkout_dir" rev-parse HEAD 2>/dev/null || printf '')"
+  remote_after_json="$(gh_json pr view "$pr" --repo "$TARGET_REPO" --json number,headRefOid,state 2>/dev/null || printf '{}')"
+  remote_after_sha="$(jq -r '.headRefOid // empty' <<<"$remote_after_json")"
+  if [ -n "$local_head" ] && [ "$local_head" != "$head_sha" ] && [ "$remote_after_sha" = "$head_sha" ] && [ -n "$head_branch" ]; then
+    git -C "$checkout_dir" push origin "HEAD:$head_branch" >/dev/null
+    remote_after_json="$(gh_json pr view "$pr" --repo "$TARGET_REPO" --json number,headRefOid,state 2>/dev/null || printf '{}')"
+    remote_after_sha="$(jq -r '.headRefOid // empty' <<<"$remote_after_json")"
+  fi
+  printf '%s\t%s\t%s\n' "$pr" "$remote_after_sha" "$(jq -r '.state // empty' <<<"$remote_after_json")"
+}
+
+
+ensure_local_pr_head() {
+  local pr="$1" head_branch="$2" head_sha="$3"
+  local local_ref="refs/heads/cron-src/stack-$pr"
+  git -C "$REPO_ROOT" update-ref -d "$local_ref" >/dev/null 2>&1 || true
+  if [ -n "$head_branch" ] && git -C "$REPO_ROOT" fetch --quiet origin "$head_branch:$local_ref" >/dev/null 2>&1; then
+    return 0
+  fi
+  if git -C "$REPO_ROOT" fetch --quiet origin "pull/$pr/head:$local_ref" >/dev/null 2>&1; then
+    return 0
+  fi
+  if [ -n "$head_sha" ] && git -C "$REPO_ROOT" fetch --quiet origin "$head_sha" >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+capture_failed_checks_context() {
+  local failed_json="$1" ctx_dir="$2"
+  local rows_file="$ctx_dir/failed-checks.jsonl"
+  : > "$rows_file"
+  while IFS= read -r row; do
+    [ -z "$row" ] && continue
+    local details_url run_id log_path=""
+    details_url="$(jq -r '.detailsUrl // empty' <<<"$row")"
+    run_id="$(extract_run_id "$details_url")"
+    if [ -n "$run_id" ]; then
+      log_path="$ctx_dir/run-$run_id.log"
+      if [ ! -f "$log_path" ]; then
+        if ! gh run view "$run_id" --repo "$TARGET_REPO" --log-failed >"$log_path" 2>/dev/null; then
+          rm -f "$log_path"
+          log_path=""
+        fi
+      fi
+    fi
+    jq -n --argjson row "$row" --arg runId "$run_id" --arg logPath "$log_path" '
+      $row + {
+        runId: (if $runId == "" then null else ($runId | tonumber) end),
+        logPath: (if $logPath == "" then null else $logPath end)
+      }
+    ' >> "$rows_file"
+  done < <(jq -c '.[]' <<<"$failed_json")
+  jq -s '.' "$rows_file"
+}
+
+build_fix_prompt() {
+  local pr="$1" base_branch="$2" ctx_file="$3"
+  cat <<EOF
+You are fixing finished failing checks on GitHub PR #$pr in repository $TARGET_REPO.
+
+A fresh checkout of the PR branch is already open in this working directory.
+Failure context is in: $ctx_file
+It includes PR metadata, stack order, the failed CI / PR Body checks, and local paths
+for failed-step logs when GitHub exposed them.
+
+Do this:
+1. Read $ctx_file and any logPath files it references.
+2. Inspect the actual PR diff with:
+   - git log origin/$base_branch..HEAD
+   - git diff origin/$base_branch...HEAD
+3. Make the smallest real fix for the listed failures.
+4. If the problem is clearly non-code (for example PR metadata or rerun-only infra),
+   you may use gh instead of editing code.
+5. Run only the targeted local checks you need.
+6. Commit changes locally if you make any. Push is optional; the wrapper will push a
+   new local HEAD if needed.
+
+Constraints:
+- Do not open a new PR.
+- Change only what the listed failures require.
+- No unrelated cleanup or formatting.
+EOF
+}
+
+launch_omp_fix() {
+  local pr="$1" base_branch="$2" ctx_file="$3" checkout_dir="$4"
+  local prompt
+  prompt="$(build_fix_prompt "$pr" "$base_branch" "$ctx_file")"
+  local omp_args=(--no-title --auto-approve)
+  [ -n "${INVOKER_PR_CRON_OMP_MODEL:-}" ] && omp_args+=(--model "$INVOKER_PR_CRON_OMP_MODEL")
+  omp_args+=(-p "$prompt")
+  local omp_run=("$OMP_COMMAND" "${omp_args[@]}")
+  if command -v timeout >/dev/null 2>&1; then
+    omp_run=(timeout --kill-after=1m "$OMP_TIMEOUT" "$OMP_COMMAND" "${omp_args[@]}")
+  fi
+  ( cd "$checkout_dir" && "${omp_run[@]}" )
+}
+
+rerun_failed_runs() {
+  local failed_json="$1" label="$2"
+  local runs
+  runs="$(jq -r '.[] | .detailsUrl // empty' <<<"$failed_json" | while IFS= read -r url; do [ -n "$url" ] && extract_run_id "$url"; done | awk 'NF && !seen[$0]++ { print $0 }')"
+  if [ -z "$runs" ]; then
+    log_line "$label: no rerunnable GitHub Actions runs found"
+    return 1
+  fi
+  local run_id
+  while IFS= read -r run_id; do
+    [ -z "$run_id" ] && continue
+    gh run rerun "$run_id" --repo "$TARGET_REPO" --failed >/dev/null
+    log_line "$label: reran failed jobs for run $run_id"
+  done <<<"$runs"
+}
+
+rerun_cancelled_pr() {
+  local pr="$1" pr_json="$2" label="$3"
+  local head_sha failed_json key
+  head_sha="$(jq -r '.headRefOid // empty' <<<"$pr_json")"
+  key="$pr@$head_sha"
+  if cap_reached rerun "$key" "$label"; then
+    return 0
+  fi
+  failed_json="$(failed_check_rows "$pr_json")"
+  if [ "$DRY_RUN" = "1" ]; then
+    log_line "$label: would rerun cancelled CI for PR #$pr"
+    return 0
+  fi
+  record_attempt rerun "$key"
+  rerun_failed_runs "$failed_json" "$label"
+  mark_action_taken
+}
+
+evaluate_higher_stack_prs() {
+  local bottom="$1" chain_text="$2" label="$3"
+  local pr pr_json pr_state summary failed_json member_label
+  for pr in $chain_text; do
+    [ "$pr" = "$bottom" ] && continue
+    pr_json="$(gh_json pr view "$pr" --repo "$TARGET_REPO" --json number,title,headRefName,baseRefName,headRefOid,labels,statusCheckRollup,state 2>/dev/null || printf '{}')"
+    pr_state="$(jq -r '.state // empty' <<<"$pr_json")"
+    member_label="$label member #$pr"
+    if [ "$pr_state" = "CLOSED" ]; then
+      if [ "$DRY_RUN" != "1" ]; then
+        clear_closed_pr_labels "$pr"
+      fi
+      log_line "$member_label: PR #$pr is closed; skip"
+      continue
+    fi
+    summary="$(check_summary "$pr_json")"
+    if [[ "$(jq -r '.active' <<<"$summary")" = "true" ]]; then
+      log_line "$member_label: CI / PR Body still running on PR #$pr; wait"
+      return 2
+    fi
+    if [[ "$(jq -r '.finished' <<<"$summary")" != "true" ]]; then
+      log_line "$member_label: CI / PR Body not finished on PR #$pr; wait"
+      return 2
+    fi
+    if [[ "$(jq -r '.passed' <<<"$summary")" = "true" ]]; then
+      continue
+    fi
+    failed_json="$(failed_check_rows "$pr_json")"
+    if [ "$(cancelled_only_failures "$failed_json")" = "true" ]; then
+      rerun_cancelled_pr "$pr" "$pr_json" "$member_label" || return 1
+      return 3
+    fi
+    fix_failed_pr "$pr" "$chain_text" "$pr_json" "$member_label" || return 1
+    return 3
+  done
+  return 0
+}
+
+fix_failed_pr() {
+  local pr="$1" chain_text="$2" pr_json="$3" label="$4"
+  local head_branch head_sha base_branch title failed_json key checkout_dir ctx_dir ctx_file enriched_json
+  head_branch="$(jq -r '.headRefName // empty' <<<"$pr_json")"
+  head_sha="$(jq -r '.headRefOid // empty' <<<"$pr_json")"
+  base_branch="$(jq -r '.baseRefName // empty' <<<"$pr_json")"
+  title="$(jq -r '.title // empty' <<<"$pr_json")"
+  key="$pr@$head_sha"
+
+  if cap_reached fix "$key" "$label"; then
+    return 0
+  fi
+
+  failed_json="$(failed_check_rows "$pr_json")"
+  if [ "$DRY_RUN" = "1" ]; then
+    if [ "$(is_generated_stack_branch "$head_branch")" = "1" ]; then
+      log_line "$label: would launch Codex fix and republish via Mergify stack for PR #$pr (chain [$chain_text])"
+    else
+      log_line "$label: would launch Codex fix for PR #$pr (chain [$chain_text])"
+    fi
+    return 0
+  fi
+
+  record_attempt fix "$key"
+  if [ "$(is_generated_stack_branch "$head_branch")" = "1" ]; then
+    checkout_dir="$(prepare_stack_parent_checkout "$pr" "$head_branch" "$head_sha" "$base_branch")" || {
+      log_line "$label: could not prepare parent stack checkout for PR #$pr"
+      return 1
+    }
+  else
+    checkout_dir="$(prepare_checkout "$pr" "$head_sha")" || {
+      log_line "$label: could not prepare checkout for PR #$pr"
+      return 1
+    }
+  fi
+  ctx_dir="$(mktemp -d "$WORKDIR/ctx-$pr.XXXXXX")"
+  trap "rm -rf '$ctx_dir'" RETURN
+  enriched_json="$(capture_failed_checks_context "$failed_json" "$ctx_dir")"
+  ctx_file="$ctx_dir/context.json"
+  jq -n \
+    --arg repo "$TARGET_REPO" \
+    --arg checkoutDir "$checkout_dir" \
+    --arg chain "$chain_text" \
+    --arg pr "$pr" \
+    --arg title "$title" \
+    --arg headBranch "$head_branch" \
+    --arg baseBranch "$base_branch" \
+    --arg headSha "$head_sha" \
+    --argjson failedChecks "$enriched_json" \
+    '{
+      repo: $repo,
+      checkoutDir: $checkoutDir,
+      stackPrs: ($chain | split(" ") | map(select(length > 0) | tonumber)),
+      pr: {
+        number: ($pr | tonumber),
+        title: $title,
+        headBranch: $headBranch,
+        baseBranch: $baseBranch,
+        headSha: $headSha
+      },
+      failedChecks: $failedChecks
+    }' > "$ctx_file"
+
+  if ! launch_omp_fix "$pr" "$base_branch" "$ctx_file" "$checkout_dir"; then
+    log_line "$label: Codex fix run failed for PR #$pr"
+    return 1
+  fi
+
+  local publish_row published_pr remote_after_sha remote_after_state
+  publish_row="$(publish_checkout_update "$pr" "$head_branch" "$head_sha" "$base_branch" "$checkout_dir" "$label")" || {
+    log_line "$label: could not publish updated checkout for PR #$pr"
+    return 1
+  }
+  published_pr="$(printf '%s' "$publish_row" | cut -f1)"
+  remote_after_sha="$(printf '%s' "$publish_row" | cut -f2)"
+  remote_after_state="$(printf '%s' "$publish_row" | cut -f3)"
+
+  if [ -n "$remote_after_sha" ] && [ "$remote_after_sha" != "$head_sha" ]; then
+    mark_action_taken
+    if [ -n "$published_pr" ] && [ "$published_pr" != "$pr" ]; then
+      log_line "$label: republished Mergify stack as PR #$published_pr; waiting on fresh CI"
+    else
+      log_line "$label: updated PR #$pr head $head_sha -> $remote_after_sha; waiting on fresh CI"
+    fi
+    return 0
+  fi
+  if [ "$remote_after_state" = "CLOSED" ]; then
+    if [ -n "$published_pr" ] && [ "$published_pr" != "$pr" ]; then
+      log_line "$label: republished stack PR #$published_pr is closed; skip queueing"
+    else
+      log_line "$label: PR #$pr is closed after publish; skip queueing"
+    fi
+    return 0
+  fi
+
+  rerun_failed_runs "$failed_json" "$label"
+  mark_action_taken
+}
+
+queue_passing_stack() {
+  local bottom="$1" chain_text="$2" bottom_json="$3" label="$4"
+  local head_sha key head_branch head_sha_each pr_json pr
+  head_sha="$(jq -r '.headRefOid // empty' <<<"$bottom_json")"
+  head_branch="$(jq -r '.headRefName // empty' <<<"$bottom_json")"
+  key="$bottom@$head_sha"
+
+  if cap_reached queue "$key" "$label"; then
+    return 0
+  fi
+  if queue_cooldown_reached "$key" "$label"; then
+    return 0
+  fi
+
+  if [ "$DRY_RUN" = "1" ]; then
+    log_line "$label: would queue passing stack [$chain_text] via bottom PR #$bottom"
+    return 0
+  fi
+
+  for pr in $chain_text; do
+    pr_json="$(gh_json pr view "$pr" --repo "$TARGET_REPO" --json number,headRefName,headRefOid 2>/dev/null || printf '{}')"
+    head_branch="$(jq -r '.headRefName // empty' <<<"$pr_json")"
+    head_sha_each="$(jq -r '.headRefOid // empty' <<<"$pr_json")"
+    if ! ensure_local_pr_head "$pr" "$head_branch" "$head_sha_each"; then
+      log_line "$label: could not fetch PR #$pr head locally"
+      return 1
+    fi
+  done
+
+  if ! ( cd "$REPO_ROOT" && run_with_optional_timeout "$REQUEUE_TIMEOUT_SECONDS" node scripts/land-stack.mjs $chain_text ); then
+    log_line "$label: land-stack verification failed for [$chain_text]"
+    return 1
+  fi
+
+  record_queue_attempt "$key"
+  for pr in $chain_text; do
+    remove_label "$pr" dequeued
+  done
+  remove_label "$bottom" admin-bypass
+  add_label "$bottom" admin-bypass
+  mark_action_taken
+  log_line "$label: queued stack [$chain_text] via bottom PR #$bottom"
+}
+
+clear_closed_pr_labels() {
+  local pr="$1"
+  remove_label "$pr" admin-bypass
+  remove_label "$pr" dequeued
+}
+
+process_stack() {
+  local spec_json="$1"
+  local overall_bottom target_bottom ambiguous chain_text label target_json summary target_state
+  overall_bottom="$(jq -r '.overallBottom' <<<"$spec_json")"
+  target_bottom="$(jq -r '.targetBottom' <<<"$spec_json")"
+  ambiguous="$(jq -r '.ambiguous' <<<"$spec_json")"
+  chain_text="$(jq -r '.prs | join(" ")' <<<"$spec_json")"
+  label="stack overall #$overall_bottom target #$target_bottom"
+
+  if [[ "$ambiguous" = "true" ]]; then
+    log_line "$label: ambiguous child linkage; skip"
+    return 0
+  fi
+
+  if [ "$overall_bottom" != "$target_bottom" ]; then
+    log_line "$label: lower PR without admin-bypass blocks stack order; skip"
+    return 0
+  fi
+
+  target_json="$(gh_json pr view "$target_bottom" --repo "$TARGET_REPO" --json number,title,headRefName,baseRefName,headRefOid,labels,statusCheckRollup,state 2>/dev/null || printf '{}')"
+  target_state="$(jq -r '.state // empty' <<<"$target_json")"
+  if [ "$target_state" = "CLOSED" ]; then
+    if [ "$DRY_RUN" != "1" ]; then
+      clear_closed_pr_labels "$target_bottom"
+    fi
+    log_line "$label: PR #$target_bottom is closed; skip"
+    return 0
+  fi
+  summary="$(check_summary "$target_json")"
+
+  if [[ "$(jq -r '.active' <<<"$summary")" = "true" ]]; then
+    log_line "$label: CI / PR Body still running on PR #$target_bottom; wait"
+    return 0
+  fi
+  if [[ "$(jq -r '.failed' <<<"$summary")" = "true" ]]; then
+    if ! claim_key "admin-bypass-stack-$target_bottom"; then
+      log_line "$label: stack already claimed by another worker; skip"
+      return 0
+    fi
+    fix_failed_pr "$target_bottom" "$chain_text" "$target_json" "$label"
+    return $?
+  fi
+  if [[ "$(jq -r '.passed' <<<"$summary")" = "true" ]]; then
+    local higher_status=0
+    if ! claim_key "admin-bypass-stack-$target_bottom"; then
+      log_line "$label: stack already claimed by another worker; skip"
+      return 0
+    fi
+    evaluate_higher_stack_prs "$target_bottom" "$chain_text" "$label" || higher_status=$?
+    case "$higher_status" in
+      0)
+        queue_passing_stack "$target_bottom" "$chain_text" "$target_json" "$label"
+        return $?
+        ;;
+      2|3)
+        return 0
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  fi
+
+  log_line "$label: no action"
+}
+
+pulls_json="$(fetch_open_pulls)"
+if ! jq empty >/dev/null 2>&1 <<<"$pulls_json"; then
+  log_line "could not parse open pulls JSON; exiting"
+  exit 0
+fi
+
+matched=0
+failed=0
+while IFS= read -r spec; do
+  [ -z "$spec" ] && continue
+  matched=$((matched + 1))
+  if ! process_stack "$spec"; then
+    failed=$((failed + 1))
+  fi
+  if action_limit_reached; then
+    break
+  fi
+done < <(printf '%s' "$pulls_json" | stack_specs)
+
+if [ "$matched" -eq 0 ]; then
+  log_line "no open admin-bypass PR stacks found"
+  exit 0
+fi
+
+if [ "$failed" -gt 0 ]; then
+  log_line "completed with $failed failed admin-bypass action(s)"
+  exit 1
+fi
+
+log_line "completed admin-bypass scan for $matched stack(s)"

--- a/scripts/cron-master-head-test-autofix.sh
+++ b/scripts/cron-master-head-test-autofix.sh
@@ -1,0 +1,405 @@
+#!/usr/bin/env bash
+# Run the full destructive suite against upstream master and open one repair PR
+# only when an OMP-authored fix makes the same suite pass.
+set -euo pipefail
+
+# shellcheck source=scripts/cron-pr-lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/cron-pr-lib.sh"
+
+INVOKER_MASTER_HEAD_AUTOFIX_REPO_URL="${INVOKER_MASTER_HEAD_AUTOFIX_REPO_URL:-git@github.com:Neko-Catpital-Labs/Invoker.git}"
+INVOKER_MASTER_HEAD_AUTOFIX_REPO_SLUG="${INVOKER_MASTER_HEAD_AUTOFIX_REPO_SLUG:-Neko-Catpital-Labs/Invoker}"
+INVOKER_MASTER_HEAD_AUTOFIX_BASE_BRANCH="${INVOKER_MASTER_HEAD_AUTOFIX_BASE_BRANCH:-master}"
+INVOKER_MASTER_HEAD_AUTOFIX_WORKDIR="${INVOKER_MASTER_HEAD_AUTOFIX_WORKDIR:-$HOME/.invoker/master-head-test-autofix}"
+INVOKER_MASTER_HEAD_AUTOFIX_STATE_FILE="${INVOKER_MASTER_HEAD_AUTOFIX_STATE_FILE:-$HOME/.invoker/master-head-test-autofix.tsv}"
+INVOKER_MASTER_HEAD_AUTOFIX_MAX_ATTEMPTS="${INVOKER_MASTER_HEAD_AUTOFIX_MAX_ATTEMPTS:-3}"
+INVOKER_MASTER_HEAD_AUTOFIX_OMP_MODEL="${INVOKER_MASTER_HEAD_AUTOFIX_OMP_MODEL:-openai-codex/gpt-5.3-codex-spark}"
+INVOKER_MASTER_HEAD_AUTOFIX_OMP_TIMEOUT_SECONDS="${INVOKER_MASTER_HEAD_AUTOFIX_OMP_TIMEOUT_SECONDS:-7200}"
+INVOKER_MASTER_HEAD_AUTOFIX_TEST_TIMEOUT_SECONDS="${INVOKER_MASTER_HEAD_AUTOFIX_TEST_TIMEOUT_SECONDS:-3600}"
+INVOKER_MASTER_HEAD_AUTOFIX_CONFIRM_FAILURE="${INVOKER_MASTER_HEAD_AUTOFIX_CONFIRM_FAILURE:-1}"
+INVOKER_MASTER_HEAD_AUTOFIX_TEST_COMMAND="${INVOKER_MASTER_HEAD_AUTOFIX_TEST_COMMAND:-pnpm run test:all:destructive}"
+
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+RUN_DIR="$INVOKER_MASTER_HEAD_AUTOFIX_WORKDIR/runs/$RUN_ID"
+CHECKOUT_DIR="$RUN_DIR/checkout"
+LOG_DIR="$RUN_DIR/logs"
+VISUAL_PROOF_DIR="$RUN_DIR/visual-proof"
+
+cron_lock
+ledger_init "$INVOKER_MASTER_HEAD_AUTOFIX_STATE_FILE"
+mkdir -p "$CHECKOUT_DIR" "$LOG_DIR" "$VISUAL_PROOF_DIR"
+
+infrastructure_unavailable() {
+  log_line "infrastructure unavailable: $1"
+  exit 1
+}
+
+preflight() {
+  local tool
+  for tool in git gh node pnpm omp docker; do
+    command -v "$tool" >/dev/null 2>&1 || infrastructure_unavailable "$tool"
+  done
+  docker info >/dev/null 2>&1 || infrastructure_unavailable "docker"
+  omp models >/dev/null 2>&1 || infrastructure_unavailable "omp-auth"
+}
+
+configure_git_identity_if_missing() {
+  git config user.name >/dev/null 2>&1 || git config user.name "Invoker Cron"
+  git config user.email >/dev/null 2>&1 || git config user.email "ci@invoker.dev"
+}
+
+
+cleanup_checkout_processes() {
+  python3 - "$CHECKOUT_DIR" <<'PYCLEANUP'
+import os
+import signal
+import sys
+import time
+
+checkout = os.path.realpath(sys.argv[1])
+self_pid = os.getpid()
+
+def matching_process_groups():
+    groups = set()
+    for name in os.listdir('/proc'):
+        if not name.isdigit():
+            continue
+        pid = int(name)
+        if pid == self_pid:
+            continue
+        try:
+            raw = open(f'/proc/{pid}/cmdline', 'rb').read()
+            cmd = raw.replace(b'\0', b' ').decode(errors='replace')
+            cwd = os.path.realpath(os.readlink(f'/proc/{pid}/cwd'))
+            pgid = os.getpgid(pid)
+        except Exception:
+            continue
+        if checkout in cmd or cwd.startswith(checkout):
+            groups.add(pgid)
+    return groups
+
+for sig in (signal.SIGTERM, signal.SIGKILL):
+    groups = matching_process_groups()
+    if not groups:
+        break
+    for pgid in groups:
+        try:
+            os.killpg(pgid, sig)
+        except ProcessLookupError:
+            pass
+        except PermissionError:
+            pass
+    time.sleep(2 if sig == signal.SIGTERM else 0)
+PYCLEANUP
+}
+
+make_log_path() {
+  local label="$1"
+  printf '%s/%s-%s.log' "$LOG_DIR" "$(date -u +%Y%m%dT%H%M%SZ)" "$label"
+}
+
+run_full_tests() {
+  local label="$1"
+  local log_file="$2"
+  local command="$INVOKER_MASTER_HEAD_AUTOFIX_TEST_COMMAND"
+
+  log_line "$label: running $command"
+  set +e
+  if [ "$INVOKER_MASTER_HEAD_AUTOFIX_TEST_TIMEOUT_SECONDS" -gt 0 ]; then
+    (
+      cd "$CHECKOUT_DIR"
+      run_with_optional_timeout "$INVOKER_MASTER_HEAD_AUTOFIX_TEST_TIMEOUT_SECONDS" \
+        env \
+          CI="${CI:-true}" \
+          INVOKER_TEST_ALL_FORCE_RERUN="${INVOKER_TEST_ALL_FORCE_RERUN:-1}" \
+          INVOKER_TEST_ALL_RESUME="${INVOKER_TEST_ALL_RESUME:-0}" \
+          INVOKER_PLAYWRIGHT_WORKERS="${INVOKER_PLAYWRIGHT_WORKERS:-1}" \
+          INVOKER_TEST_ALL_JOBS="${INVOKER_TEST_ALL_JOBS:-1}" \
+          bash -c "$command"
+    ) > "$log_file" 2>&1
+  else
+    (
+      cd "$CHECKOUT_DIR"
+      env \
+        CI="${CI:-true}" \
+        INVOKER_TEST_ALL_FORCE_RERUN="${INVOKER_TEST_ALL_FORCE_RERUN:-1}" \
+        INVOKER_TEST_ALL_RESUME="${INVOKER_TEST_ALL_RESUME:-0}" \
+        INVOKER_PLAYWRIGHT_WORKERS="${INVOKER_PLAYWRIGHT_WORKERS:-1}" \
+        INVOKER_TEST_ALL_JOBS="${INVOKER_TEST_ALL_JOBS:-1}" \
+        bash -c "$command"
+    ) > "$log_file" 2>&1
+  fi
+  local code=$?
+  cleanup_checkout_processes
+
+  if [ "$code" -eq 0 ] && grep -Eq 'Skipped unavailable:[[:space:]]*[1-9][0-9]*' "$log_file"; then
+    log_line "$label: infrastructure unavailable: skipped suite in $log_file"
+    return 125
+  fi
+
+  if [ "$code" -eq 0 ]; then
+    log_line "$label: passed; log $log_file"
+  else
+    log_line "$label: failed with exit $code; log $log_file"
+  fi
+  return "$code"
+}
+
+build_prompt() {
+  local base_sha="$1"
+  local failing_log="$2"
+  cat <<PROMPT
+Repo: $INVOKER_MASTER_HEAD_AUTOFIX_REPO_SLUG
+Base branch: $INVOKER_MASTER_HEAD_AUTOFIX_BASE_BRANCH
+Exact base SHA: $base_sha
+Failing command: $INVOKER_MASTER_HEAD_AUTOFIX_TEST_COMMAND
+Failing log path: $failing_log
+
+Required behavior:
+- Fix only the failing test run shown in the log.
+- Preserve unrelated code.
+- Run targeted checks as needed.
+- Leave the final full test rerun to this cron script.
+- Do not create the PR manually.
+PROMPT
+}
+
+run_omp() {
+  local prompt="$1"
+  local omp_cmd="${INVOKER_OMP_COMMAND:-omp}"
+  log_line "launching omp on $CHECKOUT_DIR"
+  if [ "$INVOKER_MASTER_HEAD_AUTOFIX_OMP_TIMEOUT_SECONDS" -gt 0 ]; then
+    (
+      cd "$CHECKOUT_DIR"
+      run_with_optional_timeout "$INVOKER_MASTER_HEAD_AUTOFIX_OMP_TIMEOUT_SECONDS" \
+        "$omp_cmd" --no-title --auto-approve --model "$INVOKER_MASTER_HEAD_AUTOFIX_OMP_MODEL" -p "$prompt"
+    )
+  else
+    (
+      cd "$CHECKOUT_DIR"
+      "$omp_cmd" --no-title --auto-approve --model "$INVOKER_MASTER_HEAD_AUTOFIX_OMP_MODEL" -p "$prompt"
+    )
+  fi
+}
+
+ui_impacting_files() {
+  local changed_file_list="$1"
+  (
+    cd "$CHECKOUT_DIR"
+    node --input-type=module - "$changed_file_list" <<'NODE'
+import { readFileSync } from 'node:fs';
+import { getUiImpactingFiles } from './scripts/create-pr.mjs';
+
+const listPath = process.argv[2];
+const files = readFileSync(listPath, 'utf8').split('\n').filter(Boolean);
+process.stdout.write(getUiImpactingFiles(files).join('\n'));
+NODE
+  )
+}
+
+first_visual_proof_png() {
+  find "$VISUAL_PROOF_DIR" -type f -name '*.png' | sort | sed -n '1p'
+}
+
+test_plan_command_text() {
+  printf 'CI=%s INVOKER_TEST_ALL_FORCE_RERUN=%s INVOKER_TEST_ALL_RESUME=%s INVOKER_PLAYWRIGHT_WORKERS=%s INVOKER_TEST_ALL_JOBS=%s %s' \
+    "${CI:-true}" \
+    "${INVOKER_TEST_ALL_FORCE_RERUN:-1}" \
+    "${INVOKER_TEST_ALL_RESUME:-0}" \
+    "${INVOKER_PLAYWRIGHT_WORKERS:-1}" \
+    "${INVOKER_TEST_ALL_JOBS:-1}" \
+    "$INVOKER_MASTER_HEAD_AUTOFIX_TEST_COMMAND"
+}
+
+write_pr_body() {
+  local body_file="$1"
+  local base_sha="$2"
+  local pass_log="$3"
+  local fix_sha="$4"
+  local visual_png="${5:-}"
+  local test_command_text
+  test_command_text="$(test_plan_command_text)"
+
+  cat > "$body_file" <<BODY
+## Summary
+
+The master-head test cron found a failing full destructive test run and this PR fixes it.
+
+The failing base was $base_sha. The fixed branch reran $INVOKER_MASTER_HEAD_AUTOFIX_TEST_COMMAND successfully.
+
+<details>
+<summary>Review metadata</summary>
+
+Review Claim: This PR fixes the full destructive test run from upstream master $base_sha.
+
+Review Lane: behavior
+
+Review Unit: tooling-policy
+
+Safety Invariant: The branch is based on origin/master $base_sha and the passing rerun log is $pass_log.
+
+Slice Rationale: One cron run creates one repair PR so review maps to one failing master-head run.
+
+</details>
+
+## Non-goals
+
+This PR does not change cron scheduling or unrelated tests.
+
+## Test Plan
+
+- [x] \`$test_command_text\`
+BODY
+
+  if [ -n "$visual_png" ]; then
+    cat >> "$body_file" <<BODY
+
+## Visual Proof
+
+![Visual proof]($visual_png)
+BODY
+  fi
+
+  cat >> "$body_file" <<BODY
+
+## Revert Plan
+
+- Safe to revert? Yes
+- Revert command: \`git revert $fix_sha\`
+- Post-revert steps: None
+- Data migration? No
+BODY
+}
+
+preflight
+
+log_line "cloning $INVOKER_MASTER_HEAD_AUTOFIX_REPO_URL into $CHECKOUT_DIR"
+git clone --origin origin "$INVOKER_MASTER_HEAD_AUTOFIX_REPO_URL" "$CHECKOUT_DIR"
+(
+  cd "$CHECKOUT_DIR"
+  git fetch origin "$INVOKER_MASTER_HEAD_AUTOFIX_BASE_BRANCH"
+  git switch --detach "origin/$INVOKER_MASTER_HEAD_AUTOFIX_BASE_BRANCH"
+  configure_git_identity_if_missing
+)
+
+BASE_SHA="$(cd "$CHECKOUT_DIR" && git rev-parse HEAD)"
+SHORT_SHA="$(cd "$CHECKOUT_DIR" && git rev-parse --short HEAD)"
+log_line "testing origin/$INVOKER_MASTER_HEAD_AUTOFIX_BASE_BRANCH at $BASE_SHA"
+
+log_line "installing dependencies"
+(
+  cd "$CHECKOUT_DIR"
+  pnpm install --frozen-lockfile
+)
+
+FIRST_LOG="$(make_log_path first)"
+set +e
+run_full_tests first "$FIRST_LOG"
+FIRST_STATUS=$?
+set -e
+if [ "$FIRST_STATUS" -eq 0 ]; then
+  ledger_record green "$BASE_SHA" "$(date +%s)"
+  exit 0
+fi
+if [ "$FIRST_STATUS" -eq 125 ]; then
+  exit 1
+fi
+
+FAILED_LOG="$FIRST_LOG"
+if [ "$INVOKER_MASTER_HEAD_AUTOFIX_CONFIRM_FAILURE" = "1" ]; then
+  CONFIRM_LOG="$(make_log_path confirm)"
+  set +e
+  run_full_tests confirm "$CONFIRM_LOG"
+  CONFIRM_STATUS=$?
+  set -e
+  if [ "$CONFIRM_STATUS" -eq 0 ]; then
+    ledger_record flake-green "$BASE_SHA" "$(date +%s)"
+    exit 0
+  fi
+  if [ "$CONFIRM_STATUS" -eq 125 ]; then
+    exit 1
+  fi
+  FAILED_LOG="$CONFIRM_LOG"
+fi
+
+ATTEMPTS="$(ledger_count master-head-attempt "$BASE_SHA")"
+if [ "$ATTEMPTS" -ge "$INVOKER_MASTER_HEAD_AUTOFIX_MAX_ATTEMPTS" ]; then
+  log_line "attempt cap reached for $BASE_SHA ($ATTEMPTS/$INVOKER_MASTER_HEAD_AUTOFIX_MAX_ATTEMPTS); not launching omp"
+  exit 1
+fi
+
+if ledger_marker_seen master-head-pr "$BASE_SHA" created; then
+  log_line "repair PR already exists for $BASE_SHA; exiting"
+  exit 0
+fi
+
+BRANCH="cron/master-head-test-fix-$SHORT_SHA-$RUN_ID"
+(
+  cd "$CHECKOUT_DIR"
+  git switch -c "$BRANCH" "$BASE_SHA"
+)
+
+PROMPT="$(build_prompt "$BASE_SHA" "$FAILED_LOG")"
+set +e
+run_omp "$PROMPT"
+OMP_STATUS=$?
+set -e
+cleanup_checkout_processes
+if [ "$OMP_STATUS" -ne 0 ]; then
+  ledger_record master-head-attempt "$BASE_SHA" "omp-failed-$OMP_STATUS"
+  exit 1
+fi
+
+if ( cd "$CHECKOUT_DIR" && git diff --quiet ); then
+  ledger_record master-head-attempt "$BASE_SHA" no-diff
+  log_line "omp exited without changes; no PR created"
+  exit 1
+fi
+
+RERUN_LOG="$(make_log_path rerun)"
+set +e
+run_full_tests rerun "$RERUN_LOG"
+RERUN_STATUS=$?
+set -e
+if [ "$RERUN_STATUS" -ne 0 ]; then
+  ledger_record master-head-attempt "$BASE_SHA" failed-rerun
+  exit 1
+fi
+
+(
+  cd "$CHECKOUT_DIR"
+  git add -A
+  git commit -m "Fix master HEAD full test failures"
+)
+FIX_SHA="$(cd "$CHECKOUT_DIR" && git rev-parse HEAD)"
+CHANGED_FILE_LIST="$RUN_DIR/changed-files.txt"
+(
+  cd "$CHECKOUT_DIR"
+  git diff --name-only "$BASE_SHA"...HEAD > "$CHANGED_FILE_LIST"
+)
+UI_FILES="$(ui_impacting_files "$CHANGED_FILE_LIST")"
+VISUAL_PNG=""
+if [ -n "$UI_FILES" ]; then
+  log_line "UI-impacting files changed; capturing visual proof"
+  if ! ( cd "$CHECKOUT_DIR" && bash scripts/ui-visual-proof.sh capture-after --output-dir "$VISUAL_PROOF_DIR" ); then
+    log_line "visual proof capture failed; no PR created"
+    exit 1
+  fi
+  VISUAL_PNG="$(first_visual_proof_png)"
+  if [ -z "$VISUAL_PNG" ]; then
+    log_line "visual proof capture produced no PNG; no PR created"
+    exit 1
+  fi
+fi
+
+BODY_FILE="$RUN_DIR/pr-body.md"
+write_pr_body "$BODY_FILE" "$BASE_SHA" "$RERUN_LOG" "$FIX_SHA" "$VISUAL_PNG"
+PR_URL="$(
+  cd "$CHECKOUT_DIR"
+  node scripts/create-pr.mjs \
+    --title "Fix master HEAD full test failures ($SHORT_SHA)" \
+    --base "$INVOKER_MASTER_HEAD_AUTOFIX_BASE_BRANCH" \
+    --body-file "$BODY_FILE"
+)"
+ledger_record master-head-pr "$BASE_SHA" created
+log_line "created PR: $PR_URL"
+printf '%s\n' "$PR_URL"

--- a/scripts/cron-pr-lib.sh
+++ b/scripts/cron-pr-lib.sh
@@ -11,8 +11,8 @@
 # Provides:
 #   Variables: REPO_ROOT, RUNNER, IPC_HELPER (from headless-lib.sh),
 #              TARGET_REPO, PR_AUTHOR, CODERABBIT_LOGIN, CRON_LOCK, DRY_RUN
-#   Functions: log_line, cron_lock, ledger_init, ledger_record, ledger_count,
-#              ledger_marker_seen, ledger_max_marker, gh_json,
+#   Functions: log_line, cron_lock, claim_key, ledger_init, ledger_record,
+#              ledger_count, ledger_marker_seen, ledger_max_marker, gh_json,
 #              resolve_workflow_for_pr, prune_stale_pr_workdirs
 #
 # Both jobs run their mutating operation SYNCHRONOUSLY while holding a single
@@ -33,6 +33,7 @@ TARGET_REPO="${INVOKER_GITHUB_TARGET_REPO:-Neko-Catpital-Labs/Invoker}"
 PR_AUTHOR="${INVOKER_PR_CRON_AUTHOR:-EdbertChan}"
 CODERABBIT_LOGIN="${INVOKER_CODERABBIT_LOGIN:-coderabbitai[bot]}"
 CRON_LOCK="${INVOKER_PR_CRON_LOCK:-${TMPDIR:-/tmp}/invoker-pr-crons.lock}"
+CLAIM_LOCK_ROOT="${INVOKER_PR_CLAIM_LOCK_ROOT:-${TMPDIR:-/tmp}/invoker-pr-claims}"
 DRY_RUN="${INVOKER_PR_CRON_DRY_RUN:-0}"
 
 # ---------------------------------------------------------------------------
@@ -95,6 +96,43 @@ cron_lock() {
   CRON_LOCK_DIR="$lockdir"
   # shellcheck disable=SC2064
   trap 'rm -rf "'"$lockdir"'" 2>/dev/null || true' EXIT
+}
+
+# Per-item claim lock: cron_lock already serializes a whole tick, so this is
+# only useful when a script iterates several PRs/stacks and wants to skip any
+# already claimed by another worker (fine-grained no-op when only one cron runs
+# at a time, and still safe if concurrency ever increases).
+claim_key() {
+  local key="$1"
+  local safe slot_path
+  safe="$(python3 - "$key" <<'PY'
+import hashlib, sys
+print(hashlib.sha256((sys.argv[1] or '').encode()).hexdigest())
+PY
+)"
+  mkdir -p "$CLAIM_LOCK_ROOT"
+  slot_path="$CLAIM_LOCK_ROOT/$safe.lock"
+  if command -v flock >/dev/null 2>&1; then
+    local fd
+    exec {fd}>"$slot_path"
+    if ! flock -n "$fd"; then
+      eval "exec ${fd}>&-"
+      return 1
+    fi
+    CLAIM_FD="$fd"
+    CLAIM_KEY="$key"
+    return 0
+  fi
+
+  local lockdir="${slot_path}.d"
+  [ -d "$lockdir" ] && _cron_lock_reap_stale "$lockdir"
+  if ! mkdir "$lockdir" 2>/dev/null; then
+    return 1
+  fi
+  printf '%s\n' "$$" > "$lockdir/pid"
+  CLAIM_LOCK_DIR="$lockdir"
+  CLAIM_KEY="$key"
+  return 0
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Extracts only the two brand-new scripts (and the tiny `claim_key` helper they need) from the abandoned "Save DigitalOcean 1 dangling changes" snapshot (#3219). Every other file in #3219 is either already applied on master via other PRs, a regression against master, or an edit to cron scripts that #3196 retired in favour of in-app owner workers — see the relevance table below.

- `scripts/cron-admin-bypass-requeue.sh` (new, 742 lines) — Job 3 cron that scans admin-bypass PRs, fixes finished failures via OMP in a separate checkout, and re-toggles admin-bypass on stack bottoms so Mergify re-queues them.
- `scripts/cron-master-head-test-autofix.sh` (new, 405 lines) — periodic destructive-suite run against upstream master. If the suite fails, OMP/Codex authors a fix, the suite is re-run in the same checkout, and one repair PR is opened per broken upstream SHA. This is the script behind master's CHANGELOG entry *"Add a local master-head full-test repair cron ..."* (added by #3029). Its original home #3042 was closed unmerged on 2026-07-08.
- `scripts/cron-pr-lib.sh` — additive: new `claim_key` helper + `CLAIM_LOCK_ROOT` var used by `cron-admin-bypass-requeue.sh`. Existing `cron_lock` semantics and `prune_stale_pr_workdirs` are untouched, so `cron-coderabbit-address.sh` and `cron-pr-conflict-rebase.sh` keep behaving exactly as they do today.

## What was dropped from #3219

| File | Reason for dropping |
|---|---|
| `packages/data-store/**` (5 files), `packages/surfaces/**/__tests__/**` (7 files), `packages/surfaces/src/slack/thread-session-manager.ts`, `packages/surfaces/src/slack/workflow-assistant.ts`, `docs/slack-native-workflows.md` | Already applied on master via later PRs (three-way merge is a no-op). |
| `packages/surfaces/src/slack/slack-surface.ts` (8 conflicts), `packages/surfaces/src/slack/plan-conversation.ts` (2 conflicts), `packages/surfaces/src/__tests__/slack-surface-workflows.test.ts` (1 conflict) | Regressions against master: master has admin gating on `exec local:`, per-repo checkout, output-buffer caps, stacked-workflow prompts, and stricter agent-thread submit guards; #3219 reverts them. |
| `CHANGELOG.md` (2 hunks) | Both bullets it adds are already on master via #3029 and other PRs. |
| `scripts/cron-pr-conflict-rebase.sh` (+543/-72), `scripts/cron-pr-lib.sh` (+79/-28 of the same edits), `scripts/install-pr-cron-jobs.sh` (+27/-13), `scripts/uninstall-pr-cron-jobs.sh` (+5/-3) | Master retired the host-crontab installer path in #3196; install/uninstall wrappers are deleted on master and the conflict-rebase cron is now driven by the PR-Maintenance-Workers stack (#3346/#3368/#3388/#3391/#3460). |
| `scripts/repro/repro-pr-conflict-rebase-guard.sh`, `scripts/repro/repro-pr-cron-attempt-cap.sh` | Both target the retired 605-line version of `cron-pr-conflict-rebase.sh`; they don't test either of the two salvaged scripts. If we keep the salvaged scripts, dedicated repros should be written separately. |

## Why we may want these

- Master's PR-Maintenance-Workers stack handles rebase / CI-repair on individual open PRs, but has no path for "the whole admin-bypass queue is jammed and needs the bottom PR re-toggled". `cron-admin-bypass-requeue.sh` fills that gap.
- Master's CHANGELOG already advertises the master-head autofix cron even though the script was never merged. Either land the script or revert the CHANGELOG line.
- Both scripts are the only DO1 changes that are actually novel (~1,187 net-new lines vs. ~1,180 obsolete lines in #3219); everything else has been superseded.

## Why we may not want these

- Direction of travel is host crons -> in-app owner workers (#3196 explicitly retired the installer wrappers). Adding two new host cron scripts moves in the opposite direction.
- `scripts/mergify_admin_requeue.py` + support files (#3221-#3225 Worker Subscriptions stack) already do admin-bypass requeue work from a different angle (Python + workers). The two approaches would need to be reconciled before both are enabled on the same host.
- Neither script has a repro/test in this PR (the two matching repros in #3219 target the retired 605-line cron-pr-conflict-rebase.sh and don't apply). If we keep the scripts, follow-up repros are needed.
- `cron-master-head-test-autofix.sh` opens PRs autonomously against master via OMP/Codex — high-authority action. The rejection of its parent PR #3042 may have been intentional.

## Test Plan

- [x] `bash -n scripts/cron-pr-lib.sh scripts/cron-admin-bypass-requeue.sh scripts/cron-master-head-test-autofix.sh` — syntax passes.
- [x] Sourced `cron-pr-lib.sh` and confirmed `claim_key` behaviour: same key from the same process succeeds, same key from a subshell is blocked (flock path), different key succeeds.
- [x] Ran `cron-admin-bypass-requeue.sh` with `INVOKER_PR_CRON_DRY_RUN=1`; scan completes cleanly, no repo mutation, no changes to existing crons.
- [ ] Follow-up: add repros under `scripts/repro/` targeting each new script's decision points.

## Revert Plan

- Safe to revert? **Yes.**
- Revert command: `git revert <sha>`.
- Post-revert steps: If the master-head autofix cron was installed on a host via crontab, remove that entry manually (this PR does not touch host crontabs). Also revert the CHANGELOG bullet about the master-head cron if the script is not resurrected elsewhere.
- Data migration? No.

## Related

- Origin PR: #3219 (Save DigitalOcean 1 dangling changes)
- Prior attempt for the master-head cron: #3042 (closed)
- Overlapping requeue path: #3221-#3225 (Worker Subscriptions)
- Cron -> worker migration: #3196, #3346, #3368, #3388, #3391, #3460


Made with [Cursor](https://cursor.com)