### PR TITLE
Orchestrator self-heals stale selected_attempt_id

### DIFF
--- a/packages/app/src/__tests__/action-graph-snapshot.test.ts
+++ b/packages/app/src/__tests__/action-graph-snapshot.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator, type Attempt, type TaskState } from '@invoker/workflow-core';
+import { buildCurrentActionGraphSnapshot } from '../action-graph-snapshot.js';
+import type { InvokerConfig } from '../config.js';
+
+describe('buildCurrentActionGraphSnapshot', () => {
+  const adapters: SQLiteAdapter[] = [];
+
+  afterEach(() => {
+    for (const adapter of adapters.splice(0)) {
+      adapter.close();
+    }
+  });
+
+  it('does not emit a failed blocker when the selected_attempt_id is stale but a newer active attempt exists', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+
+    const workflowId = 'wf-stale';
+    const taskId = 'wf-stale/verify';
+    adapter.saveWorkflow({
+      id: workflowId,
+      name: 'Remove Running Sidebar And Workers Screen Title',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const olderCreatedAt = new Date('2026-07-09T05:38:02.000Z');
+    const newerCreatedAt = new Date('2026-07-09T05:51:12.808Z');
+
+    const failed: Attempt = {
+      id: `${taskId}-aOLD`,
+      nodeId: taskId,
+      queuePriority: 0,
+      status: 'failed',
+      upstreamAttemptIds: [],
+      error: 'Cancelled by user (workflow)',
+      completedAt: new Date('2026-07-09T05:51:12.761Z'),
+      startedAt: new Date('2026-07-09T05:43:54.107Z'),
+      lastHeartbeatAt: new Date('2026-07-09T05:43:54.107Z'),
+      createdAt: olderCreatedAt,
+    };
+    const newerPending: Attempt = {
+      id: `${taskId}-aNEW`,
+      nodeId: taskId,
+      queuePriority: 0,
+      status: 'pending',
+      upstreamAttemptIds: [],
+      supersedesAttemptId: failed.id,
+      createdAt: newerCreatedAt,
+    };
+    const task: TaskState = {
+      id: taskId,
+      description: 'Verify sidebar and workers title removal',
+      status: 'running',
+      dependencies: [],
+      createdAt: olderCreatedAt,
+      config: { workflowId },
+      execution: {
+        startedAt: failed.startedAt,
+        lastHeartbeatAt: failed.lastHeartbeatAt,
+      },
+      taskStateVersion: 1,
+    };
+    adapter.saveTask(workflowId, task);
+    adapter.saveAttempt(failed);
+    adapter.saveAttempt(newerPending);
+    // saveTask does not persist selected_attempt_id; set it explicitly to
+    // reproduce the stale-pointer shape observed in production.
+    adapter.updateTask(taskId, { execution: { selectedAttemptId: failed.id } });
+
+    const orchestrator = new Orchestrator({
+      persistence: adapter as any,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 1,
+    });
+
+    const invokerConfig: InvokerConfig = {};
+    const snapshot = buildCurrentActionGraphSnapshot({
+      orchestrator,
+      persistence: adapter,
+      invokerConfig,
+    });
+
+    const failedBlocker = snapshot.nodes.find(
+      (node) => node.id === `blocker:${taskId}:error` && node.status === 'failed',
+    );
+    expect(failedBlocker).toBeUndefined();
+
+    const reloaded = adapter.loadTask(taskId)!;
+    expect(reloaded.execution.selectedAttemptId).toBe(newerPending.id);
+    expect(reloaded.execution.error ?? undefined).toBeUndefined();
+
+    const events = adapter.getEvents(taskId, 'desc', 10);
+    const advanceEvent = events.find((e) => e.eventType === 'task.selected_attempt_advanced');
+    expect(advanceEvent).toBeDefined();
+  });
+});

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1798,6 +1798,40 @@ describe('SQLiteAdapter', () => {
       const [task] = adapter.loadTasks('wf-1');
       expect(task.status).toBe('fixing_with_ai');
     });
+
+    it('projects the underlying task row when selected_attempt_id points at a newer active attempt (no stale failed projection)', () => {
+      adapter.saveWorkflow(testWorkflow);
+      const olderCreatedAt = new Date('2026-07-09T05:38:02.000Z');
+      const newerCreatedAt = new Date('2026-07-09T05:51:12.808Z');
+      const failed: Attempt = {
+        ...createAttempt('t1', { status: 'failed' }),
+        id: 't1-aOLD',
+        createdAt: olderCreatedAt,
+        error: 'Cancelled by user (workflow)',
+        completedAt: new Date('2026-07-09T05:51:12.761Z'),
+      };
+      const newerPending: Attempt = {
+        ...createAttempt('t1', { status: 'pending' }),
+        id: 't1-aNEW',
+        createdAt: newerCreatedAt,
+        supersedesAttemptId: failed.id,
+      };
+      adapter.saveTask('wf-1', makeTask('t1', {
+        status: 'running',
+        execution: {
+          startedAt: new Date('2026-07-09T05:43:54.107Z'),
+        },
+      }));
+      adapter.saveAttempt(failed);
+      adapter.saveAttempt(newerPending);
+      // saveTask does not persist selected_attempt_id; set it explicitly.
+      adapter.updateTask('t1', { execution: { selectedAttemptId: newerPending.id } });
+
+      const [task] = adapter.loadTasks('wf-1');
+      expect(task.status).toBe('running');
+      expect(task.execution.error).toBeUndefined();
+      expect(task.execution.selectedAttemptId).toBe(newerPending.id);
+    });
   });
 
   describe('loadActionGraphAttempts', () => {

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -3114,6 +3114,73 @@ describe('Orchestrator', () => {
 
       expect(hydrateOrchestrator.getTask('t1')!.status).toBe('completed');
     });
+
+    it('advances stale selectedAttemptId and clears projected error when a newer active attempt exists', () => {
+      const hydratePersistence = new InMemoryPersistence();
+      hydratePersistence.saveWorkflow({ id: 'wf-stale', name: 'wf-stale' } as any);
+
+      const olderCreatedAt = new Date('2026-07-09T05:38:02.000Z');
+      const newerCreatedAt = new Date('2026-07-09T05:51:12.808Z');
+
+      const failedAttempt: Attempt = {
+        id: 't1-aOLD',
+        nodeId: 't1',
+        queuePriority: 0,
+        status: 'failed',
+        upstreamAttemptIds: [],
+        error: 'Cancelled by user (workflow)',
+        completedAt: new Date('2026-07-09T05:51:12.761Z'),
+        startedAt: new Date('2026-07-09T05:43:54.107Z'),
+        lastHeartbeatAt: new Date('2026-07-09T05:43:54.107Z'),
+        createdAt: olderCreatedAt,
+      };
+      const newerPending: Attempt = {
+        id: 't1-aNEW',
+        nodeId: 't1',
+        queuePriority: 0,
+        status: 'pending',
+        upstreamAttemptIds: [],
+        supersedesAttemptId: failedAttempt.id,
+        createdAt: newerCreatedAt,
+      };
+
+      hydratePersistence.saveAttempt(failedAttempt);
+      hydratePersistence.saveAttempt(newerPending);
+
+      hydratePersistence.saveTask('wf-stale', {
+        id: 't1',
+        description: 'Verify sidebar and workers title removal',
+        status: 'running',
+        dependencies: [],
+        createdAt: olderCreatedAt,
+        config: { workflowId: 'wf-stale' },
+        execution: {
+          selectedAttemptId: failedAttempt.id,
+          error: failedAttempt.error,
+          completedAt: failedAttempt.completedAt,
+          startedAt: failedAttempt.startedAt,
+          lastHeartbeatAt: failedAttempt.lastHeartbeatAt,
+        },
+      });
+
+      const hydrateOrchestrator = new Orchestrator({
+        persistence: hydratePersistence,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 3,
+      });
+
+      hydrateOrchestrator.syncFromDb('wf-stale');
+
+      const restored = hydrateOrchestrator.getTask('t1')!;
+      expect(restored.execution.selectedAttemptId).toBe(newerPending.id);
+      expect(restored.execution.error).toBeUndefined();
+      expect(restored.execution.completedAt).toBeUndefined();
+      expect(restored.execution.lastHeartbeatAt).toBeUndefined();
+
+      const persisted = hydratePersistence.getTaskEntry('t1')!.task;
+      expect(persisted.execution.selectedAttemptId).toBe(newerPending.id);
+      expect(persisted.execution.error).toBeUndefined();
+    });
   });
 
   // ── resumeWorkflow ──────────────────────────────────────

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1112,6 +1112,82 @@ export class Orchestrator {
     return active;
   }
 
