### PR TITLE
[UI 200ms](3) Optimistic worker controls and context-menu testids

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -416,6 +416,7 @@ function WorkflowContextMenu({
     <div
       ref={menuRef}
       role="menu"
+      data-testid="workflow-context-menu"
       className="fixed z-50 min-w-[200px] rounded-lg border border-border-strong bg-secondary py-1 shadow-xl"
       style={{ left: position.left, top: position.top }}
       tabIndex={-1}
@@ -529,11 +530,11 @@ export function App() {
   const [workerStatus, refreshWorkerStatus] = useWorkerStatus();
   const handleStartWorker = useCallback(async (kind: string) => {
     await invoker.startWorker(kind);
-    await refreshWorkerStatus();
+    void refreshWorkerStatus();
   }, [invoker, refreshWorkerStatus]);
   const handleStopWorker = useCallback(async (kind: string) => {
     await invoker.stopWorker(kind);
-    await refreshWorkerStatus();
+    void refreshWorkerStatus();
   }, [invoker, refreshWorkerStatus]);
   const runningTaskIds = useMemo(
     () => new Set((queueStatus?.running ?? []).map((entry) => entry.taskId)),

--- a/packages/ui/src/components/ContextMenu.tsx
+++ b/packages/ui/src/components/ContextMenu.tsx
@@ -285,6 +285,7 @@ export function ContextMenu({
     <div
       ref={menuRef}
       role="menu"
+      data-testid="task-context-menu"
       className="fixed z-50 bg-secondary border border-border-strong rounded-lg shadow-xl py-1 min-w-[160px]"
       style={{ left: position.left, top: position.top }}
       onKeyDown={handleKeyDown}

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import type { WorkerStatusEntry, WorkerStatusSnapshot } from '../types.js';
 import { formatWorkerValue, getActiveWorkerAction, getWorkerDisplayCopy } from '../lib/worker-display.js';
 
@@ -10,16 +11,18 @@ interface WorkerActivityCardProps {
   onSelectWorker: (kind: string) => void;
 }
 
-function processClass(worker: WorkerStatusEntry): string {
-  if (worker.lifecycle === 'running') return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200';
-  if (worker.lifecycle === 'exited') return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
+type OptimisticLifecycle = 'running' | 'stopped';
+
+function processClass(lifecycle: string): string {
+  if (lifecycle === 'running') return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200';
+  if (lifecycle === 'exited') return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
   return 'border-border-strong bg-muted/60 text-muted-foreground';
 }
 
-function activityClass(worker: WorkerStatusEntry): string {
+function activityClass(worker: WorkerStatusEntry, lifecycle: string): string {
   if (getActiveWorkerAction(worker)) return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
-  if (worker.lifecycle === 'running') return 'border-border-strong bg-muted/60 text-muted-foreground';
-  if (worker.lifecycle === 'exited') return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
+  if (lifecycle === 'running') return 'border-border-strong bg-muted/60 text-muted-foreground';
+  if (lifecycle === 'exited') return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
   return 'border-border-strong bg-muted/60 text-muted-foreground';
 }
 
@@ -28,18 +31,18 @@ function policyClass(worker: WorkerStatusEntry): string {
   return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
 }
 
-function activityLabel(worker: WorkerStatusEntry): string {
+function activityLabel(worker: WorkerStatusEntry, lifecycle: string): string {
   if (getActiveWorkerAction(worker)) return 'Active work';
-  if (worker.lifecycle === 'running') return 'Idle';
-  if (worker.lifecycle === 'exited') return 'Exited';
+  if (lifecycle === 'running') return 'Idle';
+  if (lifecycle === 'exited') return 'Exited';
   return 'Stopped';
 }
 
-function activityExplanation(worker: WorkerStatusEntry): string {
+function activityExplanation(worker: WorkerStatusEntry, lifecycle: string): string {
   const action = getActiveWorkerAction(worker);
   if (action) return `Active work: ${formatWorkerValue(action.actionType)} · ${formatWorkerValue(action.status)}`;
-  if (worker.lifecycle === 'running') return getWorkerDisplayCopy(worker.kind).idleText;
-  if (worker.lifecycle === 'exited') return 'Process exited. Start it to create a fresh runtime.';
+  if (lifecycle === 'running') return getWorkerDisplayCopy(worker.kind).idleText;
+  if (lifecycle === 'exited') return 'Process exited. Start it to create a fresh runtime.';
   return 'Process stopped. Start it to listen for work.';
 }
 
@@ -51,6 +54,47 @@ export function WorkerActivityCard({
   onStopWorker,
   onSelectWorker,
 }: WorkerActivityCardProps) {
+  const [optimisticByKind, setOptimisticByKind] = useState<Record<string, OptimisticLifecycle>>({});
+  const [pendingByKind, setPendingByKind] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    if (!snapshot) return;
+    setOptimisticByKind((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const worker of snapshot.workers) {
+        if (!(worker.kind in next)) continue;
+        const serverRunning = worker.lifecycle === 'running';
+        const optimisticRunning = next[worker.kind] === 'running';
+        if (serverRunning === optimisticRunning) {
+          delete next[worker.kind];
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+    setPendingByKind((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const worker of snapshot.workers) {
+        if (!next[worker.kind]) continue;
+        const optimistic = optimisticByKind[worker.kind];
+        if (!optimistic) {
+          delete next[worker.kind];
+          changed = true;
+          continue;
+        }
+        const serverRunning = worker.lifecycle === 'running';
+        const optimisticRunning = optimistic === 'running';
+        if (serverRunning === optimisticRunning) {
+          delete next[worker.kind];
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [snapshot, optimisticByKind]);
+
   return (
     <div data-testid="worker-activity-card">
       <div className="mb-4">
@@ -65,8 +109,10 @@ export function WorkerActivityCard({
           {snapshot.workers.map((worker) => {
             const copy = getWorkerDisplayCopy(worker.kind);
             const disabledTitle = readOnly ? 'Read-only window' : worker.controlDisabledReason;
-            const showStart = worker.lifecycle !== 'running';
-            const isControlDisabled = Boolean(disabledTitle);
+            const lifecycle = optimisticByKind[worker.kind] ?? worker.lifecycle;
+            const showStart = lifecycle !== 'running';
+            const pending = Boolean(pendingByKind[worker.kind]);
+            const isControlDisabled = Boolean(disabledTitle) || pending;
             const selected = selectedWorkerKind === worker.kind;
             const footer = worker.kind === 'pr-status'
               ? 'No queue task is expected for this worker.'
@@ -97,11 +143,15 @@ export function WorkerActivityCard({
                     <div className="text-sm font-semibold text-foreground">{copy.name}</div>
                     <div className="mt-0.5 text-xs text-muted-foreground">Kind: {worker.kind}</div>
                     <div className="mt-2 flex flex-wrap items-center gap-2">
-                      <span className={`rounded-full border px-2 py-0.5 text-[11px] ${processClass(worker)}`}>
-                        Process: {formatWorkerValue(worker.lifecycle)}
+                      <span
+                        className={`rounded-full border px-2 py-0.5 text-[11px] ${processClass(lifecycle)}`}
+                        data-testid={`worker-lifecycle-${worker.kind}`}
+                        data-lifecycle={lifecycle}
+                      >
+                        Process: {formatWorkerValue(lifecycle)}
                       </span>
-                      <span className={`rounded-full border px-2 py-0.5 text-[11px] ${activityClass(worker)}`}>
-                        {activityLabel(worker)}
+                      <span className={`rounded-full border px-2 py-0.5 text-[11px] ${activityClass(worker, lifecycle)}`}>
+                        {activityLabel(worker, lifecycle)}
                       </span>
                       {worker.policy !== 'enabled' && (
                         <span className={`rounded-full border px-2 py-0.5 text-[11px] ${policyClass(worker)}`}>
@@ -114,7 +164,7 @@ export function WorkerActivityCard({
                         </span>
                       )}
                     </div>
-                    <div className="mt-2 text-sm text-muted-foreground">{activityExplanation(worker)}</div>
+                    <div className="mt-2 text-sm text-muted-foreground">{activityExplanation(worker, lifecycle)}</div>
                     {footer ? <div className="mt-1 text-xs text-muted-foreground">{footer}</div> : null}
                   </div>
                   <button
@@ -122,16 +172,28 @@ export function WorkerActivityCard({
                     className="shrink-0 rounded border border-border-strong px-2 py-1 text-xs text-foreground disabled:cursor-not-allowed disabled:opacity-50 hover:bg-muted"
                     title={disabledTitle}
                     disabled={isControlDisabled}
+                    data-testid={`worker-start-stop-${worker.kind}`}
+                    data-action={showStart ? 'start' : 'stop'}
                     onKeyDown={(event) => {
                       if (event.key === 'Enter' || event.key === ' ') event.stopPropagation();
                     }}
                     onClick={(event) => {
                       event.stopPropagation();
-                      if (showStart) void onStartWorker(worker.kind);
-                      else void onStopWorker(worker.kind);
+                      if (pending || isControlDisabled) return;
+                      const nextLifecycle: OptimisticLifecycle = showStart ? 'running' : 'stopped';
+                      setOptimisticByKind((prev) => ({ ...prev, [worker.kind]: nextLifecycle }));
+                      setPendingByKind((prev) => ({ ...prev, [worker.kind]: true }));
+                      const action = showStart ? onStartWorker(worker.kind) : onStopWorker(worker.kind);
+                      void Promise.resolve(action).finally(() => {
+                        setPendingByKind((prev) => {
+                          const next = { ...prev };
+                          delete next[worker.kind];
+                          return next;
+                        });
+                      });
                     }}
                   >
-                    {showStart ? 'Start process' : 'Stop process'}
+                    {pending ? (showStart ? 'Starting…' : 'Stopping…') : showStart ? 'Start process' : 'Stop process'}
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Start and Stop process clicks used to wait on IPC and a full status refresh before the button looked done.

This slice flips lifecycle state immediately, keeps refresh off the critical path, and adds stable testids for worker controls and context menus.

Right-click menus on workflows and tasks are tagged so the daily battery can measure menu paint under load.

## Review Claim

Approve that worker Start/Stop and context-menu open show immediate UI acknowledgment.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Optimistic lifecycle reconciles when the next status snapshot arrives. Menu open still only sets local React state.

## Slice Rationale

UI acknowledgment is separate from the runtime and controller cancel work below it.

## Non-goals

Does not add the daily battery or architecture invariant docs.

## Visual Proof

Worker Start process acknowledgment (lifecycle flips to running):

![Worker start ack](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-f99529/ui-200ms-worker-start-ack.png)

Worker Stop process acknowledgment (lifecycle flips to stopped):

![Worker stop ack](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-f99529/ui-200ms-worker-stop-ack.png)

Workflow right-click menu visible:

![Workflow context menu](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-f99529/ui-200ms-workflow-context-menu.png)

Task right-click menu visible:

![Task context menu](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-f99529/ui-200ms-task-context-menu.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/queue-view.test.tsx src/__tests__/context-menu-e2e.test.tsx src/__tests__/context-menu-dismiss.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker controls now provide immediate visual feedback when starting or stopping workers.
  * Start and stop buttons display progress states and are temporarily disabled while actions are pending.

* **Bug Fixes**
  * Worker status displays now update more responsively and reconcile with the latest server status.
  * Added stable identifiers for workflow and task context menus to improve UI targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->