### PR TITLE
[Godfile execution-engine step 3: extract task-runner-review-gate](3)

### DIFF
--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -30,6 +30,10 @@ export type {
   ExecutionPoolConfig,
   PoolSelection,
 } from './task-runner-pool.js';
+export type {
+  ReviewGateCiFailureTrigger,
+  ReviewGateCiFailureLifecyclePublisher,
+} from './task-runner-review-gate.js';
 export * from './merge-runner.js';
 export * from './conflict-resolver.js';
 export * from './merge-gate-provider.js';

--- a/packages/execution-engine/src/task-runner-review-gate.ts
+++ b/packages/execution-engine/src/task-runner-review-gate.ts
@@ -1,0 +1,342 @@
+/**
+ * Review-gate / merge-gate polling family, extracted from TaskRunner.
+ *
+ * Owns the poll loop that reconciles each merge-node task's review artifacts
+ * against the merge-gate provider, maps provider lifecycle → artifact status,
+ * completes approved gates, closes reviews on teardown, and publishes CI-failure
+ * lifecycle triggers.
+ *
+ * Stateful functions take a {@link TaskRunnerReviewGateHost} — a
+ * `Pick<TaskRunner, …>` — as their first parameter, so the type-only import of
+ * `TaskRunner` avoids a runtime cycle while the host shape stays locked to the
+ * runner's real member types (no drift). Pure helpers that read only their
+ * arguments take no host. Sibling functions call each other directly within
+ * this module; the same-named `TaskRunner` methods are thin delegates that route
+ * through `gitPlumbing`-style namespace calls.
+ *
+ * The `ReviewGateCiFailureTrigger` / `ReviewGateCiFailureLifecyclePublisher`
+ * declarations live here (their owning cluster) and stay barrel-visible via the
+ * package index re-export.
+ */
+
+import type { TaskState } from '@invoker/workflow-core';
+
+import type { MergeGateApprovalStatus } from './merge-gate-provider.js';
+import type { TaskRunner } from './task-runner.js';
+
+type ReviewGateState = NonNullable<TaskState['execution']['reviewGate']>;
+type ReviewGateArtifact = ReviewGateState['artifacts'][number];
+type ReviewGateArtifactStatus = ReviewGateArtifact['status'];
+
+export interface ReviewGateCiFailureTrigger {
+  taskId: string;
+  workflowId: string;
+  reviewId: string;
+  reviewUrl: string;
+  headSha?: string;
+  headRef?: string;
+  branch?: string;
+  selectedAttemptId?: string;
+  generation: number;
+  failedChecks: NonNullable<MergeGateApprovalStatus['checks']>['failed'];
+  statusText: string;
+}
+
+export interface ReviewGateCiFailureLifecyclePublisher {
+  publish(trigger: ReviewGateCiFailureTrigger): void | Promise<void>;
+}
+
+/**
+ * Subset of {@link TaskRunner} the review-gate polling family reads. Picked from
+ * `TaskRunner` (not hand-written) so the host stays locked to the runner's real
+ * member types. `reviewGateCiFailureInFlight` is single-cluster-owned: it lives
+ * here as an `@internal` runner field and is picked into this host.
+ */
+export type TaskRunnerReviewGateHost = Pick<
+  TaskRunner,
+  // Shared collaborators
+  | 'orchestrator'
+  | 'persistence'
+  | 'cwd'
+  | 'logger'
+  | 'mergeGateProvider'
+  | 'executeTasks'
+  // Review-gate cluster state
+  | 'reviewGateCiFailurePublisher'
+  | 'reviewGateCiFailureInFlight'
+>;
+
+export async function closeWorkflowReview(
+  host: TaskRunnerReviewGateHost,
+  workflowId: string,
+): Promise<void> {
+  const closeReview = host.mergeGateProvider?.closeReview?.bind(host.mergeGateProvider);
+  if (!closeReview) return;
+  const getAllTasks = host.orchestrator.getAllTasks?.bind(host.orchestrator);
+  if (!getAllTasks) return;
+  const mergeTask = getAllTasks().find((task) =>
+    task.config.workflowId === workflowId
+    && task.config.isMergeNode
+    && (!!task.execution.reviewGate || !!task.execution.reviewId)
+  );
+  if (!mergeTask) return;
+
+  const identifiers = getCurrentClosableReviewIdentifiers(mergeTask);
+  const cwd = mergeTask.execution.workspacePath ?? host.cwd;
+  for (const identifier of identifiers) {
+    try {
+      await closeReview({ identifier, cwd });
+    } catch (err) {
+      host.logger.error(`[merge-gate] Failed to close review ${identifier}`, { err });
+    }
+  }
+}
+
+export function isCurrentReviewGateArtifact(gate: ReviewGateState, artifact: ReviewGateArtifact): boolean {
+  return artifact.generation === gate.activeGeneration
+    && artifact.status !== 'discarded'
+    && !artifact.discardedAt;
+}
+
+export function getCurrentReviewArtifacts(task: TaskState): ReviewGateArtifact[] {
+  const gate = task.execution.reviewGate;
+  if (!gate) {
+    if (!task.execution.reviewId) {
+      return [];
+    }
+    return [{
+      id: task.execution.reviewId,
+      providerId: task.execution.reviewId,
+      required: true,
+      status: 'open',
+      generation: task.execution.generation ?? 0,
+    }];
+  }
+
+  return gate.artifacts.filter((artifact) => isCurrentReviewGateArtifact(gate, artifact));
+}
+
+export function getCurrentRequiredReviewArtifacts(task: TaskState): ReviewGateArtifact[] {
+  return getCurrentReviewArtifacts(task).filter((artifact) => artifact.required && !!artifact.providerId);
+}
+
+export function getCurrentClosableReviewIdentifiers(task: TaskState): string[] {
+  return getCurrentReviewArtifacts(task)
+    .flatMap((artifact) => (artifact.providerId ? [artifact.providerId] : []));
+}
+
+export function mapReviewGateArtifactStatus(status: MergeGateApprovalStatus): ReviewGateArtifactStatus {
+  if (status.lifecycle === 'closed') return 'closed';
+  if (status.lifecycle === 'merged') return 'approved';
+  if (status.rejected) return 'changes_requested';
+  return 'open';
+}
+
+export function reviewPollStillMatches(
+  before: TaskState,
+  current: TaskState | undefined,
+  providerId: string,
+): boolean {
+  if (!current) return false;
+  // Stale-write guard: a late poll must not write after the task already left
+  // the approval state (e.g. completed/closed/retried by another poll).
+  if (current.status !== 'review_ready' && current.status !== 'awaiting_approval') return false;
+  if (current.execution.selectedAttemptId !== before.execution.selectedAttemptId) return false;
+  if ((current.execution.generation ?? 0) !== (before.execution.generation ?? 0)) return false;
+
+  const beforeGate = before.execution.reviewGate;
+  if (!beforeGate) {
+    return !current.execution.reviewGate && current.execution.reviewId === providerId;
+  }
+
+  const currentGate = current.execution.reviewGate;
+  if (!currentGate || currentGate.activeGeneration !== beforeGate.activeGeneration) {
+    return false;
+  }
+  return currentGate.artifacts.some((artifact) =>
+    isCurrentReviewGateArtifact(currentGate, artifact)
+    && artifact.required
+    && artifact.providerId === providerId,
+  );
+}
+
+export function updateReviewGateArtifact(
+  gate: ReviewGateState,
+  providerId: string,
+  status: MergeGateApprovalStatus,
+): ReviewGateState {
+  const mappedStatus = mapReviewGateArtifactStatus(status);
+  return {
+    ...gate,
+    artifacts: gate.artifacts.map((artifact) => {
+      if (
+        !isCurrentReviewGateArtifact(gate, artifact)
+        || artifact.providerId !== providerId
+      ) {
+        return artifact;
+      }
+      const next: ReviewGateArtifact = {
+        ...artifact,
+        status: mappedStatus,
+        ...(status.headSha ? { headSha: status.headSha } : {}),
+        ...(status.headRef ? { headRef: status.headRef } : {}),
+        updatedAt: new Date().toISOString(),
+      };
+      if (mappedStatus === 'open') {
+        return { ...next, rawStatus: status.statusText };
+      }
+      return next;
+    }),
+  };
+}
+
+export function reviewGateIsApproved(gate: ReviewGateState): boolean {
+  const currentRequired = gate.artifacts.filter((artifact) =>
+    isCurrentReviewGateArtifact(gate, artifact) && artifact.required,
+  );
+  return currentRequired.length > 0
+    && currentRequired.every((artifact) => artifact.status === 'approved');
+}
+
+export async function handleApprovedMergeGate(
+  host: TaskRunnerReviewGateHost,
+  taskId: string,
+  reviewId: string,
+  source?: 'refresh' | 'manual check',
+): Promise<void> {
+  const sourceSuffix = source ? ` (${source})` : '';
+  host.logger.info(`[merge-gate] PR ${reviewId} approved${sourceSuffix}, completing merge gate`);
+  const newlyStarted = await host.orchestrator.approve(taskId);
+  if (newlyStarted.length > 0) {
+    await host.executeTasks(newlyStarted);
+  }
+}
+
+export async function pollMergeGateTask(
+  host: TaskRunnerReviewGateHost,
+  task: TaskState,
+  source: 'refresh' | 'manual check',
+): Promise<void> {
+  const artifacts = getCurrentRequiredReviewArtifacts(task);
+  if (artifacts.length === 0) return;
+
+  host.orchestrator.recordTaskHeartbeat?.(task.id, { at: new Date(), source: 'executor' });
+
+  let latestGate = task.execution.reviewGate;
+  let approvedGate = false;
+  for (const artifact of artifacts) {
+    const providerId = artifact.providerId;
+    if (!providerId) continue;
+    const gateCwd = task.execution.workspacePath ?? host.cwd;
+    const status = await host.mergeGateProvider!.checkApproval({
+      identifier: providerId,
+      cwd: gateCwd,
+    });
+
+    const current = host.orchestrator.getTask(task.id);
+    if (!reviewPollStillMatches(task, current, providerId)) {
+      continue;
+    }
+
+    // Rebase each provider update on the freshest persisted gate so concurrent
+    // polls don't clobber each other's artifact statuses with a stale snapshot.
+    const currentGate = current!.execution.reviewGate ?? latestGate;
+    if (currentGate) {
+      latestGate = updateReviewGateArtifact(currentGate, providerId, status);
+      host.persistence.updateTask(task.id, {
+        ...(status.lifecycle === 'closed' ? { status: 'closed' as const } : {}),
+        execution: { reviewGate: latestGate, reviewStatus: status.statusText },
+      });
+      if (!approvedGate && reviewGateIsApproved(latestGate)) {
+        approvedGate = true;
+        await handleApprovedMergeGate(host, task.id, providerId, source);
+      } else if (status.rejected) {
+        host.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
+      } else if (status.lifecycle === 'open') {
+        await maybePublishReviewGateCiFailure(host, current!, status, providerId);
+      }
+      continue;
+    }
+
+    host.persistence.updateTask(task.id, {
+      ...(status.lifecycle === 'closed' ? { status: 'closed' as const } : {}),
+      execution: { reviewStatus: status.statusText },
+    });
+    if (!approvedGate && status.lifecycle === 'merged') {
+      approvedGate = true;
+      await handleApprovedMergeGate(host, task.id, providerId, source);
+    } else if (status.rejected) {
+      host.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
+    } else if (status.lifecycle === 'open') {
+      await maybePublishReviewGateCiFailure(host, current!, status, providerId);
+    }
+  }
+}
+
+export async function checkMergeGateStatuses(host: TaskRunnerReviewGateHost): Promise<void> {
+  if (!host.mergeGateProvider) return;
+  for (const task of host.orchestrator.getAllTasks()) {
+    if (
+      task.config.isMergeNode &&
+      (task.status === 'review_ready' || task.status === 'awaiting_approval') &&
+      getCurrentRequiredReviewArtifacts(task).length > 0
+    ) {
+      try {
+        await pollMergeGateTask(host, task, 'refresh');
+      } catch (err) {
+        host.logger.error(`[merge-gate] PR status check error for ${task.id}`, { err });
+      }
+    }
+  }
+}
+
+export async function checkPrApprovalNow(host: TaskRunnerReviewGateHost, taskId: string): Promise<void> {
+  if (!host.mergeGateProvider) return;
+
+  const task = host.orchestrator.getTask(taskId);
+  if (!task) return;
+
+  try {
+    await pollMergeGateTask(host, task, 'manual check');
+  } catch (err) {
+    host.logger.error(`[merge-gate] Manual PR check error for ${taskId}`, { err });
+  }
+}
+
+export async function maybePublishReviewGateCiFailure(
+  host: TaskRunnerReviewGateHost,
+  task: TaskState,
+  status: MergeGateApprovalStatus,
+  reviewId: string = task.execution.reviewId ?? '',
+): Promise<void> {
+  if (!host.reviewGateCiFailurePublisher) return;
+  if (!task.config.workflowId || !reviewId) return;
+  if (status.checks?.state !== 'failure' || status.checks.failed.length === 0) return;
+
+  const key = [
+    task.id,
+    task.execution.selectedAttemptId ?? 'no-attempt',
+    task.execution.generation ?? 0,
+    status.headSha ?? 'no-head-sha',
+  ].join(':');
+  if (host.reviewGateCiFailureInFlight.has(key)) return;
+
+  host.reviewGateCiFailureInFlight.add(key);
+  try {
+    await host.reviewGateCiFailurePublisher.publish({
+      taskId: task.id,
+      workflowId: task.config.workflowId,
+      reviewId,
+      reviewUrl: status.url,
+      headSha: status.headSha,
+      headRef: status.headRef,
+      branch: task.execution.branch,
+      selectedAttemptId: task.execution.selectedAttemptId,
+      generation: task.execution.generation ?? 0,
+      failedChecks: status.checks.failed,
+      statusText: status.statusText,
+    });
+  } finally {
+    host.reviewGateCiFailureInFlight.delete(key);
+  }
+}

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -65,6 +65,8 @@ import { PRE_START_HEARTBEAT_INTERVAL_MS, nextLeaseExpiry } from './task-runner-
 import { buildWorkRequest } from './task-runner-prepare.js';
 import { dispatchExecutor } from './task-runner-dispatch.js';
 import { wireCompletion } from './task-runner-finalize.js';
