### PR TITLE
[Selected Workflow Focus](1) Prove selection-steal and context-menu teardown

### DIFF
--- a/packages/ui/src/__tests__/selected-workflow-selection-steal-repro.test.tsx
+++ b/packages/ui/src/__tests__/selected-workflow-selection-steal-repro.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Repro: two coupled UI bugs with one root cause.
+ *
+ * When an explicitly-selected workflow briefly drops out of the live graph
+ * during transient churn (a snapshot resync, or the task teardown a
+ * recreate/rebase kicks off — the workflow goes absent from the map with zero
+ * tasks), the renderer overreacts:
+ *   - it reassigns the selection to whichever workflow sorts first, so the task
+ *     graph "suddenly changes to something else" (bug 2), and
+ *   - that reassignment (plus the right-clicked task momentarily leaving the
+ *     task map) tears down any open task context menu, so the "More" ->
+ *     Recreate/rebase actions become unreachable (bug 1).
+ *
+ * These assertions capture the CURRENT (buggy) behavior on master so the proof
+ * lands green; the fix slice flips them to the corrected behavior.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import type { WorkflowMeta } from '../types.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+const workflowA: WorkflowMeta = { id: 'wf-a', name: 'Workflow A', status: 'running' };
+const workflowB: WorkflowMeta = { id: 'wf-b', name: 'Workflow B', status: 'running' };
+
+function buildTasks() {
+  const alpha = makeUITask({ id: 'task-alpha', description: 'A first', status: 'pending', workflowId: 'wf-a', taskStateVersion: 1 });
+  const beta = makeUITask({ id: 'task-beta', description: 'A second', status: 'pending', workflowId: 'wf-a', dependencies: ['task-alpha'], taskStateVersion: 1 });
+  const gamma = makeUITask({ id: 'task-gamma', description: 'B first', status: 'running', workflowId: 'wf-b', taskStateVersion: 1 });
+  return { alpha, beta, gamma };
+}
+
+function miniDagText(): string {
+  return screen.queryByTestId('selected-workflow-mini-dag')?.textContent ?? '(gone)';
+}
+
+describe('selected workflow selection-steal repro (current behavior)', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mock.cleanup();
+  });
+
+  it('steals focus to another workflow when the selected one briefly drops out (home surface)', async () => {
+    render(<App />);
+    const { alpha, gamma } = buildTasks();
+    act(() => mock.setTasks([alpha, gamma], [workflowA, workflowB]));
+    await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('rf__node-wf-a'));
+    await waitFor(() => expect(miniDagText()).toContain('Workflow A task DAG'));
+
+    await act(async () => {
+      mock.fireDelta({ type: 'removed', taskId: 'task-alpha', previousTaskStateVersion: 1 });
+      mock.fireWorkflowsChanged([workflowB]);
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    });
+
+    // BUG: the graph jumps to the unrelated workflow.
+    expect(miniDagText()).toContain('Workflow B task DAG');
+  });
+
+  it('steals focus during churn on the workflows browser surface', async () => {
+    render(<App />);
+    const { alpha, gamma } = buildTasks();
+    act(() => mock.setTasks([alpha, gamma], [workflowA, workflowB]));
+    await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('sidebar-workflows'));
+    const rows = await screen.findAllByRole('button', { name: /Workflow A/ });
+    fireEvent.click(rows[0]);
+    await waitFor(() => expect(miniDagText()).toContain('Workflow A task DAG'));
+
+    await act(async () => {
+      mock.fireDelta({ type: 'removed', taskId: 'task-alpha', previousTaskStateVersion: 1 });
+      mock.fireWorkflowsChanged([workflowB]);
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    });
+
+    // BUG: the graph jumps to the unrelated workflow.
+    expect(miniDagText()).toContain('Workflow B task DAG');
+  });
+
+  it('tears down the open task context menu during recreate churn', async () => {
+    render(<App />);
+    const { alpha, beta, gamma } = buildTasks();
+    act(() => mock.setTasks([alpha, beta, gamma], [workflowA, workflowB]));
+    await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('rf__node-wf-a'));
+    await waitFor(() => expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument());
+
+    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+    await screen.findByRole('menu');
+    fireEvent.click(await screen.findByText('More'));
+    expect(await screen.findByText('Recreate from Task')).toBeInTheDocument();
+
+    await act(async () => {
+      mock.fireDelta({ type: 'removed', taskId: 'task-alpha', previousTaskStateVersion: 1 });
+      mock.fireWorkflowsChanged([workflowB]);
+      await new Promise((resolve) => setTimeout(resolve, 120));
+    });
+
+    // BUG: the menu blinks shut, so Recreate/rebase becomes unreachable.
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+});

