### PR TITLE
[Persist Worker Desired State - Runtime Restore Semantics](5) Route app tests through a Node Vitest shim

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -62,7 +62,7 @@
     "dist": "electron-builder --publish never",
     "dist:linux": "electron-builder --linux AppImage deb --publish never",
     "dist:mac": "electron-builder --mac dmg --publish never",
-    "test": "vitest run",
+    "test": "node scripts/vitest-run.cjs",
     "start": "unset ELECTRON_RUN_AS_NODE && node ../../scripts/electron.cjs dist/main.js",
     "dev": "tsup src/main.ts src/preload.ts --format cjs --outDir dist --external electron && unset ELECTRON_RUN_AS_NODE && node ../../scripts/electron.cjs dist/main.js",
     "test:e2e": "sh -c 'if command -v xvfb-run >/dev/null 2>&1; then exec xvfb-run --auto-servernum playwright test \"$@\"; else exec playwright test \"$@\"; fi' --",

--- a/packages/app/scripts/vitest-run.cjs
+++ b/packages/app/scripts/vitest-run.cjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('node:child_process');
+
+const args = process.argv.slice(2);
+const normalizedArgs = args[0] === '--' ? args.slice(1) : args;
+const vitestCli = require.resolve('vitest/vitest.mjs');
+
+const result = spawnSync(process.execPath, [vitestCli, 'run', ...normalizedArgs], {
+  stdio: 'inherit',
+});
+
+if (result.error) {
+  console.error(result.error);
+  process.exit(1);
+}
+
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+} else {
+  process.exit(result.status ?? 1);
+}


### PR DESCRIPTION
## Summary

The app package test command now runs Vitest through a small Node launcher.

Filtered package test invocations can pass file arguments through the same runtime that runs the package script.

The launcher forwards exit status and signals without changing Vitest's test selection.

## Review Claim

Approve running the app package test command through a Node launcher that forwards arguments to Vitest.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The wrapper delegates directly to Vitest with the provided arguments. It only changes how the package command starts Vitest, not which tests run.

## Slice Rationale

This verification helper is isolated from runtime behavior so reviewers can evaluate the package command change separately from worker desired-state semantics.

## Non-goals

- Does not change worker runtime code.
- Does not change test assertions.
- Does not change repository-wide test commands.
- No UI changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/worker-control.test.ts src/__tests__/headless-autofix.test.ts src/__tests__/headless-pr-maintenance.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 6fe7c962`
- Post-revert steps: None
- Data migration? No

</details>
