### PR TITLE
[UI Responsiveness Guardrails Step 1](1) Roll up renderer ui-perf metrics

### DIFF
--- a/packages/app/src/__tests__/renderer-ui-perf.test.ts
+++ b/packages/app/src/__tests__/renderer-ui-perf.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createRendererUiPerfCounters,
+  recordRendererUiPerfMetric,
+  resetRendererUiPerfCounters,
+} from '../renderer-ui-perf.js';
+
+describe('renderer ui perf counters', () => {
+  it('aggregates renderer lag, planning chat, and embedded terminal markers', () => {
+    const counters = createRendererUiPerfCounters();
+
+    recordRendererUiPerfMetric(counters, 'renderer_event_loop_lag', {
+      lagMs: 300,
+      cumulativeLagMs: 450,
+      tickDeltaMs: 1300,
+      visibilityState: 'visible',
+      hasFocus: true,
+    });
+    recordRendererUiPerfMetric(counters, 'renderer_event_loop_lag', {
+      lagMs: 900,
+      visibilityState: 'hidden',
+      hasFocus: false,
+    });
+    recordRendererUiPerfMetric(counters, 'renderer_long_task', { durationMs: 250 });
+    recordRendererUiPerfMetric(counters, 'planning_chat_input_change', { handlerDurationMs: 12 });
+    recordRendererUiPerfMetric(counters, 'planning_chat_input_commit', { durationMs: 34 });
+    recordRendererUiPerfMetric(counters, 'planning_chat_transcript_commit', {
+      durationMs: 56,
+      lineCount: 9,
+      transcriptChars: 1234,
+    });
+    recordRendererUiPerfMetric(counters, 'planning_chat_transcript_autoscroll', { durationMs: 7 });
+    recordRendererUiPerfMetric(counters, 'planning_chat_submit', {});
+    recordRendererUiPerfMetric(counters, 'embedded_terminal_attach', { durationMs: 44 });
+    recordRendererUiPerfMetric(counters, 'embedded_terminal_input', { durationMs: 3, bytes: 5 });
+    recordRendererUiPerfMetric(counters, 'embedded_terminal_output_write', { durationMs: 80, bytes: 4096 });
+    recordRendererUiPerfMetric(counters, 'embedded_terminal_resize', { durationMs: 18 });
+    recordRendererUiPerfMetric(counters, 'embedded_terminal_snapshot_write', { durationMs: 90, bytes: 8192 });
+
+    expect(counters.rendererReports).toBe(13);
+    expect(counters.maxRendererEventLoopLagMs).toBe(300);
+    expect(counters.maxRendererHiddenEventLoopLagMs).toBe(900);
+    expect(counters.maxRendererCumulativeLagMs).toBe(450);
+    expect(counters.maxRendererTickDeltaMs).toBe(1300);
+    expect(counters.maxRendererLongTaskMs).toBe(250);
+    expect(counters.planningChatInputChangeReports).toBe(1);
+    expect(counters.maxPlanningChatInputHandlerMs).toBe(12);
+    expect(counters.planningChatInputCommitReports).toBe(1);
+    expect(counters.maxPlanningChatInputCommitMs).toBe(34);
+    expect(counters.planningChatTranscriptCommitReports).toBe(1);
+    expect(counters.maxPlanningChatTranscriptCommitMs).toBe(56);
+    expect(counters.maxPlanningChatTranscriptLines).toBe(9);
+    expect(counters.maxPlanningChatTranscriptChars).toBe(1234);
+    expect(counters.planningChatTranscriptAutoscrollReports).toBe(1);
+    expect(counters.maxPlanningChatTranscriptAutoscrollMs).toBe(7);
+    expect(counters.planningChatSubmits).toBe(1);
+    expect(counters.embeddedTerminalAttachReports).toBe(1);
+    expect(counters.maxEmbeddedTerminalAttachMs).toBe(44);
+    expect(counters.embeddedTerminalInputReports).toBe(1);
+    expect(counters.maxEmbeddedTerminalInputMs).toBe(3);
+    expect(counters.maxEmbeddedTerminalInputBytes).toBe(5);
+    expect(counters.embeddedTerminalOutputWriteReports).toBe(1);
+    expect(counters.maxEmbeddedTerminalOutputWriteMs).toBe(80);
+    expect(counters.maxEmbeddedTerminalOutputWriteBytes).toBe(4096);
+    expect(counters.embeddedTerminalResizeReports).toBe(1);
+    expect(counters.maxEmbeddedTerminalResizeMs).toBe(18);
+    expect(counters.embeddedTerminalSnapshotWriteReports).toBe(1);
+    expect(counters.maxEmbeddedTerminalSnapshotWriteMs).toBe(90);
+    expect(counters.maxEmbeddedTerminalSnapshotBytes).toBe(8192);
+
+    resetRendererUiPerfCounters(counters);
+
+    expect(counters.rendererReports).toBe(0);
+    expect(counters.maxPlanningChatInputCommitMs).toBe(0);
+    expect(counters.maxEmbeddedTerminalOutputWriteBytes).toBe(0);
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -278,6 +278,11 @@ import {
   resetTerminalUiPerfCounters,
 } from './terminal-ui-perf.js';
 import {
+  createRendererUiPerfCounters,
+  recordRendererUiPerfMetric,
+  resetRendererUiPerfCounters,
+} from './renderer-ui-perf.js';
+import {
   registerPlanningTerminalSessionIpcHandlers,
   registerTerminalSessionIpcHandlers,
   registerTerminalSessionPersistence,
@@ -2109,12 +2114,7 @@ function createEmbeddedTerminalBackendFromConfig(
     dbPollCreated: 0,
     dbPollUpdatedAsCreated: 0,
     dbPollUpdatedAsUpdated: 0,
-    rendererReports: 0,
-    maxRendererEventLoopLagMs: 0,
-    maxRendererHiddenEventLoopLagMs: 0,
-    maxRendererCumulativeLagMs: 0,
-    maxRendererTickDeltaMs: 0,
-    maxRendererLongTaskMs: 0,
+    ...createRendererUiPerfCounters(),
     workflowMetadataPublishRequests: 0,
     workflowMetadataPublishes: 0,
     workflowMetadataCoalescedRequests: 0,
@@ -2179,12 +2179,7 @@ function createEmbeddedTerminalBackendFromConfig(
     uiPerfStats.dbPollCreated = 0;
     uiPerfStats.dbPollUpdatedAsCreated = 0;
     uiPerfStats.dbPollUpdatedAsUpdated = 0;
-    uiPerfStats.rendererReports = 0;
-    uiPerfStats.maxRendererEventLoopLagMs = 0;
-    uiPerfStats.maxRendererHiddenEventLoopLagMs = 0;
-    uiPerfStats.maxRendererCumulativeLagMs = 0;
-    uiPerfStats.maxRendererTickDeltaMs = 0;
-    uiPerfStats.maxRendererLongTaskMs = 0;
+    resetRendererUiPerfCounters(uiPerfStats);
     uiPerfStats.workflowMetadataPublishRequests = 0;
     uiPerfStats.workflowMetadataPublishes = 0;
     uiPerfStats.workflowMetadataCoalescedRequests = 0;
@@ -4531,24 +4526,7 @@ function createEmbeddedTerminalBackendFromConfig(
       ) {
         logger.info(`ui metric ${metric} ${JSON.stringify(data ?? {})}`, { module: 'ui-state' });
       }
-      if (metric === 'renderer_event_loop_lag' && typeof data?.lagMs === 'number') {
-        const hiddenOrUnfocused = data.visibilityState === 'hidden' || data.hasFocus === false;
-        if (hiddenOrUnfocused) {
-          uiPerfStats.maxRendererHiddenEventLoopLagMs = Math.max(uiPerfStats.maxRendererHiddenEventLoopLagMs, data.lagMs);
-        } else {
-          uiPerfStats.maxRendererEventLoopLagMs = Math.max(uiPerfStats.maxRendererEventLoopLagMs, data.lagMs);
-        }
-        if (typeof data.cumulativeLagMs === 'number') {
-          uiPerfStats.maxRendererCumulativeLagMs = Math.max(uiPerfStats.maxRendererCumulativeLagMs, data.cumulativeLagMs);
-        }
-        if (typeof data.tickDeltaMs === 'number') {
-          uiPerfStats.maxRendererTickDeltaMs = Math.max(uiPerfStats.maxRendererTickDeltaMs, data.tickDeltaMs);
-        }
-      }
-      if (metric === 'renderer_long_task' && typeof data?.durationMs === 'number') {
-        uiPerfStats.maxRendererLongTaskMs = Math.max(uiPerfStats.maxRendererLongTaskMs, data.durationMs);
-      }
-      uiPerfStats.rendererReports += 1;
+      recordRendererUiPerfMetric(uiPerfStats, metric, data);
       try {
         persistence.writeActivityLog('ui-perf', 'info', JSON.stringify(payload));
       } catch {

--- a/packages/app/src/renderer-ui-perf.ts
+++ b/packages/app/src/renderer-ui-perf.ts
@@ -1,0 +1,186 @@
+/**
+ * Renderer-originated UI-perf counters.
+ *
+ * The main process owns persistence and IPC. This module only keeps the
+ * aggregate counters behind getUiPerfStats/query ui-perf.
+ */
+
+export type RendererUiPerfCounters = {
+  rendererReports: number;
+  maxRendererEventLoopLagMs: number;
+  maxRendererHiddenEventLoopLagMs: number;
+  maxRendererCumulativeLagMs: number;
+  maxRendererTickDeltaMs: number;
+  maxRendererLongTaskMs: number;
+  planningChatInputChangeReports: number;
+  maxPlanningChatInputHandlerMs: number;
+  planningChatInputCommitReports: number;
+  maxPlanningChatInputCommitMs: number;
+  planningChatTranscriptCommitReports: number;
+  maxPlanningChatTranscriptCommitMs: number;
+  maxPlanningChatTranscriptLines: number;
+  maxPlanningChatTranscriptChars: number;
+  planningChatTranscriptAutoscrollReports: number;
+  maxPlanningChatTranscriptAutoscrollMs: number;
+  planningChatSubmits: number;
+  embeddedTerminalAttachReports: number;
+  maxEmbeddedTerminalAttachMs: number;
+  embeddedTerminalInputReports: number;
+  maxEmbeddedTerminalInputMs: number;
+  maxEmbeddedTerminalInputBytes: number;
+  embeddedTerminalOutputWriteReports: number;
+  maxEmbeddedTerminalOutputWriteMs: number;
+  maxEmbeddedTerminalOutputWriteBytes: number;
+  embeddedTerminalResizeReports: number;
+  maxEmbeddedTerminalResizeMs: number;
+  embeddedTerminalSnapshotWriteReports: number;
+  maxEmbeddedTerminalSnapshotWriteMs: number;
+  maxEmbeddedTerminalSnapshotBytes: number;
+};
+
+export function createRendererUiPerfCounters(): RendererUiPerfCounters {
+  return {
+    rendererReports: 0,
+    maxRendererEventLoopLagMs: 0,
+    maxRendererHiddenEventLoopLagMs: 0,
+    maxRendererCumulativeLagMs: 0,
+    maxRendererTickDeltaMs: 0,
+    maxRendererLongTaskMs: 0,
+    planningChatInputChangeReports: 0,
+    maxPlanningChatInputHandlerMs: 0,
+    planningChatInputCommitReports: 0,
+    maxPlanningChatInputCommitMs: 0,
+    planningChatTranscriptCommitReports: 0,
+    maxPlanningChatTranscriptCommitMs: 0,
+    maxPlanningChatTranscriptLines: 0,
+    maxPlanningChatTranscriptChars: 0,
+    planningChatTranscriptAutoscrollReports: 0,
+    maxPlanningChatTranscriptAutoscrollMs: 0,
+    planningChatSubmits: 0,
+    embeddedTerminalAttachReports: 0,
+    maxEmbeddedTerminalAttachMs: 0,
+    embeddedTerminalInputReports: 0,
+    maxEmbeddedTerminalInputMs: 0,
+    maxEmbeddedTerminalInputBytes: 0,
+    embeddedTerminalOutputWriteReports: 0,
+    maxEmbeddedTerminalOutputWriteMs: 0,
+    maxEmbeddedTerminalOutputWriteBytes: 0,
+    embeddedTerminalResizeReports: 0,
+    maxEmbeddedTerminalResizeMs: 0,
+    embeddedTerminalSnapshotWriteReports: 0,
+    maxEmbeddedTerminalSnapshotWriteMs: 0,
+    maxEmbeddedTerminalSnapshotBytes: 0,
+  };
+}
+
+export function resetRendererUiPerfCounters(counters: RendererUiPerfCounters): void {
+  const initial = createRendererUiPerfCounters();
+  for (const key of Object.keys(initial) as Array<keyof RendererUiPerfCounters>) {
+    counters[key] = initial[key];
+  }
+}
+
+function numberField(data: Record<string, unknown> | undefined, key: string): number | null {
+  const value = data?.[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function updateMax(
+  counters: RendererUiPerfCounters,
+  key: keyof RendererUiPerfCounters,
+  value: number | null,
+): void {
+  if (value === null) return;
+  counters[key] = Math.max(counters[key], value);
+}
+
+export function recordRendererUiPerfMetric(
+  counters: RendererUiPerfCounters,
+  metric: string,
+  data?: Record<string, unknown>,
+): void {
+  counters.rendererReports += 1;
+
+  if (metric === 'renderer_event_loop_lag') {
+    const lagMs = numberField(data, 'lagMs');
+    if (lagMs !== null) {
+      const hiddenOrUnfocused = data?.visibilityState === 'hidden' || data?.hasFocus === false;
+      updateMax(
+        counters,
+        hiddenOrUnfocused ? 'maxRendererHiddenEventLoopLagMs' : 'maxRendererEventLoopLagMs',
+        lagMs,
+      );
+    }
+    updateMax(counters, 'maxRendererCumulativeLagMs', numberField(data, 'cumulativeLagMs'));
+    updateMax(counters, 'maxRendererTickDeltaMs', numberField(data, 'tickDeltaMs'));
+    return;
+  }
+
+  if (metric === 'renderer_long_task') {
+    updateMax(counters, 'maxRendererLongTaskMs', numberField(data, 'durationMs'));
+    return;
+  }
+
+  if (metric === 'planning_chat_input_change') {
+    counters.planningChatInputChangeReports += 1;
+    updateMax(counters, 'maxPlanningChatInputHandlerMs', numberField(data, 'handlerDurationMs'));
+    return;
+  }
+
+  if (metric === 'planning_chat_input_commit') {
+    counters.planningChatInputCommitReports += 1;
+    updateMax(counters, 'maxPlanningChatInputCommitMs', numberField(data, 'durationMs'));
+    return;
+  }
+
+  if (metric === 'planning_chat_transcript_commit') {
+    counters.planningChatTranscriptCommitReports += 1;
+    updateMax(counters, 'maxPlanningChatTranscriptCommitMs', numberField(data, 'durationMs'));
+    updateMax(counters, 'maxPlanningChatTranscriptLines', numberField(data, 'lineCount'));
+    updateMax(counters, 'maxPlanningChatTranscriptChars', numberField(data, 'transcriptChars'));
+    return;
+  }
+
+  if (metric === 'planning_chat_transcript_autoscroll') {
+    counters.planningChatTranscriptAutoscrollReports += 1;
+    updateMax(counters, 'maxPlanningChatTranscriptAutoscrollMs', numberField(data, 'durationMs'));
+    return;
+  }
+
+  if (metric === 'planning_chat_submit') {
+    counters.planningChatSubmits += 1;
+    return;
+  }
+
+  if (metric === 'embedded_terminal_attach') {
+    counters.embeddedTerminalAttachReports += 1;
+    updateMax(counters, 'maxEmbeddedTerminalAttachMs', numberField(data, 'durationMs'));
+    return;
+  }
+
+  if (metric === 'embedded_terminal_input') {
+    counters.embeddedTerminalInputReports += 1;
+    updateMax(counters, 'maxEmbeddedTerminalInputMs', numberField(data, 'durationMs'));
+    updateMax(counters, 'maxEmbeddedTerminalInputBytes', numberField(data, 'bytes'));
+    return;
+  }
+
+  if (metric === 'embedded_terminal_output_write') {
+    counters.embeddedTerminalOutputWriteReports += 1;
+    updateMax(counters, 'maxEmbeddedTerminalOutputWriteMs', numberField(data, 'durationMs'));
+    updateMax(counters, 'maxEmbeddedTerminalOutputWriteBytes', numberField(data, 'bytes'));
+    return;
+  }
+
+  if (metric === 'embedded_terminal_resize') {
+    counters.embeddedTerminalResizeReports += 1;
+    updateMax(counters, 'maxEmbeddedTerminalResizeMs', numberField(data, 'durationMs'));
+    return;
+  }
+
+  if (metric === 'embedded_terminal_snapshot_write') {
+    counters.embeddedTerminalSnapshotWriteReports += 1;
+    updateMax(counters, 'maxEmbeddedTerminalSnapshotWriteMs', numberField(data, 'durationMs'));
+    updateMax(counters, 'maxEmbeddedTerminalSnapshotBytes', numberField(data, 'bytes'));
+  }
+}


### PR DESCRIPTION
## Summary

UI Responsiveness Guardrails Step 1 routes renderer-originated perf reports into owner-side counters.

The new counter module keeps getUiPerfStats and query ui-perf ready for planning chat and embedded terminal metrics.

## Review Claim

Owner-side ui-perf routing aggregates planning chat and embedded terminal renderer markers through the existing report-ui-perf IPC path.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice reuses invoker:report-ui-perf and the existing ui-perf activity log. It does not change workflow mutation behavior.

## Slice Rationale

Owner aggregation lands first so renderer markers in the next slice have a stable destination.

## Non-goals

- No renderer component instrumentation in this slice.
- No new logging channel or persistence table.
- No threshold, alerting, or UI responsiveness policy changes.

## Architecture

### Before

```mermaid
graph TD
    A["Renderer calls invoker:report-ui-perf"] --> B["main.ts updates renderer lag counters inline"]
    B --> C["getUiPerfStats and ui-perf logs"]
```

### After

```mermaid
graph TD
    A["Renderer calls invoker:report-ui-perf"] --> B["renderer-ui-perf records named counters"]
    B --> C["getUiPerfStats and ui-perf logs"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/renderer-ui-perf.test.ts`
- [x] `pnpm --filter @invoker/app test -- renderer-ui-perf`

</details>

## Visual Proof

The planning terminal still renders its standard ready state while the owner-side perf path changes behind the scenes.

![Planning terminal ready state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-1705d4/planning-terminal-restore-after.png)

The restart walkthrough remains available for the planning terminal surface after this instrumentation support lands.

![Planning terminal restart walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-1705d4/planning-terminal-restart.gif)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 89702b8b`
- Post-revert steps: Re-run the focused app perf test if the UI marker slice is still present.
- Data migration? No.

</details>