### PR TITLE
[Persist Worker Desired State - Runtime Restore Semantics](4) Share restore-aware owner defaults

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -393,7 +393,11 @@ function createRegisteredWorkerRegistry(): WorkerRegistry<WorkerRuntimeDependenc
   return registerExternalWorkersFromConfig(invokerConfig.externalWorkers, registry);
 }
 
-
+function resolveDefaultOwnerWorkerAutoStartKinds(): readonly string[] {
+  return invokerConfig.e2eAutoFixEnabled
+    ? [...AUTO_STARTED_OWNER_WORKER_KINDS, E2E_AUTOFIX_WORKER_KIND]
+    : AUTO_STARTED_OWNER_WORKER_KINDS;
+}
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
@@ -1908,9 +1912,7 @@ function startHeadlessMode(): void {
               await createStandaloneTaskExecutor().checkMergeGateStatuses();
             },
           ),
-          autoStartKinds: invokerConfig.e2eAutoFixEnabled
-            ? [...AUTO_STARTED_OWNER_WORKER_KINDS, E2E_AUTOFIX_WORKER_KIND]
-            : AUTO_STARTED_OWNER_WORKER_KINDS,
+          autoStartKinds: resolveDefaultOwnerWorkerAutoStartKinds(),
           persistence,
           autoFixRetries: resolveAutoFixRetries(invokerConfig),
           canControl: () => !readOnlyMode,
@@ -3753,9 +3755,7 @@ function createEmbeddedTerminalBackendFromConfig(
             await requireTaskExecutor().checkMergeGateStatuses();
           },
         ),
-        autoStartKinds: invokerConfig.e2eAutoFixEnabled
-          ? [...AUTO_STARTED_OWNER_WORKER_KINDS, E2E_AUTOFIX_WORKER_KIND]
-          : AUTO_STARTED_OWNER_WORKER_KINDS,
+        autoStartKinds: resolveDefaultOwnerWorkerAutoStartKinds(),
         persistence,
         autoFixRetries: resolveAutoFixRetries(invokerConfig),
         canControl: () => ownerMode,
@@ -4471,13 +4471,13 @@ function createEmbeddedTerminalBackendFromConfig(
         return createLocalWorkerStatusSnapshot({
           registry: createRegisteredWorkerRegistry(),
           persistence,
-          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          autoStartKinds: resolveDefaultOwnerWorkerAutoStartKinds(),
         });
       }
       return workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
         registry: createRegisteredWorkerRegistry(),
         persistence,
-        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+        autoStartKinds: resolveDefaultOwnerWorkerAutoStartKinds(),
       });
     });
 


### PR DESCRIPTION
## Summary

Owner worker defaults now come from one resolver.

Both owner startup paths and local snapshots share the same default set, including the gated e2e worker.

This keeps restore-aware worker rows from drifting across owner modes.

## Review Claim

Approve centralizing owner worker default resolution in `main.ts` so every owner mode reports from the same default set.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The helper preserves the previous default set and only adds the e2e worker when the existing config flag is enabled. It does not start any new worker kind by default.

## Slice Rationale

Slices 2 and 3 added desired-state restore and mutation. This follow-up shares owner defaults so the restored worker rows stay consistent.

## Non-goals

- Does not change the worker controller.
- Does not change headless worker command behavior.
- Does not change the data-store schema.
- No UI changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/worker-control.test.ts src/__tests__/headless-autofix.test.ts src/__tests__/headless-pr-maintenance.test.ts`
- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/worker-tab-scroll.spec.ts --config playwright.config.ts --workers=1`

</details>

## Visual Proof

Worker Processes pane rendered with the restore-aware owner default set.

![Worker Processes pane showing default owner worker rows](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-8ead51/persist-worker-status-proof.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 65d2997c`
- Post-revert steps: None
- Data migration? No

</details>
