### PR TITLE
[Needs Attention Mutation Failure UX](2) Stop sending deprecated --yolo flag to Kimi prompt-mode agent

### DIFF
--- a/packages/execution-engine/src/__tests__/kimi-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/kimi-execution-agent.test.ts
@@ -2,13 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { KimiExecutionAgent } from '../agents/kimi-execution-agent.js';
 
 describe('KimiExecutionAgent', () => {
-  it('builds prompt command with yolo and model selector', () => {
+  it('builds prompt command with model selector without yolo', () => {
     const agent = new KimiExecutionAgent({ command: 'kimi-test' });
     const spec = agent.buildCommand('prompt text', { executionModel: 'kimi-k2.6' });
 
     expect(spec.cmd).toBe('kimi-test');
     expect(spec.args).toEqual([
-      '--yolo',
       '--model',
       'kimi-k2.6',
       '-p',
@@ -23,7 +22,6 @@ describe('KimiExecutionAgent', () => {
 
     expect(spec.cmd).toBe('kimi-test');
     expect(spec.args).toEqual([
-      '--yolo',
       '--model',
       'kimi-k2.6',
       '-p',
@@ -33,8 +31,8 @@ describe('KimiExecutionAgent', () => {
     expect(spec).not.toHaveProperty('fullPrompt');
   });
 
-  it('can disable yolo for stricter local runs', () => {
-    const agent = new KimiExecutionAgent({ command: 'kimi-test', yolo: false });
+  it('ignores the legacy yolo knob in prompt mode', () => {
+    const agent = new KimiExecutionAgent({ command: 'kimi-test', yolo: true });
     expect(agent.buildCommand('prompt text').args).toEqual([
       '-p',
       'prompt text',

--- a/packages/execution-engine/src/agents/kimi-execution-agent.ts
+++ b/packages/execution-engine/src/agents/kimi-execution-agent.ts
@@ -7,6 +7,10 @@ export interface KimiExecutionAgentConfig {
   command?: string;
   configDir?: string;
   containerHomePath?: string;
+  /**
+   * Deprecated compatibility knob. Current Kimi prompt mode rejects approval-mode
+   * flags, so Invoker never passes --yolo with -p/--prompt.
+   */
   yolo?: boolean;
 }
 
@@ -28,13 +32,11 @@ export class KimiExecutionAgent implements ExecutionAgent {
   private readonly command: string;
   private readonly configDir: string;
   private readonly containerHomePath: string;
-  private readonly yolo: boolean;
 
   constructor(config: KimiExecutionAgentConfig = {}) {
     this.command = config.command ?? process.env.INVOKER_KIMI_COMMAND ?? 'kimi';
     this.configDir = config.configDir ?? join(homedir(), '.kimi-code');
     this.containerHomePath = config.containerHomePath ?? '/home/invoker';
-    this.yolo = config.yolo ?? true;
   }
 
   buildCommand(fullPrompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
@@ -77,7 +79,6 @@ export class KimiExecutionAgent implements ExecutionAgent {
 
   private buildArgs(prompt: string, executionModel?: string): string[] {
     return [
-      ...(this.yolo ? ['--yolo'] : []),
       ...(executionModel ? ['--model', executionModel] : []),
       '-p',
       prompt,


### PR DESCRIPTION
## Summary

Kimi prompt mode no longer accepts approval-mode flags such as `--yolo`.

Invoker still appended `--yolo` with `-p`, so launches failed.

Those failures surfaced as mutation failures needing attention.

This slice never emits `--yolo` in prompt mode and keeps the config field as a deprecated no-op.

## Review Claim

Approve stopping `--yolo` emission from Kimi prompt-mode argument construction.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the Kimi agent argument list, its deprecated config comment, and unit checks change.

No Qwen or UI behavior changes in this slice.

## Slice Rationale

Kimi's obsolete flag is independent from Qwen's, so it lands as a follow-up slice.

## Non-goals

- Does not remove the deprecated `yolo` config field
- Does not change Qwen argument construction
- Does not change Needs Attention UI presentation

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/kimi-execution-agent.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
