### PR TITLE
[Worker Actions task-first](1) Lead Worker Actions rows with the target task

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2682,6 +2682,7 @@ export function App() {
       {viewMode === 'queue' ? (
         <QueueView
           tasks={tasks}
+          workflows={workflows}
           workerStatus={workerStatus}
           readOnly={runtimeStatus?.readOnly === true}
           onStartWorker={handleStartWorker}
@@ -3184,6 +3185,7 @@ export function App() {
                 <WorkerDetailsPanel
                   worker={selectedWorker}
                   tasks={tasks}
+                  workflows={workflows}
                   collapsed={effectiveInspectorCollapsed}
                   onToggleCollapsed={handleToggleInspectorCollapsed}
                   onTaskClick={handleTaskClick}

--- a/packages/ui/src/__tests__/queue-view.test.tsx
+++ b/packages/ui/src/__tests__/queue-view.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { QueueView } from '../components/QueueView.js';
 import { makeUITask } from './helpers/mock-invoker.js';
-import type { TaskState, WorkerActionSummary, WorkerStatusEntry, WorkerStatusSnapshot } from '../types.js';
+import type { TaskState, WorkerActionSummary, WorkerStatusEntry, WorkerStatusSnapshot, WorkflowMeta } from '../types.js';
 
 describe('QueueView', () => {
   const onTaskClick = vi.fn();
@@ -14,6 +14,10 @@ describe('QueueView', () => {
     generatedAt: '2026-01-01T00:00:00.000Z',
     workers: [],
   };
+
+  const DEFAULT_WORKFLOWS = new Map<string, WorkflowMeta>([
+    ['wf-1', { id: 'wf-1', name: 'My Workflow', status: 'running' }],
+  ]);
 
   function makeWorkerAction(overrides: Partial<WorkerActionSummary> = {}): WorkerActionSummary {
     return {
@@ -61,10 +65,12 @@ describe('QueueView', () => {
     selectedTaskId: string | null = null,
     readOnly = false,
     selectedWorkerKind: string | null = null,
+    workflows: Map<string, WorkflowMeta> = DEFAULT_WORKFLOWS,
   ) {
     render(
       <QueueView
         tasks={tasks}
+        workflows={workflows}
         workerStatus={workerStatus}
         readOnly={readOnly}
         onStartWorker={onStartWorker}
@@ -125,7 +131,8 @@ describe('QueueView', () => {
 
     expect(screen.getByText('Worker Actions (1)')).toBeInTheDocument();
     expect(screen.getByText('Only work started by a worker process appears here.')).toBeInTheDocument();
-    expect(screen.getByText('Fix With Agent · needs fix')).toBeInTheDocument();
+    expect(screen.getByText('needs fix')).toBeInTheDocument();
+    expect(screen.getByText('Autofix · Fix With Agent · My Workflow')).toBeInTheDocument();
     expect(screen.queryByText('normal scheduler work')).not.toBeInTheDocument();
     expect(screen.queryByText('Workflow gate for queued merge')).not.toBeInTheDocument();
     expect(screen.queryByText(/Backlog/)).not.toBeInTheDocument();
@@ -141,9 +148,42 @@ describe('QueueView', () => {
       ]),
     );
 
-    fireEvent.click(screen.getByText('Fix With Agent · needs fix'));
+    fireEvent.click(screen.getByText('needs fix'));
 
     expect(onTaskClick).toHaveBeenCalledWith(expect.objectContaining({ id: task.id }));
+  });
+
+  it('distinguishes CI failure repair rows by target task title', () => {
+    const taskA = makeUITask({ id: 'wf-1/gate-a', status: 'failed', description: 'Review gate A' });
+    const taskB = makeUITask({ id: 'wf-1/gate-b', status: 'failed', description: 'Review gate B' });
+    renderQueueView(
+      new Map([[taskA.id, taskA], [taskB.id, taskB]]),
+      makeWorkerStatus([
+        makeWorker({
+          kind: 'ci-failure',
+          recentActions: [
+            makeWorkerAction({
+              id: 'ci-a',
+              workerKind: 'ci-failure',
+              actionType: 'fix-ci-failure',
+              taskId: taskA.id,
+              subjectId: taskA.id,
+            }),
+            makeWorkerAction({
+              id: 'ci-b',
+              workerKind: 'ci-failure',
+              actionType: 'fix-ci-failure',
+              taskId: taskB.id,
+              subjectId: taskB.id,
+            }),
+          ],
+        }),
+      ]),
+    );
+
+    expect(screen.getByText('Review gate A')).toBeInTheDocument();
+    expect(screen.getByText('Review gate B')).toBeInTheDocument();
+    expect(screen.getAllByText('CI failure repair · Fix Ci Failure · My Workflow')).toHaveLength(2);
   });
 
   it('keeps worker actions and worker processes in independent scroll panes', () => {
@@ -197,9 +237,10 @@ describe('QueueView', () => {
       ]),
     );
 
-    expect(screen.getByText('Fix With Agent · missing-target')).toBeInTheDocument();
+    expect(screen.getByText('missing-target')).toBeInTheDocument();
+    expect(screen.getByText('Autofix · Fix With Agent · My Workflow')).toBeInTheDocument();
     expect(screen.getByText('Target task is not loaded.')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('Fix With Agent · missing-target'));
+    fireEvent.click(screen.getByText('missing-target'));
     expect(onTaskClick).not.toHaveBeenCalled();
   });
 
@@ -414,7 +455,7 @@ describe('QueueView', () => {
 
     const relsSection = screen.getByTestId('rels-wf-1/build');
     expect(relsSection.textContent).toContain('downstream:');
-    expect(relsSection.textContent).toContain('deploy');
+    expect(relsSection.textContent).toContain('Deploy after build');
 
     const deployChip = relsSection.querySelector('button');
     expect(deployChip).not.toBeNull();
@@ -448,7 +489,7 @@ describe('QueueView', () => {
       buildTask.id,
     );
 
-    const selectedRow = screen.getByText('Fix With Agent · Build the project').closest('[data-row-id]');
+    const selectedRow = screen.getByText('Build the project').closest('[data-row-id]');
     expect(selectedRow?.className).toContain('bg-cyan-950/30');
 
     fireEvent.click(screen.getByLabelText('Expand relationships'));

--- a/packages/ui/src/__tests__/worker-details-panel.test.tsx
+++ b/packages/ui/src/__tests__/worker-details-panel.test.tsx
@@ -2,10 +2,14 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { WorkerDetailsPanel } from '../components/WorkerDetailsPanel.js';
 import { makeUITask } from './helpers/mock-invoker.js';
-import type { WorkerActionSummary, WorkerStatusEntry } from '../types.js';
+import type { WorkerActionSummary, WorkerStatusEntry, WorkflowMeta } from '../types.js';
 
 const onToggleCollapsed = vi.fn();
 const onTaskClick = vi.fn();
+
+const DEFAULT_WORKFLOWS = new Map<string, WorkflowMeta>([
+  ['wf-1', { id: 'wf-1', name: 'My Workflow', status: 'running' }],
+]);
 
 function makeAction(overrides: Partial<WorkerActionSummary> = {}): WorkerActionSummary {
   return {
@@ -40,13 +44,19 @@ function makeWorker(overrides: Partial<WorkerStatusEntry> = {}): WorkerStatusEnt
   };
 }
 
-function renderPanel(worker: WorkerStatusEntry | null, tasks = new Map(), collapsed = false) {
+function renderPanel(
+  worker: WorkerStatusEntry | null,
+  tasks = new Map(),
+  collapsed = false,
+  workflows: Map<string, WorkflowMeta> = DEFAULT_WORKFLOWS,
+) {
   onToggleCollapsed.mockReset();
   onTaskClick.mockReset();
   render(
     <WorkerDetailsPanel
       worker={worker}
       tasks={tasks}
+      workflows={workflows}
       collapsed={collapsed}
       onToggleCollapsed={onToggleCollapsed}
       onTaskClick={onTaskClick}
@@ -61,11 +71,15 @@ describe('WorkerDetailsPanel', () => {
 
     expect(screen.getByTestId('worker-details-title')).toHaveTextContent('CI failure repair');
     expect(screen.getByText('Current work')).toBeInTheDocument();
+    expect(screen.getAllByText('Task')).toHaveLength(2);
+    expect(screen.getAllByText('needs fix')).toHaveLength(2);
+    expect(screen.getAllByText('Workflow')).toHaveLength(2);
+    expect(screen.getAllByText('My Workflow')).toHaveLength(2);
     expect(screen.getAllByText('Action')).toHaveLength(2);
     expect(screen.getAllByText('Fix With Agent')).toHaveLength(2);
     expect(screen.getAllByText('Running')).toHaveLength(2);
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Open task: fix-target' })[0]!);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Open task: needs fix · My Workflow' })[0]!);
     expect(onTaskClick).toHaveBeenCalledWith(expect.objectContaining({ id: task.id }));
   });
 
@@ -96,7 +110,7 @@ describe('WorkerDetailsPanel', () => {
     }), new Map());
 
     expect(screen.getByText('Last recorded action')).toBeInTheDocument();
-    expect(screen.getByText('Target task: merge gate')).toBeInTheDocument();
+    expect(screen.getByText('Target task: merge gate · My Workflow')).toBeInTheDocument();
     expect(screen.getByText('Autofix history')).toBeInTheDocument();
     expect(screen.getByText('Scanned 14 · submitted 2 · skipped 1 · last skip: retry budget exhausted on task merge gate')).toBeInTheDocument();
   });

--- a/packages/ui/src/components/QueueView.tsx
+++ b/packages/ui/src/components/QueueView.tsx
@@ -1,16 +1,18 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
-import type { TaskState, WorkerActionSummary, WorkerStatusEntry, WorkerStatusSnapshot } from '../types.js';
+import type { TaskState, WorkerActionSummary, WorkerStatusEntry, WorkerStatusSnapshot, WorkflowMeta } from '../types.js';
 import { getStatusColor } from '../lib/colors.js';
 import {
   displayWorkerTaskId,
   formatWorkerValue,
   getActiveWorkerActions,
   getWorkerDisplayCopy,
+  resolveWorkerActionTarget,
 } from '../lib/worker-display.js';
 import { WorkerActivityCard } from './WorkerActivityCard.js';
 
 interface QueueViewProps {
   tasks: Map<string, TaskState>;
+  workflows: Map<string, WorkflowMeta>;
   workerStatus: WorkerStatusSnapshot | null;
   readOnly: boolean;
   onStartWorker: (kind: string) => Promise<void> | void;
@@ -26,23 +28,26 @@ type WorkerActionRow = {
   worker: WorkerStatusEntry;
 };
 
-
-function actionTargetLabel(action: WorkerActionSummary, tasks: Map<string, TaskState>): string {
-  if (action.taskId) {
-    return tasks.get(action.taskId)?.description || displayWorkerTaskId(action.taskId);
-  }
-  return `${formatWorkerValue(action.subjectType)} ${action.subjectId}`;
-}
-
 function actionRowKey(row: WorkerActionRow): string {
   return `${row.worker.kind}:${row.action.id}`;
 }
 
-function actionTargetTask(action: WorkerActionSummary, tasks: Map<string, TaskState>): TaskState | null {
-  return action.taskId ? tasks.get(action.taskId) ?? null : null;
+function relatedTaskLabel(taskId: string, tasks: Map<string, TaskState>): string {
+  return tasks.get(taskId)?.description || displayWorkerTaskId(taskId);
 }
 
-export function QueueView({ tasks, workerStatus, readOnly, onStartWorker, onStopWorker, onTaskClick, selectedTaskId, selectedWorkerKind, onSelectWorker }: QueueViewProps) {
+export function QueueView({
+  tasks,
+  workflows,
+  workerStatus,
+  readOnly,
+  onStartWorker,
+  onStopWorker,
+  onTaskClick,
+  selectedTaskId,
+  selectedWorkerKind,
+  onSelectWorker,
+}: QueueViewProps) {
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
   const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
@@ -106,7 +111,8 @@ export function QueueView({ tasks, workerStatus, readOnly, onStartWorker, onStop
           <div className="space-y-1">
             {actionRows.map((row) => {
               const { action, worker } = row;
-              const task = actionTargetTask(action, tasks);
+              const target = resolveWorkerActionTarget(action, tasks, workflows);
+              const task = target.task;
               const rowKey = actionRowKey(row);
               const taskId = action.taskId;
               const upstream = task?.dependencies ?? [];
@@ -115,6 +121,11 @@ export function QueueView({ tasks, workerStatus, readOnly, onStartWorker, onStop
               const isExpanded = expandedRows.has(rowKey);
               const colors = getStatusColor(action.status);
               const copy = getWorkerDisplayCopy(worker.kind);
+              const secondaryParts = [
+                copy.name,
+                formatWorkerValue(action.actionType),
+                ...(target.workflowName ? [target.workflowName] : []),
+              ];
               return (
                 <div
                   key={rowKey}
@@ -150,14 +161,14 @@ export function QueueView({ tasks, workerStatus, readOnly, onStartWorker, onStop
                       className={`min-w-0 flex-1 p-3 text-left ${task ? 'cursor-pointer' : 'cursor-default'}`}
                     >
                       <div className="flex items-center gap-2">
-                        <span className="truncate text-sm font-medium text-foreground">{copy.name}</span>
+                        <span className="truncate text-sm font-medium text-foreground">{target.taskTitle}</span>
                         <span className={`inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-0.5 text-xs ${colors.bg} ${colors.border} ${colors.text}`}>
                           <span className={`h-1.5 w-1.5 rounded-full ${colors.dot}`} aria-hidden="true" />
                           {formatWorkerValue(action.status)}
                         </span>
                       </div>
                       <div className="mt-1 truncate text-xs text-muted-foreground">
-                        {formatWorkerValue(action.actionType)} · {actionTargetLabel(action, tasks)}
+                        {secondaryParts.join(' · ')}
                       </div>
                       {action.summary ? (
                         <div className="mt-1 truncate text-xs text-muted-foreground">{action.summary}</div>
@@ -179,7 +190,7 @@ export function QueueView({ tasks, workerStatus, readOnly, onStartWorker, onStop
                               onClick={(e) => handleRelatedClick(depId, e)}
                               className="mr-1 inline-block cursor-pointer rounded bg-secondary px-1.5 py-0.5 text-foreground hover:bg-secondary"
                             >
-                              {displayWorkerTaskId(depId)}
+                              {relatedTaskLabel(depId, tasks)}
                             </button>
                           ))}
                         </div>
@@ -194,7 +205,7 @@ export function QueueView({ tasks, workerStatus, readOnly, onStartWorker, onStop
                               onClick={(e) => handleRelatedClick(depId, e)}
                               className="mr-1 inline-block cursor-pointer rounded bg-green-900 px-1.5 py-0.5 text-green-300 hover:bg-green-800"
                             >
-                              {displayWorkerTaskId(depId)}
+                              {relatedTaskLabel(depId, tasks)}
                             </button>
                           ))}
                         </div>

--- a/packages/ui/src/components/WorkerDetailsPanel.tsx
+++ b/packages/ui/src/components/WorkerDetailsPanel.tsx
@@ -1,15 +1,17 @@
-import type { TaskState, WorkerActionSummary, WorkerStatusEntry } from '../types.js';
+import type { TaskState, WorkerActionSummary, WorkerStatusEntry, WorkflowMeta } from '../types.js';
 import {
   displayWorkerTaskId,
   formatWorkerValue,
   getActiveWorkerAction,
   getWorkerDisplayCopy,
+  resolveWorkerActionTarget,
 } from '../lib/worker-display.js';
 import { WorkerDecisionsSection } from './WorkerDecisionsSection.js';
 
 interface WorkerDetailsPanelProps {
   worker: WorkerStatusEntry | null;
   tasks: Map<string, TaskState>;
+  workflows: Map<string, WorkflowMeta>;
   collapsed: boolean;
   onToggleCollapsed: () => void;
   onTaskClick: (task: TaskState) => void;
@@ -41,39 +43,63 @@ function idleExplanation(worker: WorkerStatusEntry): string {
   return 'Process stopped. Start it to listen for work.';
 }
 
-function TargetLine({ action, tasks, onTaskClick }: {
+function TargetLine({ action, tasks, workflows, onTaskClick }: {
   action: WorkerActionSummary;
   tasks: Map<string, TaskState>;
+  workflows: Map<string, WorkflowMeta>;
   onTaskClick: (task: TaskState) => void;
 }) {
-  if (action.taskId) {
-    const task = tasks.get(action.taskId);
-    if (task) {
-      return (
-        <button
-          type="button"
-          className="mt-2 rounded border border-emerald-600/60 bg-emerald-900/40 px-2 py-1 text-xs font-medium text-emerald-100 hover:bg-emerald-800/60"
-          onClick={() => onTaskClick(task)}
-        >
-          Open task: {displayWorkerTaskId(action.taskId)}
-        </button>
-      );
-    }
-    return <div className="mt-2 text-xs text-muted-foreground">Target task: {displayWorkerTaskId(action.taskId)}</div>;
+  const target = resolveWorkerActionTarget(action, tasks, workflows);
+  const workflowSuffix = target.workflowName ? ` · ${target.workflowName}` : '';
+
+  if (target.task) {
+    return (
+      <button
+        type="button"
+        className="mt-2 rounded border border-emerald-600/60 bg-emerald-900/40 px-2 py-1 text-xs font-medium text-emerald-100 hover:bg-emerald-800/60"
+        onClick={() => onTaskClick(target.task!)}
+      >
+        Open task: {target.taskTitle}{workflowSuffix}
+      </button>
+    );
   }
-  return <div className="mt-2 text-xs text-muted-foreground">Target: {action.subjectType} {action.subjectId}</div>;
+
+  if (action.taskId) {
+    return (
+      <div className="mt-2 text-xs text-muted-foreground">
+        Target task: {target.taskTitle}{workflowSuffix}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-2 text-xs text-muted-foreground">
+      Target: {target.taskTitle}{workflowSuffix}
+    </div>
+  );
 }
 
-function ActionDetails({ title, action, tasks, onTaskClick }: {
+function ActionDetails({ title, action, tasks, workflows, onTaskClick }: {
   title: string;
   action: WorkerActionSummary;
   tasks: Map<string, TaskState>;
+  workflows: Map<string, WorkflowMeta>;
   onTaskClick: (task: TaskState) => void;
 }) {
+  const target = resolveWorkerActionTarget(action, tasks, workflows);
+
   return (
     <section className="rounded border border-border bg-card/60 p-3">
       <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">{title}</h3>
       <dl className="mt-2 grid grid-cols-[4.5rem_1fr] gap-x-3 gap-y-1 text-xs">
+        <dt className="text-muted-foreground">Task</dt>
+        <dd className="text-foreground">{target.taskTitle}</dd>
+        {target.workflowName ? (
+          <>
+            <dt className="text-muted-foreground">Workflow</dt>
+            <dd className="text-foreground">{target.workflowName}</dd>
+          </>
+        ) : null}
         <dt className="text-muted-foreground">Action</dt>
         <dd className="text-foreground">{formatWorkerValue(action.actionType)}</dd>
         <dt className="text-muted-foreground">Status</dt>
@@ -85,12 +111,19 @@ function ActionDetails({ title, action, tasks, onTaskClick }: {
           </>
         ) : null}
       </dl>
-      <TargetLine action={action} tasks={tasks} onTaskClick={onTaskClick} />
+      <TargetLine action={action} tasks={tasks} workflows={workflows} onTaskClick={onTaskClick} />
     </section>
   );
 }
 
-export function WorkerDetailsPanel({ worker, tasks, collapsed, onToggleCollapsed, onTaskClick }: WorkerDetailsPanelProps) {
+export function WorkerDetailsPanel({
+  worker,
+  tasks,
+  workflows,
+  collapsed,
+  onToggleCollapsed,
+  onTaskClick,
+}: WorkerDetailsPanelProps) {
   if (collapsed) {
     return (
       <aside className="flex h-full w-full items-start justify-center border-l border-border bg-background pt-3">
@@ -154,7 +187,13 @@ export function WorkerDetailsPanel({ worker, tasks, collapsed, onToggleCollapsed
             </section>
 
             {activeAction ? (
-              <ActionDetails title="Current work" action={activeAction} tasks={tasks} onTaskClick={onTaskClick} />
+              <ActionDetails
+                title="Current work"
+                action={activeAction}
+                tasks={tasks}
+                workflows={workflows}
+                onTaskClick={onTaskClick}
+              />
             ) : (
               <section className="rounded border border-border bg-card/60 p-3">
                 <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Current work</h3>
@@ -163,7 +202,13 @@ export function WorkerDetailsPanel({ worker, tasks, collapsed, onToggleCollapsed
             )}
 
             {latestAction ? (
-              <ActionDetails title="Last recorded action" action={latestAction} tasks={tasks} onTaskClick={onTaskClick} />
+              <ActionDetails
+                title="Last recorded action"
+                action={latestAction}
+                tasks={tasks}
+                workflows={workflows}
+                onTaskClick={onTaskClick}
+              />
             ) : (
               <section className="rounded border border-border bg-card/60 p-3">
                 <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Last recorded action</h3>

--- a/packages/ui/src/lib/worker-display.ts
+++ b/packages/ui/src/lib/worker-display.ts
@@ -1,9 +1,22 @@
-import type { WorkerActionStatus, WorkerActionSummary, WorkerStatusEntry } from '../types.js';
+import type {
+  TaskState,
+  WorkerActionStatus,
+  WorkerActionSummary,
+  WorkerStatusEntry,
+  WorkflowMeta,
+} from '../types.js';
 
 export interface WorkerDisplayCopy {
   readonly name: string;
   readonly idleText: string;
   readonly noActionText: string;
+}
+
+export interface WorkerActionTargetContext {
+  readonly task: TaskState | null;
+  readonly taskTitle: string;
+  readonly workflowId: string | undefined;
+  readonly workflowName: string | undefined;
 }
 
 export const ACTIVE_WORKER_ACTION_STATUSES: ReadonlySet<WorkerActionStatus> = new Set<WorkerActionStatus>([
@@ -26,6 +39,34 @@ export function displayWorkerTaskId(taskId: string): string {
   if (taskId.startsWith('__merge__')) return 'merge gate';
   const slash = taskId.lastIndexOf('/');
   return slash >= 0 ? taskId.slice(slash + 1) : taskId;
+}
+
+export function resolveWorkerActionTarget(
+  action: WorkerActionSummary,
+  tasks: Map<string, TaskState>,
+  workflows?: Map<string, WorkflowMeta>,
+): WorkerActionTargetContext {
+  const task = action.taskId ? tasks.get(action.taskId) ?? null : null;
+  const workflowId = action.workflowId ?? task?.config.workflowId;
+  const workflowName = workflowId
+    ? workflows?.get(workflowId)?.name ?? workflowId
+    : undefined;
+
+  let taskTitle: string;
+  if (task?.description) {
+    taskTitle = task.description;
+  } else if (action.taskId) {
+    taskTitle = displayWorkerTaskId(action.taskId);
+  } else {
+    taskTitle = `${formatWorkerValue(action.subjectType)} ${action.subjectId}`;
+  }
+
+  return {
+    task,
+    taskTitle,
+    workflowId,
+    workflowName,
+  };
 }
 
 export function getWorkerDisplayCopy(kind: string): WorkerDisplayCopy {


### PR DESCRIPTION
## Summary

Worker Actions rows used to lead with the worker kind name, so similar CI repairs looked identical.

Each row now leads with the target task title. The worker kind, action name, and workflow sit on the secondary line.

The worker inspector shows the same task and workflow context when opening current work.

## Review Claim

Worker Actions rows and inspector should identify the target task first, not the worker kind.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only presentation and prop wiring change. Worker action records, IPC, and process controls are unchanged.

## Slice Rationale

This is one UI clarity claim for the Workers surface. No persistence or worker-runtime changes belong here.

## Non-goals

- No grouping by workflow
- No CI payload fields such as review URL or failed checks in the rows
- No worker process start or stop behavior changes

## Architecture

### Before

```mermaid
graph TD
    Row["Action row primary"] --> WorkerName["CI failure repair"]
    Row --> Secondary["action name and truncated task"]
```

### After

```mermaid
graph TD
    Row["Action row primary"] --> TaskTitle["Review gate for auth stack"]
    Row --> Secondary["CI failure repair, action name, and workflow"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/queue-view.test.tsx src/__tests__/worker-details-panel.test.tsx`
- [x] Seeded Playwright capture of Workers surface before/after (task titles lead after)

</details>

## Visual Proof

Animated before/after of the Workers surface. Frame 1 leads with "CI failure repair"; frame 2 leads with the target task titles.

![Worker Actions task-first before/after walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-1eca08/worker-actions-task-first-before-after.gif)

Before still: Worker Actions rows lead with "CI failure repair"; the target task is secondary.

![Worker Actions before — worker kind first](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-1eca08/worker-actions-list-before.png)

After still: Worker Actions rows lead with "Review gate for auth stack" / "Review gate for payments"; worker kind and workflow are secondary.

![Worker Actions after — task title first](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-1eca08/worker-actions-list-after.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 66fbef8d9`
- Post-revert steps: None
- Data migration? No

</details>
