### PR TITLE
[PR maintenance workers Step 6: Add local headless query workers support](1) Add worker fleet snapshot text formatter

### DIFF
--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -6,7 +6,7 @@
 
 import type { TaskState, TaskStatus } from '@invoker/workflow-core';
 import type { TaskEvent, WorkerActionRecord, Workflow } from '@invoker/data-store';
-import type { NormalizedCostEvent, CostRollup, WorkerActionSummary } from '@invoker/contracts';
+import type { NormalizedCostEvent, CostRollup, WorkerActionSummary, WorkerStatusSnapshot } from '@invoker/contracts';
 import type { GroupedCostRollup } from './cost-rollup.js';
 
 // ── ANSI Color Codes ─────────────────────────────────────────
@@ -260,6 +260,38 @@ export function formatWorkerDecisions(actions: WorkerActionSummary[]): string {
     lines.push(
       `  ${BOLD}${decision}${RESET} ${BOLD}${id}${RESET} [${action.status}] ${workerKind}/${actionType}` +
         `${workflow}${subject}${attempts}${agent}${reason}${summary}`,
+    );
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Format the worker fleet snapshot as a human-readable roster: one line per
+ * worker with its lifecycle, policy, and auto-start posture. Mirrors the
+ * structured shape returned by `--output json`.
+ */
+export function formatWorkerStatus(snapshot: WorkerStatusSnapshot): string {
+  if (snapshot.workers.length === 0) {
+    return `${DIM}No workers registered.${RESET}`;
+  }
+
+  const lifecycleColor = (lifecycle: string): string => {
+    switch (lifecycle) {
+      case 'running': return GREEN;
+      case 'exited': return RED;
+      default: return YELLOW;
+    }
+  };
+
+  const lines: string[] = [];
+  lines.push(`${BOLD}Workers (${snapshot.workers.length})${RESET}`);
+  for (const worker of snapshot.workers) {
+    const kind = escapeTerminalText(worker.kind);
+    const color = lifecycleColor(worker.lifecycle);
+    const autoStarts = worker.autoStarts ? ' auto-start' : '';
+    const note = worker.note ? ` — ${escapeTerminalText(worker.note)}` : '';
+    lines.push(
+      `  ${color}●${RESET} ${BOLD}${kind}${RESET} [${worker.lifecycle}] policy=${worker.policy}${autoStarts}${note}`,
     );
   }
   return lines.join('\n');


### PR DESCRIPTION
## Summary

Add a `formatWorkerStatus` helper that renders a worker fleet snapshot as human-readable text.

Each worker becomes one colored line showing its lifecycle, policy, and auto-start posture.

Nothing calls the helper yet. A later slice wires it into the owner-host worker readout.

## Review Claim

Add a dormant text formatter for the worker fleet snapshot.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The helper is pure and unreferenced, so it cannot change any existing behavior or output.

## Slice Rationale

The formatter lands before its caller so each diff carries a single review unit and a reviewer can check the rendering logic on its own.

## Non-goals

Does not wire the helper into the query router, does not add a new sub-command, and does not touch existing formatters.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types` — exit 0 on the whole workspace and on the slice-1-only tree.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
