### PR TITLE
[Conflict Resolution Model](3) Wire resolve-conflict to conflictResolution config

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -7,6 +7,7 @@ import {
   resolveConfigFilePath,
   resolveDefaultExecutionAgent,
   resolveDefaultTaskExecutionSettings,
+  resolveConflictResolutionSettings,
   resolveEmbeddedTerminalBackendConfig,
 } from '../config.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
@@ -167,6 +168,36 @@ describe('loadConfig', () => {
       executionAgent: 'omp',
       executionModel: 'chatgpt-5.4',
     });
+  });
+
+  it('reads conflict resolution settings from user config', () => {
+    writeUserConfig({
+      conflictResolutionAgent: 'omp',
+      conflictResolutionModel: 'gpt-5-mini',
+    });
+    const config = loadConfig();
+    expect(config.conflictResolutionAgent).toBe('omp');
+    expect(config.conflictResolutionModel).toBe('gpt-5-mini');
+  });
+
+  it('resolves conflict resolution settings with explicit, config, and path defaults', () => {
+    expect(resolveConflictResolutionSettings({})).toEqual({});
+    expect(resolveConflictResolutionSettings(
+      { conflictResolutionModel: 'gpt-5-mini' },
+      { pathDefaultAgent: 'codex' },
+    )).toEqual({ agent: 'codex', model: 'gpt-5-mini' });
+    expect(resolveConflictResolutionSettings(
+      { conflictResolutionAgent: 'omp', conflictResolutionModel: 'gpt-5-mini' },
+      { pathDefaultAgent: 'codex' },
+    )).toEqual({ agent: 'omp', model: 'gpt-5-mini' });
+    expect(resolveConflictResolutionSettings(
+      { conflictResolutionAgent: 'omp', conflictResolutionModel: 'gpt-5-mini' },
+      { explicitAgent: 'claude', pathDefaultAgent: 'codex' },
+    )).toEqual({ agent: 'claude', model: 'gpt-5-mini' });
+    expect(resolveConflictResolutionSettings(
+      { conflictResolutionAgent: '  ', conflictResolutionModel: '  ' },
+      { pathDefaultAgent: 'codex' },
+    )).toEqual({ agent: 'codex' });
   });
 
   it('reads autoFixCi from user config', () => {

--- a/packages/app/src/__tests__/headless-fix-autofix-context.test.ts
+++ b/packages/app/src/__tests__/headless-fix-autofix-context.test.ts
@@ -99,8 +99,9 @@ describe('headless fix auto-fix context', () => {
     expect(resolveConflictActionMock).toHaveBeenCalledWith(
       'wf-1/task-1',
       expect.any(Object),
-      'custom-agent',
       undefined,
+      undefined,
+      { pathDefaultAgent: 'custom-agent' },
     );
   });
 

--- a/packages/app/src/__tests__/resolve-conflict-action.test.ts
+++ b/packages/app/src/__tests__/resolve-conflict-action.test.ts
@@ -8,6 +8,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Orchestrator } from '@invoker/workflow-core';
 import type { TaskRunner } from '@invoker/execution-engine';
 import type { SQLiteAdapter } from '@invoker/data-store';
+
+const loadConfigMock = vi.hoisted(() => vi.fn(() => ({})));
+
+vi.mock('../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../config.js')>();
+  return {
+    ...actual,
+    loadConfig: () => loadConfigMock(),
+  };
+});
+
 import { resolveConflictAction } from '../workflow-actions.js';
 
 describe('resolveConflictAction', () => {
@@ -26,6 +37,7 @@ describe('resolveConflictAction', () => {
   };
 
   beforeEach(() => {
+    loadConfigMock.mockReturnValue({});
     orchestrator = {
       getTask: vi.fn(() => ({
         id: 'task-a',
@@ -50,10 +62,50 @@ describe('resolveConflictAction', () => {
     });
 
     expect(orchestrator.beginFixSession).toHaveBeenCalledWith('task-a');
-    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', 'saved-err', undefined);
+    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', 'saved-err', 'codex', undefined);
     expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-err');
     expect(orchestrator.revertFixSession).not.toHaveBeenCalled();
     expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
+  });
+
+  it('applies conflictResolutionAgent and conflictResolutionModel from config', async () => {
+    loadConfigMock.mockReturnValue({
+      conflictResolutionAgent: 'omp',
+      conflictResolutionModel: 'gpt-5-mini',
+    });
+
+    await resolveConflictAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+
+    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith(
+      'task-a',
+      'saved-err',
+      'omp',
+      'gpt-5-mini',
+    );
+  });
+
+  it('lets an explicit agent override conflictResolutionAgent but still applies the config model', async () => {
+    loadConfigMock.mockReturnValue({
+      conflictResolutionAgent: 'omp',
+      conflictResolutionModel: 'gpt-5-mini',
+    });
+
+    await resolveConflictAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    }, 'claude');
+
+    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith(
+      'task-a',
+      'saved-err',
+      'claude',
+      'gpt-5-mini',
+    );
   });
 
   it('auto-approves after conflict resolution when configured', async () => {

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -8,6 +8,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { buildCancelInFlight, buildWorkflowInvalidationDeps, type Orchestrator } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner } from '@invoker/execution-engine';
+
+const loadConfigMock = vi.hoisted(() => vi.fn(() => ({})));
+
+vi.mock('../config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../config.js')>();
+  return {
+    ...actual,
+    loadConfig: () => loadConfigMock(),
+  };
+});
+
 import {
   cancelWorkflow,
   recreateWorkflowFromFreshBase,
@@ -34,6 +45,10 @@ import {
 vi.mock('../delete-all-snapshot.js', () => ({
   createDeleteAllSnapshot: () => '/tmp/fake-snapshot',
 }));
+
+beforeEach(() => {
+  loadConfigMock.mockReturnValue({});
+});
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -757,10 +772,62 @@ describe('autoFixOnFailure', () => {
     });
 
     expect(orchestrator.beginFixSession).toHaveBeenCalledWith('task-a');
-    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'codex');
+    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'codex', undefined);
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
     expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
     expect(taskExecutor.executeTasks).toHaveBeenCalledWith(started);
+  });
+
+  it('prefers conflictResolutionAgent over autoFixAgent for merge conflicts', async () => {
+    loadConfigMock.mockReturnValue({
+      conflictResolutionAgent: 'omp',
+      conflictResolutionModel: 'gpt-5-mini',
+    });
+    const started = [makeRunningTask({ id: 'task-a', status: 'running' })];
+    const mergeError = JSON.stringify({
+      type: 'merge_conflict',
+      failedBranch: 'experiment/foo',
+      conflictFiles: ['src/foo.ts'],
+    });
+    const orchestrator = {
+      shouldAutoFix: vi.fn(() => true),
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        execution: { error: mergeError, workspacePath: '/tmp/task-a' },
+      })),
+      getAutoFixRetryBudget: vi.fn(() => 3),
+      beginFixSession: vi.fn(() => ({ savedError: mergeError })),
+      retryTask: vi.fn(() => started),
+      cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
+      revertFixSession: vi.fn(),
+    };
+    const persistence = {
+      updateTask: vi.fn(),
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      resolveConflict: vi.fn().mockResolvedValue(undefined),
+      executeTasks: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await autoFixOnFailure('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
+      getAutoFixAgent: () => 'claude',
+    });
+
+    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith(
+      'task-a',
+      mergeError,
+      'omp',
+      'gpt-5-mini',
+    );
+    expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
   });
 
   it('uses resolveConflict for prefixed post-fix merge conflict errors', async () => {
@@ -799,7 +866,7 @@ describe('autoFixOnFailure', () => {
       commandService: makeCommandService(),
     });
 
-    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'codex');
+    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'codex', undefined);
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
   });
 
