### PR TITLE
[PR maintenance workers Step 9: Remove obsolete cron tooling](4) Align CI merge-queue policy tests

### DIFF
--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -6,6 +6,9 @@ const FULL_CI_GATE = "${{ github.event_name != 'pull_request' || startsWith(gith
 const NON_PR_GATE = "${{ github.event_name != 'pull_request' }}";
 const ORDINARY_PR_GATE = "${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}";
 const FULL_CI_JOBS = new Set(['build-artifacts', 'e2e-proof', 'e2e-proof-aggregate', 'required-fast', 'playwright', 'ssh', 'optional-other']);
+const CHECK_JOB_OVERRIDES = new Map([
+  ['UI Vitest', 'ui-vitest'],
+]);
 
 const workflow = YAML.parse(readFileSync('.github/workflows/ci.yml', 'utf8'));
 const mergify = YAML.parse(readFileSync('.mergify.yml', 'utf8'));
@@ -24,7 +27,14 @@ function jobForCheck(checkName) {
   if (checkName.startsWith('optional / ')) {
     return 'optional-other';
   }
+  if (CHECK_JOB_OVERRIDES.has(checkName)) {
+    return CHECK_JOB_OVERRIDES.get(checkName);
+  }
   return checkName.split(' / ')[0];
+}
+
+function jobRunsOnMergeQueue(job) {
+  return !job.if || job.if === FULL_CI_GATE;
 }
 
 for (const jobName of FULL_CI_JOBS) {
@@ -56,7 +66,7 @@ for (const checkName of requiredChecks) {
     continue;
   }
   assert(jobs[jobName], `Mergify requires missing CI job ${jobName} for ${checkName}`);
-  assert(jobs[jobName].if === FULL_CI_GATE, `Mergify-required job ${jobName} must run on merge queue refs`);
+  assert(jobRunsOnMergeQueue(jobs[jobName]), `Mergify-required job ${jobName} must run on merge queue refs`);
 }
 
 console.log('CI merge-queue policy is valid.');

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -73,6 +73,7 @@ class MergifyAdminRequeueTests(unittest.TestCase):
             "quality / TypeScript Types",
             "required-fast / Guardrails",
             "required-fast / Submit Workflow Chain",
+            "UI Vitest",
         }))
 
     def test_loads_admin_bypass_rule_from_any_working_directory(self):


### PR DESCRIPTION
## Summary

CI merge-queue policy tests now map the `UI Vitest` required check to the `ui-vitest` job.

The policy check also accepts required jobs that run without an explicit merge-queue guard.

## Review Claim

Merge-queue policy validation recognizes the UI Vitest required check.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice changes test tooling only. It does not alter the CI workflow or Mergify queue rules.

## Slice Rationale

The merge-queue policy adjustment stays separate from runtime and cron retirement so release gating can be checked on its own.

## Non-goals

- Do not change CI workflow definitions.
- Do not change Mergify queue rules.
- Do not retire cron wrapper files in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run test:all` (passed in `wf-1783387621902-13/run-full-test-suite`)
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-step9-pr4.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 12c61b4856a7ee9be3a5c4c1b6c907e42f28297f`
- Post-revert steps: Re-run merge-queue policy tests before requeueing the stack.
- Data migration? No

</details>
