### PR TITLE
[Invoker storm hardening](3) Relieve the owner poll sweep and honor forced refresh

### DIFF
--- a/packages/app/src/__tests__/executing-stall.test.ts
+++ b/packages/app/src/__tests__/executing-stall.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { evaluateExecutingStall } from '../executing-stall.js';
+import { evaluateExecutingStall, taskNeedsExecutingStallCheck } from '../executing-stall.js';
+import type { TaskState } from '@invoker/workflow-core';
 
 describe('evaluateExecutingStall', () => {
   const now = new Date('2026-05-13T08:00:00.000Z');
@@ -80,5 +81,42 @@ describe('evaluateExecutingStall', () => {
 
     expect(result.executingStalled).toBe(true);
     expect(result.staleReason).toBe('attempt lease expired');
+  });
+});
+
+describe('taskNeedsExecutingStallCheck', () => {
+  function task(status: string, phase?: string): Pick<TaskState, 'status' | 'execution'> {
+    return { status, execution: { phase } } as unknown as Pick<TaskState, 'status' | 'execution'>;
+  }
+
+  it('selects running, launching, and fixing tasks (the only stall-eligible states)', () => {
+    expect(taskNeedsExecutingStallCheck(task('running'))).toBe(true);
+    expect(taskNeedsExecutingStallCheck(task('fixing_with_ai'))).toBe(true);
+    expect(taskNeedsExecutingStallCheck(task('pending', 'launching'))).toBe(true);
+  });
+
+  it('skips idle and terminal tasks so the db-poll loads no attempt for them', () => {
+    expect(taskNeedsExecutingStallCheck(task('pending'))).toBe(false);
+    expect(taskNeedsExecutingStallCheck(task('pending', 'executing'))).toBe(false);
+    expect(taskNeedsExecutingStallCheck(task('completed'))).toBe(false);
+    expect(taskNeedsExecutingStallCheck(task('failed'))).toBe(false);
+    expect(taskNeedsExecutingStallCheck(task('closed'))).toBe(false);
+    expect(taskNeedsExecutingStallCheck(task('review_ready'))).toBe(false);
+  });
+
+  it('collapses the per-tick attempt-load count to the stall-eligible tasks under a storm', () => {
+    // Mirrors the live storm: dozens of idle pending frontier tasks, a couple of
+    // running/fixing ones. Before gating the db-poll loaded an attempt for EVERY
+    // task each 2s tick; now only the eligible few incur the heavy attempt query.
+    const storm: Pick<TaskState, 'status' | 'execution'>[] = [
+      ...Array.from({ length: 50 }, () => task('pending')),
+      task('running'),
+      task('pending', 'launching'),
+      task('fixing_with_ai'),
+      ...Array.from({ length: 5 }, () => task('completed')),
+    ];
+    const needingLoad = storm.filter(taskNeedsExecutingStallCheck);
+    expect(needingLoad).toHaveLength(3);
+    expect(storm.length).toBe(58);
   });
 });

--- a/packages/app/src/executing-stall.ts
+++ b/packages/app/src/executing-stall.ts
@@ -1,4 +1,4 @@
-import type { RunnerKind } from '@invoker/workflow-core';
+import type { RunnerKind, TaskState } from '@invoker/workflow-core';
 
 export interface ExecutingStallEvaluationInput {
   now: Date;
@@ -55,4 +55,13 @@ export function evaluateExecutingStall(input: ExecutingStallEvaluationInput): Ex
     executingStalled,
     staleReason,
   };
