### PR TITLE
[Planning Chat Inner Shell Cleanup](1) Stop seeding the planner starter message

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -213,6 +213,12 @@ describe('planning chat', () => {
     expect(result).toMatchObject({ ok: true, reply: 'I can help.', draftPlanAvailable: false });
     expect(result.ok && result.sessionId).toBeTruthy();
     expect(sessions.size).toBe(1);
+    const session = [...sessions.values()][0];
+    expect(session?.messages).toEqual([
+      expect.objectContaining({ id: 1, role: 'user', text: 'hello' }),
+      expect.objectContaining({ id: 2, role: 'assistant', text: 'I can help.' }),
+    ]);
+    expect(session?.messages.some((line) => line.text === 'Ask Invoker what you want to build.')).toBe(false);
     expect(spawnPlanner).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -323,17 +323,11 @@ async function createSession(
     title: typeof request?.title === 'string' && request.title.trim() ? request.title.trim() : 'Untitled plan',
     presetKey,
     status: 'still_discussing',
-    messages: [{
-      id: 1,
-      role: 'system',
-      text: 'Ask Invoker what you want to build.',
-      tone: 'muted',
-      createdAt,
-    }],
+    messages: [],
     conversation: new PlanConversation(planConversationConfig(preset, deps, id)),
     createdAt,
     updatedAt: createdAt,
-    nextMessageId: 2,
+    nextMessageId: 1,
   };
   deps.sessions.set(session.id, session);
   persistPlanningSession(session, deps.planningSessionStore, false);


### PR DESCRIPTION
## Summary

A new planning chat now opens with an empty transcript.

Before, every session began with a seeded system line reading "Ask Invoker what you want to build."

That canned line added nothing and cluttered the first frame. Dropping it lets the user's own words be the real first message.

## Review Claim

Approve removing the seeded starter system message from in-app planner session creation, so a fresh session begins with no messages.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change only drops an initial system line. Message ordering, persistence, and reply handling are unchanged, and a focused planner test now asserts a fresh session begins with no seeded line.

## Slice Rationale

This is the smallest reviewable change: it touches only the app-side planner session seed. The UI shell flattening and the e2e realignment ride in later slices so each diff carries one claim.

## Non-goals

- Does not change the planning UI layout or the outer header.
- Does not touch the visual-proof e2e assertions.
- Does not alter how replies are generated or persisted.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
