### PR TITLE
[Needs Attention Mutation Failure UX](2) Stop passing --yolo in Kimi prompt mode

### DIFF
--- a/packages/execution-engine/src/__tests__/kimi-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/kimi-execution-agent.test.ts
@@ -2,13 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { KimiExecutionAgent } from '../agents/kimi-execution-agent.js';
 
 describe('KimiExecutionAgent', () => {
-  it('builds prompt command with yolo and model selector', () => {
+  it('builds prompt command with model selector without yolo', () => {
     const agent = new KimiExecutionAgent({ command: 'kimi-test' });
     const spec = agent.buildCommand('prompt text', { executionModel: 'kimi-k2.6' });
 
     expect(spec.cmd).toBe('kimi-test');
     expect(spec.args).toEqual([
-      '--yolo',
       '--model',
       'kimi-k2.6',
       '-p',
@@ -23,7 +22,6 @@ describe('KimiExecutionAgent', () => {
 
     expect(spec.cmd).toBe('kimi-test');
     expect(spec.args).toEqual([
-      '--yolo',
       '--model',
       'kimi-k2.6',
       '-p',
@@ -33,8 +31,8 @@ describe('KimiExecutionAgent', () => {
     expect(spec).not.toHaveProperty('fullPrompt');
   });
 
-  it('can disable yolo for stricter local runs', () => {
-    const agent = new KimiExecutionAgent({ command: 'kimi-test', yolo: false });
+  it('ignores the legacy yolo knob in prompt mode', () => {
+    const agent = new KimiExecutionAgent({ command: 'kimi-test', yolo: true });
     expect(agent.buildCommand('prompt text').args).toEqual([
       '-p',
       'prompt text',

--- a/packages/execution-engine/src/agents/kimi-execution-agent.ts
+++ b/packages/execution-engine/src/agents/kimi-execution-agent.ts
@@ -7,6 +7,10 @@ export interface KimiExecutionAgentConfig {
   command?: string;
   configDir?: string;
   containerHomePath?: string;
+  /**
+   * Deprecated compatibility knob. Current Kimi prompt mode rejects approval-mode
+   * flags, so Invoker never passes --yolo with -p/--prompt.
+   */
   yolo?: boolean;
 }
 
@@ -28,13 +32,11 @@ export class KimiExecutionAgent implements ExecutionAgent {
   private readonly command: string;
   private readonly configDir: string;
   private readonly containerHomePath: string;
-  private readonly yolo: boolean;
 
   constructor(config: KimiExecutionAgentConfig = {}) {
     this.command = config.command ?? process.env.INVOKER_KIMI_COMMAND ?? 'kimi';
     this.configDir = config.configDir ?? join(homedir(), '.kimi-code');
     this.containerHomePath = config.containerHomePath ?? '/home/invoker';
-    this.yolo = config.yolo ?? true;
   }
 
   buildCommand(fullPrompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
@@ -77,7 +79,6 @@ export class KimiExecutionAgent implements ExecutionAgent {
 
   private buildArgs(prompt: string, executionModel?: string): string[] {
     return [
-      ...(this.yolo ? ['--yolo'] : []),
       ...(executionModel ? ['--model', executionModel] : []),
       '-p',
       prompt,


### PR DESCRIPTION
## Summary

The Kimi execution agent no longer sends `--yolo` with prompt-mode runs.

Current Kimi prompt mode fails with approval-mode flags when Invoker passes a prompt directly. Dropping the flag lets the prompt reach the agent.

The old `yolo` config knob stays accepted as a compatibility no-op, and the Kimi unit test pins that behavior.

## Review Claim

Approve removing `--yolo` from Kimi prompt-mode invocations while keeping the legacy `yolo` config field accepted.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice touches only the Kimi argument builder and its focused unit test. The public config shape stays compatible, and other agents are unchanged.

## Slice Rationale

This lands on top of the Qwen slice because the Kimi fix is a separate launcher route with its own compatibility note and test assertion.

## Non-goals

- Does not change Qwen, Claude, Codex, Gemini, or Docker execution agents.
- Does not remove the `yolo` config field from the Kimi config surface.
- Does not change model selection, config-directory handling, container-home handling, UI, or persistence.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/kimi-execution-agent.test.ts src/__tests__/qwen-execution-agent.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/needs-attention-mutation-failure-ux-2.md --changed-files-file /tmp/needs-attention-mutation-failure-ux-2-files.txt --diff-file /tmp/needs-attention-mutation-failure-ux-2.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 6123c79be`
- Post-revert steps: Rerun the focused execution-agent tests.
- Data migration? No

</details>
