### PR TITLE
[Persist Worker Desired State - Runtime Restore Semantics](1) Restore desired owner workers

### DIFF
--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -12,7 +12,7 @@ import {
   type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 
-import type { WorkerActionRecord } from '@invoker/data-store';
+import type { WorkerActionRecord, WorkerDesiredState } from '@invoker/data-store';
 import {
   AUTO_STARTED_OWNER_WORKER_KINDS,
   createWorkerRuntimeController,
@@ -50,12 +50,28 @@ function runtime(kind: string): TestWorkerRuntime {
   };
 }
 
-function persistence() {
+function persistence(initialDesiredStates: Record<string, WorkerDesiredState> = {}) {
+  const desiredStates = new Map(Object.entries(initialDesiredStates));
   return {
     listWorkerActions: vi.fn(() => []),
     listWorkflows: vi.fn(() => []),
     loadTasks: vi.fn(() => []),
     getEvents: vi.fn(() => []),
+    listWorkerDesiredStates: vi.fn(() => [...desiredStates.entries()].map(([workerKind, desiredState]) => ({
+      workerKind,
+      desiredState,
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    }))),
+    getWorkerDesiredState: vi.fn((workerKind: string) => {
+      const desiredState = desiredStates.get(workerKind);
+      return desiredState
+        ? { workerKind, desiredState, updatedAt: '2026-01-01T00:00:00.000Z' }
+        : undefined;
+    }),
+    setWorkerDesiredState: vi.fn((workerKind: string, desiredState: WorkerDesiredState) => {
+      desiredStates.set(workerKind, desiredState);
+      return { workerKind, desiredState, updatedAt: '2026-01-01T00:00:00.000Z' };
+    }),
   };
 }
 
@@ -72,7 +88,10 @@ function deps(): WorkerRuntimeDependencies {
   } as WorkerRuntimeDependencies;
 }
 
-function controller(autoStartKinds: readonly string[] = AUTO_STARTED_OWNER_WORKER_KINDS) {
+function controller(
+  autoStartKinds: readonly string[] = AUTO_STARTED_OWNER_WORKER_KINDS,
+  store = persistence(),
+) {
   const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
   const runtimes = new Map<string, TestWorkerRuntime[]>();
   const register = (kind: string, note: string, runtimeKind = kind) => {
@@ -103,9 +122,10 @@ function controller(autoStartKinds: readonly string[] = AUTO_STARTED_OWNER_WORKE
       registry,
       deps: deps(),
       autoStartKinds,
-      persistence: persistence() as never,
+      persistence: store as never,
       canControl: () => true,
     }),
+    persistence: store,
   };
 }
 
@@ -148,6 +168,57 @@ describe('createWorkerRuntimeController', () => {
 
     expect(row.lifecycle).toBe('running');
     expect(row.runtimeKind).toBe('recovery');
+  });
+
+  it('startup restore honors persisted desired state before default auto-starts', () => {
+    const setup = controller(AUTO_STARTED_OWNER_WORKER_KINDS, persistence({
+      [PR_STATUS_WORKER_KIND]: 'stopped',
+      [AUTO_FIX_WORKER_KIND]: 'running',
+      'removed-external': 'running',
+    }));
+
+    setup.controller.startAutoStartedWorkers();
+    const snapshot = setup.controller.snapshot();
+
+    expect(snapshot.workers.find((worker) => worker.kind === PR_STATUS_WORKER_KIND)).toMatchObject({
+      lifecycle: 'stopped',
+      autoStarts: false,
+    });
+    expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)).toMatchObject({
+      lifecycle: 'running',
+      autoStarts: true,
+    });
+    expect(setup.runtimes.has('removed-external')).toBe(false);
+    expect(setup.persistence.setWorkerDesiredState).not.toHaveBeenCalled();
+  });
+
+  it('explicit start and stop persist desired state', async () => {
+    const setup = controller();
+
+    setup.controller.start(AUTO_FIX_WORKER_KIND);
+    await setup.controller.stop(AUTO_FIX_WORKER_KIND);
+
+    expect(setup.persistence.setWorkerDesiredState).toHaveBeenNthCalledWith(1, AUTO_FIX_WORKER_KIND, 'running');
+    expect(setup.persistence.setWorkerDesiredState).toHaveBeenNthCalledWith(2, AUTO_FIX_WORKER_KIND, 'stopped');
+    expect(setup.controller.snapshot().workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)).toMatchObject({
+      autoStarts: false,
+      lifecycle: 'stopped',
+    });
+  });
+
+  it('stopAll shutdown does not persist desired state', async () => {
+    const setup = controller();
+
+    setup.controller.start(AUTO_FIX_WORKER_KIND);
+    setup.persistence.setWorkerDesiredState.mockClear();
+
+    await setup.controller.stopAll();
+
+    expect(setup.persistence.setWorkerDesiredState).not.toHaveBeenCalled();
+    expect(setup.controller.snapshot().workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)).toMatchObject({
+      autoStarts: true,
+      lifecycle: 'stopped',
+    });
   });
 
   it('duplicate start is idempotent', () => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -393,7 +393,11 @@ function createRegisteredWorkerRegistry(): WorkerRegistry<WorkerRuntimeDependenc
   return registerExternalWorkersFromConfig(invokerConfig.externalWorkers, registry);
 }
 
