### PR TITLE
[Terminal Double-Click Step 2 - Focus Existing Tab](1) Focus existing terminal tab

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -429,6 +429,7 @@ function WorkflowContextMenu({
   );
 }
 
+
 function EmptyGraphTutorial(): JSX.Element {
   return (
     <aside className="h-full w-full border-l border-gray-800 bg-gray-900/90 p-4">
@@ -1363,10 +1364,22 @@ export function App() {
     recenterForSelection('task', task.id);
   }, [recenterForSelection]);
 
-  const openTerminalForTaskId = useCallback(async (taskId: string) => {
+  const openTerminalForTaskId = useCallback(async (
+    taskId: string,
+    options: { focusExistingSession?: boolean } = {},
+  ) => {
     const task = tasks.get(taskId);
     if (task && isExperimentSpawnPivotTask(task)) {
       window.alert(EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE);
+      return;
+    }
+    const focusExistingSession = options.focusExistingSession ?? true;
+    const existingRunningSession = focusExistingSession
+      ? terminalSessions.find((session) => session.taskId === taskId && session.status === 'running')
+      : undefined;
+    if (existingRunningSession) {
+      setTerminalDrawerState('partial');
+      setActiveTerminalSessionId(existingRunningSession.sessionId);
       return;
     }
     setTerminalDrawerState('partial');
@@ -1389,7 +1402,7 @@ export function App() {
       });
       setActiveTerminalSessionId(session.sessionId);
     }
-  }, [tasks]);
+  }, [tasks, terminalSessions]);
 
   const handleTaskDoubleClick = useCallback(async (task: TaskState) => {
     setSelectedTaskId(task.id);
@@ -1563,7 +1576,7 @@ export function App() {
   const handleOpenTerminal = useCallback(
     (taskId: string) => {
       setContextMenu(null);
-      void openTerminalForTaskId(taskId);
+      void openTerminalForTaskId(taskId, { focusExistingSession: false });
     },
     [openTerminalForTaskId],
   );
@@ -3421,4 +3434,3 @@ export function App() {
     </div>
   );
 }
-

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -237,9 +237,11 @@ describe('Terminal drawer (component)', () => {
     await waitFor(() => {
       expect(screen.getByTestId('terminal-tab-task-alpha')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
+    expect(mock.api.openTerminal).toHaveBeenCalledTimes(1);
 
     // Minimize (cycle partial → maximized → minimized), then re-open —
-    // should not duplicate the tab.
+    // should focus the existing tab without another IPC open.
     fireEvent.click(screen.getByRole('button', { name: 'Maximize terminal drawer' }));
     fireEvent.click(screen.getByRole('button', { name: 'Minimize terminal drawer' }));
     expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'minimized');
@@ -249,8 +251,10 @@ describe('Terminal drawer (component)', () => {
     await waitFor(() => {
       expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
     });
+    expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
     const tabs = screen.getAllByTestId('terminal-tab-task-alpha');
     expect(tabs).toHaveLength(1);
+    expect(mock.api.openTerminal).toHaveBeenCalledTimes(1);
   });
 
   it('renders distinct tabs for different tasks side by side', async () => {
@@ -357,28 +361,36 @@ describe('Terminal drawer (component)', () => {
     });
   });
 
-  it('does not duplicate the replay snapshot when the same session re-renders', async () => {
-    const session = makeTerminalSession('task-alpha', {
-      outputSnapshot: 'replayed once\n',
-    });
-    (mock.api.openTerminal as ReturnType<typeof vi.fn>).mockResolvedValue({
+  it('focuses an existing running task tab on re-double-click without opening another terminal', async () => {
+    (mock.api.openTerminal as ReturnType<typeof vi.fn>).mockImplementation(async (taskId: string) => ({
       opened: true,
-      session,
-    });
+      session: makeTerminalSession(taskId, {
+        outputSnapshot: taskId === 'task-alpha' ? 'replayed once\n' : undefined,
+      }),
+    }));
 
     render(<App />);
-    act(() => mock.setTasks([taskAlpha], workflows));
+    act(() => mock.setTasks([taskAlpha, taskBeta], workflows));
     await selectWorkflow();
 
     fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
     await waitFor(() => {
       expect(xtermMock.writeLog).toEqual(['replayed once\n']);
     });
+    expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
+    expect(mock.api.openTerminal).toHaveBeenCalledTimes(1);
+
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-beta'));
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-tab-task-beta')).toHaveAttribute('data-active', 'true');
+    });
+    expect(mock.api.openTerminal).toHaveBeenCalledTimes(2);
 
     fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
     await waitFor(() => {
-      expect(mock.api.openTerminal).toHaveBeenCalledTimes(2);
+      expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
     });
+    expect(mock.api.openTerminal).toHaveBeenCalledTimes(2);
 
     expect(xtermMock.writeLog).toEqual(['replayed once\n']);
   });


### PR DESCRIPTION
## Summary

Terminal Double-Click Step 2 - Focus Existing Tab completed the terminal focus behavior and its focused verification.

Double-clicking a task with a running terminal session now selects that existing tab instead of starting another terminal.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1783561720142-4/focus-existing-terminal-tab-in-app | On task double-click, focus the existing terminal tab instead of reopening. | completed |
| wf-1783561720142-4/verify-focus-existing-terminal-tab | Run focused terminal drawer/tab behavior tests. | completed (passed) |

</details>

## Review Claim

Approve the activation surface change that makes task double-click select an existing running terminal tab before opening a new terminal.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The branch only changes renderer terminal drawer selection and the existing component test for that path; no backend terminal lifecycle API changes.

## Slice Rationale

Step 1 limited the DAG event source. This slice keeps the next surface local to the terminal drawer response.

## Non-goals

- No change to terminal process creation.
- No change to terminal close, resize, input, or output handling.
- No change to context-menu Open Terminal behavior; that action still asks for a new terminal session.

## Architecture

### Before

Task double-click always called the renderer terminal-open bridge, even when renderer state already contained a running session for that task.

### After

Task double-click first checks renderer terminal sessions for a running session on that task. Existing sessions set the active terminal tab and reopen the drawer locally.

Context-menu Open Terminal still requests a new terminal session.

## Visual Proof

![Alpha tab active after re-double-click](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-201e65/terminal-focus-existing-tab.png)

After opening Alpha, opening Beta, then double-clicking Alpha again, Alpha is active and the drawer remains partial. The Playwright proof asserted two open-terminal calls.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/terminal-drawer.test.tsx`
- [x] `pnpm --filter @invoker/app test:e2e -- terminal-focus-existing-tab-proof.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <published-pr-merge-commit>`
- Post-revert steps: Re-run the focused terminal drawer test.
- Data migration? No.

</details>
