### PR TITLE
[Planning Surface Tmux Step 1 Backend Session Routing](1) Add planning terminal IPC contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -640,7 +640,9 @@ export interface RuntimeStatus {
  */
 export interface TerminalSessionDescriptor {
   sessionId: string;
+  scope?: 'task' | 'planning';
   taskId: string;
+  planningSessionId?: string;
   status: 'running' | 'exited';
   exitCode?: number;
   cwd?: string;
@@ -655,13 +657,17 @@ export interface TerminalSessionDescriptor {
 
 export interface TerminalOutputEvent {
   sessionId: string;
+  scope?: 'task' | 'planning';
   taskId: string;
+  planningSessionId?: string;
   data: string;
 }
 
 export interface TerminalExitEvent {
   sessionId: string;
+  scope?: 'task' | 'planning';
   taskId: string;
+  planningSessionId?: string;
   exitCode?: number;
 }
 
@@ -670,6 +676,10 @@ export interface OpenTerminalResponse {
   reason?: string;
   /** Present when the GUI main process opened an embedded session. */
   session?: TerminalSessionDescriptor;
+}
+
+export interface PlanningTerminalOpenRequest {
+  planningSessionId: string;
 }
 
 // ── Search types ────────────────────────────────────────────
@@ -1034,6 +1044,26 @@ export const IpcChannels = {
     response: { ok: boolean; reason?: string };
   },
   'invoker:terminal-close': {} as {
+    request: [sessionId: string];
+    response: { ok: boolean; reason?: string };
+  },
+  'invoker:planning-terminal-open': {} as {
+    request: [request: PlanningTerminalOpenRequest];
+    response: OpenTerminalResponse;
+  },
+  'invoker:planning-terminal-list': {} as {
+    request: [];
+    response: TerminalSessionDescriptor[];
+  },
+  'invoker:planning-terminal-write': {} as {
+    request: [sessionId: string, data: string];
+    response: { ok: boolean; reason?: string };
+  },
+  'invoker:planning-terminal-resize': {} as {
+    request: [sessionId: string, cols: number, rows: number];
+    response: { ok: boolean; reason?: string };
+  },
+  'invoker:planning-terminal-close': {} as {
     request: [sessionId: string];
     response: { ok: boolean; reason?: string };
   },


### PR DESCRIPTION
## Summary

Adds the shared IPC pieces the planning surface will use to run its own embedded terminal sessions, kept apart from task terminals.

New request channels let a planning session open, write, resize, and close a shell.

The session descriptor now carries an optional scope tag and a planning session id, so a session can say whether it belongs to a task or the planning surface.

These are contract-only type additions. No handler reads or answers these channels yet.

## Review Claim

Approve adding the planning terminal IPC channels and the scope-tagged session descriptor types.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This only adds new optional fields and new channel constants. Existing terminal descriptors, channels, and handlers keep their current shape, so no runtime path changes.

## Slice Rationale

The type surface lands alone so it can be reviewed before any backend behavior reads or answers it. Later slices add the handlers and the planning surface.

## Non-goals

- No main-process handler answers these new channels yet.
- Task terminal behavior, listing, and persistence are unchanged.
- No planning surface UI is wired.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/contracts && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
