### PR TITLE
Fix merge-gate worktree misroute after review publish

### DIFF
--- a/packages/execution-engine/src/__tests__/merge-node-select-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/merge-node-select-executor.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TaskState } from '@invoker/workflow-core';
+import { TaskRunner } from '../task-runner.js';
+
+function makeMergeTask(runnerKind: 'worktree' | 'merge' = 'worktree'): TaskState {
+  return {
+    id: '__merge__wf-x',
+    description: 'Review gate',
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config: {
+      isMergeNode: true,
+      runnerKind,
+      workflowId: 'wf-x',
+    },
+    execution: {
+      selectedAttemptId: '__merge__wf-x-a1',
+      generation: 1,
+    },
+  } as TaskState;
+}
+
+describe('selectExecutor merge-node routing', () => {
+  it('selects MergeGateExecutor when isMergeNode is true even if runnerKind is worktree', () => {
+    const worktree = {
+      type: 'worktree',
+      start: vi.fn(),
+      onComplete: vi.fn(),
+      onOutput: vi.fn(),
+      onHeartbeat: vi.fn(),
+      kill: vi.fn(),
+      destroyAll: vi.fn(),
+    };
+    const merge = {
+      type: 'merge',
+      start: vi.fn(),
+      onComplete: vi.fn(),
+      onOutput: vi.fn(),
+      onHeartbeat: vi.fn(),
+      kill: vi.fn(),
+      destroyAll: vi.fn(),
+    };
+    const runner = new TaskRunner({
+      orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+      persistence: {} as any,
+      executorRegistry: {
+        getDefault: () => worktree,
+        get: (type: string) => {
+          if (type === 'merge') return merge;
+          if (type === 'worktree') return worktree;
+          return null;
+        },
+        getAll: () => [worktree, merge],
+        register: vi.fn(),
+      } as any,
+      cwd: '/tmp',
+    });
+
+    const selected = runner.selectExecutor(makeMergeTask('worktree'));
+    expect(selected.executor.type).toBe('merge');
+  });
+});

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -3962,19 +3962,15 @@ describe('TaskRunner', () => {
       for (let i = 0; i < 10; i++) await Promise.resolve();
     }
 
-    it('does not run merge-node work from the completion handler', async () => {
-      const log: string[] = [];
-      const deferred1 = createDeferred();
-      const deferred2 = createDeferred();
+    it('does not run legacy executeMergeNode from the completion handler', async () => {
       let mergeCallCount = 0;
-
       const completeCallbacks = new Map<string, (response: WorkResponse) => void>();
-      const manualExecutor = {
-        type: 'worktree',
+      const mergeExecutor = {
+        type: 'merge',
         start: vi.fn(async (request: any) => ({
           executionId: `exec-${request.actionId}`,
           taskId: request.actionId,
-          workspacePath: '/tmp/mock-worktree',
+          workspacePath: '/tmp/mock-merge',
           branch: `invoker/${request.actionId}`,
         })),
         onComplete: vi.fn((handle: any, cb: any) => {
@@ -3993,30 +3989,28 @@ describe('TaskRunner', () => {
         } as any,
         persistence: { updateTask: vi.fn() } as any,
         executorRegistry: {
-          getDefault: () => manualExecutor,
-          get: () => manualExecutor,
-          getAll: () => [manualExecutor],
+          getDefault: () => mergeExecutor,
+          get: (type: string) => (type === 'merge' ? mergeExecutor : null),
+          getAll: () => [mergeExecutor],
+          register: vi.fn(),
         } as any,
         cwd: '/tmp',
       });
 
       vi.spyOn(runner as any, 'executeMergeNode').mockImplementation(async () => {
-        const n = ++mergeCallCount;
-        log.push(`enter-${n}`);
-        if (n === 1) await deferred1.promise;
-        else await deferred2.promise;
-        log.push(`exit-${n}`);
+        mergeCallCount += 1;
       });
 
+      // Persisted runnerKind=worktree must still route to the merge executor.
       const task1 = makeTask({ id: 'merge-1', status: 'running', config: { isMergeNode: true, runnerKind: 'worktree' } });
       const task2 = makeTask({ id: 'merge-2', status: 'running', config: { isMergeNode: true, runnerKind: 'worktree' } });
 
       const done1 = runner.executeTask(task1);
       const done2 = runner.executeTask(task2);
       await flush();
+      expect(mergeExecutor.start).toHaveBeenCalledTimes(2);
       expect(completeCallbacks.size).toBe(2);
 
-      // Fire both onComplete callbacks simultaneously
       completeCallbacks.get('merge-1')!({
         requestId: 'r1', actionId: 'merge-1', status: 'completed', outputs: { exitCode: 0 },
       });
@@ -4026,26 +4020,23 @@ describe('TaskRunner', () => {
 
       await flush();
       await Promise.all([done1, done2]);
-      expect(log).toEqual([]);
       expect(mergeCallCount).toBe(0);
     });
 
-    it('a completed no-command merge worktree does not enter merge execution from onComplete', async () => {
+    it('routes isMergeNode + runnerKind worktree through merge executor completion', async () => {
       vi.useFakeTimers();
       try {
-        const log: string[] = [];
-        const deferred1 = createDeferred();
         const completeCallbacks = new Map<string, (response: WorkResponse) => void>();
         const updateAttempt = vi.fn();
-        const receivedHeartbeats: string[] = [];
         const onCompleteCb = vi.fn();
+        let legacyMergeCallCount = 0;
 
-        const manualExecutor = {
-          type: 'worktree',
+        const mergeExecutor = {
+          type: 'merge',
           start: vi.fn(async (request: any) => ({
             executionId: `exec-${request.actionId}`,
             taskId: request.actionId,
-            workspacePath: '/tmp/mock-worktree',
+            workspacePath: '/tmp/mock-merge',
             branch: `invoker/${request.actionId}`,
           })),
           onComplete: vi.fn((handle: any, cb: any) => {
@@ -4082,23 +4073,19 @@ describe('TaskRunner', () => {
           } as any,
           persistence: { updateTask: vi.fn(), updateAttempt } as any,
           executorRegistry: {
-            getDefault: () => manualExecutor,
-            get: () => manualExecutor,
-            getAll: () => [manualExecutor],
+            getDefault: () => mergeExecutor,
+            get: (type: string) => (type === 'merge' ? mergeExecutor : null),
+            getAll: () => [mergeExecutor],
+            register: vi.fn(),
           } as any,
           cwd: '/tmp',
           callbacks: {
-            onHeartbeat: (taskId: string) => { receivedHeartbeats.push(taskId); },
             onComplete: onCompleteCb,
           },
         });
 
-        vi.spyOn(runner as any, 'executeMergeNode').mockImplementation(async (task: TaskState) => {
-          log.push(`enter-${task.id}`);
-          if (task.id === 'merge-1') {
-            await deferred1.promise;
-          }
-          log.push(`exit-${task.id}`);
+        vi.spyOn(runner as any, 'executeMergeNode').mockImplementation(async () => {
+          legacyMergeCallCount += 1;
         });
 
         const task1 = makeTask({
@@ -4117,6 +4104,7 @@ describe('TaskRunner', () => {
         const done1 = runner.executeTask(task1);
         const done2 = runner.executeTask(task2);
         await flush();
+        expect(mergeExecutor.start).toHaveBeenCalledTimes(2);
         expect(completeCallbacks.size).toBe(2);
 
         completeCallbacks.get('merge-1')!({
@@ -4133,18 +4121,12 @@ describe('TaskRunner', () => {
         });
 
         await flush();
-        await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
-
-        expect(log).toEqual([]);
-        expect(receivedHeartbeats).not.toContain('merge-2');
+        await Promise.all([done1, done2]);
+        expect(legacyMergeCallCount).toBe(0);
         expect(onCompleteCb).toHaveBeenCalledWith(
           'merge-2',
           expect.objectContaining({ status: 'completed' }),
         );
-
-        deferred1.resolve(undefined as any);
-        await Promise.all([done1, done2]);
-        expect(log).toEqual([]);
       } finally {
         vi.useRealTimers();
       }

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -935,6 +935,11 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
       const session = this.prepareClaudeSession(request);
       return { cmd: claudeCommand, args: session.cliArgs, agentSessionId: session.sessionId, fullPrompt: session.fullPrompt };
     }
+    if (request.actionType === 'merge_gate') {
+      throw new Error(
+        'WorkRequest actionType "merge_gate" must run on MergeGateExecutor, not a worktree/command executor',
+      );
+    }
     return { cmd: '/bin/bash', args: ['-c', 'echo "Unsupported action type"'] };
   }
 

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -457,9 +457,6 @@ export function selectExecutor(
   task: TaskState,
   excludedPoolMemberKeys: Set<string> = new Set(),
 ): SelectedExecutor {
-  // Merge nodes must always use MergeGateExecutor. After a successful review-gate
-  // publish, merge-runner persists runnerKind='worktree' for gate-terminal restore;
-  // that must not win over isMergeNode on retry/recreate.
   let effectiveType = task.config.isMergeNode
     ? 'merge'
     : task.config.runnerKind;

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -457,7 +457,12 @@ export function selectExecutor(
   task: TaskState,
   excludedPoolMemberKeys: Set<string> = new Set(),
 ): SelectedExecutor {
-  let effectiveType = task.config.runnerKind ?? (task.config.isMergeNode ? 'merge' : undefined);
+  // Merge nodes must always use MergeGateExecutor. After a successful review-gate
+  // publish, merge-runner persists runnerKind='worktree' for gate-terminal restore;
+  // that must not win over isMergeNode on retry/recreate.
+  let effectiveType = task.config.isMergeNode
+    ? 'merge'
+    : task.config.runnerKind;
   let selectedPoolMemberId: string | undefined;
   const explicitPoolMemberId = (task.config as { poolMemberId?: string }).poolMemberId;
   let resolvedExecution: ResolvedExecutionSelection = {


### PR DESCRIPTION
## Summary

Review gates could finish as completed without publishing a PR.

After a successful review publish, Invoker stores runnerKind=worktree on the merge node so gate terminals can open. Later launches preferred that stored runnerKind over isMergeNode and launched WorktreeExecutor instead of MergeGateExecutor.

WorktreeExecutor treated merge_gate as an unsupported action, echoed success, and exited 0. The gate looked done, but no stack was published.

## Review Claim

Merge nodes always route to MergeGateExecutor, even when runnerKind is persisted as worktree.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only changes executor selection for isMergeNode tasks and fails loudly if merge_gate reaches a worktree or command executor. Non-merge tasks keep their existing runnerKind routing.

## Slice Rationale

One routing behavior fix with a focused regression test. No UI or schema changes.

## Non-goals

- Does not stop merge-runner from persisting runnerKind=worktree for gate-terminal restore
- Does not change make-pr publication or review-gate polling
- Does not republish any existing workflow stack

## Architecture

### Before

```mermaid
flowchart TD
  mergeNode["Merge node relaunch"] --> select["selectExecutor"]
  select -->|"runnerKind worktree wins"| worktree["WorktreeExecutor"]
  worktree -->|"echo Unsupported action type"| completed["completed with no PR"]
```

### After

```mermaid
flowchart TD
  mergeNode["Merge node relaunch"] --> select["selectExecutor"]
  select -->|"isMergeNode forces merge"| mergeExec["MergeGateExecutor"]
  mergeExec --> publish["consolidate and make-pr"]
  publish --> reviewReady["review_ready"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/merge-node-select-executor.test.ts`
- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/task-runner-fix-publish-and-ssh.test.ts -t 'legacy executeMergeNode|runnerKind worktree through merge'`
- [x] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Merge-node tasks now consistently route through the dedicated merge executor, including when configured with a worktree runner.
  - Prevented unsupported merge-gate actions from running through the standard executor path.
  - Improved merge completion handling to avoid invoking legacy execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->