### PR TITLE
[Needs Attention getEvents hitch](2) Add Needs Attention hitch responsiveness Playwright coverage

### DIFF
--- a/packages/app/e2e/attention-click-hitch-responsiveness.spec.ts
+++ b/packages/app/e2e/attention-click-hitch-responsiveness.spec.ts
@@ -1,0 +1,74 @@
+import { expect, injectTaskStates, test } from './fixtures/electron-app.js';
+
+const MAX_P95_RTT_MS = 100;
+const MAX_SAMPLE_RTT_MS = 250;
+const CLICK_SAMPLES = 8;
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)]!;
+}
+
+test('Needs Attention list clicks keep listWorkflows IPC responsive under a fat events table', async ({ page }) => {
+  const seeded = await page.evaluate(async () => {
+    if (!window.invoker.seedMainProcessHitchFixture) {
+      throw new Error('seedMainProcessHitchFixture is not exposed (NODE_ENV=test required)');
+    }
+    return window.invoker.seedMainProcessHitchFixture();
+  });
+
+  expect(seeded.eventCount).toBeGreaterThanOrEqual(10_000);
+  expect(seeded.taskCount).toBeGreaterThan(0);
+
+  const sampleCount = Math.min(seeded.taskCount, CLICK_SAMPLES);
+  const taskIds = Array.from({ length: sampleCount }, (_, i) => `${seeded.workflowId}/t${i}`);
+
+  await injectTaskStates(
+    page,
+    taskIds.map((taskId, index) => ({
+      taskId,
+      changes: {
+        status: index % 2 === 0 ? 'failed' : 'blocked',
+        description: `Attention hitch ${index}`,
+        execution: index % 2 === 0
+          ? { exitCode: 1, error: 'attention hitch failed' }
+          : { blockedBy: taskIds[0] },
+      },
+    })),
+  );
+
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await page.getByTestId('sidebar-attention').click();
+  await expect(page.getByTestId('browser-rail').getByRole('heading', { name: 'Needs Attention' })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  const samples: number[] = [];
+  for (let i = 0; i < sampleCount; i += 1) {
+    const row = page.getByTestId('browser-rail').getByRole('button', { name: new RegExp(`Attention hitch ${i}`) });
+    await row.waitFor({ state: 'visible', timeout: 10_000 });
+    await row.click();
+
+    const rtt = await page.evaluate(async () => {
+      const started = performance.now();
+      await window.invoker.listWorkflows();
+      return performance.now() - started;
+    });
+    samples.push(rtt);
+  }
+
+  expect(samples.length).toBeGreaterThanOrEqual(3);
+  const sorted = [...samples].sort((a, b) => a - b);
+  const p95 = percentile(sorted, 95);
+  const max = sorted[sorted.length - 1]!;
+
+  expect(
+    p95,
+    `p95 IPC RTT ${p95.toFixed(1)}ms exceeded ${MAX_P95_RTT_MS}ms (max=${max.toFixed(1)}ms, n=${samples.length})`,
+  ).toBeLessThanOrEqual(MAX_P95_RTT_MS);
+  expect(
+    max,
+    `max IPC RTT ${max.toFixed(1)}ms exceeded ${MAX_SAMPLE_RTT_MS}ms (p95=${p95.toFixed(1)}ms, n=${samples.length})`,
+  ).toBeLessThanOrEqual(MAX_SAMPLE_RTT_MS);
+});

--- a/packages/app/src/__tests__/attention-click-get-events-cost.test.ts
+++ b/packages/app/src/__tests__/attention-click-get-events-cost.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MAX_EVENTS_PAGE, normalizeGetEventsOptions } from '@invoker/contracts';
+import { SQLiteAdapter } from '@invoker/data-store';
+
+import { getEventsPage } from '../get-events-page.js';
+import { seedMainProcessHitchFixture } from '../main-process-hitch-fixture.js';
+
+/**
+ * Repro: Needs Attention list clicks select a task and WorkflowInspector loads
+ * logs via getEvents. An unbounded main-process read of a fat events table
+ * stalls the Electron window loop (macOS beach ball). A limited page stays cheap.
+ */
+describe('attention-click getEvents pagination cost', () => {
+  let tmpDir: string | undefined;
+  let adapter: SQLiteAdapter | undefined;
+
+  afterEach(async () => {
+    await adapter?.close();
+    adapter = undefined;
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it('proves unbounded getEvents is expensive for an attention task while a page stays cheap', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'invoker-attention-click-events-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const seeded = seedMainProcessHitchFixture(adapter, {
+      taskCount: 1,
+      eventsPerTask: 20_000,
+      actionsPerKind: 1,
+    });
+    const taskId = `${seeded.workflowId}/t0`;
+    const task = adapter.loadTask(taskId);
+    expect(task).toBeDefined();
+    adapter.saveTask(seeded.workflowId, {
+      ...task!,
+      status: 'failed',
+      description: 'Attention task with fat event history',
+    });
+
+    const unboundedStarted = performance.now();
+    const unbounded = adapter.getEvents(taskId);
+    const unboundedMs = performance.now() - unboundedStarted;
+
+    const boundedStarted = performance.now();
+    const bounded = getEventsPage(adapter, taskId, { limit: 50, sortBy: 'desc' });
+    const boundedMs = performance.now() - boundedStarted;
+
+    expect(adapter.loadTask(taskId)?.status).toBe('failed');
+    expect(unbounded.length).toBe(20_000);
+    expect(bounded.length).toBe(50);
+    expect(unboundedMs).toBeGreaterThan(boundedMs);
+    expect(boundedMs).toBeLessThan(25);
+    expect(unboundedMs).toBeGreaterThan(10);
+  });
+
+  it('rejects missing or oversized limits at the public getEvents boundary', () => {
+    expect(() => normalizeGetEventsOptions(undefined)).toThrow(/requires options/);
+    expect(() => normalizeGetEventsOptions({})).toThrow(/limit is required/);
+    expect(() => normalizeGetEventsOptions({ limit: 0 })).toThrow(/between 1 and/);
+    expect(() => normalizeGetEventsOptions({ limit: MAX_EVENTS_PAGE + 1 })).toThrow(/between 1 and/);
+    expect(normalizeGetEventsOptions({ limit: 50, sortBy: 'desc' })).toEqual({
+      sortBy: 'desc',
+      limit: 50,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Playwright hitch that clicks Needs Attention list rows under a fat events table.

It samples listWorkflows IPC RTT after each click so a main-process beachball on that surface fails CI.

## Review Claim

Approve that Needs Attention list-click hitch timing stays covered for large event histories.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Fixture only. No product behavior change beyond prior stack slices.

## Slice Rationale

Land the hitch fixture before the CI inventory update that lists it in the Playwright matrix.

## Non-goals

Does not change get-events transport or UI gesture call sites. Does not change architecture docs or CI workflows.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] Playwright: `packages/app/e2e/attention-click-hitch-responsiveness.spec.ts` (CI shard 6-of-6 after the next stack PR)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Also revert the CI inventory slice if it already landed
- Data migration? No

</details>
