### PR TITLE
Try a free retry-task before AutoFixWorker consumes an auto-fix attempt

### DIFF
--- a/packages/app/src/__tests__/autofix-defaults.test.ts
+++ b/packages/app/src/__tests__/autofix-defaults.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_AUTO_APPROVE_AI_FIXES,
+  DEFAULT_AUTO_FIX_RETRIES,
+  resolveAutoApproveAIFixes,
+  resolveAutoFixRetries,
+} from '../autofix-defaults.js';
+
+describe('resolveAutoFixRetries', () => {
+  it('returns DEFAULT_AUTO_FIX_RETRIES when the key is unset', () => {
+    expect(DEFAULT_AUTO_FIX_RETRIES).toBe(3);
+    expect(resolveAutoFixRetries({})).toBe(3);
+  });
+
+  it('returns DEFAULT_AUTO_FIX_RETRIES when the key is null', () => {
+    expect(resolveAutoFixRetries({ autoFixRetries: null as unknown as number })).toBe(3);
+  });
+
+  it('honors an explicit 0 as user opt-out', () => {
+    expect(resolveAutoFixRetries({ autoFixRetries: 0 })).toBe(0);
+  });
+
+  it('honors positive finite numbers verbatim', () => {
+    expect(resolveAutoFixRetries({ autoFixRetries: 1 })).toBe(1);
+    expect(resolveAutoFixRetries({ autoFixRetries: 5 })).toBe(5);
+  });
+
+  it('falls back to the default for negative or non-finite numbers', () => {
+    expect(resolveAutoFixRetries({ autoFixRetries: -1 })).toBe(3);
+    expect(resolveAutoFixRetries({ autoFixRetries: Number.NaN })).toBe(3);
+    expect(resolveAutoFixRetries({ autoFixRetries: Number.POSITIVE_INFINITY })).toBe(3);
+  });
+
+  it('falls back to the default for non-numeric values', () => {
+    expect(resolveAutoFixRetries({ autoFixRetries: 'three' as unknown as number })).toBe(3);
+  });
+});
+
+describe('resolveAutoApproveAIFixes', () => {
+  it('returns DEFAULT_AUTO_APPROVE_AI_FIXES when the key is unset', () => {
+    expect(DEFAULT_AUTO_APPROVE_AI_FIXES).toBe(true);
+    expect(resolveAutoApproveAIFixes({})).toBe(true);
+  });
+
+  it('returns DEFAULT_AUTO_APPROVE_AI_FIXES when the key is null', () => {
+    expect(resolveAutoApproveAIFixes({ autoApproveAIFixes: null as unknown as boolean })).toBe(true);
+  });
+
+  it('honors an explicit false as user opt-out', () => {
+    expect(resolveAutoApproveAIFixes({ autoApproveAIFixes: false })).toBe(false);
+  });
+
+  it('honors an explicit true', () => {
+    expect(resolveAutoApproveAIFixes({ autoApproveAIFixes: true })).toBe(true);
+  });
+
+  it('falls back to the default for non-boolean values', () => {
+    expect(resolveAutoApproveAIFixes({ autoApproveAIFixes: 1 as unknown as boolean })).toBe(true);
+    expect(resolveAutoApproveAIFixes({ autoApproveAIFixes: 'yes' as unknown as boolean })).toBe(true);
+  });
+});

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -6,6 +6,7 @@ import {
   createWorkerRegistry,
   PR_CONFLICT_REBASE_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
+  WORKFLOW_RESUME_WORKER_KIND,
   type WorkerRuntime,
   type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
@@ -91,6 +92,7 @@ function controller() {
   register(CI_FAILURE_WORKER_KIND, 'Repairs failed CI.');
   register(CODERABBIT_ADDRESS_WORKER_KIND, 'Addresses CodeRabbit review comments.');
   register(PR_CONFLICT_REBASE_WORKER_KIND, 'Rebases conflicted pull requests.');
+  register(WORKFLOW_RESUME_WORKER_KIND, 'Resumes incomplete workflows.');
   register('external-preview', 'External preview worker.');
 
   return {
@@ -116,6 +118,7 @@ describe('createWorkerRuntimeController', () => {
     expect(snapshot.workers.find((worker) => worker.kind === CI_FAILURE_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === CODERABBIT_ADDRESS_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === PR_CONFLICT_REBASE_WORKER_KIND)?.lifecycle).toBe('running');
+    expect(snapshot.workers.find((worker) => worker.kind === WORKFLOW_RESUME_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)?.lifecycle).toBe('stopped');
     expect(snapshot.workers.find((worker) => worker.kind === 'external-preview')?.lifecycle).toBe('stopped');
   });

--- a/packages/app/src/autofix-defaults.ts
+++ b/packages/app/src/autofix-defaults.ts
@@ -1,0 +1,21 @@
+import type { InvokerConfig } from './config.js';
+
+export const DEFAULT_AUTO_FIX_RETRIES = 3;
+
+export const DEFAULT_AUTO_APPROVE_AI_FIXES = true;
+
+export function resolveAutoFixRetries(config: InvokerConfig): number {
+  const value = config.autoFixRetries;
+  if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+    return value;
+  }
+  return DEFAULT_AUTO_FIX_RETRIES;
+}
+
+export function resolveAutoApproveAIFixes(config: InvokerConfig): boolean {
+  const value = config.autoApproveAIFixes;
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  return DEFAULT_AUTO_APPROVE_AI_FIXES;
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -137,6 +137,10 @@ import {
   type InvokerConfig,
 } from './config.js';
 import {
+  resolveAutoApproveAIFixes,
+  resolveAutoFixRetries,
+} from './autofix-defaults.js';
+import {
   DEFAULT_WORKTREE_MAX_CONCURRENCY,
   assertExecutionCapacityInvariant,
   resolveEffectiveMaxConcurrency,
@@ -349,7 +353,7 @@ function buildRegisteredOwnerWorkerDeps(
       checkMergeGateStatuses,
     },
     autoFix: {
-      defaultAutoFixRetries: invokerConfig.autoFixRetries,
+      defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
       attemptLedger: autoFixAttemptLedger,
       getAutoFixAgent: () => invokerConfig.autoFixAgent,
       getAutoFixExecutionModel: () => invokerConfig.defaultExecutionModel,
@@ -364,7 +368,7 @@ function buildRegisteredOwnerWorkerDeps(
       remoteTargets,
     },
     autoApprove: {
-      enabled: invokerConfig.autoApproveAIFixes === true,
+      enabled: resolveAutoApproveAIFixes(invokerConfig),
     },
   };
 }
@@ -906,7 +910,7 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     persistence, messageBus,
     taskRepository,
     maxConcurrency: effectiveMaxConcurrency,
-    defaultAutoFixRetries: invokerConfig.autoFixRetries,
+    defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
     executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
     defaultPoolId: invokerConfig.defaultPoolId,
     availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
@@ -1186,7 +1190,7 @@ function startHeadlessMode(): void {
               messageBus,
               taskRepository: new SqliteTaskRepository(persistence),
               maxConcurrency: effectiveMaxConcurrency,
-              defaultAutoFixRetries: invokerConfig.autoFixRetries,
+              defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
               executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
               defaultPoolId: invokerConfig.defaultPoolId,
               availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
@@ -1866,7 +1870,7 @@ function startHeadlessMode(): void {
           ),
           autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
           persistence,
-          autoFixRetries: invokerConfig.autoFixRetries,
+          autoFixRetries: resolveAutoFixRetries(invokerConfig),
           canControl: () => !readOnlyMode,
         });
         workerRuntimeController.startAutoStartedWorkers();
@@ -2379,7 +2383,7 @@ function createEmbeddedTerminalBackendFromConfig(
         commandService,
         taskExecutor: requireTaskExecutor(),
         mutationTiming: activeMutationContext?.mutationTiming,
-        autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
+        autoApproveAIFixes: resolveAutoApproveAIFixes(invokerConfig),
       },
       {
         agentName,
@@ -3233,7 +3237,7 @@ function createEmbeddedTerminalBackendFromConfig(
         persistence,
         commandService,
         taskExecutor: requireTaskExecutor(),
-        autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
+        autoApproveAIFixes: resolveAutoApproveAIFixes(invokerConfig),
         killRunningTask,
       });
       apiServer = startApiServer({
@@ -3750,7 +3754,7 @@ function createEmbeddedTerminalBackendFromConfig(
         ),
         autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
         persistence,
-        autoFixRetries: invokerConfig.autoFixRetries,
+        autoFixRetries: resolveAutoFixRetries(invokerConfig),
         canControl: () => ownerMode,
       });
       workerRuntimeController.startAutoStartedWorkers();
@@ -4098,7 +4102,7 @@ function createEmbeddedTerminalBackendFromConfig(
         messageBus,
         taskRepository: new SqliteTaskRepository(persistence),
         maxConcurrency: effectiveMaxConcurrency,
-        defaultAutoFixRetries: invokerConfig.autoFixRetries,
+        defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
         executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
         defaultPoolId: invokerConfig.defaultPoolId,
         availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
@@ -4894,7 +4898,7 @@ function createEmbeddedTerminalBackendFromConfig(
           orchestrator,
           persistence,
           taskExecutor: requireTaskExecutor(),
-          autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
+          autoApproveAIFixes: resolveAutoApproveAIFixes(invokerConfig),
         }, agentName, activeMutationContext?.signal);
         await finalizeMutationWithGlobalTopup({
           orchestrator,

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -19,6 +19,7 @@ import {
   PR_CONFLICT_REBASE_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
   REQUEUE_WORKER_KIND,
+  WORKFLOW_RESUME_WORKER_KIND,
   type WorkerRegistry,
   type WorkerRuntime,
   type WorkerRuntimeDependencies,
@@ -35,6 +36,7 @@ export const AUTO_STARTED_OWNER_WORKER_KINDS = [
   AUTO_APPROVE_WORKER_KIND,
   CODERABBIT_ADDRESS_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
+  WORKFLOW_RESUME_WORKER_KIND,
 ] as const;
 
 export interface WorkerRuntimeController {

--- a/packages/execution-engine/src/__tests__/auto-fix-bare-retry.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-bare-retry.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  WorkerActionRecord,
+  WorkerActionWrite,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+import { createAutoFixAttemptLedger } from '../auto-fix-attempt-ledger.js';
+import {
+  AUTO_FIX_WORKER_KIND,
+  createAutoFixRecoveryTick,
+} from '../auto-fix-recovery.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+function makeFailedTask(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id: 'wf-1/build',
+    description: 'build',
+    status: 'failed',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: {
+      workflowId: 'wf-1',
+      command: 'pnpm build',
+      ...(config ?? {}),
+    },
+    execution: {
+      generation: 2,
+      selectedAttemptId: 'attempt-1',
+      branch: 'feature/build',
+      error: 'pnpm build failed with exit code 1',
+      ...(execution ?? {}),
+    },
+    taskStateVersion: 7,
+    ...rest,
+  } as TaskState;
+}
+
+function toRecord(write: WorkerActionWrite): WorkerActionRecord {
+  const now = '2026-01-01T00:00:00.000Z';
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? now,
+    updatedAt: write.updatedAt ?? now,
+  };
+}
+
+function makeHarness(task = makeFailedTask()) {
+  const tasks = new Map<string, TaskState>([[task.id, task]]);
+  const actions = new Map<string, WorkerActionRecord>();
+  const submit = vi.fn((_workflowId: string, _priority: WorkflowMutationPriority, _channel: string, _args: unknown[]) => 99);
+  const store = {
+    listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+    loadTasks: vi.fn((workflowId: string) => workflowId === 'wf-1' ? Array.from(tasks.values()) : []),
+    loadTask: vi.fn((taskId: string) => tasks.get(taskId)),
+    listWorkflowMutationIntents: vi.fn(() => []),
+    getWorkerAction: vi.fn((workerKind: string, externalKey: string) =>
+      actions.get(`${workerKind}:${externalKey}`)),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+      const key = `${write.workerKind}:${write.externalKey}`;
+      const existing = actions.get(key);
+      const saved = toRecord({ ...write, id: existing?.id ?? write.id, createdAt: existing?.createdAt });
+      actions.set(key, saved);
+      return saved;
+    }),
+    logEvent: vi.fn(),
+  };
+  const attemptLedger = createAutoFixAttemptLedger();
+  return { tasks, actions, store, submit, attemptLedger };
+}
+
+describe('AutoFixWorker attempt-0 bare retry', () => {
+  it('submits invoker:restart-task on the first tick and does not consume an auto-fix attempt', async () => {
+    const harness = makeHarness();
+    const tick = createAutoFixRecoveryTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 3,
+      getAutoFixAgent: () => 'codex',
+    });
+
+    await tick({ reason: 'poll' } as never);
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    const [workflowId, priority, channel, args] = harness.submit.mock.calls[0]!;
+    expect(workflowId).toBe('wf-1');
+    expect(priority).toBe('normal');
+    expect(channel).toBe('invoker:restart-task');
+    expect(args).toEqual(['wf-1/build']);
+
+    const retryRow = harness.actions.get(`${AUTO_FIX_WORKER_KIND}:${AUTO_FIX_WORKER_KIND}:retry:wf-1/build:2:attempt-1`);
+    expect(retryRow).toBeDefined();
+    expect(retryRow?.actionType).toBe('auto-retry');
+    expect(retryRow?.attemptCount).toBe(1);
+    expect(retryRow?.status).toBe('queued');
+  });
+
+  it('escalates to invoker:fix-with-agent on the next tick once the bare retry row exists', async () => {
+    const harness = makeHarness();
+    const tick = createAutoFixRecoveryTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 3,
+      getAutoFixAgent: () => 'codex',
+    });
+
+    await tick({ reason: 'poll' } as never);
+    harness.submit.mockClear();
+    await tick({ reason: 'poll' } as never);
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    const channel = harness.submit.mock.calls[0]?.[2];
+    expect(channel).toBe('invoker:fix-with-agent');
+
+    const fixRow = harness.actions.get(`${AUTO_FIX_WORKER_KIND}:${AUTO_FIX_WORKER_KIND}:wf-1/build:2:attempt-1`);
+    expect(fixRow?.actionType).toBe('auto-fix');
+    expect(fixRow?.status).toBe('queued');
+  });
+
+  it('does not submit twice for the same task within a single tick', async () => {
+    const task = makeFailedTask();
+    const secondTask = makeFailedTask({ id: 'wf-1/build' });
+    const harness = makeHarness(task);
+    harness.tasks.set('wf-1/build', secondTask);
+
+    const tick = createAutoFixRecoveryTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 3,
+    });
+
+    await tick({ reason: 'poll' } as never);
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects existing bare-retry row across ledger resets (persistence path)', async () => {
+    const harness = makeHarness();
+    const retryKey = `${AUTO_FIX_WORKER_KIND}:${AUTO_FIX_WORKER_KIND}:retry:wf-1/build:2:attempt-1`;
+    harness.actions.set(retryKey, toRecord({
+      id: retryKey,
+      workerKind: AUTO_FIX_WORKER_KIND,
+      externalKey: `${AUTO_FIX_WORKER_KIND}:retry:wf-1/build:2:attempt-1`,
+      actionType: 'auto-retry',
+      subjectType: 'task',
+      subjectId: 'wf-1/build',
+      status: 'queued',
+      attemptCount: 1,
+      workflowId: 'wf-1',
+      taskId: 'wf-1/build',
+    }));
+
+    const tick = createAutoFixRecoveryTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: createAutoFixAttemptLedger(),
+      defaultAutoFixRetries: 3,
+      getAutoFixAgent: () => 'codex',
+    });
+
+    await tick({ reason: 'poll' } as never);
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:fix-with-agent');
+  });
+
+  it('records a recovery.worker.submit audit event for the bare retry', async () => {
+    const harness = makeHarness();
+    const tick = createAutoFixRecoveryTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 3,
+    });
+
+    await tick({ reason: 'poll' } as never);
+
+    const submitCalls = harness.store.logEvent.mock.calls.filter((call) => call[1] === 'recovery.worker.submit');
+    expect(submitCalls.length).toBeGreaterThan(0);
+    const payload = submitCalls[0]?.[2] as { phase?: string; details?: { channel?: string } };
+    expect(payload.phase).toBe('worker-autofix-bare-retry-submitted');
+    expect(payload.details?.channel).toBe('invoker:restart-task');
+  });
+});

