### PR TITLE
[Persist Worker Desired State - Runtime Restore Semantics](1) Add persisted worker desired states

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -618,7 +618,7 @@ describe('SQLiteAdapter', () => {
       expect(indexNames).toContain('idx_events_task_id_id');
     });
 
-    it('creates execution_model and worker_actions schema objects', () => {
+    it('creates execution_model and worker schema objects', () => {
       expect(tableColumns(adapter, 'tasks')).toContain('execution_model');
       expect(tableColumns(adapter, 'worker_actions')).toEqual(expect.arrayContaining([
         'id',
@@ -649,6 +649,11 @@ describe('SQLiteAdapter', () => {
       expect(tableForeignKeys(adapter, 'worker_actions')).toEqual(expect.arrayContaining([
         'workflows.id:CASCADE',
         'tasks.id:CASCADE',
+      ]));
+      expect(tableColumns(adapter, 'worker_desired_states')).toEqual(expect.arrayContaining([
+        'worker_kind',
+        'desired_state',
+        'updated_at',
       ]));
     });
 
@@ -812,6 +817,48 @@ describe('SQLiteAdapter', () => {
 
       expect(adapter.listWorkerActions({ decision: 'skip' }).map((action) => action.id)).toEqual(['wa-skip']);
       expect(adapter.listWorkerActions({ decision: 'act' }).map((action) => action.id)).toEqual(['wa-done', 'wa-act']);
+    });
+  });
+
+  describe('worker desired state persistence', () => {
+    it('upserts, reads, and lists desired worker states', () => {
+      const first = adapter.setWorkerDesiredState('pr-status', 'running');
+      expect(first).toMatchObject({
+        workerKind: 'pr-status',
+        desiredState: 'running',
+      });
+
+      const updated = adapter.setWorkerDesiredState('pr-status', 'stopped');
+      adapter.setWorkerDesiredState('external-preview', 'running');
+
+      expect(adapter.getWorkerDesiredState('pr-status')).toEqual(updated);
+      expect(adapter.listWorkerDesiredStates().map((state) => ({
+        workerKind: state.workerKind,
+        desiredState: state.desiredState,
+      }))).toEqual([
+        { workerKind: 'external-preview', desiredState: 'running' },
+        { workerKind: 'pr-status', desiredState: 'stopped' },
+      ]);
+    });
+
+    it('persists desired worker states across writable reopens', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-worker-desired-state-'));
+      const dbPath = join(dir, 'invoker.db');
+
+      try {
+        const first = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        first.setWorkerDesiredState('autofix', 'running');
+        first.close();
+
+        const reopened = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        expect(reopened.getWorkerDesiredState('autofix')).toMatchObject({
+          workerKind: 'autofix',
+          desiredState: 'running',
+        });
+        reopened.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -197,6 +197,14 @@ export interface WorkerActionListFilters {
   offset?: number;
 }
 
+export type WorkerDesiredState = 'running' | 'stopped';
+
+export interface WorkerDesiredStateRecord {
+  workerKind: string;
+  desiredState: WorkerDesiredState;
+  updatedAt: string;
+}
+
 export interface TerminalSessionRecord {
   sessionId: string;
   taskId: string;
@@ -289,6 +297,9 @@ export interface PersistenceAdapter {
   getWorkerAction(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
   upsertWorkerAction(action: WorkerActionWrite): WorkerActionRecord;
   listWorkerActions(filters?: WorkerActionListFilters): WorkerActionRecord[];
+  getWorkerDesiredState(workerKind: string): WorkerDesiredStateRecord | undefined;
+  setWorkerDesiredState(workerKind: string, desiredState: WorkerDesiredState): WorkerDesiredStateRecord;
+  listWorkerDesiredStates(): WorkerDesiredStateRecord[];
 
   // Conversations (Slack thread-based)
   saveConversation(conversation: Conversation): void;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -47,6 +47,8 @@ import type {
   WorkerActionListFilters,
   WorkerActionRecord,
   WorkerActionWrite,
+  WorkerDesiredState,
+  WorkerDesiredStateRecord,
   TerminalSessionPatch,
   TerminalSessionRecord,
   InAppPlanningSessionPatch,
@@ -1633,6 +1635,41 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return rows.map((row) => this.rowToWorkerAction(row));
   }
 
+  getWorkerDesiredState(workerKind: string): WorkerDesiredStateRecord | undefined {
+    const row = this.queryOne(
+      'SELECT * FROM worker_desired_states WHERE worker_kind = ?',
+      [workerKind],
+    );
+    return row ? this.rowToWorkerDesiredState(row) : undefined;
+  }
+
+  setWorkerDesiredState(workerKind: string, desiredState: WorkerDesiredState): WorkerDesiredStateRecord {
+    if (desiredState !== 'running' && desiredState !== 'stopped') {
+      throw new Error(`Invalid worker desired state: "${String(desiredState)}"`);
+    }
+    const updatedAt = new Date().toISOString();
+    this.execRun(
+      `INSERT INTO worker_desired_states (worker_kind, desired_state, updated_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(worker_kind) DO UPDATE SET
+         desired_state = excluded.desired_state,
+         updated_at = excluded.updated_at`,
+      [workerKind, desiredState, updatedAt],
+    );
+    const saved = this.getWorkerDesiredState(workerKind);
+    if (!saved) {
+      throw new Error(`Failed to persist worker desired state for "${workerKind}"`);
+    }
+    return saved;
+  }
+
+  listWorkerDesiredStates(): WorkerDesiredStateRecord[] {
+    const rows = this.queryAll(
+      'SELECT * FROM worker_desired_states ORDER BY worker_kind ASC',
+    );
+    return rows.map((row) => this.rowToWorkerDesiredState(row));
+  }
+
   // ── Queries ─────────────────────────────────────────
 
   getSelectedExperiment(taskId: string): string | null {
@@ -3080,6 +3117,18 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   private rowToWorkerAction(row: Record<string, unknown>): WorkerActionRecord {
     return mapRowToWorkerAction(row);
+  }
+
+  private rowToWorkerDesiredState(row: Record<string, unknown>): WorkerDesiredStateRecord {
+    const desiredState = String(row.desired_state);
+    if (desiredState !== 'running' && desiredState !== 'stopped') {
+      throw new Error(`Invalid worker desired state row for worker "${String(row.worker_kind)}"`);
+    }
+    return {
+      workerKind: String(row.worker_kind),
+      desiredState,
+      updatedAt: String(row.updated_at),
+    };
   }
 
   private requeueWorkflowMutationLease(workflowId: string): void {

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -348,6 +348,12 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_worker_actions_kind_updated
         ON worker_actions(worker_kind, updated_at DESC, id);
 
+      CREATE TABLE IF NOT EXISTS worker_desired_states (
+        worker_kind TEXT PRIMARY KEY,
+        desired_state TEXT NOT NULL CHECK (desired_state IN ('running', 'stopped')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
       CREATE TABLE IF NOT EXISTS execution_resource_leases (
         resource_key TEXT NOT NULL,
         resource_type TEXT NOT NULL,
@@ -492,6 +498,11 @@ export const POST_MIGRATION_STATEMENTS = [
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_task_updated ON worker_actions(task_id, updated_at)',
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_workflow_status ON worker_actions(workflow_id, worker_kind, status)',
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_kind_updated ON worker_actions(worker_kind, updated_at DESC, id)',
+  `CREATE TABLE IF NOT EXISTS worker_desired_states (
+      worker_kind TEXT PRIMARY KEY,
+      desired_state TEXT NOT NULL CHECK (desired_state IN ('running', 'stopped')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
   'DROP INDEX IF EXISTS idx_task_launch_dispatch_active_attempt',
   `
       CREATE UNIQUE INDEX IF NOT EXISTS idx_task_launch_dispatch_active_attempt


### PR DESCRIPTION
## Summary

Invoker workers can now store whether an owner wanted each worker kind running or stopped.

This slice adds only the data-store contract and SQLite table for that preference.

No runtime path uses the new rows yet. Later slices decide when those rows are written or honored.

## Review Claim

Approve the persisted worker desired-state contract and SQLite storage keyed by worker kind.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The schema and adapter methods are additive. Existing worker action rows, workflow rows, and runtime behavior are unchanged until later slices call the new methods.

## Slice Rationale

The storage shape lands first so reviewers can approve the durable contract before runtime restore logic depends on it.

## Non-goals

- Does not start or stop workers.
- Does not change owner startup behavior.
- Does not change headless worker commands.
- No UI changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sqlite-adapter.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2708e3f5`
- Post-revert steps: None
- Data migration? No. The table is created with `IF NOT EXISTS`; reverting leaves any unused rows ignored.

</details>
