### PR TITLE
[History Timeline](1a) Add history-tasks IPC contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -140,6 +140,12 @@ export interface TaskEvent {
   createdAt: string;
 }
 
+export interface TaskHistoryEntry extends TaskState {
+  workflowName: string;
+  lastEventAt: string | null;
+  eventCount: number;
+}
+
 export interface QueueStatus {
   maxConcurrency: number;
   runningCount: number;
@@ -797,6 +803,10 @@ export const IpcChannels = {
   'invoker:get-all-completed-tasks': {} as {
     request: [];
     response: Array<TaskState & { workflowName: string }>;
+  },
+  'invoker:get-history-tasks': {} as {
+    request: [];
+    response: TaskHistoryEntry[];
   },
 
   // Task Actions


### PR DESCRIPTION
## Summary

History needs typed IPC types before the app can fetch task history rows.

This adds `TaskHistoryEntry` and the `invoker:get-history-tasks` channel to `@invoker/contracts`.

## Review Claim

Approving this adds the typed channel surface for history task reads without changing runtime behavior.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Types-only change. No handlers, persistence queries, or UI code change in this slice.

## Slice Rationale

Types must land before later slices wire handlers or UI. This keeps the stack reviewable one unit at a time.

## Non-goals

- Not wiring handlers or SQLite queries yet.
- Not changing History UI yet.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/contracts && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8f85e9d73`
- Post-revert steps: None
- Data migration? No

</details>
