### PR TITLE
[DAG getEvents pagination](6) Add DAG-click hitch responsiveness Playwright coverage

### DIFF
--- a/packages/app/e2e/dag-click-hitch-responsiveness.spec.ts
+++ b/packages/app/e2e/dag-click-hitch-responsiveness.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from './fixtures/electron-app.js';
+
+const MAX_P95_RTT_MS = 100;
+const MAX_SAMPLE_RTT_MS = 250;
+const CLICK_SAMPLES = 8;
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)]!;
+}
+
+test('DAG task clicks keep listWorkflows IPC responsive under a fat events table', async ({ page }) => {
+  const seeded = await page.evaluate(async () => {
+    if (!window.invoker.seedMainProcessHitchFixture) {
+      throw new Error('seedMainProcessHitchFixture is not exposed (NODE_ENV=test required)');
+    }
+    return window.invoker.seedMainProcessHitchFixture();
+  });
+
+  expect(seeded.eventCount).toBeGreaterThanOrEqual(10_000);
+  expect(seeded.taskCount).toBeGreaterThan(0);
+
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  const workflowNode = page.getByTestId(`workflow-node-${seeded.workflowId}`);
+  await workflowNode.waitFor({ state: 'visible', timeout: 15_000 });
+  await workflowNode.click();
+
+  const miniDag = page.getByTestId('selected-workflow-mini-dag');
+  await miniDag.waitFor({ state: 'visible', timeout: 10_000 });
+
+  const taskIds = Array.from({ length: Math.min(seeded.taskCount, CLICK_SAMPLES) }, (_, i) =>
+    `${seeded.workflowId}/t${i}`,
+  );
+
+  const samples: number[] = [];
+  for (const taskId of taskIds) {
+    const node = miniDag.locator(`[data-testid="rf__node-${taskId}"]`).first();
+    await node.waitFor({ state: 'visible', timeout: 10_000 });
+    await node.click();
+
+    const rtt = await page.evaluate(async () => {
+      const started = performance.now();
+      await window.invoker.listWorkflows();
+      return performance.now() - started;
+    });
+    samples.push(rtt);
+  }
+
+  expect(samples.length).toBeGreaterThanOrEqual(3);
+  const sorted = [...samples].sort((a, b) => a - b);
+  const p95 = percentile(sorted, 95);
+  const max = sorted[sorted.length - 1]!;
+
+  expect(
+    p95,
+    `p95 IPC RTT ${p95.toFixed(1)}ms exceeded ${MAX_P95_RTT_MS}ms (max=${max.toFixed(1)}ms, n=${samples.length})`,
+  ).toBeLessThanOrEqual(MAX_P95_RTT_MS);
+  expect(
+    max,
+    `max IPC RTT ${max.toFixed(1)}ms exceeded ${MAX_SAMPLE_RTT_MS}ms (p95=${p95.toFixed(1)}ms, n=${samples.length})`,
+  ).toBeLessThanOrEqual(MAX_SAMPLE_RTT_MS);
+});


### PR DESCRIPTION
## Summary

Adds a Playwright hitch fixture that times DAG selection under a large event history.

This keeps the beachball class from returning without a CI signal.

## Review Claim

Approve that DAG selection hitch timing stays covered for large event histories.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Fixture only. No product behavior change beyond prior stack slices.

## Slice Rationale

Lock the beachball fix with an e2e hitch check after the UI and transport slices land.

## Non-goals

Does not change get-events transport or UI gesture call sites. Does not change architecture docs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] Playwright: `packages/app/e2e/dag-click-hitch-responsiveness.spec.ts` (CI / local Electron when available)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: none
- Data migration? No

</details>
