### PR TITLE
[Auto-fix worker scan on start](1) Scan failed tasks the moment the worker is turned on

### DIFF
--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -5,12 +5,16 @@ import type { TaskState } from '@invoker/workflow-core';
 
 import { buildFixWithAgentMutationArgs } from '../auto-fix-intents.js';
 import {
+  AUTO_FIX_WORKER_KIND,
   collectValidatedAutoFixRecoveryCandidates,
   createAutoFixRecoveryTick,
   createAutoFixAttemptLedger,
   createRecoveryWorker,
+  createWorkerRegistry,
   listAutoFixRecoveryScanCandidates,
+  registerAutoFixWorker,
   RECOVERY_WORKER_KIND,
+  type WorkerRuntimeDependencies,
 } from '../workers/auto-fix-recovery.js';
 import type { RecoveryWorkerWakeupHint } from '../lifecycle-events.js';
 
@@ -125,6 +129,38 @@ describe('auto-fix recovery worker', () => {
     await vi.advanceTimersByTimeAsync(1000);
     expect(onTick).toHaveBeenCalledTimes(1);
     await runtime.stop();
+  });
+
+  it('scans every failed task and submits a fix-with-agent intent when the registered worker is turned on', async () => {
+    const harness = makeRecoveryPolicyHarness();
+    const registry = registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>());
+    const definition = registry.get(AUTO_FIX_WORKER_KIND);
+    expect(definition).toBeDefined();
+
+    const messageBus = { subscribe: vi.fn(() => vi.fn()) };
+    const worker = definition!.factory({
+      store: harness.options.store,
+      submitter: harness.options.submitter,
+      logger,
+      messageBus,
+      autoFix: {
+        defaultAutoFixRetries: 3,
+        getAutoFixAgent: () => 'codex',
+        attemptLedger: harness.attemptLedger,
+      },
+    } as unknown as WorkerRuntimeDependencies);
+
+    worker.start();
+    await worker.stop();
+
+    expect(messageBus.subscribe).toHaveBeenCalled();
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    expect(harness.submit).toHaveBeenCalledWith(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      buildFixWithAgentMutationArgs('wf-1/task-1', 'codex', { autoFix: true }),
+    );
   });
 
 });

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -102,6 +102,7 @@ export function registerAutoFixWorker(
       createRecoveryWorker({
         logger: deps.logger,
         messageBus: deps.messageBus,
+        tickOnStart: true,
         autoFix: {
           store: deps.store,
           submitter: deps.submitter,


### PR DESCRIPTION
## Summary

Turning the auto-fix worker on now kicks off its recovery pass right away.

Before, starting the worker only armed its poll timer and its message-bus lifecycle subscription. Nothing happened until a later lifecycle event or the next timer tick woke it.

Now the worker fires one immediate wakeup the instant it starts, off the same lifecycle wiring it already sets up.

So everything already waiting for recovery is picked up at once instead of after a delay.

## Review Claim

Approve that starting the registered auto-fix worker fires one immediate wakeup, driven off its existing message-bus lifecycle subscription, instead of waking only on a later lifecycle event or the poll timer.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The startup wakeup runs the exact same code path as the periodic tick, only sooner. It reuses the existing eligibility checks, the open-intent dedupe, and the in-memory `autoFixRetries` budget, so it cannot act on anything the periodic pass would not, and cannot double-act.

The base `createRecoveryWorker` default stays `tickOnStart: false`; only the registered auto-fix worker opts in. No other worker's start behavior changes, and the existing "does not auto-run a tick on start" test still passes.

## Slice Rationale

This is the code slice of the stack. The follow-up `[2]` slice carries the changelog and reference-material updates, keeping one reviewable unit per PR to match the repo's separate code and documentation PRs.

## Non-goals

- Does not change owner auto-start policy; the worker is still started from the Workers tab, not auto-started at boot.
- Does not change eligibility, the retry-budget cap, the dedupe rule, or the fix-with-agent execution path — only when the first pass runs.
- Does not touch the headless one-shot `./run.sh --headless worker autofix`.
- Does not update the changelog or documentation — that is the `[2]` slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test -- src/__tests__/auto-fix-recovery.test.ts`
- [ ] `pnpm --filter @invoker/app test -- src/__tests__/worker-control.test.ts src/__tests__/no-autofix-outside-worker.test.ts src/__tests__/headless-autofix.test.ts src/__tests__/registered-owner-workers.test.ts`
- [ ] `pnpm --filter @invoker/execution-engine build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — the worker returns to waking only on a lifecycle event or the poll timer.
- Data migration? No

</details>