### PR TITLE
[Needs Attention Mutation Failure UX](1) Route mutation failures through Needs Attention and inspector detail

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -14,6 +14,12 @@ import yaml from 'js-yaml';
 import type { ActionGraphNode, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
+import {
+  mutationFailureBannerMessage,
+  mutationFailureDetailMessage,
+  mutationFailureTitle,
+  shouldShowMutationFailureBanner,
+} from './lib/mutation-failure-display.js';
 import { useTasks } from './hooks/useTasks.js';
 import { useQueueStatus } from './hooks/useQueueStatus.js';
 import { useWorkerStatus } from './hooks/useWorkerStatus.js';
@@ -578,6 +584,7 @@ export function App() {
   const [showSystemSetup, setShowSystemSetup] = useState(false);
   const [showSystemBanner, setShowSystemBanner] = useState(false);
   const [mutationFailure, setMutationFailure] = useState<WorkflowMutationFailedEvent | null>(null);
+  const [taskMutationFailures, setTaskMutationFailures] = useState<Record<string, WorkflowMutationFailedEvent>>({});
   const [installSkillsPending, setInstallSkillsPending] = useState(false);
   const [installSkillsError, setInstallSkillsError] = useState<string | null>(null);
   const [updateCliPending, setUpdateCliPending] = useState(false);
@@ -716,12 +723,6 @@ export function App() {
     return () => { unsubscribe?.(); };
   }, []);
 
-  useEffect(() => {
-    const unsubscribe = window.invoker?.onWorkflowMutationFailed?.((event) => {
-      setMutationFailure(event);
-    });
-    return () => { unsubscribe?.(); };
-  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !window.invoker) return;
@@ -1055,6 +1056,41 @@ export function App() {
     recenterForSelection('task', task.id);
     focusKeyboardRegion('taskGraph');
   }, [focusKeyboardRegion, recenterForSelection, tasks]);
+
+  useEffect(() => {
+    const unsubscribe = window.invoker?.onWorkflowMutationFailed?.((event) => {
+      // Task/workflow mutation failures belong in Needs Attention + inspector.
+      if (!shouldShowMutationFailureBanner(event)) {
+        if (event.taskId) {
+          setTaskMutationFailures((prev) => ({ ...prev, [event.taskId!]: event }));
+          setSidebarSurface('attention');
+          setInspectorCollapsed(false);
+          setInspectorManualOpen(true);
+          // Set selection from the event ids directly so the inspector opens even
+          // if the task map has not hydrated this id yet.
+          setSelectedTaskId(event.taskId);
+          setWorkflowSelectionDismissed(false);
+          if (event.workflowId) {
+            setSelectedWorkflowId(event.workflowId);
+          }
+          setContextMenu(null);
+          setWorkflowContextMenu(null);
+          focusKeyboardRegion('taskGraph');
+        } else if (event.workflowId) {
+          setSelectedWorkflowId(event.workflowId);
+          setSelectedTaskId(null);
+          setWorkflowSelectionDismissed(false);
+          setContextMenu(null);
+          setWorkflowContextMenu(null);
+          focusKeyboardRegion('workflowGraph');
+        }
+        setMutationFailure(null);
+        return;
+      }
+      setMutationFailure(event);
+    });
+    return () => { unsubscribe?.(); };
+  }, [focusKeyboardRegion]);
 
   const selectRelativeNode = useCallback((direction: 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight') => {
     const inTaskGraph = keyboardRegion === 'taskGraph';
@@ -3058,17 +3094,13 @@ export function App() {
         >
           <div className="text-sm text-amber-100 min-w-0">
             <div className="font-semibold text-amber-50">
-              {mutationFailure.channel === 'invoker:approve'
-                ? 'Approve failed'
-                : mutationFailure.channel === 'invoker:reject'
-                  ? 'Reject failed'
-                  : `Mutation failed (${mutationFailure.channel})`}
+              {mutationFailureTitle(mutationFailure)}
             </div>
             <div
               data-testid="workflow-mutation-failed-message"
               className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-amber-100/90"
             >
-              {mutationFailure.message}
+              {mutationFailureBannerMessage(mutationFailure)}
             </div>
           </div>
           <div className="flex items-center gap-2 shrink-0">
@@ -3164,6 +3196,7 @@ export function App() {
                   workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
                   reviewGate={selectedWorkflow ? reviewGateByWorkflowId[selectedWorkflow.id] ?? null : null}
                   actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
+                  mutationFailure={selectedTask ? taskMutationFailures[selectedTask.id] ?? null : null}
                   collapsed={effectiveInspectorCollapsed}
                   advancedExpanded={advancedMetadataExpanded}
                   remoteTargets={remoteTargets}

--- a/packages/ui/src/__tests__/mutation-failure-display.test.ts
+++ b/packages/ui/src/__tests__/mutation-failure-display.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mutationFailureBannerMessage,
+  mutationFailureDetailMessage,
+  mutationFailureTitle,
+  shouldShowMutationFailureBanner,
+} from '../lib/mutation-failure-display.js';
+
+describe('shouldShowMutationFailureBanner', () => {
+  it('hides the banner for task-scoped failures', () => {
+    expect(shouldShowMutationFailureBanner({
+      intentId: 1,
+      workflowId: 'wf-1',
+      channel: 'invoker:approve',
+      taskId: 'wf-1/task-alpha',
+      message: 'SSH remote script failed',
+      failedAt: '2026-07-09T00:00:00.000Z',
+    })).toBe(false);
+  });
+
+  it('hides the banner for workflow-scoped failures', () => {
+    expect(shouldShowMutationFailureBanner({
+      intentId: 1,
+      workflowId: 'wf-1',
+      channel: 'invoker:recreate',
+      message: 'recreate failed',
+      failedAt: '2026-07-09T00:00:00.000Z',
+    })).toBe(false);
+  });
+
+  it('shows the banner only for unscoped failures', () => {
+    expect(shouldShowMutationFailureBanner({
+      intentId: 1,
+      workflowId: '',
+      channel: 'unknown',
+      message: 'boom',
+      failedAt: '2026-07-09T00:00:00.000Z',
+    })).toBe(true);
+  });
+});
+
+describe('mutationFailureTitle', () => {
+  it('maps approve failures to a friendly title', () => {
+    expect(mutationFailureTitle({
+      intentId: 1,
+      workflowId: '',
+      channel: 'invoker:approve',
+      message: 'boom',
+      failedAt: '2026-07-09T00:00:00.000Z',
+    })).toBe('Approve failed');
+  });
+});
+
+describe('mutationFailureBannerMessage', () => {
+  it('keeps only a short first-line summary', () => {
+    expect(mutationFailureBannerMessage({
+      intentId: 1,
+      workflowId: '',
+      channel: 'unknown',
+      message: 'SSH remote script failed\nSTDOUT:\n{"type":"error"}',
+      failedAt: '2026-07-09T00:00:00.000Z',
+    })).toBe('SSH remote script failed');
+  });
+});
+
+describe('mutationFailureDetailMessage', () => {
+  it('preserves the full operator-facing message without the Error prefix', () => {
+    expect(mutationFailureDetailMessage({
+      intentId: 1,
+      workflowId: 'wf-1',
+      channel: 'invoker:approve',
+      taskId: 'wf-1/task',
+      message: 'Error: missing execution harness "codex"',
+      failedAt: '2026-07-09T00:00:00.000Z',
+    })).toBe('missing execution harness "codex"');
+  });
+});

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -611,6 +611,31 @@ describe('WorkflowInspector', () => {
     expect(screen.getByTestId('inspector-pending-fix-error')).toHaveTextContent('tests failed');
   });
 
+  it('renders the latest mutation failure detail when provided', () => {
+    render(
+      <WorkflowInspector
+        workflow={null}
+        task={makeTask({ id: 'wf-1/task-1', description: 'Task one', status: 'awaiting_approval' })}
+        collapsed={false}
+        advancedExpanded={false}
+        mutationFailure={{
+          intentId: 9,
+          workflowId: 'wf-1',
+          channel: 'invoker:approve',
+          taskId: 'wf-1/task-1',
+          message: 'Error: missing execution harness "codex"',
+          failedAt: '2026-07-08T10:00:00.000Z',
+        }}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('inspector-mutation-failure')).toHaveTextContent(
+      /missing execution harness "codex"/,
+    );
+  });
+
   it('surfaces an executor-selection failure captured in pendingFixError so approve dispatch errors are visible', () => {
     const capabilityError =
       'Error: SSH target "remote_digital_ocean_3" cannot run codex: missing execution harness "codex"';

--- a/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
+++ b/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
@@ -1,14 +1,12 @@
 /**
- * Integration test: workflow-mutation-failed banner in <App />.
+ * Integration test: workflow-mutation-failed handling in <App />.
  *
- * Reproduces the "Approve Fix does nothing" symptom by firing the
- * onWorkflowMutationFailed event that the owner-side coordinator now emits when
- * an intent dispatch throws. The renderer must surface the failure so the user
- * knows the mutation did not actually run.
+ * Task-scoped mutation failures must not open the top banner. They open Needs
+ * Attention, select the task, and show the failure detail in the inspector.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, act, waitFor, fireEvent, within } from '@testing-library/react';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { WorkflowMeta } from '../types.js';
 
@@ -32,10 +30,11 @@ const workflow: WorkflowMeta = {
   status: 'running',
 };
 
-describe('Workflow mutation failed banner', () => {
+describe('Workflow mutation failed Needs Attention flow', () => {
   let mock: MockInvoker;
 
   beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: 1600 });
     mock = createMockInvoker();
     mock.install();
   });
@@ -44,13 +43,20 @@ describe('Workflow mutation failed banner', () => {
     mock.cleanup();
   });
 
-  it('renders an alert with the coordinator message when onWorkflowMutationFailed fires', async () => {
-    render(<App />);
+  async function settleTasks(): Promise<void> {
     act(() => mock.setTasks([targetTask], [workflow]));
-
     await waitFor(() => {
-      expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-1')).toBeInTheDocument();
     });
+    fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
+    await waitFor(() => {
+      expect(screen.getByTestId('rf__node-wf-1/verify-worker-summary-surface')).toBeInTheDocument();
+    });
+  }
+
+  it('routes task-scoped approve failures into Needs Attention and inspector detail', async () => {
+    render(<App />);
+    await settleTasks();
 
     act(() => {
       mock.fireWorkflowMutationFailed({
@@ -63,85 +69,57 @@ describe('Workflow mutation failed banner', () => {
       });
     });
 
-    const banner = await screen.findByTestId('workflow-mutation-failed-banner');
-    expect(banner).toHaveAttribute('role', 'alert');
-    expect(banner).toHaveTextContent('Approve failed');
-    expect(screen.getByTestId('workflow-mutation-failed-message')).toHaveTextContent(
-      /missing execution harness "codex"/,
-    );
-  });
-
-  it('clears the banner when Dismiss is clicked', async () => {
-    render(<App />);
-    act(() => mock.setTasks([targetTask], [workflow]));
-
-    act(() => {
-      mock.fireWorkflowMutationFailed({
-        intentId: 43,
-        workflowId: 'wf-1',
-        channel: 'invoker:approve',
-        taskId: 'wf-1/verify-worker-summary-surface',
-        message: 'dispatch blew up',
-        failedAt: '2026-07-08T10:00:00.000Z',
-      });
-    });
-
-    const banner = await screen.findByTestId('workflow-mutation-failed-banner');
-    expect(banner).toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId('workflow-mutation-failed-dismiss'));
-
     await waitFor(() => {
       expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
     });
-  });
-
-  it('selects the failing task when the operator clicks Open task', async () => {
-    render(<App />);
-    act(() => mock.setTasks([targetTask], [workflow]));
-
     await waitFor(() => {
-      expect(screen.getByTestId('workflow-node-wf-1')).toBeInTheDocument();
-    });
-
-    act(() => {
-      mock.fireWorkflowMutationFailed({
-        intentId: 44,
-        workflowId: 'wf-1',
-        channel: 'invoker:approve',
-        taskId: 'wf-1/verify-worker-summary-surface',
-        message: 'dispatch blew up',
-        failedAt: '2026-07-08T10:00:00.000Z',
-      });
-    });
-
-    const openTask = await screen.findByTestId('workflow-mutation-failed-open-task');
-    fireEvent.click(openTask);
-
-    await waitFor(() => {
-      expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
+      expect(within(screen.getByTestId('browser-rail')).getByRole('heading', { name: 'Needs Attention' })).toBeVisible();
     });
     await waitFor(() => {
       expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Verify worker summary surface');
     });
+    await waitFor(() => {
+      expect(screen.getByTestId('inspector-mutation-failure')).toHaveTextContent(
+        /missing execution harness "codex"/,
+      );
+    });
   });
 
-  it('labels the banner "Mutation failed (invoker:reject)" when the channel is not approve', async () => {
+  it('does not show the banner for workflow-scoped failures', async () => {
     render(<App />);
-    act(() => mock.setTasks([targetTask], [workflow]));
+    await settleTasks();
 
     act(() => {
       mock.fireWorkflowMutationFailed({
-        intentId: 45,
+        intentId: 47,
         workflowId: 'wf-1',
-        channel: 'invoker:edit-task-command',
-        taskId: 'wf-1/verify-worker-summary-surface',
-        message: 'edit failed',
+        channel: 'invoker:recreate',
+        message: 'recreate failed',
+        failedAt: '2026-07-08T10:00:00.000Z',
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps the top banner for unscoped failures', async () => {
+    render(<App />);
+    await settleTasks();
+
+    act(() => {
+      mock.fireWorkflowMutationFailed({
+        intentId: 48,
+        workflowId: '',
+        channel: 'unknown',
+        message: 'global mutation blew up',
         failedAt: '2026-07-08T10:00:00.000Z',
       });
     });
 
     const banner = await screen.findByTestId('workflow-mutation-failed-banner');
-    expect(banner).toHaveTextContent('Mutation failed (invoker:edit-task-command)');
+    expect(banner).toHaveAttribute('role', 'alert');
+    expect(screen.getByTestId('workflow-mutation-failed-message')).toHaveTextContent('global mutation blew up');
   });
 });

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -2,7 +2,8 @@ import { useEffect, useMemo, useState } from 'react';
 import type { ReviewGateArtifact, ReviewGateQueryResponse, TaskState, WorkflowMeta } from '../types.js';
 import { getEffectiveVisualStatus, getStatusColor } from '../lib/colors.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
-import type { ActionGraphNode } from '@invoker/contracts';
+import type { ActionGraphNode, WorkflowMutationFailedEvent } from '@invoker/contracts';
+import { mutationFailureDetailMessage, mutationFailureTitle } from '../lib/mutation-failure-display.js';
 
 type MergeMode = 'manual' | 'automatic' | 'external_review';
 type TaskLogLevel = 'debug' | 'info' | 'warn' | 'error';
@@ -141,6 +142,7 @@ interface WorkflowInspectorProps {
   executionPools?: string[];
   executionAgents?: string[];
   actionNode?: ActionGraphNode | null;
+  mutationFailure?: WorkflowMutationFailedEvent | null;
   collapsed: boolean;
   advancedExpanded: boolean;
   onEditType?: (taskId: string, runnerKind: string, poolMemberId?: string) => void;
@@ -246,6 +248,7 @@ export function WorkflowInspector({
   executionPools,
   executionAgents,
   actionNode,
+  mutationFailure = null,
   collapsed,
   advancedExpanded,
   onEditPool,
@@ -471,6 +474,19 @@ export function WorkflowInspector({
               <h3 className="text-[11px] uppercase tracking-wide text-amber-200">Fix Error</h3>
               <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-amber-100">
                 {task.execution.pendingFixError}
+              </pre>
+            </div>
+          )}
+          {mutationFailure && (
+            <div
+              data-testid="inspector-mutation-failure"
+              className="mt-3 rounded border border-amber-500/40 bg-amber-950/40 p-2"
+            >
+              <h3 className="text-[11px] uppercase tracking-wide text-amber-200">
+                {mutationFailureTitle(mutationFailure)}
+              </h3>
+              <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-amber-100">
+                {mutationFailureDetailMessage(mutationFailure)}
               </pre>
             </div>
           )}

--- a/packages/ui/src/lib/mutation-failure-display.ts
+++ b/packages/ui/src/lib/mutation-failure-display.ts
@@ -1,0 +1,42 @@
+import type { WorkflowMutationFailedEvent } from '@invoker/contracts';
+
+/**
+ * Task-scoped and workflow-scoped mutation failures belong in Needs Attention /
+ * the inspector, not the top banner. The banner is only for failures with no
+ * task or workflow context to open.
+ */
+export function shouldShowMutationFailureBanner(
+  event: WorkflowMutationFailedEvent,
+): boolean {
+  if (event.taskId) return false;
+  if (event.workflowId) return false;
+  return true;
+}
+
+export function mutationFailureTitle(event: WorkflowMutationFailedEvent): string {
+  if (event.channel === 'invoker:approve') return 'Approve failed';
+  if (event.channel === 'invoker:reject') return 'Reject failed';
+  if (event.channel === 'invoker:fix-with-agent') return 'Fix failed';
+  return `Mutation failed (${event.channel})`;
+}
+
+export function mutationFailureBannerMessage(
+  event: WorkflowMutationFailedEvent,
+): string {
+  return summarizeBannerMessage(event.message);
+}
+
+export function mutationFailureDetailMessage(
+  event: WorkflowMutationFailedEvent,
+): string {
+  return event.message.replace(/^Error:\s*/, '').trim();
+}
+
+function summarizeBannerMessage(message: string): string {
+  let text = message.replace(/^Error:\s*/, '').trim();
+  const stackIdx = text.indexOf('\n    at ');
+  if (stackIdx >= 0) text = text.slice(0, stackIdx).trim();
+  const firstLine = text.split('\n').find((line) => line.trim().length > 0)?.trim() ?? text;
+  if (firstLine.length <= 160) return firstLine;
+  return `${firstLine.slice(0, 159).trimEnd()}…`;
+}


### PR DESCRIPTION
## Summary

Task and workflow mutation failures now route into Needs Attention and the task inspector instead of the top banner.

When a failure carries a task or workflow id, the app opens Needs Attention, selects that task, and shows the failure inside the inspector.

The old top banner is kept only for failures that carry no task or workflow context to open.

## Review Claim

Approve routing task/workflow-scoped mutation failures into Needs Attention and the inspector, leaving the banner for context-free failures.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Banner rendering for context-free failures is unchanged; only failures that carry an id are redirected, so no existing banner path breaks.

## Slice Rationale

This slice only routes the failure event to the right place. Later slices adjust execution agents, so each diff carries one claim.

## Non-goals

- Does not change how mutation failures are produced or their message text.
- Does not touch the execution agents.
- Does not add new failure channels.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
