### PR TITLE
[UI 200ms](4) Add hitch probe and daily UI responsiveness battery

### DIFF
--- a/packages/app/e2e/main-process-hitch-responsiveness.spec.ts
+++ b/packages/app/e2e/main-process-hitch-responsiveness.spec.ts
@@ -55,3 +55,53 @@ test('worker-status polling keeps listWorkflows IPC responsive under a fat DB', 
     `max IPC RTT ${max.toFixed(1)}ms exceeded ${MAX_SAMPLE_RTT_MS}ms (p95=${p95.toFixed(1)}ms, n=${samples.length})`,
   ).toBeLessThanOrEqual(MAX_SAMPLE_RTT_MS);
 });
+
+test('startWorker/stopWorker accept within 200ms under fat DB with concurrent listWorkflows', async ({ page }) => {
+  const seeded = await page.evaluate(async () => {
+    if (!window.invoker.seedMainProcessHitchFixture) {
+      throw new Error('seedMainProcessHitchFixture is not exposed (NODE_ENV=test required)');
+    }
+    return window.invoker.seedMainProcessHitchFixture();
+  });
+
+  expect(seeded.eventCount).toBeGreaterThanOrEqual(10_000);
+
+  const kind = await page.evaluate(async () => {
+    const snapshot = await window.invoker.getWorkerStatus();
+    const candidate = snapshot.workers.find((worker) => worker.startable || worker.stoppable || worker.lifecycle === 'running')
+      ?? snapshot.workers[0];
+    if (!candidate) throw new Error('No workers available for start/stop probe');
+    return candidate.kind;
+  });
+
+  const ACCEPT_BUDGET_MS = 200;
+
+  const startSample = await page.evaluate(async (workerKind) => {
+    const started = performance.now();
+    const [startResult] = await Promise.all([
+      window.invoker.startWorker(workerKind),
+      window.invoker.listWorkflows(),
+    ]);
+    return { rtt: performance.now() - started, lifecycle: startResult.lifecycle };
+  }, kind);
+
+  expect(
+    startSample.rtt,
+    `startWorker accept RTT ${startSample.rtt.toFixed(1)}ms exceeded ${ACCEPT_BUDGET_MS}ms`,
+  ).toBeLessThanOrEqual(ACCEPT_BUDGET_MS);
+
+  const stopSample = await page.evaluate(async (workerKind) => {
+    const started = performance.now();
+    const [stopResult] = await Promise.all([
+      window.invoker.stopWorker(workerKind),
+      window.invoker.listWorkflows(),
+    ]);
+    return { rtt: performance.now() - started, lifecycle: stopResult.lifecycle };
+  }, kind);
+
+  expect(
+    stopSample.rtt,
+    `stopWorker accept RTT ${stopSample.rtt.toFixed(1)}ms exceeded ${ACCEPT_BUDGET_MS}ms`,
+  ).toBeLessThanOrEqual(ACCEPT_BUDGET_MS);
+});
+

