### PR TITLE
[Task Inspector](1) Expand inspector when a task is selected

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1067,6 +1067,8 @@ export function App() {
     if (task.config.workflowId) {
       setSelectedWorkflowId(task.config.workflowId);
     }
+    setInspectorCollapsed(false);
+    setInspectorManualOpen(true);
     setContextMenu(null);
     setWorkflowContextMenu(null);
     recenterForSelection('task', task.id);
@@ -1402,14 +1404,8 @@ export function App() {
 
   // ── DAG interaction ───────────────────────────────────────
   const handleTaskClick = useCallback((task: TaskState) => {
-    setSelectedTaskId(task.id);
-    setWorkflowSelectionDismissed(false);
-    if (task.config.workflowId) {
-      setSelectedWorkflowId(task.config.workflowId);
-    }
-    setWorkflowContextMenu(null);
-    recenterForSelection('task', task.id);
-  }, [recenterForSelection]);
+    selectTaskById(task.id);
+  }, [selectTaskById]);
 
   const openTerminalForTaskId = useCallback(async (taskId: string) => {
     const task = tasks.get(taskId);

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -94,6 +94,31 @@ describe('Task interaction (component)', () => {
     });
   });
 
+  it('clicking a task expands a minimized inspector', async () => {
+    render(<App />);
+    act(() => mock.setTasks([alpha, beta], workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('rf__node-wf-a'));
+    await waitFor(() => {
+      expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText('Minimize inspector'));
+    expect(await screen.findByLabelText('Maximize inspector')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('rf__node-task-alpha'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Minimize inspector')).toBeInTheDocument();
+      expect(screen.getByText('echo hello-alpha')).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText('Maximize inspector')).not.toBeInTheDocument();
+  });
+
   it('clicking workflow graph background dismisses the selected mini DAG', async () => {
     render(<App />);
     act(() => mock.setTasks([alpha, beta], workflows));


### PR DESCRIPTION
## Summary

Clicking a task selected it but left a minimized inspector collapsed, so details stayed hidden behind the Show strip.

Task selection now expands the right inspector so status, prompt, and actions are visible immediately.

## Review Claim

Approve that selecting a task expands the right-hand inspector details panel.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Selection still only updates UI state. No execution, persistence, or IPC behavior changes.

## Slice Rationale

This is one selection-to-panel visibility claim. Workflow-click parity and other inspector auto-open rules stay out of this slice.

## Non-goals

- Does not change workflow-click inspector behavior.
- Does not change inspector content layout or task actions.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- src/__tests__/task-interaction.test.tsx`
- [ ] Manually minimize inspector, click a task node, confirm details panel expands

</details>

## Visual Proof

Task click expands a minimized inspector (frame cue: minimized Show strip → selected task with open details):

![Task click expands inspector](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-53eb6a/task-click-expands-inspector.gif)

Frame stills:

![Minimized inspector](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-53eb6a/frame1-minimized.png)

![Task selected with details open](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-53eb6a/frame2-task-selected.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert HEAD`
- Post-revert steps: None
- Data migration? No

</details>
