### PR TITLE
Planning Lag Step 1 Telemetry Baseline

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect } from 'react';
 import yaml from 'js-yaml';
-import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowStatus } from './types.js';
+import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
 import type { ActionGraphNode } from '@invoker/contracts';
 import { useTasks } from './hooks/useTasks.js';
 import { useInvoker } from './hooks/useInvoker.js';
@@ -58,6 +58,116 @@ interface WorkflowContextMenuProps {
   onDeleteWorkflow: (workflowId: string) => void;
   onCopyWorkflowId: (workflowId: string) => void;
   onClose: () => void;
+}
+
+type PlanningTypingMetrics = {
+  taskCount: number;
+  workflowCount: number;
+  sessionCount: number;
+  transcriptSizeChars: number;
+  transcriptLineCount: number;
+  transcriptMessageCount: number;
+  selectedWorkflowTaskCount: number;
+};
+
+type EditableTypingTarget = HTMLInputElement | HTMLTextAreaElement | HTMLElement;
+
+const NON_TEXT_INPUT_TYPES = new Set([
+  'button',
+  'checkbox',
+  'color',
+  'file',
+  'hidden',
+  'image',
+  'radio',
+  'range',
+  'reset',
+  'submit',
+]);
+
+function addTranscriptMetric(
+  metrics: Pick<PlanningTypingMetrics, 'transcriptSizeChars' | 'transcriptLineCount' | 'transcriptMessageCount'>,
+  value: unknown,
+): void {
+  if (typeof value !== 'string' || value.length === 0) return;
+  metrics.transcriptSizeChars += value.length;
+  metrics.transcriptLineCount += value.split('\n').length;
+  metrics.transcriptMessageCount += 1;
+}
+
+function collectPlanningTypingMetrics(
+  tasks: Map<string, TaskState>,
+  workflows: Map<string, WorkflowMeta>,
+  selectedWorkflowId: string | null | undefined,
+): PlanningTypingMetrics {
+  const sessionIds = new Set<string>();
+  const metrics: PlanningTypingMetrics = {
+    taskCount: tasks.size,
+    workflowCount: workflows.size,
+    sessionCount: 0,
+    transcriptSizeChars: 0,
+    transcriptLineCount: 0,
+    transcriptMessageCount: 0,
+    selectedWorkflowTaskCount: 0,
+  };
+
+  for (const task of tasks.values()) {
+    if (selectedWorkflowId && task.config.workflowId === selectedWorkflowId) {
+      metrics.selectedWorkflowTaskCount += 1;
+    }
+
+    for (const sessionId of [
+      task.execution.agentSessionId,
+      task.execution.lastAgentSessionId,
+      task.execution.actionRequestId,
+    ]) {
+      if (sessionId) sessionIds.add(sessionId);
+    }
+
+    addTranscriptMetric(metrics, task.description);
+    addTranscriptMetric(metrics, task.config.prompt);
+    addTranscriptMetric(metrics, task.config.command);
+    addTranscriptMetric(metrics, task.config.experimentPrompt);
+    addTranscriptMetric(metrics, task.config.summary);
+    addTranscriptMetric(metrics, task.config.problem);
+    addTranscriptMetric(metrics, task.config.approach);
+    addTranscriptMetric(metrics, task.config.testPlan);
+    addTranscriptMetric(metrics, task.config.reproCommand);
+    addTranscriptMetric(metrics, task.execution.inputPrompt);
+    addTranscriptMetric(metrics, task.execution.error);
+  }
+
+  metrics.sessionCount = sessionIds.size;
+  return metrics;
+}
+
+function getEditableTypingTarget(target: EventTarget | null): EditableTypingTarget | null {
+  if (!(target instanceof HTMLElement)) return null;
+  if (target instanceof HTMLTextAreaElement) return target;
+  if (target instanceof HTMLInputElement) {
+    return NON_TEXT_INPUT_TYPES.has(target.type) ? null : target;
+  }
+  return target.isContentEditable ? target : null;
+}
+
+function getEditableTargetKind(target: EditableTypingTarget): string {
+  if (target instanceof HTMLTextAreaElement) return 'textarea';
+  if (target instanceof HTMLInputElement) return `input:${target.type || 'text'}`;
+  return 'contenteditable';
+}
+
+function getEditableValueLength(target: EditableTypingTarget): number {
+  if (target instanceof HTMLTextAreaElement || target instanceof HTMLInputElement) {
+    return target.value.length;
+  }
+  return target.textContent?.length ?? 0;
+}
+
+function isReadonlyTypingTarget(target: EditableTypingTarget): boolean {
+  if (target instanceof HTMLTextAreaElement || target instanceof HTMLInputElement) {
+    return target.readOnly || target.disabled;
+  }
+  return target.getAttribute('contenteditable') === 'false';
 }
 
 function WorkflowContextMenu({
@@ -359,6 +469,94 @@ export function App() {
     }
     return next;
   }, [selectedWorkflow, selectedWorkflowId, tasks]);