+import * as reviewGate from './task-runner-review-gate.js';
+import type { ReviewGateCiFailureLifecyclePublisher } from './task-runner-review-gate.js';
 import {
   poolMemberKey,
   selectPoolMember,
@@ -108,24 +110,6 @@ export type FreshBaseCommit = {
   commit: string;
 };
 
-
-export interface ReviewGateCiFailureTrigger {
-  taskId: string;
-  workflowId: string;
-  reviewId: string;
-  reviewUrl: string;
-  headSha?: string;
-  headRef?: string;
-  branch?: string;
-  selectedAttemptId?: string;
-  generation: number;
-  failedChecks: NonNullable<MergeGateApprovalStatus['checks']>['failed'];
-  statusText: string;
-}
-
-export interface ReviewGateCiFailureLifecyclePublisher {
-  publish(trigger: ReviewGateCiFailureTrigger): void | Promise<void>;
-}
 
 const NOOP_LOGGER: Logger = {
   debug: () => {},
@@ -227,8 +211,8 @@ export class TaskRunner {
   /** @internal */ callbacks: TaskRunnerCallbacks;
   /** @internal */ mergeGateProvider?: MergeGateProvider;
   /** @internal */ reviewProviderRegistry?: ReviewProviderRegistry;
-  private reviewGateCiFailurePublisher?: ReviewGateCiFailureLifecyclePublisher;
-  private reviewGateCiFailureInFlight = new Set<string>();
+  /** @internal */ reviewGateCiFailurePublisher?: ReviewGateCiFailureLifecyclePublisher;
+  /** @internal */ reviewGateCiFailureInFlight = new Set<string>();
   /** @internal */ getRemoteTargets: () => Record<string, RemoteTargetDisplay>;
   /** @internal */ getExecutionPools: () => Record<string, ExecutionPoolConfig>;
   private getExecutionDefaults: () => { executionAgent?: string; executionModel?: string };
@@ -1239,66 +1223,27 @@ export class TaskRunner {
   }
 
   async closeWorkflowReview(workflowId: string): Promise<void> {
-    const closeReview = this.mergeGateProvider?.closeReview?.bind(this.mergeGateProvider);
-    if (!closeReview) return;
-    const getAllTasks = this.orchestrator.getAllTasks?.bind(this.orchestrator);
-    if (!getAllTasks) return;
-    const mergeTask = getAllTasks().find((task) =>
-      task.config.workflowId === workflowId
-      && task.config.isMergeNode
-      && (!!task.execution.reviewGate || !!task.execution.reviewId)
-    );
-    if (!mergeTask) return;
-
-    const identifiers = this.getCurrentClosableReviewIdentifiers(mergeTask);
-    const cwd = mergeTask.execution.workspacePath ?? this.cwd;
-    for (const identifier of identifiers) {
-      try {
-        await closeReview({ identifier, cwd });
-      } catch (err) {
-        this.logger.error(`[merge-gate] Failed to close review ${identifier}`, { err });
-      }
-    }
+    return reviewGate.closeWorkflowReview(this, workflowId);
   }
+
   private isCurrentReviewGateArtifact(gate: ReviewGateState, artifact: ReviewGateArtifact): boolean {
-    return artifact.generation === gate.activeGeneration
-      && artifact.status !== 'discarded'
-      && !artifact.discardedAt;
+    return reviewGate.isCurrentReviewGateArtifact(gate, artifact);
   }
-
 
   private getCurrentReviewArtifacts(task: TaskState): ReviewGateArtifact[] {
-    const gate = task.execution.reviewGate;
-    if (!gate) {
-      if (!task.execution.reviewId) {
-        return [];
-      }
-      return [{
-        id: task.execution.reviewId,
-        providerId: task.execution.reviewId,
-        required: true,
-        status: 'open',
-        generation: task.execution.generation ?? 0,
-      }];
-    }
-
-    return gate.artifacts.filter((artifact) => this.isCurrentReviewGateArtifact(gate, artifact));
+    return reviewGate.getCurrentReviewArtifacts(task);
   }
 
   private getCurrentRequiredReviewArtifacts(task: TaskState): ReviewGateArtifact[] {
-    return this.getCurrentReviewArtifacts(task).filter((artifact) => artifact.required && !!artifact.providerId);
+    return reviewGate.getCurrentRequiredReviewArtifacts(task);
   }
 
   private getCurrentClosableReviewIdentifiers(task: TaskState): string[] {
-    return this.getCurrentReviewArtifacts(task)
-      .flatMap((artifact) => (artifact.providerId ? [artifact.providerId] : []));
+    return reviewGate.getCurrentClosableReviewIdentifiers(task);
   }
 
   private mapReviewGateArtifactStatus(status: MergeGateApprovalStatus): ReviewGateArtifactStatus {
-    if (status.lifecycle === 'closed') return 'closed';
-    if (status.lifecycle === 'merged') return 'approved';
-    if (status.rejected) return 'changes_requested';
-    return 'open';
+    return reviewGate.mapReviewGateArtifactStatus(status);
   }
 
   private reviewPollStillMatches(
@@ -1306,27 +1251,7 @@ export class TaskRunner {
     current: TaskState | undefined,
     providerId: string,
   ): boolean {
-    if (!current) return false;
-    // Stale-write guard: a late poll must not write after the task already left
-    // the approval state (e.g. completed/closed/retried by another poll).
-    if (current.status !== 'review_ready' && current.status !== 'awaiting_approval') return false;
-    if (current.execution.selectedAttemptId !== before.execution.selectedAttemptId) return false;
-    if ((current.execution.generation ?? 0) !== (before.execution.generation ?? 0)) return false;
-
-    const beforeGate = before.execution.reviewGate;
-    if (!beforeGate) {
-      return !current.execution.reviewGate && current.execution.reviewId === providerId;
-    }
-
-    const currentGate = current.execution.reviewGate;
-    if (!currentGate || currentGate.activeGeneration !== beforeGate.activeGeneration) {
-      return false;
-    }
-    return currentGate.artifacts.some((artifact) =>
-      this.isCurrentReviewGateArtifact(currentGate, artifact)
-      && artifact.required
-      && artifact.providerId === providerId,
-    );
+    return reviewGate.reviewPollStillMatches(before, current, providerId);
   }
 
   private updateReviewGateArtifact(
@@ -1334,142 +1259,34 @@ export class TaskRunner {
     providerId: string,
     status: MergeGateApprovalStatus,
   ): ReviewGateState {
-    const mappedStatus = this.mapReviewGateArtifactStatus(status);
-    return {
-      ...gate,
-      artifacts: gate.artifacts.map((artifact) => {
-        if (
-          !this.isCurrentReviewGateArtifact(gate, artifact)
-          || artifact.providerId !== providerId
-        ) {
-          return artifact;
-        }
-        const next: ReviewGateArtifact = {
-          ...artifact,
-          status: mappedStatus,
-          ...(status.headSha ? { headSha: status.headSha } : {}),
-          ...(status.headRef ? { headRef: status.headRef } : {}),
-          updatedAt: new Date().toISOString(),
-        };
-        if (mappedStatus === 'open') {
-          return { ...next, rawStatus: status.statusText };
-        }
-        return next;
-      }),
-    };
+    return reviewGate.updateReviewGateArtifact(gate, providerId, status);
   }
 
   private reviewGateIsApproved(gate: ReviewGateState): boolean {
-    const currentRequired = gate.artifacts.filter((artifact) =>
-      this.isCurrentReviewGateArtifact(gate, artifact) && artifact.required,
-    );
-    return currentRequired.length > 0
-      && currentRequired.every((artifact) => artifact.status === 'approved');
+    return reviewGate.reviewGateIsApproved(gate);
   }
-
-
 
   private async handleApprovedMergeGate(
     taskId: string,
     reviewId: string,
     source?: 'refresh' | 'manual check',
   ): Promise<void> {
-    const sourceSuffix = source ? ` (${source})` : '';
-    this.logger.info(`[merge-gate] PR ${reviewId} approved${sourceSuffix}, completing merge gate`);
-    const newlyStarted = await this.orchestrator.approve(taskId);
-    if (newlyStarted.length > 0) {
-      await this.executeTasks(newlyStarted);
-    }
+    return reviewGate.handleApprovedMergeGate(this, taskId, reviewId, source);
   }
 
   private async pollMergeGateTask(
     task: TaskState,
     source: 'refresh' | 'manual check',
   ): Promise<void> {
-    const artifacts = this.getCurrentRequiredReviewArtifacts(task);
-    if (artifacts.length === 0) return;
-
-    this.orchestrator.recordTaskHeartbeat?.(task.id, { at: new Date(), source: 'executor' });
-
-    let latestGate = task.execution.reviewGate;
-    let approvedGate = false;
-    for (const artifact of artifacts) {
-      const providerId = artifact.providerId;
-      if (!providerId) continue;
-      const gateCwd = task.execution.workspacePath ?? this.cwd;
-      const status = await this.mergeGateProvider!.checkApproval({
-        identifier: providerId,
-        cwd: gateCwd,
-      });
-
-      const current = this.orchestrator.getTask(task.id);
-      if (!this.reviewPollStillMatches(task, current, providerId)) {
-        continue;
-      }
-
-      // Rebase each provider update on the freshest persisted gate so concurrent
-      // polls don't clobber each other's artifact statuses with a stale snapshot.
-      const currentGate = current!.execution.reviewGate ?? latestGate;
-      if (currentGate) {
-        latestGate = this.updateReviewGateArtifact(currentGate, providerId, status);
-        this.persistence.updateTask(task.id, {
-          ...(status.lifecycle === 'closed' ? { status: 'closed' as const } : {}),
-          execution: { reviewGate: latestGate, reviewStatus: status.statusText },
-        });
-        if (!approvedGate && this.reviewGateIsApproved(latestGate)) {
-          approvedGate = true;
-          await this.handleApprovedMergeGate(task.id, providerId, source);
-        } else if (status.rejected) {
-          this.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
-        } else if (status.lifecycle === 'open') {
-          await this.maybePublishReviewGateCiFailure(current!, status, providerId);
-        }
-        continue;
-      }
-
-      this.persistence.updateTask(task.id, {
-        ...(status.lifecycle === 'closed' ? { status: 'closed' as const } : {}),
-        execution: { reviewStatus: status.statusText },
-      });
-      if (!approvedGate && status.lifecycle === 'merged') {
-        approvedGate = true;
-        await this.handleApprovedMergeGate(task.id, providerId, source);
-      } else if (status.rejected) {
-        this.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
-      } else if (status.lifecycle === 'open') {
-        await this.maybePublishReviewGateCiFailure(current!, status, providerId);
-      }
-    }
+    return reviewGate.pollMergeGateTask(this, task, source);
   }
 
   async checkMergeGateStatuses(): Promise<void> {
-    if (!this.mergeGateProvider) return;
-    for (const task of this.orchestrator.getAllTasks()) {
-      if (
-        task.config.isMergeNode &&
-        (task.status === 'review_ready' || task.status === 'awaiting_approval') &&
-        this.getCurrentRequiredReviewArtifacts(task).length > 0
-      ) {
-        try {
-          await this.pollMergeGateTask(task, 'refresh');
-        } catch (err) {
-          this.logger.error(`[merge-gate] PR status check error for ${task.id}`, { err });
-        }
-      }
-    }
+    return reviewGate.checkMergeGateStatuses(this);
   }
 
   async checkPrApprovalNow(taskId: string): Promise<void> {
-    if (!this.mergeGateProvider) return;
-
-    const task = this.orchestrator.getTask(taskId);
-    if (!task) return;
-
-    try {
-      await this.pollMergeGateTask(task, 'manual check');
-    } catch (err) {
-      this.logger.error(`[merge-gate] Manual PR check error for ${taskId}`, { err });
-    }
+    return reviewGate.checkPrApprovalNow(this, taskId);
   }
 
   private async maybePublishReviewGateCiFailure(
@@ -1477,36 +1294,7 @@ export class TaskRunner {
     status: MergeGateApprovalStatus,
     reviewId: string = task.execution.reviewId ?? '',
   ): Promise<void> {
-    if (!this.reviewGateCiFailurePublisher) return;
-    if (!task.config.workflowId || !reviewId) return;
-    if (status.checks?.state !== 'failure' || status.checks.failed.length === 0) return;
-
-    const key = [
-      task.id,
-      task.execution.selectedAttemptId ?? 'no-attempt',
-      task.execution.generation ?? 0,
-      status.headSha ?? 'no-head-sha',
-    ].join(':');
-    if (this.reviewGateCiFailureInFlight.has(key)) return;
-
-    this.reviewGateCiFailureInFlight.add(key);
-    try {
-      await this.reviewGateCiFailurePublisher.publish({
-        taskId: task.id,
-        workflowId: task.config.workflowId,
-        reviewId,
-        reviewUrl: status.url,
-        headSha: status.headSha,
-        headRef: status.headRef,
-        branch: task.execution.branch,
-        selectedAttemptId: task.execution.selectedAttemptId,
-        generation: task.execution.generation ?? 0,
-        failedChecks: status.checks.failed,
-        statusText: status.statusText,
-      });
-    } finally {
-      this.reviewGateCiFailureInFlight.delete(key);
-    }
+    return reviewGate.maybePublishReviewGateCiFailure(this, task, status, reviewId);
   }
 
   spawnAgentFix(


### PR DESCRIPTION
## Summary

Slice 3 of the execution-engine god-file decomposition. `task-runner.ts` had grown past 2,700 lines and was hard to read in one sitting.

The review-gate and merge-gate polling family, plus CI-failure publication, now lives in a new file, `task-runner-review-gate.ts`, behind a `Pick<TaskRunner, ...>` host the phase modules already use.

`TaskRunner` keeps thin one-line delegates, so every caller sees the same public surface. Behavior is intentionally identical.

Invoker-on-Invoker dogfood: the workflow finished with `onFinish: pull_request` plus external review.

This slice is published on top of slice 2 as a Mergify-managed stack PR through the repo-local make-pr workflow.

## Review Claim

The review-gate and merge-gate polling family and CI-failure publication now live in `task-runner-review-gate.ts` as free functions over a host, with `TaskRunner` delegating; behavior is unchanged.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

Pure relocation slice: the bodies are copied verbatim behind one-line `TaskRunner` delegates. `reviewGateCiFailureInFlight` is single-cluster-owned (coupling analysis) and is surfaced through `@internal` plus the host `Pick`, exactly as `pendingPoolSelections` already is. The `ReviewGateCiFailureTrigger` / `ReviewGateCiFailureLifecyclePublisher` declarations relocate with their owning cluster and stay barrel-visible through `index.ts`, so app-layer importers such as `packages/app/src/workflow-actions.ts` compile with no edit. `task-runner.test.ts` and `review-gate-status-worker.test.ts` pin polling cadence, artifact-status mapping, and CI-failure dedup, so any drift fails the suite. The new file holds no runtime import back to `task-runner.ts`.

## Slice Rationale

One cohesive unit per slice, per the review-compression convention. This is slice 3 of the execution-engine decomposition chain and touches nothing else. Bundling the review-gate cluster with the slice 2 pool cluster, or with a later PR-authoring cluster, would put two claims in one diff.

## Non-goals

- No PR-authoring or branch-ops relocation; that is a later slice.
- No change to polling cadence, artifact-status mapping, or CI-failure dedup semantics.
- No `packages/app` edit: its barrel import keeps compiling.
- Behavior unchanged: this slice is a pure code relocation behind a stable public surface.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts` — the slice's pinned execution-engine suite; passes.
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/review-gate-status-worker.test.ts` — the slice's pinned app-layer suite; passes with no `packages/app` source change.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <squash-merge-sha>` (or drop this slice branch from the stack before it lands).
- Post-revert steps: None. The public surface is unchanged, so slice 2 and later slices keep compiling.
- Data migration? No.

</details>

