### PR TITLE
[Terminal upsert hitch](2) Coalesce running terminal snapshot upserts on main

### DIFF
--- a/packages/app/src/__tests__/terminal-session-persistence.test.ts
+++ b/packages/app/src/__tests__/terminal-session-persistence.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import {
   EmbeddedTerminalManager,
@@ -22,8 +22,16 @@ function createFakeChild() {
   return ee;
 }
 
-describe('terminal session persistence upsert storm (proof)', () => {
-  it('persists every running output chunk with a sync upsert (current behavior)', () => {
+describe('registerTerminalSessionPersistence coalesce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function setup(coalesceMs = 250) {
     const child = createFakeChild();
     const mgr = new EmbeddedTerminalManager({
       backend: createBashTerminalBackend({ spawnFn: (() => child) as unknown as BashSpawnFn }),
@@ -38,15 +46,19 @@ describe('terminal session persistence upsert storm (proof)', () => {
         upserts.push({ status: record.status, outputSnapshot: record.outputSnapshot });
       }),
     };
-
-    registerTerminalSessionPersistence({
+    const handle = registerTerminalSessionPersistence({
       embeddedTerminalManager: mgr,
       persistence: persistence as any,
       uiPerfStats: createTerminalUiPerfCounters(),
       terminalUiPerf: createTerminalUiPerfReporter({ throttleMs: 0 }),
       terminalUiPerfSink: createTerminalUiPerfSink(() => {}, createTerminalUiPerfCounters()),
+      coalesceMs,
     });
+    return { child, mgr, upserts, persistence, handle };
+  }
 
+  it('coalesces N running output chunks into one delayed upsert', () => {
+    const { child, mgr, upserts, handle } = setup(250);
     mgr.openOrReuse({ taskId: 'task-1', spec: {}, cwd: '/tmp' });
     expect(upserts).toHaveLength(1);
     expect(upserts[0]).toMatchObject({ status: 'running', outputSnapshot: '' });
@@ -55,9 +67,49 @@ describe('terminal session persistence upsert storm (proof)', () => {
     for (let i = 0; i < CHUNKS; i++) {
       child.stdout.emit('data', Buffer.from('x'));
     }
+    expect(upserts).toHaveLength(1);
 
-    // Proof of the main-thread hitch: every PTY chunk forces a full-snapshot upsert.
-    expect(upserts).toHaveLength(1 + CHUNKS);
-    expect(upserts[upserts.length - 1]?.outputSnapshot).toBe('x'.repeat(CHUNKS));
+    vi.advanceTimersByTime(249);
+    expect(upserts).toHaveLength(1);
+
+    vi.advanceTimersByTime(1);
+    expect(upserts).toHaveLength(2);
+    expect(upserts[1]).toMatchObject({
+      status: 'running',
+      outputSnapshot: 'x'.repeat(CHUNKS),
+    });
+
+    handle.dispose();
+  });
+
+  it('exit flushes immediately with full snapshot and cancels pending timer', () => {
+    const { child, mgr, upserts, handle } = setup(250);
+    mgr.openOrReuse({ taskId: 'task-1', spec: {}, cwd: '/tmp' });
+    child.stdout.emit('data', Buffer.from('hello'));
+    expect(upserts).toHaveLength(1);
+
+    child.emit('exit', 0);
+    expect(upserts).toHaveLength(2);
+    expect(upserts[1]).toMatchObject({
+      status: 'exited',
+      outputSnapshot: 'hello',
+    });
+
+    vi.advanceTimersByTime(1000);
+    expect(upserts).toHaveLength(2);
+
+    handle.dispose();
+  });
+
+  it('keeps only the latest snapshot across a coalesce window', () => {
+    const { child, mgr, upserts, handle } = setup(100);
+    mgr.openOrReuse({ taskId: 'task-1', spec: {}, cwd: '/tmp' });
+    child.stdout.emit('data', Buffer.from('a'));
+    child.stdout.emit('data', Buffer.from('b'));
+    child.stdout.emit('data', Buffer.from('c'));
+    vi.advanceTimersByTime(100);
+    expect(upserts).toHaveLength(2);
+    expect(upserts[1]?.outputSnapshot).toBe('abc');
+    handle.dispose();
   });
 });

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -1,7 +1,7 @@
 import type { IpcMain } from 'electron';
 import type { TerminalSessionDescriptor } from '@invoker/contracts';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import type { EmbeddedTerminalManager } from './embedded-terminal-manager.js';
+import type { EmbeddedTerminalManager, TerminalSessionPersistenceRecord } from './embedded-terminal-manager.js';
 import {
   timeTerminalResize,
   timeTerminalSessionUpsert,
@@ -10,6 +10,9 @@ import {
   type TerminalUiPerfReporter,
   type TerminalUiPerfSink,
 } from './terminal-ui-perf.js';
+
+/** Coalesce running-session snapshot upserts so PTY output does not 1:1 SQLite-write on main. */
+export const TERMINAL_SESSION_UPSERT_COALESCE_MS = 250;
 
 type TerminalSessionRow = ReturnType<SQLiteAdapter['listTerminalSessions']>[number];
 
@@ -65,32 +68,49 @@ export function restorePersistedTerminalSessions(deps: {
   }
 }
 
+function toUpsertRow(record: TerminalSessionPersistenceRecord) {
+  return {
+    sessionId: record.sessionId,
+    taskId: record.taskId,
+    targetKey: record.targetKey,
+    status: record.status,
+    exitCode: record.exitCode,
+    cwd: record.cwd,
+    command: record.spec.command,
+    args: record.spec.args,
+    linuxTerminalTail: record.spec.linuxTerminalTail,
+    mode: record.mode,
+    attached: record.attached,
+    outputSnapshot: record.outputSnapshot,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+}
+
+export interface TerminalSessionPersistenceHandle {
+  /** Flush any coalesced running-session upserts immediately. */
+  flushPending: () => void;
+  /** Remove the session-updated listener and clear timers. */
+  dispose: () => void;
+}
+
 export function registerTerminalSessionPersistence(deps: {
   embeddedTerminalManager: EmbeddedTerminalManager;
   persistence: Pick<SQLiteAdapter, 'upsertTerminalSession' | 'listTerminalSessions' | 'loadTask' | 'deleteTerminalSession' | 'updateTerminalSession'>;
   uiPerfStats: TerminalUiPerfCounters;
   terminalUiPerf: TerminalUiPerfReporter;
   terminalUiPerfSink: TerminalUiPerfSink;
-}): void {
-  deps.embeddedTerminalManager.on('session-updated', (record) => {
+  /** Override coalesce window (tests). */
+  coalesceMs?: number;
+}): TerminalSessionPersistenceHandle {
+  const coalesceMs = deps.coalesceMs ?? TERMINAL_SESSION_UPSERT_COALESCE_MS;
+  const pendingBySession = new Map<string, TerminalSessionPersistenceRecord>();
+  const timerBySession = new Map<string, ReturnType<typeof setTimeout>>();
+
+  const upsertNow = (record: TerminalSessionPersistenceRecord): void => {
     timeTerminalSessionUpsert(
       () => {
-        deps.persistence.upsertTerminalSession({
-          sessionId: record.sessionId,
-          taskId: record.taskId,
-          targetKey: record.targetKey,
-          status: record.status,
-          exitCode: record.exitCode,
-          cwd: record.cwd,
-          command: record.spec.command,
-          args: record.spec.args,
-          linuxTerminalTail: record.spec.linuxTerminalTail,
-          mode: record.mode,
-          attached: record.attached,
-          outputSnapshot: record.outputSnapshot,
-          createdAt: record.createdAt,
-          updatedAt: record.updatedAt,
-        });
+        deps.persistence.upsertTerminalSession(toUpsertRow(record));
       },
       deps.uiPerfStats,
       deps.terminalUiPerf,
@@ -102,8 +122,72 @@ export function registerTerminalSessionPersistence(deps: {
         outputSnapshotChars: record.outputSnapshot?.length ?? 0,
       },
     );
-  });
+  };
+
+  const clearTimer = (sessionId: string): void => {
+    const timer = timerBySession.get(sessionId);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timerBySession.delete(sessionId);
+    }
+  };
+
+  const flushSession = (sessionId: string): void => {
+    clearTimer(sessionId);
+    const pending = pendingBySession.get(sessionId);
+    if (!pending) return;
+    pendingBySession.delete(sessionId);
+    upsertNow(pending);
+  };
+
+  const flushPending = (): void => {
+    for (const sessionId of [...pendingBySession.keys()]) {
+      flushSession(sessionId);
+    }
+  };
+
+  const scheduleCoalesced = (record: TerminalSessionPersistenceRecord): void => {
+    pendingBySession.set(record.sessionId, record);
+    if (timerBySession.has(record.sessionId)) return;
+    timerBySession.set(
+      record.sessionId,
+      setTimeout(() => {
+        timerBySession.delete(record.sessionId);
+        flushSession(record.sessionId);
+      }, coalesceMs),
+    );
+  };
+
+  const onSessionUpdated = (record: TerminalSessionPersistenceRecord): void => {
+    // Open (empty snapshot) and exit/status boundaries persist immediately so
+    // restart restore and final state stay correct. Output while running is
+    // coalesced — that is the PTY storm path that blocked Electron main.
+    const isLifecycleBoundary =
+      record.status !== 'running' || record.outputSnapshot.length === 0;
+
+    if (isLifecycleBoundary) {
+      clearTimer(record.sessionId);
+      pendingBySession.delete(record.sessionId);
+      upsertNow(record);
+      return;
+    }
+
+    scheduleCoalesced(record);
+  };
+
+  deps.embeddedTerminalManager.on('session-updated', onSessionUpdated);
   restorePersistedTerminalSessions(deps);
+
+  return {
+    flushPending,
+    dispose: () => {
+      flushPending();
+      deps.embeddedTerminalManager.off('session-updated', onSessionUpdated);
+      for (const timer of timerBySession.values()) clearTimeout(timer);
+      timerBySession.clear();
+      pendingBySession.clear();
+    },
+  };
 }
 
 export function registerTerminalSessionIpcHandlers(deps: {


### PR DESCRIPTION
## Summary

Running terminal sessions no longer rewrite SQLite on every PTY chunk.

Open and exit still persist immediately. While running, snapshot upserts coalesce to about 250ms.

Live xterm output stays unthrottled. Only the persistence path is coalesced.

## Review Claim

Approve coalescing running-session `upsertTerminalSession` calls so PTY output no longer 1:1-blocks Electron main.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Lifecycle boundaries still persist immediately (empty open snapshot and exited status). Live `invoker:terminal-output` is unchanged. Dispose flushes any pending coalesced write.

## Slice Rationale

Behavior fix after the proof slice. Keeps the hitch evidence and flips the unit expectations to coalesced upserts.

## Non-goals

- Does not change `packages/app/src/main.ts` quit wiring.
- Does not switch `terminal-write` / `terminal-resize` from invoke to send.
- Does not change agent resume spawn / cold-start.
- Does not change the 64KB in-memory snapshot cap.

## Architecture

### Before

```mermaid
sequenceDiagram
    participant Pty as node_pty
    participant Mgr as EmbeddedTerminalManager
    participant Persist as registerTerminalSessionPersistence
    participant DB as SQLite

    Pty->>Mgr: onData(chunk)
    Mgr->>Persist: session-updated
    Persist->>DB: upsertTerminalSession(full snapshot)
```

### After

```mermaid
sequenceDiagram
    participant Pty as node_pty
    participant Mgr as EmbeddedTerminalManager
    participant Persist as registerTerminalSessionPersistence
    participant DB as SQLite

    Pty->>Mgr: onData(chunk)
    Mgr->>Persist: session-updated
    Note over Persist: coalesce ~250ms while running
    Persist->>DB: upsertTerminalSession(latest snapshot)
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && ./node_modules/.bin/vitest run src/__tests__/terminal-session-persistence.test.ts`
- [x] `cd packages/app && ./node_modules/.bin/vitest run src/__tests__/embedded-terminal-manager.test.ts src/__tests__/terminal-ui-perf.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
