### PR TITLE
[Planning Surface Tmux Step 1 Backend Session Routing](2) Route planning terminal sessions through backend IPC

### DIFF
--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -124,6 +124,72 @@ describe('EmbeddedTerminalManager', () => {
     expect(mgr.list()).toHaveLength(1);
   });
 
+  it('opens planning sessions as reusable raw shells distinct from task terminals', () => {
+    const planningChild = createFakeChild();
+    const taskChild = createFakeChild();
+    const bashSpawnFn = vi
+      .fn()
+      .mockReturnValueOnce(planningChild)
+      .mockReturnValueOnce(taskChild) as unknown as BashSpawnFn;
+    const mgr = new EmbeddedTerminalManager({
+      backend: createBashTerminalBackend({ spawnFn: bashSpawnFn }),
+      defaultShell: '/bin/manual-shell',
+    });
+    const events: Array<{ kind?: string; planningSessionId?: string; data: string }> = [];
+    mgr.on('output', (event) => {
+      events.push({
+        kind: event.kind,
+        planningSessionId: event.planningSessionId,
+        data: event.data,
+      });
+    });
+
+    const first = mgr.openOrReuse({
+      kind: 'planning',
+      taskId: 'planning:plan-session-1',
+      planningSessionId: 'plan-session-1',
+      spec: { cwd: '/repo' },
+      cwd: '/repo',
+    });
+    const reused = mgr.openOrReuse({
+      kind: 'planning',
+      taskId: 'planning:plan-session-1',
+      planningSessionId: 'plan-session-1',
+      spec: { cwd: '/repo' },
+      cwd: '/repo',
+    });
+    const taskSession = mgr.openOrReuse({
+      taskId: 'planning:plan-session-1',
+      spec: { cwd: '/repo' },
+      cwd: '/repo',
+    });
+    planningChild.stdout.emit('data', Buffer.from('planner shell\n'));
+
+    expect(reused.sessionId).toBe(first.sessionId);
+    expect(taskSession.sessionId).not.toBe(first.sessionId);
+    expect(first).toMatchObject({
+      kind: 'planning',
+      planningSessionId: 'plan-session-1',
+      taskId: 'planning:plan-session-1',
+      cwd: '/repo',
+      command: undefined,
+      args: undefined,
+      mode: 'spawn',
+      attached: false,
+    });
+    expect(taskSession.kind).toBe('task');
+    expect(events).toEqual([
+      { kind: 'planning', planningSessionId: 'plan-session-1', data: 'planner shell\n' },
+    ]);
+    expect(bashSpawnFn).toHaveBeenNthCalledWith(
+      1,
+      '/bin/manual-shell',
+      [],
+      expect.objectContaining({ cwd: '/repo' }),
+    );
+    expect(bashSpawnFn).toHaveBeenCalledTimes(2);
+  });
+
   it('opens and reuses sessions through an injected backend object', () => {
     const spawned = {
       write: vi.fn(),

--- a/packages/app/src/__tests__/terminal-session-persistence.test.ts
+++ b/packages/app/src/__tests__/terminal-session-persistence.test.ts
@@ -5,7 +5,10 @@ import {
   createBashTerminalBackend,
   type BashSpawnFn,
 } from '../embedded-terminal-manager.js';
-import { registerTerminalSessionPersistence } from '../terminal-session-ipc.js';
+import {
+  registerTerminalSessionIpcHandlers,
+  registerTerminalSessionPersistence,
+} from '../terminal-session-ipc.js';
 import {
   createTerminalUiPerfCounters,
   createTerminalUiPerfReporter,
@@ -110,6 +113,72 @@ describe('registerTerminalSessionPersistence coalesce', () => {
     vi.advanceTimersByTime(100);
     expect(upserts).toHaveLength(2);
     expect(upserts[1]?.outputSnapshot).toBe('abc');
+    handle.dispose();
+  });
+
+  it('does not persist planning terminal sessions as task terminal records', () => {
+    const { mgr, upserts, handle } = setup(100);
+
+    mgr.openOrReuse({
+      kind: 'planning',
+      taskId: 'planning:plan-1',
+      planningSessionId: 'plan-1',
+      spec: { cwd: '/repo' },
+      cwd: '/repo',
+    });
+
+    expect(upserts).toHaveLength(0);
+    handle.dispose();
+  });
+
+  it('keeps task terminal IPC routes isolated from planning sessions', async () => {
+    const { mgr, persistence, handle } = setup(100);
+    const handlers = new Map<string, (...args: any[]) => Promise<any>>();
+    const ipcMain = {
+      handle: vi.fn((channel: string, callback: (...args: any[]) => Promise<any>) => {
+        handlers.set(channel, callback);
+      }),
+    };
+    registerTerminalSessionIpcHandlers({
+      ipcMain: ipcMain as any,
+      embeddedTerminalManager: mgr,
+      persistence: persistence as any,
+      uiPerfStats: createTerminalUiPerfCounters(),
+      terminalUiPerf: createTerminalUiPerfReporter({ throttleMs: 0 }),
+      terminalUiPerfSink: createTerminalUiPerfSink(() => {}, createTerminalUiPerfCounters()),
+    });
+
+    const planningSession = mgr.openOrReuse({
+      kind: 'planning',
+      taskId: 'planning:plan-1',
+      planningSessionId: 'plan-1',
+      spec: { cwd: '/repo' },
+      cwd: '/repo',
+    });
+    const taskSession = mgr.openOrReuse({ taskId: 'task-1', spec: {}, cwd: '/tmp' });
+
+    await expect(handlers.get('invoker:terminal-list')?.({})).resolves.toEqual([
+      expect.objectContaining({ sessionId: taskSession.sessionId, kind: 'task' }),
+    ]);
+    await expect(
+      handlers.get('invoker:terminal-write')?.({}, planningSession.sessionId, 'x'),
+    ).resolves.toEqual({
+      ok: false,
+      reason: expect.stringContaining('planning terminal session'),
+    });
+    await expect(
+      handlers.get('invoker:terminal-resize')?.({}, planningSession.sessionId, 80, 24),
+    ).resolves.toEqual({
+      ok: false,
+      reason: expect.stringContaining('planning terminal session'),
+    });
+    await expect(
+      handlers.get('invoker:terminal-close')?.({}, planningSession.sessionId),
+    ).resolves.toEqual({
+      ok: false,
+      reason: expect.stringContaining('planning terminal session'),
+    });
+
     handle.dispose();
   });
 });

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -23,6 +23,7 @@ import type { TerminalSessionRecord } from '@invoker/data-store';
 import type { Executor, ExecutorHandle, TerminalSpec } from '@invoker/execution-engine';
 
 export type EmbeddedTerminalBackendName = 'bash' | 'pty';
+export type EmbeddedTerminalSessionKind = 'task' | 'planning';
 
 const MAX_OUTPUT_SNAPSHOT_CHARS = 64 * 1024;
 
@@ -92,9 +93,13 @@ export interface AttachContext {
 
 export interface TerminalSessionPersistenceRecord extends TerminalSessionRecord {
   spec: TerminalSpec;
+  kind: EmbeddedTerminalSessionKind;
+  planningSessionId?: string;
 }
 export interface OpenSessionOptions {
   taskId: string;
+  kind?: EmbeddedTerminalSessionKind;
+  planningSessionId?: string;
   spec: TerminalSpec;
   cwd: string;
   /** When provided, the session attaches to the running executor rather than spawning a child. */
@@ -103,6 +108,8 @@ export interface OpenSessionOptions {
 interface BaseSessionState {
   sessionId: string;
   taskId: string;
+  kind: EmbeddedTerminalSessionKind;
+  planningSessionId?: string;
   targetKey: string;
   spec: TerminalSpec;
   cwd: string;
@@ -139,6 +146,8 @@ function describePersistenceRecord(state: SessionState): TerminalSessionPersiste
   return {
     sessionId: state.sessionId,
     taskId: state.taskId,
+    kind: state.kind,
+    planningSessionId: state.planningSessionId,
     targetKey: state.targetKey,
     status: state.status,
     exitCode: state.exitCode,
@@ -158,6 +167,8 @@ function describeSession(state: SessionState): TerminalSessionDescriptor {
   return {
     sessionId: state.sessionId,
     taskId: state.taskId,
+    kind: state.kind,
+    planningSessionId: state.planningSessionId,
     status: state.status,
     exitCode: state.exitCode,
     cwd: state.cwd,
@@ -299,6 +310,8 @@ export class EmbeddedTerminalManager extends EventEmitter {
     const base = {
       sessionId,
       taskId: opts.taskId,
+      kind: opts.kind ?? 'task',
+      planningSessionId: opts.planningSessionId,
       targetKey,
       spec: opts.spec,
       cwd: opts.cwd,
@@ -368,6 +381,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
     return this.registerSpawnSession({
       sessionId: seed.sessionId,
       taskId: seed.taskId,
+      kind: 'task',
       targetKey: seed.targetKey,
       spec: seed.spec,
       cwd: seed.cwd,
@@ -608,6 +622,8 @@ export class EmbeddedTerminalManager extends EventEmitter {
     const payload: TerminalExitEvent = {
       sessionId: state.sessionId,
       taskId: state.taskId,
+      kind: state.kind,
+      planningSessionId: state.planningSessionId,
       exitCode,
     };
     this.emit('exit', payload);
@@ -619,6 +635,8 @@ export class EmbeddedTerminalManager extends EventEmitter {
     const payload: TerminalOutputEvent = {
       sessionId: state.sessionId,
       taskId: state.taskId,
+      kind: state.kind,
+      planningSessionId: state.planningSessionId,
       data,
     };
     this.emit('output', payload);
@@ -657,7 +675,7 @@ function loadNodePtySpawn(): PtySpawnFn {
 }
 
 function buildTargetKey(opts: OpenSessionOptions): string {
-  return JSON.stringify({
+  const taskTarget = {
     taskId: opts.taskId,
     cwd: opts.cwd,
     command: opts.spec.command ?? null,
@@ -672,5 +690,15 @@ function buildTargetKey(opts: OpenSessionOptions): string {
           branch: opts.attach.handle.branch ?? null,
         }
       : null,
+  };
+
+  if ((opts.kind ?? 'task') !== 'planning') {
+    return JSON.stringify(taskTarget);
+  }
+
+  return JSON.stringify({
+    kind: 'planning',
+    planningSessionId: opts.planningSessionId ?? opts.taskId,
+    ...taskTarget,
   });
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -5277,6 +5277,59 @@ function createEmbeddedTerminalBackendFromConfig(
     // (or selecting) an embedded session managed in the main process.
     // Headless `open-terminal` still routes to `openExternalTerminalForTask`
     // in `headless.ts` so existing CLI behaviour is preserved.
+    const planningTerminalOnly = (sessionId: string): { ok: true } | { ok: false; reason: string } => {
+      const session = embeddedTerminalManager.get(sessionId);
+      if (!session) return { ok: false, reason: `Unknown session "${sessionId}".` };
+      if (session.kind !== 'planning') {
+        return { ok: false, reason: `Session "${sessionId}" is not a planning terminal session.` };
+      }
+      return { ok: true };
+    };
+
+    ipcMain.handle('invoker:planning-terminal-open', async (_event, planningSessionIdArg: string) => {
+      const planningSessionId = String(planningSessionIdArg ?? '').trim();
+      if (!planningSessionId) {
+        return { opened: false, reason: 'Planning session id is required.' };
+      }
+      logger.info(`invoked for planningSession="${planningSessionId}"`, { module: 'planning-terminal' });
+      try {
+        const session = embeddedTerminalManager.openOrReuse({
+          kind: 'planning',
+          taskId: `planning:${planningSessionId}`,
+          planningSessionId,
+          spec: { cwd: repoRoot },
+          cwd: repoRoot,
+        });
+        return { opened: true, session };
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        logger.warn(`planning terminal spawn failed for session="${planningSessionId}": ${reason}`, { module: 'planning-terminal' });
+        return { opened: false, reason: `Failed to start planning terminal session: ${reason}` };
+      }
+    });
+
+    ipcMain.handle('invoker:planning-terminal-list', async () => {
+      return embeddedTerminalManager.list().filter((session) => session.kind === 'planning');
+    });
+
+    ipcMain.handle('invoker:planning-terminal-write', async (_event, sessionId: string, data: string) => {
+      const allowed = planningTerminalOnly(sessionId);
+      if (!allowed.ok) return allowed;
+      return embeddedTerminalManager.write(sessionId, data);
+    });
+
+    ipcMain.handle('invoker:planning-terminal-resize', async (_event, sessionId: string, cols: number, rows: number) => {
+      const allowed = planningTerminalOnly(sessionId);
+      if (!allowed.ok) return allowed;
+      return embeddedTerminalManager.resize(sessionId, cols, rows);
+    });
+
+    ipcMain.handle('invoker:planning-terminal-close', async (_event, sessionId: string) => {
+      const allowed = planningTerminalOnly(sessionId);
+      if (!allowed.ok) return allowed;
+      return embeddedTerminalManager.close(sessionId);
+    });
+
     ipcMain.handle('invoker:open-terminal', async (_event, taskId: string) => {
       logger.info(`invoked for task="${taskId}"`, { module: 'open-terminal' });
       const liveHandle = taskHandles.get(taskId);

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -20,6 +20,7 @@ export function terminalRowToDescriptor(row: TerminalSessionRow): TerminalSessio
   return {
     sessionId: row.sessionId,
     taskId: row.taskId,
+    kind: 'task',
     status: row.status,
     exitCode: row.exitCode,
     cwd: row.cwd,
@@ -159,6 +160,8 @@ export function registerTerminalSessionPersistence(deps: {
   };
 
   const onSessionUpdated = (record: TerminalSessionPersistenceRecord): void => {
+    if (record.kind !== 'task') return;
+
     // Open (empty snapshot) and exit/status boundaries persist immediately so
     // restart restore and final state stay correct. Output while running is
     // coalesced — that is the PTY storm path that blocked Electron main.
@@ -201,7 +204,10 @@ export function registerTerminalSessionIpcHandlers(deps: {
   const { ipcMain, embeddedTerminalManager, persistence, uiPerfStats, terminalUiPerf, terminalUiPerfSink } = deps;
 
   ipcMain.handle('invoker:terminal-list', async () => {
-    const live = new Map(embeddedTerminalManager.list().map((session) => [session.sessionId, session]));
+    const liveSessions = embeddedTerminalManager
+      .list()
+      .filter((session) => session.kind !== 'planning');
+    const live = new Map(liveSessions.map((session) => [session.sessionId, session]));
     const merged = persistence.listTerminalSessions().map((row) => live.get(row.sessionId) ?? terminalRowToDescriptor(row));
     const persistedIds = new Set(merged.map((session) => session.sessionId));
     for (const session of live.values()) {
@@ -213,6 +219,10 @@ export function registerTerminalSessionIpcHandlers(deps: {
   });
 
   ipcMain.handle('invoker:terminal-write', async (_event, sessionId: string, data: string) => {
+    const session = embeddedTerminalManager.get(sessionId);
+    if (session?.kind === 'planning') {
+      return { ok: false, reason: `Session "${sessionId}" is a planning terminal session.` };
+    }
     return timeTerminalWrite(
       () => embeddedTerminalManager.write(sessionId, data),
       uiPerfStats,
@@ -226,6 +236,10 @@ export function registerTerminalSessionIpcHandlers(deps: {
   });
 
   ipcMain.handle('invoker:terminal-resize', async (_event, sessionId: string, cols: number, rows: number) => {
+    const session = embeddedTerminalManager.get(sessionId);
+    if (session?.kind === 'planning') {
+      return { ok: false, reason: `Session "${sessionId}" is a planning terminal session.` };
+    }
     return timeTerminalResize(
       () => embeddedTerminalManager.resize(sessionId, cols, rows),
       uiPerfStats,
@@ -240,6 +254,10 @@ export function registerTerminalSessionIpcHandlers(deps: {
   });
 
   ipcMain.handle('invoker:terminal-close', async (_event, sessionId: string) => {
+    const session = embeddedTerminalManager.get(sessionId);
+    if (session?.kind === 'planning') {
+      return { ok: false, reason: `Session "${sessionId}" is a planning terminal session.` };
+    }
     const result = embeddedTerminalManager.close(sessionId);
     persistence.deleteTerminalSession(sessionId);
     return result.ok ? result : { ok: true };

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -240,6 +240,14 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       case 'invoker:terminal-resize':
       case 'invoker:terminal-close':
         return { ok: false, reason: 'unsupported' };
+      case 'invoker:planning-terminal-open':
+        return { opened: false, reason: 'Planning terminals are not available in the web UI' };
+      case 'invoker:planning-terminal-list':
+        return [];
+      case 'invoker:planning-terminal-write':
+      case 'invoker:planning-terminal-resize':
+      case 'invoker:planning-terminal-close':
+        return { ok: false, reason: 'unsupported' };
 
       // ── Mutations not exposed on the facade / global lifecycle ──
       case 'invoker:select-experiment':


### PR DESCRIPTION
## Summary

This routes planning-owned terminal sessions on their own IPC path, kept apart from task terminals. The main process now answers planning-terminal open, write to, resize, and close on dedicated handlers.

Each embedded session is tagged with a kind so planning and task sessions never cross. Task-terminal handlers ignore planning sessions, and the planning handlers ignore task sessions.

Persistence stays task-only, so planning sessions are ephemeral. The web path answers that planning terminals are unavailable there.

## Review Claim

Approve routing planning terminal sessions through their own main-process IPC handlers so they never mix with task terminal sessions.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Task-terminal handlers and persistence keep their old shape for task sessions. The new code adds a separate planning path guarded by a kind check, so existing terminal behavior is preserved.

## Slice Rationale

The prior slice added the shared IPC shape; this slice wires the main-process routing that uses it. UI wiring and the planning panel come later, keeping this to backend routing only.

## Non-goals

- Does not add UI, a planning panel, or renderer wiring.
- Does not change task-terminal behavior or its persistence.
- Does not persist planning sessions; they stay in-memory only.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ade2110052560824710945f1a129312846c18a1d`
- Post-revert steps: None
- Data migration? No

</details>
