### PR TITLE
Make disk-headroom reclaim critical local and remote Invoker homes

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
@@ -1,0 +1,117 @@
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildInvokerHomeCleanupScript,
+  cleanupLocalInvokerHome,
+  DiskCleanupCooldownTracker,
+  isSafeInvokerHome,
+  isSafeRemoteInvokerHomePath,
+  resolveDiskCleanupCooldownMs,
+  resolveDiskCleanupEnabled,
+} from '../workers/disk-headroom-reclaim.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('disk-headroom cleanup guards', () => {
+  it('rejects unsafe invoker homes', () => {
+    expect(isSafeInvokerHome('', '/Users/me')).toBe(false);
+    expect(isSafeInvokerHome('/', '/Users/me')).toBe(false);
+    expect(isSafeInvokerHome('~', '/Users/me')).toBe(false);
+    expect(isSafeInvokerHome('/Users/me', '/Users/me')).toBe(false);
+    expect(isSafeInvokerHome('/Users/me/', '/Users/me')).toBe(false);
+    expect(isSafeInvokerHome('/Users/me/.invoker', '/Users/me')).toBe(true);
+    expect(isSafeInvokerHome('~/.invoker', '/Users/me')).toBe(true);
+  });
+
+  it('rejects unsafe remote path literals', () => {
+    expect(isSafeRemoteInvokerHomePath('')).toBe(false);
+    expect(isSafeRemoteInvokerHomePath('/')).toBe(false);
+    expect(isSafeRemoteInvokerHomePath('~')).toBe(false);
+    expect(isSafeRemoteInvokerHomePath('$HOME')).toBe(false);
+    expect(isSafeRemoteInvokerHomePath('~/.invoker')).toBe(true);
+    expect(isSafeRemoteInvokerHomePath('/home/invoker/.invoker')).toBe(true);
+  });
+
+  it('embeds path guards and provision-only pkill in the remote script', () => {
+    const script = buildInvokerHomeCleanupScript('~/.invoker');
+    expect(script).toContain('Refusing unsafe INVOKER_HOME');
+    expect(script).toContain("pkill -9 -f 'pnpm install");
+    expect(script).not.toContain('pkill -9 -f "$INVOKER_HOME"');
+    expect(script).toContain('$INVOKER_HOME/runtime');
+    expect(script).toContain('$INVOKER_HOME/repos');
+    expect(script).toContain('$INVOKER_HOME/worktrees');
+  });
+});
+
+describe('disk-headroom cleanup env', () => {
+  it('enables cleanup by default and honors disable flags', () => {
+    expect(resolveDiskCleanupEnabled({})).toBe(true);
+    expect(resolveDiskCleanupEnabled({ INVOKER_DISK_CLEANUP_ENABLED: '0' })).toBe(false);
+    expect(resolveDiskCleanupEnabled({ INVOKER_DISK_CLEANUP_ENABLED: 'false' })).toBe(false);
+    expect(resolveDiskCleanupEnabled({ INVOKER_DISK_CLEANUP_ENABLED: '1' })).toBe(true);
+  });
+
+  it('resolves cooldown ms with a 30m default', () => {
+    expect(resolveDiskCleanupCooldownMs({})).toBe(30 * 60 * 1000);
+    expect(resolveDiskCleanupCooldownMs({ INVOKER_DISK_CLEANUP_COOLDOWN_MS: '1000' })).toBe(1000);
+    expect(resolveDiskCleanupCooldownMs({ INVOKER_DISK_CLEANUP_COOLDOWN_MS: 'nope' })).toBe(30 * 60 * 1000);
+  });
+});
+
+describe('DiskCleanupCooldownTracker', () => {
+  it('allows first cleanup then blocks until cooldown elapses', () => {
+    const tracker = new DiskCleanupCooldownTracker(60_000);
+    expect(tracker.canCleanup('local /tmp/x', 1000)).toBe(true);
+    tracker.markCleaned('local /tmp/x', 1000);
+    expect(tracker.canCleanup('local /tmp/x', 30_000)).toBe(false);
+    expect(tracker.canCleanup('local /tmp/x', 61_000)).toBe(true);
+    expect(tracker.canCleanup('other', 30_000)).toBe(true);
+  });
+});
+
+describe('cleanupLocalInvokerHome', () => {
+  it('wipes runtime/repos/worktrees and recreates empty dirs', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'invoker-disk-cleanup-'));
+    tempDirs.push(root);
+    const home = join(root, '.invoker');
+    const userHome = root;
+    mkdirSync(join(home, 'worktrees', 'abc'), { recursive: true });
+    writeFileSync(join(home, 'worktrees', 'abc', 'file.txt'), 'x');
+    mkdirSync(join(home, 'repos', 'abc'), { recursive: true });
+    writeFileSync(join(home, 'repos', 'abc', 'file.txt'), 'x');
+    mkdirSync(join(home, 'runtime', 'ssh'), { recursive: true });
+    writeFileSync(join(home, 'invoker.db'), 'keep-me');
+
+    const result = await cleanupLocalInvokerHome({
+      invokerHome: home,
+      userHome,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe('critical-cleanup');
+    expect(existsSync(join(home, 'worktrees'))).toBe(true);
+    expect(existsSync(join(home, 'repos'))).toBe(true);
+    expect(existsSync(join(home, 'runtime'))).toBe(true);
+    expect(existsSync(join(home, 'worktrees', 'abc'))).toBe(false);
+    expect(existsSync(join(home, 'invoker.db'))).toBe(true);
+  });
+
+  it('refuses to clean the user home itself', async () => {
+    const result = await cleanupLocalInvokerHome({
+      invokerHome: '/Users/me',
+      userHome: '/Users/me',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('path-guard');
+  });
+});

--- a/packages/execution-engine/src/__tests__/disk-headroom-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-worker.test.ts
@@ -8,6 +8,7 @@ import {
   registerDiskHeadroomWorker,
 } from '../workers/disk-headroom-worker.js';
 import type { DiskHeadroomMonitorDeps, RemoteDiskTarget } from '../workers/disk-headroom-monitor.js';
+import type { DiskHeadroomEvaluation } from '../workers/disk-headroom.js';
 
 function makeLogger() {
   const logger = {
@@ -20,6 +21,30 @@ function makeLogger() {
 
   logger.child.mockImplementation(() => logger as any);
   return logger as any;
+}
+
+function criticalEval(label: string): DiskHeadroomEvaluation {
+  return {
+    label,
+    level: 'critical',
+    usage: {
+      filesystem: '/dev/vda1',
+      blocks1024: 100,
+      usedBlocks1024: 96,
+      availableBlocks1024: 4,
+      usedPercent: 96,
+      mountedOn: '/',
+    },
+    thresholds: { warnPercent: 85, criticalPercent: 95 },
+  };
+}
+
+function warnEval(label: string): DiskHeadroomEvaluation {
+  return {
+    ...criticalEval(label),
+    level: 'warn',
+    usage: { ...criticalEval(label).usage, usedPercent: 90, usedBlocks1024: 90, availableBlocks1024: 10 },
+  };
 }
 
 describe('disk-headroom worker', () => {
@@ -65,5 +90,127 @@ describe('disk-headroom worker', () => {
       remoteTargets,
       thresholds: { warnPercent: 85, criticalPercent: 95 },
     });
+  });
+
+  it('cleans critical targets and skips warn-only targets', async () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerDiskHeadroomWorker(registry);
+
+    const remoteTargets: RemoteDiskTarget[] = [
+      {
+        name: 'remote-1',
+        connection: { host: 'h', user: 'u', sshKeyPath: '/k' },
+        remotePath: '~/.invoker',
+      },
+    ];
+    const localLabel = 'local /tmp/invoker-home';
+    const remoteLabel = 'ssh:remote-1 ~/.invoker';
+
+    const runCheck = vi.fn(async () => [
+      warnEval('local /tmp/other'),
+      criticalEval(localLabel),
+      criticalEval(remoteLabel),
+    ]);
+    const cleanupLocal = vi.fn(async () => ({
+      targetKey: localLabel,
+      ok: true,
+      reason: 'critical-cleanup',
+    }));
+    const cleanupRemote = vi.fn(async () => ({
+      targetKey: remoteLabel,
+      ok: true,
+      reason: 'critical-cleanup',
+    }));
+    const upsertWorkerAction = vi.fn((row: unknown) => row);
+
+    const definition = registry.get(DISK_HEADROOM_WORKER_KIND)!;
+    const runtime = definition.factory({
+      store: { upsertWorkerAction } as any,
+      submitter: { submit: vi.fn() } as any,
+      logger: makeLogger(),
+      diskHeadroom: {
+        localPath: '/tmp/invoker-home',
+        remoteTargets,
+        thresholds: { warnPercent: 85, criticalPercent: 95 },
+        intervalMs: 0,
+        tickOnStart: false,
+        cleanupCooldownMs: 60_000,
+        runCheck,
+        cleanupLocal,
+        cleanupRemote,
+      },
+    });
+
+    await runtime.tick('manual');
+
+    expect(cleanupLocal).toHaveBeenCalledTimes(1);
+    expect(cleanupLocal.mock.calls[0]?.[0]).toMatchObject({
+      invokerHome: '/tmp/invoker-home',
+      targetKey: localLabel,
+    });
+    expect(cleanupRemote).toHaveBeenCalledTimes(1);
+    expect(cleanupRemote.mock.calls[0]?.[0]).toMatchObject({
+      target: remoteTargets[0],
+    });
+    expect(upsertWorkerAction).toHaveBeenCalled();
+  });
+
+  it('respects cleanup cooldown on a second critical tick', async () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerDiskHeadroomWorker(registry);
+
+    const localLabel = 'local /tmp/invoker-home';
+    const runCheck = vi.fn(async () => [criticalEval(localLabel)]);
+    const cleanupLocal = vi.fn(async () => ({
+      targetKey: localLabel,
+      ok: true,
+      reason: 'critical-cleanup',
+    }));
+
+    const definition = registry.get(DISK_HEADROOM_WORKER_KIND)!;
+    const runtime = definition.factory({
+      store: {} as any,
+      submitter: { submit: vi.fn() } as any,
+      logger: makeLogger(),
+      diskHeadroom: {
+        localPath: '/tmp/invoker-home',
+        remoteTargets: [],
+        intervalMs: 0,
+        tickOnStart: false,
+        cleanupCooldownMs: 60_000,
+        runCheck,
+        cleanupLocal,
+      },
+    });
+
+    await runtime.tick('manual');
+    await runtime.tick('manual');
+
+    expect(cleanupLocal).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not clean when cleanup is disabled', async () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerDiskHeadroomWorker(registry);
+
+    const cleanupLocal = vi.fn();
+    const definition = registry.get(DISK_HEADROOM_WORKER_KIND)!;
+    const runtime = definition.factory({
+      store: {} as any,
+      submitter: { submit: vi.fn() } as any,
+      logger: makeLogger(),
+      diskHeadroom: {
+        localPath: '/tmp/invoker-home',
+        remoteTargets: [],
+        intervalMs: 0,
+        tickOnStart: false,
+        cleanupEnabled: false,
+        runCheck: async () => [criticalEval('local /tmp/invoker-home')],
+        cleanupLocal,
+      },
+    });
+
+    await runtime.tick('manual');
+    expect(cleanupLocal).not.toHaveBeenCalled();
   });
 });

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -61,6 +61,7 @@ export * from './workers/ci-failure-worker.js';
 export * from './workers/auto-approve-worker.js';
 export * from './workers/disk-headroom-worker.js';
 export * from './workers/disk-headroom-monitor.js';
