### PR TITLE
[Persist Worker Desired State - Runtime Restore Semantics](6) Use latest review-gate check rollups

### DIFF
--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -591,5 +591,57 @@ describe('GitHubMergeGateProvider', () => {
         ],
       });
     });
+
+    it('ignores older failed check runs when a newer duplicate check succeeds', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'OPEN',
+            reviewDecision: null,
+            url: 'https://github.com/owner/repo/pull/5',
+            headRefOid: 'def456',
+            headRefName: 'feature/fixed-pr-body',
+            mergeStateStatus: 'CLEAN',
+            statusCheckRollup: [
+              {
+                name: 'PR Body',
+                workflowName: 'PR Body',
+                status: 'COMPLETED',
+                conclusion: 'FAILURE',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/1',
+                completedAt: '2026-07-11T08:56:11Z',
+              },
+              {
+                name: 'PR Body',
+                workflowName: 'PR Body',
+                status: 'COMPLETED',
+                conclusion: 'SUCCESS',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/2',
+                completedAt: '2026-07-11T11:59:48Z',
+              },
+              {
+                name: 'quality / TypeScript Types',
+                workflowName: 'CI',
+                status: 'COMPLETED',
+                conclusion: 'SUCCESS',
+                completedAt: '2026-07-11T08:57:37Z',
+              },
+            ],
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '5', cwd: '/tmp/repo' });
+
+      expect(result.checks).toEqual({
+        state: 'success',
+        failed: [],
+      });
+    });
   });
 });

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -321,14 +321,67 @@ function stringProp(value: Record<string, unknown>, ...keys: string[]): string |
   return undefined;
 }
 
+type StatusCheckRollupItem = {
+  check: Record<string, unknown>;
+  index: number;
+  timestamp?: number;
+};
+type TimestampedStatusCheckRollupItem = StatusCheckRollupItem & { timestamp: number };
+
+function statusCheckIdentity(check: Record<string, unknown>): string | undefined {
+  const context = stringProp(check, 'context');
+  if (context) return `status:${context}`;
+
+  const name = stringProp(check, 'name');
+  const workflowName = stringProp(check, 'workflowName');
+  if (name) return `check:${workflowName ?? ''}:${name}`;
+  if (workflowName) return `check:${workflowName}`;
+
+  return undefined;
+}
+
+function statusCheckTimestamp(check: Record<string, unknown>): number | undefined {
+  for (const key of ['completedAt', 'startedAt', 'updatedAt']) {
+    const raw = stringProp(check, key);
+    if (!raw) continue;
+    const parsed = Date.parse(raw);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function latestStatusCheckRollupItems(items: unknown[]): StatusCheckRollupItem[] {
+  const latestByIdentity = new Map<string, TimestampedStatusCheckRollupItem>();
+  const passthrough: StatusCheckRollupItem[] = [];
+
+  items.forEach((item, index) => {
+    if (!item || typeof item !== 'object') return;
+    const check = item as Record<string, unknown>;
+    const timestamp = statusCheckTimestamp(check);
+    const identity = statusCheckIdentity(check);
+
+    if (!identity || timestamp === undefined) {
+      passthrough.push({ check, index, timestamp });
+      return;
+    }
+
+    const candidate = { check, index, timestamp };
+    const current = latestByIdentity.get(identity);
+    if (!current || timestamp > current.timestamp || (timestamp === current.timestamp && index > current.index)) {
+      latestByIdentity.set(identity, candidate);
+    }
+  });
+
+  return [...passthrough, ...latestByIdentity.values()]
+    .sort((a, b) => a.index - b.index);
+}
+
 function summarizeStatusChecks(items: unknown[] | undefined): MergeGateApprovalStatus['checks'] {
   if (!Array.isArray(items) || items.length === 0) return undefined;
 
   let hasPending = false;
   const failed: MergeGateFailedCheck[] = [];
-  for (const item of items) {
-    if (!item || typeof item !== 'object') continue;
-    const check = item as Record<string, unknown>;
+  for (const { check } of latestStatusCheckRollupItems(items)) {
     const name = stringProp(check, 'name', 'workflowName', 'context') ?? 'unknown check';
     const status = stringProp(check, 'status')?.toUpperCase();
     const conclusion = stringProp(check, 'conclusion')?.toUpperCase();


### PR DESCRIPTION
## Summary

Review-gate status checks now use the latest rollup entry for each check identity.

Older failed runs no longer keep a PR red after GitHub reports a newer successful run for the same check.

Rollup items without a stable identity still pass through unchanged.

## Review Claim

Approve routing repeated GitHub status rollup entries through the newest timestamped check result before computing review-gate status.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change only folds entries that share a check identity and timestamp. Unknown rollup shapes keep their previous pass-through behavior.

## Slice Rationale

This review-gate fix stays after the worker desired-state stack because it addresses the publication gate that reviewed this stack, not the worker runtime itself.

## Non-goals

- Does not change PR publication or body authoring.
- Does not change merge approval decisions.
- Does not change worker desired-state persistence.
- No UI changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/github-merge-gate-provider.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1c79e646`
- Post-revert steps: None
- Data migration? No

</details>
