### PR TITLE
[Conflict Resolution Model](1) Add conflictResolutionAgent/Model config keys

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -7,6 +7,7 @@ import {
   resolveConfigFilePath,
   resolveDefaultExecutionAgent,
   resolveDefaultTaskExecutionSettings,
+  resolveConflictResolutionSettings,
   resolveEmbeddedTerminalBackendConfig,
 } from '../config.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
@@ -167,6 +168,36 @@ describe('loadConfig', () => {
       executionAgent: 'omp',
       executionModel: 'chatgpt-5.4',
     });
+  });
+
+  it('reads conflict resolution settings from user config', () => {
+    writeUserConfig({
+      conflictResolutionAgent: 'omp',
+      conflictResolutionModel: 'gpt-5-mini',
+    });
+    const config = loadConfig();
+    expect(config.conflictResolutionAgent).toBe('omp');
+    expect(config.conflictResolutionModel).toBe('gpt-5-mini');
+  });
+
+  it('resolves conflict resolution settings with explicit, config, and path defaults', () => {
+    expect(resolveConflictResolutionSettings({})).toEqual({});
+    expect(resolveConflictResolutionSettings(
+      { conflictResolutionModel: 'gpt-5-mini' },
+      { pathDefaultAgent: 'codex' },
+    )).toEqual({ agent: 'codex', model: 'gpt-5-mini' });
+    expect(resolveConflictResolutionSettings(
+      { conflictResolutionAgent: 'omp', conflictResolutionModel: 'gpt-5-mini' },
+      { pathDefaultAgent: 'codex' },
+    )).toEqual({ agent: 'omp', model: 'gpt-5-mini' });
+    expect(resolveConflictResolutionSettings(
+      { conflictResolutionAgent: 'omp', conflictResolutionModel: 'gpt-5-mini' },
+      { explicitAgent: 'claude', pathDefaultAgent: 'codex' },
+    )).toEqual({ agent: 'claude', model: 'gpt-5-mini' });
+    expect(resolveConflictResolutionSettings(
+      { conflictResolutionAgent: '  ', conflictResolutionModel: '  ' },
+      { pathDefaultAgent: 'codex' },
+    )).toEqual({ agent: 'codex' });
   });
 
   it('reads autoFixCi from user config', () => {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -136,6 +136,18 @@ export interface InvokerConfig {
    * then to the built-in default agent.
    */
   autoFixAgent?: string;
+  /**
+   * Preferred execution agent for resolve-conflict (git merge conflicts).
+   * When unset, resolve-conflict uses the entry-point path default
+   * (explicit CLI/UI agent, then defaultExecutionAgent / autoFixAgent).
+   */
+  conflictResolutionAgent?: string;
+  /**
+   * Preferred execution model for resolve-conflict only.
+   * When set, wins over task.config.executionModel / defaultExecutionModel
+   * so conflict resolution can use a cheaper model than normal task work.
+   */
+  conflictResolutionModel?: string;
   /** Default execution harness for prompt-backed tasks when the task does not override it. */
   defaultExecutionAgent?: string;
   /** Default execution model for prompt-backed tasks when the task does not override it. */
@@ -402,6 +414,44 @@ export function resolveDefaultTaskExecutionSettings(config: InvokerConfig): Defa
   };
 }
 
+
+
+export interface ConflictResolutionSettings {
+  agent?: string;
+  model?: string;
+}
+
+/**
+ * Resolve agent/model for resolve-conflict.
+ *
+ * Precedence for agent: explicitAgent → conflictResolutionAgent → pathDefaultAgent.
+ * Model: conflictResolutionModel when set (wins over task/default execution models).
+ */
+export function resolveConflictResolutionSettings(
+  config: Pick<InvokerConfig, 'conflictResolutionAgent' | 'conflictResolutionModel'>,
+  options?: {
+    explicitAgent?: string;
+    pathDefaultAgent?: string;
+  },
+): ConflictResolutionSettings {
+  const explicit = options?.explicitAgent?.trim();
+  const configAgent = config.conflictResolutionAgent?.trim();
+  const configModel = config.conflictResolutionModel?.trim();
+  const pathDefault = options?.pathDefaultAgent?.trim();
+
+  const agent = (explicit && explicit.length > 0)
+    ? explicit
+    : (configAgent && configAgent.length > 0)
+      ? configAgent
+      : (pathDefault && pathDefault.length > 0)
+        ? pathDefault
+        : undefined;
+
+  return {
+    ...(agent ? { agent } : {}),
+    ...(configModel && configModel.length > 0 ? { model: configModel } : {}),
+  };
+}
 
 export type EmbeddedTerminalBackendConfig = 'bash' | 'pty';
 


### PR DESCRIPTION
## Summary

resolve-conflict had no packaged way to pick a cheaper agent or model.

This adds conflictResolutionAgent and conflictResolutionModel to InvokerConfig plus a small resolver helper.

## Review Claim

Approve the new conflict-resolution config keys and resolveConflictResolutionSettings helper.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Keys are optional. Unset config changes no runtime behavior until later slices wire them.

## Slice Rationale

Config surface and helper land first so wiring slices can call a stable API.

## Non-goals

- No resolve-conflict call-site wiring
- No TaskRunner API change
- No docs or settings UI

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/config.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
