### PR TITLE
[npm Slack](2) SEA build, release assets, and local cut script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,63 @@ jobs:
             release/invoker-cli-*
           if-no-files-found: error
 
+  build-slack:
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux
+            arch: x64
+          - runner: ubuntu-24.04-arm
+            platform: linux
+            arch: arm64
+          - runner: macos-15-intel
+            platform: darwin
+            arch: x64
+          - runner: macos-latest
+            platform: darwin
+            arch: arm64
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .node-version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check release version sync
+        run: pnpm run check:versions
+
+      - name: Build standalone Slack manager
+        env:
+          INVOKER_TARGET_PLATFORM: ${{ matrix.platform }}
+          INVOKER_TARGET_ARCH: ${{ matrix.arch }}
+        run: pnpm run dist:slack
+
+      - name: Upload Slack artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: slack-${{ matrix.platform }}-${{ matrix.arch }}
+          path: |
+            release/invoker-slack-*
+          if-no-files-found: error
+
   build-desktop:
     timeout-minutes: 90
     strategy:
@@ -138,6 +195,7 @@ jobs:
   publish-release:
     needs:
       - build-cli
+      - build-slack
       - build-desktop
     runs-on: ubuntu-latest
 
@@ -163,6 +221,10 @@ jobs:
             "invoker-cli-${version}-linux-arm64.tar.gz"
             "invoker-cli-${version}-darwin-x64.tar.gz"
             "invoker-cli-${version}-darwin-arm64.tar.gz"
+            "invoker-slack-${version}-linux-x64.tar.gz"
+            "invoker-slack-${version}-linux-arm64.tar.gz"
+            "invoker-slack-${version}-darwin-x64.tar.gz"
+            "invoker-slack-${version}-darwin-arm64.tar.gz"
             "Invoker-${version}-x86_64.AppImage"
             "Invoker-${version}-arm64.AppImage"
             "Invoker-${version}-amd64.deb"
