### PR TITLE
[Invoker storm hardening](1) Add optional forced flag to the snapshot contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -84,6 +84,7 @@ export type TaskGraphEvent =
       workflows: WorkflowMeta[];
       reason: string;
       streamSequence: number;
+      forced?: boolean;
     };
 
 


### PR DESCRIPTION
## Summary

Add an optional `forced` field to the task-graph snapshot event in the shared contract.

A user-initiated refresh needs a way to mark a snapshot as authoritative. This slice adds only the contract field; later slices set and read it.

## Review Claim

The task-graph snapshot contract carries an optional `forced` field.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The field is optional and additive; no existing producer or consumer changes, so runtime behavior is unchanged in this slice.

## Non-goals

Does not set or read the flag; those land in later slices. No other contract changes.

## Slice Rationale

The contract field is the shared dependency the later slices build on, so it lands first.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
