### PR TITLE
(1)[Launch Defer Park] Prove capacity-defer re-dispatch churn

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -2345,6 +2345,42 @@ describe('Orchestrator', () => {
       });
     });
 
+    // Regression proof for the capacity-defer churn. A task deferred because its
+    // execution pool has no member capacity (`reason: 'resource-limit'`) is reset to
+    // pending and re-dispatched on the very next scheduler poll, defer-looping every
+    // ~4s (hundreds of abandoned `task deferred` launch-dispatch rows in production).
+    // Desired behavior: it waits in line until a slot frees or its backoff elapses.
+    // Marked `it.fails` because the fix does not exist yet; the fix slice flips it to
+    // a passing `it` (plus slot-free / backoff-elapsed coverage).
+    it.fails('parks a resource-limit deferred task instead of re-dispatching it every poll', () => {
+      const parkOrchestrator = new Orchestrator({
+        persistence,
+        messageBus: bus,
+        logger: consoleLogger,
+        maxConcurrency: 3,
+        deferRunningUntilLaunch: true,
+      });
+      parkOrchestrator.loadPlan({
+        name: 'defer-park',
+        tasks: [{ id: 'task-a', description: 'Task A' }],
+      });
+      const firstStarted = parkOrchestrator.startExecution();
+      expect(firstStarted).toHaveLength(1);
+      const taskId = firstStarted[0].id;
+
+      parkOrchestrator.deferTask(taskId, {
+        reason: 'resource-limit',
+        message: 'Execution pool "pnpm-ssh" has no member capacity available',
+        attemptId: parkOrchestrator.getTask(taskId)!.execution.selectedAttemptId,
+        phase: 'launching',
+      });
+      expect(parkOrchestrator.getTask(taskId)!.status).toBe('pending');
+
+      // The next scheduler poll must leave the parked task in line, not re-dispatch it.
+      const restarted = parkOrchestrator.startExecution();
+      expect(restarted.map((t) => t.id)).not.toContain(taskId);
+    });
+
     it('clears deferred set on restartTask', () => {
       orchestrator.loadPlan({
         name: 'defer-restart-test',

--- a/scripts/repro/repro-launch-defer-park.sh
+++ b/scripts/repro/repro-launch-defer-park.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repro: a task deferred because its execution pool has no member capacity
+# (`reason: 'resource-limit'`) must wait in line and heartbeat instead of being
+# reset + re-dispatched on every ~4s scheduler poll. The unfixed defer/abandon
+# loop reset the task to pending, minted a fresh attempt, and abandoned the
+# launch-dispatch row with `task deferred` on every poll — hundreds of abandoned
+# rows per task in production while the SSH pool was momentarily full.
+#
+# Runs the focused workflow-core regression. On the unfixed tree the parked-defer
+# spec is marked `it.fails` (the task IS re-dispatched immediately); the fix slice
+# flips it to a passing `it` plus slot-free / backoff-elapsed coverage.
+
+ROOT="${ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+cd "$ROOT"
+
+pnpm --filter @invoker/workflow-core exec vitest run \
+  src/__tests__/orchestrator-gates-and-workflow-admin.test.ts \
+  -t "resource-limit"


### PR DESCRIPTION
## Summary

When an execution pool has no free member, a task deferred with `reason: 'resource-limit'` was reset to pending and re-dispatched on the very next scheduler poll.

That defer/re-dispatch ran every ~4 seconds, abandoning a fresh `task deferred` launch-dispatch row each time — hundreds per task while a pool was briefly full.

This slice only proves that churn. It adds a focused workflow-core spec plus a repro script; no production behavior changes here.

## Review Claim

The added spec and repro faithfully capture the capacity-defer re-dispatch churn, and stay green on the unfixed tree.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

No production code changes. The spec is marked `it.fails`, so on the unfixed tree it passes precisely because the desired parked behavior does not yet hold. CI stays green.

## Slice Rationale

Proof lands before the fix so the bug is demonstrated first. The fix slice `(2)` flips this `it.fails` to a passing `it` and adds slot-free / backoff-elapsed coverage.

## Non-goals

- No change to `Orchestrator` scheduling or defer behavior.
- No change to SSH pool member selection or pinning.
- No UI changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-launch-defer-park.sh`
- [ ] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
