### PR TITLE
[Design refresh](6) Migrate task modals to Dialog primitive

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2792,10 +2792,10 @@ export function App() {
               key={session.id}
               type="button"
               onClick={() => setActivePlanningSessionId(session.id)}
-              className={`block w-full rounded-xl px-3 py-2 text-left transition-colors ${selected ? 'bg-secondary text-white ring-1 ring-border' : 'text-foreground hover:bg-background/80'}`}
+              className={`block w-full rounded-md px-2.5 py-1.5 text-left transition-colors ${selected ? 'bg-accent/60 text-accent-foreground ring-1 ring-border-strong' : 'text-foreground hover:bg-accent/30'}`}
             >
-              <div className="truncate font-medium">{session.title}</div>
-              <div className="mt-1 truncate text-xs text-muted-foreground">{previewPlanningMessage(session)}</div>
+              <div className="truncate text-body font-medium">{session.title}</div>
+              <div className="mt-0.5 truncate text-caption text-muted-foreground">{previewPlanningMessage(session)}</div>
               <div className="mt-2 flex items-center justify-between gap-2">
                 <span className={`rounded-full px-2 py-0.5 text-[11px] ${planningStatusClass(session.status)}`}>
                   {planningStatusLabel(session.status)}

--- a/packages/ui/src/components/ApprovalModal.tsx
+++ b/packages/ui/src/components/ApprovalModal.tsx
@@ -7,6 +7,14 @@
 
 import { useState, useEffect } from 'react';
 import type { TaskState, ClaudeMessage, AgentSessionData } from '../types.js';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './primitives/index.js';
 
 interface ApprovalModalProps {
   task: TaskState;
@@ -89,17 +97,6 @@ export function ApprovalModal({
   const [sessionLoading, setSessionLoading] = useState(false);
   const [sessionError, setSessionError] = useState(false);
   const [submitting, setSubmitting] = useState(false);
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        onClose();
-      }
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [onClose]);
 
   useEffect(() => {
     if (task.execution.agentSessionId || task.execution.lastAgentSessionId || fallbackSessionId) return;
@@ -205,16 +202,12 @@ export function ApprovalModal({
     : (isFixApproval ? 'Reject Fix' : isMergeNode ? mergeRejectLabel : 'Reject');
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="bg-secondary rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col border border-border">
-        {/* Header */}
-        <div className="p-6 pb-0 shrink-0">
-          <h2 className="text-lg font-semibold text-foreground">
-            {heading}
-          </h2>
-        </div>
+    <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="max-w-2xl max-h-[90vh] flex flex-col gap-0 p-0 overflow-hidden">
+        <DialogHeader className="p-6 pb-0 shrink-0">
+          <DialogTitle>{heading}</DialogTitle>
+        </DialogHeader>
 
-        {/* Scrollable content */}
         <div className="flex-1 overflow-y-auto min-h-0 px-6 py-4 space-y-4">
           <div>
             <p className="text-sm text-muted-foreground mb-1">
@@ -281,34 +274,30 @@ export function ApprovalModal({
           )}
         </div>
 
-        {/* Footer */}
-        <div className="p-6 pt-4 shrink-0 border-t border-border">
-          <div className="flex gap-3 justify-end">
-            <button
-              onClick={onClose}
-              className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={handleReject}
+        <DialogFooter className="p-6 pt-4 shrink-0 border-t border-border sm:justify-end">
+          <Button type="button" variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={submitting}
+            onClick={handleReject}
+          >
+            {rejectButtonLabel}
+          </Button>
+          {!showRejectInput && (
+            <Button
+              type="button"
               disabled={submitting}
-              className="px-4 py-2 bg-red-600 hover:bg-red-500 disabled:bg-muted disabled:cursor-not-allowed text-white rounded text-sm font-medium transition-colors"
+              className="bg-green-600 text-white hover:bg-green-500"
+              onClick={handleApprove}
             >
-              {rejectButtonLabel}
-            </button>
-            {!showRejectInput && (
-              <button
-                onClick={handleApprove}
-                disabled={submitting}
-                className="px-4 py-2 bg-green-600 hover:bg-green-500 disabled:bg-muted disabled:cursor-not-allowed text-white rounded text-sm font-medium transition-colors"
-              >
-                {approveButtonLabel}
-              </button>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
+              {approveButtonLabel}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/packages/ui/src/components/ExperimentModal.tsx
+++ b/packages/ui/src/components/ExperimentModal.tsx
@@ -1,12 +1,17 @@
 /**
  * ExperimentModal — Modal for selecting which experiment to use.
- *
- * Shows experiment results and lets the user pick one.
- * Used for reconciliation tasks.
  */
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { TaskState } from '../types.js';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './primitives/index.js';
 
 interface ExperimentModalProps {
   task: TaskState;
@@ -20,17 +25,6 @@ export function ExperimentModal({
   onClose,
 }: ExperimentModalProps) {
   const [selected, setSelected] = useState<Set<string>>(new Set());
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        onClose();
-      }
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [onClose]);
 
   const results = task.execution.experimentResults ?? [];
 
@@ -50,13 +44,13 @@ export function ExperimentModal({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="bg-secondary rounded-lg shadow-xl w-full max-w-lg p-6 border border-border">
-        <h2 className="text-lg font-semibold text-foreground mb-2">
-          Select Experiments
-        </h2>
+    <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Select Experiments</DialogTitle>
+        </DialogHeader>
 
-        <p className="text-sm text-muted-foreground mb-4">
+        <p className="text-sm text-muted-foreground">
           Choose one or more experiment results to use for reconciliation.
         </p>
 
@@ -65,10 +59,11 @@ export function ExperimentModal({
             No experiment results available yet.
           </p>
         ) : (
-          <div className="space-y-2 mb-4 max-h-64 overflow-y-auto">
+          <div className="space-y-2 max-h-64 overflow-y-auto">
             {results.map((result) => (
               <button
                 key={result.id}
+                type="button"
                 onClick={() => toggleExperiment(result.id)}
                 className={`w-full text-left p-3 rounded border transition-colors ${
                   selected.has(result.id)
@@ -103,22 +98,20 @@ export function ExperimentModal({
           </div>
         )}
 
-        <div className="flex gap-3 justify-end">
-          <button
-            onClick={onClose}
-            className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={onClose}>
             Cancel
-          </button>
-          <button
-            onClick={handleConfirm}
+          </Button>
+          <Button
+            type="button"
             disabled={selected.size === 0}
-            className="px-4 py-2 bg-purple-600 hover:bg-purple-500 disabled:bg-muted disabled:cursor-not-allowed text-white rounded text-sm font-medium transition-colors"
+            className="bg-purple-600 text-white hover:bg-purple-500"
+            onClick={handleConfirm}
           >
             Confirm Selection ({selected.size})
-          </button>
-        </div>
-      </div>
-    </div>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/packages/ui/src/components/InputModal.tsx
+++ b/packages/ui/src/components/InputModal.tsx
@@ -1,11 +1,17 @@
 /**
  * InputModal — Modal for providing input to a task that needs it.
- *
- * Shows the task's input prompt and a text area for the response.
  */
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { TaskState } from '../types.js';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './primitives/index.js';
 
 interface InputModalProps {
   task: TaskState;
@@ -16,17 +22,6 @@ interface InputModalProps {
 export function InputModal({ task, onSubmit, onClose }: InputModalProps) {
   const [input, setInput] = useState('');
   const [submitting, setSubmitting] = useState(false);
-
-  useEffect(() => {
-    const handleGlobalKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        onClose();
-      }
-    };
-    document.addEventListener('keydown', handleGlobalKeyDown);
-    return () => document.removeEventListener('keydown', handleGlobalKeyDown);
-  }, [onClose]);
 
   const handleSubmit = () => {
     if (submitting) return;
@@ -43,13 +38,13 @@ export function InputModal({ task, onSubmit, onClose }: InputModalProps) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="bg-secondary rounded-lg shadow-xl w-full max-w-md p-6 border border-border">
-        <h2 className="text-lg font-semibold text-foreground mb-2">
-          Input Required
-        </h2>
+    <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Input Required</DialogTitle>
+        </DialogHeader>
 
-        <div className="mb-4">
+        <div>
           <p className="text-sm text-muted-foreground mb-1">
             Task: <span className="font-mono text-foreground">{task.id}</span>
           </p>
@@ -60,7 +55,7 @@ export function InputModal({ task, onSubmit, onClose }: InputModalProps) {
           )}
         </div>
 
-        <div className="mb-4">
+        <div>
           <textarea
             value={input}
             onChange={(e) => setInput(e.target.value)}
@@ -73,22 +68,20 @@ export function InputModal({ task, onSubmit, onClose }: InputModalProps) {
           <p className="text-xs text-muted-foreground mt-1">Ctrl+Enter to submit</p>
         </div>
 
-        <div className="flex gap-3 justify-end">
-          <button
-            onClick={onClose}
-            className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={onClose}>
             Cancel
-          </button>
-          <button
-            onClick={handleSubmit}
+          </Button>
+          <Button
+            type="button"
             disabled={!input.trim() || submitting}
-            className="px-4 py-2 bg-amber-600 hover:bg-amber-500 disabled:bg-muted disabled:cursor-not-allowed text-white rounded text-sm font-medium transition-colors"
+            className="bg-amber-600 text-white hover:bg-amber-500"
+            onClick={handleSubmit}
           >
             Submit
-          </button>
-        </div>
-      </div>
-    </div>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/packages/ui/src/components/ReplaceTaskModal.tsx
+++ b/packages/ui/src/components/ReplaceTaskModal.tsx
@@ -1,12 +1,17 @@
 /**
  * ReplaceTaskModal — Modal for replacing a broken/failed task with a new subgraph.
- *
- * Accepts YAML task definitions (same format as plan tasks) and calls
- * window.invoker.replaceTask() to splice the replacement into the graph.
  */
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { TaskState, TaskReplacementDef } from '../types.js';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './primitives/index.js';
 
 interface ReplaceTaskModalProps {
   task: TaskState;
@@ -55,17 +60,6 @@ export function ReplaceTaskModal({ task, onSubmit, onClose }: ReplaceTaskModalPr
   );
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const handleGlobalKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        onClose();
-      }
-    };
-    document.addEventListener('keydown', handleGlobalKeyDown);
-    return () => document.removeEventListener('keydown', handleGlobalKeyDown);
-  }, [onClose]);
-
   const handleSubmit = () => {
     setError(null);
     try {
@@ -94,13 +88,13 @@ export function ReplaceTaskModal({ task, onSubmit, onClose }: ReplaceTaskModalPr
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="bg-secondary rounded-lg shadow-xl w-full max-w-lg p-6 border border-border">
-        <h2 className="text-lg font-semibold text-foreground mb-2">
-          Replace Task
-        </h2>
+    <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Replace Task</DialogTitle>
+        </DialogHeader>
 
-        <div className="mb-4">
+        <div>
           <p className="text-sm text-muted-foreground mb-1">
             Replacing: <span className="font-mono text-foreground">{task.id}</span>
           </p>
@@ -110,7 +104,7 @@ export function ReplaceTaskModal({ task, onSubmit, onClose }: ReplaceTaskModalPr
           </p>
         </div>
 
-        <div className="mb-4">
+        <div>
           <textarea
             value={yaml}
             onChange={(e) => setYaml(e.target.value)}
@@ -124,26 +118,20 @@ export function ReplaceTaskModal({ task, onSubmit, onClose }: ReplaceTaskModalPr
         </div>
 
         {error && (
-          <div className="mb-4 bg-red-900/30 border border-red-700 rounded p-3">
+          <div className="bg-red-900/30 border border-red-700 rounded p-3">
             <p className="text-sm text-red-300">{error}</p>
           </div>
         )}
 
-        <div className="flex gap-3 justify-end">
-          <button
-            onClick={onClose}
-            className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={onClose}>
             Cancel
-          </button>
-          <button
-            onClick={handleSubmit}
-            className="px-4 py-2 bg-primary text-primary-foreground hover:bg-primary/90 rounded text-sm font-medium transition-colors"
-          >
+          </Button>
+          <Button type="button" onClick={handleSubmit}>
             Replace
-          </button>
-        </div>
-      </div>
-    </div>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/packages/ui/src/components/SystemSetupModal.tsx
+++ b/packages/ui/src/components/SystemSetupModal.tsx
@@ -6,6 +6,14 @@ import type {
   PrerequisiteStatus,
   SystemDiagnostics,
 } from '@invoker/contracts';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './primitives/index.js';
 
 const readinessStatusClasses: Record<PrerequisiteStatus, { dot: string; text: string; badge: string }> = {
   ok: {
@@ -218,16 +226,16 @@ export function SystemSetupModal({
 
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="bg-secondary rounded-lg shadow-xl w-full max-w-3xl max-h-[90vh] flex flex-col border border-border">
-        <div className="p-6 pb-3 shrink-0">
-          <h2 className="text-lg font-semibold text-foreground">System Setup</h2>
+    <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="max-w-3xl max-h-[90vh] flex flex-col gap-0 p-0 overflow-hidden" hideCloseButton>
+        <DialogHeader className="p-6 pb-3 shrink-0">
+          <DialogTitle>System Setup</DialogTitle>
           <p className="text-sm text-muted-foreground mt-1">
             {diagnostics
               ? `Invoker ${diagnostics.appVersion} on ${diagnostics.platform}/${diagnostics.arch}${diagnostics.isPackaged ? ' (packaged app)' : ' (repo/dev mode)'}`
               : 'Loading system diagnostics...'}
           </p>
-        </div>
+        </DialogHeader>
 
         <div className="flex-1 overflow-y-auto min-h-0 px-6 py-4 space-y-4">
           {onRunSetup && (
@@ -642,15 +650,12 @@ export function SystemSetupModal({
           </div>
         </div>
 
-        <div className="px-6 py-4 border-t border-border flex justify-end">
-          <button
-            onClick={onClose}
-            className="px-4 py-2 bg-muted hover:bg-accent text-white rounded text-sm font-medium transition-colors"
-          >
+        <DialogFooter className="px-6 py-4 border-t border-border sm:justify-end">
+          <Button type="button" onClick={onClose}>
             Close
-          </button>
-        </div>
-      </div>
-    </div>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
## Summary

The design refresh added Dialog and Button primitives, but task modals still used hand-rolled overlay shells.

This PR updates Input, Approval, Experiment, Replace, and System Setup modals to use the shared Dialog component.

Planning session rows now use the same compact token styling as workflow and task browser rows.

## Review Claim

Approve updating the five task modals to the shared Dialog primitive without changing modal behavior.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Modal open/close, submit, and escape handling stay behavior-equivalent. Radix Dialog replaces manual overlay markup only. All modal and app launch tests pass.

## Slice Rationale

Neutral chrome landed in the prior slice. Dialog work is a separate surface-only pass so reviewers can focus on modal accessibility and layout.

## Non-goals

- No TaskPanel or InvokerTerminal button primitive sweep
- No new modal features or validation changes
- No backend or IPC contract changes

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test`
- [ ] Manual: open System Setup and confirm Escape closes the modal
- [ ] Manual: approve/reject flow still works from task context menu

</details>

## Visual Proof

![Dialog-based System Setup modal](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-5973fd/neutral-chrome-home-graph.png)

Modals now use the shared Dialog overlay, card surface, and footer actions instead of custom fixed-position shells.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 13d5612e9`
- Post-revert steps: None
- Data migration? No

</details>