+}
+
+export function taskNeedsExecutingStallCheck(
+  task: Pick<TaskState, 'status' | 'execution'>,
+): boolean {
+  if (task.status === 'running' || task.status === 'fixing_with_ai') {
+    return true;
+  }
+  return task.status === 'pending' && task.execution.phase === 'launching';
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -235,7 +235,7 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
-import { evaluateExecutingStall } from './executing-stall.js';
+import { evaluateExecutingStall, taskNeedsExecutingStallCheck } from './executing-stall.js';
 
 
 import {
@@ -3267,7 +3267,7 @@ function createEmbeddedTerminalBackendFromConfig(
               persistence,
               logger,
             });
-            taskGraphEventPublisher.publishSnapshot('refresh-task-graph', snapshot.tasks, snapshot.workflows);
+            taskGraphEventPublisher.publishSnapshot('refresh-task-graph', snapshot.tasks, snapshot.workflows, true);
           },
           deleteWorkflow: performDeleteWorkflow,
           detachWorkflow: performDetachWorkflow,
@@ -3331,7 +3331,7 @@ function createEmbeddedTerminalBackendFromConfig(
                 let task = loadedTask;
                 const now = new Date();
                 const previousHeartbeat = parseExecutionDate(task.execution.lastHeartbeatAt);
-                const selectedAttempt = task.execution.selectedAttemptId
+                const selectedAttempt = taskNeedsExecutingStallCheck(task) && task.execution.selectedAttemptId
                   ? persistence.loadAttempt?.(task.execution.selectedAttemptId)
                   : undefined;
                 const leaseExpiresAt = parseExecutionDate(selectedAttempt?.leaseExpiresAt);
@@ -4168,6 +4168,7 @@ function createEmbeddedTerminalBackendFromConfig(
         ownerMode ? 'refresh-task-graph' : 'refresh-task-graph-delegated',
         snapshot.tasks,
         snapshot.workflows,
+        true,
       );
       recordStartupDuration('refresh-task-graph.return', startedAtMs, {
         taskCount: snapshot.tasks.length,

--- a/packages/app/src/task-graph-event-publisher.ts
+++ b/packages/app/src/task-graph-event-publisher.ts
@@ -10,7 +10,7 @@ type SnapshotTaskStates = Extract<TaskGraphEvent, { type: 'snapshot' }>['tasks']
 
 export interface TaskGraphEventPublisher {
   publishDelta(delta: TaskDelta, workflowRollups: readonly WorkflowRollupPatch[]): void;
-  publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[]): void;
+  publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[], forced?: boolean): void;
 }
 
 export interface CreateTaskGraphEventPublisherOptions {
@@ -77,13 +77,14 @@ export function createTaskGraphEventPublisher(
         workflowRollups: [...workflowRollups],
       });
     },
-    publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[]): void {
+    publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[], forced?: boolean): void {
       publishEvent({
         type: 'snapshot',
         tasks: tasks as SnapshotTaskStates,
         workflows,
         reason,
         streamSequence: options.getStreamSequence(),
+        ...(forced ? { forced: true } : {}),
       });
     },
   };

--- a/packages/app/src/web/start-web-surface.ts
+++ b/packages/app/src/web/start-web-surface.ts
@@ -104,6 +104,7 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
       'refresh-task-graph',
       tasks,
       deps.persistence.listWorkflows() as WorkflowMeta[],
+      true,
     );
   };
 

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -84,6 +84,7 @@ export type TaskGraphEvent =
       workflows: WorkflowMeta[];
       reason: string;
       streamSequence: number;
+      forced?: boolean;
     };
 
 

