### PR TITLE
[Needs Attention Mutation Failure UX](2) Drop deprecated --yolo flag from Kimi execution agent

### DIFF
--- a/packages/execution-engine/src/__tests__/kimi-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/kimi-execution-agent.test.ts
@@ -2,13 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { KimiExecutionAgent } from '../agents/kimi-execution-agent.js';
 
 describe('KimiExecutionAgent', () => {
-  it('builds prompt command with yolo and model selector', () => {
+  it('builds prompt command with model selector without yolo', () => {
     const agent = new KimiExecutionAgent({ command: 'kimi-test' });
     const spec = agent.buildCommand('prompt text', { executionModel: 'kimi-k2.6' });
 
     expect(spec.cmd).toBe('kimi-test');
     expect(spec.args).toEqual([
-      '--yolo',
       '--model',
       'kimi-k2.6',
       '-p',
@@ -23,7 +22,6 @@ describe('KimiExecutionAgent', () => {
 
     expect(spec.cmd).toBe('kimi-test');
     expect(spec.args).toEqual([
-      '--yolo',
       '--model',
       'kimi-k2.6',
       '-p',
@@ -33,8 +31,8 @@ describe('KimiExecutionAgent', () => {
     expect(spec).not.toHaveProperty('fullPrompt');
   });
 
-  it('can disable yolo for stricter local runs', () => {
-    const agent = new KimiExecutionAgent({ command: 'kimi-test', yolo: false });
+  it('ignores the legacy yolo knob in prompt mode', () => {
+    const agent = new KimiExecutionAgent({ command: 'kimi-test', yolo: true });
     expect(agent.buildCommand('prompt text').args).toEqual([
       '-p',
       'prompt text',

--- a/packages/execution-engine/src/agents/kimi-execution-agent.ts
+++ b/packages/execution-engine/src/agents/kimi-execution-agent.ts
@@ -7,6 +7,10 @@ export interface KimiExecutionAgentConfig {
   command?: string;
   configDir?: string;
   containerHomePath?: string;
+  /**
+   * Deprecated compatibility knob. Current Kimi prompt mode rejects approval-mode
+   * flags, so Invoker never passes --yolo with -p/--prompt.
+   */
   yolo?: boolean;
 }
 
@@ -28,13 +32,11 @@ export class KimiExecutionAgent implements ExecutionAgent {
   private readonly command: string;
   private readonly configDir: string;
   private readonly containerHomePath: string;
-  private readonly yolo: boolean;
 
   constructor(config: KimiExecutionAgentConfig = {}) {
     this.command = config.command ?? process.env.INVOKER_KIMI_COMMAND ?? 'kimi';
     this.configDir = config.configDir ?? join(homedir(), '.kimi-code');
     this.containerHomePath = config.containerHomePath ?? '/home/invoker';
-    this.yolo = config.yolo ?? true;
   }
 
   buildCommand(fullPrompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
@@ -77,7 +79,6 @@ export class KimiExecutionAgent implements ExecutionAgent {
 
   private buildArgs(prompt: string, executionModel?: string): string[] {
     return [
-      ...(this.yolo ? ['--yolo'] : []),
       ...(executionModel ? ['--model', executionModel] : []),
       '-p',
       prompt,


### PR DESCRIPTION
## Summary

The Kimi agent stops emitting `--yolo` in prompt-mode argument routing.

Current Kimi prompt mode no longer accepts approval-mode flags when `-p` carries the prompt.

Invoker now emits only model selection plus `-p`, and the legacy `yolo` field remains accepted as a deprecated no-op. The paired unit spec pins that behavior.

## Review Claim

Approve that Kimi prompt-mode argument routing no longer appends `--yolo` while preserving compatibility for the legacy `yolo` constructor field.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change touches only the Kimi agent's argument builder and its paired unit spec. The emitted argv and compatibility knob behavior are asserted directly.

## Slice Rationale

This slice carries only the Kimi argument routing change and its paired check, separate from the Qwen prompt flag change.

## Non-goals

- Does not touch the Qwen agent or any of its flags.
- Keeps model selection and container-home handling unchanged.
- Keeps the legacy `yolo` config field for backward-compatible construction.
- No new settings.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test src/__tests__/kimi-execution-agent.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c187fc99e1db674f75ad48d1b994edc395c61496`
- Post-revert steps: Re-run the focused Kimi agent test.
- Data migration? No

</details>
