### PR TITLE
[Codex fix error surface](2) Strip the stdin-read line when Codex emits it on stdout

### DIFF
--- a/packages/execution-engine/src/__tests__/process-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/process-utils.test.ts
@@ -272,6 +272,23 @@ describe('buildAgentExitFailureDetail', () => {
     expect(detail).toContain('openai/codex#19945');
   });
 
+  it('returns the actionable hint when the stdin/TTY noise landed on stdout, not stderr', async () => {
+    // Regression: codex can print "Reading additional input from stdin..." to STDOUT
+    // and die before emitting any JSONL. The readable output is empty (no messages
+    // parsed) and stderr is empty, so the old raw-stdout fallback echoed the noise
+    // verbatim as "codex fix exited with code 1: Reading additional input from stdin...".
+    const { processUtils } = await loadProcessUtils();
+    const detail = processUtils.buildAgentExitFailureDetail(
+      'Reading additional input from stdin...\n',
+      '',
+      '',
+    );
+    expect(detail).toContain('without a controlling TTY');
+    expect(detail).toContain('openai/codex#19945');
+    // The raw noise must not leak through as the whole detail.
+    expect(detail).not.toBe('Reading additional input from stdin...');
+  });
+
   it('returns (no output) when the process emitted nothing at all', async () => {
     const { processUtils } = await loadProcessUtils();
     expect(processUtils.buildAgentExitFailureDetail('', '', '')).toBe('(no output)');

--- a/packages/execution-engine/src/process-utils.ts
+++ b/packages/execution-engine/src/process-utils.ts
@@ -270,6 +270,15 @@ function nonEmptyTrimmedLines(text: string): string[] {
   return text.split('\n').map((line) => line.trim()).filter(Boolean);
 }
 
+/** Drop the benign "Reading additional input from stdin..." lines codex emits when it
+ * runs without a controlling TTY. This noise can land on either stdout or stderr
+ * depending on the codex version, so every candidate stream is filtered through here. */
+function stripCodexStdinNoise(text: string): string {
+  return nonEmptyTrimmedLines(text)
+    .filter((line) => !CODEX_STDIN_NOISE.test(line))
+    .join('\n');
+}
+
 function tailChars(text: string): string {
   return text.length <= AGENT_OUTPUT_DETAIL_MAX_CHARS
     ? text
@@ -281,16 +290,17 @@ export function buildAgentExitFailureDetail(
   stderr: string,
   displayStdout?: string,
 ): string {
-  const meaningfulStderr = nonEmptyTrimmedLines(stderr)
-    .filter((line) => !CODEX_STDIN_NOISE.test(line))
-    .join('\n');
-  const candidate = meaningfulStderr
-    || (displayStdout ?? '').trim()
-    || rawStdout.trim();
+  const meaningfulStderr = stripCodexStdinNoise(stderr);
+  const meaningfulDisplay = stripCodexStdinNoise(displayStdout ?? '');
+  const meaningfulStdout = stripCodexStdinNoise(rawStdout);
+  const candidate = meaningfulStderr || meaningfulDisplay || meaningfulStdout;
   if (candidate) return tailChars(candidate);
 
-  const stderrLines = nonEmptyTrimmedLines(stderr);
-  if (stderrLines.length > 0 && stderrLines.every((line) => CODEX_STDIN_NOISE.test(line))) {
+  // Nothing meaningful survived. If the only thing either stream emitted was the
+  // benign codex stdin/TTY noise, return an actionable hint instead of echoing it
+  // back verbatim (which reads as a pointless error to the user).
+  const emittedLines = [...nonEmptyTrimmedLines(stderr), ...nonEmptyTrimmedLines(rawStdout)];
+  if (emittedLines.length > 0 && emittedLines.every((line) => CODEX_STDIN_NOISE.test(line))) {
     return 'agent exited non-zero with no captured output, emitting only '
       + '"Reading additional input from stdin..." — a known codex CLI failure when it '
       + 'runs without a controlling TTY (see openai/codex#19945 and #20919). '


### PR DESCRIPTION
## Summary

When a coding agent's fix run fails, Invoker shows you why. Codex sometimes prints a harmless "Reading additional input from stdin..." line and then stops before anything else.

A prior change (#3581) hid that line from the agent's standard error channel, so the genuine cause showed instead.

But Codex can print that same line on its standard output channel. In that case Invoker fell back to raw output and surfaced the harmless line as the whole message.

Now the harmless line is dropped from every output channel.

When it is the only thing the agent emitted, Invoker returns a plain-English hint about the known Codex no-terminal failure, with links to the upstream issues.

## Review Claim

Approve dropping the harmless Codex stdin line from every output channel, not standard error alone, so it never becomes the whole failure message.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the text of a failure message changes. `buildAgentExitFailureDetail` is a pure string helper; success paths, exit codes, and session handling are untouched. Every prior case keeps its output; only the case that leaked the harmless standard-out line changes.

## Slice Rationale

A focused follow-up to the merged #3581. It touches only the execution-engine output helper and its unit tests.

## Non-goals

- Does not change how any agent is spawned, or how stdin is wired.
- Does not change success behavior, exit codes, or session persistence.
- Does not touch the CHANGELOG, keeping docs and behavior in separate slices.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/process-utils.test.ts src/__tests__/fix-prompt-transport.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
