### PR TITLE
[Remove Running Sidebar And Workers Screen Title](1) Prepare UI assertions for sidebar chrome change

### DIFF
--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -46,7 +46,8 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Planning Terminal');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
+    const runningItem = screen.queryByTestId('sidebar-running');
+    if (runningItem) expect(runningItem).toHaveTextContent('Running');
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
   });
   it('opens worker status from the left panel', async () => {
@@ -84,7 +85,8 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Planning Terminal');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
+    const runningItem = screen.queryByTestId('sidebar-running');
+    if (runningItem) expect(runningItem).toHaveTextContent('Running');
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();
   });
@@ -133,7 +135,7 @@ describe('App launch (component)', () => {
     fireEvent.click(toggle);
     expect(sidebar.className).toContain('w-16');
 
-    for (const surface of ['workflows', 'attention', 'running', 'workers', 'planning', 'home']) {
+    for (const surface of ['workflows', 'attention', 'workers', 'planning', 'home']) {
       fireEvent.click(screen.getByTestId(`sidebar-${surface}`));
       expect(sidebar.className).toContain('w-16');
     }
@@ -141,7 +143,7 @@ describe('App launch (component)', () => {
     fireEvent.click(toggle);
     expect(sidebar.className).toContain('w-60');
 
-    for (const surface of ['workflows', 'attention', 'running', 'workers', 'planning', 'home']) {
+    for (const surface of ['workflows', 'attention', 'workers', 'planning', 'home']) {
       fireEvent.click(screen.getByTestId(`sidebar-${surface}`));
       expect(sidebar.className).toContain('w-60');
     }

--- a/packages/ui/src/__tests__/queue-view.test.tsx
+++ b/packages/ui/src/__tests__/queue-view.test.tsx
@@ -167,7 +167,6 @@ describe('QueueView', () => {
     expect(actionList.className).toContain('overflow-y-auto');
     expect(workersSection.className).toContain('overflow-hidden');
     expect(within(actionSection).getByText('Worker Actions (1)')).toBeInTheDocument();
-    expect(within(workersSection).getByText('Worker processes (1)')).toBeInTheDocument();
     expect(within(workersSection).getByTestId('worker-row-autofix')).toBeInTheDocument();
     expect(within(actionSection).queryByTestId('worker-row-autofix')).not.toBeInTheDocument();
   });
@@ -258,7 +257,6 @@ describe('QueueView', () => {
       'worker-row-coderabbit-address',
       'worker-row-pr-conflict-rebase',
     ]);
-    expect(screen.getByText('Worker processes (5)')).toBeInTheDocument();
     expect(screen.getByText('Autofix')).toBeInTheDocument();
     expect(screen.getByText('PR status')).toBeInTheDocument();
     expect(screen.getByText('CI failure repair')).toBeInTheDocument();

--- a/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
+++ b/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
@@ -38,7 +38,8 @@ describe('Visual proof snapshots', () => {
     expect(screen.getByTestId('sidebar-home')).toHaveTextContent('Invoker');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
+    const runningItem = screen.queryByTestId('sidebar-running');
+    if (runningItem) expect(runningItem).toHaveTextContent('Running');
     expect(screen.getByText('Describe the change in the terminal to generate a plan.')).toBeInTheDocument();
     expect(screen.getByTestId('rail-settings')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

This updates focused UI assertions so the stack can change decorative chrome in separate slices.

Existing checks still cover the sidebar and worker rows while tolerating either label set.

## Review Claim

Approve the assertion preparation for the upcoming sidebar chrome change.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Assertions only; rendered UI and runtime behavior are unchanged.

## Slice Rationale

This keeps proof work separate from the UI rendering diff so each PR has one review unit.

## Non-goals

- This does not change rendered sidebar items.
- This does not change worker controls.
- This does not change queue behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/app-launch.test.tsx src/__tests__/queue-view.test.tsx src/__tests__/visual-proof-snapshots.test.tsx`

</details>

## Visual Proof

This proof-only slice has no rendered UI delta. The screenshots anchor the sidebar and worker states covered by the tests.

![Home view with Needs Attention, Workers, and Workflows in the sidebar](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-915e48/running-sidebar-workers-title-home.png)

![Workers view with worker status content and no Worker processes title block](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-915e48/running-sidebar-workers-title-workers-open.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f231ce8ea`
- Post-revert steps: None
- Data migration? No

</details>
