### PR TITLE
[Scheduled CI cadence](1) Run the scheduled sweep twice a day

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
   schedule:
     - cron: '17 9 * * *'
+    - cron: '17 21 * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

The scheduled CI run fired once a day, at 09:17 UTC. This adds a second firing at 21:17 UTC so the ci policy sweep happens twice a day.

A single daily sweep means up to a full day can pass before the scheduled job next reports. Two evenly spaced firings halve that window.

## Review Claim

The scheduled CI cron fires twice a day instead of once.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

One workflow file changes and only the cron cadence differs. No job definition or behavior changes.

## Slice Rationale

Scheduling cadence is a ci policy matter that create-pr and mergify treat as their own review unit, kept apart from product slices.

## Non-goals

No job definition, workflow step, or product behavior changes; only the number of daily firings.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/ci.yml')); t=d.get('on') or d.get(True); print(len(t['schedule']))"` prints `2`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
