### PR TITLE
[Needs Attention Mutation Failure UX](2) Drop --prompt flag from Qwen execution agent

### DIFF
--- a/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
@@ -22,9 +22,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec.fullPrompt).toBe('prompt text');
   });
@@ -38,9 +38,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'fix prompt',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec).not.toHaveProperty('fullPrompt');
   });
@@ -50,7 +50,6 @@ describe('QwenExecutionAgent', () => {
     expect(agent.buildCommand('prompt text').args).toEqual([
       '--approval-mode',
       'auto-edit',
-      '--prompt',
       'prompt text',
     ]);
   });
@@ -64,7 +63,6 @@ describe('QwenExecutionAgent', () => {
       'openai',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
   });

--- a/packages/execution-engine/src/agents/qwen-execution-agent.ts
+++ b/packages/execution-engine/src/agents/qwen-execution-agent.ts
@@ -85,7 +85,6 @@ export class QwenExecutionAgent implements ExecutionAgent {
       this.approvalMode,
       ...(this.authType ? ['--auth-type', this.authType] : []),
       ...(executionModel ? ['--model', executionModel] : []),
-      '--prompt',
       prompt,
     ];
   }


### PR DESCRIPTION
## Summary

The Qwen execution agent no longer passes a `--prompt` flag; it passes the prompt as the trailing positional argument its CLI now expects.

This keeps the emitted command aligned with the current Qwen CLI, which reads the prompt positionally.

## Review Claim

Approve dropping the redundant `--prompt` flag from the Qwen agent command so the prompt is passed positionally.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The model, approval-mode, and auth arguments are unchanged; only the `--prompt` label is dropped while the same prompt string is still passed.

## Slice Rationale

This slice touches only the Qwen agent command. The Kimi flag change ships in its own slice so each diff carries one claim.

## Non-goals

- Does not change the prompt text or session handling.
- Does not touch the Kimi agent.
- Does not change model selection.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
