### PR TITLE
[History Timeline](4b) Add History visual-proof e2e case with DOM asserts

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -557,6 +557,49 @@ test.describe('Read-only mode visual proof', () => {
 });
 
 test.describe('Visual proof capture', () => {
+  test('history view — task state timeline', async ({ page }) => {
+    await loadPlan(page, TEST_PLAN);
+    const now = new Date();
+    const earlier = new Date(Date.now() - 60_000);
+    await injectTaskStates(page, [
+      {
+        taskId: 'task-alpha',
+        changes: {
+          status: 'completed',
+          execution: { startedAt: earlier, completedAt: now, exitCode: 0 },
+        },
+      },
+      {
+        taskId: 'task-beta',
+        changes: {
+          status: 'failed',
+          execution: {
+            startedAt: earlier,
+            completedAt: now,
+            exitCode: 1,
+            error: 'Command exited non-zero',
+          },
+        },
+      },
+      {
+        taskId: 'task-gamma',
+        changes: {
+          status: 'fixing_with_ai',
+          execution: { startedAt: earlier },
+        },
+      },
+    ]);
+    await selectGraphMenuItem(page, 'rail-history');
+    await expect(page.getByTestId('history-view')).toBeVisible();
+    await expect(page.getByRole('searchbox', { name: 'Search history' })).toBeVisible();
+    await expect(page.getByText('First test task')).toBeVisible();
+    await expect(page.getByText('Second test task depending on alpha')).toBeVisible();
+    await expect(page.getByText('Completed').first()).toBeVisible();
+    await expect(page.getByText('Failed').first()).toBeVisible();
+    await expect(page.getByText('Autofixing').first()).toBeVisible();
+    await captureScreenshot(page, 'history-view-task-state-timeline');
+  });
+
   test('empty state', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('What do you want to build?')).toHaveCount(0);

--- a/packages/ui/src/__tests__/history-view-e2e.test.tsx
+++ b/packages/ui/src/__tests__/history-view-e2e.test.tsx
@@ -171,6 +171,34 @@ describe('History view (component)', () => {
     });
   });
 
+  it('filters by status chip and shows closed status option', async () => {
+    const completed = makeHistoryEntry({ id: 'task-done', description: 'Done task', status: 'completed' });
+    const closed = makeHistoryEntry({
+      id: 'task-closed',
+      description: 'Closed task',
+      status: 'closed',
+      lastEventAt: '2026-07-01T09:00:00.000Z',
+    });
+    mock.setHistoryTasks([completed, closed]);
+    act(() => mock.setTasks([completed, closed], workflows));
+
+    render(<App />);
+    await chooseGraphMenuItem('rail-history');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('history-row-task-done')).toBeInTheDocument();
+      expect(screen.getByTestId('history-row-task-closed')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: 'Closed' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Closed' }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('history-row-task-done')).not.toBeInTheDocument();
+      expect(screen.getByTestId('history-row-task-closed')).toBeInTheDocument();
+      expect(screen.getByText('1 / 2')).toBeInTheDocument();
+    });
+  });
 
   it('shows empty state when there is no history', async () => {
     mock.setHistoryTasks([]);


### PR DESCRIPTION
## Summary

History UI proof needs a Playwright case that opens the History rail and asserts the new DOM.

This adds the visual-proof e2e case with search, task rows, and status badge checks.

## Review Claim

Approving this adds the History visual-proof regression case used for before/after PR proof.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Harness-only change under `packages/app/e2e/`. No product runtime behavior changes.

## Slice Rationale

Visual proof belongs in the proof lane after the UI behavior it captures is already merged in earlier slices.

## Non-goals

- Not changing History UI behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `CAPTURE_MODE=after CAPTURE_VIDEO=1 npx --prefix packages/app playwright test visual-proof.spec.ts -g "history view — task state timeline"`

</details>

## Visual Proof

This slice is the proof harness itself. The before/after screenshots live on slice (1c).

![History view after — flat feed with filters and badges](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-c531ac/history-timeline-1-after.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9bf8618c8`
- Post-revert steps: None
- Data migration? No

</details>
