### PR TITLE
[Planning Chat Inner Shell Cleanup](2) Flatten the planning chat window header

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -213,6 +213,12 @@ describe('planning chat', () => {
     expect(result).toMatchObject({ ok: true, reply: 'I can help.', draftPlanAvailable: false });
     expect(result.ok && result.sessionId).toBeTruthy();
     expect(sessions.size).toBe(1);
+    const session = [...sessions.values()][0];
+    expect(session?.messages).toEqual([
+      expect.objectContaining({ id: 1, role: 'user', text: 'hello' }),
+      expect.objectContaining({ id: 2, role: 'assistant', text: 'I can help.' }),
+    ]);
+    expect(session?.messages.some((line) => line.text === 'Ask Invoker what you want to build.')).toBe(false);
     expect(spawnPlanner).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -323,17 +323,11 @@ async function createSession(
     title: typeof request?.title === 'string' && request.title.trim() ? request.title.trim() : 'Untitled plan',
     presetKey,
     status: 'still_discussing',
-    messages: [{
-      id: 1,
-      role: 'system',
-      text: 'Ask Invoker what you want to build.',
-      tone: 'muted',
-      createdAt,
-    }],
+    messages: [],
     conversation: new PlanConversation(planConversationConfig(preset, deps, id)),
     createdAt,
     updatedAt: createdAt,
-    nextMessageId: 2,
+    nextMessageId: 1,
   };
   deps.sessions.set(session.id, session);
   persistPlanningSession(session, deps.planningSessionStore, false);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -130,7 +130,7 @@ function makeInitialPlanningSession(now: string = new Date().toISOString()): Pla
     title: 'Untitled plan',
     status: 'still_discussing',
     presetKey: '',
-    messages: [{ id: 1, text: 'Ask Invoker what you want to build.', role: 'system', tone: 'muted' }],
+    messages: [],
     input: '',
     draftPlanAvailable: false,
     busy: false,
@@ -147,6 +147,14 @@ function planningNeedsAttention(status: InAppPlanningSessionStatus): boolean {
 function previewPlanningMessage(session: PlanningSessionView): string {
   const last = [...session.messages].reverse().find((line) => line.role !== 'system') ?? session.messages.at(-1);
   return last?.text.replace(/\s+/g, ' ').trim() || 'No messages yet';
+}
+
+function planningSessionStatusLabel(session: PlanningSessionView): string {
+  if (session.busy) return 'Working';
+  if (session.status === 'draft_ready') return 'Draft ready';
+  if (session.status === 'waiting_for_answer') return 'Waiting for answer';
+  if (session.status === 'submitted') return 'Submitted';
+  return 'Still discussing';
 }
 
 function relativePlanningUpdatedAt(value: string): string {
@@ -558,7 +566,7 @@ export function App() {
   const [planningSessions, setPlanningSessions] = useState<PlanningSessionView[]>(() => [makeInitialPlanningSession()]);
   const [activePlanningSessionId, setActivePlanningSessionId] = useState('local-planning-session-1');
   const nextPlanningSessionLocalIdRef = useRef(2);
-  const nextTerminalLineIdRef = useRef(2);
+  const nextTerminalLineIdRef = useRef(1);
   const [planningPresetOptions, setPlanningPresetOptions] = useState<Array<{ key: string; label: string; isDefault?: boolean }>>([]);
   const [selectedPlanningPresetKey, setSelectedPlanningPresetKey] = useState('');
   const [planningSubmitError, setPlanningSubmitError] = useState<{ title: string; message: string } | null>(null);
@@ -2065,7 +2073,6 @@ export function App() {
       conversationKey: localId,
       presetKey: selectedPlanningPresetKey,
     };
-    nextTerminalLineIdRef.current += 1;
     setPlanningSessions((prev) => [session, ...prev]);
     setActivePlanningSessionId(session.id);
     setSidebarSurface('planning');
@@ -2887,8 +2894,14 @@ export function App() {
         <div className="min-h-0 flex-1">{renderPlanningSessionList()}</div>
       </div>
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <div className="border-b border-border bg-card px-4 py-2.5">
-          <h2 className="truncate text-sm font-medium text-foreground">{activePlanningSession.title}</h2>
+        <div className="flex items-center justify-between gap-3 border-b border-border bg-card px-4 py-2.5">
+          <div className="min-w-0">
+            <h2 className="truncate text-sm font-medium text-foreground">Planning chat window</h2>
+            <p className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">{activePlanningSession.title}</p>
+          </div>
+          <span className="shrink-0 rounded-full border border-border bg-background px-2.5 py-1 font-mono text-[11px] text-muted-foreground">
+            {planningSessionStatusLabel(activePlanningSession)}
+          </span>
         </div>
         <div className="min-h-0 flex-1 overflow-hidden bg-background">
           <InvokerTerminal

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -65,19 +65,12 @@ export function makePlanningSessionSummary(
     messages: [
       {
         id: 1,
-        role: 'system',
-        text: 'Ask Invoker what you want to build.',
-        tone: 'muted',
-        createdAt: '2026-07-07T00:00:00.000Z',
-      },
-      {
-        id: 2,
         role: 'user',
         text: 'Add README',
         createdAt: '2026-07-07T00:00:01.000Z',
       },
       {
-        id: 3,
+        id: 2,
         role: 'assistant',
         text: 'Draft plan ready.',
         createdAt: '2026-07-07T00:00:02.000Z',
@@ -180,7 +173,7 @@ export function createMockInvoker(
         title: 'Untitled plan',
         status: 'still_discussing',
         presetKey: 'codex',
-        messages: [{ id: 1, role: 'system', text: 'Ask Invoker what you want to build.', tone: 'muted', createdAt: '2026-01-01T00:00:00.000Z' }],
+        messages: [],
         draftPlanAvailable: false,
         createdAt: '2026-01-01T00:00:00.000Z',
         updatedAt: '2026-01-01T00:00:00.000Z',

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -37,6 +37,24 @@ describe('Invoker terminal (component)', () => {
     fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
   }
 
+  it('renders an empty flush planning pane before the first message', async () => {
+    render(<App />);
+    await openPlanningTerminal();
+
+    expect(screen.getByRole('heading', { name: 'Planning chat window' })).toBeInTheDocument();
+    expect(screen.getByText('Still discussing')).toBeInTheDocument();
+    expect(screen.queryByText('What do you want to build?')).not.toBeInTheDocument();
+    expect(screen.queryByText('Talk it through, then submit the plan to Invoker.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Ask Invoker what you want to build.')).not.toBeInTheDocument();
+    const transcript = screen.getByTestId('invoker-terminal-transcript');
+    expect(transcript).toBeEmptyDOMElement();
+    const terminalShell = transcript.closest('section');
+    expect(terminalShell).not.toBeNull();
+    expect(terminalShell?.className).not.toContain('border border-border');
+    expect(terminalShell?.className).not.toContain('bg-card');
+    expect(screen.getByTestId('invoker-terminal-input')).toBeEnabled();
+  });
+
   it('generates a planning reply from plain language', async () => {
     render(<App />);
     await openPlanningTerminal();

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -110,12 +110,8 @@ export function InvokerTerminal({
   };
 
   return (
-    <section className="flex h-full min-h-0 flex-col border border-border bg-card">
-      <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-2.5">
-        <div className="min-w-0">
-          <h1 className="truncate text-sm font-medium tracking-tight text-foreground">What do you want to build?</h1>
-          <p className="mt-0.5 text-xs text-muted-foreground">Talk it through, then submit the plan to Invoker.</p>
-        </div>
+    <section className="flex h-full min-h-0 flex-col bg-background">
+      <div className="flex items-center justify-end gap-2 border-b border-border bg-background px-4 py-2.5">
         <div className="flex shrink-0 items-center gap-2">
           {busy && (
             <span className="font-mono text-[11px] text-muted-foreground">working…</span>
@@ -198,7 +194,7 @@ export function InvokerTerminal({
       {submitError && !readOnly && (
         <div
           data-testid="invoker-terminal-submit-error"
-          className="sticky bottom-0 z-10 border-t border-destructive/40 bg-card px-4 py-3 text-destructive-foreground"
+          className="sticky bottom-0 z-10 border-t border-destructive/40 bg-background px-4 py-3 text-destructive-foreground"
         >
           <div className="text-sm font-medium text-destructive">{submitError.title}</div>
           <div className="mt-2 whitespace-pre-wrap font-mono text-xs leading-5 text-destructive/90">{submitError.message}</div>
@@ -234,7 +230,7 @@ export function InvokerTerminal({
       {draftPlanAvailable && !readOnly && (
         <div
           data-testid="invoker-terminal-ready-bar"
-          className="sticky bottom-0 z-10 border-t border-border bg-card px-4 py-3 text-sm text-foreground"
+          className="sticky bottom-0 z-10 border-t border-border bg-background px-4 py-3 text-sm text-foreground"
         >
           <div className="flex flex-wrap items-center justify-between gap-3">
             <span className="font-mono text-xs text-muted-foreground">
@@ -264,7 +260,7 @@ export function InvokerTerminal({
       )}
 
       <form
-        className="border-t border-border bg-card px-4 py-3"
+        className="border-t border-border bg-background px-4 py-3"
         onSubmit={(event) => {
           event.preventDefault();
           if (!value.trim() || busy || readOnly) return;


### PR DESCRIPTION
## Summary

The docked planning pane now shows one header, "Planning chat window", with the plan title as a subline and a status chip. The nested inner header is gone.

The inner terminal starts flush with the conversation, so the pane reads as one surface instead of a box inside a box.

## Review Claim

Approve folding the planning pane into a single flattened "Planning chat window" header with a live status chip.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the pane chrome changes. The terminal input, send flow, error bar, and ready bar keep their behavior; the outer header just gains the title subline and status chip.

## Slice Rationale

The header layout change is kept apart from the planner data change in slice (1) and the e2e proof update in slice (3).

## Non-goals

- No change to planner replies, submission, or plan generation.
- No change to the session rail on the left.

## Visual Proof

![Flattened planning chat window](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260711-3949f6/planning-shell-flattened.png)

One "Planning chat window" header with the "Untitled plan" subline and a "Still discussing" status chip. The inner terminal starts flush with an empty transcript; the old "What do you want to build?" inner header is gone.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] cd packages/ui && pnpm test
- [ ] pnpm test

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this PR's commit>`
- Post-revert steps: None
- Data migration? No

</details>
