### PR TITLE
[Needs Attention getEvents hitch](4) Document Needs Attention as a getEvents hitch hot path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,6 +554,8 @@ jobs:
               e2e/workflow-delete-latency.spec.ts
               e2e/main-process-hitch-responsiveness.spec.ts
               e2e/dag-click-hitch-responsiveness.spec.ts
+              e2e/terminal-upsert-hitch-responsiveness.spec.ts
+              e2e/attention-click-hitch-responsiveness.spec.ts
 
     name: playwright / ${{ matrix.name }}
 

--- a/docs/architecture/main-process-read-hot-paths.md
+++ b/docs/architecture/main-process-read-hot-paths.md
@@ -14,7 +14,9 @@ matching index.
 
 A follow-on beachball class was DAG task selection: the inspector called
 unbounded `getEvents` on click, stalling main while marshaling full task
-history even though the UI only rendered 20 log rows.
+history even though the UI only rendered 20 log rows. The same inspector
+path fires when selecting a row in Needs Attention, so that surface needs
+the same hitch coverage.
 
 ## Rules
 
@@ -49,7 +51,7 @@ history even though the UI only rendered 20 log rows.
 | --- | --- | --- |
 | `useWorkerStatus` → `getWorkerStatus` → `snapshot()` | ~2s | Recovery via aggregates; indexed `listWorkerActions` (no TTL cache) |
 | Main `dbPollInterval` → `loadTasks` | ~2s | Projection must not unbounded-scan attempts |
-| Task inspector / History / Approval `getEvents` | on demand | Always paginated (`limit` required; History uses `beforeId` for Load more) |
+| Needs Attention / DAG / inspector / History / Approval `getEvents` | on demand | Always paginated (`limit` required; History uses `beforeId` for Load more) |
 
 ## Preferred APIs
 
@@ -67,7 +69,8 @@ history even though the UI only rendered 20 log rows.
 ## How to catch regressions
 
 - Unit cost guards under fat fixtures (many events / large attempt errors),
-  including `packages/app/src/__tests__/dag-click-get-events-cost.test.ts`
+  including `packages/app/src/__tests__/dag-click-get-events-cost.test.ts` and
+  `packages/app/src/__tests__/attention-click-get-events-cost.test.ts`
   (unbounded vs page cost + reject missing limit).
 - Main-process hitch e2e (`packages/app/e2e/main-process-hitch-responsiveness.spec.ts`):
   while worker-status polls against a seeded fat DB, cheap IPC RTT must stay
@@ -77,6 +80,9 @@ history even though the UI only rendered 20 log rows.
   seed fat events, click task nodes, assert `listWorkflows` RTT stays under the
   same hitch budget. Included in GitHub Playwright shards (merge-queue / master)
   and in the extended Playwright battery used by the twice-daily e2e worker.
+- Needs Attention hitch e2e (`packages/app/e2e/attention-click-hitch-responsiveness.spec.ts`):
+  seed fat events, open Needs Attention, click list rows, assert `listWorkflows`
+  RTT stays under the same hitch budget. Included in GitHub Playwright shards.
 - Slow-query telemetry: `SQLiteAdapter` logs statements slower than 25ms
   (`slowQueryThresholdMs` / `onSlowQuery`) so the next spike shows up without
   attaching a sampler. Set `slowQueryThresholdMs: 0` to disable.

