### PR TITLE
[Read-only owner-loss banner](2) Flip daemon clients to read-only on owner loss

### DIFF
--- a/packages/app/src/__tests__/app-bootstrap.test.ts
+++ b/packages/app/src/__tests__/app-bootstrap.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  computeGuiRuntimeStatus,
   configureEarlyElectronApp,
   formatGuiOwnerBootstrapFallbackMessage,
   guiOwnerBootstrapTimeoutMs,
+  isMutationOwnerUnavailableError,
   registerGuiLifecycleHandlers,
   resolveGuiOwnerPreference,
   resolveElectronUserDataDir,
@@ -249,6 +251,31 @@ describe('app-bootstrap', () => {
     expect(shouldRefreshGuiOwnerRoute('auto', true)).toBe(true);
     expect(shouldRefreshGuiOwnerRoute('auto', false)).toBe(false);
     expect(shouldRefreshGuiOwnerRoute('gui', true)).toBe(false);
+  });
+
+  it('computes runtime status so daemon clients stay writable until owner loss', () => {
+    expect(computeGuiRuntimeStatus({ ownerMode: true, guiUsingDaemonOwner: false })).toEqual({
+      ownerMode: true,
+      readOnly: false,
+      mode: 'local-owner',
+    });
+    expect(computeGuiRuntimeStatus({ ownerMode: false, guiUsingDaemonOwner: true })).toEqual({
+      ownerMode: false,
+      readOnly: false,
+      mode: 'daemon-owner',
+    });
+    expect(computeGuiRuntimeStatus({ ownerMode: false, guiUsingDaemonOwner: false })).toEqual({
+      ownerMode: false,
+      readOnly: true,
+      mode: 'read-only',
+    });
+  });
+
+  it('detects mutation-owner-unavailable transport failures', () => {
+    expect(isMutationOwnerUnavailableError(new Error('No mutation owner is available'))).toBe(true);
+    expect(isMutationOwnerUnavailableError({ code: 'NO_HANDLER', message: 'missing' })).toBe(true);
+    expect(isMutationOwnerUnavailableError(new Error('No request handler registered for channel: headless.exec'))).toBe(true);
+    expect(isMutationOwnerUnavailableError(new Error('timeout'))).toBe(false);
   });
 
   it('uses a bounded daemon bootstrap timeout and ignores invalid overrides', () => {

--- a/packages/app/src/__tests__/ipc-read-handlers.test.ts
+++ b/packages/app/src/__tests__/ipc-read-handlers.test.ts
@@ -282,4 +282,37 @@ describe('registerReadOnlyIpcHandlers', () => {
     await expect(handlers.get('invoker:list-workflows')?.({})).resolves.toEqual([{ id: 'LOCAL-FALLBACK' }]);
   });
 
+  it('notifies when owner query delegation finds no mutation owner', async () => {
+    const onMutationOwnerUnavailable = vi.fn();
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const ipcMain = {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+        handlers.set(channel, handler);
+      }),
+    };
+    registerReadOnlyIpcHandlers({
+      ipcMain: ipcMain as never,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+      persistence: { listWorkflows: vi.fn(() => [{ id: 'LOCAL-FALLBACK' }]) } as never,
+      getOrchestrator: () => ({}) as never,
+      agentRegistry: {} as never,
+      loadTaskByIdFromPersistence: () => undefined,
+      resolveAgentSession: vi.fn(async () => null),
+      getOwnerMode: () => false,
+      getMessageBus: () => ({
+        request: vi.fn(async () => {
+          throw Object.assign(new Error('No request handler registered for channel: headless.query'), { code: 'NO_HANDLER' });
+        }),
+      }),
+      onMutationOwnerUnavailable,
+      recordStartupDuration: vi.fn(),
+      getTaskDeltaStreamSequence: () => 0,
+    });
+
+    await expect(handlers.get('invoker:list-workflows')?.({})).resolves.toEqual([{ id: 'LOCAL-FALLBACK' }]);
+    expect(onMutationOwnerUnavailable).toHaveBeenCalledWith(
+      'No request handler registered for channel: headless.query',
+    );
+  });
+
 });

--- a/packages/app/src/bootstrap/app-bootstrap.ts
+++ b/packages/app/src/bootstrap/app-bootstrap.ts
@@ -37,6 +37,42 @@ export function formatGuiOwnerBootstrapFallbackMessage(message: string): string 
   ].join('\n');
 }
 
