### PR TITLE
[PR maintenance workers Step 9: Remove obsolete cron tooling](1) Tighten owner endpoint routing

### DIFF
--- a/packages/app/src/__tests__/owner-endpoint.test.ts
+++ b/packages/app/src/__tests__/owner-endpoint.test.ts
@@ -58,7 +58,7 @@ describe('owner-endpoint contract', () => {
       expect('mode' in result!).toBe(false);
     });
 
-    it('defaults ownerId to empty string when the ping response omits it', async () => {
+    it('ignores malformed ping responses that omit the owner identity', async () => {
       const bus = new LocalBus();
       bus.onRequest('headless.owner-ping', async () => ({
         ok: true,
@@ -66,9 +66,18 @@ describe('owner-endpoint contract', () => {
       }));
 
       const result = await discoverOwner(bus);
-      expect(result).not.toBeNull();
-      expect(result!.ownerId).toBe('');
-      expect(result!.canAcceptStandaloneMutations).toBe(true);
+      expect(result).toBeNull();
+    });
+
+    it('ignores malformed ping responses that omit the owner mode', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-123',
+      }));
+
+      const result = await discoverOwner(bus);
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/app/src/owner-endpoint.ts
+++ b/packages/app/src/owner-endpoint.ts
@@ -55,9 +55,12 @@ export async function discoverOwner(
 ): Promise<OwnerDiscoveryResult> {
   const raw = await tryPingHeadlessOwner(messageBus, timeoutMs);
   if (!raw) return null;
+  const ownerId = typeof raw.ownerId === 'string' ? raw.ownerId : '';
+  const mode = typeof raw.mode === 'string' ? raw.mode : '';
+  if (!ownerId || !mode) return null;
   return {
-    ownerId: raw.ownerId ?? '',
-    canAcceptStandaloneMutations: raw.mode === 'standalone' || raw.mode === 'gui',
+    ownerId,
+    canAcceptStandaloneMutations: mode === 'standalone' || mode === 'gui',
   };
 }
 


### PR DESCRIPTION
## Summary

Owner ping handling now fails closed when a response lacks the identity or mode needed for delegation.

This keeps delegated routing from treating incomplete owner responses as usable endpoints.

## Review Claim

Approve the owner ping guard used before delegated routing continues.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Valid standalone and GUI owners still resolve through the existing capability shape.

Malformed pings now fail closed before later delegation code can rely on them.

## Slice Rationale

This routing guard lands before later slices rely on owner ping results.

## Non-goals

- Do not change worker scheduling.
- Do not remove cron tooling.
- Do not change delegated mutation execution.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run test:all` (passed in workflow `wf-1783387621902-13/run-full-test-suite`)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2bcc40e0df681dafc73ba5724d9c5fda23ecc3c5`
- Post-revert steps: Re-run the owner-endpoint tests.
- Data migration? No

</details>
