### PR TITLE
[DAG getEvents pagination](1) Prove unbounded getEvents stalls and add beforeId cursor pages

### DIFF
--- a/packages/app/src/__tests__/dag-click-get-events-cost.test.ts
+++ b/packages/app/src/__tests__/dag-click-get-events-cost.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SQLiteAdapter } from '@invoker/data-store';
+
+import { seedMainProcessHitchFixture } from '../main-process-hitch-fixture.js';
+
+describe('dag-click getEvents pagination cost', () => {
+  let tmpDir: string | undefined;
+  let adapter: SQLiteAdapter | undefined;
+
+  afterEach(async () => {
+    await adapter?.close();
+    adapter = undefined;
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it('proves unbounded getEvents is expensive while a limited page stays cheap', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'invoker-dag-click-events-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const seeded = seedMainProcessHitchFixture(adapter, {
+      taskCount: 1,
+      eventsPerTask: 20_000,
+      actionsPerKind: 1,
+    });
+    const taskId = `${seeded.workflowId}/t0`;
+
+    const unboundedStarted = performance.now();
+    const unbounded = adapter.getEvents(taskId);
+    const unboundedMs = performance.now() - unboundedStarted;
+
+    const boundedStarted = performance.now();
+    const bounded = adapter.getEvents(taskId, 'desc', 50);
+    const boundedMs = performance.now() - boundedStarted;
+
+    expect(unbounded.length).toBe(20_000);
+    expect(bounded.length).toBe(50);
+    expect(unboundedMs).toBeGreaterThan(boundedMs);
+    expect(boundedMs).toBeLessThan(25);
+    expect(unboundedMs).toBeGreaterThan(10);
+  });
+
+  it('supports beforeId cursor pages without loading full history', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'invoker-dag-click-cursor-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const seeded = seedMainProcessHitchFixture(adapter, {
+      taskCount: 1,
+      eventsPerTask: 120,
+      actionsPerKind: 1,
+    });
+    const taskId = `${seeded.workflowId}/t0`;
+
+    const first = adapter.getEvents(taskId, 'desc', 50);
+    expect(first).toHaveLength(50);
+    const oldestOnPage = first[first.length - 1]!;
+    const second = adapter.getEvents(taskId, 'desc', 50, oldestOnPage.id);
+    expect(second.length).toBeGreaterThan(0);
+    expect(second.every((event) => event.id < oldestOnPage.id)).toBe(true);
+    expect(new Set([...first, ...second].map((e) => e.id)).size).toBe(first.length + second.length);
+  });
+});

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2381,6 +2381,22 @@ describe('SQLiteAdapter', () => {
       );
       expect(adapter.getEvents('t1', 'desc', 0)).toEqual([]);
     });
+
+    it('supports beforeId cursor for older pages', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      for (let index = 0; index < 30; index += 1) {
+        adapter.logEvent('t1', `event-${index}`, { index });
+      }
+
+      const first = adapter.getEvents('t1', 'desc', 10);
+      const oldest = first[first.length - 1]!;
+      const second = adapter.getEvents('t1', 'desc', 10, oldest.id);
+
+      expect(second).toHaveLength(10);
+      expect(second.every((event) => event.id < oldest.id)).toBe(true);
+      expect(second[0]!.eventType).toBe(`event-${29 - 10}`);
+    });
   });
 
   describe('JSON fields', () => {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -275,8 +275,9 @@ export interface PersistenceAdapter {
 
   // Events (audit trail)
   logEvent(taskId: string, eventType: string, payload?: unknown): void;
+  /** Unbounded history — internal/tests only. Public IPC must use the limited overload. */
   getEvents(taskId: string): TaskEvent[];
-  getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number): TaskEvent[];
+  getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number, beforeId?: number): TaskEvent[];
   getEventsByTypes?(eventTypes: readonly string[], sortBy: 'asc' | 'desc', limit: number): TaskEvent[];
   countEventsByTypes?(eventTypes: readonly string[]): Array<{
     eventType: string;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1725,20 +1725,34 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   getEvents(taskId: string): TaskEvent[];
-  getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number): TaskEvent[];
-  getEvents(taskId: string, sortBy: 'asc' | 'desc' = 'asc', limit?: number): TaskEvent[] {
+  getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number, beforeId?: number): TaskEvent[];
+  getEvents(
+    taskId: string,
+    sortBy: 'asc' | 'desc' = 'asc',
+    limit?: number,
+    beforeId?: number,
+  ): TaskEvent[] {
     const orderBy = sortBy === 'desc' ? 'DESC' : 'ASC';
-    const rows = limit === undefined
-      ? this.queryAll(
+    if (limit === undefined) {
+      const rows = this.queryAll(
         `SELECT * FROM events WHERE task_id = ? ORDER BY id ${orderBy}`,
         [taskId],
-      )
-      : limit <= 0
-        ? []
-        : this.queryAll(
-          `SELECT * FROM events WHERE task_id = ? ORDER BY id ${orderBy} LIMIT ?`,
-          [taskId, Math.floor(limit)],
-        );
+      );
+      return rows.map((row: any) => this.rowToTaskEvent(row));
+    }
+    if (limit <= 0) return [];
+    const pageLimit = Math.floor(limit);
+    if (beforeId !== undefined) {
+      const rows = this.queryAll(
+        `SELECT * FROM events WHERE task_id = ? AND id < ? ORDER BY id ${orderBy} LIMIT ?`,
+        [taskId, Math.floor(beforeId), pageLimit],
+      );
+      return rows.map((row: any) => this.rowToTaskEvent(row));
+    }
+    const rows = this.queryAll(
+      `SELECT * FROM events WHERE task_id = ? ORDER BY id ${orderBy} LIMIT ?`,
+      [taskId, pageLimit],
+    );
     return rows.map((row: any) => this.rowToTaskEvent(row));
   }
 


### PR DESCRIPTION
## Summary

Cursor beforeId on the SQLite event query lets callers page without loading a whole task history into memory.

The cost-guard regression shows a multi-thousand-event history stays page-sized under SELECT LIMIT.

## Review Claim

Approve that adapter paging uses beforeId and that the cost-guard fails if a page returns more than the requested limit.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

No public IPC shape change in this slice. Existing unbounded adapter overload stays for internal and test callers only.

## Slice Rationale

Land the storage paging primitive and cost bound before changing the public API surface.

## Non-goals

Does not change invoker get-events shapes or UI fetch shapes. Does not add hitch e2e coverage.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm exec vitest run src/__tests__/sqlite-adapter.test.ts -t beforeId`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/dag-click-get-events-cost.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: none
- Data migration? No

</details>
