### PR TITLE
[Needs Attention Mutation Failure UX](2) Drop deprecated --prompt flag from Qwen command

### DIFF
--- a/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
@@ -22,9 +22,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec.fullPrompt).toBe('prompt text');
   });
@@ -38,9 +38,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'fix prompt',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec).not.toHaveProperty('fullPrompt');
   });
@@ -50,7 +50,6 @@ describe('QwenExecutionAgent', () => {
     expect(agent.buildCommand('prompt text').args).toEqual([
       '--approval-mode',
       'auto-edit',
-      '--prompt',
       'prompt text',
     ]);
   });
@@ -64,7 +63,6 @@ describe('QwenExecutionAgent', () => {
       'openai',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
   });

--- a/packages/execution-engine/src/agents/qwen-execution-agent.ts
+++ b/packages/execution-engine/src/agents/qwen-execution-agent.ts
@@ -85,7 +85,6 @@ export class QwenExecutionAgent implements ExecutionAgent {
       this.approvalMode,
       ...(this.authType ? ['--auth-type', this.authType] : []),
       ...(executionModel ? ['--model', executionModel] : []),
-      '--prompt',
       prompt,
     ];
   }


### PR DESCRIPTION
## Summary

Invoker builds the Qwen agent argv when it routes a prompt into prompt mode.

Current Qwen builds take the prompt as a positional argument and no longer accept a leading `--prompt` flag.

This slice stops emitting `--prompt` and passes the prompt positionally instead.

Matching unit specs pin the new argv so a routed Qwen prompt can start again.

## Review Claim

Approve dropping `--prompt` from the Qwen prompt-mode argv so the prompt is passed as a positional argument.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only `qwen-execution-agent.ts` and its unit spec change. No other agent or caller depends on the removed flag, so the slice is locally reviewable from those two files.

## Slice Rationale

This slice follows the Kimi `--yolo` drop so each agent argv shape is reviewed on its own. Bundling both agents would mix two argv shapes in one claim.

## Non-goals

- Does not change Kimi, Claude, Codex, or Cursor agent argv.
- Does not change UI, Needs Attention, or inspector surfaces.
- Does not change Qwen approval-mode or auth-type flags.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/qwen-execution-agent.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
