### PR TITLE
[Disk reclaim orphans](1) Sync reclaim and cover Invoker-managed dirs

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   buildInvokerHomeCleanupScript,
   cleanupLocalInvokerHome,
+  DISK_RECLAIMABLE_DIRS,
   DiskCleanupCooldownTracker,
   isSafeInvokerHome,
   isSafeRemoteInvokerHomePath,
@@ -41,14 +42,20 @@ describe('disk-headroom cleanup guards', () => {
     expect(isSafeRemoteInvokerHomePath('/home/invoker/.invoker')).toBe(true);
   });
 
-  it('embeds path guards and provision-only pkill in the remote script', () => {
+  it('embeds path guards, reclaimable dirs, and sync delete in the remote script', () => {
     const script = buildInvokerHomeCleanupScript('~/.invoker');
     expect(script).toContain('Refusing unsafe INVOKER_HOME');
     expect(script).toContain("pkill -9 -f 'pnpm install");
     expect(script).not.toContain('pkill -9 -f "$INVOKER_HOME"');
-    expect(script).toContain('$INVOKER_HOME/runtime');
-    expect(script).toContain('$INVOKER_HOME/repos');
-    expect(script).toContain('$INVOKER_HOME/worktrees');
+    for (const name of DISK_RECLAIMABLE_DIRS) {
+      expect(script).toContain(`$INVOKER_HOME/${name}`);
+    }
+    expect(script).toContain('*.deleting.*');
+    expect(script).not.toContain('nohup');
+    expect(script).not.toMatch(/rm -rf[^\n]*&\s*$/m);
+    expect(script).not.toContain('$HOME/.cache/electron');
+    expect(script).not.toContain('$HOME/.local/share/pnpm');
+    expect(script).not.toContain('$HOME/.pnpm-store');
   });
 });
 
