### PR TITLE
Persist Worker Desired State - Runtime Restore Semantics (2) Restore worker runtime from persisted desired state

### DIFF
--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -12,7 +12,7 @@ import {
   type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 
-import type { WorkerActionRecord } from '@invoker/data-store';
+import type { WorkerActionRecord, WorkerDesiredState } from '@invoker/data-store';
 import {
   AUTO_STARTED_OWNER_WORKER_KINDS,
   createWorkerRuntimeController,
@@ -50,12 +50,28 @@ function runtime(kind: string): TestWorkerRuntime {
   };
 }
 
-function persistence() {
+function persistence(initialDesiredStates: Record<string, WorkerDesiredState> = {}) {
+  const desiredStates = new Map(Object.entries(initialDesiredStates));
   return {
     listWorkerActions: vi.fn(() => []),
     listWorkflows: vi.fn(() => []),
     loadTasks: vi.fn(() => []),
     getEvents: vi.fn(() => []),
+    listWorkerDesiredStates: vi.fn(() => [...desiredStates.entries()].map(([workerKind, desiredState]) => ({
+      workerKind,
+      desiredState,
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    }))),
+    getWorkerDesiredState: vi.fn((workerKind: string) => {
+      const desiredState = desiredStates.get(workerKind);
+      return desiredState
+        ? { workerKind, desiredState, updatedAt: '2026-01-01T00:00:00.000Z' }
+        : undefined;
+    }),
+    setWorkerDesiredState: vi.fn((workerKind: string, desiredState: WorkerDesiredState) => {
+      desiredStates.set(workerKind, desiredState);
+      return { workerKind, desiredState, updatedAt: '2026-01-01T00:00:00.000Z' };
+    }),
   };
 }
 
@@ -72,7 +88,10 @@ function deps(): WorkerRuntimeDependencies {
   } as WorkerRuntimeDependencies;
 }
 
-function controller(autoStartKinds: readonly string[] = AUTO_STARTED_OWNER_WORKER_KINDS) {
+function controller(
+  autoStartKinds: readonly string[] = AUTO_STARTED_OWNER_WORKER_KINDS,
+  store = persistence(),
+) {
   const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
   const runtimes = new Map<string, TestWorkerRuntime[]>();
   const register = (kind: string, note: string, runtimeKind = kind) => {
@@ -103,9 +122,10 @@ function controller(autoStartKinds: readonly string[] = AUTO_STARTED_OWNER_WORKE
       registry,
       deps: deps(),
       autoStartKinds,
-      persistence: persistence() as never,
+      persistence: store as never,
       canControl: () => true,
     }),
+    persistence: store,
   };
 }
 
@@ -148,6 +168,57 @@ describe('createWorkerRuntimeController', () => {
 
     expect(row.lifecycle).toBe('running');
     expect(row.runtimeKind).toBe('recovery');
+  });
+
+  it('startup restore honors persisted desired state before default auto-starts', () => {
+    const setup = controller(AUTO_STARTED_OWNER_WORKER_KINDS, persistence({
+      [PR_STATUS_WORKER_KIND]: 'stopped',
+      [AUTO_FIX_WORKER_KIND]: 'running',
+      'removed-external': 'running',
+    }));
+
+    setup.controller.startAutoStartedWorkers();
+    const snapshot = setup.controller.snapshot();
+
+    expect(snapshot.workers.find((worker) => worker.kind === PR_STATUS_WORKER_KIND)).toMatchObject({
+      lifecycle: 'stopped',
+      autoStarts: false,
+    });
+    expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)).toMatchObject({
+      lifecycle: 'running',
+      autoStarts: true,
+    });
+    expect(setup.runtimes.has('removed-external')).toBe(false);
+    expect(setup.persistence.setWorkerDesiredState).not.toHaveBeenCalled();
+  });
+
+  it('explicit start and stop persist desired state', async () => {
+    const setup = controller();
+
+    setup.controller.start(AUTO_FIX_WORKER_KIND);
+    await setup.controller.stop(AUTO_FIX_WORKER_KIND);
+
+    expect(setup.persistence.setWorkerDesiredState).toHaveBeenNthCalledWith(1, AUTO_FIX_WORKER_KIND, 'running');
+    expect(setup.persistence.setWorkerDesiredState).toHaveBeenNthCalledWith(2, AUTO_FIX_WORKER_KIND, 'stopped');
+    expect(setup.controller.snapshot().workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)).toMatchObject({
+      autoStarts: false,
+      lifecycle: 'stopped',
+    });
+  });
+
+  it('stopAll shutdown does not persist desired state', async () => {
+    const setup = controller();
+
+    setup.controller.start(AUTO_FIX_WORKER_KIND);
+    setup.persistence.setWorkerDesiredState.mockClear();
+
+    await setup.controller.stopAll();
+
+    expect(setup.persistence.setWorkerDesiredState).not.toHaveBeenCalled();
+    expect(setup.controller.snapshot().workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)).toMatchObject({
+      autoStarts: true,
+      lifecycle: 'stopped',
+    });
   });
 
   it('duplicate start is idempotent', () => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -393,7 +393,11 @@ function createRegisteredWorkerRegistry(): WorkerRegistry<WorkerRuntimeDependenc
   return registerExternalWorkersFromConfig(invokerConfig.externalWorkers, registry);
 }
 
