### PR TITLE
[PR maintenance workers Step 6: Add local headless query workers support](1) Add local query workers command surface

### DIFF
--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -1,19 +1,25 @@
 /**
  * Headless "query" command family: the read-only `query <sub>` router
  * (workflows · tasks · task · queue · review-gate · action-graph · audit ·
- * session · worker-actions · cost · cost-events · costs · ui-perf · stats), the cost-event
- * collection/rollup
- * helpers, agent session resolution, and `query-select`.
+ * session · workers · worker-actions · cost · cost-events · costs · ui-perf ·
+ * stats), the cost-event collection/rollup helpers, agent session resolution,
+ * and `query-select`.
  *
  * The deprecated top-level aliases (`list`, `status`, `task-status`, `queue`,
  * `audit`, `session`) route here through the `headless.ts` router. It depends on
- * `headless-shared.ts` and reuses `worker-control.ts` for the worker-decisions view.
+ * `headless-shared.ts` and reuses `worker-control.ts` for worker status/decisions.
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Attempt, TaskState } from '@invoker/workflow-core';
-import type { AgentSessionData, NormalizedCostEvent } from '@invoker/contracts';
-import type { AgentRegistry } from '@invoker/execution-engine';
+import type { AgentSessionData, NormalizedCostEvent, WorkerStatusSnapshot } from '@invoker/contracts';
+import {
+  createWorkerRegistry,
+  E2E_AUTOFIX_WORKER_KIND,
+  registerBuiltinWorkers,
+  type AgentRegistry,
+  type WorkerRuntimeDependencies,
+} from '@invoker/execution-engine';
 import type { CostGroupDimension } from './cost-rollup.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import {
@@ -26,7 +32,12 @@ import {
 } from './headless-shared.js';
 import { resolveDefaultExecutionAgent } from './config.js';
 import { loadAllEventsPaged } from './load-all-events-paged.js';
-import { listWorkerDecisions } from './worker-control.js';
+import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
+import {
+  AUTO_STARTED_OWNER_WORKER_KINDS,
+  createLocalWorkerStatusSnapshot,
+  listWorkerDecisions,
+} from './worker-control.js';
 import {
   collectRecoveryWorkerStatus,
   type RecoveryWorkerStatus,
@@ -62,7 +73,7 @@ export type HeadlessQueryDeps = Pick<
 export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Promise<void> {
   const subCommand = args[0];
   if (!subCommand) {
-    throw new Error('Missing query sub-command. Usage: --headless query <workflows|workflow|tasks|task|queue|review-gate|action-graph|audit|session|worker-actions|worker-decisions|cost|cost-events|costs|ui-perf|stats>');
+    throw new Error('Missing query sub-command. Usage: --headless query <workflows|workflow|tasks|task|queue|review-gate|action-graph|audit|session|workers|worker-actions|worker-decisions|cost|cost-events|costs|ui-perf|stats>');
   }
   const flags = parseQueryFlags(args.slice(1));
 
@@ -253,6 +264,24 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
       await headlessSession(taskId, deps);
       break;
     }
+    case 'workers': {
+      const snapshot = createReadOnlyWorkerStatusSnapshot(deps);
+      switch (flags.output) {
+        case 'label':
+          writeOut(snapshot.workers.map((worker) => worker.kind).join('\n') + '\n');
+          break;
+        case 'json':
+          writeOut(formatAsJson(snapshot) + '\n');
+          break;
+        case 'jsonl':
+          writeOut(formatAsJsonl(snapshot.workers.map((worker) => ({ generatedAt: snapshot.generatedAt, ...worker }))) + '\n');
+          break;
+        default:
+          writeOut(formatWorkerStatusSnapshot(snapshot) + '\n');
+          break;
+      }
+      break;
+    }
     case 'worker-actions': {
       const workflowFilter = flags.workflow ?? flags.positional[0];
       const actions = deps.persistence.listWorkerActions({
@@ -380,7 +409,7 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
       break;
     }
     default:
-      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, workflow, tasks, task, queue, review-gate, action-graph, audit, session, worker-actions, cost, cost-events, costs, ui-perf, stats`);
+      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, workflow, tasks, task, queue, review-gate, action-graph, audit, session, workers, worker-actions, worker-decisions, cost, cost-events, costs, ui-perf, stats`);
   }
 }
 
@@ -761,6 +790,39 @@ export async function headlessSession(taskId: string | undefined, deps: Pick<Hea
   for (const msg of result.messages) {
     writeOut(`[${msg.role}] ${msg.content}\n`);
   }
+}
+
+function createReadOnlyWorkerStatusSnapshot(
+  deps: Pick<HeadlessQueryDeps, 'persistence' | 'invokerConfig'>,
+): WorkerStatusSnapshot {
+  const registry = registerExternalWorkersFromConfig(
+    deps.invokerConfig.externalWorkers,
+    registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
+  );
+  const autoStartKinds = deps.invokerConfig.e2eAutoFixEnabled
+    ? [...AUTO_STARTED_OWNER_WORKER_KINDS, E2E_AUTOFIX_WORKER_KIND]
+    : AUTO_STARTED_OWNER_WORKER_KINDS;
+  return createLocalWorkerStatusSnapshot({
+    registry,
+    persistence: deps.persistence,
+    autoStartKinds,
+  });
+}
+
+function formatWorkerStatusSnapshot(snapshot: WorkerStatusSnapshot): string {
+  const lines = [
+    `${BOLD}Workers${RESET} (${snapshot.workers.length})`,
+    `  generatedAt: ${snapshot.generatedAt}`,
+  ];
+  for (const worker of snapshot.workers) {
+    const activeActions = worker.recentActions.filter((action) => (
+      action.status === 'queued' || action.status === 'running'
+    )).length;
+    lines.push(
+      `  ${worker.kind}: lifecycle=${worker.lifecycle} policy=${worker.policy} autoStarts=${worker.autoStarts ? 'yes' : 'no'} activeActions=${activeActions}`,
+    );
+  }
+  return lines.join('\n');
 }
 
 function formatRecoveryWorkerStatus(status: RecoveryWorkerStatus): string {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -178,6 +178,7 @@ import {
   wireHeadlessApproveHook,
   type HeadlessDeps,
 } from './headless.js';
+import { headlessQuery, type HeadlessQueryDeps } from './headless-query-list.js';
 import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
 import {
   startStandaloneLaunchDispatcher,
@@ -993,6 +994,28 @@ const YELLOW = '\x1b[33m';
 // HEADLESS MODE
 // ══════════════════════════════════════════════════════════════
 
+function isDatabaseFreeWorkersQuery(args: readonly string[]): boolean {
+  return args[0] === 'query' && args[1] === 'workers';
+}
+
+async function runDatabaseFreeWorkersQuery(args: string[]): Promise<void> {
+  const emptyWorkerQueryDeps: HeadlessQueryDeps = {
+    persistence: {
+      listWorkerActions: () => [],
+      listWorkflows: () => [],
+      loadTasks: () => [],
+      countEventsByTypes: () => [],
+      getEventsByTypes: () => [],
+    } as unknown as HeadlessQueryDeps['persistence'],
+    orchestrator: {} as HeadlessQueryDeps['orchestrator'],
+    executionAgentRegistry: undefined,
+    invokerConfig,
+    getUiPerfStats: () => ({}),
+    resetUiPerfStats: () => {},
+  };
+  await headlessQuery(args.slice(1), emptyWorkerQueryDeps);
+}
+
 function startHeadlessMode(): void {
   const runHeadlessMain = async (): Promise<void> => {
     const agentRegistry = registerBuiltinAgents();
@@ -1073,6 +1096,12 @@ function startHeadlessMode(): void {
         process.exit(1);
         return;
       }
+    }
+
+    if (isDatabaseFreeWorkersQuery(cliArgs) && !existsSync(path.join(resolveInvokerHomeRoot(), 'invoker.db'))) {
+      await runDatabaseFreeWorkersQuery(cliArgs);
+      process.exit(0);
+      return;
     }
 
     let exitCode = 0;

--- a/packages/execution-engine/src/omp-session-driver.ts
+++ b/packages/execution-engine/src/omp-session-driver.ts
@@ -4,11 +4,19 @@ import { homedir } from 'node:os';
 import type { AgentMessage } from './codex-session.js';
 import type { AgentSessionInspection, SessionDriver } from './session-driver.js';
 
+const DEFAULT_MAX_STORED_OMP_SESSION_BYTES = 5 * 1024 * 1024;
+
 export class OmpSessionDriver implements SessionDriver {
   processOutput(sessionId: string, rawStdout: string): string {
     const dir = this.getStorageDir();
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, `${sessionId}.omp.txt`), rawStdout);
+    const filePath = join(dir, `${sessionId}.omp.txt`);
+    try {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(filePath, truncateStoredOmpSession(rawStdout));
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      console.warn(`[OmpSessionDriver] failed to store session transcript "${filePath}": ${reason}`);
+    }
     return rawStdout;
   }
 
@@ -32,4 +40,44 @@ export class OmpSessionDriver implements SessionDriver {
     const base = process.env.INVOKER_DB_DIR || join(homedir(), '.invoker');
     return join(base, 'agent-sessions');
   }
+}
+
+function truncateStoredOmpSession(raw: string): string {
+  const maxBytes = resolveMaxStoredOmpSessionBytes();
+  if (maxBytes <= 0) return raw;
+
+  if (Buffer.byteLength(raw, 'utf8') <= maxBytes) return raw;
+
+  const marker = '\n\n[Invoker truncated stored OMP session output]\n\n';
+  const markerBytes = Buffer.byteLength(marker, 'utf8');
+  if (markerBytes >= maxBytes) return trimUtf8ToByteLimit(marker, maxBytes);
+
+  let keepChars = Math.max(0, maxBytes - markerBytes);
+  let stored = buildStoredOmpSession(raw, marker, keepChars);
+  let overflow = Buffer.byteLength(stored, 'utf8') - maxBytes;
+  while (overflow > 0 && keepChars > 0) {
+    keepChars = Math.max(0, keepChars - Math.max(1, Math.ceil(overflow / 2)));
+    stored = buildStoredOmpSession(raw, marker, keepChars);
+    overflow = Buffer.byteLength(stored, 'utf8') - maxBytes;
+  }
+  return stored;
+}
+
+function buildStoredOmpSession(raw: string, marker: string, keepChars: number): string {
+  const headChars = Math.floor(keepChars / 2);
+  const tailChars = keepChars - headChars;
+  return `${raw.slice(0, headChars)}${marker}${tailChars > 0 ? raw.slice(-tailChars) : ''}`;
+}
+
+function trimUtf8ToByteLimit(value: string, maxBytes: number): string {
+  if (maxBytes <= 0) return '';
+  return Buffer.from(value, 'utf8').subarray(0, maxBytes).toString('utf8');
+}
+
+function resolveMaxStoredOmpSessionBytes(): number {
+  const raw = process.env.INVOKER_MAX_STORED_OMP_SESSION_BYTES?.trim();
+  if (!raw) return DEFAULT_MAX_STORED_OMP_SESSION_BYTES;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_MAX_STORED_OMP_SESSION_BYTES;
+  return parsed;
 }


### PR DESCRIPTION
## Summary

Invoker owners can now run `query workers` on the headless command surface and get the current worker fleet snapshot back.

The command works even before a workflow database exists, so a fresh owner host can report worker status right away.

This slice also caps how much worker session transcript gets stored on disk and keeps task output processing working when that write fails.

## Review Claim

Approve exposing a headless `query workers` command that renders the existing worker fleet snapshot.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The command only reads the existing worker snapshot helper and adds one new headless branch; it does not change how workers start or how owners are chosen.

## Slice Rationale

The command surface is kept in its own slice so the worker-status output can be reviewed on its own, ahead of the focused proof that follows.

## Non-goals

- No change to delegated-owner routing or worker startup policy.
- No new test coverage in this slice; the focused proof lands next.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `./run.sh --headless query workers --output json`
- [ ] `pnpm --filter @invoker/app test headless-query-list`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
