### PR TITLE
[Read-only owner-loss banner](1) Add runtime-status IPC event channel

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1131,6 +1131,9 @@ export const IpcEventChannels = {
   'invoker:workflow-mutation-failed': {} as {
     payload: WorkflowMutationFailedEvent;
   },
+  'invoker:runtime-status': {} as {
+    payload: RuntimeStatus;
+  },
 } as const;
 
 // ── Type Utilities ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

The renderer needs a declared IPC event for runtime mode status.

This adds `invoker:runtime-status` to the IPC event channel registry.

## Review Claim

Approve adding the `invoker:runtime-status` IPC event channel contract.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Contract-only. No runtime behavior changes in this slice.

## Slice Rationale

The event channel must exist before main or UI can publish or subscribe to it.

## Non-goals

Does not publish runtime status yet.

Does not change the read-only banner.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/app-bootstrap.test.ts src/__tests__/ipc-registration.test.ts src/__tests__/ipc-read-handlers.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
