### PR TITLE
[Needs Attention Mutation Failure UX](2) Drop --prompt from Qwen prompt mode

### DIFF
--- a/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
@@ -22,9 +22,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec.fullPrompt).toBe('prompt text');
   });
@@ -38,9 +38,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'fix prompt',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec).not.toHaveProperty('fullPrompt');
   });
@@ -50,7 +50,6 @@ describe('QwenExecutionAgent', () => {
     expect(agent.buildCommand('prompt text').args).toEqual([
       '--approval-mode',
       'auto-edit',
-      '--prompt',
       'prompt text',
     ]);
   });
@@ -64,7 +63,6 @@ describe('QwenExecutionAgent', () => {
       'openai',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
   });

--- a/packages/execution-engine/src/agents/qwen-execution-agent.ts
+++ b/packages/execution-engine/src/agents/qwen-execution-agent.ts
@@ -85,7 +85,6 @@ export class QwenExecutionAgent implements ExecutionAgent {
       this.approvalMode,
       ...(this.authType ? ['--auth-type', this.authType] : []),
       ...(executionModel ? ['--model', executionModel] : []),
-      '--prompt',
       prompt,
     ];
   }


### PR DESCRIPTION
## Summary

Invoker no longer adds the `--prompt` flag when it starts the Qwen agent; the prompt text is passed as a positional argument instead.

Current Qwen builds treat `--prompt` as unknown next to the positional prompt, so keeping it broke startup.

Every Qwen mode now builds an argument array that matches what the agent actually accepts.

## Review Claim

Approve that the Qwen agent passes the prompt positionally and no longer sends `--prompt`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice drops one flag from the argument array the Qwen agent builds and updates its unit tests to assert the positional form across each mode. The prompt text still reaches the agent unchanged, so a reviewer can confirm safety from the small diff and the updated assertions. It builds on the Kimi flag change below and touches no other agent.

## Slice Rationale

This Qwen flag change is stacked on the Kimi flag change so each agent's fix stays reviewable on its own. The two agents share no code, and either fix can be reverted alone.

## Non-goals

- Does not touch the Kimi agent.
- Does not change how the prompt text is generated.
- Does not alter Qwen model selection, auth flags, or approval mode.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>` (revert this PR before the Kimi PR below it)
- Post-revert steps: None
- Data migration? No

</details>

