### PR TITLE
[Terminal Double-Click Step 2 - Focus Existing Tab](1) Focus existing terminal tab on task double-click

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1407,7 +1407,7 @@ export function App() {
     selectTaskById(task.id);
   }, [selectTaskById]);
 
-  const openTerminalForTaskId = useCallback(async (taskId: string) => {
+  const requestTerminalForTaskId = useCallback(async (taskId: string) => {
     const task = tasks.get(taskId);
     if (task && isExperimentSpawnPivotTask(task)) {
       window.alert(EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE);
@@ -1434,6 +1434,19 @@ export function App() {
       setActiveTerminalSessionId(session.sessionId);
     }
   }, [tasks]);
+
+  const openTerminalForTaskId = useCallback(async (taskId: string) => {
+    const existingRunningSession = terminalSessions.find(
+      (session) => session.taskId === taskId && session.status === 'running',
+    );
+    if (existingRunningSession) {
+      setTerminalDrawerState('partial');
+      setActiveTerminalSessionId(existingRunningSession.sessionId);
+      return;
+    }
+
+    await requestTerminalForTaskId(taskId);
+  }, [requestTerminalForTaskId, terminalSessions]);
 
   const handleTaskDoubleClick = useCallback(async (task: TaskState) => {
     setSelectedTaskId(task.id);
@@ -1607,9 +1620,9 @@ export function App() {
   const handleOpenTerminal = useCallback(
     (taskId: string) => {
       setContextMenu(null);
-      void openTerminalForTaskId(taskId);
+      void requestTerminalForTaskId(taskId);
     },
-    [openTerminalForTaskId],
+    [requestTerminalForTaskId],
   );
 
   const handleCloseTerminalSession = useCallback(async (sessionId: string) => {
@@ -3451,4 +3464,3 @@ export function App() {
     </div>
   );
 }
-

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -6,7 +6,7 @@
  *   - the drawer has three explicit states: minimized, partial, maximized
  *   - opening a terminal puts the drawer in the partial state
  *   - the single cycling button advances minimized → partial → maximized → minimized
- *   - the same task id reuses a single tab
+ *   - the same task id reuses and focuses a single tab without another IPC call
  *   - failures from openTerminal surface as an alert
  */
 
@@ -228,9 +228,9 @@ describe('Terminal drawer (component)', () => {
     expect(screen.getByTestId('terminal-pane-task-alpha')).toHaveClass('overflow-hidden');
   });
 
-  it('reuses an existing tab when opening the same task twice', async () => {
+  it('focuses an existing running tab when double-clicking the same task again', async () => {
     render(<App />);
-    act(() => mock.setTasks([taskAlpha], workflows));
+    act(() => mock.setTasks([taskAlpha, taskBeta], workflows));
     await selectWorkflow();
 
     fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
@@ -238,8 +238,14 @@ describe('Terminal drawer (component)', () => {
       expect(screen.getByTestId('terminal-tab-task-alpha')).toBeInTheDocument();
     });
 
-    // Minimize (cycle partial → maximized → minimized), then re-open —
-    // should not duplicate the tab.
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-beta'));
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-tab-task-beta')).toHaveAttribute('data-active', 'true');
+    });
+    expect(mock.api.openTerminal).toHaveBeenCalledTimes(2);
+
+    // Minimize (cycle partial → maximized → minimized), then re-open alpha.
+    // The existing alpha tab should be selected without another open-terminal IPC call.
     fireEvent.click(screen.getByRole('button', { name: 'Maximize terminal drawer' }));
     fireEvent.click(screen.getByRole('button', { name: 'Minimize terminal drawer' }));
     expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'minimized');
@@ -248,9 +254,16 @@ describe('Terminal drawer (component)', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
+      expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
     });
     const tabs = screen.getAllByTestId('terminal-tab-task-alpha');
     expect(tabs).toHaveLength(1);
+    expect(screen.getByTestId('terminal-tab-task-beta')).toHaveAttribute('data-active', 'false');
+    expect(mock.api.openTerminal).toHaveBeenCalledTimes(2);
+    expect((mock.api.openTerminal as ReturnType<typeof vi.fn>).mock.calls.map(([taskId]) => taskId)).toEqual([
+      'task-alpha',
+      'task-beta',
+    ]);
   });
 
   it('renders distinct tabs for different tasks side by side', async () => {
@@ -325,6 +338,29 @@ describe('Terminal drawer (component)', () => {
     expect(mock.api.openTerminal).toHaveBeenCalledWith('task-alpha');
   });
 
+  it('keeps the context-menu Open Terminal action routed through open-terminal IPC', async () => {
+    render(<App />);
+    act(() => mock.setTasks([taskAlpha], workflows));
+    await selectWorkflow();
+
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-tab-task-alpha')).toBeInTheDocument();
+    });
+
+    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+    const openTerminalItem = await screen.findByRole('menuitem', { name: /Open Terminal/i });
+    fireEvent.click(openTerminalItem);
+
+    await waitFor(() => {
+      expect(mock.api.openTerminal).toHaveBeenCalledTimes(2);
+    });
+    expect((mock.api.openTerminal as ReturnType<typeof vi.fn>).mock.calls.map(([taskId]) => taskId)).toEqual([
+      'task-alpha',
+      'task-alpha',
+    ]);
+  });
+
   it('seeds the replay snapshot before live terminal output', async () => {
     const session = makeTerminalSession('task-alpha', {
       outputSnapshot: 'early line\n',
@@ -361,24 +397,31 @@ describe('Terminal drawer (component)', () => {
     const session = makeTerminalSession('task-alpha', {
       outputSnapshot: 'replayed once\n',
     });
-    (mock.api.openTerminal as ReturnType<typeof vi.fn>).mockResolvedValue({
-      opened: true,
-      session,
-    });
 
-    render(<App />);
-    act(() => mock.setTasks([taskAlpha], workflows));
-    await selectWorkflow();
-
-    fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
+    const { rerender } = render(
+      <TerminalDrawer
+        state="partial"
+        onCycle={vi.fn()}
+        sessions={[session]}
+        activeSessionId={session.sessionId}
+        onSelectSession={vi.fn()}
+        onCloseSession={vi.fn()}
+      />,
+    );
     await waitFor(() => {
       expect(xtermMock.writeLog).toEqual(['replayed once\n']);
     });
 
-    fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
-    await waitFor(() => {
-      expect(mock.api.openTerminal).toHaveBeenCalledTimes(2);
-    });
+    rerender(
+      <TerminalDrawer
+        state="partial"
+        onCycle={vi.fn()}
+        sessions={[{ ...session }]}
+        activeSessionId={session.sessionId}
+        onSelectSession={vi.fn()}
+        onCloseSession={vi.fn()}
+      />,
+    );
 
     expect(xtermMock.writeLog).toEqual(['replayed once\n']);
   });


### PR DESCRIPTION
## Summary

Double-clicking a task that already has a running terminal now focuses its open tab instead of opening a second terminal for the same task.

Before, every double-click asked the backend for a new terminal, so a task could gain a fresh tab each time you reopened it.

The context-menu Open Terminal action is unchanged and still always asks the backend for a fresh terminal.

## Review Claim

Approve that a task double-click focuses the existing running terminal tab for that task, and only asks for a new terminal when that task has no open tab.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change only affects the task double-click handler in the terminal drawer surface. When no open tab matches the task, it falls back to the previous open-terminal path, so first-open behavior is unchanged.

## Slice Rationale

This slice carries the behavior change together with the terminal-drawer tests that pin it, since those tests directly drive the new double-click path and would fail if it were absent.

## Non-goals

- The context-menu Open Terminal action is not changed; it still asks for a fresh terminal on every use.
- Terminal creation, replay, and teardown are not changed.
- No restyling of the drawer, tabs, or task graph.

## Architecture

### Before

A task double-click always called the open-terminal path, which asked the backend to start a terminal and add a tab, even when a running tab for that task was already open.

### After

The double-click handler first looks for an open running tab that belongs to the task. If it finds one, it activates that tab and puts the drawer in its partial state. Otherwise it falls back to the original open-terminal path.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test`

</details>

## Visual Proof

This is an event-driven focus behavior: on double-click, an existing running terminal tab becomes active instead of a second tab being created. A single static screenshot cannot distinguish "focused the existing tab" from "opened a new one," so the authoritative proof is the deterministic component test in `packages/ui/src/__tests__/terminal-drawer.test.tsx`, which asserts that the second double-click keeps one tab, marks it active (`data-active="true"`), and issues no extra open-terminal IPC call. Playwright/Electron capture is not provisioned in this merge-clone gate, so no recorded media is attached.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reopening a task with a running terminal now focuses and reuses the existing terminal tab instead of opening another session.
  * Context-menu actions continue to open terminals through the standard terminal workflow.

* **Bug Fixes**
  * Prevented duplicate terminal sessions and repeated replayed terminal output when revisiting or re-rendering an existing session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->