-
+function resolveDefaultOwnerWorkerAutoStartKinds(): readonly string[] {
+  return invokerConfig.e2eAutoFixEnabled
+    ? [...AUTO_STARTED_OWNER_WORKER_KINDS, E2E_AUTOFIX_WORKER_KIND]
+    : AUTO_STARTED_OWNER_WORKER_KINDS;
+}
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
@@ -1908,9 +1912,7 @@ function startHeadlessMode(): void {
               await createStandaloneTaskExecutor().checkMergeGateStatuses();
             },
           ),
-          autoStartKinds: invokerConfig.e2eAutoFixEnabled
-            ? [...AUTO_STARTED_OWNER_WORKER_KINDS, E2E_AUTOFIX_WORKER_KIND]
-            : AUTO_STARTED_OWNER_WORKER_KINDS,
+          autoStartKinds: resolveDefaultOwnerWorkerAutoStartKinds(),
           persistence,
           autoFixRetries: resolveAutoFixRetries(invokerConfig),
           canControl: () => !readOnlyMode,
@@ -3753,9 +3755,7 @@ function createEmbeddedTerminalBackendFromConfig(
             await requireTaskExecutor().checkMergeGateStatuses();
           },
         ),
-        autoStartKinds: invokerConfig.e2eAutoFixEnabled
-          ? [...AUTO_STARTED_OWNER_WORKER_KINDS, E2E_AUTOFIX_WORKER_KIND]
-          : AUTO_STARTED_OWNER_WORKER_KINDS,
+        autoStartKinds: resolveDefaultOwnerWorkerAutoStartKinds(),
         persistence,
         autoFixRetries: resolveAutoFixRetries(invokerConfig),
         canControl: () => ownerMode,
@@ -4471,13 +4471,13 @@ function createEmbeddedTerminalBackendFromConfig(
         return createLocalWorkerStatusSnapshot({
           registry: createRegisteredWorkerRegistry(),
           persistence,
-          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          autoStartKinds: resolveDefaultOwnerWorkerAutoStartKinds(),
         });
       }
       return workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
         registry: createRegisteredWorkerRegistry(),
         persistence,
-        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+        autoStartKinds: resolveDefaultOwnerWorkerAutoStartKinds(),
       });
     });
 

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -9,7 +9,11 @@ import type {
   WorkerStatusEntry,
   WorkerStatusSnapshot,
 } from '@invoker/contracts';
