### PR TITLE
[Worker Process Pane Scroll Fix](1) Make worker processes pane scroll

### DIFF
--- a/packages/ui/src/__tests__/queue-view.test.tsx
+++ b/packages/ui/src/__tests__/queue-view.test.tsx
@@ -201,15 +201,48 @@ describe('QueueView', () => {
     const actionSection = screen.getByTestId('action-queue-section');
     const actionList = screen.getByTestId('worker-action-list');
     const workersSection = screen.getByTestId('worker-processes-section');
+    const workersScroll = screen.getByTestId('worker-process-scroll');
 
+    expect(actionSection.parentElement).toHaveClass('grid-rows-[minmax(0,1fr)]');
     expect(actionSection.compareDocumentPosition(workersSection) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(actionSection.className).toContain('overflow-hidden');
     expect(actionList.className).toContain('overflow-y-auto');
     expect(workersSection.className).toContain('overflow-hidden');
+    expect(workersScroll).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto');
     expect(within(actionSection).getByText('Worker Actions (1)')).toBeInTheDocument();
     expect(within(workersSection).getByText('Worker processes (1)')).toBeInTheDocument();
     expect(within(workersSection).getByTestId('worker-row-autofix')).toBeInTheDocument();
     expect(within(actionSection).queryByTestId('worker-row-autofix')).not.toBeInTheDocument();
+  });
+
+  it('keeps tall worker-process rows inside the middle pane scroll owner', () => {
+    const workers = Array.from({ length: 24 }, (_, index) =>
+      makeWorker({
+        kind: `worker-${index}`,
+        note: `Worker ${index}`,
+        lifecycle: index % 2 === 0 ? 'running' : 'stopped',
+        autoStarts: false,
+        startable: true,
+        stoppable: false,
+      }),
+    );
+
+    renderQueueView(new Map(), makeWorkerStatus(workers));
+
+    const workersScroll = screen.getByTestId('worker-process-scroll');
+    const workerCard = screen.getByTestId('worker-activity-card');
+    const processList = screen.getByTestId('worker-process-list');
+    const firstRow = screen.getByTestId('worker-row-worker-0');
+    const lastRow = screen.getByTestId('worker-row-worker-23');
+
+    expect(workersScroll).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto');
+    expect(workerCard).toHaveClass('flex', 'min-h-0', 'flex-col');
+    expect(processList).toHaveClass('min-h-0');
+    expect(processList.closest('.overflow-y-auto')).toBe(workersScroll);
+    expect(firstRow.closest('[data-testid="worker-process-scroll"]')).toBe(workersScroll);
+    expect(lastRow.closest('[data-testid="worker-process-scroll"]')).toBe(workersScroll);
+    expect(lastRow.closest('[data-testid="worker-action-list"]')).toBeNull();
+    expect(screen.getAllByTestId(/^worker-row-/)).toHaveLength(24);
   });
 
   it('shows an empty worker-action state without showing unrelated tasks', () => {

--- a/packages/ui/src/components/QueueView.tsx
+++ b/packages/ui/src/components/QueueView.tsx
@@ -96,7 +96,7 @@ export function QueueView({
   );
 
   return (
-    <div className="grid h-full min-h-0 grid-cols-[minmax(20rem,24rem)_minmax(28rem,1fr)] overflow-hidden bg-background">
+    <div className="grid h-full min-h-0 grid-cols-[minmax(20rem,24rem)_minmax(28rem,1fr)] grid-rows-[minmax(0,1fr)] overflow-hidden bg-background">
       <section data-testid="action-queue-section" className="flex h-full min-h-0 flex-col overflow-hidden border-r border-border">
         <div className="shrink-0 border-b border-border p-4">
           <h3 className="text-lg font-semibold text-foreground">
@@ -225,7 +225,7 @@ export function QueueView({
       </section>
 
       <section data-testid="worker-processes-section" className="flex h-full min-h-0 flex-col overflow-hidden">
-        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+        <div data-testid="worker-process-scroll" className="min-h-0 flex-1 overflow-y-auto p-4">
           <WorkerActivityCard
             snapshot={workerStatus}
             selectedWorkerKind={selectedWorkerKind}

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -96,8 +96,8 @@ export function WorkerActivityCard({
   }, [snapshot, optimisticByKind]);
 
   return (
-    <div data-testid="worker-activity-card">
-      <div className="mb-4">
+    <div data-testid="worker-activity-card" className="flex min-h-0 min-w-0 flex-col">
+      <div className="mb-4 shrink-0">
         <h3 className="text-lg font-semibold text-foreground">Worker processes ({snapshot?.workers.length ?? 0})</h3>
         <div className="mt-1 text-sm text-muted-foreground">Process status is separate from queue work. A running process can be idle.</div>
       </div>
@@ -105,7 +105,7 @@ export function WorkerActivityCard({
       {!snapshot ? (
         <div className="rounded border border-border bg-card/60 px-3 py-2 text-sm text-muted-foreground">Worker status unavailable</div>
       ) : (
-        <div className="space-y-3">
+        <div data-testid="worker-process-list" className="min-h-0 space-y-3">
           {snapshot.workers.map((worker) => {
             const copy = getWorkerDisplayCopy(worker.kind);
             const disabledTitle = readOnly ? 'Read-only window' : worker.controlDisabledReason;


### PR DESCRIPTION
## Summary

The queue screen now lets the Worker processes pane own its scroll area when worker rows exceed the available height.

The change preserves the separate Worker Actions scroller and keeps worker details behavior unchanged.

## Review Claim

Make the middle Worker processes pane scroll independently when worker rows are taller than the queue screen.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The slice only changes the QueueView and WorkerActivityCard layout classes plus focused queue-view coverage for that surface.

## Slice Rationale

This is one local UI behavior bug in one queue surface, so it lands as one reviewable slice.

## Non-goals

- Do not change worker start or stop controls.
- Do not change worker selection semantics.
- Do not change the right-side Worker details panel.
- Do not add a second queue scrolling model.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/queue-view.test.tsx`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && cd packages/app && CAPTURE_VIDEO=1 npx playwright test worker-tab-scroll.spec.ts --output=e2e/test-results/worker-tab-scroll-proof`
- [x] `pnpm run test:all`

</details>

## Visual Proof

[Worker process pane scroll video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-74d3b6/worker-process-pane-scroll-proof.webm)

![Worker process pane scrolled to lower process rows](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-74d3b6/worker-process-pane-scroll-frame-3s.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert c2d8fce65aa0b850623f1c1b7e97c6c42ac3bcad`
- Post-revert steps: Re-run `pnpm --filter @invoker/ui test -- src/__tests__/queue-view.test.tsx`.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Queue view layout behavior for long worker-process lists.
  * Ensured worker actions and worker processes maintain independent scrolling areas.
  * Prevented worker rows from appearing beneath the wrong scroll pane.
  * Preserved proper sizing and visibility of worker activity cards across varying list lengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->