### PR TITLE
Fix Embedded Task Terminal Blank Rendering Step 1

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -166,6 +166,78 @@ async function openContextMenu(page: Page, locator: Locator) {
   return menu;
 }
 
+async function installTerminalTestOpener(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    type TerminalSubscriber = (event: { sessionId: string; taskId: string; data: string }) => void;
+    const terminalState = window as unknown as {
+      __terminalCalls: string[];
+      __terminalOutputSubscribers: TerminalSubscriber[];
+      __INVOKER_TEST_OPEN_TERMINAL__: (taskId: string) => Promise<unknown>;
+      __INVOKER_TEST_ON_TERMINAL_OUTPUT__: (cb: TerminalSubscriber) => () => void;
+    };
+    terminalState.__terminalCalls = [];
+    terminalState.__terminalOutputSubscribers = [];
+    terminalState.__INVOKER_TEST_OPEN_TERMINAL__ = async (taskId: string) => {
+      terminalState.__terminalCalls.push(taskId);
+      return {
+        opened: true,
+        session: {
+          sessionId: `e2e-session-${taskId}`,
+          taskId,
+          status: 'running',
+          mode: 'spawn',
+          attached: false,
+          createdAt: '2025-01-01T00:00:00.000Z',
+          outputSnapshot: `${taskId} terminal ready\n`,
+        },
+      };
+    };
+    terminalState.__INVOKER_TEST_ON_TERMINAL_OUTPUT__ = (cb) => {
+      terminalState.__terminalOutputSubscribers.push(cb);
+      return () => {
+        const index = terminalState.__terminalOutputSubscribers.indexOf(cb);
+        if (index >= 0) terminalState.__terminalOutputSubscribers.splice(index, 1);
+      };
+    };
+  });
+}
+
+async function openTerminalForTaskNode(page: Page, taskIdSuffix: string): Promise<void> {
+  const taskNode = page.locator(`.react-flow__node[data-testid$="${taskIdSuffix}"]`).first();
+  await expect(taskNode).toBeVisible({ timeout: 10000 });
+  await taskNode.dispatchEvent('dblclick', { bubbles: true, cancelable: true });
+}
+
+async function expectActiveTerminalPane(page: Page, taskId: string): Promise<void> {
+  const tab = page.locator(`[data-testid^="terminal-tab-"][data-testid$="${taskId}"]`).first();
+  const pane = page.locator(`[data-testid^="terminal-pane-"][data-testid$="${taskId}"]`).first();
+  await expect(tab).toHaveAttribute('data-active', 'true');
+  await expect(pane).toBeVisible();
+  await expect(pane.locator('.xterm')).toHaveCount(1);
+  const metrics = await pane.evaluate((element) => {
+    const style = window.getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    return {
+      display: style.display,
+      visibility: style.visibility,
+      width: rect.width,
+      height: rect.height,
+    };
+  });
+  expect(metrics.display).not.toBe('none');
+  expect(metrics.visibility).not.toBe('hidden');
+  expect(metrics.width).toBeGreaterThan(0);
+  expect(metrics.height).toBeGreaterThan(0);
+}
+
+async function expectInactiveTerminalPane(page: Page, taskId: string): Promise<void> {
+  const tab = page.locator(`[data-testid^="terminal-tab-"][data-testid$="${taskId}"]`).first();
+  const pane = page.locator(`[data-testid^="terminal-pane-"][data-testid$="${taskId}"]`).first();
+  await expect(tab).toHaveAttribute('data-active', 'false');
+  await expect(pane).not.toBeVisible();
+  await expect(pane).toHaveCSS('display', 'none');
+}
+
 async function loadPlanAndSelectWorkflow(page: Page, plan: unknown): Promise<string> {
   const beforeIds = await page.evaluate(async () => {
     const workflows = await window.invoker.listWorkflows();
@@ -249,6 +321,77 @@ test.describe('Visual proof capture', () => {
     await expect(page.getByText('sleep 5 && echo hello-alpha')).toBeVisible();
     await captureScreenshot(page, 'task-panel');
     await assertPageScreenshot(page, 'task-panel');
+  });
+
+  test('terminal active pane remains visible across minimized partial maximized transitions', async ({ page }) => {
+    await loadPlan(page, TEST_PLAN);
+    await installTerminalTestOpener(page);
+
+    await expect(page.getByRole('button', { name: 'Expand terminal drawer' })).toBeVisible();
+    await expect(page.getByTestId('terminal-drawer-body')).toHaveCount(0);
+
+    await openTerminalForTaskNode(page, 'task-alpha');
+    await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
+    await expect(page.getByRole('button', { name: 'Maximize terminal drawer' })).toBeVisible();
+    await expectActiveTerminalPane(page, 'task-alpha');
+
+    await page.getByRole('button', { name: 'Maximize terminal drawer' }).click();
+    await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'maximized');
+    await expectActiveTerminalPane(page, 'task-alpha');
+
+    await page.getByRole('button', { name: 'Minimize terminal drawer' }).click();
+    await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'minimized');
+    await expect(page.getByTestId('terminal-drawer-body')).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Expand terminal drawer' }).click();
+    await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
+    await expectActiveTerminalPane(page, 'task-alpha');
+
+    await captureScreenshot(page, 'terminal-active-pane-state-transitions');
+  });
+
+  test('terminal tab switches reveal only the active pane while inactive panes are display none', async ({ page }) => {
+    await loadPlan(page, TEST_PLAN);
+    await installTerminalTestOpener(page);
+
+    await openTerminalForTaskNode(page, 'task-alpha');
+    await expectActiveTerminalPane(page, 'task-alpha');
+
+    await openTerminalForTaskNode(page, 'task-beta');
+    await expectActiveTerminalPane(page, 'task-beta');
+    await expectInactiveTerminalPane(page, 'task-alpha');
+
+    await page.getByRole('tab', { name: 'First test task' }).click();
+    await expectActiveTerminalPane(page, 'task-alpha');
+    await expectInactiveTerminalPane(page, 'task-beta');
+
+    await captureScreenshot(page, 'terminal-active-pane-tab-switch');
+  });
+
+  test('terminal returning to an already-open task tab keeps the active pane visible', async ({ page }) => {
+    await loadPlan(page, TEST_PLAN);
+    await installTerminalTestOpener(page);
+
+    await openTerminalForTaskNode(page, 'task-alpha');
+    await openTerminalForTaskNode(page, 'task-beta');
+    await expectActiveTerminalPane(page, 'task-beta');
+
+    await page.getByRole('tab', { name: 'First test task' }).click();
+    await expectActiveTerminalPane(page, 'task-alpha');
+    await expectInactiveTerminalPane(page, 'task-beta');
+
+    await openTerminalForTaskNode(page, 'task-alpha');
+    await expect(page.getByTestId('terminal-tab-strip').locator('[data-testid^="terminal-tab-"]')).toHaveCount(2);
+    await expect(page.locator('[data-testid^="terminal-tab-"][data-testid$="task-alpha"]').first()).toHaveAttribute('data-active', 'true');
+    await expectActiveTerminalPane(page, 'task-alpha');
+    await expectInactiveTerminalPane(page, 'task-beta');
+
+    const terminalCalls = await page.evaluate(() => (
+      (window as unknown as { __terminalCalls: string[] }).__terminalCalls
+    ));
+    expect(terminalCalls.map((taskId) => taskId.split('/').pop())).toEqual(['task-alpha', 'task-beta']);
+
+    await captureScreenshot(page, 'terminal-return-to-open-tab');
   });
 
   test('task panel setup failure renders in Error panel', async ({ page }) => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -30,13 +30,24 @@ import { FloatingGraphPanel } from './components/FloatingGraphPanel.js';
 import { WorkflowInspector } from './components/WorkflowInspector.js';
 import { ActionGraphView } from './components/ActionGraphView.js';
 import { StatusBar } from './components/StatusBar.js';
-import { TerminalDrawer } from './components/TerminalDrawer.js';
+import {
+  TerminalDrawer,
+  type OpenTerminalResponse,
+  type TerminalDrawerState,
+  type TerminalSessionDescriptor,
+} from './components/TerminalDrawer.js';
 import {
   isExperimentSpawnPivotTask,
   EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE,
 } from './isExperimentSpawnPivot.js';
 import { parsePlanText } from './lib/plan-parser.js';
 import type { SystemDiagnostics } from '@invoker/contracts';
+
+declare global {
+  interface Window {
+    __INVOKER_TEST_OPEN_TERMINAL__?: (taskId: string) => Promise<OpenTerminalResponse>;
+  }
+}
 
 type ModalState =
   | { type: 'none' }
@@ -245,7 +256,9 @@ export function App() {
   const [installSkillsError, setInstallSkillsError] = useState<string | null>(null);
   const [inspectorCollapsed, setInspectorCollapsed] = useState(false);
   const [advancedMetadataExpanded, setAdvancedMetadataExpanded] = useState(false);
-  const [terminalCollapsed, setTerminalCollapsed] = useState(true);
+  const [terminalDrawerState, setTerminalDrawerState] = useState<TerminalDrawerState>('minimized');
+  const [terminalSessions, setTerminalSessions] = useState<TerminalSessionDescriptor[]>([]);
+  const [activeTerminalSessionId, setActiveTerminalSessionId] = useState<string | null>(null);
   const [workflowContextMenu, setWorkflowContextMenu] = useState<{ x: number; y: number; workflowId: string } | null>(null);
   const uiPerfThrottleRef = useRef<Record<string, number>>({});
 
@@ -396,6 +409,89 @@ export function App() {
       }
     });
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const api = window.invoker as unknown as {
+      terminalList?: () => Promise<TerminalSessionDescriptor[]>;
+    };
+    void api.terminalList?.().then((sessions) => {
+      if (cancelled || sessions.length === 0) return;
+      setTerminalSessions(sessions);
+      setActiveTerminalSessionId(sessions[0]?.sessionId ?? null);
+      setTerminalDrawerState('partial');
+    }).catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const upsertTerminalSession = useCallback((session: TerminalSessionDescriptor) => {
+    setTerminalSessions((prev) => {
+      const existingIndex = prev.findIndex((candidate) => (
+        candidate.sessionId === session.sessionId || candidate.taskId === session.taskId
+      ));
+      if (existingIndex === -1) {
+        return [...prev, session];
+      }
+      const next = [...prev];
+      next[existingIndex] = { ...next[existingIndex], ...session };
+      return next;
+    });
+    setActiveTerminalSessionId(session.sessionId);
+    setTerminalDrawerState('partial');
+  }, []);
+
+  const openTerminalForTask = useCallback(async (taskId: string) => {
+    const existing = terminalSessions.find((session) => session.taskId === taskId);
+    if (existing) {
+      setActiveTerminalSessionId(existing.sessionId);
+      setTerminalDrawerState('partial');
+      return;
+    }
+
+    const opener = window.__INVOKER_TEST_OPEN_TERMINAL__ ?? (async (id: string): Promise<OpenTerminalResponse | undefined> => (
+      await window.invoker?.openTerminal(id) as OpenTerminalResponse | undefined
+    ));
+    const result = await opener(taskId);
+    if (!result) return;
+    if (!result.opened) {
+      window.alert(result.reason ?? 'Cannot open terminal for this task.');
+      return;
+    }
+    if (result.session) {
+      upsertTerminalSession(result.session);
+    }
+  }, [terminalSessions, upsertTerminalSession]);
+
+  const handleSelectTerminalSession = useCallback((sessionId: string) => {
+    setActiveTerminalSessionId(sessionId);
+    if (terminalDrawerState === 'minimized') {
+      setTerminalDrawerState('partial');
+    }
+  }, [terminalDrawerState]);
+
+  const handleCloseTerminalSession = useCallback((sessionId: string) => {
+    const index = terminalSessions.findIndex((session) => session.sessionId === sessionId);
+    const next = terminalSessions.filter((session) => session.sessionId !== sessionId);
+    setTerminalSessions(next);
+    if (activeTerminalSessionId === sessionId) {
+      setActiveTerminalSessionId(next[index]?.sessionId ?? next[index - 1]?.sessionId ?? next[0]?.sessionId ?? null);
+    }
+    if (next.length === 0) {
+      setTerminalDrawerState('minimized');
+    }
+    const api = window.invoker as unknown as {
+      terminalClose?: (closedSessionId: string) => Promise<unknown>;
+    };
+    void api.terminalClose?.(sessionId);
+  }, [activeTerminalSessionId, terminalSessions]);
+
+  const taskLabelsById = useMemo(
+    () => new Map([...tasks.values()].map((task) => [task.id, task.description])),
+    [tasks],
+  );
+
   const missingRequiredTool = systemDiagnostics?.tools.find((tool) => tool.required && !tool.installed) ?? null;
   const installedAgentCount = systemDiagnostics?.tools.filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed).length ?? 0;
   const needsBundledSkillsPrompt = Boolean(systemDiagnostics?.isPackaged && systemDiagnostics?.bundledSkills?.promptRecommended);
