### PR TITLE
[Persist Worker Desired State - Storage Layer](1) Persist worker desired state storage

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -4063,6 +4063,97 @@ describe('SQLiteAdapter', () => {
     });
   });
 
+  describe('worker desired state', () => {
+    it('round-trips desired state keyed by worker kind', () => {
+      adapter.saveWorkerDesiredState('workflow-mutator', { enabled: true, concurrency: 2 });
+      adapter.saveWorkerDesiredState({
+        workerKind: 'terminal-session',
+        desiredState: { enabled: false },
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      });
+
+      expect(adapter.loadWorkerDesiredState<{ enabled: boolean; concurrency: number }>('workflow-mutator'))
+        .toMatchObject({
+          workerKind: 'workflow-mutator',
+          desiredState: { enabled: true, concurrency: 2 },
+        });
+      expect(adapter.getWorkerDesiredState<{ enabled: boolean }>('terminal-session')).toEqual({ enabled: false });
+      expect(adapter.listWorkerDesiredStates().map((state) => state.workerKind)).toEqual([
+        'terminal-session',
+        'workflow-mutator',
+      ]);
+    });
+
+    it('updates an existing worker kind without changing createdAt', () => {
+      adapter.saveWorkerDesiredState({
+        workerKind: 'workflow-mutator',
+        desiredState: { enabled: true },
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      });
+      adapter.saveWorkerDesiredState({
+        workerKind: 'workflow-mutator',
+        desiredState: { enabled: false },
+        updatedAt: '2026-01-02T00:00:00.000Z',
+      });
+
+      const loaded = adapter.loadWorkerDesiredState<{ enabled: boolean }>('workflow-mutator');
+      expect(loaded).toMatchObject({
+        workerKind: 'workflow-mutator',
+        desiredState: { enabled: false },
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-02T00:00:00.000Z',
+      });
+      expect(adapter.listWorkerDesiredStates()).toHaveLength(1);
+    });
+
+    it('deletes desired state by worker kind', () => {
+      adapter.saveWorkerDesiredState('workflow-mutator', { enabled: true });
+      adapter.deleteWorkerDesiredState('workflow-mutator');
+
+      expect(adapter.loadWorkerDesiredState('workflow-mutator')).toBeUndefined();
+    });
+
+    it('persists the desired-state table migration for existing databases', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-worker-state-migration-'));
+      const dbPath = join(dir, 'invoker.db');
+      try {
+        const oldDb = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        oldDb.saveWorkflow(testWorkflow);
+        (oldDb as any).db.run('DROP TABLE worker_desired_state');
+        (oldDb as any).dirty = true;
+        oldDb.close();
+
+        const migrated = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        expect(sqliteScalar(migrated, "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'worker_desired_state'")).toBe(1);
+        migrated.close();
+
+        const reader = await SQLiteAdapter.create(dbPath, { readOnly: true });
+        expect(sqliteScalar(reader, "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'worker_desired_state'")).toBe(1);
+        reader.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects desired-state writes on a read-only adapter', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-worker-state-readonly-'));
+      const dbPath = join(dir, 'invoker.db');
+      try {
+        const writer = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        writer.saveWorkerDesiredState('workflow-mutator', { enabled: true });
+        writer.close();
+
+        const reader = await SQLiteAdapter.create(dbPath, { readOnly: true });
+        expect(reader.loadWorkerDesiredState('workflow-mutator')?.desiredState).toEqual({ enabled: true });
+        expect(() => reader.saveWorkerDesiredState('workflow-mutator', { enabled: false })).toThrow(/read-only/i);
+        expect(() => reader.deleteWorkerDesiredState('workflow-mutator')).toThrow(/read-only/i);
+        reader.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe('read-only / flush safety', () => {
     it('opens file-backed databases in WAL mode with durable pragmas', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-wal-'));

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -108,6 +108,19 @@ export interface ActivityLogEntry {
   message: string;
 }
 
+export interface WorkerDesiredState<TDesiredState = unknown> {
+  workerKind: string;
+  desiredState: TDesiredState;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkerDesiredStateInput<TDesiredState = unknown> {
+  workerKind: string;
+  desiredState: TDesiredState;
+  updatedAt?: string;
+}
+
 export interface WorkflowTaskSnapshot {
   workflows: Workflow[];
   tasks: TaskState[];
@@ -334,6 +347,15 @@ export interface PersistenceAdapter {
   // Agent queries
   /** Read the configured execution agent name for a task (e.g. 'claude', 'codex'). */
   getExecutionAgent?(taskId: string): string | null;
+
+  // Worker desired state
+  saveWorkerDesiredState<TDesiredState = unknown>(state: WorkerDesiredStateInput<TDesiredState>): void;
+  saveWorkerDesiredState<TDesiredState = unknown>(workerKind: string, desiredState: TDesiredState): void;
+  writeWorkerDesiredState<TDesiredState = unknown>(workerKind: string, desiredState: TDesiredState): void;
+  loadWorkerDesiredState<TDesiredState = unknown>(workerKind: string): WorkerDesiredState<TDesiredState> | undefined;
+  readWorkerDesiredState<TDesiredState = unknown>(workerKind: string): WorkerDesiredState<TDesiredState> | undefined;
+  listWorkerDesiredStates<TDesiredState = unknown>(): Array<WorkerDesiredState<TDesiredState>>;
+  deleteWorkerDesiredState(workerKind: string): void;
 
   // Lifecycle
   close(): void;

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -1,4 +1,5 @@
 export * from './adapter.js';
+export * from './sqlite-schema.js';
 export * from './sqlite-adapter.js';
 export * from './conversation-repository.js';
 export * from './sqlite-task-repository.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1926,7 +1926,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
   loadWorkerDesiredState<TDesiredState = unknown>(workerKind: string): WorkerDesiredState<TDesiredState> | undefined {
     const row = this.queryOne(
       `SELECT * FROM ${WORKER_DESIRED_STATE_TABLE} WHERE worker_kind = ?`,
-      [workerKind],
+      [workerKind.trim()],
     );
     return row ? this.rowToWorkerDesiredState<TDesiredState>(row) : undefined;
   }
@@ -1949,7 +1949,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
   deleteWorkerDesiredState(workerKind: string): void {
     this.execRun(
       `DELETE FROM ${WORKER_DESIRED_STATE_TABLE} WHERE worker_kind = ?`,
-      [workerKind],
+      [workerKind.trim()],
     );
   }
 

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -56,12 +56,14 @@ import type {
   WorkerActionListFilters,
   WorkerActionRecord,
   WorkerActionWrite,
+  WorkerDesiredState,
+  WorkerDesiredStateInput,
   TerminalSessionPatch,
   TerminalSessionRecord,
   InAppPlanningSessionPatch,
   InAppPlanningSessionRecord,
 } from './adapter.js';
-import { SCHEMA_DDL } from './sqlite-schema.js';
+import { SCHEMA_DDL, WORKER_DESIRED_STATE_TABLE } from './sqlite-schema.js';
 import {
   mapRowToWorkflow,
   mapRowToTask,
@@ -1881,6 +1883,76 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return this.taskAttemptRepo.getPoolMemberId(taskId);
   }
 
+  // ── Worker Desired State ─────────────────────────────────
+
+  saveWorkerDesiredState<TDesiredState = unknown>(state: WorkerDesiredStateInput<TDesiredState>): void;
+  saveWorkerDesiredState<TDesiredState = unknown>(workerKind: string, desiredState: TDesiredState): void;
+  saveWorkerDesiredState<TDesiredState = unknown>(
+    stateOrWorkerKind: WorkerDesiredStateInput<TDesiredState> | string,
+    desiredState?: TDesiredState,
+  ): void {
+    const state = typeof stateOrWorkerKind === 'string'
+      ? { workerKind: stateOrWorkerKind, desiredState: desiredState as TDesiredState }
+      : stateOrWorkerKind;
+    const workerKind = state.workerKind.trim();
+    if (!workerKind) {
+      throw new Error('workerKind is required');
+    }
+    const desiredStateJson = JSON.stringify(state.desiredState);
+    if (desiredStateJson === undefined) {
+      throw new Error('Worker desired state must be JSON-serializable');
+    }
+    const updatedAt = state.updatedAt ?? new Date().toISOString();
+
+    this.execRun(
+      `INSERT INTO ${WORKER_DESIRED_STATE_TABLE} (
+         worker_kind, desired_state, created_at, updated_at
+       ) VALUES (?, ?, ?, ?)
+       ON CONFLICT(worker_kind) DO UPDATE SET
+         desired_state = excluded.desired_state,
+         updated_at = excluded.updated_at`,
+      [workerKind, desiredStateJson, updatedAt, updatedAt],
+    );
+  }
+
+  writeWorkerDesiredState<TDesiredState = unknown>(workerKind: string, desiredState: TDesiredState): void {
+    this.saveWorkerDesiredState(workerKind, desiredState);
+  }
+
+  setWorkerDesiredState<TDesiredState = unknown>(workerKind: string, desiredState: TDesiredState): void {
+    this.saveWorkerDesiredState(workerKind, desiredState);
+  }
+
+  loadWorkerDesiredState<TDesiredState = unknown>(workerKind: string): WorkerDesiredState<TDesiredState> | undefined {
+    const row = this.queryOne(
+      `SELECT * FROM ${WORKER_DESIRED_STATE_TABLE} WHERE worker_kind = ?`,
+      [workerKind],
+    );
+    return row ? this.rowToWorkerDesiredState<TDesiredState>(row) : undefined;
+  }
+
+  readWorkerDesiredState<TDesiredState = unknown>(workerKind: string): WorkerDesiredState<TDesiredState> | undefined {
+    return this.loadWorkerDesiredState<TDesiredState>(workerKind);
+  }
+
+  getWorkerDesiredState<TDesiredState = unknown>(workerKind: string): TDesiredState | undefined {
+    return this.loadWorkerDesiredState<TDesiredState>(workerKind)?.desiredState;
+  }
+
+  listWorkerDesiredStates<TDesiredState = unknown>(): Array<WorkerDesiredState<TDesiredState>> {
+    const rows = this.queryAll(
+      `SELECT * FROM ${WORKER_DESIRED_STATE_TABLE} ORDER BY worker_kind ASC`,
+    );
+    return rows.map((row) => this.rowToWorkerDesiredState<TDesiredState>(row));
+  }
+
+  deleteWorkerDesiredState(workerKind: string): void {
+    this.execRun(
+      `DELETE FROM ${WORKER_DESIRED_STATE_TABLE} WHERE worker_kind = ?`,
+      [workerKind],
+    );
+  }
+
   // ── Conversations ───────────────────────────────────────
 
   saveConversation(conversation: Conversation): void {
@@ -3355,6 +3427,17 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   private rowToWorkerAction(row: Record<string, unknown>): WorkerActionRecord {
     return mapRowToWorkerAction(row);
+  }
+
+  private rowToWorkerDesiredState<TDesiredState = unknown>(
+    row: Record<string, unknown>,
+  ): WorkerDesiredState<TDesiredState> {
+    return {
+      workerKind: String(row.worker_kind),
+      desiredState: JSON.parse(String(row.desired_state)) as TDesiredState,
+      createdAt: String(row.created_at ?? ''),
+      updatedAt: String(row.updated_at ?? ''),
+    };
   }
 
   private requeueWorkflowMutationLease(workflowId: string): void {

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -6,6 +6,8 @@
  * has, so migration sequencing and query semantics are unchanged.
  */
 
+export const WORKER_DESIRED_STATE_TABLE = 'worker_desired_state';
+
 /** Full schema definition, executed once on `initSchema()`. */
 export const SCHEMA_DDL = `
       CREATE TABLE IF NOT EXISTS workflows (
@@ -341,6 +343,13 @@ export const SCHEMA_DDL = `
 
       CREATE INDEX IF NOT EXISTS idx_worker_actions_workflow_status
         ON worker_actions(workflow_id, worker_kind, status);
+
+      CREATE TABLE IF NOT EXISTS worker_desired_state (
+        worker_kind TEXT PRIMARY KEY,
+        desired_state TEXT NOT NULL CHECK (json_valid(desired_state)),
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+      );
 
       CREATE TABLE IF NOT EXISTS execution_resource_leases (
         resource_key TEXT NOT NULL,

--- a/scripts/repro/repro-coderabbit-pr3622-worker-kind-trim.sh
+++ b/scripts/repro/repro-coderabbit-pr3622-worker-kind-trim.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${ROOT_OVERRIDE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+cd "$ROOT"
+
+pnpm --filter @invoker/data-store build >/dev/null
+
+export ROOT
+node --input-type=module <<'NODE'
+const { SQLiteAdapter } = await import(`${process.env.ROOT}/packages/data-store/dist/index.js`);
+
+const adapter = await SQLiteAdapter.create(':memory:');
+try {
+  const rawWorkerKind = '  workflow-mutator  ';
+  adapter.saveWorkerDesiredState(rawWorkerKind, { enabled: true });
+
+  const loaded = adapter.loadWorkerDesiredState(rawWorkerKind);
+  if (!loaded) {
+    console.error('FAIL: loadWorkerDesiredState did not normalize workerKind the same way as saveWorkerDesiredState');
+    process.exit(1);
+  }
+  if (loaded.workerKind !== 'workflow-mutator') {
+    console.error(`FAIL: expected stored workerKind to be trimmed, got ${JSON.stringify(loaded.workerKind)}`);
+    process.exit(1);
+  }
+
+  adapter.deleteWorkerDesiredState(rawWorkerKind);
+  const afterDelete = adapter.loadWorkerDesiredState('workflow-mutator');
+  if (afterDelete) {
+    console.error('FAIL: deleteWorkerDesiredState did not normalize workerKind and left stale desired state');
+    process.exit(1);
+  }
+
+  console.log('PASS: worker desired-state load/delete normalize workerKind consistently');
+} finally {
+  adapter.close();
+}
+NODE


### PR DESCRIPTION
## Summary

Persist Worker Desired State - Storage Layer completed both workflow tasks with no failures.

Adds a SQLite-backed desired-state record keyed by worker kind so worker intent can survive process restarts.

The data-store adapter now stores and returns worker desired state through its persistence contract.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1783562739708-6/implement-worker-desired-state-storage | Add durable desired on/off state keyed by worker kind in SQLite persistence | completed |
| wf-1783562739708-6/verify-worker-desired-state-storage | Verify data-store persistence behavior for worker desired state | completed (passed) |

</details>

<details>
<summary>Published diff</summary>

```text
.../src/__tests__/sqlite-adapter.test.ts           | 91 ++++++++++++++++++++++
packages/data-store/src/adapter.ts                 | 22 ++++++
packages/data-store/src/index.ts                   |  1 +
packages/data-store/src/sqlite-adapter.ts          | 85 +++++++++++++++++++-
packages/data-store/src/sqlite-schema.ts           |  9 +++
5 files changed, 207 insertions(+), 1 deletion(-)
```

</details>

## Review Claim

The data-store contract has a worker-kind keyed desired-state record persisted by SQLite.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The schema change is additive, uses `CREATE TABLE IF NOT EXISTS`, and is not wired into worker scheduling or lifecycle behavior in this slice.

## Slice Rationale

This slice lands the persistence contract before worker-control code starts depending on durable desired state.

## Non-goals

- Does not wire desired state into worker scheduling or lifecycle control.
- Does not add UI, CLI, or API controls for toggling workers.
- Does not change existing workflow or task persistence semantics.

## Architecture

### Before

```mermaid
graph TD
    A["Worker desired state"] --> B["Process memory or caller-owned state"]
    B --> C["Lost when process restarts"]
```

### After

```mermaid
graph TD
    A["Worker desired state"] --> B["PersistenceAdapter API"]
    B --> C["SQLite worker_desired_state table keyed by worker_kind"]
    C --> D["State reloads after adapter restart"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-persist-worker-storage.md`
- [x] Invoker workflow task `wf-1783562739708-6/verify-worker-desired-state-storage` completed (passed).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert a074be294fd58458b52d84f5229d96dfc14e82b0`
- Post-revert steps: None.
- Data migration? No destructive migration. Existing SQLite files may retain an unused `worker_desired_state` table after revert.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for persisting typed desired state for each worker kind.
  - Added APIs to save, read, list, update, and delete worker desired state.
  - Worker kinds are normalized by trimming surrounding whitespace.
  - Desired state persists across database reopenings.
  - Added public access to the SQLite schema exports.

- **Bug Fixes**
  - Write operations now correctly reject read-only database connections.
  - Invalid or empty worker kinds and non-serializable desired state are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->