--- a/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
+++ b/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
@@ -78,6 +78,8 @@ export function createReactFlowMock() {
             <div
               key={node.id}
               data-testid={`rf__node-${node.id}`}
+              data-x={(node as { position?: { x?: number } }).position?.x}
+              data-y={(node as { position?: { y?: number } }).position?.y}
               className="react-flow__node"
               onClick={(e) => onNodeClick?.(e, node)}
               onContextMenu={(e) => onNodeContextMenu?.(e, node)}

--- a/packages/ui/src/__tests__/refresh-force-snapshot-repro.test.tsx
+++ b/packages/ui/src/__tests__/refresh-force-snapshot-repro.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Regression repro: the rail refresh button publishes a snapshot stamped with the
+ * CURRENT (non-incrementing) stream sequence. Under live delta churn the renderer
+ * watermark has already advanced past it, so the snapshot is discarded as stale and
+ * the refresh visibly no-ops.
+ *
+ * A user-initiated refresh must carry `forced: true` and bypass the stale-sequence
+ * discard. The final assertion describes the correct post-fix behavior: it fails on
+ * the pre-fix code (forced snapshot discarded) and passes after the fix.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTasks } from '../hooks/useTasks.js';
+import { makeUITask } from './helpers/mock-invoker.js';
+
+function flushPipeline(ms = 130): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setTimeout(resolve, ms);
+  return promise;
+}
+
+describe('forced refresh snapshot bypasses the stale-sequence discard', () => {
+  let taskGraphEventHandler: ((event: unknown) => void) | undefined;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    taskGraphEventHandler = undefined;
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = { tasks: [], workflows: [] };
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks: vi.fn().mockResolvedValue({ tasks: [], workflows: [], streamSequence: 0 }),
+      listWorkflows: vi.fn().mockResolvedValue([]),
+      reportUiPerf: vi.fn().mockResolvedValue(undefined),
+      onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
+        taskGraphEventHandler = cb;
+        return () => {};
+      }),
+      onWorkflowsChanged: vi.fn(() => () => {}),
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as unknown as { invoker?: unknown }).invoker;
+    delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
+  });
+
+  it('applies a forced snapshot even when its stream sequence is behind the watermark', async () => {
+    const { result } = renderHook(() => useTasks());
+
+    // Live churn advances the watermark to 10.
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'snapshot',
+        tasks: [makeUITask({ id: 't1', description: 'first' })],
+        workflows: [],
+        reason: 'live',
+        streamSequence: 10,
+      });
+      await flushPipeline();
+    });
+    expect(result.current.tasks.has('t1')).toBe(true);
+
+    // A routine (non-forced) snapshot behind the watermark must stay discarded.
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'snapshot',
+        tasks: [makeUITask({ id: 't1', description: 'first' }), makeUITask({ id: 't2-stale', description: 'stale' })],
+        workflows: [],
+        reason: 'stale',
+        streamSequence: 5,
+      });
+      await flushPipeline();
+    });
+    expect(result.current.tasks.has('t2-stale')).toBe(false);
+
+    // The manual rail refresh: forced snapshot, same low sequence, must APPLY.
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'snapshot',
+        tasks: [makeUITask({ id: 't1', description: 'first' }), makeUITask({ id: 't2-forced', description: 'forced' })],
+        workflows: [],
+        reason: 'manual-refresh',
+        streamSequence: 5,
+        forced: true,
+      });
+      await flushPipeline();
+    });
+    expect(result.current.tasks.has('t2-forced')).toBe(true);
+  });
+});

