### PR TITLE
Fix Embedded Task Terminal Blank Rendering Step 1

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -185,6 +185,33 @@ async function loadPlanAndSelectWorkflow(page: Page, plan: unknown): Promise<str
   return workflowId!;
 }
 
+async function expectSingleVisibleTerminalPane(page: Page, expectedTabText: string) {
+  const activeTabs = page.locator('[data-testid^="terminal-tab-"][data-active="true"]');
+  await expect(activeTabs).toHaveCount(1);
+  await expect(activeTabs.first()).toContainText(expectedTabText);
+
+  const panes = await page.locator('[data-testid^="terminal-pane-"]').evaluateAll((elements) =>
+    elements.map((element) => {
+      const htmlElement = element as HTMLElement;
+      const style = getComputedStyle(htmlElement);
+      const rect = htmlElement.getBoundingClientRect();
+      return {
+        testId: htmlElement.dataset.testid ?? '',
+        sessionId: htmlElement.dataset.sessionId ?? '',
+        display: style.display,
+        childCount: htmlElement.children.length,
+        hasBox: rect.width > 0 && rect.height > 0,
+      };
+    }),
+  );
+  const visiblePanes = panes.filter((pane) => pane.display !== 'none');
+  expect(visiblePanes).toHaveLength(1);
+  expect(visiblePanes[0]?.childCount).toBeGreaterThan(0);
+  expect(visiblePanes[0]?.hasBox).toBe(true);
+  await expect(page.getByTestId(visiblePanes[0]!.testId)).toBeVisible();
+  return visiblePanes[0]!;
+}
+
 test.describe('Visual proof capture', () => {
   test('empty state', async ({ page }) => {
     await expect(page.getByText('Load a plan to render workflow graph')).toBeVisible({ timeout: 5000 });
@@ -249,6 +276,74 @@ test.describe('Visual proof capture', () => {
     await expect(page.getByText('sleep 5 && echo hello-alpha')).toBeVisible();
     await captureScreenshot(page, 'task-panel');
     await assertPageScreenshot(page, 'task-panel');
+  });
+
+  test('embedded terminal active pane stays visible across drawer state and tab return', async ({ page }) => {
+    await loadPlan(page, TEST_PLAN);
+    await page.evaluate(() => {
+      type TerminalSession = {
+        sessionId: string;
+        taskId: string;
+        status: 'running';
+        mode: string;
+        attached: boolean;
+        createdAt: string;
+        command: string;
+        args: string[];
+        outputSnapshot: string;
+      };
+      const testWindow = window as unknown as {
+        __INVOKER_TEST_OPEN_TERMINAL__?: (taskId: string) => Promise<{ opened: boolean; session: TerminalSession }>;
+      };
+      testWindow.__INVOKER_TEST_OPEN_TERMINAL__ = async (taskId: string) => ({
+        opened: true,
+        session: {
+          sessionId: `visual-${taskId.replace(/[^a-zA-Z0-9_-]/g, '-')}`,
+          taskId,
+          status: 'running',
+          mode: 'spawn',
+          attached: false,
+          createdAt: '2025-01-01T00:00:00.000Z',
+          command: 'sh',
+          args: ['-lc', `echo ${taskId}`],
+          outputSnapshot: `${taskId} terminal output\n`,
+        },
+      });
+    });
+
+    const alphaNode = page.locator('.react-flow__node[data-testid$="task-alpha"]').first();
+    await expect(alphaNode).toBeVisible({ timeout: 10000 });
+    await alphaNode.dispatchEvent('dblclick', { bubbles: true });
+
+    await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
+    await expect(page.getByTestId('terminal-drawer-body')).toBeVisible();
+    const alphaPane = await expectSingleVisibleTerminalPane(page, 'First test task');
+
+    await page.getByRole('button', { name: 'Maximize terminal drawer' }).click();
+    await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'maximized');
+    expect((await expectSingleVisibleTerminalPane(page, 'First test task')).sessionId).toBe(alphaPane.sessionId);
+
+    await page.getByRole('button', { name: 'Minimize terminal drawer' }).click();
+    await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'minimized');
+    await expect(page.getByTestId('terminal-drawer-body')).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Partial terminal drawer' }).click();
+    await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
+    await expectSingleVisibleTerminalPane(page, 'First test task');
+
+    const betaNode = page.locator('.react-flow__node[data-testid$="task-beta"]').first();
+    await expect(betaNode).toBeVisible({ timeout: 10000 });
+    await betaNode.dispatchEvent('dblclick', { bubbles: true });
+    await expectSingleVisibleTerminalPane(page, 'Second test task depending on alpha');
+
+    const inactiveAlphaTab = page
+      .locator('[data-testid^="terminal-tab-"][data-active="false"]')
+      .filter({ hasText: 'First test task' })
+      .getByRole('tab');
+    await inactiveAlphaTab.click();
+    await expectSingleVisibleTerminalPane(page, 'First test task');
+
+    await captureScreenshot(page, 'embedded-terminal-active-pane-regression');
   });
 
   test('task panel setup failure renders in Error panel', async ({ page }) => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -30,7 +30,11 @@ import { FloatingGraphPanel } from './components/FloatingGraphPanel.js';
 import { WorkflowInspector } from './components/WorkflowInspector.js';
 import { ActionGraphView } from './components/ActionGraphView.js';
 import { StatusBar } from './components/StatusBar.js';
-import { TerminalDrawer } from './components/TerminalDrawer.js';
+import {
+  TerminalDrawer,
+  type TerminalDrawerState,
+  type TerminalSessionDescriptor,
+} from './components/TerminalDrawer.js';
 import {
   isExperimentSpawnPivotTask,
   EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE,
@@ -44,6 +48,20 @@ type ModalState =
   | { type: 'approval'; task: TaskState; action: 'approve' | 'reject' }
   | { type: 'experiment'; task: TaskState }
   | { type: 'replace'; task: TaskState };
+
+interface OpenTerminalResult {
+  opened: boolean;
+  reason?: string;
+  session?: TerminalSessionDescriptor;
+}
+
+interface AppTerminalTestWindow {
+  __INVOKER_TEST_OPEN_TERMINAL__?: (taskId: string) => Promise<OpenTerminalResult>;
+}
+
+interface AppTerminalInvokerMethods {
+  terminalClose?: (sessionId: string) => Promise<void>;
+}
 
 interface WorkflowContextMenuProps {
   x: number;
@@ -246,6 +264,9 @@ export function App() {
   const [inspectorCollapsed, setInspectorCollapsed] = useState(false);
   const [advancedMetadataExpanded, setAdvancedMetadataExpanded] = useState(false);
   const [terminalCollapsed, setTerminalCollapsed] = useState(true);
+  const [terminalDrawerState, setTerminalDrawerState] = useState<TerminalDrawerState>('minimized');
+  const [terminalSessions, setTerminalSessions] = useState<TerminalSessionDescriptor[]>([]);
+  const [activeTerminalSessionId, setActiveTerminalSessionId] = useState<string | null>(null);
   const [workflowContextMenu, setWorkflowContextMenu] = useState<{ x: number; y: number; workflowId: string } | null>(null);
   const uiPerfThrottleRef = useRef<Record<string, number>>({});
 
@@ -359,6 +380,13 @@ export function App() {
     }
     return next;
   }, [selectedWorkflow, selectedWorkflowId, tasks]);
+  const terminalTaskLabels = useMemo(() => {
+    const labels = new Map<string, string>();
+    for (const task of tasks.values()) {
+      labels.set(task.id, task.description);
+    }
+    return labels;
+  }, [tasks]);
 
   useEffect(() => {
     if (selectedTask?.config.workflowId) {
@@ -396,6 +424,53 @@ export function App() {
       }
     });
   }, []);
+  const openTaskTerminal = useCallback(async (taskId: string) => {
+    const testOpenTerminal = (window as typeof window & AppTerminalTestWindow).__INVOKER_TEST_OPEN_TERMINAL__;
+    const result = await (
+      testOpenTerminal
+        ? testOpenTerminal(taskId)
+        : (window.invoker?.openTerminal(taskId) as Promise<OpenTerminalResult> | undefined)
+    );
+
+    if (!result) return;
+    if (!result.opened) {
+      window.alert(result.reason ?? 'Cannot open terminal for this task.');
+      return;
+    }
+    if (!result.session) return;
+    const terminalSession = result.session;
+
+    setTerminalSessions((previous) => {
+      const withoutCurrent = previous.filter((session) =>
+        session.sessionId !== terminalSession.sessionId &&
+        session.taskId !== terminalSession.taskId
+      );
+      return [...withoutCurrent, terminalSession];
+    });
+    setActiveTerminalSessionId(terminalSession.sessionId);
+    setTerminalDrawerState('partial');
+    setTerminalCollapsed(false);
+  }, []);
+  const handleCloseTerminalSession = useCallback((sessionId: string) => {
+    const remaining = terminalSessions.filter((session) => session.sessionId !== sessionId);
+    setTerminalSessions(remaining);
+    setActiveTerminalSessionId((current) => {
+      if (current !== sessionId) return current;
+      return remaining.at(-1)?.sessionId ?? null;
+    });
+    if (remaining.length === 0) {
+      setTerminalDrawerState('minimized');
+    }
+    const invoker = window.invoker as (typeof window.invoker & AppTerminalInvokerMethods) | undefined;
+    void invoker?.terminalClose?.(sessionId);
+  }, [terminalSessions]);
+  const cycleTerminalDrawerState = useCallback(() => {
+    setTerminalDrawerState((current) => {
+      if (current === 'minimized') return 'partial';
+      if (current === 'partial') return 'maximized';
+      return 'minimized';
+    });
+  }, []);
   const missingRequiredTool = systemDiagnostics?.tools.find((tool) => tool.required && !tool.installed) ?? null;
   const installedAgentCount = systemDiagnostics?.tools.filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed).length ?? 0;
   const needsBundledSkillsPrompt = Boolean(systemDiagnostics?.isPackaged && systemDiagnostics?.bundledSkills?.promptRecommended);
@@ -416,11 +491,8 @@ export function App() {
       window.alert(EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE);
       return;
     }
-    const result = await window.invoker?.openTerminal(task.id);
-    if (result && !result.opened) {
-      window.alert(result.reason ?? 'Cannot open terminal for this task.');
-    }
-  }, []);
+    await openTaskTerminal(task.id);
+  }, [openTaskTerminal]);
 
   const handleTaskContextMenu = useCallback((task: TaskState, event: React.MouseEvent) => {
     setSelectedTaskId(task.id);
@@ -489,9 +561,9 @@ export function App() {
         window.alert(EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE);
         return;
       }
-      void window.invoker?.openTerminal(taskId);
+      void openTaskTerminal(taskId);
     },
-    [tasks],
+    [openTaskTerminal, tasks],
   );
 
   const handleReplaceTask = useCallback((taskId: string) => {
@@ -1140,10 +1212,22 @@ export function App() {
                   activeFilters={statusFilters}
                   onStatusClick={(filterKey, event) => handleStatusClick(filterKey as WorkflowStatus, event)}
                 />
-                <TerminalDrawer
-                  collapsed={terminalCollapsed}
-                  onToggle={() => setTerminalCollapsed((prev) => !prev)}
-                />
+                {terminalSessions.length > 0 ? (
+                  <TerminalDrawer
+                    state={terminalDrawerState}
+                    onCycle={cycleTerminalDrawerState}
+                    sessions={terminalSessions}
+                    activeSessionId={activeTerminalSessionId}
+                    onSelectSession={setActiveTerminalSessionId}
+                    onCloseSession={handleCloseTerminalSession}
+                    taskLabels={terminalTaskLabels}
+                  />
+                ) : (
+                  <TerminalDrawer
+                    collapsed={terminalCollapsed}
+                    onToggle={() => setTerminalCollapsed((prev) => !prev)}
+                  />
+                )}
               </>
             )}
           </div>

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -1,0 +1,221 @@
+import { useState } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  TerminalDrawer,
+  type TerminalDrawerState,
+  type TerminalSessionDescriptor,
+} from '../components/TerminalDrawer.js';
+
+const xtermMock = vi.hoisted(() => {
+  type DataHandler = (data: string) => void;
+
+  const instances: MockTerminal[] = [];
+  const fitInstances: MockFitAddon[] = [];
+  const writeLog: Array<{ taskId: string | null; data: string }> = [];
+
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    host: HTMLElement | null = null;
+    dataHandler: DataHandler | null = null;
+    loadAddon = vi.fn();
+    open = vi.fn((host: HTMLElement) => {
+      this.host = host;
+      host.setAttribute('data-xterm-open', 'true');
+    });
+    write = vi.fn((data: string) => {
+      writeLog.push({
+        taskId: this.host?.getAttribute('data-testid')?.replace('terminal-pane-', '') ?? null,
+        data,
+      });
+      const line = document.createElement('span');
+      line.textContent = data;
+      this.host?.append(line);
+    });
+    onData = vi.fn((cb: DataHandler) => {
+      this.dataHandler = cb;
+      return { dispose: vi.fn() };
+    });
+    focus = vi.fn();
+    dispose = vi.fn();
+
+    constructor() {
+      instances.push(this);
+    }
+
+    emitData(data: string) {
+      this.dataHandler?.(data);
+    }
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+
+    constructor() {
+      fitInstances.push(this);
+    }
+  }
+
+  return {
+    Terminal: MockTerminal,
+    FitAddon: MockFitAddon,
+    instances,
+    fitInstances,
+    writeLog,
+    reset: () => {
+      instances.length = 0;
+      fitInstances.length = 0;
+      writeLog.length = 0;
+    },
+  };
+});
+
+type TerminalTestWindow = typeof window & {
+  __INVOKER_TEST_XTERM__?: {
+    Terminal: typeof xtermMock.Terminal;
+    FitAddon: typeof xtermMock.FitAddon;
+  };
+};
+
+const nextDrawerState: Record<TerminalDrawerState, TerminalDrawerState> = {
+  minimized: 'partial',
+  partial: 'maximized',
+  maximized: 'minimized',
+};
+
+function makeSession(
+  taskId: string,
+  overrides: Partial<TerminalSessionDescriptor> = {},
+): TerminalSessionDescriptor {
+  return {
+    sessionId: `session-${taskId}`,
+    taskId,
+    status: 'running',
+    outputSnapshot: `${taskId} ready\n`,
+    ...overrides,
+  };
+}
+
+function TerminalDrawerHarness({
+  initialState,
+  sessions,
+  initialActiveSessionId = sessions[0]?.sessionId ?? null,
+}: {
+  initialState: TerminalDrawerState;
+  sessions: TerminalSessionDescriptor[];
+  initialActiveSessionId?: string | null;
+}) {
+  const [state, setState] = useState<TerminalDrawerState>(initialState);
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(initialActiveSessionId);
+  const labels = new Map(sessions.map((session) => [session.taskId, `${session.taskId} label`]));
+
+  return (
+    <TerminalDrawer
+      state={state}
+      onCycle={() => setState((current) => nextDrawerState[current])}
+      sessions={sessions}
+      activeSessionId={activeSessionId}
+      onSelectSession={setActiveSessionId}
+      onCloseSession={vi.fn()}
+      taskLabels={labels}
+    />
+  );
+}
+
+function expectActivePane(taskId: string, text: string) {
+  const tab = screen.getByTestId(`terminal-tab-${taskId}`);
+  const pane = screen.getByTestId(`terminal-pane-${taskId}`);
+  expect(tab).toHaveAttribute('data-active', 'true');
+  expect(pane).toHaveStyle({ display: 'block' });
+  expect(pane).toBeVisible();
+  expect(pane).toHaveTextContent(text);
+  expect(pane).toHaveAttribute('data-xterm-open', 'true');
+}
+
+function expectInactivePane(taskId: string) {
+  const tab = screen.getByTestId(`terminal-tab-${taskId}`);
+  const pane = screen.getByTestId(`terminal-pane-${taskId}`);
+  expect(tab).toHaveAttribute('data-active', 'false');
+  expect(pane).toHaveStyle({ display: 'none' });
+  expect(pane).not.toBeVisible();
+}
+
+describe('TerminalDrawer active pane regressions', () => {
+  beforeEach(() => {
+    xtermMock.reset();
+    (window as TerminalTestWindow).__INVOKER_TEST_XTERM__ = {
+      Terminal: xtermMock.Terminal,
+      FitAddon: xtermMock.FitAddon,
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    delete (window as TerminalTestWindow).__INVOKER_TEST_XTERM__;
+    vi.clearAllMocks();
+  });
+
+  it('keeps the active pane visible and nonblank across minimized -> partial -> maximized', async () => {
+    const session = makeSession('task-alpha', { outputSnapshot: 'alpha terminal output\n' });
+    render(<TerminalDrawerHarness initialState="minimized" sessions={[session]} />);
+
+    expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'minimized');
+    expect(screen.queryByTestId('terminal-drawer-body')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Partial terminal drawer' }));
+    expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
+    expect(screen.getByTestId('terminal-drawer-body')).toBeVisible();
+    await waitFor(() => expectActivePane('task-alpha', 'alpha terminal output'));
+
+    const mountedTerminal = xtermMock.instances[0];
+    fireEvent.click(screen.getByRole('button', { name: 'Maximize terminal drawer' }));
+
+    expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'maximized');
+    expect(screen.getByTestId('terminal-drawer')).toHaveClass('fixed');
+    expect(screen.getByTestId('terminal-drawer-body')).toBeVisible();
+    expectActivePane('task-alpha', 'alpha terminal output');
+    expect(xtermMock.instances).toHaveLength(1);
+    expect(mountedTerminal.dispose).not.toHaveBeenCalled();
+  });
+
+  it('shows only the newly active pane when switching tabs while inactive panes are display:none', async () => {
+    const alpha = makeSession('task-alpha', { outputSnapshot: 'alpha terminal output\n' });
+    const beta = makeSession('task-beta', { outputSnapshot: 'beta terminal output\n' });
+    render(<TerminalDrawerHarness initialState="partial" sessions={[alpha, beta]} />);
+
+    await waitFor(() => expectActivePane('task-alpha', 'alpha terminal output'));
+    expectInactivePane('task-beta');
+
+    fireEvent.click(screen.getByRole('tab', { name: /task-beta label/i }));
+
+    expectInactivePane('task-alpha');
+    await waitFor(() => expectActivePane('task-beta', 'beta terminal output'));
+    await waitFor(() => {
+      expect(xtermMock.instances[1].focus).toHaveBeenCalledTimes(1);
+      expect(xtermMock.fitInstances[1].fit).toHaveBeenCalled();
+    });
+  });
+
+  it('restores an already-open terminal tab without leaving its pane hidden or blank', async () => {
+    const alpha = makeSession('task-alpha', { outputSnapshot: 'alpha persisted output\n' });
+    const beta = makeSession('task-beta', { outputSnapshot: 'beta persisted output\n' });
+    render(<TerminalDrawerHarness initialState="partial" sessions={[alpha, beta]} />);
+
+    await waitFor(() => expectActivePane('task-alpha', 'alpha persisted output'));
+    fireEvent.click(screen.getByRole('tab', { name: /task-beta label/i }));
+    await waitFor(() => expectActivePane('task-beta', 'beta persisted output'));
+    expectInactivePane('task-alpha');
+
+    fireEvent.click(screen.getByRole('tab', { name: /task-alpha label/i }));
+
+    await waitFor(() => expectActivePane('task-alpha', 'alpha persisted output'));
+    expectInactivePane('task-beta');
+    expect(xtermMock.instances).toHaveLength(2);
+    expect(xtermMock.instances[0].open).toHaveBeenCalledTimes(1);
+    expect(xtermMock.instances[0].dispose).not.toHaveBeenCalled();
+    expect(xtermMock.writeLog.filter((entry) => entry.taskId === 'task-alpha')).toEqual([
+      { taskId: 'task-alpha', data: 'alpha persisted output\n' },
+    ]);
+  });
+});

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -1,9 +1,270 @@
-interface TerminalDrawerProps {
+import { useEffect, useRef } from 'react';
+import type { Terminal as XTermTerminal } from 'xterm';
+import type { FitAddon } from 'xterm-addon-fit';
+
+const DRAWER_BODY_HEIGHT_PX = 280;
+
+export type TerminalDrawerState = 'minimized' | 'partial' | 'maximized';
+
+export interface TerminalSessionDescriptor {
+  sessionId: string;
+  taskId: string;
+  status: 'running' | 'exited';
+  mode?: string;
+  attached?: boolean;
+  createdAt?: string;
+  cwd?: string;
+  command?: string;
+  args?: string[];
+  outputSnapshot?: string;
+}
+
+interface LegacyTerminalDrawerProps {
   collapsed: boolean;
   onToggle: () => void;
 }
 
-export function TerminalDrawer({ collapsed, onToggle }: TerminalDrawerProps): JSX.Element {
+interface SessionTerminalDrawerProps {
+  state: TerminalDrawerState;
+  onCycle: () => void;
+  sessions: TerminalSessionDescriptor[];
+  activeSessionId: string | null;
+  onSelectSession: (sessionId: string) => void;
+  onCloseSession: (sessionId: string) => void;
+  taskLabels?: Map<string, string>;
+}
+
+type TerminalDrawerProps = LegacyTerminalDrawerProps | SessionTerminalDrawerProps;
+
+interface TerminalSessionPaneProps {
+  session: TerminalSessionDescriptor;
+  isActive: boolean;
+  hasHeader: boolean;
+}
+
+interface TerminalOutputEvent {
+  sessionId: string;
+  taskId?: string;
+  data: string;
+}
+
+interface TerminalInvokerMethods {
+  terminalWrite?: (sessionId: string, data: string) => Promise<void>;
+  terminalResize?: (sessionId: string, cols: number, rows: number) => Promise<void>;
+  onTerminalOutput?: (cb: (event: TerminalOutputEvent) => void) => () => void;
+}
+
+interface TerminalTestWindow {
+  __INVOKER_TEST_ON_TERMINAL_OUTPUT__?: (cb: (event: TerminalOutputEvent) => void) => () => void;
+  __INVOKER_TEST_XTERM__?: {
+    Terminal: new (options: Record<string, unknown>) => XTermTerminal;
+    FitAddon: new () => FitAddon;
+  };
+}
+
+type SeededOutputSnapshot = {
+  sessionId: string;
+  snapshot: string;
+  term: XTermTerminal;
+};
+
+const NEXT_STATE_BY_STATE: Record<TerminalDrawerState, { label: string }> = {
+  minimized: { label: 'Partial' },
+  partial: { label: 'Maximize' },
+  maximized: { label: 'Minimize' },
+};
+
+function isSessionProps(props: TerminalDrawerProps): props is SessionTerminalDrawerProps {
+  return 'state' in props;
+}
+
+function seedTerminalOutputSnapshot(
+  term: XTermTerminal,
+  session: TerminalSessionDescriptor,
+  seededSnapshotRef: { current: SeededOutputSnapshot | null },
+): void {
+  const outputSnapshot = session.outputSnapshot;
+  const seededSnapshot = seededSnapshotRef.current;
+  if (
+    outputSnapshot &&
+    (
+      !seededSnapshot ||
+      seededSnapshot.sessionId !== session.sessionId ||
+      seededSnapshot.snapshot !== outputSnapshot ||
+      seededSnapshot.term !== term
+    )
+  ) {
+    try {
+      term.write(outputSnapshot);
+      seededSnapshotRef.current = {
+        sessionId: session.sessionId,
+        snapshot: outputSnapshot,
+        term,
+      };
+    } catch {
+      /* terminal disposed */
+    }
+  }
+}
+
+function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPaneProps): JSX.Element {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const termRef = useRef<XTermTerminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const seededSnapshotRef = useRef<SeededOutputSnapshot | null>(null);
+  const isActiveRef = useRef(isActive);
+
+  useEffect(() => {
+    isActiveRef.current = isActive;
+  }, [isActive]);
+
+  useEffect(() => {
+    const host = containerRef.current;
+    if (!host) return;
+
+    let disposed = false;
+    let term: XTermTerminal | null = null;
+    let fit: FitAddon | null = null;
+    let inputDisposable: { dispose: () => void } | null = null;
+    let unsubscribeOutput: (() => void) | undefined;
+    let raf: number | null = null;
+    let resizeObserver: ResizeObserver | null = null;
+
+    const cleanupTerminal = () => {
+      if (raf !== null && typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(raf);
+      }
+      resizeObserver?.disconnect();
+      inputDisposable?.dispose();
+      unsubscribeOutput?.();
+      try {
+        term?.dispose();
+      } catch {
+        /* already disposed */
+      }
+      termRef.current = null;
+      fitRef.current = null;
+    };
+
+    const testWindow = window as typeof window & TerminalTestWindow;
+    const constructors = testWindow.__INVOKER_TEST_XTERM__
+      ? Promise.resolve(testWindow.__INVOKER_TEST_XTERM__)
+      : Promise.all([
+        import('xterm'),
+        import('xterm-addon-fit'),
+      ]).then(([xtermModule, fitModule]) => ({
+        Terminal: xtermModule.Terminal,
+        FitAddon: fitModule.FitAddon,
+      }));
+
+    void constructors.then(({ Terminal: TerminalCtor, FitAddon: FitAddonCtor }) => {
+      if (disposed || !host.isConnected) return;
+
+      term = new TerminalCtor({
+        fontSize: 12,
+        fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+        cursorBlink: true,
+        convertEol: false,
+        scrollback: 5000,
+        theme: { background: '#0b0f1a', foreground: '#e5e7eb' },
+      });
+      fit = new FitAddonCtor();
+      term.loadAddon(fit);
+      term.open(host);
+      termRef.current = term;
+      fitRef.current = fit;
+
+      seedTerminalOutputSnapshot(term, session, seededSnapshotRef);
+
+      const invoker = window.invoker as (typeof window.invoker & TerminalInvokerMethods) | undefined;
+      inputDisposable = term.onData((data) => {
+        void invoker?.terminalWrite?.(session.sessionId, data);
+      });
+
+      const subscribeToOutput = testWindow.__INVOKER_TEST_ON_TERMINAL_OUTPUT__ ?? invoker?.onTerminalOutput;
+      unsubscribeOutput = subscribeToOutput?.((event) => {
+        if (event.sessionId !== session.sessionId || !term) return;
+        try {
+          term.write(event.data);
+        } catch {
+          /* terminal disposed */
+        }
+      });
+
+      const tryFit = () => {
+        if (!term || !fit) return;
+        try {
+          fit.fit();
+          void invoker?.terminalResize?.(session.sessionId, term.cols, term.rows);
+        } catch {
+          /* host has zero size or fit unsupported */
+        }
+      };
+
+      raf = typeof requestAnimationFrame === 'function'
+        ? requestAnimationFrame(tryFit)
+        : null;
+
+      if (typeof ResizeObserver !== 'undefined') {
+        try {
+          resizeObserver = new ResizeObserver(() => {
+            tryFit();
+          });
+          resizeObserver.observe(host);
+        } catch {
+          resizeObserver = null;
+        }
+      }
+
+      if (isActiveRef.current) {
+        tryFit();
+        try {
+          term.focus();
+        } catch {
+          /* terminal disposed */
+        }
+      }
+    }).catch(() => {});
+
+    return () => {
+      disposed = true;
+      cleanupTerminal();
+    };
+  }, [session.sessionId]);
+
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    seedTerminalOutputSnapshot(term, session, seededSnapshotRef);
+  }, [session.outputSnapshot, session.sessionId]);
+
+  useEffect(() => {
+    if (!isActive) return;
+    const term = termRef.current;
+    const fit = fitRef.current;
+    if (!term || !fit) return;
+    const invoker = window.invoker as (typeof window.invoker & TerminalInvokerMethods) | undefined;
+    try {
+      fit.fit();
+      void invoker?.terminalResize?.(session.sessionId, term.cols, term.rows);
+      term.focus();
+    } catch {
+      /* fit failed (e.g. hidden) */
+    }
+  }, [isActive, session.sessionId]);
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid={`terminal-pane-${session.taskId}`}
+      data-session-id={session.sessionId}
+      className={hasHeader ? 'absolute bottom-0 left-0 right-0 top-9 overflow-hidden' : 'absolute inset-0 overflow-hidden'}
+      style={{ display: isActive ? 'block' : 'none' }}
+    />
+  );
+}
+
+function LegacyTerminalDrawer({ collapsed, onToggle }: LegacyTerminalDrawerProps): JSX.Element {
   return (
     <div className="border-t border-gray-800 bg-gray-950">
       <div className="flex items-center justify-between px-3 py-2 border-b border-gray-800">
@@ -27,4 +288,131 @@ export function TerminalDrawer({ collapsed, onToggle }: TerminalDrawerProps): JS
       )}
     </div>
   );
