### PR TITLE
[Workflow Resume](2) Treat failed/closed/stale tasks as terminal

### DIFF
--- a/packages/execution-engine/src/__tests__/workflow-resume-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/workflow-resume-worker.test.ts
@@ -145,13 +145,67 @@ describe('workflow resume worker tick', () => {
     expect(h.submit).not.toHaveBeenCalled();
   });
 
+  it('skips a workflow whose only unfinished work is a failed task', async () => {
+    const h = harness({
+      workflows: [
+        { id: 'wf-failed', tasks: [makeTask({ id: 'wf-failed/a', status: 'failed' as TaskState['status'] })] },
+      ],
+    });
+    await h.tick(POLL_CTX);
+    expect(h.submit).not.toHaveBeenCalled();
+  });
+
+  it('skips workflows whose tasks are closed or stale', async () => {
+    const h = harness({
+      workflows: [
+        { id: 'wf-closed', tasks: [makeTask({ id: 'wf-closed/a', status: 'closed' as TaskState['status'] })] },
+        { id: 'wf-stale', tasks: [makeTask({ id: 'wf-stale/a', status: 'stale' as TaskState['status'] })] },
+      ],
+    });
+    await h.tick(POLL_CTX);
+    expect(h.submit).not.toHaveBeenCalled();
+  });
+
+  it('does not resume a workflow whose tasks are only completed and failed', async () => {
+    const h = harness({
+      workflows: [
+        {
+          id: 'wf-mixed-terminal',
+          tasks: [
+            makeTask({ id: 'wf-mixed-terminal/a', status: 'completed' as TaskState['status'] }),
+            makeTask({ id: 'wf-mixed-terminal/b', status: 'failed' as TaskState['status'] }),
+          ],
+        },
+      ],
+    });
+    await h.tick(POLL_CTX);
+    expect(h.submit).not.toHaveBeenCalled();
+  });
+
+  it('still resumes a workflow with actionable pending work alongside a failed task', async () => {
+    const h = harness({
+      workflows: [
+        {
+          id: 'wf-1',
+          tasks: [
+            makeTask({ id: 'wf-1/a', status: 'failed' as TaskState['status'] }),
+            makeTask({ id: 'wf-1/b', status: 'pending' as TaskState['status'] }),
+          ],
+        },
+      ],
+    });
+    await h.tick(POLL_CTX);
+    expect(h.submit).toHaveBeenCalledTimes(1);
+    expect(h.submit.mock.calls[0][0]).toBe('wf-1');
+  });
+
   it('honors the cooldown window and re-submits after it expires', async () => {
     const h = harness({
       cooldownMs: 60_000,
       workflows: [
         {
           id: 'wf-1',
-          tasks: [makeTask({ status: 'failed' as TaskState['status'] })],
+          tasks: [makeTask({ status: 'pending' as TaskState['status'] })],
         },
       ],
     });
@@ -173,11 +227,11 @@ describe('workflow resume worker tick', () => {
       workflows: [
         {
           id: 'wf-target',
-          tasks: [makeTask({ id: 'wf-target/a', status: 'failed' as TaskState['status'] })],
+          tasks: [makeTask({ id: 'wf-target/a', status: 'pending' as TaskState['status'] })],
         },
         {
           id: 'wf-other',
-          tasks: [makeTask({ id: 'wf-other/a', status: 'failed' as TaskState['status'] })],
+          tasks: [makeTask({ id: 'wf-other/a', status: 'pending' as TaskState['status'] })],
         },
       ],
     });
@@ -193,7 +247,7 @@ describe('workflow resume worker tick', () => {
       workflows: [
         {
           id: 'wf-1',
-          tasks: [makeTask({ status: 'failed' as TaskState['status'] })],
+          tasks: [makeTask({ status: 'pending' as TaskState['status'] })],
         },
       ],
     });
@@ -206,7 +260,7 @@ describe('workflow resume worker tick', () => {
       workflows: [
         {
           id: 'wf-1',
-          tasks: [makeTask({ status: 'failed' as TaskState['status'] })],
+          tasks: [makeTask({ status: 'pending' as TaskState['status'] })],
         },
       ],
     });

--- a/packages/execution-engine/src/workers/workflow-resume-worker.ts
+++ b/packages/execution-engine/src/workers/workflow-resume-worker.ts
@@ -22,6 +22,9 @@ export const DEFAULT_WORKFLOW_RESUME_COOLDOWN_MS = 60_000;
 const TERMINAL_TASK_STATUSES: ReadonlySet<TaskState['status']> = new Set<TaskState['status']>([
   'completed' as TaskState['status'],
   'review_ready' as TaskState['status'],
+  'failed' as TaskState['status'],
+  'closed' as TaskState['status'],
+  'stale' as TaskState['status'],
 ]);
 
 export interface WorkflowResumeWorkerStore {

--- a/scripts/repro/repro-workflow-resume-terminal.mjs
+++ b/scripts/repro/repro-workflow-resume-terminal.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// Repro: the workflow-resume worker must treat `failed` (and `closed` / `stale`)
+// as terminal, so a workflow whose only unfinished work is a failed task is left
+// alone instead of being re-submitted for retry on every 60s poll.
+//
+// This drives the SAME predicate the worker uses (`isWorkflowIncomplete` in
+// packages/execution-engine/src/workers/workflow-resume-worker.ts: a workflow is
+// resumed when ANY task status is NOT in TERMINAL_TASK_STATUSES). It reads the
+// real TERMINAL_TASK_STATUSES set straight out of the source, so it FAILS on
+// unfixed code (reproducing the bug) and PASSES once the fix lands. Real unit
+// coverage lives in the worker's __tests__/workflow-resume-worker.test.ts.
+
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+// Defaults to the shipped worker source; accepts an explicit path so the same
+// guard can be pointed at an older revision to confirm it reproduces the bug.
+const workerSrc = process.argv[2]
+  ? resolve(process.argv[2])
+  : join(here, '..', '..', 'packages', 'execution-engine', 'src', 'workers', 'workflow-resume-worker.ts');
+
+const src = readFileSync(workerSrc, 'utf8');
+const setLiteral = src.match(/TERMINAL_TASK_STATUSES[\s\S]*?new Set<[^>]*>\(\[([\s\S]*?)\]\)/);
+if (!setLiteral) {
+  console.error('FAIL: could not locate the TERMINAL_TASK_STATUSES set in the worker source.');
+  process.exit(1);
+}
+// The terminal set the worker actually ships with today (only the `'x' as TaskState`
+// entries, not the `TaskState['status']` type annotations).
+const SOURCE_TERMINAL = new Set(
+  [...setLiteral[1].matchAll(/'([a-z_]+)'\s+as\s+TaskState/g)].map((x) => x[1]),
+);
+// The terminal set BEFORE the fix, kept as the baseline the bug is measured against.
+const OLD_TERMINAL = new Set(['completed', 'review_ready']);
+
+// workflowId -> its task statuses
+const FIXTURES = {
+  'wf-failed-only': ['failed'],
+  'wf-closed-only': ['closed'],
+  'wf-stale-only': ['stale'],
+  'wf-completed+failed': ['completed', 'failed'],
+  'wf-failed+pending': ['failed', 'pending'],
+  'wf-running': ['running'],
+  'wf-done': ['completed', 'review_ready'],
+};
+
+const isIncomplete = (terminal, statuses) => statuses.some((s) => !terminal.has(s));
+const resumedUnder = (terminal) =>
+  Object.entries(FIXTURES)
+    .filter(([, statuses]) => isIncomplete(terminal, statuses))
+    .map(([id]) => id);
+
+const oldResumed = resumedUnder(OLD_TERMINAL);
+const sourceResumed = resumedUnder(SOURCE_TERMINAL);
+
+console.log('old_terminal_set     =', [...OLD_TERMINAL].join(', '));
+console.log('source_terminal_set  =', [...SOURCE_TERMINAL].join(', '));
+console.log('resumed_under_old    =', oldResumed.join(' '));
+console.log('resumed_under_source =', sourceResumed.join(' '));
+
+const failures = [];
+const expect = (cond, msg) => {
+  if (!cond) failures.push(msg);
+};
+
+// Bug baseline: under the OLD set a failed-only workflow is resumed every poll.
+expect(
+  oldResumed.includes('wf-failed-only'),
+  'expected OLD behavior to resume a failed-only workflow (the bug being reproduced)',
+);
+
+// Fix must be present in the source terminal set.
+for (const status of ['completed', 'review_ready', 'failed', 'closed', 'stale']) {
+  expect(SOURCE_TERMINAL.has(status), `expected source TERMINAL_TASK_STATUSES to include '${status}'`);
+}
+
+// Fixed behavior: dead-end workflows are left alone.
+for (const id of ['wf-failed-only', 'wf-closed-only', 'wf-stale-only', 'wf-completed+failed']) {
+  expect(!sourceResumed.includes(id), `expected the shipped worker to SKIP ${id}`);
+}
+
+// Targeting preserved: workflows with genuinely actionable work still resume.
+for (const id of ['wf-failed+pending', 'wf-running']) {
+  expect(sourceResumed.includes(id), `expected the shipped worker to STILL resume ${id}`);
+}
+
+// Sanity: an already-done workflow is never resumed under either policy.
+expect(
+  !oldResumed.includes('wf-done') && !sourceResumed.includes('wf-done'),
+  'a completed/review_ready workflow must never be resumed',
+);
+
+if (failures.length > 0) {
+  console.error('\nFAIL (bug present or fix incomplete):');
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+
+console.log('\nPASS: failed/closed/stale workflows are no longer resumed; actionable work still is.');

--- a/scripts/repro/repro-workflow-resume-terminal.sh
+++ b/scripts/repro/repro-workflow-resume-terminal.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+node scripts/repro/repro-workflow-resume-terminal.mjs "$@"


### PR DESCRIPTION
## Summary

The workflow-resume worker used to bring back any workflow that was not fully finished.

That included workflows whose leftover tasks had already ended for good.

Such a workflow still counted as unfinished, so the worker sent it back to run about once a minute with no way forward.

Now permanently ended tasks count as finished. The worker only brings back workflows that still have real work waiting.

## Review Claim

The resume worker leaves a workflow alone once its only remaining tasks have permanently ended, rather than bringing it back forever.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Adds three already-terminal task states (`failed`, `closed`, `stale`) to the worker's finished-state set; workflows with live work are unaffected. One file plus its unit tests.

## Slice Rationale

This slice changes only what the worker treats as finished work. Turning the worker off by default, the reproduction, and the changelog note each land in their own slices.

## Non-goals

Does not turn the worker off, add the reproduction, or touch the changelog. Does not change how live workflows are brought back.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/workflow-resume-worker.test.ts`
- [ ] `node scripts/repro/repro-workflow-resume-terminal.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
