### PR TITLE
Add DAG-click hitch e2e and document the getEvents pagination invariant.

### DIFF
--- a/docs/architecture/main-process-read-hot-paths.md
+++ b/docs/architecture/main-process-read-hot-paths.md
@@ -12,25 +12,34 @@ thousands of event rows. After that scan was fixed, the same poll still hitching
 window drag via per-kind `listWorkerActions` (~30ms × N workers) without a
 matching index.
 
+A follow-on beachball class was DAG task selection: the inspector called
+unbounded `getEvents` on click, stalling main while marshaling full task
+history even though the UI only rendered 20 log rows.
+
 ## Rules
 
-1. **No unbounded reads on timer or status IPC paths.**
+1. **No unbounded reads on timer, status, or user-gesture IPC paths.**
    Prefer `LIMIT`, type filters, or aggregates (`COUNT` / `MAX`). Never
    `SELECT * FROM events WHERE task_id = ?` (or equivalent full-history loads)
-   from a poll.
+   from a poll or a click handler.
 
-2. **Poll cost must be O(1) or O(workers), not O(tasks × events).**
+2. **`invoker:get-events` is always paginated.**
+   Callers must pass `{ limit }` (1..`MAX_EVENTS_PAGE`, currently 100). Optional
+   `beforeId` loads older pages. Missing or oversized limits are rejected at the
+   IPC / API boundary (`normalizeGetEventsOptions` / `getEventsPage`).
+
+3. **Poll cost must be O(1) or O(workers), not O(tasks × events).**
    If a status endpoint walks every workflow and every task, it is wrong for a
    1–2s UI poll.
 
-3. **No intentional poll staleness on status IPC.**
+4. **No intentional poll staleness on status IPC.**
    Prefer indexed bounded reads on every poll over TTL caches that hide
    freshness. Moving sync SQLite off the Electron main thread is INV-265.
 
-4. **Index every `WHERE` + `ORDER BY` used by polls.**
+5. **Index every `WHERE` + `ORDER BY` used by polls.**
    Missing indexes turn "LIMIT 5" into a multi-ten-ms scan on large tables.
 
-5. **Large text columns stay off hot paths.**
+6. **Large text columns stay off hot paths.**
    Attempt `error` blobs can be multi-MB. Projection helpers must not load every
    attempt row for a node just to pick the newest active one.
 
@@ -40,12 +49,16 @@ matching index.
 | --- | --- | --- |
 | `useWorkerStatus` → `getWorkerStatus` → `snapshot()` | ~2s | Recovery via aggregates; indexed `listWorkerActions` (no TTL cache) |
 | Main `dbPollInterval` → `loadTasks` | ~2s | Projection must not unbounded-scan attempts |
-| Task inspector `getEvents(taskId)` | on demand | Prefer bounded reads when only recent audit is needed |
+| Task inspector / History / Approval `getEvents` | on demand | Always paginated (`limit` required; History uses `beforeId` for Load more) |
 
 ## Preferred APIs
 
-- Events: `countEventsByTypes`, `getEventsByTypes(..., limit)` — not full
-  per-task history for status summaries.
+- Events (UI/IPC): `getEvents(taskId, { limit, sortBy?, beforeId? })` via
+  `getEventsPage` — never the 1-arg unbounded adapter overload.
+- Events (status): `countEventsByTypes`, `getEventsByTypes(..., limit)` — not
+  full per-task history for status summaries.
+- Events (headless full audit): loop pages server-side (`loadAllEventsPaged`) —
+  never one giant IPC payload.
 - Attempts: indexed `LIMIT 1` for "newest active" — not `loadAttempts(nodeId)`
   on every projection.
 - Worker actions: `listWorkerActions({ workerKind, limit })` backed by
@@ -53,11 +66,16 @@ matching index.
 
 ## How to catch regressions
 
