### PR TITLE
[Needs Attention Mutation Failure UX](1) Drop obsolete --prompt flag from Qwen execution agent

### DIFF
--- a/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
@@ -22,9 +22,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec.fullPrompt).toBe('prompt text');
   });
@@ -38,9 +38,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'fix prompt',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec).not.toHaveProperty('fullPrompt');
   });
@@ -50,7 +50,6 @@ describe('QwenExecutionAgent', () => {
     expect(agent.buildCommand('prompt text').args).toEqual([
       '--approval-mode',
       'auto-edit',
-      '--prompt',
       'prompt text',
     ]);
   });
@@ -64,7 +63,6 @@ describe('QwenExecutionAgent', () => {
       'openai',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
   });

--- a/packages/execution-engine/src/agents/qwen-execution-agent.ts
+++ b/packages/execution-engine/src/agents/qwen-execution-agent.ts
@@ -85,7 +85,6 @@ export class QwenExecutionAgent implements ExecutionAgent {
       this.approvalMode,
       ...(this.authType ? ['--auth-type', this.authType] : []),
       ...(executionModel ? ['--model', executionModel] : []),
-      '--prompt',
       prompt,
     ];
   }


### PR DESCRIPTION
## Summary

The Qwen agent stops emitting `--prompt` in prompt-mode argument routing.

Newer Qwen prompt mode reads the prompt as trailing positional text. The explicit flag now fails in those builds.

Invoker now appends the prompt after approval, auth, and model options. The paired unit spec asserts `--prompt` stays absent.

## Review Claim

Approve that Qwen prompt-mode argument routing passes the prompt positionally and no longer emits `--prompt`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change touches only the Qwen agent's argument builder and its paired unit spec. The emitted argv is asserted directly in the focused test.

## Slice Rationale

This slice carries only the Qwen argument routing change and its paired check, separate from the Kimi flag change.

## Non-goals

- Does not touch the Kimi agent or any of its flags.
- Keeps model selection, auth type, and approval-mode handling unchanged.
- No new settings.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test src/__tests__/qwen-execution-agent.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a38a11a687b47c56730548aa60b0734b4fb2c805`
- Post-revert steps: Re-run the focused Qwen agent test.
- Data migration? No

</details>
