### PR TITLE
[npm Slack](1) Packaged GUI relaunch and npm-slack launcher

### DIFF
--- a/packages/npm-slack/bin/invoker-slack.js
+++ b/packages/npm-slack/bin/invoker-slack.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const binary = join(root, 'vendor', 'invoker-slack');
+
+if (!existsSync(binary)) {
+  console.error(`invoker-slack binary is missing at ${binary}. Reinstall @neko-catpital-labs/invoker-slack.`);
+  process.exit(1);
+}
+
+const result = spawnSync(binary, process.argv.slice(2), { stdio: 'inherit' });
+process.exit(result.status ?? 1);

--- a/packages/npm-slack/package.json
+++ b/packages/npm-slack/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@neko-catpital-labs/invoker-slack",
+  "version": "0.0.6",
+  "description": "Invoker standalone Slack manager installer",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Neko-Catpital-Labs/Invoker.git",
+    "directory": "packages/npm-slack"
+  },
+  "bin": {
+    "invoker-slack": "bin/invoker-slack.js"
+  },
+  "files": [
+    "bin/**/*",
+    "scripts/**/*",
+    "vendor/.gitkeep",
+    "package.json"
+  ],
+  "scripts": {
+    "postinstall": "node scripts/install.js",
+    "test": "node bin/invoker-slack.js --version || true"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/npm-slack/scripts/install.js
+++ b/packages/npm-slack/scripts/install.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { createWriteStream, existsSync } from 'node:fs';
+import { chmod, mkdir, readFile, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const pkg = require(join(root, 'package.json'));
+
+if (existsSync(join(root, '..', '..', 'pnpm-workspace.yaml'))) {
+  process.exit(0);
+}
+
+const repo = process.env.INVOKER_RELEASE_REPOSITORY ?? 'Neko-Catpital-Labs/Invoker';
+const baseUrl = process.env.INVOKER_RELEASE_BASE_URL ?? `https://github.com/${repo}/releases/download/v${pkg.version}`;
+const asset = `invoker-slack-${pkg.version}-${process.platform}-${process.arch}.tar.gz`;
+const vendor = join(root, 'vendor');
+const archivePath = join(vendor, asset);
+const sumsPath = join(vendor, 'SHA256SUMS');
+const binaryPath = join(vendor, 'invoker-slack');
+
+if (!['darwin', 'linux'].includes(process.platform) || !['x64', 'arm64'].includes(process.arch)) {
+  throw new Error(`Unsupported Invoker Slack platform: ${process.platform}-${process.arch}`);
+}
+
+async function download(url, destination) {
+  const response = await fetch(url);
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download ${url}: ${response.status} ${response.statusText}`);
+  }
+  await pipeline(response.body, createWriteStream(destination));
+}
+
+async function sha256(path) {
+  const hash = createHash('sha256');
+  hash.update(await readFile(path));
+  return hash.digest('hex');
+}
+
+function expectedHash(sums, name) {
+  for (const line of sums.split(/\r?\n/)) {
+    const match = line.match(/^([a-f0-9]{64})\s+\*?(.+)$/i);
+    if (match && match[2].trim() === name) return match[1].toLowerCase();
+  }
+  return undefined;
+}
+
+await mkdir(vendor, { recursive: true });
+await rm(binaryPath, { force: true });
+await download(`${baseUrl}/SHA256SUMS`, sumsPath);
+await download(`${baseUrl}/${asset}`, archivePath);
+
+const sums = await readFile(sumsPath, 'utf8');
+const expected = expectedHash(sums, asset);
+if (!expected) {
+  throw new Error(`SHA256SUMS does not contain ${asset}`);
+}
+const actual = await sha256(archivePath);
+if (actual !== expected) {
+  throw new Error(`Checksum mismatch for ${asset}: expected ${expected}, got ${actual}`);
+}
+
+execFileSync('tar', ['-xzf', archivePath, '-C', vendor], { stdio: 'inherit' });
+const extracted = join(vendor, asset.replace(/\.tar\.gz$/, ''), 'invoker-slack');
+if (!existsSync(extracted)) {
+  throw new Error(`Downloaded archive did not contain ${extracted}`);
+}
+execFileSync('cp', [extracted, binaryPath]);
+await chmod(binaryPath, 0o755);

--- a/packages/slack-manager/deploy/install.sh
+++ b/packages/slack-manager/deploy/install.sh
@@ -1,21 +1,26 @@
 #!/usr/bin/env bash
 # Install the Invoker Slack manager as an independently-supervised daemon.
 #
+# Prefers a packaged `invoker-slack` on PATH (npm SEA binary). Falls back to
+# building and running packages/slack-manager/dist/index.js from a monorepo
+# checkout when the binary is not installed.
+#
 # Prereqs:
 #   - Slack owner credentials at ~/.invoker/.slack-owner.env with:
 #       SLACK_BOT_TOKEN, SLACK_APP_TOKEN, SLACK_SIGNING_SECRET, SLACK_CHANNEL_ID
 #       (optionally SLACK_LOBBY_CHANNEL_ID, CURSOR_COMMAND, CURSOR_MODEL,
 #        INVOKER_REPO_URL, INVOKER_DEFAULT_BRANCH)
-#   - `cursor` / `omp` on PATH (the planner subprocess), `xvfb-run` for the GUI.
+#   - `cursor` / `omp` on PATH (the planner subprocess)
 #
 # Uses systemd --user when available (Restart=always + linger survives reboots),
 # else falls back to an @reboot cron keepalive loop.
 set -euo pipefail
 
-REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || true)"
 NODE_BIN="$(command -v node)"
-SERVICE_SRC="$REPO_ROOT/packages/slack-manager/deploy/slack-manager.service"
+SERVICE_SRC="${REPO_ROOT:+$REPO_ROOT/packages/slack-manager/deploy/slack-manager.service}"
 ENV_FILE="$HOME/.invoker/.slack-owner.env"
+SLACK_BIN="$(command -v invoker-slack || true)"
 
 if [ -z "$NODE_BIN" ]; then echo "node not found on PATH" >&2; exit 1; fi
 if [ ! -f "$ENV_FILE" ]; then
@@ -23,26 +28,66 @@ if [ ! -f "$ENV_FILE" ]; then
   exit 1
 fi
 
-echo "Building @invoker/slack-manager…"
-( cd "$REPO_ROOT" && pnpm --filter @invoker/slack-manager build )
+if [ -z "$SLACK_BIN" ]; then
+  if [ -z "$REPO_ROOT" ] || [ ! -f "$REPO_ROOT/packages/slack-manager/package.json" ]; then
+    echo "invoker-slack not on PATH and no monorepo checkout found." >&2
+    echo "Install with: npm i -g @neko-catpital-labs/invoker-slack" >&2
+    exit 1
+  fi
+  echo "Building @invoker/slack-manager (dev fallback)…"
+  ( cd "$REPO_ROOT" && pnpm --filter @invoker/slack-manager build )
+  EXEC_START="$NODE_BIN $REPO_ROOT/packages/slack-manager/dist/index.js"
+  WORK_DIR="$REPO_ROOT"
+else
+  echo "Using packaged invoker-slack at $SLACK_BIN"
+  EXEC_START="$SLACK_BIN"
+  WORK_DIR="${REPO_ROOT:-$HOME}"
+fi
 
 if command -v systemctl >/dev/null 2>&1; then
   UNIT_DIR="$HOME/.config/systemd/user"
   mkdir -p "$UNIT_DIR"
-  sed -e "s#__REPO_ROOT__#$REPO_ROOT#g" -e "s#__NODE__#$NODE_BIN#g" \
-    "$SERVICE_SRC" > "$UNIT_DIR/slack-manager.service"
+  if [ -n "$SERVICE_SRC" ] && [ -f "$SERVICE_SRC" ]; then
+    sed -e "s#__REPO_ROOT__#$WORK_DIR#g" \
+        -e "s#__NODE__#$NODE_BIN#g" \
+        -e "s#ExecStart=.*#ExecStart=$EXEC_START#g" \
+      "$SERVICE_SRC" > "$UNIT_DIR/slack-manager.service"
+  else
+    cat > "$UNIT_DIR/slack-manager.service" <<EOF
+[Unit]
+Description=Invoker Slack manager (out-of-process Slack surface)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=$WORK_DIR
+EnvironmentFile=%h/.invoker/.slack-owner.env
+ExecStart=$EXEC_START
+Restart=always
+RestartSec=5
+TimeoutStopSec=20
+
+[Install]
+WantedBy=default.target
+EOF
+  fi
   systemctl --user daemon-reload
   systemctl --user enable --now slack-manager.service
-  # Keep the user manager (and the service) alive across logout/reboot.
   loginctl enable-linger "$USER" || true
   echo "Installed. Logs: journalctl --user -u slack-manager -f"
 else
   echo "systemd not available — installing @reboot cron keepalive fallback."
+  if [ -z "$REPO_ROOT" ]; then
+    echo "Cron keepalive needs the monorepo keepalive.sh; install systemd or clone the repo." >&2
+    exit 1
+  fi
   KEEPALIVE="$REPO_ROOT/packages/slack-manager/deploy/keepalive.sh"
   chmod +x "$KEEPALIVE"
-  LINE="@reboot INVOKER_REPO_ROOT=$REPO_ROOT NODE_BIN=$NODE_BIN setsid $KEEPALIVE >> $HOME/.invoker/slack-manager.keepalive.log 2>&1"
+  LINE="@reboot INVOKER_REPO_ROOT=$REPO_ROOT NODE_BIN=$NODE_BIN INVOKER_SLACK_BIN=${SLACK_BIN:-} setsid $KEEPALIVE >> $HOME/.invoker/slack-manager.keepalive.log 2>&1"
   ( crontab -l 2>/dev/null | grep -v 'slack-manager/deploy/keepalive.sh' || true; echo "$LINE" ) | crontab -
   echo "Installed cron keepalive. Starting now…"
-  INVOKER_REPO_ROOT="$REPO_ROOT" NODE_BIN="$NODE_BIN" setsid "$KEEPALIVE" >> "$HOME/.invoker/slack-manager.keepalive.log" 2>&1 &
+  INVOKER_REPO_ROOT="$REPO_ROOT" NODE_BIN="$NODE_BIN" INVOKER_SLACK_BIN="${SLACK_BIN:-}" \
+    setsid "$KEEPALIVE" >> "$HOME/.invoker/slack-manager.keepalive.log" 2>&1 &
   echo "Logs: $HOME/.invoker/slack-manager.keepalive.log"
 fi

--- a/packages/slack-manager/deploy/keepalive.sh
+++ b/packages/slack-manager/deploy/keepalive.sh
@@ -7,6 +7,7 @@ set -u
 
 REPO_ROOT="${INVOKER_REPO_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}"
 NODE_BIN="${NODE_BIN:-$(command -v node)}"
+SLACK_BIN="${INVOKER_SLACK_BIN:-$(command -v invoker-slack || true)}"
 ENV_FILE="${INVOKER_SLACK_OWNER_ENV:-$HOME/.invoker/.slack-owner.env}"
 RESTART_DELAY="${RESTART_DELAY:-5}"
 
@@ -16,7 +17,11 @@ cd "$REPO_ROOT" || exit 1
 
 while true; do
   echo "[keepalive] $(date -Is) starting slack-manager"
-  "$NODE_BIN" packages/slack-manager/dist/index.js
+  if [ -n "$SLACK_BIN" ] && [ -x "$SLACK_BIN" ]; then
+    "$SLACK_BIN"
+  else
+    "$NODE_BIN" packages/slack-manager/dist/index.js
+  fi
   echo "[keepalive] $(date -Is) slack-manager exited ($?); restarting in ${RESTART_DELAY}s"
   sleep "$RESTART_DELAY"
 done

--- a/packages/slack-manager/deploy/slack-manager.service
+++ b/packages/slack-manager/deploy/slack-manager.service
@@ -17,6 +17,8 @@ Wants=network-online.target
 Type=simple
 WorkingDirectory=__REPO_ROOT__
 EnvironmentFile=%h/.invoker/.slack-owner.env
+# install.sh rewrites ExecStart to `invoker-slack` when the npm binary is on
+# PATH; the monorepo node entry below is the dev fallback.
 ExecStart=__NODE__ packages/slack-manager/dist/index.js
 Restart=always
 RestartSec=5

--- a/packages/slack-manager/src/__tests__/invoker-launcher.test.ts
+++ b/packages/slack-manager/src/__tests__/invoker-launcher.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { resolveGuiLaunch } from '../invoker-launcher.js';
+
+describe('resolveGuiLaunch', () => {
+  it('prefers INVOKER_GUI_COMMAND when set', () => {
+    const spec = resolveGuiLaunch({
+      repoRoot: '/repo',
+      platform: 'darwin',
+      env: { INVOKER_GUI_COMMAND: '/opt/Invoker.app/Contents/MacOS/Invoker --flag' },
+      which: () => undefined,
+      existsSync: () => false,
+    });
+    expect(spec).toEqual({
+      command: '/opt/Invoker.app/Contents/MacOS/Invoker',
+      args: ['--flag'],
+    });
+  });
+
+  it('uses invoker-ui on PATH before macOS open', () => {
+    const spec = resolveGuiLaunch({
+      repoRoot: '/repo',
+      platform: 'darwin',
+      env: {},
+      which: (cmd) => (cmd === 'invoker-ui' ? '/usr/local/bin/invoker-ui' : undefined),
+      existsSync: () => false,
+    });
+    expect(spec).toEqual({ command: '/usr/local/bin/invoker-ui', args: [] });
+  });
+
+  it('falls back to open -a Invoker on macOS', () => {
+    const spec = resolveGuiLaunch({
+      repoRoot: '/repo',
+      platform: 'darwin',
+      env: {},
+      which: () => undefined,
+      existsSync: () => false,
+    });
+    expect(spec).toEqual({ command: 'open', args: ['-a', 'Invoker'] });
+  });
+
+  it('uses monorepo xvfb-run path on Linux when checkout artifacts exist', () => {
+    const spec = resolveGuiLaunch({
+      repoRoot: '/repo',
+      platform: 'linux',
+      env: {},
+      which: () => undefined,
+      existsSync: (path) =>
+        path === '/repo/scripts/electron.cjs' || path === '/repo/packages/app/dist/main.js',
+    });
+    expect(spec).toEqual({
+      command: 'xvfb-run',
+      args: ['--auto-servernum', './scripts/electron.cjs', 'packages/app/dist/main.js', '--no-sandbox'],
+      cwd: '/repo',
+    });
+  });
+
+  it('throws on Linux when no GUI launch path is available', () => {
+    expect(() =>
+      resolveGuiLaunch({
+        repoRoot: '/repo',
+        platform: 'linux',
+        env: {},
+        which: () => undefined,
+        existsSync: () => false,
+      }),
+    ).toThrow(/Cannot launch Invoker GUI/);
+  });
+});

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -26,7 +26,26 @@ import { createPlanningCommandBuilder, createPrepareRepoCheckout, createGatherWo
 import { createWatchdog } from './watchdog.js';
 import { errMessage } from './util.js';
 
+const VERSION = '0.0.6';
+
 const REQUIRED_ENV = ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_SIGNING_SECRET', 'SLACK_CHANNEL_ID'];
+
+if (process.argv.includes('--version') || process.argv.includes('-V')) {
+  console.log(VERSION);
+  process.exit(0);
+}
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  console.log(`invoker-slack ${VERSION}
+
+Usage: invoker-slack [--version] [--help]
+
+Standalone Slack manager daemon. Loads credentials from
+~/.invoker/.slack-owner.env (or INVOKER_SLACK_OWNER_ENV) and drives Invoker
+over IPC. Install via: npm i -g @neko-catpital-labs/invoker-slack
+`);
+  process.exit(0);
+}
 
 function makeLog(): { log: (level: string, message: string) => void; logFn: (source: string, level: string, message: string) => void } {
   const log = (level: string, message: string): void => {

--- a/packages/slack-manager/src/invoker-launcher.ts
+++ b/packages/slack-manager/src/invoker-launcher.ts
@@ -1,14 +1,21 @@
 /**
  * Invoker GUI launcher — spawns the Slack-free Invoker GUI as a detached process
- * group, matching `run.sh`'s headless-Linux path. Tracks the spawned child so a
- * forced restart can tear down a manager-managed instance before respawning.
+ * group. Tracks the spawned child so a forced restart can tear down a
+ * manager-managed instance before respawning.
+ *
+ * Resolution order:
+ *   1. INVOKER_GUI_COMMAND (shell-split argv[0] + args)
+ *   2. `invoker-ui` on PATH
+ *   3. macOS: `open -a Invoker`
+ *   4. monorepo checkout: xvfb-run + ./scripts/electron.cjs (Linux headless)
  *
  * Slack credentials are stripped from the child env: post-cutover Invoker has no
  * Slack surface, and the manager owns the only Slack connection.
  */
 
-import { spawn, type ChildProcess } from 'node:child_process';
-import { openSync } from 'node:fs';
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import { existsSync, openSync } from 'node:fs';
+import { join } from 'node:path';
 
 const SLACK_ENV_VARS = [
   'SLACK_BOT_TOKEN',
@@ -29,6 +36,63 @@ export interface InvokerLauncher {
   spawnInvoker: () => void;
 }
 
+export interface GuiLaunchSpec {
+  command: string;
+  args: string[];
+  cwd?: string;
+}
+
+function defaultWhich(command: string): string | undefined {
+  try {
+    return execFileSync('which', [command], { encoding: 'utf8' }).trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Exported for unit tests — pure resolution, no spawn. */
+export function resolveGuiLaunch(options: {
+  repoRoot: string;
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  which?: (command: string) => string | undefined;
+  existsSync?: (path: string) => boolean;
+}): GuiLaunchSpec {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const which = options.which ?? defaultWhich;
+  const fileExists = options.existsSync ?? existsSync;
+
+  const guiCommand = env.INVOKER_GUI_COMMAND?.trim();
+  if (guiCommand) {
+    const parts = guiCommand.split(/\s+/).filter(Boolean);
+    return { command: parts[0]!, args: parts.slice(1) };
+  }
+
+  const invokerUi = which('invoker-ui');
+  if (invokerUi) {
+    return { command: invokerUi, args: [] };
+  }
+
+  if (platform === 'darwin') {
+    return { command: 'open', args: ['-a', 'Invoker'] };
+  }
+
+  const electronCjs = join(options.repoRoot, 'scripts', 'electron.cjs');
+  const mainJs = join(options.repoRoot, 'packages', 'app', 'dist', 'main.js');
+  if (fileExists(electronCjs) && fileExists(mainJs)) {
+    return {
+      command: 'xvfb-run',
+      args: ['--auto-servernum', './scripts/electron.cjs', 'packages/app/dist/main.js', '--no-sandbox'],
+      cwd: options.repoRoot,
+    };
+  }
+
+  throw new Error(
+    'Cannot launch Invoker GUI: set INVOKER_GUI_COMMAND, install invoker-ui, or run from a built monorepo checkout',
+  );
+}
+
 export function createInvokerLauncher(options: InvokerLauncherOptions): InvokerLauncher {
   let child: ChildProcess | undefined;
 
@@ -47,14 +111,16 @@ export function createInvokerLauncher(options: InvokerLauncherOptions): InvokerL
       const env: NodeJS.ProcessEnv = { ...process.env, LIBGL_ALWAYS_SOFTWARE: '1' };
       for (const key of SLACK_ENV_VARS) delete env[key];
 
+      const spec = resolveGuiLaunch({ repoRoot: options.repoRoot });
       const out = openSync(options.logPath, 'a');
-      child = spawn(
-        'xvfb-run',
-        ['--auto-servernum', './scripts/electron.cjs', 'packages/app/dist/main.js', '--no-sandbox'],
-        { cwd: options.repoRoot, env, detached: true, stdio: ['ignore', out, out] },
-      );
+      child = spawn(spec.command, spec.args, {
+        cwd: spec.cwd,
+        env,
+        detached: true,
+        stdio: ['ignore', out, out],
+      });
       child.unref();
-      options.log('info', `spawned Invoker GUI (pid=${child.pid})`);
+      options.log('info', `spawned Invoker GUI via ${spec.command} (pid=${child.pid})`);
     },
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,6 +262,8 @@ importers:
 
   packages/npm-cli: {}
 
+  packages/npm-slack: {}
+
   packages/npm-ui:
     dependencies:
       '@neko-catpital-labs/invoker-cli':


### PR DESCRIPTION
## Summary

Slack manager installs can now relaunch the Invoker GUI without a Linux monorepo checkout.

This also adds the `@neko-catpital-labs/invoker-slack` npm launcher package files so a later release slice can publish the binary.

Deploy scripts prefer an `invoker-slack` binary on PATH and keep the monorepo node entry as a fallback.

## Review Claim

Approve packaged GUI relaunch resolution and the new npm-slack launcher package files.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Does not change Slack Socket Mode handling or planning verbs. GUI launch only gains new resolution paths before the existing xvfb monorepo fallback.

## Slice Rationale

Product package and launcher behavior must land before release scripts and docs that depend on the npm-slack package existing.

## Non-goals

Does not add SEA build scripts, release workflow assets, or documentation. Does not publish to npm.

## Architecture

### Before

```mermaid
flowchart LR
  manager["slack-manager"] --> xvfb["xvfb-run electron.cjs only"]
```

### After

```mermaid
flowchart LR
  manager["slack-manager"] --> resolve["INVOKER_GUI_COMMAND / invoker-ui / open -a Invoker / xvfb"]
  npmPkg["@neko-catpital-labs/invoker-slack"] --> vendor["vendor/invoker-slack postinstall"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/slack-manager && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an installable `invoker-slack` command for supported platforms.
  * Added `--version` and `--help` options with usage and installation guidance.
  * Added automatic verification and setup of the required Slack binary.
  * Added flexible GUI launching across macOS, Linux, and custom environments.

* **Bug Fixes**
  * Improved service and keepalive startup reliability by using the packaged command when available, with development fallback support.
  * Added clearer errors when required launch components are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->