### PR TITLE
[UI 200ms](5) Document the 200ms UI acknowledgment invariant

### DIFF
--- a/docs/architecture/ci-duration-invariant.md
+++ b/docs/architecture/ci-duration-invariant.md
@@ -13,7 +13,9 @@ Enforced by:
 
 Stacked PR pushes should stay cheap. Long Playwright batteries belong on the
 twice-daily extended e2e worker (`scripts/daily-e2e-do-submit.sh`), not on
-ordinary PR feedback.
+ordinary PR feedback. That includes the UI action responsiveness battery
+(`optional/41-ui-action-responsiveness.sh`); see
+[UI action responsiveness invariant](./ui-action-responsiveness-invariant.md).
 
 ## How to stay under budget
 

--- a/docs/architecture/main-process-read-hot-paths.md
+++ b/docs/architecture/main-process-read-hot-paths.md
@@ -95,4 +95,6 @@ timer ticks into a main-thread SQLite convoy (macOS beachball).
   (`slowQueryThresholdMs` / `onSlowQuery`) so the next spike shows up without
   attaching a sampler. Set `slowQueryThresholdMs: 0` to disable.
 
-See also: [CI duration invariant](./ci-duration-invariant.md).
+See also: [CI duration invariant](./ci-duration-invariant.md) and
+[UI action responsiveness invariant](./ui-action-responsiveness-invariant.md)
+(user actions must acknowledge within 200ms; main/IPC must not beach-ball).

--- a/docs/architecture/ui-action-responsiveness-invariant.md
+++ b/docs/architecture/ui-action-responsiveness-invariant.md
@@ -1,0 +1,57 @@
+# UI Action Responsiveness Invariant
+
+## Rule
+
+Any user-visible action must **acknowledge within 200ms**:
+
+- Click / key → immediate UI feedback (optimistic state, pending control, open overlay, selection highlight).
+- Electron **main-process event loop / IPC accept** must stay responsive: concurrent cheap IPC
+  (`listWorkflows`, `getWorkerStatus`) under load should stay **p95 ≤ 200ms**, max sample ≤ 250ms.
+
+This includes **right-click context menus** on workflow nodes and task nodes: the menu must become
+visible (and stay interactive) within 200ms. Opening the menu must not stall the main process.
+
+This does **not** require background work (worker ticks, scans, git, `df`, PR maintenance) to finish
+in 200ms. Long work continues asynchronously after the action is acknowledged.
+
+### Acknowledgment examples
+
+| Action | Ack signal |
+| --- | --- |
+| Worker Start / Stop | Lifecycle label / control `data-action` flips |
+| Workflow / task select | Selection highlight / inspector binding |
+| Workflow right-click | `[data-testid="workflow-context-menu"]` visible |
+| Task right-click | `[data-testid="task-context-menu"]` visible |
+| Search / inspector / drawer | Overlay or panel visible |
+
+## Why
+
+macOS beach balls mean the **main process event loop stalled**. A common failure mode was
+`stopWorker` awaiting an in-flight worker tick (autofix scan, disk-headroom `df`, PR-maintenance
+shell) before resolving IPC. The UI also serialized `await start/stop` + a full status refresh on
+the critical path.
+
+## Enforcement
+
+| Layer | Where |
+|-------|--------|
+| Architecture | This doc; cross-links from [main-process read hot paths](./main-process-read-hot-paths.md) and [CI duration invariant](./ci-duration-invariant.md) |
+| Unit | `packages/app/src/__tests__/worker-runtime.test.ts` — default `stop()` returns promptly; `settleTimeoutMs` bounds quit |
+| PR Playwright | `packages/app/e2e/main-process-hitch-responsiveness.spec.ts` — fat DB + `startWorker`/`stopWorker` IPC accept ≤ 200ms |
+| Daily / extended | `packages/app/e2e/ui-action-responsiveness-battery.spec.ts` via `optional/41-ui-action-responsiveness.sh` (includes workflow + task right-click menus) |
+
+PR CI keeps the narrow hitch gate. The full interaction matrix runs only on the twice-daily
+extended e2e worker (`scripts/daily-e2e-do-submit.sh` / `INVOKER_TEST_ALL_EXTENDED=1`).
+
+## Design notes
+
+- Worker runtime `stop()` aborts via `AbortSignal` and defaults `settleTimeoutMs: 0` (GUI IPC).
+- Quit / `stopAll` / OS signal handlers pass a bounded settle (e.g. 5s).
+- Auto-started workers are deferred past first paint (`startDeferredStartupWork`).
+- Worker Start/Stop buttons use optimistic lifecycle + `data-testid`s for ack measurement.
+
+## Follow-ups (out of scope here)
+
+- INV-265: move sync SQLite off the main thread.
+- Tighten workflow-delete budget from 500ms → 200ms once battery baselines are green.
+- Bootstrap `sendSync` full-graph load (separate startup project).

--- a/scripts/test-suites/README.md
+++ b/scripts/test-suites/README.md
@@ -68,5 +68,7 @@ Keep extra proof, repro, and destructive coverage on normal PRs, pushes, schedul
   - `optional/33-e2e-chaos-overload.sh`: generated overload chaos suite for saturation and mixed-operation storms
   - `optional/30-e2e-ssh.sh`: `case-3.1` to `case-3.3`
   - `optional/31-e2e-ssh-merge.sh`: `case-3.4` to `case-3.6`
+  - `optional/40-playwright-app.sh`: full Playwright app suite (also used by CI shards)
+  - `optional/41-ui-action-responsiveness.sh`: UI action responsiveness battery under fat DB (daily/extended only; see `docs/architecture/ui-action-responsiveness-invariant.md`)
 
 Do **not** add ad-hoc top-level `scripts/run-*.sh` loops for tests — add a thin wrapper under `test-suites/` and delegate to existing scripts so discovery stays in one place.


### PR DESCRIPTION
## Summary

We need a written budget so the 200ms acknowledgment rule is not tribal knowledge.

This slice adds the acknowledgment invariant page and points related architecture pages at it.

The test-suites README also notes the daily battery entry.

## Review Claim

Approve the written 200ms UI acknowledgment invariant and its cross-links.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Docs only. No product or suite-script behavior changes in this slice.

## Slice Rationale

Architecture write-up comes after the gates that enforce the budget.

## Non-goals

Does not change e2e probes, suite scripts, or product code.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Page present under `docs/architecture/ui-action-responsiveness-invariant.md`
- [x] Cross-links from main-process hot paths and CI duration invariant
- [x] Daily battery noted in `scripts/test-suites/README.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>