-import type { SQLiteAdapter, WorkerActionRecord } from '@invoker/data-store';
+import type {
+  SQLiteAdapter,
+  WorkerActionRecord,
+  WorkerDesiredState,
+} from '@invoker/data-store';
 import {
   AUTO_FIX_WORKER_KIND,
   AUTO_APPROVE_WORKER_KIND,
@@ -48,10 +52,15 @@ export interface WorkerRuntimeController {
   snapshot(): WorkerStatusSnapshot;
 }
 
+export type WorkerDesiredStatePersistence = Partial<Pick<
+  SQLiteAdapter,
+  'getWorkerDesiredState' | 'setWorkerDesiredState' | 'listWorkerDesiredStates'
+>>;
+
 type WorkerStatusPersistence = Pick<
   SQLiteAdapter,
   'listWorkerActions' | 'listWorkflows' | 'loadTasks' | 'getEvents' | 'getEventsByTypes' | 'countEventsByTypes'
->;
+> & WorkerDesiredStatePersistence;
 
 const DEFAULT_WORKER_ACTION_HISTORY_LIMIT = 20;
 const MAX_WORKER_ACTION_HISTORY_LIMIT = 100;
@@ -180,6 +189,10 @@ export function createWorkerRuntimeController(options: {
 }): WorkerRuntimeController {
   const handles = new Map<string, RuntimeHandle>();
   const stoppedAtByKind = new Map<string, string>();
+  const desiredStateByKind = loadWorkerDesiredStateMap(
+    options.persistence,
+    options.registry.list().map((definition) => definition.kind),
+  );
 
   const requireDefinition = (kind: string) => {
     const definition = options.registry.get(kind);
@@ -199,9 +212,13 @@ export function createWorkerRuntimeController(options: {
       note: definition.note,
       handle: handles.get(kind),
       stoppedAt: stoppedAtByKind.get(kind),
-      autoStarts: options.autoStartKinds.includes(kind),
       policy: policyForKind(kind),
       persistence: options.persistence,
+      autoStarts: getEffectiveWorkerDesiredState(
+        kind,
+        desiredStateByKind,
+        options.autoStartKinds,
+      ) === 'running',
       canControl: options.canControl(),
       recovery: definition.kind === AUTO_FIX_WORKER_KIND
         ? toWorkerRecoverySummary(options.persistence)
@@ -220,37 +237,58 @@ export function createWorkerRuntimeController(options: {
     handles.delete(kind);
   };
 
+  const setDesiredState = (kind: string, desiredState: WorkerDesiredState, persist: boolean): void => {
+    if (persist) {
+      persistWorkerDesiredState(options.persistence, kind, desiredState);
+    }
+    desiredStateByKind.set(kind, desiredState);
+  };
+
+  const startKind = (kind: string, persistDesiredState: boolean): WorkerStatusEntry => {
+    const definition = requireDefinition(kind);
+    setDesiredState(kind, 'running', persistDesiredState);
+
+    const existing = handles.get(kind);
+    if (existing) {
+      if (existing.runtime.isRunning()) {
+        return rowForKind(kind);
+      }
+      void existing.runtime.stop().catch(() => undefined);
+      handles.delete(kind);
+    }
+
+    const runtime = definition.factory(options.deps);
+    runtime.start();
+    handles.set(kind, {
+      runtime,
+      startedAt: new Date().toISOString(),
+    });
+    stoppedAtByKind.delete(kind);
+    return rowForKind(kind);
+  };
+
   return {
     startAutoStartedWorkers(): void {
-      for (const kind of options.autoStartKinds) {
-        if (!options.registry.get(kind)) continue;
-        this.start(kind);
+      for (const definition of options.registry.list()) {
+        if (
+          getEffectiveWorkerDesiredState(
+            definition.kind,
+            desiredStateByKind,
+            options.autoStartKinds,
+          ) !== 'running'
+        ) {
+          continue;
+        }
+        startKind(definition.kind, false);
       }
     },
 
     start(kind: string): WorkerStatusEntry {
-      const definition = requireDefinition(kind);
-
-      const existing = handles.get(kind);
-      if (existing) {
-        if (existing.runtime.isRunning()) {
-          return rowForKind(kind);
-        }
-        void existing.runtime.stop().catch(() => undefined);
-        handles.delete(kind);
-      }
-
-      const runtime = definition.factory(options.deps);
-      runtime.start();
-      handles.set(kind, {
-        runtime,
-        startedAt: new Date().toISOString(),
-      });
-      stoppedAtByKind.delete(kind);
-      return rowForKind(kind);
+      return startKind(kind, true);
     },
     async stop(kind: string): Promise<WorkerStatusEntry> {
       requireDefinition(kind);
+      setDesiredState(kind, 'stopped', true);
       const handle = handles.get(kind);
       if (!handle) {
         return rowForKind(kind);
@@ -279,6 +317,10 @@ export function createLocalWorkerStatusSnapshot(options: {
   persistence: WorkerStatusPersistence;
   autoStartKinds: readonly string[];
 }): WorkerStatusSnapshot {
+  const desiredStateByKind = loadWorkerDesiredStateMap(
+    options.persistence,
+    options.registry.list().map((definition) => definition.kind),
+  );
   const recovery = options.registry.list().some((definition) => definition.kind === AUTO_FIX_WORKER_KIND)
     ? toWorkerRecoverySummary(options.persistence)
     : undefined;
@@ -287,13 +329,63 @@ export function createLocalWorkerStatusSnapshot(options: {
     workers: options.registry.list().map((definition) => buildWorkerStatusEntry({
       definitionKind: definition.kind,
       note: definition.note,
-      autoStarts: options.autoStartKinds.includes(definition.kind),
+      autoStarts: getEffectiveWorkerDesiredState(
+        definition.kind,
+        desiredStateByKind,
+        options.autoStartKinds,
+      ) === 'running',
       policy: 'unknown',
       persistence: options.persistence,
       canControl: false,
       recovery: definition.kind === AUTO_FIX_WORKER_KIND ? recovery : undefined,
     })),
   };
+}
+
+export function persistWorkerDesiredState(
+  persistence: WorkerDesiredStatePersistence,
+  workerKind: string,
+  desiredState: WorkerDesiredState,
+): void {
+  persistence.setWorkerDesiredState?.(workerKind, desiredState);
+}
+
+function loadWorkerDesiredStateMap(
+  persistence: WorkerDesiredStatePersistence,
+  workerKinds: readonly string[],
+): Map<string, WorkerDesiredState> {
+  const states = new Map<string, WorkerDesiredState>();
+  if (persistence.listWorkerDesiredStates) {
+    for (const state of persistence.listWorkerDesiredStates()) {
+      if (isWorkerDesiredState(state.desiredState)) {
+        states.set(state.workerKind, state.desiredState);
+      }
+    }
+    return states;
+  }
+
+  if (persistence.getWorkerDesiredState) {
+    for (const kind of workerKinds) {
+      const state = persistence.getWorkerDesiredState(kind);
+      if (state && isWorkerDesiredState(state.desiredState)) {
+        states.set(kind, state.desiredState);
+      }
+    }
+  }
+  return states;
+}
+
+function getEffectiveWorkerDesiredState(
+  workerKind: string,
+  desiredStateByKind: ReadonlyMap<string, WorkerDesiredState>,
+  defaultAutoStartKinds: readonly string[],
+): WorkerDesiredState {
+  return desiredStateByKind.get(workerKind)
+    ?? (defaultAutoStartKinds.includes(workerKind) ? 'running' : 'stopped');
+}
+
+function isWorkerDesiredState(value: unknown): value is WorkerDesiredState {
+  return value === 'running' || value === 'stopped';
 }
 
 


### PR DESCRIPTION
Wire the worker runtime controller to persist desired state on explicit
start/stop and to honor persisted desired state on startup restore,
falling back to default auto-start kinds when no preference exists.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #4127