### PR TITLE
[Remove Running Sidebar And Workers Screen Title](2) Hide running sidebar item and workers heading

### DIFF
--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -48,7 +48,7 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Planning Terminal');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
   });
   it('opens worker status from the left panel', async () => {
@@ -90,7 +90,7 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Planning Terminal');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();
   });
@@ -146,8 +146,9 @@ describe('App launch (component)', () => {
 
     fireEvent.click(toggle);
     expect(sidebar.className).toContain('w-16');
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
 
-    for (const surface of ['workflows', 'attention', 'running', 'workers', 'planning', 'home']) {
+    for (const surface of ['workflows', 'attention', 'workers', 'planning', 'home']) {
       fireEvent.click(screen.getByTestId(`sidebar-${surface}`));
       expect(sidebar.className).toContain('w-16');
     }
@@ -159,7 +160,7 @@ describe('App launch (component)', () => {
     fireEvent.click(toggle);
     expect(sidebar.className).toContain('w-60');
 
-    for (const surface of ['workflows', 'attention', 'running', 'workers', 'planning', 'home']) {
+    for (const surface of ['workflows', 'attention', 'workers', 'planning', 'home']) {
       fireEvent.click(screen.getByTestId(`sidebar-${surface}`));
       expect(sidebar.className).toContain('w-60');
     }

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -46,7 +46,7 @@ describe('Invoker terminal (component)', () => {
     expect(list.parentElement).toHaveClass('flex', 'min-h-0', 'flex-1', 'flex-col');
   }
 
-  async function expectSurfaceRailList(surface: 'planning' | 'workflows' | 'attention' | 'running', listTestId: string) {
+  async function expectSurfaceRailList(surface: 'planning' | 'workflows' | 'attention', listTestId: string) {
     fireEvent.click(await screen.findByTestId(`sidebar-${surface}`));
     await waitFor(() => {
       expect(screen.getByTestId(`sidebar-${surface}`)).toHaveAttribute('aria-current', 'page');
@@ -861,6 +861,5 @@ describe('Invoker terminal (component)', () => {
     await expectSurfaceRailList('planning', 'planning-session-list');
     await expectSurfaceRailList('workflows', 'workflows-rail-list');
     await expectSurfaceRailList('attention', 'attention-rail-list');
-    await expectSurfaceRailList('running', 'running-rail-list');
   });
 });

--- a/packages/ui/src/__tests__/queue-view.test.tsx
+++ b/packages/ui/src/__tests__/queue-view.test.tsx
@@ -210,7 +210,7 @@ describe('QueueView', () => {
     expect(workersSection.className).toContain('overflow-hidden');
     expect(workersScroll).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto');
     expect(within(actionSection).getByText('Worker Actions (1)')).toBeInTheDocument();
-    expect(within(workersSection).getByText('Worker processes (1)')).toBeInTheDocument();
+    expect(within(workersSection).queryByText('Worker processes (1)')).not.toBeInTheDocument();
     expect(within(workersSection).getByTestId('worker-row-autofix')).toBeInTheDocument();
     expect(within(actionSection).queryByTestId('worker-row-autofix')).not.toBeInTheDocument();
   });
@@ -332,7 +332,7 @@ describe('QueueView', () => {
       'worker-row-coderabbit-address',
       'worker-row-pr-conflict-rebase',
     ]);
-    expect(screen.getByText('Worker processes (5)')).toBeInTheDocument();
+    expect(screen.queryByText('Worker processes (5)')).not.toBeInTheDocument();
     expect(screen.getByText('Autofix')).toBeInTheDocument();
     expect(screen.getByText('PR status')).toBeInTheDocument();
     expect(screen.getByText('CI failure repair')).toBeInTheDocument();

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -11,7 +11,6 @@ import {
   InvokerIcon,
   MoonIcon,
   PlanningTerminalIcon,
-  RunningIcon,
   SettingsIcon,
   SunIcon,
   WorkerIcon,
@@ -90,7 +89,6 @@ export function LeftStatusColumn({
 
   const sources: SourceItem[] = [
     { key: 'attention', label: 'Needs Attention', count: attentionEntries.length, tone: 'attention', icon: <AttentionIcon className={ICON_CLASS} /> },
-    { key: 'running', label: 'Running', count: runningEntries.length, tone: 'running', icon: <RunningIcon className={ICON_CLASS} /> },
     { key: 'workers', label: 'Workers', count: registeredWorkers, tone: activeWorkerActions > 0 ? 'running' : 'neutral', icon: <WorkerIcon className={ICON_CLASS} /> },
     { key: 'workflows', label: 'Workflows', count: workflowEntries.length, tone: 'neutral', icon: <WorkflowsIcon className={ICON_CLASS} /> },
   ];

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -96,12 +96,7 @@ export function WorkerActivityCard({
   }, [snapshot, optimisticByKind]);
 
   return (
-    <div data-testid="worker-activity-card" className="flex min-h-0 min-w-0 flex-col">
-      <div className="mb-4 shrink-0">
-        <h3 className="text-lg font-semibold text-foreground">Worker processes ({snapshot?.workers.length ?? 0})</h3>
-        <div className="mt-1 text-sm text-muted-foreground">Enabled workers are restored on launch. A running process can be idle.</div>
-      </div>
-
+    <div data-testid="worker-activity-card">
       {!snapshot ? (
         <div className="rounded border border-border bg-card/60 px-3 py-2 text-sm text-muted-foreground">Worker status unavailable</div>
       ) : (

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -96,7 +96,7 @@ export function WorkerActivityCard({
   }, [snapshot, optimisticByKind]);
 
   return (
-    <div data-testid="worker-activity-card">
+    <div data-testid="worker-activity-card" className="flex min-h-0 flex-col">
       {!snapshot ? (
         <div className="rounded border border-border bg-card/60 px-3 py-2 text-sm text-muted-foreground">Worker status unavailable</div>
       ) : (


### PR DESCRIPTION
## Summary

The sidebar no longer shows a Running item, and the Workers screen no longer shows the old Worker processes heading.

This trims chrome only. Worker rows, counts, and status details still render the same way.

Fresh visual proof now shows both removals, so the PR body matches the current UI.

## Review Claim

Approve hiding the Running sidebar entry and dropping the Workers screen heading block from the app chrome.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Both changes are pure chrome trims. The Running source item is removed from the sidebar source list, and the heading block is removed from the Worker activity card render. Worker data, counts, and rows stay untouched, and the focused component tests pin both removals.

## Slice Rationale

This is the one behavior slice: it changes what the chrome renders. The snapshot loosen came first and the snapshot tighten comes last, so this slice stays focused on the visible chrome and its component tests.

## Non-goals

- Does not change any worker data, count, or status logic.
- Does not touch routing, navigation targets, or icons beyond the dropped Running entry.
- Does not re-tighten the empty-state snapshot; that is the final slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/app-launch.test.tsx src/__tests__/queue-view.test.tsx src/__tests__/invoker-terminal.test.tsx`

</details>

## Visual Proof

Sidebar proof — the library list now jumps from Needs Attention straight to Workers; Running is gone.

![Sidebar proof showing Needs Attention followed by Workers and Workflows](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-009165/pr-4150-sidebar-no-running.png)

Workers proof — worker rows start immediately under the split view; the old Worker processes heading block is gone.

![Workers proof showing Worker Actions at left and worker rows at right with no Worker processes heading](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-009165/pr-4150-workers-no-heading.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <squash-merge commit>` (restores the Running entry and the heading block)
- Post-revert steps: None
- Data migration? No

</details>

