### PR TITLE
[Remove Running Sidebar And Workers Screen Title](1) Loosen empty-state sidebar snapshot

### DIFF
--- a/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
+++ b/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
@@ -38,7 +38,10 @@ describe('Visual proof snapshots', () => {
     expect(screen.getByTestId('sidebar-home')).toHaveTextContent('Invoker');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
+    const runningSidebarItem = screen.queryByTestId('sidebar-running');
+    if (runningSidebarItem) {
+      expect(runningSidebarItem).toHaveTextContent('Running');
+    }
     expect(screen.getByText('Describe the change in the terminal to generate a plan.')).toBeInTheDocument();
     expect(screen.getByTestId('rail-settings')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

The empty-state view snapshot required a Running item in the left sidebar.

That assertion would block the sidebar chrome change that lands next.

This slice relaxes only that one check. If the Running item is present, the snapshot still verifies its text; if it is gone, the snapshot passes.

Every other empty-state navigation assertion stays intact, so the guard keeps its value.

## Review Claim

Approve loosening one empty-state snapshot assertion so the Running sidebar item is optional, ahead of the chrome change.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice edits a single test file. It weakens exactly one assertion and leaves every other empty-state snapshot check in place, so no runtime code path and no rendered pixel changes.

## Slice Rationale

Loosening the snapshot ahead of the chrome change keeps each slice green for CI. The behavior slice can then land without also editing this proof, and the final slice re-tightens the assertion.

## Non-goals

- Does not touch any sidebar or Workers component.
- Does not change what the app renders.
- Does not re-tighten the snapshot; that is the final slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test` — runs the UI Vitest suite, including `packages/ui/src/__tests__/visual-proof-snapshots.test.tsx`

</details>

## Visual Proof

No user-visible pixels change in this slice; it edits one test assertion only. The Electron capture harness is not run in this publication step. The empty-state guard in `packages/ui/src/__tests__/visual-proof-snapshots.test.tsx` still covers the surrounding chrome.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <squash-merge commit>` (single test-file change)
- Post-revert steps: None
- Data migration? No

</details>
