### PR TITLE
[Main-process freeze](8) Add main-process hitch e2e under fat DB

### DIFF
--- a/packages/app/e2e/main-process-hitch-responsiveness.spec.ts
+++ b/packages/app/e2e/main-process-hitch-responsiveness.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Main-process hitch e2e: under a fat events + worker_actions DB, worker-status
+ * polling must keep cheap IPC (listWorkflows) responsive.
+ *
+ * This catches main-thread stalls (sticky window drag / unfocusable window),
+ * which renderer frame-gap tests do not cover.
+ */
+import { expect, test } from './fixtures/electron-app.js';
+
+const POLL_WINDOW_MS = 10_000;
+const SAMPLE_INTERVAL_MS = 100;
+const MAX_P95_RTT_MS = 100;
+const MAX_SAMPLE_RTT_MS = 250;
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)]!;
+}
+
+test('worker-status polling keeps listWorkflows IPC responsive under a fat DB', async ({ page }) => {
+  const seeded = await page.evaluate(async () => {
+    if (!window.invoker.seedMainProcessHitchFixture) {
+      throw new Error('seedMainProcessHitchFixture is not exposed (NODE_ENV=test required)');
+    }
+    return window.invoker.seedMainProcessHitchFixture();
+  });
+
+  expect(seeded.eventCount).toBeGreaterThanOrEqual(10_000);
+  expect(seeded.workerActionCount).toBeGreaterThan(0);
+
+  // Force an uncached worker-status rebuild against the fat DB, then keep polling
+  // while measuring cheap IPC RTT (maps to main-loop stalls).
+  await page.evaluate(async () => {
+    await window.invoker.getWorkerStatus();
+  });
+
+  const samples: number[] = [];
+  const deadline = Date.now() + POLL_WINDOW_MS;
+  while (Date.now() < deadline) {
+    const rtt = await page.evaluate(async () => {
+      const started = performance.now();
+      await Promise.all([
+        window.invoker.getWorkerStatus(),
+        window.invoker.listWorkflows(),
+      ]);
+      return performance.now() - started;
+    });
+    samples.push(rtt);
+    await page.waitForTimeout(SAMPLE_INTERVAL_MS);
+  }
+
+  expect(samples.length).toBeGreaterThanOrEqual(20);
+  const sorted = [...samples].sort((a, b) => a - b);
+  const p95 = percentile(sorted, 95);
+  const max = sorted[sorted.length - 1]!;
+
+  expect(
+    p95,
+    `p95 IPC RTT ${p95.toFixed(1)}ms exceeded ${MAX_P95_RTT_MS}ms (max=${max.toFixed(1)}ms, n=${samples.length})`,
+  ).toBeLessThanOrEqual(MAX_P95_RTT_MS);
+  expect(
+    max,
+    `max IPC RTT ${max.toFixed(1)}ms exceeded ${MAX_SAMPLE_RTT_MS}ms (p95=${p95.toFixed(1)}ms, n=${samples.length})`,
+  ).toBeLessThanOrEqual(MAX_SAMPLE_RTT_MS);
+});

