### PR TITLE
[Planning CoT](1) Parse Codex planning JSONL into readable reply

### DIFF
--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -478,6 +478,10 @@ export async function sendPlanningChatMessage(
         if (deps.plannerReplyOverride) {
           saveOverrideConversation(deps.conversationRepo, activeSession.id, formattedMessage, reply);
         }
+        const reasoningParts = deps.plannerReplyOverride
+          ? []
+          : activeSession.conversation.lastTurnReasoning;
+        const reasoning = reasoningParts.length > 0 ? reasoningParts.join('\n\n') : undefined;
         const planText = activeSession.conversation.getDraftedPlan() ?? extractYamlPlan(reply);
         if (!planText) {
           activeSession.draftPlanSummary = undefined;
@@ -485,7 +489,7 @@ export async function sendPlanningChatMessage(
           activeSession.status = reply.includes('?') ? 'waiting_for_answer' : 'still_discussing';
           appendSessionMessage(activeSession, 'assistant', reply);
           persistPlanningSession(activeSession, deps.planningSessionStore, false);
-          return { ok: true, sessionId: activeSession.id, reply, draftPlanAvailable: false };
+          return { ok: true, sessionId: activeSession.id, reply, reasoning, draftPlanAvailable: false } as InAppPlanningChatResponse;
         }
 
         const summary = summarizePlanText(planText);
@@ -512,9 +516,10 @@ export async function sendPlanningChatMessage(
           ok: true,
           sessionId: activeSession.id,
           reply,
+          reasoning,
           draftPlanAvailable: true,
           draftPlanSummary: summary,
-        };
+        } as InAppPlanningChatResponse;
       } catch (error) {
         persistPlanningSession(activeSession, deps.planningSessionStore, false);
         return {

--- a/packages/execution-engine/src/__tests__/format-codex-planner-stdout.test.ts
+++ b/packages/execution-engine/src/__tests__/format-codex-planner-stdout.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { formatCodexPlannerStdout, looksLikeCodexJsonl } from '../codex-session.js';
+
+describe('formatCodexPlannerStdout', () => {
+  it('extracts agent_message and drops lifecycle events', () => {
+    const raw = [
+      JSON.stringify({ type: 'thread.started', thread_id: '019f4d62-a2bc-7893-80a1-69b2c94e0fa5' }),
+      JSON.stringify({ type: 'turn.started' }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'item_0',
+          type: 'agent_message',
+          text: 'Hello. Tell me what you want Invoker to plan, and I’ll scope it against the repo before drafting YAML.',
+        },
+      }),
+      JSON.stringify({
+        type: 'turn.completed',
+        usage: {
+          input_tokens: 18085,
+          cached_input_tokens: 13696,
+          output_tokens: 164,
+          reasoning_output_tokens: 134,
+        },
+      }),
+    ].join('\n');
+
+    const formatted = formatCodexPlannerStdout(raw);
+    expect(formatted.reasoning).toEqual([]);
+    expect(formatted.message).toBe(
+      'Hello. Tell me what you want Invoker to plan, and I’ll scope it against the repo before drafting YAML.',
+    );
+    expect(formatted.message).not.toContain('thread.started');
+  });
+
+  it('extracts reasoning summaries and agent_message', () => {
+    const raw = [
+      JSON.stringify({ type: 'thread.started', thread_id: 't1' }),
+      JSON.stringify({ type: 'turn.started' }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { id: 'item_0', type: 'reasoning', text: '**Scanning the repo for planning context**' },
+      }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { id: 'item_1', type: 'reasoning', text: 'User said hello — greet and ask what to plan.' },
+      }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { id: 'item_2', type: 'agent_message', text: 'Hello. What should we plan?' },
+      }),
+      JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 2 } }),
+    ].join('\n');
+
+    const formatted = formatCodexPlannerStdout(raw);
+    expect(formatted.reasoning).toEqual([
+      '**Scanning the repo for planning context**',
+      'User said hello — greet and ask what to plan.',
+    ]);
+    expect(formatted.message).toBe('Hello. What should we plan?');
+  });
+
+  it('passes through plain-text planner output unchanged', () => {
+    const prose = 'I can help draft that.\n\nWhat should we build?';
+    expect(looksLikeCodexJsonl(prose)).toBe(false);
+    expect(formatCodexPlannerStdout(prose)).toEqual({
+      message: prose,
+      reasoning: [],
+    });
+  });
+
+  it('joins multiple agent_message items', () => {
+    const raw = [
+      JSON.stringify({ type: 'turn.started' }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'agent_message', text: 'First part.' },
+      }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'agent_message', text: 'Second part.' },
+      }),
+    ].join('\n');
+
+    expect(formatCodexPlannerStdout(raw).message).toBe('First part.\n\nSecond part.');
+  });
+});

--- a/packages/execution-engine/src/codex-session.ts
+++ b/packages/execution-engine/src/codex-session.ts
@@ -126,6 +126,97 @@ export function toReadableText(raw: string): string {
   return messages.map(m => `[${m.role}] ${m.content}`).join('\n');
 }
 
