### PR TITLE
[PR maintenance workers Step 5: Native TypeScript backend inside execution-engine](1)

### DIFF
--- a/packages/execution-engine/src/workers/pr-maintenance-command.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-command.ts
@@ -1,0 +1,106 @@
+import { spawn } from 'node:child_process';
+
+/**
+ * A single external command the PR-maintenance backend needs to run
+ * (`gh`, `git`, `omp`, `run.sh`, `node headless-ipc.js`, ...). Every process
+ * the native backend spawns flows through {@link PrMaintenanceCommandRunner},
+ * so tests inject one fake runner instead of stubbing individual binaries.
+ */
+export interface PrMaintenanceCommandSpec {
+  command: string;
+  args: string[];
+  /** Working directory for the child. Defaults to the current process cwd. */
+  cwd?: string;
+  /** Environment for the child. Defaults to the current process environment. */
+  env?: NodeJS.ProcessEnv;
+  /** Wall-clock ms before the child is terminated; `undefined` means no bound. */
+  timeoutMs?: number;
+  /** Grace period after SIGTERM before the child is SIGKILLed. Default 60s. */
+  killAfterMs?: number;
+}
+
+/** Outcome of running one {@link PrMaintenanceCommandSpec}. */
+export interface PrMaintenanceCommandResult {
+  /** Exit code, or `null` when the child was killed by a signal or never spawned. */
+  code: number | null;
+  /** Terminating signal, or `null`. */
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  /** True when the child was killed because it exceeded `timeoutMs`. */
+  timedOut: boolean;
+  /** Set when the child could not be spawned at all. */
+  spawnError?: Error;
+}
+
+/** Runs one external command and resolves with its captured result. Never rejects. */
+export type PrMaintenanceCommandRunner = (
+  spec: PrMaintenanceCommandSpec,
+) => Promise<PrMaintenanceCommandResult>;
+
+const DEFAULT_KILL_AFTER_MS = 60_000;
+
+/**
+ * Default runner: spawn the command, capture stdout/stderr, and resolve with a
+ * {@link PrMaintenanceCommandResult}. A spawn error resolves (not rejects) with
+ * `spawnError` set so callers branch on the result instead of try/catch.
+ */
+export function spawnPrMaintenanceCommand(
+  spec: PrMaintenanceCommandSpec,
+): Promise<PrMaintenanceCommandResult> {
+  return new Promise<PrMaintenanceCommandResult>((resolvePromise) => {
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let settled = false;
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
+    let sigkillTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const child = spawn(spec.command, spec.args, {
+      cwd: spec.cwd,
+      env: spec.env ?? process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const clearTimers = (): void => {
+      clearTimeout(killTimer);
+      clearTimeout(sigkillTimer);
+    };
+
+    const settle = (result: PrMaintenanceCommandResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      resolvePromise(result);
+    };
+
+    child.stdout?.setEncoding('utf8');
+    child.stderr?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr?.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+
+    if (spec.timeoutMs !== undefined && spec.timeoutMs > 0) {
+      killTimer = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGTERM');
+        sigkillTimer = setTimeout(() => {
+          child.kill('SIGKILL');
+        }, spec.killAfterMs ?? DEFAULT_KILL_AFTER_MS);
+        sigkillTimer.unref?.();
+      }, spec.timeoutMs);
+      killTimer.unref?.();
+    }
+
+    child.once('error', (err: Error) => {
+      settle({ code: null, signal: null, stdout, stderr, timedOut, spawnError: err });
+    });
+
+    child.once('close', (code: number | null, signal: NodeJS.Signals | null) => {
+      settle({ code, signal, stdout, stderr, timedOut });
+    });
+  });
+}

