### PR TITLE
[Needs Attention Mutation Failure UX](1) Surface mutation failures in Needs Attention with sidebar detail

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -15,11 +15,7 @@ import type { ActionGraphNode, InAppPlanningSessionStatus, InAppPlanningSessionS
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
 import { reportUiNavigation } from './lib/report-ui-navigation.js';
-import {
-  mutationFailureBannerMessage,
-  mutationFailureTitle,
-  shouldShowMutationFailureBanner,
-} from './lib/mutation-failure-display.js';
+
 import { useTasks } from './hooks/useTasks.js';
 import { useQueueStatus } from './hooks/useQueueStatus.js';
 import { useWorkerStatus } from './hooks/useWorkerStatus.js';
@@ -594,7 +590,7 @@ export function App() {
   const [systemDiagnostics, setSystemDiagnostics] = useState<SystemDiagnostics | null>(null);
   const [showSystemSetup, setShowSystemSetup] = useState(false);
   const [showSystemBanner, setShowSystemBanner] = useState(false);
-  const [mutationFailure, setMutationFailure] = useState<WorkflowMutationFailedEvent | null>(null);
+  const [mutationFailuresByTaskId, setMutationFailuresByTaskId] = useState<Map<string, WorkflowMutationFailedEvent>>(new Map());
   const [installSkillsPending, setInstallSkillsPending] = useState(false);
   const [installSkillsError, setInstallSkillsError] = useState<string | null>(null);
   const [updateCliPending, setUpdateCliPending] = useState(false);
@@ -807,6 +803,7 @@ export function App() {
   }, []);
 
   const selectedTask = selectedTaskId ? tasks.get(selectedTaskId) ?? null : null;
+  const selectedTaskMutationFailure = selectedTaskId ? mutationFailuresByTaskId.get(selectedTaskId) ?? null : null;
   const selectedWorker = workerStatus?.workers.find((worker) => worker.kind === selectedWorkerKind) ?? null;
   const contextMenuTask = contextMenu ? tasks.get(contextMenu.taskId) ?? null : null;
   const selectedWorkflowTaskCount = useMemo(() => {
@@ -1077,31 +1074,38 @@ export function App() {
 
   useEffect(() => {
     const unsubscribe = window.invoker?.onWorkflowMutationFailed?.((event) => {
-      // Task/workflow mutation failures belong in the task panel, not the top banner.
-      if (!shouldShowMutationFailureBanner(event)) {
-        if (event.taskId) {
-          // Set selection from the event ids directly so the inspector opens even
-          // if the task map has not hydrated this id yet.
-          setSelectedTaskId(event.taskId);
-          setWorkflowSelectionDismissed(false);
-          if (event.workflowId) {
-            setSelectedWorkflowId(event.workflowId);
-          }
-          setContextMenu(null);
-          setWorkflowContextMenu(null);
-          focusKeyboardRegion('taskGraph');
-        } else if (event.workflowId) {
+      // Surface mutation failures through the Needs Attention browser instead of
+      // the top banner. Persist task-scoped failures so the inspector can show
+      // them for the selected task.
+      const taskId = event.taskId;
+      if (taskId) {
+        setMutationFailuresByTaskId((prev) => {
+          const next = new Map(prev);
+          next.set(taskId, event);
+          return next;
+        });
+        setSidebarSurface('attention');
+        setInspectorCollapsed(false);
+        setInspectorManualOpen(false);
+        setSelectedTaskId(taskId);
+        setWorkflowSelectionDismissed(false);
+        if (event.workflowId) {
           setSelectedWorkflowId(event.workflowId);
-          setSelectedTaskId(null);
-          setWorkflowSelectionDismissed(false);
-          setContextMenu(null);
-          setWorkflowContextMenu(null);
-          focusKeyboardRegion('workflowGraph');
         }
-        setMutationFailure(null);
-        return;
+        setContextMenu(null);
+        setWorkflowContextMenu(null);
+        focusKeyboardRegion('taskGraph');
+      } else if (event.workflowId) {
+        setSidebarSurface('workflows');
+        setInspectorCollapsed(false);
+        setInspectorManualOpen(false);
+        setSelectedWorkflowId(event.workflowId);
+        setSelectedTaskId(null);
+        setWorkflowSelectionDismissed(false);
+        setContextMenu(null);
+        setWorkflowContextMenu(null);
+        focusKeyboardRegion('workflowGraph');
       }
-      setMutationFailure(event);
     });
     return () => { unsubscribe?.(); };
   }, [focusKeyboardRegion]);
@@ -3097,39 +3101,6 @@ export function App() {
           This window can browse workflows, but it cannot make changes until the write owner is available.
         </div>
       ) : null}
-      {mutationFailure && (
-        <div
-          role="alert"
-          aria-live="assertive"
-          data-testid="workflow-mutation-failed-banner"
-          className="px-4 py-3 border-b border-amber-700 bg-amber-950/60 flex items-start justify-between gap-4"
-        >
-          <div className="text-sm text-amber-100 min-w-0">
-            <div className="font-semibold text-amber-50">
-              {mutationFailureTitle(mutationFailure)}
-            </div>
-            <div
-              data-testid="workflow-mutation-failed-message"
-              className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-amber-100/90"
-            >
-              {mutationFailureBannerMessage(mutationFailure)}
-            </div>
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            <Button
-              size="sm"
-              variant="ghost"
-              data-testid="workflow-mutation-failed-dismiss"
-              className="text-amber-200 hover:text-white"
-              onClick={() => setMutationFailure(null)}
-            >
-              Dismiss
-            </Button>
-          </div>
-        </div>
-      )}
-
-
       {/* Main content */}
       <div className="flex-1 flex overflow-hidden">
         <LeftStatusColumn
@@ -3194,6 +3165,7 @@ export function App() {
                   workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
                   reviewGate={selectedWorkflow ? reviewGateByWorkflowId[selectedWorkflow.id] ?? null : null}
                   actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
+                  mutationFailure={selectedTaskMutationFailure}
                   collapsed={effectiveInspectorCollapsed}
                   advancedExpanded={advancedMetadataExpanded}
                   remoteTargets={remoteTargets}

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { WorkflowInspector } from '../components/WorkflowInspector.js';
 import type { TaskState, WorkflowMeta } from '../types.js';
+import type { WorkflowMutationFailedEvent } from '@invoker/contracts';
 
 function makeTask(partial?: Partial<TaskState>): TaskState {
   return {
@@ -812,5 +813,48 @@ describe('WorkflowInspector', () => {
     } finally {
       delete (window as unknown as { invoker?: unknown }).invoker;
     }
+  });
+
+  it('shows a persistent mutation failure detail panel for the selected task', () => {
+    const mutationFailure: WorkflowMutationFailedEvent = {
+      intentId: 5,
+      workflowId: 'wf-1',
+      channel: 'invoker:approve',
+      taskId: 'task-1',
+      message: 'Error: SSH target "remote_digital_ocean_3" cannot run codex: missing execution harness "codex"',
+      failedAt: '2026-07-08T10:00:00.000Z',
+    };
+
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={makeTask({ status: 'awaiting_approval' })}
+        mutationFailure={mutationFailure}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    const detail = screen.getByTestId('task-mutation-failure-detail');
+    expect(detail).toHaveTextContent('Approve failed');
+    expect(detail).toHaveTextContent('missing execution harness "codex"');
+    expect(detail).toHaveTextContent('invoker:approve');
+  });
+
+  it('hides the mutation failure detail panel when no failure is provided', () => {
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={makeTask({ status: 'awaiting_approval' })}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId('task-mutation-failure-detail')).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
+++ b/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
@@ -1,9 +1,10 @@
 /**
  * Integration test: workflow-mutation-failed handling in <App />.
  *
- * Task-scoped and workflow-scoped mutation failures must not open the top
- * banner. Task failures select the task so the right-hand panel can show the
- * error.
+ * Task-scoped and workflow-scoped mutation failures are surfaced through the
+ * Needs Attention browser instead of the top banner. Task failures select the
+ * task and open the attention surface so the right-hand panel can show the
+ * failure details.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -76,9 +77,17 @@ describe('Workflow mutation failed banner', () => {
     await waitFor(() => {
       expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Verify worker summary surface');
     });
+    await waitFor(() => {
+      expect(screen.getByTestId('browser-rail')).toBeInTheDocument();
+    });
+    const taskRow = screen.getByTestId('browser-task-row-wf-1/verify-worker-summary-surface');
+    expect(taskRow).toHaveAttribute('data-selected', 'true');
+    const detail = screen.getByTestId('task-mutation-failure-detail');
+    expect(detail).toHaveTextContent('Approve failed');
+    expect(detail).toHaveTextContent('missing execution harness "codex"');
   });
 
-  it('does not show the banner for headless fix failures', async () => {
+  it('does not show the banner for headless fix failures and surfaces the detail in Needs Attention', async () => {
     render(<App />);
     await settleTasks();
 
@@ -100,9 +109,16 @@ describe('Workflow mutation failed banner', () => {
     await waitFor(() => {
       expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Verify worker summary surface');
     });
+    await waitFor(() => {
+      expect(screen.getByTestId('browser-rail')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('browser-task-row-wf-1/verify-worker-summary-surface')).toHaveAttribute('data-selected', 'true');
+    const detail = screen.getByTestId('task-mutation-failure-detail');
+    expect(detail).toHaveTextContent('Fix failed');
+    expect(detail).toHaveTextContent('model unsupported');
   });
 
-  it('does not show the banner for workflow-scoped failures', async () => {
+  it('does not show the banner for workflow-scoped failures and opens the workflow in the Workflows browser', async () => {
     render(<App />);
     await settleTasks();
 
@@ -119,5 +135,12 @@ describe('Workflow mutation failed banner', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
     });
+    await waitFor(() => {
+      expect(screen.getByTestId('browser-rail')).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Local test plan');
+    });
+    expect(screen.queryByTestId('task-mutation-failure-detail')).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/BrowserListRows.tsx
+++ b/packages/ui/src/components/BrowserListRows.tsx
@@ -28,6 +28,8 @@ export const BrowserTaskRow = memo(function BrowserTaskRow({
     <button
       type="button"
       onClick={() => onSelect(taskId)}
+      data-testid={`browser-task-row-${taskId}`}
+      data-selected={selected}
       className={`block w-full rounded-md px-2.5 py-1.5 text-left transition-colors ${accent}`}
     >
       <div className="truncate text-body font-medium">{title}</div>

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -2,7 +2,8 @@ import { useEffect, useMemo, useState } from 'react';
 import type { ReviewGateArtifact, ReviewGateQueryResponse, TaskState, WorkflowMeta } from '../types.js';
 import { getEffectiveVisualStatus, getStatusColor } from '../lib/colors.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
-import type { ActionGraphNode } from '@invoker/contracts';
+import { mutationFailureTitle } from '../lib/mutation-failure-display.js';
+import type { ActionGraphNode, WorkflowMutationFailedEvent } from '@invoker/contracts';
 
 type MergeMode = 'manual' | 'automatic' | 'external_review';
 type TaskLogLevel = 'debug' | 'info' | 'warn' | 'error';
@@ -141,6 +142,7 @@ interface WorkflowInspectorProps {
   executionPools?: string[];
   executionAgents?: string[];
   actionNode?: ActionGraphNode | null;
+  mutationFailure?: WorkflowMutationFailedEvent | null;
   collapsed: boolean;
   advancedExpanded: boolean;
   onEditType?: (taskId: string, runnerKind: string, poolMemberId?: string) => void;
@@ -246,6 +248,7 @@ export function WorkflowInspector({
   executionPools,
   executionAgents,
   actionNode,
+  mutationFailure,
   collapsed,
   advancedExpanded,
   onEditPool,
@@ -504,6 +507,24 @@ export function WorkflowInspector({
             {workspaceRecreateNotice.workflowId && (
               <p className="mt-2 text-[11px] text-amber-300">Workflow: {workspaceRecreateNotice.workflowId}</p>
             )}
+          </section>
+        )}
+
+        {mutationFailure && (
+          <section
+            data-testid="task-mutation-failure-detail"
+            className="rounded border border-amber-500/40 bg-amber-950/40 p-3"
+          >
+            <h3 className="text-[11px] uppercase tracking-wide text-amber-200">
+              {mutationFailureTitle(mutationFailure)}
+            </h3>
+            <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-amber-100">
+              {mutationFailure.message}
+            </pre>
+            <div className="mt-2 text-[10px] text-amber-300">
+              {new Date(mutationFailure.failedAt).toLocaleString()}
+              {mutationFailure.channel && ` · ${mutationFailure.channel}`}
+            </div>
           </section>
         )}
 


### PR DESCRIPTION
## Summary

Mutation failures now appear in the Needs Attention section of the sidebar. The old red banner across the top of the window is gone.

When a task-scoped failure arrives, the app opens that task and its sidebar inspector. The inspector shows the failure title, message, time, and channel.

Workflow-scoped failures open the Workflows sidebar and select the workflow, so the failure is easy to find.

## Review Claim

Approve showing mutation failures through Needs Attention and the sidebar inspector instead of a top-of-window banner.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change only affects how the UI presents an existing failure event. No mutation, persistence, or backend behavior changes, so it is safe to review from the diff alone.

## Slice Rationale

This is one user-facing presentation change shipped with its focused UI coverage. Nothing else belongs here, so it stands alone as a single slice.

## Non-goals

- Does not change how mutation failures are detected or produced.
- Does not change any backend, persistence, or workflow execution behavior.
- Does not alter unrelated sidebar sections or the graph.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
