### PR TITLE
[PR maintenance workers Step 9: Remove obsolete cron tooling](4) Map UI Vitest in merge-queue policy

### DIFF
--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -6,6 +6,9 @@ const FULL_CI_GATE = "${{ github.event_name != 'pull_request' || startsWith(gith
 const NON_PR_GATE = "${{ github.event_name != 'pull_request' }}";
 const ORDINARY_PR_GATE = "${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}";
 const FULL_CI_JOBS = new Set(['build-artifacts', 'e2e-proof', 'e2e-proof-aggregate', 'required-fast', 'playwright', 'ssh', 'optional-other']);
+const CHECK_JOB_OVERRIDES = new Map([
+  ['UI Vitest', 'ui-vitest'],
+]);
 
 const workflow = YAML.parse(readFileSync('.github/workflows/ci.yml', 'utf8'));
 const mergify = YAML.parse(readFileSync('.mergify.yml', 'utf8'));
@@ -24,7 +27,14 @@ function jobForCheck(checkName) {
   if (checkName.startsWith('optional / ')) {
     return 'optional-other';
   }
+  if (CHECK_JOB_OVERRIDES.has(checkName)) {
+    return CHECK_JOB_OVERRIDES.get(checkName);
+  }
   return checkName.split(' / ')[0];
+}
+
+function jobRunsOnMergeQueue(job) {
+  return !job.if || job.if === FULL_CI_GATE;
 }
 
 for (const jobName of FULL_CI_JOBS) {
@@ -56,7 +66,7 @@ for (const checkName of requiredChecks) {
     continue;
   }
   assert(jobs[jobName], `Mergify requires missing CI job ${jobName} for ${checkName}`);
-  assert(jobs[jobName].if === FULL_CI_GATE, `Mergify-required job ${jobName} must run on merge queue refs`);
+  assert(jobRunsOnMergeQueue(jobs[jobName]), `Mergify-required job ${jobName} must run on merge queue refs`);
 }
 
 console.log('CI merge-queue policy is valid.');

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -73,6 +73,7 @@ class MergifyAdminRequeueTests(unittest.TestCase):
             "quality / TypeScript Types",
             "required-fast / Guardrails",
             "required-fast / Submit Workflow Chain",
+            "UI Vitest",
         }))
 
     def test_loads_admin_bypass_rule_from_any_working_directory(self):


### PR DESCRIPTION
## Summary

The merge-queue policy checks now map UI Vitest to the `ui-vitest` job.

The admin requeue fixture includes the expected policy case.

## Review Claim

Approve the merge-queue policy test alignment.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice changes policy verification scripts only and leaves runtime behavior unchanged.

## Slice Rationale

This keeps CI policy alignment separate from endpoint behavior, proof updates, startup hardening, and cron retirement.

## Non-goals

- Do not change application runtime behavior.
- Do not change GitHub workflow definitions.
- Do not remove cron tooling in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run test:all`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 12c61b485`
- Post-revert steps: Rerun `pnpm run test:all`
- Data migration? No

</details>
