### PR TITLE
[Connection lost banner](3) Show Connection lost banner on owner loss

### DIFF
--- a/packages/app/src/__tests__/ipc-registration.test.ts
+++ b/packages/app/src/__tests__/ipc-registration.test.ts
@@ -84,6 +84,7 @@ describe('ipc-registration', () => {
 
   it('preserves the no-owner error when follower delegation has no handler', async () => {
     const { ipcMain, handleHandlers } = createFakeIpcMain();
+    const onMutationOwnerUnavailable = vi.fn();
 
     registerGuiMutationHandler(
       {
@@ -94,6 +95,7 @@ describe('ipc-registration', () => {
             throw new TransportError(TransportErrorCode.NO_HANDLER, 'missing');
           },
         }),
+        onMutationOwnerUnavailable,
         translateGuiMutationToHeadless: () => ({ channel: 'headless.exec', request: {} }),
       },
       'invoker:cancel-task',
@@ -103,6 +105,7 @@ describe('ipc-registration', () => {
     await expect(handleHandlers.get('invoker:cancel-task')?.({}, 'task-1')).rejects.toThrow(
       'No mutation owner is available',
     );
+    expect(onMutationOwnerUnavailable).toHaveBeenCalledWith('missing');
   });
 
   it('refreshes and retries follower delegation when the owner route is gone', async () => {

--- a/packages/app/src/ipc/ipc-registration.ts
+++ b/packages/app/src/ipc/ipc-registration.ts
@@ -19,8 +19,17 @@ export interface GuiMutationRegistrationContext {
   getOwnerMode: () => boolean;
   getMessageBus: () => Pick<MessageBus, 'request'>;
   refreshOwnerRoute?: () => Promise<void>;
+  onMutationOwnerUnavailable?: (reason: string) => void;
   translateGuiMutationToHeadless: (payload: GuiMutationPayload) => TranslatedGuiMutation;
   guiMutationHandlers?: Map<string, (...args: unknown[]) => Promise<unknown>>;
+}
+
+function throwMutationOwnerUnavailable(
+  context: GuiMutationRegistrationContext,
+  reason: string,
+): never {
+  context.onMutationOwnerUnavailable?.(reason);
+  throw new Error('No mutation owner is available');
 }
 
 export function registerGuiMutationHandler<TResult = unknown>(
@@ -59,7 +68,7 @@ export function registerGuiMutationHandler<TResult = unknown>(
           );
         } catch (retryErr) {
           if (retryErr instanceof TransportError && retryErr.code === TransportErrorCode.NO_HANDLER) {
-            throw new Error('No mutation owner is available');
+            throwMutationOwnerUnavailable(context, String(retryErr.message ?? retryErr.code));
           }
           throw retryErr;
         }
@@ -71,7 +80,7 @@ export function registerGuiMutationHandler<TResult = unknown>(
           || err.code === TransportErrorCode.DISCONNECTED
         )
       ) {
-        throw new Error('No mutation owner is available');
+        throwMutationOwnerUnavailable(context, String(err.message ?? err.code));
       }
       throw err;
     }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -725,6 +725,13 @@ export function App() {
   }, []);
 
   useEffect(() => {
+    const unsubscribe = window.invoker?.onRuntimeStatus?.((status) => {
+      setRuntimeStatus(status);
+    });
+    return () => { unsubscribe?.(); };
+  }, []);
+
+  useEffect(() => {
     if (typeof window === 'undefined' || !window.invoker) return;
 
     const shouldEmit = (key: string, minIntervalMs: number): boolean => {
@@ -3056,7 +3063,17 @@ export function App() {
           </div>
         </div>
       )}
-      {runtimeStatus?.readOnly && (
+      {runtimeStatus?.mode === 'connection-lost' ? (
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="connection-lost-banner"
+          className="border-b border-border-strong bg-secondary px-4 py-2 text-sm text-foreground"
+        >
+          <span className="font-semibold text-foreground">Connection lost.</span>{' '}
+          This window lost contact with the write owner and cannot make changes until the connection is restored.
+        </div>
+      ) : runtimeStatus?.readOnly ? (
         <div
           role="status"
           aria-live="polite"
@@ -3066,7 +3083,7 @@ export function App() {
           <span className="font-semibold text-foreground">Read-only mode.</span>{' '}
           This window can browse workflows, but it cannot make changes until the write owner is available.
         </div>
-      )}
+      ) : null}
       {mutationFailure && (
         <div
           role="alert"

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -181,6 +181,28 @@ describe('App launch (component)', () => {
     expect(screen.queryByTestId('read-only-mode-banner')).not.toBeInTheDocument();
   });
 
+  it('shows the connection-lost banner when runtime status flips after owner loss', async () => {
+    render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('connection-lost-banner')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('read-only-mode-banner')).not.toBeInTheDocument();
+
+    await act(async () => {
+      mock.fireRuntimeStatus({
+        ownerMode: false,
+        readOnly: true,
+        mode: 'connection-lost',
+      });
+    });
+
+    expect(screen.getByTestId('connection-lost-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('connection-lost-banner')).toHaveTextContent('Connection lost.');
+    expect(screen.queryByTestId('read-only-mode-banner')).not.toBeInTheDocument();
+  });
+
   it('warns when no Claude or Codex CLI is installed', async () => {
     mock.api.getSystemDiagnostics = vi.fn(async () => ({
       platform: 'darwin',

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -39,6 +39,8 @@ export interface MockInvoker {
   fireTerminalOutput: (event: TerminalOutputEvent) => void;
   /** Fire a workflow-mutation-failed event to subscribers. */
   fireWorkflowMutationFailed: (event: WorkflowMutationFailedEvent) => void;
+  /** Fire a runtime-status event to subscribers. */
+  fireRuntimeStatus: (status: RuntimeStatus) => void;
   /** Replace the action graph snapshot returned by getActionGraph. */
   setActionGraph: (response: ActionGraphResponse) => void;
   /** Replace the runtime status returned by getRuntimeStatus. */
@@ -100,6 +102,7 @@ export function createMockInvoker(
   let workflowsCallback: ((workflows: unknown[]) => void) | undefined;
   const terminalOutputCallbacks = new Set<(event: TerminalOutputEvent) => void>();
   const workflowMutationFailedCallbacks = new Set<(event: WorkflowMutationFailedEvent) => void>();
+  const runtimeStatusCallbacks = new Set<(status: RuntimeStatus) => void>();
   let actionGraphSnapshot: ActionGraphResponse = {
     generatedAt: '2026-01-01T00:00:00.000Z',
     stallThresholdMs: 60_000,
@@ -294,6 +297,10 @@ export function createMockInvoker(
       workflowMutationFailedCallbacks.add(cb);
       return () => { workflowMutationFailedCallbacks.delete(cb); };
     }),
+    onRuntimeStatus: vi.fn((cb: (status: RuntimeStatus) => void) => {
+      runtimeStatusCallbacks.add(cb);
+      return () => { runtimeStatusCallbacks.delete(cb); };
+    }),
     resumeWorkflow: vi.fn(async () => null),
     listWorkflows: vi.fn(async () => workflowSnapshot),
     loadWorkflow: vi.fn(async () => ({ workflow: {}, tasks: [] })),
@@ -401,6 +408,13 @@ export function createMockInvoker(
     }
   }
 
+  function fireRuntimeStatus(status: RuntimeStatus) {
+    runtimeStatus = status;
+    for (const callback of runtimeStatusCallbacks) {
+      callback(status);
+    }
+  }
+
   function install() {
     (window as unknown as { invoker: InvokerAPI }).invoker = api;
     (window as unknown as { __INVOKER_BOOTSTRAP__?: { tasks: TaskState[]; workflows: WorkflowMeta[]; runtimeStatus?: RuntimeStatus } }).__INVOKER_BOOTSTRAP__ = {
@@ -415,6 +429,7 @@ export function createMockInvoker(
     delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
     terminalOutputCallbacks.clear();
     workflowMutationFailedCallbacks.clear();
+    runtimeStatusCallbacks.clear();
     eventsByTask.clear();
     historySnapshot = [];
   }
@@ -432,6 +447,7 @@ export function createMockInvoker(
     fireWorkflowsChanged,
     fireTerminalOutput,
     fireWorkflowMutationFailed,
+    fireRuntimeStatus,
     install,
     cleanup,
   };


### PR DESCRIPTION
## Summary

Owner-loss now publishes `connection-lost` runtime status.

This slice shows a non-dismissable Connection lost banner when that status arrives, instead of the intentional Read-only mode banner.

## Review Claim

Approve showing the Connection lost banner when runtime status becomes `connection-lost` after owner loss.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Uses a dedicated banner for connection loss. Intentional read-only mode keeps its own banner. Does not claim write mode.

## Slice Rationale

UI listens for runtime status and wires mutation-owner-unavailable callbacks so the banner can appear.

## Non-goals

Does not change intentional read-only banner copy.

Does not auto-reclaim write mode.

## Architecture

### Before

```mermaid
sequenceDiagram
    participant UI as "GUI renderer"
    participant Main as "GUI main"
    Main-->>UI: "no runtime-status push"
    UI-->>UI: "no banner while daemon-owner"
```

### After

```mermaid
sequenceDiagram
    participant UI as "GUI renderer"
    participant Main as "GUI main"
    Main->>UI: "invoker:runtime-status mode=connection-lost"
    UI->>UI: "show connection-lost-banner"
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/app-launch.test.tsx`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/ipc-registration.test.ts`

</details>

## Visual Proof

Before: writable GUI with no top banner.

![Writable GUI before owner loss, no banner](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-ee3e44/writable-gui-before-no-banner.png)

After: same empty home with the non-dismissable "Connection lost." banner across the top.

![Connection lost banner after owner loss](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-ee3e44/connection-lost-banner-after.png)

Transition: before → after.

![Owner loss flips GUI into connection-lost banner](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-ee3e44/owner-loss-connection-lost-banner.gif)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>