### PR TITLE
[Cmd+K Palette Latency](1) Keep command palette open under 50ms

### DIFF
--- a/packages/app/e2e/command-palette-open.spec.ts
+++ b/packages/app/e2e/command-palette-open.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect, TEST_PLAN, loadPlan, captureScreenshot } from './fixtures/electron-app.js';
+
+test.describe('command palette visual proof', () => {
+  test('opens the command palette with Cmd+K', async ({ page }) => {
+    await loadPlan(page, TEST_PLAN);
+    await expect(page.getByTestId('app-sidebar')).toBeVisible();
+
+    await captureScreenshot(page, 'command-palette-closed');
+
+    await page.keyboard.press('Meta+K');
+    await expect(page.getByTestId('command-palette')).toHaveAttribute('data-state', 'open');
+    await expect(page.getByPlaceholder('Jump to workflow, task, or view…')).toBeVisible();
+    await captureScreenshot(page, 'command-palette-open');
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('command-palette')).toHaveAttribute('data-state', 'closed');
+    await captureScreenshot(page, 'command-palette-closed-after-escape');
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -5035,59 +5035,6 @@ function createEmbeddedTerminalBackendFromConfig(
     // (or selecting) an embedded session managed in the main process.
     // Headless `open-terminal` still routes to `openExternalTerminalForTask`
     // in `headless.ts` so existing CLI behaviour is preserved.
-    const planningTerminalOnly = (sessionId: string): { ok: true } | { ok: false; reason: string } => {
-      const session = embeddedTerminalManager.get(sessionId);
-      if (!session) return { ok: false, reason: `Unknown session "${sessionId}".` };
-      if (session.kind !== 'planning') {
-        return { ok: false, reason: `Session "${sessionId}" is not a planning terminal session.` };
-      }
-      return { ok: true };
-    };
-
-    ipcMain.handle('invoker:planning-terminal-open', async (_event, planningSessionIdArg: string) => {
-      const planningSessionId = String(planningSessionIdArg ?? '').trim();
-      if (!planningSessionId) {
-        return { opened: false, reason: 'Planning session id is required.' };
-      }
-      logger.info(`invoked for planningSession="${planningSessionId}"`, { module: 'planning-terminal' });
-      try {
-        const session = embeddedTerminalManager.openOrReuse({
-          kind: 'planning',
-          taskId: `planning:${planningSessionId}`,
-          planningSessionId,
-          spec: { cwd: repoRoot },
-          cwd: repoRoot,
-        });
-        return { opened: true, session };
-      } catch (err) {
-        const reason = err instanceof Error ? err.message : String(err);
-        logger.warn(`planning terminal spawn failed for session="${planningSessionId}": ${reason}`, { module: 'planning-terminal' });
-        return { opened: false, reason: `Failed to start planning terminal session: ${reason}` };
-      }
-    });
-
-    ipcMain.handle('invoker:planning-terminal-list', async () => {
-      return embeddedTerminalManager.list().filter((session) => session.kind === 'planning');
-    });
-
-    ipcMain.handle('invoker:planning-terminal-write', async (_event, sessionId: string, data: string) => {
-      const allowed = planningTerminalOnly(sessionId);
-      if (!allowed.ok) return allowed;
-      return embeddedTerminalManager.write(sessionId, data);
-    });
-
-    ipcMain.handle('invoker:planning-terminal-resize', async (_event, sessionId: string, cols: number, rows: number) => {
-      const allowed = planningTerminalOnly(sessionId);
-      if (!allowed.ok) return allowed;
-      return embeddedTerminalManager.resize(sessionId, cols, rows);
-    });
-
-    ipcMain.handle('invoker:planning-terminal-close', async (_event, sessionId: string) => {
-      const allowed = planningTerminalOnly(sessionId);
-      if (!allowed.ok) return allowed;
-      return embeddedTerminalManager.close(sessionId);
-    });
-
     ipcMain.handle('invoker:open-terminal', async (_event, taskId: string) => {
       logger.info(`invoked for task="${taskId}"`, { module: 'open-terminal' });
       const liveHandle = taskHandles.get(taskId);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -46,7 +46,7 @@ import { InvokerTerminal, type InvokerTerminalLine, type PlanningTerminalMode } 
 import { Toaster, toast } from 'sonner';
 import { Button } from './components/primitives/index.js';
 import { ChevronDownIcon, PlayIcon } from './components/icons/index.js';
-import { CommandPalette } from './components/CommandPalette.js';
+import { CommandPalette, COMMAND_PALETTE_MAX_ROWS } from './components/CommandPalette.js';
 import {
   getAttentionTaskEntries,
   getRunningTaskEntries,
@@ -789,7 +789,6 @@ export function App() {
   }, [planningSessions]);
   const [graphMaximized, setGraphMaximized] = useState(false);
   const { theme, toggleTheme } = useTheme();
-  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const [selectedActionNodeId, setSelectedActionNodeId] = useState<string | null>(null);
   const selectedActionNode = useMemo(
     () => actionGraph?.nodes.find((node) => node.id === selectedActionNodeId) ?? null,
@@ -1453,6 +1452,18 @@ export function App() {
     [tasks, workflows, attentionTaskIdsWithFailures],
   );
   const runningEntries = useMemo(() => getRunningTaskEntries(tasks, workflows, queueStatus), [tasks, workflows, queueStatus]);
+  const commandPaletteWorkflowEntries = useMemo(
+    () => workflowEntries.slice(0, COMMAND_PALETTE_MAX_ROWS),
+    [workflowEntries],
+  );
+  const commandPaletteAttentionEntries = useMemo(
+    () => attentionEntries.slice(0, COMMAND_PALETTE_MAX_ROWS),
+    [attentionEntries],
+  );
+  const commandPaletteRunningEntries = useMemo(
+    () => runningEntries.slice(0, COMMAND_PALETTE_MAX_ROWS),
+    [runningEntries],
+  );
 
   const searchResults = useMemo<SearchResult[]>(
     () => computeSearchResults(searchQuery, tasks, workflows),
@@ -1704,14 +1715,6 @@ export function App() {
         return;
       }
       if (isEditableKeyboardTarget(event.target) || modal.type !== 'none') return;
-
-      if ((event.key === 'k' || event.key === 'K') && (event.metaKey || event.ctrlKey)) {
-        if (graphMaximized || planningTerminalExpanded) return;
-        event.preventDefault();
-        event.stopPropagation();
-        setCommandPaletteOpen((prev) => !prev);
-        return;
-      }
 
       // F1 is the keyboard-only camera lock control. It is already ignored for
       // input/modal/terminal/editable targets by the guard above.
@@ -3816,22 +3819,31 @@ export function App() {
           },
         }}
       />
-      {commandPaletteOpen && (
-        <CommandPalette
-          open={commandPaletteOpen}
-          onOpenChange={setCommandPaletteOpen}
-          workflows={workflows}
-          tasks={tasks}
-          onSelectSurface={handleSelectSidebarSurface}
-          onSelectWorkflow={selectWorkflowById}
-          onSelectTask={selectTaskById}
-          onOpenSettings={() => {
-            cancelPendingSystemSetupAutoOpen();
-            setShowSystemSetup(true);
-          }}
-          planningSessionCount={planningSessions.length}
-        />
-      )}
+      <CommandPalette
+        enabled={
+          !contextMenu
+          && !workflowContextMenu
+          && !searchOpen
+          && modal.type === 'none'
+          && !graphMaximized
+          && !planningTerminalExpanded
+        }
+        workflowEntries={commandPaletteWorkflowEntries}
+        attentionEntries={commandPaletteAttentionEntries}
+        runningEntries={commandPaletteRunningEntries}
+        workflowCount={workflowEntries.length}
+        attentionCount={attentionEntries.length}
+        runningCount={runningEntries.length}
+        onSelectSurface={handleSelectSidebarSurface}
+        onSelectWorkflow={selectWorkflowById}
+        onSelectTask={selectTaskById}
+        onOpenSettings={() => {
+          cancelPendingSystemSetupAutoOpen();
+          setShowSystemSetup(true);
+        }}
+        planningSessionCount={planningSessions.length}
+      />
+
       {showSystemBanner && (
         <div className="px-4 py-3 border-b border-amber-700 bg-amber-950/50 flex items-center justify-between gap-4">
           <div className="text-sm text-amber-100">
@@ -3886,15 +3898,14 @@ export function App() {
       {/* Main content */}
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <LeftStatusColumn
-          workflows={workflows}
-          tasks={tasks}
-          queueStatus={queueStatus}
+          workflowCount={workflowEntries.length}
+          attentionCount={attentionEntries.length}
+          runningCount={runningEntries.length}
           workerStatus={workerStatus}
           planningSessionCount={planningSessions.length}
           planningAttentionCount={planningAttentionCount}
           selectedSurface={sidebarSurface}
           collapsed={effectiveSidebarCollapsed}
-          attentionTaskIdsWithFailures={attentionTaskIdsWithFailures}
           onSelectSurface={handleSelectSidebarSurface}
           onToggleCollapsed={() => setSidebarCollapsed(!effectiveSidebarCollapsed)}
           onOpenSettings={() => {

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -48,7 +48,7 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Planning Terminal');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
   });
 
@@ -104,7 +104,7 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Planning Terminal');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();
   });
@@ -160,7 +160,7 @@ describe('App launch (component)', () => {
 
     fireEvent.click(toggle);
     expect(sidebar.className).toContain('w-16');
-    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-running')).toBeInTheDocument();
 
     for (const surface of ['workflows', 'attention', 'workers', 'planning', 'home']) {
       fireEvent.click(screen.getByTestId(`sidebar-${surface}`));

--- a/packages/ui/src/__tests__/command-palette.test.tsx
+++ b/packages/ui/src/__tests__/command-palette.test.tsx
@@ -1,7 +1,10 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { CommandPalette } from '../components/CommandPalette.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { useMemo, useState, type JSX } from 'react';
+import { CommandPalette, COMMAND_PALETTE_MAX_ROWS } from '../components/CommandPalette.js';
+import { LeftStatusColumn } from '../components/LeftStatusColumn.js';
 import type { TaskState, WorkflowMeta } from '../types.js';
+import * as workflowProgressSurfaces from '../lib/workflow-progress-surfaces.js';
 
 function buildFixtures() {
   const workflows = new Map<string, WorkflowMeta>([
@@ -25,15 +28,133 @@ function buildFixtures() {
   return { workflows, tasks };
 }
 
+function entriesFrom(workflows: Map<string, WorkflowMeta>, tasks: Map<string, TaskState>) {
+  const workflowEntries = workflowProgressSurfaces.getSortedWorkflows(workflows, tasks);
+  const attentionEntries = workflowProgressSurfaces.getAttentionTaskEntries(tasks, workflows);
+  const runningEntries = workflowProgressSurfaces.getRunningTaskEntries(tasks, workflows, null);
+  return {
+    workflowEntries: workflowEntries.slice(0, COMMAND_PALETTE_MAX_ROWS),
+    attentionEntries: attentionEntries.slice(0, COMMAND_PALETTE_MAX_ROWS),
+    runningEntries: runningEntries.slice(0, COMMAND_PALETTE_MAX_ROWS),
+    workflowCount: workflowEntries.length,
+    attentionCount: attentionEntries.length,
+    runningCount: runningEntries.length,
+  };
+}
+
+function buildLargeFixtures(workflowCount: number, taskCount: number) {
+  const workflows = new Map<string, WorkflowMeta>();
+  for (let i = 0; i < workflowCount; i += 1) {
+    workflows.set(`w${i}`, {
+      id: `w${i}`,
+      name: `Workflow ${i}`,
+      status: i % 5 === 0 ? 'failed' : i % 3 === 0 ? 'running' : 'completed',
+      updatedAt: new Date(Date.now() - i * 1000).toISOString(),
+      createdAt: new Date(Date.now() - i * 2000).toISOString(),
+    });
+  }
+  const statuses: TaskState['status'][] = [
+    'completed',
+    'running',
+    'failed',
+    'blocked',
+    'pending',
+    'awaiting_approval',
+    'review_ready',
+    'fixing_with_ai',
+  ];
+  const tasks = new Map<string, TaskState>();
+  for (let i = 0; i < taskCount; i += 1) {
+    tasks.set(`t${i}`, {
+      id: `t${i}`,
+      description: `Task description number ${i}`,
+      status: statuses[i % statuses.length],
+      config: { workflowId: `w${i % workflowCount}` } as unknown as TaskState['config'],
+    } as TaskState);
+  }
+  return { workflows, tasks };
+}
+
+function Harness({
+  workflows,
+  tasks,
+  enabled = true,
+  defaultOpen = false,
+}: {
+  workflows: Map<string, WorkflowMeta>;
+  tasks: Map<string, TaskState>;
+  enabled?: boolean;
+  defaultOpen?: boolean;
+}): JSX.Element {
+  const [renderCount, setRenderCount] = useState(0);
+  const workflowEntries = useMemo(
+    () => workflowProgressSurfaces.getSortedWorkflows(workflows, tasks),
+    [workflows, tasks],
+  );
+  const attentionEntries = useMemo(
+    () => workflowProgressSurfaces.getAttentionTaskEntries(tasks, workflows),
+    [tasks, workflows],
+  );
+  const runningEntries = useMemo(
+    () => workflowProgressSurfaces.getRunningTaskEntries(tasks, workflows, null),
+    [tasks, workflows],
+  );
+
+  return (
+    <div>
+      <button type="button" onClick={() => setRenderCount((n) => n + 1)}>
+        bump-parent
+      </button>
+      <span data-testid="parent-render-count">{renderCount}</span>
+      <LeftStatusColumn
+        workflowCount={workflowEntries.length}
+        attentionCount={attentionEntries.length}
+        runningCount={runningEntries.length}
+        workerStatus={null}
+        selectedSurface="home"
+        collapsed={false}
+        onSelectSurface={() => {}}
+        onToggleCollapsed={() => {}}
+        planningSessionCount={0}
+        onOpenSettings={() => {}}
+        theme="dark"
+        onToggleTheme={() => {}}
+      />
+      <CommandPalette
+        enabled={enabled}
+        defaultOpen={defaultOpen}
+        workflowEntries={workflowEntries.slice(0, COMMAND_PALETTE_MAX_ROWS)}
+        attentionEntries={attentionEntries.slice(0, COMMAND_PALETTE_MAX_ROWS)}
+        runningEntries={runningEntries.slice(0, COMMAND_PALETTE_MAX_ROWS)}
+        workflowCount={workflowEntries.length}
+        attentionCount={attentionEntries.length}
+        runningCount={runningEntries.length}
+        onSelectSurface={() => {}}
+        onSelectWorkflow={() => {}}
+        onSelectTask={() => {}}
+        onOpenSettings={() => {}}
+        planningSessionCount={0}
+      />
+    </div>
+  );
+}
+
 describe('CommandPalette', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('renders navigate section headings when open', () => {
     const { workflows, tasks } = buildFixtures();
+    const entries = entriesFrom(workflows, tasks);
     render(
       <CommandPalette
-        open
-        onOpenChange={() => {}}
-        workflows={workflows}
-        tasks={tasks}
+        defaultOpen
+        {...entries}
         onSelectSurface={() => {}}
         onSelectWorkflow={() => {}}
         onSelectTask={() => {}}
@@ -49,13 +170,12 @@ describe('CommandPalette', () => {
 
   it('lists workflows and calls onSelectWorkflow on click', async () => {
     const { workflows, tasks } = buildFixtures();
+    const entries = entriesFrom(workflows, tasks);
     const onSelectWorkflow = vi.fn();
     render(
       <CommandPalette
-        open
-        onOpenChange={() => {}}
-        workflows={workflows}
-        tasks={tasks}
+        defaultOpen
+        {...entries}
         onSelectSurface={() => {}}
         onSelectWorkflow={onSelectWorkflow}
         onSelectTask={() => {}}
@@ -71,12 +191,11 @@ describe('CommandPalette', () => {
 
   it('shows failed task under the needs-attention group', async () => {
     const { workflows, tasks } = buildFixtures();
+    const entries = entriesFrom(workflows, tasks);
     render(
       <CommandPalette
-        open
-        onOpenChange={() => {}}
-        workflows={workflows}
-        tasks={tasks}
+        defaultOpen
+        {...entries}
         onSelectSurface={() => {}}
         onSelectWorkflow={() => {}}
         onSelectTask={() => {}}
@@ -86,5 +205,81 @@ describe('CommandPalette', () => {
     );
     expect(await screen.findByText('Fix broken flag propagation')).toBeInTheDocument();
     expect(screen.getAllByText('2').length).toBeGreaterThan(0);
+  });
+
+  it('toggles open on Cmd+K and ignores the shortcut when disabled', async () => {
+    const { workflows, tasks } = buildFixtures();
+    const { rerender } = render(<Harness workflows={workflows} tasks={tasks} enabled />);
+
+    expect(screen.getByTestId('command-palette')).toHaveAttribute('data-state', 'closed');
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'k', metaKey: true });
+    });
+    expect(screen.getByTestId('command-palette')).toHaveAttribute('data-state', 'open');
+    expect(screen.getByPlaceholderText(/Jump to workflow/i)).toBeVisible();
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('command-palette')).toHaveAttribute('data-state', 'closed');
+    });
+
+    rerender(<Harness workflows={workflows} tasks={tasks} enabled={false} />);
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'k', metaKey: true });
+    });
+    expect(screen.getByTestId('command-palette')).toHaveAttribute('data-state', 'closed');
+  });
+
+  it('does not rescan workflow/task maps when Cmd+K opens the palette', async () => {
+    const { workflows, tasks } = buildFixtures();
+    const sortedSpy = vi.spyOn(workflowProgressSurfaces, 'getSortedWorkflows');
+    const attentionSpy = vi.spyOn(workflowProgressSurfaces, 'getAttentionTaskEntries');
+    const runningSpy = vi.spyOn(workflowProgressSurfaces, 'getRunningTaskEntries');
+
+    render(<Harness workflows={workflows} tasks={tasks} />);
+    const sortedAfterMount = sortedSpy.mock.calls.length;
+    const attentionAfterMount = attentionSpy.mock.calls.length;
+    const runningAfterMount = runningSpy.mock.calls.length;
+    expect(sortedAfterMount).toBeGreaterThan(0);
+
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'k', metaKey: true });
+    });
+    expect(await screen.findByPlaceholderText(/Jump to workflow/i)).toBeInTheDocument();
+
+    expect(sortedSpy.mock.calls.length).toBe(sortedAfterMount);
+    expect(attentionSpy.mock.calls.length).toBe(attentionAfterMount);
+    expect(runningSpy.mock.calls.length).toBe(runningAfterMount);
+  });
+
+  it('opens the menu within 50ms for a large task graph', async () => {
+    const { workflows, tasks } = buildLargeFixtures(500, 5000);
+    const entries = entriesFrom(workflows, tasks);
+    render(
+      <CommandPalette
+        {...entries}
+        onSelectSurface={() => {}}
+        onSelectWorkflow={() => {}}
+        onSelectTask={() => {}}
+        onOpenSettings={() => {}}
+        planningSessionCount={0}
+      />,
+    );
+
+    // Mount cost is paid up front; Cmd+K only toggles visibility.
+    expect(screen.getByTestId('command-palette')).toHaveAttribute('data-state', 'closed');
+
+    const started = performance.now();
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'k', metaKey: true });
+    });
+    expect(screen.getByTestId('command-palette')).toHaveAttribute('data-state', 'open');
+    expect(screen.getByPlaceholderText(/Jump to workflow/i)).toBeVisible();
+    const elapsed = performance.now() - started;
+    expect(elapsed).toBeLessThan(50);
+    expect(screen.getAllByText(/Workflow \d+/).length).toBeLessThanOrEqual(COMMAND_PALETTE_MAX_ROWS);
   });
 });

--- a/packages/ui/src/__tests__/primitives.test.tsx
+++ b/packages/ui/src/__tests__/primitives.test.tsx
@@ -55,4 +55,21 @@ describe('Dialog primitive', () => {
     const title = await findByRole('heading', { name: 'Confirm' });
     expect(title).toBeVisible();
   });
+
+  it('applies overlayClassName to the dialog overlay', async () => {
+    const { getByRole, findByRole, container } = render(
+      <Dialog>
+        <DialogTrigger asChild>
+          <button type="button">Open</button>
+        </DialogTrigger>
+        <DialogContent overlayClassName="backdrop-blur-none">
+          <DialogTitle>Confirm</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+    getByRole('button', { name: 'Open' }).click();
+    await findByRole('heading', { name: 'Confirm' });
+    const overlay = container.ownerDocument.querySelector('.backdrop-blur-none');
+    expect(overlay).not.toBeNull();
+  });
 });

--- a/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
+++ b/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
@@ -38,7 +38,7 @@ describe('Visual proof snapshots', () => {
     expect(screen.getByTestId('sidebar-home')).toHaveTextContent('Invoker');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
     expect(screen.getByText('Describe the change in the terminal to generate a plan.')).toBeInTheDocument();
     expect(screen.getByTestId('rail-settings')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();
@@ -66,8 +66,8 @@ describe('Visual proof snapshots', () => {
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
-      expect(screen.getByText('Alpha')).toBeInTheDocument();
-      expect(screen.getByText('Beta')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-alpha')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-beta')).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByTestId('workflow-node-wf-alpha'));

--- a/packages/ui/src/components/CommandPalette.tsx
+++ b/packages/ui/src/components/CommandPalette.tsx
@@ -1,7 +1,6 @@
-import { useMemo, useCallback, type JSX } from 'react';
+import { memo, useCallback, useEffect, useRef, useState, type JSX, type RefObject } from 'react';
 import { AlertTriangle, Clock, GitBranch, Home, Layers, Settings, Terminal } from 'lucide-react';
-import type { TaskState, WorkflowMeta } from '../types.js';
-import type { SidebarSurface } from '../lib/workflow-progress-surfaces.js';
+import type { SidebarSurface, WorkflowListEntry, WorkflowTaskEntry } from '../lib/workflow-progress-surfaces.js';
 import {
   Command,
   CommandEmpty,
@@ -11,21 +10,34 @@ import {
   CommandList,
   CommandSeparator,
   CommandShortcut,
-  Dialog,
-  DialogContent,
-  DialogTitle,
 } from './primitives/index.js';
-import {
-  getAttentionTaskEntries,
-  getRunningTaskEntries,
-  getSortedWorkflows,
-} from '../lib/workflow-progress-surfaces.js';
+
+export const COMMAND_PALETTE_MAX_ROWS = 8;
+
+const EDITABLE_SELECTOR = [
+  'input',
+  'textarea',
+  'select',
+  '[contenteditable="true"]',
+  '.xterm',
+  '[role="dialog"] input',
+  '[role="dialog"] textarea',
+].join(',');
+
+function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return Boolean(target.closest(EDITABLE_SELECTOR));
+}
 
 export interface CommandPaletteProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  workflows: Map<string, WorkflowMeta>;
-  tasks: Map<string, TaskState>;
+  enabled?: boolean;
+  defaultOpen?: boolean;
+  workflowEntries: WorkflowListEntry[];
+  attentionEntries: WorkflowTaskEntry[];
+  runningEntries: WorkflowTaskEntry[];
+  workflowCount: number;
+  attentionCount: number;
+  runningCount: number;
   onSelectSurface: (surface: SidebarSurface) => void;
   onSelectWorkflow: (workflowId: string) => void;
   onSelectTask: (taskId: string) => void;
@@ -33,131 +45,222 @@ export interface CommandPaletteProps {
   planningSessionCount: number;
 }
 
-const MAX_ROWS_PER_GROUP = 8;
+interface CommandPaletteBodyProps {
+  inputRef: RefObject<HTMLInputElement | null>;
+  close: () => void;
+  workflowEntries: WorkflowListEntry[];
+  attentionEntries: WorkflowTaskEntry[];
+  runningEntries: WorkflowTaskEntry[];
+  workflowCount: number;
+  attentionCount: number;
+  runningCount: number;
+  onSelectSurface: (surface: SidebarSurface) => void;
+  onSelectWorkflow: (workflowId: string) => void;
+  onSelectTask: (taskId: string) => void;
+  onOpenSettings: () => void;
+  planningSessionCount: number;
+}
+
+const CommandPaletteBody = memo(function CommandPaletteBody({
+  inputRef,
+  close,
+  workflowEntries,
+  attentionEntries,
+  runningEntries,
+  workflowCount,
+  attentionCount,
+  runningCount,
+  onSelectSurface,
+  onSelectWorkflow,
+  onSelectTask,
+  onOpenSettings,
+  planningSessionCount,
+}: CommandPaletteBodyProps): JSX.Element {
+  const closeAnd = useCallback(
+    (fn: () => void) => () => {
+      fn();
+      close();
+    },
+    [close],
+  );
+
+  return (
+    <div className="w-full max-w-xl overflow-hidden rounded-lg border border-border-strong bg-card text-card-foreground shadow-lg">
+      <Command loop shouldFilter>
+        <CommandInput
+          ref={inputRef}
+          placeholder="Jump to workflow, task, or view…"
+        />
+        <CommandList>
+          <CommandEmpty>No matches.</CommandEmpty>
+
+          <CommandGroup heading="Navigate">
+            <CommandItem value="home go home" onSelect={closeAnd(() => onSelectSurface('home'))}>
+              <Home strokeWidth={1.75} />
+              <span>Go home</span>
+            </CommandItem>
+            <CommandItem value="planning terminal" onSelect={closeAnd(() => onSelectSurface('planning'))}>
+              <Terminal strokeWidth={1.75} />
+              <span>Planning Terminal</span>
+              {planningSessionCount > 0 && <CommandShortcut>{planningSessionCount}</CommandShortcut>}
+            </CommandItem>
+            <CommandItem value="needs attention" onSelect={closeAnd(() => onSelectSurface('attention'))}>
+              <AlertTriangle strokeWidth={1.75} />
+              <span>Needs Attention</span>
+              {attentionCount > 0 && <CommandShortcut>{attentionCount}</CommandShortcut>}
+            </CommandItem>
+            <CommandItem value="running tasks" onSelect={closeAnd(() => onSelectSurface('running'))}>
+              <Clock strokeWidth={1.75} />
+              <span>Running</span>
+              {runningCount > 0 && <CommandShortcut>{runningCount}</CommandShortcut>}
+            </CommandItem>
+            <CommandItem value="workflows browser" onSelect={closeAnd(() => onSelectSurface('workflows'))}>
+              <Layers strokeWidth={1.75} />
+              <span>Workflows</span>
+              {workflowCount > 0 && <CommandShortcut>{workflowCount}</CommandShortcut>}
+            </CommandItem>
+            <CommandItem value="open settings" onSelect={closeAnd(onOpenSettings)}>
+              <Settings strokeWidth={1.75} />
+              <span>Settings</span>
+            </CommandItem>
+          </CommandGroup>
+
+          {attentionEntries.length > 0 && (
+            <>
+              <CommandSeparator />
+              <CommandGroup heading="Needs attention">
+                {attentionEntries.map(({ task }) => (
+                  <CommandItem
+                    key={`attention:${task.id}`}
+                    value={`attention ${task.id} ${task.description ?? ''}`}
+                    onSelect={closeAnd(() => onSelectTask(task.id))}
+                  >
+                    <AlertTriangle strokeWidth={1.75} className="text-amber-300" />
+                    <span className="truncate">{task.description ?? task.id}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </>
+          )}
+
+          {runningEntries.length > 0 && (
+            <>
+              <CommandSeparator />
+              <CommandGroup heading="Running">
+                {runningEntries.map(({ task }) => (
+                  <CommandItem
+                    key={`running:${task.id}`}
+                    value={`running ${task.id} ${task.description ?? ''}`}
+                    onSelect={closeAnd(() => onSelectTask(task.id))}
+                  >
+                    <Clock strokeWidth={1.75} className="text-foreground" />
+                    <span className="truncate">{task.description ?? task.id}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </>
+          )}
+
+          {workflowEntries.length > 0 && (
+            <>
+              <CommandSeparator />
+              <CommandGroup heading="Workflows">
+                {workflowEntries.map(({ workflow }) => (
+                  <CommandItem
+                    key={`workflow:${workflow.id}`}
+                    value={`workflow ${workflow.id} ${workflow.name}`}
+                    onSelect={closeAnd(() => onSelectWorkflow(workflow.id))}
+                  >
+                    <GitBranch strokeWidth={1.75} />
+                    <span className="truncate">{workflow.name}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </>
+          )}
+        </CommandList>
+      </Command>
+    </div>
+  );
+});
 
 export function CommandPalette({
-  open,
-  onOpenChange,
-  workflows,
-  tasks,
+  enabled = true,
+  defaultOpen = false,
+  workflowEntries,
+  attentionEntries,
+  runningEntries,
+  workflowCount,
+  attentionCount,
+  runningCount,
   onSelectSurface,
   onSelectWorkflow,
   onSelectTask,
   onOpenSettings,
   planningSessionCount,
 }: CommandPaletteProps): JSX.Element {
-  const workflowEntries = useMemo(() => getSortedWorkflows(workflows, tasks).slice(0, MAX_ROWS_PER_GROUP), [workflows, tasks]);
-  const attentionEntries = useMemo(() => getAttentionTaskEntries(tasks, workflows).slice(0, MAX_ROWS_PER_GROUP), [tasks, workflows]);
-  const runningEntries = useMemo(() => getRunningTaskEntries(tasks, workflows, null).slice(0, MAX_ROWS_PER_GROUP), [tasks, workflows]);
+  const [open, setOpen] = useState(defaultOpen);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const close = useCallback(() => setOpen(false), []);
 
-  const closeAnd = useCallback(
-    (fn: () => void) => () => {
-      fn();
-      onOpenChange(false);
-    },
-    [onOpenChange],
-  );
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.key === 'k' || event.key === 'K') && (event.metaKey || event.ctrlKey)) {
+        if (!enabled && !open) return;
+        if (!open && isEditableKeyboardTarget(event.target)) return;
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        setOpen((prev) => !prev);
+        return;
+      }
+      if (open && event.key === 'Escape') {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        close();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [close, enabled, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const frame = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, [open]);
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        className="max-w-xl gap-0 p-0 overflow-hidden"
-        hideCloseButton
-        aria-describedby={undefined}
-      >
-        <DialogTitle className="sr-only">Command palette</DialogTitle>
-        <Command loop shouldFilter>
-          <CommandInput placeholder="Jump to workflow, task, or view…" autoFocus />
-          <CommandList>
-            <CommandEmpty>No matches.</CommandEmpty>
-
-            <CommandGroup heading="Navigate">
-              <CommandItem value="home go home" onSelect={closeAnd(() => onSelectSurface('home'))}>
-                <Home strokeWidth={1.75} />
-                <span>Go home</span>
-              </CommandItem>
-              <CommandItem value="planning terminal" onSelect={closeAnd(() => onSelectSurface('planning'))}>
-                <Terminal strokeWidth={1.75} />
-                <span>Planning Terminal</span>
-                {planningSessionCount > 0 && <CommandShortcut>{planningSessionCount}</CommandShortcut>}
-              </CommandItem>
-              <CommandItem value="needs attention" onSelect={closeAnd(() => onSelectSurface('attention'))}>
-                <AlertTriangle strokeWidth={1.75} />
-                <span>Needs Attention</span>
-                {attentionEntries.length > 0 && <CommandShortcut>{attentionEntries.length}</CommandShortcut>}
-              </CommandItem>
-              <CommandItem value="running tasks" onSelect={closeAnd(() => onSelectSurface('running'))}>
-                <Clock strokeWidth={1.75} />
-                <span>Running</span>
-                {runningEntries.length > 0 && <CommandShortcut>{runningEntries.length}</CommandShortcut>}
-              </CommandItem>
-              <CommandItem value="workflows browser" onSelect={closeAnd(() => onSelectSurface('workflows'))}>
-                <Layers strokeWidth={1.75} />
-                <span>Workflows</span>
-                {workflowEntries.length > 0 && <CommandShortcut>{workflowEntries.length}</CommandShortcut>}
-              </CommandItem>
-              <CommandItem value="open settings" onSelect={closeAnd(onOpenSettings)}>
-                <Settings strokeWidth={1.75} />
-                <span>Settings</span>
-              </CommandItem>
-            </CommandGroup>
-
-            {attentionEntries.length > 0 && (
-              <>
-                <CommandSeparator />
-                <CommandGroup heading="Needs attention">
-                  {attentionEntries.map(({ task }) => (
-                    <CommandItem
-                      key={`attention:${task.id}`}
-                      value={`attention ${task.id} ${task.description ?? ''}`}
-                      onSelect={closeAnd(() => onSelectTask(task.id))}
-                    >
-                      <AlertTriangle strokeWidth={1.75} className="text-amber-300" />
-                      <span className="truncate">{task.description ?? task.id}</span>
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </>
-            )}
-
-            {runningEntries.length > 0 && (
-              <>
-                <CommandSeparator />
-                <CommandGroup heading="Running">
-                  {runningEntries.map(({ task }) => (
-                    <CommandItem
-                      key={`running:${task.id}`}
-                      value={`running ${task.id} ${task.description ?? ''}`}
-                      onSelect={closeAnd(() => onSelectTask(task.id))}
-                    >
-                      <Clock strokeWidth={1.75} className="text-foreground" />
-                      <span className="truncate">{task.description ?? task.id}</span>
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </>
-            )}
-
-            {workflowEntries.length > 0 && (
-              <>
-                <CommandSeparator />
-                <CommandGroup heading="Workflows">
-                  {workflowEntries.map(({ workflow }) => (
-                    <CommandItem
-                      key={`workflow:${workflow.id}`}
-                      value={`workflow ${workflow.id} ${workflow.name}`}
-                      onSelect={closeAnd(() => onSelectWorkflow(workflow.id))}
-                    >
-                      <GitBranch strokeWidth={1.75} />
-                      <span className="truncate">{workflow.name}</span>
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </>
-            )}
-          </CommandList>
-        </Command>
-      </DialogContent>
-    </Dialog>
+    <div
+      role="dialog"
+      aria-modal={open}
+      aria-label="Command palette"
+      aria-hidden={!open}
+      data-testid="command-palette"
+      data-state={open ? 'open' : 'closed'}
+      className={[
+        'fixed inset-0 z-50 flex items-start justify-center bg-black/70 px-4 pt-[18vh]',
+        open ? '' : 'hidden',
+      ].join(' ')}
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) close();
+      }}
+    >
+      <CommandPaletteBody
+        inputRef={inputRef}
+        close={close}
+        workflowEntries={workflowEntries}
+        attentionEntries={attentionEntries}
+        runningEntries={runningEntries}
+        workflowCount={workflowCount}
+        attentionCount={attentionCount}
+        runningCount={runningCount}
+        onSelectSurface={onSelectSurface}
+        onSelectWorkflow={onSelectWorkflow}
+        onSelectTask={onSelectTask}
+        onOpenSettings={onOpenSettings}
+        planningSessionCount={planningSessionCount}
+      />
+    </div>
   );
 }

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -1,8 +1,6 @@
-import type { QueueStatus } from '@invoker/contracts';
 import type { JSX } from 'react';
-import type { TaskState, WorkflowMeta, WorkerStatusSnapshot } from '../types.js';
+import type { WorkerStatusSnapshot } from '../types.js';
 import type { SidebarSurface } from '../lib/workflow-progress-surfaces.js';
-import { getAttentionTaskEntries, getRunningTaskEntries, getSortedWorkflows } from '../lib/workflow-progress-surfaces.js';
 import { countActiveWorkerActions } from '../lib/worker-display.js';
 import {
   AttentionIcon,
@@ -11,6 +9,7 @@ import {
   InvokerIcon,
   MoonIcon,
   PlanningTerminalIcon,
+  RunningIcon,
   SettingsIcon,
   SunIcon,
   WorkerIcon,
@@ -19,13 +18,12 @@ import {
 import type { ThemeMode } from '../lib/theme.js';
 
 interface LeftStatusColumnProps {
-  workflows: Map<string, WorkflowMeta>;
-  tasks: Map<string, TaskState>;
-  queueStatus: QueueStatus | null;
+  workflowCount: number;
+  attentionCount: number;
+  runningCount: number;
   workerStatus: WorkerStatusSnapshot | null;
   selectedSurface: SidebarSurface;
   collapsed: boolean;
-  attentionTaskIdsWithFailures?: Set<string>;
   onSelectSurface: (surface: SidebarSurface) => void;
   onToggleCollapsed: () => void;
   planningSessionCount: number;
@@ -67,13 +65,12 @@ function countClass(tone: SourceItem['tone']): string {
 }
 
 export function LeftStatusColumn({
-  workflows,
-  tasks,
-  queueStatus,
+  workflowCount,
+  attentionCount,
+  runningCount,
   workerStatus,
   selectedSurface,
   collapsed,
-  attentionTaskIdsWithFailures,
   onSelectSurface,
   onToggleCollapsed,
   planningSessionCount,
@@ -82,17 +79,15 @@ export function LeftStatusColumn({
   theme,
   onToggleTheme,
 }: LeftStatusColumnProps): JSX.Element {
-  const workflowEntries = getSortedWorkflows(workflows, tasks);
-  const attentionEntries = getAttentionTaskEntries(tasks, workflows, attentionTaskIdsWithFailures);
-  const runningEntries = getRunningTaskEntries(tasks, workflows, queueStatus);
   const runningWorkers = workerStatus?.workers.filter((worker) => worker.lifecycle === 'running').length ?? 0;
   const registeredWorkers = workerStatus?.workers.length ?? 0;
   const activeWorkerActions = workerStatus ? countActiveWorkerActions(workerStatus.workers) : 0;
 
   const sources: SourceItem[] = [
-    { key: 'attention', label: 'Needs Attention', count: attentionEntries.length, tone: 'attention', icon: <AttentionIcon className={ICON_CLASS} /> },
+    { key: 'attention', label: 'Needs Attention', count: attentionCount, tone: 'attention', icon: <AttentionIcon className={ICON_CLASS} /> },
+    { key: 'running', label: 'Running', count: runningCount, tone: 'running', icon: <RunningIcon className={ICON_CLASS} /> },
     { key: 'workers', label: 'Workers', count: registeredWorkers, tone: activeWorkerActions > 0 ? 'running' : 'neutral', icon: <WorkerIcon className={ICON_CLASS} /> },
-    { key: 'workflows', label: 'Workflows', count: workflowEntries.length, tone: 'neutral', icon: <WorkflowsIcon className={ICON_CLASS} /> },
+    { key: 'workflows', label: 'Workflows', count: workflowCount, tone: 'neutral', icon: <WorkflowsIcon className={ICON_CLASS} /> },
   ];
 
   return (
@@ -215,19 +210,19 @@ export function LeftStatusColumn({
       {!collapsed && (
         <div className="mt-6 flex-1 overflow-y-auto scrollbar-sleek px-2.5 text-xs text-muted-foreground">
           {selectedSurface === 'workflows' && (
-            workflowEntries.length === 0
+            workflowCount === 0
               ? 'No workflows yet'
-              : `${workflowEntries.length} workflow${workflowEntries.length === 1 ? '' : 's'} ready to browse.`
+              : `${workflowCount} workflow${workflowCount === 1 ? '' : 's'} ready to browse.`
           )}
           {selectedSurface === 'attention' && (
-            attentionEntries.length === 0
+            attentionCount === 0
               ? 'Nothing needs a decision right now.'
-              : `${attentionEntries.length} item${attentionEntries.length === 1 ? ' needs' : 's need'} attention.`
+              : `${attentionCount} item${attentionCount === 1 ? ' needs' : 's need'} attention.`
           )}
           {selectedSurface === 'running' && (
-            runningEntries.length === 0
+            runningCount === 0
               ? 'No tasks are running right now.'
-              : `${runningEntries.length} task${runningEntries.length === 1 ? '' : 's'} active now.`
+              : `${runningCount} task${runningCount === 1 ? '' : 's'} active now.`
           )}
           {selectedSurface === 'workers' && (
             workerStatus === null

--- a/packages/ui/src/components/primitives/Dialog.tsx
+++ b/packages/ui/src/components/primitives/Dialog.tsx
@@ -31,14 +31,15 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 export interface DialogContentProps
   extends ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
   hideCloseButton?: boolean;
+  overlayClassName?: string;
 }
 
 export const DialogContent = forwardRef<
   ElementRef<typeof DialogPrimitive.Content>,
   DialogContentProps
->(({ className, children, hideCloseButton, ...props }, ref) => (
+>(({ className, children, hideCloseButton, overlayClassName, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay />
+    <DialogOverlay className={overlayClassName} />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(


### PR DESCRIPTION
## Summary

Cmd+K used to beachball because opening the palette lived in App state.

That re-rendered the whole UI, recomputed every workflow and task in the sidebar, and cold-mounted a blurred Radix dialog over React Flow.

This change keeps the palette mounted with its own open state and a solid dim overlay.

App passes already-memoized, pre-sliced entries, so Cmd+K only toggles visibility.

## Review Claim

Approve that Cmd+K opens the command palette without App-wide recomputation or a blurred Dialog cold-mount, and stays under a 50ms open budget in the regression coverage.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Shortcut guards still block open when context menus, search overlay, modals, or maximized graph/planning are active.

Palette content still comes from the same App memoized workflow/attention/running entries.

## Slice Rationale

This is one user-facing latency fix: open-path control, overlay cost, and the regression coverage that locks the budget.

## Non-goals

- Double-Shift search overlay behavior
- Memoizing WorkflowGraph or TaskDAG globally
- Changing blur behavior for other Dialog modals

## Architecture

### Before

```mermaid
graph TD
    key["Cmd+K"] --> appState["App setCommandPaletteOpen"]
    appState --> appRender["Full App re-render"]
    appRender --> sidebar["LeftStatusColumn full-map sorts"]
    appRender --> mount["Cold-mount Dialog with backdrop-blur"]
```

### After

```mermaid
graph TD
    key["Cmd+K"] --> palette["CommandPalette local open state"]
    palette --> toggle["Toggle keep-mounted solid overlay"]
    app["App memoized entries"] --> palette
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/command-palette.test.tsx src/__tests__/primitives.test.tsx`
- [x] `bash scripts/ui-visual-proof.sh capture-after --spec command-palette-open.spec.ts --output-dir packages/app/e2e/visual-proof-cmdk`

</details>

## Visual Proof

Closed home graph, then Cmd+K open Navigate menu, then Escape closed again.

![Closed home graph before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-9c1871/cmdk-before-closed.png)

![Open Navigate menu before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-9c1871/cmdk-before-open.png)

[Before walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-9c1871/cmdk-before-walkthrough.webm)

![Closed home graph after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-9c1871/cmdk-after-closed.png)

![Open Navigate menu after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-9c1871/cmdk-after-open.png)

[After walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-9c1871/cmdk-after-walkthrough.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
