### PR TITLE
Enforce getEvents pagination to stop DAG click beachballs

### DIFF
--- a/docs/architecture/main-process-read-hot-paths.md
+++ b/docs/architecture/main-process-read-hot-paths.md
@@ -12,25 +12,34 @@ thousands of event rows. After that scan was fixed, the same poll still hitching
 window drag via per-kind `listWorkerActions` (~30ms × N workers) without a
 matching index.
 
+A follow-on beachball class was DAG task selection: the inspector called
+unbounded `getEvents` on click, stalling main while marshaling full task
+history even though the UI only rendered 20 log rows.
+
 ## Rules
 
-1. **No unbounded reads on timer or status IPC paths.**
+1. **No unbounded reads on timer, status, or user-gesture IPC paths.**
    Prefer `LIMIT`, type filters, or aggregates (`COUNT` / `MAX`). Never
    `SELECT * FROM events WHERE task_id = ?` (or equivalent full-history loads)
-   from a poll.
+   from a poll or a click handler.
 
-2. **Poll cost must be O(1) or O(workers), not O(tasks × events).**
+2. **`invoker:get-events` is always paginated.**
+   Callers must pass `{ limit }` (1..`MAX_EVENTS_PAGE`, currently 100). Optional
+   `beforeId` loads older pages. Missing or oversized limits are rejected at the
+   IPC / API boundary (`normalizeGetEventsOptions` / `getEventsPage`).
+
+3. **Poll cost must be O(1) or O(workers), not O(tasks × events).**
    If a status endpoint walks every workflow and every task, it is wrong for a
    1–2s UI poll.
 
-3. **No intentional poll staleness on status IPC.**
+4. **No intentional poll staleness on status IPC.**
    Prefer indexed bounded reads on every poll over TTL caches that hide
    freshness. Moving sync SQLite off the Electron main thread is INV-265.
 
-4. **Index every `WHERE` + `ORDER BY` used by polls.**
+5. **Index every `WHERE` + `ORDER BY` used by polls.**
    Missing indexes turn "LIMIT 5" into a multi-ten-ms scan on large tables.
 
-5. **Large text columns stay off hot paths.**
+6. **Large text columns stay off hot paths.**
    Attempt `error` blobs can be multi-MB. Projection helpers must not load every
    attempt row for a node just to pick the newest active one.
 
@@ -40,12 +49,16 @@ matching index.
 | --- | --- | --- |
 | `useWorkerStatus` → `getWorkerStatus` → `snapshot()` | ~2s | Recovery via aggregates; indexed `listWorkerActions` (no TTL cache) |
 | Main `dbPollInterval` → `loadTasks` | ~2s | Projection must not unbounded-scan attempts |
-| Task inspector `getEvents(taskId)` | on demand | Prefer bounded reads when only recent audit is needed |
+| Task inspector / History / Approval `getEvents` | on demand | Always paginated (`limit` required; History uses `beforeId` for Load more) |
 
 ## Preferred APIs
 
-- Events: `countEventsByTypes`, `getEventsByTypes(..., limit)` — not full
-  per-task history for status summaries.
+- Events (UI/IPC): `getEvents(taskId, { limit, sortBy?, beforeId? })` via
+  `getEventsPage` — never the 1-arg unbounded adapter overload.
+- Events (status): `countEventsByTypes`, `getEventsByTypes(..., limit)` — not
+  full per-task history for status summaries.
+- Events (headless full audit): loop pages server-side (`loadAllEventsPaged`) —
+  never one giant IPC payload.
 - Attempts: indexed `LIMIT 1` for "newest active" — not `loadAttempts(nodeId)`
   on every projection.
 - Worker actions: `listWorkerActions({ workerKind, limit })` backed by
@@ -53,11 +66,16 @@ matching index.
 
 ## How to catch regressions
 
-- Unit cost guards under fat fixtures (many events / large attempt errors).
+- Unit cost guards under fat fixtures (many events / large attempt errors),
+  including `packages/app/src/__tests__/dag-click-get-events-cost.test.ts`
+  (unbounded vs page cost + reject missing limit).
 - Main-process hitch e2e (`packages/app/e2e/main-process-hitch-responsiveness.spec.ts`):
   while worker-status polls against a seeded fat DB, cheap IPC RTT must stay
   under budget (window-drag stickiness maps to main-loop stalls, not renderer
   frame gaps alone). Included in GitHub Playwright shards (merge-queue / master).
+- DAG-click hitch e2e (`packages/app/e2e/dag-click-hitch-responsiveness.spec.ts`):
+  seed fat events, click task nodes, assert `listWorkflows` RTT stays under the
+  same hitch budget.
 - Slow-query telemetry: `SQLiteAdapter` logs statements slower than 25ms
   (`slowQueryThresholdMs` / `onSlowQuery`) so the next spike shows up without
   attaching a sampler. Set `slowQueryThresholdMs: 0` to disable.

