### PR TITLE
[Planning Chat Raw Stream Step 3](2) Route planner stream chunks to clients

### DIFF
--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -13,6 +13,7 @@ import type {
   InAppPlanningResetResponse,
   InAppPlanningSessionStatus,
   InAppPlanningSessionSummary,
+  InAppPlanningStreamEvent,
   InAppPlanningSubmitRequest,
   InAppPlanningSubmitResponse,
   PlanningPresetOption,
@@ -47,6 +48,7 @@ export interface InAppPlannerDeps {
   planningCommandBuilder?: PlanningCommandBuilder;
   conversationRepo?: ConversationRepository;
   plannerReplyOverride?: (formattedMessage: string) => Promise<string>;
+  onRawPlannerOutput?: (event: InAppPlanningStreamEvent) => void;
 }
 
 export interface InAppPlanningChatSession {
@@ -277,7 +279,7 @@ function formatConversationalPlanningMessage(message: string): string {
 
 function planConversationConfig(
   preset: HarnessPreset,
-  deps: Pick<InAppPlannerDeps, 'config' | 'workingDir' | 'planningCommandBuilder' | 'conversationRepo'>,
+  deps: Pick<InAppPlannerDeps, 'config' | 'workingDir' | 'planningCommandBuilder' | 'conversationRepo' | 'onRawPlannerOutput'>,
   threadTs: string,
 ): PlanConversationConfig {
   return {
@@ -294,6 +296,9 @@ function planConversationConfig(
     planningCommandBuilder: deps.planningCommandBuilder,
     plannerRetryLimit: deps.config.plannerRetryLimit,
     plannerRetryBaseDelayMs: deps.config.plannerRetryBaseDelayMs,
+    onRawPlannerOutput: deps.onRawPlannerOutput
+      ? (chunk) => deps.onRawPlannerOutput?.({ sessionId: threadTs, chunk })
+      : undefined,
   };
 }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -90,6 +90,7 @@ import type {
   InAppPlanningCreateSessionRequest,
   InAppPlanningChatRequest,
   InAppPlanningResetRequest,
+  InAppPlanningStreamEvent,
   InAppPlanningSubmitRequest,
   Logger,
   WorkflowMeta,
@@ -2110,6 +2111,12 @@ function createEmbeddedTerminalBackendFromConfig(
     maxTaskDeltaBatchSize: 0,
     ...createTerminalUiPerfCounters(),
   };
+  const emitPlanningChatStream = (event: InAppPlanningStreamEvent): void => {
+    if (mainWindow && !mainWindow.isDestroyed() && uiInteractive) {
+      mainWindow.webContents.send('invoker:planning-chat-stream', event);
+    }
+    webBridge?.broadcast('invoker:planning-chat-stream', event);
+  };
   const terminalUiPerf = createTerminalUiPerfReporter();
   const terminalUiPerfSink = createTerminalUiPerfSink(
     (source, level, message) => {
@@ -3916,6 +3923,7 @@ function createEmbeddedTerminalBackendFromConfig(
       loadGeneratedPlan: loadGeneratedPlanPreview,
       conversationRepo: planningConversationRepo,
       planningSessionStore: ownerMode ? persistence : undefined,
+      onRawPlannerOutput: emitPlanningChatStream,
     });
     let testPlanFromGoalResponse: { planYaml: string; planName: string } | null = null;
     // Two variants: (1) a successful override that returns a canned reply +
@@ -3950,6 +3958,7 @@ function createEmbeddedTerminalBackendFromConfig(
         loadGeneratedPlan: loadGeneratedPlanPreview,
         conversationRepo: planningConversationRepo,
         planningSessionStore: ownerMode ? persistence : undefined,
+        onRawPlannerOutput: emitPlanningChatStream,
       });
     });
     registerGuiMutationHandler('invoker:planning-chat-list', async () => {
@@ -3974,6 +3983,7 @@ function createEmbeddedTerminalBackendFromConfig(
         conversationRepo: planningConversationRepo,
         planningSessionStore: ownerMode ? persistence : undefined,
         plannerReplyOverride,
+        onRawPlannerOutput: emitPlanningChatStream,
       });
     });
     registerGuiMutationHandler('invoker:planning-chat-submit', async (request: unknown) => {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -468,6 +468,10 @@ export type InAppPlanningListSessionsResponse = {
   sessions: InAppPlanningSessionSummary[];
 };
 
+export interface InAppPlanningStreamEvent {
+  sessionId: string;
+  chunk: string;
+}
 
 export interface InAppPlanningChatRequest {
   sessionId?: string;
@@ -1188,6 +1192,9 @@ export const IpcEventChannels = {
   },
   'invoker:runtime-status': {} as {
     payload: RuntimeStatus;
+  },
+  'invoker:planning-chat-stream': {} as {
+    payload: InAppPlanningStreamEvent;
   },
 } as const;
 


### PR DESCRIPTION
## Summary

The owner can now forward raw planner output while a planning turn runs.

Each chunk is sent to the active Electron window and the web bridge.

Saved chat history still receives only the final assistant reply.

## Review Claim

The owner process routes raw planner chunks to desktop and web clients without writing them into chat history.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The path is additive and calls the existing PlanConversation stream hook. If no client listens, behavior stays whole-reply only.

## Slice Rationale

Delivery wiring sits between the first slice and the renderer slice, so failures isolate to owner-side forwarding.

## Non-goals

- Does not render the live panel.
- Does not change the final planning reply contract.
- Does not persist raw planner text.

## Architecture

### Before

```mermaid
graph TD
    A["PlanConversation final reply"] --> B["planning chat response"]
```

### After

```mermaid
graph TD
    A["PlanConversation raw chunk"] --> B["owner planning stream callback"]
    B --> C["Electron renderer"]
    B --> D["web bridge"]
    E["PlanConversation final reply"] --> F["planning chat response"]
```

## Visual Proof

[Planning stream delivery video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-b8cdc6/planning-stream-panel-transition.webm)

The recording shows a planning stream payload reaching the planning chat surface while the final reply remains in the normal transcript.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run test:all`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