@@ -1090,7 +1157,7 @@ describe('autoFixOnFailure', () => {
       getAutoFixAgent: () => undefined,
     });
 
-    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'codex');
+    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'codex', undefined);
     expect(logEvent).toHaveBeenCalledWith(
       'task-a',
       'debug.auto-fix',
@@ -1291,7 +1358,7 @@ describe('fixWithAgentAction', () => {
       agentName: 'claude',
     });
 
-    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'claude');
+    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'claude', undefined);
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
     expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', mergeError);
     expect(result).toEqual({ kind: 'resolveConflict', autoApproved: false, started: [] });
@@ -1327,7 +1394,7 @@ describe('fixWithAgentAction', () => {
       agentName: 'codex',
     });
 
-    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'codex');
+    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'codex', undefined);
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
     expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', mergeError);
     expect(result).toEqual({ kind: 'resolveConflict', autoApproved: false, started: [] });

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -136,6 +136,18 @@ export interface InvokerConfig {
    * then to the built-in default agent.
    */
   autoFixAgent?: string;
+  /**
+   * Preferred execution agent for resolve-conflict (git merge conflicts).
+   * When unset, resolve-conflict uses the entry-point path default
+   * (explicit CLI/UI agent, then defaultExecutionAgent / autoFixAgent).
+   */
+  conflictResolutionAgent?: string;
+  /**
+   * Preferred execution model for resolve-conflict only.
+   * When set, wins over task.config.executionModel / defaultExecutionModel
+   * so conflict resolution can use a cheaper model than normal task work.
+   */
+  conflictResolutionModel?: string;
   /** Default execution harness for prompt-backed tasks when the task does not override it. */
   defaultExecutionAgent?: string;
   /** Default execution model for prompt-backed tasks when the task does not override it. */
@@ -402,6 +414,44 @@ export function resolveDefaultTaskExecutionSettings(config: InvokerConfig): Defa
   };
 }
 
