### PR TITLE
[Remove Running Sidebar And Workers Screen Title](2) Remove running sidebar entry and workers title

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3106,7 +3106,6 @@ export function App() {
         <LeftStatusColumn
           workflows={workflows}
           tasks={tasks}
-          queueStatus={queueStatus}
           workerStatus={workerStatus}
           planningSessionCount={planningSessions.length}
           selectedSurface={sidebarSurface}
@@ -3421,4 +3420,3 @@ export function App() {
     </div>
   );
 }
-

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -1,8 +1,7 @@
-import type { QueueStatus } from '@invoker/contracts';
 import type { JSX } from 'react';
 import type { TaskState, WorkflowMeta, WorkerStatusSnapshot } from '../types.js';
 import type { SidebarSurface } from '../lib/workflow-progress-surfaces.js';
-import { getAttentionTaskEntries, getRunningTaskEntries, getSortedWorkflows } from '../lib/workflow-progress-surfaces.js';
+import { getAttentionTaskEntries, getSortedWorkflows } from '../lib/workflow-progress-surfaces.js';
 import { countActiveWorkerActions } from '../lib/worker-display.js';
 import {
   AttentionIcon,
@@ -11,7 +10,6 @@ import {
   InvokerIcon,
   MoonIcon,
   PlanningTerminalIcon,
-  RunningIcon,
   SettingsIcon,
   SunIcon,
   WorkerIcon,
@@ -22,7 +20,6 @@ import type { ThemeMode } from '../lib/theme.js';
 interface LeftStatusColumnProps {
   workflows: Map<string, WorkflowMeta>;
   tasks: Map<string, TaskState>;
-  queueStatus: QueueStatus | null;
   workerStatus: WorkerStatusSnapshot | null;
   selectedSurface: SidebarSurface;
   collapsed: boolean;
@@ -35,7 +32,7 @@ interface LeftStatusColumnProps {
 }
 
 interface SourceItem {
-  key: Exclude<SidebarSurface, 'home'>;
+  key: Exclude<SidebarSurface, 'home' | 'planning' | 'running'>;
   label: string;
   count: number;
   tone: 'neutral' | 'attention' | 'running';
@@ -68,7 +65,6 @@ function countClass(tone: SourceItem['tone']): string {
 export function LeftStatusColumn({
   workflows,
   tasks,
-  queueStatus,
   workerStatus,
   selectedSurface,
   collapsed,
@@ -81,14 +77,12 @@ export function LeftStatusColumn({
 }: LeftStatusColumnProps): JSX.Element {
   const workflowEntries = getSortedWorkflows(workflows, tasks);
   const attentionEntries = getAttentionTaskEntries(tasks, workflows);
-  const runningEntries = getRunningTaskEntries(tasks, workflows, queueStatus);
   const runningWorkers = workerStatus?.workers.filter((worker) => worker.lifecycle === 'running').length ?? 0;
   const registeredWorkers = workerStatus?.workers.length ?? 0;
   const activeWorkerActions = workerStatus ? countActiveWorkerActions(workerStatus.workers) : 0;
 
   const sources: SourceItem[] = [
     { key: 'attention', label: 'Needs Attention', count: attentionEntries.length, tone: 'attention', icon: <AttentionIcon className={ICON_CLASS} /> },
-    { key: 'running', label: 'Running', count: runningEntries.length, tone: 'running', icon: <RunningIcon className={ICON_CLASS} /> },
     { key: 'workers', label: 'Workers', count: registeredWorkers, tone: activeWorkerActions > 0 ? 'running' : 'neutral', icon: <WorkerIcon className={ICON_CLASS} /> },
     { key: 'workflows', label: 'Workflows', count: workflowEntries.length, tone: 'neutral', icon: <WorkflowsIcon className={ICON_CLASS} /> },
   ];
@@ -170,7 +164,7 @@ export function LeftStatusColumn({
 
       {!collapsed && <div className="mt-6 px-2.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/70">Library</div>}
       <nav className={collapsed ? 'mt-4 space-y-1' : 'mt-2 space-y-0.5'}>
-        {sources.map((source, index) => {
+        {sources.map((source) => {
           const selected = selectedSurface === source.key;
           return (
             <button
@@ -221,11 +215,6 @@ export function LeftStatusColumn({
             attentionEntries.length === 0
               ? 'Nothing needs a decision right now.'
               : `${attentionEntries.length} item${attentionEntries.length === 1 ? ' needs' : 's need'} attention.`
-          )}
-          {selectedSurface === 'running' && (
-            runningEntries.length === 0
-              ? 'No tasks are running right now.'
-              : `${runningEntries.length} task${runningEntries.length === 1 ? '' : 's'} active now.`
           )}
           {selectedSurface === 'workers' && (
             workerStatus === null

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -53,11 +53,6 @@ export function WorkerActivityCard({
 }: WorkerActivityCardProps) {
   return (
     <div data-testid="worker-activity-card">
-      <div className="mb-4">
-        <h3 className="text-lg font-semibold text-gray-100">Worker processes ({snapshot?.workers.length ?? 0})</h3>
-        <div className="mt-1 text-sm text-gray-400">Process status is separate from queue work. A running process can be idle.</div>
-      </div>
-
       {!snapshot ? (
         <div className="rounded border border-gray-800 bg-gray-950/60 px-3 py-2 text-sm text-gray-400">Worker status unavailable</div>
       ) : (


### PR DESCRIPTION
## Summary

The Running destination leaves the left rail.

The Workers view now starts with worker rows instead of a repeated title block.

## Review Claim

Approve the local UI chrome simplification for the sidebar and Workers surface.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Queue state and worker status data are unchanged; this only changes which labels render.

## Slice Rationale

This slice contains only rendered UI changes. The proof updates live in neighboring slices.

## Non-goals

- This does not change queue scheduling.
- This does not change worker process control.
- This does not change workflow state.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/app-launch.test.tsx src/__tests__/queue-view.test.tsx src/__tests__/visual-proof-snapshots.test.tsx`

</details>

## Visual Proof

The queue screenshot shows the left sidebar with Needs Attention, Workers, and Workflows, without a Running destination.

![Home view without a Running sidebar destination](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-fa1f42/running-sidebar-workers-title-home.png)

The Workers view starts directly with worker status content, without the Worker processes title block.

![Workers view without the Worker processes title block](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-fa1f42/running-sidebar-workers-title-workers-open.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 901a803d6`
- Post-revert steps: None
- Data migration? No

</details>
