### PR TITLE
[History Timeline](2) Wire History live updates to onTaskGraphEvent

### DIFF
--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -182,6 +182,8 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     delegatedRead('output-tail', { taskId }, 'tail', () => persistence.getOutputTail(taskId)));
   ipcMain.handle('invoker:get-all-completed-tasks', () =>
     delegatedRead('all-completed-tasks', {}, 'tasks', () => persistence.loadAllCompletedTasks()));
+  ipcMain.handle('invoker:get-history-tasks', () =>
+    delegatedRead('history-tasks', {}, 'tasks', () => persistence.loadAllHistoryTasks()));
   ipcMain.handle('invoker:get-worker-action-history', (_event, request: WorkerActionHistoryRequest) =>
     delegatedRead<WorkerActionHistoryResponse>(
       'worker-action-history',

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -45,6 +45,7 @@ export interface OwnerReadQueryHandlers {
   getOutputTail: (taskId: string) => unknown;
   replayOutput: (taskId: string, fromOffset: number) => unknown;
   getAllCompletedTasks: () => unknown[];
+  getHistoryTasks: () => unknown[];
 }
 
 export function answerOwnerReadQuery(
@@ -133,6 +134,8 @@ export function answerOwnerReadQuery(
       return { chunks: handlers.replayOutput(requiredString(body.taskId, 'taskId'), replayOffset(body.fromOffset)) };
     case 'all-completed-tasks':
       return { tasks: handlers.getAllCompletedTasks() };
+    case 'history-tasks':
+      return { tasks: handlers.getHistoryTasks() };
     default:
       throw new Error(`Unsupported headless query: ${String(kind)}`);
   }
@@ -178,6 +181,7 @@ type ReadPersistence = Pick<
   | 'getOutputTail'
   | 'replayOutputFrom'
   | 'loadAllCompletedTasks'
+  | 'loadAllHistoryTasks'
   | 'listWorkerActions'
 >;
 
@@ -238,5 +242,6 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     getOutputTail: (taskId: string) => persistence.getOutputTail(taskId),
     replayOutput: (taskId: string, fromOffset: number) => persistence.replayOutputFrom(taskId, fromOffset),
     getAllCompletedTasks: () => persistence.loadAllCompletedTasks(),
+    getHistoryTasks: () => persistence.loadAllHistoryTasks(),
   };
 }

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -120,6 +120,8 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return orchestrator.getTask(String(args[0])) ?? null;
       case 'invoker:get-all-completed-tasks':
         return persistence.loadAllCompletedTasks();
+      case 'invoker:get-history-tasks':
+        return persistence.loadAllHistoryTasks();
       case 'invoker:get-review-gate':
         return reviewGate(String(args[0]));
       case 'invoker:get-claude-session':

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -140,6 +140,12 @@ export interface TaskEvent {
   createdAt: string;
 }
 
+export interface TaskHistoryEntry extends TaskState {
+  workflowName: string;
+  lastEventAt: string | null;
+  eventCount: number;
+}
+
 export interface QueueStatus {
   maxConcurrency: number;
   runningCount: number;
@@ -797,6 +803,10 @@ export const IpcChannels = {
   'invoker:get-all-completed-tasks': {} as {
     request: [];
     response: Array<TaskState & { workflowName: string }>;
+  },
+  'invoker:get-history-tasks': {} as {
+    request: [];
+    response: TaskHistoryEntry[];
   },
 
   // Task Actions

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -3412,6 +3412,139 @@ describe('SQLiteAdapter', () => {
     });
   });
 
+  describe('loadAllHistoryTasks', () => {
+    it('returns tasks across all non-pending statuses with workflowName and lastEventAt', () => {
+      adapter.saveWorkflow({ id: 'wf-1', name: 'Alpha Plan', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' });
+      adapter.saveWorkflow({ id: 'wf-2', name: 'Beta Plan', createdAt: '2024-01-02T00:00:00Z', updatedAt: '2024-01-02T00:00:00Z' });
+
+      adapter.saveTask('wf-1', makeTask('completed-task', { status: 'completed', execution: { completedAt: new Date('2024-01-05T00:00:00Z') } }));
+      adapter.saveTask('wf-1', makeTask('failed-task', { status: 'failed', execution: { completedAt: new Date('2024-01-04T00:00:00Z') } }));
+      adapter.saveTask('wf-2', makeTask('running-task', { status: 'running' }));
+      adapter.saveTask('wf-2', makeTask('pending-task', { status: 'pending' }));
+
+      adapter.logEvent('running-task', 'task.started');
+      adapter.logEvent('failed-task', 'task.failed');
+
+      const results = adapter.loadAllHistoryTasks();
+      const ids = results.map((r) => r.id);
+      expect(ids).toContain('completed-task');
+      expect(ids).toContain('failed-task');
+      expect(ids).toContain('running-task');
+      expect(ids).not.toContain('pending-task');
+
+      const running = results.find((r) => r.id === 'running-task');
+      expect(running?.workflowName).toBe('Beta Plan');
+      expect(running?.lastEventAt).toBeTruthy();
+      expect(running?.eventCount).toBe(1);
+
+      const completed = results.find((r) => r.id === 'completed-task');
+      expect(completed?.eventCount).toBe(0);
+      expect(completed?.lastEventAt).toBeNull();
+    });
+
+    it('includes a pending task once it has any recorded event', () => {
+      adapter.saveWorkflow({ id: 'wf-1', name: 'Test', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' });
+      adapter.saveTask('wf-1', makeTask('pending-task', { status: 'pending' }));
+
+      expect(adapter.loadAllHistoryTasks()).toHaveLength(0);
+
+      adapter.logEvent('pending-task', 'task.pending');
+
+      const results = adapter.loadAllHistoryTasks();
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('pending-task');
+      expect(results[0].eventCount).toBe(1);
+      expect(results[0].lastEventAt).toBeTruthy();
+    });
+
+    it('orders results by most recent event descending', () => {
+      adapter.saveWorkflow({ id: 'wf-1', name: 'Test', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' });
+      adapter.saveTask('wf-1', makeTask('t-old', { status: 'completed', execution: { completedAt: new Date('2024-01-02T00:00:00Z') } }));
+      adapter.saveTask('wf-1', makeTask('t-new', { status: 'completed', execution: { completedAt: new Date('2024-01-05T00:00:00Z') } }));
+
+      // Pin created_at so ordering is deterministic across fast test runs.
+      const db = (adapter as unknown as { db: { run: (sql: string, params?: unknown[]) => void } }).db;
+      db.run(`INSERT INTO events (task_id, event_type, created_at) VALUES ('t-old', 'task.completed', '2024-01-02T12:00:00Z')`);
+      db.run(`INSERT INTO events (task_id, event_type, created_at) VALUES ('t-new', 'task.completed', '2024-01-05T12:00:00Z')`);
+
+      const results = adapter.loadAllHistoryTasks();
+      expect(results.map((r) => r.id)).toEqual(['t-new', 't-old']);
+    });
+
+    it('falls back to completed_at / started_at / created_at when there are no events', () => {
+      adapter.saveWorkflow({ id: 'wf-1', name: 'Test', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' });
+      adapter.saveTask('wf-1', makeTask('t-old', {
+        status: 'completed',
+        createdAt: new Date('2024-01-01T00:00:00Z'),
+        execution: { completedAt: new Date('2024-01-02T00:00:00Z') },
+      }));
+      adapter.saveTask('wf-1', makeTask('t-new', {
+        status: 'completed',
+        createdAt: new Date('2024-01-01T00:00:00Z'),
+        execution: { completedAt: new Date('2024-01-05T00:00:00Z') },
+      }));
+
+      const results = adapter.loadAllHistoryTasks();
+      expect(results.map((r) => r.id)).toEqual(['t-new', 't-old']);
+      expect(results.every((r) => r.eventCount === 0)).toBe(true);
+      expect(results.every((r) => r.lastEventAt === null)).toBe(true);
+    });
+
+    it('reconciles selected-attempt status like loadTasks', () => {
+      adapter.saveWorkflow(testWorkflow);
+      const attempt = createAttempt('t1', {
+        status: 'failed',
+        exitCode: 1,
+        error: 'boom',
+        completedAt: new Date(),
+      });
+      adapter.saveTask('wf-1', makeTask('t1', {
+        status: 'running',
+        execution: {
+          startedAt: new Date(),
+        },
+      }));
+      adapter.saveAttempt(attempt);
+      adapter.updateTask('t1', {
+        execution: { selectedAttemptId: attempt.id },
+      });
+
+      const [fromLoadTasks] = adapter.loadTasks('wf-1');
+      const [fromHistory] = adapter.loadAllHistoryTasks();
+      expect(fromLoadTasks.status).toBe('failed');
+      expect(fromHistory.status).toBe('failed');
+      expect(fromHistory.execution.exitCode).toBe(1);
+      expect(fromHistory.execution.error).toBe('boom');
+    });
+
+    it('does not override fixing_with_ai with a failed selected attempt', () => {
+      adapter.saveWorkflow(testWorkflow);
+      const attempt = createAttempt('t1', {
+        status: 'failed',
+        exitCode: 1,
+        error: 'boom',
+        completedAt: new Date(),
+      });
+      adapter.saveTask('wf-1', makeTask('t1', {
+        status: 'fixing_with_ai',
+        execution: {
+          startedAt: new Date(),
+        },
+      }));
+      adapter.saveAttempt(attempt);
+      adapter.updateTask('t1', {
+        execution: { selectedAttemptId: attempt.id },
+      });
+
+      const [fromHistory] = adapter.loadAllHistoryTasks();
+      expect(fromHistory.status).toBe('fixing_with_ai');
+    });
+
+    it('returns empty array on empty database', () => {
+      expect(adapter.loadAllHistoryTasks()).toHaveLength(0);
+    });
+  });
+
   describe('workflowId on tasks', () => {
     it('loadTasks returns workflowId on each task', () => {
       adapter.saveWorkflow(testWorkflow);

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1547,6 +1547,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return this.taskAttemptRepo.loadAllCompletedTasks();
   }
 
+  loadAllHistoryTasks(): Array<TaskState & { workflowName: string; lastEventAt: string | null; eventCount: number }> {
+    return this.taskAttemptRepo.loadAllHistoryTasks();
+  }
+
   deleteTask(taskId: string): void {
     this.runTransaction(() => {
       this.db.run('DELETE FROM task_launch_dispatch WHERE task_id = ?', [taskId]);

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -385,6 +385,33 @@ export class SqliteTaskAttemptRepository {
     }));
   }
 
+  loadAllHistoryTasks(): Array<TaskState & { workflowName: string; lastEventAt: string | null; eventCount: number }> {
+    const rows = this.exec.queryAll(`
+      SELECT t.*,
+             w.name AS workflow_name,
+             e.max_created_at AS last_event_at,
+             COALESCE(e.event_count, 0) AS event_count
+      FROM tasks t
+      JOIN workflows w ON w.id = t.workflow_id
+      LEFT JOIN (
+        SELECT task_id, MAX(created_at) AS max_created_at, COUNT(*) AS event_count
+        FROM events
+        GROUP BY task_id
+      ) e ON e.task_id = t.id
+      WHERE COALESCE(e.event_count, 0) > 0 OR t.status != 'pending'
+      ORDER BY COALESCE(e.max_created_at, t.completed_at, t.started_at, t.created_at) DESC
+    `);
+    return rows.map((row) => {
+      const task = this.reconcileTaskFromSelectedAttempt(mapRowToTask(row));
+      return {
+        ...task,
+        workflowName: row.workflow_name as string,
+        lastEventAt: (row.last_event_at as string | null) ?? null,
+        eventCount: Number(row.event_count ?? 0),
+      };
+    });
+  }
+
   // ── Scalar task-column getters ───────────────────────────
 
   getSelectedExperiment(taskId: string): string | null {

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -11,6 +11,8 @@ import type {
   TaskState,
   TaskDelta,
   TaskGraphEvent,
+  TaskHistoryEntry,
+  TaskEvent,
   WorkflowMeta,
   TaskStatus,
   TaskConfig,
@@ -23,6 +25,10 @@ export interface MockInvoker {
   api: InvokerAPI;
   /** Replace the task snapshot and fire matching 'created' graph events. */
   setTasks: (tasks: TaskState[], workflows?: WorkflowMeta[]) => void;
+  /** Replace the history list returned by getHistoryTasks. */
+  setHistoryTasks: (entries: TaskHistoryEntry[]) => void;
+  /** Replace the events returned by getEvents for a task id. */
+  setEvents: (taskId: string, events: TaskEvent[]) => void;
   /** Directly fire a task delta to subscribers. */
   fireDelta: (delta: TaskDelta) => void;
   /** Directly fire a task graph event to subscribers. */
@@ -88,6 +94,8 @@ export function createMockInvoker(
 ): MockInvoker {
   let taskSnapshot = initialTasks;
   let workflowSnapshot = initialWorkflows;
+  let historySnapshot: TaskHistoryEntry[] = [];
+  const eventsByTask = new Map<string, TaskEvent[]>();
   let graphEventCallback: ((event: TaskGraphEvent) => void) | undefined;
   let workflowsCallback: ((workflows: unknown[]) => void) | undefined;
   const terminalOutputCallbacks = new Set<(event: TerminalOutputEvent) => void>();
@@ -260,7 +268,8 @@ export function createMockInvoker(
     runInvokerCliSetup: vi.fn(async () => ({ ok: true, steps: [{ id: 'tools', name: 'Run setup', ok: true, output: 'setup ok' }] })),
     replaceTask: vi.fn(async () => accepted('invoker:replace-task')),
     getActivityLogs: vi.fn(async () => []),
-    getEvents: vi.fn(async () => []),
+    getEvents: vi.fn(async (taskId: string) => eventsByTask.get(taskId) ?? []),
+    getHistoryTasks: vi.fn(async () => historySnapshot),
     openTerminal: vi.fn(async (taskId: string) => ({
       opened: true,
       session: {
@@ -348,6 +357,14 @@ export function createMockInvoker(
     });
   }
 
+  function setHistoryTasks(entries: TaskHistoryEntry[]) {
+    historySnapshot = entries;
+  }
+
+  function setEvents(taskId: string, events: TaskEvent[]) {
+    eventsByTask.set(taskId, events);
+  }
+
   function setActionGraph(response: ActionGraphResponse) {
     actionGraphSnapshot = response;
   }
@@ -398,11 +415,15 @@ export function createMockInvoker(
     delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
     terminalOutputCallbacks.clear();
     workflowMutationFailedCallbacks.clear();
+    eventsByTask.clear();
+    historySnapshot = [];
   }
 
   return {
     api,
     setTasks,
+    setHistoryTasks,
+    setEvents,
     setActionGraph,
     setRuntimeStatus,
     setWorkerStatus,

--- a/packages/ui/src/__tests__/history-view-e2e.test.tsx
+++ b/packages/ui/src/__tests__/history-view-e2e.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Component test: History view rendering, filters, timeline expand, and live deltas.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import type { TaskEvent, TaskHistoryEntry, WorkflowMeta } from '../types.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+const workflows: WorkflowMeta[] = [{ id: 'wf-history', name: 'History WF', status: 'running' }];
+
+function makeHistoryEntry(overrides: Partial<TaskHistoryEntry> = {}): TaskHistoryEntry {
+  return {
+    ...makeUITask({
+      id: 'task-alpha',
+      description: 'First history task',
+      status: 'completed',
+      workflowId: 'wf-history',
+    }),
+    workflowName: 'History WF',
+    lastEventAt: '2026-07-01T12:00:00.000Z',
+    eventCount: 2,
+    ...overrides,
+  };
+}
+
+async function chooseGraphMenuItem(testId: string): Promise<void> {
+  fireEvent.click(screen.getByTestId('graph-more-button'));
+  await waitFor(() => {
+    expect(screen.getByTestId('graph-more-menu')).toBeInTheDocument();
+  });
+  fireEvent.click(screen.getByTestId(testId));
+}
+
+describe('History view (component)', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  it('loads history rows from getHistoryTasks', async () => {
+    const completed = makeHistoryEntry();
+    const failed = makeHistoryEntry({
+      id: 'task-beta',
+      description: 'Failed history task',
+      status: 'failed',
+      lastEventAt: '2026-07-01T11:00:00.000Z',
+      execution: { exitCode: 1, error: 'boom' },
+    });
+    mock.setHistoryTasks([completed, failed]);
+    act(() => mock.setTasks([completed, failed], workflows));
+
+    render(<App />);
+    await chooseGraphMenuItem('rail-history');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('history-view')).toBeInTheDocument();
+      expect(screen.getByTestId('history-row-task-alpha')).toBeInTheDocument();
+      expect(screen.getByTestId('history-row-task-beta')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('searchbox', { name: 'Search history' })).toBeInTheDocument();
+    expect(screen.getByTestId('history-row-task-alpha')).toHaveTextContent('Completed');
+    expect(screen.getByTestId('history-row-task-beta')).toHaveTextContent('Failed');
+    expect(screen.getByText('2 / 2')).toBeInTheDocument();
+  });
+
+  it('expands a row and renders newest-first timeline events', async () => {
+    const failed = makeHistoryEntry({
+      id: 'task-beta',
+      description: 'Failed history task',
+      status: 'failed',
+    });
+    const events: TaskEvent[] = [
+      {
+        id: 1,
+        taskId: 'task-beta',
+        eventType: 'task.running',
+        createdAt: '2026-07-01T10:00:00.000Z',
+      },
+      {
+        id: 2,
+        taskId: 'task-beta',
+        eventType: 'task.failed',
+        createdAt: '2026-07-01T10:01:00.000Z',
+        payload: JSON.stringify({ exitCode: 1, error: 'Command exited non-zero' }),
+      },
+    ];
+    mock.setHistoryTasks([failed]);
+    mock.setEvents('task-beta', events);
+    act(() => mock.setTasks([failed], workflows));
+
+    render(<App />);
+    await chooseGraphMenuItem('rail-history');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('history-row-task-beta')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('history-expand-task-beta'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('history-timeline-task-beta')).toBeInTheDocument();
+    });
+
+    const timeline = screen.getByTestId('history-timeline-task-beta');
+    expect(timeline).toHaveTextContent('Failed');
+    expect(timeline).toHaveTextContent('Running');
+    expect(timeline).toHaveTextContent('exit 1');
+    expect(timeline).toHaveTextContent('Command exited non-zero');
+    expect(mock.api.getEvents).toHaveBeenCalledWith('task-beta');
+
+    const labels = Array.from(timeline.querySelectorAll('li span.font-medium')).map((el) => el.textContent);
+    expect(labels[0]).toBe('Failed');
+    expect(labels[1]).toBe('Running');
+  });
+
+  it('applies live deltas from onTaskGraphEvent', async () => {
+    const older = makeHistoryEntry({
+      id: 'task-older',
+      description: 'Older task',
+      lastEventAt: '2026-07-01T10:00:00.000Z',
+    });
+    const newer = makeHistoryEntry({
+      id: 'task-newer',
+      description: 'Newer task',
+      lastEventAt: '2026-07-01T12:00:00.000Z',
+    });
+    mock.setHistoryTasks([newer, older]);
+    act(() => mock.setTasks([newer, older], workflows));
+
+    render(<App />);
+    await chooseGraphMenuItem('rail-history');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('history-task-list')).toBeInTheDocument();
+    });
+
+    const before = Array.from(screen.getByTestId('history-task-list').querySelectorAll('[data-testid^="history-row-"]'))
+      .map((el) => el.getAttribute('data-testid'));
+    expect(before[0]).toBe('history-row-task-newer');
+
+    act(() => {
+      mock.fireDelta({
+        type: 'updated',
+        taskId: 'task-older',
+        changes: { status: 'running' },
+        taskStateVersion: 2,
+        previousTaskStateVersion: 1,
+      });
+    });
+
+    await waitFor(() => {
+      const after = Array.from(screen.getByTestId('history-task-list').querySelectorAll('[data-testid^="history-row-"]'))
+        .map((el) => el.getAttribute('data-testid'));
+      expect(after[0]).toBe('history-row-task-older');
+      expect(screen.getByTestId('history-row-task-older')).toHaveTextContent('Running');
+    });
+  });
+
+
+  it('shows empty state when there is no history', async () => {
+    mock.setHistoryTasks([]);
+    act(() => mock.setTasks([], workflows));
+
+    render(<App />);
+    await chooseGraphMenuItem('rail-history');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('history-view')).toBeInTheDocument();
+      expect(screen.getByText('No task history yet')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/__tests__/history-view.test.ts
+++ b/packages/ui/src/__tests__/history-view.test.ts
@@ -1,53 +1,358 @@
 import { describe, it, expect } from 'vitest';
-import { groupByWorkflow } from '../components/HistoryView.js';
+import type { TaskHistoryEntry, TaskEvent, TaskState, TaskStatus } from '../types.js';
+import {
+  EMPTY_FILTER,
+  applyDelta,
+  filterHistory,
+  taskMatchesSearch,
+  type FilterState,
+} from '../components/HistoryView.js';
+import {
+  categorizeEvent,
+  friendlyEventLabel,
+  payloadDetail,
+  payloadErrorSummary,
+} from '../lib/event-labels.js';
 
-function makeFakeTask(id: string, workflowName: string) {
+function makeEntry(overrides: Partial<TaskHistoryEntry> = {}): TaskHistoryEntry {
   return {
-    id,
-    description: `Task ${id}`,
-    status: 'completed' as const,
-    dependencies: [] as string[],
+    id: 't1',
+    description: 'Do the thing',
+    status: 'completed' as TaskStatus,
+    dependencies: [],
+    createdAt: new Date('2026-07-01T10:00:00Z'),
     config: {},
     execution: {},
-    workflowName,
+    taskStateVersion: 1,
+    workflowName: 'Plan A',
+    lastEventAt: '2026-07-01T10:05:00Z',
+    eventCount: 3,
+    ...overrides,
   };
 }
 
-describe('groupByWorkflow', () => {
-  it('groups tasks by workflow name', () => {
-    const tasks = [
-      makeFakeTask('t1', 'Plan A'),
-      makeFakeTask('t2', 'Plan B'),
-      makeFakeTask('t3', 'Plan A'),
+function makeEvent(overrides: Partial<TaskEvent> = {}): TaskEvent {
+  return {
+    id: 1,
+    taskId: 't1',
+    eventType: 'task.running',
+    createdAt: '2026-07-01T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function filterWith(overrides: Partial<FilterState>): FilterState {
+  return { ...EMPTY_FILTER, ...overrides };
+}
+
+describe('friendlyEventLabel', () => {
+  it('maps the concrete event vocabulary to human-readable labels', () => {
+    expect(friendlyEventLabel('task.running')).toBe('Running');
+    expect(friendlyEventLabel('task.fixing_with_ai')).toBe('Submitted for autofix');
+    expect(friendlyEventLabel('task.completed')).toBe('Completed');
+    expect(friendlyEventLabel('task.failed')).toBe('Failed');
+    expect(friendlyEventLabel('task.pending')).toBe('Pending');
+    expect(friendlyEventLabel('task.executor.selected')).toBe('Executor selected');
+  });
+
+  it('falls back to the last segment title-cased for unknown events', () => {
+    expect(friendlyEventLabel('some.unknown.event_name')).toBe('Name');
+    expect(friendlyEventLabel('bareword')).toBe('Bareword');
+  });
+});
+
+describe('categorizeEvent', () => {
+  it('routes lifecycle events into visual categories', () => {
+    expect(categorizeEvent('task.completed')).toBe('terminal-success');
+    expect(categorizeEvent('task.failed')).toBe('terminal-failure');
+    expect(categorizeEvent('task.cancelled')).toBe('terminal-failure');
+    expect(categorizeEvent('task.stale')).toBe('terminal-failure');
+    expect(categorizeEvent('task.running')).toBe('running');
+    expect(categorizeEvent('task.fixing_with_ai')).toBe('autofix');
+    expect(categorizeEvent('debug.auto-fix')).toBe('autofix');
+    expect(categorizeEvent('task.awaiting_approval')).toBe('attention');
+    expect(categorizeEvent('task.needs_input')).toBe('attention');
+    expect(categorizeEvent('task.blocked')).toBe('attention');
+    expect(categorizeEvent('task.deferred')).toBe('attention');
+    expect(categorizeEvent('task.metadata.updated')).toBe('info');
+  });
+});
+
+describe('payloadDetail / payloadErrorSummary', () => {
+  it('extracts a phase from auto-fix debug payloads', () => {
+    expect(payloadDetail(JSON.stringify({ phase: 'resolve-conflict-start' }))).toBe('resolve-conflict-start');
+  });
+
+  it('extracts a reason when phase is absent', () => {
+    expect(payloadDetail(JSON.stringify({ reason: 'lease-expired' }))).toBe('lease-expired');
+  });
+
+  it('returns undefined for missing / unparseable payloads', () => {
+    expect(payloadDetail(undefined)).toBeUndefined();
+    expect(payloadDetail('not json')).toBeUndefined();
+    expect(payloadDetail('{}')).toBeUndefined();
+  });
+
+  it('extracts exit code / error text from a failure payload', () => {
+    const payload = JSON.stringify({ execution: { exitCode: 2, error: 'boom' } });
+    expect(payloadErrorSummary(payload)).toEqual({ exitCode: 2, error: 'boom' });
+  });
+
+  it('reads exit code / error at the top level as well', () => {
+    expect(payloadErrorSummary(JSON.stringify({ exitCode: 1 }))).toEqual({ exitCode: 1, error: undefined });
+    expect(payloadErrorSummary(JSON.stringify({ error: 'nope' }))).toEqual({ exitCode: undefined, error: 'nope' });
+  });
+
+  it('returns undefined when the payload has no error fields', () => {
+    expect(payloadErrorSummary(undefined)).toBeUndefined();
+    expect(payloadErrorSummary(JSON.stringify({ phase: 'ok' }))).toBeUndefined();
+  });
+});
+
+describe('taskMatchesSearch', () => {
+  it('matches on description and workflow name case-insensitively', () => {
+    const entry = makeEntry({ description: 'Refactor Foo', workflowName: 'Nightly' });
+    expect(taskMatchesSearch(entry, 'foo', undefined)).toBe(true);
+    expect(taskMatchesSearch(entry, 'NIGHTLY', undefined)).toBe(true);
+    expect(taskMatchesSearch(entry, 'unrelated', undefined)).toBe(false);
+  });
+
+  it('matches on friendly event labels and raw event types', () => {
+    const entry = makeEntry({ description: '-', workflowName: '-' });
+    const events = [makeEvent({ eventType: 'task.fixing_with_ai' })];
+    expect(taskMatchesSearch(entry, 'autofix', events)).toBe(true);
+    expect(taskMatchesSearch(entry, 'fixing_with_ai', events)).toBe(true);
+  });
+
+  it('matches on raw event payload text', () => {
+    const entry = makeEntry({ description: '-', workflowName: '-' });
+    const events = [makeEvent({ payload: JSON.stringify({ error: 'unique-payload-token' }) })];
+    expect(taskMatchesSearch(entry, 'unique-payload-token', events)).toBe(true);
+    expect(taskMatchesSearch(entry, 'missing-token', events)).toBe(false);
+  });
+
+  it('matches on execution error and exit code', () => {
+    const entry = makeEntry({
+      description: '-',
+      workflowName: '-',
+      execution: { error: 'Segmentation fault', exitCode: 139 },
+    });
+    expect(taskMatchesSearch(entry, 'segmentation', undefined)).toBe(true);
+    expect(taskMatchesSearch(entry, '139', undefined)).toBe(true);
+  });
+
+  it('treats empty / whitespace queries as always-matching', () => {
+    expect(taskMatchesSearch(makeEntry(), '   ', undefined)).toBe(true);
+  });
+});
+
+describe('filterHistory', () => {
+  const events = new Map<string, TaskEvent[]>();
+
+  it('filters by status (multi-select OR)', () => {
+    const entries = [
+      makeEntry({ id: 't1', status: 'completed' }),
+      makeEntry({ id: 't2', status: 'failed' }),
+      makeEntry({ id: 't3', status: 'running' }),
     ];
-    const grouped = groupByWorkflow(tasks as any);
-    expect(grouped.size).toBe(2);
-    expect(grouped.get('Plan A')).toHaveLength(2);
-    expect(grouped.get('Plan B')).toHaveLength(1);
+    const filter = filterWith({ statuses: new Set<TaskStatus>(['completed', 'failed']) });
+    const out = filterHistory(entries, filter, events);
+    expect(out.map((e) => e.id)).toEqual(['t1', 't2']);
   });
 
-  it('preserves insertion order within groups', () => {
-    const tasks = [
-      makeFakeTask('t1', 'Plan A'),
-      makeFakeTask('t2', 'Plan A'),
-      makeFakeTask('t3', 'Plan A'),
+  it('filters by workflow name (multi-select OR)', () => {
+    const entries = [
+      makeEntry({ id: 't1', workflowName: 'Plan A' }),
+      makeEntry({ id: 't2', workflowName: 'Plan B' }),
+      makeEntry({ id: 't3', workflowName: 'Plan C' }),
     ];
-    const grouped = groupByWorkflow(tasks as any);
-    const planA = grouped.get('Plan A')!;
-    expect(planA[0].id).toBe('t1');
-    expect(planA[1].id).toBe('t2');
-    expect(planA[2].id).toBe('t3');
+    const filter = filterWith({ workflowNames: new Set(['Plan A', 'Plan C']) });
+    const out = filterHistory(entries, filter, events);
+    expect(out.map((e) => e.id)).toEqual(['t1', 't3']);
   });
 
-  it('returns empty map for empty input', () => {
-    const grouped = groupByWorkflow([]);
-    expect(grouped.size).toBe(0);
+  it('filters by date range using lastEventAt inclusive of end-of-day', () => {
+    const entries = [
+      makeEntry({ id: 't1', lastEventAt: '2026-07-01T05:00:00Z' }),
+      makeEntry({ id: 't2', lastEventAt: '2026-07-03T23:59:00Z' }),
+      makeEntry({ id: 't3', lastEventAt: '2026-07-05T00:01:00Z' }),
+    ];
+    // Pin local date parsing so end-of-day inclusion is stable across timezones.
+    const from = new Date(2026, 6, 2);
+    const to = new Date(2026, 6, 4);
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const toDateInput = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+    const filter = filterWith({ dateFrom: toDateInput(from), dateTo: toDateInput(to) });
+    const out = filterHistory(entries, filter, events);
+    expect(out.map((e) => e.id)).toEqual(['t2']);
   });
 
-  it('handles single task', () => {
-    const tasks = [makeFakeTask('t1', 'Solo Plan')];
-    const grouped = groupByWorkflow(tasks as any);
-    expect(grouped.size).toBe(1);
-    expect(grouped.get('Solo Plan')).toHaveLength(1);
+  it('filters with only dateFrom or only dateTo', () => {
+    const entries = [
+      makeEntry({ id: 't1', lastEventAt: '2026-07-01T05:00:00Z' }),
+      makeEntry({ id: 't2', lastEventAt: '2026-07-03T12:00:00Z' }),
+      makeEntry({ id: 't3', lastEventAt: '2026-07-05T00:01:00Z' }),
+    ];
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const toDateInput = (y: number, m: number, d: number) => `${y}-${pad(m)}-${pad(d)}`;
+    expect(filterHistory(entries, filterWith({ dateFrom: toDateInput(2026, 7, 3) }), events).map((e) => e.id)).toEqual(['t2', 't3']);
+    expect(filterHistory(entries, filterWith({ dateTo: toDateInput(2026, 7, 3) }), events).map((e) => e.id)).toEqual(['t1', 't2']);
+  });
+
+  it('searches through cached events via eventsByTask', () => {
+    const entries = [
+      makeEntry({ id: 't1', description: 'Alpha', status: 'completed' }),
+      makeEntry({ id: 't2', description: 'Beta', status: 'completed' }),
+    ];
+    const eventsByTask = new Map<string, TaskEvent[]>([
+      ['t2', [makeEvent({ taskId: 't2', eventType: 'task.failed', payload: JSON.stringify({ error: 'needle-in-payload' }) })]],
+    ]);
+    const out = filterHistory(entries, filterWith({ search: 'needle-in-payload' }), eventsByTask);
+    expect(out.map((e) => e.id)).toEqual(['t2']);
+  });
+
+  it('combines search with filters (AND across kinds)', () => {
+    const entries = [
+      makeEntry({ id: 't1', description: 'Alpha', status: 'completed' }),
+      makeEntry({ id: 't2', description: 'Beta', status: 'completed' }),
+      makeEntry({ id: 't3', description: 'Alpha', status: 'failed' }),
+    ];
+    const filter = filterWith({
+      statuses: new Set<TaskStatus>(['completed']),
+      search: 'alpha',
+    });
+    const out = filterHistory(entries, filter, events);
+    expect(out.map((e) => e.id)).toEqual(['t1']);
+  });
+
+  it('excludes tasks with no lastEventAt when a date range is set', () => {
+    const entries = [makeEntry({ id: 't1', lastEventAt: null })];
+    const filter = filterWith({ dateFrom: '2026-07-01' });
+    expect(filterHistory(entries, filter, events)).toHaveLength(0);
+  });
+
+  it('can filter closed tasks by status', () => {
+    const entries = [
+      makeEntry({ id: 't1', status: 'completed' }),
+      makeEntry({ id: 't2', status: 'closed' }),
+    ];
+    const out = filterHistory(entries, filterWith({ statuses: new Set<TaskStatus>(['closed']) }), events);
+    expect(out.map((e) => e.id)).toEqual(['t2']);
+  });
+});
+
+describe('applyDelta', () => {
+  const nowIso = new Date().toISOString();
+
+  function makeTask(id: string, status: TaskStatus = 'pending', description = 'x'): TaskState {
+    return {
+      id,
+      description,
+      status,
+      dependencies: [],
+      createdAt: new Date(nowIso),
+      config: {},
+      execution: {},
+      taskStateVersion: 1,
+    };
+  }
+
+  it('appends a created task with a fresh lastEventAt', () => {
+    const list: TaskHistoryEntry[] = [];
+    const out = applyDelta(list, { type: 'created', task: makeTask('t1') });
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('t1');
+    expect(out[0].lastEventAt).toBeTruthy();
+    expect(out[0].eventCount).toBe(1);
+  });
+
+  it('upserts a created delta for an existing id, preserving workflowName', () => {
+    const start: TaskHistoryEntry[] = [
+      makeEntry({ id: 't1', workflowName: 'Plan A', eventCount: 3, lastEventAt: '2026-07-01T10:00:00Z' }),
+      makeEntry({ id: 't2', workflowName: 'Plan B', lastEventAt: '2026-07-01T11:00:00Z' }),
+    ];
+    const out = applyDelta(start, {
+      type: 'created',
+      task: makeTask('t1', 'running', 'Updated description'),
+    });
+    expect(out[0].id).toBe('t1');
+    expect(out[0].workflowName).toBe('Plan A');
+    expect(out[0].description).toBe('Updated description');
+    expect(out[0].eventCount).toBe(4);
+  });
+
+  it('applies updated deltas by merging changes into the matched entry', () => {
+    const start: TaskHistoryEntry[] = [
+      makeEntry({
+        id: 't1',
+        status: 'pending',
+        taskStateVersion: 1,
+        eventCount: 2,
+        description: 'old',
+        dependencies: ['dep-a'],
+        config: { command: 'echo old' },
+      }),
+    ];
+    const out = applyDelta(start, {
+      type: 'updated',
+      taskId: 't1',
+      changes: {
+        status: 'running',
+        description: 'new',
+        dependencies: ['dep-b'],
+        config: { command: 'echo new' },
+        execution: { branch: 'feat/x' },
+      },
+      taskStateVersion: 2,
+      previousTaskStateVersion: 1,
+    });
+    expect(out[0].status).toBe('running');
+    expect(out[0].taskStateVersion).toBe(2);
+    expect(out[0].description).toBe('new');
+    expect(out[0].dependencies).toEqual(['dep-b']);
+    expect(out[0].config.command).toBe('echo new');
+    expect(out[0].execution.branch).toBe('feat/x');
+    expect(out[0].eventCount).toBe(3);
+  });
+
+  it('ignores updated deltas for unknown tasks', () => {
+    const start: TaskHistoryEntry[] = [makeEntry({ id: 't1' })];
+    const out = applyDelta(start, {
+      type: 'updated',
+      taskId: 'nope',
+      changes: { status: 'running' },
+      taskStateVersion: 2,
+      previousTaskStateVersion: 1,
+    });
+    expect(out).toEqual(start);
+  });
+
+  it('removes tasks on removed deltas and no-ops unknown removals', () => {
+    const start: TaskHistoryEntry[] = [makeEntry({ id: 't1' }), makeEntry({ id: 't2' })];
+    expect(applyDelta(start, {
+      type: 'removed',
+      taskId: 't1',
+      previousTaskStateVersion: 1,
+    }).map((e) => e.id)).toEqual(['t2']);
+    expect(applyDelta(start, {
+      type: 'removed',
+      taskId: 'missing',
+      previousTaskStateVersion: 1,
+    })).toEqual(start);
+  });
+
+  it('re-sorts the list so the most recently updated task is on top', () => {
+    const start: TaskHistoryEntry[] = [
+      makeEntry({ id: 't-newer', lastEventAt: '2026-07-01T12:00:00Z' }),
+      makeEntry({ id: 't-older', lastEventAt: '2026-07-01T10:00:00Z' }),
+    ];
+    const out = applyDelta(start, {
+      type: 'updated',
+      taskId: 't-older',
+      changes: { status: 'completed' },
+      taskStateVersion: 2,
+      previousTaskStateVersion: 1,
+    });
+    expect(out[0].id).toBe('t-older');
   });
 });

--- a/packages/ui/src/components/HistoryView.tsx
+++ b/packages/ui/src/components/HistoryView.tsx
@@ -1,37 +1,610 @@
-import { useState, useEffect } from 'react';
-import type { TaskState } from '../types.js';
-
-type HistoryTask = TaskState & { workflowName: string };
-
-/** Groups tasks by workflowName, preserving insertion order. */
-export function groupByWorkflow(tasks: HistoryTask[]): Map<string, HistoryTask[]> {
-  const map = new Map<string, HistoryTask[]>();
-  for (const task of tasks) {
-    const group = map.get(task.workflowName);
-    if (group) {
-      group.push(task);
-    } else {
-      map.set(task.workflowName, [task]);
-    }
-  }
-  return map;
-}
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import type { TaskState, TaskStatus, TaskHistoryEntry, TaskEvent, TaskDelta, InvokerAPI } from '../types.js';
+import {
+  categorizeEvent,
+  friendlyEventLabel,
+  payloadDetail,
+  payloadErrorSummary,
+  type EventCategory,
+} from '../lib/event-labels.js';
 
 interface HistoryViewProps {
   onTaskClick: (task: TaskState) => void;
   selectedTaskId: string | null;
 }
 
+export interface FilterState {
+  search: string;
+  statuses: Set<TaskStatus>;
+  workflowNames: Set<string>;
+  dateFrom: string;
+  dateTo: string;
+}
+
+export const EMPTY_FILTER: FilterState = {
+  search: '',
+  statuses: new Set(),
+  workflowNames: new Set(),
+  dateFrom: '',
+  dateTo: '',
+};
+
+const STATUS_OPTIONS: readonly TaskStatus[] = [
+  'completed',
+  'failed',
+  'running',
+  'fixing_with_ai',
+  'awaiting_approval',
+  'needs_input',
+  'blocked',
+  'pending',
+  'review_ready',
+  'stale',
+  'closed',
+] as const;
+
+const STATUS_LABEL: Record<TaskStatus, string> = {
+  pending: 'Pending',
+  running: 'Running',
+  fixing_with_ai: 'Autofixing',
+  completed: 'Completed',
+  failed: 'Failed',
+  closed: 'Closed',
+  needs_input: 'Needs input',
+  blocked: 'Blocked',
+  review_ready: 'Review ready',
+  awaiting_approval: 'Awaiting approval',
+  stale: 'Stale',
+};
+
+const STATUS_STYLE: Record<TaskStatus, string> = {
+  pending: 'bg-gray-700 text-gray-200',
+  running: 'bg-blue-700 text-blue-100',
+  fixing_with_ai: 'bg-amber-700 text-amber-100',
+  completed: 'bg-emerald-700 text-emerald-100',
+  failed: 'bg-red-700 text-red-100',
+  closed: 'bg-gray-600 text-gray-200',
+  needs_input: 'bg-purple-700 text-purple-100',
+  blocked: 'bg-red-900 text-red-100',
+  review_ready: 'bg-teal-700 text-teal-100',
+  awaiting_approval: 'bg-purple-700 text-purple-100',
+  stale: 'bg-gray-700 text-gray-300',
+};
+
+const CATEGORY_DOT: Record<EventCategory, string> = {
+  'terminal-success': 'bg-emerald-500',
+  'terminal-failure': 'bg-red-500',
+  running: 'bg-blue-500',
+  autofix: 'bg-amber-500',
+  attention: 'bg-purple-500',
+  info: 'bg-gray-500',
+};
+
+function formatAbsolute(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.valueOf())) return '';
+  return d.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '';
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remSeconds = seconds % 60;
+  if (minutes < 60) return remSeconds ? `${minutes}m ${remSeconds}s` : `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  if (hours < 24) return remMinutes ? `${hours}h ${remMinutes}m` : `${hours}h`;
+  const days = Math.floor(hours / 24);
+  const remHours = hours % 24;
+  return remHours ? `${days}d ${remHours}h` : `${days}d`;
+}
+
+/**
+ * Match a search query against the whole task row (description, workflow name,
+ * event labels for expanded tasks, and error/exit-code payloads).
+ */
+export function taskMatchesSearch(
+  entry: TaskHistoryEntry,
+  query: string,
+  events: TaskEvent[] | undefined,
+): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  if (entry.description?.toLowerCase().includes(q)) return true;
+  if (entry.workflowName?.toLowerCase().includes(q)) return true;
+  const execError = entry.execution?.error;
+  if (typeof execError === 'string' && execError.toLowerCase().includes(q)) return true;
+  const exit = entry.execution?.exitCode;
+  if (typeof exit === 'number' && String(exit).includes(q)) return true;
+  for (const ev of events ?? []) {
+    if (ev.eventType.toLowerCase().includes(q)) return true;
+    if (friendlyEventLabel(ev.eventType).toLowerCase().includes(q)) return true;
+    if (ev.payload && ev.payload.toLowerCase().includes(q)) return true;
+  }
+  return false;
+}
+
+export function filterHistory(
+  entries: TaskHistoryEntry[],
+  filter: FilterState,
+  eventsByTask: Map<string, TaskEvent[]>,
+): TaskHistoryEntry[] {
+  const fromMs = filter.dateFrom ? new Date(filter.dateFrom).valueOf() : Number.NEGATIVE_INFINITY;
+  const toMsRaw = filter.dateTo ? new Date(filter.dateTo).valueOf() : Number.POSITIVE_INFINITY;
+  const toMs = Number.isFinite(toMsRaw) ? toMsRaw + 24 * 60 * 60 * 1000 - 1 : toMsRaw;
+
+  return entries.filter((entry) => {
+    if (filter.statuses.size > 0 && !filter.statuses.has(entry.status)) return false;
+    if (filter.workflowNames.size > 0 && !filter.workflowNames.has(entry.workflowName)) return false;
+    const lastEventIso = entry.lastEventAt ?? undefined;
+    const lastEventMs = lastEventIso ? new Date(lastEventIso).valueOf() : NaN;
+    if (Number.isFinite(lastEventMs)) {
+      if (lastEventMs < fromMs || lastEventMs > toMs) return false;
+    } else if (filter.dateFrom || filter.dateTo) {
+      return false;
+    }
+    if (filter.search && !taskMatchesSearch(entry, filter.search, eventsByTask.get(entry.id))) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function StatusBadge({ status }: { status: TaskStatus }) {
+  const style = STATUS_STYLE[status] ?? 'bg-gray-700 text-gray-200';
+  const label = STATUS_LABEL[status] ?? status;
+  return <span className={`px-2 py-0.5 rounded text-xs font-medium ${style}`}>{label}</span>;
+}
+
+function TimelineEntry({
+  event,
+  prevChronologicalCreatedAt,
+}: {
+  event: TaskEvent;
+  prevChronologicalCreatedAt: string | undefined;
+}) {
+  const category = categorizeEvent(event.eventType);
+  const label = friendlyEventLabel(event.eventType);
+  const detail = payloadDetail(event.payload);
+  const errorInfo = category === 'terminal-failure' ? payloadErrorSummary(event.payload) : undefined;
+
+  const durationSincePrev = useMemo(() => {
+    if (!prevChronologicalCreatedAt) return '';
+    const currentMs = new Date(event.createdAt).valueOf();
+    const prevMs = new Date(prevChronologicalCreatedAt).valueOf();
+    if (!Number.isFinite(currentMs) || !Number.isFinite(prevMs)) return '';
+    return formatDuration(currentMs - prevMs);
+  }, [event.createdAt, prevChronologicalCreatedAt]);
+
+  return (
+    <li className="flex gap-3 py-1.5">
+      <div className="flex flex-col items-center pt-1.5">
+        <span className={`inline-block w-2 h-2 rounded-full ${CATEGORY_DOT[category]}`} />
+        <span className="w-px flex-1 bg-gray-700 mt-1" aria-hidden="true" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+          <span
+            className="text-sm font-medium text-gray-100"
+            title={event.eventType}
+          >
+            {label}
+          </span>
+          {detail && (
+            <span className="text-xs text-gray-400 truncate" title={detail}>
+              {detail}
+            </span>
+          )}
+          <span className="text-xs text-gray-500 ml-auto shrink-0">
+            {formatAbsolute(event.createdAt)}
+          </span>
+        </div>
+        {durationSincePrev && (
+          <div className="text-xs text-gray-500">
+            +{durationSincePrev} since previous
+          </div>
+        )}
+        {errorInfo && (
+          <div className="mt-0.5 text-xs text-red-300 break-words">
+            {typeof errorInfo.exitCode === 'number' && <span className="font-mono mr-2">exit {errorInfo.exitCode}</span>}
+            {errorInfo.error && <span className="whitespace-pre-wrap">{errorInfo.error}</span>}
+          </div>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function Timeline({
+  taskId,
+  events,
+  loading,
+}: {
+  taskId: string;
+  events: TaskEvent[] | undefined;
+  loading: boolean;
+}) {
+  if (loading) {
+    return <div className="text-xs text-gray-500 py-2">Loading timeline...</div>;
+  }
+  if (!events || events.length === 0) {
+    return <div className="text-xs text-gray-500 py-2">No recorded events for this task.</div>;
+  }
+  // getEvents() returns oldest-first; the timeline UI shows newest-first.
+  const newestFirst = [...events].reverse();
+  return (
+    <ol
+      className="mt-1 pl-1"
+      aria-label={`Timeline for task ${taskId}`}
+      data-testid={`history-timeline-${taskId}`}
+    >
+      {newestFirst.map((event, idxFromTop) => {
+        // The chronologically-previous event sits BELOW the current one in a
+        // newest-first list, i.e. at index+1.
+        const chronologicallyPrev = newestFirst[idxFromTop + 1]?.createdAt;
+        return (
+          <TimelineEntry
+            key={event.id}
+            event={event}
+            prevChronologicalCreatedAt={chronologicallyPrev}
+          />
+        );
+      })}
+    </ol>
+  );
+}
+
+function HistoryRow({
+  entry,
+  selected,
+  expanded,
+  events,
+  eventsLoading,
+  onToggleExpand,
+  onSelect,
+}: {
+  entry: TaskHistoryEntry;
+  selected: boolean;
+  expanded: boolean;
+  events: TaskEvent[] | undefined;
+  eventsLoading: boolean;
+  onToggleExpand: (taskId: string) => void;
+  onSelect: (task: TaskState) => void;
+}) {
+  const rowClass = selected
+    ? 'bg-indigo-900/60 border-indigo-600'
+    : 'bg-gray-800 border-gray-800 hover:border-gray-600';
+  return (
+    <li
+      className={`border rounded-md ${rowClass} transition-colors`}
+      data-testid={`history-row-${entry.id}`}
+    >
+      <div className="flex items-start gap-2 px-3 py-2">
+        <button
+          type="button"
+          onClick={() => onToggleExpand(entry.id)}
+          className="mt-0.5 text-gray-400 hover:text-gray-100 w-4 shrink-0"
+          aria-expanded={expanded}
+          aria-label={expanded ? 'Collapse timeline' : 'Expand timeline'}
+          data-testid={`history-expand-${entry.id}`}
+        >
+          {expanded ? '▾' : '▸'}
+        </button>
+        <button
+          type="button"
+          onClick={() => onSelect(entry)}
+          className="flex-1 min-w-0 text-left"
+        >
+          <div className="flex flex-wrap items-baseline gap-x-2">
+            <span className="text-sm text-gray-100 truncate max-w-full" title={entry.description}>
+              {entry.description}
+            </span>
+          </div>
+          <div className="flex flex-wrap items-center gap-x-2 mt-1 text-xs text-gray-400">
+            <StatusBadge status={entry.status} />
+            <span className="truncate" title={entry.workflowName}>
+              {entry.workflowName}
+            </span>
+            <span className="ml-auto shrink-0" title={entry.lastEventAt ?? undefined}>
+              {formatAbsolute(entry.lastEventAt)}
+            </span>
+          </div>
+        </button>
+      </div>
+      {expanded && (
+        <div className="px-3 pb-2 pl-8 border-t border-gray-700/60">
+          <Timeline taskId={entry.id} events={events} loading={eventsLoading} />
+        </div>
+      )}
+    </li>
+  );
+}
+
+function FilterBar({
+  filter,
+  onChange,
+  workflowNames,
+  visibleCount,
+  totalCount,
+}: {
+  filter: FilterState;
+  onChange: (next: FilterState) => void;
+  workflowNames: string[];
+  visibleCount: number;
+  totalCount: number;
+}) {
+  const toggleStatus = useCallback(
+    (status: TaskStatus) => {
+      const next = new Set(filter.statuses);
+      if (next.has(status)) next.delete(status);
+      else next.add(status);
+      onChange({ ...filter, statuses: next });
+    },
+    [filter, onChange],
+  );
+
+  const toggleWorkflow = useCallback(
+    (name: string) => {
+      const next = new Set(filter.workflowNames);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      onChange({ ...filter, workflowNames: next });
+    },
+    [filter, onChange],
+  );
+
+  const anyActive =
+    filter.search !== '' ||
+    filter.statuses.size > 0 ||
+    filter.workflowNames.size > 0 ||
+    filter.dateFrom !== '' ||
+    filter.dateTo !== '';
+
+  return (
+    <div className="border-b border-gray-800 p-3 space-y-3 bg-gray-900/40">
+      <div className="flex items-center gap-2">
+        <input
+          type="search"
+          value={filter.search}
+          onChange={(e) => onChange({ ...filter, search: e.target.value })}
+          placeholder="Search description, workflow, event, error…"
+          className="flex-1 bg-gray-900 border border-gray-700 rounded px-2 py-1 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"
+          aria-label="Search history"
+        />
+        <span className="text-xs text-gray-500 shrink-0">
+          {visibleCount} / {totalCount}
+        </span>
+        {anyActive && (
+          <button
+            type="button"
+            onClick={() => onChange(EMPTY_FILTER)}
+            className="text-xs text-gray-400 hover:text-gray-100 shrink-0"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+      <div className="flex flex-wrap gap-1.5" aria-label="Filter by status">
+        {STATUS_OPTIONS.map((status) => {
+          const active = filter.statuses.has(status);
+          return (
+            <button
+              key={status}
+              type="button"
+              onClick={() => toggleStatus(status)}
+              className={`text-xs px-2 py-0.5 rounded border transition-colors ${
+                active
+                  ? `${STATUS_STYLE[status]} border-transparent`
+                  : 'bg-transparent text-gray-400 border-gray-700 hover:border-gray-500'
+              }`}
+              aria-pressed={active}
+            >
+              {STATUS_LABEL[status]}
+            </button>
+          );
+        })}
+      </div>
+      {workflowNames.length > 0 && (
+        <div className="flex flex-wrap gap-1.5" aria-label="Filter by workflow">
+          {workflowNames.map((name) => {
+            const active = filter.workflowNames.has(name);
+            return (
+              <button
+                key={name}
+                type="button"
+                onClick={() => toggleWorkflow(name)}
+                className={`text-xs px-2 py-0.5 rounded border transition-colors max-w-[240px] truncate ${
+                  active
+                    ? 'bg-indigo-700 text-indigo-100 border-transparent'
+                    : 'bg-transparent text-gray-400 border-gray-700 hover:border-gray-500'
+                }`}
+                aria-pressed={active}
+                title={name}
+              >
+                {name}
+              </button>
+            );
+          })}
+        </div>
+      )}
+      <div className="flex flex-wrap items-center gap-2 text-xs text-gray-400">
+        <label className="flex items-center gap-1">
+          <span>From</span>
+          <input
+            type="date"
+            value={filter.dateFrom}
+            onChange={(e) => onChange({ ...filter, dateFrom: e.target.value })}
+            className="bg-gray-900 border border-gray-700 rounded px-1.5 py-0.5 text-xs text-gray-100"
+            aria-label="From date"
+          />
+        </label>
+        <label className="flex items-center gap-1">
+          <span>To</span>
+          <input
+            type="date"
+            value={filter.dateTo}
+            onChange={(e) => onChange({ ...filter, dateTo: e.target.value })}
+            className="bg-gray-900 border border-gray-700 rounded px-1.5 py-0.5 text-xs text-gray-100"
+            aria-label="To date"
+          />
+        </label>
+      </div>
+    </div>
+  );
+}
+
+export function applyDelta(prev: TaskHistoryEntry[], delta: TaskDelta): TaskHistoryEntry[] {
+  const nowIso = new Date().toISOString();
+  if (delta.type === 'removed') {
+    return prev.filter((entry) => entry.id !== delta.taskId);
+  }
+  if (delta.type === 'created') {
+    const existingIdx = prev.findIndex((e) => e.id === delta.task.id);
+    const existing = existingIdx >= 0 ? prev[existingIdx] : undefined;
+    const entry: TaskHistoryEntry = {
+      ...delta.task,
+      workflowName: existing?.workflowName ?? '',
+      lastEventAt: nowIso,
+      eventCount: (existing?.eventCount ?? 0) + 1,
+    };
+    if (existingIdx >= 0) {
+      const next = prev.slice();
+      next[existingIdx] = entry;
+      return sortByLastEvent(next);
+    }
+    return sortByLastEvent([entry, ...prev]);
+  }
+  const idx = prev.findIndex((e) => e.id === delta.taskId);
+  if (idx < 0) return prev;
+  const existing = prev[idx];
+  const changes = delta.changes;
+  const nextStatus = changes.status ?? existing.status;
+  const nextExecution = { ...existing.execution, ...(changes.execution ?? {}) };
+  const nextConfig = { ...existing.config, ...(changes.config ?? {}) };
+  const updated: TaskHistoryEntry = {
+    ...existing,
+    status: nextStatus,
+    description: changes.description ?? existing.description,
+    dependencies: changes.dependencies ?? existing.dependencies,
+    execution: nextExecution,
+    config: nextConfig,
+    taskStateVersion: delta.taskStateVersion,
+    lastEventAt: nowIso,
+    eventCount: existing.eventCount + 1,
+  };
+  const next = prev.slice();
+  next[idx] = updated;
+  return sortByLastEvent(next);
+}
+
+function getInvoker(): InvokerAPI | undefined {
+  return typeof window !== 'undefined' ? window.invoker : undefined;
+}
+
+function sortByLastEvent(entries: TaskHistoryEntry[]): TaskHistoryEntry[] {
+  return entries.slice().sort((a, b) => {
+    const at = a.lastEventAt ? new Date(a.lastEventAt).valueOf() : 0;
+    const bt = b.lastEventAt ? new Date(b.lastEventAt).valueOf() : 0;
+    return bt - at;
+  });
+}
+
 export function HistoryView({ onTaskClick, selectedTaskId }: HistoryViewProps) {
-  const [tasks, setTasks] = useState<HistoryTask[]>([]);
+  const [entries, setEntries] = useState<TaskHistoryEntry[]>([]);
   const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<FilterState>(EMPTY_FILTER);
+  const [expandedTaskId, setExpandedTaskId] = useState<string | null>(null);
+  const [eventsByTask, setEventsByTask] = useState<Map<string, TaskEvent[]>>(new Map());
+  const [eventsLoadingTaskId, setEventsLoadingTaskId] = useState<string | null>(null);
 
   useEffect(() => {
-    window.invoker?.getAllCompletedTasks().then((t) => {
-      setTasks(t);
+    let cancelled = false;
+    const invoker = getInvoker();
+    if (!invoker?.getHistoryTasks) {
+      setLoading(false);
+      setEntries([]);
+      return;
+    }
+    invoker.getHistoryTasks().then((rows) => {
+      if (cancelled) return;
+      setEntries(sortByLastEvent(rows));
+      setLoading(false);
+    }).catch(() => {
+      if (cancelled) return;
       setLoading(false);
     });
+    return () => {
+      cancelled = true;
+    };
   }, []);
+
+  const refetchEvents = useCallback(async (taskId: string) => {
+    const invoker = getInvoker();
+    if (!invoker?.getEvents) return;
+    setEventsLoadingTaskId(taskId);
+    try {
+      const evs = await invoker.getEvents(taskId);
+      setEventsByTask((prev) => {
+        const next = new Map(prev);
+        next.set(taskId, evs);
+        return next;
+      });
+    } finally {
+      setEventsLoadingTaskId((current) => (current === taskId ? null : current));
+    }
+  }, []);
+
+  useEffect(() => {
+    const invoker = getInvoker();
+    if (!invoker?.onTaskGraphEvent) return;
+    return invoker.onTaskGraphEvent((event) => {
+      if (event.type !== 'delta') return;
+      const delta = event.delta;
+      setEntries((prev) => applyDelta(prev, delta));
+      const affectedId = 'taskId' in delta ? delta.taskId : delta.task.id;
+      if (affectedId && expandedTaskId === affectedId) {
+        void refetchEvents(affectedId);
+      }
+    });
+  }, [expandedTaskId, refetchEvents]);
+
+  const toggleExpand = useCallback(
+    (taskId: string) => {
+      setExpandedTaskId((current) => {
+        if (current === taskId) return null;
+        void refetchEvents(taskId);
+        return taskId;
+      });
+    },
+    [refetchEvents],
+  );
+
+  const workflowNames = useMemo(() => {
+    const seen = new Set<string>();
+    const ordered: string[] = [];
+    for (const entry of entries) {
+      if (!entry.workflowName || seen.has(entry.workflowName)) continue;
+      seen.add(entry.workflowName);
+      ordered.push(entry.workflowName);
+    }
+    return ordered;
+  }, [entries]);
+
+  const filtered = useMemo(
+    () => filterHistory(entries, filter, eventsByTask),
+    [entries, filter, eventsByTask],
+  );
 
   if (loading) {
     return (
@@ -41,47 +614,39 @@ export function HistoryView({ onTaskClick, selectedTaskId }: HistoryViewProps) {
     );
   }
 
-  if (tasks.length === 0) {
-    return (
-      <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
-        No completed tasks
-      </div>
-    );
-  }
-
-  const grouped = groupByWorkflow(tasks);
-
   return (
-    <div className="h-full overflow-y-auto p-4">
-      {Array.from(grouped.entries()).map(([workflowName, workflowTasks]) => (
-        <div key={workflowName} className="mb-6">
-          <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-            {workflowName}
-          </h3>
-          <div className="space-y-1">
-            {workflowTasks.map((task) => (
-              <button
-                key={task.id}
-                onClick={() => onTaskClick(task)}
-                className={`w-full text-left px-3 py-2 rounded text-sm transition-colors ${
-                  selectedTaskId === task.id
-                    ? 'bg-indigo-600 text-white'
-                    : 'bg-secondary hover:bg-muted text-foreground'
-                }`}
-              >
-                <div className="flex justify-between items-center">
-                  <span className="truncate mr-2">{task.description}</span>
-                  <span className="text-xs text-muted-foreground shrink-0">
-                    {task.execution?.completedAt
-                      ? new Date(task.execution.completedAt).toLocaleDateString()
-                      : ''}
-                  </span>
-                </div>
-              </button>
-            ))}
-          </div>
+    <div className="h-full flex flex-col" data-testid="history-view">
+      <FilterBar
+        filter={filter}
+        onChange={setFilter}
+        workflowNames={workflowNames}
+        visibleCount={filtered.length}
+        totalCount={entries.length}
+      />
+      {entries.length === 0 ? (
+        <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
+          No task history yet
         </div>
-      ))}
+      ) : filtered.length === 0 ? (
+        <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
+          No tasks match the current filters
+        </div>
+      ) : (
+        <ul className="flex-1 overflow-y-auto p-3 space-y-1.5" aria-label="Task history" data-testid="history-task-list">
+          {filtered.map((entry) => (
+            <HistoryRow
+              key={entry.id}
+              entry={entry}
+              selected={selectedTaskId === entry.id}
+              expanded={expandedTaskId === entry.id}
+              events={eventsByTask.get(entry.id)}
+              eventsLoading={eventsLoadingTaskId === entry.id}
+              onToggleExpand={toggleExpand}
+              onSelect={onTaskClick}
+            />
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/lib/event-labels.ts
+++ b/packages/ui/src/lib/event-labels.ts
@@ -1,0 +1,128 @@
+/**
+ * Friendly display labels for the raw `event_type` values written to the SQLite
+ * `events` table. Used by the History timeline to render human-readable rows
+ * while keeping the raw name available on hover.
+ */
+
+const RAW_TO_FRIENDLY: Record<string, string> = {
+  'task.created': 'Task created',
+  'task.pending': 'Pending',
+  'task.running': 'Running',
+  'task.completed': 'Completed',
+  'task.failed': 'Failed',
+  'task.cancelled': 'Cancelled',
+  'task.blocked': 'Blocked',
+  'task.stale': 'Marked stale',
+  'task.deferred': 'Deferred',
+  'task.needs_input': 'Needs input',
+  'task.awaiting_approval': 'Awaiting approval',
+  'task.fixing_with_ai': 'Submitted for autofix',
+  'task.updated': 'Task updated',
+  'task.prepared_for_new_attempt': 'Prepared for retry',
+  'task.forked_from': 'Forked from another task',
+  'task.experiment_results_recorded': 'Experiment results recorded',
+  'task.external_dependency_policy_updated': 'External dependency policy updated',
+  'task.external_dependency_detached': 'External dependency detached',
+  'task.workflow_detached': 'Workflow detached',
+  'task.executor.routed': 'Executor routed',
+  'task.executor.selected': 'Executor selected',
+  'task.executor.deferred': 'Executor deferred',
+  'task.launch_dispatch_enqueued': 'Launch dispatch enqueued',
+  'task.launch_dispatch_claimed': 'Launch dispatch claimed',
+  'task.launch_claimed': 'Launch claimed',
+  'task.metadata.updated': 'Metadata updated',
+  'task.log': 'Log',
+  'workflow.mutation.timing': 'Workflow mutation timing',
+  'debug.auto-fix': 'Autofix debug',
+  // Legacy short names (pre-2025-01 event vocabulary):
+  started: 'Started',
+  completed: 'Completed',
+};
+
+const TERMINAL_STATUS_LIKE = new Set<string>([
+  'task.completed',
+  'task.failed',
+  'task.cancelled',
+  'task.stale',
+  'completed',
+]);
+
+const RUNNING_STATUS_LIKE = new Set<string>([
+  'task.running',
+  'started',
+]);
+
+const AUTOFIX_LIKE = new Set<string>([
+  'task.fixing_with_ai',
+  'debug.auto-fix',
+]);
+
+const ATTENTION_LIKE = new Set<string>([
+  'task.awaiting_approval',
+  'task.needs_input',
+  'task.blocked',
+  'task.deferred',
+]);
+
+export function friendlyEventLabel(eventType: string): string {
+  if (RAW_TO_FRIENDLY[eventType]) return RAW_TO_FRIENDLY[eventType];
+  // Fall back to a title-cased version of the last segment.
+  const last = eventType.split(/[.:_-]/).pop() ?? eventType;
+  return last.charAt(0).toUpperCase() + last.slice(1);
+}
+
+export type EventCategory = 'terminal-success' | 'terminal-failure' | 'running' | 'autofix' | 'attention' | 'info';
+
+export function categorizeEvent(eventType: string): EventCategory {
+  if (eventType === 'task.completed' || eventType === 'completed') return 'terminal-success';
+  if (eventType === 'task.failed' || eventType === 'task.cancelled' || eventType === 'task.stale') return 'terminal-failure';
+  if (RUNNING_STATUS_LIKE.has(eventType)) return 'running';
+  if (AUTOFIX_LIKE.has(eventType)) return 'autofix';
+  if (ATTENTION_LIKE.has(eventType)) return 'attention';
+  if (TERMINAL_STATUS_LIKE.has(eventType)) return 'terminal-success';
+  return 'info';
+}
+
+/**
+ * When the payload carries a discriminating `phase` field (as `debug.auto-fix`
+ * events do), surface it after the friendly label. Returns undefined when the
+ * payload has no useful discriminator.
+ */
+export function payloadDetail(payload: string | undefined): string | undefined {
+  if (!payload) return undefined;
+  try {
+    const parsed = JSON.parse(payload) as Record<string, unknown>;
+    if (typeof parsed.phase === 'string') return parsed.phase;
+    if (typeof parsed.reason === 'string') return parsed.reason;
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Extract a short error message from an event payload, if any. Used to display
+ * exit code / error text next to failure entries in the timeline.
+ */
+export function payloadErrorSummary(payload: string | undefined): { exitCode?: number; error?: string } | undefined {
+  if (!payload) return undefined;
+  try {
+    const parsed = JSON.parse(payload) as Record<string, unknown>;
+    const exitCode =
+      typeof parsed.exitCode === 'number'
+        ? parsed.exitCode
+        : typeof (parsed.execution as Record<string, unknown> | undefined)?.exitCode === 'number'
+          ? (parsed.execution as Record<string, unknown>).exitCode as number
+          : undefined;
+    const error =
+      typeof parsed.error === 'string'
+        ? parsed.error
+        : typeof (parsed.execution as Record<string, unknown> | undefined)?.error === 'string'
+          ? (parsed.execution as Record<string, unknown>).error as string
+          : undefined;
+    if (exitCode === undefined && !error) return undefined;
+    return { exitCode, error };
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -322,6 +322,8 @@ export type {
   AgentSessionData,
   QueueStatus,
   ReviewGateQueryResponse,
+  TaskEvent,
+  TaskHistoryEntry,
   WorkerActionSummary,
   WorkerDecisionsRequest,
   WorkerDecisionsResponse,


### PR DESCRIPTION
## Summary

History listened for `onTaskDelta`, but that method does not exist on Invoker. Live History updates never ran, even though `applyDelta` had unit coverage.

This connects History to `onTaskGraphEvent`, keeps only delta events, and applies them through `applyDelta`. When the expanded task changes, its events are fetched again.

## Review Claim

Approving this makes History follow the same task-graph delta stream as the rest of the UI, with component coverage for load, expand, and live reorder.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

No persistence or channel payload changes. The listener is additive and torn down on unmount. Non-delta graph events are ignored.

Mock helpers only change the test harness. Product behavior still uses the existing preload `onTaskGraphEvent` path.

## Slice Rationale

Slice (1) shipped History with a dead live-update listener. This slice isolates that wiring fix and the component coverage that would have caught it.

## Non-goals

- Not changing history SQL reconciliation. That is slice (3).
- Not adding `closed` status filters or e2e DOM asserts. That is slice (4).
- Not changing the task-graph event payload fields.

## Architecture

### Before

```mermaid
graph TD
    A["HistoryView"] -->|"onTaskDelta?"| B["never fires"]
    C["onTaskGraphEvent"] --> D["useTasks / DAG only"]
```

### After

```mermaid
graph TD
    A["HistoryView"] -->|"onTaskGraphEvent"| B["keep delta events"]
    B --> C["applyDelta + optional getEvents refetch"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/history-view-e2e.test.tsx src/__tests__/history-view.test.ts`
- [ ] Confirm History rows reorder after a live task status change in the Electron app

</details>

## Visual Proof

The live-update claim is event-driven. The screenshot shows the History surface that now receives graph deltas; the component case fires `mock.fireDelta` and asserts reorder.

![History surface that receives live task-graph deltas](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-c531ac/history-timeline-2-live-surface.png)

Caption: History rows with expand controls. Live reorder is covered by `history-view-e2e.test.tsx` (`applies live deltas from onTaskGraphEvent`), which a static screenshot cannot show by itself.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert with: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the task history view with better real-time updates when task graph changes occur.
  * Expanded history entries now show a more detailed timeline, including event ordering and payload information.

* **Bug Fixes**
  * History updates now respond only to relevant delta events, reducing unexpected refreshes.
  * Added support for empty-state handling when no task history is available.

* **Tests**
  * Added end-to-end coverage for history loading, expansion, live updates, and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #3749