### PR TITLE
[UI Responsiveness Guardrails Step 1](2) Instrument planning chat and terminal perf markers

### DIFF
--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -299,6 +299,8 @@ export function createMockInvoker(
     runInvokerCliSetup: vi.fn(async () => ({ ok: true, steps: [{ id: 'tools', name: 'Run setup', ok: true, output: 'setup ok' }] })),
     replaceTask: vi.fn(async () => accepted('invoker:replace-task')),
     getActivityLogs: vi.fn(async () => []),
+    reportUiPerf: vi.fn(async () => {}),
+    getUiPerfStats: vi.fn(async () => ({})),
     getEvents: vi.fn(async (taskId: string, options?: { limit: number; sortBy?: 'asc' | 'desc'; beforeId?: number }) => {
       const events = [...(eventsByTask.get(taskId) ?? [])];
       const sorted = options?.sortBy === 'desc'

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -119,6 +119,80 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
+  it('reports planning chat input, submit, and transcript render perf markers', async () => {
+    const props = {
+      activeConversationKey: 'chat-1',
+      lines: [{ id: 1, text: 'First line', role: 'system' as const }],
+      busy: false,
+      value: '',
+      selectedPresetKey: 'codex',
+      presetOptions: [{ key: 'codex', label: 'Codex' }],
+      draftPlanAvailable: false,
+      onValueChange: vi.fn(),
+      onSubmit: vi.fn(),
+      onSubmitDraft: vi.fn(),
+      onPresetChange: vi.fn(),
+      onExpand: vi.fn(),
+    };
+    const { rerender } = render(<InvokerTerminal {...props} />);
+    vi.mocked(mock.api.reportUiPerf).mockClear();
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello' } });
+    expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+      'planning_chat_input_change',
+      expect.objectContaining({
+        valueLength: 5,
+        previousValueLength: 0,
+        deltaLength: 5,
+        conversationKey: 'chat-1',
+        transcriptLineCount: 1,
+      }),
+    );
+
+    rerender(<InvokerTerminal {...props} value="hello" />);
+    await waitFor(() => {
+      expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+        'planning_chat_input_commit',
+        expect.objectContaining({
+          valueLength: 5,
+          previousValueLength: 0,
+          deltaLength: 5,
+          conversationKey: 'chat-1',
+          transcriptLineCount: 1,
+        }),
+      );
+    });
+
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+    expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+      'planning_chat_submit',
+      expect.objectContaining({
+        source: 'form',
+        valueLength: 5,
+        trimmedLength: 5,
+        conversationKey: 'chat-1',
+      }),
+    );
+
+    rerender(<InvokerTerminal
+      {...props}
+      value="hello"
+      lines={[...props.lines, { id: 2, text: 'Second line', role: 'assistant' as const }]}
+    />);
+    await waitFor(() => {
+      expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+        'planning_chat_transcript_commit',
+        expect.objectContaining({
+          conversationKey: 'chat-1',
+          lineCount: 2,
+          lineDelta: 1,
+          transcriptChars: 'First lineSecond line'.length,
+          lastLineRole: 'assistant',
+        }),
+      );
+    });
+  });
+
   it('continues the same planning session', async () => {
     render(<App />);
     await openPlanningTerminal();

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -488,6 +488,79 @@ describe('Terminal drawer (component)', () => {
     });
   });
 