+  /**
+   * Self-heal `selectedAttemptId` drift after DB hydration.
+   *
+   * A task's `selectedAttemptId` can end up pointing at an outcome-terminal
+   * (failed/completed) or discarded (superseded) attempt while a newer active
+   * attempt exists for the same task — e.g. a workflow cancellation invalidates
+   * a leased launch dispatch, a fresh attempt is created, but the pointer
+   * doesn't get swapped forward before the next UI read. The
+   * `SQLiteAdapter.reconcileTaskFromSelectedAttempt` projection then upgrades
+   * the loaded task to `failed`, which causes `buildActionGraphDiagnostics` to
+   * emit a `blocker:{taskId}:error` node and the workflow card to render the
+   * red "Failed: see details" pill even though the workflow has already moved
+   * on to a fresh attempt.
+   *
+   * Called at the end of `syncAllFromDb` / `syncFromDb` so every UI refresh
+   * clears drift by advancing the pointer to the newest active attempt and
+   * clearing the terminal fields the stale projection injected.
+   */
+  private reconcileStaleSelectedAttempts(): void {
+    const loadAttempts = (this.persistence as Partial<OrchestratorPersistence>).loadAttempts;
+    if (typeof loadAttempts !== 'function') return;
+
+    for (const task of this.stateMachine.getAllTasks()) {
+      const selected = this.getSelectedAttempt(task);
+      if (!selected) continue;
+      // Only heal drift caused by outcome-terminal (`failed`) or discarded
+      // (`superseded`) pointers where a strictly newer active attempt already
+      // exists. A `completed` selected attempt is left alone — that's a
+      // legitimate hand-off state (merge / fix flows). We intentionally do
+      // NOT guard on `task.status` here, because
+      // `SQLiteAdapter.reconcileTaskFromSelectedAttempt` may have already
+      // projected the failed attempt onto the task's in-memory status; the
+      // whole point of this pass is to undo that projection by advancing the
+      // pointer.
+      if (selected.status !== 'failed' && selected.status !== 'superseded') continue;
+
+      const attempts = loadAttempts.call(this.persistence, task.id);
+      let newer: Attempt | undefined;
+      for (const attempt of attempts) {
+        if (attempt.id === selected.id) continue;
+        if (!isActiveAttempt(attempt)) continue;
+        if (attempt.createdAt.getTime() <= selected.createdAt.getTime()) continue;
+        if (!newer || attempt.createdAt.getTime() > newer.createdAt.getTime()) {
+          newer = attempt;
+        }
+      }
+      if (!newer) continue;
+
+      this.writeAndSync(
+        task.id,
+        {
+          execution: {
+            selectedAttemptId: newer.id,
+            error: undefined,
+            exitCode: undefined,
+            completedAt: undefined,
+            lastHeartbeatAt: undefined,
+            branch: undefined,
+            commit: undefined,
+            workspacePath: undefined,
+            agentSessionId: undefined,
+            containerId: undefined,
+          },
+        },
+        { skipWorkflowStatusSync: true },
+      );
+      this.persistence.logEvent?.(task.id, 'task.selected_attempt_advanced', {
+        previousAttemptId: selected.id,
+        previousStatus: selected.status,
+        newAttemptId: newer.id,
+        newStatus: newer.status,
+        reason: 'stale selected pointer superseded by newer active attempt',
+      });
+    }
+  }
+
   private ensureCurrentPendingAttempt(task: TaskState): string {
     const selected = this.getSelectedAttempt(task);
     if (selected && isActiveAttempt(selected)) {
@@ -3230,6 +3306,7 @@ export class Orchestrator {
         this.stateMachine.restoreTask(task);
       }
     }
+    this.reconcileStaleSelectedAttempts();
     for (const wf of workflows) {
       this.assertMergeLeavesInvariant(wf.id);
     }
@@ -3248,6 +3325,7 @@ export class Orchestrator {
         this.stateMachine.restoreTask(task);
       }
     }
