### PR TITLE
Needs Attention Mutation Failure UX — drop approval-mode flags from Kimi/Qwen prompt mode

### DIFF
--- a/packages/execution-engine/src/__tests__/kimi-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/kimi-execution-agent.test.ts
@@ -2,13 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { KimiExecutionAgent } from '../agents/kimi-execution-agent.js';
 
 describe('KimiExecutionAgent', () => {
-  it('builds prompt command with yolo and model selector', () => {
+  it('builds prompt command with model selector without yolo', () => {
     const agent = new KimiExecutionAgent({ command: 'kimi-test' });
     const spec = agent.buildCommand('prompt text', { executionModel: 'kimi-k2.6' });
 
     expect(spec.cmd).toBe('kimi-test');
     expect(spec.args).toEqual([
-      '--yolo',
       '--model',
       'kimi-k2.6',
       '-p',
@@ -23,7 +22,6 @@ describe('KimiExecutionAgent', () => {
 
     expect(spec.cmd).toBe('kimi-test');
     expect(spec.args).toEqual([
-      '--yolo',
       '--model',
       'kimi-k2.6',
       '-p',
@@ -33,8 +31,8 @@ describe('KimiExecutionAgent', () => {
     expect(spec).not.toHaveProperty('fullPrompt');
   });
 
-  it('can disable yolo for stricter local runs', () => {
-    const agent = new KimiExecutionAgent({ command: 'kimi-test', yolo: false });
+  it('ignores the legacy yolo knob in prompt mode', () => {
+    const agent = new KimiExecutionAgent({ command: 'kimi-test', yolo: true });
     expect(agent.buildCommand('prompt text').args).toEqual([
       '-p',
       'prompt text',

--- a/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
@@ -22,9 +22,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec.fullPrompt).toBe('prompt text');
   });
@@ -38,9 +38,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'fix prompt',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec).not.toHaveProperty('fullPrompt');
   });
@@ -50,7 +50,6 @@ describe('QwenExecutionAgent', () => {
     expect(agent.buildCommand('prompt text').args).toEqual([
       '--approval-mode',
       'auto-edit',
-      '--prompt',
       'prompt text',
     ]);
   });
@@ -64,7 +63,6 @@ describe('QwenExecutionAgent', () => {
       'openai',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
   });

--- a/packages/execution-engine/src/agents/kimi-execution-agent.ts
+++ b/packages/execution-engine/src/agents/kimi-execution-agent.ts
@@ -7,6 +7,10 @@ export interface KimiExecutionAgentConfig {
   command?: string;
   configDir?: string;
   containerHomePath?: string;
+  /**
+   * Deprecated compatibility knob. Current Kimi prompt mode rejects approval-mode
+   * flags, so Invoker never passes --yolo with -p/--prompt.
+   */
   yolo?: boolean;
 }
 
@@ -28,13 +32,11 @@ export class KimiExecutionAgent implements ExecutionAgent {
   private readonly command: string;
   private readonly configDir: string;
   private readonly containerHomePath: string;
-  private readonly yolo: boolean;
 
   constructor(config: KimiExecutionAgentConfig = {}) {
     this.command = config.command ?? process.env.INVOKER_KIMI_COMMAND ?? 'kimi';
     this.configDir = config.configDir ?? join(homedir(), '.kimi-code');
     this.containerHomePath = config.containerHomePath ?? '/home/invoker';
-    this.yolo = config.yolo ?? true;
   }
 
   buildCommand(fullPrompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
@@ -77,7 +79,6 @@ export class KimiExecutionAgent implements ExecutionAgent {
 
   private buildArgs(prompt: string, executionModel?: string): string[] {
     return [
-      ...(this.yolo ? ['--yolo'] : []),
       ...(executionModel ? ['--model', executionModel] : []),
       '-p',
       prompt,

--- a/packages/execution-engine/src/agents/qwen-execution-agent.ts
+++ b/packages/execution-engine/src/agents/qwen-execution-agent.ts
@@ -85,7 +85,6 @@ export class QwenExecutionAgent implements ExecutionAgent {
       this.approvalMode,
       ...(this.authType ? ['--auth-type', this.authType] : []),
       ...(executionModel ? ['--model', executionModel] : []),
-      '--prompt',
       prompt,
     ];
   }


### PR DESCRIPTION
## Summary

Invoker no longer passes the `--yolo` approval flag when it drives the Kimi agent in prompt mode, and it drops the redundant `--prompt` marker for the Qwen agent.

Newer Kimi builds refuse approval-mode flags in prompt mode, so sending `--yolo` broke every run.

The `yolo` option stays as a no-op compatibility field so existing callers keep working.

## Review Claim

Approve dropping `--yolo` and `--prompt` from the Kimi and Qwen prompt-mode argument builders.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Both agents assert their exact argument arrays in unit tests, so a wrong flag change fails locally under `pnpm test` before it can reach a real run.

## Slice Rationale

This slice changes only the execution-engine prompt routing for the Kimi and Qwen agents.

It stays separate from UI and docs work in the wider effort.

## Non-goals

Does not change Claude, Codex, Gemini, or any other agent.

Does not touch UI, docs, or the merge and approval flow.

Does not alter approval behavior outside prompt mode; the `yolo` field is kept for compatibility.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Reverting re-adds `--yolo`/`--prompt`, which newer Kimi builds refuse in prompt mode; only revert if pinned to an older Kimi.
- Data migration? No

</details>