+
+
+export interface ConflictResolutionSettings {
+  agent?: string;
+  model?: string;
+}
+
+/**
+ * Resolve agent/model for resolve-conflict.
+ *
+ * Precedence for agent: explicitAgent → conflictResolutionAgent → pathDefaultAgent.
+ * Model: conflictResolutionModel when set (wins over task/default execution models).
+ */
+export function resolveConflictResolutionSettings(
+  config: Pick<InvokerConfig, 'conflictResolutionAgent' | 'conflictResolutionModel'>,
+  options?: {
+    explicitAgent?: string;
+    pathDefaultAgent?: string;
+  },
+): ConflictResolutionSettings {
+  const explicit = options?.explicitAgent?.trim();
+  const configAgent = config.conflictResolutionAgent?.trim();
+  const configModel = config.conflictResolutionModel?.trim();
+  const pathDefault = options?.pathDefaultAgent?.trim();
+
+  const agent = (explicit && explicit.length > 0)
+    ? explicit
+    : (configAgent && configAgent.length > 0)
+      ? configAgent
+      : (pathDefault && pathDefault.length > 0)
+        ? pathDefault
+        : undefined;
+
+  return {
+    ...(agent ? { agent } : {}),
+    ...(configModel && configModel.length > 0 ? { model: configModel } : {}),
+  };
+}
 
 export type EmbeddedTerminalBackendConfig = 'bash' | 'pty';
 

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -26,7 +26,7 @@ import {
   forkWorkflow as sharedForkWorkflow,
 } from './workflow-actions.js';
 import { parseHeadlessFixArgs } from './auto-fix-intents.js';
