### PR TITLE
[Planning Chat Raw Stream Step 3](1) Define the planning stream event contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -468,6 +468,10 @@ export type InAppPlanningListSessionsResponse = {
   sessions: InAppPlanningSessionSummary[];
 };
 
+export interface InAppPlanningStreamEvent {
+  sessionId: string;
+  chunk: string;
+}
 
 export interface InAppPlanningChatRequest {
   sessionId?: string;
@@ -1188,6 +1192,9 @@ export const IpcEventChannels = {
   },
   'invoker:runtime-status': {} as {
     payload: RuntimeStatus;
+  },
+  'invoker:planning-chat-stream': {} as {
+    payload: InAppPlanningStreamEvent;
   },
 } as const;
 


### PR DESCRIPTION
## Summary

The contract now defines a planning chat stream event for raw planner chunks.

The event carries a session id and the next text chunk, leaving saved planning messages unchanged.

## Review Claim

The shared IPC contract defines raw planner chunks as a typed planning chat stream event.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This is additive contract shape only. No caller emits or consumes the event until later slices, and saved planning messages are untouched.

## Slice Rationale

The event type must exist before owner and renderer code can compile against the live text path.

## Non-goals

- Does not emit planner chunks.
- Does not render planner chunks.
- Does not persist raw planner text.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run test:all`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
