### PR TITLE
Bound UI gesture reads to paginated getEvents pages.

### DIFF
--- a/packages/ui/src/__tests__/approval-modal.test.tsx
+++ b/packages/ui/src/__tests__/approval-modal.test.tsx
@@ -692,7 +692,7 @@ describe('ApprovalModal', () => {
     );
 
     await waitFor(() => {
-      expect(mockGetEvents).toHaveBeenCalledWith('task-1');
+      expect(mockGetEvents).toHaveBeenCalledWith('task-1', { limit: 50, sortBy: 'desc' });
     });
 
     expect(mockGetAgentSession).not.toHaveBeenCalled();

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -271,7 +271,8 @@ export function createMockInvoker(
     runInvokerCliSetup: vi.fn(async () => ({ ok: true, steps: [{ id: 'tools', name: 'Run setup', ok: true, output: 'setup ok' }] })),
     replaceTask: vi.fn(async () => accepted('invoker:replace-task')),
     getActivityLogs: vi.fn(async () => []),
-    getEvents: vi.fn(async (taskId: string) => eventsByTask.get(taskId) ?? []),
+    getEvents: vi.fn(async (taskId: string, _options?: { limit: number; sortBy?: 'asc' | 'desc'; beforeId?: number }) =>
+      eventsByTask.get(taskId) ?? []),
     getHistoryTasks: vi.fn(async () => historySnapshot),
     openTerminal: vi.fn(async (taskId: string) => ({
       opened: true,

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -697,14 +697,14 @@ describe('WorkflowInspector', () => {
 
   it('shows task logs and filters by minimum level', async () => {
     (window as unknown as {
-      invoker: { getEvents: (taskId: string) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };
+      invoker: { getEvents: (taskId: string, options: { limit: number }) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };
     }).invoker = {
       getEvents: vi.fn(async () => [
         {
-          id: 1,
-          eventType: 'debug.auto-fix',
-          payload: JSON.stringify({ message: 'debug detail', attempt: 1, value: 'secret' }),
-          createdAt: '2025-01-01T00:00:01.000Z',
+          id: 3,
+          eventType: 'task.failed',
+          payload: JSON.stringify({ message: 'Merge gate failed' }),
+          createdAt: '2025-01-01T00:00:03.000Z',
         },
         {
           id: 2,
@@ -713,10 +713,10 @@ describe('WorkflowInspector', () => {
           createdAt: '2025-01-01T00:00:02.000Z',
         },
         {
-          id: 3,
-          eventType: 'task.failed',
-          payload: JSON.stringify({ message: 'Merge gate failed' }),
-          createdAt: '2025-01-01T00:00:03.000Z',
+          id: 1,
+          eventType: 'debug.auto-fix',
+          payload: JSON.stringify({ message: 'debug detail', attempt: 1, value: 'secret' }),
+          createdAt: '2025-01-01T00:00:01.000Z',
         },
       ]),
     };
@@ -749,7 +749,7 @@ describe('WorkflowInspector', () => {
 
   it('shows a visible notice when fix recreated the workflow because workspace was missing', async () => {
     (window as unknown as {
-      invoker: { getEvents: (taskId: string) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };
+      invoker: { getEvents: (taskId: string, options: { limit: number }) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };
     }).invoker = {
       getEvents: vi.fn(async () => [
         {
@@ -789,7 +789,7 @@ describe('WorkflowInspector', () => {
 
   it('shows a retrying log error when task events fail to load', async () => {
     (window as unknown as {
-      invoker: { getEvents: (taskId: string) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };
+      invoker: { getEvents: (taskId: string, options: { limit: number }) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };
     }).invoker = {
       getEvents: vi.fn(async () => {
         throw new Error('offline');

--- a/packages/ui/src/components/ApprovalModal.tsx
+++ b/packages/ui/src/components/ApprovalModal.tsx
@@ -102,7 +102,7 @@ export function ApprovalModal({
     if (task.execution.agentSessionId || task.execution.lastAgentSessionId || fallbackSessionId) return;
     let cancelled = false;
     window.invoker
-      .getEvents(task.id)
+      .getEvents(task.id, { limit: 50, sortBy: 'desc' })
       .then((events) => {
         if (cancelled) return;
         const recovered = extractSessionFromEvents(events as Array<{ eventType?: string; payload?: string }>);

--- a/packages/ui/src/components/HistoryView.tsx
+++ b/packages/ui/src/components/HistoryView.tsx
@@ -226,14 +226,22 @@ function TimelineEntry({
   );
 }
 
+const HISTORY_EVENTS_PAGE_SIZE = 50;
+
 function Timeline({
   taskId,
   events,
   loading,
+  hasMore,
+  loadingMore,
+  onLoadMore,
 }: {
   taskId: string;
   events: TaskEvent[] | undefined;
   loading: boolean;
+  hasMore: boolean;
+  loadingMore: boolean;
+  onLoadMore: () => void;
 }) {
   if (loading) {
     return <div className="text-xs text-gray-500 py-2">Loading timeline...</div>;
@@ -241,27 +249,37 @@ function Timeline({
   if (!events || events.length === 0) {
     return <div className="text-xs text-gray-500 py-2">No recorded events for this task.</div>;
   }
-  // getEvents() returns oldest-first; the timeline UI shows newest-first.
-  const newestFirst = [...events].reverse();
+  const newestFirst = events;
   return (
-    <ol
-      className="mt-1 pl-1"
-      aria-label={`Timeline for task ${taskId}`}
-      data-testid={`history-timeline-${taskId}`}
-    >
-      {newestFirst.map((event, idxFromTop) => {
-        // The chronologically-previous event sits BELOW the current one in a
-        // newest-first list, i.e. at index+1.
-        const chronologicallyPrev = newestFirst[idxFromTop + 1]?.createdAt;
-        return (
-          <TimelineEntry
-            key={event.id}
-            event={event}
-            prevChronologicalCreatedAt={chronologicallyPrev}
-          />
-        );
-      })}
-    </ol>
+    <div>
+      <ol
+        className="mt-1 pl-1"
+        aria-label={`Timeline for task ${taskId}`}
+        data-testid={`history-timeline-${taskId}`}
+      >
+        {newestFirst.map((event, idxFromTop) => {
+          const chronologicallyPrev = newestFirst[idxFromTop + 1]?.createdAt;
+          return (
+            <TimelineEntry
+              key={event.id}
+              event={event}
+              prevChronologicalCreatedAt={chronologicallyPrev}
+            />
+          );
+        })}
+      </ol>
+      {hasMore && (
+        <button
+          type="button"
+          className="mt-2 text-xs text-indigo-300 hover:text-indigo-100"
+          onClick={onLoadMore}
+          disabled={loadingMore}
+          data-testid={`history-load-more-${taskId}`}
+        >
+          {loadingMore ? 'Loading…' : 'Load more'}
+        </button>
+      )}
+    </div>
   );
 }
 
@@ -271,7 +289,10 @@ function HistoryRow({
   expanded,
   events,
   eventsLoading,
+  hasMore,
+  loadingMore,
   onToggleExpand,
+  onLoadMore,
   onSelect,
 }: {
   entry: TaskHistoryEntry;
@@ -279,7 +300,10 @@ function HistoryRow({
   expanded: boolean;
   events: TaskEvent[] | undefined;
   eventsLoading: boolean;
+  hasMore: boolean;
+  loadingMore: boolean;
   onToggleExpand: (taskId: string) => void;
+  onLoadMore: (taskId: string) => void;
   onSelect: (task: TaskState) => void;
 }) {
   const rowClass = selected
@@ -324,7 +348,14 @@ function HistoryRow({
       </div>
       {expanded && (
         <div className="px-3 pb-2 pl-8 border-t border-gray-700/60">
-          <Timeline taskId={entry.id} events={events} loading={eventsLoading} />
+          <Timeline
+            taskId={entry.id}
+            events={events}
+            loading={eventsLoading}
+            hasMore={hasMore}
+            loadingMore={loadingMore}
+            onLoadMore={() => onLoadMore(entry.id)}
+          />
         </div>
       )}
     </li>
@@ -526,7 +557,9 @@ export function HistoryView({ onTaskClick, selectedTaskId }: HistoryViewProps) {
   const [filter, setFilter] = useState<FilterState>(EMPTY_FILTER);
   const [expandedTaskId, setExpandedTaskId] = useState<string | null>(null);
   const [eventsByTask, setEventsByTask] = useState<Map<string, TaskEvent[]>>(new Map());
+  const [eventsHasMoreByTask, setEventsHasMoreByTask] = useState<Map<string, boolean>>(new Map());
   const [eventsLoadingTaskId, setEventsLoadingTaskId] = useState<string | null>(null);
+  const [eventsLoadingMoreTaskId, setEventsLoadingMoreTaskId] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -554,16 +587,54 @@ export function HistoryView({ onTaskClick, selectedTaskId }: HistoryViewProps) {
     if (!invoker?.getEvents) return;
     setEventsLoadingTaskId(taskId);
     try {
-      const evs = await invoker.getEvents(taskId);
+      const evs = await invoker.getEvents(taskId, {
+        limit: HISTORY_EVENTS_PAGE_SIZE,
+        sortBy: 'desc',
+      });
       setEventsByTask((prev) => {
         const next = new Map(prev);
         next.set(taskId, evs);
+        return next;
+      });
+      setEventsHasMoreByTask((prev) => {
+        const next = new Map(prev);
+        next.set(taskId, evs.length >= HISTORY_EVENTS_PAGE_SIZE);
         return next;
       });
     } finally {
       setEventsLoadingTaskId((current) => (current === taskId ? null : current));
     }
   }, []);
+
+  const loadMoreEvents = useCallback(async (taskId: string) => {
+    const invoker = getInvoker();
+    if (!invoker?.getEvents) return;
+    const existing = eventsByTask.get(taskId) ?? [];
+    const oldest = existing[existing.length - 1];
+    if (!oldest) return;
+    setEventsLoadingMoreTaskId(taskId);
+    try {
+      const page = await invoker.getEvents(taskId, {
+        limit: HISTORY_EVENTS_PAGE_SIZE,
+        sortBy: 'desc',
+        beforeId: oldest.id,
+      });
+      setEventsByTask((prev) => {
+        const next = new Map(prev);
+        const current = next.get(taskId) ?? [];
+        const seen = new Set(current.map((event) => event.id));
+        next.set(taskId, [...current, ...page.filter((event) => !seen.has(event.id))]);
+        return next;
+      });
+      setEventsHasMoreByTask((prev) => {
+        const next = new Map(prev);
+        next.set(taskId, page.length >= HISTORY_EVENTS_PAGE_SIZE);
+        return next;
+      });
+    } finally {
+      setEventsLoadingMoreTaskId((current) => (current === taskId ? null : current));
+    }
+  }, [eventsByTask]);
 
   useEffect(() => {
     const invoker = getInvoker();
@@ -641,7 +712,10 @@ export function HistoryView({ onTaskClick, selectedTaskId }: HistoryViewProps) {
               expanded={expandedTaskId === entry.id}
               events={eventsByTask.get(entry.id)}
               eventsLoading={eventsLoadingTaskId === entry.id}
+              hasMore={eventsHasMoreByTask.get(entry.id) === true}
+              loadingMore={eventsLoadingMoreTaskId === entry.id}
               onToggleExpand={toggleExpand}
+              onLoadMore={loadMoreEvents}
               onSelect={onTaskClick}
             />
           ))}

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -271,7 +271,7 @@ export function TaskPanel({
 
     let cancelled = false;
     setWorkspaceSetupFailures([]);
-    window.invoker?.getEvents(task.id)
+    window.invoker?.getEvents(task.id, { limit: 50, sortBy: 'desc' })
       .then((events) => {
         const failures = extractWorkspaceSetupFailures(events);
         if (!cancelled && failures.length > 0) {

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -291,7 +291,7 @@ export function WorkflowInspector({
     let inFlight = false;
     const refreshEvents = () => {
       if (inFlight) return;
-      const eventsPromise = window.invoker?.getEvents(task.id);
+      const eventsPromise = window.invoker?.getEvents(task.id, { limit: 50, sortBy: 'desc' });
       if (!eventsPromise) return;
 
       inFlight = true;
@@ -365,15 +365,12 @@ export function WorkflowInspector({
     && onReject,
   );
   const statusHeading = task ? 'Task Status' : 'Status';
-  const workspaceRecreateNotice = [...taskLogEvents]
-    .reverse()
+  const workspaceRecreateNotice = taskLogEvents
     .map(workspaceRecreateNoticeFromEvent)
     .find((notice): notice is WorkspaceRecreateNotice => Boolean(notice));
   const logEntries = taskLogEvents.map(taskEventToLogEntry);
   const visibleLogEntries = logEntries
-    .filter((entry) => LOG_LEVEL_RANK[entry.level] >= LOG_LEVEL_RANK[logLevelFilter])
-    .slice()
-    .reverse();
+    .filter((entry) => LOG_LEVEL_RANK[entry.level] >= LOG_LEVEL_RANK[logLevelFilter]);
 
   const savePrompt = () => {
     if (task && onEditPrompt && editPromptValue !== (task.config.prompt ?? '')) {


### PR DESCRIPTION
Fetch newest logs with an explicit limit on inspector/task/approval paths, and paginate HistoryView via beforeId Load more.

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #3930