### PR TITLE
Attach CHANGELOG notes to GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,9 +244,16 @@ jobs:
           done
           exit "$missing"
 
+      - name: Generate release notes from CHANGELOG
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          node scripts/extract-changelog-section.mjs "$version" --out release/RELEASE_NOTES.md
+          cat release/RELEASE_NOTES.md
+
       - name: Publish GitHub release assets
         uses: softprops/action-gh-release@v2
         with:
+          body_path: release/RELEASE_NOTES.md
           files: |
             release/*.dmg
             release/*.deb

--- a/scripts/extract-changelog-section.mjs
+++ b/scripts/extract-changelog-section.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Extract one CHANGELOG.md version section for GitHub Release notes.
+//
+//   node scripts/extract-changelog-section.mjs 0.0.7
+//   node scripts/extract-changelog-section.mjs 0.0.7 --out release-notes.md
+//
+// Prints markdown for "## <version>" through the line before the next "## ".
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+export function extractChangelogSection(changelog, version) {
+  const heading = `## ${version}`;
+  const lines = String(changelog).split('\n');
+  const start = lines.findIndex((line) => line.trim() === heading);
+  if (start === -1) {
+    throw new Error(`CHANGELOG.md has no "${heading}" section`);
+  }
+
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (/^##\s+/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+
+  const body = lines.slice(start + 1, end).join('\n').replace(/^\n+/, '').replace(/\n+$/, '');
+  if (!body.trim()) {
+    throw new Error(`CHANGELOG.md section "${heading}" is empty`);
+  }
+
+  return [`# Invoker ${version}`, '', body, ''].join('\n');
+}
+
+function main() {
+  const version = process.argv[2];
+  if (!version || !/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(version)) {
+    console.error('Usage: node scripts/extract-changelog-section.mjs <semver> [--out <file>]');
+    process.exit(64);
+  }
+
+  let outPath;
+  for (let i = 3; i < process.argv.length; i += 1) {
+    if (process.argv[i] === '--out') {
+      outPath = process.argv[i + 1];
+      i += 1;
+    }
+  }
+
+  const notes = extractChangelogSection(readFileSync(join(root, 'CHANGELOG.md'), 'utf8'), version);
+  if (outPath) {
+    writeFileSync(outPath, notes);
+    console.log(outPath);
+  } else {
+    process.stdout.write(notes);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/test-extract-changelog-section.mjs
+++ b/scripts/test-extract-changelog-section.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { extractChangelogSection } from './extract-changelog-section.mjs';
+
+const sample = `# Changelog
+
+## Unreleased
+
+## 0.0.7
+
+- First thing
+- Second thing
+
+## 0.0.6
+
+- Older thing
+`;
+
+const notes = extractChangelogSection(sample, '0.0.7');
+assert.match(notes, /^# Invoker 0\.0\.7\n/);
+assert.match(notes, /- First thing/);
+assert.match(notes, /- Second thing/);
+assert.doesNotMatch(notes, /Older thing/);
+assert.doesNotMatch(notes, /Unreleased/);
+
+assert.throws(
+  () => extractChangelogSection(sample, '9.9.9'),
+  /no "## 9\.9\.9"/,
+);
+
+assert.throws(
+  () => extractChangelogSection('# Changelog\n\n## 1.0.0\n\n', '1.0.0'),
+  /empty/,
+);
+
+console.log('ok extract-changelog-section');


### PR DESCRIPTION
## Summary

GitHub Releases now get their body from the matching CHANGELOG.md version section.

Tagged cuts will no longer publish with an empty release description.

## Test plan
- [x] `node scripts/test-extract-changelog-section.mjs`
- [x] Backfilled v0.0.7 release notes via `gh release edit`


Made with [Cursor](https://cursor.com)