### PR TITLE
[PR maintenance workers Step 9: Remove obsolete cron tooling](2) Stabilize headless owner read delegation

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -1,3 +1,7 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LocalBus } from '@invoker/transport';
 
@@ -5,14 +9,21 @@ import { SharedMutationOwnerTimeoutError, electronCommandArgs, runHeadlessClient
 
 describe('headless-client', () => {
   const savedStandalone = process.env.INVOKER_HEADLESS_STANDALONE;
+  const savedDbDir = process.env.INVOKER_DB_DIR;
   beforeEach(() => {
     delete process.env.INVOKER_HEADLESS_STANDALONE;
+    delete process.env.INVOKER_DB_DIR;
   });
   afterEach(() => {
     if (savedStandalone === undefined) {
       delete process.env.INVOKER_HEADLESS_STANDALONE;
     } else {
       process.env.INVOKER_HEADLESS_STANDALONE = savedStandalone;
+    }
+    if (savedDbDir === undefined) {
+      delete process.env.INVOKER_DB_DIR;
+    } else {
+      process.env.INVOKER_DB_DIR = savedDbDir;
     }
   });
 
@@ -62,14 +73,24 @@ describe('headless-client', () => {
     expect(runElectronHeadless).not.toHaveBeenCalled();
   });
 
-  it('falls back to direct execution for generic standalone reads when no owner exists', async () => {
+  it('bootstraps and delegates generic standalone reads when no owner exists', async () => {
     process.env.INVOKER_HEADLESS_STANDALONE = '1';
     const firstBus = new LocalBus();
     const secondBus = new LocalBus();
+    const ownerBus = new LocalBus();
+
+    ownerBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-read-bootstrap', mode: 'standalone' }));
+    ownerBus.onRequest('headless.query', async (request: { kind: string; args: string[] }) => {
+      expect(request).toEqual({ kind: 'cli-query', args: ['task-status', 'wf-1/task-a'] });
+      return { output: 'failed\n' };
+    });
 
     const ensureStandaloneOwner = vi.fn(async () => {});
-    const refreshMessageBus = vi.fn().mockResolvedValue(secondBus);
+    const refreshMessageBus = vi.fn()
+      .mockResolvedValueOnce(secondBus)
+      .mockResolvedValue(ownerBus);
     const runElectronHeadless = vi.fn(async () => 23);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
 
     const argv = ['task-status', 'wf-1/task-a'];
     const exitCode = await runHeadlessClientCommand(argv, {
@@ -79,10 +100,52 @@ describe('headless-client', () => {
       runElectronHeadless,
     });
 
-    expect(exitCode).toBe(23);
-    expect(refreshMessageBus).toHaveBeenCalledTimes(1);
-    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
-    expect(runElectronHeadless).toHaveBeenCalledWith(argv);
+    expect(exitCode).toBe(0);
+    expect(refreshMessageBus).toHaveBeenCalled();
+    expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
+    expect(runElectronHeadless).not.toHaveBeenCalled();
+    expect(stdout).toHaveBeenCalledWith('failed\n');
+    stdout.mockRestore();
+  });
+
+  it('bootstraps and delegates generic reads when WAL sidecars make direct read-only open unsafe', async () => {
+    const dbDir = mkdtempSync(join(tmpdir(), 'headless-read-wal-'));
+    process.env.INVOKER_DB_DIR = dbDir;
+    writeFileSync(join(dbDir, 'invoker.db-wal'), '');
+
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    const ownerBus = new LocalBus();
+
+    ownerBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-read-wal', mode: 'standalone' }));
+    ownerBus.onRequest('headless.query', async (request: { kind: string; args: string[] }) => {
+      expect(request).toEqual({ kind: 'cli-query', args: ['query', 'workflows', '--output', 'label'] });
+      return { output: 'wf-1\n' };
+    });
+
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const refreshMessageBus = vi.fn()
+      .mockResolvedValueOnce(secondBus)
+      .mockResolvedValue(ownerBus);
+    const runElectronHeadless = vi.fn(async () => 23);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    try {
+      const exitCode = await runHeadlessClientCommand(['query', 'workflows', '--output', 'label'], {
+        messageBus: firstBus,
+        ensureStandaloneOwner,
+        refreshMessageBus,
+        runElectronHeadless,
+      });
+
+      expect(exitCode).toBe(0);
+      expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
+      expect(runElectronHeadless).not.toHaveBeenCalled();
+      expect(stdout).toHaveBeenCalledWith('wf-1\n');
+    } finally {
+      stdout.mockRestore();
+      rmSync(dbDir, { recursive: true, force: true });
+    }
   });
 
   it('delegates mutating commands to a standalone-capable owner endpoint', async () => {
@@ -490,6 +553,28 @@ describe('headless-client', () => {
     expect(stdout).toHaveBeenCalledWith('wf-1\n');
     stdout.mockRestore();
   }, 15_000);
+
+  it('falls back to direct execution when a stale generic-read owner disappears after ping', async () => {
+    const staleBus = new LocalBus();
+    const refreshedBus = new LocalBus();
+
+    staleBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'stale-owner', mode: 'standalone' }));
+
+    const refreshMessageBus = vi.fn().mockResolvedValue(refreshedBus);
+    const runElectronHeadless = vi.fn(async () => 17);
+    const argv = ['task-status', 'e2e-g443-taskA'];
+
+    const exitCode = await runHeadlessClientCommand(argv, {
+      messageBus: staleBus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      refreshMessageBus,
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(17);
+    expect(refreshMessageBus).toHaveBeenCalled();
+    expect(runElectronHeadless).toHaveBeenCalledWith(argv);
+  });
 
   it('refreshes past a non-mutation owner before delegating a mutation', async () => {
     const firstBus = new LocalBus();

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
-import { resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 
 import { resolveRepoRoot } from '@invoker/contracts';
 import { IpcBus } from '@invoker/transport';
@@ -196,22 +197,32 @@ async function delegateGenericReadQuery(
     }
     if (!refreshMessageBus) break;
     messageBus = await refreshMessageBus();
+    owner = await discoverOwner(messageBus, GENERIC_READ_OWNER_PING_TIMEOUT_MS);
+    if (!owner) return false;
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
 
+  owner = await discoverOwner(messageBus, GENERIC_READ_OWNER_PING_TIMEOUT_MS);
+  if (!owner) return false;
   throw new Error('Live owner is present but did not serve cli-query');
 }
 
-function shouldBootstrapStandaloneReadQuery(
+function invokerDatabaseHasWalSidecars(): boolean {
+  const dbPath = join(resolveInvokerHomeRoot(), 'invoker.db');
+  return existsSync(`${dbPath}-wal`) || existsSync(`${dbPath}-shm`);
+}
+
+function shouldBootstrapReadQuery(
   args: string[],
   standaloneMode: boolean,
   internalOwnerServe: boolean,
 ): boolean {
-  if (!standaloneMode || internalOwnerServe) return false;
+  if (internalOwnerServe) return false;
   const isSpecialRead =
     (args[0] === 'query' && (args[1] === 'queue' || args[1] === 'ui-perf' || args[1] === 'action-graph'))
     || args[0] === 'queue';
-  return isSpecialRead;
+  if (!isSpecialRead && !isGenericDelegatableReadCommand(args)) return false;
+  return standaloneMode || invokerDatabaseHasWalSidecars();
 }
 
 async function delegateReadOnlyQuery(
@@ -313,10 +324,14 @@ export interface HeadlessClientDeps {
   runElectronHeadless: (args: string[]) => Promise<number>;
 }
 
-async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void> {
+async function ensureStandaloneOwnerViaBootstrap(
+  bus: MessageBus,
+  refreshMessageBus?: () => Promise<MessageBus>,
+): Promise<void> {
   const invokerHomeRoot = resolveInvokerHomeRoot();
   const bootstrapLock = tryAcquireOwnerBootstrapLock(invokerHomeRoot);
   const startedAt = Date.now();
+  let currentBus = bus;
   delegationClientLog(`bootstrap begin lockAcquired=${bootstrapLock ? 'true' : 'false'} home=${invokerHomeRoot}`);
   try {
     if (bootstrapLock) {
@@ -327,12 +342,15 @@ async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void>
     let attempts = 0;
     while (Date.now() < deadline) {
       attempts += 1;
-      const owner = await discoverOwner(bus, 500);
+      const owner = await discoverOwner(currentBus, 500);
       if (isStandaloneCapable(owner)) {
         delegationClientLog(
           `bootstrap owner ready attempts=${attempts} elapsedMs=${Date.now() - startedAt} ownerId=${owner.ownerId}`,
         );
         return;
+      }
+      if (refreshMessageBus) {
+        currentBus = await refreshMessageBus();
       }
       await new Promise((resolveDelay) => setTimeout(resolveDelay, 200));
     }
@@ -459,7 +477,7 @@ export async function runHeadlessClientCommand(
     const exitCode = process.exitCode;
     return typeof exitCode === 'number' ? exitCode : 0;
   }
-  if (shouldBootstrapStandaloneReadQuery(args, standaloneMode, internalOwnerServe)) {
+  if (shouldBootstrapReadQuery(args, standaloneMode, internalOwnerServe)) {
     await deps.ensureStandaloneOwner(deps.messageBus);
     const delegatedAfterBootstrap = await delegateReadOnlyQuery(
       args,
@@ -499,7 +517,7 @@ export async function runHeadlessClient(argv: string[]): Promise<number> {
     await bus.ready();
     return await runHeadlessClientCommand(argv, {
       messageBus: bus,
-      ensureStandaloneOwner: (currentBus) => ensureStandaloneOwnerViaBootstrap(currentBus ?? bus),
+      ensureStandaloneOwner: (currentBus) => ensureStandaloneOwnerViaBootstrap(currentBus ?? bus, refreshMessageBus),
       refreshMessageBus,
       runElectronHeadless,
     });

--- a/packages/app/src/headless-owner-bootstrap.ts
+++ b/packages/app/src/headless-owner-bootstrap.ts
@@ -1,8 +1,11 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { spawn } from 'node:child_process';
-import { join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
 
 export const OWNER_BOOTSTRAP_LOCK_DIR = 'headless-owner-bootstrap.lock';
+const DEFAULT_BOOTSTRAPPED_OWNER_IDLE_TIMEOUT_MS = '5000';
+const requireFromHere = createRequire(__filename);
 
 export type OwnerBootstrapLock = {
   lockDir: string;
@@ -49,20 +52,45 @@ export function tryAcquireOwnerBootstrapLock(invokerHomeRoot: string): OwnerBoot
   };
 }
 
+function resolveInstalledElectronBinary(repoRoot: string): string | null {
+  let electronPackageJson: string;
+  try {
+    electronPackageJson = requireFromHere.resolve('electron/package.json', {
+      paths: [
+        join(repoRoot, 'packages', 'app'),
+        repoRoot,
+      ],
+    });
+  } catch {
+    return null;
+  }
+
+  const electronPackageDir = dirname(electronPackageJson);
+  const pathFile = join(electronPackageDir, 'path.txt');
+  if (!existsSync(pathFile)) return null;
+
+  const executablePath = readFileSync(pathFile, 'utf8').trim();
+  if (!executablePath) return null;
+
+  const distRoot = process.env.ELECTRON_OVERRIDE_DIST_PATH || join(electronPackageDir, 'dist');
+  const binaryPath = join(distRoot, executablePath);
+  return existsSync(binaryPath) ? binaryPath : null;
+}
+
 export function spawnDetachedStandaloneOwner(
   repoRoot: string,
   extraEnv: NodeJS.ProcessEnv = {},
 ): void {
   const electronLauncher = resolve(repoRoot, 'scripts', 'electron.cjs');
+  const electronBinary = resolveInstalledElectronBinary(repoRoot);
   const mainJs = resolve(repoRoot, 'packages', 'app', 'dist', 'main.js');
-  const args = [
-    electronLauncher,
+  const electronArgs = [
     ...(process.platform === 'linux' ? ['--no-sandbox'] : []),
     mainJs,
     '--headless',
     'owner-serve',
   ];
-  const child = spawn(process.execPath, args, {
+  const child = spawn(electronBinary ?? process.execPath, electronBinary ? electronArgs : [electronLauncher, ...electronArgs], {
     cwd: repoRoot,
     detached: true,
     stdio: 'ignore',
@@ -70,6 +98,10 @@ export function spawnDetachedStandaloneOwner(
       ...process.env,
       ...extraEnv,
       INVOKER_HEADLESS_STANDALONE: '1',
+      INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS:
+        extraEnv.INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS
+        ?? process.env.INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS
+        ?? DEFAULT_BOOTSTRAPPED_OWNER_IDLE_TIMEOUT_MS,
       LIBGL_ALWAYS_SOFTWARE: process.platform === 'linux' ? '1' : process.env.LIBGL_ALWAYS_SOFTWARE,
     },
   });


### PR DESCRIPTION
## Summary

Headless CLI reads now reconnect while waiting for a standalone owner to serve delegated queries.

The bootstrap path prefers the installed Electron binary and gives bootstrapped owners a short idle timeout.

Generic reads use owner delegation when WAL sidecars make direct database reads unsafe.

## Review Claim

Headless CLI read delegation uses a refreshed owner bootstrap before falling back to direct execution.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Focused headless client tests cover owner refresh, WAL sidecars, and owner-disconnect fallback. It leaves the lower cron retirement slice untouched.

## Slice Rationale

This activation-surface change sits above the endpoint guard so CLI startup behavior reviews separately from endpoint ping handling.

## Non-goals

- Do not change PR maintenance worker scheduling.
- Do not change the lower cron retirement slice.
- Do not change merge-queue policy checks.

## Architecture

### Before

```mermaid
graph TD
    A["Headless read command"] --> B["Try current owner"]
    B --> C["Direct Electron execution when safe"]
```

### After

```mermaid
graph TD
    A["Headless read command"] --> B["Try current owner"]
    B --> C["Refresh bus and bootstrap owner when needed"]
    C --> D["Delegate read query"]
    C --> E["Direct Electron execution only when safe or no owner remains"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run test:all` (passed in workflow task `wf-1783387621902-13/run-full-test-suite`)
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-step9-pr2-headless-body.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 35144e42060529abd74d476354d3297ac487a7ab`
- Post-revert steps: None
- Data migration? No

</details>
