### PR TITLE
[History Timeline](4a) Add closed status filters and History coverage

### DIFF
--- a/packages/ui/src/__tests__/history-view-e2e.test.tsx
+++ b/packages/ui/src/__tests__/history-view-e2e.test.tsx
@@ -171,6 +171,34 @@ describe('History view (component)', () => {
     });
   });
 
+  it('filters by status chip and shows closed status option', async () => {
+    const completed = makeHistoryEntry({ id: 'task-done', description: 'Done task', status: 'completed' });
+    const closed = makeHistoryEntry({
+      id: 'task-closed',
+      description: 'Closed task',
+      status: 'closed',
+      lastEventAt: '2026-07-01T09:00:00.000Z',
+    });
+    mock.setHistoryTasks([completed, closed]);
+    act(() => mock.setTasks([completed, closed], workflows));
+
+    render(<App />);
+    await chooseGraphMenuItem('rail-history');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('history-row-task-done')).toBeInTheDocument();
+      expect(screen.getByTestId('history-row-task-closed')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: 'Closed' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Closed' }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('history-row-task-done')).not.toBeInTheDocument();
+      expect(screen.getByTestId('history-row-task-closed')).toBeInTheDocument();
+      expect(screen.getByText('1 / 2')).toBeInTheDocument();
+    });
+  });
 
   it('shows empty state when there is no history', async () => {
     mock.setHistoryTasks([]);


### PR DESCRIPTION
## Summary

`TaskStatus` includes `closed`, but History filters and badges omitted it. Pure-function cases also omitted several real filter and search paths.

This adds `closed` to History status options and hardens unit and component coverage for search, date, `applyDelta`, and closed-status filtering.

## Review Claim

Approving this makes closed tasks filterable and visible in History, with focused UI coverage for those filter paths.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Filter and badge changes are UI-only. Closed tasks already exist in the status union; this only shows them in History controls and labels.

No e2e or persistence changes land here.

## Slice Rationale

This is the filter-completeness follow-up after the core History UI, live-update fix, and read-path reconciliation. The visual-proof e2e assert hardening is the next slice.

## Non-goals

- Not changing the visual-proof Playwright case. That is slice (4b).
- Not inserting SQLite events for expanded timelines.
- Not changing non-History surfaces that already handle `closed`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/history-view.test.ts src/__tests__/history-view-e2e.test.tsx`

</details>

## Visual Proof

History filter surface after adding the Closed chip.

![History filters including Closed status chip](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-c531ac/history-timeline-4-filter-surface.png)

Caption: History filter bar with status chips including Closed, plus searchable flat task rows.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert with: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #3726