### PR TITLE
[Remove Running Sidebar And Workers Screen Title](1) Omit running navigation and worker title

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3106,7 +3106,6 @@ export function App() {
         <LeftStatusColumn
           workflows={workflows}
           tasks={tasks}
-          queueStatus={queueStatus}
           workerStatus={workerStatus}
           planningSessionCount={planningSessions.length}
           selectedSurface={sidebarSurface}
@@ -3421,4 +3420,3 @@ export function App() {
     </div>
   );
 }
-

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -46,7 +46,7 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Planning Terminal');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
   });
   it('opens worker status from the left panel', async () => {
@@ -84,7 +84,7 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Planning Terminal');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();
   });
@@ -133,7 +133,7 @@ describe('App launch (component)', () => {
     fireEvent.click(toggle);
     expect(sidebar.className).toContain('w-16');
 
-    for (const surface of ['workflows', 'attention', 'running', 'workers', 'planning', 'home']) {
+    for (const surface of ['workflows', 'attention', 'workers', 'planning', 'home']) {
       fireEvent.click(screen.getByTestId(`sidebar-${surface}`));
       expect(sidebar.className).toContain('w-16');
     }
@@ -141,7 +141,7 @@ describe('App launch (component)', () => {
     fireEvent.click(toggle);
     expect(sidebar.className).toContain('w-60');
 
-    for (const surface of ['workflows', 'attention', 'running', 'workers', 'planning', 'home']) {
+    for (const surface of ['workflows', 'attention', 'workers', 'planning', 'home']) {
       fireEvent.click(screen.getByTestId(`sidebar-${surface}`));
       expect(sidebar.className).toContain('w-60');
     }

--- a/packages/ui/src/__tests__/queue-view.test.tsx
+++ b/packages/ui/src/__tests__/queue-view.test.tsx
@@ -167,7 +167,7 @@ describe('QueueView', () => {
     expect(actionList.className).toContain('overflow-y-auto');
     expect(workersSection.className).toContain('overflow-hidden');
     expect(within(actionSection).getByText('Worker Actions (1)')).toBeInTheDocument();
-    expect(within(workersSection).getByText('Worker processes (1)')).toBeInTheDocument();
+    expect(within(workersSection).queryByText(/Worker processes/)).not.toBeInTheDocument();
     expect(within(workersSection).getByTestId('worker-row-autofix')).toBeInTheDocument();
     expect(within(actionSection).queryByTestId('worker-row-autofix')).not.toBeInTheDocument();
   });
@@ -258,7 +258,7 @@ describe('QueueView', () => {
       'worker-row-coderabbit-address',
       'worker-row-pr-conflict-rebase',
     ]);
-    expect(screen.getByText('Worker processes (5)')).toBeInTheDocument();
+    expect(screen.queryByText(/Worker processes/)).not.toBeInTheDocument();
     expect(screen.getByText('Autofix')).toBeInTheDocument();
     expect(screen.getByText('PR status')).toBeInTheDocument();
     expect(screen.getByText('CI failure repair')).toBeInTheDocument();

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -1,8 +1,7 @@
-import type { QueueStatus } from '@invoker/contracts';
 import type { JSX } from 'react';
 import type { TaskState, WorkflowMeta, WorkerStatusSnapshot } from '../types.js';
 import type { SidebarSurface } from '../lib/workflow-progress-surfaces.js';
-import { getAttentionTaskEntries, getRunningTaskEntries, getSortedWorkflows } from '../lib/workflow-progress-surfaces.js';
+import { getAttentionTaskEntries, getSortedWorkflows } from '../lib/workflow-progress-surfaces.js';
 import { countActiveWorkerActions } from '../lib/worker-display.js';
 import {
   AttentionIcon,
@@ -11,7 +10,6 @@ import {
   InvokerIcon,
   MoonIcon,
   PlanningTerminalIcon,
-  RunningIcon,
   SettingsIcon,
   SunIcon,
   WorkerIcon,
@@ -22,7 +20,6 @@ import type { ThemeMode } from '../lib/theme.js';
 interface LeftStatusColumnProps {
   workflows: Map<string, WorkflowMeta>;
   tasks: Map<string, TaskState>;
-  queueStatus: QueueStatus | null;
   workerStatus: WorkerStatusSnapshot | null;
   selectedSurface: SidebarSurface;
   collapsed: boolean;
@@ -35,7 +32,7 @@ interface LeftStatusColumnProps {
 }
 
 interface SourceItem {
-  key: Exclude<SidebarSurface, 'home'>;
+  key: Exclude<SidebarSurface, 'home' | 'planning' | 'running'>;
   label: string;
   count: number;
   tone: 'neutral' | 'attention' | 'running';
@@ -68,7 +65,6 @@ function countClass(tone: SourceItem['tone']): string {
 export function LeftStatusColumn({
   workflows,
   tasks,
-  queueStatus,
   workerStatus,
   selectedSurface,
   collapsed,
@@ -81,14 +77,12 @@ export function LeftStatusColumn({
 }: LeftStatusColumnProps): JSX.Element {
   const workflowEntries = getSortedWorkflows(workflows, tasks);
   const attentionEntries = getAttentionTaskEntries(tasks, workflows);
-  const runningEntries = getRunningTaskEntries(tasks, workflows, queueStatus);
   const runningWorkers = workerStatus?.workers.filter((worker) => worker.lifecycle === 'running').length ?? 0;
   const registeredWorkers = workerStatus?.workers.length ?? 0;
   const activeWorkerActions = workerStatus ? countActiveWorkerActions(workerStatus.workers) : 0;
 
   const sources: SourceItem[] = [
     { key: 'attention', label: 'Needs Attention', count: attentionEntries.length, tone: 'attention', icon: <AttentionIcon className={ICON_CLASS} /> },
-    { key: 'running', label: 'Running', count: runningEntries.length, tone: 'running', icon: <RunningIcon className={ICON_CLASS} /> },
     { key: 'workers', label: 'Workers', count: registeredWorkers, tone: activeWorkerActions > 0 ? 'running' : 'neutral', icon: <WorkerIcon className={ICON_CLASS} /> },
     { key: 'workflows', label: 'Workflows', count: workflowEntries.length, tone: 'neutral', icon: <WorkflowsIcon className={ICON_CLASS} /> },
   ];
@@ -170,7 +164,7 @@ export function LeftStatusColumn({
 
       {!collapsed && <div className="mt-6 px-2.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/70">Library</div>}
       <nav className={collapsed ? 'mt-4 space-y-1' : 'mt-2 space-y-0.5'}>
-        {sources.map((source, index) => {
+        {sources.map((source) => {
           const selected = selectedSurface === source.key;
           return (
             <button
@@ -221,11 +215,6 @@ export function LeftStatusColumn({
             attentionEntries.length === 0
               ? 'Nothing needs a decision right now.'
               : `${attentionEntries.length} item${attentionEntries.length === 1 ? ' needs' : 's need'} attention.`
-          )}
-          {selectedSurface === 'running' && (
-            runningEntries.length === 0
-              ? 'No tasks are running right now.'
-              : `${runningEntries.length} task${runningEntries.length === 1 ? '' : 's'} active now.`
           )}
           {selectedSurface === 'workers' && (
             workerStatus === null

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -53,11 +53,6 @@ export function WorkerActivityCard({
 }: WorkerActivityCardProps) {
   return (
     <div data-testid="worker-activity-card">
-      <div className="mb-4">
-        <h3 className="text-lg font-semibold text-gray-100">Worker processes ({snapshot?.workers.length ?? 0})</h3>
-        <div className="mt-1 text-sm text-gray-400">Process status is separate from queue work. A running process can be idle.</div>
-      </div>
-
       {!snapshot ? (
         <div className="rounded border border-gray-800 bg-gray-950/60 px-3 py-2 text-sm text-gray-400">Worker status unavailable</div>
       ) : (


### PR DESCRIPTION
## Summary

The left sidebar no longer shows a Running entry. The Library nav now shows Needs Attention, Workers, and Workflows.

The Workers screen no longer shows the Worker processes title block. The worker cards now start at the top of the panel.

Both were redundant labels. Dropping them tightens the layout without changing any data.

## Review Claim

Approve hiding the Running sidebar entry and the Worker processes title block on the Workers screen.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change only edits sidebar rendering and the worker card header. Component tests assert the Running entry is gone and the Worker processes heading is absent, so the surface stays covered.

## Slice Rationale

This slice changes only the sidebar and worker card UI. The matching snapshot assertion lands in the next slice so this diff stays purely a UI edit.

## Non-goals

Does not touch queue logic, worker runtime, or backend contracts.

Does not update the visual-proof snapshot; that alignment is the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test` — sidebar and workers component tests pass

</details>

## Visual Proof

Sidebar on master (baseline) — the Library nav includes a Running entry:

![Sidebar on master with a Running entry in the Library nav](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-c83285/sidebar-master.png)

Sidebar on this branch — the Running entry is gone, leaving Needs Attention, Workers, and Workflows:

![Sidebar on this branch with no Running entry in the Library nav](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-c83285/sidebar-branch.png)

Workers screen on master (baseline) — the right column opens with a "Worker processes (10)" heading block:

![Workers screen on master showing the Worker processes heading block](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-c83285/workers-master.png)

Workers screen on this branch — the heading block is gone and the Autofix card sits at the top:

![Workers screen on this branch with no Worker processes heading block](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-c83285/workers-branch.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 617635160`
- Post-revert steps: None
- Data migration? No

</details>
