### PR TITLE
[Needs Attention Mutation Failure UX](2) Drop deprecated --prompt flag from Qwen command

### DIFF
--- a/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
@@ -22,9 +22,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec.fullPrompt).toBe('prompt text');
   });
@@ -38,9 +38,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'fix prompt',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec).not.toHaveProperty('fullPrompt');
   });
@@ -50,7 +50,6 @@ describe('QwenExecutionAgent', () => {
     expect(agent.buildCommand('prompt text').args).toEqual([
       '--approval-mode',
       'auto-edit',
-      '--prompt',
       'prompt text',
     ]);
   });
@@ -64,7 +63,6 @@ describe('QwenExecutionAgent', () => {
       'openai',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
   });

--- a/packages/execution-engine/src/agents/qwen-execution-agent.ts
+++ b/packages/execution-engine/src/agents/qwen-execution-agent.ts
@@ -85,7 +85,6 @@ export class QwenExecutionAgent implements ExecutionAgent {
       this.approvalMode,
       ...(this.authType ? ['--auth-type', this.authType] : []),
       ...(executionModel ? ['--model', executionModel] : []),
-      '--prompt',
       prompt,
     ];
   }


### PR DESCRIPTION
## Summary

The Qwen tool reads its prompt as a trailing positional argument. Passing `--prompt` before it made the tool treat the text as an unknown option.

Invoker now appends the prompt text directly after the model selector, with no `--prompt` in between.

## Review Claim

Approve that Qwen launches pass the prompt as the trailing positional value without the `--prompt` flag.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Qwen still receives the same prompt text, model, approval mode, and auth type; only the redundant `--prompt` flag is dropped, matching the tool's positional argument contract.

## Slice Rationale

This slice changes only how the Qwen agent assembles its argument array. It stacks on the Kimi `--yolo` slice so each tool's flag change reviews independently.

## Non-goals

Does not change Kimi flags. Does not alter the Qwen model selector, approval mode, or auth-type handling.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