--- a/packages/app/src/__tests__/main-process-hitch-fixture.test.ts
+++ b/packages/app/src/__tests__/main-process-hitch-fixture.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SQLiteAdapter } from '@invoker/data-store';
+
+import { seedMainProcessHitchFixture } from '../main-process-hitch-fixture.js';
+
+describe('seedMainProcessHitchFixture', () => {
+  let tmpDir: string | undefined;
+  let adapter: SQLiteAdapter | undefined;
+
+  afterEach(async () => {
+    await adapter?.close();
+    adapter = undefined;
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it('seeds enough events and worker actions for hitch e2e', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'invoker-hitch-seed-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const seeded = seedMainProcessHitchFixture(adapter, {
+      taskCount: 4,
+      eventsPerTask: 10,
+      actionsPerKind: 2,
+    });
+
+    expect(seeded.eventCount).toBe(40);
+    expect(seeded.workerActionCount).toBeGreaterThan(0);
+    expect(adapter.listWorkflows().some((wf) => wf.id === seeded.workflowId)).toBe(true);
+    expect(adapter.listWorkerActions({ limit: 5 }).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -259,6 +259,11 @@ describe('createWorkerRuntimeController', () => {
     expect(second).toBe(first);
     expect(listWorkerActions).toHaveBeenCalledTimes(1);
 
+    controller.invalidateSnapshotCache();
+    listWorkerActions.mockClear();
+    expect(controller.snapshot()).not.toBe(first);
+    expect(listWorkerActions).toHaveBeenCalledTimes(1);
+
     controller.start('history');
     expect(controller.snapshot()).not.toBe(first);
   });

--- a/packages/app/src/main-process-hitch-fixture.ts
+++ b/packages/app/src/main-process-hitch-fixture.ts
@@ -1,0 +1,121 @@
+import type { SQLiteAdapter, Workflow, WorkerActionWrite } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+import { AUTO_STARTED_OWNER_WORKER_KINDS } from './worker-control.js';
+import {
+  buildRecoveryWorkerAuditPayload,
+  recoveryWorkerEventType,
+} from './recovery-worker-observability.js';
+
+export const MAIN_PROCESS_HITCH_FIXTURE_WORKFLOW_ID = 'wf-hitch-fat';
+
+const DEFAULT_TASK_COUNT = 40;
+const DEFAULT_EVENTS_PER_TASK = 250;
+const DEFAULT_ACTIONS_PER_KIND = 80;
+
+const ACTION_WORKER_KINDS = [
+  'autofix',
+  ...AUTO_STARTED_OWNER_WORKER_KINDS,
+] as const;
+
+export interface MainProcessHitchFixtureOptions {
+  taskCount?: number;
+  eventsPerTask?: number;
+  actionsPerKind?: number;
+}
+
+export interface MainProcessHitchFixtureResult {
+  workflowId: string;
+  taskCount: number;
+  eventCount: number;
+  workerActionCount: number;
+}
+
+function makeWorkflow(id: string, name: string): Workflow {
+  return {
+    id,
+    name,
+    status: 'running',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+  };
+}
+
+function makeTask(id: string): TaskState {
+  return {
+    id,
+    description: `Task ${id}`,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date('2026-07-01T00:00:00.000Z'),
+    config: {},
+    execution: {},
+    taskStateVersion: 1,
+  };
+}
+
+/**
+ * Seed a fat events + worker_actions dataset for main-process hitch e2e.
+ * Mirrors the unit cost-guard fixture so unbounded poll reads would stall IPC.
+ */
+export function seedMainProcessHitchFixture(
+  persistence: Pick<SQLiteAdapter, 'saveWorkflow' | 'saveTask' | 'logEvent' | 'upsertWorkerAction'>,
+  options: MainProcessHitchFixtureOptions = {},
+): MainProcessHitchFixtureResult {
+  const taskCount = options.taskCount ?? DEFAULT_TASK_COUNT;
+  const eventsPerTask = options.eventsPerTask ?? DEFAULT_EVENTS_PER_TASK;
+  const actionsPerKind = options.actionsPerKind ?? DEFAULT_ACTIONS_PER_KIND;
+  const workflowId = MAIN_PROCESS_HITCH_FIXTURE_WORKFLOW_ID;
+
+  persistence.saveWorkflow(makeWorkflow(workflowId, 'Main-process hitch fixture'));
+
+  for (let t = 0; t < taskCount; t += 1) {
+    const taskId = `${workflowId}/t${t}`;
+    persistence.saveTask(workflowId, makeTask(taskId));
+    for (let e = 0; e < eventsPerTask; e += 1) {
+      const action = e % 4 === 0 ? 'wakeup'
+        : e % 4 === 1 ? 'scan'
+          : e % 4 === 2 ? 'submit'
+            : 'skip';
+      persistence.logEvent(
+        taskId,
+        recoveryWorkerEventType(action),
+        buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
+          workflowId,
+          reason: action === 'skip' ? 'budget' : undefined,
+        }),
+      );
+    }
+  }
+
+  let workerActionCount = 0;
+  for (const workerKind of ACTION_WORKER_KINDS) {
+    for (let i = 0; i < actionsPerKind; i += 1) {
+      const taskId = `${workflowId}/t${i % Math.max(taskCount, 1)}`;
+      const write: WorkerActionWrite = {
+        id: `wa-hitch-${workerKind}-${i}`,
+        workerKind,
+        actionType: 'hitch-fixture',
+        workflowId,
+        taskId,
+        subjectType: 'task',
+        subjectId: taskId,
+        externalKey: `hitch:${workerKind}:${i}`,
+        status: i % 5 === 0 ? 'skipped' : 'completed',
+        attemptCount: 1,
+        summary: `Hitch fixture ${workerKind} ${i}`,
+        payload: { reason: i % 5 === 0 ? 'budget' : 'ok' },
+        createdAt: `2026-07-01T00:00:${String(i % 60).padStart(2, '0')}.000Z`,
+        updatedAt: `2026-07-01T00:01:${String(i % 60).padStart(2, '0')}.000Z`,
+      };
+      persistence.upsertWorkerAction(write);
+      workerActionCount += 1;
+    }
+  }
+
+  return {
+    workflowId,
+    taskCount,
+    eventCount: taskCount * eventsPerTask,
+    workerActionCount,
+  };
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -273,6 +273,7 @@ import {
   classifyAutoFixRecoveryPhase,
   recoveryWorkerEventType,
 } from './recovery-worker-observability.js';
+import { seedMainProcessHitchFixture } from './main-process-hitch-fixture.js';
 import {
   executeNoTrackHeadlessBatch,
   type HeadlessBatchExecRequest,
@@ -1302,6 +1303,15 @@ function startHeadlessMode(): void {
             }
             orchestrator.syncAllFromDb();
             return undefined;
+          }
+          case 'invoker:seed-main-process-hitch-fixture': {
+            if (process.env.NODE_ENV !== 'test') {
+              throw new Error('seed-main-process-hitch-fixture is only available in tests');
+            }
+            const seeded = seedMainProcessHitchFixture(persistence);
+            orchestrator.syncAllFromDb();
+            workerRuntimeController?.invalidateSnapshotCache();
+            return seeded;
           }
           case 'invoker:set-merge-branch': {
             const workflowId = String(payload.args[0]);
@@ -4044,6 +4054,18 @@ function createEmbeddedTerminalBackendFromConfig(
           testPlanningChatResponse = response;
         },
       );
+      ipcMain.handle('invoker:seed-main-process-hitch-fixture', async () => {
+        if (!ownerMode) {
+          return await messageBus.request('headless.gui-mutation', {
+            channel: 'invoker:seed-main-process-hitch-fixture',
+            args: [],
+          } satisfies GuiMutationPayload);
+        }
+        const seeded = seedMainProcessHitchFixture(persistence);
+        orchestrator.syncAllFromDb();
+        workerRuntimeController?.invalidateSnapshotCache();
+        return seeded;
+      });
     }
 
     registerGuiMutationHandler('invoker:start', async () => {

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -46,6 +46,8 @@ export interface WorkerRuntimeController {
   stop(kind: string): Promise<WorkerStatusEntry>;
   stopAll(): Promise<void>;
   snapshot(): WorkerStatusSnapshot;
+  /** Drop cached snapshot/recovery so the next poll rebuilds against current DB. */
+  invalidateSnapshotCache(): void;
 }
 
 type WorkerStatusPersistence = Pick<
@@ -294,6 +296,8 @@ export function createWorkerRuntimeController(options: {
       cachedSnapshotAt = now;
       return cachedSnapshot;
     },
+
+    invalidateSnapshotCache,
   };
 }
 export function createLocalWorkerStatusSnapshot(options: {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1104,6 +1104,15 @@ export const IpcTestOnlyChannels = {
     ];
     response: void;
   },
+  'invoker:seed-main-process-hitch-fixture': {} as {
+    request: [];
+    response: {
+      workflowId: string;
+      taskCount: number;
+      eventCount: number;
+      workerActionCount: number;
+    };
+  },
 } as const;
 
 // ── Event Channel Registry ──────────────────────────────────


### PR DESCRIPTION
Seed fat events and worker_actions via a test-only IPC, then assert
listWorkflows/getWorkerStatus RTT stays under budget while status polls.
Expose invalidateSnapshotCache so the fixture rebuilds against the fat DB.

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #3820