+  it('reports embedded terminal attach, snapshot, input, and output perf markers', async () => {
+    const session = makeTerminalSession('task-alpha', {
+      outputSnapshot: 'early line\n',
+      command: 'sh',
+      args: ['-lc', 'printf ready'],
+    });
+
+    render(
+      <TerminalDrawer
+        state="partial"
+        onCycle={vi.fn()}
+        sessions={[session]}
+        activeSessionId={session.sessionId}
+        onSelectSession={vi.fn()}
+        onCloseSession={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+        'embedded_terminal_attach',
+        expect.objectContaining({
+          sessionId: session.sessionId,
+          taskId: session.taskId,
+          active: true,
+          hasSnapshot: true,
+        }),
+      );
+    });
+    expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+      'embedded_terminal_snapshot_write',
+      expect.objectContaining({
+        source: 'attach',
+        sessionId: session.sessionId,
+        taskId: session.taskId,
+        bytes: 'early line\n'.length,
+      }),
+    );
+
+    vi.mocked(mock.api.reportUiPerf).mockClear();
+    act(() => {
+      xtermMock.instances[0]?.emitData('pwd\n');
+    });
+    expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+      'embedded_terminal_input',
+      expect.objectContaining({
+        sessionId: session.sessionId,
+        taskId: session.taskId,
+        bytes: 'pwd\n'.length,
+        active: true,
+      }),
+    );
+
+    act(() => {
+      mock.fireTerminalOutput({
+        sessionId: session.sessionId,
+        taskId: session.taskId,
+        data: 'live line\n',
+      });
+    });
+    await waitFor(() => {
+      expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+        'embedded_terminal_output_write',
+        expect.objectContaining({
+          sessionId: session.sessionId,
+          taskId: session.taskId,
+          bytes: 'live line\n'.length,
+          active: true,
+        }),
+      );
+    });
+  });
+
   it('does not duplicate the replay snapshot when the same session re-renders', async () => {
     const session = makeTerminalSession('task-alpha', {
       outputSnapshot: 'replayed once\n',

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ChangeEvent, type FormEvent, type KeyboardEvent } from 'react';
 import { Terminal as XTermTerminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import type { TerminalSessionDescriptor } from '@invoker/contracts';
@@ -23,6 +23,18 @@ const TRANSCRIPT_BOTTOM_TOLERANCE_PX = 32;
 
 function isTranscriptNearBottom(element: HTMLDivElement): boolean {
   return element.scrollHeight - element.scrollTop - element.clientHeight <= TRANSCRIPT_BOTTOM_TOLERANCE_PX;
+}
+
+function nowMs(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
+function roundMs(durationMs: number): number {
+  return Math.max(0, Math.round(durationMs));
+}
+
+function reportPlanningChatPerf(metric: string, data: Record<string, unknown>): void {
+  void window.invoker?.reportUiPerf?.(metric, data);
 }
 
 interface InvokerTerminalProps {
@@ -273,26 +285,91 @@ export function InvokerTerminal({
   onCollapse,
   activeConversationKey,
 }: InvokerTerminalProps): JSX.Element {
+  const renderStartedAt = nowMs();
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const transcriptRef = useRef<HTMLDivElement | null>(null);
   const [shouldFollowTranscript, setShouldFollowTranscript] = useState(true);
+  const inputSequenceRef = useRef(0);
+  const latestLineCountRef = useRef(lines.length);
+  const perfContextRef = useRef({ activeConversationKey, expanded });
+  const pendingInputRef = useRef<{
+    sequence: number;
+    startedAt: number;
+    nextLength: number;
+    previousLength: number;
+  } | null>(null);
+  const transcriptCommitRef = useRef<{ signature: string; lineCount: number } | null>(null);
+  latestLineCountRef.current = lines.length;
+  perfContextRef.current = { activeConversationKey, expanded };
 
-  const scrollTranscriptToBottom = useCallback((): void => {
+  const scrollTranscriptToBottom = useCallback((reason: 'conversation_change' | 'line_change', lineCount: number): void => {
     const transcript = transcriptRef.current;
     if (!transcript) return;
+    const startedAt = nowMs();
+    const context = perfContextRef.current;
     transcript.scrollTop = transcript.scrollHeight;
+    reportPlanningChatPerf('planning_chat_transcript_autoscroll', {
+      reason,
+      durationMs: roundMs(nowMs() - startedAt),
+      conversationKey: context.activeConversationKey,
+      lineCount,
+      scrollHeight: transcript.scrollHeight,
+      clientHeight: transcript.clientHeight,
+      expanded: context.expanded,
+    });
   }, []);
 
   useLayoutEffect(() => {
     setShouldFollowTranscript(true);
-    scrollTranscriptToBottom();
+    scrollTranscriptToBottom('conversation_change', latestLineCountRef.current);
   }, [activeConversationKey, scrollTranscriptToBottom]);
 
   useLayoutEffect(() => {
     if (shouldFollowTranscript) {
-      scrollTranscriptToBottom();
+      scrollTranscriptToBottom('line_change', lines.length);
     }
   }, [lines.length, scrollTranscriptToBottom, shouldFollowTranscript]);
+
+  useLayoutEffect(() => {
+    const pending = pendingInputRef.current;
+    if (!pending || pending.nextLength !== value.length) return;
+    pendingInputRef.current = null;
+    reportPlanningChatPerf('planning_chat_input_commit', {
+      sequence: pending.sequence,
+      durationMs: roundMs(nowMs() - pending.startedAt),
+      valueLength: value.length,
+      previousValueLength: pending.previousLength,
+      deltaLength: value.length - pending.previousLength,
+      conversationKey: activeConversationKey,
+      transcriptLineCount: lines.length,
+      expanded,
+      busy,
+      readOnly,
+    });
+  }, [activeConversationKey, busy, expanded, lines.length, readOnly, value]);
+
+  useLayoutEffect(() => {
+    const lastLine = lines.at(-1);
+    const signature = `${activeConversationKey}:${lines.length}:${lastLine?.id ?? 'none'}:${lastLine?.role ?? 'none'}:${lastLine?.text.length ?? 0}:${lastLine?.reasoning?.length ?? 0}`;
+    const previous = transcriptCommitRef.current;
+    transcriptCommitRef.current = { signature, lineCount: lines.length };
+    if (!previous || previous.signature === signature) return;
+    const transcriptChars = lines.reduce((total, line) => total + line.text.length + (line.reasoning?.length ?? 0), 0);
+    reportPlanningChatPerf('planning_chat_transcript_commit', {
+      durationMs: roundMs(nowMs() - renderStartedAt),
+      conversationKey: activeConversationKey,
+      lineCount: lines.length,
+      lineDelta: lines.length - previous.lineCount,
+      transcriptChars,
+      lastLineRole: lastLine?.role,
+      lastLineChars: lastLine?.text.length ?? 0,
+      hasReasoning: Boolean(lastLine?.reasoning),
+      busy,
+      expanded,
+      draftPlanAvailable,
+      readOnly,
+    });
+  }, [activeConversationKey, busy, draftPlanAvailable, expanded, lines, readOnly]);
 
   const handleTranscriptScroll = useCallback((): void => {
     const transcript = transcriptRef.current;
@@ -308,6 +385,58 @@ export function InvokerTerminal({
 
   const focusComposer = (): void => {
     inputRef.current?.focus();
+  };
+
+  const handleValueChange = (event: ChangeEvent<HTMLTextAreaElement>): void => {
+    const startedAt = nowMs();
+    const nextValue = event.target.value;
+    const sequence = inputSequenceRef.current + 1;
+    inputSequenceRef.current = sequence;
+    pendingInputRef.current = {
+      sequence,
+      startedAt,
+      nextLength: nextValue.length,
+      previousLength: value.length,
+    };
+    onValueChange(nextValue);
+    reportPlanningChatPerf('planning_chat_input_change', {
+      sequence,
+      handlerDurationMs: roundMs(nowMs() - startedAt),
+      valueLength: nextValue.length,
+      previousValueLength: value.length,
+      deltaLength: nextValue.length - value.length,
+      conversationKey: activeConversationKey,
+      transcriptLineCount: lines.length,
+      expanded,
+      busy,
+      readOnly,
+    });
+  };
+
+  const submitFromComposer = (source: 'form' | 'enter'): void => {
+    if (!value.trim() || busy || readOnly) return;
+    reportPlanningChatPerf('planning_chat_submit', {
+      source,
+      valueLength: value.length,
+      trimmedLength: value.trim().length,
+      conversationKey: activeConversationKey,
+      transcriptLineCount: lines.length,
+      draftPlanAvailable,
+      expanded,
+    });
+    onSubmit();
+  };
+
+  const handleFormSubmit = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    submitFromComposer('form');
+  };
+
+  const handleInputKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): void => {
+    if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing && !busy && !readOnly && value.trim()) {
+      event.preventDefault();
+      submitFromComposer('enter');
+    }
   };
 
   return (

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -625,11 +625,7 @@ export function InvokerTerminal({
 
           <form
             className="border-t border-border bg-background px-4 py-3"
-            onSubmit={(event) => {
-              event.preventDefault();
-              if (!value.trim() || busy || readOnly) return;
-              onSubmit();
-            }}
+            onSubmit={handleFormSubmit}
           >
             <div className="flex items-start gap-2">
               <span className="mt-2.5 shrink-0 font-mono text-xs text-muted-foreground" aria-hidden="true">›</span>
@@ -639,13 +635,8 @@ export function InvokerTerminal({
                 value={value}
                 disabled={busy || readOnly}
                 rows={expanded ? 8 : 3}
-                onChange={(event) => onValueChange(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing && !busy && !readOnly && value.trim()) {
-                    event.preventDefault();
-                    onSubmit();
-                  }
-                }}
+                onChange={handleValueChange}
+                onKeyDown={handleInputKeyDown}
                 placeholder={readOnly ? 'This planning session was already submitted.' : 'Describe the change, ask questions, or say “draft the full plan”.'}
                 className="min-h-20 w-full resize-none border-0 bg-transparent py-2 font-mono text-[13px] leading-6 text-foreground outline-none placeholder:text-muted-foreground focus:ring-0 disabled:cursor-wait"
               />

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -125,10 +125,12 @@ function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: Term
   const fitRef = useRef<FitAddon | null>(null);
   const seededSnapshotRef = useRef<SeededOutputSnapshot | null>(null);
   const isActiveRef = useRef(isActive);
+  const sessionRef = useRef(session);
   const fitFrameRef = useRef<number | null>(null);
   const secondFitFrameRef = useRef<number | null>(null);
 
   isActiveRef.current = isActive;
+  sessionRef.current = session;
 
   const clearScheduledFit = useCallback(() => {
     if (fitFrameRef.current !== null) {
@@ -223,7 +225,7 @@ function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: Term
         chars: data.length,
         sessionId: session.sessionId,
         taskId: session.taskId,
-        active: activeRef.current,
+        active: isActiveRef.current,
       });
     });
 
@@ -240,7 +242,7 @@ function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: Term
           chars: event.data.length,
           sessionId: event.sessionId,
           taskId: event.taskId,
-          active: activeRef.current,
+          active: isActiveRef.current,
           status: currentSession.status,
         });
       } catch {

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -56,10 +56,31 @@ type SeededOutputSnapshot = {
   term: XTermTerminal;
 };
 
+function nowMs(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
+function roundMs(durationMs: number): number {
+  return Math.max(0, Math.round(durationMs));
+}
+
+function byteLength(value: string): number {
+  try {
+    return new TextEncoder().encode(value).byteLength;
+  } catch {
+    return value.length;
+  }
+}
+
+function reportTerminalPerf(metric: string, data: Record<string, unknown>): void {
+  void window.invoker?.reportUiPerf?.(metric, data);
+}
+
 function seedTerminalOutputSnapshot(
   term: XTermTerminal,
   session: TerminalSessionDescriptor,
   seededSnapshotRef: { current: SeededOutputSnapshot | null },
+  source: 'attach' | 'session_update',
 ): void {
   const outputSnapshot = session.outputSnapshot;
   const seededSnapshot = seededSnapshotRef.current;
@@ -73,12 +94,22 @@ function seedTerminalOutputSnapshot(
     )
   ) {
     try {
+      const startedAt = nowMs();
       term.write(outputSnapshot);
       seededSnapshotRef.current = {
         sessionId: session.sessionId,
         snapshot: outputSnapshot,
         term,
       };
+      reportTerminalPerf('embedded_terminal_snapshot_write', {
+        source,
+        durationMs: roundMs(nowMs() - startedAt),
+        bytes: byteLength(outputSnapshot),
+        chars: outputSnapshot.length,
+        sessionId: session.sessionId,
+        taskId: session.taskId,
+        status: session.status,
+      });
     } catch (err) {
       console.warn(
         `Failed to seed output snapshot for terminal session ${session.sessionId}:`,
@@ -152,6 +183,7 @@ function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: Term
     let term: XTermTerminal;
     let fit: FitAddon;
     try {
+      const attachStartedAt = nowMs();
       term = new XTermTerminal({
         fontSize: 12,
         fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
@@ -163,23 +195,54 @@ function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: Term
       fit = new FitAddon();
       term.loadAddon(fit);
       term.open(host);
+      reportTerminalPerf('embedded_terminal_attach', {
+        durationMs: roundMs(nowMs() - attachStartedAt),
+        sessionId: session.sessionId,
+        taskId: session.taskId,
+        mode: session.mode,
+        status: session.status,
+        active: isActive,
+        hasHeader,
+        hasSnapshot: Boolean(session.outputSnapshot),
+        snapshotBytes: session.outputSnapshot ? byteLength(session.outputSnapshot) : 0,
+      });
     } catch {
       return;
     }
     termRef.current = term;
     fitRef.current = fit;
 
-    seedTerminalOutputSnapshot(term, session, seededSnapshotRef);
+    seedTerminalOutputSnapshot(term, session, seededSnapshotRef, 'attach');
 
     const inputDisposable = term.onData((data) => {
+      const startedAt = nowMs();
       void window.invoker?.terminalWrite?.(session.sessionId, data);
+      reportTerminalPerf('embedded_terminal_input', {
+        durationMs: roundMs(nowMs() - startedAt),
+        bytes: byteLength(data),
+        chars: data.length,
+        sessionId: session.sessionId,
+        taskId: session.taskId,
+        active: activeRef.current,
+      });
     });
 
     const subscribeToOutput = window.__INVOKER_TEST_ON_TERMINAL_OUTPUT__ ?? window.invoker?.onTerminalOutput;
     const unsubscribeOutput = subscribeToOutput?.((event) => {
       if (event.sessionId !== session.sessionId) return;
       try {
+        const currentSession = sessionRef.current;
+        const startedAt = nowMs();
         term.write(event.data);
+        reportTerminalPerf('embedded_terminal_output_write', {
+          durationMs: roundMs(nowMs() - startedAt),
+          bytes: byteLength(event.data),
+          chars: event.data.length,
+          sessionId: event.sessionId,
+          taskId: event.taskId,
+          active: activeRef.current,
+          status: currentSession.status,
+        });
       } catch {
         /* terminal disposed */
       }
@@ -221,7 +284,7 @@ function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: Term
   useEffect(() => {
     const term = termRef.current;
     if (!term) return;
-    seedTerminalOutputSnapshot(term, session, seededSnapshotRef);
+    seedTerminalOutputSnapshot(term, session, seededSnapshotRef, 'session_update');
   }, [session.outputSnapshot, session.sessionId]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

UI Responsiveness Guardrails Step 1 instruments planning chat and embedded terminal renderer work.

The markers report input, transcript, attach, output, resize, and snapshot timing through the existing ui-perf bridge.

## Review Claim

Planning chat and embedded terminal surfaces emit actionable renderer perf markers through window.invoker.reportUiPerf.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice only reports measurements through the existing bridge. It does not change planning chat submission or terminal command behavior.

## Slice Rationale

Renderer markers land after owner counters can aggregate them, keeping the stack reviewable and green at each step.

## Non-goals

- No owner-side counter schema changes beyond the previous slice.
- No responsiveness thresholds or fail-fast policy.
- No visual layout or interaction changes.

## Architecture

### Before

```mermaid
graph TD
    A["Planning chat and terminal render work"] --> B["No surface-specific ui-perf markers"]
    B --> C["Owner sees only generic renderer lag"]
```

### After

```mermaid
graph TD
    A["Planning chat and terminal render work"] --> B["window.invoker.reportUiPerf emits named markers"]
    B --> C["Owner ui-perf counters and logs receive raw payloads"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx src/__tests__/terminal-drawer.test.tsx`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/renderer-ui-perf.test.ts`

</details>

## Visual Proof

The planning terminal remains visually unchanged while renderer measurements are emitted behind the scenes.

![Planning terminal ready state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-580f96/planning-terminal-restore-after.png)

The restart walkthrough still shows the planning terminal restoring correctly with the instrumented renderer surface.

![Planning terminal restart walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-580f96/planning-terminal-restart.gif)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 82348bbc`
- Post-revert steps: Keep or revert the owner-side counter slice depending on whether later markers still need it.
- Data migration? No.

</details>