### PR TITLE
[UI 200ms](2) Cancel heavy worker ticks and defer auto-start past paint

### DIFF
--- a/packages/app/src/__tests__/worker-runtime.test.ts
+++ b/packages/app/src/__tests__/worker-runtime.test.ts
@@ -271,7 +271,33 @@ describe('worker runtime', () => {
       expect(runtime.isRunning()).toBe(false);
     });
 
-    it('awaits the in-flight tick before resolving stop', async () => {
+    it('resolves stop promptly without awaiting an in-flight tick by default', async () => {
+      const inFlight = deferred();
+      let tickSignal: AbortSignal | undefined;
+      const onTick = vi.fn().mockImplementation((ctx) => {
+        tickSignal = ctx.signal;
+        return inFlight.promise;
+      });
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick,
+        installSignalHandlers: false,
+      });
+
+      void runtime.tick();
+      await Promise.resolve();
+      const started = Date.now();
+      await runtime.stop();
+      expect(Date.now() - started).toBeLessThan(50);
+      expect(tickSignal?.aborted).toBe(true);
+      expect(runtime.isRunning()).toBe(false);
+
+      inFlight.resolve();
+      await Promise.resolve();
+    });
+
+    it('awaits the in-flight tick when settleTimeoutMs is set', async () => {
       const inFlight = deferred();
       let settled = false;
       const onTick = vi.fn().mockReturnValueOnce(inFlight.promise);
@@ -284,7 +310,7 @@ describe('worker runtime', () => {
 
       void runtime.tick();
       await Promise.resolve();
-      const stopping = runtime.stop().then(() => {
+      const stopping = runtime.stop({ settleTimeoutMs: 5_000 }).then(() => {
         settled = true;
       });
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3209,6 +3209,12 @@ function createEmbeddedTerminalBackendFromConfig(
     if (deferredStartupTriggered) return;
     deferredStartupTriggered = true;
     recordStartupMark('deferred-startup.begin');
+    if (ownerMode && workerRuntimeController) {
+      setTimeout(() => {
+        workerRuntimeController?.startAutoStartedWorkers();
+        recordStartupMark('workers.auto-started');
+      }, 0);
+    }
     const configuredStartupPollDelayMs = Number.parseInt(process.env.INVOKER_STARTUP_POLL_DELAY_MS ?? '10000', 10);
     const startupPollDelayMs = Number.isFinite(configuredStartupPollDelayMs)
       ? configuredStartupPollDelayMs
@@ -3754,7 +3760,6 @@ function createEmbeddedTerminalBackendFromConfig(
         autoFixRetries: resolveAutoFixRetries(invokerConfig),
         canControl: () => ownerMode,
       });
-      workerRuntimeController.startAutoStartedWorkers();
     }
 
     // Relaunch orphaned running tasks and start any pending-but-ready tasks.

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -55,6 +55,8 @@ type WorkerStatusPersistence = Pick<
 
 const DEFAULT_WORKER_ACTION_HISTORY_LIMIT = 20;
 const MAX_WORKER_ACTION_HISTORY_LIMIT = 100;
+/** Bounded wait for quit / stopAll so in-flight ticks cannot hang process exit. */
+export const STOP_ALL_SETTLE_TIMEOUT_MS = 5_000;
 
 function positiveIntegerOrDefault(value: number | undefined, fallback: number): number {
   if (value === undefined) return fallback;
@@ -207,8 +209,12 @@ export function createWorkerRuntimeController(options: {
     });
   };
 
-  const stopHandle = async (kind: string, handle: RuntimeHandle): Promise<void> => {
-    await handle.runtime.stop();
+  const stopHandle = async (
+    kind: string,
+    handle: RuntimeHandle,
+    settleTimeoutMs = 0,
+  ): Promise<void> => {
+    await handle.runtime.stop({ settleTimeoutMs });
     const stoppedAt = new Date().toISOString();
     stoppedAtByKind.set(kind, stoppedAt);
     handles.delete(kind);
@@ -254,7 +260,9 @@ export function createWorkerRuntimeController(options: {
     },
 
     async stopAll(): Promise<void> {
-      const stopping = [...handles.entries()].map(([kind, handle]) => stopHandle(kind, handle).catch(() => undefined));
+      const stopping = [...handles.entries()].map(([kind, handle]) =>
+        stopHandle(kind, handle, STOP_ALL_SETTLE_TIMEOUT_MS).catch(() => undefined),
+      );
       await Promise.all(stopping);
     },
 

--- a/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
@@ -129,6 +129,7 @@ describe('autoapprove worker', () => {
       identity: { kind: 'autoapprove', instanceId: 'test' },
       reason: 'manual',
       tickNumber: 1,
+      signal: new AbortController().signal,
     });
 
     expect(submitter.submit).not.toHaveBeenCalled();
@@ -167,7 +168,8 @@ describe('autoapprove worker', () => {
       logger,
       enabled: true,
       drainWakeupHints: () => [wakeup(), wakeup()],
-    })({ identity: { kind: 'autoapprove', instanceId: 'test' }, reason: 'wake', tickNumber: 1 });
+    })({ identity: { kind: 'autoapprove', instanceId: 'test' }, reason: 'wake', tickNumber: 1,
+      signal: new AbortController().signal });
 
     expect(submitter.submit).toHaveBeenCalledTimes(1);
   });
@@ -194,6 +196,7 @@ describe('autoapprove worker', () => {
       identity: { kind: 'autoapprove', instanceId: 'test' },
       reason: 'manual',
       tickNumber: 1,
+      signal: new AbortController().signal,
     });
 
     expect(submitter.submit).toHaveBeenCalledWith('wf-1', 'normal', 'invoker:approve', ['wf-1/task-1']);
@@ -217,6 +220,7 @@ describe('autoapprove worker', () => {
       identity: { kind: 'autoapprove', instanceId: 'test' },
       reason: 'manual',
       tickNumber: 1,
+      signal: new AbortController().signal,
     });
 
     expect(store.listWorkflows).not.toHaveBeenCalled();

--- a/packages/execution-engine/src/__tests__/e2e-autofix-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/e2e-autofix-worker.test.ts
@@ -42,6 +42,7 @@ function makeCtx(): WorkerTickContext {
     identity: { kind: E2E_AUTOFIX_WORKER_KIND, instanceId: `${E2E_AUTOFIX_WORKER_KIND}-test` },
     reason: 'manual',
     tickNumber: 1,
+    signal: new AbortController().signal,
   };
 }
 

--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -180,7 +180,7 @@ describe('PR status and CI failure workers', () => {
       drainEvents: () => [event],
     });
 
-    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1 });
+    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
 
     expect(ciFailureActionKey(sameChecksDifferentOrder)).toBe(ciFailureActionKey(event));
     expect(harness.submit).toHaveBeenCalledTimes(1);
@@ -221,7 +221,7 @@ describe('PR status and CI failure workers', () => {
       drainEvents: () => [event],
     });
 
-    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1 });
+    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
 
     expect(harness.submit).toHaveBeenCalledTimes(1);
   });
