### PR TITLE
[Planning Surface Tmux Step 1 Backend Session Routing](3) Mock planning terminal bridge methods in UI tests

### DIFF
--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -199,6 +199,23 @@ export function createMockInvoker(
       workflowId: 'wf-1',
     })),
     planningChatReset: vi.fn(async () => ({ ok: true })),
+    planningTerminalOpen: vi.fn(async (planningSessionId: string) => ({
+      opened: true,
+      session: {
+        sessionId: `mock-planning-terminal-${planningSessionId}`,
+        taskId: `planning:${planningSessionId}`,
+        kind: 'planning',
+        planningSessionId,
+        status: 'running',
+        mode: 'spawn',
+        attached: false,
+        createdAt: new Date('2025-01-01T00:00:00Z').toISOString(),
+      },
+    })),
+    planningTerminalList: vi.fn(async () => []),
+    planningTerminalWrite: vi.fn(async () => ({ ok: true })),
+    planningTerminalResize: vi.fn(async () => ({ ok: true })),
+    planningTerminalClose: vi.fn(async () => ({ ok: true })),
     getPlanningPresets: vi.fn(async () => [
       { key: 'codex', label: 'Codex', tool: 'codex', isDefault: true },
       { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude', isDefault: false },


### PR DESCRIPTION
## Summary

UI test suites build against a mock of the app bridge. This adds stub implementations for the new planning terminal methods so those suites keep compiling and passing.

The stubs return simple canned values and add no product behavior. Only the shared test mock changes.

## Review Claim

Approve stubbing the new planning terminal bridge methods on the shared UI test mock so UI suites stay green.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only a test helper changes; no product code path is touched, so app behavior cannot change from this slice.

## Slice Rationale

The prior slices added new bridge methods; UI test mocks must implement them or UI suites fail to build. This test-only slice is kept separate from product routing and from the shared IPC shape.

## Non-goals

- Adds no product code and no runtime behavior.
- Does not test the new planning routing end to end; it only keeps existing UI suites building.
- Does not change task-terminal mocks.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5edd1c07c6e8813ebaae4153ae9209537fb0e36f`
- Post-revert steps: None
- Data migration? No

</details>
