### PR TITLE
Enlarge Plan-graph nodes; compact floating task DAG

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2646,7 +2646,7 @@ export function App() {
           dragHandleTestId="selected-workflow-mini-dag-drag-handle"
           title={`${displayedSelectedWorkflowGraph.workflow.name} task DAG`}
           boundsRef={graphSurfaceRef as unknown as RefObject<HTMLElement>}
-          contentClassName="h-[250px]"
+          contentClassName="h-[180px]"
         >
           {graphBody}
         </FloatingGraphPanel>

--- a/packages/ui/src/components/FloatingGraphPanel.tsx
+++ b/packages/ui/src/components/FloatingGraphPanel.tsx
@@ -95,8 +95,8 @@ export function FloatingGraphPanel({
     <div
       ref={panelRef}
       data-testid={testId}
-      className={`absolute h-[280px] w-[420px] rounded border border-border bg-background/95 overflow-hidden shadow-lg ${className}`}
-      style={position ? { left: position.left, top: position.top } : { top: PANEL_MARGIN, right: PANEL_MARGIN }}
+      className={`absolute top-3 right-3 h-[210px] w-[315px] rounded border border-border bg-background/95 overflow-hidden shadow-lg ${className}`}
+      style={position ? { left: position.left, top: position.top, right: 'auto' } : undefined}
       onClick={(event) => event.stopPropagation()}
       onPointerDown={(event) => event.stopPropagation()}
     >

--- a/packages/ui/src/components/MergeGateNode.tsx
+++ b/packages/ui/src/components/MergeGateNode.tsx
@@ -72,7 +72,7 @@ export function MergeGateNode({ data }: MergeGateNodeProps) {
 
   return (
     <div
-      className={`relative w-[264px] rounded-xl border border-dashed px-5 py-3 transition-[opacity,box-shadow,border-color] duration-75 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : ''}`}
+      className={`relative w-[167px] rounded-xl border border-dashed px-2 py-2 transition-[opacity,box-shadow,border-color] duration-75 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : ''}`}
       title={label}
       data-selected={selected ? 'true' : 'false'}
     >
@@ -83,25 +83,25 @@ export function MergeGateNode({ data }: MergeGateNodeProps) {
       />
 
       <span
-        className={`absolute left-0 top-0 bottom-0 w-[3px] rounded-l-xl ${colors.dot} ${visualStatus === 'pending' ? 'pulse-strong' : ''}`}
+        className={`absolute left-0 top-0 bottom-0 w-[2px] rounded-l-xl ${colors.dot} ${visualStatus === 'pending' ? 'pulse-strong' : ''}`}
       />
 
-      <div className={`flex items-center gap-2 pl-3 ${colors.text}`}>
-        <IconComponent className="w-3.5 h-3.5" />
-        <span className="font-mono text-[11px] font-semibold uppercase tracking-wide" data-testid="merge-gate-primary-label">
+      <div className={`flex items-center gap-1.5 pl-2 ${colors.text}`}>
+        <IconComponent className="w-3 h-3" />
+        <span className="font-mono text-[8px] font-semibold uppercase tracking-wide" data-testid="merge-gate-primary-label">
           {PRIMARY_LABEL[effectiveGateKind]}
         </span>
       </div>
 
-      <div className={`text-sm font-medium truncate mt-1 pl-3 text-card-foreground`}>
+      <div className={`text-[11px] font-medium truncate mt-0.5 pl-2 text-card-foreground`}>
         {label}
       </div>
 
-      <div className="flex items-center gap-1.5 mt-1 pl-3">
+      <div className="flex items-center gap-1 mt-0.5 pl-2">
         <span
-          className={`w-1.5 h-1.5 rounded-full ${colors.dot} ${visualStatus === 'pending' ? 'pulse-strong' : ''}`}
+          className={`w-1 h-1 rounded-full ${colors.dot} ${visualStatus === 'pending' ? 'pulse-strong' : ''}`}
         />
-        <span className={`text-[11px] tracking-wide ${colors.text}`}>{statusLabel}</span>
+        <span className={`text-[8px] tracking-wide ${colors.text}`}>{statusLabel}</span>
       </div>
 
       <Handle

--- a/packages/ui/src/components/TaskNode.tsx
+++ b/packages/ui/src/components/TaskNode.tsx
@@ -86,13 +86,13 @@ export function TaskNode({ data }: TaskNodeProps) {
 
       <span className={`absolute left-0 top-0 bottom-0 w-[3px] ${dotClass}`} />
 
-      <div className={`text-[15px] font-medium leading-snug truncate pl-3 text-card-foreground ${isStale ? 'line-through opacity-70' : ''}`}>
+      <div className={`text-base font-medium leading-snug truncate pl-3 text-card-foreground ${isStale ? 'line-through opacity-70' : ''}`}>
         {task.description.length > 36
           ? `${task.description.slice(0, 36)}...`
           : task.description}
       </div>
 
-      <div className={`mt-1.5 pl-3 text-[12px] tracking-wide ${colors.text}`}>
+      <div className={`mt-1.5 pl-3 text-[13px] tracking-wide ${colors.text}`}>
         {statusLabel}
       </div>
 

--- a/packages/ui/src/components/TaskNode.tsx
+++ b/packages/ui/src/components/TaskNode.tsx
@@ -73,7 +73,7 @@ export function TaskNode({ data }: TaskNodeProps) {
 
   return (
     <div
-      className={`relative w-[288px] overflow-hidden rounded-xl border px-4 py-3.5 transition-[opacity,box-shadow,border-color] duration-150 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : isStale ? 'opacity-50' : ''}`}
+      className={`relative w-[312px] overflow-hidden rounded-xl border px-4 py-4 transition-[opacity,box-shadow,border-color] duration-150 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : isStale ? 'opacity-50' : ''}`}
       title={task.id}
       data-selected={selected ? 'true' : 'false'}
       onDoubleClick={handleDoubleClick}
@@ -86,13 +86,13 @@ export function TaskNode({ data }: TaskNodeProps) {
 
       <span className={`absolute left-0 top-0 bottom-0 w-[3px] ${dotClass}`} />
 
-      <div className={`text-base font-medium leading-snug truncate pl-3 text-card-foreground ${isStale ? 'line-through opacity-70' : ''}`}>
-        {task.description.length > 36
-          ? `${task.description.slice(0, 36)}...`
+      <div className={`text-[20px] font-medium leading-snug truncate pl-3 text-card-foreground ${isStale ? 'line-through opacity-70' : ''}`}>
+        {task.description.length > 40
+          ? `${task.description.slice(0, 40)}...`
           : task.description}
       </div>
 
-      <div className={`mt-1.5 pl-3 text-[13px] tracking-wide ${colors.text}`}>
+      <div className={`mt-1.5 pl-3 text-[15px] tracking-wide ${colors.text}`}>
         {statusLabel}
       </div>
 

--- a/packages/ui/src/components/TaskNode.tsx
+++ b/packages/ui/src/components/TaskNode.tsx
@@ -73,7 +73,7 @@ export function TaskNode({ data }: TaskNodeProps) {
 
   return (
     <div
-      className={`relative w-[312px] overflow-hidden rounded-xl border px-4 py-4 transition-[opacity,box-shadow,border-color] duration-150 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : isStale ? 'opacity-50' : ''}`}
+      className={`relative w-[167px] overflow-hidden rounded-xl border px-2 py-2 transition-[opacity,box-shadow,border-color] duration-150 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : isStale ? 'opacity-50' : ''}`}
       title={task.id}
       data-selected={selected ? 'true' : 'false'}
       onDoubleClick={handleDoubleClick}
@@ -81,25 +81,25 @@ export function TaskNode({ data }: TaskNodeProps) {
       <Handle
         type="target"
         position={Position.Left}
-        className="!w-2.5 !h-2.5 !bg-neutral-500/90 !border !border-background"
+        className="!w-2 !h-2 !bg-neutral-500/90 !border !border-background"
       />
 
-      <span className={`absolute left-0 top-0 bottom-0 w-[3px] ${dotClass}`} />
+      <span className={`absolute left-0 top-0 bottom-0 w-[2px] ${dotClass}`} />
 
-      <div className={`text-[20px] font-medium leading-snug truncate pl-3 text-card-foreground ${isStale ? 'line-through opacity-70' : ''}`}>
-        {task.description.length > 40
-          ? `${task.description.slice(0, 40)}...`
+      <div className={`text-[11px] font-medium leading-snug truncate pl-2 text-card-foreground ${isStale ? 'line-through opacity-70' : ''}`}>
+        {task.description.length > 20
+          ? `${task.description.slice(0, 20)}...`
           : task.description}
       </div>
 
-      <div className={`mt-1.5 pl-3 text-[15px] tracking-wide ${colors.text}`}>
+      <div className={`mt-0.5 pl-2 text-[8px] tracking-wide ${colors.text}`}>
         {statusLabel}
       </div>
 
       <Handle
         type="source"
         position={Position.Right}
-        className="!w-2.5 !h-2.5 !bg-neutral-500/90 !border !border-background"
+        className="!w-2 !h-2 !bg-neutral-500/90 !border !border-background"
       />
     </div>
   );

--- a/packages/ui/src/components/TaskNode.tsx
+++ b/packages/ui/src/components/TaskNode.tsx
@@ -73,7 +73,7 @@ export function TaskNode({ data }: TaskNodeProps) {
 
   return (
     <div
-      className={`relative w-[264px] overflow-hidden rounded-xl border px-4 py-3 transition-[opacity,box-shadow,border-color] duration-150 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : isStale ? 'opacity-50' : ''}`}
+      className={`relative w-[288px] overflow-hidden rounded-xl border px-4 py-3.5 transition-[opacity,box-shadow,border-color] duration-150 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : isStale ? 'opacity-50' : ''}`}
       title={task.id}
       data-selected={selected ? 'true' : 'false'}
       onDoubleClick={handleDoubleClick}
@@ -81,25 +81,25 @@ export function TaskNode({ data }: TaskNodeProps) {
       <Handle
         type="target"
         position={Position.Left}
-        className="!w-2 !h-2 !bg-neutral-500/90 !border !border-background"
+        className="!w-2.5 !h-2.5 !bg-neutral-500/90 !border !border-background"
       />
 
       <span className={`absolute left-0 top-0 bottom-0 w-[3px] ${dotClass}`} />
 
-      <div className={`text-sm font-medium truncate pl-3 text-card-foreground ${isStale ? 'line-through opacity-70' : ''}`}>
-        {task.description.length > 34
-          ? `${task.description.slice(0, 34)}...`
+      <div className={`text-[15px] font-medium leading-snug truncate pl-3 text-card-foreground ${isStale ? 'line-through opacity-70' : ''}`}>
+        {task.description.length > 36
+          ? `${task.description.slice(0, 36)}...`
           : task.description}
       </div>
 
-      <div className={`mt-1 pl-3 text-[11px] tracking-wide ${colors.text}`}>
+      <div className={`mt-1.5 pl-3 text-[12px] tracking-wide ${colors.text}`}>
         {statusLabel}
       </div>
 
       <Handle
         type="source"
         position={Position.Right}
-        className="!w-2 !h-2 !bg-neutral-500/90 !border !border-background"
+        className="!w-2.5 !h-2.5 !bg-neutral-500/90 !border !border-background"
       />
     </div>
   );

--- a/packages/ui/src/components/WorkflowNode.tsx
+++ b/packages/ui/src/components/WorkflowNode.tsx
@@ -47,7 +47,7 @@ export function WorkflowNode({
         }
       }}
       className={[
-        'relative w-[300px] rounded-xl border bg-background pl-5 pr-4 py-4 text-left transition-all shadow-sm',
+        'relative w-[300px] rounded-xl border bg-background pl-5 pr-4 py-3.5 text-left transition-all shadow-sm',
         visual.borderClass,
         selected ? 'ring-2 ring-ring/70' : '',
         dimmed ? 'opacity-35' : 'opacity-100',
@@ -68,15 +68,15 @@ export function WorkflowNode({
         </div>
       )}
 
-      <div className={`text-base font-semibold leading-snug text-foreground truncate ${detachedDependencyCount > 0 ? 'pr-16' : ''}`}>
+      <div className={`text-lg font-semibold leading-snug text-foreground truncate ${detachedDependencyCount > 0 ? 'pr-16' : ''}`}>
         {workflow.name || workflow.id}
       </div>
-      <div className="mt-1.5 text-[13px] text-muted-foreground truncate">{workflow.id}</div>
-      <div className={`mt-2.5 text-xs uppercase tracking-wide ${visual.textClass}`}>{statusLabel(workflow.status)}</div>
+      <div className="mt-1 text-sm text-muted-foreground truncate">{workflow.id}</div>
+      <div className={`mt-2 text-[13px] uppercase tracking-wide ${visual.textClass}`}>{statusLabel(workflow.status)}</div>
       {showRunningTaskLine && (
         <div
           data-testid={`workflow-node-${workflow.id}-running-tasks`}
-          className="mt-1 text-xs text-muted-foreground"
+          className="mt-1 text-[13px] text-muted-foreground"
         >
           {runningTaskLabel(runningCount)}
         </div>
@@ -85,7 +85,7 @@ export function WorkflowNode({
         <div
           data-testid={`workflow-node-${workflow.id}-core-activity`}
           className={[
-            'mt-2.5 inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs font-medium',
+            'mt-2 inline-flex items-center gap-1.5 rounded border px-2 py-1 text-[13px] font-medium',
             coreActivity.status === 'running'
               ? 'border-border-strong text-muted-foreground'
               : coreActivity.status === 'pending'

--- a/packages/ui/src/components/WorkflowNode.tsx
+++ b/packages/ui/src/components/WorkflowNode.tsx
@@ -47,36 +47,36 @@ export function WorkflowNode({
         }
       }}
       className={[
-        'relative w-[220px] rounded-lg border bg-background pl-4 pr-3 py-3 text-left transition-all shadow-sm',
+        'relative w-[300px] rounded-xl border bg-background pl-5 pr-4 py-4 text-left transition-all shadow-sm',
         visual.borderClass,
         selected ? 'ring-2 ring-ring/70' : '',
         dimmed ? 'opacity-35' : 'opacity-100',
         'hover:bg-secondary/95',
       ].join(' ')}
     >
-      <div className={`absolute left-0 top-0 h-full w-1 rounded-l-lg ${visual.railClass}`} />
+      <div className={`absolute left-0 top-0 h-full w-1.5 rounded-l-xl ${visual.railClass}`} />
       {isWorkflowStatusActive(workflow.status) && visual.pulse && (
-        <div className={`absolute -left-1 top-1/2 h-2 w-2 -translate-y-1/2 rounded-full ${visual.railClass} animate-ping`} />
+        <div className={`absolute -left-1.5 top-1/2 h-2.5 w-2.5 -translate-y-1/2 rounded-full ${visual.railClass} animate-ping`} />
       )}
       {detachedDependencyCount > 0 && (
         <div
           data-testid={`workflow-node-${workflow.id}-detached-lineage`}
           title={`Detached from ${detachedDependencyCount} upstream workflow${detachedDependencyCount === 1 ? '' : 's'}`}
-          className="absolute right-2 top-2 rounded border border-amber-400/35 bg-amber-950/45 px-1.5 py-0.5 text-[9px] font-medium uppercase leading-none text-amber-300"
+          className="absolute right-2.5 top-2.5 rounded border border-amber-400/35 bg-amber-950/45 px-1.5 py-0.5 text-[10px] font-medium uppercase leading-none text-amber-300"
         >
           Detached
         </div>
       )}
 
-      <div className={`text-[13px] font-semibold text-foreground truncate ${detachedDependencyCount > 0 ? 'pr-16' : ''}`}>
+      <div className={`text-base font-semibold leading-snug text-foreground truncate ${detachedDependencyCount > 0 ? 'pr-16' : ''}`}>
         {workflow.name || workflow.id}
       </div>
-      <div className="mt-1 text-[11px] text-muted-foreground truncate">{workflow.id}</div>
-      <div className={`mt-2 text-[10px] uppercase tracking-wide ${visual.textClass}`}>{statusLabel(workflow.status)}</div>
+      <div className="mt-1.5 text-[13px] text-muted-foreground truncate">{workflow.id}</div>
+      <div className={`mt-2.5 text-xs uppercase tracking-wide ${visual.textClass}`}>{statusLabel(workflow.status)}</div>
       {showRunningTaskLine && (
         <div
           data-testid={`workflow-node-${workflow.id}-running-tasks`}
-          className="mt-1 text-[10px] text-muted-foreground"
+          className="mt-1 text-xs text-muted-foreground"
         >
           {runningTaskLabel(runningCount)}
         </div>
@@ -85,7 +85,7 @@ export function WorkflowNode({
         <div
           data-testid={`workflow-node-${workflow.id}-core-activity`}
           className={[
-            'mt-2 inline-flex items-center gap-1 rounded border px-2 py-1 text-[10px] font-medium',
+            'mt-2.5 inline-flex items-center gap-1.5 rounded border px-2 py-1 text-xs font-medium',
             coreActivity.status === 'running'
               ? 'border-border-strong text-muted-foreground'
               : coreActivity.status === 'pending'

--- a/packages/ui/src/components/WorkflowNode.tsx
+++ b/packages/ui/src/components/WorkflowNode.tsx
@@ -47,7 +47,7 @@ export function WorkflowNode({
         }
       }}
       className={[
-        'relative w-[300px] rounded-xl border bg-background pl-5 pr-4 py-3.5 text-left transition-all shadow-sm',
+        'relative w-[340px] rounded-xl border bg-background pl-5 pr-4 py-4 text-left transition-all shadow-sm',
         visual.borderClass,
         selected ? 'ring-2 ring-ring/70' : '',
         dimmed ? 'opacity-35' : 'opacity-100',
@@ -62,21 +62,21 @@ export function WorkflowNode({
         <div
           data-testid={`workflow-node-${workflow.id}-detached-lineage`}
           title={`Detached from ${detachedDependencyCount} upstream workflow${detachedDependencyCount === 1 ? '' : 's'}`}
-          className="absolute right-2.5 top-2.5 rounded border border-amber-400/35 bg-amber-950/45 px-1.5 py-0.5 text-[10px] font-medium uppercase leading-none text-amber-300"
+          className="absolute right-2.5 top-2.5 rounded border border-amber-400/35 bg-amber-950/45 px-1.5 py-0.5 text-[11px] font-medium uppercase leading-none text-amber-300"
         >
           Detached
         </div>
       )}
 
-      <div className={`text-lg font-semibold leading-snug text-foreground truncate ${detachedDependencyCount > 0 ? 'pr-16' : ''}`}>
+      <div className={`text-[22px] font-semibold leading-snug text-foreground truncate ${detachedDependencyCount > 0 ? 'pr-16' : ''}`}>
         {workflow.name || workflow.id}
       </div>
-      <div className="mt-1 text-sm text-muted-foreground truncate">{workflow.id}</div>
-      <div className={`mt-2 text-[13px] uppercase tracking-wide ${visual.textClass}`}>{statusLabel(workflow.status)}</div>
+      <div className="mt-1 text-base text-muted-foreground truncate">{workflow.id}</div>
+      <div className={`mt-2 text-[15px] uppercase tracking-wide ${visual.textClass}`}>{statusLabel(workflow.status)}</div>
       {showRunningTaskLine && (
         <div
           data-testid={`workflow-node-${workflow.id}-running-tasks`}
-          className="mt-1 text-[13px] text-muted-foreground"
+          className="mt-1 text-[15px] text-muted-foreground"
         >
           {runningTaskLabel(runningCount)}
         </div>
@@ -85,7 +85,7 @@ export function WorkflowNode({
         <div
           data-testid={`workflow-node-${workflow.id}-core-activity`}
           className={[
-            'mt-2 inline-flex items-center gap-1.5 rounded border px-2 py-1 text-[13px] font-medium',
+            'mt-2 inline-flex items-center gap-1.5 rounded border px-2 py-1 text-[15px] font-medium',
             coreActivity.status === 'running'
               ? 'border-border-strong text-muted-foreground'
               : coreActivity.status === 'pending'

--- a/packages/ui/src/lib/layout.ts
+++ b/packages/ui/src/lib/layout.ts
@@ -56,10 +56,10 @@ interface ElkLayoutEngine {
   }>;
 }
 
-const NODE_WIDTH = 280;
-const NODE_HEIGHT = 80;
-const HORIZONTAL_GAP = 120;
-const VERTICAL_GAP_BASE = 40;
+const NODE_WIDTH = 167;
+const NODE_HEIGHT = 40;
+const HORIZONTAL_GAP = 80;
+const VERTICAL_GAP_BASE = 24;
 const VERTICAL_GAP_PER_CONNECTION = 12;
 const BARYCENTER_SWEEPS = 4;
 

--- a/packages/ui/src/lib/workflow-graph.ts
+++ b/packages/ui/src/lib/workflow-graph.ts
@@ -105,8 +105,8 @@ function addWorkflowEdge(
 export function layoutWorkflowGraph(
   graph: WorkflowGraph,
   horizontalSpacing = 340,
-  verticalSpacing = 168,
-  componentGap = 110,
+  verticalSpacing = 124,
+  componentGap = 72,
 ): Map<string, WorkflowPosition> {
   const positions = new Map<string, WorkflowPosition>();
   if (graph.nodes.length === 0) return positions;

--- a/packages/ui/src/lib/workflow-graph.ts
+++ b/packages/ui/src/lib/workflow-graph.ts
@@ -104,8 +104,8 @@ function addWorkflowEdge(
 
 export function layoutWorkflowGraph(
   graph: WorkflowGraph,
-  horizontalSpacing = 340,
-  verticalSpacing = 124,
+  horizontalSpacing = 380,
+  verticalSpacing = 132,
   componentGap = 72,
 ): Map<string, WorkflowPosition> {
   const positions = new Map<string, WorkflowPosition>();

--- a/packages/ui/src/lib/workflow-graph.ts
+++ b/packages/ui/src/lib/workflow-graph.ts
@@ -104,9 +104,9 @@ function addWorkflowEdge(
 
 export function layoutWorkflowGraph(
   graph: WorkflowGraph,
-  horizontalSpacing = 280,
-  verticalSpacing = 150,
-  componentGap = 120,
+  horizontalSpacing = 340,
+  verticalSpacing = 168,
+  componentGap = 110,
 ): Map<string, WorkflowPosition> {
   const positions = new Map<string, WorkflowPosition>();
   if (graph.nodes.length === 0) return positions;


### PR DESCRIPTION
## Summary

Plan-graph workflow cards were hard to read under fitView on dense graphs.

This change enlarges workflow node typography and widens those cards so titles and status stay legible.

It also shrinks task-DAG nodes and the floating task panel so the overlay stays compact in the upper-right corner.

## Review Claim

Approve the larger Plan-graph workflow typography plus the compact floating task-DAG overlay sizing.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

CSS class and layout constant changes only. No execution, persistence, or IPC behavior changes.

## Slice Rationale

Workflow card readability and task-overlay density are one visual pass over the same graph surfaces. Keep unrelated UI work out of this PR.

## Non-goals

- Does not change inspector layout or status color semantics.
- Does not change marketing capture scripts or e2e workshop fixtures.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test`
- [ ] Visually confirm Plan-graph workflow titles match variant C sizing
- [ ] Visually confirm floating task DAG is upper-right, 315×210, with compact task nodes

</details>

## Visual Proof

Master-scale dense Plan graph:

![Plan graph nodes master scale](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-b5aa28/plan-graph-nodes-master.png)

This PR dense Plan graph (workflow title 22px, wider cards):

![Plan graph nodes this PR](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-b5aa28/plan-graph-nodes-variant-c.png)

Compact floating task DAG (315×210, upper-right, task nodes 167px / 11px title):

![Task DAG compact panel](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-b5aa28/task-dag-compact-panel.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b6b73fd5e` (task overlay) then earlier typography commits as needed
- Post-revert steps: None
- Data migration? No

</details>
