### PR TITLE
Show queue running vs queued in the UI

### DIFF
--- a/packages/app/e2e/queue-running-vs-queued.spec.ts
+++ b/packages/app/e2e/queue-running-vs-queued.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Visual proof: home bottom chrome shows queue executing vs queued.
+ * Running sidebar keeps the detailed list split.
+ */
+import {
+  test,
+  expect,
+  E2E_REPO_URL,
+  loadPlan,
+  startPlan,
+  captureScreenshot,
+} from './fixtures/electron-app.js';
+
+test.use({
+  repoConfig: {
+    autoFixRetries: 0,
+    maxConcurrency: 1,
+  },
+});
+
+const QUEUE_SPLIT_PLAN = {
+  name: 'Running Queued Split Proof',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    {
+      id: 'slot-holder',
+      description: 'Occupies the only runner slot',
+      command: 'sleep 30 && echo slot-holder-done',
+      dependencies: [],
+    },
+    {
+      id: 'waiting-task',
+      description: 'Waits for a free runner slot',
+      command: 'echo waiting-task-done',
+      dependencies: [],
+    },
+  ],
+};
+
+test.describe('queue running vs queued', () => {
+  test('home bottom chrome shows executing and queued chips', async ({ page }) => {
+    await loadPlan(page, QUEUE_SPLIT_PLAN);
+    await startPlan(page);
+
+    await expect.poll(async () => {
+      const status = await page.evaluate(async () => await window.invoker.getQueueStatus());
+      return {
+        running: status?.running?.length ?? 0,
+        queued: status?.queued?.length ?? 0,
+      };
+    }, { timeout: 30000 }).toEqual({ running: 1, queued: 1 });
+
+    // Stay on home — this is the live bottom bar surface.
+    await expect(page.getByTestId('sidebar-home')).toBeVisible();
+    await expect(page.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/1)');
+    await expect(page.getByTestId('queue-chip-queued')).toHaveTextContent('Queued (1)');
+    await captureScreenshot(page, 'home-queue-capacity-chips');
+
+    await page.getByTestId('sidebar-running').click();
+    await expect(page.getByTestId('running-queue-section-running')).toContainText('Running (1)');
+    await expect(page.getByTestId('running-queue-section-queued')).toContainText('Queued (1)');
+    await captureScreenshot(page, 'running-queued-split');
+  });
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3789,6 +3789,8 @@ export function App() {
           activeFilters={statusFilters}
           keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
           onStatusClick={handleStatusClick}
+          queueStatus={queueStatus}
+          onOpenRunningSurface={() => handleSelectSidebarSurface('running')}
         />
       )}
       <TerminalDrawer

--- a/packages/ui/src/__tests__/workflow-status-chips-queue.test.tsx
+++ b/packages/ui/src/__tests__/workflow-status-chips-queue.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { WorkflowStatusChips } from '../components/WorkflowStatusChips.js';
+import type { QueueStatus, WorkflowMeta } from '../types.js';
+
+describe('WorkflowStatusChips queue capacity', () => {
+  it('shows executing and queued counts from queue status on the home bottom chrome', () => {
+    const workflows = new Map<string, WorkflowMeta>([
+      ['wf-1', { id: 'wf-1', name: 'One', status: 'running' }],
+    ]);
+    const queueStatus: QueueStatus = {
+      maxConcurrency: 8,
+      runningCount: 3,
+      running: [
+        { taskId: 'a', description: 'a' },
+        { taskId: 'b', description: 'b' },
+        { taskId: 'c', description: 'c' },
+      ],
+      queued: [
+        { taskId: 'd', priority: 0, description: 'd' },
+        { taskId: 'e', priority: 0, description: 'e' },
+      ],
+    };
+    const onOpenRunningSurface = vi.fn();
+
+    render(
+      <WorkflowStatusChips
+        workflows={workflows}
+        activeFilters={new Set()}
+        onStatusClick={() => {}}
+        queueStatus={queueStatus}
+        onOpenRunningSurface={onOpenRunningSurface}
+      />,
+    );
+
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (3/8)');
+    expect(screen.getByTestId('queue-chip-queued')).toHaveTextContent('Queued (2)');
+    expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('running (1)');
+
+    fireEvent.click(screen.getByTestId('queue-chip-queued'));
+    expect(onOpenRunningSurface).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/WorkflowStatusChips.tsx
+++ b/packages/ui/src/components/WorkflowStatusChips.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent } from 'react';
-import type { WorkflowMeta, WorkflowStatus } from '../types.js';
+import type { QueueStatus, WorkflowMeta, WorkflowStatus } from '../types.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
 
 interface WorkflowStatusChipsProps {
@@ -7,6 +7,8 @@ interface WorkflowStatusChipsProps {
   activeFilters: Set<WorkflowStatus>;
   onStatusClick: (status: WorkflowStatus, event: MouseEvent<HTMLButtonElement>) => void;
   keyboardActiveKey?: WorkflowStatus | null;
+  queueStatus?: QueueStatus | null;
+  onOpenRunningSurface?: () => void;
 }
 
 const DISPLAY_ORDER: WorkflowStatus[] = [
@@ -27,6 +29,8 @@ export function WorkflowStatusChips({
   activeFilters,
   onStatusClick,
   keyboardActiveKey = null,
+  queueStatus = null,
+  onOpenRunningSurface,
 }: WorkflowStatusChipsProps): JSX.Element {
   const counts = new Map<WorkflowStatus, number>();
   for (const status of DISPLAY_ORDER) counts.set(status, 0);
@@ -35,9 +39,32 @@ export function WorkflowStatusChips({
   }
 
   const hasFilters = activeFilters.size > 0;
+  const queueRunning = queueStatus?.runningCount ?? 0;
+  const queueMax = queueStatus?.maxConcurrency ?? 0;
+  const queueQueued = queueStatus?.queued.length ?? 0;
 
   return (
     <div data-testid="workflow-status-chips" className="flex items-center gap-6 px-4 py-2 bg-secondary border-t border-border text-sm">
+      {queueStatus && (
+        <div data-testid="queue-capacity-chips" className="flex items-center gap-3 border-r border-border pr-6">
+          <button
+            type="button"
+            data-testid="queue-chip-running"
+            onClick={() => onOpenRunningSurface?.()}
+            className="px-2 py-0.5 text-xs rounded-full cursor-pointer select-none text-blue-300 hover:brightness-125"
+          >
+            Executing ({queueRunning}/{queueMax})
+          </button>
+          <button
+            type="button"
+            data-testid="queue-chip-queued"
+            onClick={() => onOpenRunningSurface?.()}
+            className="px-2 py-0.5 text-xs rounded-full cursor-pointer select-none text-amber-300 hover:brightness-125"
+          >
+            Queued ({queueQueued})
+          </button>
+        </div>
+      )}
       {DISPLAY_ORDER.map((status) => {
         const visual = workflowStatusVisual(status);
         const active = activeFilters.has(status);


### PR DESCRIPTION
## Summary

Home bottom chrome and the Running sidebar treated queue occupancy as one blob of "active" work.

That made tasks waiting for a runner look the same as tasks that already hold a slot.

This change mirrors `query queue` on the live home graph bar (`WorkflowStatusChips`): Executing (n/max) and Queued (n) sit beside the workflow status pills. The Running sidebar keeps the detailed list split for drill-down.

## Review Claim

Approve that the home bottom chrome now shows the same executing vs queued distinction operators already get from `query queue`, without opening the Running tab.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Task durable statuses are unchanged. Queued work stays `pending` in the graph; only queue membership presentation changes.

## Slice Rationale

This is a presentation-only fix for an existing queue API. It does not change scheduler capacity, launch dispatch, or workflow rollup rules.

## Non-goals

- No new durable `queued` task status
- No change to `maxConcurrency` or pool selection
- No change to workflow status rollup semantics
- Do not extract scheduler logic or move ownership of queue state

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- src/__tests__/workflow-status-chips-queue.test.tsx`
- [x] `cd packages/ui && pnpm test -- src/__tests__/workflow-progress-surfaces.test.ts`
- [ ] `cd packages/app && CAPTURE_MODE=after npx playwright test e2e/queue-running-vs-queued.spec.ts` (asserts home `queue-chip-*` then Running drill-down)
- [x] `bash scripts/test-make-pr-skill.sh`

</details>

## Visual Proof

Primary live surface: home bottom chrome (`data-testid="queue-capacity-chips"` / `queue-chip-running` / `queue-chip-queued`).

Secondary drill-down: Running sidebar (`data-testid="running-queue-list"`).

Home bottom Executing/Queued chips proof still needs a fresh capture after this commit; prior media below is the Running sidebar drill-down only.

Old flat Running list (only the occupied slot appears; queued work is hidden):

![queue-running-vs-queued-old](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-3160eb/queue-running-vs-queued-old.png)

New Running and Queued sections with subtitle `1 running · 1 queued`:

![queue-running-vs-queued-new](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-3160eb/queue-running-vs-queued-new.png)

Walkthrough video of the concurrency-limited run opening the Running surface:

![queue-running-vs-queued-walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260710-3160eb/queue-running-vs-queued-walkthrough.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>