### PR TITLE
[Needs Attention Mutation Failure UX](1) Drop redundant --prompt flag from Qwen execution agent

### DIFF
--- a/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
@@ -22,9 +22,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec.fullPrompt).toBe('prompt text');
   });
@@ -38,9 +38,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'fix prompt',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec).not.toHaveProperty('fullPrompt');
   });
@@ -50,7 +50,6 @@ describe('QwenExecutionAgent', () => {
     expect(agent.buildCommand('prompt text').args).toEqual([
       '--approval-mode',
       'auto-edit',
-      '--prompt',
       'prompt text',
     ]);
   });
@@ -64,7 +63,6 @@ describe('QwenExecutionAgent', () => {
       'openai',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
   });

--- a/packages/execution-engine/src/agents/qwen-execution-agent.ts
+++ b/packages/execution-engine/src/agents/qwen-execution-agent.ts
@@ -85,7 +85,6 @@ export class QwenExecutionAgent implements ExecutionAgent {
       this.approvalMode,
       ...(this.authType ? ['--auth-type', this.authType] : []),
       ...(executionModel ? ['--model', executionModel] : []),
-      '--prompt',
       prompt,
     ];
   }


### PR DESCRIPTION
## Summary

The Qwen agent stops emitting a `--prompt` flag when it builds its prompt-mode invocation.

Newer Qwen prompt mode reads the prompt as a trailing positional argument. Passing `--prompt` on top of that was dead weight.

So the agent now appends only the prompt text, and its paired unit check confirms the flag is gone.

## Review Claim

Approve that the Qwen agent no longer appends `--prompt` in prompt mode and instead passes the prompt as the trailing positional argument.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change touches only the Qwen agent's argument builder and its paired unit spec. The emitted argv is asserted in the test, so a reviewer confirms the new shape from the diff alone.

## Slice Rationale

This slice carries only the Qwen argument change and its paired check, kept separate from the Kimi flag change so each agent's prompt-mode behavior lands on its own.

## Non-goals

- Does not touch the Kimi agent or any of its flags.
- Keeps model selection, auth-type, and approval-mode handling unchanged.
- No new configuration knobs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/qwen-execution-agent.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>