### PR TITLE
Bump version to 0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Invoker will be documented in this file.
 
 ## Unreleased
 
+## 0.0.7
+
 - Ship Slack as a separate npm-released SEA binary (`@neko-catpital-labs/invoker-slack` / `invoker-slack`), built and archived like the CLI, published from the release workflow, and always included in `scripts/local-macos-release-build.sh` maintainer cuts. The desktop app no longer embeds Slack; GUI relaunch from the manager resolves `INVOKER_GUI_COMMAND`, `invoker-ui`, macOS `open -a Invoker`, then the monorepo xvfb path.
 - Fix Cursor→Invoker macOS beachball on app switch: Action Graph / queue status polls were stalling the Electron main thread. `getQueueStatus` re-queried workflow external-deps once per ready task (~200ms at 200 tasks), and Action Graph re-ran a full `refreshFromDb` after `syncAllFromDb`. Queue status now caches blockers per workflow and accepts `{ refresh: false }` after an explicit sync; Action Graph only loads attempt/event detail for active/attention tasks. Renderer status polls (`useWorkerStatus` / `useQueueStatus` / `useActionGraphSnapshot`) pause while `document.hidden` and refresh once on restore so Cmd-Tab cannot herd deferred timers. Locked by `focus-switch-main-process-cost` unit guards and `focus-switch-hitch-responsiveness` e2e.
 - Show a non-dismissable Connection lost banner when a daemon-backed GUI loses its mutation owner. Previously the window stayed in `daemon-owner` mode (`readOnly: false`) after the owner died, so detach/mutations failed with "No mutation owner is available" and no banner appeared. Owner-loss now publishes `connection-lost` runtime status (still write-blocked) and pushes `invoker:runtime-status` to the renderer, instead of pretending the window entered intentional read-only mode.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "invoker",
   "private": true,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -2,7 +2,7 @@
   "name": "@invoker/app",
   "productName": "Invoker",
   "desktopName": "invoker.desktop",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Invoker desktop app",
   "homepage": "https://github.com/Neko-Catpital-Labs/Invoker",
   "author": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/cli",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Standalone Invoker command-line runner",
   "type": "module",
   "bin": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -40,7 +40,7 @@ import { logCaughtException } from './logging.js';
 import { runMcpServer } from './mcp-server.js';
 import { runDoctor, runSetup } from './onboarding.js';
 
-const VERSION = '0.0.6';
+const VERSION = '0.0.7';
 
 type CliOptions = {
   dbDir?: string;

--- a/packages/npm-cli/package.json
+++ b/packages/npm-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-cli",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Invoker standalone CLI installer",
   "type": "module",
   "repository": {

--- a/packages/npm-slack/package.json
+++ b/packages/npm-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-slack",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Invoker standalone Slack manager installer",
   "type": "module",
   "repository": {

--- a/packages/npm-ui/package.json
+++ b/packages/npm-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-ui",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Invoker desktop UI launcher",
   "type": "module",
   "repository": {

--- a/packages/slack-manager/package.json
+++ b/packages/slack-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/slack-manager",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -26,7 +26,7 @@ import { createPlanningCommandBuilder, createPrepareRepoCheckout, createGatherWo
 import { createWatchdog } from './watchdog.js';
 import { errMessage } from './util.js';
 
-const VERSION = '0.0.6';
+const VERSION = '0.0.7';
 
 const REQUIRED_ENV = ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_SIGNING_SECRET', 'SLACK_CHANNEL_ID'];
 


### PR DESCRIPTION
## Summary

Cut release 0.0.7. Version strings are synced across app, CLI, Slack, and npm packages.

CHANGELOG Unreleased notes are rolled under ## 0.0.7 so the GitHub Release notes match the cut.

## Test plan
- [x] `node scripts/check-version-sync.mjs`
- [ ] Tag `v0.0.7` after merge to trigger the release workflow


Made with [Cursor](https://cursor.com)