### PR TITLE
[Main-process freeze](11) Point hot-path docs at hitch e2e and slow-query logs

### DIFF
--- a/docs/architecture/main-process-read-hot-paths.md
+++ b/docs/architecture/main-process-read-hot-paths.md
@@ -54,8 +54,10 @@ matching index.
 ## How to catch regressions
 
 - Unit cost guards under fat fixtures (many events / large attempt errors).
-- Main-process hitch e2e: while worker-status polls, cheap IPC RTT must stay
+- Main-process hitch e2e (`packages/app/e2e/main-process-hitch-responsiveness.spec.ts`):
+  while worker-status polls against a seeded fat DB, cheap IPC RTT must stay
   under budget (window-drag stickiness maps to main-loop stalls, not renderer
   frame gaps alone).
-- Optional: log main-process queries slower than a small threshold to activity /
-  ui-perf so the next spike shows up without attaching a sampler.
+- Slow-query telemetry: `SQLiteAdapter` logs statements slower than 25ms
+  (`slowQueryThresholdMs` / `onSlowQuery`) so the next spike shows up without
+  attaching a sampler. Set `slowQueryThresholdMs: 0` to disable.


### PR DESCRIPTION
## Summary

Prevention slices landed the hitch e2e and slow-query knobs.

This updates the hot-path architecture doc to point at the concrete e2e path and `SQLiteAdapter` slow-query options.

## Review Claim

Approve the docs-only update that references the hitch e2e and slow-query telemetry after those behavior slices.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Docs-only. No runtime code changes.

## Slice Rationale

Review compression forbids shipping docs with behavior. Concrete prevention references land after the e2e and telemetry slices.

## Non-goals

- Does not change runtime behavior.
- Does not add new tests.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `git diff --name-only` for this slice is docs-only

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>