-- Unit cost guards under fat fixtures (many events / large attempt errors).
+- Unit cost guards under fat fixtures (many events / large attempt errors),
+  including `packages/app/src/__tests__/dag-click-get-events-cost.test.ts`
+  (unbounded vs page cost + reject missing limit).
 - Main-process hitch e2e (`packages/app/e2e/main-process-hitch-responsiveness.spec.ts`):
   while worker-status polls against a seeded fat DB, cheap IPC RTT must stay
   under budget (window-drag stickiness maps to main-loop stalls, not renderer
   frame gaps alone). Included in GitHub Playwright shards (merge-queue / master).
+- DAG-click hitch e2e (`packages/app/e2e/dag-click-hitch-responsiveness.spec.ts`):
+  seed fat events, click task nodes, assert `listWorkflows` RTT stays under the
+  same hitch budget.
 - Slow-query telemetry: `SQLiteAdapter` logs statements slower than 25ms
   (`slowQueryThresholdMs` / `onSlowQuery`) so the next spike shows up without
   attaching a sampler. Set `slowQueryThresholdMs: 0` to disable.

--- a/packages/app/e2e/dag-click-hitch-responsiveness.spec.ts
+++ b/packages/app/e2e/dag-click-hitch-responsiveness.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from './fixtures/electron-app.js';
+
+const MAX_P95_RTT_MS = 100;
+const MAX_SAMPLE_RTT_MS = 250;
+const CLICK_SAMPLES = 8;
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)]!;
+}
+
+test('DAG task clicks keep listWorkflows IPC responsive under a fat events table', async ({ page }) => {
+  const seeded = await page.evaluate(async () => {
+    if (!window.invoker.seedMainProcessHitchFixture) {
+      throw new Error('seedMainProcessHitchFixture is not exposed (NODE_ENV=test required)');
+    }
+    return window.invoker.seedMainProcessHitchFixture();
+  });
+
+  expect(seeded.eventCount).toBeGreaterThanOrEqual(10_000);
+  expect(seeded.taskCount).toBeGreaterThan(0);
+
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  const workflowNode = page.getByTestId(`workflow-node-${seeded.workflowId}`);
+  await workflowNode.waitFor({ state: 'visible', timeout: 15_000 });
+  await workflowNode.click();
+
+  const miniDag = page.getByTestId('selected-workflow-mini-dag');
+  await miniDag.waitFor({ state: 'visible', timeout: 10_000 });
+
+  const taskIds = Array.from({ length: Math.min(seeded.taskCount, CLICK_SAMPLES) }, (_, i) =>
+    `${seeded.workflowId}/t${i}`,
+  );
+
+  const samples: number[] = [];
+  for (const taskId of taskIds) {
+    const node = miniDag.locator(`[data-testid="rf__node-${taskId}"]`).first();
+    await node.waitFor({ state: 'visible', timeout: 10_000 });
+    await node.click();
+
+    const rtt = await page.evaluate(async () => {
+      const started = performance.now();
+      await window.invoker.listWorkflows();
+      return performance.now() - started;
+    });
+    samples.push(rtt);
+  }
+
+  expect(samples.length).toBeGreaterThanOrEqual(3);
+  const sorted = [...samples].sort((a, b) => a - b);
+  const p95 = percentile(sorted, 95);
+  const max = sorted[sorted.length - 1]!;
+
+  expect(
+    p95,
+    `p95 IPC RTT ${p95.toFixed(1)}ms exceeded ${MAX_P95_RTT_MS}ms (max=${max.toFixed(1)}ms, n=${samples.length})`,
+  ).toBeLessThanOrEqual(MAX_P95_RTT_MS);
+  expect(
+    max,
+    `max IPC RTT ${max.toFixed(1)}ms exceeded ${MAX_SAMPLE_RTT_MS}ms (p95=${p95.toFixed(1)}ms, n=${samples.length})`,
+  ).toBeLessThanOrEqual(MAX_SAMPLE_RTT_MS);
+});


### PR DESCRIPTION
Lock main-process responsiveness under fat events during task selection, and record the required-limit rule on the hot-path doc.

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #3931