--- a/packages/execution-engine/src/workers/pr-maintenance-github.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-github.ts
@@ -1,0 +1,217 @@
+import type { Logger } from '@invoker/contracts';
+
+import type { PrMaintenanceCommandResult, PrMaintenanceCommandRunner } from './pr-maintenance-command.js';
+
+/** One CodeRabbit review comment, normalized from the inline + summary endpoints. */
+export interface CoderabbitComment {
+  body: string;
+  updatedAt: string;
+  path: string | null;
+  htmlUrl: string | null;
+}
+
+/** Options for {@link createPrMaintenanceGitHub}. */
+export interface PrMaintenanceGitHubOptions {
+  /** Runs `gh` (and only `gh`) subcommands. */
+  run: PrMaintenanceCommandRunner;
+  /** `owner/repo` the jobs operate on. */
+  repo: string;
+  /** PR author filter for the open-PR listing. */
+  author: string;
+  logger: Logger;
+  /** Delay between the first `gh` attempt and its single retry. */
+  sleep: (ms: number) => Promise<void>;
+}
+
+/**
+ * Typed GitHub surface for the PR-maintenance jobs, ported from `gh_json` and
+ * the coderabbit-comment collectors. Every call runs `gh` with a single retry
+ * on transient failure.
+ */
+export interface PrMaintenanceGitHub {
+  /** `gh pr list` for open PRs by the configured author; returns parsed rows. */
+  listOpenPullRequests(fields: string[]): Promise<Array<Record<string, unknown>>>;
+  /** `gh pr view`; returns the parsed object, or `{}` on failure (parity with `|| {}`). */
+  viewPullRequest(num: number, fields: string[]): Promise<Record<string, unknown>>;
+  /** CodeRabbit inline + summary comments authored by `login`. Tolerant of endpoint failure. */
+  fetchCoderabbitComments(num: number, login: string): Promise<CoderabbitComment[]>;
+  /** `gh pr comment`; `true` only when the comment actually posted. */
+  postPullRequestComment(num: number, body: string): Promise<boolean>;
+}
+
+/** Raised when a `gh` invocation fails after its retry. */
+export class PrMaintenanceGhError extends Error {
+  readonly result: PrMaintenanceCommandResult;
+
+  constructor(message: string, result: PrMaintenanceCommandResult) {
+    super(message);
+    this.name = 'PrMaintenanceGhError';
+    this.result = result;
+  }
+}
+
+const GH_RETRY_DELAY_MS = 2000;
+
+export function createPrMaintenanceGitHub(options: PrMaintenanceGitHubOptions): PrMaintenanceGitHub {
+  const { run, repo, author, logger, sleep } = options;
+
+  const ghJson = async (args: string[]): Promise<string> => {
+    let result = await run({ command: 'gh', args });
+    if (!isGhSuccess(result)) {
+      await sleep(GH_RETRY_DELAY_MS);
+      result = await run({ command: 'gh', args });
+    }
+    if (!isGhSuccess(result)) {
+      const detail = result.stderr.trim() || result.stdout.trim() || result.spawnError?.message || 'unknown error';
+      logger.warn(`[pr-maintenance] gh failed (gh ${args.join(' ')}): ${detail}`, {
+        module: 'pr-maintenance-github',
+      });
+      throw new PrMaintenanceGhError(`gh ${args.join(' ')} failed`, result);
+    }
+    return result.stdout;
+  };
+
+  const fetchEndpoint = async (endpoint: string): Promise<Array<Record<string, unknown>>> => {
+    try {
+      return parseConcatenatedJsonArray(await ghJson(['api', endpoint, '--paginate']));
+    } catch {
+      // Parity with `gh api ... 2>/dev/null || true | jq -s 'add // []'`: a failed
+      // endpoint contributes no comments rather than aborting the whole run.
+      return [];
+    }
+  };
+
+  return {
+    async listOpenPullRequests(fields): Promise<Array<Record<string, unknown>>> {
+      const out = await ghJson([
+        'pr', 'list',
+        '--repo', repo,
+        '--author', author,
+        '--state', 'open',
+        '--json', fields.join(','),
+        '--limit', '100',
+      ]);
+      const parsed = tryParseJson(out);
+      return Array.isArray(parsed) ? (parsed as Array<Record<string, unknown>>) : [];
+    },
+
+    async viewPullRequest(num, fields): Promise<Record<string, unknown>> {
+      try {
+        const out = await ghJson(['pr', 'view', String(num), '--repo', repo, '--json', fields.join(',')]);
+        const parsed = tryParseJson(out);
+        return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+          ? (parsed as Record<string, unknown>)
+          : {};
+      } catch {
+        return {};
+      }
+    },
+
+    async fetchCoderabbitComments(num, login): Promise<CoderabbitComment[]> {
+      const inline = await fetchEndpoint(`repos/${repo}/pulls/${num}/comments`);
+      const summary = await fetchEndpoint(`repos/${repo}/issues/${num}/comments`);
+      const comments: CoderabbitComment[] = [];
+      for (const raw of [...inline, ...summary]) {
+        if (commentLogin(raw) !== login) continue;
+        comments.push({
+          body: asString(raw.body),
+          updatedAt: asString(raw.updated_at),
+          path: asStringOrNull(raw.path),
+          htmlUrl: asStringOrNull(raw.html_url),
+        });
+      }
+      return comments;
+    },
+
+    async postPullRequestComment(num, body): Promise<boolean> {
+      const result = await run({
+        command: 'gh',
+        args: ['pr', 'comment', String(num), '--repo', repo, '--body', body],
+      });
+      if (isGhSuccess(result)) return true;
+      // Single attempt then retry, matching gh_json, before reporting failure.
+      const retry = await run({
+        command: 'gh',
+        args: ['pr', 'comment', String(num), '--repo', repo, '--body', body],
+      });
+      return isGhSuccess(retry);
+    },
+  };
+}
+
+function isGhSuccess(result: PrMaintenanceCommandResult): boolean {
+  return result.spawnError === undefined && result.code === 0;
+}
+
+function tryParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function commentLogin(raw: Record<string, unknown>): string | undefined {
+  const user = raw.user;
+  if (user && typeof user === 'object') {
+    const login = (user as Record<string, unknown>).login;
+    if (typeof login === 'string') return login;
+  }
+  return undefined;
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function asStringOrNull(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+/**
+ * Flatten `gh api --paginate` output for an array endpoint into one array of
+ * objects. `--paginate` concatenates one JSON array per page with no separator,
+ * so this scans top-level bracketed values (respecting strings/escapes) exactly
+ * as the shell `jq -s 'add // []'` did.
+ */
+export function parseConcatenatedJsonArray(text: string): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = [];
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  let start = -1;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === '{' || ch === '[') {
+      if (depth === 0) start = i;
+      depth += 1;
+      continue;
+    }
+    if (ch === '}' || ch === ']') {
+      depth -= 1;
+      if (depth === 0 && start !== -1) {
+        const parsed = tryParseJson(text.slice(start, i + 1));
+        if (Array.isArray(parsed)) {
+          for (const item of parsed) {
+            if (item && typeof item === 'object') out.push(item as Record<string, unknown>);
+          }
+        } else if (parsed && typeof parsed === 'object') {
+          out.push(parsed as Record<string, unknown>);
+        }
+        start = -1;
+      }
+    }
+  }
+  return out;
+}

