### PR TITLE
ci: route UI Vitest to Runner_Vitest heavy fleet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
   ui-vitest:
     name: UI Vitest
     runs-on:
-      labels: Runner_2_4_core
+      labels: Runner_Vitest
     timeout-minutes: 5
 
     steps:


### PR DESCRIPTION
## Summary
- Point the `UI Vitest` job at the new `Runner_Vitest` label.
- Leaves light jobs on `Runner_2_4_core` / `Github_Runner` / `Runner_1`.

## Context
Two DigitalOcean 8GB heavies are registered as:
- `invoker-do-v-01` (159.65.100.195)
- `invoker-do-v-02` (206.189.69.94)

## Note
Open PRs only pick this up after they include this workflow change (merge/rebase onto master). Until then the heavies also carry `Runner_2_4_core` so they can still absorb Vitest from the shared pool.