### PR TITLE
[Needs Attention Mutation Failure UX](1) drop rejected prompt-mode flags for Kimi and Qwen

### DIFF
--- a/packages/execution-engine/src/__tests__/kimi-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/kimi-execution-agent.test.ts
@@ -2,13 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { KimiExecutionAgent } from '../agents/kimi-execution-agent.js';
 
 describe('KimiExecutionAgent', () => {
-  it('builds prompt command with yolo and model selector', () => {
+  it('builds prompt command with model selector without yolo', () => {
     const agent = new KimiExecutionAgent({ command: 'kimi-test' });
     const spec = agent.buildCommand('prompt text', { executionModel: 'kimi-k2.6' });
 
     expect(spec.cmd).toBe('kimi-test');
     expect(spec.args).toEqual([
-      '--yolo',
       '--model',
       'kimi-k2.6',
       '-p',
@@ -23,7 +22,6 @@ describe('KimiExecutionAgent', () => {
 
     expect(spec.cmd).toBe('kimi-test');
     expect(spec.args).toEqual([
-      '--yolo',
       '--model',
       'kimi-k2.6',
       '-p',
@@ -33,8 +31,8 @@ describe('KimiExecutionAgent', () => {
     expect(spec).not.toHaveProperty('fullPrompt');
   });
 
-  it('can disable yolo for stricter local runs', () => {
-    const agent = new KimiExecutionAgent({ command: 'kimi-test', yolo: false });
+  it('ignores the legacy yolo knob in prompt mode', () => {
+    const agent = new KimiExecutionAgent({ command: 'kimi-test', yolo: true });
     expect(agent.buildCommand('prompt text').args).toEqual([
       '-p',
       'prompt text',

--- a/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
@@ -22,9 +22,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec.fullPrompt).toBe('prompt text');
   });
@@ -38,9 +38,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'fix prompt',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec).not.toHaveProperty('fullPrompt');
   });
@@ -50,7 +50,6 @@ describe('QwenExecutionAgent', () => {
     expect(agent.buildCommand('prompt text').args).toEqual([
       '--approval-mode',
       'auto-edit',
-      '--prompt',
       'prompt text',
     ]);
   });
@@ -64,7 +63,6 @@ describe('QwenExecutionAgent', () => {
       'openai',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
   });

--- a/packages/execution-engine/src/agents/kimi-execution-agent.ts
+++ b/packages/execution-engine/src/agents/kimi-execution-agent.ts
@@ -7,6 +7,10 @@ export interface KimiExecutionAgentConfig {
   command?: string;
   configDir?: string;
   containerHomePath?: string;
+  /**
+   * Deprecated compatibility knob. Current Kimi prompt mode rejects approval-mode
+   * flags, so Invoker never passes --yolo with -p/--prompt.
+   */
   yolo?: boolean;
 }
 
@@ -28,13 +32,11 @@ export class KimiExecutionAgent implements ExecutionAgent {
   private readonly command: string;
   private readonly configDir: string;
   private readonly containerHomePath: string;
-  private readonly yolo: boolean;
 
   constructor(config: KimiExecutionAgentConfig = {}) {
     this.command = config.command ?? process.env.INVOKER_KIMI_COMMAND ?? 'kimi';
     this.configDir = config.configDir ?? join(homedir(), '.kimi-code');
     this.containerHomePath = config.containerHomePath ?? '/home/invoker';
-    this.yolo = config.yolo ?? true;
   }
 
   buildCommand(fullPrompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
@@ -77,7 +79,6 @@ export class KimiExecutionAgent implements ExecutionAgent {
 
   private buildArgs(prompt: string, executionModel?: string): string[] {
     return [
-      ...(this.yolo ? ['--yolo'] : []),
       ...(executionModel ? ['--model', executionModel] : []),
       '-p',
       prompt,

--- a/packages/execution-engine/src/agents/qwen-execution-agent.ts
+++ b/packages/execution-engine/src/agents/qwen-execution-agent.ts
@@ -85,7 +85,6 @@ export class QwenExecutionAgent implements ExecutionAgent {
       this.approvalMode,
       ...(this.authType ? ['--auth-type', this.authType] : []),
       ...(executionModel ? ['--model', executionModel] : []),
-      '--prompt',
       prompt,
     ];
   }


### PR DESCRIPTION
## Summary

Invoker stops sending two flags that the Kimi and Qwen agents no longer accept in prompt mode, so those runs stop failing at launch.

Kimi prompt mode turns away the approval-mode flag. The agent stops passing `--yolo` alongside `-p`, and the old config knob stays only as a no-op for compatibility.

Qwen prompt mode turns away the named prompt flag. The agent now hands the prompt as a plain positional argument instead of behind `--prompt`.

Both agents keep their model and mode selection unchanged. Only the two unwanted flags are dropped.

## Review Claim

Approve dropping the `--yolo` flag from Kimi prompt runs and the `--prompt` flag from Qwen prompt runs, matching the argv the current agents accept.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change only removes two argv entries in the two agents' command builders. Model, auth, and approval-mode selection are untouched, and the updated unit tests pin the exact argv arrays for every build path.

## Slice Rationale

Both edits fix one launch failure — flags the agents no longer accept in prompt mode — so they belong in one reviewable claim. The verify task added no separate files, so there is no second non-empty slice to split out.

## Non-goals

- No change to how models, auth types, or approval modes are selected.
- No change to any agent other than Kimi and Qwen.
- No change to UI, task lifecycle, or persistence.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/kimi-execution-agent.test.ts src/__tests__/qwen-execution-agent.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
