### PR TITLE
[Stale app tests](1) Align autofix tests with bare-retry-first recovery

### DIFF
--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { WorkflowMutationIntent, WorkflowMutationPriority } from '@invoker/data-store';
+import type {
+  WorkerActionRecord,
+  WorkerActionWrite,
+  WorkflowMutationIntent,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
 
 import { buildFixWithAgentMutationArgs } from '../auto-fix-intents.js';
@@ -50,6 +55,16 @@ function makeTask(overrides: Partial<TaskState> = {}): TaskState {
   };
 }
 
+function toWorkerActionRecord(write: WorkerActionWrite): WorkerActionRecord {
+  const now = '2026-01-01T00:00:00.000Z';
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? now,
+    updatedAt: write.updatedAt ?? now,
+  };
+}
+
 function makeRecoveryPolicyHarness(
   task: TaskState = makeTask(),
   existingIntents: WorkflowMutationIntent[] = [],
@@ -59,6 +74,7 @@ function makeRecoveryPolicyHarness(
   const workflows = [{ id: 'wf-1' }];
   const tasks = new Map<string, TaskState>([[task.id, task]]);
   const intents: WorkflowMutationIntent[] = [...existingIntents];
+  const actions = new Map<string, WorkerActionRecord>();
   const logEvent = vi.fn();
   const submit = vi.fn((workflowId: string, priority: WorkflowMutationPriority, channel: string, args: unknown[]) => {
     const id = intents.length + 1;
@@ -82,6 +98,19 @@ function makeRecoveryPolicyHarness(
         (!workflowId || intent.workflowId === workflowId)
         && (!statuses || statuses.includes(intent.status))
       ))),
+      getWorkerAction: vi.fn((workerKind: string, externalKey: string) =>
+        actions.get(`${workerKind}:${externalKey}`)),
+      upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+        const key = `${write.workerKind}:${write.externalKey}`;
+        const existing = actions.get(key);
+        const saved = toWorkerActionRecord({
+          ...write,
+          id: existing?.id ?? write.id,
+          createdAt: existing?.createdAt,
+        });
+        actions.set(key, saved);
+        return saved;
+      }),
       logEvent,
     },
     submitter: { submit },
@@ -91,7 +120,7 @@ function makeRecoveryPolicyHarness(
     getAutoFixAgent: () => 'codex',
     ...(drainWakeupHints ? { drainWakeupHints } : {}),
   };
