### PR TITLE
[Main-process freeze](4) Index worker_actions for status polls

### DIFF
--- a/packages/app/src/__tests__/recovery-worker-observability.test.ts
+++ b/packages/app/src/__tests__/recovery-worker-observability.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildRecoveryWorkerAuditPayload,
@@ -6,58 +6,68 @@ import {
   recoveryWorkerEventType,
 } from '../recovery-worker-observability.js';
 
+const allEvents = [
+  {
+    id: 1,
+    taskId: 'wf-1/task-a',
+    eventType: recoveryWorkerEventType('wakeup'),
+    payload: JSON.stringify(buildRecoveryWorkerAuditPayload('wakeup', 'delta-failed', { workflowId: 'wf-1' })),
+    createdAt: '2026-06-22T10:00:00.000Z',
+  },
+  {
+    id: 2,
+    taskId: 'wf-1/task-a',
+    eventType: recoveryWorkerEventType('skip'),
+    payload: JSON.stringify(buildRecoveryWorkerAuditPayload('skip', 'delta-skip', { workflowId: 'wf-1', reason: 'cancellation-error' })),
+    createdAt: '2026-06-22T10:00:01.000Z',
+  },
+  {
+    id: 3,
+    taskId: 'wf-1/task-b',
+    eventType: recoveryWorkerEventType('scan'),
+    payload: JSON.stringify(buildRecoveryWorkerAuditPayload('scan', 'schedule-enter', { workflowId: 'wf-1' })),
+    createdAt: '2026-06-22T10:00:02.000Z',
+  },
+  {
+    id: 4,
+    taskId: 'wf-1/task-b',
+    eventType: recoveryWorkerEventType('submit'),
+    payload: JSON.stringify(buildRecoveryWorkerAuditPayload('submit', 'worker-autofix-submitted', { workflowId: 'wf-1' })),
+    createdAt: '2026-06-22T10:00:03.000Z',
+  },
+  {
+    id: 5,
+    taskId: 'wf-1/task-b',
+    eventType: recoveryWorkerEventType('skip'),
+    payload: JSON.stringify(buildRecoveryWorkerAuditPayload('skip', 'schedule-skip', { workflowId: 'wf-1', reason: 'already-queued-intent' })),
+    createdAt: '2026-06-22T10:00:04.000Z',
+  },
+];
+
 describe('recovery-worker-observability', () => {
-  it('derives recovery ownership and latest decisions from task audit events', () => {
-    const workflows = [{ id: 'wf-1' }];
-    const tasks = [{ id: 'wf-1/task-a' }, { id: 'wf-1/task-b' }];
-    const eventsByTask = new Map([
-      ['wf-1/task-a', [
-        {
-          id: 1,
-          taskId: 'wf-1/task-a',
-          eventType: recoveryWorkerEventType('wakeup'),
-          payload: JSON.stringify(buildRecoveryWorkerAuditPayload('wakeup', 'delta-failed', { workflowId: 'wf-1' })),
-          createdAt: '2026-06-22T10:00:00.000Z',
-        },
-        {
-          id: 2,
-          taskId: 'wf-1/task-a',
-          eventType: recoveryWorkerEventType('skip'),
-          payload: JSON.stringify(buildRecoveryWorkerAuditPayload('skip', 'delta-skip', { workflowId: 'wf-1', reason: 'cancellation-error' })),
-          createdAt: '2026-06-22T10:00:01.000Z',
-        },
-      ]],
-      ['wf-1/task-b', [
-        {
-          id: 3,
-          taskId: 'wf-1/task-b',
-          eventType: recoveryWorkerEventType('scan'),
-          payload: JSON.stringify(buildRecoveryWorkerAuditPayload('scan', 'schedule-enter', { workflowId: 'wf-1' })),
-          createdAt: '2026-06-22T10:00:02.000Z',
-        },
-        {
-          id: 4,
-          taskId: 'wf-1/task-b',
-          eventType: recoveryWorkerEventType('submit'),
-          payload: JSON.stringify(buildRecoveryWorkerAuditPayload('submit', 'worker-autofix-submitted', { workflowId: 'wf-1' })),
-          createdAt: '2026-06-22T10:00:03.000Z',
-        },
-        {
-          id: 5,
-          taskId: 'wf-1/task-b',
-          eventType: recoveryWorkerEventType('skip'),
-          payload: JSON.stringify(buildRecoveryWorkerAuditPayload('skip', 'schedule-skip', { workflowId: 'wf-1', reason: 'already-queued-intent' })),
-          createdAt: '2026-06-22T10:00:04.000Z',
-        },
-      ]],
-    ]);
+  it('derives recovery ownership and latest decisions via aggregate event queries', () => {
+    const getEventsByTypes = vi.fn((eventTypes: readonly string[], _sortBy: 'asc' | 'desc', limit: number) =>
+      allEvents
+        .filter((event) => eventTypes.includes(event.eventType))
+        .slice()
+        .reverse()
+        .slice(0, limit),
+    );
+    const countEventsByTypes = vi.fn((eventTypes: readonly string[]) =>
+      eventTypes.map((eventType) => {
+        const matching = allEvents.filter((event) => event.eventType === eventType);
+        return {
+          eventType,
+          count: matching.length,
+          lastCreatedAt: matching.at(-1)?.createdAt ?? null,
+        };
+      }),
+    );
 
-    const status = collectRecoveryWorkerStatus({
-      listWorkflows: () => workflows as never,
-      loadTasks: () => tasks as never,
-      getEvents: (taskId) => (eventsByTask.get(taskId) ?? []) as never,
-    });
+    const status = collectRecoveryWorkerStatus({ getEventsByTypes, countEventsByTypes });
 
+    expect(countEventsByTypes).toHaveBeenCalled();
+    expect(getEventsByTypes).toHaveBeenCalled();
     expect(status).toMatchObject({
       kind: 'recovery',
       workerId: 'auto-fix-recovery',
@@ -77,6 +87,29 @@ describe('recovery-worker-observability', () => {
       action: 'skip',
       taskId: 'wf-1/task-b',
       reason: 'already-queued-intent',
+    });
+  });
+
+  it('falls back to per-task event scans when aggregate APIs are unavailable', () => {
+    const workflows = [{ id: 'wf-1' }];
+    const tasks = [{ id: 'wf-1/task-a' }, { id: 'wf-1/task-b' }];
+    const eventsByTask = new Map([
+      ['wf-1/task-a', allEvents.filter((event) => event.taskId === 'wf-1/task-a')],
+      ['wf-1/task-b', allEvents.filter((event) => event.taskId === 'wf-1/task-b')],
+    ]);
+
+    const status = collectRecoveryWorkerStatus({
+      listWorkflows: () => workflows as never,
+      loadTasks: () => tasks as never,
+      getEvents: (taskId) => (eventsByTask.get(taskId) ?? []) as never,
+    });
+
+    expect(status).toMatchObject({
+      wakeups: 1,
+      scans: 1,
+      submissions: 1,
+      skips: 2,
+      lastSkipReason: 'already-queued-intent',
     });
   });
 });

--- a/packages/app/src/recovery-worker-observability.ts
+++ b/packages/app/src/recovery-worker-observability.ts
@@ -1,5 +1,4 @@
-import type { TaskEvent, Workflow } from '@invoker/data-store';
-import type { TaskState } from '@invoker/workflow-core';
+import type { TaskEvent } from '@invoker/data-store';
 
 import { RECOVERY_WORKER_KIND } from './workers/auto-fix-recovery.js';
 
@@ -50,9 +49,19 @@ export interface RecoveryWorkerStatusEvent {
 }
 
 export interface RecoveryWorkerStatusPersistence {
-  listWorkflows(): Workflow[];
-  loadTasks(workflowId: string): TaskState[];
-  getEvents(taskId: string): TaskEvent[];
+  getEventsByTypes?(
+    eventTypes: readonly string[],
+    sortBy: 'asc' | 'desc',
+    limit: number,
+  ): TaskEvent[];
+  countEventsByTypes?(eventTypes: readonly string[]): Array<{
+    eventType: string;
+    count: number;
+    lastCreatedAt: string | null;
+  }>;
+  listWorkflows?(): Array<{ id: string }>;
+  loadTasks?(workflowId: string): Array<{ id: string }>;
+  getEvents?(taskId: string): TaskEvent[];
 }
 
 const RECOVERY_EVENT_TYPES: Record<RecoveryWorkerAuditAction, RecoveryWorkerAuditEventType> = {
@@ -61,6 +70,8 @@ const RECOVERY_EVENT_TYPES: Record<RecoveryWorkerAuditAction, RecoveryWorkerAudi
   submit: 'recovery.worker.submit',
   skip: 'recovery.worker.skip',
 };
+
+const ALL_RECOVERY_EVENT_TYPES = Object.values(RECOVERY_EVENT_TYPES);
 
 export function recoveryWorkerEventType(action: RecoveryWorkerAuditAction): RecoveryWorkerAuditEventType {
   return RECOVERY_EVENT_TYPES[action];
@@ -112,23 +123,70 @@ export function collectRecoveryWorkerStatus(
   persistence: RecoveryWorkerStatusPersistence,
 ): RecoveryWorkerStatus {
   const status = emptyRecoveryWorkerStatus();
+
+  if (typeof persistence.countEventsByTypes === 'function'
+    && typeof persistence.getEventsByTypes === 'function') {
+    return collectFromAggregates(persistence, status);
+  }
+
+  return collectFromLegacyScan(persistence, status);
+}
+
+function collectFromAggregates(
+  persistence: RecoveryWorkerStatusPersistence,
+  status: RecoveryWorkerStatus,
+): RecoveryWorkerStatus {
+  const counts = persistence.countEventsByTypes!(ALL_RECOVERY_EVENT_TYPES);
+  const countByType = new Map(counts.map((row) => [row.eventType, row]));
+
+  const wakeups = countByType.get(RECOVERY_EVENT_TYPES.wakeup)?.count ?? 0;
+  const scans = countByType.get(RECOVERY_EVENT_TYPES.scan)?.count ?? 0;
+  const submissions = countByType.get(RECOVERY_EVENT_TYPES.submit)?.count ?? 0;
+  const skips = countByType.get(RECOVERY_EVENT_TYPES.skip)?.count ?? 0;
+
+  const lastWakeupAt = countByType.get(RECOVERY_EVENT_TYPES.wakeup)?.lastCreatedAt ?? undefined;
+  const lastScanAt = countByType.get(RECOVERY_EVENT_TYPES.scan)?.lastCreatedAt ?? undefined;
+  const lastSubmitAt = countByType.get(RECOVERY_EVENT_TYPES.submit)?.lastCreatedAt ?? undefined;
+
+  const recentEvents = persistence.getEventsByTypes!(ALL_RECOVERY_EVENT_TYPES, 'desc', 50)
+    .filter((event): event is TaskEvent & { eventType: RecoveryWorkerAuditEventType } =>
+      isRecoveryWorkerAuditEventType(event.eventType))
+    .map((event) => toStatusEvent(event));
+
+  const lastSkipEvent = persistence.getEventsByTypes!([RECOVERY_EVENT_TYPES.skip], 'desc', 1)[0];
+  const lastSkip = lastSkipEvent && isRecoveryWorkerAuditEventType(lastSkipEvent.eventType)
+    ? toStatusEvent(lastSkipEvent as TaskEvent & { eventType: RecoveryWorkerAuditEventType })
+    : undefined;
+
+  return {
+    ...status,
+    ...(lastWakeupAt ? { lastWakeupAt } : {}),
+    ...(lastScanAt ? { lastScanAt } : {}),
+    ...(lastSubmitAt ? { lastSubmitAt } : {}),
+    ...(lastSkip ? {
+      lastSkipAt: lastSkip.at,
+      lastSkipReason: lastSkip.reason ?? 'unknown',
+      lastSkipTaskId: lastSkip.taskId,
+    } : {}),
+    wakeups,
+    scans,
+    submissions,
+    skips,
+    recent: recentEvents.slice(0, 10),
+  };
+}
+
+function collectFromLegacyScan(
+  persistence: RecoveryWorkerStatusPersistence,
+  status: RecoveryWorkerStatus,
+): RecoveryWorkerStatus {
   const events: RecoveryWorkerStatusEvent[] = [];
 
-  for (const workflow of persistence.listWorkflows()) {
-    for (const task of persistence.loadTasks(workflow.id)) {
-      for (const event of persistence.getEvents(task.id)) {
+  for (const workflow of persistence.listWorkflows?.() ?? []) {
+    for (const task of persistence.loadTasks?.(workflow.id) ?? []) {
+      for (const event of persistence.getEvents?.(task.id) ?? []) {
         if (!isRecoveryWorkerAuditEventType(event.eventType)) continue;
-        const payload = parsePayload(event.payload);
-        const action = actionForEventType(event.eventType);
-        events.push({
-          at: event.createdAt,
-          taskId: event.taskId,
-          eventType: event.eventType,
-          action,
-          ...(typeof payload.phase === 'string' ? { phase: payload.phase } : {}),
-          ...(typeof payload.reason === 'string' ? { reason: payload.reason } : {}),
-          ...(typeof payload.workflowId === 'string' || payload.workflowId === null ? { workflowId: payload.workflowId } : {}),
-        });
+        events.push(toStatusEvent(event as TaskEvent & { eventType: RecoveryWorkerAuditEventType }));
       }
     }
   }
@@ -175,6 +233,24 @@ export function collectRecoveryWorkerStatus(
     submissions,
     skips,
     recent: events.slice(-10).reverse(),
+  };
+}
+
+function toStatusEvent(
+  event: TaskEvent & { eventType: RecoveryWorkerAuditEventType },
+): RecoveryWorkerStatusEvent {
+  const payload = parsePayload(event.payload);
+  const action = actionForEventType(event.eventType);
+  return {
+    at: event.createdAt,
+    taskId: event.taskId,
+    eventType: event.eventType,
+    action,
+    ...(typeof payload.phase === 'string' ? { phase: payload.phase } : {}),
+    ...(typeof payload.reason === 'string' ? { reason: payload.reason } : {}),
+    ...(typeof payload.workflowId === 'string' || payload.workflowId === null
+      ? { workflowId: payload.workflowId }
+      : {}),
   };
 }
 

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -48,7 +48,10 @@ export interface WorkerRuntimeController {
   snapshot(): WorkerStatusSnapshot;
 }
 
-type WorkerStatusPersistence = Pick<SQLiteAdapter, 'listWorkerActions' | 'listWorkflows' | 'loadTasks' | 'getEvents'>;
+type WorkerStatusPersistence = Pick<
+  SQLiteAdapter,
+  'listWorkerActions' | 'listWorkflows' | 'loadTasks' | 'getEvents' | 'getEventsByTypes' | 'countEventsByTypes'
+>;
 
 const DEFAULT_WORKER_ACTION_HISTORY_LIMIT = 20;
 const MAX_WORKER_ACTION_HISTORY_LIMIT = 100;
@@ -184,7 +187,6 @@ export function createWorkerRuntimeController(options: {
     return definition;
   };
 
-
   const rowForKind = (kind: string): WorkerStatusEntry => {
     const definition = options.registry.get(kind);
     if (!definition) {
@@ -199,6 +201,9 @@ export function createWorkerRuntimeController(options: {
       policy: policyForKind(kind),
       persistence: options.persistence,
       canControl: options.canControl(),
+      recovery: definition.kind === AUTO_FIX_WORKER_KIND
+        ? toWorkerRecoverySummary(options.persistence)
+        : undefined,
     });
   };
 
@@ -266,6 +271,9 @@ export function createLocalWorkerStatusSnapshot(options: {
   persistence: WorkerStatusPersistence;
   autoStartKinds: readonly string[];
 }): WorkerStatusSnapshot {
+  const recovery = options.registry.list().some((definition) => definition.kind === AUTO_FIX_WORKER_KIND)
+    ? toWorkerRecoverySummary(options.persistence)
+    : undefined;
   return {
     generatedAt: new Date().toISOString(),
     workers: options.registry.list().map((definition) => buildWorkerStatusEntry({
@@ -275,6 +283,7 @@ export function createLocalWorkerStatusSnapshot(options: {
       policy: 'unknown',
       persistence: options.persistence,
       canControl: false,
+      recovery: definition.kind === AUTO_FIX_WORKER_KIND ? recovery : undefined,
     })),
   };
 }
@@ -289,6 +298,7 @@ function buildWorkerStatusEntry(args: {
   policy: WorkerPolicyStatus;
   persistence: WorkerStatusPersistence;
   canControl: boolean;
+  recovery?: WorkerRecoverySummary;
 }): WorkerStatusEntry {
   const lifecycle = args.handle
     ? args.handle.runtime.isRunning() ? 'running' : 'exited'
@@ -308,7 +318,7 @@ function buildWorkerStatusEntry(args: {
     ...(args.handle?.startedAt ? { startedAt: args.handle.startedAt } : {}),
     ...(args.stoppedAt ? { stoppedAt: args.stoppedAt } : {}),
     recentActions: args.persistence.listWorkerActions({ workerKind: args.definitionKind, limit: 5 }).slice(0, 5).map(toWorkerActionSummary),
-    ...(args.definitionKind === AUTO_FIX_WORKER_KIND ? { recovery: toWorkerRecoverySummary(args.persistence) } : {}),
+    ...(args.recovery ? { recovery: args.recovery } : {}),
   };
 }
 

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, statSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -1876,6 +1876,59 @@ describe('SQLiteAdapter', () => {
       const [task] = adapter.loadTasks('wf-1');
       expect(task.status).toBe('stale');
     });
+
+    it('projects the newest active attempt without scanning every attempt for the node (perf regression #3746)', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1', { status: 'running' }));
+
+      const selectedFailed: Attempt = {
+        ...createAttempt('t1', { status: 'failed' }),
+        id: 't1-aOLD',
+        createdAt: new Date('2026-07-09T05:00:00.000Z'),
+        error: 'boom',
+      };
+      const newerPending: Attempt = {
+        ...createAttempt('t1', { status: 'pending' }),
+        id: 't1-aNEW',
+        createdAt: new Date('2026-07-09T06:00:00.000Z'),
+        supersedesAttemptId: selectedFailed.id,
+      };
+      adapter.saveAttempt(selectedFailed);
+      adapter.saveAttempt(newerPending);
+
+      const bigError = 'x'.repeat(200_000);
+      for (let i = 0; i < 50; i += 1) {
+        adapter.saveAttempt({
+          ...createAttempt('t1', { status: i % 2 === 0 ? 'failed' : 'superseded' }),
+          id: `t1-old-${i}`,
+          createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, i)),
+          error: bigError,
+        });
+      }
+
+      adapter.updateTask('t1', { execution: { selectedAttemptId: selectedFailed.id } });
+
+      const spy = vi.spyOn(
+        adapter as unknown as { queryAll: (sql: string, params?: unknown[]) => unknown },
+        'queryAll',
+      );
+      try {
+        const [task] = adapter.loadTasks('wf-1');
+        expect(task.status).toBe('running');
+        expect(task.execution.error).toBeUndefined();
+        expect(task.execution.selectedAttemptId).toBe(selectedFailed.id);
+      } finally {
+        spy.mockRestore();
+      }
+
+      const ranUnboundedScan = spy.mock.calls.some(
+        ([sql]) =>
+          typeof sql === 'string' &&
+          /FROM attempts\s+WHERE node_id = \?\s+ORDER BY created_at ASC/.test(sql),
+      );
+      expect(ranUnboundedScan).toBe(false);
+    });
+
   });
 
   describe('loadActionGraphAttempts', () => {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -644,6 +644,7 @@ describe('SQLiteAdapter', () => {
       expect(tableIndexes(adapter, 'worker_actions')).toEqual(expect.arrayContaining([
         'idx_worker_actions_task_updated',
         'idx_worker_actions_workflow_status',
+        'idx_worker_actions_kind_updated',
       ]));
       expect(tableForeignKeys(adapter, 'worker_actions')).toEqual(expect.arrayContaining([
         'workflows.id:CASCADE',

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -277,6 +277,12 @@ export interface PersistenceAdapter {
   logEvent(taskId: string, eventType: string, payload?: unknown): void;
   getEvents(taskId: string): TaskEvent[];
   getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number): TaskEvent[];
+  getEventsByTypes?(eventTypes: readonly string[], sortBy: 'asc' | 'desc', limit: number): TaskEvent[];
+  countEventsByTypes?(eventTypes: readonly string[]): Array<{
+    eventType: string;
+    count: number;
+    lastCreatedAt: string | null;
+  }>;
 
   // Worker actions (durable worker-owned action state/history)
   getWorkerAction(workerKind: string, externalKey: string): WorkerActionRecord | undefined;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1703,13 +1703,68 @@ export class SQLiteAdapter implements PersistenceAdapter {
           `SELECT * FROM events WHERE task_id = ? ORDER BY id ${orderBy} LIMIT ?`,
           [taskId, Math.floor(limit)],
         );
-    return rows.map((row: any) => ({
+    return rows.map((row: any) => this.rowToTaskEvent(row));
+  }
+
+  getEventsByTypes(
+    eventTypes: readonly string[],
+    sortBy: 'asc' | 'desc' = 'desc',
+    limit = 50,
+  ): TaskEvent[] {
+    if (eventTypes.length === 0 || limit <= 0) return [];
+    const orderBy = sortBy === 'desc' ? 'DESC' : 'ASC';
+    const placeholders = eventTypes.map(() => '?').join(', ');
+    const rows = this.queryAll(
+      `SELECT * FROM events
+       WHERE event_type IN (${placeholders})
+       ORDER BY created_at ${orderBy}, id ${orderBy}
+       LIMIT ?`,
+      [...eventTypes, Math.floor(limit)],
+    );
+    return rows.map((row: any) => this.rowToTaskEvent(row));
+  }
+
+  countEventsByTypes(eventTypes: readonly string[]): Array<{
+    eventType: string;
+    count: number;
+    lastCreatedAt: string | null;
+  }> {
+    if (eventTypes.length === 0) return [];
+    const placeholders = eventTypes.map(() => '?').join(', ');
+    const rows = this.queryAll(
+      `SELECT event_type AS eventType,
+              COUNT(*) AS count,
+              MAX(created_at) AS lastCreatedAt
+       FROM events
+       WHERE event_type IN (${placeholders})
+       GROUP BY event_type`,
+      [...eventTypes],
+    );
+    const byType = new Map(
+      rows.map((row) => [
+        String(row.eventType),
+        {
+          eventType: String(row.eventType),
+          count: Number(row.count ?? 0),
+          lastCreatedAt: (row.lastCreatedAt as string | null) ?? null,
+        },
+      ]),
+    );
+    return eventTypes.map((eventType) => byType.get(eventType) ?? {
+      eventType,
+      count: 0,
+      lastCreatedAt: null,
+    });
+  }
+
+  private rowToTaskEvent(row: any): TaskEvent {
+    return {
       id: row.id,
       taskId: row.task_id,
       eventType: row.event_type,
       payload: row.payload ?? undefined,
       createdAt: row.created_at,
-    }));
+    };
   }
 
   getWorkerAction(workerKind: string, externalKey: string): WorkerActionRecord | undefined {

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -345,6 +345,9 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_worker_actions_workflow_status
         ON worker_actions(workflow_id, worker_kind, status);
 
+      CREATE INDEX IF NOT EXISTS idx_worker_actions_kind_updated
+        ON worker_actions(worker_kind, updated_at DESC, id);
+
       CREATE TABLE IF NOT EXISTS execution_resource_leases (
         resource_key TEXT NOT NULL,
         resource_type TEXT NOT NULL,
@@ -488,6 +491,7 @@ export const POST_MIGRATION_STATEMENTS = [
   'CREATE INDEX IF NOT EXISTS idx_tasks_workflow_id ON tasks(workflow_id)',
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_task_updated ON worker_actions(task_id, updated_at)',
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_workflow_status ON worker_actions(workflow_id, worker_kind, status)',
+  'CREATE INDEX IF NOT EXISTS idx_worker_actions_kind_updated ON worker_actions(worker_kind, updated_at DESC, id)',
   'DROP INDEX IF EXISTS idx_task_launch_dispatch_active_attempt',
   `
       CREATE UNIQUE INDEX IF NOT EXISTS idx_task_launch_dispatch_active_attempt

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -109,6 +109,9 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_events_task_id_id
         ON events(task_id, id);
 
+      CREATE INDEX IF NOT EXISTS idx_events_type_created
+        ON events(event_type, created_at);
+
       CREATE TABLE IF NOT EXISTS activity_log (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         timestamp TEXT NOT NULL DEFAULT (datetime('now')),
@@ -481,6 +484,7 @@ export const POST_MIGRATION_STATEMENTS = [
   'DROP INDEX IF EXISTS idx_attempts_node',
   'CREATE INDEX IF NOT EXISTS idx_attempts_node_created ON attempts(node_id, created_at)',
   'CREATE INDEX IF NOT EXISTS idx_events_task_id_id ON events(task_id, id)',
+  'CREATE INDEX IF NOT EXISTS idx_events_type_created ON events(event_type, created_at)',
   'CREATE INDEX IF NOT EXISTS idx_tasks_workflow_id ON tasks(workflow_id)',
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_task_updated ON worker_actions(task_id, updated_at)',
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_workflow_status ON worker_actions(workflow_id, worker_kind, status)',

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -11,7 +11,6 @@
 import type { TaskState, TaskStateChanges, Attempt } from '@invoker/workflow-core';
 import {
   assertTaskConsistent,
-  isActiveAttempt,
   isDiscardedAttempt,
   normalizeRunnerKind,
 } from '@invoker/workflow-core';
@@ -700,8 +699,8 @@ export class SqliteTaskAttemptRepository {
     if (!attempt) return task;
 
     if (attempt.status === 'failed' || isDiscardedAttempt(attempt)) {
-      const newer = this.findNewerActiveAttempt(task.id, attempt);
-      if (newer) {
+      const [activeAfter] = this.findActiveAttemptsAfter(task.id, attempt, 1);
+      if (activeAfter) {
         const cleaned: TaskState = {
           ...task,
           execution: {
@@ -711,7 +710,7 @@ export class SqliteTaskAttemptRepository {
             completedAt: undefined,
           },
         };
-        if (newer.status === 'needs_input') {
+        if (activeAfter.status === 'needs_input') {
           return { ...cleaned, status: 'needs_input' };
         }
         return cleaned;
@@ -777,18 +776,18 @@ export class SqliteTaskAttemptRepository {
     return task;
   }
 
-  private findNewerActiveAttempt(nodeId: string, selected: Attempt): Attempt | undefined {
-    const attempts = this.loadAttempts(nodeId);
-    const selectedTs = selected.createdAt.getTime();
-    let newest: Attempt | undefined;
-    for (const candidate of attempts) {
-      if (candidate.id === selected.id) continue;
-      if (!isActiveAttempt(candidate)) continue;
-      if (candidate.createdAt.getTime() <= selectedTs) continue;
-      if (!newest || candidate.createdAt.getTime() > newest.createdAt.getTime()) {
-        newest = candidate;
-      }
-    }
-    return newest;
+  private findActiveAttemptsAfter(nodeId: string, selected: Attempt, limit = 1): Attempt[] {
+    const cappedLimit = Math.max(0, Math.floor(limit));
+    if (cappedLimit === 0) return [];
+    const rows = this.exec.queryAll(
+      `SELECT * FROM attempts
+       WHERE node_id = ?
+         AND created_at > ?
+         AND status IN ('pending', 'claimed', 'running', 'needs_input')
+       ORDER BY created_at DESC
+       LIMIT ?`,
+      [nodeId, selected.createdAt.toISOString(), cappedLimit],
+    );
+    return rows.map((row) => mapRowToAttempt(row));
   }
 }


### PR DESCRIPTION
## Summary

UI polls worker status every 2s and re-runs `listWorkerActions` once per worker kind.

Without a matching index those reads were ~30ms each and made window dragging sticky. This slice adds `idx_worker_actions_kind_updated` so bounded per-kind polls stay cheap.

It does **not** TTL-cache worker-status snapshots. Intentional 3s staleness was rejected; every poll rebuilds from indexed SQL. Moving sync SQLite off the Electron main thread is tracked in INV-265.

## Review Claim

Approve adding `idx_worker_actions_kind_updated` for `listWorkerActions({ workerKind, limit })` on the worker-status poll path, without a snapshot TTL cache.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Index is additive (`IF NOT EXISTS`). Status polls remain fresh on every tick. No intentional staleness.

## Slice Rationale

Separate from the freeze fix (aggregates): this addresses residual hitching from per-kind action history queries after recovery status was already cheap. Cache was considered and dropped in favor of indexed reads + INV-265.

## Non-goals

- Does not cache worker-status snapshots.
- Does not change recovery event aggregation logic.
- Does not change the UI poll interval itself.
- Does not move SQLite off the main thread (INV-265).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/worker-control.test.ts`
- [x] `cd packages/data-store && pnpm exec vitest run src/__tests__/sqlite-adapter.test.ts -t "worker_actions"`
- [ ] Stack hitch e2e after restack

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? Index-only; safe to leave or drop `idx_worker_actions_kind_updated`

</details>

Depends-On: #3816