--- a/packages/ui/src/__tests__/task-dag-layout-jump-repro.test.tsx
+++ b/packages/ui/src/__tests__/task-dag-layout-jump-repro.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Regression repro: the task graph flickers because adding a node makes EVERY
+ * already-placed node jump to the synchronous fallback layout until the async ELK
+ * layout for the new node set resolves, then snap back.
+ *
+ * `activeLayout` fell back to `makeFallbackLayout` for ALL nodes whenever the
+ * resolved ELK layout did not cover the current task set. Under the recreate
+ * storm the set changes constantly, so nodes visibly jumped once per change.
+ *
+ * The correct behavior (asserted below): while a re-layout is in flight, nodes
+ * that already have an ELK position keep it; only genuinely-new nodes use the
+ * fallback. Fails on the pre-fix code (existing nodes jump), passes after the fix.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import type { TaskState } from '../types.js';
+import { makeUITask } from './helpers/mock-invoker.js';
+
+// vitest hoists vi.mock; its factory cannot close over test-scope bindings, so
+// the controllable ELK layout lives inside the factory closure.
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+// Deterministic ELK: each task gets a distinctive large coordinate so an ELK
+// position is unmistakable from a fallback position. The FIRST layout resolves;
+// the SECOND (triggered by the added node) stays pending, holding the transition
+// window open so the test can observe whether existing nodes jumped.
+vi.mock('../lib/layout.js', async () => {
+  const actual = await vi.importActual<typeof import('../lib/layout.js')>('../lib/layout.js');
+  let call = 0;
+  const { promise: pendingSecondLayout } = Promise.withResolvers<never>();
+  const layoutTaskGraph = vi.fn((tasks: { id: string }[]) => {
+    call += 1;
+    const positions = new Map<string, { x: number; y: number }>();
+    [...tasks]
+      .sort((a, b) => a.id.localeCompare(b.id))
+      .forEach((task, index) => positions.set(task.id, { x: 5000 + index * 100, y: 6000 + index * 100 }));
+    const result = { positions, edgePoints: new Map(), usedFallback: false };
+    return call === 1 ? Promise.resolve(result) : pendingSecondLayout;
+  });
+  return { ...actual, layoutTaskGraph };
+});
+
+const { TaskDAG } = await import('../components/TaskDAG.js');
+
+function taskMap(...tasks: TaskState[]): Map<string, TaskState> {
+  return new Map(tasks.map((task) => [task.id, task]));
+}
+
+function nodeX(id: string): string | null {
+  return document.querySelector(`[data-testid="rf__node-${id}"]`)?.getAttribute('data-x') ?? null;
+}
+
+describe('task graph does not flicker on node-set change', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps existing nodes at their ELK positions while a re-layout for a new node is in flight', async () => {
+    const a = makeUITask({ id: 'wf-1/a', workflowId: 'wf-1', status: 'running' });
+    const b = makeUITask({ id: 'wf-1/b', workflowId: 'wf-1', status: 'pending' });
+    const c = makeUITask({ id: 'wf-1/c', workflowId: 'wf-1', status: 'pending' });
+
+    const { rerender } = render(<TaskDAG tasks={taskMap(a, b)} />);
+
+    // First ELK layout resolves: A and B settle at their ELK coordinates.
+    await waitFor(() => {
+      expect(nodeX('wf-1/a')).toBe('5000');
+      expect(nodeX('wf-1/b')).toBe('5100');
+    });
+
+    // A new node arrives → a fresh ELK layout is requested but stays in flight.
+    rerender(<TaskDAG tasks={taskMap(a, b, c)} />);
+
+    // The new node must appear, proving the re-layout window is active.
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="rf__node-wf-1/c"]')).not.toBeNull();
+    });
+
+    // Existing nodes must NOT have jumped to the fallback layout.
+    expect(nodeX('wf-1/a')).toBe('5000');
+    expect(nodeX('wf-1/b')).toBe('5100');
+    // The genuinely-new node uses the fallback (the in-flight ELK never resolved),
+    // so it is NOT at the ELK coordinate 5200.
+    expect(nodeX('wf-1/c')).not.toBe('5200');
+  });
+});

