### PR TITLE
[Terminal Double-Click Step 2 - Focus Existing Tab](1) Focus existing terminal tab

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1407,7 +1407,7 @@ export function App() {
     selectTaskById(task.id);
   }, [selectTaskById]);
 
-  const openTerminalForTaskId = useCallback(async (taskId: string) => {
+  const requestTerminalForTaskId = useCallback(async (taskId: string) => {
     const task = tasks.get(taskId);
     if (task && isExperimentSpawnPivotTask(task)) {
       window.alert(EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE);
@@ -1434,6 +1434,19 @@ export function App() {
       setActiveTerminalSessionId(session.sessionId);
     }
   }, [tasks]);
+
+  const openTerminalForTaskId = useCallback(async (taskId: string) => {
+    const existingRunningSession = terminalSessions.find(
+      (session) => session.taskId === taskId && session.status === 'running',
+    );
+    if (existingRunningSession) {
+      setTerminalDrawerState('partial');
+      setActiveTerminalSessionId(existingRunningSession.sessionId);
+      return;
+    }
+
+    await requestTerminalForTaskId(taskId);
+  }, [requestTerminalForTaskId, terminalSessions]);
 
   const handleTaskDoubleClick = useCallback(async (task: TaskState) => {
     setSelectedTaskId(task.id);
@@ -1607,9 +1620,9 @@ export function App() {
   const handleOpenTerminal = useCallback(
     (taskId: string) => {
       setContextMenu(null);
-      void openTerminalForTaskId(taskId);
+      void requestTerminalForTaskId(taskId);
     },
-    [openTerminalForTaskId],
+    [requestTerminalForTaskId],
   );
 
   const handleCloseTerminalSession = useCallback(async (sessionId: string) => {
@@ -3451,4 +3464,3 @@ export function App() {
     </div>
   );
 }
-

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -6,7 +6,7 @@
  *   - the drawer has three explicit states: minimized, partial, maximized
  *   - opening a terminal puts the drawer in the partial state
  *   - the single cycling button advances minimized → partial → maximized → minimized
- *   - the same task id reuses a single tab
+ *   - the same task id reuses and focuses a single tab without another IPC call
  *   - failures from openTerminal surface as an alert
  */
 
@@ -228,9 +228,9 @@ describe('Terminal drawer (component)', () => {
     expect(screen.getByTestId('terminal-pane-task-alpha')).toHaveClass('overflow-hidden');
   });
 
-  it('reuses an existing tab when opening the same task twice', async () => {
+  it('focuses an existing running tab when double-clicking the same task again', async () => {
     render(<App />);
-    act(() => mock.setTasks([taskAlpha], workflows));
+    act(() => mock.setTasks([taskAlpha, taskBeta], workflows));
     await selectWorkflow();
 
     fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
@@ -238,8 +238,14 @@ describe('Terminal drawer (component)', () => {
       expect(screen.getByTestId('terminal-tab-task-alpha')).toBeInTheDocument();
     });
 
-    // Minimize (cycle partial → maximized → minimized), then re-open —
-    // should not duplicate the tab.
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-beta'));
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-tab-task-beta')).toHaveAttribute('data-active', 'true');
+    });
+    expect(mock.api.openTerminal).toHaveBeenCalledTimes(2);
+
+    // Minimize (cycle partial → maximized → minimized), then re-open alpha.
+    // The existing alpha tab should be selected without another open-terminal IPC call.
     fireEvent.click(screen.getByRole('button', { name: 'Maximize terminal drawer' }));
     fireEvent.click(screen.getByRole('button', { name: 'Minimize terminal drawer' }));
     expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'minimized');
@@ -248,9 +254,16 @@ describe('Terminal drawer (component)', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
+      expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
     });
     const tabs = screen.getAllByTestId('terminal-tab-task-alpha');
     expect(tabs).toHaveLength(1);
+    expect(screen.getByTestId('terminal-tab-task-beta')).toHaveAttribute('data-active', 'false');
+    expect(mock.api.openTerminal).toHaveBeenCalledTimes(2);
+    expect((mock.api.openTerminal as ReturnType<typeof vi.fn>).mock.calls.map(([taskId]) => taskId)).toEqual([
+      'task-alpha',
+      'task-beta',
+    ]);
   });
 
   it('renders distinct tabs for different tasks side by side', async () => {
@@ -325,6 +338,29 @@ describe('Terminal drawer (component)', () => {
     expect(mock.api.openTerminal).toHaveBeenCalledWith('task-alpha');
   });
 
+  it('keeps the context-menu Open Terminal action routed through open-terminal IPC', async () => {
+    render(<App />);
+    act(() => mock.setTasks([taskAlpha], workflows));
+    await selectWorkflow();
+
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-tab-task-alpha')).toBeInTheDocument();
+    });
+
+    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+    const openTerminalItem = await screen.findByRole('menuitem', { name: /Open Terminal/i });
+    fireEvent.click(openTerminalItem);
+
+    await waitFor(() => {
+      expect(mock.api.openTerminal).toHaveBeenCalledTimes(2);
+    });
+    expect((mock.api.openTerminal as ReturnType<typeof vi.fn>).mock.calls.map(([taskId]) => taskId)).toEqual([
+      'task-alpha',
+      'task-alpha',
+    ]);
+  });
+
   it('seeds the replay snapshot before live terminal output', async () => {
     const session = makeTerminalSession('task-alpha', {
       outputSnapshot: 'early line\n',
@@ -361,24 +397,31 @@ describe('Terminal drawer (component)', () => {
     const session = makeTerminalSession('task-alpha', {
       outputSnapshot: 'replayed once\n',
     });
-    (mock.api.openTerminal as ReturnType<typeof vi.fn>).mockResolvedValue({
-      opened: true,
-      session,
-    });
 
-    render(<App />);
-    act(() => mock.setTasks([taskAlpha], workflows));
-    await selectWorkflow();
-
-    fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
+    const { rerender } = render(
+      <TerminalDrawer
+        state="partial"
+        onCycle={vi.fn()}
+        sessions={[session]}
+        activeSessionId={session.sessionId}
+        onSelectSession={vi.fn()}
+        onCloseSession={vi.fn()}
+      />,
+    );
     await waitFor(() => {
       expect(xtermMock.writeLog).toEqual(['replayed once\n']);
     });
 
-    fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
-    await waitFor(() => {
-      expect(mock.api.openTerminal).toHaveBeenCalledTimes(2);
-    });
+    rerender(
+      <TerminalDrawer
+        state="partial"
+        onCycle={vi.fn()}
+        sessions={[{ ...session }]}
+        activeSessionId={session.sessionId}
+        onSelectSession={vi.fn()}
+        onCloseSession={vi.fn()}
+      />,
+    );
 
     expect(xtermMock.writeLog).toEqual(['replayed once\n']);
   });


### PR DESCRIPTION
## Summary

Terminal Double-Click Step 2 - Focus Existing Tab completed the terminal focus behavior and focused verification

Double-clicking a task with a running terminal session now selects that existing tab instead of starting another terminal.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1783561720142-4/focus-existing-terminal-tab-in-app | On task double-click, focus the existing terminal tab instead of reopening. | completed |
| wf-1783561720142-4/verify-focus-existing-terminal-tab | Run focused terminal drawer/tab behavior tests. | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1783561720142-4/focus-existing-terminal-tab-in-app - On task double-click, focus the existing terminal tab instead of reopening.

### wf-1783561720142-4/verify-focus-existing-terminal-tab - Run focused terminal drawer/tab behavior tests.
packages/ui/src/App.tsx                            | 20 ++++--
packages/ui/src/__tests__/terminal-drawer.test.tsx | 79 +++++++++++++++++-----
2 files changed, 77 insertions(+), 22 deletions(-)

</details>

## Review Claim

Approve the activation surface change that makes task double-click select an existing running terminal tab before opening a new terminal.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The branch only changes renderer terminal drawer selection and the existing component test for that path; no backend terminal lifecycle API changes.

## Slice Rationale

This is one reviewable behavior slice: the implementation and focused terminal drawer assertions are coupled to the same double-click activation path.

## Non-goals

- No change to terminal process creation.
- No change to terminal close, resize, input, or output handling.
- No change to context-menu Open Terminal behavior; that action still asks for a new terminal session.

## Architecture

### Before

Task double-click always called the renderer terminal-open bridge, even when renderer state already contained a running session for that task.

### After

Task double-click first checks renderer terminal sessions for a running session on that task. Existing sessions set the active terminal tab and reopen the drawer locally.

Context-menu Open Terminal still requests a new terminal session.

## Visual Proof

![Alpha tab active after re-double-click](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-201e65/terminal-focus-existing-tab.png)

After opening Alpha, opening Beta, then double-clicking Alpha again, Alpha is active and the drawer remains partial. The Playwright proof asserted two open-terminal calls.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- terminal-drawer.test.tsx`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/terminal-dblclick-step2-pr.md --require-visual-proof --changed-files-file /tmp/terminal-dblclick-step2-changed-files.txt --diff-file /tmp/terminal-dblclick-step2-diff.patch`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <published-pr-merge-commit>`
- Post-revert steps: Re-run the focused terminal drawer test.
- Data migration? No.

</details>
