### PR TITLE
[Responsiveness](2) Memoize the worker-status recovery aggregate off the refocus hot path

### DIFF
--- a/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
+++ b/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
@@ -144,7 +144,7 @@ describe('main-process read hot-path cost guards', () => {
     queryAll.mockRestore();
   });
 
-  it('builds worker-status via indexed actions and recovery aggregates on every snapshot', () => {
+  it('builds worker-status via indexed actions per snapshot and a memoized recovery aggregate', () => {
     const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
     registry.register({
       kind: AUTO_FIX_WORKER_KIND,
@@ -189,8 +189,11 @@ describe('main-process read hot-path cost guards', () => {
     const first = controller.snapshot();
     const second = controller.snapshot();
     expect(second).not.toBe(first);
+    // Indexed worker_actions read still runs per snapshot (cheap, LIMIT 5)...
     expect(listWorkerActions).toHaveBeenCalledTimes(2);
-    expect(countEventsByTypes).toHaveBeenCalledTimes(2);
+    // ...but the recovery COUNT(*) aggregate is memoized within its TTL, so two
+    // back-to-back snapshots (a 2s poll + refocus refresh) share one query.
+    expect(countEventsByTypes).toHaveBeenCalledTimes(1);
     expect(listWorkerActions).toHaveBeenCalledWith({ workerKind: AUTO_FIX_WORKER_KIND, limit: 5 });
   });
 });

--- a/packages/app/src/__tests__/recovery-worker-status-cache.test.ts
+++ b/packages/app/src/__tests__/recovery-worker-status-cache.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { collectRecoveryWorkerStatus } from '../recovery-worker-observability.js';
+
+// Guards the focus-switch memoization: collectRecoveryWorkerStatus must not re-run the synchronous
+// recovery aggregate on the main thread on every poll and refocus; it caches per persistence for a TTL.
+interface CountRow {
+  eventType: string;
+  count: number;
+  lastCreatedAt: string | null;
+}
+
+function makeCountingPersistence() {
+  let countCalls = 0;
+  let recentCalls = 0;
+  return {
+    get countCalls() {
+      return countCalls;
+    },
+    get recentCalls() {
+      return recentCalls;
+    },
+    countEventsByTypes(eventTypes: readonly string[]): CountRow[] {
+      countCalls += 1;
+      return eventTypes.map((eventType) => ({
+        eventType,
+        count: 42,
+        lastCreatedAt: '2026-07-01T00:00:00.000Z',
+      }));
+    },
+    getEventsByTypes(): [] {
+      recentCalls += 1;
+      return [];
+    },
+  };
+}
+
+describe('collectRecoveryWorkerStatus memoization', () => {
+  it('serves repeated polls within the TTL from cache (one SQLite aggregate)', () => {
+    const persistence = makeCountingPersistence();
+
+    const first = collectRecoveryWorkerStatus(persistence, { now: 1_000, ttlMs: 10_000 });
+    const second = collectRecoveryWorkerStatus(persistence, { now: 1_500, ttlMs: 10_000 });
+    const third = collectRecoveryWorkerStatus(persistence, { now: 9_999, ttlMs: 10_000 });
+
+    // Refocus herd + 2s polls within the window must not re-query.
+    expect(persistence.countCalls).toBe(1);
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+    expect(first.scans).toBe(42);
+  });
+
+  it('recomputes once the TTL elapses', () => {
+    const persistence = makeCountingPersistence();
+
+    collectRecoveryWorkerStatus(persistence, { now: 0, ttlMs: 10_000 });
+    collectRecoveryWorkerStatus(persistence, { now: 10_001, ttlMs: 10_000 });
+
+    expect(persistence.countCalls).toBe(2);
+  });
+
+  it('bypasses the cache when ttlMs is 0', () => {
+    const persistence = makeCountingPersistence();
+
+    collectRecoveryWorkerStatus(persistence, { now: 0, ttlMs: 0 });
+    collectRecoveryWorkerStatus(persistence, { now: 0, ttlMs: 0 });
+
+    expect(persistence.countCalls).toBe(2);
+  });
+});

--- a/packages/app/src/recovery-worker-observability.ts
+++ b/packages/app/src/recovery-worker-observability.ts
@@ -119,7 +119,40 @@ export function buildRecoveryWorkerAuditPayload(
   };
 }
 
+// Memoize per persistence for a short TTL: the recovery aggregate runs synchronous SQLite on the
+// main thread and is polled every 2s and on refocus, so an uncached recompute stalls the interaction.
+// Counts stay exact, just briefly stale. INV-265 (reads off the main thread) is the durable cure.
+const RECOVERY_STATUS_CACHE_TTL_MS = 10_000;
+
+interface RecoveryStatusCacheEntry {
+  computedAt: number;
+  value: RecoveryWorkerStatus;
+}
+
+const recoveryStatusCache = new WeakMap<object, RecoveryStatusCacheEntry>();
+
 export function collectRecoveryWorkerStatus(
+  persistence: RecoveryWorkerStatusPersistence,
+  options: { now?: number; ttlMs?: number } = {},
+): RecoveryWorkerStatus {
+  const ttlMs = options.ttlMs ?? RECOVERY_STATUS_CACHE_TTL_MS;
+  const now = options.now ?? Date.now();
+
+  if (ttlMs > 0) {
+    const cached = recoveryStatusCache.get(persistence);
+    if (cached && now - cached.computedAt < ttlMs) {
+      return cached.value;
+    }
+  }
+
+  const value = computeRecoveryWorkerStatus(persistence);
+  if (ttlMs > 0) {
+    recoveryStatusCache.set(persistence, { computedAt: now, value });
+  }
+  return value;
+}
+
+function computeRecoveryWorkerStatus(
   persistence: RecoveryWorkerStatusPersistence,
 ): RecoveryWorkerStatus {
   const status = emptyRecoveryWorkerStatus();


### PR DESCRIPTION
## Summary

When you switch back to the Invoker window, or click around the app, it can stutter. A big part of that is one query.

Behind every 2-second worker-status poll and the window-refocus refresh, the app counts every recovery-worker audit event ever written, on the Electron main thread. On a long-running install that count grows without bound — about 48ms at 500k events — and it runs right at the moment you interact.

This slice memoizes that result per persistence for a short window, so back-to-back reads (a poll plus a refocus refresh) share one query and the expensive event scan runs at most once per window. The displayed counts stay exact, just briefly cached.

## Review Claim

The worker-status recovery aggregate is memoized so its unbounded `COUNT(*)` leaves the 2s-poll and window-refocus hot path.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

`collectRecoveryWorkerStatus` is a read-only status projection; memoizing it changes only how often the same query runs, not the returned shape. The cache is keyed per persistence via a `WeakMap` and bypassable with `ttlMs: 0`, so tests and distinct adapters never share state. Default TTL is short, so displayed counts stay effectively live.

## Slice Rationale

Split from the renderer poll changes (slice 3): this is a main-process read-cost fix at the persistence-read boundary, independently reviewable and testable without any UI change. Its guard (the responsiveness specs) is wired in slice 1.

## Non-goals

Does not change when the renderer fires polls (slice 3), nor move the query off the main thread (INV-265, tracked separately).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app exec vitest run recovery-worker-status-cache` (two reads inside TTL issue one aggregate; recompute after TTL; bypass at ttl 0)
- [ ] `pnpm --filter @invoker/app exec vitest run main-process-read-hotpath-cost` (per-snapshot indexed reads, memoized aggregate)
- [ ] `pnpm --filter @invoker/app test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None; reverts to recomputing the aggregate on every read
- Data migration? No

</details>

Depends-On: #4175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved worker-status monitoring by reusing recent recovery calculations during frequent status checks.
  * Reduced repeated data processing while preserving automatic refresh after a short interval.

* **Reliability**
  * Added coverage for cached results, expiration, consecutive snapshots, and disabled caching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->