### PR TITLE
[Needs Attention Mutation Failure UX](1) Drop legacy --prompt flag from Qwen execution agent

### DIFF
--- a/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
@@ -22,9 +22,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec.fullPrompt).toBe('prompt text');
   });
@@ -38,9 +38,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'fix prompt',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec).not.toHaveProperty('fullPrompt');
   });
@@ -50,7 +50,6 @@ describe('QwenExecutionAgent', () => {
     expect(agent.buildCommand('prompt text').args).toEqual([
       '--approval-mode',
       'auto-edit',
-      '--prompt',
       'prompt text',
     ]);
   });
@@ -64,7 +63,6 @@ describe('QwenExecutionAgent', () => {
       'openai',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
   });

--- a/packages/execution-engine/src/agents/qwen-execution-agent.ts
+++ b/packages/execution-engine/src/agents/qwen-execution-agent.ts
@@ -85,7 +85,6 @@ export class QwenExecutionAgent implements ExecutionAgent {
       this.approvalMode,
       ...(this.authType ? ['--auth-type', this.authType] : []),
       ...(executionModel ? ['--model', executionModel] : []),
-      '--prompt',
       prompt,
     ];
   }


### PR DESCRIPTION
## Summary

The Qwen agent no longer passes a `--prompt` flag before the prompt text. The prompt now rides as the final positional argument to the `qwen` program.

Current Qwen prompt mode does not accept `--prompt`, so keeping it produced a broken invocation. Dropping the flag makes the built argument line match what the tool actually wants.

Only the Qwen agent argument builder changes here. Its unit tests are updated to assert the leaner argument line.

## Review Claim

Approve that the Qwen agent builds its prompt-mode arguments with the prompt as a positional value and without the `--prompt` flag.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Safe to review alone: the change only alters how one agent assembles its own argument array, and the accompanying unit tests pin the exact array for every prompt-mode branch.

## Slice Rationale

Kept to the Qwen agent alone. The Kimi flag change is a separate concern and rides in the next slice, so each agent's argument change is reviewed on its own.

## Non-goals

- Does not touch the Kimi agent or its `--yolo` flag (that is slice 2).
- Does not change model selection, auth-type, or approval-mode arguments.
- Does not alter session id or full-prompt behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test src/__tests__/qwen-execution-agent.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
