### PR TITLE
[PR maintenance workers Step 9: Remove obsolete cron tooling](5) Align merge-queue policy checks with UI Vitest

### DIFF
--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -6,6 +6,9 @@ const FULL_CI_GATE = "${{ github.event_name != 'pull_request' || startsWith(gith
 const NON_PR_GATE = "${{ github.event_name != 'pull_request' }}";
 const ORDINARY_PR_GATE = "${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}";
 const FULL_CI_JOBS = new Set(['build-artifacts', 'e2e-proof', 'e2e-proof-aggregate', 'required-fast', 'playwright', 'ssh', 'optional-other']);
+const CHECK_JOB_OVERRIDES = new Map([
+  ['UI Vitest', 'ui-vitest'],
+]);
 
 const workflow = YAML.parse(readFileSync('.github/workflows/ci.yml', 'utf8'));
 const mergify = YAML.parse(readFileSync('.mergify.yml', 'utf8'));
@@ -24,7 +27,14 @@ function jobForCheck(checkName) {
   if (checkName.startsWith('optional / ')) {
     return 'optional-other';
   }
+  if (CHECK_JOB_OVERRIDES.has(checkName)) {
+    return CHECK_JOB_OVERRIDES.get(checkName);
+  }
   return checkName.split(' / ')[0];
+}
+
+function jobRunsOnMergeQueue(job) {
+  return !job.if || job.if === FULL_CI_GATE;
 }
 
 for (const jobName of FULL_CI_JOBS) {
@@ -56,7 +66,7 @@ for (const checkName of requiredChecks) {
     continue;
   }
   assert(jobs[jobName], `Mergify requires missing CI job ${jobName} for ${checkName}`);
-  assert(jobs[jobName].if === FULL_CI_GATE, `Mergify-required job ${jobName} must run on merge queue refs`);
+  assert(jobRunsOnMergeQueue(jobs[jobName]), `Mergify-required job ${jobName} must run on merge queue refs`);
 }
 
 console.log('CI merge-queue policy is valid.');

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -73,6 +73,7 @@ class MergifyAdminRequeueTests(unittest.TestCase):
             "quality / TypeScript Types",
             "required-fast / Guardrails",
             "required-fast / Submit Workflow Chain",
+            "UI Vitest",
         }))
 
     def test_loads_admin_bypass_rule_from_any_working_directory(self):


### PR DESCRIPTION
## Summary

Map the UI Vitest required check to the `ui-vitest` workflow job in the merge-queue guardrail tests.

The guardrail now accepts required checks whose workflow job has a different display name.

## Review Claim

Approve the merge-queue guardrail test mapping for the UI Vitest required check.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice changes guardrail tests only. It does not modify the CI workflow or Mergify configuration.

## Slice Rationale

The guardrail alignment stays separate from product behavior and E2E proof updates so the policy expectation is reviewable by itself.

## Non-goals

- Do not change runtime owner behavior.
- Do not change the CI workflow definition.
- Do not remove additional cron tooling in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run test:all` (passed in workflow task `wf-1783387621902-13/run-full-test-suite`)
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-step9-pr-3808.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert fca7f41c34ae7a1ae2a3d98d7c8a8882f2192766`
- Post-revert steps: Re-run `pnpm run test:all` before landing the stack.
- Data migration? No

</details>
