### PR TITLE
PR maintenance workers Step 8: Finalize worker-only operator docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ Branches, merges, conflicts, and pull requests are part of the execution model �
 <tr>
 <td width="50%" valign="top">
 
-### Control cloud and remote agents
+### Control cloud and owner-host workers
 
-Spread work across SSH targets and remote machines you already manage — same actions from desktop, CLI, or Slack.
+Run one owner host with built-in recovery and maintenance workers, and spread task execution across SSH targets you manage — same control plane from desktop, CLI, or Slack.
 
 </td>
 <td width="50%">
 
-<img src="docs/assets/readme/control-cloud-agents.png" alt="Control cloud and remote agents" />
+<img src="docs/assets/readme/control-cloud-agents.png" alt="Control cloud and owner-host workers" />
 
 </td>
 </tr>
@@ -116,7 +116,7 @@ Or grab desktop builds and standalone binaries from [GitHub Releases](https://gi
 - [Contributing](CONTRIBUTING.md)
 - [License](LICENSE)
 
-More: [local macOS release build](docs/local-macos-release-build.md), [remote SSH targets](docs/remote-ssh-targets.md), [Docker executor](docs/docker-executor.md), [web surface](docs/web-surface.md), [product story](docs/invoker-medium-article.md).
+More: [local macOS release build](docs/local-macos-release-build.md), [remote SSH targets and owner-host workers](docs/remote-ssh-targets.md), [Docker executor](docs/docker-executor.md), [web surface](docs/web-surface.md), [product story](docs/invoker-medium-article.md).
 
 ## License
 

--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -16,13 +16,13 @@
       "comment": "DockerExecutor configuration"
     },
     "ssh": {
-      "comment": "SshExecutor uses per-target settings from remoteTargets"
+      "comment": "SshExecutor runs task work on SSH targets; owner-host automation stays in built-in workers"
     }
   },
 
   "remoteTargets": {
     "staging-server": {
-      "comment": "Managed SSH target configuration for remote execution",
+      "comment": "Managed SSH execution target for task work; not a background worker host",
       "host": "192.168.1.100",
       "user": "deploy",
       "sshKeyPath": "/home/user/.ssh/id_staging",
@@ -34,7 +34,7 @@
       "remoteHeartbeatIntervalSeconds": 30
     },
     "build-server-b": {
-      "comment": "Second SSH target for running different tasks on a different host",
+      "comment": "Second managed SSH execution target for task work",
       "host": "192.168.1.101",
       "user": "deploy",
       "sshKeyPath": "/home/user/.ssh/id_build_b",
@@ -49,7 +49,7 @@
 
   "executionPools": {
     "mixed-local-ssh": {
-      "comment": "Pool routes tasks across mixed SSH/local members with shared queue/drain semantics",
+      "comment": "Pool routes task execution across mixed SSH/local members with shared queue/drain semantics",
       "members": [
         { "type": "ssh", "id": "staging-server" },
         { "type": "ssh", "id": "build-server-b" },
@@ -59,7 +59,7 @@
       "maxConcurrentTasksPerMember": 1
     },
     "pnpm-ssh": {
-      "comment": "Pool for pnpm commands that should run only on SSH machines",
+      "comment": "Pool for pnpm task commands that should run only on SSH execution targets",
       "members": [
         { "type": "ssh", "id": "staging-server" },
         { "type": "ssh", "id": "build-server-b" }
@@ -94,14 +94,23 @@
   "defaultRepoUrl": "git@github.com:acme/web.git",
 
   "autoFixRetries": 3,
+  "autoFixAgent": "codex",
   "autoApproveAIFixes": true,
   "autoFixCi": false,
+  "e2eAutoFixEnabled": false,
+  "e2eAutoFixIntervalMs": 43200000,
+  "prMaintenance": {
+    "comment": "Owner-host built-in PR-maintenance workers. Enable on exactly one owner process; no separate host scheduler is required.",
+    "enabled": true,
+    "intervalMs": 300000
+  },
 
   "webToken": "change-me-to-a-long-random-secret",
   "webHost": "127.0.0.1",
   "webPort": 4200,
 
   "notes": {
+    "owner_host_workers": "Run recovery and maintenance from the owner process (desktop owner or headless owner-serve). Built-in workers are the supported operator path; external host schedulers should not be configured.",
     "web_surface": "webToken enables the browser UI + Slack live status card surfaces. Env vars INVOKER_WEB_TOKEN / INVOKER_WEB_HOST / INVOKER_WEB_PORT override these. Set webHost to 0.0.0.0 to reach it from another machine (e.g. the DigitalOcean host); open http://<host>:<webPort>/?token=<webToken>.",
     "fetch_behavior": "Git fetch failures always abort the task. Fix the underlying network/auth issue and rerun.",
     "config_locations": [
@@ -111,7 +120,7 @@
     "runner_kinds": [
       "worktree - Git worktree isolation (default)",
       "docker - Docker container execution",
-      "ssh - Remote SSH execution"
+      "ssh - Remote SSH task execution"
     ]
   }
 }

--- a/docs/remote-ssh-targets.md
+++ b/docs/remote-ssh-targets.md
@@ -1,18 +1,18 @@
-# Remote SSH Targets
+# Remote SSH Targets and Owner-Host Workers
 
-Execute Invoker tasks on remote machines via SSH key-based authentication.
+Run Invoker task execution on remote machines via SSH, while operator automation runs inside the single Invoker owner process.
 
 ## Overview
 
 The SSH executor (`runnerKind: ssh`) runs task commands on remote hosts over SSH. Authentication is exclusively key-based — no password auth or `sshpass` dependency is required.
 
-Each remote target is defined in the Invoker config with a host, user, and path to an SSH private key. Tasks reference targets by ID.
+Remote targets are execution substrates only. Recovery, PR maintenance, CI-failure repair, disk-headroom checks, and workflow resume automation are built-in owner-host workers. Run them from the owner process; do not configure a separate host scheduler against the workflow database.
 
 ## Configuration
 
-Add remote targets to `~/.invoker/config.json`.
+Add remote execution targets and owner-host worker settings to `~/.invoker/config.json`.
 
-If you want to use a repo-specific config file, launch Invoker with `INVOKER_REPO_CONFIG_PATH=/path/to/config.json`.
+If you want to use a repo-specific config file, launch the owner with `INVOKER_REPO_CONFIG_PATH=/path/to/config.json`.
 
 ```json
 {
@@ -36,11 +36,18 @@ If you want to use a repo-specific config file, launch Invoker with `INVOKER_REP
       "provisionCommand": "pnpm install --frozen-lockfile",
       "remoteHeartbeatIntervalSeconds": 30
     }
+  },
+  "autoFixRetries": 3,
+  "autoFixAgent": "codex",
+  "autoFixCi": true,
+  "prMaintenance": {
+    "enabled": true,
+    "intervalMs": 300000
   }
 }
 ```
 
-### Fields
+### Remote target fields
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -52,6 +59,27 @@ If you want to use a repo-specific config file, launch Invoker with `INVOKER_REP
 | `remoteInvokerHome` | string | no | Base directory used by managed remote workspaces (default: `~/.invoker`) |
 | `provisionCommand` | string | no | Command run after worktree creation in managed mode |
 | `remoteHeartbeatIntervalSeconds` | number | no | Interval (seconds) for SSH remote workload heartbeat markers used by executing-stall detection (default: `30`) |
+
+### Owner-host worker fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `autoFixRetries` | number | no | Per-task retry budget consumed by the built-in auto-fix worker; `0` disables task auto-fix |
+| `autoFixAgent` | string | no | Preferred agent for built-in auto-fix submissions |
+| `autoFixCi` | boolean | no | Enables the built-in CI-failure worker to submit fixes for failed review-gate checks |
+| `prMaintenance.enabled` | boolean | no | Enables built-in PR-maintenance workers on the owner host |
+| `prMaintenance.intervalMs` | number | no | Poll cadence for built-in PR-maintenance workers |
+
+Only one owner process should enable owner-host workers for a shared workflow database. Use the Workers tab or `./run.sh --headless worker status --output text` to inspect worker ownership and recent decisions.
+
+## Owner-Host Worker Setup
+
+1. Start exactly one writable owner: the desktop app, or a headless owner such as `./run.sh --headless owner-serve`.
+2. Put recovery and maintenance settings in that owner's Invoker config.
+3. Let the owner auto-start built-in workers, or start/stop them from the Workers tab. Headless `worker` commands use the same worker implementations for explicit operator scans.
+4. Configure `remoteTargets` only for task execution capacity. SSH targets do not own recovery or PR-maintenance decisions.
+
+This is the supported owner-host path. The owner owns SQLite writes, workers read durable state through the owner process, and worker actions are recorded for status/audit queries.
 
 ## Multiple SSH Targets
 
@@ -115,7 +143,7 @@ Both fields are required for SSH tasks. The executor validates at runtime that t
 2. When `TaskRunner.selectExecutor()` sees `runnerKind: ssh`, it looks up the `poolMemberId` in the `remoteTargets` config map.
 3. An `SshExecutor` instance is created with the target's connection details.
 4. The runner spawns: `ssh -i <keyPath> -p <port> -o StrictHostKeyChecking=accept-new -o BatchMode=yes user@host <command>`
-5. For `claude` action types, the Claude CLI command is shell-quoted and executed remotely.
+5. Built-in workers run separately inside the owner process and submit normal owner commands when recovery or maintenance is needed.
 
 ### SSH options
 

--- a/packages/app/src/__tests__/headless-query-list.test.ts
+++ b/packages/app/src/__tests__/headless-query-list.test.ts
@@ -147,3 +147,40 @@ describe('headless query worker-decisions', () => {
     ).rejects.toThrow('Invalid --decision');
   });
 });