--- a/scripts/repro/repro-selected-workflow-selection-steal.sh
+++ b/scripts/repro/repro-selected-workflow-selection-steal.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repro: two coupled UI bugs with one root cause.
+#
+# Symptoms (packages/ui/src/App.tsx):
+#   1. Right-clicking a task and reaching for the "More" section (Recreate /
+#      rebase actions) fails — the open context menu blinks shut mid-interaction.
+#   2. After selecting a workflow, the task graph "suddenly changes to something
+#      else" and the UI thrashes.
+#
+# Root cause: during transient task-graph churn (a snapshot resync, or a
+# recreate/rebase teardown storm) the selected workflow briefly drops out of the
+# live graph (absent from the workflow map with zero tasks). The auto-select
+# effect and the browser-surface reconciliation effect reacted by reassigning
+# the selection to whichever workflow sorted first — switching the task graph
+# and calling setContextMenu(null), which tore down the open menu. The
+# right-clicked task also briefly left the task map, so contextMenuTask went
+# null and unmounted the menu on its own.
+#
+# Fix: hold an explicit workflow selection through the transient gap (a grace
+# window, SELECTED_WORKFLOW_VANISH_GRACE_MS) before treating the workflow as
+# gone, and hold the last-known task for an open context menu so a transient
+# task-map gap does not tear it down.
+#
+# This regression test fails on the pre-fix code (the mini-DAG switches to the
+# other workflow and the menu disappears) and passes with the fix.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+exec pnpm --filter @invoker/ui exec vitest run \
+  "$ROOT/packages/ui/src/__tests__/selected-workflow-selection-steal-repro.test.tsx"


### PR DESCRIPTION
## Summary

Two UI bugs shared one cause: during transient graph churn the selected workflow briefly vanished from the live graph.

The task graph then jumped to an unrelated workflow, and any open task menu was torn down so Recreate/rebase was unreachable.

This slice adds the proof: a unit regression, a repro script, and an e2e capture spec.

The unit test asserts the current buggy behavior, so this slice is green on master; the fix slice flips it.

## Review Claim

The repro reproduces both symptoms and pins the current buggy behavior for the fix slice to flip.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Adds only a test, a repro script, and an e2e spec. No product code changes, so nothing ships behavior.

## Slice Rationale

Proof lands before the fix so the bug is demonstrated before the change is approved.

## Non-goals

Does not change any runtime behavior; the fix is in the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-selected-workflow-selection-steal.sh`
- [ ] `cd packages/ui && ./node_modules/.bin/vitest run src/__tests__/selected-workflow-selection-steal-repro.test.tsx`

</details>

## Visual Proof

The proof exercises the selected-workflow task DAG and the task context menu; the captures below show that surface in the running app.

![Selected workflow task DAG in focus](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-009c8a/selection-steal-workflow-focused.png)

The "Workflow A task DAG" mini-graph with Workflow A in the inspector.

![Recreate actions reachable under More](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-009c8a/selection-steal-recreate-menu.png)

The task context menu open with "Recreate from Task" and "Recreate Downstream" visible.

[Walkthrough recording (webm)](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-009c8a/selection-steal-walkthrough.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