+}
+
+function SessionTerminalDrawer({
+  state,
+  onCycle,
+  sessions,
+  activeSessionId,
+  onSelectSession,
+  onCloseSession,
+  taskLabels,
+}: SessionTerminalDrawerProps): JSX.Element {
+  const isMaximized = state === 'maximized';
+  const showBody = state !== 'minimized';
+  const cycleLabel = NEXT_STATE_BY_STATE[state].label;
+  const activeSession = sessions.find((session) => session.sessionId === activeSessionId) ?? null;
+  const activeCommand = activeSession?.command
+    ? [activeSession.command, ...(activeSession.args ?? [])].join(' ')
+    : null;
+
+  return (
+    <div
+      data-testid="terminal-drawer"
+      data-state={state}
+      className={
+        isMaximized
+          ? 'fixed inset-0 z-40 flex min-h-0 flex-col overflow-hidden border-t border-gray-800 bg-gray-950'
+          : 'border-t border-gray-800 bg-gray-950'
+      }
+    >
+      <div className="flex items-center gap-2 border-b border-gray-800 px-3 py-2">
+        <div
+          role="tablist"
+          data-testid="terminal-tab-strip"
+          className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto"
+        >
+          {sessions.length === 0 ? (
+            <span className="text-xs text-gray-500">No terminal sessions</span>
+          ) : (
+            sessions.map((session) => {
+              const isActive = session.sessionId === activeSessionId;
+              const label = taskLabels?.get(session.taskId) ?? session.taskId;
+              const tabClass = isActive
+                ? 'border-gray-500 bg-gray-800 text-white'
+                : 'border-transparent text-gray-300 hover:bg-gray-800/60';
+              return (
+                <div
+                  key={session.sessionId}
+                  data-testid={`terminal-tab-${session.taskId}`}
+                  data-active={isActive ? 'true' : 'false'}
+                  className={`flex shrink-0 items-center gap-1 rounded border ${tabClass}`}
+                >
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    onClick={() => onSelectSession(session.sessionId)}
+                    className="max-w-[180px] truncate px-2 py-0.5 text-xs"
+                    title={label}
+                  >
+                    {label}
+                    {session.status === 'exited' && (
+                      <span className="ml-1 text-[10px] text-amber-300">exited</span>
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Close terminal for ${label}`}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onCloseSession(session.sessionId);
+                    }}
+                    className="px-1 text-xs text-gray-400 hover:text-white"
+                  >
+                    x
+                  </button>
+                </div>
+              );
+            })
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onCycle}
+          aria-label={`${cycleLabel} terminal drawer`}
+          className="shrink-0 rounded border border-gray-700 px-2 py-1 text-[11px] text-gray-300 hover:bg-gray-800"
+        >
+          {cycleLabel}
+        </button>
+      </div>
+      {showBody && (
+        <div
+          data-testid="terminal-drawer-body"
+          className={isMaximized ? 'relative min-h-0 flex-1 overflow-hidden bg-black' : 'relative overflow-hidden bg-black'}
+          style={isMaximized ? undefined : { height: DRAWER_BODY_HEIGHT_PX }}
+        >
+          {sessions.length === 0 && (
+            <div className="absolute inset-0 flex items-center justify-center px-3 text-xs text-gray-500">
+              Open a terminal from a task to attach.
+            </div>
+          )}
+          {activeSession && activeCommand && (
+            <div
+              data-testid="terminal-session-command"
+              className="absolute left-0 right-0 top-0 z-10 flex h-9 items-center gap-2 border-b border-gray-800 bg-gray-950 px-3 text-[11px]"
+            >
+              <span className="text-gray-500">SSH</span>
+              <span className="min-w-0 flex-1 truncate font-mono text-emerald-200">
+                {activeCommand}
+              </span>
+            </div>
+          )}
+          {sessions.map((session) => (
+            <TerminalSessionPane
+              key={session.sessionId}
+              session={session}
+              isActive={session.sessionId === activeSessionId}
+              hasHeader={Boolean(session.sessionId === activeSessionId && activeCommand)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function TerminalDrawer(props: TerminalDrawerProps): JSX.Element {
+  return isSessionProps(props) ? <SessionTerminalDrawer {...props} /> : <LegacyTerminalDrawer {...props} />;
 }


### PR DESCRIPTION
## Summary

Fix Embedded Task Terminal Blank Rendering Step 1 keeps embedded task terminals in the in-app drawer instead of losing their visible pane during drawer and tab transitions.

The drawer now owns open terminal sessions, the active tab, and the minimized/partial/maximized state so a mounted xterm host stays visible.

Workflow wf-1783567209648-14 completed both terminal blank regression tasks with no failed, closed, or skipped tasks.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1783567209648-14/add-terminal-blank-regressions | Add regression coverage for blank terminal panes during drawer state changes and tab switches | completed |
| wf-1783567209648-14/verify-terminal-blank-regressions | Run focused UI regression tests for terminal drawer behavior | completed (passed) |

</details>

## Review Claim

Embedded task terminal panes remain mounted, visible, and nonblank across drawer state changes and tab switches.

## Review Lane

behavior

## Review Unit

terminal-drawer

## Safety Invariant

The change is limited to renderer-side terminal drawer ownership and focused UI coverage; task execution and PTY process launch semantics stay unchanged.

## Slice Rationale

The drawer behavior and direct regression proof belong together because the tests exercise the new active-pane state flow.

## Non-goals

- No change to task scheduling, queueing, or workflow execution.
- No change to backend terminal process lifecycle beyond closing sessions the drawer removes.
- No change to persisted workflow data.

## Architecture

### Before

The app asked the preload bridge to open a task terminal, while the drawer only tracked collapsed state. The renderer did not own the session list or active pane.

### After

The app stores terminal sessions, selects the active session, and passes that state into the drawer. The drawer keeps inactive panes mounted with `display: none` and re-fits the active xterm pane when it becomes visible.

## Visual Proof

Embedded terminal drawer after minimize, restore, tab switch, and tab return: the first task tab is active and its terminal output remains visible.

![Embedded terminal drawer showing restored first-task output after drawer and tab transitions](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-e233fb/embedded-terminal-active-pane-regression.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/terminal-drawer.test.tsx`
- [x] `CAPTURE_MODE=after pnpm --filter @invoker/app exec playwright test visual-proof.spec.ts -g "embedded terminal active pane stays visible"`
- [x] `node scripts/validate-pr-body.mjs --body-file pr-body-fix-terminal-blank-step-1.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 51d3f3bb2`
- Post-revert steps: rerun the focused terminal drawer test if the terminal surface still changes nearby.
- Data migration? No

</details>
