### PR TITLE
(2)[Launch Defer Park] Park capacity-defers with backoff + heartbeat

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -2345,20 +2345,14 @@ describe('Orchestrator', () => {
       });
     });
 
-    // Regression proof for the capacity-defer churn. A task deferred because its
-    // execution pool has no member capacity (`reason: 'resource-limit'`) is reset to
-    // pending and re-dispatched on the very next scheduler poll, defer-looping every
-    // ~4s (hundreds of abandoned `task deferred` launch-dispatch rows in production).
-    // Desired behavior: it waits in line until a slot frees or its backoff elapses.
-    // Marked `it.fails` because the fix does not exist yet; the fix slice flips it to
-    // a passing `it` (plus slot-free / backoff-elapsed coverage).
-    it.fails('parks a resource-limit deferred task instead of re-dispatching it every poll', () => {
+    it('parks a resource-limit deferred task instead of re-dispatching it every poll', () => {
       const parkOrchestrator = new Orchestrator({
         persistence,
         messageBus: bus,
         logger: consoleLogger,
         maxConcurrency: 3,
         deferRunningUntilLaunch: true,
+        launchDeferralBackoffMs: 60_000,
       });
       parkOrchestrator.loadPlan({
         name: 'defer-park',
@@ -2379,6 +2373,74 @@ describe('Orchestrator', () => {
       // The next scheduler poll must leave the parked task in line, not re-dispatch it.
       const restarted = parkOrchestrator.startExecution();
       expect(restarted.map((t) => t.id)).not.toContain(taskId);
+      expect(parkOrchestrator.getTask(taskId)!.status).toBe('pending');
+
+      // A heartbeat proves the task is still alive and waiting in line.
+      const waiting = persistence.events.filter((e) => e.eventType === 'task.launch_waiting');
+      expect(waiting.length).toBeGreaterThan(0);
+      expect(waiting.at(-1)?.payload).toMatchObject({ attempts: 1 });
+    });
+
+    it('re-dispatches a resource-limit parked task when a slot frees, ignoring the backoff', () => {
+      const parkOrchestrator = new Orchestrator({
+        persistence,
+        messageBus: bus,
+        logger: consoleLogger,
+        maxConcurrency: 3,
+        launchDeferralBackoffMs: 600_000,
+      });
+      parkOrchestrator.loadPlan({
+        name: 'defer-park-slotfree',
+        tasks: [
+          { id: 'task-a', description: 'Task A' },
+          { id: 'task-b', description: 'Task B' },
+        ],
+      });
+      const started = parkOrchestrator.startExecution();
+      expect(started).toHaveLength(2);
+      const taskAId = started.find((t) => t.id.endsWith('/task-a'))!.id;
+
+      parkOrchestrator.deferTask(taskAId, {
+        reason: 'resource-limit',
+        message: 'Execution pool "pnpm-ssh" has no member capacity available',
+        attemptId: parkOrchestrator.getTask(taskAId)!.execution.selectedAttemptId,
+      });
+      expect(parkOrchestrator.getTask(taskAId)!.status).toBe('pending');
+      // Periodic poll keeps it parked behind the long backoff.
+      expect(parkOrchestrator.startExecution().map((t) => t.id)).not.toContain(taskAId);
+
+      // A real slot-free (task-b completes) re-dispatches it despite the backoff.
+      parkOrchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 'task-b', status: 'completed', outputs: { exitCode: 0 } }),
+      );
+      expect(parkOrchestrator.getTask(taskAId)!.status).toBe('running');
+    });
+
+    it('re-dispatches a resource-limit deferred task once its backoff elapses', () => {
+      const parkOrchestrator = new Orchestrator({
+        persistence,
+        messageBus: bus,
+        logger: consoleLogger,
+        maxConcurrency: 3,
+        deferRunningUntilLaunch: true,
+        launchDeferralBackoffMs: 0,
+      });
+      parkOrchestrator.loadPlan({
+        name: 'defer-elapsed',
+        tasks: [{ id: 'task-a', description: 'Task A' }],
+      });
+      const started = parkOrchestrator.startExecution();
+      const taskId = started[0].id;
+
+      parkOrchestrator.deferTask(taskId, {
+        reason: 'resource-limit',
+        message: 'Execution pool "pnpm-ssh" has no member capacity available',
+        attemptId: parkOrchestrator.getTask(taskId)!.execution.selectedAttemptId,
+        phase: 'launching',
+      });
+
+      // Backoff already elapsed (0ms) → the next poll re-dispatches it.
+      expect(parkOrchestrator.startExecution().map((t) => t.id)).toContain(taskId);
     });
 
     it('clears deferred set on restartTask', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -608,6 +608,14 @@ export interface OrchestratorConfig {
   /** Resolve the repo default branch. Must throw when no safe branch is known. */
   resolveRepoDefaultBranch?: (repoUrl: string) => string;
   /**
+   * Backoff (ms) before a task deferred for a resource limit (no execution-pool
+   * member capacity) is re-dispatched by the periodic scheduler. Default is an
+   * exponential schedule (15s → 5min cap) so a capacity-starved task waits in
+   * line and heartbeats instead of thrashing the launch outbox every poll.
+   * A fixed number overrides the schedule (primarily for tests).
+   */
+  launchDeferralBackoffMs?: number;
+  /**
    * When the persistence layer implements `enqueueLaunchDispatch`,
    * `drainScheduler` writes a durable `task_launch_dispatch` row for each
    * claimed launch and emits a `task.dispatch_enqueued` event.
@@ -624,6 +632,9 @@ export interface TaskLineageExpectation {
 
 export class Orchestrator {
   private static readonly EXPEDITED_PRIORITY = 100;
+  private static readonly LAUNCH_DEFERRAL_BASE_BACKOFF_MS = 15_000;
+  private static readonly LAUNCH_DEFERRAL_MAX_BACKOFF_MS = 5 * 60_000;
+  private static readonly LAUNCH_DEFERRAL_HEARTBEAT_MS = 30_000;
 
   private readonly stateMachine: TaskStateMachine;
   private readonly responseHandler: ResponseHandler;
@@ -638,10 +649,19 @@ export class Orchestrator {
   private readonly defaultPoolId: string | undefined;
   private readonly defaultAutoFixRetries: number;
   private readonly deferRunningUntilLaunch: boolean;
+  private readonly launchDeferralBackoffMs?: number;
   private readonly resolveRepoDefaultBranch: (repoUrl: string) => string;
 
   private activeWorkflowIds = new Set<string>();
   private deferredTaskIds = new Set<string>();
+  /**
+   * Owner-local backoff for tasks deferred due to execution-pool capacity.
+   * Keyed to `deferredTaskIds` membership: the periodic scheduler skips
+   * re-dispatching a parked task until its `until` elapses, while a freed slot
+   * (completion path) still re-enqueues it immediately. Pruned when the task
+   * leaves the deferred set (retry / cancel / recreate / completion / delete).
+   */
+  private launchDeferrals = new Map<string, { until: number; attempts: number; lastHeartbeatAt: number }>();
   private beforeApproveHook?: (task: TaskState) => Promise<void>;
   private lastInvalidationPlan?: InvalidationPlan;
 
@@ -683,6 +703,7 @@ export class Orchestrator {
     this.defaultPoolId = config.defaultPoolId;
     this.defaultAutoFixRetries = Math.max(0, Math.floor(config.defaultAutoFixRetries ?? 0));
     this.deferRunningUntilLaunch = config.deferRunningUntilLaunch ?? false;
+    this.launchDeferralBackoffMs = config.launchDeferralBackoffMs;
     this.resolveRepoDefaultBranch = config.resolveRepoDefaultBranch ?? requireDefaultBranchRemote;
 
     this.stateMachine = new TaskStateMachine(new ActionGraph());
@@ -1447,6 +1468,7 @@ export class Orchestrator {
    */
   startExecution(): TaskState[] {
     this.refreshFromDb();
+    this.pruneLaunchDeferrals();
 
     const activeAttempts = this.countActivePersistedAttempts();
     const readyTasks = this.stateMachine
@@ -1460,7 +1482,14 @@ export class Orchestrator {
     });
     const started: TaskState[] = [];
 
+    const launchPollNow = Date.now();
     for (const task of readyTasks) {
+      // A task deferred for execution-pool capacity waits in line with a
+      // heartbeat instead of being re-dispatched (and re-deferred) every poll.
+      if (this.isLaunchParked(task.id, launchPollNow)) {
+        this.emitLaunchWaitingHeartbeat(task.id, launchPollNow);
+        continue;
+      }
       this.enqueueIfNotScheduled(task.id);
     }
 
@@ -3577,6 +3606,67 @@ export class Orchestrator {
     },
   ): void {
     deferTaskImpl(this as unknown as CancellationHost, taskId, reason);
+    if (reason?.reason === 'resource-limit') {
+      this.recordLaunchDeferral(taskId);
+    }
+  }
+
+  /**
+   * Record (or extend) the launch backoff for a task deferred because its
+   * execution pool had no member capacity. Attempts drive an exponential
+   * schedule so a persistently starved task backs off toward the cap.
+   */
+  private recordLaunchDeferral(taskId: string): void {
+    const attempts = (this.launchDeferrals.get(taskId)?.attempts ?? 0) + 1;
+    const backoff = this.computeLaunchBackoffMs(attempts);
+    // lastHeartbeatAt=0 forces a heartbeat on the first parked poll.
+    this.launchDeferrals.set(taskId, { until: Date.now() + backoff, attempts, lastHeartbeatAt: 0 });
+  }
+
+  private computeLaunchBackoffMs(attempts: number): number {
+    if (this.launchDeferralBackoffMs !== undefined) {
+      return Math.max(0, this.launchDeferralBackoffMs);
+    }
+    const scaled = Orchestrator.LAUNCH_DEFERRAL_BASE_BACKOFF_MS * 2 ** Math.max(0, attempts - 1);
+    return Math.min(scaled, Orchestrator.LAUNCH_DEFERRAL_MAX_BACKOFF_MS);
+  }
+
+  /**
+   * True when the task is parked for capacity and its backoff has not elapsed.
+   * Gated on `deferredTaskIds` so any lifecycle transition that clears the
+   * deferred set (retry / cancel / recreate / completion re-enqueue) releases
+   * the park immediately, without a per-transition clear at every call site.
+   */
+  private isLaunchParked(taskId: string, now: number): boolean {
+    const deferral = this.launchDeferrals.get(taskId);
+    return deferral !== undefined
+      && this.deferredTaskIds.has(taskId)
+      && deferral.until > now;
+  }
+
+  private pruneLaunchDeferrals(): void {
+    if (this.launchDeferrals.size === 0) return;
+    for (const taskId of [...this.launchDeferrals.keys()]) {
+      if (!this.deferredTaskIds.has(taskId)) {
+        this.launchDeferrals.delete(taskId);
+      }
+    }
+  }
+
+  /**
+   * Emit a throttled `task.launch_waiting` heartbeat proving a parked task is
+   * still alive and in line (replacing the abandon/re-dispatch churn as the
+   * observable signal), carrying the retry attempt count and next retry time.
+   */
+  private emitLaunchWaitingHeartbeat(taskId: string, now: number): void {
+    const deferral = this.launchDeferrals.get(taskId);
+    if (!deferral) return;
+    if (now - deferral.lastHeartbeatAt < Orchestrator.LAUNCH_DEFERRAL_HEARTBEAT_MS) return;
+    deferral.lastHeartbeatAt = now;
+    this.persistence.logEvent?.(taskId, 'task.launch_waiting', {
+      attempts: deferral.attempts,
+      nextRetryAt: new Date(deferral.until),
+    });
   }
 
   getQueueStatus(options?: { refresh?: boolean }): {


### PR DESCRIPTION
## Summary

A task whose execution pool is momentarily full now waits in line instead of thrashing.

It parks with an exponential backoff (15s to a 5min cap) and emits a throttled `task.launch_waiting` heartbeat.

Before, every scheduler poll reset the task, minted a new attempt, and abandoned a `task deferred` dispatch row — hundreds per task.

A freed slot still re-dispatches the parked task immediately, so the backoff never strands runnable work. It stays visible in the queue the whole time.

## Review Claim

A `resource-limit` defer parks the task with backoff and a heartbeat instead of re-dispatching every poll, while a freed slot still re-dispatches it immediately.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only `resource-limit` defers back off; every other `deferTask` path is unchanged. The backoff map is owner-local and keyed to the existing `deferredTaskIds` set, so cancel / recreate / completion release the park with no new call sites. The scheduler gate no-ops when the map is empty.

## Slice Rationale

One behavior claim, stacked on the earlier `(1)` slice. It flips that slice's `it.fails` spec to a passing `it` and adds slot-free / backoff-elapsed coverage next to the change it justifies.

## Non-goals

- Does not change SSH pool member selection or the pinned-member behavior (a task pinned to an excluded member still defers — accepted).
- Does not add a worktree fallback to SSH-only pools.
- No UI changes; the parked task already renders as `queued`.

## Architecture

The change is a control-flow gate on re-dispatch of a capacity-deferred task.

### Before

```mermaid
graph TD
    A["resource-limit defer"] --> B["reset to pending + new attempt"]
    B --> C["next poll: startExecution re-enqueues"]
    C --> D["dispatch -> no capacity"]
    D --> A
```

### After

```mermaid
graph TD
    A["resource-limit defer"] --> B["park: set backoff + deferred set"]
    B --> C["next poll: startExecution holds the parked task"]
    C --> E["emit throttled task.launch_waiting heartbeat"]
    E --> F{"backoff elapsed or slot freed?"}
    F -- "no" --> C
    F -- "yes" --> G["re-dispatch"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-launch-defer-park.sh`
- [ ] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`
- [ ] `pnpm --filter @invoker/workflow-core build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the prior re-dispatch-every-poll behavior.
- Data migration? No

</details>