### PR TITLE
fix(headless): answer delegated `worker status` on the running owner

### DIFF
--- a/packages/app/src/__tests__/headless-query-capture.test.ts
+++ b/packages/app/src/__tests__/headless-query-capture.test.ts
@@ -112,4 +112,30 @@ describe('runReadOnlyHeadlessQueryToString', () => {
     await expect(runReadOnlyHeadlessQueryToString(['query', 'ui-perf'], deps)).resolves.toContain('mainDeltaToUi');
     expect(resetUiPerfStats).not.toHaveBeenCalled();
   });
+
+  it('answers a delegated `worker status` query on the writable owner', async () => {
+    const deps = makeQueryDeps(() => []);
+    deps.persistence = {
+      listWorkflows: () => [],
+      loadTasks: () => [],
+      getEvents: () => [],
+    } as unknown as HeadlessQueryDeps['persistence'];
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    try {
+      const label = await runReadOnlyHeadlessQueryToString(['worker', 'status', '--output', 'label'], deps);
+      expect(label).toBe('auto-fix-recovery\n');
+      const json = await runReadOnlyHeadlessQueryToString(['worker', 'status', '--output', 'json'], deps);
+      expect(JSON.parse(json).workerId).toBe('auto-fix-recovery');
+      expect(writeSpy).not.toHaveBeenCalled();
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it('rejects a mutating `worker autofix` scan as non-delegatable', async () => {
+    const deps = makeQueryDeps(() => []);
+    await expect(
+      runReadOnlyHeadlessQueryToString(['worker', 'autofix'], deps),
+    ).rejects.toThrow(/worker autofix is not a delegatable read-only query/);
+  });
 });

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -19,11 +19,17 @@ import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import {
   type HeadlessDeps,
   type QueryFlags,
+  BOLD,
+  RESET,
   parseQueryFlags,
   restoreWorkflowForTask,
 } from './headless-shared.js';
 import { resolveDefaultExecutionAgent } from './config.js';
 import { listWorkerDecisions } from './worker-control.js';
+import {
+  collectRecoveryWorkerStatus,
+  type RecoveryWorkerStatus,
+} from './recovery-worker-observability.js';
 
 /**
  * The read-query family writes its formatted output through {@link writeOut}.
@@ -756,6 +762,53 @@ export async function headlessSession(taskId: string | undefined, deps: Pick<Hea
   }
 }
 
+function formatRecoveryWorkerStatus(status: RecoveryWorkerStatus): string {
+  const lines = [
+    `${BOLD}Recovery worker${RESET}`,
+    `  kind: ${status.kind}`,
+    `  workerId: ${status.workerId}`,
+    `  owner: ${status.owner}`,
+    `  lastWakeupAt: ${status.lastWakeupAt ?? 'never'}`,
+    `  lastScanAt: ${status.lastScanAt ?? 'never'}`,
+    `  lastSubmitAt: ${status.lastSubmitAt ?? 'never'}`,
+    `  lastSkip: ${status.lastSkipAt ?? 'never'}${status.lastSkipReason ? ` (${status.lastSkipReason} task=${status.lastSkipTaskId})` : ''}`,
+    `  counts: wakeups=${status.wakeups} scans=${status.scans} submissions=${status.submissions} skips=${status.skips}`,
+  ];
+  if (status.recent.length > 0) {
+    lines.push('');
+    lines.push(`${BOLD}Recent recovery decisions${RESET}`);
+    for (const event of status.recent) {
+      const reason = event.reason ? ` reason=${event.reason}` : '';
+      const phase = event.phase ? ` phase=${event.phase}` : '';
+      lines.push(`  ${event.at} ${event.taskId} ${event.action}${phase}${reason}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export async function renderWorkerStatus(
+  flagArgs: string[],
+  deps: Pick<HeadlessQueryDeps, 'persistence'>,
+): Promise<void> {
+  const flags = parseQueryFlags(flagArgs);
+  const status = collectRecoveryWorkerStatus(deps.persistence);
+  const { formatAsJson, formatAsJsonl } = await import('./formatter.js');
+  switch (flags.output) {
+    case 'label':
+      writeOut(`${status.workerId}\n`);
+      break;
+    case 'json':
+      writeOut(formatAsJson(status) + '\n');
+      break;
+    case 'jsonl':
+      writeOut(formatAsJsonl([status]) + '\n');
+      break;
+    default:
+      writeOut(formatRecoveryWorkerStatus(status) + '\n');
+      break;
+  }
+}
+
 /**
  * Top-level read-only headless commands that the writable owner can answer on
  * behalf of a non-owner caller. Mirrors the read-command routing in
@@ -786,6 +839,13 @@ async function dispatchReadOnlyHeadlessQuery(args: string[], deps: HeadlessQuery
       return headlessQuery(['audit', ...args.slice(1)], deps);
     case 'session':
       return headlessQuery(['session', ...args.slice(1)], deps);
+    case 'worker': {
+      const workerSub = args[1] ?? 'list';
+      if (workerSub === 'status') {
+        return renderWorkerStatus(args.slice(2), deps);
+      }
+      throw new Error(`worker ${workerSub} is not a delegatable read-only query`);
+    }
     default:
       throw new Error(`Command "${String(command)}" is not a delegatable read-only query`);
   }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -40,10 +40,6 @@ import {
 } from './global-topup.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
 import { formatHeadlessSetSubcommands } from './headless-command-registry.js';
-import {
-  collectRecoveryWorkerStatus,
-  type RecoveryWorkerStatus,
-} from './recovery-worker-observability.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 
 export {
@@ -76,7 +72,7 @@ import {
 
 export { createHeadlessExecutor, wireHeadlessApproveHook, parseQueryFlags };
 export type { HeadlessDeps, QueryFlags };
-import { headlessQuery, headlessQuerySelect } from './headless-query-list.js';
+import { headlessQuery, headlessQuerySelect, renderWorkerStatus } from './headless-query-list.js';
 export { resolveAgentSession } from './headless-query-list.js';
 import {
   headlessRun,
@@ -440,23 +436,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   }
 
   if (subCommand === 'status') {
-    const flags = parseQueryFlags(args.slice(1));
-    const status = collectRecoveryWorkerStatus(deps.persistence);
-    const { formatAsJson, formatAsJsonl } = await import('./formatter.js');
-    switch (flags.output) {
-      case 'label':
-        process.stdout.write(`${status.workerId}\n`);
-        break;
-      case 'json':
-        process.stdout.write(formatAsJson(status) + '\n');
-        break;
-      case 'jsonl':
-        process.stdout.write(formatAsJsonl([status]) + '\n');
-        break;
-      default:
-        process.stdout.write(formatRecoveryWorkerStatus(status) + '\n');
-        break;
-    }
+    await renderWorkerStatus(args.slice(1), deps);
     return;
   }
 
@@ -502,30 +482,6 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   }
   const label = definition.kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : definition.kind;
   process.stdout.write(`${label} worker scan completed.\n`);
-}
-
-function formatRecoveryWorkerStatus(status: RecoveryWorkerStatus): string {
-  const lines = [
-    `${BOLD}Recovery worker${RESET}`,
-    `  kind: ${status.kind}`,
-    `  workerId: ${status.workerId}`,
-    `  owner: ${status.owner}`,
-    `  lastWakeupAt: ${status.lastWakeupAt ?? 'never'}`,
-    `  lastScanAt: ${status.lastScanAt ?? 'never'}`,
-    `  lastSubmitAt: ${status.lastSubmitAt ?? 'never'}`,
-    `  lastSkip: ${status.lastSkipAt ?? 'never'}${status.lastSkipReason ? ` (${status.lastSkipReason} task=${status.lastSkipTaskId})` : ''}`,
-    `  counts: wakeups=${status.wakeups} scans=${status.scans} submissions=${status.submissions} skips=${status.skips}`,
-  ];
-  if (status.recent.length > 0) {
-    lines.push('');
-    lines.push(`${BOLD}Recent recovery decisions${RESET}`);
-    for (const event of status.recent) {
-      const reason = event.reason ? ` reason=${event.reason}` : '';
-      const phase = event.phase ? ` phase=${event.phase}` : '';
-      lines.push(`  ${event.at} ${event.taskId} ${event.action}${phase}${reason}`);
-    }
-  }
-  return lines.join('\n');
 }
 
 async function headlessOwnerServe(deps: Pick<HeadlessDeps, 'isStandaloneOwnerIdle'>): Promise<void> {


### PR DESCRIPTION
## Summary

The `worker status` headless command failed whenever the desktop app was running, so operators could not check auto-fix worker health from the CLI.

The running app owns the database. A read-only command from a second process is answered by that owner.

The owner had no handler for `worker`, so the delegated command errored instead of returning status.

Now the owner answers `worker status` and returns the diagnostic, matching the standalone command.

## Review Claim

The running owner answers a delegated `worker status` headless command instead of erroring, and mutating `worker <kind>` commands stay non-delegatable.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The shared renderer only reads worker audit rows through the existing persistence accessor and writes through the same output sink the query path already uses. The owner still refuses to delegate mutating `worker <kind>` scans, so no new mutation path is opened; classification is unchanged.

## Slice Rationale

One focused headless command fix plus its regression test; it changes only the `worker` command handling and shares a single status renderer between the standalone and owner code paths.

## Non-goals

- Does not change the mutating `worker <kind>` scan path, which still runs standalone and acquires the worker lock.
- Does not make `worker list` delegatable; only `worker status` is answered by the owner.
- Does not change the auto-fix worker's behavior, retry budget, or scheduling.
- Does not touch command classification; `worker` stays read-only in the registry.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-query-capture.test.ts`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
