### PR TITLE
[Needs Attention Mutation Failure UX](1) Move mutation failures into Needs Attention with inspector detail

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -15,11 +15,7 @@ import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppP
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
 import { reportUiNavigation } from './lib/report-ui-navigation.js';
-import {
-  mutationFailureBannerMessage,
-  mutationFailureTitle,
-  shouldShowMutationFailureBanner,
-} from './lib/mutation-failure-display.js';
+
 import { useTasks } from './hooks/useTasks.js';
 import { useQueueStatus } from './hooks/useQueueStatus.js';
 import { useWorkerStatus } from './hooks/useWorkerStatus.js';
@@ -598,7 +594,7 @@ export function App() {
   const [systemDiagnostics, setSystemDiagnostics] = useState<SystemDiagnostics | null>(null);
   const [showSystemSetup, setShowSystemSetup] = useState(false);
   const [showSystemBanner, setShowSystemBanner] = useState(false);
-  const [mutationFailure, setMutationFailure] = useState<WorkflowMutationFailedEvent | null>(null);
+  const [mutationFailuresByTaskId, setMutationFailuresByTaskId] = useState<Map<string, WorkflowMutationFailedEvent>>(new Map());
   const [installSkillsPending, setInstallSkillsPending] = useState(false);
   const [installSkillsError, setInstallSkillsError] = useState<string | null>(null);
   const [updateCliPending, setUpdateCliPending] = useState(false);
@@ -1013,7 +1009,14 @@ export function App() {
     return STATUS_KEY_ORDER.filter((key) => key === 'completed' || key === 'running' || key === 'failed' || key === 'pending' || (counts.get(key) ?? 0) > 0);
   }, [workflows]);
   const workflowEntries = useMemo(() => getSortedWorkflows(workflows, tasks), [workflows, tasks]);
