### PR TITLE
[PR maintenance workers Step 6: Add local headless query workers support](2) Prove local query workers via focused tests

### DIFF
--- a/packages/app/src/__tests__/headless-query-list.test.ts
+++ b/packages/app/src/__tests__/headless-query-list.test.ts
@@ -147,3 +147,40 @@ describe('headless query worker-decisions', () => {
     ).rejects.toThrow('Invalid --decision');
   });
 });
+
+describe('headless query workers', () => {
+  it('renders the local worker fleet snapshot as JSON', async () => {
+    const output = await runReadOnlyHeadlessQueryToString(
+      ['query', 'workers', '--output', 'json'],
+      {
+        persistence: {
+          listWorkerActions: (filters?: unknown) => {
+            const workerKind = (filters as { workerKind?: string } | undefined)?.workerKind;
+            return workerKind === 'autofix' ? workerActions : [];
+          },
+          listWorkflows: () => [],
+          loadTasks: () => [],
+          countEventsByTypes: () => [],
+          getEventsByTypes: () => [],
+        } as unknown as HeadlessQueryDeps['persistence'],
+        orchestrator: {} as unknown as HeadlessQueryDeps['orchestrator'],
+        executionAgentRegistry: undefined,
+        invokerConfig: {} as unknown as HeadlessQueryDeps['invokerConfig'],
+        getUiPerfStats: () => ({}),
+        resetUiPerfStats: () => {},
+      },
+    );
+
+    const parsed = JSON.parse(output) as {
+      generatedAt?: string;
+      workers?: Array<{ kind?: string; lifecycle?: string; policy?: string; recentActions?: unknown[] }>;
+    };
+    expect(typeof parsed.generatedAt).toBe('string');
+    expect(parsed.workers?.length).toBeGreaterThan(0);
+    expect(parsed.workers?.find((worker) => worker.kind === 'autofix')).toMatchObject({
+      lifecycle: 'stopped',
+      policy: 'unknown',
+      recentActions: [expect.objectContaining({ id: 'wa-1' })],
+    });
+  });
+});

--- a/packages/execution-engine/src/__tests__/omp-session-driver.test.ts
+++ b/packages/execution-engine/src/__tests__/omp-session-driver.test.ts
@@ -1,14 +1,22 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { OmpSessionDriver } from '../omp-session-driver.js';
 
 const originalDbDir = process.env.INVOKER_DB_DIR;
+const originalMaxStoredSessionBytes = process.env.INVOKER_MAX_STORED_OMP_SESSION_BYTES;
 
 afterEach(() => {
-  process.env.INVOKER_DB_DIR = originalDbDir;
+  restoreEnv('INVOKER_DB_DIR', originalDbDir);
+  restoreEnv('INVOKER_MAX_STORED_OMP_SESSION_BYTES', originalMaxStoredSessionBytes);
+  vi.restoreAllMocks();
 });
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
 
 describe('OmpSessionDriver', () => {
   it('stores raw stdout and returns it as readable text', () => {
@@ -31,5 +39,41 @@ describe('OmpSessionDriver', () => {
     const driver = new OmpSessionDriver();
     expect(driver.parseSession('')).toEqual([]);
     expect(driver.inspectSession('')).toEqual({ state: 'error', reason: 'Empty OMP session output' });
+  });
+
+  it('does not fail task output processing when session transcript storage fails', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omp-session-driver-unwritable-'));
+    const dbRootFile = join(dir, 'db-root-file');
+    process.env.INVOKER_DB_DIR = dbRootFile;
+    writeFileSync(dbRootFile, 'not a directory');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const driver = new OmpSessionDriver();
+      const raw = 'OMP answer text';
+
+      expect(driver.processOutput('session-1', raw)).toBe(raw);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('failed to store session transcript'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('caps stored OMP transcripts while keeping process output unchanged', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omp-session-driver-truncate-'));
+    process.env.INVOKER_DB_DIR = dir;
+    process.env.INVOKER_MAX_STORED_OMP_SESSION_BYTES = '120';
+    try {
+      const driver = new OmpSessionDriver();
+      const raw = `${'a'.repeat(100)}${'b'.repeat(100)}`;
+
+      expect(driver.processOutput('session-1', raw)).toBe(raw);
+      const stored = readFileSync(join(dir, 'agent-sessions', 'session-1.omp.txt'), 'utf-8');
+      expect(Buffer.byteLength(stored, 'utf8')).toBeLessThanOrEqual(120);
+      expect(stored).toContain('Invoker truncated stored OMP session output');
+      expect(stored).toContain('aaa');
+      expect(stored).toContain('bbb');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

This change proves the new `query workers` command with focused tests, without touching any production code.

One test runs the local command and checks it renders the worker fleet snapshot as JSON.

Another test confirms task output processing keeps working when storing a worker session transcript fails.

## Review Claim

Approve the focused tests that prove the local `query workers` command and the worker-transcript storage safeguard.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice adds test files only and changes no production code, so it cannot alter runtime behavior.

## Slice Rationale

The proof is kept in its own slice so a failure points straight at the new command and the storage safeguard, separate from the behavior change below it.

## Non-goals

- No production code changes.
- No change to worker startup policy or delegated-owner routing.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test headless-query-list`
- [ ] `pnpm --filter @invoker/execution-engine test omp-session-driver`
- [ ] `./run.sh --headless query workers --output json`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4132
