### PR TITLE
[Needs Attention Mutation Failure UX](1) Drop obsolete --prompt flag from Qwen execution agent

### DIFF
--- a/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/qwen-execution-agent.test.ts
@@ -22,9 +22,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec.fullPrompt).toBe('prompt text');
   });
@@ -38,9 +38,9 @@ describe('QwenExecutionAgent', () => {
       'yolo',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'fix prompt',
     ]);
+    expect(spec.args).not.toContain('--prompt');
     expect(spec.sessionId).toBeDefined();
     expect(spec).not.toHaveProperty('fullPrompt');
   });
@@ -50,7 +50,6 @@ describe('QwenExecutionAgent', () => {
     expect(agent.buildCommand('prompt text').args).toEqual([
       '--approval-mode',
       'auto-edit',
-      '--prompt',
       'prompt text',
     ]);
   });
@@ -64,7 +63,6 @@ describe('QwenExecutionAgent', () => {
       'openai',
       '--model',
       'qwen3-coder-plus',
-      '--prompt',
       'prompt text',
     ]);
   });

--- a/packages/execution-engine/src/agents/qwen-execution-agent.ts
+++ b/packages/execution-engine/src/agents/qwen-execution-agent.ts
@@ -85,7 +85,6 @@ export class QwenExecutionAgent implements ExecutionAgent {
       this.approvalMode,
       ...(this.authType ? ['--auth-type', this.authType] : []),
       ...(executionModel ? ['--model', executionModel] : []),
-      '--prompt',
       prompt,
     ];
   }


### PR DESCRIPTION
## Summary

Qwen prompt mode now takes the prompt as a positional argument.

Invoker still appended an obsolete `--prompt` flag the current Qwen binary no longer accepts.

This slice drops that flag so Qwen launches pass the prompt positionally.

## Review Claim

Approve routing Qwen execution-agent prompts as positional args instead of an obsolete `--prompt` flag.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only `QwenExecutionAgent` argument assembly and its focused vitest coverage change. Approval-mode, auth-type, and model flags stay the same.

## Slice Rationale

Qwen's obsolete `--prompt` flag is its own launch-routing claim. The Kimi `--yolo` change stays in the next slice so each agent can be reviewed alone.

## Non-goals

- Does not change Kimi agent argument assembly.
- Does not change Qwen approval-mode or auth-type defaults.
- Does not change UI mutation-failure or Needs Attention surfaces.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/qwen-execution-agent.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