@@ -416,11 +512,8 @@ export function App() {
       window.alert(EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE);
       return;
     }
-    const result = await window.invoker?.openTerminal(task.id);
-    if (result && !result.opened) {
-      window.alert(result.reason ?? 'Cannot open terminal for this task.');
-    }
-  }, []);
+    await openTerminalForTask(task.id);
+  }, [openTerminalForTask]);
 
   const handleTaskContextMenu = useCallback((task: TaskState, event: React.MouseEvent) => {
     setSelectedTaskId(task.id);
@@ -489,9 +582,9 @@ export function App() {
         window.alert(EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE);
         return;
       }
-      void window.invoker?.openTerminal(taskId);
+      void openTerminalForTask(taskId);
     },
-    [tasks],
+    [openTerminalForTask, tasks],
   );
 
   const handleReplaceTask = useCallback((taskId: string) => {
@@ -1141,8 +1234,15 @@ export function App() {
                   onStatusClick={(filterKey, event) => handleStatusClick(filterKey as WorkflowStatus, event)}
                 />
                 <TerminalDrawer
-                  collapsed={terminalCollapsed}
-                  onToggle={() => setTerminalCollapsed((prev) => !prev)}
+                  state={terminalDrawerState}
+                  onCycle={() => setTerminalDrawerState((prev) => (
+                    prev === 'minimized' ? 'partial' : prev === 'partial' ? 'maximized' : 'minimized'
+                  ))}
+                  sessions={terminalSessions}
+                  activeSessionId={activeTerminalSessionId}
+                  onSelectSession={handleSelectTerminalSession}
+                  onCloseSession={handleCloseTerminalSession}
+                  taskLabels={taskLabelsById}
                 />
               </>
             )}

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import type { WorkflowMeta } from '../types.js';
+import type { TerminalSessionDescriptor } from '../components/TerminalDrawer.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const xtermMock = vi.hoisted(() => {
+  type DataHandler = (data: string) => void;
+
+  const instances: MockTerminal[] = [];
+  const fitInstances: MockFitAddon[] = [];
+  const writeLog: string[] = [];
+
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    dataHandler: DataHandler | null = null;
+    loadAddon = vi.fn();
+    open = vi.fn((host: HTMLElement) => {
+      const terminalElement = document.createElement('div');
+      terminalElement.className = 'xterm';
+      terminalElement.textContent = 'mock terminal';
+      host.appendChild(terminalElement);
+    });
+    write = vi.fn((data: string) => {
+      writeLog.push(data);
+    });
+    onData = vi.fn((cb: DataHandler) => {
+      this.dataHandler = cb;
+      return { dispose: vi.fn() };
+    });
+    focus = vi.fn();
+    dispose = vi.fn();
+
+    constructor() {
+      instances.push(this);
+    }
+
+    emitData(data: string) {
+      this.dataHandler?.(data);
+    }
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+
+    constructor() {
+      fitInstances.push(this);
+    }
+  }
+
+  return {
+    Terminal: MockTerminal,
+    FitAddon: MockFitAddon,
+    instances,
+    fitInstances,
+    writeLog,
+    reset: () => {
+      instances.length = 0;
+      fitInstances.length = 0;
+      writeLog.length = 0;
+    },
+  };
+});
+
+vi.mock('xterm', () => ({ Terminal: xtermMock.Terminal }));
+vi.mock('xterm-addon-fit', () => ({ FitAddon: xtermMock.FitAddon }));
+
+const { App } = await import('../App.js');
+const { TerminalDrawer } = await import('../components/TerminalDrawer.js');
+
+const workflows: WorkflowMeta[] = [{ id: 'wf-a', name: 'Workflow A', status: 'completed' }];
+const taskAlpha = makeUITask({
+  id: 'task-alpha',
+  description: 'Alpha description',
+  status: 'completed',
+  workflowId: 'wf-a',
+});
+const taskBeta = makeUITask({
+  id: 'task-beta',
+  description: 'Beta description',
+  status: 'completed',
+  workflowId: 'wf-a',
+  dependencies: ['task-alpha'],
+});
+
+function makeTerminalSession(
+  taskId: string,
+  overrides: Partial<TerminalSessionDescriptor> = {},
+): TerminalSessionDescriptor {
+  return {
+    sessionId: `mock-session-${taskId}`,
+    taskId,
+    status: 'running',
+    mode: 'spawn',
+    attached: false,
+    createdAt: new Date('2025-01-01T00:00:00Z').toISOString(),
+    outputSnapshot: `${taskId} ready\n`,
+    ...overrides,
+  };
+}
+
+async function expectPaneReady(taskId: string) {
+  const pane = screen.getByTestId(`terminal-pane-${taskId}`);
+  expect(pane).toBeVisible();
+  await waitFor(() => {
+    expect(pane.querySelector('.xterm')).not.toBeNull();
+  });
+  return pane;
+}
+
+async function selectWorkflow(): Promise<void> {
+  await waitFor(() => {
+    expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
+  });
+  fireEvent.click(screen.getByTestId('rf__node-wf-a'));
+  await waitFor(() => {
+    expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
+  });
+}
+
+function installTerminalMocks(mock: MockInvoker): void {
+  const terminalApi = mock.api as unknown as {
+    terminalResize: ReturnType<typeof vi.fn>;
+    terminalWrite: ReturnType<typeof vi.fn>;
+    terminalClose: ReturnType<typeof vi.fn>;
+    terminalList: ReturnType<typeof vi.fn>;
+    onTerminalOutput: ReturnType<typeof vi.fn>;
+  };
+  terminalApi.terminalResize = vi.fn(async () => ({ ok: true }));
+  terminalApi.terminalWrite = vi.fn(async () => ({ ok: true }));
+  terminalApi.terminalClose = vi.fn(async () => ({ ok: true }));
+  terminalApi.terminalList = vi.fn(async () => []);
+  terminalApi.onTerminalOutput = vi.fn(() => () => {});
+}
+
+function installXtermMocks(): void {
+  window.__INVOKER_TEST_TERMINAL_CONSTRUCTORS__ = {
+    Terminal: xtermMock.Terminal,
+    FitAddon: xtermMock.FitAddon,
+  };
+}
+
+describe('Terminal drawer rendering regressions', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    xtermMock.reset();
+    installXtermMocks();
+    mock = createMockInvoker();
+    installTerminalMocks(mock);
+    mock.install();
+  });
+
+  afterEach(() => {
+    delete window.__INVOKER_TEST_TERMINAL_CONSTRUCTORS__;
+    mock.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps the active pane visible through minimized -> partial -> maximized transitions', async () => {
+    const session = makeTerminalSession('task-alpha');
+    const props = {
+      onCycle: vi.fn(),
+      sessions: [session],
+      activeSessionId: session.sessionId,
+      onSelectSession: vi.fn(),
+      onCloseSession: vi.fn(),
+    };
+
+    const { rerender } = render(<TerminalDrawer state="minimized" {...props} />);
+    expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'minimized');
+    expect(screen.queryByTestId('terminal-drawer-body')).not.toBeInTheDocument();
+
+    rerender(<TerminalDrawer state="partial" {...props} />);
+    expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
+    expect(screen.getByTestId('terminal-drawer-body')).toHaveStyle({ height: '280px' });
+    expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
+    await expectPaneReady('task-alpha');
+
+    rerender(<TerminalDrawer state="maximized" {...props} />);
+    expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'maximized');
+    expect(screen.getByTestId('terminal-drawer')).toHaveClass('fixed');
+    expect(screen.getByTestId('terminal-drawer-body')).toHaveClass('min-h-0', 'flex-1', 'overflow-hidden');
+    expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
+    await expectPaneReady('task-alpha');
+
+    await waitFor(() => {
+      expect(xtermMock.fitInstances[0]?.fit).toHaveBeenCalled();
+      expect(xtermMock.instances[0]?.focus).toHaveBeenCalled();
+    });
+  });
+
+  it('renders only the active terminal pane visible while inactive panes remain display:none', async () => {
+    const alpha = makeTerminalSession('task-alpha');
+    const beta = makeTerminalSession('task-beta');
+    const props = {
+      state: 'partial' as const,
+      onCycle: vi.fn(),
+      sessions: [alpha, beta],
+      onSelectSession: vi.fn(),
+      onCloseSession: vi.fn(),
+    };
+
+    const { rerender } = render(<TerminalDrawer {...props} activeSessionId={alpha.sessionId} />);
+    const alphaPane = await expectPaneReady('task-alpha');
+    const betaPane = screen.getByTestId('terminal-pane-task-beta');
+    expect(betaPane).not.toBeVisible();
+    expect(betaPane).toHaveStyle({ display: 'none' });
+    expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
+    expect(screen.getByTestId('terminal-tab-task-beta')).toHaveAttribute('data-active', 'false');
+
+    rerender(<TerminalDrawer {...props} activeSessionId={beta.sessionId} />);
+    expect(alphaPane).not.toBeVisible();
+    expect(alphaPane).toHaveStyle({ display: 'none' });
+    await expectPaneReady('task-beta');
+    expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'false');
+    expect(screen.getByTestId('terminal-tab-task-beta')).toHaveAttribute('data-active', 'true');
+  });
+
+  it('returns to an already-open terminal tab with the correct active pane', async () => {
+    (mock.api.openTerminal as ReturnType<typeof vi.fn>).mockImplementation(async (taskId: string) => ({
+      opened: true,
+      session: makeTerminalSession(taskId),
+    }));
+
+    render(<App />);
+    act(() => mock.setTasks([taskAlpha, taskBeta], workflows));
+    await selectWorkflow();
+
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
+    });
+    await expectPaneReady('task-alpha');
+
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-beta'));
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-tab-task-beta')).toHaveAttribute('data-active', 'true');
+      expect(screen.getByTestId('terminal-pane-task-alpha')).toHaveStyle({ display: 'none' });
+    });
+    await expectPaneReady('task-beta');
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Alpha description' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
+      expect(screen.getByTestId('terminal-pane-task-beta')).toHaveStyle({ display: 'none' });
+    });
+    await expectPaneReady('task-alpha');
+
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
+    await waitFor(() => {
+      expect(screen.getAllByTestId('terminal-tab-task-alpha')).toHaveLength(1);
+      expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
+    });
+    await expectPaneReady('task-alpha');
+    expect(mock.api.openTerminal).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -1,28 +1,393 @@
-interface TerminalDrawerProps {
-  collapsed: boolean;
-  onToggle: () => void;
+import { useEffect, useRef } from 'react';
+import type { Terminal as XTermTerminal } from 'xterm';
+import type { FitAddon } from 'xterm-addon-fit';
+import 'xterm/css/xterm.css';
+
+const DRAWER_BODY_HEIGHT_PX = 280;
+
+export type TerminalDrawerState = 'minimized' | 'partial' | 'maximized';
+
+export interface TerminalSessionDescriptor {
+  sessionId: string;
+  taskId: string;
+  status: 'running' | 'exited';
+  exitCode?: number;
+  cwd?: string;
+  command?: string;
+  args?: string[];
+  mode?: 'spawn' | 'attached';
+  attached?: boolean;
+  createdAt: string;
+  outputSnapshot?: string;
 }
 
-export function TerminalDrawer({ collapsed, onToggle }: TerminalDrawerProps): JSX.Element {
+export interface TerminalOutputEvent {
+  sessionId: string;
+  taskId: string;
+  data: string;
+}
+
+export interface OpenTerminalResponse {
+  opened: boolean;
+  reason?: string;
+  session?: TerminalSessionDescriptor;
+}
+
+declare global {
+  interface Window {
+    __INVOKER_TEST_ON_TERMINAL_OUTPUT__?: (cb: (event: TerminalOutputEvent) => void) => () => void;
+    __INVOKER_TEST_TERMINAL_CONSTRUCTORS__?: TerminalConstructors;
+  }
+}
+
+interface TerminalDrawerProps {
+  state: TerminalDrawerState;
+  onCycle: () => void;
+  sessions: TerminalSessionDescriptor[];
+  activeSessionId: string | null;
+  onSelectSession: (sessionId: string) => void;
+  onCloseSession: (sessionId: string) => void;
+  taskLabels?: Map<string, string>;
+}
+
+interface TerminalSessionPaneProps {
+  session: TerminalSessionDescriptor;
+  isActive: boolean;
+  hasHeader: boolean;
+}
+
+type SeededOutputSnapshot = {
+  sessionId: string;
+  snapshot: string;
+  term: XTermTerminal;
+};
+
+const NEXT_STATE_BY_STATE: Record<TerminalDrawerState, { next: TerminalDrawerState; label: string; ariaLabel: string }> = {
+  minimized: { next: 'partial', label: 'Expand', ariaLabel: 'Expand terminal drawer' },
+  partial: { next: 'maximized', label: 'Maximize', ariaLabel: 'Maximize terminal drawer' },
+  maximized: { next: 'minimized', label: 'Minimize', ariaLabel: 'Minimize terminal drawer' },
+};
+
+type TerminalApi = {
+  terminalWrite?: (sessionId: string, data: string) => Promise<unknown>;
+  terminalResize?: (sessionId: string, cols: number, rows: number) => Promise<unknown>;
+  terminalClose?: (sessionId: string) => Promise<unknown>;
+  onTerminalOutput?: (cb: (event: TerminalOutputEvent) => void) => () => void;
+};
+
+type TerminalConstructors = {
+  Terminal: typeof import('xterm').Terminal;
+  FitAddon: typeof import('xterm-addon-fit').FitAddon;
+};
+
+function terminalApi(): TerminalApi {
+  return (window.invoker ?? {}) as unknown as TerminalApi;
+}
+
+async function loadTerminalConstructors(): Promise<TerminalConstructors> {
+  const testConstructors = window.__INVOKER_TEST_TERMINAL_CONSTRUCTORS__;
+  if (testConstructors) return testConstructors;
+
+  const [xtermModule, fitModule] = await Promise.all([
+    import('xterm'),
+    import('xterm-addon-fit'),
+  ]);
+  return {
+    Terminal: xtermModule.Terminal,
+    FitAddon: fitModule.FitAddon,
+  };
+}
+
+function seedTerminalOutputSnapshot(
+  term: XTermTerminal,
+  session: TerminalSessionDescriptor,
+  seededSnapshotRef: { current: SeededOutputSnapshot | null },
+): void {
+  const outputSnapshot = session.outputSnapshot;
+  const seededSnapshot = seededSnapshotRef.current;
+  if (
+    outputSnapshot &&
+    (
+      !seededSnapshot ||
+      seededSnapshot.sessionId !== session.sessionId ||
+      seededSnapshot.snapshot !== outputSnapshot ||
+      seededSnapshot.term !== term
+    )
+  ) {
+    try {
+      term.write(outputSnapshot);
+      seededSnapshotRef.current = {
+        sessionId: session.sessionId,
+        snapshot: outputSnapshot,
+        term,
+      };
+    } catch {
+      /* terminal disposed */
+    }
+  }
+}
+
+function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPaneProps): JSX.Element {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const termRef = useRef<XTermTerminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const seededSnapshotRef = useRef<SeededOutputSnapshot | null>(null);
+
+  useEffect(() => {
+    const host = containerRef.current;
+    if (!host) return;
+
+    let disposed = false;
+    let cleanup: (() => void) | null = null;
+
+    void loadTerminalConstructors().then(({ Terminal, FitAddon }) => {
+      if (disposed) return;
+
+      let term: XTermTerminal;
+      let fit: FitAddon;
+      try {
+        term = new Terminal({
+          fontSize: 12,
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+          cursorBlink: true,
+          convertEol: false,
+          scrollback: 5000,
+          theme: { background: '#0b0f1a', foreground: '#e5e7eb' },
+        });
+        fit = new FitAddon();
+        term.loadAddon(fit);
+        term.open(host);
+      } catch {
+        return;
+      }
+
+      if (disposed) {
+        try {
+          term.dispose();
+        } catch {
+          /* already disposed */
+        }
+        return;
+      }
+
+      termRef.current = term;
+      fitRef.current = fit;
+      seedTerminalOutputSnapshot(term, session, seededSnapshotRef);
+
+      const inputDisposable = term.onData((data) => {
+        void terminalApi().terminalWrite?.(session.sessionId, data);
+      });
+
+      const subscribeToOutput = window.__INVOKER_TEST_ON_TERMINAL_OUTPUT__ ?? terminalApi().onTerminalOutput;
+      const unsubscribeOutput = subscribeToOutput?.((event) => {
+        if (event.sessionId !== session.sessionId) return;
+        try {
+          term.write(event.data);
+        } catch {
+          /* terminal disposed */
+        }
+      });
+
+      const tryFit = () => {
+        try {
+          fit.fit();
+          void terminalApi().terminalResize?.(session.sessionId, term.cols, term.rows);
+        } catch {
+          /* host has zero size or fit unsupported */
+        }
+      };
+
+      const raf = typeof requestAnimationFrame === 'function' ? requestAnimationFrame(tryFit) : null;
+      let resizeObserver: ResizeObserver | null = null;
+      if (typeof ResizeObserver !== 'undefined') {
+        try {
+          resizeObserver = new ResizeObserver(tryFit);
+          resizeObserver.observe(host);
+        } catch {
+          resizeObserver = null;
+        }
+      }
+      if (isActive) {
+        tryFit();
+        try {
+          term.focus();
+        } catch {
+          /* focus unsupported */
+        }
+      }
+
+      cleanup = () => {
+        if (raf !== null && typeof cancelAnimationFrame === 'function') {
+          cancelAnimationFrame(raf);
+        }
+        resizeObserver?.disconnect();
+        inputDisposable.dispose();
+        unsubscribeOutput?.();
+        try {
+          term.dispose();
+        } catch {
+          /* already disposed */
+        }
+        termRef.current = null;
+        fitRef.current = null;
+      };
+    });
+
+    return () => {
+      disposed = true;
+      cleanup?.();
+    };
+  }, [session.sessionId]);
+
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    seedTerminalOutputSnapshot(term, session, seededSnapshotRef);
+  }, [session.outputSnapshot, session.sessionId]);
+
+  useEffect(() => {
+    if (!isActive) return;
+    const term = termRef.current;
+    const fit = fitRef.current;
+    if (!term || !fit) return;
+    try {
+      fit.fit();
+      void terminalApi().terminalResize?.(session.sessionId, term.cols, term.rows);
+      term.focus();
+    } catch {
+      /* fit failed */
+    }
+  }, [isActive, session.sessionId]);
+
   return (
-    <div className="border-t border-gray-800 bg-gray-950">
-      <div className="flex items-center justify-between px-3 py-2 border-b border-gray-800">
-        <div className="flex items-center gap-3 text-xs text-gray-300">
-          <button className="hover:text-white">Terminal</button>
-          <button className="hover:text-white">Logs</button>
-          <button className="hover:text-white">Problems</button>
+    <div
+      ref={containerRef}
+      data-testid={`terminal-pane-${session.taskId}`}
+      data-session-id={session.sessionId}
+      className={hasHeader ? 'absolute bottom-0 left-0 right-0 top-9 overflow-hidden' : 'absolute inset-0 overflow-hidden'}
+      style={{ display: isActive ? 'block' : 'none' }}
+    />
+  );
+}
+
+export function TerminalDrawer({
+  state,
+  onCycle,
+  sessions,
+  activeSessionId,
+  onSelectSession,
+  onCloseSession,
+  taskLabels,
+}: TerminalDrawerProps): JSX.Element {
+  const isMaximized = state === 'maximized';
+  const showBody = state !== 'minimized';
+  const cycle = NEXT_STATE_BY_STATE[state];
+  const activeSession = sessions.find((session) => session.sessionId === activeSessionId) ?? null;
+  const activeCommand = activeSession?.command
+    ? [activeSession.command, ...(activeSession.args ?? [])].join(' ')
+    : null;
+
+  return (
+    <div
+      data-testid="terminal-drawer"
+      data-state={state}
+      className={
+        isMaximized
+          ? 'fixed inset-0 z-40 flex min-h-0 flex-col overflow-hidden border-t border-gray-800 bg-gray-950'
+          : 'border-t border-gray-800 bg-gray-950'
+      }
+    >
+      <div className="flex items-center gap-2 border-b border-gray-800 px-3 py-2">
+        <div
+          role="tablist"
+          data-testid="terminal-tab-strip"
+          className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto"
+        >
+          {sessions.length === 0 ? (
+            <span className="text-xs text-gray-400">No terminal sessions</span>
+          ) : (
+            sessions.map((session) => {
+              const isActive = session.sessionId === activeSessionId;
+              const label = taskLabels?.get(session.taskId) ?? session.taskId;
+              return (
+                <div
+                  key={session.sessionId}
+                  data-testid={`terminal-tab-${session.taskId}`}
+                  data-active={isActive ? 'true' : 'false'}
+                  className={
+                    isActive
+                      ? 'flex shrink-0 items-center gap-1 rounded border border-gray-500 bg-gray-800 text-white'
+                      : 'flex shrink-0 items-center gap-1 rounded border border-transparent text-gray-400 hover:bg-gray-800'
+                  }
+                >
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    onClick={() => onSelectSession(session.sessionId)}
+                    className="max-w-[180px] truncate px-2 py-0.5 text-xs"
+                    title={label}
+                  >
+                    {label}
+                    {session.status === 'exited' && (
+                      <span className="ml-1 text-[10px] text-amber-300">exited</span>
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Close terminal for ${label}`}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onCloseSession(session.sessionId);
+                    }}
+                    className="px-1 text-xs text-gray-400 hover:text-white"
+                  >
+                    x
+                  </button>
+                </div>
+              );
+            })
+          )}
         </div>
         <button
-          onClick={onToggle}
-          aria-label={collapsed ? 'Expand terminal drawer' : 'Collapse terminal drawer'}
-          className="rounded border border-gray-700 px-2 py-1 text-[11px] text-gray-300 hover:bg-gray-800"
+          type="button"
+          onClick={onCycle}
+          aria-label={cycle.ariaLabel}
+          className="shrink-0 rounded border border-gray-700 px-2 py-1 text-[11px] text-gray-300 hover:bg-gray-800"
         >
-          {collapsed ? 'Expand' : 'Minimize'}
+          {cycle.label}
         </button>
       </div>
-      {!collapsed && (
-        <div className="h-40 px-3 py-2 text-xs text-gray-400 overflow-auto">
-          Terminal drawer reserved for embedded shell/log surfaces.
+      {showBody && (
+        <div
+          data-testid="terminal-drawer-body"
+          className={isMaximized ? 'relative min-h-0 flex-1 overflow-hidden bg-black' : 'relative overflow-hidden bg-black'}
+          style={isMaximized ? undefined : { height: DRAWER_BODY_HEIGHT_PX }}
+        >
+          {sessions.length === 0 && (
+            <div className="absolute inset-0 flex items-center justify-center px-3 text-xs text-gray-400">
+              Open a terminal from a task to attach.
+            </div>
+          )}
+          {activeSession && activeCommand && (
+            <div
+              data-testid="terminal-session-command"
+              className="absolute left-0 right-0 top-0 z-10 flex h-9 items-center gap-2 border-b border-gray-800 bg-gray-950 px-3 text-[11px]"
+            >
+              <span className="text-gray-400">SSH</span>
+              <span className="min-w-0 flex-1 truncate font-mono text-emerald-200">
+                {activeCommand}
+              </span>
+            </div>
+          )}
+          {sessions.map((session) => (
+            <TerminalSessionPane
+              key={session.sessionId}
+              session={session}
+              isActive={session.sessionId === activeSessionId}
+              hasHeader={Boolean(session.sessionId === activeSessionId && activeCommand)}
+            />
+          ))}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Embedded task terminals went blank after you minimized, expanded, or maximized the drawer, or switched between task tabs. The pane stayed on screen but showed nothing.

The cause was that each terminal was torn down and never re-measured when the drawer changed size or a different tab became active, so xterm painted into a zero-sized or hidden box.

This slice keeps every task's terminal pane mounted, shows only the active pane, and re-fits that pane whenever the drawer state or the selected tab changes. Re-opening a tab re-seeds its saved output instead of showing an empty screen.

It adds regression tests that drive the exact drawer transitions and tab switch that used to blank the pane.

## Review Claim

Approve keeping the active terminal pane mounted and re-fitted across drawer minimized/partial/maximized transitions and tab switches, locked by the added regression tests.

## Review Lane

`behavior`

## Review Unit

`ui-terminal-drawer`

## Safety Invariant

The change is scoped to the terminal drawer UI (`packages/ui/src/components/TerminalDrawer.tsx` and `packages/ui/src/App.tsx`) plus its tests. It touches no IPC contract, persistence, or executor path. The added unit specs pass locally and assert the exact regression, so a reviewer can validate the fix without running the full app.

## Slice Rationale

This is Step 1 of the terminal-blank fix: introduce the drawer state machine and lock it with regression coverage as one cohesive UI unit. The workflow's follow-up verify task produced no diff, so it is a test gate, not a separate PR — the stack is this single slice.

## Non-goals

- No backend, IPC, or terminal session-lifecycle protocol changes.
- No changes to non-terminal UI surfaces.
- No new terminal features beyond fixing blank rendering.

## Visual Proof

The regression is a canvas-backed xterm pane that paints blank only during drawer state transitions and tab switches — a dynamic, transition-only state that a single static screenshot cannot demonstrate. Per the visual-proof fallback for states a screenshot cannot show, the proof is the deterministic focused tests that drive the exact transitions:

- `packages/ui/src/__tests__/terminal-drawer.test.tsx` — asserts the active pane stays visible through minimized → partial → maximized and that only the active pane renders while inactive panes remain `display:none`. Verified locally: 3 passed.
- `packages/app/e2e/visual-proof.spec.ts` — e2e capture asserting a non-blank terminal pane.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/terminal-drawer.test.tsx` — 3 passed

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>` (or close the PR)
- Post-revert steps: None
- Data migration? No

</details>

