### PR TITLE
Fix kimi execution agent: drop approval flag rejected in prompt mode

### DIFF
--- a/packages/execution-engine/src/__tests__/kimi-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/kimi-execution-agent.test.ts
@@ -2,13 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { KimiExecutionAgent } from '../agents/kimi-execution-agent.js';
 
 describe('KimiExecutionAgent', () => {
-  it('builds prompt command with yolo and model selector', () => {
+  it('builds prompt command with model selector and no approval flag', () => {
     const agent = new KimiExecutionAgent({ command: 'kimi-test' });
     const spec = agent.buildCommand('prompt text', { executionModel: 'kimi-k2.6' });
 
     expect(spec.cmd).toBe('kimi-test');
     expect(spec.args).toEqual([
-      '--yolo',
       '--model',
       'kimi-k2.6',
       '-p',
@@ -23,7 +22,6 @@ describe('KimiExecutionAgent', () => {
 
     expect(spec.cmd).toBe('kimi-test');
     expect(spec.args).toEqual([
-      '--yolo',
       '--model',
       'kimi-k2.6',
       '-p',
@@ -33,12 +31,16 @@ describe('KimiExecutionAgent', () => {
     expect(spec).not.toHaveProperty('fullPrompt');
   });
 
-  it('can disable yolo for stricter local runs', () => {
-    const agent = new KimiExecutionAgent({ command: 'kimi-test', yolo: false });
-    expect(agent.buildCommand('prompt text').args).toEqual([
-      '-p',
-      'prompt text',
-    ]);
+  it('never emits an approval flag in prompt mode (regression: "Cannot combine --prompt with --yolo")', () => {
+    const agent = new KimiExecutionAgent({ command: 'kimi-test' });
+    const promptArgs = agent.buildCommand('prompt text', { executionModel: 'kimi-k2.6' }).args;
+    const fixArgs = agent.buildFixCommand('fix prompt').args;
+    for (const args of [promptArgs, fixArgs]) {
+      expect(args).toContain('-p');
+      expect(args).not.toContain('--yolo');
+      expect(args).not.toContain('--auto');
+      expect(args).not.toContain('--plan');
+    }
   });
 
   it('uses Kimi session id for resume', () => {

--- a/packages/execution-engine/src/agents/kimi-execution-agent.ts
+++ b/packages/execution-engine/src/agents/kimi-execution-agent.ts
@@ -7,7 +7,6 @@ export interface KimiExecutionAgentConfig {
   command?: string;
   configDir?: string;
   containerHomePath?: string;
-  yolo?: boolean;
 }
 
 const KIMI_SUPPORTED_MODELS: readonly ExecutionModelOption[] = [
@@ -28,13 +27,11 @@ export class KimiExecutionAgent implements ExecutionAgent {
   private readonly command: string;
   private readonly configDir: string;
   private readonly containerHomePath: string;
-  private readonly yolo: boolean;
 
   constructor(config: KimiExecutionAgentConfig = {}) {
     this.command = config.command ?? process.env.INVOKER_KIMI_COMMAND ?? 'kimi';
     this.configDir = config.configDir ?? join(homedir(), '.kimi-code');
     this.containerHomePath = config.containerHomePath ?? '/home/invoker';
-    this.yolo = config.yolo ?? true;
   }
 
   buildCommand(fullPrompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
@@ -76,8 +73,11 @@ export class KimiExecutionAgent implements ExecutionAgent {
   }
 
   private buildArgs(prompt: string, executionModel?: string): string[] {
+    // Kimi's `-p` prompt mode runs non-interactively and auto-approves tool
+    // use on its own. The kimi CLI rejects combining `--prompt` with an
+    // approval flag (`--yolo`, `--auto`, `--plan`) — it exits with
+    // "Cannot combine --prompt with --yolo." — so we pass no approval flag.
     return [
-      ...(this.yolo ? ['--yolo'] : []),
       ...(executionModel ? ['--model', executionModel] : []),
       '-p',
       prompt,


### PR DESCRIPTION
## Summary

Every task that ran on the `kimi` agent failed the instant it started. Setup finished, then the run died with `Cannot combine --prompt with --yolo.`

The kimi tool used to accept `--yolo` next to a one-shot `-p` prompt. A recent update made those two flags mutually exclusive.

The agent always runs in `-p` prompt mode, which is non-interactive and already approves its own tool use. The `--yolo` flag added nothing there.

This drops the `--yolo` flag (and the unused `yolo` option) so kimi tasks run again.

## Review Claim

Dropping the `--yolo` flag from the kimi agent's prompt-mode arguments makes kimi tasks run instead of failing at start, and changes nothing else.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change only edits the argument array `KimiExecutionAgent` builds; nothing else is touched. A new unit test asserts the prompt-mode arguments never include `--yolo`, `--auto`, or `--plan`.

## Slice Rationale

One file, one root cause: the invalid flag pairing. Switching which agent runs a task is runtime configuration, done outside this diff.

## Non-goals

- Does not change the `codex`, `claude`, `qwen`, or `omp` agents.
- Does not change executor routing, pools, or `defaultExecutionAgent`.
- Does not touch resume (`--session`) behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/kimi-execution-agent.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