+export type RuntimeModeSnapshot = 'local-owner' | 'daemon-owner' | 'read-only';
+
+export interface RuntimeStatusFields {
+  ownerMode: boolean;
+  readOnly: boolean;
+  mode: RuntimeModeSnapshot;
+}
+
+/** Compute the GUI runtime status from ownership flags. */
+export function computeGuiRuntimeStatus(input: {
+  ownerMode: boolean;
+  guiUsingDaemonOwner: boolean;
+}): RuntimeStatusFields {
+  const { ownerMode, guiUsingDaemonOwner } = input;
+  return {
+    ownerMode,
+    readOnly: !ownerMode && !guiUsingDaemonOwner,
+    mode: ownerMode ? 'local-owner' : guiUsingDaemonOwner ? 'daemon-owner' : 'read-only',
+  };
+}
+
+/** True when an owner IPC/delegation failure means no mutation owner is reachable. */
+export function isMutationOwnerUnavailableError(error: unknown): boolean {
+  if (error instanceof Error && error.message === 'No mutation owner is available') {
+    return true;
+  }
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  const code = typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code ?? '')
+    : '';
+  return code === 'NO_HANDLER'
+    || code === 'DISCONNECTED'
+    || message.includes('No request handler registered')
+    || message.includes('No mutation owner is available');
+}
+
 export interface ElectronUserDataEnv {
   INVOKER_USER_DATA_DIR?: string;
   INVOKER_DB_DIR?: string;

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -25,6 +25,8 @@ export interface RegisterReadOnlyIpcHandlersContext {
   ) => Promise<unknown>;
   getOwnerMode?: () => boolean;
   getMessageBus?: () => Pick<MessageBus, 'request'>;
+  /** Called when owner query delegation finds no reachable mutation owner. */
+  onMutationOwnerUnavailable?: (reason: string) => void;
   recordStartupDuration: (label: string, startedAtMs: number, fields?: Record<string, unknown>) => void;
   getTaskDeltaStreamSequence: () => number;
 }
@@ -61,6 +63,7 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     resolveAgentSession,
     getOwnerMode,
     getMessageBus,
+    onMutationOwnerUnavailable,
     recordStartupDuration,
     getTaskDeltaStreamSequence,
   } = context;
@@ -83,6 +86,7 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
       if (code !== 'NO_HANDLER' && !message.includes('No request handler registered')) {
         throw err;
       }
