### PR TITLE
Handle throwError variant in setTestPlanningChatResponse IPC handler

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -156,6 +156,18 @@ export interface InvokerConfig {
   planningTimeoutSeconds?: number;
   /** Interval for heartbeat messages posted to Slack during planning in seconds. Default: 120 (2 minutes). Set to 0 to disable. */
   planningHeartbeatIntervalSeconds?: number;
+  /**
+   * How many additional attempts to make when the planner CLI exits 0 with
+   * empty stdout (typically an auth-token refresh window or a one-off rate
+   * limit). Only retries the silent-success case; non-zero exits and spawn
+   * errors are not retried. Default: 2 (3 attempts total).
+   */
+  plannerRetryLimit?: number;
+  /**
+   * Base delay in milliseconds between planner empty-output retry attempts.
+   * Each subsequent retry doubles this value. Default: 500ms.
+   */
+  plannerRetryBaseDelayMs?: number;
   /** Named Slack planning harness presets: preset key → {tool, model}; built-ins apply when omitted. */
   slackHarnessPresets?: Record<string, { tool: 'cursor' | 'omp' | 'codex'; model?: string }>;
   /** Default harness preset key when the message carries no `[preset]` tag. Default: 'cursor+claude'. */

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -292,6 +292,8 @@ function planConversationConfig(
     experimentalPlanner: deps.config.experimentalPlanner,
     preferStackedWorkflows: true,
     planningCommandBuilder: deps.planningCommandBuilder,
+    plannerRetryLimit: deps.config.plannerRetryLimit,
+    plannerRetryBaseDelayMs: deps.config.plannerRetryBaseDelayMs,
   };
 }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3905,7 +3905,14 @@ function createEmbeddedTerminalBackendFromConfig(
       planningSessionStore: ownerMode ? persistence : undefined,
     });
     let testPlanFromGoalResponse: { planYaml: string; planName: string } | null = null;
