### PR TITLE
Default autoFix retries and AI-fix auto-approve on so builds fix themselves without user config

### DIFF
--- a/packages/app/src/__tests__/autofix-defaults.test.ts
+++ b/packages/app/src/__tests__/autofix-defaults.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_AUTO_APPROVE_AI_FIXES,
+  DEFAULT_AUTO_FIX_RETRIES,
+  resolveAutoApproveAIFixes,
+  resolveAutoFixRetries,
+} from '../autofix-defaults.js';
+
+describe('resolveAutoFixRetries', () => {
+  it('returns DEFAULT_AUTO_FIX_RETRIES when the key is unset', () => {
+    expect(DEFAULT_AUTO_FIX_RETRIES).toBe(3);
+    expect(resolveAutoFixRetries({})).toBe(3);
+  });
+
+  it('returns DEFAULT_AUTO_FIX_RETRIES when the key is null', () => {
+    expect(resolveAutoFixRetries({ autoFixRetries: null as unknown as number })).toBe(3);
+  });
+
+  it('honors an explicit 0 as user opt-out', () => {
+    expect(resolveAutoFixRetries({ autoFixRetries: 0 })).toBe(0);
+  });
+
+  it('honors positive finite numbers verbatim', () => {
+    expect(resolveAutoFixRetries({ autoFixRetries: 1 })).toBe(1);
+    expect(resolveAutoFixRetries({ autoFixRetries: 5 })).toBe(5);
+  });
+
+  it('falls back to the default for negative or non-finite numbers', () => {
+    expect(resolveAutoFixRetries({ autoFixRetries: -1 })).toBe(3);
+    expect(resolveAutoFixRetries({ autoFixRetries: Number.NaN })).toBe(3);
+    expect(resolveAutoFixRetries({ autoFixRetries: Number.POSITIVE_INFINITY })).toBe(3);
+  });
+
+  it('falls back to the default for non-numeric values', () => {
+    expect(resolveAutoFixRetries({ autoFixRetries: 'three' as unknown as number })).toBe(3);
+  });
+});
+
+describe('resolveAutoApproveAIFixes', () => {
+  it('returns DEFAULT_AUTO_APPROVE_AI_FIXES when the key is unset', () => {
+    expect(DEFAULT_AUTO_APPROVE_AI_FIXES).toBe(true);
+    expect(resolveAutoApproveAIFixes({})).toBe(true);
+  });
+
+  it('returns DEFAULT_AUTO_APPROVE_AI_FIXES when the key is null', () => {
+    expect(resolveAutoApproveAIFixes({ autoApproveAIFixes: null as unknown as boolean })).toBe(true);
+  });
+
+  it('honors an explicit false as user opt-out', () => {
+    expect(resolveAutoApproveAIFixes({ autoApproveAIFixes: false })).toBe(false);
+  });
+
+  it('honors an explicit true', () => {
+    expect(resolveAutoApproveAIFixes({ autoApproveAIFixes: true })).toBe(true);
+  });
+
+  it('falls back to the default for non-boolean values', () => {
+    expect(resolveAutoApproveAIFixes({ autoApproveAIFixes: 1 as unknown as boolean })).toBe(true);
+    expect(resolveAutoApproveAIFixes({ autoApproveAIFixes: 'yes' as unknown as boolean })).toBe(true);
+  });
+});

