### PR TITLE
execution agents: assert leaner prompt-mode argument line in unit tests

### DIFF
--- a/packages/execution-engine/src/__tests__/kimi-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/kimi-execution-agent.test.ts
@@ -2,13 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { KimiExecutionAgent } from '../agents/kimi-execution-agent.js';
 
 describe('KimiExecutionAgent', () => {
-  it('builds prompt command with yolo and model selector', () => {
+  it('builds prompt command with model selector without yolo', () => {
     const agent = new KimiExecutionAgent({ command: 'kimi-test' });
     const spec = agent.buildCommand('prompt text', { executionModel: 'kimi-k2.6' });
 
     expect(spec.cmd).toBe('kimi-test');
     expect(spec.args).toEqual([
-      '--yolo',
       '--model',
       'kimi-k2.6',
       '-p',
@@ -23,7 +22,6 @@ describe('KimiExecutionAgent', () => {
 
     expect(spec.cmd).toBe('kimi-test');
     expect(spec.args).toEqual([
-      '--yolo',
       '--model',
       'kimi-k2.6',
       '-p',
@@ -33,8 +31,8 @@ describe('KimiExecutionAgent', () => {
     expect(spec).not.toHaveProperty('fullPrompt');
   });
 
-  it('can disable yolo for stricter local runs', () => {
-    const agent = new KimiExecutionAgent({ command: 'kimi-test', yolo: false });
+  it('ignores the legacy yolo knob in prompt mode', () => {
+    const agent = new KimiExecutionAgent({ command: 'kimi-test', yolo: true });
     expect(agent.buildCommand('prompt text').args).toEqual([
       '-p',
       'prompt text',

--- a/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
@@ -22,9 +22,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec.fullPrompt).toBe('prompt text');
   });
@@ -38,9 +38,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'fix prompt',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec).not.toHaveProperty('fullPrompt');
   });
@@ -50,7 +50,6 @@ describe('QwenExecutionAgent', () => {
     expect(agent.buildCommand('prompt text').args).toEqual([
       '--approval-mode',
       'auto-edit',
-      '--prompt',
       'prompt text',
     ]);
   });
@@ -64,7 +63,6 @@ describe('QwenExecutionAgent', () => {
       'openai',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
   });


### PR DESCRIPTION
Update Kimi and Qwen agent specs to expect no approval-mode flag and no
--prompt separator.

Depends-On: #3915