### PR TITLE
[PR maintenance workers Step 6: Add local headless query workers support](2) Harden omp session transcript storage

### DIFF
--- a/packages/execution-engine/src/__tests__/omp-session-driver.test.ts
+++ b/packages/execution-engine/src/__tests__/omp-session-driver.test.ts
@@ -1,14 +1,22 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { OmpSessionDriver } from '../omp-session-driver.js';
 
 const originalDbDir = process.env.INVOKER_DB_DIR;
+const originalMaxStoredSessionBytes = process.env.INVOKER_MAX_STORED_OMP_SESSION_BYTES;
 
 afterEach(() => {
-  process.env.INVOKER_DB_DIR = originalDbDir;
+  restoreEnv('INVOKER_DB_DIR', originalDbDir);
+  restoreEnv('INVOKER_MAX_STORED_OMP_SESSION_BYTES', originalMaxStoredSessionBytes);
+  vi.restoreAllMocks();
 });
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
 
 describe('OmpSessionDriver', () => {
   it('stores raw stdout and returns it as readable text', () => {
@@ -31,5 +39,41 @@ describe('OmpSessionDriver', () => {
     const driver = new OmpSessionDriver();
     expect(driver.parseSession('')).toEqual([]);
     expect(driver.inspectSession('')).toEqual({ state: 'error', reason: 'Empty OMP session output' });
+  });
+
+  it('does not fail task output processing when session transcript storage fails', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omp-session-driver-unwritable-'));
+    const dbRootFile = join(dir, 'db-root-file');
+    process.env.INVOKER_DB_DIR = dbRootFile;
+    writeFileSync(dbRootFile, 'not a directory');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const driver = new OmpSessionDriver();
+      const raw = 'OMP answer text';
+
+      expect(driver.processOutput('session-1', raw)).toBe(raw);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('failed to store session transcript'));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('caps stored OMP transcripts while keeping process output unchanged', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omp-session-driver-truncate-'));
+    process.env.INVOKER_DB_DIR = dir;
+    process.env.INVOKER_MAX_STORED_OMP_SESSION_BYTES = '120';
+    try {
+      const driver = new OmpSessionDriver();
+      const raw = `${'a'.repeat(100)}${'b'.repeat(100)}`;
+
+      expect(driver.processOutput('session-1', raw)).toBe(raw);
+      const stored = readFileSync(join(dir, 'agent-sessions', 'session-1.omp.txt'), 'utf-8');
+      expect(Buffer.byteLength(stored, 'utf8')).toBeLessThanOrEqual(120);
+      expect(stored).toContain('Invoker truncated stored OMP session output');
+      expect(stored).toContain('aaa');
+      expect(stored).toContain('bbb');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/execution-engine/src/omp-session-driver.ts
+++ b/packages/execution-engine/src/omp-session-driver.ts
@@ -4,11 +4,19 @@ import { homedir } from 'node:os';
 import type { AgentMessage } from './codex-session.js';
 import type { AgentSessionInspection, SessionDriver } from './session-driver.js';
 
+const DEFAULT_MAX_STORED_OMP_SESSION_BYTES = 5 * 1024 * 1024;
+
 export class OmpSessionDriver implements SessionDriver {
   processOutput(sessionId: string, rawStdout: string): string {
     const dir = this.getStorageDir();
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, `${sessionId}.omp.txt`), rawStdout);
+    const filePath = join(dir, `${sessionId}.omp.txt`);
+    try {
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(filePath, truncateStoredOmpSession(rawStdout));
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      console.warn(`[OmpSessionDriver] failed to store session transcript "${filePath}": ${reason}`);
+    }
     return rawStdout;
   }
 
@@ -32,4 +40,44 @@ export class OmpSessionDriver implements SessionDriver {
     const base = process.env.INVOKER_DB_DIR || join(homedir(), '.invoker');
     return join(base, 'agent-sessions');
   }
+}
+
+function truncateStoredOmpSession(raw: string): string {
+  const maxBytes = resolveMaxStoredOmpSessionBytes();
+  if (maxBytes <= 0) return raw;
+
+  if (Buffer.byteLength(raw, 'utf8') <= maxBytes) return raw;
+
+  const marker = '\n\n[Invoker truncated stored OMP session output]\n\n';
+  const markerBytes = Buffer.byteLength(marker, 'utf8');
+  if (markerBytes >= maxBytes) return trimUtf8ToByteLimit(marker, maxBytes);
+
+  let keepChars = Math.max(0, maxBytes - markerBytes);
+  let stored = buildStoredOmpSession(raw, marker, keepChars);
+  let overflow = Buffer.byteLength(stored, 'utf8') - maxBytes;
+  while (overflow > 0 && keepChars > 0) {
+    keepChars = Math.max(0, keepChars - Math.max(1, Math.ceil(overflow / 2)));
+    stored = buildStoredOmpSession(raw, marker, keepChars);
+    overflow = Buffer.byteLength(stored, 'utf8') - maxBytes;
+  }
+  return stored;
+}
+
+function buildStoredOmpSession(raw: string, marker: string, keepChars: number): string {
+  const headChars = Math.floor(keepChars / 2);
+  const tailChars = keepChars - headChars;
+  return `${raw.slice(0, headChars)}${marker}${tailChars > 0 ? raw.slice(-tailChars) : ''}`;
+}
+
+function trimUtf8ToByteLimit(value: string, maxBytes: number): string {
+  if (maxBytes <= 0) return '';
+  return Buffer.from(value, 'utf8').subarray(0, maxBytes).toString('utf8');
+}
+
+function resolveMaxStoredOmpSessionBytes(): number {
+  const raw = process.env.INVOKER_MAX_STORED_OMP_SESSION_BYTES?.trim();
+  if (!raw) return DEFAULT_MAX_STORED_OMP_SESSION_BYTES;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_MAX_STORED_OMP_SESSION_BYTES;
+  return parsed;
 }


### PR DESCRIPTION
## Summary

Storing an agent's session transcript can no longer break a task's output handling.

If the transcript file cannot be written, the driver logs the error with context and keeps processing the task result.

Very large transcripts are now capped to a configurable byte budget before they are saved, so one huge session cannot fill the disk.

## Review Claim

The omp session driver stores transcripts defensively: write failures are logged and non-fatal, and oversized transcripts are truncated.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the transcript-storage helper changes; task result parsing and every other session-driver code path keep their current behavior.

## Slice Rationale

This slice isolates the session-transcript storage hardening so it can be reviewed apart from the worker query change stacked below it.

## Non-goals

This slice does not change worker startup policy, the query command surface, or how transcripts are consumed downstream.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && npx vitest run src/__tests__/omp-session-driver.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
