### PR TITLE
[Terminal upsert hitch](1) Prove every PTY chunk sync-upserts the session snapshot

### DIFF
--- a/packages/app/src/__tests__/terminal-session-persistence.test.ts
+++ b/packages/app/src/__tests__/terminal-session-persistence.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import {
+  EmbeddedTerminalManager,
+  createBashTerminalBackend,
+  type BashSpawnFn,
+} from '../embedded-terminal-manager.js';
+import { registerTerminalSessionPersistence } from '../terminal-session-ipc.js';
+import {
+  createTerminalUiPerfCounters,
+  createTerminalUiPerfReporter,
+  createTerminalUiPerfSink,
+} from '../terminal-ui-perf.js';
+
+function createFakeChild() {
+  const ee = new EventEmitter() as any;
+  ee.stdout = new EventEmitter();
+  ee.stderr = new EventEmitter();
+  ee.stdin = { write: vi.fn() };
+  ee.killed = false;
+  ee.kill = vi.fn();
+  return ee;
+}
+
+describe('terminal session persistence upsert storm (proof)', () => {
+  it('persists every running output chunk with a sync upsert (current behavior)', () => {
+    const child = createFakeChild();
+    const mgr = new EmbeddedTerminalManager({
+      backend: createBashTerminalBackend({ spawnFn: (() => child) as unknown as BashSpawnFn }),
+    });
+    const upserts: Array<{ status: string; outputSnapshot: string }> = [];
+    const persistence = {
+      listTerminalSessions: () => [],
+      loadTask: () => ({ id: 'task-1' }),
+      deleteTerminalSession: vi.fn(),
+      updateTerminalSession: vi.fn(),
+      upsertTerminalSession: vi.fn((record: { status: string; outputSnapshot: string }) => {
+        upserts.push({ status: record.status, outputSnapshot: record.outputSnapshot });
+      }),
+    };
+
+    registerTerminalSessionPersistence({
+      embeddedTerminalManager: mgr,
+      persistence: persistence as any,
+      uiPerfStats: createTerminalUiPerfCounters(),
+      terminalUiPerf: createTerminalUiPerfReporter({ throttleMs: 0 }),
+      terminalUiPerfSink: createTerminalUiPerfSink(() => {}, createTerminalUiPerfCounters()),
+    });
+
+    mgr.openOrReuse({ taskId: 'task-1', spec: {}, cwd: '/tmp' });
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0]).toMatchObject({ status: 'running', outputSnapshot: '' });
+
+    const CHUNKS = 100;
+    for (let i = 0; i < CHUNKS; i++) {
+      child.stdout.emit('data', Buffer.from('x'));
+    }
+
+    // Proof of the main-thread hitch: every PTY chunk forces a full-snapshot upsert.
+    expect(upserts).toHaveLength(1 + CHUNKS);
+    expect(upserts[upserts.length - 1]?.outputSnapshot).toBe('x'.repeat(CHUNKS));
+  });
+});


### PR DESCRIPTION
## Summary

Every embedded-terminal PTY output chunk currently forces a synchronous SQLite upsert of the full session snapshot on Electron main.

That 1:1 write path is the hitch class behind laggy task-terminal interaction when agents or shells print quickly.

This slice only locks the current storm in a unit test so the fix can flip the expectation without losing the evidence.

## Review Claim

Approve a regression proof that `registerTerminalSessionPersistence` upserts once per running output chunk today.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

No product behavior changes. The test asserts the existing sync upsert storm only.

## Slice Rationale

Evidence before change: land the hitch proof first, then coalesce in the next slice.

## Non-goals

- Does not coalesce or debounce upserts.
- Does not change terminal IPC write/resize transport.
- Does not change agent-resume startup latency.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && ./node_modules/.bin/vitest run src/__tests__/terminal-session-persistence.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify terminal session output is persisted correctly during rapid successive updates.
  * Confirmed session status and accumulated terminal output remain accurate after multiple output events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->