### PR TITLE
[Main-process freeze](12) Enforce 5m CI budget and shard hitch e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
   quality-required:
     runs-on:
       labels: ${{ matrix.runner_label }}
-    timeout-minutes: 30
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
@@ -112,7 +112,7 @@ jobs:
     name: UI Vitest
     runs-on:
       labels: Runner_2_4_core
-    timeout-minutes: 20
+    timeout-minutes: 5
 
     steps:
       - name: Checkout
@@ -142,7 +142,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     runs-on:
       labels: ${{ matrix.runner_label }}
-    timeout-minutes: 30
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
@@ -504,12 +504,12 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
-    timeout-minutes: 45
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: 1-of-3
+          - name: 1-of-6
             files: >-
               e2e/visual-proof.spec.ts
               e2e/edit-task-command.spec.ts
@@ -517,31 +517,42 @@ jobs:
               e2e/launching-stall-watchdog.spec.ts
               e2e/embedded-terminal-pty.spec.ts
               e2e/keyboard-navigation.spec.ts
+          - name: 2-of-6
+            files: >-
               e2e/action-graph-visual-proof.spec.ts
               e2e/invalid-merge-workspace-visual.spec.ts
-          - name: 2-of-3
-            files: >-
               e2e/persistence-lifecycle.spec.ts
               e2e/task-death-logs.spec.ts
               e2e/restart-failed-task.spec.ts
               e2e/task-new-attempt-reset.spec.ts
+          - name: 3-of-6
+            files: >-
               e2e/ui-graph-drag-performance.spec.ts
               e2e/pending-review-gate-target-repo.proof.spec.ts
               e2e/workflow-status-composition.spec.ts
               e2e/startup-window-liveness.spec.ts
-          - name: 3-of-3
-            files: >-
               e2e/workflow-lifecycle.spec.ts
               e2e/persistence-recovery.spec.ts
+          - name: 4-of-6
+            files: >-
               e2e/edit-task-prompt.spec.ts
               e2e/fix-with-claude.spec.ts
               e2e/fix-with-agent-transition.spec.ts
               e2e/autofix-worker-ui.spec.ts
               e2e/orphan-relaunch.spec.ts
               e2e/gap-recovery-bench.spec.ts
+          - name: 5-of-6
+            files: >-
               e2e/system-setup-visual-proof.spec.ts
               e2e/startup-nonempty-responsiveness.spec.ts
               e2e/embedded-terminal-spawn-failure.spec.ts
+              e2e/embedded-terminal-restart-persistence.spec.ts
+              e2e/planning-terminal-restart-persistence.spec.ts
+              e2e/worker-tab-scroll.spec.ts
+          - name: 6-of-6
+            files: >-
+              e2e/workflow-delete-latency.spec.ts
+              e2e/main-process-hitch-responsiveness.spec.ts
 
     name: playwright / ${{ matrix.name }}
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs",
-    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-pr-diff-atomicity.mjs && node scripts/test-check-added-comments.mjs && node scripts/test-ci-workflow-merge-queue-policy.mjs && node scripts/test-review-unit-classification.mjs && bash scripts/workspace-test.sh && bash scripts/test-daily-e2e-do-submit.sh",
+    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-pr-diff-atomicity.mjs && node scripts/test-check-added-comments.mjs && node scripts/test-ci-workflow-merge-queue-policy.mjs && node scripts/test-ci-duration-invariant.mjs && node scripts/test-review-unit-classification.mjs && bash scripts/workspace-test.sh && bash scripts/test-daily-e2e-do-submit.sh",
     "test:high-resource": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && INVOKER_VITEST_HIGH_RESOURCE=1 bash scripts/workspace-test.sh",
     "test:low-resource": "pnpm run test",
     "test:low-resource:packages": "bash scripts/workspace-test.sh",

