### PR TITLE
[Focus-switch beachball](1) Prove Action Graph poll stalls main under a fat DB

### DIFF
--- a/packages/app/e2e/focus-switch-hitch-responsiveness.spec.ts
+++ b/packages/app/e2e/focus-switch-hitch-responsiveness.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test } from './fixtures/electron-app.js';
+
+const MAX_P95_RTT_MS = 100;
+const MAX_SAMPLE_RTT_MS = 250;
+const HIDDEN_MS = 6_000;
+const REFOCUS_SAMPLES = 8;
+const SAMPLE_INTERVAL_MS = 100;
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)]!;
+}
+
+async function seedHitchFixture(page: import('@playwright/test').Page) {
+  const seeded = await page.evaluate(async () => {
+    if (!window.invoker.seedMainProcessHitchFixture) {
+      throw new Error('seedMainProcessHitchFixture is not exposed (NODE_ENV=test required)');
+    }
+    return window.invoker.seedMainProcessHitchFixture();
+  });
+  expect(seeded.eventCount).toBeGreaterThanOrEqual(10_000);
+  expect(seeded.workerActionCount).toBeGreaterThan(0);
+  return seeded;
+}
+
+/**
+ * Repro for Cursor→Invoker beachball: while the window is backgrounded,
+ * Chromium throttles renderer timers; on show/focus the deferred status polls
+ * (worker + queue + action-graph) fire together and stall the main process.
+ *
+ * This test forces that herd after hide→show and asserts cheap IPC stays under
+ * the hitch budget. It should fail until polls are visibility-gated / coalesced.
+ */
+test('hide→show status-poll herd keeps listWorkflows IPC responsive under a fat DB', async ({
+  page,
+  electronApp,
+}) => {
+  await seedHitchFixture(page);
+
+  // Warm the same IPC paths the UI polls every 2s.
+  await page.evaluate(async () => {
+    await Promise.all([
+      window.invoker.getWorkerStatus(),
+      window.invoker.getQueueStatus(),
+      window.invoker.getActionGraph?.(),
+    ]);
+  });
+
+  await electronApp.evaluate(({ BrowserWindow }) => {
+    const win = BrowserWindow.getAllWindows()[0];
+    if (!win) throw new Error('no BrowserWindow found');
+    win.hide();
+  });
+
+  await page.waitForTimeout(HIDDEN_MS);
+
+  await electronApp.evaluate(({ BrowserWindow }) => {
+    const win = BrowserWindow.getAllWindows()[0];
+    if (!win) throw new Error('no BrowserWindow found');
+    win.show();
+    win.focus();
+  });
+
+  // Isolate which status IPC dominates the refocus herd (diagnostic, not asserted).
+  const isolated = await page.evaluate(async () => {
+    const time = async (label: string, fn: () => Promise<unknown>) => {
+      const started = performance.now();
+      await fn();
+      return { label, ms: performance.now() - started };
+    };
+    return {
+      worker: await time('getWorkerStatus', () => window.invoker.getWorkerStatus()),
+      queue: await time('getQueueStatus', () => window.invoker.getQueueStatus()),
+      actionGraph: await time('getActionGraph', () => window.invoker.getActionGraph?.() ?? Promise.resolve(null)),
+      list: await time('listWorkflows', () => window.invoker.listWorkflows()),
+    };
+  });
+  // eslint-disable-next-line no-console
+  console.log('[focus-switch-hitch] isolated IPC ms', isolated);
+
+  const samples: number[] = [];
+  for (let i = 0; i < REFOCUS_SAMPLES; i += 1) {
+    const rtt = await page.evaluate(async () => {
+      const started = performance.now();
+      // Simulate Chromium releasing throttled timers: all status polls + a cheap
+      // probe share one main-thread turn (the beachball signature).
+      await Promise.all([
+        window.invoker.getWorkerStatus(),
+        window.invoker.getQueueStatus(),
+        window.invoker.getActionGraph?.(),
+        window.invoker.listWorkflows(),
+      ]);
+      return performance.now() - started;
+    });
+    samples.push(rtt);
+    await page.waitForTimeout(SAMPLE_INTERVAL_MS);
+  }
+
+  const sorted = [...samples].sort((a, b) => a - b);
+  const p95 = percentile(sorted, 95);
+  const max = sorted[sorted.length - 1]!;
+  // eslint-disable-next-line no-console
+  console.log('[focus-switch-hitch] herd RTT ms', { samples, p95, max, isolated });
+
+  expect(
+    p95,
+    `p95 refocus-herd IPC RTT ${p95.toFixed(1)}ms exceeded ${MAX_P95_RTT_MS}ms `
+      + `(max=${max.toFixed(1)}ms, n=${samples.length}, isolated=${JSON.stringify(isolated)})`,
+  ).toBeLessThanOrEqual(MAX_P95_RTT_MS);
+  expect(
+    max,
+    `max refocus-herd IPC RTT ${max.toFixed(1)}ms exceeded ${MAX_SAMPLE_RTT_MS}ms `
+      + `(p95=${p95.toFixed(1)}ms, n=${samples.length}, isolated=${JSON.stringify(isolated)})`,
+  ).toBeLessThanOrEqual(MAX_SAMPLE_RTT_MS);
+});

