### PR TITLE
Reject silent planner exits instead of surfacing "(no output)" placeholder

### DIFF
--- a/packages/surfaces/src/__tests__/planner-no-output-repro.test.ts
+++ b/packages/surfaces/src/__tests__/planner-no-output-repro.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import * as child_process from 'node:child_process';
+import { PlanConversation } from '../slack/plan-conversation.js';
+
+// This test reproduces the bug where the planner CLI (Cursor/Codex/etc.) exits
+// with code 0 but writes nothing to stdout — commonly because a silent
+// authentication/tool-permission/context-limit failure ends up on stderr while
+// the wrapper still reports success. Before the fix, `spawnPlanner` resolved
+// with the literal placeholder `"(no output)"`. That placeholder then landed in
+// the in-app planning chat as if the planner had answered, hiding the real
+// failure from the user. The fix converts that "success with no output" case
+// into a rejection whose message surfaces the stderr tail so the caller can
+// treat it as the error it is.
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof child_process>();
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
+
+const mockSpawn = vi.mocked(child_process.spawn);
+
+interface FakeChildOptions {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+}
+
+function fakePlannerChild({ stdout = '', stderr = '', exitCode = 0 }: FakeChildOptions): any {
+  const proc = new EventEmitter() as any;
+  const stdoutEmitter = new EventEmitter();
+  const stderrEmitter = new EventEmitter();
+  proc.stdout = stdoutEmitter;
+  proc.stderr = stderrEmitter;
+  proc.kill = vi.fn();
+
+  setTimeout(() => {
+    if (stdout) stdoutEmitter.emit('data', Buffer.from(stdout));
+    if (stderr) stderrEmitter.emit('data', Buffer.from(stderr));
+    proc.emit('close', exitCode);
+  }, 0);
+
+  return proc;
+}
+
+describe('planner exit=0 with no stdout — repro for hidden "(no output)" placeholder', () => {
+  let conversation: PlanConversation;
+
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    conversation = new PlanConversation({});
+  });
+
+  it('rejects instead of resolving with the "(no output)" placeholder when planner exits 0 with empty stdout', async () => {
+    mockSpawn.mockReturnValueOnce(fakePlannerChild({ stdout: '', stderr: '', exitCode: 0 }));
+
+    const promise = conversation.sendMessage('Any prompt');
+    const outcome = await promise.then(
+      (reply) => ({ kind: 'resolved' as const, reply }),
+      (err: Error) => ({ kind: 'rejected' as const, err }),
+    );
+
+    expect(outcome.kind).toBe('rejected');
+    if (outcome.kind === 'resolved') {
+      expect(outcome.reply).not.toBe('(no output)');
+      expect(outcome.reply).not.toBe('');
+    } else {
+      expect(outcome.err.message).toMatch(/no output|no stdout/i);
+    }
+  });
+
+  it('includes the stderr tail in the rejection when the planner wrote diagnostics before exiting 0', async () => {
+    const stderrTail = 'auth: session expired; please re-authenticate';
+    mockSpawn.mockReturnValueOnce(fakePlannerChild({ stdout: '', stderr: stderrTail, exitCode: 0 }));
+
+    const outcome = await conversation.sendMessage('Any prompt').then(
+      (reply) => ({ kind: 'resolved' as const, reply }),
+      (err: Error) => ({ kind: 'rejected' as const, err }),
+    );
+
+    expect(outcome.kind).toBe('rejected');
+    if (outcome.kind === 'rejected') {
+      expect(outcome.err.message).toContain(stderrTail);
+    }
+  });
+
+  it('does not append the "(no output)" placeholder to the conversation history when the planner is silent', async () => {
+    mockSpawn.mockReturnValueOnce(fakePlannerChild({ stdout: '', stderr: '', exitCode: 0 }));
+
+    await conversation.sendMessage('Any prompt').catch(() => undefined);
+
+    const assistantEntries = conversation.history.filter((entry) => entry.role === 'assistant');
+    for (const entry of assistantEntries) {
+      expect(entry.content).not.toBe('(no output)');
+    }
+  });
+});

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -41,6 +41,19 @@ export function defaultPlanningCommand(
   return { command: cursorCommand, args };
 }
 