-import { resolveDefaultExecutionAgent } from './config.js';
+import { resolveDefaultExecutionAgent, resolveConflictResolutionSettings } from './config.js';
 import {
   dispatchStartedTasksWithGlobalTopup,
   executeGlobalTopup,
@@ -359,13 +359,19 @@ export async function headlessResolveConflict(taskId: string, deps: HeadlessDeps
   taskId = restored.resolvedTaskId;
 
   const te = createHeadlessExecutor(deps);
-  const agent = (agentArg ?? resolveDefaultExecutionAgent(deps.invokerConfig)).toLowerCase();
+  const settings = resolveConflictResolutionSettings(deps.invokerConfig, {
+    explicitAgent: agentArg?.toLowerCase(),
+    pathDefaultAgent: resolveDefaultExecutionAgent(deps.invokerConfig),
+  });
+  const agent = settings.agent ?? resolveDefaultExecutionAgent(deps.invokerConfig);
   try {
     const result = await resolveConflictAction(taskId, {
       ...deps,
       taskExecutor: te,
       autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
-    }, agent, deps.signal);
+    }, agentArg?.toLowerCase(), deps.signal, {
+      pathDefaultAgent: resolveDefaultExecutionAgent(deps.invokerConfig),
+    });
     await finalizeMutationWithGlobalTopup({
       orchestrator: deps.orchestrator,
       taskExecutor: te,

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -32,6 +32,7 @@ import {
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import { isDispatchableLaunch } from './global-topup.js';
+import { loadConfig, resolveConflictResolutionSettings, resolveDefaultExecutionAgent } from './config.js';
 
 type LoadedWorkflow = NonNullable<ReturnType<SQLiteAdapter['loadWorkflow']>>;
 type FreshBaseState = { branch: string; commit: string };
@@ -832,6 +833,7 @@ export async function resolveConflictAction(
   deps: Pick<ActionDeps, 'orchestrator' | 'persistence' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },
   agentName?: string,
   signal?: AbortSignal,
+  options?: { pathDefaultAgent?: string },
 ): Promise<{ autoApproved: boolean; started: TaskState[] }> {
   const { orchestrator, persistence, taskExecutor } = deps;
   const entryLineage = captureTaskLineage(taskId, orchestrator);
@@ -840,7 +842,12 @@ export async function resolveConflictAction(
   const lineage = captureTaskLineage(taskId, orchestrator);
   try {
     assertLineageCurrent(lineage, orchestrator, signal);
-    await taskExecutor.resolveConflict(taskId, savedError, agentName);
+    const config = loadConfig();
+    const settings = resolveConflictResolutionSettings(config, {
+      explicitAgent: agentName,
+      pathDefaultAgent: options?.pathDefaultAgent ?? resolveDefaultExecutionAgent(config),
+    });
+    await taskExecutor.resolveConflict(taskId, savedError, settings.agent, settings.model);
     assertLineageCurrent(lineage, orchestrator, signal);
     return await finalizeAppliedFix(taskId, savedError, deps, signal, lineage);
   } catch (err) {
@@ -931,7 +938,16 @@ export async function fixWithAgentAction(
   try {
     assertLineageCurrent(lineage, orchestrator, options.signal);
     if (recoveryRoute.kind === 'resolveConflict') {
-      await taskExecutor.resolveConflict(taskId, persistedSavedError, effectiveAgentName);
+      const conflictSettings = resolveConflictResolutionSettings(loadConfig(), {
+        explicitAgent: options.agentName,
+        pathDefaultAgent: resolveTaskRunnerDefaultExecutionAgent(taskExecutor),
+      });
+      await taskExecutor.resolveConflict(
+        taskId,
+        persistedSavedError,
+        conflictSettings.agent,
+        conflictSettings.model,
+      );
     } else {
       const output = persistence.getTaskOutput(taskId);
       const fixContext = options.reviewGateContext?.fixContext;
@@ -1276,7 +1292,15 @@ export async function autoFixOnFailure(
       savedErrorLength: persistedSavedError.length,
     });
     if (recoveryRoute.kind === 'resolveConflict') {
-      await taskExecutor.resolveConflict(taskId, persistedSavedError, agentSelection.selectedAgent);
+      const conflictSettings = resolveConflictResolutionSettings(loadConfig(), {
+        pathDefaultAgent: agentSelection.selectedAgent,
+      });
+      await taskExecutor.resolveConflict(
+        taskId,
+        persistedSavedError,
+        conflictSettings.agent,
+        conflictSettings.model,
+      );
     } else {
       const output = persistence.getTaskOutput(taskId);
       await taskExecutor.fixWithAgent(taskId, output, agentSelection.selectedAgent, persistedSavedError);

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -326,6 +326,58 @@ describe('TaskRunner', () => {
       // All git calls should use the task's workspacePath
       expect(gitCwds.every(c => c === workspacePath)).toBe(true);
     });
+
+    it('passes explicit executionModel to spawnAgentFix over task model', async () => {
+      const workspacePath = createTempWorkspace();
+      const conflictError = JSON.stringify({
+        type: 'merge_conflict',
+        failedBranch: 'invoker/dep-task',
+        conflictFiles: ['shared.ts'],
+      });
+
+      const tasks = new Map<string, TaskState>();
+      tasks.set('conflict-task', makeTask({
+        id: 'conflict-task',
+        status: 'failed',
+        config: { executionAgent: 'codex', executionModel: 'gpt-5.2' },
+        execution: {
+          error: conflictError,
+          branch: 'invoker/conflict-task',
+          workspacePath,
+        },
+      }));
+
+      const orchestrator = {
+        getTask: (id: string) => tasks.get(id),
+        getAllTasks: () => Array.from(tasks.values()),
+      };
+      const executor = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: { logEvent: vi.fn() } as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+      });
+
+      (executor as any).execGitIn = async (args: string[]) => {
+        if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        if (args[0] === 'checkout') return '';
+        if (args[0] === 'merge') throw new Error('conflict');
+        return '';
+      };
+      let capturedModel: string | undefined;
+      (executor as any).spawnAgentFix = async (
+        _prompt: string,
+        _cwd: string,
+        _agent?: string,
+        executionModel?: string,
+      ) => {
+        capturedModel = executionModel;
+        return { stdout: '', sessionId: 'sess-conflict-model' };
+      };
+
+      await executor.resolveConflict('conflict-task', undefined, 'codex', 'gpt-5-mini');
+      expect(capturedModel).toBe('gpt-5-mini');
+    });
   });
 
   describe('fixWithAgent', () => {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1193,10 +1193,18 @@ export class TaskRunner {
    * Resolve a merge conflict by re-creating the merge state and spawning an agent to fix it.
    * After resolution, the task is restarted so it can proceed normally.
    */
-  async resolveConflict(taskId: string, savedError?: string, agentName?: string): Promise<void> {
+  async resolveConflict(
+    taskId: string,
+    savedError?: string,
+    agentName?: string,
+    executionModel?: string,
+  ): Promise<void> {
     const task = this.orchestrator.getTask(taskId);
-    const executionModel = task ? this.resolveExecutionModel(task) : undefined;
-    return this.withAttemptHeartbeat(taskId, () => resolveConflictImpl(this, taskId, savedError, agentName, executionModel));
+    const explicitModel = executionModel?.trim();
+    const resolvedModel = explicitModel && explicitModel.length > 0
+      ? explicitModel
+      : (task ? this.resolveExecutionModel(task) : undefined);
+    return this.withAttemptHeartbeat(taskId, () => resolveConflictImpl(this, taskId, savedError, agentName, resolvedModel));
   }
 
   /**


### PR DESCRIPTION
## Summary

resolve-conflict still ignored the new conflictResolution config.

This connects resolveConflictAction, autofix merge-conflict recovery, and headless resolve-conflict to those settings.

## Review Claim

Approve connecting resolve-conflict entry points to conflictResolutionAgent and conflictResolutionModel.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Unset config falls back to existing path defaults. Explicit agent arguments still win for agent selection.

## Slice Rationale

Headless and shared action wiring comes last so it can use the config helper and TaskRunner model override from earlier slices.

## Non-goals

- No CI fixWithAgent model changes
- No settings UI
- No packages/app/src/main.ts change

## Architecture

### Before

```mermaid
flowchart TD
  entry["resolve-conflict entry"]
  pathDefault["path default agent"]
  taskModel["task executionModel"]
  spawn["spawnAgentFix"]
  entry --> pathDefault --> spawn
  entry --> taskModel --> spawn
```

### After

```mermaid
flowchart TD
  entry["resolve-conflict entry"]
  explicit["explicit agent argument"]
  cfg["conflictResolution settings"]
  pathDefault["path default agent"]
  taskModel["task executionModel"]
  spawn["spawnAgentFix"]
  entry --> explicit
  explicit -->|"unset"| cfg
  cfg -->|"unset"| pathDefault
  explicit --> spawn
  cfg -->|"model set"| spawn
  cfg -->|"model unset"| taskModel --> spawn
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/resolve-conflict-action.test.ts src/__tests__/workflow-actions.test.ts src/__tests__/headless-fix-autofix-context.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Remove conflictResolution* from ~/.invoker/config.json if set
- Data migration? No

</details>
