### PR TITLE
Persist Worker Desired State - Runtime Restore Semantics (3) Record desired state from the headless worker command

### DIFF
--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -55,6 +55,7 @@ describe('headless worker autofix', () => {
       _args: unknown[],
       _priority: WorkflowMutationPriority,
     ) => 1);
+    const setWorkerDesiredState = vi.fn();
     const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     // Point the worker lock at a throwaway home so the scan never touches the
     // real Invoker home (the door acquires/releases the cross-process lock).
@@ -87,6 +88,7 @@ describe('headless worker autofix', () => {
           }),
           logEvent: vi.fn(),
           enqueueWorkflowMutationIntent,
+          setWorkerDesiredState,
         },
         invokerConfig: { autoFixRetries: 3, autoFixAgent: 'codex' },
       } as any);
@@ -103,6 +105,7 @@ describe('headless worker autofix', () => {
       ['wf-1/task-1'],
       'normal',
     );
+    expect(setWorkerDesiredState).toHaveBeenCalledWith('autofix', 'running');
   });
 
   it('lists worker kinds from the registry', async () => {

--- a/packages/app/src/__tests__/headless-pr-maintenance.test.ts
+++ b/packages/app/src/__tests__/headless-pr-maintenance.test.ts
@@ -25,12 +25,15 @@ function writeCronScript(repoRoot: string, scriptRelativePath: string, markerNam
 }
 
 /** Minimal headless deps for a one-shot PR-maintenance worker run. */
-function makeWorkerDeps(repoRoot: string, token: string): unknown {
+function makeWorkerDeps(repoRoot: string, token: string) {
   return {
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn(), child: vi.fn() },
     // The PR-maintenance tick never touches the store/submitter; provide a stub
     // so the shared factory-deps construction has something to reference.
-    persistence: { enqueueWorkflowMutationIntent: vi.fn(() => 1) },
+    persistence: {
+      enqueueWorkflowMutationIntent: vi.fn(() => 1),
+      setWorkerDesiredState: vi.fn(),
+    },
     invokerConfig: {
       prMaintenance: {
         enabled: true,
@@ -73,22 +76,32 @@ describe('headless worker PR-maintenance', () => {
 
   it('runs the coderabbit-address worker one-shot with the threaded config', async () => {
     writeCronScript(repoRoot, 'scripts/cron-coderabbit-address.sh', 'coderabbit.marker');
+    const deps = makeWorkerDeps(repoRoot, 'cr-token');
 
-    await runHeadless(['worker', CODERABBIT_ADDRESS_WORKER_KIND], makeWorkerDeps(repoRoot, 'cr-token') as never);
+    await runHeadless(['worker', CODERABBIT_ADDRESS_WORKER_KIND], deps as never);
 
     // Marker written under the threaded repoRoot, carrying the threaded env
     // override — proves the launch config reached the shell entrypoint.
     expect(readFileSync(join(repoRoot, 'coderabbit.marker'), 'utf8')).toBe('cr-token');
     expect(stdout).toContain(`${CODERABBIT_ADDRESS_WORKER_KIND} worker scan completed.`);
+    expect(deps.persistence.setWorkerDesiredState).toHaveBeenCalledWith(
+      CODERABBIT_ADDRESS_WORKER_KIND,
+      'running',
+    );
   });
 
   it('runs the pr-conflict-rebase worker one-shot with the threaded config', async () => {
     writeCronScript(repoRoot, 'scripts/cron-pr-conflict-rebase.sh', 'rebase.marker');
+    const deps = makeWorkerDeps(repoRoot, 'rebase-token');
 
-    await runHeadless(['worker', PR_CONFLICT_REBASE_WORKER_KIND], makeWorkerDeps(repoRoot, 'rebase-token') as never);
+    await runHeadless(['worker', PR_CONFLICT_REBASE_WORKER_KIND], deps as never);
 
     expect(readFileSync(join(repoRoot, 'rebase.marker'), 'utf8')).toBe('rebase-token');
     expect(stdout).toContain(`${PR_CONFLICT_REBASE_WORKER_KIND} worker scan completed.`);
+    expect(deps.persistence.setWorkerDesiredState).toHaveBeenCalledWith(
+      PR_CONFLICT_REBASE_WORKER_KIND,
+      'running',
+    );
   });
 
   it('lists both PR-maintenance worker kinds from the manual entrypoint', async () => {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -41,6 +41,7 @@ import {
 import { LaunchDispatcher } from './launch-dispatcher.js';
 import { formatHeadlessSetSubcommands } from './headless-command-registry.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
+import { persistWorkerDesiredState } from './worker-control.js';
 
 export {
   DEFAULT_DELEGATION_TIMEOUT_MS,
@@ -458,6 +459,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   }
   const autoFixAttemptLedger = createAutoFixAttemptLedger();
   try {
+    persistWorkerDesiredState(deps.persistence, definition.kind, 'running');
     const worker = definition.factory({
       store: deps.persistence,
       submitter: {
@@ -929,4 +931,3 @@ async function headlessSetTaskMetadata(
   );
   process.stdout.write(`Updated task "${result.id}" ${result.fieldPath} → ${JSON.stringify(result.value)}\n`);
 }
-


### PR DESCRIPTION
Have the headless worker entrypoint record a running desired state when
it starts a worker kind, so a later app launch restores that worker
instead of falling back to the default auto-start set.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #4128