+    this.reconcileStaleSelectedAttempts();
     this.assertMergeLeavesInvariant(workflowId);
   }
 


### PR DESCRIPTION
## Summary

A workflow card kept rendering a red "Failed: see details" pill for a task whose underlying DB row had no error.

The task's `selected_attempt_id` still pointed at an older `failed` attempt even though a strictly newer active attempt already existed.

`SQLiteAdapter.reconcileTaskFromSelectedAttempt` reads status and error off the selected attempt when the task itself is non-terminal, so the outdated pointer leaked the old failure to the UI.

This PR routes a self-healing pass through `syncAllFromDb` / `syncFromDb`, the existing hydration lifecycle events.

If the selected attempt is failed or superseded and a newer active attempt exists, the pointer advances and the injected terminal fields are cleared.

Reconciliation logs a `task.selected_attempt_advanced` event so the swap is auditable in the activity log.

## Review Claim

`Orchestrator.reconcileStaleSelectedAttempts()`, routed through `syncAllFromDb` / `syncFromDb`, is the right place to heal `selected_attempt_id` drift so the projection stops emitting an outdated `failed` view of a task that has a newer active attempt.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The reconciliation only touches a task when its currently selected attempt is `failed` or `superseded` AND a strictly newer attempt with `isActiveAttempt(...)` is present. A `completed` selected attempt is intentionally left alone — that is a legitimate hand-off state used by merge and fix flows. The pointer never regresses in time because the newer candidate must have `createdAt > selected.createdAt`.

