### PR TITLE
[Terminal lag telemetry](2) Emit ui_navigation marks on sidebar and view changes

### DIFF
--- a/packages/app/src/__tests__/terminal-ui-perf.test.ts
+++ b/packages/app/src/__tests__/terminal-ui-perf.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createTerminalUiPerfCounters,
+  createTerminalUiPerfReporter,
+  createTerminalUiPerfSink,
+  timeTerminalWrite,
+  TERMINAL_SESSION_UPSERT_SLOW_MS,
+  TERMINAL_WRITE_SLOW_MS,
+} from '../terminal-ui-perf.js';
+
+describe('createTerminalUiPerfReporter', () => {
+  it('emits terminal_write_slow when write duration crosses the threshold', () => {
+    const writeActivityLog = vi.fn();
+    const onSlowMetric = vi.fn();
+    const reporter = createTerminalUiPerfReporter({
+      throttleMs: 0,
+      now: () => 1_000,
+    });
+
+    reporter.recordWrite(TERMINAL_WRITE_SLOW_MS - 1, { sessionId: 's1' }, { writeActivityLog, onSlowMetric });
+    expect(writeActivityLog).not.toHaveBeenCalled();
+
+    reporter.recordWrite(TERMINAL_WRITE_SLOW_MS, { sessionId: 's1', bytes: 1 }, { writeActivityLog, onSlowMetric });
+    expect(writeActivityLog).toHaveBeenCalledTimes(1);
+    const [, , message] = writeActivityLog.mock.calls[0]!;
+    const payload = JSON.parse(message as string) as Record<string, unknown>;
+    expect(payload.metric).toBe('terminal_write_slow');
+    expect(payload.durationMs).toBe(TERMINAL_WRITE_SLOW_MS);
+    expect(payload.sessionId).toBe('s1');
+    expect(onSlowMetric).toHaveBeenCalledWith(
+      'terminal_write_slow',
+      expect.objectContaining({ durationMs: TERMINAL_WRITE_SLOW_MS, sessionId: 's1' }),
+    );
+  });
+
+  it('emits terminal_session_upsert_slow for slow upserts and for burst frequency', () => {
+    let now = 0;
+    const writeActivityLog = vi.fn();
+    const reporter = createTerminalUiPerfReporter({
+      throttleMs: 0,
+      upsertBurstCount: 3,
+      upsertBurstWindowMs: 1000,
+      now: () => now,
+    });
+
+    reporter.recordUpsert(TERMINAL_SESSION_UPSERT_SLOW_MS, { sessionId: 's1' }, { writeActivityLog });
+    expect(writeActivityLog).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(writeActivityLog.mock.calls[0]![2] as string).metric).toBe('terminal_session_upsert_slow');
+    expect(JSON.parse(writeActivityLog.mock.calls[0]![2] as string).slow).toBe(true);
+
+    writeActivityLog.mockClear();
+    now = 10;
+    reporter.recordUpsert(1, { sessionId: 's1' }, { writeActivityLog });
+    reporter.recordUpsert(1, { sessionId: 's1' }, { writeActivityLog });
+    expect(writeActivityLog).not.toHaveBeenCalled();
+    reporter.recordUpsert(1, { sessionId: 's1' }, { writeActivityLog });
+    expect(writeActivityLog).toHaveBeenCalledTimes(1);
+    const burstPayload = JSON.parse(writeActivityLog.mock.calls[0]![2] as string) as Record<string, unknown>;
+    expect(burstPayload.metric).toBe('terminal_session_upsert_slow');
+    expect(burstPayload.burst).toBe(true);
+    expect(burstPayload.upsertsInWindow).toBe(3);
+  });
+
+  it('throttles repeated slow metrics within the throttle window', () => {
+    let now = 1000;
+    const writeActivityLog = vi.fn();
+    const reporter = createTerminalUiPerfReporter({
+      throttleMs: 1000,
+      now: () => now,
+    });
+
+    reporter.recordWrite(100, { sessionId: 's1' }, { writeActivityLog });
+    reporter.recordWrite(120, { sessionId: 's1' }, { writeActivityLog });
+    expect(writeActivityLog).toHaveBeenCalledTimes(1);
+
+    now = 2000;
+    reporter.recordWrite(130, { sessionId: 's1' }, { writeActivityLog });
+    expect(writeActivityLog).toHaveBeenCalledTimes(2);
+  });
+
+  it('timeTerminalWrite updates counters and reports slow writes', () => {
+    const counters = createTerminalUiPerfCounters();
+    const writeActivityLog = vi.fn();
+    const sink = createTerminalUiPerfSink(writeActivityLog, counters);
+    const reporter = createTerminalUiPerfReporter({
+      writeSlowMs: 0,
+      throttleMs: 0,
+      now: () => 1_000,
+    });
+
+    const result = timeTerminalWrite(
+      () => ({ ok: true as const }),
+      counters,
+      reporter,
+      sink,
+      { sessionId: 's1', bytes: 2 },
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(counters.maxTerminalWriteMs).toBeGreaterThanOrEqual(0);
+    expect(writeActivityLog).toHaveBeenCalledTimes(1);
+    expect(counters.terminalWriteSlowCount).toBe(1);
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -95,7 +95,6 @@ import type {
   WorkflowMeta,
   WorkflowMutationAcceptedResult,
   WorkResponse,
-  TerminalSessionDescriptor,
 } from '@invoker/contracts';
 import { ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
 import type { SQLiteAdapter } from '@invoker/data-store';
@@ -271,6 +270,16 @@ import {
   type WorkflowScopedGuiMutationRegistrationContext,
 } from './ipc/ipc-registration.js';
 import { createTaskDeltaStreamSequence } from './task-delta-stream-sequence.js';
+import {
+  createTerminalUiPerfCounters,
+  createTerminalUiPerfReporter,
+  createTerminalUiPerfSink,
+  resetTerminalUiPerfCounters,
+} from './terminal-ui-perf.js';
+import {
+  registerTerminalSessionIpcHandlers,
+  registerTerminalSessionPersistence,
+} from './terminal-session-ipc.js';
 import { startLifecycleEventBridge, type LifecycleEventBridge } from './lifecycle-event-bridge.js';
 import {
   buildRecoveryWorkerAuditPayload,
@@ -2023,74 +2032,7 @@ function createEmbeddedTerminalBackendFromConfig(
   const embeddedTerminalManager = new EmbeddedTerminalManager({
     backend: createEmbeddedTerminalBackendFromConfig(resolveEmbeddedTerminalBackendConfig(invokerConfig)),
   });
-  const terminalRowToDescriptor = (row: ReturnType<SQLiteAdapter['listTerminalSessions']>[number]): TerminalSessionDescriptor => ({
-    sessionId: row.sessionId,
-    taskId: row.taskId,
-    status: row.status,
-    exitCode: row.exitCode,
-    cwd: row.cwd,
-    command: row.command,
-    args: row.args,
-    mode: row.mode,
-    attached: row.attached,
-    createdAt: row.createdAt,
-    outputSnapshot: row.outputSnapshot,
-  });
 
-  const restorePersistedTerminalSessions = (): void => {
-    const nowIso = () => new Date().toISOString();
-    for (const row of persistence.listTerminalSessions()) {
-      if (!persistence.loadTask(row.taskId)) {
-        persistence.deleteTerminalSession(row.sessionId);
-        continue;
-      }
-      if (row.status !== 'running') continue;
-      if (row.mode === 'attached') {
-        persistence.updateTerminalSession(row.sessionId, { status: 'exited', updatedAt: nowIso() });
-        continue;
-      }
-      try {
-        embeddedTerminalManager.restoreSpawnSession({
-          sessionId: row.sessionId,
-          taskId: row.taskId,
-          targetKey: row.targetKey,
-          spec: {
-            cwd: row.cwd,
-            command: row.command,
-            args: row.args,
-            linuxTerminalTail: row.linuxTerminalTail,
-          },
-          cwd: row.cwd ?? process.cwd(),
-          createdAt: row.createdAt,
-          outputSnapshot: row.outputSnapshot,
-        });
-      } catch {
-        persistence.updateTerminalSession(row.sessionId, { status: 'exited', updatedAt: nowIso() });
-      }
-    }
-  };
-
-  const registerTerminalSessionPersistence = (): void => {
-    embeddedTerminalManager.on('session-updated', (record) => {
-      persistence.upsertTerminalSession({
-        sessionId: record.sessionId,
-        taskId: record.taskId,
-        targetKey: record.targetKey,
-        status: record.status,
-        exitCode: record.exitCode,
-        cwd: record.cwd,
-        command: record.spec.command,
-        args: record.spec.args,
-        linuxTerminalTail: record.spec.linuxTerminalTail,
-        mode: record.mode,
-        attached: record.attached,
-        outputSnapshot: record.outputSnapshot,
-        createdAt: record.createdAt,
-        updatedAt: record.updatedAt,
-      });
-    });
-    restorePersistedTerminalSessions();
-  };
   embeddedTerminalManager.on('output', (payload) => {
     if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.webContents.send('invoker:terminal-output', payload);
@@ -2166,7 +2108,15 @@ function createEmbeddedTerminalBackendFromConfig(
     workflowMetadataCoalescedRequests: 0,
     largeTaskDeltaBatches: 0,
     maxTaskDeltaBatchSize: 0,
+    ...createTerminalUiPerfCounters(),
   };
+  const terminalUiPerf = createTerminalUiPerfReporter();
+  const terminalUiPerfSink = createTerminalUiPerfSink(
+    (source, level, message) => {
+      persistence.writeActivityLog(source, level, message);
+    },
+    uiPerfStats,
+  );
   const startupMarks = new Map<string, number>();
   const startupPhaseDetails: Array<Record<string, unknown>> = [];
   const recordStartupMark = (phase: string, extra?: Record<string, unknown>): void => {
@@ -2228,6 +2178,8 @@ function createEmbeddedTerminalBackendFromConfig(
     uiPerfStats.workflowMetadataCoalescedRequests = 0;
     uiPerfStats.largeTaskDeltaBatches = 0;
     uiPerfStats.maxTaskDeltaBatchSize = 0;
+    resetTerminalUiPerfCounters(uiPerfStats);
+    terminalUiPerf.reset();
   };
 
   const getUiPerfStats = (): Record<string, unknown> => ({
@@ -3605,7 +3557,13 @@ function createEmbeddedTerminalBackendFromConfig(
     }
 
     if (ownerMode) {
-      registerTerminalSessionPersistence();
+      registerTerminalSessionPersistence({
+        embeddedTerminalManager,
+        persistence,
+        uiPerfStats,
+        terminalUiPerf,
+        terminalUiPerfSink,
+      });
     }
 
     if (ownerMode) {
@@ -5351,30 +5309,13 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    ipcMain.handle('invoker:terminal-list', async () => {
-      const live = new Map(embeddedTerminalManager.list().map((session) => [session.sessionId, session]));
-      const merged = persistence.listTerminalSessions().map((row) => live.get(row.sessionId) ?? terminalRowToDescriptor(row));
-      const persistedIds = new Set(merged.map((session) => session.sessionId));
-      for (const session of live.values()) {
-        if (!persistedIds.has(session.sessionId)) {
-          merged.push(session);
-        }
-      }
-      return merged;
-    });
-
-    ipcMain.handle('invoker:terminal-write', async (_event, sessionId: string, data: string) => {
-      return embeddedTerminalManager.write(sessionId, data);
-    });
-
-    ipcMain.handle('invoker:terminal-resize', async (_event, sessionId: string, cols: number, rows: number) => {
-      return embeddedTerminalManager.resize(sessionId, cols, rows);
-    });
-
-    ipcMain.handle('invoker:terminal-close', async (_event, sessionId: string) => {
-      const result = embeddedTerminalManager.close(sessionId);
-      persistence.deleteTerminalSession(sessionId);
-      return result.ok ? result : { ok: true };
+    registerTerminalSessionIpcHandlers({
+      ipcMain,
+      embeddedTerminalManager,
+      persistence,
+      uiPerfStats,
+      terminalUiPerf,
+      terminalUiPerfSink,
     });
 
     Menu.setApplicationMenu(

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -1,0 +1,163 @@
+import type { IpcMain } from 'electron';
+import type { TerminalSessionDescriptor } from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { EmbeddedTerminalManager } from './embedded-terminal-manager.js';
+import {
+  timeTerminalResize,
+  timeTerminalSessionUpsert,
+  timeTerminalWrite,
+  type TerminalUiPerfCounters,
+  type TerminalUiPerfReporter,
+  type TerminalUiPerfSink,
+} from './terminal-ui-perf.js';
+
+type TerminalSessionRow = ReturnType<SQLiteAdapter['listTerminalSessions']>[number];
+
+export function terminalRowToDescriptor(row: TerminalSessionRow): TerminalSessionDescriptor {
+  return {
+    sessionId: row.sessionId,
+    taskId: row.taskId,
+    status: row.status,
+    exitCode: row.exitCode,
+    cwd: row.cwd,
+    command: row.command,
+    args: row.args,
+    mode: row.mode,
+    attached: row.attached,
+    createdAt: row.createdAt,
+    outputSnapshot: row.outputSnapshot,
+  };
+}
+
+export function restorePersistedTerminalSessions(deps: {
+  persistence: Pick<SQLiteAdapter, 'listTerminalSessions' | 'loadTask' | 'deleteTerminalSession' | 'updateTerminalSession'>;
+  embeddedTerminalManager: Pick<EmbeddedTerminalManager, 'restoreSpawnSession'>;
+}): void {
+  const nowIso = () => new Date().toISOString();
+  for (const row of deps.persistence.listTerminalSessions()) {
+    if (!deps.persistence.loadTask(row.taskId)) {
+      deps.persistence.deleteTerminalSession(row.sessionId);
+      continue;
+    }
+    if (row.status !== 'running') continue;
+    if (row.mode === 'attached') {
+      deps.persistence.updateTerminalSession(row.sessionId, { status: 'exited', updatedAt: nowIso() });
+      continue;
+    }
+    try {
+      deps.embeddedTerminalManager.restoreSpawnSession({
+        sessionId: row.sessionId,
+        taskId: row.taskId,
+        targetKey: row.targetKey,
+        spec: {
+          cwd: row.cwd,
+          command: row.command,
+          args: row.args,
+          linuxTerminalTail: row.linuxTerminalTail,
+        },
+        cwd: row.cwd ?? process.cwd(),
+        createdAt: row.createdAt,
+        outputSnapshot: row.outputSnapshot,
+      });
+    } catch {
+      deps.persistence.updateTerminalSession(row.sessionId, { status: 'exited', updatedAt: nowIso() });
+    }
+  }
+}
+
+export function registerTerminalSessionPersistence(deps: {
+  embeddedTerminalManager: EmbeddedTerminalManager;
+  persistence: Pick<SQLiteAdapter, 'upsertTerminalSession' | 'listTerminalSessions' | 'loadTask' | 'deleteTerminalSession' | 'updateTerminalSession'>;
+  uiPerfStats: TerminalUiPerfCounters;
+  terminalUiPerf: TerminalUiPerfReporter;
+  terminalUiPerfSink: TerminalUiPerfSink;
+}): void {
+  deps.embeddedTerminalManager.on('session-updated', (record) => {
+    timeTerminalSessionUpsert(
+      () => {
+        deps.persistence.upsertTerminalSession({
+          sessionId: record.sessionId,
+          taskId: record.taskId,
+          targetKey: record.targetKey,
+          status: record.status,
+          exitCode: record.exitCode,
+          cwd: record.cwd,
+          command: record.spec.command,
+          args: record.spec.args,
+          linuxTerminalTail: record.spec.linuxTerminalTail,
+          mode: record.mode,
+          attached: record.attached,
+          outputSnapshot: record.outputSnapshot,
+          createdAt: record.createdAt,
+          updatedAt: record.updatedAt,
+        });
+      },
+      deps.uiPerfStats,
+      deps.terminalUiPerf,
+      deps.terminalUiPerfSink,
+      {
+        sessionId: record.sessionId,
+        taskId: record.taskId,
+        status: record.status,
+        outputSnapshotChars: record.outputSnapshot?.length ?? 0,
+      },
+    );
+  });
+  restorePersistedTerminalSessions(deps);
+}
+
+export function registerTerminalSessionIpcHandlers(deps: {
+  ipcMain: IpcMain;
+  embeddedTerminalManager: EmbeddedTerminalManager;
+  persistence: Pick<SQLiteAdapter, 'listTerminalSessions' | 'deleteTerminalSession'>;
+  uiPerfStats: TerminalUiPerfCounters;
+  terminalUiPerf: TerminalUiPerfReporter;
+  terminalUiPerfSink: TerminalUiPerfSink;
+}): void {
+  const { ipcMain, embeddedTerminalManager, persistence, uiPerfStats, terminalUiPerf, terminalUiPerfSink } = deps;
+
+  ipcMain.handle('invoker:terminal-list', async () => {
+    const live = new Map(embeddedTerminalManager.list().map((session) => [session.sessionId, session]));
+    const merged = persistence.listTerminalSessions().map((row) => live.get(row.sessionId) ?? terminalRowToDescriptor(row));
+    const persistedIds = new Set(merged.map((session) => session.sessionId));
+    for (const session of live.values()) {
+      if (!persistedIds.has(session.sessionId)) {
+        merged.push(session);
+      }
+    }
+    return merged;
+  });
+
+  ipcMain.handle('invoker:terminal-write', async (_event, sessionId: string, data: string) => {
+    return timeTerminalWrite(
+      () => embeddedTerminalManager.write(sessionId, data),
+      uiPerfStats,
+      terminalUiPerf,
+      terminalUiPerfSink,
+      {
+        sessionId,
+        bytes: typeof data === 'string' ? data.length : 0,
+      },
+    );
+  });
+
+  ipcMain.handle('invoker:terminal-resize', async (_event, sessionId: string, cols: number, rows: number) => {
+    return timeTerminalResize(
+      () => embeddedTerminalManager.resize(sessionId, cols, rows),
+      uiPerfStats,
+      terminalUiPerf,
+      terminalUiPerfSink,
+      {
+        sessionId,
+        cols,
+        rows,
+      },
+    );
+  });
+
+  ipcMain.handle('invoker:terminal-close', async (_event, sessionId: string) => {
+    const result = embeddedTerminalManager.close(sessionId);
+    persistence.deleteTerminalSession(sessionId);
+    return result.ok ? result : { ok: true };
+  });
+}

--- a/packages/app/src/terminal-ui-perf.ts
+++ b/packages/app/src/terminal-ui-perf.ts
@@ -1,0 +1,209 @@
+/**
+ * Thresholded terminal UI-perf reporters for main-process beachball forensics.
+ *
+ * Telemetry only — does not change terminal write/resize/persist behavior.
+ */
+
+export const TERMINAL_WRITE_SLOW_MS = 50;
+export const TERMINAL_RESIZE_SLOW_MS = 50;
+export const TERMINAL_SESSION_UPSERT_SLOW_MS = 25;
+export const TERMINAL_UPSERT_BURST_COUNT = 20;
+export const TERMINAL_UPSERT_BURST_WINDOW_MS = 1000;
+export const TERMINAL_PERF_THROTTLE_MS = 1000;
+
+export type TerminalUiPerfSink = {
+  writeActivityLog: (source: string, level: string, message: string) => void;
+  onSlowMetric?: (metric: string, data: Record<string, unknown>) => void;
+};
+
+export type TerminalUiPerfReporter = {
+  recordWrite: (durationMs: number, extra: Record<string, unknown>, sink: TerminalUiPerfSink) => void;
+  recordResize: (durationMs: number, extra: Record<string, unknown>, sink: TerminalUiPerfSink) => void;
+  recordUpsert: (durationMs: number, extra: Record<string, unknown>, sink: TerminalUiPerfSink) => void;
+  reset: () => void;
+};
+
+export type TerminalUiPerfCounters = {
+  maxTerminalWriteMs: number;
+  maxTerminalResizeMs: number;
+  maxTerminalSessionUpsertMs: number;
+  terminalWriteSlowCount: number;
+  terminalResizeSlowCount: number;
+  terminalSessionUpsertSlowCount: number;
+};
+
+export function createTerminalUiPerfCounters(): TerminalUiPerfCounters {
+  return {
+    maxTerminalWriteMs: 0,
+    maxTerminalResizeMs: 0,
+    maxTerminalSessionUpsertMs: 0,
+    terminalWriteSlowCount: 0,
+    terminalResizeSlowCount: 0,
+    terminalSessionUpsertSlowCount: 0,
+  };
+}
+
+export function resetTerminalUiPerfCounters(counters: TerminalUiPerfCounters): void {
+  counters.maxTerminalWriteMs = 0;
+  counters.maxTerminalResizeMs = 0;
+  counters.maxTerminalSessionUpsertMs = 0;
+  counters.terminalWriteSlowCount = 0;
+  counters.terminalResizeSlowCount = 0;
+  counters.terminalSessionUpsertSlowCount = 0;
+}
+
+export function createTerminalUiPerfSink(
+  writeActivityLog: (source: string, level: string, message: string) => void,
+  counters: TerminalUiPerfCounters,
+): TerminalUiPerfSink {
+  return {
+    writeActivityLog,
+    onSlowMetric: (metric, data) => {
+      const durationMs = typeof data.durationMs === 'number' ? data.durationMs : 0;
+      if (metric === 'terminal_write_slow') {
+        counters.terminalWriteSlowCount += 1;
+        counters.maxTerminalWriteMs = Math.max(counters.maxTerminalWriteMs, durationMs);
+      } else if (metric === 'terminal_resize_slow') {
+        counters.terminalResizeSlowCount += 1;
+        counters.maxTerminalResizeMs = Math.max(counters.maxTerminalResizeMs, durationMs);
+      } else if (metric === 'terminal_session_upsert_slow') {
+        counters.terminalSessionUpsertSlowCount += 1;
+        counters.maxTerminalSessionUpsertMs = Math.max(counters.maxTerminalSessionUpsertMs, durationMs);
+      }
+    },
+  };
+}
+
+export function timeTerminalWrite<T>(
+  write: () => T,
+  counters: TerminalUiPerfCounters,
+  reporter: TerminalUiPerfReporter,
+  sink: TerminalUiPerfSink,
+  extra: Record<string, unknown>,
+): T {
+  const startedAt = performance.now();
+  const result = write();
+  const durationMs = performance.now() - startedAt;
+  counters.maxTerminalWriteMs = Math.max(counters.maxTerminalWriteMs, durationMs);
+  reporter.recordWrite(durationMs, extra, sink);
+  return result;
+}
+
+export function timeTerminalResize<T>(
+  resize: () => T,
+  counters: TerminalUiPerfCounters,
+  reporter: TerminalUiPerfReporter,
+  sink: TerminalUiPerfSink,
+  extra: Record<string, unknown>,
+): T {
+  const startedAt = performance.now();
+  const result = resize();
+  const durationMs = performance.now() - startedAt;
+  counters.maxTerminalResizeMs = Math.max(counters.maxTerminalResizeMs, durationMs);
+  reporter.recordResize(durationMs, extra, sink);
+  return result;
+}
+
+export function timeTerminalSessionUpsert(
+  upsert: () => void,
+  counters: TerminalUiPerfCounters,
+  reporter: TerminalUiPerfReporter,
+  sink: TerminalUiPerfSink,
+  extra: Record<string, unknown>,
+): void {
+  const startedAt = performance.now();
+  upsert();
+  const durationMs = performance.now() - startedAt;
+  counters.maxTerminalSessionUpsertMs = Math.max(counters.maxTerminalSessionUpsertMs, durationMs);
+  reporter.recordUpsert(durationMs, extra, sink);
+}
+
+export function createTerminalUiPerfReporter(options?: {
+  writeSlowMs?: number;
+  resizeSlowMs?: number;
+  upsertSlowMs?: number;
+  upsertBurstCount?: number;
+  upsertBurstWindowMs?: number;
+  throttleMs?: number;
+  now?: () => number;
+}): TerminalUiPerfReporter {
+  const writeSlowMs = options?.writeSlowMs ?? TERMINAL_WRITE_SLOW_MS;
+  const resizeSlowMs = options?.resizeSlowMs ?? TERMINAL_RESIZE_SLOW_MS;
+  const upsertSlowMs = options?.upsertSlowMs ?? TERMINAL_SESSION_UPSERT_SLOW_MS;
+  const upsertBurstCount = options?.upsertBurstCount ?? TERMINAL_UPSERT_BURST_COUNT;
+  const upsertBurstWindowMs = options?.upsertBurstWindowMs ?? TERMINAL_UPSERT_BURST_WINDOW_MS;
+  const throttleMs = options?.throttleMs ?? TERMINAL_PERF_THROTTLE_MS;
+  const nowFn = options?.now ?? (() => Date.now());
+
+  const lastEmitByMetric = new Map<string, number>();
+  let upsertWindowStartedAt = 0;
+  let upsertsInWindow = 0;
+
+  const shouldEmit = (metric: string, at: number): boolean => {
+    const prev = lastEmitByMetric.get(metric) ?? 0;
+    if (at - prev < throttleMs) return false;
+    lastEmitByMetric.set(metric, at);
+    return true;
+  };
+
+  const emit = (sink: TerminalUiPerfSink, metric: string, data: Record<string, unknown>): void => {
+    const payload = {
+      ts: new Date().toISOString(),
+      metric,
+      ...data,
+    };
+    try {
+      sink.writeActivityLog('ui-perf', 'info', JSON.stringify(payload));
+    } catch {
+      // DB might be locked
+    }
+    sink.onSlowMetric?.(metric, data);
+  };
+
+  return {
+    recordWrite(durationMs, extra, sink) {
+      if (durationMs < writeSlowMs) return;
+      const at = nowFn();
+      if (!shouldEmit('terminal_write_slow', at)) return;
+      emit(sink, 'terminal_write_slow', {
+        durationMs: Math.round(durationMs),
+        ...extra,
+      });
+    },
+    recordResize(durationMs, extra, sink) {
+      if (durationMs < resizeSlowMs) return;
+      const at = nowFn();
+      if (!shouldEmit('terminal_resize_slow', at)) return;
+      emit(sink, 'terminal_resize_slow', {
+        durationMs: Math.round(durationMs),
+        ...extra,
+      });
+    },
+    recordUpsert(durationMs, extra, sink) {
+      const at = nowFn();
+      if (upsertWindowStartedAt === 0 || at - upsertWindowStartedAt >= upsertBurstWindowMs) {
+        upsertWindowStartedAt = at;
+        upsertsInWindow = 0;
+      }
+      upsertsInWindow += 1;
+
+      const slow = durationMs >= upsertSlowMs;
+      const burst = upsertsInWindow >= upsertBurstCount;
+      if (!slow && !burst) return;
+      if (!shouldEmit('terminal_session_upsert_slow', at)) return;
+      emit(sink, 'terminal_session_upsert_slow', {
+        durationMs: Math.round(durationMs),
+        upsertsInWindow,
+        upsertBurstWindowMs,
+        slow,
+        burst,
+        ...extra,
+      });
+    },
+    reset() {
+      lastEmitByMetric.clear();
+      upsertWindowStartedAt = 0;
+      upsertsInWindow = 0;
+    },
+  };
+}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -14,6 +14,7 @@ import yaml from 'js-yaml';
 import type { ActionGraphNode, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
+import { reportUiNavigation } from './lib/report-ui-navigation.js';
 import {
   mutationFailureBannerMessage,
   mutationFailureTitle,
@@ -2167,6 +2168,12 @@ export function App() {
 
   const selectViewMode = useCallback((nextView: 'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph') => {
     setGraphActionsMenuOpen(false);
+    reportUiNavigation(window.invoker?.reportUiPerf, {
+      kind: 'viewMode',
+      from: viewMode,
+      to: nextView,
+      sidebarSurface,
+    });
     if (nextView !== 'actionGraph' && selectedActionNodeId !== null) {
       setSelectedActionNodeId(null);
     }
@@ -2189,7 +2196,7 @@ export function App() {
       setSidebarSurface('home');
     }
     setViewMode(nextView);
-  }, [selectedActionNodeId]);
+  }, [selectedActionNodeId, sidebarSurface, viewMode]);
 
   const handleToggleInspectorCollapsed = useCallback(() => {
     if (autoCollapseInspector) {
@@ -2203,6 +2210,12 @@ export function App() {
 
   const handleSelectSidebarSurface = useCallback((nextSurface: SidebarSurface) => {
     setGraphActionsMenuOpen(false);
+    reportUiNavigation(window.invoker?.reportUiPerf, {
+      kind: 'sidebarSurface',
+      from: sidebarSurface,
+      to: nextSurface,
+      viewMode,
+    });
     if (nextSurface === 'workers') {
       setSidebarSurface('workers');
       setInspectorCollapsed(true);
@@ -2220,14 +2233,21 @@ export function App() {
     setSidebarSurface(nextSurface);
     setInspectorManualOpen(false);
     setStatusFilters(new Set<WorkflowStatus>());
-  }, []);
+  }, [sidebarSurface, viewMode]);
 
   const handleDismissBrowserSurface = useCallback(() => {
     setGraphActionsMenuOpen(false);
+    reportUiNavigation(window.invoker?.reportUiPerf, {
+      kind: 'sidebarSurface',
+      from: sidebarSurface,
+      to: 'home',
+      viewMode,
+      dismiss: true,
+    });
     setSidebarSurface('home');
     setInspectorManualOpen(false);
     setViewMode('dag');
-  }, []);
+  }, [sidebarSurface, viewMode]);
 
   // ── Task actions ──────────────────────────────────────────
   const handleProvideInput = useCallback(

--- a/packages/ui/src/__tests__/report-ui-navigation.test.ts
+++ b/packages/ui/src/__tests__/report-ui-navigation.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { reportUiNavigation } from '../lib/report-ui-navigation.js';
+
+describe('reportUiNavigation', () => {
+  it('reports ui_navigation via reportUiPerf', () => {
+    const reportUiPerf = vi.fn();
+    reportUiNavigation(reportUiPerf, {
+      kind: 'sidebarSurface',
+      from: 'home',
+      to: 'workflows',
+      viewMode: 'dag',
+    });
+    expect(reportUiPerf).toHaveBeenCalledWith('ui_navigation', {
+      kind: 'sidebarSurface',
+      from: 'home',
+      to: 'workflows',
+      viewMode: 'dag',
+    });
+  });
+
+  it('no-ops when reportUiPerf is missing', () => {
+    expect(() =>
+      reportUiNavigation(undefined, {
+        kind: 'viewMode',
+        from: 'dag',
+        to: 'queue',
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/ui/src/lib/report-ui-navigation.ts
+++ b/packages/ui/src/lib/report-ui-navigation.ts
@@ -1,0 +1,21 @@
+/**
+ * Emit a ui_navigation mark so renderer_event_loop_lag can be correlated
+ * with sidebar / view transitions. Telemetry only.
+ */
+
+export type UiNavigationKind = 'sidebarSurface' | 'viewMode';
+
+export function reportUiNavigation(
+  reportUiPerf: ((metric: string, data?: Record<string, unknown>) => unknown) | undefined,
+  data: {
+    kind: UiNavigationKind;
+    from: string;
+    to: string;
+    sidebarSurface?: string;
+    viewMode?: string;
+    dismiss?: boolean;
+  },
+): void {
+  if (!reportUiPerf) return;
+  void reportUiPerf('ui_navigation', data);
+}


### PR DESCRIPTION
## Summary

Renderer event-loop lag already lands in ui-perf, but lag after navigation could not be tied to a recent surface change.

This slice emits a `ui_navigation` mark when the sidebar surface or view mode changes.

What you see on screen stays the same. The mark only helps correlate the next lag spike with navigation.

## Review Claim

Approve emitting ui_navigation marks for sidebar and view-mode changes so lag spikes can be correlated with navigation.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Navigation still updates the same React state. The only addition is a best-effort reportUiPerf call that no-ops when the bridge is missing.

## Slice Rationale

UI navigation hooks classify as activation-surface and must stay separate from the main-process terminal telemetry routing slice below this one.

## Non-goals

- No terminal IPC or upsert timing in this slice
- No change to sidebar layout, view content, or navigation destinations
- No coalescing of navigation marks

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/report-ui-navigation.test.ts`
- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/context-menu-dismiss.test.tsx`

</details>

## Visual Proof

No user-visible UI change. Navigation still shows the same home shell; only a background ui-perf mark is added.

![Home shell unchanged after ui_navigation marks](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-4cb563/terminal-lag-telemetry-home-unchanged.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #3925