--- a/packages/ui/src/__tests__/workflow-blank-storm-repro.test.tsx
+++ b/packages/ui/src/__tests__/workflow-blank-storm-repro.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * Regression repro: the workflow list must never blank out — and must self-heal —
+ * under the recreate/quarantine storm that the recovery worker + db-poll watchdog
+ * drive across all workflows.
+ *
+ * Two distinct failure modes are proven here:
+ *  A) A `{ removed: true }` rollup patch HARD-deletes a workflow even when a task
+ *     still references it (a transient-empty projection during the storm). The
+ *     entry vanishes and never returns.
+ *  B) Once the map has lost a workflow, no delta batch re-fetches it: only a
+ *     `created` delta for an unknown workflow triggered a re-fetch, so idle/pending
+ *     workflows stayed gone forever.
+ *
+ * Both assertions describe the CORRECT post-fix behavior; they fail on the
+ * pre-fix code (proving the bug) and pass after the fix.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useTasks } from '../hooks/useTasks.js';
+import { makeUITask } from './helpers/mock-invoker.js';
+import type { WorkflowMeta } from '../types.js';
+
+/** Awaits the 100ms delta-pipeline flush window without the executor callback form. */
+function flushPipeline(ms = 130): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setTimeout(resolve, ms);
+  return promise;
+}
+
+function makeWorkflowRollup(
+  status: NonNullable<WorkflowMeta['rollup']>['status'],
+  counts: Partial<NonNullable<WorkflowMeta['rollup']>['countsByStatus']> = {},
+): NonNullable<WorkflowMeta['rollup']> {
+  return {
+    status,
+    countsByStatus: {
+      pending: 0,
+      running: 0,
+      fixing_with_ai: 0,
+      completed: 0,
+      failed: 0,
+      closed: 0,
+      needs_input: 0,
+      blocked: 0,
+      review_ready: 0,
+      awaiting_approval: 0,
+      stale: 0,
+      ...counts,
+    },
+    failedTasks: [],
+    fixingTasks: [],
+    waitingTasks: [],
+  };
+}
+
+describe('workflow list blank-out under storm', () => {
+  let taskGraphEventHandler: ((event: unknown) => void) | undefined;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    taskGraphEventHandler = undefined;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as unknown as { invoker?: unknown }).invoker;
+    delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
+  });
+
+  it('keeps a workflow whose removed rollup arrives while a task still references it', async () => {
+    const tasks = [
+      makeUITask({ id: 'wf-1/task-1', workflowId: 'wf-1', status: 'pending' }),
+      makeUITask({ id: 'wf-2/task-1', workflowId: 'wf-2', status: 'pending' }),
+      makeUITask({ id: 'wf-3/task-1', workflowId: 'wf-3', status: 'pending' }),
+    ];
+    const workflows: WorkflowMeta[] = [
+      { id: 'wf-1', name: 'Workflow 1', status: 'pending' },
+      { id: 'wf-2', name: 'Workflow 2', status: 'pending' },
+      { id: 'wf-3', name: 'Workflow 3', status: 'pending' },
+    ];
+    const listWorkflows = vi.fn().mockResolvedValue(workflows);
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = { tasks, workflows };
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks: vi.fn().mockResolvedValue({ tasks, workflows }),
+      listWorkflows,
+      reportUiPerf: vi.fn().mockResolvedValue(undefined),
+      onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
+        taskGraphEventHandler = cb;
+        return () => {};
+      }),
+      onWorkflowsChanged: vi.fn(() => () => {}),
+    };
+
+    const { result } = renderHook(() => useTasks());
+    expect(result.current.workflows.size).toBe(3);
+
+    // Storm: wf-2's task set transiently empties in the projection, emitting a
+    // removed rollup — but the task is still present in this very batch.
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'delta',
+        delta: {
+          type: 'updated',
+          taskId: 'wf-2/task-1',
+          changes: { status: 'running' },
+          taskStateVersion: 2,
+          previousTaskStateVersion: 1,
+        },
+        workflowRollups: [
+          { workflowId: 'wf-2', status: 'pending', rollup: makeWorkflowRollup('pending'), removed: true },
+        ],
+      });
+      await flushPipeline();
+    });
+
+    // wf-2 is still task-backed, so it must survive the removed rollup.
+    expect(result.current.workflows.has('wf-2')).toBe(true);
+    expect(result.current.workflows.size).toBe(3);
+    expect(result.current.tasks.get('wf-2/task-1')?.status).toBe('running');
+    // No spurious full re-fetch: the entry never left, nothing references a missing workflow.
+    expect(listWorkflows).not.toHaveBeenCalled();
+  });
+
+  it('self-heals: re-fetches the workflow list when a batch references workflows the map lost', async () => {
+    // Simulate the already-wiped state: tasks are present but the workflow map
+    // has been emptied by an earlier storm event.
+    const tasks = [
+      makeUITask({ id: 'wf-1/task-1', workflowId: 'wf-1', status: 'pending' }),
+      makeUITask({ id: 'wf-2/task-1', workflowId: 'wf-2', status: 'pending' }),
+      makeUITask({ id: 'wf-3/task-1', workflowId: 'wf-3', status: 'pending' }),
+    ];
+    const workflows: WorkflowMeta[] = [
+      { id: 'wf-1', name: 'Workflow 1', status: 'pending' },
+      { id: 'wf-2', name: 'Workflow 2', status: 'pending' },
+      { id: 'wf-3', name: 'Workflow 3', status: 'pending' },
+    ];
+    const listWorkflows = vi.fn().mockResolvedValue(workflows);
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = { tasks, workflows: [] };
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks: vi.fn().mockResolvedValue({ tasks, workflows: [] }),
+      listWorkflows,
+      reportUiPerf: vi.fn().mockResolvedValue(undefined),
+      onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
+        taskGraphEventHandler = cb;
+        return () => {};
+      }),
+      onWorkflowsChanged: vi.fn(() => () => {}),
+    };
+
+    const { result } = renderHook(() => useTasks());
+    expect(result.current.workflows.size).toBe(0);
+
+    // Any routine task delta arrives during the storm; the idle/pending workflows
+    // emit no `created` delta, so only a general missing-reference check can heal.
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'delta',
+        delta: {
+          type: 'updated',
+          taskId: 'wf-1/task-1',
+          changes: { status: 'running' },
+          taskStateVersion: 2,
+          previousTaskStateVersion: 1,
+        },
+        workflowRollups: [],
+      });
+      await flushPipeline();
+    });
+
+    await waitFor(() => {
+      expect(listWorkflows).toHaveBeenCalled();
+      expect(result.current.workflows.size).toBe(3);
+    });
+    expect(result.current.workflows.get('wf-2')?.name).toBe('Workflow 2');
+  });
+});

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -166,6 +166,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
   const initFitFrameRef = useRef(0);
   const nodesRef = useRef<typeof nodes>([]);
   const [layoutState, setLayoutState] = useState<LayoutState | null>(null);