--- a/packages/execution-engine/src/workers/pr-maintenance-ledger.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-ledger.ts
@@ -1,0 +1,88 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/**
+ * Durable append-only attempt ledger (TSV: `kind \t key \t marker \t epoch`),
+ * ported from the shell `ledger_*` helpers. Markers are opaque strings: the
+ * coderabbit job records a comment's ISO-8601 `updated_at`, the conflict-rebase
+ * job records a workflow generation.
+ */
+export interface PrMaintenanceLedger {
+  /** Append one attempt row. */
+  record(kind: string, key: string, marker: string): void;
+  /**
+   * Rows matching `kind`+`key`, further scoped to `marker` when given. The
+   * marker scope keeps an attempt cap per feedback-batch instead of
+   * per-key-lifetime.
+   */
+  count(kind: string, key: string, marker?: string): number;
+  /** True when this exact `kind`+`key`+`marker` row was recorded before. */
+  markerSeen(kind: string, key: string, marker: string): boolean;
+  /** The lexically greatest marker recorded for `kind`+`key` (`''` when none). */
+  maxMarker(kind: string, key: string): string;
+}
+
+/** Tuning for {@link openPrMaintenanceLedger}. */
+export interface PrMaintenanceLedgerOptions {
+  /** Clock seam (ms epoch) for the recorded timestamp column. Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+interface LedgerRow {
+  kind: string;
+  key: string;
+  marker: string;
+}
+
+/**
+ * Open (creating if needed) the ledger at `path` and return its accessor. Reads
+ * re-scan the file each call — the files are tiny (one line per attempt).
+ */
+export function openPrMaintenanceLedger(
+  path: string,
+  options: PrMaintenanceLedgerOptions = {},
+): PrMaintenanceLedger {
+  const now = options.now ?? Date.now;
+  mkdirSync(dirname(path), { recursive: true });
+  if (!existsSync(path)) writeFileSync(path, '');
+
+  const readRows = (): LedgerRow[] => {
+    const raw = readFileSync(path, 'utf8');
+    const rows: LedgerRow[] = [];
+    for (const line of raw.split(/\r?\n/)) {
+      if (line.length === 0) continue;
+      const fields = line.split('\t');
+      if (fields.length < 3) continue;
+      rows.push({ kind: fields[0], key: fields[1], marker: fields[2] });
+    }
+    return rows;
+  };
+
+  return {
+    record(kind, key, marker): void {
+      const epochSeconds = Math.floor(now() / 1000);
+      appendFileSync(path, `${kind}\t${key}\t${marker}\t${epochSeconds}\n`);
+    },
+    count(kind, key, marker): number {
+      let total = 0;
+      for (const row of readRows()) {
+        if (row.kind !== kind || row.key !== key) continue;
+        if (marker !== undefined && row.marker !== marker) continue;
+        total += 1;
+      }
+      return total;
+    },
+    markerSeen(kind, key, marker): boolean {
+      return readRows().some((row) => row.kind === kind && row.key === key && row.marker === marker);
+    },
+    maxMarker(kind, key): string {
+      let max = '';
+      for (const row of readRows()) {
+        if (row.kind !== kind || row.key !== key) continue;
+        // Lexical comparison: ISO-8601 timestamps sort lexically == chronologically.
+        if (max === '' || row.marker > max) max = row.marker;
+      }
+      return max;
+    },
+  };
+}

--- a/packages/execution-engine/src/workers/pr-maintenance-lock.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-lock.ts
@@ -1,0 +1,139 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Options for acquiring the shared PR-maintenance lock. The lock guarantees
+ * that only one PR-maintenance operation (across both the coderabbit-address
+ * and pr-conflict-rebase jobs) runs at a time, mirroring the shell `cron_lock`.
+ */
+export interface PrMaintenanceLockOptions {
+  /** Base lock path; the on-disk lock is `${lockPath}.d`. */
+  lockPath: string;
+  /** Environment used to resolve the stale-lock threshold when not passed. */
+  env: NodeJS.ProcessEnv;
+  /** Seconds after which a pid-less lock is considered stale. Default 3600. */
+  staleLockSeconds?: number;
+  /** Clock seam (ms epoch) for stale-age math. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Pid recorded as the lock holder. Defaults to `process.pid`. */
+  pid?: number;
+}
+
+/** A held PR-maintenance lock; call {@link PrMaintenanceLockHandle.release} to free it. */
+export interface PrMaintenanceLockHandle {
+  /** How the lock was acquired, surfaced in logs for parity with the shell. */
+  reason: string;
+  /** Release the lock. Idempotent. */
+  release(): void;
+}
+
+/**
+ * Acquire the shared lock, or return `null` when another operation holds it.
+ * Tests inject a fake to exercise the busy path.
+ */
+export type PrMaintenanceLockAcquire = (
+  options: PrMaintenanceLockOptions,
+) => PrMaintenanceLockHandle | null;
+
+/**
+ * Atomic mkdir lock, reaped only on a dead holder pid (or, for a pid-less
+ * legacy lock, on age). A healthy long run keeps the lock no matter how long it
+ * takes — age-based reaping of a live holder would break mutual exclusion.
+ */
+export function acquirePrMaintenanceLock(
+  options: PrMaintenanceLockOptions,
+): PrMaintenanceLockHandle | null {
+  const now = options.now ?? Date.now;
+  const holderPid = options.pid ?? process.pid;
+  const staleSeconds =
+    options.staleLockSeconds ?? parsePositiveInteger(options.env.INVOKER_PR_CRON_LOCK_STALE_SECS) ?? 3600;
+  const lockDir = `${options.lockPath}.d`;
+
+  if (existsSync(lockDir)) reapStaleLock(lockDir, staleSeconds, now());
+
+  try {
+    mkdirSync(lockDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') return null;
+    throw err;
+  }
+
+  try {
+    writeFileSync(resolve(lockDir, 'pid'), `${holderPid}\n`);
+  } catch {
+    // Best effort: a missing pid file only weakens dead-holder reaping later,
+    // it never breaks the mutual-exclusion the mkdir itself already provides.
+  }
+
+  let released = false;
+  return {
+    reason: 'mkdir-lock-acquired',
+    release(): void {
+      if (released) return;
+      released = true;
+      try {
+        rmSync(lockDir, { recursive: true, force: true });
+      } catch {
+        // Best effort: a leftover dir is reaped on the next dead-holder check.
+      }
+    },
+  };
+}
+
+/** Default lock path when neither config nor env pins one: `${TMPDIR:-/tmp}/invoker-pr-crons.lock`. */
+export function defaultPrCronLockPath(env: NodeJS.ProcessEnv): string {
+  const tmpRoot = env.TMPDIR && env.TMPDIR.length > 0 ? env.TMPDIR : '/tmp';
+  return resolve(tmpRoot, 'invoker-pr-crons.lock');
+}
+
+/** Parse a strictly-positive integer, or `undefined` for blank/invalid input. */
+export function parsePositiveInteger(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function reapStaleLock(lockDir: string, staleSeconds: number, nowMs: number): void {
+  const holderPid = readMkdirLockHolder(lockDir);
+  let shouldReap: boolean;
+  if (holderPid !== undefined) {
+    // Alive holder: never reap. Dead holder: steal the lock.
+    shouldReap = !isProcessAlive(holderPid);
+  } else {
+    // No pid recorded (pre-pid or garbled lock): fall back to an age threshold
+    // so a crashed legacy holder is still cleaned up eventually.
+    let mtimeMs: number;
+    try {
+      mtimeMs = statSync(lockDir).mtimeMs;
+    } catch {
+      return;
+    }
+    const ageSeconds = Math.max(0, Math.floor((nowMs - mtimeMs) / 1000));
+    shouldReap = ageSeconds >= staleSeconds;
+  }
+  if (!shouldReap) return;
+  try {
+    rmSync(lockDir, { recursive: true, force: true });
+  } catch {
+    // Best effort: if we cannot reap, the mkdir below simply fails and we skip.
+  }
+}
+
+function readMkdirLockHolder(lockDir: string): number | undefined {
+  try {
+    const raw = readFileSync(resolve(lockDir, 'pid'), 'utf8').trim();
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}


### PR DESCRIPTION
## Summary

PR-maintenance worker ticks now run their backend inside execution-engine, next to the routing code that already drives those ticks.

Before, each tick shelled out to cron child processes on one host. That backend now lives in Invoker code instead.

## Review Claim

Approve adding four new execution-engine modules that provide the in-process backend the PR-maintenance routing ticks will call.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

These four modules are new and nothing imports them yet, so the running product behaves exactly as it did before this slice. The reviewer only has to read four self-contained files.

## Slice Rationale

This slice lands only the execution-engine backend modules. The worker wiring, proof, and file retirement ride on later slices so each one stays small.

## Non-goals

- Does not wire the new backend into the worker tick entrypoints.
- Does not change or retire the existing shell cron scripts.
- Does not add or move tests, proof scripts, or benchmarks.
- Does not touch docs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `git diff --stat origin/master...HEAD` shows only the four new `packages/execution-engine/src/workers/pr-maintenance-*.ts` files
- [ ] `node scripts/validate-pr-body.mjs --body-file /tmp/step5/pr-body.md` passes

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`, or drop the PR before merge
- Post-revert steps: None — no caller imports these modules yet
- Data migration? No

</details>
