### PR TITLE
[Remove Running Sidebar And Workers Screen Title](3) Assert running sidebar and workers title stay absent

### DIFF
--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -46,8 +46,7 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Planning Terminal');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    const runningItem = screen.queryByTestId('sidebar-running');
-    if (runningItem) expect(runningItem).toHaveTextContent('Running');
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
   });
   it('opens worker status from the left panel', async () => {
@@ -85,8 +84,7 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Planning Terminal');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    const runningItem = screen.queryByTestId('sidebar-running');
-    if (runningItem) expect(runningItem).toHaveTextContent('Running');
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();
   });

--- a/packages/ui/src/__tests__/queue-view.test.tsx
+++ b/packages/ui/src/__tests__/queue-view.test.tsx
@@ -167,6 +167,7 @@ describe('QueueView', () => {
     expect(actionList.className).toContain('overflow-y-auto');
     expect(workersSection.className).toContain('overflow-hidden');
     expect(within(actionSection).getByText('Worker Actions (1)')).toBeInTheDocument();
+    expect(within(workersSection).queryByText(/Worker processes/)).not.toBeInTheDocument();
     expect(within(workersSection).getByTestId('worker-row-autofix')).toBeInTheDocument();
     expect(within(actionSection).queryByTestId('worker-row-autofix')).not.toBeInTheDocument();
   });
@@ -257,6 +258,7 @@ describe('QueueView', () => {
       'worker-row-coderabbit-address',
       'worker-row-pr-conflict-rebase',
     ]);
+    expect(screen.queryByText(/Worker processes/)).not.toBeInTheDocument();
     expect(screen.getByText('Autofix')).toBeInTheDocument();
     expect(screen.getByText('PR status')).toBeInTheDocument();
     expect(screen.getByText('CI failure repair')).toBeInTheDocument();

--- a/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
+++ b/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
@@ -38,8 +38,7 @@ describe('Visual proof snapshots', () => {
     expect(screen.getByTestId('sidebar-home')).toHaveTextContent('Invoker');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    const runningItem = screen.queryByTestId('sidebar-running');
-    if (runningItem) expect(runningItem).toHaveTextContent('Running');
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
     expect(screen.getByText('Describe the change in the terminal to generate a plan.')).toBeInTheDocument();
     expect(screen.getByTestId('rail-settings')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

This tightens the focused UI assertions to the final sidebar and Workers labels.

The tests now fail if the Running destination or Worker processes title returns.

## Review Claim

Approve the final assertion coverage for the sidebar and Workers label contract.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Assertions only; rendered UI already changed in the previous slice.

## Slice Rationale

This proof slice lands after the UI change so the stricter assertions stay green.

## Non-goals

- This does not change rendered sidebar items.
- This does not change worker controls.
- This does not change queue behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/app-launch.test.tsx src/__tests__/queue-view.test.tsx src/__tests__/visual-proof-snapshots.test.tsx`

</details>

## Visual Proof

This proof-only slice has no rendered UI delta. The screenshots anchor the final sidebar and worker states covered by the tests.

![Home view without a Running sidebar destination](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-e39651/running-sidebar-workers-title-home.png)

![Workers view without the Worker processes title block](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-e39651/running-sidebar-workers-title-workers-open.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert eed618627`
- Post-revert steps: None
- Data migration? No

</details>
