### PR TITLE
Keep verbose mutation failures out of the top banner.

### DIFF
--- a/packages/app/src/__tests__/mutation-failure-message.test.ts
+++ b/packages/app/src/__tests__/mutation-failure-message.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveHeadlessExecCommand,
+  resolveMutationFailureTaskId,
+  summarizeMutationFailureMessage,
+  summarizeMutationFailureText,
+} from '../mutation-failure-message.js';
+
+describe('resolveMutationFailureTaskId', () => {
+  it('extracts task id from headless.exec fix payload', () => {
+    expect(resolveMutationFailureTaskId('headless.exec', [{
+      args: ['fix', 'wf-1/task-alpha', 'codex'],
+      noTrack: true,
+    }])).toBe('wf-1/task-alpha');
+  });
+
+  it('extracts task id from invoker:approve args', () => {
+    expect(resolveMutationFailureTaskId('invoker:approve', ['wf-1/task-alpha'])).toBe('wf-1/task-alpha');
+  });
+});
+
+describe('summarizeMutationFailureMessage', () => {
+  it('uses error.message only and strips stack traces', () => {
+    const err = new Error('SSH remote script failed (exit=1)\nSTDOUT:\n{"type":"error"}');
+    err.stack = `${err.message}\n    at createSshRemoteScriptError (/tmp/main.js:1:1)`;
+    expect(summarizeMutationFailureMessage(err)).not.toContain('createSshRemoteScriptError');
+    expect(summarizeMutationFailureMessage(err)).toContain('SSH remote script failed');
+  });
+
+  it('prefers legible nested agent errors over raw stdout', () => {
+    const text = summarizeMutationFailureText(`SSH remote script failed (exit=1, phase=remote_agent_fix)
+STDOUT:
+{"type":"error","message":"{\\"error\\":{\\"message\\":\\"Model unavailable\\"}}"}`);
+    expect(text).toBe('Model unavailable');
+  });
+});
+
+describe('resolveHeadlessExecCommand', () => {
+  it('returns the CLI subcommand from headless.exec payload', () => {
+    expect(resolveHeadlessExecCommand([{ args: ['fix', 'wf-1/task-alpha'] }])).toBe('fix');
+  });
+});

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -1738,6 +1738,52 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(Number.isFinite(Date.parse(event.failedAt))).toBe(true);
   });
 
+  it('emits headless.exec task metadata and banner-safe messages without stack traces', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    adapter.saveTask('wf-1', makeTask('wf-1/task-alpha'));
+
+    const failureEvents: Array<{
+      taskId?: string;
+      headlessCommand?: string;
+      message: string;
+    }> = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async () => {
+        const err = new Error('SSH remote script failed (exit=1, phase=remote_agent_fix)\nSTDOUT:\n{"type":"error"}');
+        err.stack = `${err.message}\n    at createSshRemoteScriptError (/tmp/main.js:1:1)`;
+        throw err;
+      },
+      {
+        onIntentFailed: (event) => {
+          failureEvents.push(event);
+        },
+      },
+    );
+
+    const attempt = coordinator.enqueue<void>('wf-1', 'normal', 'headless.exec', [{
+      args: ['fix', 'wf-1/task-alpha', 'codex'],
+      noTrack: true,
+    }]);
+    await expect(attempt).rejects.toThrow(/SSH remote script failed/);
+
+    expect(failureEvents).toHaveLength(1);
+    const [event] = failureEvents;
+    expect(event.taskId).toBe('wf-1/task-alpha');
+    expect(event.headlessCommand).toBe('fix');
+    expect(event.message).toContain('SSH remote script failed');
+    expect(event.message).not.toContain('createSshRemoteScriptError');
+  });
+
   it('leaves onIntentFailed out of the successful-completion path', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);

