### PR TITLE
Projection prefers newest active attempt over outdated pointer

### DIFF
--- a/packages/app/src/__tests__/action-graph-snapshot.test.ts
+++ b/packages/app/src/__tests__/action-graph-snapshot.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator, type Attempt, type TaskState } from '@invoker/workflow-core';
+import { buildCurrentActionGraphSnapshot } from '../action-graph-snapshot.js';
+import type { InvokerConfig } from '../config.js';
+
+describe('buildCurrentActionGraphSnapshot', () => {
+  const adapters: SQLiteAdapter[] = [];
+
+  afterEach(() => {
+    for (const adapter of adapters.splice(0)) {
+      adapter.close();
+    }
+  });
+
+  it('does not emit a failed blocker when selected_attempt_id targets a failed attempt but a newer active attempt exists', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+
+    const workflowId = 'wf-stale';
+    const taskId = 'wf-stale/verify';
+    adapter.saveWorkflow({
+      id: workflowId,
+      name: 'Remove Running Sidebar And Workers Screen Title',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const olderCreatedAt = new Date('2026-07-09T05:38:02.000Z');
+    const newerCreatedAt = new Date('2026-07-09T05:51:12.808Z');
+
+    const failed: Attempt = {
+      id: `${taskId}-aOLD`,
+      nodeId: taskId,
+      queuePriority: 0,
+      status: 'failed',
+      upstreamAttemptIds: [],
+      error: 'Cancelled by user (workflow)',
+      completedAt: new Date('2026-07-09T05:51:12.761Z'),
+      startedAt: new Date('2026-07-09T05:43:54.107Z'),
+      lastHeartbeatAt: new Date('2026-07-09T05:43:54.107Z'),
+      createdAt: olderCreatedAt,
+    };
+    const newerPending: Attempt = {
+      id: `${taskId}-aNEW`,
+      nodeId: taskId,
+      queuePriority: 0,
+      status: 'pending',
+      upstreamAttemptIds: [],
+      supersedesAttemptId: failed.id,
+      createdAt: newerCreatedAt,
+    };
+    const task: TaskState = {
+      id: taskId,
+      description: 'Verify sidebar and workers title removal',
+      status: 'running',
+      dependencies: [],
+      createdAt: olderCreatedAt,
+      config: { workflowId },
+      execution: {
+        startedAt: failed.startedAt,
+        lastHeartbeatAt: failed.lastHeartbeatAt,
+      },
+      taskStateVersion: 1,
+    };
+    adapter.saveTask(workflowId, task);
+    adapter.saveAttempt(failed);
+    adapter.saveAttempt(newerPending);
+    // Production shape: selected_attempt_id lags on the failed attempt.
+    adapter.updateTask(taskId, { execution: { selectedAttemptId: failed.id } });
+
+    const orchestrator = new Orchestrator({
+      persistence: adapter as any,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 1,
+    });
+
+    const invokerConfig: InvokerConfig = {};
+    const snapshot = buildCurrentActionGraphSnapshot({
+      orchestrator,
+      persistence: adapter,
+      invokerConfig,
+    });
+
+    const failedBlocker = snapshot.nodes.find(
+      (node) => node.id === `blocker:${taskId}:error` && node.status === 'failed',
+    );
+    expect(failedBlocker).toBeUndefined();
+
+    // Pointer stays as-persisted; the projection is read-only.
+    const reloaded = adapter.loadTask(taskId)!;
+    expect(reloaded.execution.selectedAttemptId).toBe(failed.id);
+    expect(reloaded.execution.error).toBeUndefined();
+  });
+});

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1798,6 +1798,84 @@ describe('SQLiteAdapter', () => {
       const [task] = adapter.loadTasks('wf-1');
       expect(task.status).toBe('fixing_with_ai');
     });
+
+    it('projects from the newest active attempt when selected_attempt_id lags behind a failed attempt with a newer pending replacement', () => {
+      adapter.saveWorkflow(testWorkflow);
+      const olderCreatedAt = new Date('2026-07-09T05:38:02.000Z');
+      const newerCreatedAt = new Date('2026-07-09T05:51:12.808Z');
+      const failed: Attempt = {
+        ...createAttempt('t1', { status: 'failed' }),
+        id: 't1-aOLD',
+        createdAt: olderCreatedAt,
+        error: 'Cancelled by user (workflow)',
+        completedAt: new Date('2026-07-09T05:51:12.761Z'),
+      };
+      const newerPending: Attempt = {
+        ...createAttempt('t1', { status: 'pending' }),
+        id: 't1-aNEW',
+        createdAt: newerCreatedAt,
+        supersedesAttemptId: failed.id,
+      };
+      adapter.saveTask('wf-1', makeTask('t1', {
+        status: 'running',
+        execution: { startedAt: new Date('2026-07-09T05:43:54.107Z') },
+      }));
+      adapter.saveAttempt(failed);
+      adapter.saveAttempt(newerPending);
+      // Production shape: selected_attempt_id lags on the FAILED attempt even
+      // though a newer pending replacement exists.
+      adapter.updateTask('t1', { execution: { selectedAttemptId: failed.id } });
+
+      const [task] = adapter.loadTasks('wf-1');
+      expect(task.status).toBe('running');
+      expect(task.execution.error).toBeUndefined();
+      expect(task.execution.completedAt).toBeUndefined();
+      // Pointer stays as-persisted; the projection does not rewrite the row.
+      expect(task.execution.selectedAttemptId).toBe(failed.id);
+    });
+
+    it('projects from the newest active attempt when selected_attempt_id lags behind a superseded attempt', () => {
+      adapter.saveWorkflow(testWorkflow);
+      const olderCreatedAt = new Date('2026-07-09T05:38:02.000Z');
+      const newerCreatedAt = new Date('2026-07-09T05:51:12.808Z');
+      const superseded: Attempt = {
+        ...createAttempt('t1', { status: 'superseded' }),
+        id: 't1-aOLD',
+        createdAt: olderCreatedAt,
+      };
+      const newerRunning: Attempt = {
+        ...createAttempt('t1', { status: 'running' }),
+        id: 't1-aNEW',
+        createdAt: newerCreatedAt,
+        supersedesAttemptId: superseded.id,
+      };
+      adapter.saveTask('wf-1', makeTask('t1', {
+        status: 'running',
+        execution: { startedAt: newerCreatedAt },
+      }));
+      adapter.saveAttempt(superseded);
+      adapter.saveAttempt(newerRunning);
+      adapter.updateTask('t1', { execution: { selectedAttemptId: superseded.id } });
+
+      const [task] = adapter.loadTasks('wf-1');
+      // Without the fix this would project `stale`; the newer active attempt
+      // wins and keeps the task as running.
+      expect(task.status).toBe('running');
+    });
+
+    it('keeps projecting `stale` when selected_attempt_id targets a superseded attempt with no newer active replacement', () => {
+      adapter.saveWorkflow(testWorkflow);
+      const attempt: Attempt = {
+        ...createAttempt('t1', { status: 'superseded' }),
+        id: 't1-aOLD',
+      };
+      adapter.saveTask('wf-1', makeTask('t1', { status: 'running' }));
+      adapter.saveAttempt(attempt);
+      adapter.updateTask('t1', { execution: { selectedAttemptId: attempt.id } });
+
+      const [task] = adapter.loadTasks('wf-1');
+      expect(task.status).toBe('stale');
+    });
   });
 
   describe('loadActionGraphAttempts', () => {

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -11,6 +11,7 @@
 import type { TaskState, TaskStateChanges, Attempt } from '@invoker/workflow-core';
 import {
   assertTaskConsistent,
+  isActiveAttempt,
   isDiscardedAttempt,
   normalizeRunnerKind,
 } from '@invoker/workflow-core';
@@ -671,6 +672,32 @@ export class SqliteTaskAttemptRepository {
     const attempt = this.loadAttempt(attemptId);
     if (!attempt) return task;
 
+    // The pointer becomes advisory once the workflow has moved on. If the
+    // selected attempt is outcome-terminal (`failed`) or discarded
+    // (`superseded`) AND a strictly newer active attempt exists for the same
+    // task, project from the newer active attempt instead. Otherwise a task
+    // whose selected_attempt_id lags behind a fresh pending/running attempt
+    // renders as `failed` in the UI even though the workflow has already
+    // queued a replacement.
+    if (attempt.status === 'failed' || isDiscardedAttempt(attempt)) {
+      const newer = this.findNewerActiveAttempt(task.id, attempt);
+      if (newer) {
+        const cleaned: TaskState = {
+          ...task,
+          execution: {
+            ...task.execution,
+            error: undefined,
+            exitCode: undefined,
+            completedAt: undefined,
+          },
+        };
+        if (newer.status === 'needs_input') {
+          return { ...cleaned, status: 'needs_input' };
+        }
+        return cleaned;
+      }
+    }
+
     if (isDiscardedAttempt(attempt)) {
       return {
         ...task,
@@ -728,5 +755,20 @@ export class SqliteTaskAttemptRepository {
     }
 
     return task;
+  }
+
+  private findNewerActiveAttempt(nodeId: string, selected: Attempt): Attempt | undefined {
+    const attempts = this.loadAttempts(nodeId);
+    const selectedTs = selected.createdAt.getTime();
+    let newest: Attempt | undefined;
+    for (const candidate of attempts) {
+      if (candidate.id === selected.id) continue;
+      if (!isActiveAttempt(candidate)) continue;
+      if (candidate.createdAt.getTime() <= selectedTs) continue;
+      if (!newest || candidate.createdAt.getTime() > newest.createdAt.getTime()) {
+        newest = candidate;
+      }
+    }
+    return newest;
   }
 }

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -672,13 +672,6 @@ export class SqliteTaskAttemptRepository {
     const attempt = this.loadAttempt(attemptId);
     if (!attempt) return task;
 
-    // The pointer becomes advisory once the workflow has moved on. If the
-    // selected attempt is outcome-terminal (`failed`) or discarded
-    // (`superseded`) AND a strictly newer active attempt exists for the same
-    // task, project from the newer active attempt instead. Otherwise a task
-    // whose selected_attempt_id lags behind a fresh pending/running attempt
-    // renders as `failed` in the UI even though the workflow has already
-    // queued a replacement.
     if (attempt.status === 'failed' || isDiscardedAttempt(attempt)) {
       const newer = this.findNewerActiveAttempt(task.id, attempt);
       if (newer) {


### PR DESCRIPTION
## Summary

A workflow card kept rendering a red "Failed: see details" pill for a task whose underlying DB row had no error.

The task's `selected_attempt_id` still pointed at an older `failed` attempt even though a strictly newer active attempt already existed.

`reconcileTaskFromSelectedAttempt` blindly followed that pointer and projected the old failure onto every read path, including the action graph the UI consumes.

This PR extends the projection layer to prefer the newest active attempt when the pointer targets a failed or superseded attempt but a newer active replacement exists.

The persisted pointer is not rewritten. Readers see the current truth without mutating the row on every hydration.

## Review Claim

`SQLiteAdapter.reconcileTaskFromSelectedAttempt` should project from the newest active attempt when `selected_attempt_id` lags behind a failed or superseded attempt, so the UI stops showing an outdated "Failed: see details" pill.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The override only fires when the selected attempt is `failed` or `superseded` AND `findNewerActiveAttempt` returns a strictly newer `isActiveAttempt` candidate. A `completed` selected attempt is untouched — that is a legitimate hand-off state.

When a superseded attempt has no newer active replacement, the existing terminal projection path is preserved unchanged.

No writes occur in this path; only the in-memory projection returned by `loadTasks` / `loadTask` changes.

## Slice Rationale

PR #3698 proposed healing the pointer on every orchestrator hydration. Review feedback correctly identified that as a symptom fix that rewrites DB state on every sync.

The outdated failed view is amplified at the projection layer, so fixing it there clears the UI without mutating persisted state and without touching orchestrator lifecycle routing.

A separate write-side investigation will track which code path creates a newer attempt without advancing `selected_attempt_id`.

## Non-goals

- Not advancing `selected_attempt_id` in the orchestrator or persisting pointer changes.
- Not changing how attempts are created during cancellation or retry.
- Not changing merge-node or gate reconciliation invariants.

## Architecture

### Before

```mermaid
graph TD
    A["loadTasks / loadTask"] --> B["reconcileTaskFromSelectedAttempt"]
    B --> C["loadAttempt(selected_attempt_id)"]
    C --> D{"attempt.status?"}
    D -- "failed" --> E["project task.status = failed + error"]
    E --> F["buildActionGraphDiagnostics -> blocker:{taskId}:error"]
    F --> G["Failed: see details pill"]
```

### After

```mermaid
graph TD
    A["loadTasks / loadTask"] --> B["reconcileTaskFromSelectedAttempt"]
    B --> C["loadAttempt(selected_attempt_id)"]
    C --> D{"failed or superseded?"}
    D -- "no" --> H["existing projection paths"]
    D -- "yes" --> E["findNewerActiveAttempt"]
    E --> F{"newer active exists?"}
    F -- "yes" --> G["project from newer attempt, clear error fields"]
    F -- "no" --> H
    G --> I["no failed blocker emitted"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm test`
- [x] `cd packages/workflow-core && pnpm test`
- [x] `cd packages/app && pnpm test src/__tests__/action-graph-snapshot.test.ts`

</details>

## Visual Proof

The user-visible effect is that a workflow card stops showing the red "Failed: see details" pill once a newer active attempt exists. A static screenshot alone cannot demonstrate this because the buggy state requires a specific cancellation-then-fresh-attempt timing sequence.

The inspectable state proof is `packages/app/src/__tests__/action-graph-snapshot.test.ts`, which constructs the stuck production state, runs `buildCurrentActionGraphSnapshot`, and asserts no `blocker:{taskId}:error` node is emitted. That is the same signal the UI reads to render the pill.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Revert restores the prior projection behavior where an outdated pointer surfaces as "Failed: see details".
- Data migration? No. This change only affects the read-side projection; no schema or persisted-row mutations.

</details>
