### PR TITLE
[Read-only owner-loss banner](3) Show banner when runtime status becomes read-only

### DIFF
--- a/packages/app/src/__tests__/ipc-registration.test.ts
+++ b/packages/app/src/__tests__/ipc-registration.test.ts
@@ -84,6 +84,7 @@ describe('ipc-registration', () => {
 
   it('preserves the no-owner error when follower delegation has no handler', async () => {
     const { ipcMain, handleHandlers } = createFakeIpcMain();
+    const onMutationOwnerUnavailable = vi.fn();
 
     registerGuiMutationHandler(
       {
@@ -94,6 +95,7 @@ describe('ipc-registration', () => {
             throw new TransportError(TransportErrorCode.NO_HANDLER, 'missing');
           },
         }),
+        onMutationOwnerUnavailable,
         translateGuiMutationToHeadless: () => ({ channel: 'headless.exec', request: {} }),
       },
       'invoker:cancel-task',
@@ -103,6 +105,7 @@ describe('ipc-registration', () => {
     await expect(handleHandlers.get('invoker:cancel-task')?.({}, 'task-1')).rejects.toThrow(
       'No mutation owner is available',
     );
+    expect(onMutationOwnerUnavailable).toHaveBeenCalledWith('missing');
   });
 
   it('refreshes and retries follower delegation when the owner route is gone', async () => {

--- a/packages/app/src/ipc/ipc-registration.ts
+++ b/packages/app/src/ipc/ipc-registration.ts
@@ -19,8 +19,18 @@ export interface GuiMutationRegistrationContext {
   getOwnerMode: () => boolean;
   getMessageBus: () => Pick<MessageBus, 'request'>;
   refreshOwnerRoute?: () => Promise<void>;
+  /** Called when follower delegation cannot reach any mutation owner. */
+  onMutationOwnerUnavailable?: (reason: string) => void;
   translateGuiMutationToHeadless: (payload: GuiMutationPayload) => TranslatedGuiMutation;
   guiMutationHandlers?: Map<string, (...args: unknown[]) => Promise<unknown>>;
+}
+
+function throwMutationOwnerUnavailable(
+  context: GuiMutationRegistrationContext,
+  reason: string,
+): never {
+  context.onMutationOwnerUnavailable?.(reason);
+  throw new Error('No mutation owner is available');
 }
 
 export function registerGuiMutationHandler<TResult = unknown>(
@@ -59,7 +69,7 @@ export function registerGuiMutationHandler<TResult = unknown>(
           );
         } catch (retryErr) {
           if (retryErr instanceof TransportError && retryErr.code === TransportErrorCode.NO_HANDLER) {
-            throw new Error('No mutation owner is available');
+            throwMutationOwnerUnavailable(context, String(retryErr.message ?? retryErr.code));
           }
           throw retryErr;
         }
@@ -71,7 +81,7 @@ export function registerGuiMutationHandler<TResult = unknown>(
           || err.code === TransportErrorCode.DISCONNECTED
         )
       ) {
-        throw new Error('No mutation owner is available');
+        throwMutationOwnerUnavailable(context, String(err.message ?? err.code));
       }
       throw err;
     }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -727,6 +727,13 @@ export function App() {
   }, []);
 
   useEffect(() => {
+    const unsubscribe = window.invoker?.onRuntimeStatus?.((status) => {
+      setRuntimeStatus(status);
+    });
+    return () => { unsubscribe?.(); };
+  }, []);
+
+  useEffect(() => {
     if (typeof window === 'undefined' || !window.invoker) return;
 
     const shouldEmit = (key: string, minIntervalMs: number): boolean => {

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -181,6 +181,26 @@ describe('App launch (component)', () => {
     expect(screen.queryByTestId('read-only-mode-banner')).not.toBeInTheDocument();
   });
 
+  it('shows the read-only banner when runtime status flips after owner loss', async () => {
+    render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('read-only-mode-banner')).not.toBeInTheDocument();
+
+    await act(async () => {
+      mock.fireRuntimeStatus({
+        ownerMode: false,
+        readOnly: true,
+        mode: 'read-only',
+      });
+    });
+
+    expect(screen.getByTestId('read-only-mode-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('read-only-mode-banner')).toHaveTextContent('Read-only mode.');
+  });
+
   it('warns when no Claude or Codex CLI is installed', async () => {
     mock.api.getSystemDiagnostics = vi.fn(async () => ({
       platform: 'darwin',

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -39,6 +39,8 @@ export interface MockInvoker {
   fireTerminalOutput: (event: TerminalOutputEvent) => void;
   /** Fire a workflow-mutation-failed event to subscribers. */
   fireWorkflowMutationFailed: (event: WorkflowMutationFailedEvent) => void;
+  /** Fire a runtime-status event to subscribers. */
+  fireRuntimeStatus: (status: RuntimeStatus) => void;
   /** Replace the action graph snapshot returned by getActionGraph. */
   setActionGraph: (response: ActionGraphResponse) => void;
   /** Replace the runtime status returned by getRuntimeStatus. */
@@ -100,6 +102,7 @@ export function createMockInvoker(
   let workflowsCallback: ((workflows: unknown[]) => void) | undefined;
   const terminalOutputCallbacks = new Set<(event: TerminalOutputEvent) => void>();
   const workflowMutationFailedCallbacks = new Set<(event: WorkflowMutationFailedEvent) => void>();
+  const runtimeStatusCallbacks = new Set<(status: RuntimeStatus) => void>();
   let actionGraphSnapshot: ActionGraphResponse = {
     generatedAt: '2026-01-01T00:00:00.000Z',
     stallThresholdMs: 60_000,
@@ -294,6 +297,10 @@ export function createMockInvoker(
       workflowMutationFailedCallbacks.add(cb);
       return () => { workflowMutationFailedCallbacks.delete(cb); };
     }),
+    onRuntimeStatus: vi.fn((cb: (status: RuntimeStatus) => void) => {
+      runtimeStatusCallbacks.add(cb);
+      return () => { runtimeStatusCallbacks.delete(cb); };
+    }),
     resumeWorkflow: vi.fn(async () => null),
     listWorkflows: vi.fn(async () => workflowSnapshot),
     loadWorkflow: vi.fn(async () => ({ workflow: {}, tasks: [] })),
@@ -401,6 +408,13 @@ export function createMockInvoker(
     }
   }
 
+  function fireRuntimeStatus(status: RuntimeStatus) {
+    runtimeStatus = status;
+    for (const callback of runtimeStatusCallbacks) {
+      callback(status);
+    }
+  }
+
   function install() {
     (window as unknown as { invoker: InvokerAPI }).invoker = api;
     (window as unknown as { __INVOKER_BOOTSTRAP__?: { tasks: TaskState[]; workflows: WorkflowMeta[]; runtimeStatus?: RuntimeStatus } }).__INVOKER_BOOTSTRAP__ = {
@@ -415,6 +429,7 @@ export function createMockInvoker(
     delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
     terminalOutputCallbacks.clear();
     workflowMutationFailedCallbacks.clear();
+    runtimeStatusCallbacks.clear();
     eventsByTask.clear();
     historySnapshot = [];
   }
@@ -432,6 +447,7 @@ export function createMockInvoker(
     fireWorkflowsChanged,
     fireTerminalOutput,
     fireWorkflowMutationFailed,
+    fireRuntimeStatus,
     install,
     cleanup,
   };


### PR DESCRIPTION
## Summary

Owner-loss now publishes read-only runtime status.

This slice shows the existing non-dismissable Read-only mode banner when that status arrives.

## Review Claim

Approve showing the existing non-dismissable read-only banner when runtime status becomes read-only after owner loss.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Uses the existing banner. No new dismiss control and does not claim write mode.

## Slice Rationale

UI listens for runtime status and wires mutation-owner-unavailable callbacks so the banner can appear.

## Non-goals

Does not change banner copy.

Does not auto-reclaim write mode.

## Architecture

### Before

```mermaid
sequenceDiagram
    participant UI as "GUI renderer"
    participant Main as "GUI main"
    Main-->>UI: "no runtime-status push"
    UI-->>UI: "no banner while daemon-owner"
```

### After

```mermaid
sequenceDiagram
    participant UI as "GUI renderer"
    participant Main as "GUI main"
    Main->>UI: "invoker:runtime-status readOnly=true"
    UI->>UI: "show read-only-mode-banner"
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/app-launch.test.tsx`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/ipc-registration.test.ts`
- [x] `cd packages/app && CAPTURE_MODE=after npx playwright test e2e/visual-proof.spec.ts -g "read-only mode banner"`

</details>

## Visual Proof

Before: writable GUI with no top banner.

![Writable GUI before owner loss, no read-only banner](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-2f9ba3/writable-gui-before-no-banner.png)

After: same empty home with the non-dismissable "Read-only mode." banner across the top.

![Read-only mode banner after owner loss](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-2f9ba3/read-only-banner-after-owner-loss.png)

Transition: before → after.

![Owner loss flips GUI into read-only banner](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-2f9ba3/owner-loss-read-only-banner.gif)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