+const EMPTY_PLANNER_STDERR_TAIL_LIMIT = 500;
+
+// Shared with slack-surface.ts so both planner spawn paths surface the same
+// actionable error when the CLI exits 0 but writes nothing to stdout. The
+// stderr tail is preserved because Cursor/Codex/OMP often log the real reason
+// (auth expiry, permission denial, context overflow) to stderr while still
+// reporting a successful exit.
+export function buildEmptyPlannerOutputError(plannerLabel: string, stderr: string): Error {
+  const trimmed = stderr.trim();
+  const tail = trimmed ? ` — stderr tail: ${trimmed.slice(-EMPTY_PLANNER_STDERR_TAIL_LIMIT)}` : '';
+  return new Error(`${plannerLabel} exited 0 but produced no output${tail}`);
+}
+
 export interface PlanConversationConfig {
   /** Command to invoke the agent CLI. Default: 'agent'. */
   cursorCommand?: string;
@@ -490,7 +503,12 @@ export class PlanConversation {
         clearTimeout(timer);
         this.log('plan-conversation', 'info', `[PERF] cursor_exit: code=${code}, stdoutBytes=${stdout.length}, stderrBytes=${stderr.length}, stdoutChunks=${stdoutChunks}, stderrChunks=${stderrChunks}, elapsed=${Date.now() - spawnStart}ms`);
         if (code === 0) {
-          resolve(stdout.trim() || '(no output)');
+          const trimmed = stdout.trim();
+          if (trimmed) {
+            resolve(trimmed);
+          } else {
+            reject(buildEmptyPlannerOutputError(plannerLabel, stderr));
+          }
         } else {
           const errMsg = stderr.trim() || stdout.trim() || 'Unknown error';
           reject(new Error(`${plannerLabel} exited with code ${code}: ${errMsg}`));

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -13,7 +13,7 @@ import type { ConversationCommand } from './slack-commands.js';
 import { formatSurfaceEvent, formatWorkflowStatus } from './slack-formatter.js';
 import { splitForSlack, sanitizeSlashCommands } from './slack-message-helpers.js';
 import type { SlackMessage } from './slack-formatter.js';
-import { PlanConversation, defaultPlanningCommand, isConfirmation, isNegation } from './plan-conversation.js';
+import { PlanConversation, buildEmptyPlannerOutputError, defaultPlanningCommand, isConfirmation, isNegation } from './plan-conversation.js';
 import type { ConversationMode, PlanningCommandBuilder } from './plan-conversation.js';
 import { parseLobbyControl } from './lobby-control.js';
 import type { LobbyControl } from './lobby-control.js';
@@ -1447,6 +1447,7 @@ ${text}`;
     const { command, args } = this.planningCommandBuilder
       ? this.planningCommandBuilder({ tool: harness.tool, model: harness.model, prompt })
       : defaultPlanningCommand(this.cursorCommand, { model: harness.model, prompt });
+    const plannerLabel = harness.tool ?? command;
     const timeoutMs = (this.planningTimeoutSeconds ?? 7_200) * 1_000;
     return new Promise((resolve, reject) => {
       const child = spawn(command, args, {
@@ -1464,8 +1465,16 @@ ${text}`;
       }, timeoutMs);
       child.on('close', (code) => {
         clearTimeout(timer);
-        if (code === 0) resolve(stdout.trim() || '(no output)');
-        else reject(new Error(stderr.trim() || stdout.trim() || `Planner exited with code ${code}`));
+        if (code === 0) {
+          const trimmed = stdout.trim();
+          if (trimmed) {
+            resolve(trimmed);
+          } else {
+            reject(buildEmptyPlannerOutputError(plannerLabel, stderr));
+          }
+        } else {
+          reject(new Error(stderr.trim() || stdout.trim() || `Planner exited with code ${code}`));
+        }
       });
       child.on('error', (err) => {
         clearTimeout(timer);


### PR DESCRIPTION
## Summary

The planning-chat CLI wrapper resolved with the literal string `"(no output)"` whenever the planner exited 0 with empty stdout. The placeholder appeared in chat as if the planner answered.

The real failure is usually an auth expiry, permission denial, or context overflow logged to stderr while the CLI still exits 0. Dropping stderr on success hid the reason.

Both planner spawn paths now fail with an error that preserves the last 500 bytes of stderr. The existing chat error path renders it as an error-tone message.

## Review Claim

`spawnPlanner` and `runOneShotPlanner` must not surface `"(no output)"` as an assistant reply; a silent successful exit is an error and must fail with the stderr tail included.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Non-zero-exit failure semantics are unchanged and existing planner replies with any stdout still resolve normally. Only the previously-silent `code === 0 && stdout.trim() === ''` branch changes, and it moves from a hidden placeholder to a failed promise the existing chat error path already renders. Failed `sendMessage` calls do not persist assistant history (see `plan-conversation.test.ts` "emits partial stdout before planner failure without persisting assistant history"), so no stray `(no output)` entries remain in restored sessions.

## Slice Rationale

Single-lane behavior fix scoped to the two planner-spawn callsites in `packages/surfaces`. The repro test lives in the same package and is committed with the fix because the change is small enough that a separate proof slice would add ceremony without new information; the test is written to fail against the pre-fix code and pass after the fix, satisfying "the bug is demonstrated before the change is approved" for a same-slice repro.

## Non-goals

- Does not change non-zero-exit error formatting.
- Does not touch the `[PERF] cursor_exit` log line or its byte counters.
- Does not modify `buildAgentExitFailureDetail` in `packages/execution-engine/src/process-utils.ts`, which uses `(no output)` as a failure-detail display string (separate concern).
- No UI, IPC, or persistence-schema changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test`
- [x] `cd packages/app && npx vitest run src/__tests__/in-app-planner.test.ts`
- [x] `cd packages/ui && npx vitest run src/__tests__/invoker-terminal.test.tsx`
- [x] `cd packages/surfaces && pnpm build`

</details>

## Visual Proof

The exhausted-attempt error surface end-to-end after this slice, the retry slice (#3629), the card exposure (#3634), and the proof spec (#3633) all land. The raw error message this slice introduces is the string labelled "Planner could not respond" in the card and inline in the transcript:

![planner attempts exhausted](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-ee2634/planner-retry-exhausted-error-fixed.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
