### PR TITLE
[Needs Attention Mutation Failure UX](1) Stop passing --prompt in Qwen agent argument list

### DIFF
--- a/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
@@ -22,9 +22,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec.fullPrompt).toBe('prompt text');
   });
@@ -38,9 +38,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'fix prompt',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec).not.toHaveProperty('fullPrompt');
   });
@@ -50,7 +50,6 @@ describe('QwenExecutionAgent', () => {
     expect(agent.buildCommand('prompt text').args).toEqual([
       '--approval-mode',
       'auto-edit',
-      '--prompt',
       'prompt text',
     ]);
   });
@@ -64,7 +63,6 @@ describe('QwenExecutionAgent', () => {
       'openai',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
   });

--- a/packages/execution-engine/src/agents/qwen-execution-agent.ts
+++ b/packages/execution-engine/src/agents/qwen-execution-agent.ts
@@ -85,7 +85,6 @@ export class QwenExecutionAgent implements ExecutionAgent {
       this.approvalMode,
       ...(this.authType ? ['--auth-type', this.authType] : []),
       ...(executionModel ? ['--model', executionModel] : []),
-      '--prompt',
       prompt,
     ];
   }


### PR DESCRIPTION
## Summary

The Qwen launcher now passes prompt text positionally instead of inserting the legacy `--prompt` token.

Current Qwen builds take the trailing prompt directly, so Invoker's Qwen routing now matches that input shape.

The focused agent tests now pin the supported argument shape.

## Review Claim

Approve the Qwen routing change that passes prompt text positionally while preserving model, auth, and local-edit settings.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice touches only the Qwen argument builder and its focused unit tests. Other execution agents and workflow runtime paths are unchanged.

## Slice Rationale

Qwen and Kimi fail on separate prompt-mode flags. This slice keeps Qwen isolated so the next slice can review Kimi independently.

## Non-goals

- Does not change the Kimi, Claude, or Codex execution agents.
- Does not change model selection, auth type, or approval mode.
- Does not alter the prompt text itself.
- Does not touch UI, persistence, docs, or workflow mutation behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/kimi-execution-agent.test.ts src/__tests__/qwen-execution-agent.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/needs-attention-pr-final/1.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 660b56c4e`
- Post-revert steps: Rerun the focused execution-agent tests.
- Data migration? No

</details>



