### PR TITLE
[Remove Running Sidebar And Workers Screen Title](2) Cover sidebar visual snapshot text

### DIFF
--- a/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
+++ b/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
@@ -38,7 +38,7 @@ describe('Visual proof snapshots', () => {
     expect(screen.getByTestId('sidebar-home')).toHaveTextContent('Invoker');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
     expect(screen.getByText('Describe the change in the terminal to generate a plan.')).toBeInTheDocument();
     expect(screen.getByTestId('rail-settings')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

The sidebar snapshot test still expected a Running entry. That expectation matched the old UI, not the shipped one.

This slice updates that one assertion to expect the Running entry to be absent. The test now matches slice (1).

Nothing in the app changes here. Only the test expectation changes.

## Review Claim

Approve updating the sidebar snapshot assertion to expect the Running entry to be absent, matching slice (1).

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the snapshot test file changes. No shipped code is touched, so app behavior cannot shift from this slice.

## Slice Rationale

The snapshot assertion lives in its own slice so slice (1) stays a focused UI change and this test lock-in is reviewed on its own.

## Non-goals

- Does not change any shipped UI or app code.
- Does not touch worker data or navigation behavior.
- Does not add test cases beyond the sidebar assertion.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
