### PR TITLE
[DAG getEvents pagination](2) Add get-events pagination contract helpers

### DIFF
--- a/packages/app/src/__tests__/dag-click-get-events-cost.test.ts
+++ b/packages/app/src/__tests__/dag-click-get-events-cost.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SQLiteAdapter } from '@invoker/data-store';
+
+import { seedMainProcessHitchFixture } from '../main-process-hitch-fixture.js';
+
+describe('dag-click getEvents pagination cost', () => {
+  let tmpDir: string | undefined;
+  let adapter: SQLiteAdapter | undefined;
+
+  afterEach(async () => {
+    await adapter?.close();
+    adapter = undefined;
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it('proves unbounded getEvents is expensive while a limited page stays cheap', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'invoker-dag-click-events-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const seeded = seedMainProcessHitchFixture(adapter, {
+      taskCount: 1,
+      eventsPerTask: 20_000,
+      actionsPerKind: 1,
+    });
+    const taskId = `${seeded.workflowId}/t0`;
+
+    const unboundedStarted = performance.now();
+    const unbounded = adapter.getEvents(taskId);
+    const unboundedMs = performance.now() - unboundedStarted;
+
+    const boundedStarted = performance.now();
+    const bounded = adapter.getEvents(taskId, 'desc', 50);
+    const boundedMs = performance.now() - boundedStarted;
+
+    expect(unbounded.length).toBe(20_000);
+    expect(bounded.length).toBe(50);
+    expect(unboundedMs).toBeGreaterThan(boundedMs);
+    expect(boundedMs).toBeLessThan(25);
+    expect(unboundedMs).toBeGreaterThan(10);
+  });
+
+  it('supports beforeId cursor pages without loading full history', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'invoker-dag-click-cursor-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const seeded = seedMainProcessHitchFixture(adapter, {
+      taskCount: 1,
+      eventsPerTask: 120,
+      actionsPerKind: 1,
+    });
+    const taskId = `${seeded.workflowId}/t0`;
+
+    const first = adapter.getEvents(taskId, 'desc', 50);
+    expect(first).toHaveLength(50);
+    const oldestOnPage = first[first.length - 1]!;
+    const second = adapter.getEvents(taskId, 'desc', 50, oldestOnPage.id);
+    expect(second.length).toBeGreaterThan(0);
+    expect(second.every((event) => event.id < oldestOnPage.id)).toBe(true);
+    expect(new Set([...first, ...second].map((e) => e.id)).size).toBe(first.length + second.length);
+  });
+});

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -140,6 +140,51 @@ export interface TaskEvent {
   createdAt: string;
 }
 