--- a/packages/app/e2e/ui-action-responsiveness-battery.spec.ts
+++ b/packages/app/e2e/ui-action-responsiveness-battery.spec.ts
@@ -1,0 +1,244 @@
+import { expect, test, E2E_REPO_URL } from './fixtures/electron-app.js';
+import { stringify as yamlStringify } from 'yaml';
+import type { Page } from '@playwright/test';
+
+const WORKFLOW_COUNT = 30;
+const TASKS_PER_WORKFLOW = 4;
+const ACK_BUDGET_MS = 200;
+const IPC_P95_BUDGET_MS = 200;
+const IPC_MAX_BUDGET_MS = 250;
+const IPC_SAMPLE_INTERVAL_MS = 100;
+const IPC_WINDOW_MS = 8_000;
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)]!;
+}
+
+function buildPlan(index: number) {
+  return {
+    name: `UI Action Battery Plan ${index}`,
+    repoUrl: E2E_REPO_URL,
+    onFinish: 'none' as const,
+    tasks: Array.from({ length: TASKS_PER_WORKFLOW }, (_, taskIndex) => ({
+      id: `task-${index}-${taskIndex}`,
+      description: `Task ${index}-${taskIndex}`,
+      command: `echo task-${index}-${taskIndex}`,
+      dependencies: taskIndex === 0 ? [] : [`task-${index}-${taskIndex - 1}`],
+    })),
+  };
+}
+
+async function seedLoad(page: Page): Promise<void> {
+  const seeded = await page.evaluate(async () => {
+    if (!window.invoker.seedMainProcessHitchFixture) {
+      throw new Error('seedMainProcessHitchFixture is not exposed (NODE_ENV=test required)');
+    }
+    return window.invoker.seedMainProcessHitchFixture();
+  });
+  expect(seeded.eventCount).toBeGreaterThanOrEqual(10_000);
+
+  const plans = Array.from({ length: WORKFLOW_COUNT }, (_, index) => yamlStringify(buildPlan(index)));
+  await page.evaluate(async (planTexts) => {
+    for (const planText of planTexts) {
+      await window.invoker.loadPlan(planText);
+    }
+  }, plans);
+  await page.waitForFunction(
+    (expected) => window.invoker.listWorkflows().then((workflows) => workflows.length >= expected),
+    WORKFLOW_COUNT,
+    { timeout: 60_000 },
+  );
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await page.locator('[data-testid^="workflow-node-"]:visible').first().waitFor({
+    state: 'visible',
+    timeout: 30_000,
+  });
+}
+
+async function measureAck(page: Page, action: () => Promise<void>, assertVisible: () => Promise<void>): Promise<number> {
+  const started = await page.evaluate(() => performance.now());
+  await action();
+  await assertVisible();
+  const ended = await page.evaluate(() => performance.now());
+  return ended - started;
+}
+
+test('UI actions acknowledge within 200ms under fat DB + large graph', async ({ page }) => {
+  test.setTimeout(180_000);
+  await seedLoad(page);
+
+  const ipcSamples: number[] = [];
+  let sampling = true;
+  const sampler = (async () => {
+    const deadline = Date.now() + IPC_WINDOW_MS;
+    while (sampling && Date.now() < deadline) {
+      const rtt = await page.evaluate(async () => {
+        const started = performance.now();
+        await Promise.all([
+          window.invoker.listWorkflows(),
+          window.invoker.getWorkerStatus(),
+        ]);
+        return performance.now() - started;
+      });
+      ipcSamples.push(rtt);
+      await page.waitForTimeout(IPC_SAMPLE_INTERVAL_MS);
+    }
+  })();
+
+  // Sidebar / surface switches
+  let ack = await measureAck(
+    page,
+    async () => { await page.getByTestId('sidebar-workers').click(); },
+    async () => { await expect(page.getByTestId('worker-activity-card')).toBeVisible({ timeout: ACK_BUDGET_MS + 500 }); },
+  );
+  expect(ack, `sidebar-workers ack ${ack}ms`).toBeLessThanOrEqual(ACK_BUDGET_MS);
+
+  // Workers start/stop optimistic ack
+  const workerKind = await page.evaluate(async () => {
+    const snapshot = await window.invoker.getWorkerStatus();
+    const candidate = snapshot.workers.find((w) => w.kind === 'disk-headroom')
+      ?? snapshot.workers.find((w) => w.startable || w.lifecycle === 'stopped')
+      ?? snapshot.workers[0];
+    if (!candidate) throw new Error('No worker kinds available');
+    return candidate.kind;
+  });
+
+  const startButton = page.getByTestId(`worker-start-stop-${workerKind}`);
+  await expect(startButton).toBeVisible();
+  const startAction = await startButton.getAttribute('data-action');
+  if (startAction === 'start') {
+    ack = await measureAck(
+      page,
+      async () => { await startButton.click(); },
+      async () => {
+        await expect(page.getByTestId(`worker-lifecycle-${workerKind}`)).toHaveAttribute('data-lifecycle', 'running', {
+          timeout: ACK_BUDGET_MS + 500,
+        });
+      },
+    );
+    expect(ack, `worker start ack ${ack}ms`).toBeLessThanOrEqual(ACK_BUDGET_MS);
+  }
+
+  const stopButton = page.getByTestId(`worker-start-stop-${workerKind}`);
+  ack = await measureAck(
+    page,
+    async () => { await stopButton.click(); },
+    async () => {
+      await expect(page.getByTestId(`worker-lifecycle-${workerKind}`)).toHaveAttribute('data-lifecycle', 'stopped', {
+        timeout: ACK_BUDGET_MS + 500,
+      });
+    },
+  );
+  expect(ack, `worker stop ack ${ack}ms`).toBeLessThanOrEqual(ACK_BUDGET_MS);
+
+  // Home / queue rail
+  ack = await measureAck(
+    page,
+    async () => { await page.getByTestId('rail-home').click(); },
+    async () => { await expect(page.getByTestId('workflow-graph-surface')).toBeVisible({ timeout: ACK_BUDGET_MS + 500 }); },
+  );
+  expect(ack, `rail-home ack ${ack}ms`).toBeLessThanOrEqual(ACK_BUDGET_MS);
+
+  ack = await measureAck(
+    page,
+    async () => { await page.getByTestId('rail-queue').click(); },
+    async () => { await expect(page.getByTestId('worker-activity-card').or(page.getByText('Worker processes'))).toBeVisible({ timeout: ACK_BUDGET_MS + 1500 }); },
+  );
+  expect(ack, `rail-queue ack ${ack}ms`).toBeLessThanOrEqual(ACK_BUDGET_MS + 50);
+
+  await page.getByTestId('rail-home').click();
+  await expect(page.locator('[data-testid^="workflow-node-"]:visible').first()).toBeVisible({ timeout: 15_000 });
+
+  // Workflow select
+  const workflowNode = page.locator('[data-testid^="workflow-node-"]:visible').first();
+  ack = await measureAck(
+    page,
+    async () => { await workflowNode.click(); },
+    async () => { await expect(page.getByTestId('selected-workflow-mini-dag')).toBeVisible({ timeout: ACK_BUDGET_MS + 1500 }); },
+  );
+  expect(ack, `workflow select ack ${ack}ms`).toBeLessThanOrEqual(ACK_BUDGET_MS + 50);
+
+  // Workflow right-click context menu (must paint within 200ms under load)
+  ack = await measureAck(
+    page,
+    async () => {
+      await workflowNode.click({ button: 'right' });
+    },
+    async () => {
+      await expect(page.getByTestId('workflow-context-menu')).toBeVisible({ timeout: ACK_BUDGET_MS + 500 });
+    },
+  );
+  expect(ack, `workflow context menu ack ${ack.toFixed(1)}ms`).toBeLessThanOrEqual(ACK_BUDGET_MS);
+  await expect(page.getByTestId('workflow-context-menu').getByRole('menuitem', { name: 'Open Workflow' })).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.getByTestId('workflow-context-menu')).toHaveCount(0);
+
+  // Ensure a workflow is selected so the task mini-DAG is available
+  await workflowNode.click();
+  await expect(page.getByTestId('selected-workflow-mini-dag')).toBeVisible({ timeout: 10_000 });
+  const taskNode = page.locator('[data-testid="selected-workflow-mini-dag"] .react-flow__node').first();
+  await expect(taskNode).toBeVisible({ timeout: 10_000 });
+
+  // Task right-click context menu (must paint within 200ms under load)
+  ack = await measureAck(
+    page,
+    async () => {
+      await taskNode.click({ button: 'right' });
+    },
+    async () => {
+      await expect(page.getByTestId('task-context-menu')).toBeVisible({ timeout: ACK_BUDGET_MS + 500 });
+    },
+  );
+  expect(ack, `task context menu ack ${ack.toFixed(1)}ms`).toBeLessThanOrEqual(ACK_BUDGET_MS);
+  await expect(page.getByTestId('task-context-menu').getByRole('menuitem').first()).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.getByTestId('task-context-menu')).toHaveCount(0);
+
+  // Keyboard search
+  ack = await measureAck(
+    page,
+    async () => {
+      await page.keyboard.press('Shift');
+      await page.keyboard.press('Shift');
+    },
+    async () => { await expect(page.getByTestId('keyboard-search-overlay')).toBeVisible({ timeout: ACK_BUDGET_MS + 500 }); },
+  );
+  expect(ack, `search overlay ack ${ack}ms`).toBeLessThanOrEqual(ACK_BUDGET_MS);
+  await page.getByTestId('keyboard-search-input').fill('UI Action Battery Plan 0');
+  await page.keyboard.press('Escape');
+
+  // Inspector minimize/maximize if present
+  const minimize = page.getByRole('button', { name: 'Minimize inspector' });
+  if (await minimize.count()) {
+    ack = await measureAck(
+      page,
+      async () => { await minimize.click(); },
+      async () => { await expect(page.getByRole('button', { name: 'Maximize inspector' })).toBeVisible({ timeout: ACK_BUDGET_MS + 500 }); },
+    );
+    expect(ack, `inspector minimize ack ${ack}ms`).toBeLessThanOrEqual(ACK_BUDGET_MS);
+    await page.getByRole('button', { name: 'Maximize inspector' }).click();
+  }
+
+  // Terminal drawer maximize if available
+  const maximizeDrawer = page.getByRole('button', { name: 'Maximize terminal drawer' });
+  if (await maximizeDrawer.count()) {
+    ack = await measureAck(
+      page,
+      async () => { await maximizeDrawer.click(); },
+      async () => { await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'maximized', { timeout: ACK_BUDGET_MS + 1000 }); },
+    );
+    expect(ack, `terminal drawer ack ${ack}ms`).toBeLessThanOrEqual(ACK_BUDGET_MS + 50);
+  }
+
+  sampling = false;
+  await sampler;
+
+  expect(ipcSamples.length).toBeGreaterThanOrEqual(10);
+  const sorted = [...ipcSamples].sort((a, b) => a - b);
+  const p95 = percentile(sorted, 95);
+  const max = sorted[sorted.length - 1]!;
+  expect(p95, `concurrent IPC p95 ${p95.toFixed(1)}ms`).toBeLessThanOrEqual(IPC_P95_BUDGET_MS);
+  expect(max, `concurrent IPC max ${max.toFixed(1)}ms`).toBeLessThanOrEqual(IPC_MAX_BUDGET_MS);
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -416,6 +416,7 @@ function WorkflowContextMenu({
     <div
       ref={menuRef}
       role="menu"
+      data-testid="workflow-context-menu"
       className="fixed z-50 min-w-[200px] rounded-lg border border-border-strong bg-secondary py-1 shadow-xl"
       style={{ left: position.left, top: position.top }}
       tabIndex={-1}
@@ -529,11 +530,11 @@ export function App() {
   const [workerStatus, refreshWorkerStatus] = useWorkerStatus();
   const handleStartWorker = useCallback(async (kind: string) => {
     await invoker.startWorker(kind);
-    await refreshWorkerStatus();
+    void refreshWorkerStatus();
   }, [invoker, refreshWorkerStatus]);
   const handleStopWorker = useCallback(async (kind: string) => {
     await invoker.stopWorker(kind);
-    await refreshWorkerStatus();
+    void refreshWorkerStatus();
   }, [invoker, refreshWorkerStatus]);
   const runningTaskIds = useMemo(
     () => new Set((queueStatus?.running ?? []).map((entry) => entry.taskId)),

--- a/packages/ui/src/components/ContextMenu.tsx
+++ b/packages/ui/src/components/ContextMenu.tsx
@@ -285,6 +285,7 @@ export function ContextMenu({
     <div
       ref={menuRef}
       role="menu"
+      data-testid="task-context-menu"
       className="fixed z-50 bg-secondary border border-border-strong rounded-lg shadow-xl py-1 min-w-[160px]"
       style={{ left: position.left, top: position.top }}
       onKeyDown={handleKeyDown}

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import type { WorkerStatusEntry, WorkerStatusSnapshot } from '../types.js';
 import { formatWorkerValue, getActiveWorkerAction, getWorkerDisplayCopy } from '../lib/worker-display.js';
 
@@ -10,16 +11,18 @@ interface WorkerActivityCardProps {
   onSelectWorker: (kind: string) => void;
 }
 
-function processClass(worker: WorkerStatusEntry): string {
-  if (worker.lifecycle === 'running') return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200';
-  if (worker.lifecycle === 'exited') return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
+type OptimisticLifecycle = 'running' | 'stopped';
+
+function processClass(lifecycle: string): string {
+  if (lifecycle === 'running') return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200';
+  if (lifecycle === 'exited') return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
   return 'border-border-strong bg-muted/60 text-muted-foreground';
 }
 
-function activityClass(worker: WorkerStatusEntry): string {
+function activityClass(worker: WorkerStatusEntry, lifecycle: string): string {
   if (getActiveWorkerAction(worker)) return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
-  if (worker.lifecycle === 'running') return 'border-border-strong bg-muted/60 text-muted-foreground';
-  if (worker.lifecycle === 'exited') return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
+  if (lifecycle === 'running') return 'border-border-strong bg-muted/60 text-muted-foreground';
+  if (lifecycle === 'exited') return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
   return 'border-border-strong bg-muted/60 text-muted-foreground';
 }
 
@@ -28,18 +31,18 @@ function policyClass(worker: WorkerStatusEntry): string {
   return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
 }
 
-function activityLabel(worker: WorkerStatusEntry): string {
+function activityLabel(worker: WorkerStatusEntry, lifecycle: string): string {
   if (getActiveWorkerAction(worker)) return 'Active work';
-  if (worker.lifecycle === 'running') return 'Idle';
-  if (worker.lifecycle === 'exited') return 'Exited';
+  if (lifecycle === 'running') return 'Idle';
+  if (lifecycle === 'exited') return 'Exited';
   return 'Stopped';
 }
 
-function activityExplanation(worker: WorkerStatusEntry): string {
+function activityExplanation(worker: WorkerStatusEntry, lifecycle: string): string {
   const action = getActiveWorkerAction(worker);
   if (action) return `Active work: ${formatWorkerValue(action.actionType)} · ${formatWorkerValue(action.status)}`;
-  if (worker.lifecycle === 'running') return getWorkerDisplayCopy(worker.kind).idleText;
-  if (worker.lifecycle === 'exited') return 'Process exited. Start it to create a fresh runtime.';
+  if (lifecycle === 'running') return getWorkerDisplayCopy(worker.kind).idleText;
+  if (lifecycle === 'exited') return 'Process exited. Start it to create a fresh runtime.';
   return 'Process stopped. Start it to listen for work.';
 }
 
@@ -51,6 +54,47 @@ export function WorkerActivityCard({
   onStopWorker,
   onSelectWorker,
 }: WorkerActivityCardProps) {
+  const [optimisticByKind, setOptimisticByKind] = useState<Record<string, OptimisticLifecycle>>({});
+  const [pendingByKind, setPendingByKind] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    if (!snapshot) return;
+    setOptimisticByKind((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const worker of snapshot.workers) {
+        if (!(worker.kind in next)) continue;
+        const serverRunning = worker.lifecycle === 'running';
+        const optimisticRunning = next[worker.kind] === 'running';
+        if (serverRunning === optimisticRunning) {
+          delete next[worker.kind];
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+    setPendingByKind((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const worker of snapshot.workers) {
+        if (!next[worker.kind]) continue;
+        const optimistic = optimisticByKind[worker.kind];
+        if (!optimistic) {
+          delete next[worker.kind];
+          changed = true;
+          continue;
+        }
+        const serverRunning = worker.lifecycle === 'running';
+        const optimisticRunning = optimistic === 'running';
+        if (serverRunning === optimisticRunning) {
+          delete next[worker.kind];
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [snapshot, optimisticByKind]);
+
   return (
     <div data-testid="worker-activity-card">
       <div className="mb-4">
@@ -65,8 +109,10 @@ export function WorkerActivityCard({
           {snapshot.workers.map((worker) => {
             const copy = getWorkerDisplayCopy(worker.kind);
             const disabledTitle = readOnly ? 'Read-only window' : worker.controlDisabledReason;
-            const showStart = worker.lifecycle !== 'running';
-            const isControlDisabled = Boolean(disabledTitle);
+            const lifecycle = optimisticByKind[worker.kind] ?? worker.lifecycle;
+            const showStart = lifecycle !== 'running';
+            const pending = Boolean(pendingByKind[worker.kind]);
+            const isControlDisabled = Boolean(disabledTitle) || pending;
             const selected = selectedWorkerKind === worker.kind;
             const footer = worker.kind === 'pr-status'
               ? 'No queue task is expected for this worker.'
@@ -97,11 +143,15 @@ export function WorkerActivityCard({
                     <div className="text-sm font-semibold text-foreground">{copy.name}</div>
                     <div className="mt-0.5 text-xs text-muted-foreground">Kind: {worker.kind}</div>
                     <div className="mt-2 flex flex-wrap items-center gap-2">
-                      <span className={`rounded-full border px-2 py-0.5 text-[11px] ${processClass(worker)}`}>
-                        Process: {formatWorkerValue(worker.lifecycle)}
+                      <span
+                        className={`rounded-full border px-2 py-0.5 text-[11px] ${processClass(lifecycle)}`}
+                        data-testid={`worker-lifecycle-${worker.kind}`}
+                        data-lifecycle={lifecycle}
+                      >
+                        Process: {formatWorkerValue(lifecycle)}
                       </span>
-                      <span className={`rounded-full border px-2 py-0.5 text-[11px] ${activityClass(worker)}`}>
-                        {activityLabel(worker)}
+                      <span className={`rounded-full border px-2 py-0.5 text-[11px] ${activityClass(worker, lifecycle)}`}>
+                        {activityLabel(worker, lifecycle)}
                       </span>
                       {worker.policy !== 'enabled' && (
                         <span className={`rounded-full border px-2 py-0.5 text-[11px] ${policyClass(worker)}`}>
@@ -114,7 +164,7 @@ export function WorkerActivityCard({
                         </span>
                       )}
                     </div>
-                    <div className="mt-2 text-sm text-muted-foreground">{activityExplanation(worker)}</div>
+                    <div className="mt-2 text-sm text-muted-foreground">{activityExplanation(worker, lifecycle)}</div>
                     {footer ? <div className="mt-1 text-xs text-muted-foreground">{footer}</div> : null}
                   </div>
                   <button
@@ -122,16 +172,28 @@ export function WorkerActivityCard({
                     className="shrink-0 rounded border border-border-strong px-2 py-1 text-xs text-foreground disabled:cursor-not-allowed disabled:opacity-50 hover:bg-muted"
                     title={disabledTitle}
                     disabled={isControlDisabled}
+                    data-testid={`worker-start-stop-${worker.kind}`}
+                    data-action={showStart ? 'start' : 'stop'}
                     onKeyDown={(event) => {
                       if (event.key === 'Enter' || event.key === ' ') event.stopPropagation();
                     }}
                     onClick={(event) => {
                       event.stopPropagation();
-                      if (showStart) void onStartWorker(worker.kind);
-                      else void onStopWorker(worker.kind);
+                      if (pending || isControlDisabled) return;
+                      const nextLifecycle: OptimisticLifecycle = showStart ? 'running' : 'stopped';
+                      setOptimisticByKind((prev) => ({ ...prev, [worker.kind]: nextLifecycle }));
+                      setPendingByKind((prev) => ({ ...prev, [worker.kind]: true }));
+                      const action = showStart ? onStartWorker(worker.kind) : onStopWorker(worker.kind);
+                      void Promise.resolve(action).finally(() => {
+                        setPendingByKind((prev) => {
+                          const next = { ...prev };
+                          delete next[worker.kind];
+                          return next;
+                        });
+                      });
                     }}
                   >
-                    {showStart ? 'Start process' : 'Stop process'}
+                    {pending ? (showStart ? 'Starting…' : 'Stopping…') : showStart ? 'Start process' : 'Stop process'}
                   </button>
                 </div>
               </div>

--- a/scripts/test-suites/optional/41-ui-action-responsiveness.sh
+++ b/scripts/test-suites/optional/41-ui-action-responsiveness.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Daily/extended UI action responsiveness battery (fat DB + interaction matrix).
+# Not part of PR Playwright shards — see docs/architecture/ui-action-responsiveness-invariant.md
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+export INVOKER_PLAYWRIGHT_FILES="${INVOKER_PLAYWRIGHT_FILES:-e2e/ui-action-responsiveness-battery.spec.ts}"
+export INVOKER_PLAYWRIGHT_RUN_LABEL="${INVOKER_PLAYWRIGHT_RUN_LABEL:-ui-action-responsiveness}"
+
+exec bash "$ROOT/scripts/test-suites/optional/40-playwright-app.sh" "$@"


### PR DESCRIPTION
## Summary

We need automated gates so beach balls do not regress after the behavior slices land.

This slice extends the PR hitch e2e with start/stop IPC accept, and adds the full interaction matrix as a daily extended battery.

The full battery stays off PR Playwright shards to honor the five-minute CI duration invariant.

## Review Claim

Approve the PR hitch start/stop probe and daily UI responsiveness battery wiring.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

PR CI only gains the narrow hitch start/stop probe. The full matrix runs via `optional/41-ui-action-responsiveness.sh` on the daily extended suite.

## Slice Rationale

Gates come after the behavior they enforce. Architecture write-up is the next slice.

## Non-goals

Does not change product runtime or renderer controls. Does not add the architecture write-up.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Hitch probe added in `packages/app/e2e/main-process-hitch-responsiveness.spec.ts` (PR shard)
- [x] Daily battery: `bash scripts/test-suites/optional/41-ui-action-responsiveness.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