--- a/packages/app/src/__tests__/focus-switch-main-process-cost.test.ts
+++ b/packages/app/src/__tests__/focus-switch-main-process-cost.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator } from '@invoker/workflow-core';
+import { buildCurrentActionGraphSnapshot } from '../action-graph-snapshot.js';
+import { seedMainProcessHitchFixture } from '../main-process-hitch-fixture.js';
+import type { InvokerConfig } from '../config.js';
+
+/**
+ * Cost repro for Cursor→Invoker beachball suspects that survive the worker-status
+ * fix: Action Graph full snapshot and owner dbPoll-like loadTasks under a fat DB.
+ *
+ * Budgets match docs/architecture/ui-action-responsiveness-invariant.md (p95 ≤ 200ms
+ * ack; hitch e2e uses 100ms for cheap IPC). Anything above 100ms on the main thread
+ * is enough to beachball window chrome on refocus.
+ */
+describe('focus-switch main-process cost repro', () => {
+  let tmpDir: string | undefined;
+  let adapter: SQLiteAdapter | undefined;
+
+  afterEach(async () => {
+    await adapter?.close();
+    adapter = undefined;
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it('buildCurrentActionGraphSnapshot stays under 100ms on default hitch fixture', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'focus-ag-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+    const seeded = seedMainProcessHitchFixture(adapter);
+    expect(seeded.eventCount).toBeGreaterThanOrEqual(10_000);
+
+    const orchestrator = new Orchestrator({
+      persistence: adapter as never,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 4,
+    });
+    orchestrator.syncAllFromDb();
+
+    const invokerConfig: InvokerConfig = {};
+    const started = performance.now();
+    const snapshot = buildCurrentActionGraphSnapshot({
+      orchestrator,
+      persistence: adapter,
+      invokerConfig,
+    });
+    const elapsedMs = performance.now() - started;
+
+    expect(snapshot.nodes.length).toBeGreaterThan(0);
+    expect(
+      elapsedMs,
+      `action-graph snapshot took ${elapsedMs.toFixed(1)}ms (tasks=${seeded.taskCount}, events=${seeded.eventCount})`,
+    ).toBeLessThan(100);
+  });
+
+  // Documents the Cursor→Invoker beachball: Action Graph poll stalls main under a fat DB.
+  // it.fails until the getQueueStatus / snapshot fix lands in the next stack slice.
+  it.fails('buildCurrentActionGraphSnapshot stays under 100ms with 200 mostly-idle tasks × 250 events', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'focus-ag-fat-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+    const seeded = seedMainProcessHitchFixture(adapter, {
+      taskCount: 200,
+      eventsPerTask: 250,
+      actionsPerKind: 20,
+    });
+    expect(seeded.eventCount).toBe(50_000);
+
+    const orchestrator = new Orchestrator({
+      persistence: adapter as never,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 4,
+    });
+    orchestrator.syncAllFromDb();
+
+    const invokerConfig: InvokerConfig = {};
+    const started = performance.now();
+    const snapshot = buildCurrentActionGraphSnapshot({
+      orchestrator,
+      persistence: adapter,
+      invokerConfig,
+    });
+    const elapsedMs = performance.now() - started;
+
+    expect(snapshot.nodes.length).toBeGreaterThan(0);
+    expect(
+      elapsedMs,
+      `fat action-graph snapshot took ${elapsedMs.toFixed(1)}ms (tasks=${seeded.taskCount}, events=${seeded.eventCount})`,
+    ).toBeLessThan(100);
+  });
+
+  it('dbPoll-like loadTasks+JSON.stringify stays under 100ms across 50 running workflows × 8 tasks', async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'focus-dbpoll-'));
+    adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
+
+    const workflowCount = 50;
+    const tasksPerWorkflow = 8;
+    for (let w = 0; w < workflowCount; w += 1) {
+      const workflowId = `wf-dbpoll-${w}`;
+      adapter.saveWorkflow({
+        id: workflowId,
+        name: `DB poll workflow ${w}`,
+        status: 'running',
+        createdAt: '2026-07-01T00:00:00.000Z',
+        updatedAt: '2026-07-01T00:00:00.000Z',
+      });
+      for (let t = 0; t < tasksPerWorkflow; t += 1) {
+        const taskId = `${workflowId}/t${t}`;
+        adapter.saveTask(workflowId, {
+          id: taskId,
+          description: `Task ${taskId}`,
+          status: t === 0 ? 'running' : 'pending',
+          dependencies: [],
+          createdAt: new Date('2026-07-01T00:00:00.000Z'),
+          config: {},
+          execution: t === 0
+            ? { phase: 'executing', startedAt: new Date('2026-07-01T00:00:00.000Z') }
+            : {},
+          taskStateVersion: 1,
+        });
+      }
+    }
+
+    const started = performance.now();
+    const workflows = adapter.listWorkflows();
+    let taskVisits = 0;
+    for (const wf of workflows) {
+      if (wf.status === 'completed' || wf.status === 'failed') continue;
+      const tasks = adapter.loadTasks(wf.id);
+      for (const task of tasks) {
+        taskVisits += 1;
+        if (task.execution.selectedAttemptId) {
+          adapter.loadAttempt?.(task.execution.selectedAttemptId);
+        }
+        JSON.stringify(task);
+      }
+    }
+    const elapsedMs = performance.now() - started;
+
+    expect(taskVisits).toBe(workflowCount * tasksPerWorkflow);
+    expect(
+      elapsedMs,
+      `dbPoll-like scan took ${elapsedMs.toFixed(1)}ms (workflows=${workflowCount}, tasks=${taskVisits})`,
+    ).toBeLessThan(100);
+  });
+});


### PR DESCRIPTION
## Summary

Cmd-Tab from Cursor back to Invoker can beachball the window.

This slice only adds proof. It does not change product behavior yet.

A unit cost guard marks the fat Action Graph poll as `it.fails` under 200 tasks and 50k events.

A hide-then-show Playwright hitch e2e also lands so later slices can keep the budget green.

## Review Claim

Approve adding a failing cost guard and hide→show hitch e2e that document the Action Graph main-thread stall before any fix.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

No product code changes. The fat cost case uses `it.fails`, so CI stays green while the bug remains.

## Slice Rationale

Evidence before change. Reviewers should see the stall proven before approving the `getQueueStatus` fix.

## Non-goals

Does not fix queue status, Action Graph snapshot cost, or visibility-gated polling.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test src/__tests__/focus-switch-main-process-cost.test.ts` (fat case expected `it.fails` until slice 2)
- [x] `pnpm --filter @invoker/app test:e2e e2e/focus-switch-hitch-responsiveness.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