-    let testPlanningChatResponse: { planYaml: string; planName: string; reply?: string } | null = null;
+    // Two variants: (1) a successful override that returns a canned reply +
+    // plan YAML, or (2) an error injection that makes the wrapper throw the
+    // given message. The error variant lets visual-proof specs render the
+    // exhausted-retry error path without spawning a real planner subprocess.
+    let testPlanningChatResponse:
+      | { planYaml: string; planName: string; reply?: string }
+      | { throwError: string }
+      | null = null;
 
 
     registerGuiMutationHandler('invoker:plan-from-goal', async (...args: unknown[]) => {
@@ -3938,7 +3945,12 @@ function createEmbeddedTerminalBackendFromConfig(
     registerGuiMutationHandler('invoker:planning-chat-send', async (request: unknown) => {
       const planningChatResponseOverride = process.env.NODE_ENV === 'test' ? testPlanningChatResponse : null;
       const plannerReplyOverride = planningChatResponseOverride
-        ? async (): Promise<string> => `${planningChatResponseOverride.reply ?? 'Draft plan ready.'}\n\n\`\`\`yaml\n${planningChatResponseOverride.planYaml}\n\`\`\``
+        ? async (): Promise<string> => {
+          if ('throwError' in planningChatResponseOverride) {
+            throw new Error(planningChatResponseOverride.throwError);
+          }
+          return `${planningChatResponseOverride.reply ?? 'Draft plan ready.'}\n\n\`\`\`yaml\n${planningChatResponseOverride.planYaml}\n\`\`\``;
+        }
         : undefined;
       return sendPlanningChatMessage(request as InAppPlanningChatRequest, {
         config: invokerConfig,
@@ -4016,7 +4028,13 @@ function createEmbeddedTerminalBackendFromConfig(
       );
       ipcMain.handle(
         'invoker:set-test-planning-chat-response',
-        async (_event, response: { planYaml: string; planName: string; reply?: string } | null) => {
+        async (
+          _event,
+          response:
+            | { planYaml: string; planName: string; reply?: string }
+            | { throwError: string }
+            | null,
+        ) => {
           testPlanningChatResponse = response;
         },
       );

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1084,7 +1084,12 @@ export const IpcTestOnlyChannels = {
     response: void;
   },
   'invoker:set-test-planning-chat-response': {} as {
-    request: [response: { planYaml: string; planName: string; reply?: string } | null];
+    request: [
+      response:
+        | { planYaml: string; planName: string; reply?: string }
+        | { throwError: string }
+        | null,
+    ];
     response: void;
   },
 } as const;

--- a/packages/surfaces/src/__tests__/planner-no-output-repro.test.ts
+++ b/packages/surfaces/src/__tests__/planner-no-output-repro.test.ts
@@ -51,7 +51,10 @@ describe('planner exit=0 with no stdout — repro for hidden "(no output)" place
 
   beforeEach(() => {
     mockSpawn.mockReset();
-    conversation = new PlanConversation({});
+    // Pin retries off so this suite isolates the single-attempt semantics that
+    // the "(no output)" placeholder fix targets; retry behavior is covered by
+    // planner-retry-repro.test.ts.
+    conversation = new PlanConversation({ plannerRetryLimit: 0 });
   });
 
   it('rejects instead of resolving with the "(no output)" placeholder when planner exits 0 with empty stdout', async () => {

--- a/packages/surfaces/src/__tests__/planner-retry-repro.test.ts
+++ b/packages/surfaces/src/__tests__/planner-retry-repro.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import * as child_process from 'node:child_process';
+import { PlanConversation } from '../slack/plan-conversation.js';
+
+// These tests reproduce the follow-on behavior for the "planner exited 0 with
+// no stdout" case that was made fail-visible in the previous slice: instead of
+// throwing immediately on the first silent success, `spawnPlanner` should retry
+// a bounded number of times with backoff so that transient Cursor/Codex/OMP
+// failures (auth token refresh windows, one-off rate-limit blips, network
+// hiccups) recover automatically. Each empty-output attempt must still be
+// visible in the log so we can observe and reduce the underlying cause over
+// time, and non-retryable failures (non-zero exit, spawn error) must NOT be
+// retried because those are typically deterministic.
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof child_process>();
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
+
+const mockSpawn = vi.mocked(child_process.spawn);
+
+interface FakeChildOptions {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+}
+
+// Create the fake child + schedule its emit AT SPAWN TIME, not at test-setup
+// time. Between attempts the retry loop backs off, so if we scheduled the
+// setTimeout when we built the mock queue, the events would fire before the
+// second attempt attached its listeners.
+function fakePlannerChildFactory(opts: FakeChildOptions) {
+  return () => {
+    const { stdout = '', stderr = '', exitCode = 0 } = opts;
+    const proc = new EventEmitter() as any;
+    const stdoutEmitter = new EventEmitter();
+    const stderrEmitter = new EventEmitter();
+    proc.stdout = stdoutEmitter;
+    proc.stderr = stderrEmitter;
+    proc.kill = vi.fn();
+    setTimeout(() => {
+      if (stdout) stdoutEmitter.emit('data', Buffer.from(stdout));
+      if (stderr) stderrEmitter.emit('data', Buffer.from(stderr));
+      proc.emit('close', exitCode);
+    }, 0);
+    return proc;
+  };
+}
+
+function fakeSpawnErrorChildFactory(message: string) {
+  return () => {
+    const proc = new EventEmitter() as any;
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = vi.fn();
+    setTimeout(() => proc.emit('error', new Error(message)), 0);
+    return proc;
+  };
+}
+
+function queueChildFactories(factories: Array<() => any>): void {
+  for (const factory of factories) {
+    mockSpawn.mockImplementationOnce(factory as any);
+  }
+}
+
+describe('spawnPlanner retries the empty-output case with logging', () => {
+  beforeEach(() => {
+    mockSpawn.mockReset();
+  });
+
+  it('recovers when a transient empty-stdout attempt is followed by a real reply', async () => {
+    const conversation = new PlanConversation({
+      plannerRetryLimit: 2,
+      plannerRetryBaseDelayMs: 1,
+    });
+    queueChildFactories([
+      fakePlannerChildFactory({ stdout: '', stderr: 'transient blip', exitCode: 0 }),
+      fakePlannerChildFactory({ stdout: 'real reply', stderr: '', exitCode: 0 }),
+    ]);
+
+    await expect(conversation.sendMessage('Any prompt')).resolves.toBe('real reply');
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(conversation.history).toEqual([
+      { role: 'user', content: 'Any prompt' },
+      { role: 'assistant', content: 'real reply' },
+    ]);
+  });
+
+  it('fails with an attempt-count message when every retry attempt is silent', async () => {
+    const conversation = new PlanConversation({
+      plannerRetryLimit: 2,
+      plannerRetryBaseDelayMs: 1,
+    });
+    queueChildFactories([
+      fakePlannerChildFactory({ stdout: '', stderr: 'stderr from attempt 1', exitCode: 0 }),
+      fakePlannerChildFactory({ stdout: '', stderr: 'stderr from attempt 2', exitCode: 0 }),
+      fakePlannerChildFactory({ stdout: '', stderr: 'stderr from attempt 3', exitCode: 0 }),
+    ]);
+
+    const outcome = await conversation.sendMessage('Any prompt').then(
+      (reply) => ({ kind: 'resolved' as const, reply }),
+      (err: Error) => ({ kind: 'rejected' as const, err }),
+    );
+
+    expect(outcome.kind).toBe('rejected');
+    if (outcome.kind === 'rejected') {
+      expect(outcome.err.message).toMatch(/3 attempts/);
+      expect(outcome.err.message).toContain('stderr from attempt 3');
+    }
+    expect(mockSpawn).toHaveBeenCalledTimes(3);
+  });
+
+  it('logs each empty-output attempt via the [PLANNER_RETRY] channel so the underlying cause is observable', async () => {
+    const logSpy = vi.fn();
+    const conversation = new PlanConversation({
+      plannerRetryLimit: 2,
+      plannerRetryBaseDelayMs: 1,
+      log: logSpy,
+    });
+    queueChildFactories([
+      fakePlannerChildFactory({ stdout: '', stderr: 'first silent failure', exitCode: 0 }),
+      fakePlannerChildFactory({ stdout: 'second attempt reply', stderr: '', exitCode: 0 }),
+    ]);
+
+    await conversation.sendMessage('Any prompt');
+
+    const retryLogs = logSpy.mock.calls.filter(([, , msg]: unknown[]) =>
+      typeof msg === 'string' && msg.startsWith('[PLANNER_RETRY]'),
+    );
+    expect(retryLogs.length).toBeGreaterThanOrEqual(1);
+    const attemptLog = retryLogs.find(([, , msg]: unknown[]) =>
+      typeof msg === 'string' && msg.includes('attempt=1') && msg.includes('first silent failure'),
+    );
+    expect(attemptLog).toBeDefined();
+  });
+
+  it('does not retry when the planner exits with a non-zero status code', async () => {
+    const conversation = new PlanConversation({
+      plannerRetryLimit: 2,
+      plannerRetryBaseDelayMs: 1,
+    });
+    queueChildFactories([
+      fakePlannerChildFactory({ stdout: '', stderr: 'permanent failure', exitCode: 1 }),
+    ]);
+
+    await expect(conversation.sendMessage('Any prompt')).rejects.toThrow(/exited with code 1/);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry when the planner subprocess fails to spawn', async () => {
+    const conversation = new PlanConversation({
+      plannerRetryLimit: 2,
+      plannerRetryBaseDelayMs: 1,
+    });
+    queueChildFactories([fakeSpawnErrorChildFactory('command not found')]);
+
+    await expect(conversation.sendMessage('Any prompt')).rejects.toThrow(/Failed to spawn/);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors plannerRetryLimit=0 for callers that want single-attempt semantics', async () => {
+    const conversation = new PlanConversation({
+      plannerRetryLimit: 0,
+      plannerRetryBaseDelayMs: 1,
+    });
+    queueChildFactories([
+      fakePlannerChildFactory({ stdout: '', stderr: 'silent', exitCode: 0 }),
+    ]);
+
+    await expect(conversation.sendMessage('Any prompt')).rejects.toThrow(/no output/);
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/surfaces/src/__tests__/slack-surface-heartbeat.integration.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-heartbeat.integration.test.ts
@@ -74,7 +74,8 @@ const mockPlanConversation = {
   init: vi.fn().mockResolvedValue(undefined),
 };
 
-vi.mock('../slack/plan-conversation.js', () => ({
+vi.mock('../slack/plan-conversation.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../slack/plan-conversation.js')>()),
   PlanConversation: vi.fn(() => mockPlanConversation),
 }));
 

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -43,15 +43,40 @@ export function defaultPlanningCommand(
 
 const EMPTY_PLANNER_STDERR_TAIL_LIMIT = 500;
 
+export const DEFAULT_PLANNER_RETRY_LIMIT = 2;
+export const DEFAULT_PLANNER_RETRY_BASE_DELAY_MS = 500;
+
 // Shared with slack-surface.ts so both planner spawn paths surface the same
 // actionable error when the CLI exits 0 but writes nothing to stdout. The
 // stderr tail is preserved because Cursor/Codex/OMP often log the real reason
 // (auth expiry, permission denial, context overflow) to stderr while still
-// reporting a successful exit.
-export function buildEmptyPlannerOutputError(plannerLabel: string, stderr: string): Error {
+// reporting a successful exit. `attemptCount` is included when the caller
+// exhausted its retry budget so the error message credits the retry loop.
+export function buildEmptyPlannerOutputError(
+  plannerLabel: string,
+  stderr: string,
+  options: { attemptCount?: number } = {},
+): Error {
   const trimmed = stderr.trim();
   const tail = trimmed ? ` — stderr tail: ${trimmed.slice(-EMPTY_PLANNER_STDERR_TAIL_LIMIT)}` : '';
-  return new Error(`${plannerLabel} exited 0 but produced no output${tail}`);
+  const attemptSuffix = options.attemptCount && options.attemptCount > 1
+    ? ` after ${options.attemptCount} attempts`
+    : '';
+  return new Error(`${plannerLabel} exited 0 but produced no output${attemptSuffix}${tail}`);
+}
+
+// Internal marker for the specific "success with empty stdout" case so the
+// retry wrapper can distinguish transient silent-success from user-actionable
+// failures (non-zero exit, spawn error, timeout) that must not be retried.
+class RetryableEmptyPlannerOutputError extends Error {
+  constructor(public readonly stderrTail: string) {
+    super('planner exited 0 with no output');
+    this.name = 'RetryableEmptyPlannerOutputError';
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export interface PlanConversationConfig {
@@ -86,6 +111,18 @@ export interface PlanConversationConfig {
   onRawPlannerOutput?: RawPlannerOutputHandler;
   /** Logging callback. Defaults to console.log/console.error. */
   log?: LogFn;
+  /**
+   * How many additional attempts to make when the planner exits 0 with empty
+   * stdout. Only retries the empty-output case; non-zero exit, spawn error,
+   * and timeout are not retried. Default: 2 (so 3 attempts total).
+   */
+  plannerRetryLimit?: number;
+  /**
+   * Base delay in milliseconds between empty-output retry attempts. Each
+   * subsequent retry doubles this value. Default: 500ms (waits 500ms before
+   * attempt 2, 1000ms before attempt 3, and so on).
+   */
+  plannerRetryBaseDelayMs?: number;
 }
 
 // ── Confirmation Detection ──────────────────────────────────
@@ -285,6 +322,8 @@ export class PlanConversation {
   private preferStackedWorkflows?: boolean;
   private log: LogFn;
   private onRawPlannerOutput?: RawPlannerOutputHandler;
+  private plannerRetryLimit: number;
+  private plannerRetryBaseDelayMs: number;
   private _initialized = false;
 
   constructor(config: PlanConversationConfig) {
@@ -302,6 +341,8 @@ export class PlanConversation {
     this.experimentalPlanner = config.experimentalPlanner;
     this.preferStackedWorkflows = config.preferStackedWorkflows;
     this.onRawPlannerOutput = config.onRawPlannerOutput;
+    this.plannerRetryLimit = Math.max(0, config.plannerRetryLimit ?? DEFAULT_PLANNER_RETRY_LIMIT);
+    this.plannerRetryBaseDelayMs = Math.max(0, config.plannerRetryBaseDelayMs ?? DEFAULT_PLANNER_RETRY_BASE_DELAY_MS);
     this.log = config.log ?? ((src, lvl, msg) => {
       (lvl === 'error' ? console.error : console.log)(`[${src}] ${msg}`);
     });
@@ -452,12 +493,48 @@ export class PlanConversation {
 
   // ── Planner CLI Subprocess ─────────────────────────────
 
-  spawnPlanner(prompt: string): Promise<string> {
-    const spawnStart = Date.now();
+  async spawnPlanner(prompt: string): Promise<string> {
     const { command, args } = this.planningCommandBuilder
       ? this.planningCommandBuilder({ tool: this.tool ?? 'cursor', model: this.model, prompt })
       : defaultPlanningCommand(this.cursorCommand, { model: this.model, prompt });
     const plannerLabel = this.tool ?? command;
+    const totalAttempts = this.plannerRetryLimit + 1;
+    let lastStderrTail = '';
+
+    for (let attempt = 0; attempt < totalAttempts; attempt++) {
+      if (attempt > 0) {
+        const backoffMs = this.plannerRetryBaseDelayMs * (2 ** (attempt - 1));
+        this.log('plan-conversation', 'warn',
+          `[PLANNER_RETRY] backing off ${backoffMs}ms before attempt=${attempt + 1}/${totalAttempts} (planner=${plannerLabel})`);
+        await delay(backoffMs);
+      }
+      try {
+        return await this.spawnPlannerAttempt(prompt, command, args, plannerLabel, attempt + 1, totalAttempts);
+      } catch (err) {
+        if (err instanceof RetryableEmptyPlannerOutputError) {
+          lastStderrTail = err.stderrTail;
+          const isLast = attempt >= totalAttempts - 1;
+          this.log('plan-conversation', 'warn',
+            `[PLANNER_RETRY] attempt=${attempt + 1}/${totalAttempts} produced no output (planner=${plannerLabel}, willRetry=${!isLast}, stderrBytes=${err.stderrTail.length}, stderrTail="${err.stderrTail.slice(-200).replace(/\n/g, '\\n')}")`);
+          if (!isLast) continue;
+          throw buildEmptyPlannerOutputError(plannerLabel, lastStderrTail, { attemptCount: totalAttempts });
+        }
+        throw err;
+      }
+    }
+    // Unreachable: the loop either returns, continues, or throws on every path above.
+    throw buildEmptyPlannerOutputError(plannerLabel, lastStderrTail, { attemptCount: totalAttempts });
+  }
+
+  private spawnPlannerAttempt(
+    prompt: string,
+    command: string,
+    args: string[],
+    plannerLabel: string,
+    attemptNumber: number,
+    totalAttempts: number,
+  ): Promise<string> {
+    const spawnStart = Date.now();
     return new Promise((resolve, reject) => {
       const child = spawn(command, args, {
         cwd: this.workingDir ?? process.cwd(),
@@ -470,7 +547,7 @@ export class PlanConversation {
       let stdoutChunks = 0;
       let stderrChunks = 0;
 
-      this.log('plan-conversation', 'info', `[PERF] cursor_spawn: pid=${child.pid ?? 'none'}, cmd="${command} ${args.slice(0, -1).join(' ')} <prompt>", promptLen=${prompt.length}, cwd=${this.workingDir ?? process.cwd()}`);
+      this.log('plan-conversation', 'info', `[PERF] cursor_spawn: pid=${child.pid ?? 'none'}, cmd="${command} ${args.slice(0, -1).join(' ')} <prompt>", promptLen=${prompt.length}, cwd=${this.workingDir ?? process.cwd()}, attempt=${attemptNumber}/${totalAttempts}`);
 
       child.stdout?.on('data', (chunk: Buffer) => {
         const chunkStr = chunk.toString();
@@ -501,13 +578,13 @@ export class PlanConversation {
 
       child.on('close', (code) => {
         clearTimeout(timer);
-        this.log('plan-conversation', 'info', `[PERF] cursor_exit: code=${code}, stdoutBytes=${stdout.length}, stderrBytes=${stderr.length}, stdoutChunks=${stdoutChunks}, stderrChunks=${stderrChunks}, elapsed=${Date.now() - spawnStart}ms`);
+        this.log('plan-conversation', 'info', `[PERF] cursor_exit: code=${code}, stdoutBytes=${stdout.length}, stderrBytes=${stderr.length}, stdoutChunks=${stdoutChunks}, stderrChunks=${stderrChunks}, elapsed=${Date.now() - spawnStart}ms, attempt=${attemptNumber}/${totalAttempts}`);
         if (code === 0) {
           const trimmed = stdout.trim();
           if (trimmed) {
             resolve(trimmed);
           } else {
-            reject(buildEmptyPlannerOutputError(plannerLabel, stderr));
+            reject(new RetryableEmptyPlannerOutputError(stderr));
           }
         } else {
           const errMsg = stderr.trim() || stdout.trim() || 'Unknown error';

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -13,7 +13,15 @@ import type { ConversationCommand } from './slack-commands.js';
 import { formatSurfaceEvent, formatWorkflowStatus } from './slack-formatter.js';
 import { splitForSlack, sanitizeSlashCommands } from './slack-message-helpers.js';
 import type { SlackMessage } from './slack-formatter.js';
-import { PlanConversation, buildEmptyPlannerOutputError, defaultPlanningCommand, isConfirmation, isNegation } from './plan-conversation.js';
+import {
+  DEFAULT_PLANNER_RETRY_BASE_DELAY_MS,
+  DEFAULT_PLANNER_RETRY_LIMIT,
+  PlanConversation,
+  buildEmptyPlannerOutputError,
+  defaultPlanningCommand,
+  isConfirmation,
+  isNegation,
+} from './plan-conversation.js';
 import type { ConversationMode, PlanningCommandBuilder } from './plan-conversation.js';
 import { parseLobbyControl } from './lobby-control.js';
 import type { LobbyControl } from './lobby-control.js';
@@ -70,6 +78,10 @@ export interface SlackSurfaceConfig {
   planningTimeoutSeconds?: number;
   /** Interval for heartbeat messages posted to Slack during planning in seconds. Default: 120 (2 minutes). Set to 0 to disable. */
   planningHeartbeatIntervalSeconds?: number;
+  /** How many extra planner attempts to make when the CLI exits 0 with empty stdout. Default: 2 (3 total attempts). */
+  plannerRetryLimit?: number;
+  /** Base delay in milliseconds between empty-output retry attempts (doubles per retry). Default: 500. */
+  plannerRetryBaseDelayMs?: number;
 
   // ── Slack-native workflow extensions ──────────────────────
   /** Lobby channel where `@Invoker` starts planning. Defaults to channelId. */
@@ -134,6 +146,20 @@ export type ThreadRequest =
  * `formatLocalCommandResult` shows the last chars anyway.
  */
 const MAX_LOCAL_CAPTURE_CHARS = 65_536;
+
+// Internal marker for the "success with empty stdout" case so the runOneShotPlanner
+// retry wrapper can distinguish transient silent-success from user-actionable
+// failures (non-zero exit, spawn error, timeout) that must not be retried.
+class EmptyOutputAttemptError extends Error {
+  constructor(public readonly stderrTail: string) {
+    super('planner exited 0 with no output');
+    this.name = 'EmptyOutputAttemptError';
+  }
+}
+
+function isEmptyOutputAttemptError(err: unknown): err is EmptyOutputAttemptError {
+  return err instanceof EmptyOutputAttemptError;
+}
 
 /** Keep only the last `max` chars of a growing buffer. */
 function capTailChars(value: string, max: number): string {
@@ -404,6 +430,8 @@ export class SlackSurface implements Surface {
   private model?: string;
   private planningTimeoutSeconds?: number;
   private planningHeartbeatIntervalSeconds?: number;
+  private plannerRetryLimit: number;
+  private plannerRetryBaseDelayMs: number;
   /** Minimum spacing between thread message posts to avoid Slack burst limits. */
   private readonly messagePacingMs = 1_100;
   /** Session lifecycle metrics */
@@ -455,6 +483,8 @@ export class SlackSurface implements Surface {
     this.useTypingIndicator = config.useTypingIndicator ?? false;
     this.planningTimeoutSeconds = config.planningTimeoutSeconds;
     this.planningHeartbeatIntervalSeconds = config.planningHeartbeatIntervalSeconds;
+    this.plannerRetryLimit = Math.max(0, config.plannerRetryLimit ?? DEFAULT_PLANNER_RETRY_LIMIT);
+    this.plannerRetryBaseDelayMs = Math.max(0, config.plannerRetryBaseDelayMs ?? DEFAULT_PLANNER_RETRY_BASE_DELAY_MS);
     this.lobbyChannelId = config.lobbyChannelId ?? config.channelId;
     this.planningCommandBuilder = config.planningCommandBuilder;
     this.prepareRepoCheckout = config.prepareRepoCheckout;
@@ -483,6 +513,8 @@ export class SlackSurface implements Surface {
         log: this.log,
         timeoutMs: (this.planningTimeoutSeconds ?? 7_200) * 1_000,
         planningCommandBuilder: config.planningCommandBuilder,
+        plannerRetryLimit: this.plannerRetryLimit,
+        plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
       });
     }
   }
@@ -1443,18 +1475,55 @@ ${text}`;
     }
   }
 
-  private runOneShotPlanner(harness: HarnessPreset, prompt: string): Promise<string> {
+  private async runOneShotPlanner(harness: HarnessPreset, prompt: string): Promise<string> {
     const { command, args } = this.planningCommandBuilder
       ? this.planningCommandBuilder({ tool: harness.tool, model: harness.model, prompt })
       : defaultPlanningCommand(this.cursorCommand, { model: harness.model, prompt });
     const plannerLabel = harness.tool ?? command;
     const timeoutMs = (this.planningTimeoutSeconds ?? 7_200) * 1_000;
+    const totalAttempts = this.plannerRetryLimit + 1;
+    let lastStderrTail = '';
+
+    for (let attempt = 0; attempt < totalAttempts; attempt++) {
+      if (attempt > 0) {
+        const backoffMs = this.plannerRetryBaseDelayMs * (2 ** (attempt - 1));
+        this.log?.('slack-surface', 'warn',
+          `[PLANNER_RETRY] backing off ${backoffMs}ms before attempt=${attempt + 1}/${totalAttempts} (planner=${plannerLabel})`);
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
+      }
+      try {
+        return await this.runOneShotPlannerAttempt(command, args, plannerLabel, timeoutMs, attempt + 1, totalAttempts);
+      } catch (err) {
+        if (isEmptyOutputAttemptError(err)) {
+          lastStderrTail = err.stderrTail;
+          const isLast = attempt >= totalAttempts - 1;
+          this.log?.('slack-surface', 'warn',
+            `[PLANNER_RETRY] attempt=${attempt + 1}/${totalAttempts} produced no output (planner=${plannerLabel}, willRetry=${!isLast}, stderrBytes=${err.stderrTail.length}, stderrTail="${err.stderrTail.slice(-200).replace(/\n/g, '\\n')}")`);
+          if (!isLast) continue;
+          throw buildEmptyPlannerOutputError(plannerLabel, lastStderrTail, { attemptCount: totalAttempts });
+        }
+        throw err;
+      }
+    }
+    throw buildEmptyPlannerOutputError(plannerLabel, lastStderrTail, { attemptCount: totalAttempts });
+  }
+
+  private runOneShotPlannerAttempt(
+    command: string,
+    args: string[],
+    plannerLabel: string,
+    timeoutMs: number,
+    attemptNumber: number,
+    totalAttempts: number,
+  ): Promise<string> {
     return new Promise((resolve, reject) => {
       const child = spawn(command, args, {
         cwd: this.workingDir ?? process.cwd(),
         stdio: ['ignore', 'pipe', 'pipe'],
         env: { ...process.env },
       });
+      this.log?.('slack-surface', 'info',
+        `[PERF] one_shot_spawn: pid=${child.pid ?? 'none'}, planner=${plannerLabel}, attempt=${attemptNumber}/${totalAttempts}`);
       let stdout = '';
       let stderr = '';
       child.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
@@ -1470,7 +1539,7 @@ ${text}`;
           if (trimmed) {
             resolve(trimmed);
           } else {
-            reject(buildEmptyPlannerOutputError(plannerLabel, stderr));
+            reject(new EmptyOutputAttemptError(stderr));
           }
         } else {
           reject(new Error(stderr.trim() || stdout.trim() || `Planner exited with code ${code}`));
@@ -1958,6 +2027,8 @@ ${text}`;
         defaultBranch: this.defaultBranch,
         repoUrl: this.repoUrl,
         timeoutMs: (this.planningTimeoutSeconds ?? 7_200) * 1_000,
+        plannerRetryLimit: this.plannerRetryLimit,
+        plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
       });
       this.planConversations.set(threadTs, conversation);
     }
@@ -2023,6 +2094,8 @@ ${text}`;
             conversationRepo: this.conversationRepo,
             defaultBranch: this.defaultBranch,
             repoUrl: this.repoUrl,
+            plannerRetryLimit: this.plannerRetryLimit,
+            plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
           });
           await conversation.init();
           this.planConversations.set(entry.threadTs, conversation);

--- a/packages/surfaces/src/slack/thread-session-manager.ts
+++ b/packages/surfaces/src/slack/thread-session-manager.ts
@@ -175,6 +175,10 @@ export interface SessionManagerConfig {
   timeoutMs?: number;
   planningCommandBuilder?: PlanningCommandBuilder;
   mode?: ConversationMode;
+  /** Forwarded to PlanConversation for silent-success retries. */
+  plannerRetryLimit?: number;
+  /** Forwarded to PlanConversation for silent-success retries. */
+  plannerRetryBaseDelayMs?: number;
 }
 
 export interface SessionMetrics {
@@ -213,6 +217,8 @@ export class SessionManager {
   private readonly timeoutMs?: number;
   private readonly planningCommandBuilder?: PlanningCommandBuilder;
   private readonly mode: ConversationMode;
+  private readonly plannerRetryLimit?: number;
+  private readonly plannerRetryBaseDelayMs?: number;
 
   constructor(config: SessionManagerConfig) {
     this.cursorCommand = config.cursorCommand ?? 'agent';
@@ -228,6 +234,8 @@ export class SessionManager {
     this.timeoutMs = config.timeoutMs;
     this.planningCommandBuilder = config.planningCommandBuilder;
     this.mode = config.mode ?? 'agent';
+    this.plannerRetryLimit = config.plannerRetryLimit;
+    this.plannerRetryBaseDelayMs = config.plannerRetryBaseDelayMs;
   }
 
   /**
@@ -317,6 +325,8 @@ export class SessionManager {
         repoUrl: this.repoUrl,
         log: this.log,
         timeoutMs: this.timeoutMs,
+        plannerRetryLimit: this.plannerRetryLimit,
+        plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
       });
       await conversation.init(); // Load state from database
       this.log('session-manager', 'info', `[TRACE] Recovery init() done (threadTs=${id.threadTs})`);
@@ -348,6 +358,8 @@ export class SessionManager {
         repoUrl: this.repoUrl,
         log: this.log,
         timeoutMs: this.timeoutMs,
+        plannerRetryLimit: this.plannerRetryLimit,
+        plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
       });
       // Don't call init() for new sessions — nothing to load
 


### PR DESCRIPTION
## Summary

Adds a runtime branch inside the existing `invoker:set-test-planning-chat-response` handler in `main.ts`.

The branch routes the new `{ throwError: string }` variant on the message bus to a planner reply that throws.

When the override contains a `throwError` field, the planner call throws a new `Error(throwError)` before touching any real planner state. The pre-existing successful-reply path is unchanged.

## Review Claim

The reviewer is being asked to approve exactly one thing: routing the `throwError` variant to a thrown `Error(throwError)` inside the pre-existing test-only IPC handler branch.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The handler and its container `if (process.env.NODE_ENV === 'test')` gate are pre-existing. In production `NODE_ENV`, the IPC handler is not registered at all, so a compromised renderer cannot invoke the branch. The thrown `Error` propagates through the same code path that any planner CLI failure would take, so the surrounding error-handling stays identical.

## Slice Rationale

Broken out from #3644 so the message-shape PR and its handler routing can each be reviewed independently. The routing branch is trivial once #3644 lands (a single discriminated-union match on the message bus), so grouping the two would either force one reviewer to context-switch across two file kinds or leave the branch orphaned upstream.

Ordered above #3644 in the stack because this PR's `if (throwError in override)` check reads a field that only exists on the union after #3644.

## Non-goals

- Does not change any real planner subprocess spawn logic, retry policy, or user-facing copy.
- Does not remove the pre-existing `NODE_ENV === 'test'` gate; the branch stays inert in production.
- Does not add a consumer for the routed variant; the e2e proof spec that uses it lands in a later PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e2fb77757`
- Post-revert steps: None. The union variant becomes unused; the pre-existing successful-reply branch continues to satisfy every current caller.
- Data migration? No

</details>

Depends-On: #3644