### PR TITLE
[Planning Surface Tmux Step 1 Backend Session Routing](1) Add planning terminal IPC contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -640,7 +640,9 @@ export interface RuntimeStatus {
  */
 export interface TerminalSessionDescriptor {
   sessionId: string;
+  scope?: 'task' | 'planning';
   taskId: string;
+  planningSessionId?: string;
   status: 'running' | 'exited';
   exitCode?: number;
   cwd?: string;
@@ -655,13 +657,17 @@ export interface TerminalSessionDescriptor {
 
 export interface TerminalOutputEvent {
   sessionId: string;
+  scope?: 'task' | 'planning';
   taskId: string;
+  planningSessionId?: string;
   data: string;
 }
 
 export interface TerminalExitEvent {
   sessionId: string;
+  scope?: 'task' | 'planning';
   taskId: string;
+  planningSessionId?: string;
   exitCode?: number;
 }
 
@@ -670,6 +676,10 @@ export interface OpenTerminalResponse {
   reason?: string;
   /** Present when the GUI main process opened an embedded session. */
   session?: TerminalSessionDescriptor;
+}
+
+export interface PlanningTerminalOpenRequest {
+  planningSessionId: string;
 }
 
 // ── Search types ────────────────────────────────────────────
@@ -1034,6 +1044,26 @@ export const IpcChannels = {
     response: { ok: boolean; reason?: string };
   },
   'invoker:terminal-close': {} as {
+    request: [sessionId: string];
+    response: { ok: boolean; reason?: string };
+  },
+  'invoker:planning-terminal-open': {} as {
+    request: [request: PlanningTerminalOpenRequest];
+    response: OpenTerminalResponse;
+  },
+  'invoker:planning-terminal-list': {} as {
+    request: [];
+    response: TerminalSessionDescriptor[];
+  },
+  'invoker:planning-terminal-write': {} as {
+    request: [sessionId: string, data: string];
+    response: { ok: boolean; reason?: string };
+  },
+  'invoker:planning-terminal-resize': {} as {
+    request: [sessionId: string, cols: number, rows: number];
+    response: { ok: boolean; reason?: string };
+  },
+  'invoker:planning-terminal-close': {} as {
     request: [sessionId: string];
     response: { ok: boolean; reason?: string };
   },

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -276,6 +276,23 @@ export function createMockInvoker(
     terminalWrite: vi.fn(async () => ({ ok: true })),
     terminalResize: vi.fn(async () => ({ ok: true })),
     terminalClose: vi.fn(async () => ({ ok: true })),
+    planningTerminalOpen: vi.fn(async ({ planningSessionId }: { planningSessionId: string }) => ({
+      opened: true,
+      session: {
+        sessionId: `mock-planning-terminal-${planningSessionId}`,
+        scope: 'planning' as const,
+        taskId: `planning:${planningSessionId}`,
+        planningSessionId,
+        status: 'running' as const,
+        mode: 'spawn' as const,
+        attached: false,
+        createdAt: new Date('2025-01-01T00:00:00Z').toISOString(),
+      },
+    })),
+    planningTerminalList: vi.fn(async () => []),
+    planningTerminalWrite: vi.fn(async () => ({ ok: true })),
+    planningTerminalResize: vi.fn(async () => ({ ok: true })),
+    planningTerminalClose: vi.fn(async () => ({ ok: true })),
     onTerminalOutput: vi.fn((cb: (event: TerminalOutputEvent) => void) => {
       terminalOutputCallbacks.add(cb);
       return () => { terminalOutputCallbacks.delete(cb); };


### PR DESCRIPTION
## Summary

This adds the planning-owned terminal channels to the shared IPC contract package.

Planning sessions need their own request and response shapes so a later slice can attach them without touching task terminals.

The descriptor and event types gain optional scope and planning-session fields, defaulting to the task scope so existing payloads stay valid.

## Review Claim

Approve the new planning-terminal IPC channel definitions and the optional scope fields on the shared terminal types.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The new fields are optional and default to the task scope, so every existing task-terminal payload still type-checks and behaves the same. No runtime path reads the new channels yet.

## Slice Rationale

The contract lands first so reviewers can approve the shared type shape on its own, before any handler or backend code depends on it.

## Non-goals

- Does not register any handler for the new channels.
- Does not change task-terminal behavior.
- Does not add renderer or UI wiring.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/contracts && pnpm test`
- [ ] `cd packages/ui && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
