### PR TITLE
[PR maintenance workers Step 9: Remove obsolete cron tooling](4) Map UI Vitest in merge-queue proof

### DIFF
--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -6,6 +6,9 @@ const FULL_CI_GATE = "${{ github.event_name != 'pull_request' || startsWith(gith
 const NON_PR_GATE = "${{ github.event_name != 'pull_request' }}";
 const ORDINARY_PR_GATE = "${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}";
 const FULL_CI_JOBS = new Set(['build-artifacts', 'e2e-proof', 'e2e-proof-aggregate', 'required-fast', 'playwright', 'ssh', 'optional-other']);
+const CHECK_JOB_OVERRIDES = new Map([
+  ['UI Vitest', 'ui-vitest'],
+]);
 
 const workflow = YAML.parse(readFileSync('.github/workflows/ci.yml', 'utf8'));
 const mergify = YAML.parse(readFileSync('.mergify.yml', 'utf8'));
@@ -24,7 +27,14 @@ function jobForCheck(checkName) {
   if (checkName.startsWith('optional / ')) {
     return 'optional-other';
   }
+  if (CHECK_JOB_OVERRIDES.has(checkName)) {
+    return CHECK_JOB_OVERRIDES.get(checkName);
+  }
   return checkName.split(' / ')[0];
+}
+
+function jobRunsOnMergeQueue(job) {
+  return !job.if || job.if === FULL_CI_GATE;
 }
 
 for (const jobName of FULL_CI_JOBS) {
@@ -56,7 +66,7 @@ for (const checkName of requiredChecks) {
     continue;
   }
   assert(jobs[jobName], `Mergify requires missing CI job ${jobName} for ${checkName}`);
-  assert(jobs[jobName].if === FULL_CI_GATE, `Mergify-required job ${jobName} must run on merge queue refs`);
+  assert(jobRunsOnMergeQueue(jobs[jobName]), `Mergify-required job ${jobName} must run on merge queue refs`);
 }
 
 console.log('CI merge-queue policy is valid.');

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -73,6 +73,7 @@ class MergifyAdminRequeueTests(unittest.TestCase):
             "quality / TypeScript Types",
             "required-fast / Guardrails",
             "required-fast / Submit Workflow Chain",
+            "UI Vitest",
         }))
 
     def test_loads_admin_bypass_rule_from_any_working_directory(self):


### PR DESCRIPTION
## Summary

The merge-queue policy proof now maps the UI Vitest required check to its workflow job.

Required-check auditing still verifies that merge-queue jobs run under the expected CI gate.

## Review Claim

The merge-queue policy proof recognizes the UI Vitest required check.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This changes CI policy proof tooling only. It does not change runtime behavior or cron files.

## Slice Rationale

The required-check mapping is a tooling policy claim, so it stays separate from headless behavior and file retirement.

## Non-goals

- Do not change GitHub workflow jobs.
- Do not change Mergify queue rules.
- Do not retire cron wrapper files in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run test:all` (passed in workflow task `wf-1783387621902-13/run-full-test-suite`)
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-step9-pr4-policy-body.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert db0e3b22ea53e0039ea20abbfe3fd79fa7e0f6c5`
- Post-revert steps: None
- Data migration? No

</details>