--- a/packages/execution-engine/src/__tests__/pool-member-mismatch-publish-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/pool-member-mismatch-publish-repro.test.ts
@@ -83,7 +83,7 @@ describe('publishApprovedFix pool member mismatch', () => {
         // poolMemberId NOT yet set — first run populates it
       },
     });
-    const execExecutor = runner.selectExecutor(execTask);
+    const execExecutor = runner.selectExecutor(execTask).executor;
     expect((execExecutor as any).host).toBe('alpha.example.com'); // RR cursor=0 → alpha
 
     // Step 2: Now simulate another task execution — round-rotates to beta
@@ -94,7 +94,7 @@ describe('publishApprovedFix pool member mismatch', () => {
         poolId: 'ssh-pool',
       },
     });
-    const otherExecutor = runner.selectExecutor(otherTask);
+    const otherExecutor = runner.selectExecutor(otherTask).executor;
     expect((otherExecutor as any).host).toBe('beta.example.com'); // RR cursor=1 → beta
 
     // Advance the round-robin cursor so a fresh pool selection would choose beta.
@@ -124,7 +124,7 @@ describe('publishApprovedFix pool member mismatch', () => {
     selectPoolMemberSpy.mockClear();
 
     // Call selectExecutor exactly as publishApprovedFix does.
-    const publishExecutor = runner.selectExecutor(publishTask);
+    const publishExecutor = runner.selectExecutor(publishTask).executor;
 
     expect(selectPoolMemberSpy).not.toHaveBeenCalled();
     expect((publishExecutor as any).host).toBe('alpha.example.com');

--- a/packages/execution-engine/src/__tests__/worker-decision-ledger.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-decision-ledger.test.ts
@@ -153,8 +153,30 @@ function makeAutoFixHarness(options: {
 const tickCtx = { identity: { kind: 'recovery', instanceId: 'test' }, reason: 'poll' as const, tickNumber: 1 };
 
 describe('autofix decision ledger', () => {
-  it('records a queued decision row when it submits an auto-fix', async () => {
+  it('records a queued decision row when it escalates to an auto-fix on the second tick', async () => {
     const { store, submit } = makeAutoFixHarness();
+    const upserts: WorkerActionWrite[] = [];
+    store.upsertWorkerAction = vi.fn((write: WorkerActionWrite) => {
+      upserts.push(write);
+      return {
+        ...write,
+        attemptCount: write.attemptCount ?? 0,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      } as WorkerActionRecord;
+    });
+    store.getWorkerAction = vi.fn((kind: string, externalKey: string) => {
+      if (kind !== 'autofix') return undefined;
+      if (!externalKey.startsWith('autofix:retry:')) return undefined;
+      const retryUpsert = upserts.find((w) => w.workerKind === 'autofix' && w.externalKey === externalKey);
+      if (!retryUpsert) return undefined;
+      return {
+        ...retryUpsert,
+        attemptCount: retryUpsert.attemptCount ?? 0,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      } as WorkerActionRecord;
+    });
     const tick = createAutoFixRecoveryTick({
       store,
       submitter: { submit },
@@ -165,10 +187,13 @@ describe('autofix decision ledger', () => {
     });
 
     await tick(tickCtx);
+    await tick(tickCtx);
 
-    expect(submit).toHaveBeenCalledTimes(1);
-    const write = store.upsertWorkerAction.mock.calls.at(-1)?.[0];
-    expect(write).toMatchObject({
+    expect(submit).toHaveBeenCalledTimes(2);
+    expect(submit.mock.calls[0]?.[2]).toBe('invoker:restart-task');
+    expect(submit.mock.calls[1]?.[2]).toBe('invoker:fix-with-agent');
+    const autoFixWrite = upserts.find((w) => w.actionType === 'auto-fix');
+    expect(autoFixWrite).toMatchObject({
       workerKind: 'autofix',
       actionType: 'auto-fix',
       status: 'queued',
@@ -178,7 +203,7 @@ describe('autofix decision ledger', () => {
       intentId: '42',
       agentName: 'claude',
     });
-    expect(write?.externalKey).toBe('autofix:wf-1/task-a:1:a1');
+    expect(autoFixWrite?.externalKey).toBe('autofix:wf-1/task-a:1:a1');
   });
 
   it('records a skipped decision row for a meaningful skip (budget disabled)', async () => {

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -19,6 +19,7 @@ import {
 import { PR_STATUS_WORKER_KIND } from '../workers/pr-status-worker.js';
 import { DISK_HEADROOM_WORKER_KIND } from '../workers/disk-headroom-worker.js';
 import { REQUEUE_WORKER_KIND } from '../workers/requeue-worker.js';
+import { WORKFLOW_RESUME_WORKER_KIND } from '../workers/workflow-resume-worker.js';
 
 const silentLogger = {
   debug: () => {},
@@ -67,6 +68,7 @@ describe('worker registry', () => {
     expect(registry.list().map((d) => d.kind)).toEqual([
       AUTO_FIX_WORKER_KIND,
       REQUEUE_WORKER_KIND,
+      WORKFLOW_RESUME_WORKER_KIND,
       PR_STATUS_WORKER_KIND,
       CI_FAILURE_WORKER_KIND,
       DISK_HEADROOM_WORKER_KIND,
@@ -76,6 +78,7 @@ describe('worker registry', () => {
     ]);
     expect(registry.get(AUTO_FIX_WORKER_KIND)).toBeDefined();
     expect(registry.get(REQUEUE_WORKER_KIND)).toBeDefined();
+    expect(registry.get(WORKFLOW_RESUME_WORKER_KIND)).toBeDefined();
     expect(registry.get(PR_STATUS_WORKER_KIND)).toBeDefined();
     expect(registry.get(CI_FAILURE_WORKER_KIND)).toBeDefined();
     expect(registry.get(DISK_HEADROOM_WORKER_KIND)).toBeDefined();

--- a/packages/execution-engine/src/__tests__/workflow-resume-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/workflow-resume-worker.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { WorkflowMutationIntent, WorkflowMutationPriority } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+import {
+  createWorkflowResumeCooldownLedger,
+  createWorkflowResumeTick,
+  DEFAULT_WORKFLOW_RESUME_COOLDOWN_MS,
+  WORKFLOW_RESUME_COMMAND_CHANNEL,
+} from '../workers/workflow-resume-worker.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+const POLL_CTX = {
+  identity: { kind: 'workflow-resume', instanceId: 'w1' },
+  reason: 'poll' as const,
+  tickNumber: 1,
+};
+const WAKE_CTX = {
+  identity: { kind: 'workflow-resume', instanceId: 'w1' },
+  reason: 'wake' as const,
+  tickNumber: 2,
+};
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  return {
+    id: 'wf-1/task',
+    description: 'task',
+    status: overrides.status ?? ('running' as TaskState['status']),
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: 'wf-1', ...(overrides.config ?? {}) },
+    execution: { ...(overrides.execution ?? {}) },
+    taskStateVersion: 1,
+    ...overrides,
+  } as TaskState;
+}
+
+interface HarnessOptions {
+  workflows?: Array<{ id: string; tasks: TaskState[] }>;
+  cooldownMs?: number;
+  wakeupWorkflowIds?: string[];
+}
+
+function harness(options: HarnessOptions = {}) {
+  const workflows = options.workflows ?? [];
+  const workflowIds = workflows.map((w) => ({ id: w.id }));
+  const tasksById = new Map(workflows.map((w) => [w.id, w.tasks]));
+
+  const intents: WorkflowMutationIntent[] = [];
+  const submit = vi.fn(
+    (workflowId: string, priority: WorkflowMutationPriority, channel: string, args: unknown[]) => {
+      const id = intents.length + 1;
+      intents.push({
+        id,
+        workflowId,
+        priority,
+        channel,
+        args,
+        status: 'queued',
+        createdAt: new Date().toISOString(),
+      });
+      return id;
+    },
+  );
+  const logEvent = vi.fn();
+  const store = {
+    listWorkflows: () => workflowIds,
+    loadTasks: (workflowId: string) => tasksById.get(workflowId) ?? [],
+    logEvent,
+  };
+
+  let now = 0;
+  const ledger = createWorkflowResumeCooldownLedger();
+  const tick = createWorkflowResumeTick({
+    store,
+    submitter: { submit },
+    logger,
+    ledger,
+    cooldownMs: options.cooldownMs ?? DEFAULT_WORKFLOW_RESUME_COOLDOWN_MS,
+    now: () => now,
+    drainWakeupHints: () => (options.wakeupWorkflowIds ?? []).map((workflowId) => ({
+      workflowId,
+      reason: 'workflow_status_changed' as const,
+    })),
+  });
+
+  return {
+    submit,
+    logEvent,
+    intents,
+    tick,
+    setNow: (t: number) => {
+      now = t;
+    },
+  };
+}
+
+describe('workflow resume worker tick', () => {
+  it('submits a retry for a workflow that has any non-terminal task', async () => {
+    const h = harness({
+      workflows: [
+        {
+          id: 'wf-1',
+          tasks: [makeTask({ status: 'running' as TaskState['status'] })],
+        },
+      ],
+    });
+    await h.tick(POLL_CTX);
+    expect(h.submit).toHaveBeenCalledTimes(1);
+    const [workflowId, priority, channel, args] = h.submit.mock.calls[0];
+    expect(workflowId).toBe('wf-1');
+    expect(priority).toBe('normal');
+    expect(channel).toBe(WORKFLOW_RESUME_COMMAND_CHANNEL);
+    expect(args).toEqual(['wf-1']);
+  });
+
+  it('skips workflows whose tasks are all terminal', async () => {
+    const h = harness({
+      workflows: [
+        {
+          id: 'wf-done',
+          tasks: [
+            makeTask({ id: 'wf-done/a', status: 'completed' as TaskState['status'] }),
+            makeTask({ id: 'wf-done/b', status: 'review_ready' as TaskState['status'] }),
+          ],
+        },
+        {
+          id: 'wf-empty',
+          tasks: [],
+        },
+      ],
+    });
+    await h.tick(POLL_CTX);
+    expect(h.submit).not.toHaveBeenCalled();
+  });
+
+  it('honors the cooldown window and re-submits after it expires', async () => {
+    const h = harness({
+      cooldownMs: 60_000,
+      workflows: [
+        {
+          id: 'wf-1',
+          tasks: [makeTask({ status: 'failed' as TaskState['status'] })],
+        },
+      ],
+    });
+    await h.tick(POLL_CTX);
+    expect(h.submit).toHaveBeenCalledTimes(1);
+
+    h.setNow(30_000);
+    await h.tick(POLL_CTX);
+    expect(h.submit).toHaveBeenCalledTimes(1);
+
+    h.setNow(60_000);
+    await h.tick(POLL_CTX);
+    expect(h.submit).toHaveBeenCalledTimes(2);
+  });
+
+  it('on a wake event, only checks the hinted workflowIds and skips others', async () => {
+    const h = harness({
+      wakeupWorkflowIds: ['wf-target'],
+      workflows: [
+        {
+          id: 'wf-target',
+          tasks: [makeTask({ id: 'wf-target/a', status: 'failed' as TaskState['status'] })],
+        },
+        {
+          id: 'wf-other',
+          tasks: [makeTask({ id: 'wf-other/a', status: 'failed' as TaskState['status'] })],
+        },
+      ],
+    });
+    await h.tick(WAKE_CTX);
+    expect(h.submit).toHaveBeenCalledTimes(1);
+    const [workflowId] = h.submit.mock.calls[0];
+    expect(workflowId).toBe('wf-target');
+  });
+
+  it('deduplicates within a single tick when the wake hint list has duplicates', async () => {
+    const h = harness({
+      wakeupWorkflowIds: ['wf-1', 'wf-1', 'wf-1'],
+      workflows: [
+        {
+          id: 'wf-1',
+          tasks: [makeTask({ status: 'failed' as TaskState['status'] })],
+        },
+      ],
+    });
+    await h.tick(WAKE_CTX);
+    expect(h.submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs a recovery.worker.submit event with the workflow id and intent id', async () => {
+    const h = harness({
+      workflows: [
+        {
+          id: 'wf-1',
+          tasks: [makeTask({ status: 'failed' as TaskState['status'] })],
+        },
+      ],
+    });
+    await h.tick(POLL_CTX);
+    expect(h.logEvent).toHaveBeenCalledWith(
+      'wf-1',
+      'recovery.worker.submit',
+      expect.objectContaining({
+        worker: 'workflow-resume',
+        phase: 'retry-workflow',
+        workflowId: 'wf-1',
+        channel: WORKFLOW_RESUME_COMMAND_CHANNEL,
+        intentId: expect.any(Number),
+      }),
+    );
+  });
+
+  it('does not submit for a workflow that only appears in wake hints and has all terminal tasks', async () => {
+    const h = harness({
+      wakeupWorkflowIds: ['wf-1'],
+      workflows: [
+        {
+          id: 'wf-1',
+          tasks: [makeTask({ status: 'completed' as TaskState['status'] })],
+        },
+      ],
+    });
+    await h.tick(WAKE_CTX);
+    expect(h.submit).not.toHaveBeenCalled();
+  });
+});
+
+describe('createWorkflowResumeCooldownLedger', () => {
+  it('allows the first submit at any time', () => {
+    const ledger = createWorkflowResumeCooldownLedger();
+    expect(ledger.shouldSubmit('wf-1', 0)).toBe(true);
+    expect(ledger.shouldSubmit('wf-1', 100_000)).toBe(true);
+  });
+
+  it('blocks a second submit until the eligible-at moment passes', () => {
+    const ledger = createWorkflowResumeCooldownLedger();
+    ledger.markSubmitted('wf-1', 60_000);
+    expect(ledger.shouldSubmit('wf-1', 0)).toBe(false);
+    expect(ledger.shouldSubmit('wf-1', 30_000)).toBe(false);
+    expect(ledger.shouldSubmit('wf-1', 59_999)).toBe(false);
+    expect(ledger.shouldSubmit('wf-1', 60_000)).toBe(true);
+    expect(ledger.shouldSubmit('wf-1', 120_000)).toBe(true);
+  });
+
+  it('tracks workflows independently', () => {
+    const ledger = createWorkflowResumeCooldownLedger();
+    ledger.markSubmitted('wf-1', 60_000);
+    expect(ledger.shouldSubmit('wf-1', 0)).toBe(false);
+    expect(ledger.shouldSubmit('wf-2', 0)).toBe(true);
+  });
+});

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -37,10 +37,13 @@ export const RECOVERY_WORKER_KIND = 'recovery';
 
 const DEFAULT_RECOVERY_POLL_INTERVAL_MS = 60_000;
 const AUTO_FIX_COMMAND_CHANNEL = 'invoker:fix-with-agent';
+const AUTO_FIX_BARE_RETRY_CHANNEL = 'invoker:restart-task';
 const AUTO_FIX_ACTION_TYPE = 'auto-fix';
+const AUTO_FIX_BARE_RETRY_ACTION_TYPE = 'auto-retry';
 
 const AUTO_FIX_WORKER_AUDIT_EVENTS: Record<string, { eventType: string; action: 'submit' | 'skip' }> = {
   'worker-autofix-submitted': { eventType: 'recovery.worker.submit', action: 'submit' },
+  'worker-autofix-bare-retry-submitted': { eventType: 'recovery.worker.submit', action: 'submit' },
   'worker-autofix-skip': { eventType: 'recovery.worker.skip', action: 'skip' },
 };
 
@@ -61,7 +64,7 @@ export interface AutoFixRecoverySubmitter {
   submit(
     workflowId: string,
     priority: WorkflowMutationPriority,
-    channel: typeof AUTO_FIX_COMMAND_CHANNEL,
+    channel: typeof AUTO_FIX_COMMAND_CHANNEL | typeof AUTO_FIX_BARE_RETRY_CHANNEL,
     args: unknown[],
     options?: { deferDrain?: boolean },
   ): number;
@@ -266,6 +269,14 @@ function logAutoFixWorkerEvent(
   });
 }
 
+function autoFixDecisionExternalKey(candidate: AutoFixRecoveryCandidate): string {
+  return `${AUTO_FIX_WORKER_KIND}:${candidate.taskId}:${candidate.generation}:${candidate.attemptId ?? ''}`;
+}
+
+function autoFixBareRetryExternalKey(candidate: AutoFixRecoveryCandidate): string {
+  return `${AUTO_FIX_WORKER_KIND}:retry:${candidate.taskId}:${candidate.generation}:${candidate.attemptId ?? ''}`;
+}
+
 function recordAutoFixDecisionRow(
   options: AutoFixRecoveryPolicyOptions,
   candidate: AutoFixRecoveryCandidate,
@@ -282,7 +293,7 @@ function recordAutoFixDecisionRow(
   recordWorkerDecisionRow(options.store, {
     workerKind: AUTO_FIX_WORKER_KIND,
     actionType: AUTO_FIX_ACTION_TYPE,
-    externalKey: `${AUTO_FIX_WORKER_KIND}:${candidate.taskId}:${candidate.generation}:${candidate.attemptId ?? ''}`,
+    externalKey: autoFixDecisionExternalKey(candidate),
     subjectType: 'task',
     subjectId: candidate.taskId,
     workflowId: candidate.workflowId,
@@ -301,6 +312,50 @@ function recordAutoFixDecisionRow(
       ...fields.extraPayload,
     },
   });
+}
+
+function recordAutoFixBareRetryRow(
+  options: AutoFixRecoveryPolicyOptions,
+  candidate: AutoFixRecoveryCandidate,
+  fields: {
+    status: WorkerActionStatus;
+    summary: string;
+    intentId?: number;
+    extraPayload?: Record<string, unknown>;
+  },
+): void {
+  recordWorkerDecisionRow(options.store, {
+    workerKind: AUTO_FIX_WORKER_KIND,
+    actionType: AUTO_FIX_BARE_RETRY_ACTION_TYPE,
+    externalKey: autoFixBareRetryExternalKey(candidate),
+    subjectType: 'task',
+    subjectId: candidate.taskId,
+    workflowId: candidate.workflowId,
+    taskId: candidate.taskId,
+    status: fields.status,
+    summary: fields.summary,
+    intentId: fields.intentId,
+    incrementAttempt: true,
+    payload: {
+      source: candidate.source,
+      generation: candidate.generation,
+      attemptId: candidate.attemptId ?? null,
+      taskStateVersion: candidate.taskStateVersion,
+      ...fields.extraPayload,
+    },
+  });
+}
+
+function hasBareRetryAlreadySubmitted(
+  options: AutoFixRecoveryPolicyOptions,
+  candidate: AutoFixRecoveryCandidate,
+): boolean {
+  const existing = options.store.getWorkerAction?.(
+    AUTO_FIX_WORKER_KIND,
+    autoFixBareRetryExternalKey(candidate),
+  );
+  if (!existing) return false;
+  return existing.attemptCount > 0;
 }
 
 function skipAutoFixCandidate(
@@ -438,6 +493,34 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
         skipAutoFixCandidate(options, candidate, 'duplicate-candidate');
         continue;
       }
+
+      if (!hasBareRetryAlreadySubmitted(options, candidate)) {
+        const intentId = options.submitter.submit(
+          candidate.workflowId,
+          'normal',
+          AUTO_FIX_BARE_RETRY_CHANNEL,
+          [candidate.taskId],
+        );
+        submittedThisTick.add(candidate.taskId);
+        logAutoFixWorkerEvent(options, candidate.taskId, 'worker-autofix-bare-retry-submitted', {
+          workflowId: candidate.workflowId,
+          intentId,
+          channel: AUTO_FIX_BARE_RETRY_CHANNEL,
+          generation: candidate.generation,
+          taskStateVersion: candidate.taskStateVersion,
+          attemptId: candidate.attemptId ?? null,
+        });
+        recordAutoFixBareRetryRow(options, candidate, {
+          status: 'queued',
+          summary: 'Queued bare retry-task before consuming auto-fix attempts',
+          intentId,
+          extraPayload: {
+            channel: AUTO_FIX_BARE_RETRY_CHANNEL,
+          },
+        });
+        continue;
+      }
+
       const retryBudget = retryBudgetForTask(candidate.task, options);
       const attemptDecision = options.attemptLedger.consume(
         autoFixAttemptLedgerKeyFromTask(candidate.task),

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -7,6 +7,7 @@ import { registerDiskHeadroomWorker } from './workers/disk-headroom-worker.js';
 import { registerPrMaintenanceWorkers } from './workers/pr-maintenance-workers.js';
 import { registerPrStatusWorker } from './workers/pr-status-worker.js';
 import { registerRequeueWorker } from './workers/requeue-worker.js';
+import { registerWorkflowResumeWorker } from './workers/workflow-resume-worker.js';
 
 /** Register every built-in worker in the stable built-in order. */
 export function registerBuiltinWorkers(
@@ -14,6 +15,7 @@ export function registerBuiltinWorkers(
 ): WorkerRegistry<WorkerRuntimeDependencies> {
   registerAutoFixWorker(registry);
   registerRequeueWorker(registry);
+  registerWorkflowResumeWorker(registry);
   registerPrStatusWorker(registry);
   registerCiFailureWorker(registry);
   registerDiskHeadroomWorker(registry);

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -59,6 +59,7 @@ export * from './workers/disk-headroom-monitor.js';
 export * from './workers/disk-headroom.js';
 export * from './workers/pr-maintenance-workers.js';
 export * from './workers/requeue-worker.js';
+export * from './workers/workflow-resume-worker.js';
 export * from './requeue-attempt-ledger.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-attempt-ledger.js';

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -16,13 +16,18 @@ import type { PrMaintenanceWorkerConfig } from './workers/pr-maintenance-workers
 import type { DiskHeadroomWorkerConfig } from './workers/disk-headroom-worker.js';
 import type { PrStatusReviewGate } from './workers/pr-status-worker.js';
 import type { RequeueWorkerConfig, RequeueWorkerSubmitter } from './workers/requeue-worker.js';
+import type {
+  WorkflowResumeWorkerConfig,
+  WorkflowResumeWorkerStore,
+  WorkflowResumeWorkerSubmitter,
+} from './workers/workflow-resume-worker.js';
 
 /** Dependencies injected into a built-in worker factory when its runtime is built. */
 export interface WorkerRuntimeDependencies {
   /** Persisted workflow/task state accessor. */
-  store: AutoFixRecoveryStore & CiFailureWorkerStore & AutoApproveWorkerStore;
+  store: AutoFixRecoveryStore & CiFailureWorkerStore & AutoApproveWorkerStore & WorkflowResumeWorkerStore;
   /** Action-output channel used to submit follow-up mutation intents. */
-  submitter: AutoFixRecoverySubmitter & CiFailureWorkerSubmitter & RequeueWorkerSubmitter & AutoApproveWorkerSubmitter;
+  submitter: AutoFixRecoverySubmitter & CiFailureWorkerSubmitter & RequeueWorkerSubmitter & AutoApproveWorkerSubmitter & WorkflowResumeWorkerSubmitter;
   /** Operator logger. */
   logger: Logger;
   /** Optional bus that turns lifecycle events into immediate wakeups. */
@@ -39,4 +44,6 @@ export interface WorkerRuntimeDependencies {
   diskHeadroom?: DiskHeadroomWorkerConfig;
   /** Auto-approval tuning for worker-owned AI fix approvals. */
   autoApprove?: AutoApproveWorkerConfig;
+  /** Workflow-resume worker tuning (cooldown and poll cadence). */
+  workflowResume?: WorkflowResumeWorkerConfig;
 }

--- a/packages/execution-engine/src/workers/workflow-resume-worker.ts
+++ b/packages/execution-engine/src/workers/workflow-resume-worker.ts
@@ -1,0 +1,239 @@
+import type { Logger } from '@invoker/contracts';
+import type { WorkflowMutationPriority } from '@invoker/data-store';
+import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
+import type { TaskState } from '@invoker/workflow-core';
+
+import type { WorkflowLifecycleEvent, RecoveryWorkerWakeupHint } from '../lifecycle-events.js';
+import {
+  createWorkerRuntime,
+  type WorkerRuntime,
+  type WorkerTick,
+} from '../worker-runtime.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+
+export const WORKFLOW_RESUME_WORKER_KIND = 'workflow-resume';
+
+export const WORKFLOW_RESUME_COMMAND_CHANNEL = 'invoker:retry-workflow';
+
+const DEFAULT_WORKFLOW_RESUME_POLL_INTERVAL_MS = 60_000;
+export const DEFAULT_WORKFLOW_RESUME_COOLDOWN_MS = 60_000;
+
+const TERMINAL_TASK_STATUSES: ReadonlySet<TaskState['status']> = new Set<TaskState['status']>([
+  'completed' as TaskState['status'],
+  'review_ready' as TaskState['status'],
+]);
+
+export interface WorkflowResumeWorkerStore {
+  listWorkflows(): ReadonlyArray<{ id: string }>;
+  loadTasks(workflowId: string): TaskState[];
+  logEvent?(entityId: string, eventType: string, payload?: unknown): void;
+}
+
+export interface WorkflowResumeWorkerSubmitter {
+  submit(
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: typeof WORKFLOW_RESUME_COMMAND_CHANNEL,
+    args: unknown[],
+    options?: { deferDrain?: boolean },
+  ): number;
+}
+
+export interface WorkflowResumeWorkerConfig {
+  cooldownMs?: number;
+  pollIntervalMs?: number;
+  enabled?: boolean;
+}
+
+export interface WorkflowResumeCooldownLedger {
+  shouldSubmit(workflowId: string, nowMs: number): boolean;
+  markSubmitted(workflowId: string, nowMs: number): void;
+}
+
+export interface WorkflowResumeWorkerPolicyOptions {
+  store: WorkflowResumeWorkerStore;
+  submitter: WorkflowResumeWorkerSubmitter;
+  logger: Logger;
+  ledger: WorkflowResumeCooldownLedger;
+  cooldownMs?: number;
+  now?: () => number;
+  drainWakeupHints?: () => RecoveryWorkerWakeupHint[];
+}
+
+export function createWorkflowResumeCooldownLedger(): WorkflowResumeCooldownLedger {
+  const nextEligibleAtMs = new Map<string, number>();
+  return {
+    shouldSubmit(workflowId, nowMs) {
+      const eligibleAt = nextEligibleAtMs.get(workflowId);
+      return eligibleAt === undefined ? true : nowMs >= eligibleAt;
+    },
+    markSubmitted(workflowId, eligibleAtMs) {
+      nextEligibleAtMs.set(workflowId, eligibleAtMs);
+    },
+  };
+}
+
+function isWorkflowIncomplete(store: WorkflowResumeWorkerStore, workflowId: string): boolean {
+  const tasks = store.loadTasks(workflowId);
+  if (tasks.length === 0) return false;
+  for (const task of tasks) {
+    if (!TERMINAL_TASK_STATUSES.has(task.status)) return true;
+  }
+  return false;
+}
+
+function collectWakeupWorkflowIds(hints: RecoveryWorkerWakeupHint[]): string[] {
+  const seen = new Set<string>();
+  for (const hint of hints) {
+    const workflowId = hint?.workflowId?.trim();
+    if (workflowId) seen.add(workflowId);
+  }
+  return Array.from(seen);
+}
+
+function listAllIncompleteWorkflowIds(store: WorkflowResumeWorkerStore): string[] {
+  const targets: string[] = [];
+  for (const workflow of store.listWorkflows()) {
+    if (isWorkflowIncomplete(store, workflow.id)) {
+      targets.push(workflow.id);
+    }
+  }
+  return targets;
+}
+
+export function createWorkflowResumeTick(options: WorkflowResumeWorkerPolicyOptions): WorkerTick {
+  const cooldownMs = options.cooldownMs ?? DEFAULT_WORKFLOW_RESUME_COOLDOWN_MS;
+
+  return async (ctx) => {
+    const nowMs = options.now?.() ?? Date.now();
+    const wakeups = options.drainWakeupHints?.() ?? [];
+    const wakeupWorkflowIds = collectWakeupWorkflowIds(wakeups);
+
+    const candidateIds = wakeupWorkflowIds.length > 0 && ctx.reason === 'wake'
+      ? wakeupWorkflowIds.filter((id) => isWorkflowIncomplete(options.store, id))
+      : listAllIncompleteWorkflowIds(options.store);
+
+    const submitted = new Set<string>();
+    for (const workflowId of candidateIds) {
+      if (submitted.has(workflowId)) continue;
+      if (!options.ledger.shouldSubmit(workflowId, nowMs)) {
+        options.logger.debug?.(`[worker:${WORKFLOW_RESUME_WORKER_KIND}] cooldown-skip`, {
+          module: 'workflow-resume-worker',
+          workflowId,
+          cooldownMs,
+        });
+        continue;
+      }
+      submitted.add(workflowId);
+
+      const intentId = options.submitter.submit(
+        workflowId,
+        'normal',
+        WORKFLOW_RESUME_COMMAND_CHANNEL,
+        [workflowId],
+      );
+      options.ledger.markSubmitted(workflowId, nowMs + cooldownMs);
+      options.store.logEvent?.(workflowId, 'recovery.worker.submit', {
+        worker: WORKFLOW_RESUME_WORKER_KIND,
+        phase: 'retry-workflow',
+        workflowId,
+        intentId,
+        channel: WORKFLOW_RESUME_COMMAND_CHANNEL,
+      });
+      options.logger.info(`[worker:${WORKFLOW_RESUME_WORKER_KIND}] submitted retry for incomplete workflow`, {
+        module: 'workflow-resume-worker',
+        workflowId,
+        intentId,
+      });
+    }
+  };
+}
+
+export interface WorkflowResumeWorkerOptions {
+  logger: Logger;
+  instanceId?: string;
+  intervalMs?: number;
+  installSignalHandlers?: boolean;
+  tickOnStart?: boolean;
+  messageBus?: MessageBus;
+  workflowResume?: Omit<WorkflowResumeWorkerPolicyOptions, 'logger' | 'drainWakeupHints' | 'ledger'> & {
+    readonly ledger?: WorkflowResumeCooldownLedger;
+  };
+  onTick?: WorkerTick;
+}
+
+export function createWorkflowResumeWorker(options: WorkflowResumeWorkerOptions): WorkerRuntime {
+  const pendingWakeups: RecoveryWorkerWakeupHint[] = [];
+  let lifecycleUnsubscribe: Unsubscribe | undefined;
+  const onTick = options.onTick ?? (
+    options.workflowResume
+      ? createWorkflowResumeTick({
+        ...options.workflowResume,
+        ledger: options.workflowResume.ledger ?? createWorkflowResumeCooldownLedger(),
+        logger: options.logger,
+        drainWakeupHints: () => pendingWakeups.splice(0),
+      })
+      : (() => {})
+  );
+  const runtime = createWorkerRuntime({
+    kind: WORKFLOW_RESUME_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_WORKFLOW_RESUME_POLL_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick,
+  });
+  if (!options.messageBus || !options.workflowResume || options.onTick) {
+    return runtime;
+  }
+
+  const start = (): void => {
+    if (!lifecycleUnsubscribe) {
+      lifecycleUnsubscribe = options.messageBus?.subscribe<WorkflowLifecycleEvent>(
+        Channels.WORKFLOW_LIFECYCLE,
+        (event) => {
+          pendingWakeups.push(event.recoveryWakeup);
+          runtime.wake('wake');
+        },
+      );
+    }
+    runtime.start();
+  };
+  const stop = async (): Promise<void> => {
+    lifecycleUnsubscribe?.();
+    lifecycleUnsubscribe = undefined;
+    await runtime.stop();
+  };
+
+  return {
+    identity: runtime.identity,
+    start,
+    wake: runtime.wake,
+    tick: runtime.tick,
+    stop,
+    isRunning: runtime.isRunning,
+  };
+}
+
+export function registerWorkflowResumeWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: WORKFLOW_RESUME_WORKER_KIND,
+    note: 'Submits retry-workflow intents for workflows that have any non-terminal task.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createWorkflowResumeWorker({
+        logger: deps.logger,
+        messageBus: deps.messageBus,
+        intervalMs: deps.workflowResume?.pollIntervalMs,
+        workflowResume: {
+          store: deps.store,
+          submitter: deps.submitter,
+          cooldownMs: deps.workflowResume?.cooldownMs,
+        },
+      }),
+  });
+  return registry;
+}


### PR DESCRIPTION
Review Claim: AutoFixWorker submits a bare invoker:restart-task once per
(taskId, generation, attemptId) triple before falling back to
invoker:fix-with-agent, so the free rerun the external retry loop performs
at attempt 0 happens in-app without user-visible autofix escalation.

Review Lane: recovery workers

Review Unit: routing

Safety Invariant: The bare retry is gated on a persisted WorkerActionRecord
(externalKey prefix "autofix:retry:") so a restart or a stale in-memory
attempt-ledger cannot re-submit it, and it does not consume the auto-fix
attempt budget so a bare-retry followed by two fix attempts still fits in
the default autoFixRetries=3 budget.

Slice Rationale: The retry-task and fix-with-agent flows share the same
candidate discovery, snapshot validation, and dedupe logic. Splitting the
new channel into a separate worker would duplicate all of that code and
create two rows per task attempt to reconcile. Keeping both submissions in
the AutoFixWorker's single tick is the smallest change that ports the
loop's retry-failed bucket.

Non-goals: No changes to fix-with-agent semantics, no changes to
autoFixRetries budget, no new IPC channel (uses existing
invoker:restart-task which the CLI already routes to
commandService.retryTask).

Test Plan: pnpm --filter @invoker/execution-engine exec vitest run
src/__tests__/auto-fix-bare-retry.test.ts (5 new tests: bare-retry
submission, escalation on the second tick, single-submit dedupe within a
tick, persisted-row skip across ledger resets, audit event contents) and
src/__tests__/worker-decision-ledger.test.ts src/__tests__/worker-registry.test.ts
(updated for the new two-tick escalation and workflow-resume kind).

Revert Plan: git revert this commit. The AutoFixWorker returns to
submitting fix-with-agent on the first tick; the bare-retry rows persist
but stop being read, so nothing else has to be rolled back.

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #3631