### PR TITLE
[Persist Worker Desired State - Runtime Restore Semantics](2) Persist headless worker preference

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -62,7 +62,7 @@
     "dist": "electron-builder --publish never",
     "dist:linux": "electron-builder --linux AppImage deb --publish never",
     "dist:mac": "electron-builder --mac dmg --publish never",
-    "test": "vitest run",
+    "test": "node scripts/vitest-run.cjs",
     "start": "unset ELECTRON_RUN_AS_NODE && node ../../scripts/electron.cjs dist/main.js",
     "dev": "tsup src/main.ts src/preload.ts --format cjs --outDir dist --external electron && unset ELECTRON_RUN_AS_NODE && node ../../scripts/electron.cjs dist/main.js",
     "test:e2e": "sh -c 'if command -v xvfb-run >/dev/null 2>&1; then exec xvfb-run --auto-servernum playwright test \"$@\"; else exec playwright test \"$@\"; fi' --",

--- a/packages/app/scripts/vitest-run.cjs
+++ b/packages/app/scripts/vitest-run.cjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('node:child_process');
+
+const args = process.argv.slice(2);
+const normalizedArgs = args[0] === '--' ? args.slice(1) : args;
+const vitestCli = require.resolve('vitest/vitest.mjs');
+
+const result = spawnSync(process.execPath, [vitestCli, 'run', ...normalizedArgs], {
+  stdio: 'inherit',
+});
+
+if (result.error) {
+  console.error(result.error);
+  process.exit(1);
+}
+
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+} else {
+  process.exit(result.status ?? 1);
+}

--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -55,6 +55,7 @@ describe('headless worker autofix', () => {
       _args: unknown[],
       _priority: WorkflowMutationPriority,
     ) => 1);
+    const setWorkerDesiredState = vi.fn();
     const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     // Point the worker lock at a throwaway home so the scan never touches the
     // real Invoker home (the door acquires/releases the cross-process lock).
@@ -87,6 +88,7 @@ describe('headless worker autofix', () => {
           }),
           logEvent: vi.fn(),
           enqueueWorkflowMutationIntent,
+          setWorkerDesiredState,
         },
         invokerConfig: { autoFixRetries: 3, autoFixAgent: 'codex' },
       } as any);
