### PR TITLE
[Terminal Double-Click Step 1 - Deduplicate DAG Dispatch](1) Route DAG double-clicks through React Flow

### DIFF
--- a/packages/ui/src/__tests__/task-dag-interaction.test.ts
+++ b/packages/ui/src/__tests__/task-dag-interaction.test.ts
@@ -1,40 +1,84 @@
-import { describe, it, expect, vi } from 'vitest';
+import { createElement } from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TaskDAG } from '../components/TaskDAG.js';
+import { makeUITask } from './helpers/mock-invoker.js';
 
-// Test the callback behavior by simulating what ReactFlow's onNodeDoubleClick does
-describe('TaskDAG double-click', () => {
-  it('onNodeDoubleClick resolves task from map and calls handler', () => {
-    const mockTask = {
-      id: 'task-1',
-      description: 'Test task',
-      status: 'running' as const,
-      dependencies: [] as string[],
-      createdAt: new Date(),
-      config: {},
-      execution: {},
-    };
-    const tasks = new Map([['task-1', mockTask]]);
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+type TaskDAGProps = Parameters<typeof TaskDAG>[0];
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderOneTaskDag(props: Partial<Omit<TaskDAGProps, 'tasks'>> = {}) {
+  const task = makeUITask({
+    id: 'task-1',
+    description: 'Test task',
+    status: 'running',
+  });
+  const tasks = new Map([[task.id, task]]);
+
+  render(createElement(TaskDAG, { tasks, ...props }));
+
+  return { task };
+}
+
+async function findRenderedTaskCard(taskId: string): Promise<HTMLElement> {
+  const node = await screen.findByTestId(`rf__node-${taskId}`);
+  return node.firstElementChild instanceof HTMLElement ? node.firstElementChild : node;
+}
+
+function dispatchUserDoubleClick(target: HTMLElement) {
+  fireEvent.click(target);
+  fireEvent.click(target);
+  fireEvent.doubleClick(target);
+}
+
+describe('TaskDAG interactions', () => {
+  it('dispatches exactly one double-click callback per user double-click', async () => {
+    const onTaskClick = vi.fn();
     const onTaskDoubleClick = vi.fn();
+    const { task } = renderOneTaskDag({ onTaskClick, onTaskDoubleClick });
+    const taskCard = await findRenderedTaskCard(task.id);
 
-    // Simulate the callback logic from TaskDAGInner
-    const nodeId = 'task-1';
-    const task = tasks.get(nodeId);
-    if (task && onTaskDoubleClick) {
-      onTaskDoubleClick(task);
-    }
+    dispatchUserDoubleClick(taskCard);
 
-    expect(onTaskDoubleClick).toHaveBeenCalledWith(mockTask);
+    expect(onTaskDoubleClick).toHaveBeenCalledTimes(1);
+    expect(onTaskDoubleClick).toHaveBeenCalledWith(task);
+    expect(onTaskClick).toHaveBeenCalledTimes(2);
+    expect(onTaskClick).toHaveBeenNthCalledWith(1, task);
+    expect(onTaskClick).toHaveBeenNthCalledWith(2, task);
   });
 
-  it('onNodeDoubleClick does nothing when task not found', () => {
-    const tasks = new Map<string, any>();
+  it('preserves single-click selection without double-click dispatch', async () => {
+    const onTaskClick = vi.fn();
     const onTaskDoubleClick = vi.fn();
+    const { task } = renderOneTaskDag({ onTaskClick, onTaskDoubleClick });
+    const taskCard = await findRenderedTaskCard(task.id);
 
-    const nodeId = 'nonexistent';
-    const task = tasks.get(nodeId);
-    if (task && onTaskDoubleClick) {
-      onTaskDoubleClick(task);
-    }
+    fireEvent.click(taskCard);
 
+    expect(onTaskClick).toHaveBeenCalledTimes(1);
+    expect(onTaskClick).toHaveBeenCalledWith(task);
     expect(onTaskDoubleClick).not.toHaveBeenCalled();
+  });
+
+  it('preserves task context menu dispatch and default prevention', async () => {
+    const onTaskContextMenu = vi.fn();
+    const { task } = renderOneTaskDag({ onTaskContextMenu });
+    const taskCard = await findRenderedTaskCard(task.id);
+    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+
+    const wasNotPrevented = fireEvent(taskCard, event);
+
+    expect(wasNotPrevented).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+    expect(onTaskContextMenu).toHaveBeenCalledTimes(1);
+    expect(onTaskContextMenu.mock.calls[0][0]).toBe(task);
   });
 });

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -157,7 +157,6 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
   const { fitView, setCenter, getZoom } = useReactFlow();
   const graphRootRef = useRef<HTMLDivElement>(null);
   const prevNodeCount = useRef(0);
-  const lastNodeClickRef = useRef<{ id: string; at: number } | null>(null);
   const reportedGraphVisibleRef = useRef(false);
   const watchdogMissCountRef = useRef(0);
   const watchdogRecoveryAttemptedRef = useRef(false);
@@ -333,7 +332,6 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
             dimmed,
             selected: selectedTaskId === task.id,
             runningLike,
-            ...(onTaskDoubleClick ? { onDoubleClick: onTaskDoubleClick } : {}),
           },
         });
       }
@@ -415,7 +413,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
     });
 
     return { nodes: allNodes, edges: newEdges };
