### PR TITLE
[Planning Surface Tmux Step 1 Backend Session Routing](2) Route planning terminal sessions through backend IPC

### DIFF
--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -6,6 +6,8 @@
  *   - spawn mode wires stdout/stderr → output events and exit
  *   - attached mode forwards executor.onOutput → output events and
  *     executor.sendInput → write()
+ *   - planning shells reuse by planning session identity without colliding
+ *     with task terminals
  *   - GUI route through resolveTaskTerminalSpec + manager returns a session
  *     descriptor (the deterministic outcome required by the task spec)
  */
@@ -122,6 +124,76 @@ describe('EmbeddedTerminalManager', () => {
     expect(second.sessionId).toBe(first.sessionId);
     expect(bashSpawnFn).toHaveBeenCalledTimes(1);
     expect(mgr.list()).toHaveLength(1);
+  });
+
+  it('opens a raw planning shell in repo cwd and reuses it by planning session id', () => {
+    const spawned = {
+      write: vi.fn(),
+      resize: vi.fn(),
+      close: vi.fn(),
+    };
+    const backend: EmbeddedTerminalBackend = {
+      name: 'pty',
+      spawn: vi.fn(() => spawned),
+    };
+    const mgr = new EmbeddedTerminalManager({ backend });
+
+    const first = mgr.openOrReusePlanningShell({
+      planningSessionId: 'planning-session-1',
+      cwd: '/repo/root',
+    });
+    const second = mgr.openOrReusePlanningShell({
+      planningSessionId: 'planning-session-1',
+      cwd: '/repo/root',
+    });
+
+    expect(second.sessionId).toBe(first.sessionId);
+    expect(first).toMatchObject({
+      scope: 'planning',
+      planningSessionId: 'planning-session-1',
+      taskId: 'planning:planning-session-1',
+      cwd: '/repo/root',
+      mode: 'spawn',
+      attached: false,
+    });
+    expect(first.command).toBeUndefined();
+    expect(first.args).toBeUndefined();
+    expect(backend.spawn).toHaveBeenCalledTimes(1);
+    expect(backend.spawn).toHaveBeenCalledWith(expect.objectContaining({
+      spec: {},
+      cwd: '/repo/root',
+      defaultShell: expect.any(String),
+    }));
+  });
+
+  it('keeps planning terminal targets distinct from task terminal targets', () => {
+    const spawned = {
+      write: vi.fn(),
+      resize: vi.fn(),
+      close: vi.fn(),
+    };
+    const backend: EmbeddedTerminalBackend = {
+      name: 'pty',
+      spawn: vi.fn(() => spawned),
+    };
+    const mgr = new EmbeddedTerminalManager({ backend });
+
+    const planning = mgr.openOrReusePlanningShell({
+      planningSessionId: 'same-id',
+      cwd: '/repo/root',
+    });
+    const task = mgr.openOrReuse({
+      taskId: 'planning:same-id',
+      spec: {},
+      cwd: '/repo/root',
+    });
+
+    expect(task.sessionId).not.toBe(planning.sessionId);
+    expect(mgr.list()).toEqual([
+      expect.objectContaining({ sessionId: planning.sessionId, scope: 'planning' }),
+      expect.objectContaining({ sessionId: task.sessionId, scope: 'task' }),
+    ]);
+    expect(backend.spawn).toHaveBeenCalledTimes(2);
   });
 
   it('opens and reuses sessions through an injected backend object', () => {

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -92,17 +92,27 @@ export interface AttachContext {
 
 export interface TerminalSessionPersistenceRecord extends TerminalSessionRecord {
   spec: TerminalSpec;
+  scope?: 'task' | 'planning';
+  planningSessionId?: string;
 }
 export interface OpenSessionOptions {
   taskId: string;
   spec: TerminalSpec;
   cwd: string;
+  scope?: 'task' | 'planning';
+  planningSessionId?: string;
   /** When provided, the session attaches to the running executor rather than spawning a child. */
   attach?: AttachContext;
+}
+export interface OpenPlanningShellOptions {
+  planningSessionId: string;
+  cwd: string;
 }
 interface BaseSessionState {
   sessionId: string;
   taskId: string;
+  scope: 'task' | 'planning';
+  planningSessionId?: string;
   targetKey: string;
   spec: TerminalSpec;
   cwd: string;
@@ -139,6 +149,8 @@ function describePersistenceRecord(state: SessionState): TerminalSessionPersiste
   return {
     sessionId: state.sessionId,
     taskId: state.taskId,
+    scope: state.scope,
+    planningSessionId: state.planningSessionId,
     targetKey: state.targetKey,
     status: state.status,
     exitCode: state.exitCode,
@@ -158,6 +170,8 @@ function describeSession(state: SessionState): TerminalSessionDescriptor {
   return {
     sessionId: state.sessionId,
     taskId: state.taskId,
+    scope: state.scope,
+    planningSessionId: state.planningSessionId,
     status: state.status,
     exitCode: state.exitCode,
     cwd: state.cwd,
@@ -296,9 +310,12 @@ export class EmbeddedTerminalManager extends EventEmitter {
 
     const sessionId = randomUUID();
     const createdAt = new Date().toISOString();
+    const scope = opts.scope ?? 'task';
     const base = {
       sessionId,
       taskId: opts.taskId,
+      scope,
+      planningSessionId: scope === 'planning' ? opts.planningSessionId : undefined,
       targetKey,
       spec: opts.spec,
       cwd: opts.cwd,
@@ -341,6 +358,16 @@ export class EmbeddedTerminalManager extends EventEmitter {
     return this.registerSpawnSession(base);
   }
 
+  openOrReusePlanningShell(opts: OpenPlanningShellOptions): TerminalSessionDescriptor {
+    return this.openOrReuse({
+      taskId: buildPlanningTaskId(opts.planningSessionId),
+      scope: 'planning',
+      planningSessionId: opts.planningSessionId,
+      spec: {},
+      cwd: opts.cwd,
+    });
+  }
+
   restoreSpawnSession(seed: {
     sessionId: string;
     taskId: string;
@@ -368,6 +395,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
     return this.registerSpawnSession({
       sessionId: seed.sessionId,
       taskId: seed.taskId,
+      scope: 'task',
       targetKey: seed.targetKey,
       spec: seed.spec,
       cwd: seed.cwd,
@@ -607,7 +635,9 @@ export class EmbeddedTerminalManager extends EventEmitter {
 
     const payload: TerminalExitEvent = {
       sessionId: state.sessionId,
+      scope: state.scope,
       taskId: state.taskId,
+      planningSessionId: state.planningSessionId,
       exitCode,
     };
     this.emit('exit', payload);
@@ -618,7 +648,9 @@ export class EmbeddedTerminalManager extends EventEmitter {
     state.updatedAt = new Date().toISOString();
     const payload: TerminalOutputEvent = {
       sessionId: state.sessionId,
+      scope: state.scope,
       taskId: state.taskId,
+      planningSessionId: state.planningSessionId,
       data,
     };
     this.emit('output', payload);
@@ -657,6 +689,17 @@ function loadNodePtySpawn(): PtySpawnFn {
 }
 
 function buildTargetKey(opts: OpenSessionOptions): string {
+  if (opts.scope === 'planning') {
+    return JSON.stringify({
+      scope: 'planning',
+      planningSessionId: opts.planningSessionId ?? null,
+      cwd: opts.cwd,
+      command: opts.spec.command ?? null,
+      args: opts.spec.args ?? [],
+      linuxTerminalTail: opts.spec.linuxTerminalTail ?? null,
+    });
+  }
+
   return JSON.stringify({
     taskId: opts.taskId,
     cwd: opts.cwd,
@@ -673,4 +716,8 @@ function buildTargetKey(opts: OpenSessionOptions): string {
         }
       : null,
   });
+}
+
+function buildPlanningTaskId(planningSessionId: string): string {
+  return `planning:${planningSessionId}`;
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -88,6 +88,7 @@ import type {
   InAppPlanningResetRequest,
   InAppPlanningSubmitRequest,
   Logger,
+  PlanningTerminalOpenRequest,
   WorkflowMeta,
   WorkflowMutationAcceptedResult,
   WorkResponse,
@@ -1996,6 +1997,7 @@ function createEmbeddedTerminalBackendFromConfig(
   });
   const terminalRowToDescriptor = (row: ReturnType<SQLiteAdapter['listTerminalSessions']>[number]): TerminalSessionDescriptor => ({
     sessionId: row.sessionId,
+    scope: 'task',
     taskId: row.taskId,
     status: row.status,
     exitCode: row.exitCode,
@@ -2043,6 +2045,7 @@ function createEmbeddedTerminalBackendFromConfig(
 
   const registerTerminalSessionPersistence = (): void => {
     embeddedTerminalManager.on('session-updated', (record) => {
+      if (record.scope === 'planning') return;
       persistence.upsertTerminalSession({
         sessionId: record.sessionId,
         taskId: record.taskId,
@@ -5304,7 +5307,8 @@ function createEmbeddedTerminalBackendFromConfig(
     });
 
     ipcMain.handle('invoker:terminal-list', async () => {
-      const live = new Map(embeddedTerminalManager.list().map((session) => [session.sessionId, session]));
+      const liveTaskSessions = embeddedTerminalManager.list().filter((session) => session.scope !== 'planning');
+      const live = new Map(liveTaskSessions.map((session) => [session.sessionId, session]));
       const merged = persistence.listTerminalSessions().map((row) => live.get(row.sessionId) ?? terminalRowToDescriptor(row));
       const persistedIds = new Set(merged.map((session) => session.sessionId));
       for (const session of live.values()) {
@@ -5316,17 +5320,81 @@ function createEmbeddedTerminalBackendFromConfig(
     });
 
     ipcMain.handle('invoker:terminal-write', async (_event, sessionId: string, data: string) => {
+      const session = embeddedTerminalManager.get(sessionId);
+      if (session?.scope === 'planning') {
+        return { ok: false, reason: `Session "${sessionId}" is not a task terminal.` };
+      }
       return embeddedTerminalManager.write(sessionId, data);
     });
 
     ipcMain.handle('invoker:terminal-resize', async (_event, sessionId: string, cols: number, rows: number) => {
+      const session = embeddedTerminalManager.get(sessionId);
+      if (session?.scope === 'planning') {
+        return { ok: false, reason: `Session "${sessionId}" is not a task terminal.` };
+      }
       return embeddedTerminalManager.resize(sessionId, cols, rows);
     });
 
     ipcMain.handle('invoker:terminal-close', async (_event, sessionId: string) => {
+      const session = embeddedTerminalManager.get(sessionId);
+      if (session?.scope === 'planning') {
+        return { ok: false, reason: `Session "${sessionId}" is not a task terminal.` };
+      }
       const result = embeddedTerminalManager.close(sessionId);
       persistence.deleteTerminalSession(sessionId);
       return result.ok ? result : { ok: true };
+    });
+
+    ipcMain.handle('invoker:planning-terminal-open', async (_event, request: PlanningTerminalOpenRequest) => {
+      const planningSessionId = typeof request?.planningSessionId === 'string'
+        ? request.planningSessionId.trim()
+        : '';
+      if (!planningSessionId) {
+        return { opened: false, reason: 'Missing planning session id.' };
+      }
+      logger.info(`invoked for planningSession="${planningSessionId}"`, { module: 'planning-terminal' });
+      try {
+        const session = embeddedTerminalManager.openOrReusePlanningShell({
+          planningSessionId,
+          cwd: repoRoot,
+        });
+        return { opened: true, session };
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        logger.warn(`planning terminal spawn failed for session="${planningSessionId}": ${reason}`, { module: 'planning-terminal' });
+        return { opened: false, reason: `Failed to start planning terminal session: ${reason}` };
+      }
+    });
+
+    ipcMain.handle('invoker:planning-terminal-list', async () => {
+      return embeddedTerminalManager.list().filter((session) => session.scope === 'planning');
+    });
+
+    ipcMain.handle('invoker:planning-terminal-write', async (_event, sessionId: string, data: string) => {
+      const session = embeddedTerminalManager.get(sessionId);
+      if (!session) return { ok: false, reason: `Unknown session "${sessionId}".` };
+      if (session.scope !== 'planning') {
+        return { ok: false, reason: `Session "${sessionId}" is not a planning terminal.` };
+      }
+      return embeddedTerminalManager.write(sessionId, data);
+    });
+
+    ipcMain.handle('invoker:planning-terminal-resize', async (_event, sessionId: string, cols: number, rows: number) => {
+      const session = embeddedTerminalManager.get(sessionId);
+      if (!session) return { ok: false, reason: `Unknown session "${sessionId}".` };
+      if (session.scope !== 'planning') {
+        return { ok: false, reason: `Session "${sessionId}" is not a planning terminal.` };
+      }
+      return embeddedTerminalManager.resize(sessionId, cols, rows);
+    });
+
+    ipcMain.handle('invoker:planning-terminal-close', async (_event, sessionId: string) => {
+      const session = embeddedTerminalManager.get(sessionId);
+      if (!session) return { ok: false, reason: `Unknown session "${sessionId}".` };
+      if (session.scope !== 'planning') {
+        return { ok: false, reason: `Session "${sessionId}" is not a planning terminal.` };
+      }
+      return embeddedTerminalManager.close(sessionId);
     });
 
     Menu.setApplicationMenu(

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -230,12 +230,17 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
 
       // ── Terminals: no pty over HTTP — degrade gracefully ──
       case 'invoker:open-terminal':
+      case 'invoker:planning-terminal-open':
         return { opened: false, reason: 'Terminals are not available in the web UI' };
       case 'invoker:terminal-list':
+      case 'invoker:planning-terminal-list':
         return [];
       case 'invoker:terminal-write':
       case 'invoker:terminal-resize':
       case 'invoker:terminal-close':
+      case 'invoker:planning-terminal-write':
+      case 'invoker:planning-terminal-resize':
+      case 'invoker:planning-terminal-close':
         return { ok: false, reason: 'unsupported' };
 
       // ── Mutations not exposed on the facade / global lifecycle ──

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -276,6 +276,23 @@ export function createMockInvoker(
     terminalWrite: vi.fn(async () => ({ ok: true })),
     terminalResize: vi.fn(async () => ({ ok: true })),
     terminalClose: vi.fn(async () => ({ ok: true })),
+    planningTerminalOpen: vi.fn(async ({ planningSessionId }: { planningSessionId: string }) => ({
+      opened: true,
+      session: {
+        sessionId: `mock-planning-terminal-${planningSessionId}`,
+        scope: 'planning' as const,
+        taskId: `planning:${planningSessionId}`,
+        planningSessionId,
+        status: 'running' as const,
+        mode: 'spawn' as const,
+        attached: false,
+        createdAt: new Date('2025-01-01T00:00:00Z').toISOString(),
+      },
+    })),
+    planningTerminalList: vi.fn(async () => []),
+    planningTerminalWrite: vi.fn(async () => ({ ok: true })),
+    planningTerminalResize: vi.fn(async () => ({ ok: true })),
+    planningTerminalClose: vi.fn(async () => ({ ok: true })),
     onTerminalOutput: vi.fn((cb: (event: TerminalOutputEvent) => void) => {
       terminalOutputCallbacks.add(cb);
       return () => { terminalOutputCallbacks.delete(cb); };


### PR DESCRIPTION
## Summary

Planning sessions can now open their own shell through the main process, kept separate from task terminals.

The main process routes planning terminal open, write, resize, and close over dedicated IPC channels.

Task terminal channels ignore planning sessions, and planning channels ignore task sessions, so the two never cross.

Planning shells are not saved to the terminal persistence store; only task sessions persist across restarts.

## Review Claim

Approve routing planning-owned embedded terminal sessions through main-process IPC handlers.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The guards added to the task channels only reject sessions tagged planning. Task sessions keep their prior behavior, and the new planning handlers are not consumed by any renderer yet.

## Slice Rationale

The shared IPC shapes already landed, so this slice only adds the backend routing and its manager support. Renderer and UI wiring come in a later step.

## Non-goals

- Task terminal open, write, resize, close, and listing behavior stays unchanged.
- No renderer or UI wiring for planning shells.
- No IPC shape changes; those landed in the earlier slice.
- Planning shells are intentionally not persisted.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
