### PR TITLE
[Planning CoT](2) Show collapsed Thinking disclosure in Planning Terminal

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2020,7 +2020,7 @@ export function App() {
               ? (input.length > 56 ? `${input.slice(0, 53).trimEnd()}…` : input)
               : session.title,
             status: result.draftPlanAvailable ? 'draft_ready' : result.reply.includes('?') ? 'waiting_for_answer' : 'still_discussing',
-            messages: [...session.messages, { id: replyLineId, text: result.reply, role: 'assistant' }],
+            messages: [...session.messages, { id: replyLineId, text: result.reply, role: 'assistant', ...((result as { reasoning?: string }).reasoning ? { reasoning: (result as { reasoning?: string }).reasoning } : {}) }],
             draftPlanAvailable: result.draftPlanAvailable,
             draftPlanSummary: result.draftPlanAvailable ? result.draftPlanSummary : undefined,
             updatedAt,

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -50,6 +50,30 @@ describe('Invoker terminal (component)', () => {
     expect(screen.queryByText(/Unknown command/)).not.toBeInTheDocument();
   });
 
+  it('shows collapsed Thinking disclosure when reasoning is present', async () => {
+    mock.api.planningChatSend = vi.fn(async () => ({
+      ok: true,
+      sessionId: 'session-1',
+      reply: 'Hello. What should we plan?',
+      reasoning: 'Greet the user and ask what to plan.',
+      draftPlanAvailable: false,
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+    submitPlanningText('hello');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Hello. What should we plan?');
+    });
+    const thinking = screen.getByTestId('invoker-terminal-thinking');
+    expect(thinking).toBeInTheDocument();
+    expect(thinking).not.toHaveAttribute('open');
+    expect(thinking).toHaveTextContent('Thinking');
+    expect(thinking).toHaveTextContent('Greet the user and ask what to plan.');
+    expect(screen.queryByText('thread.started')).not.toBeInTheDocument();
+  });
+
   it('sends plain language when Enter is pressed', async () => {
     render(<App />);
     await openPlanningTerminal();

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -5,6 +5,7 @@ export interface InvokerTerminalLine {
   id: number;
   text: string;
   role: 'user' | 'assistant' | 'system';
+  reasoning?: string;
   tone?: 'muted' | 'error' | 'success';
 }
 
@@ -175,6 +176,19 @@ export function InvokerTerminal({
           return (
             <div key={line.id} className="space-y-1">
               <div className="text-[11px] text-muted-foreground">{rolePrompt(line.role)}</div>
+              {line.reasoning ? (
+                <details
+                  data-testid="invoker-terminal-thinking"
+                  className="rounded-sm border border-border/60 bg-background/40 px-2 py-1 text-muted-foreground"
+                >
+                  <summary className="cursor-pointer select-none text-[11px] text-muted-foreground">
+                    Thinking
+                  </summary>
+                  <div className="mt-1 whitespace-pre-wrap text-[12px] leading-5 text-muted-foreground">
+                    {line.reasoning}
+                  </div>
+                </details>
+              ) : null}
               <div className={`whitespace-pre-wrap ${toneClass}`}>{line.text}</div>
             </div>
           );


### PR DESCRIPTION
Render optional planner reasoning as a collapsed-by-default Thinking
section above the readable invoker reply.

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #4071