### PR TITLE
Fix Embedded Task Terminal Blank Rendering Step 1

### DIFF
--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -11,10 +11,12 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useState } from 'react';
 import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { WorkflowMeta } from '../types.js';
 import type { TerminalSessionDescriptor } from '@invoker/contracts';
+import type { TerminalDrawerState } from '../components/TerminalDrawer.js';
 
 vi.mock('@xyflow/react', async () => {
   const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
@@ -31,11 +33,18 @@ const xtermMock = vi.hoisted(() => {
   class MockTerminal {
     cols = 80;
     rows = 24;
+    host: HTMLElement | null = null;
     dataHandler: DataHandler | null = null;
     loadAddon = vi.fn();
-    open = vi.fn();
+    open = vi.fn((host: HTMLElement) => {
+      this.host = host;
+      host.setAttribute('data-xterm-open', 'true');
+    });
     write = vi.fn((data: string) => {
       writeLog.push(data);
+      const line = document.createElement('span');
+      line.textContent = data;
+      this.host?.append(line);
     });
     onData = vi.fn((cb: DataHandler) => {
       this.dataHandler = cb;
@@ -109,6 +118,56 @@ function makeTerminalSession(
     createdAt: new Date('2025-01-01T00:00:00Z').toISOString(),
     ...overrides,
   };
+}
+
+const nextDrawerState: Record<TerminalDrawerState, TerminalDrawerState> = {
+  minimized: 'partial',
+  partial: 'maximized',
+  maximized: 'minimized',
+};
+
+function TerminalDrawerHarness({
+  initialState,
+  sessions,
+  initialActiveSessionId = sessions[0]?.sessionId ?? null,
+}: {
+  initialState: TerminalDrawerState;
+  sessions: TerminalSessionDescriptor[];
+  initialActiveSessionId?: string | null;
+}) {
+  const [state, setState] = useState<TerminalDrawerState>(initialState);
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(initialActiveSessionId);
+  const labels = new Map(sessions.map((session) => [session.taskId, `${session.taskId} label`]));
+
+  return (
+    <TerminalDrawer
+      state={state}
+      onCycle={() => setState((current) => nextDrawerState[current])}
+      sessions={sessions}
+      activeSessionId={activeSessionId}
+      onSelectSession={setActiveSessionId}
+      onCloseSession={vi.fn()}
+      taskLabels={labels}
+    />
+  );
+}
+
+function expectActivePane(taskId: string, text: string) {
+  const tab = screen.getByTestId(`terminal-tab-${taskId}`);
+  const pane = screen.getByTestId(`terminal-pane-${taskId}`);
+  expect(tab).toHaveAttribute('data-active', 'true');
+  expect(pane).toHaveStyle({ display: 'block' });
+  expect(pane).toBeVisible();
+  expect(pane).toHaveTextContent(text);
+  expect(pane).toHaveAttribute('data-xterm-open', 'true');
+}
+
+function expectInactivePane(taskId: string) {
+  const tab = screen.getByTestId(`terminal-tab-${taskId}`);
+  const pane = screen.getByTestId(`terminal-pane-${taskId}`);
+  expect(tab).toHaveAttribute('data-active', 'false');
+  expect(pane).toHaveStyle({ display: 'none' });
+  expect(pane).not.toBeVisible();
 }
 
 async function selectWorkflow(): Promise<void> {
@@ -226,6 +285,55 @@ describe('Terminal drawer (component)', () => {
     expect(screen.getByTestId('terminal-drawer')).toHaveClass('min-h-0', 'overflow-hidden');
     expect(screen.getByTestId('terminal-drawer-body')).toHaveClass('min-h-0', 'flex-1', 'overflow-hidden');
     expect(screen.getByTestId('terminal-pane-task-alpha')).toHaveClass('overflow-hidden');
+  });
+
+  it('keeps the active xterm mounted while minimized and restores it nonblank', async () => {
+    const session = makeTerminalSession('task-alpha', {
+      outputSnapshot: 'alpha persisted output\n',
+    });
+
+    render(<TerminalDrawerHarness initialState="partial" sessions={[session]} />);
+
+    await waitFor(() => expectActivePane('task-alpha', 'alpha persisted output'));
+    const mountedTerminal = xtermMock.instances[0];
+
+    fireEvent.click(screen.getByRole('button', { name: 'Maximize terminal drawer' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Minimize terminal drawer' }));
+
+    expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'minimized');
+    expect(screen.getByTestId('terminal-drawer-body')).not.toBeVisible();
+    expect(mountedTerminal.dispose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Partial terminal drawer' }));
+
+    await waitFor(() => expectActivePane('task-alpha', 'alpha persisted output'));
+    expect(xtermMock.instances).toHaveLength(1);
+    expect(mountedTerminal.open).toHaveBeenCalledTimes(1);
+    expect(mountedTerminal.dispose).not.toHaveBeenCalled();
+  });
+
+  it('shows only the newly active mounted pane when switching tabs', async () => {
+    const alpha = makeTerminalSession('task-alpha', {
+      outputSnapshot: 'alpha terminal output\n',
+    });
+    const beta = makeTerminalSession('task-beta', {
+      outputSnapshot: 'beta terminal output\n',
+    });
+
+    render(<TerminalDrawerHarness initialState="partial" sessions={[alpha, beta]} />);
+
+    await waitFor(() => expectActivePane('task-alpha', 'alpha terminal output'));
+    expectInactivePane('task-beta');
+
+    fireEvent.click(screen.getByRole('tab', { name: /task-beta label/i }));
+
+    expectInactivePane('task-alpha');
+    await waitFor(() => expectActivePane('task-beta', 'beta terminal output'));
+    expect(xtermMock.instances).toHaveLength(2);
+    expect(xtermMock.instances[0].dispose).not.toHaveBeenCalled();
+    expect(xtermMock.instances[1].dispose).not.toHaveBeenCalled();
+    expect(xtermMock.instances[1].focus).toHaveBeenCalled();
+    expect(xtermMock.fitInstances[1].fit).toHaveBeenCalled();
   });
 
   it('reuses an existing tab when opening the same task twice', async () => {

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -46,6 +46,7 @@ interface TerminalDrawerProps {
 interface TerminalSessionPaneProps {
   session: TerminalSessionDescriptor;
   isActive: boolean;
+  isDrawerVisible: boolean;
   hasHeader: boolean;
 }
 
@@ -87,7 +88,7 @@ function seedTerminalOutputSnapshot(
   }
 }
 
-function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPaneProps): JSX.Element {
+function TerminalSessionPane({ session, isActive, isDrawerVisible, hasHeader }: TerminalSessionPaneProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<XTermTerminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
@@ -182,7 +183,7 @@ function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPa
   }, [session.outputSnapshot, session.sessionId]);
 
   useEffect(() => {
-    if (!isActive) return;
+    if (!isActive || !isDrawerVisible) return;
     const term = termRef.current;
     const fit = fitRef.current;
     if (!term || !fit) return;
@@ -193,7 +194,7 @@ function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPa
     } catch {
       /* fit failed (e.g., hidden) */
     }
-  }, [isActive, session.sessionId]);
+  }, [isActive, isDrawerVisible, session.sessionId]);
 
   return (
     <div
@@ -217,6 +218,7 @@ export function TerminalDrawer({
 }: TerminalDrawerProps): JSX.Element {
   const isMaximized = state === 'maximized';
   const showBody = state !== 'minimized';
+  const mountBody = showBody || sessions.length > 0;
   const cycleLabel = NEXT_STATE_BY_STATE[state].label;
   const activeSession = sessions.find((session) => session.sessionId === activeSessionId) ?? null;
   const activeCommand = activeSession?.command
@@ -293,11 +295,16 @@ export function TerminalDrawer({
           {cycleLabel}
         </button>
       </div>
-      {showBody && (
+      {mountBody && (
         <div
           data-testid="terminal-drawer-body"
           className={isMaximized ? 'relative min-h-0 flex-1 overflow-hidden bg-black' : 'relative overflow-hidden bg-black'}
-          style={isMaximized ? undefined : { height: DRAWER_BODY_HEIGHT_PX }}
+          style={
+            showBody
+              ? isMaximized ? undefined : { height: DRAWER_BODY_HEIGHT_PX }
+              : { display: 'none', height: 0 }
+          }
+          aria-hidden={!showBody}
         >
           {sessions.length === 0 && (
             <div className="absolute inset-0 flex items-center justify-center px-3 text-xs text-gray-500">
@@ -320,6 +327,7 @@ export function TerminalDrawer({
               key={session.sessionId}
               session={session}
               isActive={session.sessionId === activeSessionId}
+              isDrawerVisible={showBody}
               hasHeader={Boolean(session.sessionId === activeSessionId && activeCommand)}
             />
           ))}


### PR DESCRIPTION
## Summary

Terminal drawer sessions now stay mounted while minimized and refit when restored or reselected.

## Review Claim

Approve that embedded terminal panes remain attached and nonblank across minimize, restore, and tab selection.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Limited to renderer terminal drawer mounting behavior and component coverage; no backend terminal IPC or task execution changes.

## Slice Rationale

Drawer visibility and active-pane fitting are one UI surface concern; keeping them together preserves the terminal mount lifecycle.

## Non-goals

- No terminal backend or PTY changes.
- No workflow execution or queue changes.
- No visual design refresh.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- terminal-drawer`
- [x] `pnpm run check:types`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/fix-terminal-blank-pr.md --changed-files-file /tmp/fix-terminal-blank-files.txt --diff-file /tmp/fix-terminal-blank.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <merge-commit>`.
- Post-revert steps: Rerun the focused terminal drawer tests.
- Data migration? No.

</details>
