### PR TITLE
[PR maintenance workers Step 9: Remove obsolete cron tooling](2) Require well-formed owner ping responses

### DIFF
--- a/packages/app/src/__tests__/owner-endpoint.test.ts
+++ b/packages/app/src/__tests__/owner-endpoint.test.ts
@@ -58,7 +58,7 @@ describe('owner-endpoint contract', () => {
       expect('mode' in result!).toBe(false);
     });
 
-    it('defaults ownerId to empty string when the ping response omits it', async () => {
+    it('ignores malformed ping responses that omit the owner identity', async () => {
       const bus = new LocalBus();
       bus.onRequest('headless.owner-ping', async () => ({
         ok: true,
@@ -66,9 +66,18 @@ describe('owner-endpoint contract', () => {
       }));
 
       const result = await discoverOwner(bus);
-      expect(result).not.toBeNull();
-      expect(result!.ownerId).toBe('');
-      expect(result!.canAcceptStandaloneMutations).toBe(true);
+      expect(result).toBeNull();
+    });
+
+    it('ignores malformed ping responses that omit the owner mode', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-123',
+      }));
+
+      const result = await discoverOwner(bus);
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/app/src/owner-endpoint.ts
+++ b/packages/app/src/owner-endpoint.ts
@@ -55,9 +55,12 @@ export async function discoverOwner(
 ): Promise<OwnerDiscoveryResult> {
   const raw = await tryPingHeadlessOwner(messageBus, timeoutMs);
   if (!raw) return null;
+  const ownerId = typeof raw.ownerId === 'string' ? raw.ownerId : '';
+  const mode = typeof raw.mode === 'string' ? raw.mode : '';
+  if (!ownerId || !mode) return null;
   return {
-    ownerId: raw.ownerId ?? '',
-    canAcceptStandaloneMutations: raw.mode === 'standalone' || raw.mode === 'gui',
+    ownerId,
+    canAcceptStandaloneMutations: mode === 'standalone' || mode === 'gui',
   };
 }
 


### PR DESCRIPTION
## Summary

Ignore owner pings that omit owner identity or mode.

That keeps incomplete owner replies from becoming reachable endpoints.

## Review Claim

Owner endpoint routing accepts only complete owner ping replies from the message bus.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Focused owner-endpoint tests cover standalone replies, GUI replies, and pings with missing fields.

## Slice Rationale

This endpoint change sits below the client bootstrap changes, keeping ping handling local to one boundary.

## Non-goals

- Do not change standalone owner bootstrap behavior.
- Do not change cron file retirement.
- Do not change merge-queue policy checks.

## Architecture

### Before

Owner discovery accepted a successful ping even when the response omitted the owner identity or mode.

### After

Owner discovery treats those pings as unreachable and returns an endpoint only for complete replies.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run test:all` (passed in workflow task `wf-1783387621902-13/run-full-test-suite`)
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-step9-pr3805-body-codex.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 978425977dd0de0bac0bda706eda062057b5e126`
- Post-revert steps: Re-run `pnpm run test:all` because downstream headless delegation depends on complete owner pings.
- Data migration? No

</details>

Depends-On: #3804