@@ -239,7 +239,7 @@ describe('PR status and CI failure workers', () => {
       drainEvents: () => [event],
     });
 
-    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1 });
+    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
 
     expect(harness.submit).not.toHaveBeenCalled();
     expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toMatchObject({
@@ -279,7 +279,7 @@ describe('PR status and CI failure workers', () => {
       drainEvents: () => [event],
     });
 
-    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1 });
+    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
 
     expect(harness.submit).not.toHaveBeenCalled();
     // Stale events are routine scan noise: logged, but NOT recorded as a durable

--- a/packages/execution-engine/src/__tests__/repro-ci-failure-action-stuck-queued.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-ci-failure-action-stuck-queued.test.ts
@@ -179,7 +179,7 @@ function makeHarness(opts: { intents: WorkflowMutationIntent[]; existingActionSt
     getAutoFixAgent: () => 'codex',
     drainEvents: () => [event],
   });
-  const runTick = () => tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1 });
+  const runTick = () => tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
   return { actions, store, submit, event, externalKey, runTick };
 }
 

--- a/packages/execution-engine/src/__tests__/requeue-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/requeue-worker.test.ts
@@ -22,7 +22,7 @@ const logger = {
   child: vi.fn(),
 };
 
-const POLL_CTX = { identity: { kind: 'requeue', instanceId: 'r1' }, reason: 'poll' as const, tickNumber: 1 };
+const POLL_CTX = { identity: { kind: 'requeue', instanceId: 'r1' }, reason: 'poll' as const, tickNumber: 1, signal: new AbortController().signal };
 
 function makeTask(overrides: Partial<TaskState> = {}): TaskState {
   const { config, execution, ...rest } = overrides;

--- a/packages/execution-engine/src/__tests__/worker-decision-ledger.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-decision-ledger.test.ts
@@ -150,7 +150,7 @@ function makeAutoFixHarness(options: {
   return { store, submit };
 }
 
-const tickCtx = { identity: { kind: 'recovery', instanceId: 'test' }, reason: 'poll' as const, tickNumber: 1 };
+const tickCtx = { identity: { kind: 'recovery', instanceId: 'test' }, reason: 'poll' as const, tickNumber: 1, signal: new AbortController().signal };
 
 describe('autofix decision ledger', () => {
   it('records a queued decision row when it escalates to an auto-fix on the second tick', async () => {

--- a/packages/execution-engine/src/__tests__/workflow-resume-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/workflow-resume-worker.test.ts
@@ -23,11 +23,13 @@ const POLL_CTX = {
   identity: { kind: 'workflow-resume', instanceId: 'w1' },
   reason: 'poll' as const,
   tickNumber: 1,
+  signal: new AbortController().signal,
 };
 const WAKE_CTX = {
   identity: { kind: 'workflow-resume', instanceId: 'w1' },
   reason: 'wake' as const,
   tickNumber: 2,
+  signal: new AbortController().signal,
 };
 
 function makeTask(overrides: Partial<TaskState> = {}): TaskState {

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -172,10 +172,13 @@ function candidateFromTask(task: TaskState): AutoFixRecoveryCandidate | undefine
 
 export function listAutoFixRecoveryScanCandidates(
   options: Pick<AutoFixRecoveryPolicyOptions, 'store'>,
+  signal?: AbortSignal,
 ): AutoFixRecoveryCandidate[] {
   const candidates: AutoFixRecoveryCandidate[] = [];
   for (const workflow of options.store.listWorkflows()) {
+    if (signal?.aborted) break;
     for (const task of options.store.loadTasks(workflow.id)) {
+      if (signal?.aborted) break;
       if (task.status !== 'failed') continue;
       const candidate = candidateFromTask(task);
       if (candidate) candidates.push(candidate);
@@ -480,16 +483,19 @@ export function collectValidatedAutoFixRecoveryCandidates(
 
 export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions): WorkerTick {
   return async (ctx) => {
+    if (ctx.signal?.aborted) return;
     const wakeups = options.drainWakeupHints?.() ?? [];
     const wakeupCandidates = wakeups.map(candidateFromWakeup).filter((c): c is AutoFixRecoveryCandidate => Boolean(c));
     const candidates = dedupeCandidates(
       wakeupCandidates.length > 0 && ctx.reason === 'wake'
         ? wakeupCandidates
-        : listAutoFixRecoveryScanCandidates(options),
+        : listAutoFixRecoveryScanCandidates(options, ctx.signal),
     );
+    if (ctx.signal?.aborted) return;
     const submittedThisTick = new Set<string>();
 
     for (const candidate of collectValidatedAutoFixRecoveryCandidates(options, candidates)) {
+      if (ctx.signal?.aborted) return;
       if (submittedThisTick.has(candidate.taskId)) {
         skipAutoFixCandidate(options, candidate, 'duplicate-candidate');
         continue;

--- a/packages/execution-engine/src/worker-runtime.ts
+++ b/packages/execution-engine/src/worker-runtime.ts
@@ -7,9 +7,9 @@
  *   - poll       — an optional periodic timer drives ticks on an interval
  *   - coalesce   — overlapping wake/poll requests collapse into a single
  *                  follow-up tick; ticks never run concurrently
- *   - shutdown   — `stop()` is deterministic and idempotent: it clears the
- *                  timer, drops SIGINT/SIGTERM handlers, and awaits the
- *                  in-flight tick before resolving
+ *   - shutdown   — `stop()` requests cooperative cancel via AbortSignal and
+ *                  returns promptly; callers that need deterministic cleanup
+ *                  (quit / stopAll) pass `settleTimeoutMs` for a bounded wait
  */
 
 import type { Logger } from '@invoker/contracts';
@@ -32,10 +32,20 @@ export interface WorkerTickContext {
   readonly reason: WorkerTickReason;
   /** 1-based count of ticks that have started for this runtime. */
   readonly tickNumber: number;
+  /** Aborted when `stop()` is requested; ticks should check between units of work. */
+  readonly signal: AbortSignal;
 }
 
 /** The unit of work a worker performs on each tick. */
 export type WorkerTick = (ctx: WorkerTickContext) => void | Promise<void>;
+
+export interface WorkerRuntimeStopOptions {
+  /**
+   * When > 0, wait up to this many ms for an in-flight tick after cancel.
+   * Default 0: return as soon as cancel is requested (GUI IPC path).
+   */
+  settleTimeoutMs?: number;
+}
 
 export interface WorkerRuntimeOptions {
   /** Worker family. Combined with `instanceId` to form the identity. */
@@ -65,10 +75,11 @@ export interface WorkerRuntime {
   /** Run a single tick now and await it (manual/test hook). */
   tick(reason?: WorkerTickReason): Promise<void>;
   /**
-   * Deterministically stop: clear the timer, drop signal handlers, and await
-   * any in-flight tick before resolving. Idempotent.
+   * Request stop: clear the timer, drop signal handlers, abort the tick
+   * signal. Resolves promptly unless `settleTimeoutMs` is set for a bounded
+   * wait on the in-flight tick. Idempotent.
    */
-  stop(): Promise<void>;
+  stop(options?: WorkerRuntimeStopOptions): Promise<void>;
   /** True between `start()` and `stop()`. */
   isRunning(): boolean;
 }
@@ -82,6 +93,13 @@ function nextInstanceId(kind: string): string {
   instanceCounter += 1;
   const pid = typeof process !== 'undefined' && process.pid ? process.pid : 0;
   return `${kind}-${pid}-${instanceCounter}`;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+  });
 }
 
 /**
@@ -106,13 +124,23 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
   let pendingReason: WorkerTickReason | null = null;
   let tickNumber = 0;
   const signalHandlers = new Map<NodeJS.Signals, () => void>();
+  let abortController = new AbortController();
 
   const runOnce = async (reason: WorkerTickReason): Promise<void> => {
     tickNumber += 1;
-    const ctx: WorkerTickContext = { identity, reason, tickNumber };
+    const ctx: WorkerTickContext = {
+      identity,
+      reason,
+      tickNumber,
+      signal: abortController.signal,
+    };
     try {
       await options.onTick(ctx);
     } catch (err) {
+      if (abortController.signal.aborted) {
+        options.logger.info(`[worker:${identity.kind}] tick aborted`, { ...logFields, reason });
+        return;
+      }
       options.logger.error(`[worker:${identity.kind}] tick failed`, { ...logFields, reason, err });
     }
   };
@@ -148,6 +176,31 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
 
   const tick = (reason: WorkerTickReason = 'manual'): Promise<void> => schedule(reason);
 
+  const beginStop = (): void => {
+    if (stopped) return;
+    stopped = true;
+    pendingReason = null;
+    if (!abortController.signal.aborted) {
+      abortController.abort();
+    }
+    if (interval) {
+      clearInterval(interval);
+      interval = null;
+    }
+    for (const [signal, handler] of signalHandlers) {
+      process.removeListener(signal, handler);
+    }
+    signalHandlers.clear();
+  };
+
+  const settleInFlight = async (settleTimeoutMs: number): Promise<void> => {
+    if (!inFlight || settleTimeoutMs <= 0) return;
+    await Promise.race([
+      inFlight.catch(() => undefined),
+      delay(settleTimeoutMs),
+    ]);
+  };
+
   const start = (): void => {
     if (stopped) {
       throw new Error(`worker runtime ${identity.kind}/${identity.instanceId} cannot start after stop`);
@@ -163,7 +216,7 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
       for (const signal of shutdownSignals) {
         const handler = (): void => {
           options.logger.info(`[worker:${identity.kind}] received ${signal}; shutting down`, logFields);
-          void stop();
+          void stop({ settleTimeoutMs: 5_000 });
         };
         signalHandlers.set(signal, handler);
         process.once(signal, handler);
@@ -178,24 +231,14 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
     if (tickOnStart) wake('startup');
   };
 
-  const stop = async (): Promise<void> => {
+  const stop = async (stopOptions?: WorkerRuntimeStopOptions): Promise<void> => {
+    const settleTimeoutMs = stopOptions?.settleTimeoutMs ?? 0;
     if (stopped) {
-      // Idempotent: a second stop still waits for any in-flight tick to settle.
-      if (inFlight) await inFlight.catch(() => undefined);
+      await settleInFlight(settleTimeoutMs);
       return;
     }
-    stopped = true;
-    pendingReason = null;
-    if (interval) {
-      clearInterval(interval);
-      interval = null;
-    }
-    for (const [signal, handler] of signalHandlers) {
-      process.removeListener(signal, handler);
-    }
-    signalHandlers.clear();
-    // Deterministic shutdown: never resolve while a tick is still running.
-    if (inFlight) await inFlight.catch(() => undefined);
+    beginStop();
+    await settleInFlight(settleTimeoutMs);
     options.logger.info(`[worker:${identity.kind}] stopped`, logFields);
   };
 

--- a/packages/execution-engine/src/workers/disk-headroom-worker.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-worker.ts
@@ -54,7 +54,9 @@ export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): Wo
     intervalMs: options.intervalMs ?? resolveDiskCheckIntervalMs(),
     tickOnStart: options.tickOnStart ?? true,
     onTick: async (ctx) => {
+      if (ctx.signal?.aborted) return;
       await options.onTick?.(ctx);
+      if (ctx.signal?.aborted) return;
 
       const thresholds = options.thresholds ?? resolveDiskHeadroomThresholds();
       await runCheck({

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -136,8 +136,8 @@ export function createPrConflictRebaseWorker(options: PrMaintenanceWorkerOptions
 }
 
 export function createPrMaintenanceTick(options: PrMaintenanceTickOptions): WorkerTick {
-  return async () => {
-    await runPrMaintenanceEntrypoint(options);
+  return async (ctx) => {
+    await runPrMaintenanceEntrypoint(options, ctx.signal);
   };
 }
 
@@ -145,6 +145,8 @@ export function probePrMaintenanceLock(options: PrMaintenanceLockProbeOptions): 
   const flockProbe = spawnSync('flock', ['-n', options.lockPath, '-c', 'true'], {
     env: options.env,
     stdio: 'ignore',
+    timeout: 3_000,
+    killSignal: 'SIGKILL',
   });
   if (!flockProbe.error || (flockProbe.error as NodeJS.ErrnoException).code !== 'ENOENT') {
     return flockProbe.status === 0
@@ -195,7 +197,12 @@ function createPrMaintenanceWorker(
   });
 }
 
-async function runPrMaintenanceEntrypoint(options: PrMaintenanceTickOptions): Promise<void> {
+async function runPrMaintenanceEntrypoint(
+  options: PrMaintenanceTickOptions,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (signal?.aborted) return;
+
   const repoRoot = resolvePrMaintenanceRepoRoot(options.repoRoot);
   const startedAt = new Date().toISOString();
   const runExternalKey = `${options.entrypoint.kind}:${repoRoot}:${startedAt}`;
@@ -208,6 +215,8 @@ async function runPrMaintenanceEntrypoint(options: PrMaintenanceTickOptions): Pr
     env,
     staleLockSeconds: parsePositiveInteger(env.INVOKER_PR_CRON_LOCK_STALE_SECS),
   });
+
+  if (signal?.aborted) return;
 
   if (lock.held) {
     options.logger.info(`[worker:${options.entrypoint.kind}] shared PR maintenance lock held; skipping tick`, {
@@ -263,7 +272,28 @@ async function runPrMaintenanceEntrypoint(options: PrMaintenanceTickOptions): Pr
       fn();
     };
 
+    const onAbort = (): void => {
+      if (!child.killed) {
+        child.kill('SIGTERM');
+      }
+      settle(() => {
+        recordPrMaintenanceRun(options, runExternalKey, repoRoot, 'failed', 'PR maintenance aborted by stop', {
+          reason: 'aborted',
+        });
+        resolvePromise();
+      });
+    };
+
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+
     child.once('error', (err) => {
+      signal?.removeEventListener('abort', onAbort);
       settle(() => {
         options.logger.error(`[worker:${options.entrypoint.kind}] process error`, {
           module: 'pr-maintenance-worker',
@@ -278,13 +308,14 @@ async function runPrMaintenanceEntrypoint(options: PrMaintenanceTickOptions): Pr
       });
     });
 
-    child.once('close', (code, signal) => {
+    child.once('close', (code, closeSignal) => {
+      signal?.removeEventListener('abort', onAbort);
       settle(() => {
         const fields = {
           module: 'pr-maintenance-worker',
           worker: options.entrypoint.kind,
           code,
-          signal,
+          signal: closeSignal,
         };
         if (code === 0) {
           options.logger.info(`[worker:${options.entrypoint.kind}] shell entrypoint completed`, fields);
@@ -292,13 +323,17 @@ async function runPrMaintenanceEntrypoint(options: PrMaintenanceTickOptions): Pr
           resolvePromise();
           return;
         }
+        if (signal?.aborted) {
+          resolvePromise();
+          return;
+        }
         const message = `PR maintenance worker ${options.entrypoint.kind} exited with code ${code ?? 'null'}`
-          + (signal ? ` signal ${signal}` : '');
+          + (closeSignal ? ` signal ${closeSignal}` : '');
         options.logger.error(`[worker:${options.entrypoint.kind}] shell entrypoint failed`, fields);
         recordPrMaintenanceRun(options, runExternalKey, repoRoot, 'failed', message, {
           reason: 'nonzero-exit',
           code,
-          signal,
+          signal: closeSignal,
         });
         rejectPromise(new Error(message));
       });


### PR DESCRIPTION
## Summary

Even with a prompt runtime stop, heavy ticks could still hog the main process after cancel was requested.

This slice checks AbortSignal in autofix and disk-headroom ticks, kills PR-maintenance children on abort, and bounds flock probes.

Owner auto-start is deferred past first paint so boot does not stack startup ticks before the window is ready.

## Review Claim

Approve that heavy worker ticks cooperate with cancel and that auto-start no longer runs before first paint.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`stopAll` still uses a bounded settle timeout. Headless auto-start is unchanged.

## Slice Rationale

Depends on the runtime AbortSignal from slice 1. UI acknowledgment is the next slice.

## Non-goals

Does not change renderer Start/Stop UX or add the daily battery.

## Visual Proof

Workers surface after first paint with auto-start deferred off the critical path:

![Workers surface after paint](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-c4c18f/ui-200ms-workers-surface.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/worker-control.test.ts`
- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/pr-maintenance-workers.test.ts src/__tests__/disk-headroom-worker.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
