### PR TITLE
Planning Lag Step 1 Telemetry Baseline (2) Lock planning typing baseline with a regression test

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -242,6 +242,122 @@ function relativePlanningUpdatedAt(value: string): string {
   if (months < 12) return `${months}mo`;
   return `${Math.round(months / 12)}y`;
 }
+const PLANNING_TYPING_LAG_METRIC = 'planning_typing_lag_baseline';
+const PLANNING_TYPING_SCENARIO = 'many-chats-many-messages-typing';
+
+interface PlanningTypingTelemetryState {
+  tasks: Map<string, TaskState>;
+  workflows: Map<string, WorkflowMeta>;
+  viewMode: 'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph';
+  terminalDrawerState: TerminalDrawerState;
+  selectedTaskId: string | null;
+  selectedWorkflowId: string | null;
+  hasLoadedPlan: boolean;
+  hasStarted: boolean;
+}
+
+function utf8Size(value: string): number {
+  if (typeof Blob !== 'undefined') {
+    return new Blob([value]).size;
+  }
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(value).length;
+  }
+  return value.length;
+}
+
+function transcriptPartsForTask(task: TaskState): string[] {
+  return [
+    task.config.prompt,
+    task.config.experimentPrompt,
+    task.config.summary,
+    task.config.problem,
+    task.config.approach,
+    task.config.testPlan,
+    task.execution.inputPrompt,
+    task.execution.pendingFixError,
+  ].filter((value): value is string => typeof value === 'string' && value.length > 0);
+}
+
+function transcriptMessageCount(value: string): number {
+  return value.split(/\n+/).filter((line) => line.trim().length > 0).length;
+}
+
+function sessionIdsForTask(task: TaskState): string[] {
+  return [
+    task.execution.agentSessionId,
+    task.execution.lastAgentSessionId,
+  ].filter((value): value is string => typeof value === 'string' && value.length > 0);
+}
+
+function selectionState(selectedTaskId: string | null, selectedWorkflowId: string | null): string {
+  if (selectedTaskId) return 'task_selected';
+  if (selectedWorkflowId) return 'workflow_selected';
+  return 'none';
+}
+
+function createPlanningTypingTelemetryContext({
+  tasks,
+  workflows,
+  viewMode,
+  terminalDrawerState,
+  selectedTaskId,
+  selectedWorkflowId,
+  hasLoadedPlan,
+  hasStarted,
+}: PlanningTypingTelemetryState): Record<string, unknown> {
+  const sessions = new Set<string>();
+  const taskStatusCounts: Record<string, number> = {};
+  let transcriptSizeBytes = 0;
+  let transcriptLineCount = 0;
+
+  for (const task of tasks.values()) {
+    taskStatusCounts[task.status] = (taskStatusCounts[task.status] ?? 0) + 1;
+    for (const sessionId of sessionIdsForTask(task)) {
+      sessions.add(sessionId);
+    }
+    for (const part of transcriptPartsForTask(task)) {
+      transcriptSizeBytes += utf8Size(part);
+      transcriptLineCount += transcriptMessageCount(part);
+    }
+  }
+
+  const activeSelectionState = selectionState(selectedTaskId, selectedWorkflowId);
+
+  return {
+    scenario: PLANNING_TYPING_SCENARIO,
+    sessionCount: sessions.size,
+    transcriptSizeBytes,
+    transcriptMessageCount: transcriptLineCount,
+    taskCount: tasks.size,
+    workflowCount: workflows.size,
+    taskStatusCounts,
+    activeSurface: viewMode === 'dag' ? 'planning' : viewMode,
+    activeState: `${viewMode}:${activeSelectionState}:terminal-${terminalDrawerState}`,
+    viewMode,
+    terminalDrawerState,
+    selectionState: activeSelectionState,
+    selectedTaskId,
+    selectedWorkflowId,
+    hasLoadedPlan,
+    hasStarted,
+  };
+}
+
+function isTextInputElement(target: EventTarget | null): target is HTMLInputElement | HTMLTextAreaElement {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target instanceof HTMLTextAreaElement) return true;
+  if (!(target instanceof HTMLInputElement)) return false;
+  return [
+    'email',
+    'number',
+    'password',
+    'search',
+    'tel',
+    'text',
+    'url',
+  ].includes(target.type);
+}
 
 function PlanningSessionStatusIcon({
   busy,
@@ -618,6 +734,7 @@ export function App() {
     () => new Set((queueStatus?.running ?? []).map((entry) => entry.taskId)),
     [queueStatus],
   );
+  const appRootRef = useRef<HTMLDivElement>(null);
   const graphSurfaceRef = useRef<HTMLDivElement>(null);
   const graphActionsMenuRef = useRef<HTMLDivElement>(null);
   const startReadyMenuRef = useRef<HTMLDivElement>(null);
@@ -739,6 +856,9 @@ export function App() {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchActiveIndex, setSearchActiveIndex] = useState(0);
   const uiPerfThrottleRef = useRef<Record<string, number>>({});
+  const planningTypingStateRef = useRef<PlanningTypingTelemetryState | null>(null);
+  const planningTypingSequenceRef = useRef(0);
+  const planningTypingFrameIdsRef = useRef<Set<number>>(new Set());
   const systemSetupAutoOpenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const cancelPendingSystemSetupAutoOpen = useCallback(() => {
@@ -1040,6 +1160,89 @@ export function App() {
       perfObserver?.disconnect();
     };
   }, []);
+  useEffect(() => {
+    planningTypingStateRef.current = {
+      tasks,
+      workflows,
+      viewMode,
+      terminalDrawerState,
+      selectedTaskId,
+      selectedWorkflowId,
+      hasLoadedPlan,
+      hasStarted,
+    };
+  }, [
+    tasks,
+    workflows,
+    viewMode,
+    terminalDrawerState,
+    selectedTaskId,
+    selectedWorkflowId,
+    hasLoadedPlan,
+    hasStarted,
+  ]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+    const scheduleFrame = (callback: FrameRequestCallback): number => {
+      if (typeof window.requestAnimationFrame === 'function') {
+        return window.requestAnimationFrame(callback);
+      }
+      return window.setTimeout(() => callback(performance.now()), 0);
+    };
+    const cancelFrame = (id: number) => {
+      if (typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(id);
+      } else {
+        window.clearTimeout(id);
+      }
+    };
+
+    const reportTypingLag = (event: Event) => {
+      const target = event.target;
+      if (!isTextInputElement(target)) return;
+      if (!appRootRef.current?.contains(target)) return;
+
+      const startedAt = performance.now();
+      const sequence = ++planningTypingSequenceRef.current;
+      const inputEvent = event as InputEvent;
+      const targetTestId = target.getAttribute('data-testid') ?? undefined;
+      const targetAriaLabel = target.getAttribute('aria-label') ?? undefined;
+      const targetName = targetTestId ?? targetAriaLabel ?? target.tagName.toLowerCase();
+      const valueLength = target.value.length;
+
+      const frameId = scheduleFrame(() => {
+        planningTypingFrameIdsRef.current.delete(frameId);
+        const telemetryState = planningTypingStateRef.current;
+        void window.invoker?.reportUiPerf?.(PLANNING_TYPING_LAG_METRIC, {
+          ...(telemetryState ? createPlanningTypingTelemetryContext(telemetryState) : {}),
+          sequence,
+          eventType: event.type,
+          lagMs: Math.round(performance.now() - startedAt),
+          targetName,
+          targetTagName: target.tagName.toLowerCase(),
+          targetValueLength: valueLength,
+          targetReadOnly: target.readOnly,
+          targetDisabled: target.disabled,
+          targetIsComposing: inputEvent.isComposing === true,
+          inputType: typeof inputEvent.inputType === 'string' ? inputEvent.inputType : undefined,
+        });
+      });
+      planningTypingFrameIdsRef.current.add(frameId);
+    };
+
+    document.addEventListener('input', reportTypingLag, true);
+    document.addEventListener('change', reportTypingLag, true);
+    return () => {
+      document.removeEventListener('input', reportTypingLag, true);
+      document.removeEventListener('change', reportTypingLag, true);
+      for (const frameId of planningTypingFrameIdsRef.current) {
+        cancelFrame(frameId);
+      }
+      planningTypingFrameIdsRef.current.clear();
+    };
+  }, [appRootRef]);
 
   const selectedTask = selectedTaskId ? tasks.get(selectedTaskId) ?? null : null;
   const selectedWorker = workerStatus?.workers.find((worker) => worker.kind === selectedWorkerKind) ?? null;
@@ -3644,7 +3847,7 @@ export function App() {
       ? `${selectedWorkflow.name} · ${formatWorkflowStatus(selectedWorkflow.status)}`
       : `${workflowEntries.length} workflow${workflowEntries.length === 1 ? '' : 's'} ready`;
   return (
-    <div className="h-screen flex flex-col bg-background text-foreground font-sans" onClick={() => closeContextMenu()}>
+    <div ref={appRootRef} className="h-screen flex flex-col bg-background text-foreground font-sans" onClick={() => closeContextMenu()}>
       <Toaster
         theme="dark"
         position="bottom-right"
@@ -3801,6 +4004,8 @@ export function App() {
                   executionDefaults={executionDefaults}
                   onEditAgent={handleEditAgent}
                   onEditModel={handleEditModel}
+                  onEditPrompt={handleEditPrompt}
+                  onEditCommand={handleEditCommand}
                   onApprove={openApprovalModal}
                   onReject={openRejectModal}
                   onSetMergeBranch={handleSetMergeBranch}

--- a/packages/ui/src/__tests__/plan-loading.test.tsx
+++ b/packages/ui/src/__tests__/plan-loading.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, act, waitFor } from '@testing-library/react';
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { WorkflowMeta } from '../types.js';
@@ -37,6 +37,31 @@ const beta = makeUITask({
 const workflows: WorkflowMeta[] = [
   { id: 'wf-load', name: 'Loaded Workflow', status: 'running' },
 ];
+function makeTypingLagScenario(sessionCount: number, messagesPerSession: number) {
+  const tasks = Array.from({ length: sessionCount }, (_, sessionIndex) => {
+    const id = `task-${String(sessionIndex).padStart(2, '0')}`;
+    const prompt = Array.from({ length: messagesPerSession }, (_message, messageIndex) => (
+      `session-${sessionIndex} message-${messageIndex}: deterministic planning transcript payload`
+    )).join('\n');
+
+    return makeUITask({
+      id,
+      description: `Typing lag scenario task ${sessionIndex}`,
+      status: 'pending',
+      workflowId: 'wf-typing',
+      dependencies: sessionIndex === 0 ? [] : [`task-${String(sessionIndex - 1).padStart(2, '0')}`],
+      prompt,
+      execution: {
+        agentSessionId: `session-${String(sessionIndex).padStart(2, '0')}`,
+      },
+    });
+  });
+
+  return {
+    tasks,
+    workflows: [{ id: 'wf-typing', name: 'Typing Baseline Workflow', status: 'running' }] as WorkflowMeta[],
+  };
+}
 
 describe('Plan loading (component)', () => {
   let mock: MockInvoker;
@@ -84,5 +109,65 @@ describe('Plan loading (component)', () => {
     });
     screen.getByTestId('workflow-node-wf-load').click();
     await waitFor(() => expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Loaded Workflow task DAG'));
+  });
+  it('reports a deterministic many-session planning typing lag baseline', async () => {
+    const sessionCount = 12;
+    const messagesPerSession = 16;
+    const scenario = makeTypingLagScenario(sessionCount, messagesPerSession);
+    render(<App />);
+    act(() => mock.setTasks(scenario.tasks, scenario.workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-typing')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('workflow-node-wf-typing'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('rf__node-task-00')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('rf__node-task-00'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('prompt-command-display')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('prompt-command-display'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-prompt-input')).toBeInTheDocument();
+    });
+    const editPromptInput = screen.getByTestId('edit-prompt-input');
+    const nextPrompt = `${scenario.tasks[0].config.prompt}\noperator typed follow-up`;
+    fireEvent.change(editPromptInput, { target: { value: nextPrompt } });
+
+    await waitFor(() => {
+      expect(vi.mocked(mock.api.reportUiPerf).mock.calls.some(([metric]) => metric === 'planning_typing_lag_baseline')).toBe(true);
+    });
+
+    const perfCall = vi.mocked(mock.api.reportUiPerf).mock.calls.find(
+      ([metric]) => metric === 'planning_typing_lag_baseline',
+    );
+    expect(perfCall?.[1]).toEqual(expect.objectContaining({
+      scenario: 'many-chats-many-messages-typing',
+      sessionCount,
+      transcriptMessageCount: sessionCount * messagesPerSession,
+      taskCount: sessionCount,
+      workflowCount: 1,
+      activeSurface: 'planning',
+      activeState: 'dag:task_selected:terminal-minimized',
+      viewMode: 'dag',
+      terminalDrawerState: 'minimized',
+      selectionState: 'task_selected',
+      selectedTaskId: 'task-00',
+      selectedWorkflowId: 'wf-typing',
+      targetName: 'edit-prompt-input',
+      targetTagName: 'textarea',
+      targetValueLength: nextPrompt.length,
+      targetReadOnly: false,
+      targetDisabled: false,
+      targetIsComposing: false,
+      eventType: 'change',
+      lagMs: expect.any(Number),
+    }));
+    expect((perfCall?.[1] as Record<string, unknown>).transcriptSizeBytes).toBeGreaterThan(10_000);
   });
 });


### PR DESCRIPTION
## Summary

This adds a deterministic App-level regression test for the planning-surface typing probe.

The test edits the prompt editor inside a many-session planning workflow and checks the reported latency sample.

It also exposes a `reportUiPerf` spy in the shared UI mock so the App test can observe the sample.

## Review Claim

Approve an App-level regression that protects the exposed `planning_typing_lag_baseline` sample on the planning surface.

## Review Lane

- behavior

## Review Unit

- activation-surface

## Safety Invariant

This slice changes only UI test code and the shared UI mock.

It adds no production runtime behavior, and the assertion locks the emitted App sample to one deterministic planning-surface scenario.

## Slice Rationale

The typing probe needs one App-level regression so later UI refactors do not silently drop the exposed sample or its planning-surface context.

Keeping that proof in its own stacked slice makes the runtime probe and the regression easy to review separately.

## Non-goals

- Does not change production behavior or visible UI.
- Does not change the telemetry probe implementation.
- Does not benchmark or fix planning typing lag.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `./node_modules/.bin/vitest run src/__tests__/plan-loading.test.tsx`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/planning-lag-step-1-telemetry-baseline-2.md --changed-files-file /tmp/planning-lag-step-2.changed --diff-file /tmp/planning-lag-step-2.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2d7d707b592d8bd63e9cac9623afa9d61f0f2fa0`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4116