--- a/scripts/test-ci-duration-invariant.mjs
+++ b/scripts/test-ci-duration-invariant.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import YAML from 'yaml';
+
+const MAX_PR_FACING_TIMEOUT_MINUTES = 5;
+
+const BUDGETED_JOBS = new Set([
+  'quality-required',
+  'ui-vitest',
+  'quality-extra',
+  'playwright',
+]);
+
+const EXEMPT_JOBS = new Set([
+  'build-artifacts',
+  'e2e-proof',
+  'e2e-proof-aggregate',
+  'required-fast',
+  'required-fast-extra',
+  'ssh',
+  'optional-other',
+  'docker',
+  'scheduled-repros',
+]);
+
+const workflow = YAML.parse(readFileSync('.github/workflows/ci.yml', 'utf8'));
+const jobs = workflow.jobs ?? {};
+const errors = [];
+
+function assert(condition, message) {
+  if (!condition) errors.push(message);
+}
+
+for (const jobName of BUDGETED_JOBS) {
+  const job = jobs[jobName];
+  assert(job, `Missing budgeted CI job ${jobName}`);
+  if (!job) continue;
+  const timeout = job['timeout-minutes'];
+  assert(
+    typeof timeout === 'number',
+    `${jobName} must declare timeout-minutes (expected <= ${MAX_PR_FACING_TIMEOUT_MINUTES})`,
+  );
+  assert(
+    timeout <= MAX_PR_FACING_TIMEOUT_MINUTES,
+    `${jobName} timeout-minutes=${timeout} exceeds hard invariant of ${MAX_PR_FACING_TIMEOUT_MINUTES} minutes`,
+  );
+}
+
+const playwright = jobs.playwright;
+if (playwright) {
+  const shards = playwright.strategy?.matrix?.include ?? [];
+  assert(shards.length >= 6, `playwright must use at least 6 shards to stay under ${MAX_PR_FACING_TIMEOUT_MINUTES}m (found ${shards.length})`);
+  for (const shard of shards) {
+    const files = String(shard.files ?? '').trim().split(/\s+/).filter(Boolean);
+    assert(
+      files.length > 0 && files.length <= 6,
+      `playwright shard ${shard.name} has ${files.length} specs; keep <= 6 per shard for the ${MAX_PR_FACING_TIMEOUT_MINUTES}m budget`,
+    );
+  }
+  const listed = shards.flatMap((shard) => String(shard.files).trim().split(/\s+/).filter(Boolean));
+  assert(
+    listed.includes('e2e/main-process-hitch-responsiveness.spec.ts'),
+    'playwright shards must include e2e/main-process-hitch-responsiveness.spec.ts',
+  );
+}
+
+for (const [jobName, job] of Object.entries(jobs)) {
+  if (BUDGETED_JOBS.has(jobName) || EXEMPT_JOBS.has(jobName)) continue;
+  const timeout = job?.['timeout-minutes'];
+  if (typeof timeout === 'number' && timeout > MAX_PR_FACING_TIMEOUT_MINUTES) {
+    errors.push(
+      `Unknown job ${jobName} has timeout-minutes=${timeout}. Add it to BUDGETED_JOBS (must be <= ${MAX_PR_FACING_TIMEOUT_MINUTES}) or EXEMPT_JOBS.`,
+    );
+  }
+}
+
+if (errors.length > 0) {
+  console.error('CI duration invariant failed:');
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+console.log(
+  `CI duration invariant ok: budgeted jobs <= ${MAX_PR_FACING_TIMEOUT_MINUTES}m; playwright shards include hitch e2e.`,
+);

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -21,6 +21,9 @@ function jobForCheck(checkName) {
   if (checkName === 'PR Body' || checkName.startsWith('quality / ')) {
     return null;
   }
+  if (checkName === 'UI Vitest') {
+    return 'ui-vitest';
+  }
   if (checkName.startsWith('optional / ')) {
     return 'optional-other';
   }
@@ -56,7 +59,11 @@ for (const checkName of requiredChecks) {
     continue;
   }
   assert(jobs[jobName], `Mergify requires missing CI job ${jobName} for ${checkName}`);
-  assert(jobs[jobName].if === FULL_CI_GATE, `Mergify-required job ${jobName} must run on merge queue refs`);
+  const jobIf = jobs[jobName].if;
+  assert(
+    jobIf === undefined || jobIf === FULL_CI_GATE,
+    `Mergify-required job ${jobName} must run on merge queue refs`,
+  );
 }
 
 console.log('CI merge-queue policy is valid.');


### PR DESCRIPTION
## Summary

Playwright shards were already ~5 minutes and missing several e2e specs, including hitch responsiveness.

This reshardes 3→6, adds hitch plus the previously unlisted specs, sets `timeout-minutes: 5` on PR-facing jobs, and locks the budget with `test-ci-duration-invariant.mjs`.

## Review Claim

Approve enforcing a hard 5-minute CI budget for PR-facing and Playwright shard jobs, and including hitch e2e in the shard inventory.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Budgeted jobs fail the workflow if they exceed 5 minutes. Heavy batteries (`required-fast`, SSH, docker, daily e2e) stay exempt. Shard inventory still requires every `e2e/*.spec.ts` to be listed.

## Slice Rationale

Policy before proof/docs: CI must refuse to grow past 5 minutes when hitch e2e joins the matrix.

## Non-goals

- Does not change Mergify required-check names beyond shard renames (repros follow).
- Does not shorten individual Playwright test bodies beyond sharding.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-ci-duration-invariant.mjs`
- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [x] Playwright shard inventory lists every `packages/app/e2e/*.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Restore 3-shard matrix if needed
- Data migration? No

</details>