--- a/packages/app/src/autofix-defaults.ts
+++ b/packages/app/src/autofix-defaults.ts
@@ -1,0 +1,21 @@
+import type { InvokerConfig } from './config.js';
+
+export const DEFAULT_AUTO_FIX_RETRIES = 3;
+
+export const DEFAULT_AUTO_APPROVE_AI_FIXES = true;
+
+export function resolveAutoFixRetries(config: InvokerConfig): number {
+  const value = config.autoFixRetries;
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+    return value;
+  }
+  return DEFAULT_AUTO_FIX_RETRIES;
+}
+
+export function resolveAutoApproveAIFixes(config: InvokerConfig): boolean {
+  const value = config.autoApproveAIFixes;
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  return DEFAULT_AUTO_APPROVE_AI_FIXES;
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -137,6 +137,10 @@ import {
   type InvokerConfig,
 } from './config.js';
 import {
+  resolveAutoApproveAIFixes,
+  resolveAutoFixRetries,
+} from './autofix-defaults.js';
+import {
   DEFAULT_WORKTREE_MAX_CONCURRENCY,
   assertExecutionCapacityInvariant,
   resolveEffectiveMaxConcurrency,
@@ -349,7 +353,7 @@ function buildRegisteredOwnerWorkerDeps(
       checkMergeGateStatuses,
     },
     autoFix: {
-      defaultAutoFixRetries: invokerConfig.autoFixRetries,
+      defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
       attemptLedger: autoFixAttemptLedger,
       getAutoFixAgent: () => invokerConfig.autoFixAgent,
       getAutoFixExecutionModel: () => invokerConfig.defaultExecutionModel,
@@ -364,7 +368,7 @@ function buildRegisteredOwnerWorkerDeps(
       remoteTargets,
     },
     autoApprove: {
-      enabled: invokerConfig.autoApproveAIFixes === true,
+      enabled: resolveAutoApproveAIFixes(invokerConfig),
     },
   };
 }
@@ -906,7 +910,7 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     persistence, messageBus,
     taskRepository,
     maxConcurrency: effectiveMaxConcurrency,
-    defaultAutoFixRetries: invokerConfig.autoFixRetries,
+    defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
     executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
     defaultPoolId: invokerConfig.defaultPoolId,
     availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
@@ -1186,7 +1190,7 @@ function startHeadlessMode(): void {
               messageBus,
               taskRepository: new SqliteTaskRepository(persistence),
               maxConcurrency: effectiveMaxConcurrency,
-              defaultAutoFixRetries: invokerConfig.autoFixRetries,
+              defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
               executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
               defaultPoolId: invokerConfig.defaultPoolId,
               availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
@@ -1866,7 +1870,7 @@ function startHeadlessMode(): void {
           ),
           autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
           persistence,
-          autoFixRetries: invokerConfig.autoFixRetries,
+          autoFixRetries: resolveAutoFixRetries(invokerConfig),
           canControl: () => !readOnlyMode,
         });
         workerRuntimeController.startAutoStartedWorkers();
@@ -2379,7 +2383,7 @@ function createEmbeddedTerminalBackendFromConfig(
         commandService,
         taskExecutor: requireTaskExecutor(),
         mutationTiming: activeMutationContext?.mutationTiming,
-        autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
+        autoApproveAIFixes: resolveAutoApproveAIFixes(invokerConfig),
       },
       {
         agentName,
@@ -3233,7 +3237,7 @@ function createEmbeddedTerminalBackendFromConfig(
         persistence,
         commandService,
         taskExecutor: requireTaskExecutor(),
-        autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
+        autoApproveAIFixes: resolveAutoApproveAIFixes(invokerConfig),
         killRunningTask,
       });
       apiServer = startApiServer({
@@ -3750,7 +3754,7 @@ function createEmbeddedTerminalBackendFromConfig(
         ),
         autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
         persistence,
-        autoFixRetries: invokerConfig.autoFixRetries,
+        autoFixRetries: resolveAutoFixRetries(invokerConfig),
         canControl: () => ownerMode,
       });
       workerRuntimeController.startAutoStartedWorkers();
@@ -4098,7 +4102,7 @@ function createEmbeddedTerminalBackendFromConfig(
         messageBus,
         taskRepository: new SqliteTaskRepository(persistence),
         maxConcurrency: effectiveMaxConcurrency,
-        defaultAutoFixRetries: invokerConfig.autoFixRetries,
+        defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
         executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
         defaultPoolId: invokerConfig.defaultPoolId,
         availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
@@ -4894,7 +4898,7 @@ function createEmbeddedTerminalBackendFromConfig(
           orchestrator,
           persistence,
           taskExecutor: requireTaskExecutor(),
-          autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
+          autoApproveAIFixes: resolveAutoApproveAIFixes(invokerConfig),
         }, agentName, activeMutationContext?.signal);
         await finalizeMutationWithGlobalTopup({
           orchestrator,

--- a/packages/execution-engine/src/__tests__/pool-member-mismatch-publish-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/pool-member-mismatch-publish-repro.test.ts
@@ -83,7 +83,7 @@ describe('publishApprovedFix pool member mismatch', () => {
         // poolMemberId NOT yet set — first run populates it
       },
     });
-    const execExecutor = runner.selectExecutor(execTask);
+    const execExecutor = runner.selectExecutor(execTask).executor;
     expect((execExecutor as any).host).toBe('alpha.example.com'); // RR cursor=0 → alpha
 
     // Step 2: Now simulate another task execution — round-rotates to beta
@@ -94,7 +94,7 @@ describe('publishApprovedFix pool member mismatch', () => {
         poolId: 'ssh-pool',
       },
     });