--- a/packages/app/e2e/attention-click-hitch-responsiveness.spec.ts
+++ b/packages/app/e2e/attention-click-hitch-responsiveness.spec.ts
@@ -1,0 +1,74 @@
+import { expect, injectTaskStates, test } from './fixtures/electron-app.js';
+
+const MAX_P95_RTT_MS = 100;
+const MAX_SAMPLE_RTT_MS = 250;
+const CLICK_SAMPLES = 8;
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)]!;
+}
+
+test('Needs Attention list clicks keep listWorkflows IPC responsive under a fat events table', async ({ page }) => {
+  const seeded = await page.evaluate(async () => {
+    if (!window.invoker.seedMainProcessHitchFixture) {
+      throw new Error('seedMainProcessHitchFixture is not exposed (NODE_ENV=test required)');
+    }
+    return window.invoker.seedMainProcessHitchFixture();
+  });
+
+  expect(seeded.eventCount).toBeGreaterThanOrEqual(10_000);
+  expect(seeded.taskCount).toBeGreaterThan(0);
+
+  const sampleCount = Math.min(seeded.taskCount, CLICK_SAMPLES);
+  const taskIds = Array.from({ length: sampleCount }, (_, i) => `${seeded.workflowId}/t${i}`);
+
+  await injectTaskStates(
+    page,
+    taskIds.map((taskId, index) => ({
+      taskId,
+      changes: {
+        status: index % 2 === 0 ? 'failed' : 'blocked',
+        description: `Attention hitch ${index}`,
+        execution: index % 2 === 0
+          ? { exitCode: 1, error: 'attention hitch failed' }
+          : { blockedBy: taskIds[0] },
+      },
+    })),
+  );
+
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await page.getByTestId('sidebar-attention').click();
+  await expect(page.getByTestId('browser-rail').getByRole('heading', { name: 'Needs Attention' })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  const samples: number[] = [];
+  for (let i = 0; i < sampleCount; i += 1) {
+    const row = page.getByTestId('browser-rail').getByRole('button', { name: new RegExp(`Attention hitch ${i}`) });
+    await row.waitFor({ state: 'visible', timeout: 10_000 });
+    await row.click();
+
+    const rtt = await page.evaluate(async () => {
+      const started = performance.now();
+      await window.invoker.listWorkflows();
+      return performance.now() - started;
+    });
+    samples.push(rtt);
+  }
+
+  expect(samples.length).toBeGreaterThanOrEqual(3);
+  const sorted = [...samples].sort((a, b) => a - b);
+  const p95 = percentile(sorted, 95);
+  const max = sorted[sorted.length - 1]!;
+
+  expect(
+    p95,
+    `p95 IPC RTT ${p95.toFixed(1)}ms exceeded ${MAX_P95_RTT_MS}ms (max=${max.toFixed(1)}ms, n=${samples.length})`,
+  ).toBeLessThanOrEqual(MAX_P95_RTT_MS);
+  expect(
+    max,
+    `max IPC RTT ${max.toFixed(1)}ms exceeded ${MAX_SAMPLE_RTT_MS}ms (p95=${p95.toFixed(1)}ms, n=${samples.length})`,
+  ).toBeLessThanOrEqual(MAX_SAMPLE_RTT_MS);
+});

--- a/packages/app/src/__tests__/attention-click-get-events-cost.test.ts
+++ b/packages/app/src/__tests__/attention-click-get-events-cost.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MAX_EVENTS_PAGE, normalizeGetEventsOptions } from '@invoker/contracts';
+import { SQLiteAdapter } from '@invoker/data-store';
+
+import { getEventsPage } from '../get-events-page.js';
+import { seedMainProcessHitchFixture } from '../main-process-hitch-fixture.js';
+
+/**
+ * Repro: Needs Attention list clicks select a task and WorkflowInspector loads
+ * logs via getEvents. An unbounded main-process read of a fat events table
+ * stalls the Electron window loop (macOS beach ball). A limited page stays cheap.
+ */
+describe('attention-click getEvents pagination cost', () => {
+  let tmpDir: string | undefined;
+  let adapter: SQLiteAdapter | undefined;
+
+  afterEach(async () => {
+    await adapter?.close();
+    adapter = undefined;
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it('proves unbounded getEvents is expensive for an attention task while a page stays cheap', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'invoker-attention-click-events-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const seeded = seedMainProcessHitchFixture(adapter, {
+      taskCount: 1,
+      eventsPerTask: 20_000,
+      actionsPerKind: 1,
+    });
+    const taskId = `${seeded.workflowId}/t0`;
+    const task = adapter.loadTask(taskId);
+    expect(task).toBeDefined();
+    adapter.saveTask(seeded.workflowId, {
+      ...task!,
+      status: 'failed',
+      description: 'Attention task with fat event history',
+    });
+
+    const unboundedStarted = performance.now();
+    const unbounded = adapter.getEvents(taskId);
+    const unboundedMs = performance.now() - unboundedStarted;
+
+    const boundedStarted = performance.now();
+    const bounded = getEventsPage(adapter, taskId, { limit: 50, sortBy: 'desc' });
+    const boundedMs = performance.now() - boundedStarted;
+
+    expect(adapter.loadTask(taskId)?.status).toBe('failed');
+    expect(unbounded.length).toBe(20_000);
+    expect(bounded.length).toBe(50);
+    expect(unboundedMs).toBeGreaterThan(boundedMs);
+    expect(boundedMs).toBeLessThan(25);
+    expect(unboundedMs).toBeGreaterThan(10);
+  });
+
+  it('rejects missing or oversized limits at the public getEvents boundary', () => {
+    expect(() => normalizeGetEventsOptions(undefined)).toThrow(/requires options/);
+    expect(() => normalizeGetEventsOptions({})).toThrow(/limit is required/);
+    expect(() => normalizeGetEventsOptions({ limit: 0 })).toThrow(/between 1 and/);
+    expect(() => normalizeGetEventsOptions({ limit: MAX_EVENTS_PAGE + 1 })).toThrow(/between 1 and/);
+    expect(normalizeGetEventsOptions({ limit: 50, sortBy: 'desc' })).toEqual({
+      sortBy: 'desc',
+      limit: 50,
+    });
+  });
+});

--- a/scripts/test-ci-duration-invariant.mjs
+++ b/scripts/test-ci-duration-invariant.mjs
@@ -66,6 +66,10 @@ if (playwright) {
     listed.includes('e2e/dag-click-hitch-responsiveness.spec.ts'),
     'playwright shards must include e2e/dag-click-hitch-responsiveness.spec.ts',
   );
+  assert(
+    listed.includes('e2e/attention-click-hitch-responsiveness.spec.ts'),
+    'playwright shards must include e2e/attention-click-hitch-responsiveness.spec.ts',
+  );
 }
 
 for (const [jobName, job] of Object.entries(jobs)) {


### PR DESCRIPTION
## Summary

Records Needs Attention list selection as a getEvents hitch hot path beside DAG click.

Also points at the attention-click cost unit and hitch e2e coverage.

## Review Claim

Approve the architecture note that Needs Attention selection is a paginated getEvents gesture hot path.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Documentation only. No product behavior change.

## Slice Rationale

Keep the hot-path note separate from product, hitch fixture, and CI policy slices.

## Non-goals

Does not change product code, e2e fixtures, or CI workflows.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Docs: `docs/architecture/main-process-read-hot-paths.md` Needs Attention hitch coverage

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: none
- Data migration? No

</details>
