### PR TITLE
[Needs Attention Mutation Failure UX](2) Qwen prompt mode drops --prompt

### DIFF
--- a/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
@@ -22,9 +22,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec.fullPrompt).toBe('prompt text');
   });
@@ -38,9 +38,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'fix prompt',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec).not.toHaveProperty('fullPrompt');
   });
@@ -50,7 +50,6 @@ describe('QwenExecutionAgent', () => {
     expect(agent.buildCommand('prompt text').args).toEqual([
       '--approval-mode',
       'auto-edit',
-      '--prompt',
       'prompt text',
     ]);
   });
@@ -64,7 +63,6 @@ describe('QwenExecutionAgent', () => {
       'openai',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
   });

--- a/packages/execution-engine/src/agents/qwen-execution-agent.ts
+++ b/packages/execution-engine/src/agents/qwen-execution-agent.ts
@@ -85,7 +85,6 @@ export class QwenExecutionAgent implements ExecutionAgent {
       this.approvalMode,
       ...(this.authType ? ['--auth-type', this.authType] : []),
       ...(executionModel ? ['--model', executionModel] : []),
-      '--prompt',
       prompt,
     ];
   }


### PR DESCRIPTION
## Summary

Invoker launches the Qwen agent with the prompt as a positional argument. The extra `--prompt` flag in front of it was redundant.

So the agent now hands Qwen just the prompt text, with no `--prompt` label ahead of it.

The model selector, approval mode, and provider auth still flow through unchanged.

## Review Claim

Approve that the Qwen agent stops sending the redundant `--prompt` flag and passes the prompt as a bare positional argument.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The Qwen agent's unit tests assert the exact argument list and now check that `--prompt` is absent while the prompt text is still present. They pass with the flag dropped.

## Slice Rationale

The Kimi and Qwen agents each build their own argv, so each fix is a one-file behavior change that a reviewer can check on its own. This slice sits on top of the Kimi slice because both share the mandated umbrella but carry independent claims.

## Non-goals

No change to the Kimi agent, to the model selector, to approval mode, or to auth handling. Only the redundant leading flag is dropped.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
