### PR TITLE
[Daily e2e worker](1) Add e2e auto-fix config gates

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -105,6 +105,14 @@ export interface InvokerConfig {
    * Default: 0 (disabled).
    */
   autoFixRetries?: number;
+  /**
+   * When true, the owner process auto-starts the e2e-autofix worker (runs the
+   * extended battery on a schedule and opens one fix PR per failing suite).
+   * Default: false.
+   */
+  e2eAutoFixEnabled?: boolean;
+  /** Cadence for the e2e-autofix worker in milliseconds. Default: 43_200_000 (12h). */
+  e2eAutoFixIntervalMs?: number;
   stallRequeueRetries?: number;
   stallRequeueBackoffMs?: number;
   /**


### PR DESCRIPTION
## Summary

Add two optional config fields for a coming worker that runs the extended end-to-end battery on a schedule.

`e2eAutoFixEnabled` decides whether that worker starts on its own. `e2eAutoFixIntervalMs` sets how often it runs.

Both are optional and default off, so nothing behaves differently yet; a later slice reads them.

## Review Claim

Add `e2eAutoFixEnabled` and `e2eAutoFixIntervalMs` as optional, default-off config fields.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

The fields are optional and read by no code in this slice, so the config surface only grows and no runtime path changes.

## Slice Rationale

The config gate lands first so the worker-wiring slice can read these fields and still compile on its own.

## Non-goals

- Does not register, wire, or start any worker.
- Does not remove the existing OS cron scripts.
- Does not change any default behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm run check:types`
- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/config.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>