### PR TITLE
[Planning Surface Tmux Step 1 Backend Session Routing](1) Add planning terminal IPC contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -694,6 +694,8 @@ export interface RuntimeStatus {
 export interface TerminalSessionDescriptor {
   sessionId: string;
   taskId: string;
+  kind?: 'task' | 'planning';
+  planningSessionId?: string;
   status: 'running' | 'exited';
   exitCode?: number;
   cwd?: string;
@@ -709,12 +711,16 @@ export interface TerminalSessionDescriptor {
 export interface TerminalOutputEvent {
   sessionId: string;
   taskId: string;
+  kind?: 'task' | 'planning';
+  planningSessionId?: string;
   data: string;
 }
 
 export interface TerminalExitEvent {
   sessionId: string;
   taskId: string;
+  kind?: 'task' | 'planning';
+  planningSessionId?: string;
   exitCode?: number;
 }
 
@@ -772,6 +778,26 @@ export const IpcChannels = {
   'invoker:planning-chat-reset': {} as {
     request: [request: InAppPlanningResetRequest];
     response: InAppPlanningResetResponse;
+  },
+  'invoker:planning-terminal-open': {} as {
+    request: [planningSessionId: string];
+    response: OpenTerminalResponse;
+  },
+  'invoker:planning-terminal-list': {} as {
+    request: [];
+    response: TerminalSessionDescriptor[];
+  },
+  'invoker:planning-terminal-write': {} as {
+    request: [sessionId: string, data: string];
+    response: { ok: boolean; reason?: string };
+  },
+  'invoker:planning-terminal-resize': {} as {
+    request: [sessionId: string, cols: number, rows: number];
+    response: { ok: boolean; reason?: string };
+  },
+  'invoker:planning-terminal-close': {} as {
+    request: [sessionId: string];
+    response: { ok: boolean; reason?: string };
   },
   'invoker:get-planning-presets': {} as {
     request: [];


### PR DESCRIPTION
## Summary

This adds the type-level contract for a planning-owned embedded terminal, kept apart from task terminals.

It marks terminal descriptor and event types with an optional `kind` and a `planningSessionId`, so a session can say whether it belongs to a task or to planning.

It also declares five planning-terminal IPC channel types.

Nothing reads these yet. They are dormant type additions the next slice builds on.

## Review Claim

Approve the planning-terminal IPC channel and descriptor type additions in the contracts package.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Every added field is optional and every added channel is a type-only declaration with no handler, so existing task-terminal contracts and callers are unchanged and no code path reads the new fields yet.

## Slice Rationale

The contract lives in its own package and the review-unit rules require it to ship on its own, apart from the app-side handlers. Landing the types first gives the follow-up slice a stable surface to build on.

## Non-goals

- No IPC handlers, main-process wiring, or terminal-manager behavior.
- No change to task-terminal channels or their descriptors.
- No web-surface or renderer behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/contracts && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