+/** Max rows returned by a single `invoker:get-events` page. */
+export const MAX_EVENTS_PAGE = 100;
+
+/** Required pagination options for `invoker:get-events`. */
+export interface GetEventsOptions {
+  /** Default `'desc'` (newest first). */
+  sortBy?: 'asc' | 'desc';
+  /** Required page size; must be 1..MAX_EVENTS_PAGE. */
+  limit: number;
+  /** Optional cursor: return events with id strictly less than this (older). */
+  beforeId?: number;
+}
+
+export interface NormalizedGetEventsOptions {
+  sortBy: 'asc' | 'desc';
+  limit: number;
+  beforeId?: number;
+}
+
+/**
+ * Validate and normalize get-events pagination options.
+ * Rejects missing/invalid limit and pages larger than MAX_EVENTS_PAGE.
+ */
+export function normalizeGetEventsOptions(raw: unknown): NormalizedGetEventsOptions {
+  if (raw === undefined || raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('getEvents requires options with a numeric limit');
+  }
+  const opts = raw as Record<string, unknown>;
+  if (typeof opts.limit !== 'number' || !Number.isFinite(opts.limit)) {
+    throw new Error('getEvents options.limit is required and must be a finite number');
+  }
+  const limit = Math.floor(opts.limit);
+  if (limit <= 0 || limit > MAX_EVENTS_PAGE) {
+    throw new Error(`getEvents options.limit must be between 1 and ${MAX_EVENTS_PAGE}`);
+  }
+  const sortBy = opts.sortBy === 'asc' ? 'asc' : 'desc';
+  if (opts.beforeId === undefined) {
+    return { sortBy, limit };
+  }
+  if (typeof opts.beforeId !== 'number' || !Number.isFinite(opts.beforeId)) {
+    throw new Error('getEvents options.beforeId must be a finite number when provided');
+  }
+  return { sortBy, limit, beforeId: Math.floor(opts.beforeId) };
+}
+
 export interface TaskHistoryEntry extends TaskState {
   workflowName: string;
   lastEventAt: string | null;
@@ -787,7 +832,7 @@ export const IpcChannels = {
     response: void;
   },
   'invoker:get-events': {} as {
-    request: [taskId: string];
+    request: [taskId: string, options?: GetEventsOptions];
     response: TaskEvent[];
   },
   'invoker:get-status': {} as {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2381,6 +2381,22 @@ describe('SQLiteAdapter', () => {
       );
       expect(adapter.getEvents('t1', 'desc', 0)).toEqual([]);
     });
+
+    it('supports beforeId cursor for older pages', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      for (let index = 0; index < 30; index += 1) {
+        adapter.logEvent('t1', `event-${index}`, { index });
+      }
+
+      const first = adapter.getEvents('t1', 'desc', 10);
+      const oldest = first[first.length - 1]!;
+      const second = adapter.getEvents('t1', 'desc', 10, oldest.id);
+
+      expect(second).toHaveLength(10);
+      expect(second.every((event) => event.id < oldest.id)).toBe(true);
+      expect(second[0]!.eventType).toBe(`event-${29 - 10}`);
+    });
   });
 
   describe('JSON fields', () => {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -275,8 +275,9 @@ export interface PersistenceAdapter {
 
   // Events (audit trail)
   logEvent(taskId: string, eventType: string, payload?: unknown): void;
+  /** Unbounded history — internal/tests only. Public IPC must use the limited overload. */
   getEvents(taskId: string): TaskEvent[];
-  getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number): TaskEvent[];
+  getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number, beforeId?: number): TaskEvent[];
   getEventsByTypes?(eventTypes: readonly string[], sortBy: 'asc' | 'desc', limit: number): TaskEvent[];
   countEventsByTypes?(eventTypes: readonly string[]): Array<{
     eventType: string;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1725,20 +1725,34 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   getEvents(taskId: string): TaskEvent[];
-  getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number): TaskEvent[];
-  getEvents(taskId: string, sortBy: 'asc' | 'desc' = 'asc', limit?: number): TaskEvent[] {
+  getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number, beforeId?: number): TaskEvent[];
+  getEvents(
+    taskId: string,
+    sortBy: 'asc' | 'desc' = 'asc',
+    limit?: number,
+    beforeId?: number,
+  ): TaskEvent[] {
     const orderBy = sortBy === 'desc' ? 'DESC' : 'ASC';
-    const rows = limit === undefined
-      ? this.queryAll(
+    if (limit === undefined) {
+      const rows = this.queryAll(
         `SELECT * FROM events WHERE task_id = ? ORDER BY id ${orderBy}`,
         [taskId],
-      )
-      : limit <= 0
-        ? []
-        : this.queryAll(
-          `SELECT * FROM events WHERE task_id = ? ORDER BY id ${orderBy} LIMIT ?`,
-          [taskId, Math.floor(limit)],
-        );
+      );
+      return rows.map((row: any) => this.rowToTaskEvent(row));
+    }
+    if (limit <= 0) return [];
+    const pageLimit = Math.floor(limit);
+    if (beforeId !== undefined) {
+      const rows = this.queryAll(
+        `SELECT * FROM events WHERE task_id = ? AND id < ? ORDER BY id ${orderBy} LIMIT ?`,
+        [taskId, Math.floor(beforeId), pageLimit],
+      );
+      return rows.map((row: any) => this.rowToTaskEvent(row));
+    }
+    const rows = this.queryAll(
+      `SELECT * FROM events WHERE task_id = ? ORDER BY id ${orderBy} LIMIT ?`,
+      [taskId, pageLimit],
+    );
     return rows.map((row: any) => this.rowToTaskEvent(row));
   }
 


### PR DESCRIPTION
## Summary

Shared get-events page helpers live in contracts so every transport can apply the same required limit.

IPC request typing still allows omitting options for intermediate stack greenness; runtime helpers refuse missing limits.

## Review Claim

Approve MAX_EVENTS_PAGE, GetEventsOptions, and normalizeGetEventsOptions as the shared pagination contract.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

No transport or UI caller changes in this slice. Later slices wire the helpers into IPC and surfaces.

## Slice Rationale

Land the shared page-size helpers before transport enforcement so consumers import one definition.

## Non-goals

Does not change IPC handlers, REST, headless, or UI gesture call sites.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Typecheck via package build consumers; helpers are covered by later transport tests

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Revert dependent transport slices first if already landed
- Data migration? No

</details>
