### PR TITLE
[Connection lost banner](4) Add connection-lost visual-proof e2e case

### DIFF
--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -104,6 +104,7 @@ exit 64
     chmodSync(codexStub, 0o755);
     const pathEnv = `${stubDir}${path.delimiter}${process.env.PATH ?? ''}`;
     const forceReadOnlyStatus = guiOwnerMode === 'read-only-status';
+    const forceConnectionLostStatus = guiOwnerMode === 'connection-lost-status';
     // Playwright's `use.video` option only applies to browser contexts, so the
     // Electron walkthrough video must be requested at launch time.
     const recordVideo = process.env.CAPTURE_VIDEO
@@ -123,7 +124,7 @@ exit 64
         NODE_ENV: 'test',
         INVOKER_DISABLE_SLACK: '1',
         TZ: 'UTC',
-        INVOKER_GUI_OWNER_MODE: forceReadOnlyStatus ? 'gui' : guiOwnerMode,
+        INVOKER_GUI_OWNER_MODE: (forceReadOnlyStatus || forceConnectionLostStatus) ? 'gui' : guiOwnerMode,
         INVOKER_DB_DIR: testDir,
         INVOKER_IPC_SOCKET: ipcSocketPath,
         INVOKER_ALLOW_DELETE_ALL: '1',
@@ -139,6 +140,7 @@ exit 64
         INVOKER_CLAUDE_FIX_COMMAND: claudeMarker,
         ...(breakTerminalSpawn ? { INVOKER_E2E_BREAK_TERMINAL_SPAWN: '1' } : {}),
         ...(forceReadOnlyStatus ? { INVOKER_E2E_FORCE_READ_ONLY_STATUS: '1' } : {}),
+        ...(forceConnectionLostStatus ? { INVOKER_E2E_FORCE_CONNECTION_LOST_STATUS: '1' } : {}),
         PATH: pathEnv,
       },
     });

--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -556,6 +556,16 @@ test.describe('Read-only mode visual proof', () => {
   });
 });
 