The write goes through `writeAndSync(..., { skipWorkflowStatusSync: true })` so the sweep does not spuriously toggle workflow rollups; the caller's own status sync in `syncAllFromDb` / `syncFromDb` still runs afterwards via `assertMergeLeavesInvariant`.

## Slice Rationale

The bug reproduced against real production data — a cancellation-then-fresh-attempt sequence that left the pointer outdated. Fixing it in `SQLiteAdapter.reconcileTaskFromSelectedAttempt` would only hide the failed row on the read path — the orchestrator would keep leaking an outdated pointer, and other callers of `loadTasks` would still see the failed projection. Healing the pointer at hydration is the root-cause fix and keeps the DB self-consistent for every reader.

## Non-goals

- Not changing how `selected_attempt_id` is set during normal task lifecycle transitions.
- Not changing `SQLiteAdapter.reconcileTaskFromSelectedAttempt`; the projection stays as-is for tasks whose pointer is legitimately terminal.
- Not adding a background job or scheduler; the sweep piggybacks on the existing hydration entry points.
- Not touching merge-node or gate reconciliation invariants.

## Architecture

### Before

```mermaid
graph TD
    A["syncAllFromDb / syncFromDb"] --> B["stateMachine.restoreTask(...)"]
    B --> J["assertMergeLeavesInvariant"]
    B -.projection.-> P["SQLiteAdapter.reconcileTaskFromSelectedAttempt"]
    P -.reads.-> Q["selected_attempt_id -> failed attempt"]
    Q -.emits.-> R["task.status = failed, task.execution.error set"]
    R -.consumed by.-> S["buildActionGraphDiagnostics -> blocker:{taskId}:error"]
    S -.renders.-> T["Failed: see details pill"]
```

### After

```mermaid
graph TD
    A["syncAllFromDb / syncFromDb"] --> B["stateMachine.restoreTask(...)"]
    B --> C["reconcileStaleSelectedAttempts()"]
    C --> D{"selected.status in {failed, superseded}?"}
    D -- "no" --> E["skip"]
    D -- "yes" --> F["loadAttempts(task.id)"]
    F --> G{"newer active attempt exists?"}
    G -- "no" --> E
    G -- "yes" --> H["writeAndSync: advance pointer, clear terminal fields"]
    H --> I["logEvent task.selected_attempt_advanced"]
    C --> J["assertMergeLeavesInvariant"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-core && pnpm test`
- [x] `cd packages/data-store && pnpm test`
- [x] `cd packages/app && pnpm test src/__tests__/action-graph-snapshot.test.ts`

</details>

## Visual Proof

The user-visible effect is that a workflow card in the DAG stops showing the red "Failed: see details" pill once a newer active attempt exists. A static screenshot alone cannot demonstrate this behavior because the buggy state is only reachable by a specific timing sequence — workflow cancellation while a leased launch dispatch is in flight, followed by a fresh attempt — that cannot be dropped into a demo screen deterministically.

The inspectable state proof lives in `packages/app/src/__tests__/action-graph-snapshot.test.ts`, which constructs exactly the stuck state observed in production, runs `buildCurrentActionGraphSnapshot`, and asserts the failed blocker is absent from the graph and the `task.selected_attempt_advanced` audit event is present. That is the same signal the UI reads to render the pill.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. The revert restores the prior behavior where outdated `selected_attempt_id` pointers surface as "Failed: see details" pills. Existing DB rows are untouched by this change.
- Data migration? No. The reconciliation runs at hydration and writes only if drift is detected; no schema or migration changes.

</details>