-  }, [activeLayout.positions, onTaskDoubleClick, rawGraph, routedEdgePoints, runningTaskIds, selectedTaskId, statusFilters, tasks, workflows]);
+  }, [activeLayout.positions, rawGraph, routedEdgePoints, runningTaskIds, selectedTaskId, statusFilters, tasks, workflows]);
 
   // Merge task-derived nodes with React Flow's internal dimension state.
   // Without this, each task-delta re-render creates new node objects that discard
@@ -599,18 +597,8 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
       if (task && onTaskClick) {
         onTaskClick(task);
       }
-      if (task && onTaskDoubleClick) {
-        const now = Date.now();
-        const lastClick = lastNodeClickRef.current;
-        if (lastClick?.id === node.id && now - lastClick.at <= 500) {
-          lastNodeClickRef.current = null;
-          onTaskDoubleClick(task);
-        } else {
-          lastNodeClickRef.current = { id: node.id, at: now };
-        }
-      }
     },
-    [tasks, onTaskClick, onTaskDoubleClick],
+    [tasks, onTaskClick],
   );
 
   const onNodeDoubleClick = useCallback(


### PR DESCRIPTION
## Summary

Task DAG double-click handling now lets React Flow be the single source for terminal-open dispatch.

The click handler keeps selection behavior only, so one physical double-click sends one terminal-open intent.

## Review Claim

Task DAG task cards send exactly one terminal-open intent for one user double-click while preserving single-click selection.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice is limited to the Task DAG interaction surface and its focused regression coverage.

## Slice Rationale

The event dispatch correction belongs with the component-level regression that exercises the actual rendered task card.

## Non-goals

- Do not change terminal startup, task execution, graph layout, or DAG data construction.
- Do not alter context menu behavior beyond keeping the existing dispatch covered.

## Architecture

### Before

```mermaid
graph TD
    A["User double-clicks a task card"] --> B["Node click handler observes two clicks"]
    A --> C["React Flow double-click handler fires"]
    B --> D["Terminal-open callback"]
    C --> D
```

### After

```mermaid
graph TD
    A["User double-clicks a task card"] --> B["Node click handler keeps selection only"]
    A --> C["React Flow double-click handler fires"]
    C --> D["Terminal-open callback"]
```

## Visual Proof

![Task DAG loaded with task cards visible for the double-click interaction surface](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-d8e2ed/dag-loaded.png)

The changed behavior is event-count based, so the focused component regression is the inspectable proof for the callback count.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/task-dag-interaction.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/terminal-dblclick-pr.md --require-visual-proof --changed-files-file /tmp/terminal-dblclick-files.txt --diff-file /tmp/terminal-dblclick.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 35c52d1bd`
- Post-revert steps: Re-run the focused Task DAG interaction regression.
- Data migration? No

</details>