+export * from './workers/disk-headroom-reclaim.js';
 export * from './workers/disk-headroom.js';
 export * from './workers/pr-maintenance-workers.js';
 export * from './workers/e2e-autofix-worker.js';

--- a/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
@@ -1,0 +1,258 @@
+/**
+ * Critical-disk remediation for the disk-headroom worker.
+ *
+ * Wipes reclaimable Invoker-managed dirs (runtime/repos/worktrees) plus common
+ * provision caches. Never touches invoker.db / config.json / the home root.
+ */
+
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import type { Logger } from '@invoker/contracts';
+
+import { buildSshConnectionArgs } from '../ssh-transport-options.js';
+import { bashNormalizeTildePath, execRemoteCapture, shellPosixSingleQuote } from '../ssh-git-exec.js';
+
+import type { RemoteDiskTarget } from './disk-headroom-monitor.js';
+
+export const DEFAULT_DISK_CLEANUP_COOLDOWN_MS = 30 * 60 * 1000;
+
+export interface DiskCleanupResult {
+  targetKey: string;
+  ok: boolean;
+  reason: string;
+  detail?: string;
+}
+
+/**
+ * Refuse empty, `/`, and `$HOME` (or literal `~`) so cleanup cannot wipe the
+ * whole machine. Relative paths and other absolute homes are allowed.
+ */
+export function isSafeInvokerHome(
+  invokerHome: string,
+  userHome: string = homedir(),
+): boolean {
+  const trimmed = invokerHome.trim();
+  if (!trimmed) return false;
+  if (trimmed === '/' || trimmed === '~') return false;
+  const expanded = expandTildeHome(trimmed, userHome);
+  if (!expanded || expanded === '/') return false;
+  if (expanded === userHome || expanded === `${userHome}/`) return false;
+  return true;
+}
+
+export function expandTildeHome(path: string, userHome: string = homedir()): string {
+  if (path === '~') return userHome;
+  if (path.startsWith('~/')) return join(userHome, path.slice(2));
+  return path;
+}
+
+/** True unless explicitly disabled with `INVOKER_DISK_CLEANUP_ENABLED=0|false`. */
+export function resolveDiskCleanupEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.INVOKER_DISK_CLEANUP_ENABLED;
+  if (raw === undefined || raw === '') return true;
+  return raw !== '0' && raw.toLowerCase() !== 'false';
+}
+
+export function resolveDiskCleanupCooldownMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.INVOKER_DISK_CLEANUP_COOLDOWN_MS;
+  if (!raw) return DEFAULT_DISK_CLEANUP_COOLDOWN_MS;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_DISK_CLEANUP_COOLDOWN_MS;
+  return n;
+}
+
+/**
+ * Whether a configured remote path is safe to pass into the cleanup script.
+ * `~/.invoker` is allowed (expanded on the remote). Bare `~` / `$HOME` / `/` are not.
+ */
+export function isSafeRemoteInvokerHomePath(remotePath: string): boolean {
+  const raw = remotePath.trim();
+  if (!raw || raw === '/' || raw === '~' || raw === '$HOME') return false;
+  if (raw === '~/') return false;
+  return true;
+}
+
+/**
+ * Remote bash that frees Invoker-managed disk under `$INVOKER_HOME`.
+ * Kills only provision grinders (pnpm install / electron unzip), not every
+ * process whose argv mentions the home (that can kill the SSH session).
+ */
+export function buildInvokerHomeCleanupScript(invokerHome: string): string {
+  const homeQ = shellPosixSingleQuote(invokerHome);
+  return `set +e
+INVOKER_HOME=${homeQ}
+${bashNormalizeTildePath('INVOKER_HOME')}
+case "$INVOKER_HOME" in
+  ""|"/"|"$HOME"|"~")
+    echo "Refusing unsafe INVOKER_HOME: $INVOKER_HOME" >&2
+    exit 64
+    ;;
+esac
+echo "[disk-headroom-cleanup] begin home=$INVOKER_HOME"
+df -h / | tail -1
+# Provision grinders only — do not pkill -f INVOKER_HOME (kills this SSH session).
+pkill -9 -f 'pnpm install --frozen-lockfile' >/dev/null 2>&1
+pkill -9 -f 'pnpm install' >/dev/null 2>&1
+pkill -9 -f 'electron-v[0-9].*-linux-x64.zip' >/dev/null 2>&1
+pkill -9 -f 'node_modules/.pnpm/electron@' >/dev/null 2>&1
+sleep 1
+remove_path() {
+  local path="$1"
+  if [ -e "$path" ]; then
+    mv "$path" "\${path}.deleting.$$" 2>/dev/null || true
+    nohup rm -rf "\${path}.deleting.$$" >/dev/null 2>&1 &
+    rm -rf "$path" 2>/dev/null || true
+  fi
+}
+remove_path "$INVOKER_HOME/runtime"
+remove_path "$INVOKER_HOME/repos"
+remove_path "$INVOKER_HOME/worktrees"
+remove_path "$INVOKER_HOME/merge-clones"
+rm -rf "$INVOKER_HOME"/*.deleting.* >/dev/null 2>&1
+# Common provision caches (best effort).
+rm -rf "$HOME/.cache/electron" "$HOME/.local/share/pnpm" "$HOME/.pnpm-store" >/dev/null 2>&1
+mkdir -p "$INVOKER_HOME/runtime" "$INVOKER_HOME/repos" "$INVOKER_HOME/worktrees"
+chmod 700 "$INVOKER_HOME/runtime" "$INVOKER_HOME/repos" "$INVOKER_HOME/worktrees"
+echo "[disk-headroom-cleanup] done"
+df -h / | tail -1
+exit 0
+`;
+}
+
+function removeLocalDir(path: string, errors: string[]): void {
+  if (!existsSync(path)) return;
+  try {
+    rmSync(path, { recursive: true, force: true });
+  } catch (err) {
+    errors.push(`${path}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+function ensureLocalDir(path: string, errors: string[]): void {
+  try {
+    mkdirSync(path, { recursive: true, mode: 0o700 });
+  } catch (err) {
+    errors.push(`mkdir ${path}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+export async function cleanupLocalInvokerHome(opts: {
+  invokerHome: string;
+  targetKey?: string;
+  logger?: Logger;
+  userHome?: string;
+}): Promise<DiskCleanupResult> {
+  const targetKey = opts.targetKey ?? `local ${opts.invokerHome}`;
+  const userHome = opts.userHome ?? homedir();
+  const home = expandTildeHome(opts.invokerHome, userHome);
+  if (!isSafeInvokerHome(home, userHome)) {
+    return { targetKey, ok: false, reason: 'path-guard', detail: home };
+  }
+
+  opts.logger?.info?.(`[disk-headroom-cleanup] local begin home=${home}`, {
+    module: 'disk-headroom',
+    targetKey,
+  });
+
+  const errors: string[] = [];
+  for (const name of ['runtime', 'repos', 'worktrees', 'merge-clones'] as const) {
+    removeLocalDir(join(home, name), errors);
+  }
+  for (const name of ['runtime', 'repos', 'worktrees'] as const) {
+    ensureLocalDir(join(home, name), errors);
+  }
+  for (const cache of [
+    join(userHome, '.cache', 'electron'),
+    join(userHome, '.local', 'share', 'pnpm'),
+    join(userHome, '.pnpm-store'),
+  ]) {
+    removeLocalDir(cache, errors);
+  }
+
+  if (errors.length > 0) {
+    opts.logger?.warn?.(`[disk-headroom-cleanup] local partial failures`, {
+      module: 'disk-headroom',
+      targetKey,
+      errors,
+    });
+    return {
+      targetKey,
+      ok: false,
+      reason: 'cleanup-error',
+      detail: errors.slice(0, 5).join('; '),
+    };
+  }
+
+  opts.logger?.info?.(`[disk-headroom-cleanup] local done home=${home}`, {
+    module: 'disk-headroom',
+    targetKey,
+  });
+  return { targetKey, ok: true, reason: 'critical-cleanup' };
+}
+
+export async function cleanupRemoteInvokerHome(opts: {
+  target: RemoteDiskTarget;
+  logger?: Logger;
+  runRemoteScript?: (target: RemoteDiskTarget, script: string) => Promise<string>;
+}): Promise<DiskCleanupResult> {
+  const targetKey = `ssh:${opts.target.name} ${opts.target.remotePath}`;
+  if (!isSafeRemoteInvokerHomePath(opts.target.remotePath)) {
+    return {
+      targetKey,
+      ok: false,
+      reason: 'path-guard',
+      detail: opts.target.remotePath,
+    };
+  }
+
+  const script = buildInvokerHomeCleanupScript(opts.target.remotePath);
+  const run = opts.runRemoteScript ?? defaultRunRemoteCleanup;
+  try {
+    opts.logger?.info?.(`[disk-headroom-cleanup] remote begin ${targetKey}`, {
+      module: 'disk-headroom',
+      targetKey,
+    });
+    const output = await run(opts.target, script);
+    opts.logger?.info?.(`[disk-headroom-cleanup] remote done ${targetKey}`, {
+      module: 'disk-headroom',
+      targetKey,
+      outputTail: output.slice(-400),
+    });
+    return { targetKey, ok: true, reason: 'critical-cleanup', detail: output.slice(-400) };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    opts.logger?.error?.(`[disk-headroom-cleanup] remote failed ${targetKey}: ${detail}`, {
+      module: 'disk-headroom',
+      targetKey,
+    });
+    return { targetKey, ok: false, reason: 'cleanup-error', detail };
+  }
+}
+
+function defaultRunRemoteCleanup(target: RemoteDiskTarget, script: string): Promise<string> {
+  const sshArgs = buildSshConnectionArgs(target.connection, { batchMode: true });
+  return execRemoteCapture({
+    sshArgs,
+    script,
+    phase: `disk-headroom-cleanup:${target.name}`,
+  });
+}
+
+export class DiskCleanupCooldownTracker {
+  private readonly lastCleanupAt = new Map<string, number>();
+
+  constructor(private readonly cooldownMs: number) {}
+
+  canCleanup(targetKey: string, nowMs: number = Date.now()): boolean {
+    if (this.cooldownMs <= 0) return true;
+    const last = this.lastCleanupAt.get(targetKey);
+    if (last === undefined) return true;
+    return nowMs - last >= this.cooldownMs;
+  }
+
+  markCleaned(targetKey: string, nowMs: number = Date.now()): void {
+    this.lastCleanupAt.set(targetKey, nowMs);
+  }
+}

--- a/packages/execution-engine/src/workers/disk-headroom-worker.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-worker.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@invoker/contracts';
 
 import { resolveInvokerHomeRoot } from '../worker-lock.js';
+import { recordWorkerDecisionRow, type WorkerDecisionStore } from '../worker-decision-ledger.js';
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import type { WorkerRegistry } from '../worker-registry.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
@@ -8,10 +9,20 @@ import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../wor
 import {
   resolveDiskCheckIntervalMs,
   resolveDiskHeadroomThresholds,
+  type DiskHeadroomEvaluation,
   type DiskHeadroomThresholds,
 } from './disk-headroom.js';
 import {
+  cleanupLocalInvokerHome,
+  cleanupRemoteInvokerHome,
+  DiskCleanupCooldownTracker,
+  resolveDiskCleanupCooldownMs,
+  resolveDiskCleanupEnabled,
+  type DiskCleanupResult,
+} from './disk-headroom-reclaim.js';
+import {
   runDiskHeadroomCheck,
+  type ActivityLogLevel,
   type DiskHeadroomMonitorDeps,
   type RemoteDiskTarget,
 } from './disk-headroom-monitor.js';
@@ -28,8 +39,22 @@ export interface DiskHeadroomWorkerConfig {
   intervalMs?: number;
   tickOnStart?: boolean;
 
+  /** When false, critical disks are logged only. Default: enabled. */
+  cleanupEnabled?: boolean;
+  /** Min ms between cleanups for the same target. Default: 30 min. */
+  cleanupCooldownMs?: number;
+
+  /** Optional decision ledger for cleanup act/skip rows. */
+  store?: WorkerDecisionStore;
+  /** Optional activity-log sink (wired from owner persistence). */
+  writeActivityLog?: (level: ActivityLogLevel, message: string) => void;
+
   /** Test seam: override the check runner. */
-  runCheck?: (deps: DiskHeadroomMonitorDeps) => Promise<unknown>;
+  runCheck?: (deps: DiskHeadroomMonitorDeps) => Promise<DiskHeadroomEvaluation[] | unknown>;
+  /** Test seam: override local cleanup. */
+  cleanupLocal?: typeof cleanupLocalInvokerHome;
+  /** Test seam: override remote cleanup. */
+  cleanupRemote?: typeof cleanupRemoteInvokerHome;
   /** Test seam: wrap the worker tick for observability. */
   onTick?: WorkerTick;
 }
@@ -41,12 +66,51 @@ export interface DiskHeadroomWorkerOptions {
   thresholds?: DiskHeadroomThresholds;
   intervalMs?: number;
   tickOnStart?: boolean;
-  runCheck?: (deps: DiskHeadroomMonitorDeps) => Promise<unknown>;
+  cleanupEnabled?: boolean;
+  cleanupCooldownMs?: number;
+  store?: WorkerDecisionStore;
+  writeActivityLog?: (level: ActivityLogLevel, message: string) => void;
+  runCheck?: (deps: DiskHeadroomMonitorDeps) => Promise<DiskHeadroomEvaluation[] | unknown>;
+  cleanupLocal?: typeof cleanupLocalInvokerHome;
+  cleanupRemote?: typeof cleanupRemoteInvokerHome;
   onTick?: WorkerTick;
+}
+
+function isEvaluationList(value: unknown): value is DiskHeadroomEvaluation[] {
+  return Array.isArray(value);
+}
+
+function recordCleanupDecision(
+  store: WorkerDecisionStore | undefined,
+  result: DiskCleanupResult,
+): void {
+  if (!store) return;
+  recordWorkerDecisionRow(store, {
+    workerKind: DISK_HEADROOM_WORKER_KIND,
+    actionType: 'disk-cleanup',
+    externalKey: `cleanup:${result.targetKey}:${result.reason}`,
+    subjectType: 'disk-target',
+    subjectId: result.targetKey,
+    status: result.ok ? 'completed' : result.reason === 'cooldown' || result.reason === 'disabled'
+      ? 'skipped'
+      : 'failed',
+    summary: result.ok
+      ? `Cleaned ${result.targetKey}`
+      : `Cleanup ${result.reason} for ${result.targetKey}`,
+    reason: result.reason,
+    payload: result.detail ? { detail: result.detail } : undefined,
+    incrementAttempt: result.ok,
+  });
 }
 
 export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): WorkerRuntime {
   const runCheck = options.runCheck ?? runDiskHeadroomCheck;
+  const cleanupLocal = options.cleanupLocal ?? cleanupLocalInvokerHome;
+  const cleanupRemote = options.cleanupRemote ?? cleanupRemoteInvokerHome;
+  const cleanupEnabled = options.cleanupEnabled ?? resolveDiskCleanupEnabled();
+  const cooldown = new DiskCleanupCooldownTracker(
+    options.cleanupCooldownMs ?? resolveDiskCleanupCooldownMs(),
+  );
 
   return createWorkerRuntime({
     kind: DISK_HEADROOM_WORKER_KIND,
@@ -59,23 +123,85 @@ export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): Wo
       if (ctx.signal?.aborted) return;
 
       const thresholds = options.thresholds ?? resolveDiskHeadroomThresholds();
-      await runCheck({
+      const evaluationsRaw = await runCheck({
         logger: options.logger,
         thresholds,
         localPath: options.localPath,
         remoteTargets: options.remoteTargets,
+        writeActivityLog: options.writeActivityLog,
       });
+      if (ctx.signal?.aborted) return;
+      if (!cleanupEnabled) return;
+      if (!isEvaluationList(evaluationsRaw)) return;
+
+      const critical = evaluationsRaw.filter((e) => e.level === 'critical');
+      for (const evaluation of critical) {
+        if (ctx.signal?.aborted) return;
+        const targetKey = evaluation.label;
+        if (!cooldown.canCleanup(targetKey)) {
+          const skipped: DiskCleanupResult = {
+            targetKey,
+            ok: false,
+            reason: 'cooldown',
+          };
+          options.logger.info?.(
+            `[disk-headroom-cleanup] skip ${targetKey}: cooldown`,
+            { module: 'disk-headroom', targetKey },
+          );
+          recordCleanupDecision(options.store, skipped);
+          continue;
+        }
+
+        let result: DiskCleanupResult;
+        if (targetKey.startsWith('ssh:')) {
+          const target = options.remoteTargets.find(
+            (t) => `ssh:${t.name} ${t.remotePath}` === targetKey,
+          );
+          if (!target) {
+            result = {
+              targetKey,
+              ok: false,
+              reason: 'cleanup-error',
+              detail: `remote target not found for ${targetKey}`,
+            };
+          } else {
+            result = await cleanupRemote({
+              target,
+              logger: options.logger,
+            });
+          }
+        } else {
+          result = await cleanupLocal({
+            invokerHome: options.localPath,
+            targetKey,
+            logger: options.logger,
+          });
+        }
+
+        if (result.ok || result.reason === 'critical-cleanup') {
+          cooldown.markCleaned(targetKey);
+        } else if (result.reason !== 'cooldown') {
+          // Mark failed attempts too so we do not hammer a wedged host every tick.
+          cooldown.markCleaned(targetKey);
+        }
+        recordCleanupDecision(options.store, result);
+        options.writeActivityLog?.(
+          result.ok ? 'warn' : 'error',
+          `[disk-headroom-cleanup] ${result.reason}: ${result.targetKey}`
+            + (result.detail ? ` (${result.detail.slice(0, 200)})` : ''),
+        );
+      }
     },
   });
 }
 
-/** Register the built-in disk-headroom worker (best-effort `df` checks only). */
+/** Register the built-in disk-headroom worker (df checks + critical cleanup). */
 export function registerDiskHeadroomWorker(
   registry: WorkerRegistry<WorkerRuntimeDependencies>,
 ): WorkerRegistry<WorkerRuntimeDependencies> {
   registry.register({
     kind: DISK_HEADROOM_WORKER_KIND,
-    note: 'Monitors local and remote disk usage, logging warnings at high utilization.',
+    note: 'Monitors local/remote disk usage and cleans Invoker-managed dirs on critical pressure.',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime => {
       const config = deps.diskHeadroom;
       return createDiskHeadroomWorker({
@@ -85,7 +211,13 @@ export function registerDiskHeadroomWorker(
         thresholds: config?.thresholds,
         intervalMs: config?.intervalMs,
         tickOnStart: config?.tickOnStart,
-        runCheck: config?.runCheck,
+        cleanupEnabled: config?.cleanupEnabled,
+        cleanupCooldownMs: config?.cleanupCooldownMs,
+        store: config?.store ?? deps.store,
+        writeActivityLog: config?.writeActivityLog,
+        runCheck: config?.runCheck as DiskHeadroomWorkerOptions['runCheck'],
+        cleanupLocal: config?.cleanupLocal,
+        cleanupRemote: config?.cleanupRemote,
         onTick: config?.onTick,
       });
     },


### PR DESCRIPTION
## Summary

Disk-headroom used to only log when a machine was critically full.

That left local and remote Invoker homes filling until launches failed with ENOSPC.

On critical pressure, the worker now clears reclaimable runtime, repos, and worktrees on that machine.

## Review Claim

Critical disk-headroom ticks remediate by reclaiming Invoker-managed dirs on the affected local or remote machine.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Reclaim refuses `/`, `$HOME`, and bare `~`, never deletes `invoker.db` or `config.json`, and only kills provision grinders rather than every process matching the Invoker home.

## Slice Rationale

This is one worker behavior fix: observe critical pressure and free the same reclaimable dirs that already unblocked production remotes.

## Non-goals

- Does not change autofix restart or recreate storm behavior.
- Does not enable per-task `INVOKER_ENABLE_WORKSPACE_CLEANUP`.
- Does not clean at warn threshold; only critical.
- Does not change owner wiring in `packages/app/src/main.ts` (including per-target `remoteInvokerHome` monitoring) in this slice.
- Does not wipe arbitrary paths outside Invoker-managed homes and known provision caches.

## Architecture

### Before

```mermaid
flowchart LR
  tick["disk-headroom tick"] --> df["df local + remotes"]
  df --> eval["evaluate thresholds"]
  eval -->|"warn/critical"| log["logger only"]
  log --> none["no reclaim"]
```

### After

```mermaid
flowchart LR
  tick["disk-headroom tick"] --> df["df local + remotes"]
  df --> eval["evaluate thresholds"]
  eval -->|"critical + cooldown ok"| reclaim["reclaim runtime/repos/worktrees"]
  reclaim --> decide["record worker decision"]
  eval -->|"warn/ok or cooling down"| log["log only"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test -- src/__tests__/disk-headroom-reclaim.test.ts src/__tests__/disk-headroom-worker.test.ts src/__tests__/disk-headroom.test.ts src/__tests__/disk-headroom-monitor.test.ts`
- [ ] Confirm critical evaluations call reclaim and warn evaluations do not.
- [ ] Confirm cooldown skips a second reclaim within 30 minutes for the same target.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Disk-headroom returns to monitor-only logging.
- Data migration? No

</details>
