### PR TITLE
[Mutation Failure Context Enrichment](2c) Keep task and workflow failures out of the top banner

### DIFF
--- a/packages/app/src/__tests__/mutation-failure-message.test.ts
+++ b/packages/app/src/__tests__/mutation-failure-message.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveHeadlessExecCommand,
+  resolveMutationFailureTaskId,
+  summarizeMutationFailureMessage,
+  summarizeMutationFailureText,
+} from '../mutation-failure-message.js';
+
+describe('resolveMutationFailureTaskId', () => {
+  it('extracts task id from headless.exec fix payload', () => {
+    expect(resolveMutationFailureTaskId('headless.exec', [{
+      args: ['fix', 'wf-1/task-alpha', 'codex'],
+      noTrack: true,
+    }])).toBe('wf-1/task-alpha');
+  });
+
+  it('extracts task id from invoker:approve args', () => {
+    expect(resolveMutationFailureTaskId('invoker:approve', ['wf-1/task-alpha'])).toBe('wf-1/task-alpha');
+  });
+});
+
+describe('summarizeMutationFailureMessage', () => {
+  it('uses error.message only and strips stack traces', () => {
+    const err = new Error('SSH remote script failed (exit=1)\nSTDOUT:\n{"type":"error"}');
+    err.stack = `${err.message}\n    at createSshRemoteScriptError (/tmp/main.js:1:1)`;
+    expect(summarizeMutationFailureMessage(err)).not.toContain('createSshRemoteScriptError');
+    expect(summarizeMutationFailureMessage(err)).toContain('SSH remote script failed');
+  });
+
+  it('prefers legible nested agent errors over raw stdout', () => {
+    const text = summarizeMutationFailureText(`SSH remote script failed (exit=1, phase=remote_agent_fix)
+STDOUT:
+{"type":"error","message":"{\\"error\\":{\\"message\\":\\"Model unavailable\\"}}"}`);
+    expect(text).toBe('Model unavailable');
+  });
+});
+
+describe('resolveHeadlessExecCommand', () => {
+  it('returns the CLI subcommand from headless.exec payload', () => {
+    expect(resolveHeadlessExecCommand([{ args: ['fix', 'wf-1/task-alpha'] }])).toBe('fix');
+  });
+});

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -1738,6 +1738,52 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(Number.isFinite(Date.parse(event.failedAt))).toBe(true);
   });
 
+  it('emits headless.exec task metadata and banner-safe messages without stack traces', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    adapter.saveTask('wf-1', makeTask('wf-1/task-alpha'));
+
+    const failureEvents: Array<{
+      taskId?: string;
+      headlessCommand?: string;
+      message: string;
+    }> = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async () => {
+        const err = new Error('SSH remote script failed (exit=1, phase=remote_agent_fix)\nSTDOUT:\n{"type":"error"}');
+        err.stack = `${err.message}\n    at createSshRemoteScriptError (/tmp/main.js:1:1)`;
+        throw err;
+      },
+      {
+        onIntentFailed: (event) => {
+          failureEvents.push(event);
+        },
+      },
+    );
+
+    const attempt = coordinator.enqueue<void>('wf-1', 'normal', 'headless.exec', [{
+      args: ['fix', 'wf-1/task-alpha', 'codex'],
+      noTrack: true,
+    }]);
+    await expect(attempt).rejects.toThrow(/SSH remote script failed/);
+
+    expect(failureEvents).toHaveLength(1);
+    const [event] = failureEvents;
+    expect(event.taskId).toBe('wf-1/task-alpha');
+    expect(event.headlessCommand).toBe('fix');
+    expect(event.message).toContain('SSH remote script failed');
+    expect(event.message).not.toContain('createSshRemoteScriptError');
+  });
+
   it('leaves onIntentFailed out of the successful-completion path', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);