-    const otherExecutor = runner.selectExecutor(otherTask);
+    const otherExecutor = runner.selectExecutor(otherTask).executor;
     expect((otherExecutor as any).host).toBe('beta.example.com'); // RR cursor=1 → beta
 
     // Advance the round-robin cursor so a fresh pool selection would choose beta.
@@ -124,7 +124,7 @@ describe('publishApprovedFix pool member mismatch', () => {
     selectPoolMemberSpy.mockClear();
 
     // Call selectExecutor exactly as publishApprovedFix does.
-    const publishExecutor = runner.selectExecutor(publishTask);
+    const publishExecutor = runner.selectExecutor(publishTask).executor;
 
     expect(selectPoolMemberSpy).not.toHaveBeenCalled();
     expect((publishExecutor as any).host).toBe('alpha.example.com');


### PR DESCRIPTION
## Summary

Two in-app workers (`AutoFixWorker` and `AutoApproveWorker`) are already registered in `registerBuiltinWorkers`, but they only wake up when the user has explicitly set two config keys. In a fresh install those keys are `undefined` or `null`, so both workers stay dormant and background bash tooling has been picking up the slack.

This PR wakes the two workers on a fresh install by wiring `main.ts` through opinionated defaults, without changing the semantics for any user who has explicitly opted in or opted out.

The change is confined to `packages/app/src/main.ts` and one new tiny helper module (`packages/app/src/autofix-defaults.ts`) plus its unit tests. `config.ts` and the shared config field surface are not touched.

## Review Claim

Approve waking `AutoFixWorker` and `AutoApproveWorker` on a fresh install by wiring `main.ts` through the two new resolvers in `autofix-defaults.ts`, while preserving every explicit user opt-out.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Explicit user opt-outs are preserved. `resolveAutoFixRetries(config)` returns `config.autoFixRetries` when it is a non-negative finite number (including `0`), and only substitutes `DEFAULT_AUTO_FIX_RETRIES = 3` when the value is unset, `null`, or non-numeric. `resolveAutoApproveAIFixes(config)` returns `config.autoApproveAIFixes` when it is a boolean (including `false`), and only substitutes `DEFAULT_AUTO_APPROVE_AI_FIXES = true` otherwise. All eight call sites in `main.ts` flow through the resolvers uniformly.

The two workers being woken are already wired into `registerBuiltinWorkers` and already receive their dependency objects at owner startup today. Only their gating flags were previously off in default configs. Downstream policy code (`retryBudgetForTask`, `AutoApproveWorker.enabled`) is not touched.

## Slice Rationale

This is the smallest safe wiring slice for `main.ts`. It adds one small helper module beside `main.ts`, changes only the eight sites in `main.ts` that read the two keys, and leaves `config.ts`, the worker code, and every other package alone, so it can be reviewed end-to-end from `main.ts` and the new helper.

## Non-goals

- Does not add a new worker or change `registerBuiltinWorkers`.
- Does not change `retryBudgetForTask` at the engine layer; that helper still uses its own `?? 0` fallback for library callers that pass `undefined`.
- Does not change the `DEFAULT_STALL_REQUEUE_RETRIES` or `DEFAULT_STALL_REQUEUE_BACKOFF_MS` constants inside `requeue-worker.ts` (already `3` and `120_000`; not touched here).
- Does not change `config.ts` or the `InvokerConfig` field surface. The new constants and resolvers live in a separate `autofix-defaults.ts` beside `main.ts`.
- Does not change `autoFixAgent`, `autoFixCi`, or any Slack/planning defaults.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/autofix-defaults.test.ts`
- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/task-runner-wiring.test.ts src/__tests__/headless-autofix.test.ts src/__tests__/headless-fix-autofix-context.test.ts`
- [ ] `pnpm --filter @invoker/execution-engine test`

Local runs on the rebased branch:
- `autofix-defaults.test.ts` — 11/11 pass (covers default, `null`, explicit-`0`/`false`, positive/`true`, and invalid values for both resolvers).
- `config.test.ts` — 33/33 pass (unchanged; `config.ts` is not touched).
- Related wiring/autofix suites — 60/60 pass.
- Full execution-engine — 1215/1215 pass.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the previous default resolution where the two workers stay dormant unless the user has set the keys explicitly.
- Data migration? No. Persisted state is not affected; only the runtime default resolution changes.

</details>

Depends-On: #3620