### PR TITLE
[Launch & Graph](1) Bundle execution-engine into surfaces so the app launches

### DIFF
--- a/packages/surfaces/tsup.config.ts
+++ b/packages/surfaces/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     '@invoker/workflow-core',
     '@invoker/contracts',
     '@invoker/data-store',
+    '@invoker/execution-engine',
     '@invoker/transport',
     'yaml',
   ],


### PR DESCRIPTION
## Summary

The desktop app quit itself right after startup and never showed a window.

The cause was a packaging gap. `@invoker/surfaces` pulls a helper from `@invoker/execution-engine`, whose package resolves to TypeScript source.

`surfaces` did not bundle `execution-engine`, so its built output loaded the raw `.ts` at runtime. Node threw a syntax error and the app quit.

This adds `@invoker/execution-engine` to the `surfaces` bundler config, matching how its other workspace dependencies are already handled.

## Review Claim

Bundling `@invoker/execution-engine` into `surfaces` lets the app launch instead of quitting at startup.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the `surfaces` bundler config changes. It inlines one more workspace dependency that is already imported, so no runtime logic changes.

## Slice Rationale

This launch-blocking fix stands alone. It shares nothing with the script and UI slices above it.

## Non-goals

Does not change `execution-engine` exports, other packages' bundling, or any runtime behavior beyond making the `surfaces` bundle self-contained.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/surfaces build`
- [ ] `grep -c 'require("@invoker/execution-engine")' packages/surfaces/dist/index.js` returns `0`
- [ ] `./run.sh` launches and the window stays open

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