@@ -103,6 +105,7 @@ describe('headless worker autofix', () => {
       ['wf-1/task-1'],
       'normal',
     );
+    expect(setWorkerDesiredState).toHaveBeenCalledWith('autofix', 'running');
   });
 
   it('lists worker kinds from the registry', async () => {

--- a/packages/app/src/__tests__/headless-pr-maintenance.test.ts
+++ b/packages/app/src/__tests__/headless-pr-maintenance.test.ts
@@ -25,12 +25,15 @@ function writeCronScript(repoRoot: string, scriptRelativePath: string, markerNam
 }
 
 /** Minimal headless deps for a one-shot PR-maintenance worker run. */
-function makeWorkerDeps(repoRoot: string, token: string): unknown {
+function makeWorkerDeps(repoRoot: string, token: string) {
   return {
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn(), child: vi.fn() },
     // The PR-maintenance tick never touches the store/submitter; provide a stub
     // so the shared factory-deps construction has something to reference.
-    persistence: { enqueueWorkflowMutationIntent: vi.fn(() => 1) },
+    persistence: {
+      enqueueWorkflowMutationIntent: vi.fn(() => 1),
+      setWorkerDesiredState: vi.fn(),
+    },
     invokerConfig: {
       prMaintenance: {
         enabled: true,
@@ -73,22 +76,32 @@ describe('headless worker PR-maintenance', () => {
 
   it('runs the coderabbit-address worker one-shot with the threaded config', async () => {
     writeCronScript(repoRoot, 'scripts/cron-coderabbit-address.sh', 'coderabbit.marker');
+    const deps = makeWorkerDeps(repoRoot, 'cr-token');
 
-    await runHeadless(['worker', CODERABBIT_ADDRESS_WORKER_KIND], makeWorkerDeps(repoRoot, 'cr-token') as never);
+    await runHeadless(['worker', CODERABBIT_ADDRESS_WORKER_KIND], deps as never);
 
     // Marker written under the threaded repoRoot, carrying the threaded env
     // override — proves the launch config reached the shell entrypoint.
     expect(readFileSync(join(repoRoot, 'coderabbit.marker'), 'utf8')).toBe('cr-token');
     expect(stdout).toContain(`${CODERABBIT_ADDRESS_WORKER_KIND} worker scan completed.`);
+    expect(deps.persistence.setWorkerDesiredState).toHaveBeenCalledWith(
+      CODERABBIT_ADDRESS_WORKER_KIND,
+      'running',
+    );
   });
 
   it('runs the pr-conflict-rebase worker one-shot with the threaded config', async () => {
     writeCronScript(repoRoot, 'scripts/cron-pr-conflict-rebase.sh', 'rebase.marker');
+    const deps = makeWorkerDeps(repoRoot, 'rebase-token');
 
-    await runHeadless(['worker', PR_CONFLICT_REBASE_WORKER_KIND], makeWorkerDeps(repoRoot, 'rebase-token') as never);
+    await runHeadless(['worker', PR_CONFLICT_REBASE_WORKER_KIND], deps as never);
 
     expect(readFileSync(join(repoRoot, 'rebase.marker'), 'utf8')).toBe('rebase-token');
     expect(stdout).toContain(`${PR_CONFLICT_REBASE_WORKER_KIND} worker scan completed.`);
+    expect(deps.persistence.setWorkerDesiredState).toHaveBeenCalledWith(
+      PR_CONFLICT_REBASE_WORKER_KIND,
+      'running',
+    );
   });
 
   it('lists both PR-maintenance worker kinds from the manual entrypoint', async () => {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -41,6 +41,7 @@ import {
 import { LaunchDispatcher } from './launch-dispatcher.js';
 import { formatHeadlessSetSubcommands } from './headless-command-registry.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
+import { persistWorkerDesiredState } from './worker-control.js';
 
 export {
   DEFAULT_DELEGATION_TIMEOUT_MS,
@@ -458,6 +459,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   }
   const autoFixAttemptLedger = createAutoFixAttemptLedger();
   try {
+    persistWorkerDesiredState(deps.persistence, definition.kind, 'running');
     const worker = definition.factory({
       store: deps.persistence,
       submitter: {
@@ -929,4 +931,3 @@ async function headlessSetTaskMetadata(
   );
   process.stdout.write(`Updated task "${result.id}" ${result.fieldPath} → ${JSON.stringify(result.value)}\n`);
 }
-


### PR DESCRIPTION
## Summary

Headless one-shot worker commands now save a running preference when an operator invokes them.

Targeted app tests run through a tiny Node wrapper that preserves pnpm argument forwarding.

Autofix and PR-maintenance headless tests assert the saved preference mutation.

## Review Claim

Approve the headless worker command path that records an operator-invoked worker as desired running.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The one-shot worker still acquires and releases the same cross-process lock.

The saved preference call is optional through the shared helper, so minimal test stores can still omit it.

## Slice Rationale

This slice stays after owner runtime support because the headless path calls the shared persistence helper added below it.

The app test wrapper is included here because it only supports the targeted headless verification command.

## Non-goals

- Does not change owner worker startup restore behavior.
- Does not change worker definitions, worker locks, or worker tick logic.
- Does not alter data-store persistence methods.

## Architecture

### Before

Headless one-shot worker commands ran the worker once without updating desired lifecycle preference.

Targeted app test invocations depended on package-manager argument forwarding reaching Vitest unchanged.

### After

Headless one-shot worker commands save a running desired lifecycle before constructing and ticking the worker.

Targeted app test invocations enter Vitest through a small Node wrapper that removes an optional leading separator.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/worker-control.test.ts src/__tests__/headless-autofix.test.ts src/__tests__/headless-pr-maintenance.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/persist-worker-runtime-restore-2.md --changed-files-file /tmp/persist-worker-runtime-restore-2.files --diff-file /tmp/persist-worker-runtime-restore-2.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 40a4768a1beb11e25bec3f45e2eaeb33da30a2b2`
- Post-revert steps: Re-run `pnpm --filter @invoker/app test -- src/__tests__/headless-autofix.test.ts src/__tests__/headless-pr-maintenance.test.ts`.
- Data migration? No

</details>