+  const planningTypingContext = useMemo(() => {
+    const activeSurface =
+      viewMode === 'dag'
+        ? terminalCollapsed
+          ? selectedWorkflow
+            ? 'workflow_task_dag'
+            : 'workflow_graph'
+          : 'terminal_drawer'
+        : viewMode;
+    const activeNodeKind = selectedTask ? 'task' : selectedWorkflow ? 'workflow' : 'none';
+    return {
+      ...collectPlanningTypingMetrics(tasks, workflows, selectedWorkflow?.id ?? selectedWorkflowId),
+      activeSurface,
+      activeState: selectedTask?.status ?? selectedWorkflow?.status ?? 'none',
+      activeNodeKind,
+      statusFilterCount: statusFilters.size,
+      terminalState: terminalCollapsed ? 'collapsed' : 'expanded',
+      inspectorState: inspectorCollapsed ? 'collapsed' : 'expanded',
+    };
+  }, [
+    inspectorCollapsed,
+    selectedTask,
+    selectedWorkflow,
+    selectedWorkflowId,
+    statusFilters.size,
+    tasks,
+    terminalCollapsed,
+    viewMode,
+    workflows,
+  ]);
+  const planningTypingContextRef = useRef(planningTypingContext);
+
+  useEffect(() => {
+    planningTypingContextRef.current = planningTypingContext;
+  }, [planningTypingContext]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+    let pendingFrame: number | null = null;
+
+    const handleTypingInput = (event: Event) => {
+      if (!window.invoker?.reportUiPerf) return;
+      const target = getEditableTypingTarget(event.target);
+      if (!target || isReadonlyTypingTarget(target)) return;
+
+      const inputEvent = event as InputEvent & { isComposing?: boolean; inputType?: string };
+      if (inputEvent.isComposing) return;
+
+      const now = Date.now();
+      const throttleKey = 'planning_typing_lag';
+      const prev = uiPerfThrottleRef.current[throttleKey] ?? 0;
+      if (now - prev < 250) return;
+      uiPerfThrottleRef.current[throttleKey] = now;
+
+      const startedAt = performance.now();
+      const targetKind = getEditableTargetKind(target);
+      const targetValueLength = getEditableValueLength(target);
+      const inputType =
+        typeof inputEvent.inputType === 'string' && inputEvent.inputType
+          ? inputEvent.inputType
+          : 'unknown';
+
+      pendingFrame = requestAnimationFrame(() => {
+        pendingFrame = null;
+        void window.invoker?.reportUiPerf?.('planning_typing_lag', {
+          ...planningTypingContextRef.current,
+          durationMs: Math.round((performance.now() - startedAt) * 100) / 100,
+          eventType: event.type,
+          inputType,
+          targetKind,
+          targetValueLength,
+          readOnly: false,
+          isComposing: false,
+          visibilityState: document.visibilityState,
+          hasFocus: document.hasFocus(),
+        });
+      });
+    };
+
+    document.addEventListener('input', handleTypingInput, { capture: true, passive: true });
+    return () => {
+      document.removeEventListener('input', handleTypingInput, true);
+      if (pendingFrame !== null) {
+        cancelAnimationFrame(pendingFrame);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (selectedTask?.config.workflowId) {

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -82,6 +82,7 @@ export function createMockInvoker(
     getRemoteTargets: vi.fn(async () => []),
     getExecutionPools: vi.fn(async () => ['mixed-local-ssh', 'pnpm-ssh']),
     getExecutionAgents: vi.fn(async () => ['claude', 'codex']),
+    reportUiPerf: vi.fn(async () => {}),
     getSystemDiagnostics: vi.fn(async () => ({
       platform: 'linux',
       arch: 'x64',

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import type { TaskState, WorkflowMeta } from '../types.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+function makePlanningTypingFixture(
+  sessionCount = 8,
+  messagesPerSession = 12,
+): { tasks: TaskState[]; workflows: WorkflowMeta[] } {
+  const tasks: TaskState[] = [];
+  const workflows: WorkflowMeta[] = [];
+
+  for (let sessionIndex = 0; sessionIndex < sessionCount; sessionIndex += 1) {
+    const workflowId = `wf-chat-${sessionIndex}`;
+    workflows.push({
+      id: workflowId,
+      name: `Planning Chat ${sessionIndex}`,
+      status: 'running',
+    });
+
+    for (let messageIndex = 0; messageIndex < messagesPerSession; messageIndex += 1) {
+      const messageId = `message-${String(messageIndex).padStart(2, '0')}`;
+      const previousMessageId = `message-${String(messageIndex - 1).padStart(2, '0')}`;
+      tasks.push(makeUITask({
+        id: `${workflowId}/${messageId}`,
+        description: `Planning transcript message ${sessionIndex}.${messageIndex}`,
+        status: 'pending',
+        workflowId,
+        dependencies: messageIndex === 0 ? [] : [`${workflowId}/${previousMessageId}`],
+        prompt: [
+          `session=${sessionIndex}`,
+          `message=${messageIndex}`,
+          `content=${'planning-context '.repeat(6)}${sessionIndex}-${messageIndex}`,
+        ].join('\n'),
+        execution: {
+          agentSessionId: `session-${sessionIndex}`,
+        },
+      }));
+    }
+  }
+
+  return { tasks, workflows };
+}
+
+function expectedTranscriptSize(tasks: TaskState[]): number {
+  return tasks.reduce((total, task) => (
+    total +
+    task.description.length +
+    (task.config.prompt?.length ?? 0)
+  ), 0);
+}
+
+function expectedTranscriptLineCount(tasks: TaskState[]): number {
+  return tasks.reduce((total, task) => (
+    total +
+    1 +
+    (task.config.prompt ? task.config.prompt.split('\n').length : 0)
+  ), 0);
+}
+
+describe('Invoker terminal planning typing telemetry (component)', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mock.cleanup();
+  });
+
+  it('reports a deterministic many-chats/many-messages planning typing baseline', async () => {
+    const { tasks, workflows } = makePlanningTypingFixture();
+    render(<App />);
+
+    act(() => mock.setTasks(tasks, workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('rf__node-wf-chat-0')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('rf__node-wf-chat-0'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('rf__node-wf-chat-0/message-00')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('rf__node-wf-chat-0/message-00'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('command-display')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('command-display'));
+    const promptInput = await screen.findByTestId('edit-prompt-input') as HTMLTextAreaElement;
+
+    const reportUiPerf = vi.mocked(mock.api.reportUiPerf);
+    reportUiPerf.mockClear();
+
+    let nowMs = 5_000;
+    const performanceNowSpy = vi.spyOn(performance, 'now').mockImplementation(() => nowMs);
+    const requestAnimationFrameSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      nowMs += 18;
+      callback(nowMs);
+      return 1;
+    });
+
+    fireEvent.input(promptInput, {
+      target: { value: `${promptInput.value} typed` },
+    });
+
+    await waitFor(() => {
+      expect(reportUiPerf).toHaveBeenCalledWith('planning_typing_lag', expect.any(Object));
+    });
+
+    performanceNowSpy.mockRestore();
+    requestAnimationFrameSpy.mockRestore();
+
+    const planningCalls = reportUiPerf.mock.calls.filter(([metric]) => metric === 'planning_typing_lag');
+    expect(planningCalls).toHaveLength(1);
+    expect(planningCalls[0][1]).toEqual(expect.objectContaining({
+      durationMs: 18,
+      taskCount: tasks.length,
+      workflowCount: workflows.length,
+      sessionCount: workflows.length,
+      transcriptSizeChars: expectedTranscriptSize(tasks),
+      transcriptLineCount: expectedTranscriptLineCount(tasks),
+      transcriptMessageCount: tasks.length * 2,
+      selectedWorkflowTaskCount: 12,
+      activeSurface: 'workflow_task_dag',
+      activeState: 'pending',
+      activeNodeKind: 'task',
+      terminalState: 'collapsed',
+      inspectorState: 'expanded',
+      statusFilterCount: 0,
+      eventType: 'input',
+      inputType: 'unknown',
+      targetKind: 'textarea',
+      targetValueLength: promptInput.value.length,
+      readOnly: false,
+      isComposing: false,
+    }));
+  });
+
+  it('does not report read-only or composing input events', async () => {
+    render(<App />);
+    await waitFor(() => {
+      expect(mock.api.getTasks).toHaveBeenCalled();
+    });
+
+    const reportUiPerf = vi.mocked(mock.api.reportUiPerf);
+    reportUiPerf.mockClear();
+
+    const readOnlyInput = document.createElement('textarea');
+    readOnlyInput.readOnly = true;
+    document.body.appendChild(readOnlyInput);
+    fireEvent.input(readOnlyInput, { target: { value: 'read only' } });
+
+    const composingInput = document.createElement('textarea');
+    document.body.appendChild(composingInput);
+    const composingEvent = new Event('input', { bubbles: true });
+    Object.defineProperty(composingEvent, 'isComposing', { value: true });
+    composingInput.value = 'composing';
+    fireEvent(composingInput, composingEvent);
+
+    expect(reportUiPerf.mock.calls.filter(([metric]) => metric === 'planning_typing_lag')).toHaveLength(0);
+
+    readOnlyInput.remove();
+    composingInput.remove();
+  });
+});


### PR DESCRIPTION
## Summary

The renderer now measures how long a planning input takes to react to a keystroke, so we have a real baseline before touching the lag itself.

A passive capture-phase `input` listener records how much planning state is loaded at that moment — how many workflows, tasks, sessions, and how big the combined transcript is — plus which surface is active.

Those numbers go to the optional UI perf IPC (`window.invoker.reportUiPerf`). Nothing on screen changes; this is measurement only.

The listener is throttled to at most once every 250ms and no-ops when the IPC is absent or the focused element is not an editable text field, so it stays cheap while a user types.

## Review Claim

Approve adding renderer-side planning typing-lag telemetry and its tests, with no change to how the editor behaves.

## Review Lane

`proof`

## Review Unit

`ui-telemetry`

## Safety Invariant

The change is purely additive. The listener is passive and capture-phase, guarded on `window.invoker.reportUiPerf`, throttled, and returns early for non-editable, read-only, or composing targets. No existing control flow, state, or rendered output is altered, so it is safe to review in isolation.

## Slice Rationale

This is Step 1: establish the measurement baseline before any lag fix. Evidence-before-change means the instrumentation lands as its own slice so a later behavior fix can be judged against recorded numbers. The new tests are the directly-affected tests for this instrumentation, so they stay in this slice.

## Non-goals

- Does not fix or reduce planning typing lag.
- Does not change editor, input, or workflow behavior.
- Does not add persistence, dashboards, or aggregation of the telemetry.
- Does not modify the `reportUiPerf` IPC contract beyond sending a new payload.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test invoker-terminal`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 45ede7b9a2cafb0c93189eac9b315202d9fe6a10`
- Post-revert steps: None
- Data migration? No

</details>