+      onMutationOwnerUnavailable?.(message);
       logger.warn(
         `${kind} owner delegation found no owner handler; falling back to local read-only snapshot: ${message}`,
         { module: 'ipc' },

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -38,9 +38,11 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { config as loadDotenv } from 'dotenv';
 import {
+  computeGuiRuntimeStatus,
   configureEarlyElectronApp,
   formatGuiOwnerBootstrapFallbackMessage,
   guiOwnerBootstrapTimeoutMs,
+  isMutationOwnerUnavailableError,
   registerGuiLifecycleHandlers,
   resolveGuiOwnerPreference,
   runElectronReadyBootstrap,
@@ -659,16 +661,37 @@ async function ensureStandaloneOwnerForGui(): Promise<void> {
 }
 
 let guiOwnerRouteRefreshPromise: Promise<void> | null = null;
+let notifyRuntimeStatusChanged: (() => void) | null = null;
+
+/**
+ * Daemon-backed GUI clients stay writable only while the owner answers IPC.
+ * When the owner disappears, drop the daemon-owner flag so runtime status
+ * becomes read-only and the UI banner can show.
+ */
+function markDaemonOwnerUnavailable(reason: string): void {
+  if (!guiUsingDaemonOwner) return;
+  guiUsingDaemonOwner = false;
+  logger.warn(`daemon mutation owner unavailable; entering read-only mode: ${reason}`, { module: 'ipc' });
+  notifyRuntimeStatusChanged?.();
+}
 
 async function refreshGuiMutationOwnerRoute(): Promise<void> {
   const ownerPreference = resolveGuiOwnerPreference();
   if (!shouldRefreshGuiOwnerRoute(ownerPreference, guiUsingDaemonOwner)) return;
   if (!guiOwnerRouteRefreshPromise) {
     guiOwnerRouteRefreshPromise = (async () => {
-      if (ownerPreference === 'daemon') {
-        await ensureStandaloneOwnerForGui();
-      } else if (!await discoverStandaloneOwnerForGui(2_000)) {
-        throw new Error('No mutation owner is available');
+      try {
+        if (ownerPreference === 'daemon') {
+          await ensureStandaloneOwnerForGui();
+        } else if (!await discoverStandaloneOwnerForGui(2_000)) {
+          markDaemonOwnerUnavailable('daemon owner discovery timed out');
+          throw new Error('No mutation owner is available');
+        }
+      } catch (err) {
+        if (isMutationOwnerUnavailableError(err) || (err instanceof Error && /Timed out after .* waiting for daemon owner/.test(err.message))) {
+          markDaemonOwnerUnavailable(err instanceof Error ? err.message : String(err));
+        }
+        throw err;
       }
       const previousMessageBus = typeof messageBus === 'undefined' ? null : messageBus;
       const refreshedMessageBus = new IpcBus(undefined, { allowServe: false });
@@ -2994,6 +3017,7 @@ function createEmbeddedTerminalBackendFromConfig(
     getOwnerMode: () => ownerMode,
     getMessageBus: () => messageBus,
     refreshOwnerRoute: refreshGuiMutationOwnerRoute,
+    onMutationOwnerUnavailable: markDaemonOwnerUnavailable,
     translateGuiMutationToHeadless,
     guiMutationHandlers,
   };
@@ -3822,12 +3846,12 @@ function createEmbeddedTerminalBackendFromConfig(
     const computeRuntimeStatus = () => (
       process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E_FORCE_READ_ONLY_STATUS === '1'
         ? { ownerMode: false, readOnly: true, mode: 'read-only' as const }
-        : {
-            ownerMode,
-            readOnly: !ownerMode && !guiUsingDaemonOwner,
-            mode: ownerMode ? 'local-owner' as const : guiUsingDaemonOwner ? 'daemon-owner' as const : 'read-only' as const,
-          }
+        : computeGuiRuntimeStatus({ ownerMode, guiUsingDaemonOwner })
     );
+    notifyRuntimeStatusChanged = () => {
+      if (!mainWindow || mainWindow.isDestroyed() || !uiInteractive) return;
+      mainWindow.webContents.send('invoker:runtime-status', computeRuntimeStatus());
+    };
 
     registerBootstrapStateIpc({
       ipcMain,
@@ -4177,6 +4201,7 @@ function createEmbeddedTerminalBackendFromConfig(
       resolveAgentSession,
       getOwnerMode: () => ownerMode,
       getMessageBus: () => messageBus,
+      onMutationOwnerUnavailable: markDaemonOwnerUnavailable,
       recordStartupDuration,
       getTaskDeltaStreamSequence,
     });
@@ -4451,6 +4476,9 @@ function createEmbeddedTerminalBackendFromConfig(
             return delegated.workerStatus;
           }
         } catch (err) {
+          if (isMutationOwnerUnavailableError(err)) {
+            markDaemonOwnerUnavailable(err instanceof Error ? err.message : String(err));
+          }
           logger.warn(
             `get-worker-status owner delegation failed; falling back to local read-only snapshot: ${
               err instanceof Error ? err.message : String(err)
@@ -4477,6 +4505,9 @@ function createEmbeddedTerminalBackendFromConfig(
         try {
           return await messageBus.request('headless.query', { kind: 'action-graph' });
         } catch (err) {
+          if (isMutationOwnerUnavailableError(err)) {
+            markDaemonOwnerUnavailable(err instanceof Error ? err.message : String(err));
+          }
           logger.warn(
             `get-action-graph owner delegation failed; falling back to local read-only snapshot: ${
               err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## Summary

Daemon-backed GUI windows could lose their mutation owner and keep looking writable.

This slice clears the daemon-owner flag and publishes read-only runtime status when owner IPC fails.

## Review Claim

Approve flipping daemon GUI clients to read-only when the mutation owner becomes unreachable.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Does not claim write mode. The GUI only clears its daemon-owner flag and publishes status.

## Slice Rationale

Owner-loss detection lives in main-process routing before the UI can react.

## Non-goals

Does not restart a dead daemon owner.

Does not render the banner yet.

## Architecture

### Before

```mermaid
sequenceDiagram
    participant Main as "GUI main (daemon client)"
    participant Owner as "Mutation owner"
    Main->>Owner: "headless.exec / headless.query"
    Owner--xMain: "NO_HANDLER / disconnected"
    Main-->>Main: "stay daemon-owner"
```

### After

```mermaid
sequenceDiagram
    participant Main as "GUI main (daemon client)"
    participant Owner as "Mutation owner"
    Main->>Owner: "headless.exec / headless.query"
    Owner--xMain: "NO_HANDLER / disconnected"
    Main->>Main: "guiUsingDaemonOwner = false"
    Main->>Main: "publish invoker:runtime-status"
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/app-bootstrap.test.ts src/__tests__/ipc-read-handlers.test.ts`

</details>


## Visual Proof

Before: writable GUI with no top banner while the daemon owner is still reachable.

![Writable GUI before owner loss, no read-only banner](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-189862/writable-gui-before-no-banner.png)

After: owner IPC fails, main publishes read-only runtime status, and the non-dismissable banner appears.

![Read-only mode banner after owner loss](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-189862/read-only-banner-after-owner-loss.png)

Transition: before → after.

![Owner loss flips GUI into read-only banner](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-189862/owner-loss-read-only-banner.gif)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
