### PR TITLE
[Planning Chat Inner Shell Cleanup](1) Realign planning visual-proof e2e to the flat shell

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -754,7 +754,10 @@ test.describe('Visual proof capture', () => {
       await window.invoker.setTestPlanningChatResponse({ planYaml, planName, reply: 'I drafted the stacked plan.' });
     }, { planYaml: plannedYaml, planName: 'Workers Surface' });
 
-    await expect(page.getByRole('heading', { name: 'What do you want to build?' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Planning chat window' })).toBeVisible();
+    await expect(page.getByText('Still discussing')).toBeVisible();
+    await expect(page.getByText('What do you want to build?')).toHaveCount(0);
+    await expect(page.getByText('Ask Invoker what you want to build.')).toHaveCount(0);
     await expect(page.getByTestId('invoker-terminal-input')).toBeVisible();
     await page.getByTestId('invoker-terminal-input').fill('Build the Workers Surface');
     await page.getByRole('button', { name: 'Send' }).click();


### PR DESCRIPTION
## Summary

The Electron visual-proof spec now expects the flat planning shell.

It checks for the outer "Planning chat window" header, the "Still discussing" status, and the missing seeded starter line.

This keeps the proof spec aligned with the planning chat layout already in the branch history.

## Review Claim

Approve the planning visual-proof assertion update for the flattened shell.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only changes one e2e spec file. Product code stays untouched.

## Slice Rationale

The UI shell change is already separate from this remaining open PR. Keeping this diff assertion-only makes the last review step narrow and easy to verify.

## Non-goals

- Does not change product code.
- Does not add new screenshots.
- Does not change planner behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test:e2e visual-proof.spec.ts --grep "terminal planning submits Workers Surface as stacked workflows"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
