### PR TITLE
[Preserve Sidebar Collapse State](1) Stop Home navigation from changing sidebar width

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2142,7 +2142,7 @@ export function App() {
   const showStart = hasLoadedPlan && !hasStarted;
   const showStop = hasStarted && !allSettled;
   const showEmptyGraphTutorial = sidebarSurface === 'home' && !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
-  const autoCollapseSidebar = sidebarSurface !== 'home' && sidebarSurface !== 'planning' && viewportWidth < 1440;
+  const autoCollapseSidebar = viewportWidth < 1440;
   const effectiveSidebarCollapsed = sidebarCollapsed ?? autoCollapseSidebar;
   const autoCollapseInspector = sidebarSurface !== 'home' && viewportWidth < 1440;
   const effectiveInspectorCollapsed = inspectorCollapsed || (autoCollapseInspector && !inspectorManualOpen);

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -37,7 +37,9 @@ describe('App launch (component)', () => {
     vi.restoreAllMocks();
   });
   it('shows the reskinned empty shell when no plan is loaded', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
     render(<App />);
+    act(() => window.dispatchEvent(new Event('resize')));
     expect(await screen.findByText('Plan graph')).toBeInTheDocument();
     expect(screen.queryByText('What do you want to build?')).not.toBeInTheDocument();
     expect(screen.getByText('What to expect')).toBeInTheDocument();
@@ -50,6 +52,8 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
   });
   it('opens worker status from the left panel', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
+    act(() => window.dispatchEvent(new Event('resize')));
     mock.setWorkerStatus({
       generatedAt: '2026-01-01T00:00:00.000Z',
       workers: [
@@ -77,7 +81,9 @@ describe('App launch (component)', () => {
     expect(screen.getByText('PR status')).toBeInTheDocument();
   });
   it('renders the Apple-like source list without manual plan loading', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
     render(<App />);
+    act(() => window.dispatchEvent(new Event('resize')));
     expect(await screen.findByTestId('sidebar-home')).toHaveTextContent('Invoker');
     expect(screen.queryByTestId('rail-open-file')).not.toBeInTheDocument();
     expect(screen.getByTestId('rail-settings')).toBeInTheDocument();
@@ -105,19 +111,25 @@ describe('App launch (component)', () => {
     expect(await screen.findByText('Plan graph')).toBeInTheDocument();
     expect(screen.getByText('Alpha · running')).toBeInTheDocument();
   });
-  it('auto-collapses the app sidebar for browser views on narrow windows', async () => {
+  it('auto-collapses the app sidebar on narrow windows without changing width across surfaces', async () => {
     Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
 
     render(<App />);
     await screen.findByTestId('sidebar-workflows');
     act(() => window.dispatchEvent(new Event('resize')));
 
+    const sidebar = screen.getByTestId('app-sidebar');
+    expect(sidebar.className).toContain('w-16');
+
     fireEvent.click(screen.getByTestId('sidebar-workflows'));
     expect(await screen.findByTestId('browser-rail')).toBeInTheDocument();
-    expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
+    expect(sidebar.className).toContain('w-16');
     expect(screen.queryByText('What do you want to build?')).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Workflows' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Partial terminal drawer' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+    expect(sidebar.className).toContain('w-16');
 
     Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
   });

--- a/packages/ui/src/test-setup.ts
+++ b/packages/ui/src/test-setup.ts
@@ -39,3 +39,10 @@ if (typeof window !== 'undefined' && !window.localStorage) {
     value: storage,
   });
 }
+
+// jsdom defaults to 1024px; pin a wide viewport so App auto-collapse matches desktop
+// unless a test explicitly overrides window.innerWidth.
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "innerWidth", { value: 1600, configurable: true, writable: true });
+  Object.defineProperty(window, "innerHeight", { value: 900, configurable: true, writable: true });
+}


### PR DESCRIPTION
## Summary

Leaving Home for Workflows no longer plays the sidebar expand/collapse animation.

Before this change, a narrow window treated Home as expanded and other surfaces as collapsed, so the rail width flipped on every left-rail click.

Now auto-collapse depends only on window width. Surface switches keep the same width until you toggle it yourself.

## Review Claim

Home and Library navigation no longer change the effective app sidebar width.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

One App line plus app-launch coverage and a shared vitest viewport pin. Manual toggle behavior stays the same.


## Slice Rationale

Behavior first. The Playwright walkthrough lands in the next proof slice.


## Non-goals

- Does not change the manual collapse toggle.
- Does not change inspector auto-collapse.
- Does not change visual-proof capture media.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/app-launch.test.tsx`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/app-launch.test.tsx src/__tests__/visual-proof-snapshots.test.tsx`

</details>

## Visual Proof

Before: Home starts expanded on a narrow window, then Workflows collapses the rail.

![before home expanded](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-eb04f2/sidebar-default-width-before-1-home.png)

![before workflows collapsed](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-eb04f2/sidebar-default-width-before-2-workflows.png)

![before home expands again](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-eb04f2/sidebar-default-width-before-3-home-return.png)

After: Home and Workflows stay collapsed across the same navigation.

![after home collapsed](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-eb04f2/sidebar-default-width-after-1-home.png)

![after workflows still collapsed](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-eb04f2/sidebar-default-width-after-2-workflows.png)

![after home return still collapsed](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-eb04f2/sidebar-default-width-after-3-home-return.png)

Walkthrough video of the fixed Home to Workflows path:

![after walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-eb04f2/sidebar-default-width-after-walkthrough.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run the focused UI sidebar regression.
- Data migration? No

</details>
