### PR TITLE
[Planning Surface Tmux Step 1 Backend Session Routing](1) Define planning terminal IPC contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -694,6 +694,8 @@ export interface RuntimeStatus {
 export interface TerminalSessionDescriptor {
   sessionId: string;
   taskId: string;
+  kind?: 'task' | 'planning';
+  planningSessionId?: string;
   status: 'running' | 'exited';
   exitCode?: number;
   cwd?: string;
@@ -709,12 +711,16 @@ export interface TerminalSessionDescriptor {
 export interface TerminalOutputEvent {
   sessionId: string;
   taskId: string;
+  kind?: 'task' | 'planning';
+  planningSessionId?: string;
   data: string;
 }
 
 export interface TerminalExitEvent {
   sessionId: string;
   taskId: string;
+  kind?: 'task' | 'planning';
+  planningSessionId?: string;
   exitCode?: number;
 }
 
@@ -772,6 +778,26 @@ export const IpcChannels = {
   'invoker:planning-chat-reset': {} as {
     request: [request: InAppPlanningResetRequest];
     response: InAppPlanningResetResponse;
+  },
+  'invoker:planning-terminal-open': {} as {
+    request: [planningSessionId: string];
+    response: OpenTerminalResponse;
+  },
+  'invoker:planning-terminal-list': {} as {
+    request: [];
+    response: TerminalSessionDescriptor[];
+  },
+  'invoker:planning-terminal-write': {} as {
+    request: [sessionId: string, data: string];
+    response: { ok: boolean; reason?: string };
+  },
+  'invoker:planning-terminal-resize': {} as {
+    request: [sessionId: string, cols: number, rows: number];
+    response: { ok: boolean; reason?: string };
+  },
+  'invoker:planning-terminal-close': {} as {
+    request: [sessionId: string];
+    response: { ok: boolean; reason?: string };
   },
   'invoker:get-planning-presets': {} as {
     request: [];

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -199,6 +199,23 @@ export function createMockInvoker(
       workflowId: 'wf-1',
     })),
     planningChatReset: vi.fn(async () => ({ ok: true })),
+    planningTerminalOpen: vi.fn(async (planningSessionId: string) => ({
+      opened: true,
+      session: {
+        sessionId: `mock-planning-terminal-${planningSessionId}`,
+        taskId: `planning:${planningSessionId}`,
+        kind: 'planning',
+        planningSessionId,
+        status: 'running',
+        mode: 'spawn',
+        attached: false,
+        createdAt: new Date('2025-01-01T00:00:00Z').toISOString(),
+      },
+    })),
+    planningTerminalList: vi.fn(async () => []),
+    planningTerminalWrite: vi.fn(async () => ({ ok: true })),
+    planningTerminalResize: vi.fn(async () => ({ ok: true })),
+    planningTerminalClose: vi.fn(async () => ({ ok: true })),
     getPlanningPresets: vi.fn(async () => [
       { key: 'codex', label: 'Codex', tool: 'codex', isDefault: true },
       { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude', isDefault: false },


### PR DESCRIPTION
## Summary

This slice defines the typed planning terminal IPC surface.

It also keeps the UI test bridge mock aligned with the expanded Invoker API.

## Review Claim

The contracts now define planning terminal session metadata and IPC method shapes without changing existing task terminal fields.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The new descriptor fields are optional, and existing task terminal callers can continue using the previous shape.

## Slice Rationale

This contract slice lands first so the handler implementation can depend on named planning terminal channels.

## Non-goals

- Does not implement Electron main-process handlers.
- Does not start terminal processes.
- Does not change task terminal behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/embedded-terminal-manager.test.ts src/__tests__/terminal-session-persistence.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/planning-tmux-pr1.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0dfb8c2fe83be4d05be68a09c71011e8199c8421`
- Post-revert steps: Revert the dependent routing slice first if it has landed.
- Data migration? No

</details>