--- a/packages/app/src/mutation-failure-message.ts
+++ b/packages/app/src/mutation-failure-message.ts
@@ -1,0 +1,42 @@
+import { extractLegibleAgentFailure, resolveHeadlessExecTaskId } from '@invoker/execution-engine';
+
+const BANNER_MESSAGE_MAX_LEN = 160;
+
+export function resolveHeadlessExecCommand(args: unknown[]): string | undefined {
+  const payload = args[0] as { args?: unknown[] } | undefined;
+  const rawArgs = Array.isArray(payload?.args) ? payload.args : [];
+  const command = typeof rawArgs[0] === 'string' ? rawArgs[0] : undefined;
+  return command || undefined;
+}
+
+export function resolveMutationFailureTaskId(channel: string, args: unknown[]): string | undefined {
+  if (channel === 'headless.exec') {
+    return resolveHeadlessExecTaskId(args);
+  }
+  const firstArg = args[0];
+  return typeof firstArg === 'string' ? firstArg : undefined;
+}
+
+export function summarizeMutationFailureMessage(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  return summarizeMutationFailureText(raw);
+}
+
+export function summarizeMutationFailureText(raw: string): string {
+  let message = raw.replace(/^Error:\s*/, '').trim();
+  const stackIdx = message.indexOf('\n    at ');
+  if (stackIdx >= 0) {
+    message = message.slice(0, stackIdx).trim();
+  }
+
+  const legible = extractLegibleAgentFailure(message);
+  if (legible) return truncateBannerMessage(legible);
+
+  const firstLine = message.split('\n').find((line) => line.trim().length > 0)?.trim() ?? message;
+  return truncateBannerMessage(firstLine);
+}
+
+function truncateBannerMessage(message: string): string {
+  if (message.length <= BANNER_MESSAGE_MAX_LEN) return message;
+  return `${message.slice(0, BANNER_MESSAGE_MAX_LEN - 1).trimEnd()}…`;
+}

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -7,6 +7,10 @@ import {
 import type { Logger, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import { resolveHeadlessTarget } from './headless-command-classification.js';
 import { createWorkflowMutationTiming, type WorkflowMutationTiming } from './workflow-mutation-timing.js';
+import {
+  resolveHeadlessExecCommand,
+  summarizeMutationFailureMessage,
+} from './mutation-failure-message.js';
 
 export type WorkflowMutationFailedHandler = (event: WorkflowMutationFailedEvent) => void;
 
@@ -370,7 +374,7 @@ export class PersistedWorkflowMutationCoordinator {
       });
       deferred?.resolve(result);
     } catch (error) {
-      const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+      const message = summarizeMutationFailureMessage(error);
       const latestIntent = this.persistence.loadWorkflowMutationIntent(intent.id);
       if (latestIntent?.status === 'running') {
         this.persistence.failWorkflowMutationIntent(intent.id, message);
@@ -541,6 +545,9 @@ export class PersistedWorkflowMutationCoordinator {
   }
 
   private notifyIntentFailed(intent: WorkflowMutationIntent, message: string): void {
+    const headlessCommand = intent.channel === 'headless.exec'
+      ? resolveHeadlessExecCommand(intent.args ?? [])
+      : undefined;
     const event = compactFailedEvent({
       workflowId: intent.workflowId,
       intentId: intent.id,
@@ -548,6 +555,7 @@ export class PersistedWorkflowMutationCoordinator {
       message,
       failedAt: new Date().toISOString(),
       taskId: this.resolveIntentFailureTaskId(intent),
+      headlessCommand,
     });
     try {
       this.options?.onIntentFailed?.(event);

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -22,7 +22,7 @@ import {
   parseMergeConflictError,
 } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import { DEFAULT_EXECUTION_AGENT, type TaskRunner, type ReviewGateCiFailureTrigger } from '@invoker/execution-engine';
+import { DEFAULT_EXECUTION_AGENT, type TaskRunner, type ReviewGateCiFailureTrigger, formatAgentFailureForTask } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import {
   isReviewGateCiContextStale,
@@ -845,7 +845,7 @@ export async function resolveConflictAction(
     return await finalizeAppliedFix(taskId, savedError, deps, signal, lineage);
   } catch (err) {
     if (err instanceof StaleLineageError) throw err;
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = formatAgentFailureForTask(err);
     assertLineageCurrent(lineage, orchestrator, signal);
     persistence.appendTaskOutput(taskId, `\n[Resolve Conflict] Failed: ${msg}`);
     assertLineageCurrent(lineage, orchestrator, signal);
@@ -950,7 +950,7 @@ export async function fixWithAgentAction(
     };
   } catch (err) {
     if (err instanceof StaleLineageError) throw err;
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = formatAgentFailureForTask(err);
     const errorLabel = options.failureOutputLabel
       ?? (recoveryRoute.kind === 'resolveConflict' ? 'Resolve Conflict' : `Fix with ${effectiveAgentName}`);
     assertLineageCurrent(lineage, orchestrator, options.signal);
@@ -1343,7 +1343,7 @@ export async function autoFixOnFailure(
     if (runnable.length > 0) await taskExecutor.executeTasks(runnable);
   } catch (err) {
     if (err instanceof StaleLineageError) throw err;
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = formatAgentFailureForTask(err);
     const diagnostics = formatAutoFixDiagnostics(err);
     if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -490,6 +490,8 @@ export interface WorkflowMutationFailedEvent {
   workflowId: string;
   channel: string;
   taskId?: string;
+  /** Present for headless.exec failures — the CLI subcommand (e.g. fix, approve). */
+  headlessCommand?: string;
   message: string;
   failedAt: string;
 }

--- a/packages/execution-engine/src/__tests__/remote-agent-error-format.test.ts
+++ b/packages/execution-engine/src/__tests__/remote-agent-error-format.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractLegibleAgentFailure,
+  formatRemoteAgentFailureForTask,
+} from '../remote-agent-error-format.js';
+
+const nestedAgentError = JSON.stringify({
+  type: 'error',
+  status: 400,
+  error: {
+    type: 'invalid_request_error',
+    message: "The 'claude' model is not supported when using Codex with a ChatGPT account.",
+  },
+});
+
+const SSH_FIX_FAILURE = `SSH remote script failed (exit=1, phase=remote_agent_fix)
+STDERR:
+Reading additional input from stdin...
+STDOUT:
+{"type":"thread.started","thread_id":"019f45d7-61f0-74a1-a604-7b2aa94a9d1f"}
+{"type":"turn.started"}
+${JSON.stringify({ type: 'error', message: nestedAgentError })}
+${JSON.stringify({ type: 'turn.failed', error: { message: nestedAgentError } })}`;
+
+describe('extractLegibleAgentFailure', () => {
+  it('extracts nested JSON error messages from SSH stdout JSONL', () => {
+    expect(extractLegibleAgentFailure(SSH_FIX_FAILURE)).toBe(
+      "The 'claude' model is not supported when using Codex with a ChatGPT account.",
+    );
+  });
+
+  it('returns undefined when no agent error is present', () => {
+    expect(extractLegibleAgentFailure('plain command failed')).toBeUndefined();
+  });
+});
+
+describe('formatRemoteAgentFailureForTask', () => {
+  it('keeps SSH header and replaces JSONL dump with legible agent error', () => {
+    const formatted = formatRemoteAgentFailureForTask(SSH_FIX_FAILURE);
+    expect(formatted).toContain('SSH remote script failed (exit=1, phase=remote_agent_fix)');
+    expect(formatted).toContain("The 'claude' model is not supported when using Codex with a ChatGPT account.");
+    expect(formatted).not.toContain('thread.started');
+  });
+
+  it('strips stack traces from the stored task error', () => {
+    const withStack = `${SSH_FIX_FAILURE}\n    at createSshRemoteScriptError (/tmp/main.js:1:1)`;
+    const formatted = formatRemoteAgentFailureForTask(withStack);
+    expect(formatted).not.toContain('createSshRemoteScriptError');
+  });
+});

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -44,6 +44,7 @@ export * from './review-provider-registry.js';
 export * from './agents/index.js';
 export * from './plan-execution-agents.js';
 export * from './codex-session.js';
+export * from './remote-agent-error-format.js';
 export * from './session-driver.js';
 export * from './codex-session-driver.js';
 export * from './claude-session-driver.js';

--- a/packages/execution-engine/src/remote-agent-error-format.ts
+++ b/packages/execution-engine/src/remote-agent-error-format.ts
@@ -1,0 +1,124 @@
+const TASK_SCOPED_HEADLESS_COMMANDS = new Set([
+  'approve',
+  'reject',
+  'fix',
+  'resolve-conflict',
+  'cancel',
+  'retry-task',
+  'recreate-task',
+  'delete-task',
+  'select',
+  'input',
+]);
+
+const TASK_SCOPED_SET_SUBCOMMANDS = new Set([
+  'command',
+  'prompt',
+  'executor',
+  'agent',
+  'fix-prompt',
+  'fix-context',
+  'gate-policy',
+  'task',
+  'model',
+]);
+
+function unwrapNestedJsonMessage(raw: unknown): string | undefined {
+  if (typeof raw !== 'string' || !raw.trim()) return undefined;
+  let current: unknown = raw;
+  for (let depth = 0; depth < 3; depth += 1) {
+    if (typeof current !== 'string') break;
+    const trimmed = current.trim();
+    if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+      return trimmed;
+    }
+    try {
+      current = JSON.parse(trimmed);
+    } catch {
+      return trimmed;
+    }
+  }
+  if (typeof current === 'object' && current !== null) {
+    const record = current as Record<string, unknown>;
+    const nestedError = record.error;
+    if (typeof nestedError === 'object' && nestedError !== null) {
+      const message = (nestedError as Record<string, unknown>).message;
+      if (typeof message === 'string' && message.trim()) return message.trim();
+    }
+    const message = record.message;
+    if (typeof message === 'string' && message.trim()) return message.trim();
+  }
+  return typeof raw === 'string' ? raw.trim() : undefined;
+}
+
+function extractMessageFromJsonLine(line: string): string | undefined {
+  try {
+    const entry = JSON.parse(line) as Record<string, unknown>;
+    if (entry.type === 'error' && entry.message !== undefined) {
+      return unwrapNestedJsonMessage(entry.message);
+    }
+    if (entry.type === 'turn.failed') {
+      const turnError = entry.error;
+      if (typeof turnError === 'object' && turnError !== null) {
+        return unwrapNestedJsonMessage((turnError as Record<string, unknown>).message);
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function stdoutSection(raw: string): string | undefined {
+  const marker = 'STDOUT:';
+  const idx = raw.indexOf(marker);
+  if (idx < 0) return undefined;
+  return raw.slice(idx + marker.length).replace(/^\n+/, '');
+}
+
+export function extractLegibleAgentFailure(raw: string): string | undefined {
+  const section = stdoutSection(raw) ?? raw;
+  for (const line of section.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{')) continue;
+    const message = extractMessageFromJsonLine(trimmed);
+    if (message) return message;
+  }
+  return undefined;
+}
+
+export function formatRemoteAgentFailureForTask(raw: string): string {
+  const stackIdx = raw.indexOf('\n    at ');
+  const withoutStack = stackIdx >= 0 ? raw.slice(0, stackIdx) : raw;
+  const legible = extractLegibleAgentFailure(withoutStack);
+  if (!legible) return withoutStack.trim();
+
+  const header = withoutStack.split('\n')[0]?.trim() ?? 'Remote agent fix failed';
+  return `${header}\n${legible}`;
+}
+
+export function formatAgentFailureForTask(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  return formatRemoteAgentFailureForTask(raw);
+}
+
+export function resolveHeadlessExecTaskId(args: unknown[]): string | undefined {
+  const payload = args[0] as { args?: unknown[] } | undefined;
+  const rawArgs = Array.isArray(payload?.args) ? payload.args : [];
+  const command = typeof rawArgs[0] === 'string' ? rawArgs[0] : '';
+  if (!command) return undefined;
+
+  if (TASK_SCOPED_HEADLESS_COMMANDS.has(command)) {
+    const target = typeof rawArgs[1] === 'string' ? rawArgs[1] : '';
+    return target.includes('/') ? target : undefined;
+  }
+
+  if (command === 'set') {
+    const subCommand = typeof rawArgs[1] === 'string' ? rawArgs[1] : '';
+    if (!TASK_SCOPED_SET_SUBCOMMANDS.has(subCommand)) return undefined;
+    const target = typeof rawArgs[2] === 'string' ? rawArgs[2] : '';
+    return target.includes('/') ? target : undefined;
+  }
+
+  return undefined;
+}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -14,6 +14,11 @@ import yaml from 'js-yaml';
 import type { ActionGraphNode, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
+import {
+  mutationFailureBannerMessage,
+  mutationFailureHasTaskTarget,
+  mutationFailureTitle,
+} from './lib/mutation-failure-display.js';
 import { useTasks } from './hooks/useTasks.js';
 import { useQueueStatus } from './hooks/useQueueStatus.js';
 import { useWorkerStatus } from './hooks/useWorkerStatus.js';
@@ -3049,7 +3054,9 @@ export function App() {
           This window can browse workflows, but it cannot make changes until the write owner is available.
         </div>
       )}
-      {mutationFailure && (
+      {mutationFailure && (() => {
+        const taskLoaded = Boolean(mutationFailure.taskId && tasks.get(mutationFailure.taskId));
+        return (
         <div
           role="alert"
           aria-live="assertive"
@@ -3058,21 +3065,17 @@ export function App() {
         >
           <div className="text-sm text-amber-100 min-w-0">
             <div className="font-semibold text-amber-50">
-              {mutationFailure.channel === 'invoker:approve'
-                ? 'Approve failed'
-                : mutationFailure.channel === 'invoker:reject'
-                  ? 'Reject failed'
-                  : `Mutation failed (${mutationFailure.channel})`}
+              {mutationFailureTitle(mutationFailure)}
             </div>
             <div
               data-testid="workflow-mutation-failed-message"
-              className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-amber-100/90"
+              className={`mt-1 whitespace-pre-wrap break-words text-xs text-amber-100/90${mutationFailureHasTaskTarget(mutationFailure) ? '' : ' font-mono'}`}
             >
-              {mutationFailure.message}
+              {mutationFailureBannerMessage(mutationFailure)}
             </div>
           </div>
           <div className="flex items-center gap-2 shrink-0">
-            {mutationFailure.taskId && tasks.get(mutationFailure.taskId) && (
+            {mutationFailure.taskId && taskLoaded && (
               <Button
                 size="sm"
                 data-testid="workflow-mutation-failed-open-task"
@@ -3098,7 +3101,8 @@ export function App() {
             </Button>
           </div>
         </div>
-      )}
+        );
+      })()}
 
 
       {/* Main content */}

--- a/packages/ui/src/__tests__/mutation-failure-display.test.ts
+++ b/packages/ui/src/__tests__/mutation-failure-display.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mutationFailureBannerMessage,
+  mutationFailureHasTaskTarget,
+  mutationFailureTitle,
+} from '../lib/mutation-failure-display.js';
+
+describe('mutationFailureTitle', () => {
+  it('maps headless fix failures to a friendly title', () => {
+    expect(mutationFailureTitle({
+      intentId: 1,
+      workflowId: 'wf-1',
+      channel: 'headless.exec',
+      headlessCommand: 'fix',
+      message: 'boom',
+      failedAt: '2026-07-09T00:00:00.000Z',
+    })).toBe('Fix failed');
+  });
+});
+
+describe('mutationFailureBannerMessage', () => {
+  it('shows a task-panel hint instead of verbose errors when the task is loaded', () => {
+    const event = {
+      intentId: 1,
+      workflowId: 'wf-1',
+      channel: 'headless.exec',
+      headlessCommand: 'fix',
+      taskId: 'wf-1/task-alpha',
+      message: 'SSH remote script failed\nSTDOUT:\n{"type":"error"}',
+      failedAt: '2026-07-09T00:00:00.000Z',
+    };
+    expect(mutationFailureHasTaskTarget(event)).toBe(true);
+    expect(mutationFailureBannerMessage(event)).toBe('See the task panel for details.');
+  });
+});

--- a/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
+++ b/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
@@ -67,8 +67,32 @@ describe('Workflow mutation failed banner', () => {
     expect(banner).toHaveAttribute('role', 'alert');
     expect(banner).toHaveTextContent('Approve failed');
     expect(screen.getByTestId('workflow-mutation-failed-message')).toHaveTextContent(
-      /missing execution harness "codex"/,
+      /See the task panel for details/,
     );
+  });
+
+  it('does not dump verbose SSH output into the banner for headless fix failures', async () => {
+    render(<App />);
+    act(() => mock.setTasks([targetTask], [workflow]));
+
+    act(() => {
+      mock.fireWorkflowMutationFailed({
+        intentId: 46,
+        workflowId: 'wf-1',
+        channel: 'headless.exec',
+        headlessCommand: 'fix',
+        taskId: 'wf-1/verify-worker-summary-surface',
+        message: 'SSH remote script failed (exit=1, phase=remote_agent_fix)\nSTDOUT:\n{"type":"thread.started"}\n{"type":"error","message":"model unsupported"}',
+        failedAt: '2026-07-08T10:00:00.000Z',
+      });
+    });
+
+    const banner = await screen.findByTestId('workflow-mutation-failed-banner');
+    expect(banner).toHaveTextContent('Fix failed');
+    expect(screen.getByTestId('workflow-mutation-failed-message')).toHaveTextContent(
+      /See the task panel for details/,
+    );
+    expect(banner).not.toHaveTextContent('thread.started');
   });
 
   it('clears the banner when Dismiss is clicked', async () => {

--- a/packages/ui/src/lib/mutation-failure-display.ts
+++ b/packages/ui/src/lib/mutation-failure-display.ts
@@ -1,0 +1,47 @@
+import type { WorkflowMutationFailedEvent } from '@invoker/contracts';
+
+const HEADLESS_COMMAND_LABELS: Record<string, string> = {
+  fix: 'Fix failed',
+  approve: 'Approve failed',
+  reject: 'Reject failed',
+  'resolve-conflict': 'Resolve conflict failed',
+  cancel: 'Cancel failed',
+  'retry-task': 'Retry failed',
+  'recreate-task': 'Recreate task failed',
+  'delete-task': 'Delete task failed',
+};
+
+export function mutationFailureTitle(event: WorkflowMutationFailedEvent): string {
+  if (event.channel === 'invoker:approve') return 'Approve failed';
+  if (event.channel === 'invoker:reject') return 'Reject failed';
+  if (event.channel === 'invoker:fix-with-agent') return 'Fix failed';
+  if (event.headlessCommand) {
+    const label = HEADLESS_COMMAND_LABELS[event.headlessCommand];
+    if (label) return label;
+  }
+  return `Mutation failed (${event.channel})`;
+}
+
+export function mutationFailureHasTaskTarget(
+  event: WorkflowMutationFailedEvent,
+): boolean {
+  return Boolean(event.taskId);
+}
+
+export function mutationFailureBannerMessage(
+  event: WorkflowMutationFailedEvent,
+): string {
+  if (mutationFailureHasTaskTarget(event)) {
+    return 'See the task panel for details.';
+  }
+  return summarizeBannerMessage(event.message);
+}
+
+function summarizeBannerMessage(message: string): string {
+  let text = message.replace(/^Error:\s*/, '').trim();
+  const stackIdx = text.indexOf('\n    at ');
+  if (stackIdx >= 0) text = text.slice(0, stackIdx).trim();
+  const firstLine = text.split('\n').find((line) => line.trim().length > 0)?.trim() ?? text;
+  if (firstLine.length <= 160) return firstLine;
+  return `${firstLine.slice(0, 159).trimEnd()}…`;
+}


### PR DESCRIPTION
Summarize coordinator failure messages for the banner, surface legible agent errors on the task, and point operators to the task panel for details.

Co-authored-by: Cursor <cursoragent@cursor.com>