### PR TITLE
[Main-process freeze](1) Bound findActiveAttemptsAfter with LIMIT

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, statSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -1876,6 +1876,59 @@ describe('SQLiteAdapter', () => {
       const [task] = adapter.loadTasks('wf-1');
       expect(task.status).toBe('stale');
     });
+
+    it('projects the newest active attempt without scanning every attempt for the node (perf regression #3746)', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1', { status: 'running' }));
+
+      const selectedFailed: Attempt = {
+        ...createAttempt('t1', { status: 'failed' }),
+        id: 't1-aOLD',
+        createdAt: new Date('2026-07-09T05:00:00.000Z'),
+        error: 'boom',
+      };
+      const newerPending: Attempt = {
+        ...createAttempt('t1', { status: 'pending' }),
+        id: 't1-aNEW',
+        createdAt: new Date('2026-07-09T06:00:00.000Z'),
+        supersedesAttemptId: selectedFailed.id,
+      };
+      adapter.saveAttempt(selectedFailed);
+      adapter.saveAttempt(newerPending);
+
+      const bigError = 'x'.repeat(200_000);
+      for (let i = 0; i < 50; i += 1) {
+        adapter.saveAttempt({
+          ...createAttempt('t1', { status: i % 2 === 0 ? 'failed' : 'superseded' }),
+          id: `t1-old-${i}`,
+          createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, i)),
+          error: bigError,
+        });
+      }
+
+      adapter.updateTask('t1', { execution: { selectedAttemptId: selectedFailed.id } });
+
+      const spy = vi.spyOn(
+        adapter as unknown as { queryAll: (sql: string, params?: unknown[]) => unknown },
+        'queryAll',
+      );
+      try {
+        const [task] = adapter.loadTasks('wf-1');
+        expect(task.status).toBe('running');
+        expect(task.execution.error).toBeUndefined();
+        expect(task.execution.selectedAttemptId).toBe(selectedFailed.id);
+      } finally {
+        spy.mockRestore();
+      }
+
+      const ranUnboundedScan = spy.mock.calls.some(
+        ([sql]) =>
+          typeof sql === 'string' &&
+          /FROM attempts\s+WHERE node_id = \?\s+ORDER BY created_at ASC/.test(sql),
+      );
+      expect(ranUnboundedScan).toBe(false);
+    });
+
   });
 
   describe('loadActionGraphAttempts', () => {

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -11,7 +11,6 @@
 import type { TaskState, TaskStateChanges, Attempt } from '@invoker/workflow-core';
 import {
   assertTaskConsistent,
-  isActiveAttempt,
   isDiscardedAttempt,
   normalizeRunnerKind,
 } from '@invoker/workflow-core';
@@ -700,8 +699,8 @@ export class SqliteTaskAttemptRepository {
     if (!attempt) return task;
 
     if (attempt.status === 'failed' || isDiscardedAttempt(attempt)) {
-      const newer = this.findNewerActiveAttempt(task.id, attempt);
-      if (newer) {
+      const [activeAfter] = this.findActiveAttemptsAfter(task.id, attempt, 1);
+      if (activeAfter) {
         const cleaned: TaskState = {
           ...task,
           execution: {
@@ -711,7 +710,7 @@ export class SqliteTaskAttemptRepository {
             completedAt: undefined,
           },
         };
-        if (newer.status === 'needs_input') {
+        if (activeAfter.status === 'needs_input') {
           return { ...cleaned, status: 'needs_input' };
         }
         return cleaned;
@@ -777,18 +776,18 @@ export class SqliteTaskAttemptRepository {
     return task;
   }
 
-  private findNewerActiveAttempt(nodeId: string, selected: Attempt): Attempt | undefined {
-    const attempts = this.loadAttempts(nodeId);
-    const selectedTs = selected.createdAt.getTime();
-    let newest: Attempt | undefined;
-    for (const candidate of attempts) {
-      if (candidate.id === selected.id) continue;
-      if (!isActiveAttempt(candidate)) continue;
-      if (candidate.createdAt.getTime() <= selectedTs) continue;
-      if (!newest || candidate.createdAt.getTime() > newest.createdAt.getTime()) {
-        newest = candidate;
-      }
-    }
-    return newest;
+  private findActiveAttemptsAfter(nodeId: string, selected: Attempt, limit = 1): Attempt[] {
+    const cappedLimit = Math.max(0, Math.floor(limit));
+    if (cappedLimit === 0) return [];
+    const rows = this.exec.queryAll(
+      `SELECT * FROM attempts
+       WHERE node_id = ?
+         AND created_at > ?
+         AND status IN ('pending', 'claimed', 'running', 'needs_input')
+       ORDER BY created_at DESC
+       LIMIT ?`,
+      [nodeId, selected.createdAt.toISOString(), cappedLimit],
+    );
+    return rows.map((row) => mapRowToAttempt(row));
   }
 }


### PR DESCRIPTION
## Summary

Bound the selected-attempt reconciliation query that previously called unbounded `loadAttempts` (full attempt rows including large `error` blobs) on every projection.

Rename to `findActiveAttemptsAfter(nodeId, selected, limit = 1)` and use SQL `LIMIT` so existence checks stay cheap while callers can request more than one row when needed.

Call site: `const [activeAfter] = this.findActiveAttemptsAfter(task.id, attempt, 1)`.

## Review Claim

Approve bounding selected-attempt reconciliation with `findActiveAttemptsAfter(..., limit)` so projection no longer unbounded-scans attempt rows (including large `error` blobs).

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

Existence of a newer active attempt is answered with an indexed `LIMIT` query. Callers that need more than one row can raise `limit`. Projection no longer loads every attempt for the node on the hot path.

## Slice Rationale

Part of fixing Electron main-process freezes from sync SQLite on the UI poll path. This slice specifically addresses the #3746 landmine where a stale `selectedAttemptId` could force an unbounded attempt scan during projection. Separate from recovery aggregates and worker_actions indexing.

## Non-goals

- Does not change recovery event aggregation.
- Does not add `idx_worker_actions_kind_updated`.
- Does not move SQLite off the Electron main thread (INV-265).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Focused vitest for selected-attempt reconciliation / #3746
- [ ] Stack CI green after restack

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>