-  return { options, submit, logEvent, tasks, intents, attemptLedger };
+  return { options, submit, logEvent, tasks, intents, actions, attemptLedger };
 }
 
 describe('auto-fix recovery worker', () => {
@@ -131,7 +160,7 @@ describe('auto-fix recovery worker', () => {
     await runtime.stop();
   });
 
-  it('scans every failed task and submits a fix-with-agent intent when the registered worker is turned on', async () => {
+  it('scans every failed task and submits a bare restart on the first tick when the registered worker is turned on', async () => {
     const harness = makeRecoveryPolicyHarness();
     const registry = registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>());
     const definition = registry.get(AUTO_FIX_WORKER_KIND);
@@ -158,8 +187,8 @@ describe('auto-fix recovery worker', () => {
     expect(harness.submit).toHaveBeenCalledWith(
       'wf-1',
       'normal',
-      'invoker:fix-with-agent',
-      buildFixWithAgentMutationArgs('wf-1/task-1', 'codex', { autoFix: true }),
+      'invoker:restart-task',
+      ['wf-1/task-1'],
     );
   });
 
@@ -378,7 +407,7 @@ describe('auto-fix recovery candidate validation', () => {
 });
 
 describe('auto-fix recovery scan submission', () => {
-  it('submits eligible failed tasks through the command route', async () => {
+  it('submits a bare restart first, then escalates to fix-with-agent', async () => {
     const harness = makeRecoveryPolicyHarness();
     const tick = createAutoFixRecoveryTick(harness.options);
 
@@ -386,6 +415,29 @@ describe('auto-fix recovery scan submission', () => {
       identity: { kind: 'recovery', instanceId: 'test' },
       reason: 'startup',
       tickNumber: 1,
+    });
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    expect(harness.submit).toHaveBeenCalledWith(
+      'wf-1',
+      'normal',
+      'invoker:restart-task',
+      ['wf-1/task-1'],
+    );
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'debug.auto-fix',
+      expect.objectContaining({
+        phase: 'worker-autofix-bare-retry-submitted',
+        channel: 'invoker:restart-task',
+      }),
+    );
+
+    harness.submit.mockClear();
+    await tick({
+      identity: { kind: 'recovery', instanceId: 'test' },
+      reason: 'startup',
+      tickNumber: 2,
     });
 
     expect(harness.submit).toHaveBeenCalledTimes(1);
@@ -427,15 +479,24 @@ describe('auto-fix recovery scan submission', () => {
       reason: 'startup',
       tickNumber: 1,
     });
-    harness.intents.length = 0;
-
     await tick({
       identity: { kind: 'recovery', instanceId: 'test' },
       reason: 'startup',
       tickNumber: 2,
     });
+    harness.intents.length = 0;
 
-    expect(harness.submit).toHaveBeenCalledTimes(1);
+    await tick({
+      identity: { kind: 'recovery', instanceId: 'test' },
+      reason: 'startup',
+      tickNumber: 3,
+    });
+
+    expect(harness.submit).toHaveBeenCalledTimes(2);
+    expect(harness.submit.mock.calls.map((call) => call[2])).toEqual([
+      'invoker:restart-task',
+      'invoker:fix-with-agent',
+    ]);
     expect(task.execution).not.toHaveProperty(attemptStateKey);
     expect(harness.logEvent).toHaveBeenCalledWith(
       'wf-1/task-1',
@@ -477,5 +538,9 @@ describe('auto-fix recovery scan submission', () => {
     });
 
     expect(harness.submit).toHaveBeenCalledTimes(2);
+    expect(harness.submit.mock.calls.map((call) => call[2])).toEqual([
+      'invoker:restart-task',
+      'invoker:restart-task',
+    ]);
   });
 });

--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -4,9 +4,12 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 import { runHeadless } from '../headless.js';
-import { buildFixWithAgentMutationArgs } from '../auto-fix-intents.js';
 import type { TaskState } from '@invoker/workflow-core';
-import type { WorkflowMutationPriority } from '@invoker/data-store';
+import type {
+  WorkerActionRecord,
+  WorkerActionWrite,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
 
 function makeTask(overrides: Partial<TaskState> = {}): TaskState {
   const { config, execution, ...rest } = overrides;
@@ -43,8 +46,9 @@ describe('headless auto-fix cutover', () => {
 });
 
 describe('headless worker autofix', () => {
-  it('runs a one-shot scan under the single-instance lock and enqueues the normal fix command intent', async () => {
+  it('runs a one-shot scan under the single-instance lock and enqueues a bare restart first', async () => {
     const task = makeTask();
+    const actions = new Map<string, WorkerActionRecord>();
     const enqueueWorkflowMutationIntent = vi.fn((
       _workflowId: string,
       _channel: string,
@@ -66,6 +70,21 @@ describe('headless worker autofix', () => {
           loadTasks: vi.fn(() => [task]),
           loadTask: vi.fn(() => task),
           listWorkflowMutationIntents: vi.fn(() => []),
+          getWorkerAction: vi.fn((workerKind: string, externalKey: string) =>
+            actions.get(`${workerKind}:${externalKey}`)),
+          upsertWorkerAction: vi.fn((writeAction: WorkerActionWrite) => {
+            const key = `${writeAction.workerKind}:${writeAction.externalKey}`;
+            const existing = actions.get(key);
+            const now = '2026-01-01T00:00:00.000Z';
+            const saved: WorkerActionRecord = {
+              ...writeAction,
+              attemptCount: writeAction.attemptCount ?? 0,
+              createdAt: existing?.createdAt ?? writeAction.createdAt ?? now,
+              updatedAt: writeAction.updatedAt ?? now,
+            };
+            actions.set(key, saved);
+            return saved;
+          }),
           logEvent: vi.fn(),
           enqueueWorkflowMutationIntent,
         },
@@ -80,8 +99,8 @@ describe('headless worker autofix', () => {
 
     expect(enqueueWorkflowMutationIntent).toHaveBeenCalledWith(
       'wf-1',
-      'invoker:fix-with-agent',
-      buildFixWithAgentMutationArgs('wf-1/task-1', 'codex', { autoFix: true }),
+      'invoker:restart-task',
+      ['wf-1/task-1'],
       'normal',
     );
   });


### PR DESCRIPTION
## Summary

App-layer autofix suite expectations lagged production recovery behavior from #3637.

The first recovery tick now uses a free restart channel before agent escalation, once a worker-action row exists.

This slice updates harness mocks and assertions so those tests match current production behavior.

## Review Claim

Approve updating autofix app tests and harness worker-action mocks so first-tick and escalation expectations match #3637.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only. No production code changes. Engine coverage in `auto-fix-bare-retry.test.ts` remains the source of truth for product behavior.

## Slice Rationale

Separate from MockGit merge-harness fixes. Autofix expectation drift is an independent stale-test cluster.

## Non-goals

- Does not change auto-fix recovery production routing, retries, or eligibility.
- Does not fix MockGit push or remote-head simulation.
- Does not change headless CLI command surfaces.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/auto-fix-recovery.test.ts src/__tests__/headless-autofix.test.ts`
- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/auto-fix-bare-retry.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-fix recovery behavior so the worker now retries tasks with a restart first before escalating to a deeper fix.
  * Updated recovery handling to better preserve task history across retries, helping scans and follow-up actions stay consistent.
  * Refined headless auto-fix behavior so queued actions follow the new retry sequence more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->