--- a/packages/app/e2e/autofix-worker-ui.spec.ts
+++ b/packages/app/e2e/autofix-worker-ui.spec.ts
@@ -40,7 +40,7 @@ test('worker-triggered autofix reaches approval UI with mocked Claude', async ({
         return payload && typeof payload === 'object' ? payload as Record<string, unknown> : {};
       };
 
-      const events = await window.invoker.getEvents(taskId);
+      const events = await window.invoker.getEvents(taskId, { limit: 100, sortBy: 'desc' });
       return events.some((event: { eventType: string }) => event.eventType === 'task.failed')
         && events.some((event: { eventType: string; payload?: unknown }) => {
           const payload = parsePayload(event.payload);

--- a/packages/app/e2e/dag-click-hitch-responsiveness.spec.ts
+++ b/packages/app/e2e/dag-click-hitch-responsiveness.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from './fixtures/electron-app.js';
+
+const MAX_P95_RTT_MS = 100;
+const MAX_SAMPLE_RTT_MS = 250;
+const CLICK_SAMPLES = 8;
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)]!;
+}
+
+test('DAG task clicks keep listWorkflows IPC responsive under a fat events table', async ({ page }) => {
+  const seeded = await page.evaluate(async () => {
+    if (!window.invoker.seedMainProcessHitchFixture) {
+      throw new Error('seedMainProcessHitchFixture is not exposed (NODE_ENV=test required)');
+    }
+    return window.invoker.seedMainProcessHitchFixture();
+  });
+
+  expect(seeded.eventCount).toBeGreaterThanOrEqual(10_000);
+  expect(seeded.taskCount).toBeGreaterThan(0);
+
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  const workflowNode = page.getByTestId(`workflow-node-${seeded.workflowId}`);
+  await workflowNode.waitFor({ state: 'visible', timeout: 15_000 });
+  await workflowNode.click();
+
+  const miniDag = page.getByTestId('selected-workflow-mini-dag');
+  await miniDag.waitFor({ state: 'visible', timeout: 10_000 });
+
+  const taskIds = Array.from({ length: Math.min(seeded.taskCount, CLICK_SAMPLES) }, (_, i) =>
+    `${seeded.workflowId}/t${i}`,
+  );
+
+  const samples: number[] = [];
+  for (const taskId of taskIds) {
+    const node = miniDag.locator(`[data-testid="rf__node-${taskId}"]`).first();
+    await node.waitFor({ state: 'visible', timeout: 10_000 });
+    await node.click();
+
+    const rtt = await page.evaluate(async () => {
+      const started = performance.now();
+      await window.invoker.listWorkflows();
+      return performance.now() - started;
+    });
+    samples.push(rtt);
+  }
+
+  expect(samples.length).toBeGreaterThanOrEqual(3);
+  const sorted = [...samples].sort((a, b) => a - b);
+  const p95 = percentile(sorted, 95);
+  const max = sorted[sorted.length - 1]!;
+
+  expect(
+    p95,
+    `p95 IPC RTT ${p95.toFixed(1)}ms exceeded ${MAX_P95_RTT_MS}ms (max=${max.toFixed(1)}ms, n=${samples.length})`,
+  ).toBeLessThanOrEqual(MAX_P95_RTT_MS);
+  expect(
+    max,
+    `max IPC RTT ${max.toFixed(1)}ms exceeded ${MAX_SAMPLE_RTT_MS}ms (p95=${p95.toFixed(1)}ms, n=${samples.length})`,
+  ).toBeLessThanOrEqual(MAX_SAMPLE_RTT_MS);
+});

--- a/packages/app/e2e/persistence-lifecycle.spec.ts
+++ b/packages/app/e2e/persistence-lifecycle.spec.ts
@@ -104,8 +104,14 @@ test.describe('Persistence lifecycle', () => {
 
     const alphaId = await resolveTaskId(page, 'task-alpha');
     const betaId = await resolveTaskId(page, 'task-beta');
-    const alphaEvents = await page.evaluate((id) => window.invoker.getEvents(id), alphaId);
-    const betaEvents = await page.evaluate((id) => window.invoker.getEvents(id), betaId);
+    const alphaEvents = await page.evaluate(
+      (id) => window.invoker.getEvents(id, { limit: 100, sortBy: 'asc' }),
+      alphaId,
+    );
+    const betaEvents = await page.evaluate(
+      (id) => window.invoker.getEvents(id, { limit: 100, sortBy: 'asc' }),
+      betaId,
+    );
 
     const alphaTypes = alphaEvents.map((e: any) => e.eventType);
     const betaTypes = betaEvents.map((e: any) => e.eventType);
@@ -120,7 +126,10 @@ test.describe('Persistence lifecycle', () => {
     await loadPlan(page, PERSISTENCE_PLAN);
     await startPlan(page);
     const mergeNodeId = await waitForWorkflowReviewReady(page);
-    const events = await page.evaluate((id) => window.invoker.getEvents(id), mergeNodeId);
+    const events = await page.evaluate(
+      (id) => window.invoker.getEvents(id, { limit: 100, sortBy: 'asc' }),
+      mergeNodeId,
+    );
     const types = events.map((e: any) => e.eventType);
     expect(types).toContain('task.review_ready');
   });

--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -495,12 +495,18 @@ describe('GET /api/queue', () => {
 });
 
 describe('GET /api/tasks/:id/events', () => {
-  it('returns event log', async () => {
-    const res = await request(port, 'GET', '/api/tasks/task-1/events');
+  it('returns event log page when limit is provided', async () => {
+    const res = await request(port, 'GET', '/api/tasks/task-1/events?limit=50&sortBy=desc');
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
     expect(res.body[0].eventType).toBe('started');
-    expect(mocks.persistence.getEvents).toHaveBeenCalledWith('task-1');
+    expect(mocks.persistence.getEvents).toHaveBeenCalledWith('task-1', 'desc', 50, undefined);
+  });
+
+  it('rejects missing limit', async () => {
+    const res = await request(port, 'GET', '/api/tasks/task-1/events');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/limit/i);
   });
 });
 

--- a/packages/app/src/__tests__/dag-click-get-events-cost.test.ts
+++ b/packages/app/src/__tests__/dag-click-get-events-cost.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MAX_EVENTS_PAGE, normalizeGetEventsOptions } from '@invoker/contracts';
+import { SQLiteAdapter } from '@invoker/data-store';
+
+import { getEventsPage } from '../get-events-page.js';
+import { seedMainProcessHitchFixture } from '../main-process-hitch-fixture.js';
+
+describe('dag-click getEvents pagination cost', () => {
+  let tmpDir: string | undefined;
+  let adapter: SQLiteAdapter | undefined;
+
+  afterEach(async () => {
+    await adapter?.close();
+    adapter = undefined;
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it('proves unbounded getEvents is expensive while a bounded page stays cheap', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'invoker-dag-click-events-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const seeded = seedMainProcessHitchFixture(adapter, {
+      taskCount: 1,
+      eventsPerTask: 20_000,
+      actionsPerKind: 1,
+    });
+    const taskId = `${seeded.workflowId}/t0`;
+
+    const unboundedStarted = performance.now();
+    const unbounded = adapter.getEvents(taskId);
+    const unboundedMs = performance.now() - unboundedStarted;
+
+    const boundedStarted = performance.now();
+    const bounded = getEventsPage(adapter, taskId, { limit: 50, sortBy: 'desc' });
+    const boundedMs = performance.now() - boundedStarted;
+
+    expect(unbounded.length).toBe(20_000);
+    expect(bounded.length).toBe(50);
+    expect(unboundedMs).toBeGreaterThan(boundedMs);
+    expect(boundedMs).toBeLessThan(25);
+    expect(unboundedMs).toBeGreaterThan(10);
+  });
+
+  it('rejects missing or oversized limits at the public getEvents boundary', () => {
+    expect(() => normalizeGetEventsOptions(undefined)).toThrow(/requires options/);
+    expect(() => normalizeGetEventsOptions({})).toThrow(/limit is required/);
+    expect(() => normalizeGetEventsOptions({ limit: 0 })).toThrow(/between 1 and/);
+    expect(() => normalizeGetEventsOptions({ limit: MAX_EVENTS_PAGE + 1 })).toThrow(/between 1 and/);
+    expect(normalizeGetEventsOptions({ limit: 50, sortBy: 'desc' })).toEqual({
+      sortBy: 'desc',
+      limit: 50,
+    });
+  });
+
+  it('supports beforeId cursor pages without loading full history', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'invoker-dag-click-cursor-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const seeded = seedMainProcessHitchFixture(adapter, {
+      taskCount: 1,
+      eventsPerTask: 120,
+      actionsPerKind: 1,
+    });
+    const taskId = `${seeded.workflowId}/t0`;
+
+    const first = getEventsPage(adapter, taskId, { limit: 50, sortBy: 'desc' });
+    expect(first).toHaveLength(50);
+    const oldestOnPage = first[first.length - 1]!;
+    const second = getEventsPage(adapter, taskId, {
+      limit: 50,
+      sortBy: 'desc',
+      beforeId: oldestOnPage.id,
+    });
+    expect(second.length).toBeGreaterThan(0);
+    expect(second.every((event) => event.id < oldestOnPage.id)).toBe(true);
+    expect(new Set([...first, ...second].map((e) => e.id)).size).toBe(first.length + second.length);
+  });
+});

