### PR TITLE
[Graph Node Sizing](2) Shrink task DAG nodes and floating panel

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3255,7 +3255,7 @@ export function App() {
           dragHandleTestId="selected-workflow-mini-dag-drag-handle"
           title={`${displayedSelectedWorkflowGraph.workflow.name} task DAG`}
           boundsRef={graphSurfaceRef as unknown as RefObject<HTMLElement>}
-          contentClassName="min-h-0 h-[250px] overflow-hidden"
+          contentClassName="min-h-0 h-[180px] overflow-hidden"
         >
           {graphBody}
         </FloatingGraphPanel>

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -150,16 +150,14 @@ describe('Browser-surface camera (component)', () => {
     mock.fireDelta({
       type: 'updated',
       taskId: 'wf-a/two',
-      changes: { description: 'Task Two (live update)' },
+      changes: { description: 'Task Two live' },
       taskStateVersion: 2,
       previousTaskStateVersion: 1,
     });
 
     // Wait until the update propagated and re-rendered (the node label updates),
     // then drain the frames any (buggy) re-issued camera command would use.
-    await waitFor(() =>
-      expect(screen.getAllByText('Task Two (live update)').length).toBeGreaterThan(0),
-    );
+    await waitFor(() => expect(screen.getAllByText('Task Two live').length).toBeGreaterThan(0));
     await flushFrames(6);
 
     // The camera must not move on a live update that changed no selection.

--- a/packages/ui/src/__tests__/layout.test.ts
+++ b/packages/ui/src/__tests__/layout.test.ts
@@ -128,10 +128,10 @@ describe('layoutNodes', () => {
     expect(posA.x).toBe(posX.x);
     expect(posA.y).not.toBe(posX.y);
 
-    // The gap between A and X should be > base gap (40)
+    // The gap between A and X should be > base gap (24)
     // because A has 4 children (4 connections)
-    const gap = Math.abs(posA.y - posX.y) - 80; // subtract NODE_HEIGHT
-    expect(gap).toBeGreaterThan(40);
+    const gap = Math.abs(posA.y - posX.y) - 40; // subtract NODE_HEIGHT
+    expect(gap).toBeGreaterThan(24);
   });
 
   it('reduces edge crossings in a diamond+crossing pattern', () => {

--- a/packages/ui/src/components/FloatingGraphPanel.tsx
+++ b/packages/ui/src/components/FloatingGraphPanel.tsx
@@ -95,8 +95,8 @@ export function FloatingGraphPanel({
     <div
       ref={panelRef}
       data-testid={testId}
-      className={`absolute h-[280px] w-[420px] rounded border border-border bg-background/95 overflow-hidden shadow-lg ${className}`}
-      style={position ? { left: position.left, top: position.top } : { top: PANEL_MARGIN, right: PANEL_MARGIN }}
+      className={`absolute top-3 right-3 h-[210px] w-[315px] rounded border border-border bg-background/95 overflow-hidden shadow-lg ${className}`}
+      style={position ? { left: position.left, top: position.top, right: 'auto' } : undefined}
       onClick={(event) => event.stopPropagation()}
       onPointerDown={(event) => event.stopPropagation()}
     >

--- a/packages/ui/src/components/MergeGateNode.tsx
+++ b/packages/ui/src/components/MergeGateNode.tsx
@@ -72,7 +72,7 @@ export function MergeGateNode({ data }: MergeGateNodeProps) {
 
   return (
     <div
-      className={`relative w-[264px] rounded-xl border border-dashed px-5 py-3 transition-[opacity,box-shadow,border-color] duration-75 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : ''}`}
+      className={`relative w-[167px] rounded-xl border border-dashed px-2 py-2 transition-[opacity,box-shadow,border-color] duration-75 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : ''}`}
       title={label}
       data-selected={selected ? 'true' : 'false'}
     >
@@ -83,25 +83,25 @@ export function MergeGateNode({ data }: MergeGateNodeProps) {
       />
 
       <span
-        className={`absolute left-0 top-0 bottom-0 w-[3px] rounded-l-xl ${colors.dot} ${visualStatus === 'pending' ? 'pulse-strong' : ''}`}
+        className={`absolute left-0 top-0 bottom-0 w-[2px] rounded-l-xl ${colors.dot} ${visualStatus === 'pending' ? 'pulse-strong' : ''}`}
       />
 
-      <div className={`flex items-center gap-2 pl-3 ${colors.text}`}>
-        <IconComponent className="w-3.5 h-3.5" />
-        <span className="font-mono text-[11px] font-semibold uppercase tracking-wide" data-testid="merge-gate-primary-label">
+      <div className={`flex items-center gap-1.5 pl-2 ${colors.text}`}>
+        <IconComponent className="w-3 h-3" />
+        <span className="font-mono text-[8px] font-semibold uppercase tracking-wide" data-testid="merge-gate-primary-label">
           {PRIMARY_LABEL[effectiveGateKind]}
         </span>
       </div>
 
-      <div className={`text-sm font-medium truncate mt-1 pl-3 text-card-foreground`}>
+      <div className={`text-[11px] font-medium truncate mt-0.5 pl-2 text-card-foreground`}>
         {label}
       </div>
 
-      <div className="flex items-center gap-1.5 mt-1 pl-3">
+      <div className="flex items-center gap-1 mt-0.5 pl-2">
         <span
-          className={`w-1.5 h-1.5 rounded-full ${colors.dot} ${visualStatus === 'pending' ? 'pulse-strong' : ''}`}
+          className={`w-1 h-1 rounded-full ${colors.dot} ${visualStatus === 'pending' ? 'pulse-strong' : ''}`}
         />
-        <span className={`text-[11px] tracking-wide ${colors.text}`}>{statusLabel}</span>
+        <span className={`text-[8px] tracking-wide ${colors.text}`}>{statusLabel}</span>
       </div>
 
       <Handle

--- a/packages/ui/src/components/TaskNode.tsx
+++ b/packages/ui/src/components/TaskNode.tsx
@@ -73,7 +73,7 @@ export function TaskNode({ data }: TaskNodeProps) {
 
   return (
     <div
-      className={`relative w-[264px] overflow-hidden rounded-xl border px-4 py-3 transition-[opacity,box-shadow,border-color] duration-150 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : isStale ? 'opacity-50' : ''}`}
+      className={`relative w-[167px] overflow-hidden rounded-xl border px-2 py-2 transition-[opacity,box-shadow,border-color] duration-150 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : isStale ? 'opacity-50' : ''}`}
       title={task.id}
       data-selected={selected ? 'true' : 'false'}
       onDoubleClick={handleDoubleClick}
@@ -84,15 +84,15 @@ export function TaskNode({ data }: TaskNodeProps) {
         className="!w-2 !h-2 !bg-neutral-500/90 !border !border-background"
       />
 
-      <span className={`absolute left-0 top-0 bottom-0 w-[3px] ${dotClass}`} />
+      <span className={`absolute left-0 top-0 bottom-0 w-[2px] ${dotClass}`} />
 
-      <div className={`text-sm font-medium truncate pl-3 text-card-foreground ${isStale ? 'line-through opacity-70' : ''}`}>
-        {task.description.length > 34
-          ? `${task.description.slice(0, 34)}...`
+      <div className={`text-[11px] font-medium leading-snug truncate pl-2 text-card-foreground ${isStale ? 'line-through opacity-70' : ''}`}>
+        {task.description.length > 20
+          ? `${task.description.slice(0, 20)}...`
           : task.description}
       </div>
 
-      <div className={`mt-1 pl-3 text-[11px] tracking-wide ${colors.text}`}>
+      <div className={`mt-0.5 pl-2 text-[8px] tracking-wide ${colors.text}`}>
         {statusLabel}
       </div>
 

--- a/packages/ui/src/lib/layout.ts
+++ b/packages/ui/src/lib/layout.ts
@@ -56,10 +56,10 @@ interface ElkLayoutEngine {
   }>;
 }
 
-const NODE_WIDTH = 280;
-const NODE_HEIGHT = 80;
-const HORIZONTAL_GAP = 120;
-const VERTICAL_GAP_BASE = 40;
+const NODE_WIDTH = 167;
+const NODE_HEIGHT = 40;
+const HORIZONTAL_GAP = 80;
+const VERTICAL_GAP_BASE = 24;
 const VERTICAL_GAP_PER_CONNECTION = 12;
 const BARYCENTER_SWEEPS = 4;
 


### PR DESCRIPTION
## Summary

The floating task DAG overlay was too large and its task cards competed with the Plan graph.

This change shrinks TaskNode and MergeGate cards, tightens task-graph layout spacing, and scales the floating panel down 25%.

The panel stays anchored in the upper-right corner of the graph surface.

## Review Claim

Approve the compact floating task-DAG overlay sizing on top of the enlarged workflow cards.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

CSS class and layout constant changes only. No execution, persistence, or IPC behavior changes.

## Slice Rationale

Task-overlay density is a separate visual claim from workflow card typography, so it stacks on top of that slice.

## Non-goals

- Does not change WorkflowNode typography or Plan-graph layout spacing.
- Does not change inspector layout or status color semantics.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test`
- [ ] Visually confirm floating task DAG is upper-right, 315×210, with compact task nodes

</details>

## Visual Proof

Compact floating task DAG (315×210, upper-right, task nodes 167px / 11px title):

![Task DAG compact panel](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-036c26/task-dag-compact-panel.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 6880f90ef`
- Post-revert steps: None
- Data migration? No

</details>