+test.describe('Connection lost visual proof', () => {
+  test.use({ guiOwnerMode: 'connection-lost-status' });
+
+  test('connection lost banner', async ({ page }) => {
+    await expect(page.getByTestId('connection-lost-banner')).toContainText('Connection lost.', { timeout: 5000 });
+    await expect(page.getByTestId('connection-lost-banner')).toContainText('lost contact with the write owner');
+    await captureScreenshot(page, 'connection-lost-banner');
+  });
+});
+
 test.describe('Visual proof capture', () => {
   test('history view — task state timeline', async ({ page }) => {
     await loadPlan(page, TEST_PLAN);

--- a/packages/app/src/__tests__/ipc-registration.test.ts
+++ b/packages/app/src/__tests__/ipc-registration.test.ts
@@ -84,6 +84,7 @@ describe('ipc-registration', () => {
 
   it('preserves the no-owner error when follower delegation has no handler', async () => {
     const { ipcMain, handleHandlers } = createFakeIpcMain();
+    const onMutationOwnerUnavailable = vi.fn();
 
     registerGuiMutationHandler(
       {
@@ -94,6 +95,7 @@ describe('ipc-registration', () => {
             throw new TransportError(TransportErrorCode.NO_HANDLER, 'missing');
           },
         }),
+        onMutationOwnerUnavailable,
         translateGuiMutationToHeadless: () => ({ channel: 'headless.exec', request: {} }),
       },
       'invoker:cancel-task',
@@ -103,6 +105,7 @@ describe('ipc-registration', () => {
     await expect(handleHandlers.get('invoker:cancel-task')?.({}, 'task-1')).rejects.toThrow(
       'No mutation owner is available',
     );
+    expect(onMutationOwnerUnavailable).toHaveBeenCalledWith('missing');
   });
 
   it('refreshes and retries follower delegation when the owner route is gone', async () => {

--- a/packages/app/src/ipc/ipc-registration.ts
+++ b/packages/app/src/ipc/ipc-registration.ts
@@ -19,8 +19,17 @@ export interface GuiMutationRegistrationContext {
   getOwnerMode: () => boolean;
   getMessageBus: () => Pick<MessageBus, 'request'>;
   refreshOwnerRoute?: () => Promise<void>;
+  onMutationOwnerUnavailable?: (reason: string) => void;
   translateGuiMutationToHeadless: (payload: GuiMutationPayload) => TranslatedGuiMutation;
   guiMutationHandlers?: Map<string, (...args: unknown[]) => Promise<unknown>>;
+}
+
+function throwMutationOwnerUnavailable(
+  context: GuiMutationRegistrationContext,
+  reason: string,
+): never {
+  context.onMutationOwnerUnavailable?.(reason);
+  throw new Error('No mutation owner is available');
 }
 
 export function registerGuiMutationHandler<TResult = unknown>(
@@ -59,7 +68,7 @@ export function registerGuiMutationHandler<TResult = unknown>(
           );
         } catch (retryErr) {
           if (retryErr instanceof TransportError && retryErr.code === TransportErrorCode.NO_HANDLER) {
-            throw new Error('No mutation owner is available');
+            throwMutationOwnerUnavailable(context, String(retryErr.message ?? retryErr.code));
           }
           throw retryErr;
         }
@@ -71,7 +80,7 @@ export function registerGuiMutationHandler<TResult = unknown>(
           || err.code === TransportErrorCode.DISCONNECTED
         )
       ) {
-        throw new Error('No mutation owner is available');
+        throwMutationOwnerUnavailable(context, String(err.message ?? err.code));
       }
       throw err;
     }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -725,6 +725,13 @@ export function App() {
   }, []);
 
   useEffect(() => {
+    const unsubscribe = window.invoker?.onRuntimeStatus?.((status) => {
+      setRuntimeStatus(status);
+    });
+    return () => { unsubscribe?.(); };
+  }, []);
+
+  useEffect(() => {
     if (typeof window === 'undefined' || !window.invoker) return;
 
     const shouldEmit = (key: string, minIntervalMs: number): boolean => {
@@ -3056,7 +3063,17 @@ export function App() {
           </div>
         </div>
       )}
-      {runtimeStatus?.readOnly && (
+      {runtimeStatus?.mode === 'connection-lost' ? (
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="connection-lost-banner"
+          className="border-b border-border-strong bg-secondary px-4 py-2 text-sm text-foreground"
+        >
+          <span className="font-semibold text-foreground">Connection lost.</span>{' '}
+          This window lost contact with the write owner and cannot make changes until the connection is restored.
+        </div>
+      ) : runtimeStatus?.readOnly ? (
         <div
           role="status"
           aria-live="polite"
@@ -3066,7 +3083,7 @@ export function App() {
           <span className="font-semibold text-foreground">Read-only mode.</span>{' '}
           This window can browse workflows, but it cannot make changes until the write owner is available.
         </div>
-      )}
+      ) : null}
       {mutationFailure && (
         <div
           role="alert"

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -181,6 +181,28 @@ describe('App launch (component)', () => {
     expect(screen.queryByTestId('read-only-mode-banner')).not.toBeInTheDocument();
   });
 
+  it('shows the connection-lost banner when runtime status flips after owner loss', async () => {
+    render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('connection-lost-banner')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('read-only-mode-banner')).not.toBeInTheDocument();
+
+    await act(async () => {
+      mock.fireRuntimeStatus({
+        ownerMode: false,
+        readOnly: true,
+        mode: 'connection-lost',
+      });
+    });
+
+    expect(screen.getByTestId('connection-lost-banner')).toBeInTheDocument();
+    expect(screen.getByTestId('connection-lost-banner')).toHaveTextContent('Connection lost.');
+    expect(screen.queryByTestId('read-only-mode-banner')).not.toBeInTheDocument();
+  });
+
   it('warns when no Claude or Codex CLI is installed', async () => {
     mock.api.getSystemDiagnostics = vi.fn(async () => ({
       platform: 'darwin',

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -39,6 +39,8 @@ export interface MockInvoker {
   fireTerminalOutput: (event: TerminalOutputEvent) => void;
   /** Fire a workflow-mutation-failed event to subscribers. */
   fireWorkflowMutationFailed: (event: WorkflowMutationFailedEvent) => void;
+  /** Fire a runtime-status event to subscribers. */
+  fireRuntimeStatus: (status: RuntimeStatus) => void;
   /** Replace the action graph snapshot returned by getActionGraph. */
   setActionGraph: (response: ActionGraphResponse) => void;
   /** Replace the runtime status returned by getRuntimeStatus. */
@@ -100,6 +102,7 @@ export function createMockInvoker(
   let workflowsCallback: ((workflows: unknown[]) => void) | undefined;
   const terminalOutputCallbacks = new Set<(event: TerminalOutputEvent) => void>();
   const workflowMutationFailedCallbacks = new Set<(event: WorkflowMutationFailedEvent) => void>();
+  const runtimeStatusCallbacks = new Set<(status: RuntimeStatus) => void>();
   let actionGraphSnapshot: ActionGraphResponse = {
     generatedAt: '2026-01-01T00:00:00.000Z',
     stallThresholdMs: 60_000,
@@ -294,6 +297,10 @@ export function createMockInvoker(
       workflowMutationFailedCallbacks.add(cb);
       return () => { workflowMutationFailedCallbacks.delete(cb); };
     }),
+    onRuntimeStatus: vi.fn((cb: (status: RuntimeStatus) => void) => {
+      runtimeStatusCallbacks.add(cb);
+      return () => { runtimeStatusCallbacks.delete(cb); };
+    }),
     resumeWorkflow: vi.fn(async () => null),
     listWorkflows: vi.fn(async () => workflowSnapshot),
     loadWorkflow: vi.fn(async () => ({ workflow: {}, tasks: [] })),
@@ -401,6 +408,13 @@ export function createMockInvoker(
     }
   }
 
+  function fireRuntimeStatus(status: RuntimeStatus) {
+    runtimeStatus = status;
+    for (const callback of runtimeStatusCallbacks) {
+      callback(status);
+    }
+  }
+
   function install() {
     (window as unknown as { invoker: InvokerAPI }).invoker = api;
     (window as unknown as { __INVOKER_BOOTSTRAP__?: { tasks: TaskState[]; workflows: WorkflowMeta[]; runtimeStatus?: RuntimeStatus } }).__INVOKER_BOOTSTRAP__ = {
@@ -415,6 +429,7 @@ export function createMockInvoker(
     delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
     terminalOutputCallbacks.clear();
     workflowMutationFailedCallbacks.clear();
+    runtimeStatusCallbacks.clear();
     eventsByTask.clear();
     historySnapshot = [];
   }
@@ -432,6 +447,7 @@ export function createMockInvoker(
     fireWorkflowsChanged,
     fireTerminalOutput,
     fireWorkflowMutationFailed,
+    fireRuntimeStatus,
     install,
     cleanup,
   };


### PR DESCRIPTION
## Summary

Owner-loss now shows a Connection lost banner in the GUI.

This slice adds an e2e visual-proof case that forces connection-lost runtime status and captures the banner.

## Review Claim

Approve the connection-lost visual-proof e2e case and fixture force flag.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only. No product behavior changes beyond the e2e harness force flag.

## Slice Rationale

Proof capture belongs in its own slice after the UI activation lands.

## Non-goals

Does not change banner copy.

Does not change production runtime status logic.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && CAPTURE_MODE=after npx playwright test e2e/visual-proof.spec.ts -g "connection lost banner"`

</details>

## Visual Proof

Before: writable GUI with no top banner.

![Writable GUI before owner loss, no banner](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-7023d8/writable-gui-before-no-banner.png)

After: forced connection-lost status shows the non-dismissable banner.

![Connection lost banner after owner loss](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-7023d8/connection-lost-banner-after.png)

Transition: before → after.

![Owner loss flips GUI into connection-lost banner](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-7023d8/owner-loss-connection-lost-banner.gif)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #3841