@@ -191,6 +253,7 @@ jobs:
             release/*.AppImage
             release/*.zip
             release/invoker-cli-*
+            release/invoker-slack-*
             release/SHA256SUMS
 
       - name: Install pnpm
@@ -237,3 +300,4 @@ jobs:
 
           publish_if_missing packages/npm-cli
           publish_if_missing packages/npm-ui
+          publish_if_missing packages/npm-slack

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ packages/app/test-results/
 .claude.json.backup*
 tmp/plans/
 release/
+local-builds/
 
 # Local pipeline secrets/config
 config/nightly-usage.env

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dist:desktop:mac:arm64": "bash scripts/package-desktop.sh --mac --arm64",
     "dist:desktop:mac:x64": "bash scripts/package-desktop.sh --mac --x64",
     "dist:cli": "node scripts/build-cli-standalone.mjs && bash scripts/archive-cli-binary.sh",
+    "dist:slack": "node scripts/build-slack-standalone.mjs && bash scripts/archive-slack-binary.sh",
     "build:tsc": "tsc -b tsconfig.build.json",
     "build:tsc:clean": "tsc -b tsconfig.build.json --clean",
     "clean": "pnpm -r clean",

--- a/scripts/archive-slack-binary.sh
+++ b/scripts/archive-slack-binary.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="$(node -p "require('$ROOT/packages/slack-manager/package.json').version")"
+PLATFORM="${INVOKER_TARGET_PLATFORM:-$(node -p "process.platform")}"
+ARCH="${INVOKER_TARGET_ARCH:-$(node -p "process.arch")}"
+RELEASE_DIR="${INVOKER_RELEASE_DIR:-$ROOT/release}"
+BINARY="$RELEASE_DIR/invoker-slack-$VERSION-$PLATFORM-$ARCH"
+
+if [ ! -x "$BINARY" ]; then
+  echo "Standalone Slack binary not found: $BINARY" >&2
+  exit 66
+fi
+
+STAGE="$(mktemp -d "${TMPDIR:-/tmp}/invoker-slack-archive.XXXXXX")"
+NAME="invoker-slack-$VERSION-$PLATFORM-$ARCH"
+mkdir -p "$STAGE/$NAME"
+cp "$BINARY" "$STAGE/$NAME/invoker-slack"
+chmod +x "$STAGE/$NAME/invoker-slack"
+cp "$ROOT/packages/npm-slack/README.md" "$STAGE/$NAME/README.md"
+
+(cd "$STAGE" && tar -czf "$RELEASE_DIR/$NAME.tar.gz" "$NAME")
+rm -rf "$STAGE"
+echo "$RELEASE_DIR/$NAME.tar.gz"

--- a/scripts/build-slack-standalone.mjs
+++ b/scripts/build-slack-standalone.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { createWriteStream, existsSync } from 'node:fs';
+import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const pkg = require(join(root, 'packages/slack-manager/package.json'));
+const nodeVersion = process.env.INVOKER_STANDALONE_NODE_VERSION ?? process.version.replace(/^v/, '');
+const platform = process.env.INVOKER_TARGET_PLATFORM ?? process.platform;
+const arch = process.env.INVOKER_TARGET_ARCH ?? process.arch;
+const outDir = resolve(process.env.INVOKER_SLACK_STANDALONE_DIR ?? join(root, 'release'));
+const binaryName = `invoker-slack-${pkg.version}-${platform}-${arch}${platform === 'win32' ? '.exe' : ''}`;
+const outPath = join(outDir, binaryName);
+
+if (!['darwin', 'linux'].includes(platform)) {
+  throw new Error(`Unsupported standalone Slack platform: ${platform}`);
+}
+if (!['x64', 'arm64'].includes(arch)) {
+  throw new Error(`Unsupported standalone Slack architecture: ${arch}`);
+}
+
+function run(command, args, options = {}) {
+  execFileSync(command, args, {
+    cwd: root,
+    stdio: 'inherit',
+    ...options,
+  });
+}
+
+async function download(url, destination) {
+  const response = await fetch(url);
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download ${url}: ${response.status} ${response.statusText}`);
+  }
+  await pipeline(response.body, createWriteStream(destination));
+}
+
+async function ensureTargetNode(stage) {
+  if (process.env.INVOKER_USE_HOST_NODE_FOR_SEA === '1' && platform === process.platform && arch === process.arch) {
+    return process.execPath;
+  }
+
+  const ext = platform === 'darwin' ? 'tar.gz' : 'tar.xz';
+  const archiveBase = `node-v${nodeVersion}-${platform}-${arch}`;
+  const archiveName = `${archiveBase}.${ext}`;
+  const archivePath = join(stage, archiveName);
+  const url = `https://nodejs.org/dist/v${nodeVersion}/${archiveName}`;
+  await download(url, archivePath);
+  run('tar', ['-xf', archivePath, '-C', stage]);
+  return join(stage, archiveBase, 'bin', 'node');
+}
+
+async function sha256(path) {
+  const hash = createHash('sha256');
+  hash.update(await readFile(path));
+  return hash.digest('hex');
+}
+
+await mkdir(outDir, { recursive: true });
+const stage = await mkdtemp(join(tmpdir(), 'invoker-slack-sea-'));
+
+try {
+  // Surfaces must be built first — standalone tsup resolves its dist entry.
+  run('pnpm', ['--filter', '@invoker/surfaces', 'build']);
+
+  const bundlePath = join(stage, 'index.js');
+  const blobPath = join(stage, 'sea-prep.blob');
+  const seaConfigPath = join(stage, 'sea-config.json');
+  const standaloneEntryPath = join(stage, 'index.ts');
+  const targetNode = await ensureTargetNode(stage);
+  const slackEntryImportPath = join(root, 'packages/slack-manager/src/index.ts').replaceAll('\\', '/');
+
+  await writeFile(standaloneEntryPath, [
+    `import ${JSON.stringify(slackEntryImportPath)};`,
+    '',
+  ].join('\n'));
+
+  // Bundle @invoker/surfaces and @slack/bolt into the SEA blob. Keep only
+  // true native / node builtins external (same set as the CLI SEA builder).
+  run('pnpm', [
+    'exec',
+    'tsup',
+    standaloneEntryPath,
+    '--format',
+    'cjs',
+    '--platform',
+    'node',
+    '--target',
+    'node26',
+    '--no-dts',
+    '--no-splitting',
+    '--no-config',
+    '--out-dir',
+    stage,
+    '--external',
+    'node:sqlite',
+    '--external',
+    'dockerode',
+    '--external',
+    'ssh2',
+    '--external',
+    'cpu-features',
+    '--external',
+    'node-pty',
+  ]);
+
+  if (!existsSync(bundlePath)) {
+    throw new Error(`Standalone Slack bundle missing at ${bundlePath}`);
+  }
+
+  await writeFile(seaConfigPath, JSON.stringify({
+    main: bundlePath,
+    output: blobPath,
+    disableExperimentalSEAWarning: true,
+    useCodeCache: false,
+    useSnapshot: false,
+  }, null, 2));
+
+  run(process.execPath, ['--experimental-sea-config', seaConfigPath]);
+  await copyFile(targetNode, outPath);
+  await chmod(outPath, 0o755);
+
+  if (platform === 'darwin') {
+    try {
+      run('codesign', ['--remove-signature', outPath]);
+    } catch {
+      // Downloaded Node binaries are not always signed in local/dev builds.
+    }
+  }
+
+  const postjectArgs = [
+    outPath,
+    'NODE_SEA_BLOB',
+    blobPath,
+    '--sentinel-fuse',
+    'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2',
+  ];
+  if (platform === 'darwin') {
+    postjectArgs.push('--macho-segment-name', 'NODE_SEA');
+  }
+  run('pnpm', ['exec', 'postject', ...postjectArgs]);
+
+  if (platform === 'darwin') {
+    try {
+      run('codesign', ['--sign', '-', outPath]);
+    } catch {
+      // Ad-hoc signing is best-effort for local builds. Release runners have codesign.
+    }
+  }
+
+  console.log(`${outPath}`);
+  console.log(`${await sha256(outPath)}  ${basename(outPath)}`);
+} finally {
+  if (process.env.INVOKER_KEEP_STANDALONE_STAGE !== '1') {
+    await rm(stage, { recursive: true, force: true });
+  }
+}

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -4,8 +4,9 @@
 //
 //   node scripts/bump-version.mjs 0.0.7
 //
-// Covers the root + four publishable package.json files, the VERSION constant
-// baked into the CLI source, and CHANGELOG.md (renames "## Unreleased" to the
+// Covers the root + publishable package.json files (app, cli, slack-manager,
+// npm-cli, npm-ui, npm-slack), the VERSION constants baked into the CLI and
+// Slack manager sources, and CHANGELOG.md (renames "## Unreleased" to the
 // new version and starts a fresh "## Unreleased"). After this, commit and tag
 // (vX.Y.Z) to trigger the release workflow.
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -42,8 +43,10 @@ function main() {
     'package.json',
     'packages/app/package.json',
     'packages/cli/package.json',
+    'packages/slack-manager/package.json',
     'packages/npm-cli/package.json',
     'packages/npm-ui/package.json',
+    'packages/npm-slack/package.json',
   ];
 
   for (const relPath of packageJsonPaths) {
@@ -55,14 +58,20 @@ function main() {
     console.log(`${relPath}: ${oldVersion} -> ${newVersion}`);
   }
 
-  const cliSourcePath = join(root, 'packages/cli/src/index.ts');
-  const cliSource = readFileSync(cliSourcePath, 'utf8');
-  if (!/^const VERSION = '[^']+';$/m.test(cliSource)) {
-    console.error(`Could not find "const VERSION = '...'" in ${cliSourcePath}`);
-    process.exit(1);
+  const versionConstFiles = [
+    'packages/cli/src/index.ts',
+    'packages/slack-manager/src/index.ts',
+  ];
+  for (const relPath of versionConstFiles) {
+    const absPath = join(root, relPath);
+    const source = readFileSync(absPath, 'utf8');
+    if (!/^const VERSION = '[^']+';$/m.test(source)) {
+      console.error(`Could not find "const VERSION = '...'" in ${absPath}`);
+      process.exit(1);
+    }
+    writeFileSync(absPath, source.replace(/^const VERSION = '[^']+';$/m, `const VERSION = '${newVersion}';`));
+    console.log(`${relPath}: VERSION -> ${newVersion}`);
   }
-  writeFileSync(cliSourcePath, cliSource.replace(/^const VERSION = '[^']+';$/m, `const VERSION = '${newVersion}';`));
-  console.log(`packages/cli/src/index.ts: VERSION -> ${newVersion}`);
 
   const changelogPath = join(root, 'CHANGELOG.md');
   writeFileSync(changelogPath, applyChangelogRelease(readFileSync(changelogPath, 'utf8'), newVersion));

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -13,11 +13,17 @@ const sources = [
   ['package.json', JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version],
   ['packages/app/package.json', JSON.parse(readFileSync(join(root, 'packages/app/package.json'), 'utf8')).version],
   ['packages/cli/package.json', JSON.parse(readFileSync(join(root, 'packages/cli/package.json'), 'utf8')).version],
+  ['packages/slack-manager/package.json', JSON.parse(readFileSync(join(root, 'packages/slack-manager/package.json'), 'utf8')).version],
   ['packages/npm-cli/package.json', JSON.parse(readFileSync(join(root, 'packages/npm-cli/package.json'), 'utf8')).version],
   ['packages/npm-ui/package.json', JSON.parse(readFileSync(join(root, 'packages/npm-ui/package.json'), 'utf8')).version],
+  ['packages/npm-slack/package.json', JSON.parse(readFileSync(join(root, 'packages/npm-slack/package.json'), 'utf8')).version],
   [
     'packages/cli/src/index.ts (const VERSION)',
     readFileSync(join(root, 'packages/cli/src/index.ts'), 'utf8').match(/^const VERSION = '([^']+)';$/m)?.[1],
+  ],
+  [
+    'packages/slack-manager/src/index.ts (const VERSION)',
+    readFileSync(join(root, 'packages/slack-manager/src/index.ts'), 'utf8').match(/^const VERSION = '([^']+)';$/m)?.[1],
   ],
 ];
 

--- a/scripts/e2e-npm-slack-install.sh
+++ b/scripts/e2e-npm-slack-install.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# E2E: prove that `npm install` of @neko-catpital-labs/invoker-slack yields a
+# working `invoker-slack` command, using a locally built release artifact served
+# over localhost instead of a GitHub release (postinstall honors
+# INVOKER_RELEASE_BASE_URL).
+#
+# Usage: bash scripts/e2e-npm-slack-install.sh
+#   INVOKER_E2E_SKIP_BUILD=1   reuse existing release/ artifacts
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+VERSION="$(node -p "require('./packages/npm-slack/package.json').version")"
+PLATFORM="$(node -p "process.platform")"
+ARCH="$(node -p "process.arch")"
+SLACK_TARBALL="release/invoker-slack-$VERSION-$PLATFORM-$ARCH.tar.gz"
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/invoker-e2e-npm-slack.XXXXXX")"
+SERVER_PID=""
+cleanup() {
+  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+  rm -rf "$SCRATCH"
+}
+trap cleanup EXIT
+
+if [ "${INVOKER_E2E_SKIP_BUILD:-0}" != "1" ]; then
+  pnpm run dist:slack
+fi
+if [ ! -f "$SLACK_TARBALL" ]; then
+  echo "Missing $SLACK_TARBALL — run without INVOKER_E2E_SKIP_BUILD=1 to build it." >&2
+  exit 1
+fi
+bash scripts/release-sha256.sh
+
+PORT="${INVOKER_E2E_PORT:-8764}"
+python3 -m http.server "$PORT" --directory release --bind 127.0.0.1 >/dev/null 2>&1 &
+SERVER_PID=$!
+for _ in $(seq 1 50); do
+  curl -fsS "http://127.0.0.1:$PORT/SHA256SUMS" >/dev/null 2>&1 && break
+  sleep 0.2
+done
+curl -fsS "http://127.0.0.1:$PORT/SHA256SUMS" >/dev/null
+
+PACK_DIR="$SCRATCH/tarballs"
+mkdir -p "$PACK_DIR"
+pnpm --filter @neko-catpital-labs/invoker-slack pack --pack-destination "$PACK_DIR" >/dev/null
+SLACK_TGZ="$(ls "$PACK_DIR"/*invoker-slack*.tgz)"
+
+PROJECT_DIR="$SCRATCH/project"
+mkdir -p "$PROJECT_DIR"
+(
+  cd "$PROJECT_DIR"
+  INVOKER_RELEASE_BASE_URL="http://127.0.0.1:$PORT" \
+    npm install --no-fund --no-audit "$SLACK_TGZ"
+)
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+ACTUAL_VERSION="$("$PROJECT_DIR/node_modules/.bin/invoker-slack" --version)"
+[ "$ACTUAL_VERSION" = "$VERSION" ] \
+  || fail "node_modules/.bin/invoker-slack --version printed '$ACTUAL_VERSION', expected '$VERSION'"
+
+[ -x "$PROJECT_DIR/node_modules/@neko-catpital-labs/invoker-slack/vendor/invoker-slack" ] \
+  || fail "invoker-slack postinstall did not install vendor binary"
+
+echo "ok npm install yields working invoker-slack $VERSION"

--- a/scripts/local-macos-release-build.sh
+++ b/scripts/local-macos-release-build.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Local maintainer cut from master: desktop DMG/zip + invoker-slack SEA binary.
+#
+# Usage:
+#   bash scripts/local-macos-release-build.sh
+#   bash scripts/local-macos-release-build.sh --arch arm64
+#   bash scripts/local-macos-release-build.sh --skip-pull
+#
+# Writes commit-named copies under local-builds/<short-sha>/.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+ARCH="arm64"
+SKIP_PULL=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --arch)
+      ARCH="${2:-}"
+      shift 2
+      ;;
+    --skip-pull)
+      SKIP_PULL=1
+      shift
+      ;;
+    -h|--help)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Usage: bash scripts/local-macos-release-build.sh [--arch arm64|x64] [--skip-pull]" >&2
+      exit 64
+      ;;
+  esac
+done
+
+if [ "$ARCH" != "arm64" ] && [ "$ARCH" != "x64" ]; then
+  echo "--arch must be arm64 or x64" >&2
+  exit 64
+fi
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "This script builds macOS desktop artifacts; run it on a Mac." >&2
+  exit 64
+fi
+
+if [ "$SKIP_PULL" -eq 0 ]; then
+  REMOTE="upstream"
+  if ! git remote get-url upstream >/dev/null 2>&1; then
+    REMOTE="origin"
+  fi
+  git fetch "$REMOTE" master
+  git checkout master
+  git merge --ff-only "$REMOTE/master"
+fi
+
+pnpm install --frozen-lockfile
+
+pnpm run "dist:desktop:mac:${ARCH}"
+pnpm run dist:slack
+
+SHA="$(git rev-parse --short HEAD)"
+VERSION="$(node -p "require('./packages/app/package.json').version")"
+PLATFORM="$(node -p "process.platform")"
+OUT="local-builds/$SHA"
+mkdir -p "$OUT"
+
+cp "release/Invoker-${VERSION}-${ARCH}.dmg" "$OUT/Invoker-master-${SHA}-${ARCH}.dmg"
+cp "release/Invoker-${VERSION}-${ARCH}.zip" "$OUT/Invoker-master-${SHA}-${ARCH}.zip"
+
+SLACK_BIN="release/invoker-slack-${VERSION}-${PLATFORM}-${ARCH}"
+SLACK_TGZ="${SLACK_BIN}.tar.gz"
+cp "$SLACK_BIN" "$OUT/invoker-slack-master-${SHA}-${PLATFORM}-${ARCH}"
+chmod +x "$OUT/invoker-slack-master-${SHA}-${PLATFORM}-${ARCH}"
+cp "$SLACK_TGZ" "$OUT/invoker-slack-master-${SHA}-${PLATFORM}-${ARCH}.tar.gz"
+
+(
+  cd "$OUT"
+  shasum -a 256 ./*
+)
+
+cat <<EOF
+
+Local cut ready under $OUT
+
+Desktop (unsigned):
+  xattr -cr $OUT/Invoker-master-${SHA}-${ARCH}.dmg
+  open $OUT/Invoker-master-${SHA}-${ARCH}.dmg
+
+Slack binary:
+  $OUT/invoker-slack-master-${SHA}-${PLATFORM}-${ARCH} --version
+
+Published path (after a tagged release):
+  npm i -g @neko-catpital-labs/invoker-slack
+EOF


### PR DESCRIPTION
## Summary

Tagged releases and local maintainer cuts can now produce a standalone `invoker-slack` SEA binary.

The release workflow builds four platform tarballs and can publish `@neko-catpital-labs/invoker-slack`. Version sync and bump cover the new package.

`scripts/local-macos-release-build.sh` always cuts desktop and Slack together from master.

## Review Claim

Approve the Slack SEA build path, release-workflow assets, and local macOS cut script.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Additive release tooling only. Existing CLI and desktop release jobs stay unchanged aside from publishing the new Slack assets on tags.

## Slice Rationale

Release scripts and CI wiring land after the npm-slack package exists so version sync and publish targets resolve.

## Non-goals

Does not change Slack runtime behavior or documentation. Does not cut a version tag.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/check-version-sync.mjs`
- [x] `pnpm run dist:slack`
- [x] `INVOKER_E2E_SKIP_BUILD=1 bash scripts/e2e-npm-slack-install.sh`
- [x] `bash scripts/local-macos-release-build.sh --skip-pull`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None unless a tag already published Slack assets
- Data migration? No

</details>
