### PR TITLE
[PR maintenance workers Step 6: Add local headless query workers support](2) Add local headless query workers support

### DIFF
--- a/packages/app/src/__tests__/headless-query-list.test.ts
+++ b/packages/app/src/__tests__/headless-query-list.test.ts
@@ -4,6 +4,7 @@ import {
   runReadOnlyHeadlessQueryToString,
   type HeadlessQueryDeps,
 } from '../headless-query-list.js';
+import { AUTO_STARTED_OWNER_WORKER_KINDS } from '../worker-control.js';
 
 const workerActions: WorkerActionRecord[] = [
   {
@@ -145,5 +146,79 @@ describe('headless query worker-decisions', () => {
         makeDecisionDeps(),
       ),
     ).rejects.toThrow('Invalid --decision');
+  });
+});
+
+function makeWorkersDeps(): HeadlessQueryDeps {
+  return {
+    persistence: {
+      // Snapshot construction reads recent actions per worker and walks
+      // workflow events for the auto-fix recovery summary; empty results keep
+      // the fleet shape deterministic.
+      listWorkerActions: () => [],
+      listWorkflows: () => [],
+      loadTasks: () => [],
+      getEvents: () => [],
+    } as unknown as HeadlessQueryDeps['persistence'],
+    orchestrator: {} as unknown as HeadlessQueryDeps['orchestrator'],
+    executionAgentRegistry: undefined,
+    invokerConfig: {} as unknown as HeadlessQueryDeps['invokerConfig'],
+    getUiPerfStats: () => ({}),
+    resetUiPerfStats: () => {},
+  };
+}
+
+type WorkerSnapshotEntry = {
+  kind: string;
+  lifecycle: string;
+  policy: string;
+  autoStarts: boolean;
+  recentActions: unknown[];
+};
+
+describe('headless query workers', () => {
+  it('returns the worker fleet snapshot as JSON', async () => {
+    const output = await runReadOnlyHeadlessQueryToString(
+      ['query', 'workers', '--output', 'json'],
+      makeWorkersDeps(),
+    );
+    const snapshot = JSON.parse(output) as { generatedAt: string; workers: WorkerSnapshotEntry[] };
+
+    expect(typeof snapshot.generatedAt).toBe('string');
+    expect(snapshot.workers.length).toBeGreaterThan(0);
+
+    // Every auto-started owner worker must appear in the fleet and be flagged
+    // as auto-starting; the local snapshot cannot control workers, so each is
+    // reported stopped with an empty action history.
+    for (const autoKind of AUTO_STARTED_OWNER_WORKER_KINDS) {
+      const entry = snapshot.workers.find(worker => worker.kind === autoKind);
+      expect(entry, `missing worker ${autoKind}`).toBeDefined();
+      expect(entry!.autoStarts).toBe(true);
+      expect(entry!.lifecycle).toBe('stopped');
+      expect(Array.isArray(entry!.recentActions)).toBe(true);
+    }
+  });
+
+  it('lists worker kinds one per line in label output', async () => {
+    const output = await runReadOnlyHeadlessQueryToString(
+      ['query', 'workers', '--output', 'label'],
+      makeWorkersDeps(),
+    );
+    const lines = output.trim().split('\n');
+    for (const autoKind of AUTO_STARTED_OWNER_WORKER_KINDS) {
+      expect(lines).toContain(autoKind);
+    }
+  });
+
+  it('emits one worker per line in jsonl output', async () => {
+    const output = await runReadOnlyHeadlessQueryToString(
+      ['query', 'workers', '--output', 'jsonl'],
+      makeWorkersDeps(),
+    );
+    const lines = output.trim().split('\n').filter(Boolean);
+    const jsonKinds = new Set(lines.map(line => (JSON.parse(line) as WorkerSnapshotEntry).kind));
+    for (const autoKind of AUTO_STARTED_OWNER_WORKER_KINDS) {
+      expect(jsonKinds.has(autoKind)).toBe(true);
+    }
   });
 });

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -1,7 +1,8 @@
 /**
  * Headless "query" command family: the read-only `query <sub>` router
  * (workflows · tasks · task · queue · review-gate · action-graph · audit ·
- * session · worker-actions · cost · cost-events · costs · ui-perf · stats), the cost-event
+ * session · worker-actions · worker-decisions · workers · cost · cost-events · costs ·
+ * ui-perf · stats), the cost-event
  * collection/rollup
  * helpers, agent session resolution, and `query-select`.
  *
@@ -13,7 +14,8 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Attempt, TaskState } from '@invoker/workflow-core';
 import type { AgentSessionData, NormalizedCostEvent } from '@invoker/contracts';
-import type { AgentRegistry } from '@invoker/execution-engine';
+import type { AgentRegistry, WorkerRuntimeDependencies } from '@invoker/execution-engine';
+import { createWorkerRegistry, registerBuiltinWorkers } from '@invoker/execution-engine';
 import type { CostGroupDimension } from './cost-rollup.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import {
@@ -23,7 +25,12 @@ import {
   restoreWorkflowForTask,
 } from './headless-shared.js';
 import { resolveDefaultExecutionAgent } from './config.js';
-import { listWorkerDecisions } from './worker-control.js';
+import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
+import {
+  AUTO_STARTED_OWNER_WORKER_KINDS,
+  createLocalWorkerStatusSnapshot,
+  listWorkerDecisions,
+} from './worker-control.js';
 
 /**
  * The read-query family writes its formatted output through {@link writeOut}.
@@ -55,13 +62,13 @@ export type HeadlessQueryDeps = Pick<
 export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Promise<void> {
   const subCommand = args[0];
   if (!subCommand) {
-    throw new Error('Missing query sub-command. Usage: --headless query <workflows|workflow|tasks|task|queue|review-gate|action-graph|audit|session|worker-actions|worker-decisions|cost|cost-events|costs|ui-perf|stats>');
+    throw new Error('Missing query sub-command. Usage: --headless query <workflows|workflow|tasks|task|queue|review-gate|action-graph|audit|session|worker-actions|worker-decisions|workers|cost|cost-events|costs|ui-perf|stats>');
   }
   const flags = parseQueryFlags(args.slice(1));
 
   const {
     formatWorkflowList, formatTaskStatus, formatWorkflowStatus,
-    formatEventLog, formatQueueStatus, formatWorkflowStats, formatWorkerActions, formatWorkerDecisions,
+    formatEventLog, formatQueueStatus, formatWorkflowStats, formatWorkerActions, formatWorkerDecisions, formatWorkerStatus,
     serializeWorkflow, serializeTask, serializeEvent, serializeWorkerAction,
     formatAsLabel, formatAsJson, formatAsJsonl,
   } = await import('./formatter.js');
@@ -276,6 +283,27 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
       }
       break;
     }
+    case 'workers': {
+      const registry = registerExternalWorkersFromConfig(
+        deps.invokerConfig?.externalWorkers,
+        registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
+      );
+      const snapshot = createLocalWorkerStatusSnapshot({
+        registry,
+        persistence: deps.persistence,
+        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+      });
+      switch (flags.output) {
+        case 'label': writeOut(snapshot.workers.map(worker => worker.kind).join('\n') + '\n'); break;
+        case 'json':  writeOut(formatAsJson(snapshot) + '\n'); break;
+        case 'jsonl': {
+          for (const worker of snapshot.workers) writeOut(JSON.stringify(worker) + '\n');
+          break;
+        }
+        default: writeOut(formatWorkerStatus(snapshot) + '\n'); break;
+      }
+      break;
+    }
     case 'ui-perf': {
       if (flags.reset) {
         deps.resetUiPerfStats?.();
@@ -373,7 +401,7 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
       break;
     }
     default:
-      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, workflow, tasks, task, queue, review-gate, action-graph, audit, session, worker-actions, cost, cost-events, costs, ui-perf, stats`);
+      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, workflow, tasks, task, queue, review-gate, action-graph, audit, session, worker-actions, worker-decisions, workers, cost, cost-events, costs, ui-perf, stats`);
   }
 }
 


### PR DESCRIPTION
## Summary

Add local `query workers` to the headless command surface so the owner host can read its worker fleet without the desktop UI.

The command builds the worker registry, snapshots each worker, and prints the roster as text, JSON, JSONL, or bare kinds.

## Review Claim

Local `query workers` returns the worker fleet snapshot.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The new branch only reads worker state through the existing snapshot helper; it cannot start, stop, or mutate any worker.

## Slice Rationale

This slice sits on top of the formatter so the command wiring and its tests review as one activation change, separate from the rendering helper below it.

## Non-goals

Does not change delegated-owner routing, does not alter worker startup policy, and does not modify the desktop worker panel.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-query-list.test.ts` — 7 passed, covering the `workers` json/label/jsonl output.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #3686