--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -67,8 +67,10 @@ describe('answerOwnerReadQuery', () => {
     expect(answerOwnerReadQuery({ kind: 'workflow', workflowId: 'wf-9' }, h)).toEqual({ workflow: { id: 'wf-9' }, tasks: [] });
     expect(h.loadWorkflowBundle).toHaveBeenCalledWith('wf-9');
     expect(answerOwnerReadQuery({ kind: 'review-gate', workflowId: 'wf-9' }, h)).toEqual({ reviewGate: { gate: true } });
-    expect(answerOwnerReadQuery({ kind: 'events', taskId: 't-1' }, h)).toEqual({ events: [{ e: 1 }] });
-    expect(h.getEvents).toHaveBeenCalledWith('t-1');
+    expect(answerOwnerReadQuery({ kind: 'events', taskId: 't-1', limit: 50, sortBy: 'desc' }, h)).toEqual({
+      events: [{ e: 1 }],
+    });
+    expect(h.getEvents).toHaveBeenCalledWith('t-1', { limit: 50, sortBy: 'desc' });
     expect(answerOwnerReadQuery({ kind: 'task-by-id', taskId: 't-1' }, h)).toEqual({ task: { id: 't-1' } });
     expect(answerOwnerReadQuery({ kind: 'task-output', taskId: 't-1' }, h)).toEqual({ output: 'output-text' });
     expect(answerOwnerReadQuery({ kind: 'output-chunks', taskId: 't-1' }, h)).toEqual({ chunks: [{ c: 1 }] });
@@ -163,7 +165,7 @@ describe('buildOwnerReadQueryHandlers', () => {
   it('passes reads straight through to persistence', () => {
     const h = build();
     expect(h.listWorkflows()).toEqual([{ id: 'wf' }]);
-    expect(h.getEvents('t1')).toEqual([{ e: 1 }]);
+    expect(h.getEvents('t1', { limit: 50, sortBy: 'desc' })).toEqual([{ e: 1 }]);
     expect(h.getTaskOutput('t1')).toBe('out');
     expect(h.getTaskById('t1')).toEqual({ id: 't1' });
     expect(h.getOutputChunks('t1')).toEqual([{ c: 1 }]);

--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -108,7 +108,7 @@ describe('buildWebInvokerDispatch', () => {
     expect(await dispatch('invoker:get-history-tasks', [])).toEqual(historyRows);
   });
 
-  it('get-events returns persistence events for a task', async () => {
+  it('get-events returns a paginated page for a task', async () => {
     const events = [{ id: 1, taskId: 't1', eventType: 'task.running', createdAt: '2026-07-01T00:00:00Z' }];
     const getEvents = vi.fn(() => events);
     const { dispatch } = makeDispatch({
@@ -117,8 +117,18 @@ describe('buildWebInvokerDispatch', () => {
         getEvents,
       },
     });
-    expect(await dispatch('invoker:get-events', ['t1'])).toEqual(events);
-    expect(getEvents).toHaveBeenCalledWith('t1');
+    expect(await dispatch('invoker:get-events', ['t1', { limit: 50, sortBy: 'desc' }])).toEqual(events);
+    expect(getEvents).toHaveBeenCalledWith('t1', 'desc', 50, undefined);
+  });
+
+  it('get-events rejects missing limit', async () => {
+    const { dispatch } = makeDispatch({
+      persistence: {
+        listWorkflows: () => [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
+        getEvents: vi.fn(() => []),
+      },
+    });
+    await expect(dispatch('invoker:get-events', ['t1'])).rejects.toThrow(/limit/i);
   });
 
   it('approve routes to the mutation facade', async () => {

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -61,6 +61,7 @@ import type {
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { parseMetadataPatchBody, type MetadataSetResult } from './metadata-setter.js';
+import { getEventsPage } from './get-events-page.js';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
 
 export interface ApiMutationFacade {
@@ -560,12 +561,22 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
-      // GET /api/tasks/:id/events
+      // GET /api/tasks/:id/events?limit=&sortBy=&beforeId=
       const eventsMatch = path.match(/^\/api\/tasks\/([^/]+)\/events$/);
       if (method === 'GET' && eventsMatch) {
         const taskId = decodeURIComponent(eventsMatch[1]);
-        const events = persistence.getEvents(taskId);
-        json(res, 200, events);
+        try {
+          const limit = query.limit !== undefined ? Number(query.limit) : NaN;
+          const beforeId = query.beforeId !== undefined ? Number(query.beforeId) : undefined;
+          const events = getEventsPage(persistence, taskId, {
+            limit,
+            ...(query.sortBy === 'asc' || query.sortBy === 'desc' ? { sortBy: query.sortBy } : {}),
+            ...(beforeId !== undefined ? { beforeId } : {}),
+          });
+          json(res, 200, events);
+        } catch (err) {
+          json(res, 400, { error: errorMessage(err) });
+        }
         return;
       }
 

--- a/packages/app/src/get-events-page.ts
+++ b/packages/app/src/get-events-page.ts
@@ -1,0 +1,31 @@
+import {
+  normalizeGetEventsOptions,
+  type GetEventsOptions,
+  type TaskEvent,
+} from '@invoker/contracts';
+
+export interface GetEventsPagePersistence {
+  getEvents(
+    taskId: string,
+    sortBy: 'asc' | 'desc',
+    limit: number,
+    beforeId?: number,
+  ): TaskEvent[];
+}
+
+/** Public get-events path: always paginated. Rejects missing/oversized limits. */
+export function getEventsPage(
+  persistence: GetEventsPagePersistence,
+  taskId: string,
+  options: unknown,
+): TaskEvent[] {
+  const normalized = normalizeGetEventsOptions(options);
+  return persistence.getEvents(
+    taskId,
+    normalized.sortBy,
+    normalized.limit,
+    normalized.beforeId,
+  );
+}
+
+export type { GetEventsOptions };

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -25,6 +25,7 @@ import {
   restoreWorkflowForTask,
 } from './headless-shared.js';
 import { resolveDefaultExecutionAgent } from './config.js';
+import { loadAllEventsPaged } from './load-all-events-paged.js';
 import { listWorkerDecisions } from './worker-control.js';
 import {
   collectRecoveryWorkerStatus,
@@ -234,7 +235,7 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
     case 'audit': {
       const taskId = flags.positional[0];
       if (!taskId) throw new Error('Usage: --headless query audit <taskId>');
-      const events = deps.persistence.getEvents(taskId);
+      const events = loadAllEventsPaged(deps.persistence, taskId);
 
       switch (flags.output) {
         case 'label': writeOut(events.map(e => `${e.taskId}:${e.eventType}`).join('\n') + '\n'); break;
@@ -719,7 +720,7 @@ export async function headlessSession(taskId: string | undefined, deps: Pick<Hea
   // Fallback: if current execution dropped agentSessionId, recover the most
   // recent session from task event payloads.
   if (!sessionId) {
-    const events = deps.persistence.getEvents(taskId) ?? [];
+    const events = loadAllEventsPaged(deps.persistence, taskId);
     for (let i = events.length - 1; i >= 0; i -= 1) {
       const payload = events[i].payload;
       if (!payload) continue;

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -1,11 +1,12 @@
 import type { IpcMain } from 'electron';
-import type { Logger, SearchOptions, WorkerActionHistoryRequest, WorkerActionHistoryResponse, WorkerDecisionsRequest, WorkerDecisionsResponse } from '@invoker/contracts';
+import type { GetEventsOptions, Logger, SearchOptions, WorkerActionHistoryRequest, WorkerActionHistoryResponse, WorkerDecisionsRequest, WorkerDecisionsResponse } from '@invoker/contracts';
 import { resolveInvokerHomeRoot } from '@invoker/contracts';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { DEFAULT_EXECUTION_AGENT, type AgentRegistry } from '@invoker/execution-engine';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import type { MessageBus } from '@invoker/transport';
 import { loadConfig } from './config.js';
+import { getEventsPage } from './get-events-page.js';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
 import { buildTaskGraphSnapshot } from './web/task-graph-snapshot.js';
 import { listWorkerActionHistory, listWorkerDecisions } from './worker-control.js';
@@ -169,8 +170,9 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     return { tasks, workflows, streamSequence };
   });
 
-  ipcMain.handle('invoker:get-events', (_event, taskId: string) =>
-    delegatedRead('events', { taskId }, 'events', () => persistence.getEvents(taskId)));
+  ipcMain.handle('invoker:get-events', (_event, taskId: string, options: GetEventsOptions) =>
+    delegatedRead('events', { taskId, options }, 'events', () =>
+      getEventsPage(persistence, String(taskId), options)));
   ipcMain.handle('invoker:get-status', async () => (
     await delegateOwnerQuery('workflow-status') ?? getOrchestrator().getWorkflowStatus()
   ));

--- a/packages/app/src/load-all-events-paged.ts
+++ b/packages/app/src/load-all-events-paged.ts
@@ -1,0 +1,27 @@
+import { MAX_EVENTS_PAGE, type TaskEvent } from '@invoker/contracts';
+
+export interface LoadAllEventsPagedPersistence {
+  getEvents(
+    taskId: string,
+    sortBy: 'asc' | 'desc',
+    limit: number,
+    beforeId?: number,
+  ): TaskEvent[];
+}
+
+/** Server-side full history via repeated pages. Never used by UI/IPC gesture paths. */
+export function loadAllEventsPaged(
+  persistence: LoadAllEventsPagedPersistence,
+  taskId: string,
+): TaskEvent[] {
+  const newestFirst: TaskEvent[] = [];
+  let beforeId: number | undefined;
+  for (;;) {
+    const page = persistence.getEvents(taskId, 'desc', MAX_EVENTS_PAGE, beforeId);
+    if (page.length === 0) break;
+    newestFirst.push(...page);
+    if (page.length < MAX_EVENTS_PAGE) break;
+    beforeId = page[page.length - 1]!.id;
+  }
+  return newestFirst.slice().reverse();
+}

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -1,6 +1,14 @@
 import type { Orchestrator } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import type { WorkerActionHistoryRequest, WorkerActionHistoryResponse, WorkerDecisionsRequest, WorkerDecisionsResponse, WorkerStatusSnapshot } from '@invoker/contracts';
+import type {
+  GetEventsOptions,
+  WorkerActionHistoryRequest,
+  WorkerActionHistoryResponse,
+  WorkerDecisionsRequest,
+  WorkerDecisionsResponse,
+  WorkerStatusSnapshot,
+} from '@invoker/contracts';
+import { getEventsPage } from './get-events-page.js';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
 import { isHeadlessReadOnlyCommand } from './headless-command-classification.js';
 import { runReadOnlyHeadlessQueryToString, type HeadlessQueryDeps } from './headless-query-list.js';
@@ -38,7 +46,7 @@ export interface OwnerReadQueryHandlers {
   listWorkflows: () => unknown[];
   loadWorkflowBundle: (workflowId: string) => Record<string, unknown>;
   getReviewGate: (workflowId: string) => unknown;
-  getEvents: (taskId: string) => unknown[];
+  getEvents: (taskId: string, options: GetEventsOptions) => unknown[];
   getTaskById: (taskId: string) => unknown;
   getTaskOutput: (taskId: string) => string;
   getOutputChunks: (taskId: string) => unknown[];
@@ -63,6 +71,9 @@ export function answerOwnerReadQuery(
     reason?: string;
     limit?: number;
     offset?: number;
+    beforeId?: number;
+    sortBy?: 'asc' | 'desc';
+    options?: GetEventsOptions;
   };
   const { kind, reset } = body;
   handlers.onActivity?.();
@@ -120,8 +131,16 @@ export function answerOwnerReadQuery(
       return handlers.loadWorkflowBundle(requiredString(body.workflowId, 'workflowId'));
     case 'review-gate':
       return { reviewGate: handlers.getReviewGate(requiredString(body.workflowId, 'workflowId')) ?? null };
-    case 'events':
-      return { events: handlers.getEvents(requiredString(body.taskId, 'taskId')) };
+    case 'events': {
+      const options: GetEventsOptions = body.options ?? {
+        limit: body.limit as number,
+        ...(body.sortBy !== undefined ? { sortBy: body.sortBy } : {}),
+        ...(body.beforeId !== undefined ? { beforeId: body.beforeId } : {}),
+      };
+      return {
+        events: handlers.getEvents(requiredString(body.taskId, 'taskId'), options),
+      };
+    }
     case 'task-by-id':
       return { task: handlers.getTaskById(requiredString(body.taskId, 'taskId')) ?? null };
     case 'task-output':
@@ -235,7 +254,8 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
       if (!workflow) return null;
       return buildReviewGateQueryResponse({ workflowId, workflow, tasks: persistence.loadTasks(workflowId) });
     },
-    getEvents: (taskId: string) => persistence.getEvents(taskId),
+    getEvents: (taskId: string, options: GetEventsOptions) =>
+      getEventsPage(persistence, taskId, options),
     getTaskById: (taskId: string) => persistence.loadTask(taskId),
     getTaskOutput: (taskId: string) => persistence.getTaskOutput(taskId),
     getOutputChunks: (taskId: string) => persistence.getOutputChunks(taskId),

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -24,6 +24,7 @@ import type { ExternalGatePolicyUpdate, Orchestrator } from '@invoker/workflow-c
 import { resolveDefaultTaskExecutionSettings, type InvokerConfig } from '../config.js';
 import { listInAppPlanningPresets } from '../in-app-planner.js';
 import type { ApiMutationFacade } from '../api-server.js';
+import { getEventsPage } from '../get-events-page.js';
 import { buildReviewGateQueryResponse } from '../review-gate-query.js';
 import { buildCurrentActionGraphSnapshot } from '../action-graph-snapshot.js';
 import { collectSystemDiagnostics } from '../system-diagnostics.js';
@@ -113,7 +114,7 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
           invokerConfig: deps.loadConfig(),
         });
       case 'invoker:get-events':
-        return persistence.getEvents(String(args[0]));
+        return getEventsPage(persistence, String(args[0]), args[1]);
       case 'invoker:get-task-output':
         return persistence.getTaskOutput(String(args[0]));
       case 'invoker:get-task-by-id':

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -140,6 +140,51 @@ export interface TaskEvent {
   createdAt: string;
 }
 
+/** Max rows returned by a single `invoker:get-events` page. */
+export const MAX_EVENTS_PAGE = 100;
+
+/** Required pagination options for `invoker:get-events`. */
+export interface GetEventsOptions {
+  /** Default `'desc'` (newest first). */
+  sortBy?: 'asc' | 'desc';
+  /** Required page size; must be 1..MAX_EVENTS_PAGE. */
+  limit: number;
+  /** Optional cursor: return events with id strictly less than this (older). */
+  beforeId?: number;
+}
+
+export interface NormalizedGetEventsOptions {
+  sortBy: 'asc' | 'desc';
+  limit: number;
+  beforeId?: number;
+}
+
+/**
+ * Validate and normalize get-events pagination options.
+ * Rejects missing/invalid limit and pages larger than MAX_EVENTS_PAGE.
+ */
+export function normalizeGetEventsOptions(raw: unknown): NormalizedGetEventsOptions {
+  if (raw === undefined || raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('getEvents requires options with a numeric limit');
+  }
+  const opts = raw as Record<string, unknown>;
+  if (typeof opts.limit !== 'number' || !Number.isFinite(opts.limit)) {
+    throw new Error('getEvents options.limit is required and must be a finite number');
+  }
+  const limit = Math.floor(opts.limit);
+  if (limit <= 0 || limit > MAX_EVENTS_PAGE) {
+    throw new Error(`getEvents options.limit must be between 1 and ${MAX_EVENTS_PAGE}`);
+  }
+  const sortBy = opts.sortBy === 'asc' ? 'asc' : 'desc';
+  if (opts.beforeId === undefined) {
+    return { sortBy, limit };
+  }
+  if (typeof opts.beforeId !== 'number' || !Number.isFinite(opts.beforeId)) {
+    throw new Error('getEvents options.beforeId must be a finite number when provided');
+  }
+  return { sortBy, limit, beforeId: Math.floor(opts.beforeId) };
+}
+
 export interface TaskHistoryEntry extends TaskState {
   workflowName: string;
   lastEventAt: string | null;
@@ -787,7 +832,7 @@ export const IpcChannels = {
     response: void;
   },
   'invoker:get-events': {} as {
-    request: [taskId: string];
+    request: [taskId: string, options: GetEventsOptions];
     response: TaskEvent[];
   },
   'invoker:get-status': {} as {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2381,6 +2381,22 @@ describe('SQLiteAdapter', () => {
       );
       expect(adapter.getEvents('t1', 'desc', 0)).toEqual([]);
     });
+
+    it('supports beforeId cursor for older pages', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      for (let index = 0; index < 30; index += 1) {
+        adapter.logEvent('t1', `event-${index}`, { index });
+      }
+
+      const first = adapter.getEvents('t1', 'desc', 10);
+      const oldest = first[first.length - 1]!;
+      const second = adapter.getEvents('t1', 'desc', 10, oldest.id);
+
+      expect(second).toHaveLength(10);
+      expect(second.every((event) => event.id < oldest.id)).toBe(true);
+      expect(second[0]!.eventType).toBe(`event-${29 - 10}`);
+    });
   });
 
   describe('JSON fields', () => {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -275,8 +275,9 @@ export interface PersistenceAdapter {
 
   // Events (audit trail)
   logEvent(taskId: string, eventType: string, payload?: unknown): void;
+  /** Unbounded history — internal/tests only. Public IPC must use the limited overload. */
   getEvents(taskId: string): TaskEvent[];
-  getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number): TaskEvent[];
+  getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number, beforeId?: number): TaskEvent[];
   getEventsByTypes?(eventTypes: readonly string[], sortBy: 'asc' | 'desc', limit: number): TaskEvent[];
   countEventsByTypes?(eventTypes: readonly string[]): Array<{
     eventType: string;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1725,20 +1725,34 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   getEvents(taskId: string): TaskEvent[];
-  getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number): TaskEvent[];
-  getEvents(taskId: string, sortBy: 'asc' | 'desc' = 'asc', limit?: number): TaskEvent[] {
+  getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number, beforeId?: number): TaskEvent[];
+  getEvents(
+    taskId: string,
+    sortBy: 'asc' | 'desc' = 'asc',
+    limit?: number,
+    beforeId?: number,
+  ): TaskEvent[] {
     const orderBy = sortBy === 'desc' ? 'DESC' : 'ASC';
-    const rows = limit === undefined
-      ? this.queryAll(
+    if (limit === undefined) {
+      const rows = this.queryAll(
         `SELECT * FROM events WHERE task_id = ? ORDER BY id ${orderBy}`,
         [taskId],
-      )
-      : limit <= 0
-        ? []
-        : this.queryAll(
-          `SELECT * FROM events WHERE task_id = ? ORDER BY id ${orderBy} LIMIT ?`,
-          [taskId, Math.floor(limit)],
-        );
+      );
+      return rows.map((row: any) => this.rowToTaskEvent(row));
+    }
+    if (limit <= 0) return [];
+    const pageLimit = Math.floor(limit);
+    if (beforeId !== undefined) {
+      const rows = this.queryAll(
+        `SELECT * FROM events WHERE task_id = ? AND id < ? ORDER BY id ${orderBy} LIMIT ?`,
+        [taskId, Math.floor(beforeId), pageLimit],
+      );
+      return rows.map((row: any) => this.rowToTaskEvent(row));
+    }
+    const rows = this.queryAll(
+      `SELECT * FROM events WHERE task_id = ? ORDER BY id ${orderBy} LIMIT ?`,
+      [taskId, pageLimit],
+    );
     return rows.map((row: any) => this.rowToTaskEvent(row));
   }
 

--- a/packages/ui/src/__tests__/approval-modal.test.tsx
+++ b/packages/ui/src/__tests__/approval-modal.test.tsx
@@ -692,7 +692,7 @@ describe('ApprovalModal', () => {
     );
 
     await waitFor(() => {
-      expect(mockGetEvents).toHaveBeenCalledWith('task-1');
+      expect(mockGetEvents).toHaveBeenCalledWith('task-1', { limit: 50, sortBy: 'desc' });
     });
 
     expect(mockGetAgentSession).not.toHaveBeenCalled();

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -271,7 +271,8 @@ export function createMockInvoker(
     runInvokerCliSetup: vi.fn(async () => ({ ok: true, steps: [{ id: 'tools', name: 'Run setup', ok: true, output: 'setup ok' }] })),
     replaceTask: vi.fn(async () => accepted('invoker:replace-task')),
     getActivityLogs: vi.fn(async () => []),
-    getEvents: vi.fn(async (taskId: string) => eventsByTask.get(taskId) ?? []),
+    getEvents: vi.fn(async (taskId: string, _options?: { limit: number; sortBy?: 'asc' | 'desc'; beforeId?: number }) =>
+      eventsByTask.get(taskId) ?? []),
     getHistoryTasks: vi.fn(async () => historySnapshot),
     openTerminal: vi.fn(async (taskId: string) => ({
       opened: true,

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -697,14 +697,14 @@ describe('WorkflowInspector', () => {
 
   it('shows task logs and filters by minimum level', async () => {
     (window as unknown as {
-      invoker: { getEvents: (taskId: string) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };
+      invoker: { getEvents: (taskId: string, options: { limit: number }) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };
     }).invoker = {
       getEvents: vi.fn(async () => [
         {
-          id: 1,
-          eventType: 'debug.auto-fix',
-          payload: JSON.stringify({ message: 'debug detail', attempt: 1, value: 'secret' }),
-          createdAt: '2025-01-01T00:00:01.000Z',
+          id: 3,
+          eventType: 'task.failed',
+          payload: JSON.stringify({ message: 'Merge gate failed' }),
+          createdAt: '2025-01-01T00:00:03.000Z',
         },
         {
           id: 2,
@@ -713,10 +713,10 @@ describe('WorkflowInspector', () => {
           createdAt: '2025-01-01T00:00:02.000Z',
         },
         {
-          id: 3,
-          eventType: 'task.failed',
-          payload: JSON.stringify({ message: 'Merge gate failed' }),
-          createdAt: '2025-01-01T00:00:03.000Z',
+          id: 1,
+          eventType: 'debug.auto-fix',
+          payload: JSON.stringify({ message: 'debug detail', attempt: 1, value: 'secret' }),
+          createdAt: '2025-01-01T00:00:01.000Z',
         },
       ]),
     };
@@ -749,7 +749,7 @@ describe('WorkflowInspector', () => {
 
   it('shows a visible notice when fix recreated the workflow because workspace was missing', async () => {
     (window as unknown as {
-      invoker: { getEvents: (taskId: string) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };
+      invoker: { getEvents: (taskId: string, options: { limit: number }) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };
     }).invoker = {
       getEvents: vi.fn(async () => [
         {
@@ -789,7 +789,7 @@ describe('WorkflowInspector', () => {
 
   it('shows a retrying log error when task events fail to load', async () => {
     (window as unknown as {
-      invoker: { getEvents: (taskId: string) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };
+      invoker: { getEvents: (taskId: string, options: { limit: number }) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };
     }).invoker = {
       getEvents: vi.fn(async () => {
         throw new Error('offline');

--- a/packages/ui/src/components/ApprovalModal.tsx
+++ b/packages/ui/src/components/ApprovalModal.tsx
@@ -102,7 +102,7 @@ export function ApprovalModal({
     if (task.execution.agentSessionId || task.execution.lastAgentSessionId || fallbackSessionId) return;
     let cancelled = false;
     window.invoker
-      .getEvents(task.id)
+      .getEvents(task.id, { limit: 50, sortBy: 'desc' })
       .then((events) => {
         if (cancelled) return;
         const recovered = extractSessionFromEvents(events as Array<{ eventType?: string; payload?: string }>);

--- a/packages/ui/src/components/HistoryView.tsx
+++ b/packages/ui/src/components/HistoryView.tsx
@@ -226,14 +226,22 @@ function TimelineEntry({
   );
 }
 
+const HISTORY_EVENTS_PAGE_SIZE = 50;
+
 function Timeline({
   taskId,
   events,
   loading,
+  hasMore,
+  loadingMore,
+  onLoadMore,
 }: {
   taskId: string;
   events: TaskEvent[] | undefined;
   loading: boolean;
+  hasMore: boolean;
+  loadingMore: boolean;
+  onLoadMore: () => void;
 }) {
   if (loading) {
     return <div className="text-xs text-gray-500 py-2">Loading timeline...</div>;
@@ -241,27 +249,37 @@ function Timeline({
   if (!events || events.length === 0) {
     return <div className="text-xs text-gray-500 py-2">No recorded events for this task.</div>;
   }
-  // getEvents() returns oldest-first; the timeline UI shows newest-first.
-  const newestFirst = [...events].reverse();
+  const newestFirst = events;
   return (
-    <ol
-      className="mt-1 pl-1"
-      aria-label={`Timeline for task ${taskId}`}
-      data-testid={`history-timeline-${taskId}`}
-    >
-      {newestFirst.map((event, idxFromTop) => {
-        // The chronologically-previous event sits BELOW the current one in a
-        // newest-first list, i.e. at index+1.
-        const chronologicallyPrev = newestFirst[idxFromTop + 1]?.createdAt;
-        return (
-          <TimelineEntry
-            key={event.id}
-            event={event}
-            prevChronologicalCreatedAt={chronologicallyPrev}
-          />
-        );
-      })}
-    </ol>
+    <div>
+      <ol
+        className="mt-1 pl-1"
+        aria-label={`Timeline for task ${taskId}`}
+        data-testid={`history-timeline-${taskId}`}
+      >
+        {newestFirst.map((event, idxFromTop) => {
+          const chronologicallyPrev = newestFirst[idxFromTop + 1]?.createdAt;
+          return (
+            <TimelineEntry
+              key={event.id}
+              event={event}
+              prevChronologicalCreatedAt={chronologicallyPrev}
+            />
+          );
+        })}
+      </ol>
+      {hasMore && (
+        <button
+          type="button"
+          className="mt-2 text-xs text-indigo-300 hover:text-indigo-100"
+          onClick={onLoadMore}
+          disabled={loadingMore}
+          data-testid={`history-load-more-${taskId}`}
+        >
+          {loadingMore ? 'Loading…' : 'Load more'}
+        </button>
+      )}
+    </div>
   );
 }
 
@@ -271,7 +289,10 @@ function HistoryRow({
   expanded,
   events,
   eventsLoading,
+  hasMore,
+  loadingMore,
   onToggleExpand,
+  onLoadMore,
   onSelect,
 }: {
   entry: TaskHistoryEntry;
@@ -279,7 +300,10 @@ function HistoryRow({
   expanded: boolean;
   events: TaskEvent[] | undefined;
   eventsLoading: boolean;
+  hasMore: boolean;
+  loadingMore: boolean;
   onToggleExpand: (taskId: string) => void;
+  onLoadMore: (taskId: string) => void;
   onSelect: (task: TaskState) => void;
 }) {
   const rowClass = selected
@@ -324,7 +348,14 @@ function HistoryRow({
       </div>
       {expanded && (
         <div className="px-3 pb-2 pl-8 border-t border-gray-700/60">
-          <Timeline taskId={entry.id} events={events} loading={eventsLoading} />
+          <Timeline
+            taskId={entry.id}
+            events={events}
+            loading={eventsLoading}
+            hasMore={hasMore}
+            loadingMore={loadingMore}
+            onLoadMore={() => onLoadMore(entry.id)}
+          />
         </div>
       )}
     </li>
@@ -526,7 +557,9 @@ export function HistoryView({ onTaskClick, selectedTaskId }: HistoryViewProps) {
   const [filter, setFilter] = useState<FilterState>(EMPTY_FILTER);
   const [expandedTaskId, setExpandedTaskId] = useState<string | null>(null);
   const [eventsByTask, setEventsByTask] = useState<Map<string, TaskEvent[]>>(new Map());
+  const [eventsHasMoreByTask, setEventsHasMoreByTask] = useState<Map<string, boolean>>(new Map());
   const [eventsLoadingTaskId, setEventsLoadingTaskId] = useState<string | null>(null);
+  const [eventsLoadingMoreTaskId, setEventsLoadingMoreTaskId] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -554,16 +587,54 @@ export function HistoryView({ onTaskClick, selectedTaskId }: HistoryViewProps) {
     if (!invoker?.getEvents) return;
     setEventsLoadingTaskId(taskId);
     try {
-      const evs = await invoker.getEvents(taskId);
+      const evs = await invoker.getEvents(taskId, {
+        limit: HISTORY_EVENTS_PAGE_SIZE,
+        sortBy: 'desc',
+      });
       setEventsByTask((prev) => {
         const next = new Map(prev);
         next.set(taskId, evs);
+        return next;
+      });
+      setEventsHasMoreByTask((prev) => {
+        const next = new Map(prev);
+        next.set(taskId, evs.length >= HISTORY_EVENTS_PAGE_SIZE);
         return next;
       });
     } finally {
       setEventsLoadingTaskId((current) => (current === taskId ? null : current));
     }
   }, []);
+
+  const loadMoreEvents = useCallback(async (taskId: string) => {
+    const invoker = getInvoker();
+    if (!invoker?.getEvents) return;
+    const existing = eventsByTask.get(taskId) ?? [];
+    const oldest = existing[existing.length - 1];
+    if (!oldest) return;
+    setEventsLoadingMoreTaskId(taskId);
+    try {
+      const page = await invoker.getEvents(taskId, {
+        limit: HISTORY_EVENTS_PAGE_SIZE,
+        sortBy: 'desc',
+        beforeId: oldest.id,
+      });
+      setEventsByTask((prev) => {
+        const next = new Map(prev);
+        const current = next.get(taskId) ?? [];
+        const seen = new Set(current.map((event) => event.id));
+        next.set(taskId, [...current, ...page.filter((event) => !seen.has(event.id))]);
+        return next;
+      });
+      setEventsHasMoreByTask((prev) => {
+        const next = new Map(prev);
+        next.set(taskId, page.length >= HISTORY_EVENTS_PAGE_SIZE);
+        return next;
+      });
+    } finally {
+      setEventsLoadingMoreTaskId((current) => (current === taskId ? null : current));
+    }
+  }, [eventsByTask]);
 
   useEffect(() => {
     const invoker = getInvoker();
@@ -641,7 +712,10 @@ export function HistoryView({ onTaskClick, selectedTaskId }: HistoryViewProps) {
               expanded={expandedTaskId === entry.id}
               events={eventsByTask.get(entry.id)}
               eventsLoading={eventsLoadingTaskId === entry.id}
+              hasMore={eventsHasMoreByTask.get(entry.id) === true}
+              loadingMore={eventsLoadingMoreTaskId === entry.id}
               onToggleExpand={toggleExpand}
+              onLoadMore={loadMoreEvents}
               onSelect={onTaskClick}
             />
           ))}

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -271,7 +271,7 @@ export function TaskPanel({
 
     let cancelled = false;
     setWorkspaceSetupFailures([]);
-    window.invoker?.getEvents(task.id)
+    window.invoker?.getEvents(task.id, { limit: 50, sortBy: 'desc' })
       .then((events) => {
         const failures = extractWorkspaceSetupFailures(events);
         if (!cancelled && failures.length > 0) {

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -291,7 +291,7 @@ export function WorkflowInspector({
     let inFlight = false;
     const refreshEvents = () => {
       if (inFlight) return;
-      const eventsPromise = window.invoker?.getEvents(task.id);
+      const eventsPromise = window.invoker?.getEvents(task.id, { limit: 50, sortBy: 'desc' });
       if (!eventsPromise) return;
 
       inFlight = true;
@@ -365,15 +365,12 @@ export function WorkflowInspector({
     && onReject,
   );
   const statusHeading = task ? 'Task Status' : 'Status';
-  const workspaceRecreateNotice = [...taskLogEvents]
-    .reverse()
+  const workspaceRecreateNotice = taskLogEvents
     .map(workspaceRecreateNoticeFromEvent)
     .find((notice): notice is WorkspaceRecreateNotice => Boolean(notice));
   const logEntries = taskLogEvents.map(taskEventToLogEntry);
   const visibleLogEntries = logEntries
-    .filter((entry) => LOG_LEVEL_RANK[entry.level] >= LOG_LEVEL_RANK[logLevelFilter])
-    .slice()
-    .reverse();
+    .filter((entry) => LOG_LEVEL_RANK[entry.level] >= LOG_LEVEL_RANK[logLevelFilter]);
 
   const savePrompt = () => {
     if (task && onEditPrompt && editPromptValue !== (task.config.prompt ?? '')) {


### PR DESCRIPTION
## Summary
- Require `{ limit, sortBy?, beforeId? }` on `invoker:get-events` (max page 100) so unbounded SQLite/IPC event reads cannot stall Electron main on DAG task clicks
- Bound inspector/history/approval/UI call sites; HistoryView uses Load more via `beforeId`
- Add cost-guard unit test (20k unbounded vs bounded page) and DAG-click hitch e2e under a fat events fixture

## Test plan
- [x] `packages/app` unit: `dag-click-get-events-cost`, `owner-read-query`, `web-invoker-dispatch`, `api-server` (events paths)
- [x] `packages/data-store` unit: `beforeId` / limited `getEvents` sqlite tests
- [x] `packages/ui` unit: workflow-inspector + approval-modal event paths
- [ ] Playwright: `packages/app/e2e/dag-click-hitch-responsiveness.spec.ts`
- [ ] Manually click tasks with large event history and confirm no beachball; inspector still shows recent logs


Made with [Cursor](https://cursor.com)