### PR TITLE
[Selected Workflow Focus](2) Hold the selected workflow and its open menu through churn

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -88,6 +88,7 @@ type ContextMenuState = { x: number; y: number; taskId: string; returnFocusRegio
 type WorkflowContextMenuState = { x: number; y: number; workflowId: string; returnFocusRegion?: GraphKeyboardRegion };
 const KEYBOARD_REGION_ORDER: readonly KeyboardRegion[] = ['workflowGraph', 'taskGraph', 'inspector', 'bottomBar'];
 const SIDEBAR_NAV_ITEM_SELECTOR = '[data-sidebar-nav-item]';
+export const SELECTED_WORKFLOW_VANISH_GRACE_MS = 1000;
 const STATUS_KEY_ORDER: readonly WorkflowStatus[] = [
   'completed',
   'running',
@@ -543,6 +544,7 @@ export function App() {
   const graphSurfaceRef = useRef<HTMLDivElement>(null);
   const graphActionsMenuRef = useRef<HTMLDivElement>(null);
   const lastGoodSelectedWorkflowGraphRef = useRef<SelectedWorkflowGraphSnapshot | null>(null);
+  const contextMenuTaskRef = useRef<TaskState | null>(null);
   const [sidebarSurface, setSidebarSurface] = useState<SidebarSurface>('home');
   const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean | null>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
@@ -551,6 +553,7 @@ export function App() {
   const [reviewGateByWorkflowId, setReviewGateByWorkflowId] = useState<Record<string, ReviewGateQueryResponse | null>>({});
   const [stickySelectedWorkflow, setStickySelectedWorkflow] = useState<WorkflowMeta | null>(null);
   const [workflowSelectionDismissed, setWorkflowSelectionDismissed] = useState(false);
+  const [selectedWorkflowVanished, setSelectedWorkflowVanished] = useState(false);
   const [modal, setModal] = useState<ModalState>({ type: 'none' });
   const [hasLoadedPlan, setHasLoadedPlan] = useState(false);
   const [hasStarted, setHasStarted] = useState(false);
@@ -808,7 +811,20 @@ export function App() {
 
   const selectedTask = selectedTaskId ? tasks.get(selectedTaskId) ?? null : null;
   const selectedWorker = workerStatus?.workers.find((worker) => worker.kind === selectedWorkerKind) ?? null;
-  const contextMenuTask = contextMenu ? tasks.get(contextMenu.taskId) ?? null : null;
+  const liveContextMenuTask = contextMenu ? tasks.get(contextMenu.taskId) ?? null : null;
+  useEffect(() => {
+    if (!contextMenu) {
+      contextMenuTaskRef.current = null;
+      return;
+    }
+    if (liveContextMenuTask) {
+      contextMenuTaskRef.current = liveContextMenuTask;
+    }
+  }, [contextMenu, liveContextMenuTask]);
+  const contextMenuTask = liveContextMenuTask
+    ?? (contextMenu && contextMenuTaskRef.current?.id === contextMenu.taskId
+      ? contextMenuTaskRef.current
+      : null);
   const selectedWorkflowTaskCount = useMemo(() => {
     if (!selectedWorkflowId) return 0;
     let count = 0;
@@ -936,6 +952,17 @@ export function App() {
     }
   }, [selectedWorkflowId, selectedWorkflowTaskCount, workflows]);
 
+  const selectedWorkflowPresent = selectedWorkflowId !== null
+    && (workflows.has(selectedWorkflowId) || selectedWorkflowTaskCount > 0);
+  useEffect(() => {
+    if (selectedWorkflowId === null || selectedWorkflowPresent) {
+      setSelectedWorkflowVanished(false);
+      return;
+    }
+    const timer = setTimeout(() => setSelectedWorkflowVanished(true), SELECTED_WORKFLOW_VANISH_GRACE_MS);
+    return () => clearTimeout(timer);
+  }, [selectedWorkflowId, selectedWorkflowPresent]);
+
   useEffect(() => {
     if (selectedTask?.config.workflowId) {
       setWorkflowSelectionDismissed(false);
@@ -948,9 +975,12 @@ export function App() {
     if (workflowSelectionDismissed) {
       return;
     }
+    if (selectedWorkflowId && !selectedWorkflowVanished) {
+      return;
+    }
     const firstWorkflowId = workflows.keys().next().value as string | undefined;
     setSelectedWorkflowId(firstWorkflowId ?? null);
-  }, [selectedTask, selectedWorkflowId, selectedWorkflowTaskCount, workflowSelectionDismissed, workflows]);
+  }, [selectedTask, selectedWorkflowId, selectedWorkflowTaskCount, selectedWorkflowVanished, workflowSelectionDismissed, workflows]);
 
   const handleStatusClick = useCallback((filterKey: WorkflowStatus, event: React.MouseEvent) => {
     setStatusFilters(prev => {
@@ -1481,6 +1511,9 @@ export function App() {
       if (workflowEntries.some((entry) => entry.workflow.id === activeWorkflowId)) {
         return;
       }
+      if (activeWorkflowId !== null && !selectedWorkflowVanished) {
+        return;
+      }
       selectWorkflowById(workflowEntries[0].workflow.id);
       return;
     }
@@ -1523,6 +1556,7 @@ export function App() {
     selectedTaskId,
     selectedWorkflow?.id,
     selectedWorkflowId,
+    selectedWorkflowVanished,
     sidebarSurface,
     workflowEntries,
   ]);

--- a/packages/ui/src/__tests__/selected-workflow-selection-steal-repro.test.tsx
+++ b/packages/ui/src/__tests__/selected-workflow-selection-steal-repro.test.tsx
@@ -1,18 +1,11 @@
 /**
- * Repro: two coupled UI bugs with one root cause.
- *
- * When an explicitly-selected workflow briefly drops out of the live graph
- * during transient churn (a snapshot resync, or the task teardown a
- * recreate/rebase kicks off — the workflow goes absent from the map with zero
- * tasks), the renderer overreacts:
- *   - it reassigns the selection to whichever workflow sorts first, so the task
- *     graph "suddenly changes to something else" (bug 2), and
- *   - that reassignment (plus the right-clicked task momentarily leaving the
- *     task map) tears down any open task context menu, so the "More" ->
- *     Recreate/rebase actions become unreachable (bug 1).
- *
- * These assertions capture the CURRENT (buggy) behavior on master so the proof
- * lands green; the fix slice flips them to the corrected behavior.
+ * Regression: an explicitly-selected workflow must keep the task graph focused
+ * on itself. During transient graph churn (a snapshot resync or a task-teardown
+ * storm from recreate/rebase) the selected workflow can briefly drop out of the
+ * live graph. The UI used to react by reassigning the selection to whatever
+ * workflow sorted first — yanking the task graph onto an unrelated workflow and
+ * tearing down any open task context menu. It must instead hold the selection
+ * through the transient gap, and only fall back once the workflow is really gone.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -25,7 +18,8 @@ vi.mock('@xyflow/react', async () => {
   return createReactFlowMock();
 });
 
-const { App } = await import('../App.js');
+// The App module and its grace constant must resolve after the mock installs.
+const { App, SELECTED_WORKFLOW_VANISH_GRACE_MS } = await import('../App.js');
 
 const workflowA: WorkflowMeta = { id: 'wf-a', name: 'Workflow A', status: 'running' };
 const workflowB: WorkflowMeta = { id: 'wf-b', name: 'Workflow B', status: 'running' };
@@ -41,7 +35,7 @@ function miniDagText(): string {
   return screen.queryByTestId('selected-workflow-mini-dag')?.textContent ?? '(gone)';
 }
 
-describe('selected workflow selection-steal repro (current behavior)', () => {
+describe('selected workflow selection-steal regression', () => {
   let mock: MockInvoker;
 
   beforeEach(() => {
@@ -55,7 +49,7 @@ describe('selected workflow selection-steal repro (current behavior)', () => {
     mock.cleanup();
   });
 
-  it('steals focus to another workflow when the selected one briefly drops out (home surface)', async () => {
+  it('keeps focus on the selected workflow when it briefly drops out of the graph (home surface)', async () => {
     render(<App />);
     const { alpha, gamma } = buildTasks();
     act(() => mock.setTasks([alpha, gamma], [workflowA, workflowB]));
@@ -64,17 +58,20 @@ describe('selected workflow selection-steal repro (current behavior)', () => {
     fireEvent.click(screen.getByTestId('rf__node-wf-a'));
     await waitFor(() => expect(miniDagText()).toContain('Workflow A task DAG'));
 
+    // Transient churn: Workflow A's only task is torn down and A is momentarily
+    // omitted from the workflow list (as during a recreate/rebase resync).
     await act(async () => {
       mock.fireDelta({ type: 'removed', taskId: 'task-alpha', previousTaskStateVersion: 1 });
       mock.fireWorkflowsChanged([workflowB]);
       await new Promise((resolve) => setTimeout(resolve, 150));
     });
 
-    // BUG: the graph jumps to the unrelated workflow.
-    expect(miniDagText()).toContain('Workflow B task DAG');
+    // Focus must NOT jump to Workflow B.
+    expect(miniDagText()).toContain('Workflow A task DAG');
+    expect(miniDagText()).not.toContain('Workflow B task DAG');
   });
 
-  it('steals focus during churn on the workflows browser surface', async () => {
+  it('keeps focus on the selected workflow during churn (workflows browser surface)', async () => {
     render(<App />);
     const { alpha, gamma } = buildTasks();
     act(() => mock.setTasks([alpha, gamma], [workflowA, workflowB]));
@@ -91,11 +88,11 @@ describe('selected workflow selection-steal repro (current behavior)', () => {
       await new Promise((resolve) => setTimeout(resolve, 150));
     });
 
-    // BUG: the graph jumps to the unrelated workflow.
-    expect(miniDagText()).toContain('Workflow B task DAG');
+    expect(miniDagText()).toContain('Workflow A task DAG');
+    expect(miniDagText()).not.toContain('Workflow B task DAG');
   });
 
-  it('tears down the open task context menu during recreate churn', async () => {
+  it('keeps an open task context menu usable through recreate churn', async () => {
     render(<App />);
     const { alpha, beta, gamma } = buildTasks();
     act(() => mock.setTasks([alpha, beta, gamma], [workflowA, workflowB]));
@@ -109,13 +106,45 @@ describe('selected workflow selection-steal repro (current behavior)', () => {
     fireEvent.click(await screen.findByText('More'));
     expect(await screen.findByText('Recreate from Task')).toBeInTheDocument();
 
+    // The right-clicked task is torn down and re-added while A is briefly omitted.
     await act(async () => {
       mock.fireDelta({ type: 'removed', taskId: 'task-alpha', previousTaskStateVersion: 1 });
       mock.fireWorkflowsChanged([workflowB]);
       await new Promise((resolve) => setTimeout(resolve, 120));
     });
 
-    // BUG: the menu blinks shut, so Recreate/rebase becomes unreachable.
-    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    // The menu (and its Recreate action) must remain available, not blink shut.
+    expect(screen.queryByRole('menu')).toBeInTheDocument();
+    expect(screen.getByText('Recreate from Task')).toBeInTheDocument();
+    expect(miniDagText()).toContain('Workflow A task DAG');
+  });
+
+  it('still moves off the selected workflow once it is genuinely gone (after the grace window)', async () => {
+    render(<App />);
+    const { alpha, gamma } = buildTasks();
+    act(() => mock.setTasks([alpha, gamma], [workflowA, workflowB]));
+    await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('rf__node-wf-a'));
+    await waitFor(() => expect(miniDagText()).toContain('Workflow A task DAG'));
+
+    // Tear the task down first and let it settle so Workflow A is no longer
+    // task-backed, then drop it from the workflow list. Now it is genuinely gone
+    // (absent from the map with no tasks), not merely mid-churn.
+    await act(async () => {
+      mock.fireDelta({ type: 'removed', taskId: 'task-alpha', previousTaskStateVersion: 1 });
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    });
+    await act(async () => {
+      mock.fireWorkflowsChanged([workflowB]);
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    });
+    // Workflow A is now absent from the map with no tasks. Once the grace window
+    // elapses it is treated as gone and focus moves to the remaining workflow.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, SELECTED_WORKFLOW_VANISH_GRACE_MS + 400));
+    });
+
+    await waitFor(() => expect(miniDagText()).toContain('Workflow B task DAG'));
   });
 });


### PR DESCRIPTION
## Summary

When you select a workflow, the task graph now stays focused on it, and a task's right-click menu stays usable.

Transient churn — a snapshot resync or a recreate/rebase teardown — can briefly drop the selected workflow from the live graph.

The renderer used to react by reassigning the selection to whichever workflow sorted first, which switched the graph and closed any open menu.

An explicit selection is now held for a grace window before the workflow counts as gone, and an open menu keeps its last-known task.

**Known follow-up (tech debt):** the grace window is a `setTimeout` heuristic — a time-based guess at whether the workflow is really gone. Landing this quickly; tracked in [INV-267](https://linear.app/invokerorchestrator/issue/INV-267) to drive selection from an explicit backend signal instead of a timer.

## Review Claim

An explicit workflow selection (and its open task menu) survives transient graph churn instead of being reassigned.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Changes only renderer selection state in `App.tsx`. A genuinely-removed workflow still hands focus off after the grace window, proven by a recovery test.

## Slice Rationale

The fix is isolated from its proof (previous slice) and its changelog (next slice) so the behavior change is reviewed on its own.

## Non-goals

Does not change workflow deletion, the backend graph stream, or the context-menu action set.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && ./node_modules/.bin/vitest run src/__tests__/selected-workflow-selection-steal-repro.test.tsx`
- [ ] `cd packages/ui && ./node_modules/.bin/vitest run`

</details>

## Visual Proof

With two workflows present, selecting one keeps its task DAG in focus, and right-clicking a task exposes the Recreate/rebase actions under More.

![Selected workflow task DAG in focus](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-60669b/selection-steal-workflow-focused.png)

The "Workflow A task DAG" mini-graph stays focused on the selected workflow.

![Recreate actions reachable under More](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-60669b/selection-steal-recreate-menu.png)

The task context menu open with "Recreate from Task" and "Recreate Downstream" reachable.

[Walkthrough recording (webm)](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-60669b/selection-steal-walkthrough.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

