### PR TITLE
[PR maintenance workers Step 9: Remove obsolete cron tooling](1) Tighten owner endpoint routing

### DIFF
--- a/packages/app/src/__tests__/owner-endpoint.test.ts
+++ b/packages/app/src/__tests__/owner-endpoint.test.ts
@@ -58,7 +58,7 @@ describe('owner-endpoint contract', () => {
       expect('mode' in result!).toBe(false);
     });
 
-    it('defaults ownerId to empty string when the ping response omits it', async () => {
+    it('ignores malformed ping responses that omit the owner identity', async () => {
       const bus = new LocalBus();
       bus.onRequest('headless.owner-ping', async () => ({
         ok: true,
@@ -66,9 +66,18 @@ describe('owner-endpoint contract', () => {
       }));
 
       const result = await discoverOwner(bus);
-      expect(result).not.toBeNull();
-      expect(result!.ownerId).toBe('');
-      expect(result!.canAcceptStandaloneMutations).toBe(true);
+      expect(result).toBeNull();
+    });
+
+    it('ignores malformed ping responses that omit the owner mode', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-123',
+      }));
+
+      const result = await discoverOwner(bus);
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/app/src/owner-endpoint.ts
+++ b/packages/app/src/owner-endpoint.ts
@@ -55,9 +55,12 @@ export async function discoverOwner(
 ): Promise<OwnerDiscoveryResult> {
   const raw = await tryPingHeadlessOwner(messageBus, timeoutMs);
   if (!raw) return null;
+  const ownerId = typeof raw.ownerId === 'string' ? raw.ownerId : '';
+  const mode = typeof raw.mode === 'string' ? raw.mode : '';
+  if (!ownerId || !mode) return null;
   return {
-    ownerId: raw.ownerId ?? '',
-    canAcceptStandaloneMutations: raw.mode === 'standalone' || raw.mode === 'gui',
+    ownerId,
+    canAcceptStandaloneMutations: mode === 'standalone' || mode === 'gui',
   };
 }
 


### PR DESCRIPTION
## Summary

Owner discovery now ignores ping replies missing the owner id or launch mode.

That keeps later owner routing from trusting a half-formed process response.

## Review Claim

Owner discovery routes only through complete ping replies.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice touches owner discovery and its tests. It does not change PR-maintenance worker execution or shell file retirement.

## Slice Rationale

This routing guard lands before read startup changes, so one owner-selection rule is reviewed at a time.

## Non-goals

- Do not change standalone owner bootstrap behavior.
- Do not change PR-maintenance worker behavior.
- Do not retire cron wrapper files in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run test:all` (passed in `wf-1783387621902-13/run-full-test-suite`)
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-step9-pr1.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5c50954d2d092579d83f61f69a31928a413fc6c9`
- Post-revert steps: Re-run owner endpoint contract tests before continuing the stack.
- Data migration? No

</details>
