### PR TITLE
[Remove Running Sidebar And Workers Screen Title](3) Pin removed sidebar label in visual snapshot

### DIFF
--- a/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
+++ b/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
@@ -38,10 +38,7 @@ describe('Visual proof snapshots', () => {
     expect(screen.getByTestId('sidebar-home')).toHaveTextContent('Invoker');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    const runningSidebarItem = screen.queryByTestId('sidebar-running');
-    if (runningSidebarItem) {
-      expect(runningSidebarItem).toHaveTextContent('Running');
-    }
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
     expect(screen.getByText('Describe the change in the terminal to generate a plan.')).toBeInTheDocument();
     expect(screen.getByTestId('rail-settings')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();


### PR DESCRIPTION
Depends-On: #4150

## Summary

The empty-state snapshot was loosened in slice 1 so the Running sidebar item became optional.

Now that the Running item is gone, this slice pins its absence in the snapshot.

It restores the assertion to a strict check, so a future regression that re-adds the item would fail the guard.

This is the only change; no component or runtime code is touched.

## Review Claim

Approve tightening the empty-state snapshot to assert the Running sidebar item stays absent.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice edits a single test file. It strengthens one assertion in the empty-state snapshot and changes no runtime code path and no rendered pixel.

## Slice Rationale

The snapshot could only be tightened after the behavior slice made the Running item absent. Keeping the tighten as its own final slice keeps the proof honest: it flips from optional back to strict once the change has landed.

## Non-goals

- Does not touch any sidebar or Workers component.
- Does not change what the app renders.
- Does not alter any other snapshot assertion.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test` — runs the UI Vitest suite, including `packages/ui/src/__tests__/visual-proof-snapshots.test.tsx`

</details>

## Visual Proof

No user-visible pixels change in this slice; it strengthens one test assertion only. The Electron capture harness is not run in this publication step. The tightened guard in `packages/ui/src/__tests__/visual-proof-snapshots.test.tsx` now asserts the Running item stays absent.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <squash-merge commit>` (single test-file change)
- Post-revert steps: None
- Data migration? No

</details>
