### PR TITLE
Fix pool-member-mismatch publish repro test after selectExecutor return-shape change

### DIFF
--- a/packages/execution-engine/src/__tests__/pool-member-mismatch-publish-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/pool-member-mismatch-publish-repro.test.ts
@@ -83,7 +83,7 @@ describe('publishApprovedFix pool member mismatch', () => {
         // poolMemberId NOT yet set — first run populates it
       },
     });
-    const execExecutor = runner.selectExecutor(execTask);
+    const execExecutor = runner.selectExecutor(execTask).executor;
     expect((execExecutor as any).host).toBe('alpha.example.com'); // RR cursor=0 → alpha
 
     // Step 2: Now simulate another task execution — round-rotates to beta
@@ -94,7 +94,7 @@ describe('publishApprovedFix pool member mismatch', () => {
         poolId: 'ssh-pool',
       },
     });
-    const otherExecutor = runner.selectExecutor(otherTask);
+    const otherExecutor = runner.selectExecutor(otherTask).executor;
     expect((otherExecutor as any).host).toBe('beta.example.com'); // RR cursor=1 → beta
 
     // Advance the round-robin cursor so a fresh pool selection would choose beta.
@@ -124,7 +124,7 @@ describe('publishApprovedFix pool member mismatch', () => {
     selectPoolMemberSpy.mockClear();
 
     // Call selectExecutor exactly as publishApprovedFix does.
-    const publishExecutor = runner.selectExecutor(publishTask);
+    const publishExecutor = runner.selectExecutor(publishTask).executor;
 
     expect(selectPoolMemberSpy).not.toHaveBeenCalled();
     expect((publishExecutor as any).host).toBe('alpha.example.com');


### PR DESCRIPTION
## Summary

A companion test file was missed in the `#3589` task-runner-pool extraction. That PR changed `TaskRunner.selectExecutor` from returning a bare `Executor` to returning `{ executor, resolvedExecution, selectedPoolMemberId }`. The eight sibling assertions in `task-runner-fix-publish-and-ssh.test.ts` were updated in that PR, but three assertions in `pool-member-mismatch-publish-repro.test.ts` were not.

The remaining assertions still read `.host` off the wrapper object instead of `.executor.host`, so one regression test fails on upstream/master today.

This PR updates the three affected lines to read `.executor` on the returned wrapper. No production code is touched.

## Review Claim

Approve three one-line accessor updates in `pool-member-mismatch-publish-repro.test.ts` so it reconciles with the `TaskRunner.selectExecutor` return shape introduced in `#3589`.

## Review Lane

cleanup

## Review Unit

cleanup

## Safety Invariant

Only one test file is touched. The three edits change `.selectExecutor(task)` accesses from a bare-executor reading to `.selectExecutor(task).executor` reading; the equality assertions themselves are unchanged. No production source file is modified. No test expectation is weakened.

## Slice Rationale

A focused follow-up to `#3589` that closes the last of the pre-existing execution-engine test failures on upstream/master, so downstream work on the autofix workers can build on a green baseline.

## Non-goals

- Does not change any production source file.
- Does not modify the second `it(...)` in the same file, which already passes.
- Does not modify `task-runner-fix-publish-and-ssh.test.ts` (already updated in `#3589`).
- Does not change the `selectExecutor` return contract or the pool-member-mismatch guard behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/pool-member-mismatch-publish-repro.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts`
- [ ] `pnpm --filter @invoker/execution-engine test`

Local: 99/99 pass on the two SSH-heavy files. 1215/1215 pass on the full execution-engine suite.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the one failing test that exists on upstream/master today.
- Data migration? No

</details>