@@ -79,7 +86,7 @@ describe('DiskCleanupCooldownTracker', () => {
 });
 
 describe('cleanupLocalInvokerHome', () => {
-  it('wipes runtime/repos/worktrees and recreates empty dirs', async () => {
+  it('wipes reclaimable dirs, orphans, and recreates empty dirs', async () => {
     const root = mkdtempSync(join(tmpdir(), 'invoker-disk-cleanup-'));
     tempDirs.push(root);
     const home = join(root, '.invoker');
@@ -89,7 +96,17 @@ describe('cleanupLocalInvokerHome', () => {
     mkdirSync(join(home, 'repos', 'abc'), { recursive: true });
     writeFileSync(join(home, 'repos', 'abc', 'file.txt'), 'x');
     mkdirSync(join(home, 'runtime', 'ssh'), { recursive: true });
+    mkdirSync(join(home, 'merge-clones', 'gate-wf'), { recursive: true });
+    writeFileSync(join(home, 'merge-clones', 'gate-wf', 'file.txt'), 'x');
+    mkdirSync(join(home, 'merge-launches', 'launch-1'), { recursive: true });
+    writeFileSync(join(home, 'merge-launches', 'launch-1', 'file.txt'), 'x');
+    mkdirSync(join(home, 'merge-clones.deleting.123', 'stale'), { recursive: true });
+    writeFileSync(join(home, 'merge-clones.deleting.123', 'stale', 'file.txt'), 'x');
     writeFileSync(join(home, 'invoker.db'), 'keep-me');
+    mkdirSync(join(home, 'plans'), { recursive: true });
+    writeFileSync(join(home, 'plans', 'keep.yaml'), 'name: keep');
+    mkdirSync(join(userHome, '.cache', 'electron'), { recursive: true });
+    writeFileSync(join(userHome, '.cache', 'electron', 'keep.bin'), 'x');
 
     const result = await cleanupLocalInvokerHome({
       invokerHome: home,
@@ -99,11 +116,16 @@ describe('cleanupLocalInvokerHome', () => {
 
     expect(result.ok).toBe(true);
     expect(result.reason).toBe('critical-cleanup');
-    expect(existsSync(join(home, 'worktrees'))).toBe(true);
-    expect(existsSync(join(home, 'repos'))).toBe(true);
-    expect(existsSync(join(home, 'runtime'))).toBe(true);
+    for (const name of DISK_RECLAIMABLE_DIRS) {
+      expect(existsSync(join(home, name))).toBe(true);
+      expect(readdirSync(join(home, name))).toEqual([]);
+    }
+    expect(existsSync(join(home, 'merge-clones.deleting.123'))).toBe(false);
     expect(existsSync(join(home, 'worktrees', 'abc'))).toBe(false);
+    expect(existsSync(join(home, 'merge-launches', 'launch-1'))).toBe(false);
     expect(existsSync(join(home, 'invoker.db'))).toBe(true);
+    expect(existsSync(join(home, 'plans', 'keep.yaml'))).toBe(true);
+    expect(existsSync(join(userHome, '.cache', 'electron', 'keep.bin'))).toBe(true);
   });
 
   it('refuses to clean the user home itself', async () => {

--- a/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
@@ -1,11 +1,11 @@
 /**
  * Critical-disk remediation for the disk-headroom worker.
  *
- * Wipes reclaimable Invoker-managed dirs (runtime/repos/worktrees) plus common
- * provision caches. Never touches invoker.db / config.json / the home root.
+ * Wipes reclaimable Invoker-managed dirs under the Invoker home only.
+ * Never touches invoker.db / config.json / the home root / paths outside the home.
  */
 
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -17,6 +17,17 @@ import { bashNormalizeTildePath, execRemoteCapture, shellPosixSingleQuote } from
 import type { RemoteDiskTarget } from './disk-headroom-monitor.js';
 
 export const DEFAULT_DISK_CLEANUP_COOLDOWN_MS = 30 * 60 * 1000;
+
+/** Invoker-managed dirs reclaimed on critical disk pressure (local + remote). */
+export const DISK_RECLAIMABLE_DIRS = [
+  'runtime',
+  'repos',
+  'worktrees',
+  'merge-clones',
+  'merge-launches',
+] as const;
+
+export type DiskReclaimableDir = (typeof DISK_RECLAIMABLE_DIRS)[number];
 
 export interface DiskCleanupResult {
   targetKey: string;
@@ -74,13 +85,24 @@ export function isSafeRemoteInvokerHomePath(remotePath: string): boolean {
   return true;
 }
 
+function isDeletingOrphanName(name: string): boolean {
+  return name.includes('.deleting.');
+}
+
 /**
  * Remote bash that frees Invoker-managed disk under `$INVOKER_HOME`.
  * Kills only provision grinders (pnpm install / electron unzip), not every
  * process whose argv mentions the home (that can kill the SSH session).
+ * Deletes synchronously so SSH timeout cannot leave fire-and-forget orphans.
  */
 export function buildInvokerHomeCleanupScript(invokerHome: string): string {
   const homeQ = shellPosixSingleQuote(invokerHome);
+  const removeCalls = DISK_RECLAIMABLE_DIRS
+    .map((name) => `remove_path "$INVOKER_HOME/${name}"`)
+    .join('\n');
+  const mkdirArgs = DISK_RECLAIMABLE_DIRS
+    .map((name) => `"$INVOKER_HOME/${name}"`)
+    .join(' ');
   return `set +e
 INVOKER_HOME=${homeQ}
 ${bashNormalizeTildePath('INVOKER_HOME')}
@@ -98,23 +120,22 @@ pkill -9 -f 'pnpm install' >/dev/null 2>&1
 pkill -9 -f 'electron-v[0-9].*-linux-x64.zip' >/dev/null 2>&1
 pkill -9 -f 'node_modules/.pnpm/electron@' >/dev/null 2>&1
 sleep 1
+# Prior rename leftovers from interrupted cleanups.
+rm -rf "$INVOKER_HOME"/*.deleting.* >/dev/null 2>&1
 remove_path() {
   local path="$1"
   if [ -e "$path" ]; then
-    mv "$path" "\${path}.deleting.$$" 2>/dev/null || true
-    nohup rm -rf "\${path}.deleting.$$" >/dev/null 2>&1 &
+    local staged="\${path}.deleting.$$"
+    if mv "$path" "$staged" 2>/dev/null; then
+      rm -rf "$staged" 2>/dev/null || true
+    fi
     rm -rf "$path" 2>/dev/null || true
   fi
 }
-remove_path "$INVOKER_HOME/runtime"
-remove_path "$INVOKER_HOME/repos"
-remove_path "$INVOKER_HOME/worktrees"
-remove_path "$INVOKER_HOME/merge-clones"
+${removeCalls}
 rm -rf "$INVOKER_HOME"/*.deleting.* >/dev/null 2>&1
-# Common provision caches (best effort).
-rm -rf "$HOME/.cache/electron" "$HOME/.local/share/pnpm" "$HOME/.pnpm-store" >/dev/null 2>&1
-mkdir -p "$INVOKER_HOME/runtime" "$INVOKER_HOME/repos" "$INVOKER_HOME/worktrees"
-chmod 700 "$INVOKER_HOME/runtime" "$INVOKER_HOME/repos" "$INVOKER_HOME/worktrees"
+mkdir -p ${mkdirArgs}
+chmod 700 ${mkdirArgs}
 echo "[disk-headroom-cleanup] done"
 df -h / | tail -1
 exit 0
@@ -138,6 +159,21 @@ function ensureLocalDir(path: string, errors: string[]): void {
   }
 }
 
+function sweepLocalDeletingOrphans(home: string, errors: string[]): void {
+  if (!existsSync(home)) return;
+  let entries: string[];
+  try {
+    entries = readdirSync(home);
+  } catch (err) {
+    errors.push(`readdir ${home}: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+  for (const name of entries) {
+    if (!isDeletingOrphanName(name)) continue;
+    removeLocalDir(join(home, name), errors);
+  }
+}
+
 export async function cleanupLocalInvokerHome(opts: {
   invokerHome: string;
   targetKey?: string;
@@ -157,18 +193,12 @@ export async function cleanupLocalInvokerHome(opts: {
   });
 
   const errors: string[] = [];
-  for (const name of ['runtime', 'repos', 'worktrees', 'merge-clones'] as const) {
+  sweepLocalDeletingOrphans(home, errors);
+  for (const name of DISK_RECLAIMABLE_DIRS) {
     removeLocalDir(join(home, name), errors);
   }
-  for (const name of ['runtime', 'repos', 'worktrees'] as const) {
+  for (const name of DISK_RECLAIMABLE_DIRS) {
     ensureLocalDir(join(home, name), errors);
-  }
-  for (const cache of [
-    join(userHome, '.cache', 'electron'),
-    join(userHome, '.local', 'share', 'pnpm'),
-    join(userHome, '.pnpm-store'),
-  ]) {
-    removeLocalDir(cache, errors);
   }
 
   if (errors.length > 0) {


### PR DESCRIPTION
## Summary

Critical disk reclaim could leave Invoker homes full after a remediation pass.

Remote reclaim renamed managed dirs to `.deleting.<pid>` and freed them in the background, so SSH timeouts left orphans that still used disk.

Local reclaim never swept those orphans, missed `merge-launches`, and also wiped electron/pnpm caches outside the Invoker home.

## Review Claim

Critical disk-headroom reclaim synchronously frees Invoker-managed dirs under the home, including prior `.deleting.*` orphans and `merge-launches`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Reclaim still refuses `/`, `$HOME`, and bare `~`, never touches `invoker.db` or `config.json`, and only kills provision grinders rather than every process matching the Invoker home.

## Slice Rationale

This is one worker remediation fix: make critical reclaim complete and scoped to Invoker-managed dirs.

## Non-goals

- Does not re-enable per-task `INVOKER_ENABLE_WORKSPACE_CLEANUP`.
- Does not reclaim `plans`, cron work dirs, or DB backups.
- Does not change warn-threshold behavior or cooldown defaults.
- Does not wipe electron/pnpm caches outside the Invoker home.

## Architecture

### Before

```mermaid
flowchart TD
  critical["critical disk tick"] --> remoteRm["remote nohup rm .deleting"]
  remoteRm --> orphans["orphans may remain"]
  critical --> localRm["local rmSync live dirs only"]
  localRm --> miss["misses orphans and merge-launches"]
```

### After

```mermaid
flowchart TD
  critical["critical disk tick"] --> sweep["sweep INVOKER_HOME/*.deleting.*"]
  sweep --> wipe["sync wipe reclaimable dirs"]
  wipe --> recreate["recreate empty runtime/repos/worktrees/merge-clones/merge-launches"]
  recreate --> doneNode["return ok/fail"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/disk-headroom-reclaim.test.ts src/__tests__/disk-headroom-worker.test.ts`
- [ ] Confirm remote script has no `nohup` background `rm` and includes `merge-launches`.
- [ ] Confirm local reclaim clears a planted `*.deleting.*` orphan and recreates empty reclaimable dirs.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Critical reclaim returns to fire-and-forget remote `rm` and the previous target set.
- Data migration? No

</details>