-
+function resolveDefaultOwnerWorkerAutoStartKinds(): readonly string[] {
+  return invokerConfig.e2eAutoFixEnabled
+    ? [...AUTO_STARTED_OWNER_WORKER_KINDS, E2E_AUTOFIX_WORKER_KIND]
+    : AUTO_STARTED_OWNER_WORKER_KINDS;
+}
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
@@ -1908,9 +1912,7 @@ function startHeadlessMode(): void {
               await createStandaloneTaskExecutor().checkMergeGateStatuses();
             },
           ),
-          autoStartKinds: invokerConfig.e2eAutoFixEnabled
-            ? [...AUTO_STARTED_OWNER_WORKER_KINDS, E2E_AUTOFIX_WORKER_KIND]
-            : AUTO_STARTED_OWNER_WORKER_KINDS,
+          autoStartKinds: resolveDefaultOwnerWorkerAutoStartKinds(),
           persistence,
           autoFixRetries: resolveAutoFixRetries(invokerConfig),
           canControl: () => !readOnlyMode,
@@ -3753,9 +3755,7 @@ function createEmbeddedTerminalBackendFromConfig(
             await requireTaskExecutor().checkMergeGateStatuses();
           },
         ),
-        autoStartKinds: invokerConfig.e2eAutoFixEnabled
-          ? [...AUTO_STARTED_OWNER_WORKER_KINDS, E2E_AUTOFIX_WORKER_KIND]
-          : AUTO_STARTED_OWNER_WORKER_KINDS,
+        autoStartKinds: resolveDefaultOwnerWorkerAutoStartKinds(),
         persistence,
         autoFixRetries: resolveAutoFixRetries(invokerConfig),
         canControl: () => ownerMode,
@@ -4471,13 +4471,13 @@ function createEmbeddedTerminalBackendFromConfig(
         return createLocalWorkerStatusSnapshot({
           registry: createRegisteredWorkerRegistry(),
           persistence,
-          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          autoStartKinds: resolveDefaultOwnerWorkerAutoStartKinds(),
         });
       }
       return workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
         registry: createRegisteredWorkerRegistry(),
         persistence,
-        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+        autoStartKinds: resolveDefaultOwnerWorkerAutoStartKinds(),
       });
     });
 

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -9,7 +9,11 @@ import type {
   WorkerStatusEntry,
   WorkerStatusSnapshot,
 } from '@invoker/contracts';
