### PR TITLE
[Planning Surface Tmux Step 1 Backend Session Routing](3) Guard auto-fix bare re-run on worker-action tracking

### DIFF
--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -358,6 +358,11 @@ function hasBareRetryAlreadySubmitted(
   return existing.attemptCount > 0;
 }
 
+function canTrackBareRetrySubmission(options: AutoFixRecoveryPolicyOptions): boolean {
+  return typeof options.store.getWorkerAction === 'function' &&
+    typeof options.store.upsertWorkerAction === 'function';
+}
+
 function skipAutoFixCandidate(
   options: AutoFixRecoveryPolicyOptions,
   candidate: AutoFixRecoveryCandidate,
@@ -494,7 +499,7 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
         continue;
       }
 
-      if (!hasBareRetryAlreadySubmitted(options, candidate)) {
+      if (canTrackBareRetrySubmission(options) && !hasBareRetryAlreadySubmitted(options, candidate)) {
         const intentId = options.submitter.submit(
           candidate.workflowId,
           'normal',


### PR DESCRIPTION
## Summary

This keeps the auto-fix recovery tick from issuing a bare re-run when it cannot record that the attempt happened.

The recovery tick only fires its automatic re-run when the persistence store provides the worker-action hooks it uses to remember prior attempts.

Without those hooks the tick leaves the candidate alone instead of firing again on every pass.

## Review Claim

Approve gating the automatic bare re-run on whether the store can record the attempt.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

When the store provides the worker-action hooks, the recovery tick behaves exactly as before. The guard only adds a short-circuit for stores that lack those hooks, so no new re-run can fire that was not already possible.

## Slice Rationale

This slice sits above the routing change and isolates the recovery tick guard, so the auto-fix change is reviewed on its own, apart from the terminal wiring and the test-double.

## Non-goals

- Does not change the terminal routing from the earlier slices.
- Does not alter the test double.
- Does not change how attempts are counted when the hooks are present.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
