### PR TITLE
[Planning Chat Inner Shell Cleanup](3) Refresh the planning-shell visual proof

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -754,7 +754,10 @@ test.describe('Visual proof capture', () => {
       await window.invoker.setTestPlanningChatResponse({ planYaml, planName, reply: 'I drafted the stacked plan.' });
     }, { planYaml: plannedYaml, planName: 'Workers Surface' });
 
-    await expect(page.getByRole('heading', { name: 'What do you want to build?' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Planning chat window' })).toBeVisible();
+    await expect(page.getByText('Still discussing')).toBeVisible();
+    await expect(page.getByText('What do you want to build?')).toHaveCount(0);
+    await expect(page.getByText('Ask Invoker what you want to build.')).toHaveCount(0);
     await expect(page.getByTestId('invoker-terminal-input')).toBeVisible();
     await page.getByTestId('invoker-terminal-input').fill('Build the Workers Surface');
     await page.getByRole('button', { name: 'Send' }).click();


### PR DESCRIPTION
## Summary

The Workers Surface visual-proof e2e test now expects the flattened "Planning chat window" header. It also checks that the old inner header and the seeded starter line are gone.

## Review Claim

Approve updating the visual-proof e2e test to match the flattened planning header.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only test expectations change. No product code is touched, so this slice cannot alter runtime behavior; it just pins the shipped planning header.

## Slice Rationale

The proof update trails the header behavior in slice (2) so the e2e test asserts the result that actually shipped.

## Non-goals

- No product or UI code changes.
- No new visual-proof states beyond the Workers Surface flow.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] cd packages/app && npx playwright test visual-proof.spec.ts -g "Workers Surface"
- [ ] pnpm test

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this PR's commit>`
- Post-revert steps: None
- Data migration? No

</details>
