### PR TITLE
[Conflict Resolution Model](2) Allow resolveConflict explicit execution model

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -7,6 +7,7 @@ import {
   resolveConfigFilePath,
   resolveDefaultExecutionAgent,
   resolveDefaultTaskExecutionSettings,
+  resolveConflictResolutionSettings,
   resolveEmbeddedTerminalBackendConfig,
 } from '../config.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
@@ -167,6 +168,36 @@ describe('loadConfig', () => {
       executionAgent: 'omp',
       executionModel: 'chatgpt-5.4',
     });
+  });
+
+  it('reads conflict resolution settings from user config', () => {
+    writeUserConfig({
+      conflictResolutionAgent: 'omp',
+      conflictResolutionModel: 'gpt-5-mini',
+    });
+    const config = loadConfig();
+    expect(config.conflictResolutionAgent).toBe('omp');
+    expect(config.conflictResolutionModel).toBe('gpt-5-mini');
+  });
+
+  it('resolves conflict resolution settings with explicit, config, and path defaults', () => {
+    expect(resolveConflictResolutionSettings({})).toEqual({});
+    expect(resolveConflictResolutionSettings(
+      { conflictResolutionModel: 'gpt-5-mini' },
+      { pathDefaultAgent: 'codex' },
+    )).toEqual({ agent: 'codex', model: 'gpt-5-mini' });
+    expect(resolveConflictResolutionSettings(
+      { conflictResolutionAgent: 'omp', conflictResolutionModel: 'gpt-5-mini' },
+      { pathDefaultAgent: 'codex' },
+    )).toEqual({ agent: 'omp', model: 'gpt-5-mini' });
+    expect(resolveConflictResolutionSettings(
+      { conflictResolutionAgent: 'omp', conflictResolutionModel: 'gpt-5-mini' },
+      { explicitAgent: 'claude', pathDefaultAgent: 'codex' },
+    )).toEqual({ agent: 'claude', model: 'gpt-5-mini' });
+    expect(resolveConflictResolutionSettings(
+      { conflictResolutionAgent: '  ', conflictResolutionModel: '  ' },
+      { pathDefaultAgent: 'codex' },
+    )).toEqual({ agent: 'codex' });
   });
 
   it('reads autoFixCi from user config', () => {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -136,6 +136,18 @@ export interface InvokerConfig {
    * then to the built-in default agent.
    */
   autoFixAgent?: string;
+  /**
+   * Preferred execution agent for resolve-conflict (git merge conflicts).
+   * When unset, resolve-conflict uses the entry-point path default
+   * (explicit CLI/UI agent, then defaultExecutionAgent / autoFixAgent).
+   */
+  conflictResolutionAgent?: string;
+  /**
+   * Preferred execution model for resolve-conflict only.
+   * When set, wins over task.config.executionModel / defaultExecutionModel
+   * so conflict resolution can use a cheaper model than normal task work.
+   */
+  conflictResolutionModel?: string;
   /** Default execution harness for prompt-backed tasks when the task does not override it. */
   defaultExecutionAgent?: string;
   /** Default execution model for prompt-backed tasks when the task does not override it. */
@@ -402,6 +414,44 @@ export function resolveDefaultTaskExecutionSettings(config: InvokerConfig): Defa
   };
 }
 
+
+
+export interface ConflictResolutionSettings {
+  agent?: string;
+  model?: string;
+}
+
+/**
+ * Resolve agent/model for resolve-conflict.
+ *
+ * Precedence for agent: explicitAgent → conflictResolutionAgent → pathDefaultAgent.
+ * Model: conflictResolutionModel when set (wins over task/default execution models).
+ */
+export function resolveConflictResolutionSettings(
+  config: Pick<InvokerConfig, 'conflictResolutionAgent' | 'conflictResolutionModel'>,
+  options?: {
+    explicitAgent?: string;
+    pathDefaultAgent?: string;
+  },
+): ConflictResolutionSettings {
+  const explicit = options?.explicitAgent?.trim();
+  const configAgent = config.conflictResolutionAgent?.trim();
+  const configModel = config.conflictResolutionModel?.trim();
+  const pathDefault = options?.pathDefaultAgent?.trim();
+
+  const agent = (explicit && explicit.length > 0)
+    ? explicit
+    : (configAgent && configAgent.length > 0)
+      ? configAgent
+      : (pathDefault && pathDefault.length > 0)
+        ? pathDefault
+        : undefined;
+
+  return {
+    ...(agent ? { agent } : {}),
+    ...(configModel && configModel.length > 0 ? { model: configModel } : {}),
+  };
+}
 
 export type EmbeddedTerminalBackendConfig = 'bash' | 'pty';
 

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -326,6 +326,58 @@ describe('TaskRunner', () => {
       // All git calls should use the task's workspacePath
       expect(gitCwds.every(c => c === workspacePath)).toBe(true);
     });
+
+    it('passes explicit executionModel to spawnAgentFix over task model', async () => {
+      const workspacePath = createTempWorkspace();
+      const conflictError = JSON.stringify({
+        type: 'merge_conflict',
+        failedBranch: 'invoker/dep-task',
+        conflictFiles: ['shared.ts'],
+      });
+
+      const tasks = new Map<string, TaskState>();
+      tasks.set('conflict-task', makeTask({
+        id: 'conflict-task',
+        status: 'failed',
+        config: { executionAgent: 'codex', executionModel: 'gpt-5.2' },
+        execution: {
+          error: conflictError,
+          branch: 'invoker/conflict-task',
+          workspacePath,
+        },
+      }));
+
+      const orchestrator = {
+        getTask: (id: string) => tasks.get(id),
+        getAllTasks: () => Array.from(tasks.values()),
+      };
+      const executor = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: { logEvent: vi.fn() } as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+      });
+
+      (executor as any).execGitIn = async (args: string[]) => {
+        if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        if (args[0] === 'checkout') return '';
+        if (args[0] === 'merge') throw new Error('conflict');
+        return '';
+      };
+      let capturedModel: string | undefined;
+      (executor as any).spawnAgentFix = async (
+        _prompt: string,
+        _cwd: string,
+        _agent?: string,
+        executionModel?: string,
+      ) => {
+        capturedModel = executionModel;
+        return { stdout: '', sessionId: 'sess-conflict-model' };
+      };
+
+      await executor.resolveConflict('conflict-task', undefined, 'codex', 'gpt-5-mini');
+      expect(capturedModel).toBe('gpt-5-mini');
+    });
   });
 
   describe('fixWithAgent', () => {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1193,10 +1193,18 @@ export class TaskRunner {
    * Resolve a merge conflict by re-creating the merge state and spawning an agent to fix it.
    * After resolution, the task is restarted so it can proceed normally.
    */
-  async resolveConflict(taskId: string, savedError?: string, agentName?: string): Promise<void> {
+  async resolveConflict(
+    taskId: string,
+    savedError?: string,
+    agentName?: string,
+    executionModel?: string,
+  ): Promise<void> {
     const task = this.orchestrator.getTask(taskId);
-    const executionModel = task ? this.resolveExecutionModel(task) : undefined;
-    return this.withAttemptHeartbeat(taskId, () => resolveConflictImpl(this, taskId, savedError, agentName, executionModel));
+    const explicitModel = executionModel?.trim();
+    const resolvedModel = explicitModel && explicitModel.length > 0
+      ? explicitModel
+      : (task ? this.resolveExecutionModel(task) : undefined);
+    return this.withAttemptHeartbeat(taskId, () => resolveConflictImpl(this, taskId, savedError, agentName, resolvedModel));
   }
 
   /**


### PR DESCRIPTION
## Summary

resolveConflict always derived the model from the task defaults.

This lets callers pass an explicit executionModel that wins when set.

## Review Claim

Approve the optional executionModel argument on TaskRunner.resolveConflict.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Omitting the new argument keeps the previous resolveExecutionModel behavior.

## Slice Rationale

The TaskRunner API must accept an override before later slices can pass conflictResolutionModel into resolveConflict.

## Non-goals

- No config key wiring
- No headless or workflow-actions changes

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts -t "passes explicit executionModel"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