--- a/packages/app/src/mutation-failure-message.ts
+++ b/packages/app/src/mutation-failure-message.ts
@@ -1,0 +1,42 @@
+import { extractLegibleAgentFailure, resolveHeadlessExecTaskId } from '@invoker/execution-engine';
+
+const BANNER_MESSAGE_MAX_LEN = 160;
+
+export function resolveHeadlessExecCommand(args: unknown[]): string | undefined {
+  const payload = args[0] as { args?: unknown[] } | undefined;
+  const rawArgs = Array.isArray(payload?.args) ? payload.args : [];
+  const command = typeof rawArgs[0] === 'string' ? rawArgs[0] : undefined;
+  return command || undefined;
+}
+
+export function resolveMutationFailureTaskId(channel: string, args: unknown[]): string | undefined {
+  if (channel === 'headless.exec') {
+    return resolveHeadlessExecTaskId(args);
+  }
+  const firstArg = args[0];
+  return typeof firstArg === 'string' ? firstArg : undefined;
+}
+
+export function summarizeMutationFailureMessage(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  return summarizeMutationFailureText(raw);
+}
+
+export function summarizeMutationFailureText(raw: string): string {
+  let message = raw.replace(/^Error:\s*/, '').trim();
+  const stackIdx = message.indexOf('\n    at ');
+  if (stackIdx >= 0) {
+    message = message.slice(0, stackIdx).trim();
+  }
+
+  const legible = extractLegibleAgentFailure(message);
+  if (legible) return truncateBannerMessage(legible);
+
+  const firstLine = message.split('\n').find((line) => line.trim().length > 0)?.trim() ?? message;
+  return truncateBannerMessage(firstLine);
+}
+
+function truncateBannerMessage(message: string): string {
+  if (message.length <= BANNER_MESSAGE_MAX_LEN) return message;
+  return `${message.slice(0, BANNER_MESSAGE_MAX_LEN - 1).trimEnd()}…`;
+}

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -7,6 +7,10 @@ import {
 import type { Logger, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import { resolveHeadlessTarget } from './headless-command-classification.js';
 import { createWorkflowMutationTiming, type WorkflowMutationTiming } from './workflow-mutation-timing.js';
+import {
+  resolveHeadlessExecCommand,
+  summarizeMutationFailureMessage,
+} from './mutation-failure-message.js';
 
 export type WorkflowMutationFailedHandler = (event: WorkflowMutationFailedEvent) => void;
 
@@ -370,7 +374,7 @@ export class PersistedWorkflowMutationCoordinator {
       });
       deferred?.resolve(result);
     } catch (error) {
-      const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+      const message = summarizeMutationFailureMessage(error);
       const latestIntent = this.persistence.loadWorkflowMutationIntent(intent.id);
       if (latestIntent?.status === 'running') {
         this.persistence.failWorkflowMutationIntent(intent.id, message);
@@ -541,6 +545,9 @@ export class PersistedWorkflowMutationCoordinator {
   }
 
   private notifyIntentFailed(intent: WorkflowMutationIntent, message: string): void {
+    const headlessCommand = intent.channel === 'headless.exec'
+      ? resolveHeadlessExecCommand(intent.args ?? [])
+      : undefined;
     const event = compactFailedEvent({
       workflowId: intent.workflowId,
       intentId: intent.id,
@@ -548,6 +555,7 @@ export class PersistedWorkflowMutationCoordinator {
       message,
       failedAt: new Date().toISOString(),
       taskId: this.resolveIntentFailureTaskId(intent),
+      headlessCommand,
     });
     try {
       this.options?.onIntentFailed?.(event);

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -22,7 +22,7 @@ import {
   parseMergeConflictError,
 } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import { DEFAULT_EXECUTION_AGENT, type TaskRunner, type ReviewGateCiFailureTrigger } from '@invoker/execution-engine';
+import { DEFAULT_EXECUTION_AGENT, type TaskRunner, type ReviewGateCiFailureTrigger, formatAgentFailureForTask } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import {
   isReviewGateCiContextStale,
@@ -845,7 +845,7 @@ export async function resolveConflictAction(
     return await finalizeAppliedFix(taskId, savedError, deps, signal, lineage);
   } catch (err) {
     if (err instanceof StaleLineageError) throw err;
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = formatAgentFailureForTask(err);
     assertLineageCurrent(lineage, orchestrator, signal);
     persistence.appendTaskOutput(taskId, `\n[Resolve Conflict] Failed: ${msg}`);
     assertLineageCurrent(lineage, orchestrator, signal);
@@ -950,7 +950,7 @@ export async function fixWithAgentAction(
     };
   } catch (err) {
     if (err instanceof StaleLineageError) throw err;
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = formatAgentFailureForTask(err);
     const errorLabel = options.failureOutputLabel
       ?? (recoveryRoute.kind === 'resolveConflict' ? 'Resolve Conflict' : `Fix with ${effectiveAgentName}`);
     assertLineageCurrent(lineage, orchestrator, options.signal);
@@ -1343,7 +1343,7 @@ export async function autoFixOnFailure(
     if (runnable.length > 0) await taskExecutor.executeTasks(runnable);
   } catch (err) {
     if (err instanceof StaleLineageError) throw err;
-    const msg = err instanceof Error ? err.message : String(err);
+    const msg = formatAgentFailureForTask(err);
     const diagnostics = formatAutoFixDiagnostics(err);
     if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {

--- a/packages/execution-engine/src/__tests__/remote-agent-error-format.test.ts
+++ b/packages/execution-engine/src/__tests__/remote-agent-error-format.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractLegibleAgentFailure,
+  formatRemoteAgentFailureForTask,
+} from '../remote-agent-error-format.js';
+
+const nestedAgentError = JSON.stringify({
+  type: 'error',
+  status: 400,
+  error: {
+    type: 'invalid_request_error',
+    message: "The 'claude' model is not supported when using Codex with a ChatGPT account.",
+  },
+});
+
+const SSH_FIX_FAILURE = `SSH remote script failed (exit=1, phase=remote_agent_fix)
+STDERR:
+Reading additional input from stdin...
+STDOUT:
+{"type":"thread.started","thread_id":"019f45d7-61f0-74a1-a604-7b2aa94a9d1f"}
+{"type":"turn.started"}
+${JSON.stringify({ type: 'error', message: nestedAgentError })}
+${JSON.stringify({ type: 'turn.failed', error: { message: nestedAgentError } })}`;
+
+describe('extractLegibleAgentFailure', () => {
+  it('extracts nested JSON error messages from SSH stdout JSONL', () => {
+    expect(extractLegibleAgentFailure(SSH_FIX_FAILURE)).toBe(
+      "The 'claude' model is not supported when using Codex with a ChatGPT account.",
+    );
+  });
+
+  it('returns undefined when no agent error is present', () => {
+    expect(extractLegibleAgentFailure('plain command failed')).toBeUndefined();
+  });
+});
+
+describe('formatRemoteAgentFailureForTask', () => {
+  it('keeps SSH header and replaces JSONL dump with legible agent error', () => {
+    const formatted = formatRemoteAgentFailureForTask(SSH_FIX_FAILURE);
+    expect(formatted).toContain('SSH remote script failed (exit=1, phase=remote_agent_fix)');
+    expect(formatted).toContain("The 'claude' model is not supported when using Codex with a ChatGPT account.");
+    expect(formatted).not.toContain('thread.started');
+  });
+
+  it('strips stack traces from the stored task error', () => {
+    const withStack = `${SSH_FIX_FAILURE}\n    at createSshRemoteScriptError (/tmp/main.js:1:1)`;
+    const formatted = formatRemoteAgentFailureForTask(withStack);
+    expect(formatted).not.toContain('createSshRemoteScriptError');
+  });
+});

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -44,6 +44,7 @@ export * from './review-provider-registry.js';
 export * from './agents/index.js';
 export * from './plan-execution-agents.js';
 export * from './codex-session.js';
+export * from './remote-agent-error-format.js';
 export * from './session-driver.js';
 export * from './codex-session-driver.js';
 export * from './claude-session-driver.js';

--- a/packages/execution-engine/src/remote-agent-error-format.ts
+++ b/packages/execution-engine/src/remote-agent-error-format.ts
@@ -1,0 +1,124 @@
+const TASK_SCOPED_HEADLESS_COMMANDS = new Set([
+  'approve',
+  'reject',
+  'fix',
+  'resolve-conflict',
+  'cancel',
+  'retry-task',
+  'recreate-task',
+  'delete-task',
+  'select',
+  'input',
+]);
+
+const TASK_SCOPED_SET_SUBCOMMANDS = new Set([
+  'command',
+  'prompt',
+  'executor',
+  'agent',
+  'fix-prompt',
+  'fix-context',
+  'gate-policy',
+  'task',
+  'model',
+]);
+
+function unwrapNestedJsonMessage(raw: unknown): string | undefined {
+  if (typeof raw !== 'string' || !raw.trim()) return undefined;
+  let current: unknown = raw;
+  for (let depth = 0; depth < 3; depth += 1) {
+    if (typeof current !== 'string') break;
+    const trimmed = current.trim();
+    if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+      return trimmed;
+    }
+    try {
+      current = JSON.parse(trimmed);
+    } catch {
+      return trimmed;
+    }
+  }
+  if (typeof current === 'object' && current !== null) {
+    const record = current as Record<string, unknown>;
+    const nestedError = record.error;
+    if (typeof nestedError === 'object' && nestedError !== null) {
+      const message = (nestedError as Record<string, unknown>).message;
+      if (typeof message === 'string' && message.trim()) return message.trim();
+    }
+    const message = record.message;
+    if (typeof message === 'string' && message.trim()) return message.trim();
+  }
+  return typeof raw === 'string' ? raw.trim() : undefined;
+}
+
+function extractMessageFromJsonLine(line: string): string | undefined {
+  try {
+    const entry = JSON.parse(line) as Record<string, unknown>;
+    if (entry.type === 'error' && entry.message !== undefined) {
+      return unwrapNestedJsonMessage(entry.message);
+    }
+    if (entry.type === 'turn.failed') {
+      const turnError = entry.error;
+      if (typeof turnError === 'object' && turnError !== null) {
+        return unwrapNestedJsonMessage((turnError as Record<string, unknown>).message);
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function stdoutSection(raw: string): string | undefined {
+  const marker = 'STDOUT:';
+  const idx = raw.indexOf(marker);
+  if (idx < 0) return undefined;
+  return raw.slice(idx + marker.length).replace(/^\n+/, '');
+}
+
+export function extractLegibleAgentFailure(raw: string): string | undefined {
+  const section = stdoutSection(raw) ?? raw;
+  for (const line of section.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{')) continue;
+    const message = extractMessageFromJsonLine(trimmed);
+    if (message) return message;
+  }
+  return undefined;
+}
+
+export function formatRemoteAgentFailureForTask(raw: string): string {
+  const stackIdx = raw.indexOf('\n    at ');
+  const withoutStack = stackIdx >= 0 ? raw.slice(0, stackIdx) : raw;
+  const legible = extractLegibleAgentFailure(withoutStack);
+  if (!legible) return withoutStack.trim();
+
+  const header = withoutStack.split('\n')[0]?.trim() ?? 'Remote agent fix failed';
+  return `${header}\n${legible}`;
+}
+
+export function formatAgentFailureForTask(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  return formatRemoteAgentFailureForTask(raw);
+}
+
+export function resolveHeadlessExecTaskId(args: unknown[]): string | undefined {
+  const payload = args[0] as { args?: unknown[] } | undefined;
+  const rawArgs = Array.isArray(payload?.args) ? payload.args : [];
+  const command = typeof rawArgs[0] === 'string' ? rawArgs[0] : '';
+  if (!command) return undefined;
+
+  if (TASK_SCOPED_HEADLESS_COMMANDS.has(command)) {
+    const target = typeof rawArgs[1] === 'string' ? rawArgs[1] : '';
+    return target.includes('/') ? target : undefined;
+  }
+
+  if (command === 'set') {
+    const subCommand = typeof rawArgs[1] === 'string' ? rawArgs[1] : '';
+    if (!TASK_SCOPED_SET_SUBCOMMANDS.has(subCommand)) return undefined;
+    const target = typeof rawArgs[2] === 'string' ? rawArgs[2] : '';
+    return target.includes('/') ? target : undefined;
+  }
+
+  return undefined;
+}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -14,6 +14,11 @@ import yaml from 'js-yaml';
 import type { ActionGraphNode, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
+import {
+  mutationFailureBannerMessage,
+  mutationFailureTitle,
+  shouldShowMutationFailureBanner,
+} from './lib/mutation-failure-display.js';
 import { useTasks } from './hooks/useTasks.js';
 import { useQueueStatus } from './hooks/useQueueStatus.js';
 import { useWorkerStatus } from './hooks/useWorkerStatus.js';
@@ -720,13 +725,6 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    const unsubscribe = window.invoker?.onWorkflowMutationFailed?.((event) => {
-      setMutationFailure(event);
-    });
-    return () => { unsubscribe?.(); };
-  }, []);
-
-  useEffect(() => {
     if (typeof window === 'undefined' || !window.invoker) return;
 
     const shouldEmit = (key: string, minIntervalMs: number): boolean => {
@@ -1058,6 +1056,37 @@ export function App() {
     recenterForSelection('task', task.id);
     focusKeyboardRegion('taskGraph');
   }, [focusKeyboardRegion, recenterForSelection]);
+
+  useEffect(() => {
+    const unsubscribe = window.invoker?.onWorkflowMutationFailed?.((event) => {
+      // Task/workflow mutation failures belong in the task panel, not the top banner.
+      if (!shouldShowMutationFailureBanner(event)) {
+        if (event.taskId) {
+          // Set selection from the event ids directly so the inspector opens even
+          // if the task map has not hydrated this id yet.
+          setSelectedTaskId(event.taskId);
+          setWorkflowSelectionDismissed(false);
+          if (event.workflowId) {
+            setSelectedWorkflowId(event.workflowId);
+          }
+          setContextMenu(null);
+          setWorkflowContextMenu(null);
+          focusKeyboardRegion('taskGraph');
+        } else if (event.workflowId) {
+          setSelectedWorkflowId(event.workflowId);
+          setSelectedTaskId(null);
+          setWorkflowSelectionDismissed(false);
+          setContextMenu(null);
+          setWorkflowContextMenu(null);
+          focusKeyboardRegion('workflowGraph');
+        }
+        setMutationFailure(null);
+        return;
+      }
+      setMutationFailure(event);
+    });
+    return () => { unsubscribe?.(); };
+  }, [focusKeyboardRegion]);
 
   const selectRelativeNode = useCallback((direction: 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight') => {
     const inTaskGraph = keyboardRegion === 'taskGraph';
@@ -3047,35 +3076,16 @@ export function App() {
         >
           <div className="text-sm text-amber-100 min-w-0">
             <div className="font-semibold text-amber-50">
-              {mutationFailure.channel === 'invoker:approve'
-                ? 'Approve failed'
-                : mutationFailure.channel === 'invoker:reject'
-                  ? 'Reject failed'
-                  : `Mutation failed (${mutationFailure.channel})`}
+              {mutationFailureTitle(mutationFailure)}
             </div>
             <div
               data-testid="workflow-mutation-failed-message"
               className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-amber-100/90"
             >
-              {mutationFailure.message}
+              {mutationFailureBannerMessage(mutationFailure)}
             </div>
           </div>
           <div className="flex items-center gap-2 shrink-0">
-            {mutationFailure.taskId && tasks.get(mutationFailure.taskId) && (
-              <Button
-                size="sm"
-                data-testid="workflow-mutation-failed-open-task"
-                className="bg-amber-600 text-white hover:bg-amber-500"
-                onClick={() => {
-                  const targetTaskId = mutationFailure.taskId;
-                  if (!targetTaskId) return;
-                  selectTaskById(targetTaskId);
-                  setMutationFailure(null);
-                }}
-              >
-                Open task
-              </Button>
-            )}
             <Button
               size="sm"
               variant="ghost"

--- a/packages/ui/src/__tests__/mutation-failure-display.test.ts
+++ b/packages/ui/src/__tests__/mutation-failure-display.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mutationFailureBannerMessage,
+  mutationFailureTitle,
+  shouldShowMutationFailureBanner,
+} from '../lib/mutation-failure-display.js';
+
+describe('shouldShowMutationFailureBanner', () => {
+  it('hides the banner for task-scoped failures', () => {
+    expect(shouldShowMutationFailureBanner({
+      intentId: 1,
+      workflowId: 'wf-1',
+      channel: 'headless.exec',
+      headlessCommand: 'fix',
+      taskId: 'wf-1/task-alpha',
+      message: 'SSH remote script failed',
+      failedAt: '2026-07-09T00:00:00.000Z',
+    })).toBe(false);
+  });
+
+  it('hides the banner for workflow-scoped failures', () => {
+    expect(shouldShowMutationFailureBanner({
+      intentId: 1,
+      workflowId: 'wf-1',
+      channel: 'invoker:recreate',
+      message: 'recreate failed',
+      failedAt: '2026-07-09T00:00:00.000Z',
+    })).toBe(false);
+  });
+});
+
+describe('mutationFailureTitle', () => {
+  it('maps headless fix failures to a friendly title', () => {
+    expect(mutationFailureTitle({
+      intentId: 1,
+      workflowId: '',
+      channel: 'headless.exec',
+      headlessCommand: 'fix',
+      message: 'boom',
+      failedAt: '2026-07-09T00:00:00.000Z',
+    })).toBe('Fix failed');
+  });
+});
+
+describe('mutationFailureBannerMessage', () => {
+  it('keeps only a short first-line summary', () => {
+    expect(mutationFailureBannerMessage({
+      intentId: 1,
+      workflowId: '',
+      channel: 'unknown',
+      message: 'SSH remote script failed\nSTDOUT:\n{"type":"error"}',
+      failedAt: '2026-07-09T00:00:00.000Z',
+    })).toBe('SSH remote script failed');
+  });
+});

--- a/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
+++ b/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
@@ -1,10 +1,9 @@
 /**
- * Integration test: workflow-mutation-failed banner in <App />.
+ * Integration test: workflow-mutation-failed handling in <App />.
  *
- * Reproduces the "Approve Fix does nothing" symptom by firing the
- * onWorkflowMutationFailed event that the owner-side coordinator now emits when
- * an intent dispatch throws. The renderer must surface the failure so the user
- * knows the mutation did not actually run.
+ * Task-scoped and workflow-scoped mutation failures must not open the top
+ * banner. Task failures select the task so the right-hand panel can show the
+ * error.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -44,13 +43,21 @@ describe('Workflow mutation failed banner', () => {
     mock.cleanup();
   });
 
-  it('renders an alert with the coordinator message when onWorkflowMutationFailed fires', async () => {
-    render(<App />);
+  async function settleTasks(): Promise<void> {
     act(() => mock.setTasks([targetTask], [workflow]));
-
     await waitFor(() => {
-      expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-1')).toBeInTheDocument();
     });
+    // Open the workflow so task nodes are mounted before mutation-failure selection.
+    fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
+    await waitFor(() => {
+      expect(screen.getByTestId('rf__node-wf-1/verify-worker-summary-surface')).toBeInTheDocument();
+    });
+  }
+
+  it('does not show the banner for task-scoped approve failures and opens the task instead', async () => {
+    render(<App />);
+    await settleTasks();
 
     act(() => {
       mock.fireWorkflowMutationFailed({
@@ -63,60 +70,29 @@ describe('Workflow mutation failed banner', () => {
       });
     });
 
-    const banner = await screen.findByTestId('workflow-mutation-failed-banner');
-    expect(banner).toHaveAttribute('role', 'alert');
-    expect(banner).toHaveTextContent('Approve failed');
-    expect(screen.getByTestId('workflow-mutation-failed-message')).toHaveTextContent(
-      /missing execution harness "codex"/,
-    );
-  });
-
-  it('clears the banner when Dismiss is clicked', async () => {
-    render(<App />);
-    act(() => mock.setTasks([targetTask], [workflow]));
-
-    act(() => {
-      mock.fireWorkflowMutationFailed({
-        intentId: 43,
-        workflowId: 'wf-1',
-        channel: 'invoker:approve',
-        taskId: 'wf-1/verify-worker-summary-surface',
-        message: 'dispatch blew up',
-        failedAt: '2026-07-08T10:00:00.000Z',
-      });
-    });
-
-    const banner = await screen.findByTestId('workflow-mutation-failed-banner');
-    expect(banner).toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId('workflow-mutation-failed-dismiss'));
-
     await waitFor(() => {
       expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
     });
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Verify worker summary surface');
+    });
   });
 
-  it('selects the failing task when the operator clicks Open task', async () => {
+  it('does not show the banner for headless fix failures', async () => {
     render(<App />);
-    act(() => mock.setTasks([targetTask], [workflow]));
-
-    await waitFor(() => {
-      expect(screen.getByTestId('workflow-node-wf-1')).toBeInTheDocument();
-    });
+    await settleTasks();
 
     act(() => {
       mock.fireWorkflowMutationFailed({
-        intentId: 44,
+        intentId: 46,
         workflowId: 'wf-1',
-        channel: 'invoker:approve',
+        channel: 'headless.exec',
+        headlessCommand: 'fix',
         taskId: 'wf-1/verify-worker-summary-surface',
-        message: 'dispatch blew up',
+        message: 'SSH remote script failed (exit=1, phase=remote_agent_fix)\nSTDOUT:\n{"type":"thread.started"}\n{"type":"error","message":"model unsupported"}',
         failedAt: '2026-07-08T10:00:00.000Z',
       });
     });
-
-    const openTask = await screen.findByTestId('workflow-mutation-failed-open-task');
-    fireEvent.click(openTask);
 
     await waitFor(() => {
       expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
@@ -126,22 +102,22 @@ describe('Workflow mutation failed banner', () => {
     });
   });
 
-  it('labels the banner "Mutation failed (invoker:reject)" when the channel is not approve', async () => {
+  it('does not show the banner for workflow-scoped failures', async () => {
     render(<App />);
-    act(() => mock.setTasks([targetTask], [workflow]));
+    await settleTasks();
 
     act(() => {
       mock.fireWorkflowMutationFailed({
-        intentId: 45,
+        intentId: 47,
         workflowId: 'wf-1',
-        channel: 'invoker:edit-task-command',
-        taskId: 'wf-1/verify-worker-summary-surface',
-        message: 'edit failed',
+        channel: 'invoker:recreate',
+        message: 'recreate failed',
         failedAt: '2026-07-08T10:00:00.000Z',
       });
     });
 
-    const banner = await screen.findByTestId('workflow-mutation-failed-banner');
-    expect(banner).toHaveTextContent('Mutation failed (invoker:edit-task-command)');
+    await waitFor(() => {
+      expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/ui/src/lib/mutation-failure-display.ts
+++ b/packages/ui/src/lib/mutation-failure-display.ts
@@ -1,0 +1,39 @@
+import type { WorkflowMutationFailedEvent } from '@invoker/contracts';
+
+/**
+ * Task-scoped and workflow-scoped mutation failures belong in the task panel /
+ * workflow UI, not the top banner. The banner is only for failures with no
+ * task or workflow context to open.
+ */
+export function shouldShowMutationFailureBanner(
+  event: WorkflowMutationFailedEvent,
+): boolean {
+  if (event.taskId) return false;
+  if (event.workflowId) return false;
+  return true;
+}
+
+export function mutationFailureTitle(event: WorkflowMutationFailedEvent): string {
+  if (event.channel === 'invoker:approve') return 'Approve failed';
+  if (event.channel === 'invoker:reject') return 'Reject failed';
+  if (event.channel === 'invoker:fix-with-agent') return 'Fix failed';
+  if (event.headlessCommand === 'fix') return 'Fix failed';
+  if (event.headlessCommand === 'approve') return 'Approve failed';
+  if (event.headlessCommand === 'reject') return 'Reject failed';
+  return `Mutation failed (${event.channel})`;
+}
+
+export function mutationFailureBannerMessage(
+  event: WorkflowMutationFailedEvent,
+): string {
+  return summarizeBannerMessage(event.message);
+}
+
+function summarizeBannerMessage(message: string): string {
+  let text = message.replace(/^Error:\s*/, '').trim();
+  const stackIdx = text.indexOf('\n    at ');
+  if (stackIdx >= 0) text = text.slice(0, stackIdx).trim();
+  const firstLine = text.split('\n').find((line) => line.trim().length > 0)?.trim() ?? text;
+  if (firstLine.length <= 160) return firstLine;
+  return `${firstLine.slice(0, 159).trimEnd()}…`;
+}


### PR DESCRIPTION
## Summary

Task-scoped and workflow-scoped mutation failures no longer open the top banner.

Those failures select the task or workflow so the right-hand inspector can show the error.

The banner remains only for failures with no task or workflow context.

## Review Claim

Task and workflow mutation failures stay out of the top banner and open the inspector instead.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice only changes banner gating and selection on failure events. Mutation dispatch and taskId resolution stay in earlier slices.

## Slice Rationale

UI presentation depends on the earlier event-shape and coordinator emission slices, so it lands last as the operator-facing surface.

## Non-goals

- Does not change mutation dispatch ordering or queue fences.
- Does not persist approve-dispatch failures onto pendingFixError.
- Does not redesign the task panel Error section layout.

## Architecture

### Before

```mermaid
graph TD
    A["Mutation failure event"] --> B["Top banner shows failure message"]
    B --> C["Operator sees alert above the graph"]
```

### After

```mermaid
graph TD
    A["Task or workflow mutation failure"] --> B["No top banner"]
    A --> C["Select task or workflow"]
    C --> D["Inspector shows the failure"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/workflow-mutation-failed-banner.test.tsx src/__tests__/mutation-failure-display.test.ts`

</details>

## Visual Proof

Before/after: verbose top banner disappears; the selected task panel keeps the legible error.

![mutation banner before after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-66ddeb/mutation-banner-before-after.gif)

Before still frame: top banner stuffed with SSH remote script output and stack frames.

![mutation banner before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-66ddeb/mutation-banner-before.png)

After still frame: no top banner; error remains in the task panel.

![mutation banner after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-66ddeb/mutation-banner-after.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit>`
- Post-revert steps: Re-run the focused banner tests.
- Data migration? No

</details>

Depends-On: #3757