+export interface CodexPlannerStdout {
+  message: string;
+  reasoning: string[];
+}
+
+const CODEX_JSONL_EVENT_TYPES = new Set([
+  'thread.started',
+  'turn.started',
+  'turn.completed',
+  'turn.failed',
+  'item.started',
+  'item.updated',
+  'item.completed',
+  'error',
+  'event_msg',
+  'response_item',
+  'session_meta',
+]);
+
+export function looksLikeCodexJsonl(raw: string): boolean {
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const entry = JSON.parse(trimmed);
+      return Boolean(
+        entry
+        && typeof entry === 'object'
+        && typeof entry.type === 'string'
+        && CODEX_JSONL_EVENT_TYPES.has(entry.type),
+      );
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+export function formatCodexPlannerStdout(raw: string): CodexPlannerStdout {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { message: '', reasoning: [] };
+  }
+  if (!looksLikeCodexJsonl(trimmed)) {
+    return { message: trimmed, reasoning: [] };
+  }
+
+  const reasoning: string[] = [];
+  const messages: string[] = [];
+
+  for (const line of trimmed.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (entry.type === 'item.completed' && entry.item) {
+        const item = entry.item;
+        if (item.type === 'reasoning' && typeof item.text === 'string' && item.text.trim()) {
+          reasoning.push(item.text.trim());
+          continue;
+        }
+        if (item.type === 'agent_message' && typeof item.text === 'string' && item.text.trim()) {
+          messages.push(item.text.trim());
+          continue;
+        }
+      }
+
+      const payload = entry.payload;
+      if (
+        entry.type === 'response_item'
+        && payload?.type === 'message'
+        && payload.role === 'assistant'
+      ) {
+        const blocks = Array.isArray(payload.content) ? payload.content : [];
+        const text = blocks
+          .filter((b) => typeof b === 'string' || b?.type === 'output_text')
+          .map((b) => typeof b === 'string' ? b : b.text ?? '')
+          .join('\n')
+          .trim();
+        if (text) messages.push(text);
+      }
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  return {
+    message: messages.join('\n\n'),
+    reasoning,
+  };
+}
+
 /**
  * Extract usage events from Codex session JSONL.
  *

--- a/packages/surfaces/package.json
+++ b/packages/surfaces/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@invoker/contracts": "workspace:*",
     "@invoker/data-store": "workspace:*",
+    "@invoker/execution-engine": "workspace:*",
     "@invoker/transport": "workspace:*",
     "@invoker/workflow-core": "workspace:*",
     "@slack/bolt": "^4.6.0",

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -435,6 +435,31 @@ describe('PlanConversation', () => {
     expect(reply).toBe('What kind of project is this?');
   });
 
+  it('formats Codex JSONL into agent message and exposes reasoning', async () => {
+    const jsonl = [
+      JSON.stringify({ type: 'thread.started', thread_id: 'tid-1' }),
+      JSON.stringify({ type: 'turn.started' }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { id: 'item_0', type: 'reasoning', text: 'Greet the user and ask what to plan.' },
+      }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { id: 'item_1', type: 'agent_message', text: 'Hello. What should we plan?' },
+      }),
+      JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1, output_tokens: 2 } }),
+    ].join('\n');
+    mockCursorResponse(jsonl);
+    const reply = await conversation.sendMessage('hello');
+    expect(reply).toBe('Hello. What should we plan?');
+    expect(reply).not.toContain('thread.started');
+    expect(conversation.lastTurnReasoning).toEqual(['Greet the user and ask what to plan.']);
+    expect(conversation.history[1]).toEqual({
+      role: 'assistant',
+      content: 'Hello. What should we plan?',
+    });
+  });
+
   it('tracks conversation history', async () => {
     mockCursorResponse('Tell me more.');
     await conversation.sendMessage('Build a REST API');

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -13,6 +13,7 @@
 import { spawn } from 'node:child_process';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import type { ConversationRepository } from '@invoker/data-store';
+import { formatCodexPlannerStdout } from '@invoker/execution-engine';
 import type { LogFn } from '../surface.js';
 
 // ── Types ───────────────────────────────────────────────────
@@ -325,6 +326,7 @@ export class PlanConversation {
   private plannerRetryLimit: number;
   private plannerRetryBaseDelayMs: number;
   private _initialized = false;
+  private _lastTurnReasoning: string[] = [];
 
   constructor(config: PlanConversationConfig) {
     this.cursorCommand = config.cursorCommand ?? 'agent';
@@ -407,14 +409,22 @@ export class PlanConversation {
 
     const response = await this.spawnPlanner(prompt);
     const tCursor = Date.now();
-    this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: responseLen=${response.length}, responsePreview="${response.slice(0, 500).replace(/\n/g, '\\n')}"`);
+    const formatted = formatCodexPlannerStdout(response);
+    const message = formatted.message;
+    this._lastTurnReasoning = formatted.reasoning;
+    this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: responseLen=${response.length}, messageLen=${message.length}, reasoningParts=${formatted.reasoning.length}, responsePreview="${message.slice(0, 500).replace(/\n/g, '\\n')}"`);
 
-    this.messages.push({ role: 'assistant', content: response });
+    this.messages.push({ role: 'assistant', content: message });
     this.saveState();
     const tSave = Date.now();
 
     this.log('plan-conversation', 'info', `[PERF] sendMessage: init=${tInit - t0}ms, buildPrompt=${tPrompt - tInit}ms, cursor=${tCursor - tPrompt}ms, saveState=${tSave - tCursor}ms, total=${tSave - t0}ms`);
-    return response;
+    return message;
+  }
+
+  /** Reasoning summaries from the most recent planner turn (Codex JSONL), if any. */
+  get lastTurnReasoning(): string[] {
+    return this._lastTurnReasoning;
   }
 
   /** Returns the raw plan text that was submitted via confirmation, or null. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,6 +428,9 @@ importers:
       '@invoker/data-store':
         specifier: workspace:*
         version: link:../data-store
+      '@invoker/execution-engine':
+        specifier: workspace:*
+        version: link:../execution-engine
       '@invoker/transport':
         specifier: workspace:*
         version: link:../transport


### PR DESCRIPTION
Extract agent_message and reasoning from codex exec --json so planning
chat history and replies are prose, not raw protocol events.

Co-authored-by: Cursor <cursoragent@cursor.com>