### PR TITLE
[Connection lost banner](2) Publish connection-lost status when owner dies

### DIFF
--- a/packages/app/src/__tests__/app-bootstrap.test.ts
+++ b/packages/app/src/__tests__/app-bootstrap.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  computeGuiRuntimeStatus,
+  createDaemonOwnerLossController,
+  shouldTreatAsDaemonOwnerLoss,
   configureEarlyElectronApp,
   formatGuiOwnerBootstrapFallbackMessage,
   guiOwnerBootstrapTimeoutMs,
+  isMutationOwnerUnavailableError,
   registerGuiLifecycleHandlers,
   resolveGuiOwnerPreference,
   resolveElectronUserDataDir,
@@ -251,6 +255,40 @@ describe('app-bootstrap', () => {
     expect(shouldRefreshGuiOwnerRoute('gui', true)).toBe(false);
   });
 
+  it('computes runtime status so daemon clients stay writable until owner loss', () => {
+    expect(computeGuiRuntimeStatus({ ownerMode: true, guiUsingDaemonOwner: false })).toEqual({
+      ownerMode: true,
+      readOnly: false,
+      mode: 'local-owner',
+    });
+    expect(computeGuiRuntimeStatus({ ownerMode: false, guiUsingDaemonOwner: true })).toEqual({
+      ownerMode: false,
+      readOnly: false,
+      mode: 'daemon-owner',
+    });
+    expect(computeGuiRuntimeStatus({ ownerMode: false, guiUsingDaemonOwner: false })).toEqual({
+      ownerMode: false,
+      readOnly: true,
+      mode: 'read-only',
+    });
+    expect(computeGuiRuntimeStatus({
+      ownerMode: false,
+      guiUsingDaemonOwner: false,
+      connectionLost: true,
+    })).toEqual({
+      ownerMode: false,
+      readOnly: true,
+      mode: 'connection-lost',
+    });
+  });
+
+  it('detects mutation-owner-unavailable transport failures', () => {
+    expect(isMutationOwnerUnavailableError(new Error('No mutation owner is available'))).toBe(true);
+    expect(isMutationOwnerUnavailableError({ code: 'NO_HANDLER', message: 'missing' })).toBe(true);
+    expect(isMutationOwnerUnavailableError(new Error('No request handler registered for channel: headless.exec'))).toBe(true);
+    expect(isMutationOwnerUnavailableError(new Error('timeout'))).toBe(false);
+  });
+
   it('uses a bounded daemon bootstrap timeout and ignores invalid overrides', () => {
     expect(guiOwnerBootstrapTimeoutMs({ INVOKER_GUI_OWNER_BOOTSTRAP_TIMEOUT_MS: '2500' })).toBe(2500);
     expect(guiOwnerBootstrapTimeoutMs({ INVOKER_GUI_OWNER_BOOTSTRAP_TIMEOUT_MS: '-1' })).toBe(60000);
@@ -306,4 +344,24 @@ describe('app-bootstrap', () => {
 
     expect([...handlers.keys()]).toEqual(['window-all-closed', 'before-quit']);
   });
+
+  it('tracks daemon owner loss and restore through the controller', () => {
+    let state = { usingDaemonOwner: true, connectionLost: false };
+    const warn = vi.fn();
+    const notify = vi.fn();
+    const controller = createDaemonOwnerLossController({
+      getState: () => state,
+      setState: (next) => { state = next; },
+      warn,
+    });
+    controller.setNotify(notify);
+    controller.markUnavailable('owner gone');
+    expect(state).toEqual({ usingDaemonOwner: false, connectionLost: true });
+    expect(warn).toHaveBeenCalledOnce();
+    expect(notify).toHaveBeenCalledOnce();
+    controller.restoreDaemonOwner();
+    expect(state).toEqual({ usingDaemonOwner: true, connectionLost: false });
+    expect(shouldTreatAsDaemonOwnerLoss(new Error('No mutation owner is available'))).toBe(true);
+  });
+
 });