-  const attentionEntries = useMemo(() => getAttentionTaskEntries(tasks, workflows), [tasks, workflows]);
+  const attentionTaskIdsWithFailures = useMemo(
+    () => new Set(mutationFailuresByTaskId.keys()),
+    [mutationFailuresByTaskId],
+  );
+  const attentionEntries = useMemo(
+    () => getAttentionTaskEntries(tasks, workflows, attentionTaskIdsWithFailures),
+    [tasks, workflows, attentionTaskIdsWithFailures],
+  );
   const runningEntries = useMemo(() => getRunningTaskEntries(tasks, workflows, queueStatus), [tasks, workflows, queueStatus]);
 
   const searchResults = useMemo<SearchResult[]>(
@@ -1109,34 +1112,41 @@ export function App() {
 
   useEffect(() => {
     const unsubscribe = window.invoker?.onWorkflowMutationFailed?.((event) => {
-      // Task/workflow mutation failures belong in the task panel, not the top banner.
-      if (!shouldShowMutationFailureBanner(event)) {
-        if (event.taskId) {
+      const failedTaskId = event.taskId;
+      if (failedTaskId) {
+        setMutationFailuresByTaskId((prev) => new Map(prev).set(failedTaskId, event));
+        const task = tasksRef.current.get(failedTaskId);
+        if (task) {
+          selectTaskById(task.id);
+        } else {
           // Set selection from the event ids directly so the inspector opens even
           // if the task map has not hydrated this id yet.
-          setSelectedTaskId(event.taskId);
+          setSelectedTaskId(failedTaskId);
           setWorkflowSelectionDismissed(false);
           if (event.workflowId) {
             setSelectedWorkflowId(event.workflowId);
           }
+          setInspectorCollapsed(false);
+          setInspectorManualOpen(true);
           setContextMenu(null);
           setWorkflowContextMenu(null);
           focusKeyboardRegion('taskGraph');
-        } else if (event.workflowId) {
-          setSelectedWorkflowId(event.workflowId);
-          setSelectedTaskId(null);
-          setWorkflowSelectionDismissed(false);
-          setContextMenu(null);
-          setWorkflowContextMenu(null);
-          focusKeyboardRegion('workflowGraph');
         }
-        setMutationFailure(null);
-        return;
+        setSidebarSurface('attention');
+      } else if (event.workflowId) {
+        setSelectedWorkflowId(event.workflowId);
+        setSelectedTaskId(null);
+        setWorkflowSelectionDismissed(false);
+        setContextMenu(null);
+        setWorkflowContextMenu(null);
+        setSidebarSurface('workflows');
+        focusKeyboardRegion('workflowGraph');
+      } else {
+        notifyMutationError('Mutation failed', event.message);
       }
-      setMutationFailure(event);
     });
     return () => { unsubscribe?.(); };
-  }, [focusKeyboardRegion]);
+  }, [focusKeyboardRegion, selectTaskById]);
 
   const selectRelativeNode = useCallback((direction: 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight') => {
     const inTaskGraph = keyboardRegion === 'taskGraph';
@@ -3150,39 +3160,6 @@ export function App() {
           This window can browse workflows, but it cannot make changes until the write owner is available.
         </div>
       ) : null}
-      {mutationFailure && (
-        <div
-          role="alert"
-          aria-live="assertive"
-          data-testid="workflow-mutation-failed-banner"
-          className="px-4 py-3 border-b border-amber-700 bg-amber-950/60 flex items-start justify-between gap-4"
-        >
-          <div className="text-sm text-amber-100 min-w-0">
-            <div className="font-semibold text-amber-50">
-              {mutationFailureTitle(mutationFailure)}
-            </div>
-            <div
-              data-testid="workflow-mutation-failed-message"
-              className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-amber-100/90"
-            >
-              {mutationFailureBannerMessage(mutationFailure)}
-            </div>
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            <Button
-              size="sm"
-              variant="ghost"
-              data-testid="workflow-mutation-failed-dismiss"
-              className="text-amber-200 hover:text-white"
-              onClick={() => setMutationFailure(null)}
-            >
-              Dismiss
-            </Button>
-          </div>
-        </div>
-      )}
-
-
       {/* Main content */}
       <div className="flex-1 flex overflow-hidden">
         <LeftStatusColumn
@@ -3193,6 +3170,7 @@ export function App() {
           planningSessionCount={planningSessions.length}
           selectedSurface={sidebarSurface}
           collapsed={effectiveSidebarCollapsed}
+          attentionTaskIdsWithFailures={attentionTaskIdsWithFailures}
           onSelectSurface={handleSelectSidebarSurface}
           onToggleCollapsed={() => setSidebarCollapsed(!effectiveSidebarCollapsed)}
           onOpenSettings={() => {
@@ -3247,6 +3225,7 @@ export function App() {
                   workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
                   reviewGate={selectedWorkflow ? reviewGateByWorkflowId[selectedWorkflow.id] ?? null : null}
                   actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
+                  mutationFailure={selectedTaskId ? mutationFailuresByTaskId.get(selectedTaskId) ?? null : null}
                   collapsed={effectiveInspectorCollapsed}
                   advancedExpanded={advancedMetadataExpanded}
                   remoteTargets={remoteTargets}

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { WorkflowInspector } from '../components/WorkflowInspector.js';
 import type { TaskState, WorkflowMeta } from '../types.js';
+import type { WorkflowMutationFailedEvent } from '@invoker/contracts';
 
 function makeTask(partial?: Partial<TaskState>): TaskState {
   return {
@@ -847,5 +848,77 @@ describe('WorkflowInspector', () => {
     } finally {
       delete (window as unknown as { invoker?: unknown }).invoker;
     }
+  });
+
+  it('renders a persistent mutation failure detail panel for the selected task', () => {
+    const mutationFailure: WorkflowMutationFailedEvent = {
+      intentId: 42,
+      workflowId: 'wf-1',
+      channel: 'invoker:approve',
+      taskId: 'task-1',
+      message: 'Error: SSH target "remote_digital_ocean_3" cannot run codex: missing execution harness "codex"',
+      failedAt: '2026-07-08T10:00:00.000Z',
+    };
+
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={makeTask({ status: 'awaiting_approval' })}
+        mutationFailure={mutationFailure}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    const detail = screen.getByTestId('task-mutation-failure-detail');
+    expect(detail).toBeInTheDocument();
+    expect(detail).toHaveTextContent('Approve failed');
+    expect(detail).toHaveTextContent('missing execution harness "codex"');
+    expect(detail).toHaveTextContent('Channel: invoker:approve');
+  });
+
+  it('renders headless command metadata in the mutation failure detail panel', () => {
+    const mutationFailure: WorkflowMutationFailedEvent = {
+      intentId: 46,
+      workflowId: 'wf-1',
+      channel: 'headless.exec',
+      headlessCommand: 'fix',
+      taskId: 'task-1',
+      message: 'SSH remote script failed (exit=1, phase=remote_agent_fix)',
+      failedAt: '2026-07-08T10:00:00.000Z',
+    };
+
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={makeTask({ status: 'awaiting_approval' })}
+        mutationFailure={mutationFailure}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    const detail = screen.getByTestId('task-mutation-failure-detail');
+    expect(detail).toHaveTextContent('Fix failed');
+    expect(detail).toHaveTextContent('Command: fix');
+  });
+
+  it('does not render the mutation failure detail panel when no failure is provided', () => {
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={makeTask({ status: 'awaiting_approval' })}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId('task-mutation-failure-detail')).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
+++ b/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
@@ -1,9 +1,11 @@
 /**
  * Integration test: workflow-mutation-failed handling in <App />.
  *
- * Task-scoped and workflow-scoped mutation failures must not open the top
- * banner. Task failures select the task so the right-hand panel can show the
- * error.
+ * Task-scoped mutation failures are surfaced through the Needs Attention
+ * workflow/task browser: the relevant task is selected, the attention surface is
+ * opened/focused, and the inspector shows a persistent mutation-failure detail
+ * panel. Workflow-scoped failures open the Workflows browser. Routine failures
+ * no longer render a global top banner.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -55,7 +57,7 @@ describe('Workflow mutation failed banner', () => {
     });
   }
 
-  it('does not show the banner for task-scoped approve failures and opens the task instead', async () => {
+  it('does not show the top banner for task-scoped approve failures', async () => {
     render(<App />);
     await settleTasks();
 
@@ -73,12 +75,42 @@ describe('Workflow mutation failed banner', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
     });
+  });
+
+  it('selects the task, opens Needs Attention, and surfaces failure details in the inspector', async () => {
+    render(<App />);
+    await settleTasks();
+
+    act(() => {
+      mock.fireWorkflowMutationFailed({
+        intentId: 42,
+        workflowId: 'wf-1',
+        channel: 'invoker:approve',
+        taskId: 'wf-1/verify-worker-summary-surface',
+        message: 'Error: SSH target "remote_digital_ocean_3" cannot run codex: missing execution harness "codex"',
+        failedAt: '2026-07-08T10:00:00.000Z',
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sidebar-attention')).toHaveAttribute('aria-current', 'page');
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('browser-rail')).toHaveTextContent('Needs Attention');
+    });
     await waitFor(() => {
       expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Verify worker summary surface');
     });
+    await waitFor(() => {
+      const detail = screen.getByTestId('task-mutation-failure-detail');
+      expect(detail).toBeInTheDocument();
+      expect(detail).toHaveTextContent('Approve failed');
+      expect(detail).toHaveTextContent('missing execution harness "codex"');
+      expect(detail).toHaveTextContent('Channel: invoker:approve');
+    });
   });
 
-  it('does not show the banner for headless fix failures', async () => {
+  it('keeps mutation failure details visible when reselecting the task from Needs Attention', async () => {
     render(<App />);
     await settleTasks();
 
@@ -89,20 +121,35 @@ describe('Workflow mutation failed banner', () => {
         channel: 'headless.exec',
         headlessCommand: 'fix',
         taskId: 'wf-1/verify-worker-summary-surface',
-        message: 'SSH remote script failed (exit=1, phase=remote_agent_fix)\nSTDOUT:\n{"type":"thread.started"}\n{"type":"error","message":"model unsupported"}',
+        message: 'SSH remote script failed (exit=1, phase=remote_agent_fix)',
         failedAt: '2026-07-08T10:00:00.000Z',
       });
     });
 
     await waitFor(() => {
-      expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
+      expect(screen.getByTestId('task-mutation-failure-detail')).toBeInTheDocument();
     });
+
+    // Navigate home and then back to Needs Attention.
+    fireEvent.click(screen.getByTestId('sidebar-home'));
     await waitFor(() => {
-      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Verify worker summary surface');
+      expect(screen.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
+    });
+
+    fireEvent.click(screen.getByTestId('sidebar-attention'));
+    await waitFor(() => {
+      expect(screen.getByTestId('sidebar-attention')).toHaveAttribute('aria-current', 'page');
+    });
+
+    await waitFor(() => {
+      const detail = screen.getByTestId('task-mutation-failure-detail');
+      expect(detail).toBeInTheDocument();
+      expect(detail).toHaveTextContent('Fix failed');
+      expect(detail).toHaveTextContent('Command: fix');
     });
   });
 
-  it('does not show the banner for workflow-scoped failures', async () => {
+  it('opens the Workflows browser for workflow-scoped failures', async () => {
     render(<App />);
     await settleTasks();
 
@@ -118,6 +165,12 @@ describe('Workflow mutation failed banner', () => {
 
     await waitFor(() => {
       expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('sidebar-workflows')).toHaveAttribute('aria-current', 'page');
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('browser-rail')).toHaveTextContent('Workflows');
     });
   });
 });

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -26,6 +26,7 @@ interface LeftStatusColumnProps {
   workerStatus: WorkerStatusSnapshot | null;
   selectedSurface: SidebarSurface;
   collapsed: boolean;
+  attentionTaskIdsWithFailures?: Set<string>;
   onSelectSurface: (surface: SidebarSurface) => void;
   onToggleCollapsed: () => void;
   planningSessionCount: number;
@@ -72,6 +73,7 @@ export function LeftStatusColumn({
   workerStatus,
   selectedSurface,
   collapsed,
+  attentionTaskIdsWithFailures,
   onSelectSurface,
   onToggleCollapsed,
   planningSessionCount,
@@ -80,7 +82,7 @@ export function LeftStatusColumn({
   onToggleTheme,
 }: LeftStatusColumnProps): JSX.Element {
   const workflowEntries = getSortedWorkflows(workflows, tasks);
-  const attentionEntries = getAttentionTaskEntries(tasks, workflows);
+  const attentionEntries = getAttentionTaskEntries(tasks, workflows, attentionTaskIdsWithFailures);
   const runningEntries = getRunningTaskEntries(tasks, workflows, queueStatus);
   const runningWorkers = workerStatus?.workers.filter((worker) => worker.lifecycle === 'running').length ?? 0;
   const registeredWorkers = workerStatus?.workers.length ?? 0;

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -3,7 +3,8 @@ import type { ReviewGateArtifact, ReviewGateQueryResponse, TaskState, WorkflowMe
 import { getEffectiveVisualStatus, getStatusColor } from '../lib/colors.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
 import { subscribeVisibilityAwarePoll } from '../hooks/visibilityAwarePoll.js';
-import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption } from '@invoker/contracts';
+import { mutationFailureTitle } from '../lib/mutation-failure-display.js';
+import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, WorkflowMutationFailedEvent } from '@invoker/contracts';
 
 type MergeMode = 'manual' | 'automatic' | 'external_review';
 type TaskLogLevel = 'debug' | 'info' | 'warn' | 'error';
@@ -143,6 +144,7 @@ interface WorkflowInspectorProps {
   executionHarnesses?: ExecutionHarnessOption[];
   executionDefaults?: ExecutionDefaults | null;
   actionNode?: ActionGraphNode | null;
+  mutationFailure?: WorkflowMutationFailedEvent | null;
   collapsed: boolean;
   advancedExpanded: boolean;
   onEditType?: (taskId: string, runnerKind: string, poolMemberId?: string) => void;
@@ -250,6 +252,7 @@ export function WorkflowInspector({
   executionHarnesses,
   executionDefaults,
   actionNode,
+  mutationFailure,
   collapsed,
   advancedExpanded,
   onEditPool,
@@ -525,6 +528,19 @@ export function WorkflowInspector({
             </div>
           )}
         </section>
+
+        {mutationFailure && (
+          <section data-testid="task-mutation-failure-detail" className="rounded border border-amber-700 bg-amber-950/40 p-3">
+            <h3 className="text-[11px] uppercase tracking-wide text-amber-200">
+              {mutationFailureTitle(mutationFailure)}
+            </h3>
+            <p className="mt-1 text-xs text-amber-100 break-words">{mutationFailure.message}</p>
+            <p className="mt-2 text-[11px] text-amber-300">Channel: {mutationFailure.channel}</p>
+            {mutationFailure.headlessCommand && (
+              <p className="mt-1 text-[11px] text-amber-300">Command: {mutationFailure.headlessCommand}</p>
+            )}
+          </section>
+        )}
 
         {workspaceRecreateNotice && (
           <section data-testid="workspace-recreate-notice" className="rounded border border-amber-700 bg-amber-950/40 p-3">

--- a/packages/ui/src/lib/workflow-progress-surfaces.ts
+++ b/packages/ui/src/lib/workflow-progress-surfaces.ts
@@ -106,8 +106,9 @@ export function getSortedWorkflows(
 export function getAttentionTaskEntries(
   tasks: Map<string, TaskState>,
   workflows: Map<string, WorkflowMeta>,
+  extraTaskIds?: Set<string>,
 ): WorkflowTaskEntry[] {
-  return [...tasks.values()]
+  const baseEntries = [...tasks.values()]
     .filter(isAttentionTask)
     .sort((a, b) => {
       const priority = (ATTENTION_STATUS_PRIORITY[a.status] ?? 99) - (ATTENTION_STATUS_PRIORITY[b.status] ?? 99);
@@ -121,6 +122,20 @@ export function getAttentionTaskEntries(
       task,
       workflow: task.config.workflowId ? workflows.get(task.config.workflowId) ?? null : null,
     }));
+
+  if (!extraTaskIds || extraTaskIds.size === 0) return baseEntries;
+
+  const existingIds = new Set(baseEntries.map((entry) => entry.task.id));
+  const extraEntries = [...extraTaskIds]
+    .filter((id) => !existingIds.has(id))
+    .map((id) => tasks.get(id))
+    .filter((task): task is TaskState => Boolean(task))
+    .map((task) => ({
+      task,
+      workflow: task.config.workflowId ? workflows.get(task.config.workflowId) ?? null : null,
+    }));
+
+  return [...baseEntries, ...extraEntries];
 }
 
 export function getRunningTaskEntries(


### PR DESCRIPTION
## Summary

Needs Attention Mutation Failure UX finished both workflow tasks.

Task and workflow mutation failures no longer use a top-of-app banner as the primary operator surface.

Task failures now open Needs Attention and keep the failure details visible in the inspector.

Workflow-only failures open Workflows, while failures with no context remain transient toast errors.

## Review Claim

Approve showing task-scoped mutation failures through Needs Attention and persistent inspector detail instead of the global banner.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The slice changes only renderer state and presentation for an existing mutation-failure event. It adds no IPC, persistence, executor, or mutation semantics.

The focused tests cover banner removal, Needs Attention selection, inspector detail text, workflow-only failures, and detail persistence after returning to Needs Attention.

## Slice Rationale

This is one cohesive UI behavior change with its tests. The verification task produced no code diff, so publishing it as a separate PR would create an empty slice.

## Non-goals

- Does not change when mutation-failure events are emitted.
- Does not change backend, IPC, executor, or persistence behavior.
- Does not change task status transitions or approval/reject mutation semantics.
- Does not change Needs Attention ordering except adding task ids with mutation failures.

## Architecture

### Before

```mermaid
graph TD
    A["onWorkflowMutationFailed event"] --> B["banner decision"]
    B --> C["Top-of-app mutation failure banner"]
    C --> D["Operator dismisses manually"]
```

### After

```mermaid
graph TD
    A["onWorkflowMutationFailed event"] --> B["Has task id?"]
    B -->|yes| C["Needs Attention surface"]
    C --> D["Selected task inspector detail"]
    B -->|workflow only| E["Workflows surface"]
    B -->|no context| F["Transient toast"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-mutation-failed-banner.test.tsx src/__tests__/workflow-inspector.test.tsx`

</details>

## Visual Proof

Mutation failure driven live in the Electron app: after an `invoker:approve` failure for a task, Needs Attention holds the task and the inspector shows the "Approve failed" detail panel.

![Needs Attention surface selected with the inspector showing the Approve failed detail panel](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-e332e2/mutation-failure-needs-attention.png)

[Walkthrough video: the banner is gone, the failure lands in Needs Attention, and the inspector detail panel remains visible](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-e332e2/mutation-failure-walkthrough.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b21c8d279276a5b3904f97174cd1b64bf8aa2e20`
- Post-revert steps: None
- Data migration? No

</details>
