### PR TITLE
[PR maintenance workers Step 9: Remove obsolete cron tooling](1) Tighten owner endpoint routing

### DIFF
--- a/packages/app/src/__tests__/owner-endpoint.test.ts
+++ b/packages/app/src/__tests__/owner-endpoint.test.ts
@@ -58,7 +58,7 @@ describe('owner-endpoint contract', () => {
       expect('mode' in result!).toBe(false);
     });
 
-    it('defaults ownerId to empty string when the ping response omits it', async () => {
+    it('ignores malformed ping responses that omit the owner identity', async () => {
       const bus = new LocalBus();
       bus.onRequest('headless.owner-ping', async () => ({
         ok: true,
@@ -66,9 +66,18 @@ describe('owner-endpoint contract', () => {
       }));
 
       const result = await discoverOwner(bus);
-      expect(result).not.toBeNull();
-      expect(result!.ownerId).toBe('');
-      expect(result!.canAcceptStandaloneMutations).toBe(true);
+      expect(result).toBeNull();
+    });
+
+    it('ignores malformed ping responses that omit the owner mode', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-123',
+      }));
+
+      const result = await discoverOwner(bus);
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/app/src/owner-endpoint.ts
+++ b/packages/app/src/owner-endpoint.ts
@@ -55,9 +55,12 @@ export async function discoverOwner(
 ): Promise<OwnerDiscoveryResult> {
   const raw = await tryPingHeadlessOwner(messageBus, timeoutMs);
   if (!raw) return null;
+  const ownerId = typeof raw.ownerId === 'string' ? raw.ownerId : '';
+  const mode = typeof raw.mode === 'string' ? raw.mode : '';
+  if (!ownerId || !mode) return null;
   return {
-    ownerId: raw.ownerId ?? '',
-    canAcceptStandaloneMutations: raw.mode === 'standalone' || raw.mode === 'gui',
+    ownerId,
+    canAcceptStandaloneMutations: mode === 'standalone' || mode === 'gui',
   };
 }
 


### PR DESCRIPTION
Reject owner pings that lack a stable owner identity or mode.