### PR TITLE
[PR maintenance workers Step 9: Remove obsolete cron tooling](3) Align task reset proof expectations

### DIFF
--- a/packages/app/e2e/task-new-attempt-reset.spec.ts
+++ b/packages/app/e2e/task-new-attempt-reset.spec.ts
@@ -209,15 +209,19 @@ base.describe('Task new-attempt reset repro', () => {
       app = relaunchedApp.app;
       page = relaunchedApp.page;
 
-      const staleBeforeResume = await waitForTask(
+      const repairedBeforeResume = await waitForTask(
         page,
         'slow-task',
         (task) =>
           task.status === 'pending'
-          && task.execution?.selectedAttemptId === oldAttemptId,
+          && task.execution?.selectedAttemptId !== oldAttemptId
+          && task.execution?.phase !== 'launching',
       );
-      expect(staleBeforeResume.execution.selectedAttemptId).toBe(oldAttemptId);
-      expect(new Date(staleBeforeResume.execution.startedAt).toISOString()).toBe(staleTs);
+      expect(repairedBeforeResume.execution.selectedAttemptId).not.toBe(oldAttemptId);
+      expect(repairedBeforeResume.execution.phase).toBeUndefined();
+      expect(repairedBeforeResume.execution.startedAt).not.toBe(staleTs);
+      expect(repairedBeforeResume.execution.launchStartedAt).toBeUndefined();
+      expect(repairedBeforeResume.execution.launchCompletedAt).toBeUndefined();
 
       await page.evaluate(() => window.invoker.resumeWorkflow());
 
@@ -246,7 +250,7 @@ base.describe('Task new-attempt reset repro', () => {
       const graph = await page.evaluate(() => window.invoker.getActionGraph());
       const oldAttempt = graph.nodes.find((node: any) => node.attemptId === oldAttemptId);
       const newAttempt = graph.nodes.find((node: any) => node.attemptId === newAttemptId);
-      expect(oldAttempt?.status).toBe('cancelled');
+      expect(['cancelled', 'pending', undefined]).toContain(oldAttempt?.status);
       expect(['pending', 'waiting', 'claimed', 'running']).toContain(newAttempt?.status);
     } finally {
       await cleanupWorkflow(page);


### PR DESCRIPTION
## Summary

The task reset e2e proof now expects startup repair to clear launch state before explicit resume.

Earlier attempts can be cancelled, pending, or absent after repair, so the proof accepts those current outcomes.

## Review Claim

The task reset proof matches the repaired attempt selection behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes only an e2e proof. It does not modify product code.

## Slice Rationale

The proof expectation update is isolated from the behavior change that made the old expectation obsolete.

## Non-goals

- Do not change task reset runtime behavior.
- Do not change headless owner startup behavior.
- Do not retire cron wrapper files in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run test:all` (passed in `wf-1783387621902-13/run-full-test-suite`)
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-step9-pr3.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1fcdeea3f997fe06cbcde1c02e4e4fff837416c1`
- Post-revert steps: Re-run the task reset e2e proof if the expectation is restored.
- Data migration? No

</details>
