### PR TITLE
[Planning ADE chrome](3) Simplify planning rail status to Cursor-style cues

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -140,30 +140,8 @@ function makeInitialPlanningSession(now: string = new Date().toISOString()): Pla
   };
 }
 
-function planningStatusLabel(status: InAppPlanningSessionStatus): string {
-  switch (status) {
-    case 'waiting_for_answer':
-      return 'Waiting for you';
-    case 'draft_ready':
-      return 'Draft ready';
-    case 'submitted':
-      return 'Submitted';
-    case 'still_discussing':
-      return 'Still discussing';
-  }
-}
-
-function planningStatusDotClass(status: InAppPlanningSessionStatus): string {
-  switch (status) {
-    case 'waiting_for_answer':
-      return 'bg-amber-400';
-    case 'draft_ready':
-      return 'bg-emerald-400';
-    case 'submitted':
-      return 'bg-muted-foreground';
-    case 'still_discussing':
-      return 'bg-border-strong';
-  }
+function planningNeedsAttention(status: InAppPlanningSessionStatus): boolean {
+  return status === 'waiting_for_answer' || status === 'draft_ready';
 }
 
 function previewPlanningMessage(session: PlanningSessionView): string {
@@ -173,15 +151,44 @@ function previewPlanningMessage(session: PlanningSessionView): string {
 
 function relativePlanningUpdatedAt(value: string): string {
   const timestamp = Date.parse(value);
-  if (!Number.isFinite(timestamp)) return 'Updated just now';
+  if (!Number.isFinite(timestamp)) return 'now';
   const seconds = Math.max(0, Math.round((Date.now() - timestamp) / 1000));
-  if (seconds < 60) return 'Updated just now';
+  if (seconds < 60) return 'now';
   const minutes = Math.round(seconds / 60);
-  if (minutes < 60) return `Updated ${minutes}m ago`;
+  if (minutes < 60) return `${minutes}m`;
   const hours = Math.round(minutes / 60);
-  if (hours < 24) return `Updated ${hours}h ago`;
+  if (hours < 24) return `${hours}h`;
   const days = Math.round(hours / 24);
-  return `Updated ${days}d ago`;
+  if (days < 30) return `${days}d`;
+  const months = Math.round(days / 30);
+  if (months < 12) return `${months}mo`;
+  return `${Math.round(months / 12)}y`;
+}
+
+function PlanningSessionStatusIcon({
+  busy,
+  status,
+}: {
+  busy: boolean;
+  status: InAppPlanningSessionStatus;
+}): JSX.Element {
+  if (busy) {
+    return (
+      <span
+        className="mt-1 inline-block h-2.5 w-2.5 shrink-0 animate-spin rounded-full border border-muted-foreground border-t-foreground"
+        aria-label="Running"
+      />
+    );
+  }
+  if (planningNeedsAttention(status)) {
+    return (
+      <span
+        className="mt-1.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-foreground"
+        aria-label="Needs attention"
+      />
+    );
+  }
+  return <span className="mt-1.5 inline-block h-1.5 w-1.5 shrink-0" aria-hidden="true" />;
 }
 
 
@@ -2837,16 +2844,19 @@ export function App() {
               key={session.id}
               type="button"
               onClick={() => setActivePlanningSessionId(session.id)}
-              className={`block w-full border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              className={`flex w-full items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
             >
-              <div className="truncate text-sm font-medium">{session.title}</div>
-              <div className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">{previewPlanningMessage(session)}</div>
-              <div className="mt-1.5 flex items-center justify-between gap-2">
-                <span className="inline-flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground">
-                  <span className={`h-1.5 w-1.5 rounded-full ${planningStatusDotClass(session.status)}`} aria-hidden="true" />
-                  {planningStatusLabel(session.status)}
-                </span>
-                <span className="shrink-0 font-mono text-[11px] text-muted-foreground">{relativePlanningUpdatedAt(session.updatedAt)}</span>
+              <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="truncate text-sm font-medium">{session.title}</div>
+                  <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
+                    {relativePlanningUpdatedAt(session.updatedAt)}
+                  </span>
+                </div>
+                <div className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">
+                  {previewPlanningMessage(session)}
+                </div>
               </div>
             </button>
           );
@@ -2879,22 +2889,8 @@ export function App() {
         <div className="min-h-0 flex-1">{renderPlanningSessionList()}</div>
       </div>
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <div className="flex items-center justify-between gap-3 border-b border-border bg-card px-4 py-2.5">
-          <div className="min-w-0">
-            <h2 className="truncate text-sm font-medium text-foreground">{activePlanningSession.title}</h2>
-            <div className="mt-1 inline-flex items-center gap-1.5 font-mono text-[11px] text-muted-foreground">
-              <span className={`h-1.5 w-1.5 rounded-full ${planningStatusDotClass(activePlanningSession.status)}`} aria-hidden="true" />
-              {planningStatusLabel(activePlanningSession.status)}
-            </div>
-          </div>
-          <button
-            type="button"
-            aria-label="Return home"
-            onClick={handleDismissBrowserSurface}
-            className="rounded-sm border border-border px-2.5 py-1 text-xs text-muted-foreground hover:border-border-strong hover:text-foreground"
-          >
-            Home
-          </button>
+        <div className="border-b border-border bg-card px-4 py-2.5">
+          <h2 className="truncate text-sm font-medium text-foreground">{activePlanningSession.title}</h2>
         </div>
         <div className="min-h-0 flex-1 overflow-hidden bg-background">
           <InvokerTerminal


### PR DESCRIPTION
## Summary

Planning sessions still showed text status pills and a Home button in the chat header.

This slice switches that chrome to Cursor-style rail cues.

Needs attention is a white dot. Running is a spinner. Relative time is compact on the right.

## Review Claim

Approve replacing planning Home button and header status text with a left needs-attention/running icon and compact relative times on the rail.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Session create/select/submit wiring is unchanged. Only planning surface presentation changes in `App.tsx`.

## Slice Rationale

Depends on the prior ADE rail chrome. This slice is the status/layout polish users asked for after that restyle landed.

## Non-goals

- Does not change planner IPC or session persistence.
- Does not restyle the app sidebar Home nav item.
- Does not change the draft-ready action bar inside `InvokerTerminal`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/invoker-terminal.test.tsx src/__tests__/app-launch.test.tsx`
- [x] Focused Playwright capture of draft-ready planning conversation with rail white-dot + `now` timestamp

</details>

## Visual Proof

Planning rail before this slice (status label text, Home button still present in prior ADE chrome):

![Rail status before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-047cb4/rail-status-before.png)

Planning rail after (white needs-attention dot, compact `now`, no Home, no header status):

![Rail status after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-047cb4/rail-status-after.png)

Planning conversation walkthrough before:

![Rail status before walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-047cb4/rail-status-before-walkthrough.webm)

Planning conversation walkthrough after:

![Rail status after walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-047cb4/rail-status-after-walkthrough.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1fe000413`
- Post-revert steps: None
- Data migration? No

</details>