+  const lastLayoutRef = useRef<TaskGraphLayout | null>(null);
   const [flowInstanceKey, setFlowInstanceKey] = useState(0);
   const onInitHandler = useCallback(() => {
     initFitFrameRef.current = requestAnimationFrame(() => fitView({ padding: 0.2 }));
@@ -266,6 +267,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
 
     void layoutTaskGraph(layoutTasks, layoutEdges).then((result) => {
       if (!stale) {
+        lastLayoutRef.current = result;
         setLayoutState({ key: rawGraph.layoutKey, result });
       }
     });
@@ -279,7 +281,22 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
     if (layoutState && layoutHasAllTasks(layoutState.result, rawGraph.taskArray)) {
       return layoutState.result;
     }
-    return rawGraph.fallbackLayout;
+    const priorPositions = layoutState?.result.positions ?? lastLayoutRef.current?.positions;
+    if (!priorPositions) {
+      return rawGraph.fallbackLayout;
+    }
+    const positions = new Map<string, { x: number; y: number }>();
+    let usedFallback = false;
+    for (const task of rawGraph.taskArray) {
+      const prior = priorPositions.get(task.id);
+      if (prior) {
+        positions.set(task.id, prior);
+      } else {
+        positions.set(task.id, rawGraph.fallbackLayout.positions.get(task.id) ?? { x: 0, y: 0 });
+        usedFallback = true;
+      }
+    }
+    return { positions, edgePoints: new Map(), usedFallback };
   }, [layoutState, rawGraph.fallbackLayout, rawGraph.taskArray]);
 
   const emptyEdgePoints = useMemo(() => new Map<string, { x: number; y: number }[]>(), []);

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -55,9 +55,22 @@ function replaceWorkflowMapPreservingTaskBackedEntries(
   return next;
 }
 
