### PR TITLE
[Connection lost banner](1) Add runtime-status channel and connection-lost mode

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -625,7 +625,7 @@ export interface SystemDiagnostics {
   readiness?: PrerequisiteReport | PrerequisiteCheck[];
 }
 
-export type RuntimeMode = 'local-owner' | 'daemon-owner' | 'read-only';
+export type RuntimeMode = 'local-owner' | 'daemon-owner' | 'read-only' | 'connection-lost';
 
 export interface RuntimeStatus {
   ownerMode: boolean;
@@ -1130,6 +1130,9 @@ export const IpcEventChannels = {
   },
   'invoker:workflow-mutation-failed': {} as {
     payload: WorkflowMutationFailedEvent;
+  },
+  'invoker:runtime-status': {} as {
+    payload: RuntimeStatus;
   },
 } as const;
 


### PR DESCRIPTION
## Summary

The renderer needs a declared IPC event for runtime mode status, including connection loss.

This adds `invoker:runtime-status` and extends `RuntimeMode` with `connection-lost`.

## Review Claim

Approve adding the `invoker:runtime-status` IPC event channel and `connection-lost` runtime mode.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Contract-only. No runtime behavior changes in this slice.

## Slice Rationale

The event channel and mode must exist before main or UI can publish or subscribe to them.

## Non-goals

Does not publish runtime status yet.

Does not change any banner.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/app-bootstrap.test.ts src/__tests__/ipc-registration.test.ts src/__tests__/ipc-read-handlers.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
