### PR TITLE
[Needs Attention perf](1) Stop the panel freezing the UI on click with many tasks

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -38,6 +38,7 @@ import { ActionGraphView } from './components/ActionGraphView.js';
 import { WorkflowStatusChips } from './components/WorkflowStatusChips.js';
 import { TerminalDrawer, type TerminalDrawerState } from './components/TerminalDrawer.js';
 import { LeftStatusColumn } from './components/LeftStatusColumn.js';
+import { BrowserTaskRow, BrowserWorkflowRow } from './components/BrowserListRows.js';
 import { useTheme } from './lib/theme.js';
 import { InvokerTerminal, type InvokerTerminalLine } from './components/InvokerTerminal.js';
 import { Toaster, toast } from 'sonner';
@@ -492,6 +493,8 @@ export function App() {
   const { tasks, workflows, clearTasks, refreshTaskGraph } = useTasks({
     onTaskGraphSnapshotApplied: handleTaskGraphSnapshotApplied,
   });
+  const tasksRef = useRef(tasks);
+  tasksRef.current = tasks;
   const [viewMode, setViewMode] = useState<'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph'>('dag');
   const {
     graph: actionGraph,
@@ -1043,7 +1046,7 @@ export function App() {
   }, [focusKeyboardRegion, recenterForSelection]);
 
   const selectTaskById = useCallback((taskId: string) => {
-    const task = tasks.get(taskId);
+    const task = tasksRef.current.get(taskId);
     if (!task) return;
     setSelectedTaskId(task.id);
     setWorkflowSelectionDismissed(false);
@@ -1054,7 +1057,7 @@ export function App() {
     setWorkflowContextMenu(null);
     recenterForSelection('task', task.id);
     focusKeyboardRegion('taskGraph');
-  }, [focusKeyboardRegion, recenterForSelection, tasks]);
+  }, [focusKeyboardRegion, recenterForSelection]);
 
   const selectRelativeNode = useCallback((direction: 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight') => {
     const inTaskGraph = keyboardRegion === 'taskGraph';
@@ -2730,23 +2733,17 @@ export function App() {
     workflowEntries.length === 0 ? renderBrowserEmptyState('No workflows yet', 'Use the terminal to plan your first run.') : (
       <div className="overflow-y-auto p-3">
         <div className="space-y-1">
-          {workflowEntries.map((entry) => {
-            const selected = selectedWorkflow?.id === entry.workflow.id;
-            return (
-              <button
-                key={entry.workflow.id}
-                type="button"
-                onClick={() => selectWorkflowById(entry.workflow.id)}
-                className={`block w-full rounded-md px-2.5 py-1.5 text-left transition-colors ${selected ? 'bg-accent/60 text-accent-foreground ring-1 ring-border-strong' : 'text-foreground hover:bg-accent/30'}`}
-              >
-                <div className="truncate text-body font-medium">{entry.workflow.name}</div>
-                <div className="mt-0.5 truncate text-caption text-muted-foreground">
-                  {formatWorkflowStatus(entry.workflow.status)}
-                  {entry.taskCount > 0 && ` · ${entry.taskCount} task${entry.taskCount === 1 ? '' : 's'}`}
-                </div>
-              </button>
-            );
-          })}
+          {workflowEntries.map((entry) => (
+            <BrowserWorkflowRow
+              key={entry.workflow.id}
+              workflowId={entry.workflow.id}
+              name={entry.workflow.name}
+              taskCount={entry.taskCount}
+              statusLabel={formatWorkflowStatus(entry.workflow.status)}
+              selected={selectedWorkflow?.id === entry.workflow.id}
+              onSelect={selectWorkflowById}
+            />
+          ))}
         </div>
       </div>
     )
@@ -2756,26 +2753,18 @@ export function App() {
     entries.length === 0 ? renderBrowserEmptyState(emptyTitle, emptyCopy) : (
       <div className="overflow-y-auto p-3">
         <div className="space-y-1">
-          {entries.map((entry) => {
-            const selected = selectedTask?.id === entry.task.id;
-            const accent = tone === 'attention'
-              ? selected ? 'bg-amber-500/15 text-amber-100 ring-1 ring-amber-500/40' : 'text-foreground hover:bg-accent/30'
-              : selected ? 'bg-accent/60 text-accent-foreground ring-1 ring-border-strong' : 'text-foreground hover:bg-accent/30';
-            return (
-              <button
-                key={entry.task.id}
-                type="button"
-                onClick={() => selectTaskById(entry.task.id)}
-                className={`block w-full rounded-md px-2.5 py-1.5 text-left transition-colors ${accent}`}
-              >
-                <div className="truncate text-body font-medium">{entry.task.description || entry.task.id}</div>
-                <div className="mt-0.5 truncate text-caption text-muted-foreground">
-                  {formatTaskStatus(entry.task.status)}
-                  {entry.workflow?.name && ` · ${entry.workflow.name}`}
-                </div>
-              </button>
-            );
-          })}
+          {entries.map((entry) => (
+            <BrowserTaskRow
+              key={entry.task.id}
+              taskId={entry.task.id}
+              title={entry.task.description || entry.task.id}
+              workflowName={entry.workflow?.name}
+              statusLabel={formatTaskStatus(entry.task.status)}
+              tone={tone}
+              selected={selectedTaskId === entry.task.id}
+              onSelect={selectTaskById}
+            />
+          ))}
         </div>
       </div>
     )

--- a/packages/ui/src/__tests__/browser-list-rows.test.tsx
+++ b/packages/ui/src/__tests__/browser-list-rows.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserTaskRow, BrowserWorkflowRow } from '../components/BrowserListRows.js';
+
+describe('BrowserTaskRow', () => {
+  it('renders the title and status·workflow line and reports the task id on click', () => {
+    const onSelect = vi.fn();
+    render(
+      <BrowserTaskRow
+        taskId="wf-1/build"
+        title="Build the thing"
+        workflowName="wf-1"
+        statusLabel="awaiting review"
+        tone="attention"
+        selected={false}
+        onSelect={onSelect}
+      />,
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('Build the thing');
+    expect(button).toHaveTextContent('awaiting review · wf-1');
+
+    fireEvent.click(button);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith('wf-1/build');
+  });
+
+  it('omits the workflow suffix when no workflow name is provided', () => {
+    render(
+      <BrowserTaskRow taskId="t1" title="t" statusLabel="running" tone="running" selected={false} onSelect={() => {}} />,
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('running');
+    expect(button.textContent).not.toContain('·');
+  });
+
+  it('applies the tone-specific selected accent only when selected', () => {
+    const { rerender } = render(
+      <BrowserTaskRow taskId="t1" title="t" statusLabel="s" tone="attention" selected={false} onSelect={() => {}} />,
+    );
+    expect(screen.getByRole('button').className).not.toContain('ring-amber-500/40');
+
+    rerender(
+      <BrowserTaskRow taskId="t1" title="t" statusLabel="s" tone="attention" selected={true} onSelect={() => {}} />,
+    );
+    expect(screen.getByRole('button').className).toContain('ring-amber-500/40');
+  });
+
+  it('is a memo component so unchanged rows bail out of re-render', () => {
+    expect((BrowserTaskRow as { $$typeof?: symbol }).$$typeof).toBe(Symbol.for('react.memo'));
+  });
+});
+
+describe('BrowserWorkflowRow', () => {
+  it('appends a pluralized task count and reports the workflow id on click', () => {
+    const onSelect = vi.fn();
+    const { rerender } = render(
+      <BrowserWorkflowRow workflowId="wf-1" name="My workflow" taskCount={1} statusLabel="running" selected={false} onSelect={onSelect} />,
+    );
+    expect(screen.getByRole('button')).toHaveTextContent('running · 1 task');
+
+    rerender(
+      <BrowserWorkflowRow workflowId="wf-1" name="My workflow" taskCount={3} statusLabel="running" selected={false} onSelect={onSelect} />,
+    );
+    expect(screen.getByRole('button')).toHaveTextContent('running · 3 tasks');
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(onSelect).toHaveBeenCalledWith('wf-1');
+  });
+
+  it('omits the task-count suffix when there are no tasks', () => {
+    render(
+      <BrowserWorkflowRow workflowId="wf-1" name="Empty" taskCount={0} statusLabel="pending" selected={false} onSelect={() => {}} />,
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('pending');
+    expect(button.textContent).not.toContain('·');
+  });
+
+  it('is a memo component so unchanged rows bail out of re-render', () => {
+    expect((BrowserWorkflowRow as { $$typeof?: symbol }).$$typeof).toBe(Symbol.for('react.memo'));
+  });
+});

--- a/packages/ui/src/components/BrowserListRows.tsx
+++ b/packages/ui/src/components/BrowserListRows.tsx
@@ -1,0 +1,72 @@
+import { memo } from 'react';
+
+export type BrowserTaskRowTone = 'attention' | 'running';
+
+interface BrowserTaskRowProps {
+  taskId: string;
+  title: string;
+  workflowName?: string;
+  statusLabel: string;
+  tone: BrowserTaskRowTone;
+  selected: boolean;
+  onSelect: (taskId: string) => void;
+}
+
+export const BrowserTaskRow = memo(function BrowserTaskRow({
+  taskId,
+  title,
+  workflowName,
+  statusLabel,
+  tone,
+  selected,
+  onSelect,
+}: BrowserTaskRowProps) {
+  const accent = tone === 'attention'
+    ? selected ? 'bg-amber-500/15 text-amber-100 ring-1 ring-amber-500/40' : 'text-foreground hover:bg-accent/30'
+    : selected ? 'bg-accent/60 text-accent-foreground ring-1 ring-border-strong' : 'text-foreground hover:bg-accent/30';
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(taskId)}
+      className={`block w-full rounded-md px-2.5 py-1.5 text-left transition-colors ${accent}`}
+    >
+      <div className="truncate text-body font-medium">{title}</div>
+      <div className="mt-0.5 truncate text-caption text-muted-foreground">
+        {statusLabel}
+        {workflowName ? ` · ${workflowName}` : ''}
+      </div>
+    </button>
+  );
+});
+
+interface BrowserWorkflowRowProps {
+  workflowId: string;
+  name: string;
+  taskCount: number;
+  statusLabel: string;
+  selected: boolean;
+  onSelect: (workflowId: string) => void;
+}
+
+export const BrowserWorkflowRow = memo(function BrowserWorkflowRow({
+  workflowId,
+  name,
+  taskCount,
+  statusLabel,
+  selected,
+  onSelect,
+}: BrowserWorkflowRowProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(workflowId)}
+      className={`block w-full rounded-md px-2.5 py-1.5 text-left transition-colors ${selected ? 'bg-accent/60 text-accent-foreground ring-1 ring-border-strong' : 'text-foreground hover:bg-accent/30'}`}
+    >
+      <div className="truncate text-body font-medium">{name}</div>
+      <div className="mt-0.5 truncate text-caption text-muted-foreground">
+        {statusLabel}
+        {taskCount > 0 ? ` · ${taskCount} task${taskCount === 1 ? '' : 's'}` : ''}
+      </div>
+    </button>
+  );
+});


### PR DESCRIPTION
## Summary

The Needs Attention panel no longer freezes the app when you click an item while many tasks are open.

Every row was a plain button with no memo, and the panel is not windowed. So one click re-rendered every row and repainted the whole sidebar.

Now each row is a memoized component and the click handler keeps a stable identity. A selection change re-renders only the two rows whose highlight actually changes.

Row markup is byte-for-byte identical, so nothing looks different.

Measured on 2000 rows, a click drops from 2000 row re-renders to just 2.

## Review Claim

Selecting an item in the Needs Attention (and Running / Workflows) panel re-renders only the two affected rows, with identical rendered markup.

## Review Lane

refactor

## Review Unit

activation-surface

## Safety Invariant

Safe to review locally: the two new components render the same DOM the inline rows produced, and `selectTaskById` now reads the current tasks through a ref, so a click still resolves the right task.

## Slice Rationale

This is one self-contained rendering-performance change to the Needs Attention panel. It touches only the browser-surface rows and their click handler, so it stands on its own.

## Non-goals

- No behavior change: rendered markup, selection, and keyboard navigation stay unchanged.
- No windowing/virtualization yet; the first paint of a very large panel is still proportional to row count.
- No change to the task graph, ELK layout, or any data flow.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm run check:types`
- [ ] `pnpm --filter @invoker/ui test` (652 passed, incl. new `browser-list-rows.test.tsx`)
- [ ] `node scripts/check-added-comments.mjs` (no violations in changed files)
- [ ] Render-count check (2000 rows): a selection click re-renders 2000 rows before the change vs 2 after (memoized rows + stable `selectTaskById`); `memo` alone with an inline handler stays at 2000.

</details>

## Visual Proof

![Needs Attention panel rendered by the memoized BrowserTaskRow components; the amber highlight marks the selected row and the status · workflow line is unchanged](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-3559d1/needs-attention-list.png)

This is a render-path optimization, so a static image cannot show the removed main-thread stall. That guarantee is pinned by the focused test `packages/ui/src/__tests__/browser-list-rows.test.tsx`, which asserts the memo boundary on each row.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 66883cda9`
- Post-revert steps: None
- Data migration? No

</details>

