### PR TITLE
[Needs Attention Mutation Failure UX](1) Drop legacy --prompt flag from Qwen execution agent

### DIFF
--- a/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
@@ -22,9 +22,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec.fullPrompt).toBe('prompt text');
   });
@@ -38,9 +38,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'fix prompt',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec).not.toHaveProperty('fullPrompt');
   });
@@ -50,7 +50,6 @@ describe('QwenExecutionAgent', () => {
     expect(agent.buildCommand('prompt text').args).toEqual([
       '--approval-mode',
       'auto-edit',
-      '--prompt',
       'prompt text',
     ]);
   });
@@ -64,7 +63,6 @@ describe('QwenExecutionAgent', () => {
       'openai',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
   });

--- a/packages/execution-engine/src/agents/qwen-execution-agent.ts
+++ b/packages/execution-engine/src/agents/qwen-execution-agent.ts
@@ -85,7 +85,6 @@ export class QwenExecutionAgent implements ExecutionAgent {
       this.approvalMode,
       ...(this.authType ? ['--auth-type', this.authType] : []),
       ...(executionModel ? ['--model', executionModel] : []),
-      '--prompt',
       prompt,
     ];
   }


### PR DESCRIPTION
## Summary

The Qwen agent no longer inserts a `--prompt` flag before the prompt text when Invoker runs it.

Newer Qwen builds read the trailing prompt positionally, so the extra flag broke those runs.

Dropping the flag keeps the launched Qwen invocation aligned with what the tool now accepts.

## Review Claim

Approve removing the deprecated `--prompt` flag from the Qwen agent invocation so the trailing prompt is passed positionally.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice touches only the Qwen agent argument builder and its unit test. Other agents and every runtime path stay untouched, so the blast radius is one launcher.

## Slice Rationale

This slice carries only the Qwen change so a reviewer approves one launcher's argument change at a time. The Kimi `--yolo` change rides in the next stacked slice.

## Non-goals

- Does not change the Kimi agent; a later stacked slice drops its `--yolo` flag.
- Does not change Qwen model selection, auth type, or approval mode.
- Does not alter the prompt text itself.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

