### PR TITLE
[Planning Surface Tmux Step 1 Backend Session Routing](3) Keep backend verification reruns trackable

### DIFF
--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -359,6 +359,11 @@ function hasBareRetryAlreadySubmitted(
   return existing.attemptCount > 0;
 }
 
+function canTrackBareRetrySubmission(options: AutoFixRecoveryPolicyOptions): boolean {
+  return typeof options.store.getWorkerAction === 'function' &&
+    typeof options.store.upsertWorkerAction === 'function';
+}
+
 function skipAutoFixCandidate(
   options: AutoFixRecoveryPolicyOptions,
   candidate: AutoFixRecoveryCandidate,
@@ -495,7 +500,7 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
         continue;
       }
 
-      if (!hasBareRetryAlreadySubmitted(options, candidate)) {
+      if (canTrackBareRetrySubmission(options) && !hasBareRetryAlreadySubmitted(options, candidate)) {
         const intentId = options.submitter.submit(
           candidate.workflowId,
           'normal',

--- a/packages/test-kit/src/mock-git.ts
+++ b/packages/test-kit/src/mock-git.ts
@@ -21,6 +21,7 @@ export class MockGit {
   private scripts: ScriptedResponse[] = [];
   private defaultBranch = 'master';
   private hasStagedChanges = false;
+  private remoteRefs = new Map<string, string>();
 
   /** Script a response for calls matching a predicate. */
   on(match: (args: string[]) => boolean, response: string | Error, once = false): this {
@@ -66,6 +67,7 @@ export class MockGit {
     this.scripts = [];
     this.calls = [];
     this.hasStagedChanges = false;
+    this.remoteRefs.clear();
     return this;
   }
 
@@ -105,34 +107,22 @@ export class MockGit {
       if (script.match(args)) {
         script.used = true;
         if (script.response instanceof Error) throw script.response;
+        this.applySuccessfulCommandSideEffects(args);
         return script.response;
       }
     }
 
     // Default responses for common commands
     if (args[0] === 'branch' && args[1] === '--show-current') return this.defaultBranch;
-    if (args[0] === 'checkout') {
-      // Reset staged changes on checkout
-      this.hasStagedChanges = false;
-      return '';
-    }
-    if (args[0] === 'merge') {
-      // Squash merge stages changes
-      if (args.includes('--squash')) {
-        this.hasStagedChanges = true;
-      }
-      return '';
-    }
+    if (args[0] === 'checkout') return this.returnSuccess(args);
+    if (args[0] === 'merge') return this.returnSuccess(args);
     if (args[0] === 'rebase') return '';
-    if (args[0] === 'commit') {
-      // Commit clears staged changes
-      this.hasStagedChanges = false;
-      return '';
-    }
+    if (args[0] === 'commit') return this.returnSuccess(args);
     if (args[0] === 'branch') return '';
     if (args[0] === 'symbolic-ref') return `refs/remotes/origin/${this.defaultBranch}`;
     if (args[0] === 'rev-parse') return 'abc123';
-    if (args[0] === 'push') return '';
+    if (args[0] === 'push') return this.returnSuccess(args);
+    if (args[0] === 'ls-remote') return this.lsRemote(args);
     // diff --cached --quiet exits non-zero when there are staged changes
     if (args[0] === 'diff' && args.includes('--cached') && args.includes('--quiet')) {
       if (this.hasStagedChanges) {
@@ -141,5 +131,47 @@ export class MockGit {
       return '';
     }
     return '';
+  }
+
+  private returnSuccess(args: string[]): string {
+    this.applySuccessfulCommandSideEffects(args);
+    return '';
+  }
+
+  private applySuccessfulCommandSideEffects(args: string[]): void {
+    if (args[0] === 'checkout') {
+      this.hasStagedChanges = false;
+    } else if (args[0] === 'merge' && args.includes('--squash')) {
+      this.hasStagedChanges = true;
+    } else if (args[0] === 'commit') {
+      this.hasStagedChanges = false;
+    } else if (args[0] === 'push') {
+      this.recordPushedRefs(args);
+    }
+  }
+
+  private recordPushedRefs(args: string[]): void {
+    for (const spec of args.slice(1)) {
+      const separator = spec.indexOf(':');
+      if (separator <= 0) continue;
+      const source = spec.slice(0, separator);
+      const destination = spec.slice(separator + 1);
+      if (!destination.startsWith('refs/heads/')) continue;
+      this.remoteRefs.set(destination, this.shaForRef(source));
+    }
+  }
+
+  private shaForRef(ref: string): string {
+    return ref === 'HEAD' ? 'abc123' : 'abc123';
+  }
+
+  private lsRemote(args: string[]): string {
+    if (!args.includes('--heads')) return '';
+    const remote = args.find((arg, index) => index > 0 && args[index - 1] !== 'ls-remote' && !arg.startsWith('-'));
+    if (remote !== 'origin') return '';
+    const branch = args[args.length - 1];
+    const ref = `refs/heads/${branch}`;
+    const sha = this.remoteRefs.get(ref);
+    return sha ? `${sha}\t${ref}` : '';
   }
 }


### PR DESCRIPTION
## Summary

Guards the auto-fix recovery path so it only routes a fresh rerun when the store can persist worker actions.

Without that capability the recovery tick would fire a rerun it can never track, so it now stays idle instead.

The MockGit test double gains a way to report the refs it was told to push, so focused backend checks can observe the pushed branch.

## Review Claim

Approve routing a bare rerun only when the store can persist worker actions, plus a MockGit helper that reports pushed refs.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The recovery path gains one extra precondition before it routes a rerun. When the store already persists worker actions, behavior is identical to before; only the untrackable case changes.

## Slice Rationale

The recovery routing guard and its test-double support ship together because the guard is only observable once MockGit can report pushed refs. This stays out of the terminal slices, which change unrelated files.

## Non-goals

- No change to how reruns are chosen once tracking is available.
- No terminal, planning, or IPC changes.
- No new production dependency on MockGit.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test`
- [ ] `cd packages/test-kit && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
