### PR TITLE
[UI 200ms](7) Log worker abort and settle-timeout events

### DIFF
--- a/docs/architecture/ci-duration-invariant.md
+++ b/docs/architecture/ci-duration-invariant.md
@@ -13,7 +13,9 @@ Enforced by:
 
 Stacked PR pushes should stay cheap. Long Playwright batteries belong on the
 twice-daily extended e2e worker (`scripts/daily-e2e-do-submit.sh`), not on
-ordinary PR feedback.
+ordinary PR feedback. That includes the UI action responsiveness battery
+(`optional/41-ui-action-responsiveness.sh`); see
+[UI action responsiveness invariant](./ui-action-responsiveness-invariant.md).
 
 ## How to stay under budget
 

--- a/docs/architecture/main-process-read-hot-paths.md
+++ b/docs/architecture/main-process-read-hot-paths.md
@@ -95,4 +95,6 @@ timer ticks into a main-thread SQLite convoy (macOS beachball).
   (`slowQueryThresholdMs` / `onSlowQuery`) so the next spike shows up without
   attaching a sampler. Set `slowQueryThresholdMs: 0` to disable.
 
-See also: [CI duration invariant](./ci-duration-invariant.md).
+See also: [CI duration invariant](./ci-duration-invariant.md) and
+[UI action responsiveness invariant](./ui-action-responsiveness-invariant.md)
+(user actions must acknowledge within 200ms; main/IPC must not beach-ball).

--- a/docs/architecture/ui-action-responsiveness-invariant.md
+++ b/docs/architecture/ui-action-responsiveness-invariant.md
@@ -1,0 +1,57 @@
+# UI Action Responsiveness Invariant
+
+## Rule
+
+Any user-visible action must **acknowledge within 200ms**:
+
+- Click / key → immediate UI feedback (optimistic state, pending control, open overlay, selection highlight).
+- Electron **main-process event loop / IPC accept** must stay responsive: concurrent cheap IPC
+  (`listWorkflows`, `getWorkerStatus`) under load should stay **p95 ≤ 200ms**, max sample ≤ 250ms.
+
+This includes **right-click context menus** on workflow nodes and task nodes: the menu must become
+visible (and stay interactive) within 200ms. Opening the menu must not stall the main process.
+
+This does **not** require background work (worker ticks, scans, git, `df`, PR maintenance) to finish
+in 200ms. Long work continues asynchronously after the action is acknowledged.
+
+### Acknowledgment examples
+
+| Action | Ack signal |
+| --- | --- |
+| Worker Start / Stop | Lifecycle label / control `data-action` flips |
+| Workflow / task select | Selection highlight / inspector binding |
+| Workflow right-click | `[data-testid="workflow-context-menu"]` visible |
+| Task right-click | `[data-testid="task-context-menu"]` visible |
+| Search / inspector / drawer | Overlay or panel visible |
+
+## Why
+
+macOS beach balls mean the **main process event loop stalled**. A common failure mode was
+`stopWorker` awaiting an in-flight worker tick (autofix scan, disk-headroom `df`, PR-maintenance
+shell) before resolving IPC. The UI also serialized `await start/stop` + a full status refresh on
+the critical path.
+
+## Enforcement
+
+| Layer | Where |
+|-------|--------|
+| Architecture | This doc; cross-links from [main-process read hot paths](./main-process-read-hot-paths.md) and [CI duration invariant](./ci-duration-invariant.md) |
+| Unit | `packages/app/src/__tests__/worker-runtime.test.ts` — default `stop()` returns promptly; `settleTimeoutMs` bounds quit |
+| PR Playwright | `packages/app/e2e/main-process-hitch-responsiveness.spec.ts` — fat DB + `startWorker`/`stopWorker` IPC accept ≤ 200ms |
+| Daily / extended | `packages/app/e2e/ui-action-responsiveness-battery.spec.ts` via `optional/41-ui-action-responsiveness.sh` (includes workflow + task right-click menus) |
+
+PR CI keeps the narrow hitch gate. The full interaction matrix runs only on the twice-daily
+extended e2e worker (`scripts/daily-e2e-do-submit.sh` / `INVOKER_TEST_ALL_EXTENDED=1`).
+
+## Design notes
+
+- Worker runtime `stop()` aborts via `AbortSignal` and defaults `settleTimeoutMs: 0` (GUI IPC).
+- Quit / `stopAll` / OS signal handlers pass a bounded settle (e.g. 5s).
+- Auto-started workers are deferred past first paint (`startDeferredStartupWork`).
+- Worker Start/Stop buttons use optimistic lifecycle + `data-testid`s for ack measurement.
+
+## Follow-ups (out of scope here)
+
+- INV-265: move sync SQLite off the main thread.
+- Tighten workflow-delete budget from 500ms → 200ms once battery baselines are green.
+- Bootstrap `sendSync` full-graph load (separate startup project).

