### PR TITLE
[PR maintenance workers Step 6: Add local headless query workers support](2) Serve query workers without an invoker.db

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -178,6 +178,7 @@ import {
   wireHeadlessApproveHook,
   type HeadlessDeps,
 } from './headless.js';
+import { headlessQuery, type HeadlessQueryDeps } from './headless-query-list.js';
 import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
 import {
   startStandaloneLaunchDispatcher,
@@ -993,6 +994,28 @@ const YELLOW = '\x1b[33m';
 // HEADLESS MODE
 // ══════════════════════════════════════════════════════════════
 
+function isDatabaseFreeWorkersQuery(args: readonly string[]): boolean {
+  return args[0] === 'query' && args[1] === 'workers';
+}
+
+async function runDatabaseFreeWorkersQuery(args: string[]): Promise<void> {
+  const emptyWorkerQueryDeps: HeadlessQueryDeps = {
+    persistence: {
+      listWorkerActions: () => [],
+      listWorkflows: () => [],
+      loadTasks: () => [],
+      countEventsByTypes: () => [],
+      getEventsByTypes: () => [],
+    } as unknown as HeadlessQueryDeps['persistence'],
+    orchestrator: {} as HeadlessQueryDeps['orchestrator'],
+    executionAgentRegistry: undefined,
+    invokerConfig,
+    getUiPerfStats: () => ({}),
+    resetUiPerfStats: () => {},
+  };
+  await headlessQuery(args.slice(1), emptyWorkerQueryDeps);
+}
+
 function startHeadlessMode(): void {
   const runHeadlessMain = async (): Promise<void> => {
     const agentRegistry = registerBuiltinAgents();
@@ -1073,6 +1096,12 @@ function startHeadlessMode(): void {
         process.exit(1);
         return;
       }
+    }
+
+    if (isDatabaseFreeWorkersQuery(cliArgs) && !existsSync(path.join(resolveInvokerHomeRoot(), 'invoker.db'))) {
+      await runDatabaseFreeWorkersQuery(cliArgs);
+      process.exit(0);
+      return;
     }
 
     let exitCode = 0;


### PR DESCRIPTION
## Summary

When the owner host has no `invoker.db`, serve the worker-status query from an empty in-memory source instead of failing to open a database.

This routes `query workers` through a database-free path, so the health check still returns a snapshot on a fresh host.

## Review Claim

Route the `query workers` request through a database-free path when the owner host has no `invoker.db`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The database-free path only runs for `query workers` when no `invoker.db` exists, then exits. Every other headless command keeps its current path unchanged.

## Slice Rationale

Keeping the database-free path in its own slice keeps each behavior change small. The prior slice added the `query workers` request; this one makes it work before any `invoker.db` exists on the host.

## Non-goals

- Does not change how the command is registered or how workers start.
- Only adds the no-database serving path; the database-backed path is untouched.

## Visual Proof

No user-visible UI changes. The change adds a headless code path in `main.ts` that runs before window setup and then exits. Its observable surface is the terminal output of `./run.sh --headless query workers --output json` on a host with no `invoker.db`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`
- [ ] In a home directory with no `invoker.db`: `./run.sh --headless query workers --output json`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b86b01804`
- Post-revert steps: None
- Data migration? No

</details>