+function workflowHasBackingTask(
+  tasks: Map<string, TaskState>,
+  workflowId: string,
+): boolean {
+  for (const task of tasks.values()) {
+    if (task.config.workflowId === workflowId) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function applyWorkflowRollupPatches(
   previous: Map<string, WorkflowMeta>,
   patches: readonly WorkflowRollupPatch[],
+  tasks: Map<string, TaskState>,
 ): Map<string, WorkflowMeta> {
   if (patches.length === 0) {
     return previous;
@@ -65,8 +78,9 @@ function applyWorkflowRollupPatches(
   const next = new Map(previous);
   for (const patch of patches) {
     if (patch.removed) {
-      // Safety invariant: drop, never patch — patching resurrects a ghost node.
-      next.delete(patch.workflowId);
+      if (!workflowHasBackingTask(tasks, patch.workflowId)) {
+        next.delete(patch.workflowId);
+      }
       continue;
     }
     const existing = next.get(patch.workflowId);
@@ -132,6 +146,8 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
   const reportedStartupSnapshotRef = useRef(false);
   const uiTaskGraphStreamWatermarkRef = useRef<number>(bootstrapState?.streamSequence ?? 0);
   const isResyncInFlightRef = useRef<boolean>(false);
+  const workflowMetadataRefreshInFlightRef = useRef<boolean>(false);
+  const workflowMetadataRefreshPendingRef = useRef<boolean>(false);
 
   const invalidateStartupSnapshot = useCallback(() => {
     startupSnapshotGenerationRef.current += 1;
@@ -186,24 +202,47 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
   }, []);
   const refreshWorkflowMetadata = useCallback((): Promise<void> => {
     if (typeof window === 'undefined' || !window.invoker) return Promise.resolve();
-    const requestedAt = performance.now();
-    const request = window.invoker.listWorkflows().then((wfList) => {
-      setWorkflows((previous) => {
-        const nextWorkflows = replaceWorkflowMapPreservingTaskBackedEntries(
-          previous,
-          wfList,
-          tasksRef.current,
-        );
-        workflowsRef.current = nextWorkflows;
-        return nextWorkflows;
-      });
-      void window.invoker.reportUiPerf?.('useTasks_workflow_metadata_refresh', {
-        workflowCount: wfList.length,
-        requestDurationMs: performance.now() - requestedAt,
-        jsonSizeBytes: new Blob([JSON.stringify(wfList)]).size,
-      });
-    });
-    return request.then(() => undefined);
+    const invoker = window.invoker;
+    if (workflowMetadataRefreshInFlightRef.current) {
+      workflowMetadataRefreshPendingRef.current = true;
+      return Promise.resolve();
+    }
+    const runOnce = (): Promise<void> => {
+      workflowMetadataRefreshInFlightRef.current = true;
+      const requestedAt = performance.now();
+      return invoker
+        .listWorkflows()
+        .then((wfList) => {
+          setWorkflows((previous) => {
+            const nextWorkflows = replaceWorkflowMapPreservingTaskBackedEntries(
+              previous,
+              wfList,
+              tasksRef.current,
+            );
+            workflowsRef.current = nextWorkflows;
+            return nextWorkflows;
+          });
+          void invoker.reportUiPerf?.('useTasks_workflow_metadata_refresh', {
+            workflowCount: wfList.length,
+            requestDurationMs: performance.now() - requestedAt,
+            jsonSizeBytes: new Blob([JSON.stringify(wfList)]).size,
+          });
+        })
+        .catch((error: unknown) => {
+          void invoker.reportUiPerf?.('useTasks_workflow_metadata_refresh_error', {
+            message: error instanceof Error ? error.message : String(error),
+          });
+        })
+        .then(() => {
+          workflowMetadataRefreshInFlightRef.current = false;
+          if (workflowMetadataRefreshPendingRef.current) {
+            workflowMetadataRefreshPendingRef.current = false;
+            return runOnce();
+          }
+          return undefined;
+        });
+    };
+    return runOnce();
   }, []);
   const refreshTaskGraph = useCallback((): Promise<void> => {
     if (typeof window === 'undefined' || !window.invoker) return Promise.resolve();
@@ -307,24 +346,31 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
               );
             }
           }
-          if (
-            delta.type === 'created' &&
-            delta.task?.config.workflowId &&
-            !nextWorkflows.has(delta.task.config.workflowId)
-          ) {
-            shouldRefreshWorkflows = true;
-          }
           if (!hasAppliedTaskDelta) {
             nextTasks = new Map(nextTasks);
             hasAppliedTaskDelta = true;
           }
           applyDeltaInPlace(nextTasks, delta);
           for (const patch of event.workflowRollups) {
-            if (patch.removed && nextWorkflows.has(patch.workflowId)) {
+            if (
+              patch.removed &&
+              nextWorkflows.has(patch.workflowId) &&
+              !workflowHasBackingTask(nextTasks, patch.workflowId)
+            ) {
               removedWorkflowIds.push(patch.workflowId);
             }
           }
-          nextWorkflows = applyWorkflowRollupPatches(nextWorkflows, event.workflowRollups);
+          nextWorkflows = applyWorkflowRollupPatches(nextWorkflows, event.workflowRollups, nextTasks);
+        }
+
+        if (!shouldRefreshWorkflows) {
+          for (const task of nextTasks.values()) {
+            const workflowId = task.config.workflowId;
+            if (workflowId && !nextWorkflows.has(workflowId)) {
+              shouldRefreshWorkflows = true;
+              break;
+            }
+          }
         }
 
         const dt = performance.now() - t0;
@@ -353,7 +399,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
       if (event.type === 'snapshot') {
         const snapshotStreamSequence = event.streamSequence;
         const currentStreamSequence = uiTaskGraphStreamWatermarkRef.current;
-        if (snapshotStreamSequence < currentStreamSequence) {
+        if (snapshotStreamSequence < currentStreamSequence && !event.forced) {
           window.invoker.reportUiPerf?.('ui_task_graph_stale_snapshot_ignored', {
             current: currentStreamSequence,
             snapshot: snapshotStreamSequence,

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -208,6 +208,7 @@ export type TaskGraphEvent =
       readonly workflows: readonly WorkflowMeta[];
       readonly reason: string;
       readonly streamSequence: number;
+      readonly forced?: boolean;
     };
 
 


### PR DESCRIPTION
## Summary

Switching sidebar sections stalled under the storm because the owner's 2-second poll loaded every task's attempt each tick, and the rail refresh silently did nothing.

This slice loads an attempt only for the tasks that can stall (running, launching, or fixing), and a user-initiated refresh now applies its snapshot instead of being dropped as out of order.

## Review Claim

The owner stops loading every task's attempt on each poll tick and honors a user-initiated refresh.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The attempt load is gated by `taskNeedsExecutingStallCheck`, exactly the set the stall watchdog already acted on, so watchdog behavior is unchanged; the predicate is unit-tested. The forced flag only widens which snapshots apply, never narrows.

## Non-goals

Does not change the recovery worker cadence, executor routing, or renderer rendering.

## Slice Rationale

The owner-process poll and refresh handling is one reviewable area, separate from the renderer slice.

## Visual Proof

From the running fixed build with the storm and autofix active; the app stays responsive rather than stalling.

![Section switching lands on the Needs Attention surface with full task cards while the storm runs; the switch does not hang](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-0f2766/03-workers-surface.png)

Switch responsiveness is a timing property; the attempt-load gating is proven by `executing-stall.test.ts`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/executing-stall.test.ts`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