--- a/packages/app/src/__tests__/worker-runtime.test.ts
+++ b/packages/app/src/__tests__/worker-runtime.test.ts
@@ -292,6 +292,10 @@ describe('worker runtime', () => {
       expect(Date.now() - started).toBeLessThan(50);
       expect(tickSignal?.aborted).toBe(true);
       expect(runtime.isRunning()).toBe(false);
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[worker:recovery] aborting in-flight tick',
+        expect.objectContaining({ kind: 'recovery', reason: 'stop', tickNumber: 1 }),
+      );
 
       inFlight.resolve();
       await Promise.resolve();
@@ -320,6 +324,60 @@ describe('worker runtime', () => {
       inFlight.resolve();
       await stopping;
       expect(settled).toBe(true);
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[worker:recovery] aborting in-flight tick',
+        expect.objectContaining({ kind: 'recovery', reason: 'stop' }),
+      );
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        '[worker:recovery] settle timed out after abort',
+        expect.anything(),
+      );
+    });
+
+    it('logs when settle times out after abort', async () => {
+      vi.useFakeTimers();
+      const inFlight = deferred();
+      const onTick = vi.fn().mockReturnValueOnce(inFlight.promise);
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick,
+        installSignalHandlers: false,
+      });
+
+      void runtime.tick();
+      await Promise.resolve();
+      const stopping = runtime.stop({ settleTimeoutMs: 25 });
+      await vi.advanceTimersByTimeAsync(25);
+      await stopping;
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[worker:recovery] settle timed out after abort',
+        expect.objectContaining({ kind: 'recovery', settleTimeoutMs: 25, tickNumber: 1 }),
+      );
+
+      inFlight.resolve();
+      await Promise.resolve();
+    });
+
+    it('logs stop requested when no tick is in flight', async () => {
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick: () => {},
+        tickOnStart: false,
+        installSignalHandlers: false,
+      });
+      runtime.start();
+      await runtime.stop();
+      expect(logger.info).toHaveBeenCalledWith(
+        '[worker:recovery] stop requested',
+        expect.objectContaining({ kind: 'recovery' }),
+      );
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        '[worker:recovery] aborting in-flight tick',
+        expect.anything(),
+      );
     });
 
     it('is idempotent', async () => {

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -172,13 +172,10 @@ function candidateFromTask(task: TaskState): AutoFixRecoveryCandidate | undefine
 
 export function listAutoFixRecoveryScanCandidates(
   options: Pick<AutoFixRecoveryPolicyOptions, 'store'>,
-  signal?: AbortSignal,
 ): AutoFixRecoveryCandidate[] {
   const candidates: AutoFixRecoveryCandidate[] = [];
   for (const workflow of options.store.listWorkflows()) {
-    if (signal?.aborted) break;
     for (const task of options.store.loadTasks(workflow.id)) {
-      if (signal?.aborted) break;
       if (task.status !== 'failed') continue;
       const candidate = candidateFromTask(task);
       if (candidate) candidates.push(candidate);
@@ -483,19 +480,17 @@ export function collectValidatedAutoFixRecoveryCandidates(
 
 export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions): WorkerTick {
   return async (ctx) => {
-    if (ctx.signal?.aborted) return;
+    ctx.signal?.throwIfAborted();
     const wakeups = options.drainWakeupHints?.() ?? [];
     const wakeupCandidates = wakeups.map(candidateFromWakeup).filter((c): c is AutoFixRecoveryCandidate => Boolean(c));
     const candidates = dedupeCandidates(
       wakeupCandidates.length > 0 && ctx.reason === 'wake'
         ? wakeupCandidates
-        : listAutoFixRecoveryScanCandidates(options, ctx.signal),
+        : listAutoFixRecoveryScanCandidates(options),
     );
-    if (ctx.signal?.aborted) return;
     const submittedThisTick = new Set<string>();
 
     for (const candidate of collectValidatedAutoFixRecoveryCandidates(options, candidates)) {
-      if (ctx.signal?.aborted) return;
       if (submittedThisTick.has(candidate.taskId)) {
         skipAutoFixCandidate(options, candidate, 'duplicate-candidate');
         continue;

--- a/packages/execution-engine/src/worker-runtime.ts
+++ b/packages/execution-engine/src/worker-runtime.ts
@@ -181,6 +181,15 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
     stopped = true;
     pendingReason = null;
     if (!abortController.signal.aborted) {
+      if (inFlight) {
+        options.logger.warn(`[worker:${identity.kind}] aborting in-flight tick`, {
+          ...logFields,
+          tickNumber,
+          reason: 'stop',
+        });
+      } else {
+        options.logger.info(`[worker:${identity.kind}] stop requested`, logFields);
+      }
       abortController.abort();
     }
     if (interval) {
@@ -195,10 +204,20 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
 
   const settleInFlight = async (settleTimeoutMs: number): Promise<void> => {
     if (!inFlight || settleTimeoutMs <= 0) return;
+    let settled = false;
     await Promise.race([
-      inFlight.catch(() => undefined),
+      inFlight.catch(() => undefined).then(() => {
+        settled = true;
+      }),
       delay(settleTimeoutMs),
     ]);
+    if (!settled) {
+      options.logger.warn(`[worker:${identity.kind}] settle timed out after abort`, {
+        ...logFields,
+        settleTimeoutMs,
+        tickNumber,
+      });
+    }
   };
 
   const start = (): void => {

--- a/packages/execution-engine/src/workers/disk-headroom-worker.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-worker.ts
@@ -118,9 +118,9 @@ export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): Wo
     intervalMs: options.intervalMs ?? resolveDiskCheckIntervalMs(),
     tickOnStart: options.tickOnStart ?? true,
     onTick: async (ctx) => {
-      if (ctx.signal?.aborted) return;
+      ctx.signal?.throwIfAborted();
       await options.onTick?.(ctx);
-      if (ctx.signal?.aborted) return;
+      ctx.signal?.throwIfAborted();
 
       const thresholds = options.thresholds ?? resolveDiskHeadroomThresholds();
       const evaluationsRaw = await runCheck({

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -201,7 +201,7 @@ async function runPrMaintenanceEntrypoint(
   options: PrMaintenanceTickOptions,
   signal?: AbortSignal,
 ): Promise<void> {
-  if (signal?.aborted) return;
+  signal?.throwIfAborted();
 
   const repoRoot = resolvePrMaintenanceRepoRoot(options.repoRoot);
   const startedAt = new Date().toISOString();
@@ -216,7 +216,7 @@ async function runPrMaintenanceEntrypoint(
     staleLockSeconds: parsePositiveInteger(env.INVOKER_PR_CRON_LOCK_STALE_SECS),
   });
 
-  if (signal?.aborted) return;
+  signal?.throwIfAborted();
 
   if (lock.held) {
     options.logger.info(`[worker:${options.entrypoint.kind}] shared PR maintenance lock held; skipping tick`, {

--- a/scripts/test-suites/README.md
+++ b/scripts/test-suites/README.md
@@ -68,5 +68,7 @@ Keep extra proof, repro, and destructive coverage on normal PRs, pushes, schedul
   - `optional/33-e2e-chaos-overload.sh`: generated overload chaos suite for saturation and mixed-operation storms
   - `optional/30-e2e-ssh.sh`: `case-3.1` to `case-3.3`
   - `optional/31-e2e-ssh-merge.sh`: `case-3.4` to `case-3.6`
+  - `optional/40-playwright-app.sh`: full Playwright app suite (also used by CI shards)
+  - `optional/41-ui-action-responsiveness.sh`: UI action responsiveness battery under fat DB (daily/extended only; see `docs/architecture/ui-action-responsiveness-invariant.md`)
 
 Do **not** add ad-hoc top-level `scripts/run-*.sh` loops for tests — add a thin wrapper under `test-suites/` and delegate to existing scripts so discovery stays in one place.


### PR DESCRIPTION
## Summary

Worker stop already aborts in-flight ticks for the 200ms ack path.

That abort was mostly silent unless the tick threw afterward.

This slice logs a warning when stop aborts an in-flight tick, another when settle times out, and an info line for idle stops.

## Review Claim

Approve that cooperative worker cancel now emits explicit abort and settle-timeout logs.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Stop still returns promptly by default. Logging does not await the in-flight tick.

Settle timeout behavior is unchanged; only observability is added.

## Slice Rationale

AbortSignal cancel landed earlier in this stack. Logging belongs as its own follow-up so cancel behavior and observability can be reviewed separately.

## Non-goals

- Changing settleTimeoutMs defaults
- Adding abort logging to Cmd+K or renderer UI paths
- Changing worker tick business logic

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/worker-runtime.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4021