-import type { SQLiteAdapter, WorkerActionRecord } from '@invoker/data-store';
+import type {
+  SQLiteAdapter,
+  WorkerActionRecord,
+  WorkerDesiredState,
+} from '@invoker/data-store';
 import {
   AUTO_FIX_WORKER_KIND,
   AUTO_APPROVE_WORKER_KIND,
@@ -48,10 +52,15 @@ export interface WorkerRuntimeController {
   snapshot(): WorkerStatusSnapshot;
 }
 
+export type WorkerDesiredStatePersistence = Partial<Pick<
+  SQLiteAdapter,
+  'getWorkerDesiredState' | 'setWorkerDesiredState' | 'listWorkerDesiredStates'
+>>;
+
 type WorkerStatusPersistence = Pick<
   SQLiteAdapter,
   'listWorkerActions' | 'listWorkflows' | 'loadTasks' | 'getEvents' | 'getEventsByTypes' | 'countEventsByTypes'
->;
+> & WorkerDesiredStatePersistence;
 
 const DEFAULT_WORKER_ACTION_HISTORY_LIMIT = 20;
 const MAX_WORKER_ACTION_HISTORY_LIMIT = 100;
@@ -180,6 +189,10 @@ export function createWorkerRuntimeController(options: {
 }): WorkerRuntimeController {
   const handles = new Map<string, RuntimeHandle>();
   const stoppedAtByKind = new Map<string, string>();
+  const desiredStateByKind = loadWorkerDesiredStateMap(
+    options.persistence,
+    options.registry.list().map((definition) => definition.kind),
+  );
 
   const requireDefinition = (kind: string) => {
     const definition = options.registry.get(kind);
@@ -199,9 +212,13 @@ export function createWorkerRuntimeController(options: {
       note: definition.note,
       handle: handles.get(kind),
       stoppedAt: stoppedAtByKind.get(kind),
-      autoStarts: options.autoStartKinds.includes(kind),
       policy: policyForKind(kind),
       persistence: options.persistence,
+      autoStarts: getEffectiveWorkerDesiredState(
+        kind,
+        desiredStateByKind,
+        options.autoStartKinds,
+      ) === 'running',
       canControl: options.canControl(),
       recovery: definition.kind === AUTO_FIX_WORKER_KIND
         ? toWorkerRecoverySummary(options.persistence)
@@ -220,37 +237,58 @@ export function createWorkerRuntimeController(options: {
     handles.delete(kind);
   };
 
+  const setDesiredState = (kind: string, desiredState: WorkerDesiredState, persist: boolean): void => {
+    if (persist) {
+      persistWorkerDesiredState(options.persistence, kind, desiredState);
+    }
+    desiredStateByKind.set(kind, desiredState);
+  };
+
+  const startKind = (kind: string, persistDesiredState: boolean): WorkerStatusEntry => {
+    const definition = requireDefinition(kind);
+    setDesiredState(kind, 'running', persistDesiredState);
+
+    const existing = handles.get(kind);
+    if (existing) {
+      if (existing.runtime.isRunning()) {
+        return rowForKind(kind);
+      }
+      void existing.runtime.stop().catch(() => undefined);
+      handles.delete(kind);
+    }
+
+    const runtime = definition.factory(options.deps);
+    runtime.start();
+    handles.set(kind, {
+      runtime,
+      startedAt: new Date().toISOString(),
+    });
+    stoppedAtByKind.delete(kind);
+    return rowForKind(kind);
+  };
+
   return {
     startAutoStartedWorkers(): void {
-      for (const kind of options.autoStartKinds) {
-        if (!options.registry.get(kind)) continue;
-        this.start(kind);
+      for (const definition of options.registry.list()) {
+        if (
+          getEffectiveWorkerDesiredState(
+            definition.kind,
+            desiredStateByKind,
+            options.autoStartKinds,
+          ) !== 'running'
+        ) {
+          continue;
+        }
+        startKind(definition.kind, false);
       }
     },
 
     start(kind: string): WorkerStatusEntry {
-      const definition = requireDefinition(kind);
-
-      const existing = handles.get(kind);
-      if (existing) {
-        if (existing.runtime.isRunning()) {
-          return rowForKind(kind);
-        }
-        void existing.runtime.stop().catch(() => undefined);
-        handles.delete(kind);
-      }
-
-      const runtime = definition.factory(options.deps);
-      runtime.start();
-      handles.set(kind, {
-        runtime,
-        startedAt: new Date().toISOString(),
-      });
-      stoppedAtByKind.delete(kind);
-      return rowForKind(kind);
+      return startKind(kind, true);
     },
     async stop(kind: string): Promise<WorkerStatusEntry> {
       requireDefinition(kind);
+      setDesiredState(kind, 'stopped', true);
       const handle = handles.get(kind);
       if (!handle) {
         return rowForKind(kind);
@@ -279,6 +317,10 @@ export function createLocalWorkerStatusSnapshot(options: {
   persistence: WorkerStatusPersistence;
   autoStartKinds: readonly string[];
 }): WorkerStatusSnapshot {
+  const desiredStateByKind = loadWorkerDesiredStateMap(
+    options.persistence,
+    options.registry.list().map((definition) => definition.kind),
+  );
   const recovery = options.registry.list().some((definition) => definition.kind === AUTO_FIX_WORKER_KIND)
     ? toWorkerRecoverySummary(options.persistence)
     : undefined;
@@ -287,13 +329,63 @@ export function createLocalWorkerStatusSnapshot(options: {
     workers: options.registry.list().map((definition) => buildWorkerStatusEntry({
       definitionKind: definition.kind,
       note: definition.note,
-      autoStarts: options.autoStartKinds.includes(definition.kind),
+      autoStarts: getEffectiveWorkerDesiredState(
+        definition.kind,
+        desiredStateByKind,
+        options.autoStartKinds,
+      ) === 'running',
       policy: 'unknown',
       persistence: options.persistence,
       canControl: false,
       recovery: definition.kind === AUTO_FIX_WORKER_KIND ? recovery : undefined,
     })),
   };
+}
+
+export function persistWorkerDesiredState(
+  persistence: WorkerDesiredStatePersistence,
+  workerKind: string,
+  desiredState: WorkerDesiredState,
+): void {
+  persistence.setWorkerDesiredState?.(workerKind, desiredState);
+}
+
+function loadWorkerDesiredStateMap(
+  persistence: WorkerDesiredStatePersistence,
+  workerKinds: readonly string[],
+): Map<string, WorkerDesiredState> {
+  const states = new Map<string, WorkerDesiredState>();
+  if (persistence.listWorkerDesiredStates) {
+    for (const state of persistence.listWorkerDesiredStates()) {
+      if (isWorkerDesiredState(state.desiredState)) {
+        states.set(state.workerKind, state.desiredState);
+      }
+    }
+    return states;
+  }
+
+  if (persistence.getWorkerDesiredState) {
+    for (const kind of workerKinds) {
+      const state = persistence.getWorkerDesiredState(kind);
+      if (state && isWorkerDesiredState(state.desiredState)) {
+        states.set(kind, state.desiredState);
+      }
+    }
+  }
+  return states;
+}
+
+function getEffectiveWorkerDesiredState(
+  workerKind: string,
+  desiredStateByKind: ReadonlyMap<string, WorkerDesiredState>,
+  defaultAutoStartKinds: readonly string[],
+): WorkerDesiredState {
+  return desiredStateByKind.get(workerKind)
+    ?? (defaultAutoStartKinds.includes(workerKind) ? 'running' : 'stopped');
+}
+
+function isWorkerDesiredState(value: unknown): value is WorkerDesiredState {
+  return value === 'running' || value === 'stopped';
 }
 
 

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -618,7 +618,7 @@ describe('SQLiteAdapter', () => {
       expect(indexNames).toContain('idx_events_task_id_id');
     });
 
-    it('creates execution_model and worker_actions schema objects', () => {
+    it('creates execution_model and worker schema objects', () => {
       expect(tableColumns(adapter, 'tasks')).toContain('execution_model');
       expect(tableColumns(adapter, 'worker_actions')).toEqual(expect.arrayContaining([
         'id',
@@ -649,6 +649,11 @@ describe('SQLiteAdapter', () => {
       expect(tableForeignKeys(adapter, 'worker_actions')).toEqual(expect.arrayContaining([
         'workflows.id:CASCADE',
         'tasks.id:CASCADE',
+      ]));
+      expect(tableColumns(adapter, 'worker_desired_states')).toEqual(expect.arrayContaining([
+        'worker_kind',
+        'desired_state',
+        'updated_at',
       ]));
     });
 
@@ -812,6 +817,48 @@ describe('SQLiteAdapter', () => {
 
       expect(adapter.listWorkerActions({ decision: 'skip' }).map((action) => action.id)).toEqual(['wa-skip']);
       expect(adapter.listWorkerActions({ decision: 'act' }).map((action) => action.id)).toEqual(['wa-done', 'wa-act']);
+    });
+  });
+
+  describe('worker desired state persistence', () => {
+    it('upserts, reads, and lists desired worker states', () => {
+      const first = adapter.setWorkerDesiredState('pr-status', 'running');
+      expect(first).toMatchObject({
+        workerKind: 'pr-status',
+        desiredState: 'running',
+      });
+
+      const updated = adapter.setWorkerDesiredState('pr-status', 'stopped');
+      adapter.setWorkerDesiredState('external-preview', 'running');
+
+      expect(adapter.getWorkerDesiredState('pr-status')).toEqual(updated);
+      expect(adapter.listWorkerDesiredStates().map((state) => ({
+        workerKind: state.workerKind,
+        desiredState: state.desiredState,
+      }))).toEqual([
+        { workerKind: 'external-preview', desiredState: 'running' },
+        { workerKind: 'pr-status', desiredState: 'stopped' },
+      ]);
+    });
+
+    it('persists desired worker states across writable reopens', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-worker-desired-state-'));
+      const dbPath = join(dir, 'invoker.db');
+
+      try {
+        const first = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        first.setWorkerDesiredState('autofix', 'running');
+        first.close();
+
+        const reopened = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        expect(reopened.getWorkerDesiredState('autofix')).toMatchObject({
+          workerKind: 'autofix',
+          desiredState: 'running',
+        });
+        reopened.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -197,6 +197,14 @@ export interface WorkerActionListFilters {
   offset?: number;
 }
 
+export type WorkerDesiredState = 'running' | 'stopped';
+
+export interface WorkerDesiredStateRecord {
+  workerKind: string;
+  desiredState: WorkerDesiredState;
+  updatedAt: string;
+}
+
 export interface TerminalSessionRecord {
   sessionId: string;
   taskId: string;
@@ -289,6 +297,9 @@ export interface PersistenceAdapter {
   getWorkerAction(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
   upsertWorkerAction(action: WorkerActionWrite): WorkerActionRecord;
   listWorkerActions(filters?: WorkerActionListFilters): WorkerActionRecord[];
+  getWorkerDesiredState(workerKind: string): WorkerDesiredStateRecord | undefined;
+  setWorkerDesiredState(workerKind: string, desiredState: WorkerDesiredState): WorkerDesiredStateRecord;
+  listWorkerDesiredStates(): WorkerDesiredStateRecord[];
 
   // Conversations (Slack thread-based)
   saveConversation(conversation: Conversation): void;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -47,6 +47,8 @@ import type {
   WorkerActionListFilters,
   WorkerActionRecord,
   WorkerActionWrite,
+  WorkerDesiredState,
+  WorkerDesiredStateRecord,
   TerminalSessionPatch,
   TerminalSessionRecord,
   InAppPlanningSessionPatch,
@@ -1633,6 +1635,41 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return rows.map((row) => this.rowToWorkerAction(row));
   }
 
+  getWorkerDesiredState(workerKind: string): WorkerDesiredStateRecord | undefined {
+    const row = this.queryOne(
+      'SELECT * FROM worker_desired_states WHERE worker_kind = ?',
+      [workerKind],
+    );
+    return row ? this.rowToWorkerDesiredState(row) : undefined;
+  }
+
+  setWorkerDesiredState(workerKind: string, desiredState: WorkerDesiredState): WorkerDesiredStateRecord {
+    if (desiredState !== 'running' && desiredState !== 'stopped') {
+      throw new Error(`Invalid worker desired state: "${String(desiredState)}"`);
+    }
+    const updatedAt = new Date().toISOString();
+    this.execRun(
+      `INSERT INTO worker_desired_states (worker_kind, desired_state, updated_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(worker_kind) DO UPDATE SET
+         desired_state = excluded.desired_state,
+         updated_at = excluded.updated_at`,
+      [workerKind, desiredState, updatedAt],
+    );
+    const saved = this.getWorkerDesiredState(workerKind);
+    if (!saved) {
+      throw new Error(`Failed to persist worker desired state for "${workerKind}"`);
+    }
+    return saved;
+  }
+
+  listWorkerDesiredStates(): WorkerDesiredStateRecord[] {
+    const rows = this.queryAll(
+      'SELECT * FROM worker_desired_states ORDER BY worker_kind ASC',
+    );
+    return rows.map((row) => this.rowToWorkerDesiredState(row));
+  }
+
   // ── Queries ─────────────────────────────────────────
 
   getSelectedExperiment(taskId: string): string | null {
@@ -3080,6 +3117,18 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   private rowToWorkerAction(row: Record<string, unknown>): WorkerActionRecord {
     return mapRowToWorkerAction(row);
+  }
+
+  private rowToWorkerDesiredState(row: Record<string, unknown>): WorkerDesiredStateRecord {
+    const desiredState = String(row.desired_state);
+    if (desiredState !== 'running' && desiredState !== 'stopped') {
+      throw new Error(`Invalid worker desired state row for worker "${String(row.worker_kind)}"`);
+    }
+    return {
+      workerKind: String(row.worker_kind),
+      desiredState,
+      updatedAt: String(row.updated_at),
+    };
   }
 
   private requeueWorkflowMutationLease(workflowId: string): void {

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -348,6 +348,12 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_worker_actions_kind_updated
         ON worker_actions(worker_kind, updated_at DESC, id);
 
+      CREATE TABLE IF NOT EXISTS worker_desired_states (
+        worker_kind TEXT PRIMARY KEY,
+        desired_state TEXT NOT NULL CHECK (desired_state IN ('running', 'stopped')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
       CREATE TABLE IF NOT EXISTS execution_resource_leases (
         resource_key TEXT NOT NULL,
         resource_type TEXT NOT NULL,
@@ -492,6 +498,11 @@ export const POST_MIGRATION_STATEMENTS = [
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_task_updated ON worker_actions(task_id, updated_at)',
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_workflow_status ON worker_actions(workflow_id, worker_kind, status)',
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_kind_updated ON worker_actions(worker_kind, updated_at DESC, id)',
+  `CREATE TABLE IF NOT EXISTS worker_desired_states (
+      worker_kind TEXT PRIMARY KEY,
+      desired_state TEXT NOT NULL CHECK (desired_state IN ('running', 'stopped')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
   'DROP INDEX IF EXISTS idx_task_launch_dispatch_active_attempt',
   `
       CREATE UNIQUE INDEX IF NOT EXISTS idx_task_launch_dispatch_active_attempt


### PR DESCRIPTION
## Summary

Worker startup now routes owner workers through saved desired-state policy instead of unconditional default startup.

Manual worker controls record the next desired lifecycle, while shutdown remains transient.

SQLite now has durable desired-state rows covered by adapter and controller tests.

## Review Claim

Approve the owner worker routing that applies saved desired state to startup and explicit control requests.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Workers without a saved desired state keep the existing default auto-start behavior.

Shutdown stopAll still avoids saving desired state, so application exit cannot silently disable workers.

## Slice Rationale

This slice keeps the owner runtime path and its durable preference row together because startup needs both sides.

Headless one-shot mutation stays in the next slice because it enters through a separate command surface.

## Non-goals

- Does not change worker tick behavior, retry policy, or worker action history.
- Does not add UI controls or new IPC commands.
- Does not change headless one-shot worker commands.

## Architecture

### Before

Owner startup applied the configured default worker list every time.

Manual start and stop requests only affected the current process lifetime.

### After

Owner startup resolves each registered worker against saved desired state, falling back to the configured default list when no row exists.

Explicit owner start and stop requests save the desired lifecycle. Shutdown stopAll remains process-local.

## Visual Proof

The worker decisions panel remains the visible worker surface; focused controller tests cover the changed runtime behavior because this PR has no distinct renderer cue.

![Worker decisions panel](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-db4008/worker-decisions-panel.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/worker-control.test.ts src/__tests__/headless-autofix.test.ts src/__tests__/headless-pr-maintenance.test.ts`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sqlite-adapter.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/persist-worker-runtime-restore-1.md --require-visual-proof --changed-files-file /tmp/persist-worker-runtime-restore-1.files --diff-file /tmp/persist-worker-runtime-restore-1.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3778e22abd9ca676fb7762ec604d3d3566b92a83`
- Post-revert steps: Re-run `pnpm --filter @invoker/app test -- src/__tests__/worker-control.test.ts` and `pnpm --filter @invoker/data-store test -- src/__tests__/sqlite-adapter.test.ts`.
- Data migration? No

</details>