--- a/packages/app/src/__tests__/ipc-read-handlers.test.ts
+++ b/packages/app/src/__tests__/ipc-read-handlers.test.ts
@@ -282,4 +282,37 @@ describe('registerReadOnlyIpcHandlers', () => {
     await expect(handlers.get('invoker:list-workflows')?.({})).resolves.toEqual([{ id: 'LOCAL-FALLBACK' }]);
   });
 
+  it('notifies when owner query delegation finds no mutation owner', async () => {
+    const onMutationOwnerUnavailable = vi.fn();
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const ipcMain = {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+        handlers.set(channel, handler);
+      }),
+    };
+    registerReadOnlyIpcHandlers({
+      ipcMain: ipcMain as never,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+      persistence: { listWorkflows: vi.fn(() => [{ id: 'LOCAL-FALLBACK' }]) } as never,
+      getOrchestrator: () => ({}) as never,
+      agentRegistry: {} as never,
+      loadTaskByIdFromPersistence: () => undefined,
+      resolveAgentSession: vi.fn(async () => null),
+      getOwnerMode: () => false,
+      getMessageBus: () => ({
+        request: vi.fn(async () => {
+          throw Object.assign(new Error('No request handler registered for channel: headless.query'), { code: 'NO_HANDLER' });
+        }),
+      }),
+      onMutationOwnerUnavailable,
+      recordStartupDuration: vi.fn(),
+      getTaskDeltaStreamSequence: () => 0,
+    });
+
+    await expect(handlers.get('invoker:list-workflows')?.({})).resolves.toEqual([{ id: 'LOCAL-FALLBACK' }]);
+    expect(onMutationOwnerUnavailable).toHaveBeenCalledWith(
+      'No request handler registered for channel: headless.query',
+    );
+  });
+
 });

--- a/packages/app/src/bootstrap/app-bootstrap.ts
+++ b/packages/app/src/bootstrap/app-bootstrap.ts
@@ -37,6 +37,48 @@ export function formatGuiOwnerBootstrapFallbackMessage(message: string): string 
   ].join('\n');
 }
 
+export type RuntimeModeSnapshot = 'local-owner' | 'daemon-owner' | 'read-only' | 'connection-lost';
+
+export interface RuntimeStatusFields {
+  ownerMode: boolean;
+  readOnly: boolean;
+  mode: RuntimeModeSnapshot;
+}
+
+/** Compute the GUI runtime status from ownership flags. */
+export function computeGuiRuntimeStatus(input: {
+  ownerMode: boolean;
+  guiUsingDaemonOwner: boolean;
+  connectionLost?: boolean;
+}): RuntimeStatusFields {
+  const { ownerMode, guiUsingDaemonOwner, connectionLost = false } = input;
+  if (ownerMode) {
+    return { ownerMode: true, readOnly: false, mode: 'local-owner' };
+  }
+  if (guiUsingDaemonOwner) {
+    return { ownerMode: false, readOnly: false, mode: 'daemon-owner' };
+  }
+  if (connectionLost) {
+    return { ownerMode: false, readOnly: true, mode: 'connection-lost' };
+  }
+  return { ownerMode: false, readOnly: true, mode: 'read-only' };
+}
+
+/** True when an owner IPC/delegation failure means no mutation owner is reachable. */
+export function isMutationOwnerUnavailableError(error: unknown): boolean {
+  if (error instanceof Error && error.message === 'No mutation owner is available') {
+    return true;
+  }
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  const code = typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code ?? '')
+    : '';
+  return code === 'NO_HANDLER'
+    || code === 'DISCONNECTED'
+    || message.includes('No request handler registered')
+    || message.includes('No mutation owner is available');
+}
+
 export interface ElectronUserDataEnv {
   INVOKER_USER_DATA_DIR?: string;
   INVOKER_DB_DIR?: string;
@@ -141,6 +183,44 @@ export interface MainProcessBootstrapOptions {
   isHeadless: boolean;
   startHeadlessMode: () => void;
   startGuiMode: () => void;
+}
+
+
+export interface DaemonOwnerLossState {
+  usingDaemonOwner: boolean;
+  connectionLost: boolean;
+}
+
+export function shouldTreatAsDaemonOwnerLoss(error: unknown): boolean {
+  if (isMutationOwnerUnavailableError(error)) return true;
+  return error instanceof Error && /Timed out after .* waiting for daemon owner/.test(error.message);
+}
+
+export function createDaemonOwnerLossController(options: {
+  getState: () => DaemonOwnerLossState;
+  setState: (state: DaemonOwnerLossState) => void;
+  warn: (message: string) => void;
+}) {
+  let notify: (() => void) | null = null;
+  return {
+    setNotify(fn: (() => void) | null) {
+      notify = fn;
+    },
+    markUnavailable(reason: string): void {
+      const state = options.getState();
+      if (!state.usingDaemonOwner && !state.connectionLost) return;
+      options.setState({ usingDaemonOwner: false, connectionLost: true });
+      options.warn(`daemon mutation owner unavailable; connection lost: ${reason}`);
+      notify?.();
+    },
+    restoreDaemonOwner(): void {
+      options.setState({ usingDaemonOwner: true, connectionLost: false });
+      notify?.();
+    },
+    clearConnectionLost(): void {
+      options.setState({ ...options.getState(), connectionLost: false });
+    },
+  };
 }
 
 export function startMainProcessBootstrap(options: MainProcessBootstrapOptions): void {

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -25,6 +25,8 @@ export interface RegisterReadOnlyIpcHandlersContext {
   ) => Promise<unknown>;
   getOwnerMode?: () => boolean;
   getMessageBus?: () => Pick<MessageBus, 'request'>;
+  /** Called when owner query delegation finds no reachable mutation owner. */
+  onMutationOwnerUnavailable?: (reason: string) => void;
   recordStartupDuration: (label: string, startedAtMs: number, fields?: Record<string, unknown>) => void;
   getTaskDeltaStreamSequence: () => number;
 }
@@ -61,6 +63,7 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     resolveAgentSession,
     getOwnerMode,
     getMessageBus,
+    onMutationOwnerUnavailable,
     recordStartupDuration,
     getTaskDeltaStreamSequence,
   } = context;