+
+describe('headless query workers', () => {
+  it('renders the local worker fleet snapshot as JSON', async () => {
+    const output = await runReadOnlyHeadlessQueryToString(
+      ['query', 'workers', '--output', 'json'],
+      {
+        persistence: {
+          listWorkerActions: (filters?: unknown) => {
+            const workerKind = (filters as { workerKind?: string } | undefined)?.workerKind;
+            return workerKind === 'autofix' ? workerActions : [];
+          },
+          listWorkflows: () => [],
+          loadTasks: () => [],
+          countEventsByTypes: () => [],
+          getEventsByTypes: () => [],
+        } as unknown as HeadlessQueryDeps['persistence'],
+        orchestrator: {} as unknown as HeadlessQueryDeps['orchestrator'],
+        executionAgentRegistry: undefined,
+        invokerConfig: {} as unknown as HeadlessQueryDeps['invokerConfig'],
+        getUiPerfStats: () => ({}),
+        resetUiPerfStats: () => {},
+      },
+    );
+
+    const parsed = JSON.parse(output) as {
+      generatedAt?: string;
+      workers?: Array<{ kind?: string; lifecycle?: string; policy?: string; recentActions?: unknown[] }>;
+    };
+    expect(typeof parsed.generatedAt).toBe('string');
+    expect(parsed.workers?.length).toBeGreaterThan(0);
+    expect(parsed.workers?.find((worker) => worker.kind === 'autofix')).toMatchObject({
+      lifecycle: 'stopped',
+      policy: 'unknown',
+      recentActions: [expect.objectContaining({ id: 'wa-1' })],
+    });
+  });
+});

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -1,19 +1,25 @@
 /**
  * Headless "query" command family: the read-only `query <sub>` router
  * (workflows · tasks · task · queue · review-gate · action-graph · audit ·
- * session · worker-actions · cost · cost-events · costs · ui-perf · stats), the cost-event
- * collection/rollup
- * helpers, agent session resolution, and `query-select`.
+ * session · workers · worker-actions · cost · cost-events · costs · ui-perf ·
+ * stats), the cost-event collection/rollup helpers, agent session resolution,
+ * and `query-select`.
  *
  * The deprecated top-level aliases (`list`, `status`, `task-status`, `queue`,
  * `audit`, `session`) route here through the `headless.ts` router. It depends on
- * `headless-shared.ts` and reuses `worker-control.ts` for the worker-decisions view.
+ * `headless-shared.ts` and reuses `worker-control.ts` for worker status/decisions.
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Attempt, TaskState } from '@invoker/workflow-core';
-import type { AgentSessionData, NormalizedCostEvent } from '@invoker/contracts';
-import type { AgentRegistry } from '@invoker/execution-engine';
+import type { AgentSessionData, NormalizedCostEvent, WorkerStatusSnapshot } from '@invoker/contracts';
+import {
+  createWorkerRegistry,
+  E2E_AUTOFIX_WORKER_KIND,
+  registerBuiltinWorkers,
+  type AgentRegistry,
+  type WorkerRuntimeDependencies,
+} from '@invoker/execution-engine';
 import type { CostGroupDimension } from './cost-rollup.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import {
@@ -26,7 +32,12 @@ import {
 } from './headless-shared.js';
 import { resolveDefaultExecutionAgent } from './config.js';
 import { loadAllEventsPaged } from './load-all-events-paged.js';
-import { listWorkerDecisions } from './worker-control.js';
+import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
+import {
+  AUTO_STARTED_OWNER_WORKER_KINDS,
+  createLocalWorkerStatusSnapshot,
+  listWorkerDecisions,
+} from './worker-control.js';
 import {
   collectRecoveryWorkerStatus,
   type RecoveryWorkerStatus,
@@ -62,7 +73,7 @@ export type HeadlessQueryDeps = Pick<
 export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Promise<void> {
   const subCommand = args[0];
   if (!subCommand) {
-    throw new Error('Missing query sub-command. Usage: --headless query <workflows|workflow|tasks|task|queue|review-gate|action-graph|audit|session|worker-actions|worker-decisions|cost|cost-events|costs|ui-perf|stats>');
+    throw new Error('Missing query sub-command. Usage: --headless query <workflows|workflow|tasks|task|queue|review-gate|action-graph|audit|session|workers|worker-actions|worker-decisions|cost|cost-events|costs|ui-perf|stats>');
   }
   const flags = parseQueryFlags(args.slice(1));
 
@@ -253,6 +264,24 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
       await headlessSession(taskId, deps);
       break;
     }
+    case 'workers': {
+      const snapshot = createReadOnlyWorkerStatusSnapshot(deps);
+      switch (flags.output) {
+        case 'label':
+          writeOut(snapshot.workers.map((worker) => worker.kind).join('\n') + '\n');
+          break;
+        case 'json':
+          writeOut(formatAsJson(snapshot) + '\n');
+          break;
+        case 'jsonl':
+          writeOut(formatAsJsonl(snapshot.workers.map((worker) => ({ generatedAt: snapshot.generatedAt, ...worker }))) + '\n');
+          break;
+        default:
+          writeOut(formatWorkerStatusSnapshot(snapshot) + '\n');
+          break;
+      }
+      break;
+    }
     case 'worker-actions': {
       const workflowFilter = flags.workflow ?? flags.positional[0];
       const actions = deps.persistence.listWorkerActions({
@@ -380,7 +409,7 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
       break;
     }
     default:
-      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, workflow, tasks, task, queue, review-gate, action-graph, audit, session, worker-actions, cost, cost-events, costs, ui-perf, stats`);
+      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, workflow, tasks, task, queue, review-gate, action-graph, audit, session, workers, worker-actions, worker-decisions, cost, cost-events, costs, ui-perf, stats`);
   }
 }
 
@@ -761,6 +790,39 @@ export async function headlessSession(taskId: string | undefined, deps: Pick<Hea
   for (const msg of result.messages) {
     writeOut(`[${msg.role}] ${msg.content}\n`);
   }
+}
+
+function createReadOnlyWorkerStatusSnapshot(
+  deps: Pick<HeadlessQueryDeps, 'persistence' | 'invokerConfig'>,
+): WorkerStatusSnapshot {
+  const registry = registerExternalWorkersFromConfig(
+    deps.invokerConfig.externalWorkers,
+    registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
+  );
+  const autoStartKinds = deps.invokerConfig.e2eAutoFixEnabled
+    ? [...AUTO_STARTED_OWNER_WORKER_KINDS, E2E_AUTOFIX_WORKER_KIND]
+    : AUTO_STARTED_OWNER_WORKER_KINDS;
+  return createLocalWorkerStatusSnapshot({
+    registry,
+    persistence: deps.persistence,
+    autoStartKinds,
+  });
+}
+
+function formatWorkerStatusSnapshot(snapshot: WorkerStatusSnapshot): string {
+  const lines = [
+    `${BOLD}Workers${RESET} (${snapshot.workers.length})`,
+    `  generatedAt: ${snapshot.generatedAt}`,
+  ];
+  for (const worker of snapshot.workers) {
+    const activeActions = worker.recentActions.filter((action) => (
+      action.status === 'queued' || action.status === 'running'
+    )).length;
+    lines.push(
+      `  ${worker.kind}: lifecycle=${worker.lifecycle} policy=${worker.policy} autoStarts=${worker.autoStarts ? 'yes' : 'no'} activeActions=${activeActions}`,
+    );
+  }
+  return lines.join('\n');
 }
 
 function formatRecoveryWorkerStatus(status: RecoveryWorkerStatus): string {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -178,6 +178,7 @@ import {
   wireHeadlessApproveHook,
   type HeadlessDeps,
 } from './headless.js';
+import { headlessQuery, type HeadlessQueryDeps } from './headless-query-list.js';
 import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
 import {
   startStandaloneLaunchDispatcher,
@@ -993,6 +994,28 @@ const YELLOW = '\x1b[33m';
 // HEADLESS MODE
 // ══════════════════════════════════════════════════════════════
 
+function isDatabaseFreeWorkersQuery(args: readonly string[]): boolean {
+  return args[0] === 'query' && args[1] === 'workers';
+}
+
+async function runDatabaseFreeWorkersQuery(args: string[]): Promise<void> {
+  const emptyWorkerQueryDeps: HeadlessQueryDeps = {
+    persistence: {
+      listWorkerActions: () => [],
+      listWorkflows: () => [],
+      loadTasks: () => [],
+      countEventsByTypes: () => [],
+      getEventsByTypes: () => [],
+    } as unknown as HeadlessQueryDeps['persistence'],
+    orchestrator: {} as HeadlessQueryDeps['orchestrator'],
+    executionAgentRegistry: undefined,
+    invokerConfig,
+    getUiPerfStats: () => ({}),
+    resetUiPerfStats: () => {},
+  };
+  await headlessQuery(args.slice(1), emptyWorkerQueryDeps);
+}
+
 function startHeadlessMode(): void {
   const runHeadlessMain = async (): Promise<void> => {
     const agentRegistry = registerBuiltinAgents();
@@ -1073,6 +1096,12 @@ function startHeadlessMode(): void {
         process.exit(1);
         return;
       }
+    }
+
+    if (isDatabaseFreeWorkersQuery(cliArgs) && !existsSync(path.join(resolveInvokerHomeRoot(), 'invoker.db'))) {
+      await runDatabaseFreeWorkersQuery(cliArgs);
+      process.exit(0);
+      return;
     }
 
     let exitCode = 0;

--- a/packages/execution-engine/src/__tests__/omp-session-driver.test.ts
+++ b/packages/execution-engine/src/__tests__/omp-session-driver.test.ts
@@ -1,14 +1,22 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { OmpSessionDriver } from '../omp-session-driver.js';
 
 const originalDbDir = process.env.INVOKER_DB_DIR;
+const originalMaxStoredSessionBytes = process.env.INVOKER_MAX_STORED_OMP_SESSION_BYTES;
 
 afterEach(() => {
-  process.env.INVOKER_DB_DIR = originalDbDir;
+  restoreEnv('INVOKER_DB_DIR', originalDbDir);
+  restoreEnv('INVOKER_MAX_STORED_OMP_SESSION_BYTES', originalMaxStoredSessionBytes);
+  vi.restoreAllMocks();
 });
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
 
 describe('OmpSessionDriver', () => {
   it('stores raw stdout and returns it as readable text', () => {
@@ -31,5 +39,41 @@ describe('OmpSessionDriver', () => {
     const driver = new OmpSessionDriver();
     expect(driver.parseSession('')).toEqual([]);
     expect(driver.inspectSession('')).toEqual({ state: 'error', reason: 'Empty OMP session output' });
+  });
+
+  it('does not fail task output processing when session transcript storage fails', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omp-session-driver-unwritable-'));
+    const dbRootFile = join(dir, 'db-root-file');
+    process.env.INVOKER_DB_DIR = dbRootFile;
+    writeFileSync(dbRootFile, 'not a directory');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const driver = new OmpSessionDriver();
+      const raw = 'OMP answer text';
+
+      expect(driver.processOutput('session-1', raw)).toBe(raw);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('failed to store session transcript'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('caps stored OMP transcripts while keeping process output unchanged', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omp-session-driver-truncate-'));
+    process.env.INVOKER_DB_DIR = dir;
+    process.env.INVOKER_MAX_STORED_OMP_SESSION_BYTES = '120';
+    try {
+      const driver = new OmpSessionDriver();
+      const raw = `${'a'.repeat(100)}${'b'.repeat(100)}`;
+
+      expect(driver.processOutput('session-1', raw)).toBe(raw);
+      const stored = readFileSync(join(dir, 'agent-sessions', 'session-1.omp.txt'), 'utf-8');
+      expect(Buffer.byteLength(stored, 'utf8')).toBeLessThanOrEqual(120);
+      expect(stored).toContain('Invoker truncated stored OMP session output');
+      expect(stored).toContain('aaa');
+      expect(stored).toContain('bbb');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/execution-engine/src/omp-session-driver.ts
+++ b/packages/execution-engine/src/omp-session-driver.ts
@@ -4,11 +4,19 @@ import { homedir } from 'node:os';
 import type { AgentMessage } from './codex-session.js';
 import type { AgentSessionInspection, SessionDriver } from './session-driver.js';
 
+const DEFAULT_MAX_STORED_OMP_SESSION_BYTES = 5 * 1024 * 1024;
+
 export class OmpSessionDriver implements SessionDriver {
   processOutput(sessionId: string, rawStdout: string): string {
     const dir = this.getStorageDir();
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, `${sessionId}.omp.txt`), rawStdout);
+    const filePath = join(dir, `${sessionId}.omp.txt`);
+    try {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(filePath, truncateStoredOmpSession(rawStdout));
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      console.warn(`[OmpSessionDriver] failed to store session transcript "${filePath}": ${reason}`);
+    }
     return rawStdout;
   }
 
@@ -32,4 +40,44 @@ export class OmpSessionDriver implements SessionDriver {
     const base = process.env.INVOKER_DB_DIR || join(homedir(), '.invoker');
     return join(base, 'agent-sessions');
   }
+}
+
+function truncateStoredOmpSession(raw: string): string {
+  const maxBytes = resolveMaxStoredOmpSessionBytes();
+  if (maxBytes <= 0) return raw;
+
+  if (Buffer.byteLength(raw, 'utf8') <= maxBytes) return raw;
+
+  const marker = '\n\n[Invoker truncated stored OMP session output]\n\n';
+  const markerBytes = Buffer.byteLength(marker, 'utf8');
+  if (markerBytes >= maxBytes) return trimUtf8ToByteLimit(marker, maxBytes);
+
+  let keepChars = Math.max(0, maxBytes - markerBytes);
+  let stored = buildStoredOmpSession(raw, marker, keepChars);
+  let overflow = Buffer.byteLength(stored, 'utf8') - maxBytes;
+  while (overflow > 0 && keepChars > 0) {
+    keepChars = Math.max(0, keepChars - Math.max(1, Math.ceil(overflow / 2)));
+    stored = buildStoredOmpSession(raw, marker, keepChars);
+    overflow = Buffer.byteLength(stored, 'utf8') - maxBytes;
+  }
+  return stored;
+}
+
+function buildStoredOmpSession(raw: string, marker: string, keepChars: number): string {
+  const headChars = Math.floor(keepChars / 2);
+  const tailChars = keepChars - headChars;
+  return `${raw.slice(0, headChars)}${marker}${tailChars > 0 ? raw.slice(-tailChars) : ''}`;
+}
+
+function trimUtf8ToByteLimit(value: string, maxBytes: number): string {
+  if (maxBytes <= 0) return '';
+  return Buffer.from(value, 'utf8').subarray(0, maxBytes).toString('utf8');
+}
+
+function resolveMaxStoredOmpSessionBytes(): number {
+  const raw = process.env.INVOKER_MAX_STORED_OMP_SESSION_BYTES?.trim();
+  if (!raw) return DEFAULT_MAX_STORED_OMP_SESSION_BYTES;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_MAX_STORED_OMP_SESSION_BYTES;
+  return parsed;
 }

--- a/scripts/repro/repro-coderabbit-address-dedup.sh
+++ b/scripts/repro/repro-coderabbit-address-dedup.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Dedup proof for Job 1 (scripts/cron-coderabbit-address.sh):
+# Dedup proof for the native CodeRabbit PR-maintenance worker path:
 #   1. a PR with a coderabbitai[bot] comment updated at T -> "would launch omp ... at T"
 #   2. once T is in the ledger -> "no new CodeRabbit comments since T; skip"
 #   3. a newer comment T2 -> "would launch omp ... at T2" again
 #   4. once the per-PR attempt cap is reached -> "hit cap"
 #
-# Runs fully offline in dry-run with a fake `gh` serving captured comment JSON;
-# touches only a temp ledger/lock.
+# Runs fully offline through `--headless worker coderabbit-address` in dry-run
+# with a fake `gh` serving captured comment JSON; touches only temp state.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -16,6 +16,53 @@ TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-coderabbit.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
 
 fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+REAL_NODE="$(command -v node)"
+WORKER_SOURCE="$ROOT/packages/execution-engine/src/workers/pr-maintenance-workers.ts"
+WORKER_RUNNER_SRC="$TMP/run-native-worker.ts"
+WORKER_RUNNER_DIR="$TMP/worker-runner-dist"
+WORKER_RUNNER="$WORKER_RUNNER_DIR/run-native-worker.mjs"
+
+write_native_worker_runner() {
+  mkdir -p "$WORKER_RUNNER_DIR"
+  cat > "$WORKER_RUNNER_SRC" <<TS
+import { createCoderabbitAddressWorker, createPrConflictRebaseWorker } from '${WORKER_SOURCE}';
+
+const kind = process.argv[2];
+const logger = {
+  info: (message: string) => console.log(message),
+  warn: (message: string) => console.log(message),
+  error: (message: string) => console.log(message),
+  debug: () => {},
+  child: () => logger,
+};
+const factories = {
+  'coderabbit-address': createCoderabbitAddressWorker,
+  'pr-conflict-rebase': createPrConflictRebaseWorker,
+};
+const factory = factories[kind as keyof typeof factories];
+if (!factory) throw new Error(\`unknown PR-maintenance worker kind: \${kind}\`);
+const worker = factory({
+  logger,
+  repoRoot: process.cwd(),
+  lockPath: process.env.INVOKER_PR_CRON_LOCK,
+  installSignalHandlers: false,
+});
+try {
+  await worker.tick('manual');
+} finally {
+  await worker.stop();
+}
+console.log(\`\${kind} worker scan completed.\`);
+TS
+  pnpm exec tsup "$WORKER_RUNNER_SRC" --format esm --platform node --out-dir "$WORKER_RUNNER_DIR" >/dev/null
+}
+
+run_native_worker() {
+  "$REAL_NODE" "$WORKER_RUNNER" "$1" 2>&1
+}
+
+write_native_worker_runner
 
 LEDGER="$TMP/ledger.tsv"; : > "$LEDGER"
 
@@ -49,7 +96,7 @@ export INVOKER_PR_CRON_DRY_RUN=1
 export INVOKER_PR_CODERABBIT_STATE_FILE="$LEDGER"
 export INVOKER_PR_CRON_LOCK="$TMP/crons.lock"
 
-run() { bash scripts/cron-coderabbit-address.sh 2>&1; }
+run() { run_native_worker coderabbit-address; }
 
 T1="2026-06-25T08:00:00Z"
 T2="2026-06-25T09:30:00Z"

--- a/scripts/repro/repro-pr-conflict-rebase-guard.sh
+++ b/scripts/repro/repro-pr-conflict-rebase-guard.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Guard proof for Job 2 (scripts/cron-pr-conflict-rebase.sh):
+# Guard proof for the native PR conflict rebase worker path:
 #   1. a DIRTY PR mapped to a workflow at generation g -> "would rebase-recreate"
 #   2. once generation g is in the ledger -> "already fired for generation g; skip"
 #   3. once the per-workflow attempt cap is reached -> "giving up"
 #
-# Runs fully offline in dry-run with a fake `gh` and a stubbed review-gate
-# resolver; touches only a temp ledger/lock.
+# Runs fully offline through `--headless worker pr-conflict-rebase` in dry-run
+# with a fake `gh` and a stubbed review-gate resolver; touches only temp state.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -15,6 +15,53 @@ TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-pr-conflict.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
 
 fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+REAL_NODE="$(command -v node)"
+WORKER_SOURCE="$ROOT/packages/execution-engine/src/workers/pr-maintenance-workers.ts"
+WORKER_RUNNER_SRC="$TMP/run-native-worker.ts"
+WORKER_RUNNER_DIR="$TMP/worker-runner-dist"
+WORKER_RUNNER="$WORKER_RUNNER_DIR/run-native-worker.mjs"
+
+write_native_worker_runner() {
+  mkdir -p "$WORKER_RUNNER_DIR"
+  cat > "$WORKER_RUNNER_SRC" <<TS
+import { createCoderabbitAddressWorker, createPrConflictRebaseWorker } from '${WORKER_SOURCE}';
+
+const kind = process.argv[2];
+const logger = {
+  info: (message: string) => console.log(message),
+  warn: (message: string) => console.log(message),
+  error: (message: string) => console.log(message),
+  debug: () => {},
+  child: () => logger,
+};
+const factories = {
+  'coderabbit-address': createCoderabbitAddressWorker,
+  'pr-conflict-rebase': createPrConflictRebaseWorker,
+};
+const factory = factories[kind as keyof typeof factories];
+if (!factory) throw new Error(\`unknown PR-maintenance worker kind: \${kind}\`);
+const worker = factory({
+  logger,
+  repoRoot: process.cwd(),
+  lockPath: process.env.INVOKER_PR_CRON_LOCK,
+  installSignalHandlers: false,
+});
+try {
+  await worker.tick('manual');
+} finally {
+  await worker.stop();
+}
+console.log(\`\${kind} worker scan completed.\`);
+TS
+  pnpm exec tsup "$WORKER_RUNNER_SRC" --format esm --platform node --out-dir "$WORKER_RUNNER_DIR" >/dev/null
+}
+
+run_native_worker() {
+  "$REAL_NODE" "$WORKER_RUNNER" "$1" 2>&1
+}
+
+write_native_worker_runner
 
 LEDGER="$TMP/ledger.tsv"; : > "$LEDGER"
 
@@ -45,7 +92,7 @@ export INVOKER_PR_CONFLICT_STATE_FILE="$LEDGER"
 export INVOKER_PR_CRON_LOCK="$TMP/crons.lock"
 export INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh"
 
-run() { bash scripts/cron-pr-conflict-rebase.sh 2>&1; }
+run() { run_native_worker pr-conflict-rebase; }
 
 # Branch 1: fresh ledger -> would rebase-recreate at generation 2.
 out="$(INVOKER_TEST_WF_GEN=2 run)"

--- a/scripts/repro/repro-pr-cron-attempt-cap.sh
+++ b/scripts/repro/repro-pr-cron-attempt-cap.sh
@@ -7,12 +7,12 @@
 # nothing and re-fired every tick indefinitely. The fix records an attempt on
 # every real try and caps on that ledger.
 #
-# This drives the REAL (non-dry) failure paths offline with fakes:
+# This drives the native worker REAL (non-dry) failure paths offline with fakes:
 #   Job 2: fake `node` accepts the dispatch; CONFIRM_TIMEOUT=0 means it never
 #          confirms -> each run records one rebase-recreate-attempt and exits 1.
 #   Job 1: fake `gh repo clone` fails -> prepare_checkout fails after the
 #          attempt is recorded -> each run records one coderabbit-attempt, exits 1.
-# After MAX attempts the next run hits the cap instead of dispatching again.
+# After MAX attempts the next worker run hits the cap instead of dispatching again.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -22,6 +22,53 @@ TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-attempt-cap.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
 
 fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+REAL_NODE="$(command -v node)"
+WORKER_SOURCE="$ROOT/packages/execution-engine/src/workers/pr-maintenance-workers.ts"
+WORKER_RUNNER_SRC="$TMP/run-native-worker.ts"
+WORKER_RUNNER_DIR="$TMP/worker-runner-dist"
+WORKER_RUNNER="$WORKER_RUNNER_DIR/run-native-worker.mjs"
+
+write_native_worker_runner() {
+  mkdir -p "$WORKER_RUNNER_DIR"
+  cat > "$WORKER_RUNNER_SRC" <<TS
+import { createCoderabbitAddressWorker, createPrConflictRebaseWorker } from '${WORKER_SOURCE}';
+
+const kind = process.argv[2];
+const logger = {
+  info: (message: string) => console.log(message),
+  warn: (message: string) => console.log(message),
+  error: (message: string) => console.log(message),
+  debug: () => {},
+  child: () => logger,
+};
+const factories = {
+  'coderabbit-address': createCoderabbitAddressWorker,
+  'pr-conflict-rebase': createPrConflictRebaseWorker,
+};
+const factory = factories[kind as keyof typeof factories];
+if (!factory) throw new Error(\`unknown PR-maintenance worker kind: \${kind}\`);
+const worker = factory({
+  logger,
+  repoRoot: process.cwd(),
+  lockPath: process.env.INVOKER_PR_CRON_LOCK,
+  installSignalHandlers: false,
+});
+try {
+  await worker.tick('manual');
+} finally {
+  await worker.stop();
+}
+console.log(\`\${kind} worker scan completed.\`);
+TS
+  pnpm exec tsup "$WORKER_RUNNER_SRC" --format esm --platform node --out-dir "$WORKER_RUNNER_DIR" >/dev/null
+}
+
+run_native_worker() {
+  "$REAL_NODE" "$WORKER_RUNNER" "$1" 2>&1
+}
+
+write_native_worker_runner
 
 mkdir -p "$TMP/bin"
 
@@ -56,7 +103,7 @@ run_job2() {
   INVOKER_PR_CRON_LOCK="$TMP/j2.lock" \
   INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh" \
   INVOKER_PR_REBASE_CONFIRM_TIMEOUT=0 \
-  bash scripts/cron-pr-conflict-rebase.sh 2>&1
+  run_native_worker pr-conflict-rebase
 }
 
 for i in 1 2 3; do
@@ -111,7 +158,7 @@ run_job1() {
   INVOKER_PR_CRON_LOCK="$TMP/j1.lock" \
   INVOKER_PR_CRON_WORKDIR="$TMP/work" \
   INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate-empty.sh" \
-  bash scripts/cron-coderabbit-address.sh 2>&1
+  run_native_worker coderabbit-address
 }
 
 for i in 1 2 3; do

--- a/scripts/repro/repro-pr-crons-mutex.sh
+++ b/scripts/repro/repro-pr-crons-mutex.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Cross-job mutual exclusion proof: while the shared lock is held, EACH PR
-# maintenance worker tick script must print "another PR maintenance operation in
-# progress" and exit 0 (clean no-op), so only one operation ever runs at a time.
+# Cross-job mutual exclusion proof: while the shared PR-maintenance lock is
+# held, EACH native PR-maintenance worker must report the held lock and exit 0
+# (clean no-op), so only one operation ever runs at a time.
 #
-# Holds the lock the same way the lib acquires it (flock if available, else the
-# atomic mkdir fallback), then runs each worker. Fully offline; cron_lock is the
-# first thing each worker does, so no `gh` is reached.
+# Holds the lock the same way the shell lib acquires it (flock if available,
+# else the atomic mkdir fallback), then runs each native worker. Fully offline;
+# the native lock probe runs before the shell entrypoint, so no `gh` is reached.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -22,6 +22,53 @@ cleanup() {
 trap cleanup EXIT
 
 fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+REAL_NODE="$(command -v node)"
+WORKER_SOURCE="$ROOT/packages/execution-engine/src/workers/pr-maintenance-workers.ts"
+WORKER_RUNNER_SRC="$TMP/run-native-worker.ts"
+WORKER_RUNNER_DIR="$TMP/worker-runner-dist"
+WORKER_RUNNER="$WORKER_RUNNER_DIR/run-native-worker.mjs"
+
+write_native_worker_runner() {
+  mkdir -p "$WORKER_RUNNER_DIR"
+  cat > "$WORKER_RUNNER_SRC" <<TS
+import { createCoderabbitAddressWorker, createPrConflictRebaseWorker } from '${WORKER_SOURCE}';
+
+const kind = process.argv[2];
+const logger = {
+  info: (message: string) => console.log(message),
+  warn: (message: string) => console.log(message),
+  error: (message: string) => console.log(message),
+  debug: () => {},
+  child: () => logger,
+};
+const factories = {
+  'coderabbit-address': createCoderabbitAddressWorker,
+  'pr-conflict-rebase': createPrConflictRebaseWorker,
+};
+const factory = factories[kind as keyof typeof factories];
+if (!factory) throw new Error(\`unknown PR-maintenance worker kind: \${kind}\`);
+const worker = factory({
+  logger,
+  repoRoot: process.cwd(),
+  lockPath: process.env.INVOKER_PR_CRON_LOCK,
+  installSignalHandlers: false,
+});
+try {
+  await worker.tick('manual');
+} finally {
+  await worker.stop();
+}
+console.log(\`\${kind} worker scan completed.\`);
+TS
+  pnpm exec tsup "$WORKER_RUNNER_SRC" --format esm --platform node --out-dir "$WORKER_RUNNER_DIR" >/dev/null
+}
+
+run_native_worker() {
+  "$REAL_NODE" "$WORKER_RUNNER" "$1" 2>&1
+}
+
+write_native_worker_runner
 
 # Acquire and hold the lock out-of-band, mirroring cron-pr-lib.sh's mechanism.
 if command -v flock >/dev/null 2>&1; then
@@ -48,12 +95,12 @@ export INVOKER_PR_CRON_DRY_RUN=1
 export INVOKER_PR_CONFLICT_STATE_FILE="$TMP/conflict.tsv"
 export INVOKER_PR_CODERABBIT_STATE_FILE="$TMP/coderabbit.tsv"
 
-for worker in cron-coderabbit-address cron-pr-conflict-rebase; do
+for worker in coderabbit-address pr-conflict-rebase; do
   set +e
-  out="$(bash "scripts/$worker.sh" 2>&1)"
+  out="$(run_native_worker "$worker" 2>&1)"
   code=$?
   set -e
-  echo "$out" | grep -q "another PR maintenance operation in progress" \
+  echo "$out" | grep -q "shared PR maintenance lock held; skipping tick" \
     || fail "$worker did not report the lock as held" "$out"
   [ "$code" -eq 0 ] || fail "$worker exited $code (expected 0 clean no-op)" "$out"
 done


### PR DESCRIPTION
## Summary

The operator docs now describe one way to run Invoker: from the owner host, whose built-in workers handle recovery and PR maintenance while remote SSH machines only carry task execution.

Older guidance still mentioned a mixed local-and-SSH pool and a standalone auto-fix engine. Native parity is now proven, so the written setup should point at one supported path.

This change rewrites prose in the README and the SSH guide, and updates the sample config so its pool and PR-maintenance settings match that path.

## Review Claim

The remaining operator docs point only at the worker-based owner-host path.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice edits documentation and one sample config file; no product code, tooling, or runtime behavior is touched, so it is safe to review on its own.

## Slice Rationale

Final operator guidance reads more clearly on its own, ahead of the later slice that retires the old files.

## Non-goals

- Do not delete or move any retired files in this slice.
- Do not change product code, tooling, or proof scripts.
- Do not alter runtime behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/validate-pr-body.mjs --body-file /tmp/step8-pr-body.md --changed-files-file /tmp/step8-changed.txt --diff-file /tmp/step8.diff`
- [ ] `git diff --stat origin/plan/pr-maintenance-workers-step-7-repro-migration...HEAD` shows only README.md, docs/invoker-config-example.json, and docs/remote-ssh-targets.md

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