@@ -83,6 +86,7 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
       if (code !== 'NO_HANDLER' && !message.includes('No request handler registered')) {
         throw err;
       }
+      onMutationOwnerUnavailable?.(message);
       logger.warn(
         `${kind} owner delegation found no owner handler; falling back to local read-only snapshot: ${message}`,
         { module: 'ipc' },

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -38,9 +38,13 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { config as loadDotenv } from 'dotenv';
 import {
+  computeGuiRuntimeStatus,
   configureEarlyElectronApp,
+  createDaemonOwnerLossController,
   formatGuiOwnerBootstrapFallbackMessage,
   guiOwnerBootstrapTimeoutMs,
+  isMutationOwnerUnavailableError,
+  shouldTreatAsDaemonOwnerLoss,
   registerGuiLifecycleHandlers,
   resolveGuiOwnerPreference,
   runElectronReadyBootstrap,
@@ -452,6 +456,7 @@ let commandService: CommandService;
 // resolve via this getter at cancel-in-flight time.
 let latestTaskExecutor: TaskRunner | null = null;
 let guiUsingDaemonOwner = false;
+let guiDaemonOwnerConnectionLost = false;
 
 function buildCommandServiceInvalidationDeps() {
   return buildWorkflowInvalidationDeps({
@@ -660,22 +665,37 @@ async function ensureStandaloneOwnerForGui(): Promise<void> {
 }
 
 let guiOwnerRouteRefreshPromise: Promise<void> | null = null;
+const daemonOwnerLoss = createDaemonOwnerLossController({
+  getState: () => ({ usingDaemonOwner: guiUsingDaemonOwner, connectionLost: guiDaemonOwnerConnectionLost }),
+  setState: (state) => { guiUsingDaemonOwner = state.usingDaemonOwner; guiDaemonOwnerConnectionLost = state.connectionLost; },
+  warn: (message) => logger.warn(message, { module: 'ipc' }),
+});
+const markDaemonOwnerUnavailable = (reason: string) => daemonOwnerLoss.markUnavailable(reason);
 
 async function refreshGuiMutationOwnerRoute(): Promise<void> {
   const ownerPreference = resolveGuiOwnerPreference();
   if (!shouldRefreshGuiOwnerRoute(ownerPreference, guiUsingDaemonOwner)) return;
   if (!guiOwnerRouteRefreshPromise) {
     guiOwnerRouteRefreshPromise = (async () => {
-      if (ownerPreference === 'daemon') {
-        await ensureStandaloneOwnerForGui();
-      } else if (!await discoverStandaloneOwnerForGui(2_000)) {
-        throw new Error('No mutation owner is available');
+      try {
+        if (ownerPreference === 'daemon') {
+          await ensureStandaloneOwnerForGui();
+        } else if (!await discoverStandaloneOwnerForGui(2_000)) {
+          markDaemonOwnerUnavailable('daemon owner discovery timed out');
+          throw new Error('No mutation owner is available');
+        }
+      } catch (err) {
+        if (shouldTreatAsDaemonOwnerLoss(err)) {
+          markDaemonOwnerUnavailable(err instanceof Error ? err.message : String(err));
+        }
+        throw err;
       }
       const previousMessageBus = typeof messageBus === 'undefined' ? null : messageBus;
       const refreshedMessageBus = new IpcBus(undefined, { allowServe: false });
       await refreshedMessageBus.ready();
       messageBus = refreshedMessageBus;
       previousMessageBus?.disconnect();
+      daemonOwnerLoss.restoreDaemonOwner();
       logger.info('refreshed daemon owner IPC route for GUI mutation', { module: 'ipc-delegate' });
     })().finally(() => {
       guiOwnerRouteRefreshPromise = null;
@@ -2998,14 +3018,15 @@ function createEmbeddedTerminalBackendFromConfig(
     });
   }
 
-  const guiMutationRegistrationContext: GuiMutationRegistrationContext = {
+  const guiMutationRegistrationContext = {
     ipcMain,
     getOwnerMode: () => ownerMode,
     getMessageBus: () => messageBus,
     refreshOwnerRoute: refreshGuiMutationOwnerRoute,
+    onMutationOwnerUnavailable: markDaemonOwnerUnavailable,
     translateGuiMutationToHeadless,
     guiMutationHandlers,
-  };
+  } as GuiMutationRegistrationContext;
 
   const workflowScopedGuiMutationRegistrationContext: WorkflowScopedGuiMutationRegistrationContext = {
     ...guiMutationRegistrationContext,
@@ -3541,6 +3562,7 @@ function createEmbeddedTerminalBackendFromConfig(
     if (daemonGuiOwner) {
       ownerMode = false;
       guiUsingDaemonOwner = true;
+      daemonOwnerLoss.clearConnectionLost();
       try {
         recordStartupMark('initServices.readOnly.start');
         await initServices({ detachedViewer: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
@@ -3554,6 +3576,7 @@ function createEmbeddedTerminalBackendFromConfig(
     } else {
       ownerMode = true;
       guiUsingDaemonOwner = false;
+      daemonOwnerLoss.clearConnectionLost();
       try {
         recordStartupMark('initServices.start');
         await initServices({ executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
@@ -3576,6 +3599,7 @@ function createEmbeddedTerminalBackendFromConfig(
         await initServices({ detachedViewer: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
         ownerMode = false;
         guiUsingDaemonOwner = false;
+        daemonOwnerLoss.clearConnectionLost();
         recordStartupMark('initServices.readOnly.end', { ownerMode: false, ownerId: owner.ownerId });
       }
     }
@@ -3828,15 +3852,16 @@ function createEmbeddedTerminalBackendFromConfig(
     });
 
     // Register IPC handlers
-    const computeRuntimeStatus = () => (
-      process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E_FORCE_READ_ONLY_STATUS === '1'
-        ? { ownerMode: false, readOnly: true, mode: 'read-only' as const }
-        : {
-            ownerMode,
-            readOnly: !ownerMode && !guiUsingDaemonOwner,
-            mode: ownerMode ? 'local-owner' as const : guiUsingDaemonOwner ? 'daemon-owner' as const : 'read-only' as const,
-          }
-    );
+    const computeRuntimeStatus = () => {
+      if (process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E_FORCE_CONNECTION_LOST_STATUS === '1') {
+        return { ownerMode: false, readOnly: true, mode: 'connection-lost' as const };
+      }
+      if (process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E_FORCE_READ_ONLY_STATUS === '1') {
+        return { ownerMode: false, readOnly: true, mode: 'read-only' as const };
+      }
+      return computeGuiRuntimeStatus({ ownerMode, guiUsingDaemonOwner, connectionLost: guiDaemonOwnerConnectionLost });
+    };
+    daemonOwnerLoss.setNotify(() => { if (mainWindow && !mainWindow.isDestroyed() && uiInteractive) mainWindow.webContents.send('invoker:runtime-status', computeRuntimeStatus()); });
 
     registerBootstrapStateIpc({
       ipcMain,
@@ -4197,6 +4222,7 @@ function createEmbeddedTerminalBackendFromConfig(
       resolveAgentSession,
       getOwnerMode: () => ownerMode,
       getMessageBus: () => messageBus,
+      onMutationOwnerUnavailable: markDaemonOwnerUnavailable,
       recordStartupDuration,
       getTaskDeltaStreamSequence,
     });
@@ -4471,6 +4497,7 @@ function createEmbeddedTerminalBackendFromConfig(
             return delegated.workerStatus;
           }
         } catch (err) {
+          if (isMutationOwnerUnavailableError(err)) markDaemonOwnerUnavailable(err instanceof Error ? err.message : String(err));
           logger.warn(
             `get-worker-status owner delegation failed; falling back to local read-only snapshot: ${
               err instanceof Error ? err.message : String(err)
@@ -4497,6 +4524,7 @@ function createEmbeddedTerminalBackendFromConfig(
         try {
           return await messageBus.request('headless.query', { kind: 'action-graph' });
         } catch (err) {
+          if (isMutationOwnerUnavailableError(err)) markDaemonOwnerUnavailable(err instanceof Error ? err.message : String(err));
           logger.warn(
             `get-action-graph owner delegation failed; falling back to local read-only snapshot: ${
               err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## Summary

Daemon-backed GUI windows could lose their mutation owner and keep looking writable.

This slice clears the daemon-owner flag, marks connection lost, and publishes write-blocked runtime status when owner IPC fails.

## Review Claim

Approve publishing `connection-lost` runtime status when the mutation owner becomes unreachable.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Does not claim write mode. The GUI only clears its daemon-owner flag and publishes status.

## Slice Rationale

Owner-loss detection lives in main-process routing before the UI can react.

## Non-goals

Does not restart a dead daemon owner.

Does not render the banner yet.

## Architecture

### Before

```mermaid
sequenceDiagram
    participant Main as "GUI main (daemon client)"
    participant Owner as "Mutation owner"
    Main->>Owner: "headless.exec / headless.query"
    Owner--xMain: "NO_HANDLER / disconnected"
    Main-->>Main: "stay daemon-owner"
```

### After

```mermaid
sequenceDiagram
    participant Main as "GUI main (daemon client)"
    participant Owner as "Mutation owner"
    Main->>Owner: "headless.exec / headless.query"
    Owner--xMain: "NO_HANDLER / disconnected"
    Main->>Main: "guiUsingDaemonOwner = false"
    Main->>Main: "mode = connection-lost"
    Main->>Main: "publish invoker:runtime-status"
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/app-bootstrap.test.ts src/__tests__/ipc-read-handlers.test.ts`

</details>

## Visual Proof

Before: writable GUI with no top banner while the daemon owner is still reachable.

![Writable GUI before owner loss, no banner](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-032209/writable-gui-before-no-banner.png)

After: owner IPC fails, main publishes connection-lost status, and writes are blocked.

![Connection lost banner after owner loss](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-032209/connection-lost-banner-after.png)

Transition: before → after.

![Owner loss flips GUI into connection-lost banner](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-032209/owner-loss-connection-lost-banner.gif)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>