### PR TITLE
[Planning Chat Raw Stream Step 3](3) Show live planner text in planning chat

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -170,6 +170,11 @@ function planningSessionFromSummary(
   };
 }
 
+type PlanningStreamState = {
+  text: string;
+  status: 'streaming' | 'failed';
+};
+
 function makeInitialPlanningSession(now: string = new Date().toISOString()): PlanningSessionView {
   return {
     id: 'local-planning-session-1',
@@ -632,10 +637,14 @@ export function App() {
   const [hasStarted, setHasStarted] = useState(false);
   const [planName, setPlanName] = useState<string | null>(null);
   const [planningSessions, setPlanningSessions] = useState<PlanningSessionView[]>(() => [makeInitialPlanningSession()]);
+  const planningSessionsRef = useRef<PlanningSessionView[]>(planningSessions);
+  const activePlanningSessionIdRef = useRef('local-planning-session-1');
+  const pendingPlanningStreamSessionIdsRef = useRef<Set<string>>(new Set());
+  const planningStreamSessionAliasesRef = useRef<Map<string, string>>(new Map());
   const [activePlanningSessionId, setActivePlanningSessionId] = useState('local-planning-session-1');
-  const planningSessionsRef = useRef(planningSessions);
   const nextPlanningSessionLocalIdRef = useRef(2);
   const nextTerminalLineIdRef = useRef(1);
+  const [planningStreamBySessionId, setPlanningStreamBySessionId] = useState<Record<string, PlanningStreamState>>({});
   const [planningPresetOptions, setPlanningPresetOptions] = useState<Array<{ key: string; label: string; isDefault?: boolean }>>([]);
   const [selectedPlanningPresetKey, setSelectedPlanningPresetKey] = useState('');
   const [planningSubmitError, setPlanningSubmitError] = useState<{ title: string; message: string } | null>(null);
@@ -644,6 +653,7 @@ export function App() {
     () => planningSessions.find((session) => session.id === activePlanningSessionId) ?? planningSessions[0] ?? makeInitialPlanningSession(),
     [activePlanningSessionId, planningSessions],
   );
+  const activePlanningStream = planningStreamBySessionId[activePlanningSession.id] ?? null;
   const activePlanningConversationKey = activePlanningSession.conversationKey;
   const terminalLines = activePlanningSession.messages;
   const planningInput = activePlanningSession.input;
@@ -767,6 +777,14 @@ export function App() {
       }
     }).catch(() => {});
   }, [cancelPendingSystemSetupAutoOpen, scheduleSystemSetupAutoOpen]);
+
+  useEffect(() => {
+    planningSessionsRef.current = planningSessions;
+  }, [planningSessions]);
+
+  useEffect(() => {
+    activePlanningSessionIdRef.current = activePlanningSessionId;
+  }, [activePlanningSessionId]);
 
   useEffect(() => {
     window.invoker?.getRemoteTargets?.().then(setRemoteTargets).catch(() => {});
@@ -909,6 +927,50 @@ export function App() {
   useEffect(() => {
     const unsubscribe = window.invoker?.onRuntimeStatus?.((status) => {
       setRuntimeStatus(status);
+    });
+    return () => { unsubscribe?.(); };
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = window.invoker?.onPlanningChatStream?.((event) => {
+      const sessionId = typeof event.sessionId === 'string' ? event.sessionId.trim() : '';
+      if (!sessionId || typeof event.chunk !== 'string' || !event.chunk) return;
+
+      const sessions = planningSessionsRef.current;
+      const isStreamingTarget = (session: PlanningSessionView): boolean => (
+        session.busy || pendingPlanningStreamSessionIdsRef.current.has(session.id)
+      );
+      const matchingSession = sessions.find((session) => session.id === sessionId);
+      const aliasedSessionId = planningStreamSessionAliasesRef.current.get(sessionId);
+      const aliasedSession = aliasedSessionId
+        ? sessions.find((session) => session.id === aliasedSessionId)
+        : undefined;
+      const activeLocalSession = sessions.find((session) => (
+        session.id === activePlanningSessionIdRef.current
+        && session.id.startsWith('local-')
+        && isStreamingTarget(session)
+      ));
+      const localBusySession = sessions.find((session) => session.id.startsWith('local-') && isStreamingTarget(session));
+      const targetSessionId = matchingSession && isStreamingTarget(matchingSession)
+        ? matchingSession.id
+        : aliasedSession && isStreamingTarget(aliasedSession)
+          ? aliasedSession.id
+          : activeLocalSession?.id ?? localBusySession?.id;
+      if (!targetSessionId) return;
+      if (!matchingSession) {
+        planningStreamSessionAliasesRef.current.set(sessionId, targetSessionId);
+      }
+
+      setPlanningStreamBySessionId((prev) => {
+        const current = prev[targetSessionId];
+        return {
+          ...prev,
+          [targetSessionId]: {
+            text: `${current?.text ?? ''}${event.chunk}`,
+            status: 'streaming',
+          },
+        };
+      });
     });
     return () => { unsubscribe?.(); };
   }, []);
@@ -2102,6 +2164,49 @@ export function App() {
     updatePlanningSessionById(activePlanningSessionId, updater);
   }, [activePlanningSessionId, updatePlanningSessionById]);
 
+  const clearPlanningStreamForSessionIds = useCallback((sessionIds: Array<string | null | undefined>) => {
+    const ids = new Set(sessionIds.filter((sessionId): sessionId is string => Boolean(sessionId)));
+    if (ids.size === 0) return;
+    setPlanningStreamBySessionId((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const id of ids) {
+        if (id in next) {
+          delete next[id];
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, []);
+
+  const forgetPlanningStreamAliasesForSessionIds = useCallback((sessionIds: Array<string | null | undefined>) => {
+    const ids = new Set(sessionIds.filter((sessionId): sessionId is string => Boolean(sessionId)));
+    if (ids.size === 0) return;
+    for (const [streamSessionId, targetSessionId] of planningStreamSessionAliasesRef.current) {
+      if (ids.has(streamSessionId) || ids.has(targetSessionId)) {
+        planningStreamSessionAliasesRef.current.delete(streamSessionId);
+      }
+    }
+  }, []);
+
+  const keepPlanningStreamFailureForSessionIds = useCallback((sessionIds: Array<string | null | undefined>, message: string) => {
+    const ids = new Set(sessionIds.filter((sessionId): sessionId is string => Boolean(sessionId)));
+    if (ids.size === 0 || !message) return;
+    setPlanningStreamBySessionId((prev) => {
+      const next = { ...prev };
+      for (const id of ids) {
+        const existing = next[id]?.text ?? '';
+        const separator = existing && !existing.endsWith('\n') ? '\n' : '';
+        next[id] = {
+          text: existing ? `${existing}${separator}${message}` : message,
+          status: 'failed',
+        };
+      }
+      return next;
+    });
+  }, []);
+
   const setPlanningInput = useCallback((value: string) => {
     updateActivePlanningSession((session) => ({ ...session, input: value }));
   }, [updateActivePlanningSession]);
@@ -2285,6 +2390,9 @@ export function App() {
     }
 
     const previousSessionId = activePlanningSessionId;
+    pendingPlanningStreamSessionIdsRef.current.add(previousSessionId);
+    clearPlanningStreamForSessionIds([previousSessionId, planningSessionId]);
+    forgetPlanningStreamAliasesForSessionIds([previousSessionId, planningSessionId]);
     updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: true }));
     try {
       const request = {
@@ -2316,15 +2424,27 @@ export function App() {
         setActivePlanningSessionId((currentSessionId) => (
           currentSessionId === previousSessionId ? result.sessionId : currentSessionId
         ));
+        clearPlanningStreamForSessionIds([previousSessionId, result.sessionId]);
+        forgetPlanningStreamAliasesForSessionIds([previousSessionId, result.sessionId]);
+        pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
+        pendingPlanningStreamSessionIdsRef.current.delete(result.sessionId);
         setHasLoadedPlan(false);
       } else {
         updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: false }));
+        keepPlanningStreamFailureForSessionIds([previousSessionId, result.sessionId], result.error);
+        forgetPlanningStreamAliasesForSessionIds([previousSessionId, result.sessionId]);
+        pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
+        if (result.sessionId) pendingPlanningStreamSessionIdsRef.current.delete(result.sessionId);
         appendTerminalLine(result.error, 'system', 'error');
         setPlanningSubmitError({ title: 'Planner could not respond', message: result.error });
       }
     } catch (err) {
       updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: false }));
       const message = err instanceof Error ? err.message : 'Failed to reach the planner.';
+      keepPlanningStreamFailureForSessionIds([previousSessionId, planningSessionId], message);
+      forgetPlanningStreamAliasesForSessionIds([previousSessionId, planningSessionId]);
+      pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
+      if (planningSessionId) pendingPlanningStreamSessionIdsRef.current.delete(planningSessionId);
       setPlanningSubmitError({ title: 'Planner could not respond', message });
       appendTerminalLine(message, 'system', 'error');
     }
@@ -2333,10 +2453,13 @@ export function App() {
     activePlanningSessionId,
     activePlanningReadOnly,
     appendTerminalLine,
+    clearPlanningStreamForSessionIds,
+    forgetPlanningStreamAliasesForSessionIds,
     handlePlanningSubmitDraft,
     handleStart,
     hasLoadedPlan,
     hasStarted,
+    keepPlanningStreamFailureForSessionIds,
     invoker,
     planningInput,
     planningSessionId,
@@ -3402,6 +3525,7 @@ export function App() {
             presetOptions={planningPresetOptions}
             draftPlanAvailable={draftPlanAvailable}
             draftPlanSummary={draftPlanSummary}
+            planningStream={activePlanningStream}
             submitError={planningSubmitError}
             readOnly={activePlanningReadOnly}
             mode={activePlanningMode}
@@ -3709,6 +3833,7 @@ export function App() {
             presetOptions={planningPresetOptions}
             draftPlanAvailable={draftPlanAvailable}
             draftPlanSummary={draftPlanSummary}
+            planningStream={activePlanningStream}
             submitError={planningSubmitError}
             expanded
             mode={activePlanningMode}

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -18,7 +18,7 @@ import type {
   TaskConfig,
   TaskExecution,
 } from '../../types.js';
-import type { ActionGraphResponse, InAppPlanningSessionSummary, RuntimeStatus, StartReadyResult, TerminalOutputEvent, WorkerStatusEntry, WorkerStatusSnapshot, WorkflowMutationAcceptedResult, WorkflowMutationFailedEvent } from '@invoker/contracts';
+import type { ActionGraphResponse, InAppPlanningSessionSummary, InAppPlanningStreamEvent, RuntimeStatus, StartReadyResult, TerminalOutputEvent, WorkerStatusEntry, WorkerStatusSnapshot, WorkflowMutationAcceptedResult, WorkflowMutationFailedEvent } from '@invoker/contracts';
 
 export interface MockInvoker {
   /** The mock InvokerAPI object installed on window.invoker. */
@@ -37,6 +37,8 @@ export interface MockInvoker {
   fireWorkflowsChanged: (workflows: WorkflowMeta[]) => void;
   /** Fire an embedded terminal output event to subscribers. */
   fireTerminalOutput: (event: TerminalOutputEvent) => void;
+  /** Fire a planning chat raw stream event to subscribers. */
+  firePlanningChatStream: (event: InAppPlanningStreamEvent) => void;
   /** Fire a workflow-mutation-failed event to subscribers. */
   fireWorkflowMutationFailed: (event: WorkflowMutationFailedEvent) => void;
   /** Fire a runtime-status event to subscribers. */
@@ -93,6 +95,7 @@ export function createMockInvoker(
   const eventsByTask = new Map<string, TaskEvent[]>();
   let graphEventCallback: ((event: TaskGraphEvent) => void) | undefined;
   let workflowsCallback: ((workflows: unknown[]) => void) | undefined;
+  const planningChatStreamCallbacks = new Set<(event: InAppPlanningStreamEvent) => void>();
   const terminalOutputCallbacks = new Set<(event: TerminalOutputEvent) => void>();
   const workflowMutationFailedCallbacks = new Set<(event: WorkflowMutationFailedEvent) => void>();
   const runtimeStatusCallbacks = new Set<(status: RuntimeStatus) => void>();
@@ -192,6 +195,10 @@ export function createMockInvoker(
       workflowId: 'wf-1',
     })),
     planningChatReset: vi.fn(async () => ({ ok: true })),
+    onPlanningChatStream: vi.fn((cb: (event: InAppPlanningStreamEvent) => void) => {
+      planningChatStreamCallbacks.add(cb);
+      return () => { planningChatStreamCallbacks.delete(cb); };
+    }),
     planningChatSetTerminalMode: vi.fn(async () => ({ ok: true })),
     planningTerminalOpen: vi.fn(async (planningSessionId: string) => ({
       opened: true,
@@ -460,6 +467,12 @@ export function createMockInvoker(
     }
   }
 
+  function firePlanningChatStream(event: InAppPlanningStreamEvent) {
+    for (const callback of planningChatStreamCallbacks) {
+      callback(event);
+    }
+  }
+
   function fireWorkflowMutationFailed(event: WorkflowMutationFailedEvent) {
     for (const callback of workflowMutationFailedCallbacks) {
       callback(event);
@@ -485,6 +498,7 @@ export function createMockInvoker(
   function cleanup() {
     delete (window as unknown as { invoker?: InvokerAPI }).invoker;
     delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
+    planningChatStreamCallbacks.clear();
     terminalOutputCallbacks.clear();
     workflowMutationFailedCallbacks.clear();
     runtimeStatusCallbacks.clear();
@@ -504,6 +518,7 @@ export function createMockInvoker(
     fireGraphEvent,
     fireWorkflowsChanged,
     fireTerminalOutput,
+    firePlanningChatStream,
     fireWorkflowMutationFailed,
     fireRuntimeStatus,
     install,

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { vi } from 'vitest';
 import { useState } from 'react';
 import { createMockInvoker, makePlanningSessionSummary, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
@@ -91,6 +91,129 @@ describe('Invoker terminal (component)', () => {
       expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('I can help draft that.');
     });
     expect(screen.queryByText(/Unknown command/)).not.toBeInTheDocument();
+  });
+
+  it('shows live raw planner output while busy and removes it when the final reply arrives', async () => {
+    let resolveSend: ((value: any) => void) | null = null;
+    mock.api.planningChatSend = vi.fn(() => new Promise((resolve) => {
+      resolveSend = resolve;
+    }) as any) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft a streamed plan');
+    await waitFor(() => expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      mock.firePlanningChatStream({ sessionId: 'session-1', chunk: 'raw planner ' });
+      mock.firePlanningChatStream({ sessionId: 'session-1', chunk: 'text' });
+    });
+
+    const panel = await screen.findByTestId('invoker-terminal-planner-stream');
+    expect(panel).toHaveAttribute('data-state', 'streaming');
+    expect(panel).toHaveTextContent('raw planner text');
+
+    await act(async () => {
+      resolveSend?.({
+        ok: true,
+        sessionId: 'session-1',
+        reply: 'Final assistant reply.',
+        draftPlanAvailable: false,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('invoker-terminal-planner-stream')).not.toBeInTheDocument();
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Final assistant reply.');
+      expect(screen.getByTestId('invoker-terminal-transcript')).not.toHaveTextContent('raw planner text');
+    });
+  });
+
+  it('keeps failed raw planner output visible until the next send starts', async () => {
+    const plannerError = 'planner exited with code 1';
+    let resolveFirstSend: ((value: any) => void) | null = null;
+    let resolveSecondSend: ((value: any) => void) | null = null;
+    mock.api.planningChatSend = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveFirstSend = resolve;
+      }))
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveSecondSend = resolve;
+      })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft a failing streamed plan');
+    await waitFor(() => expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      mock.firePlanningChatStream({ sessionId: 'session-1', chunk: 'partial raw output' });
+    });
+    expect(await screen.findByTestId('invoker-terminal-planner-stream')).toHaveTextContent('partial raw output');
+
+    await act(async () => {
+      resolveFirstSend?.({ ok: false, sessionId: 'session-1', error: plannerError });
+    });
+
+    await waitFor(() => {
+      const panel = screen.getByTestId('invoker-terminal-planner-stream');
+      expect(panel).toHaveAttribute('data-state', 'failed');
+      expect(panel).toHaveTextContent('partial raw output');
+      expect(panel).toHaveTextContent(plannerError);
+    });
+
+    submitPlanningText('try again');
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledTimes(2);
+      expect(screen.queryByTestId('invoker-terminal-planner-stream')).not.toBeInTheDocument();
+    });
+
+    await act(async () => {
+      resolveSecondSend?.({
+        ok: true,
+        sessionId: 'session-2',
+        reply: 'Recovered.',
+        draftPlanAvailable: false,
+      });
+    });
+    await waitFor(() => expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Recovered.'));
+  });
+
+  it('keeps live planner output isolated when switching planning sessions', async () => {
+    mock.api.planningChatSend = vi.fn(() => new Promise(() => {}) as any) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('first session request');
+    await waitFor(() => expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      mock.firePlanningChatStream({ sessionId: 'session-1', chunk: 'first raw stream' });
+    });
+    expect(await screen.findByTestId('invoker-terminal-planner-stream')).toHaveTextContent('first raw stream');
+
+    fireEvent.click(screen.getByRole('button', { name: 'New' }));
+    expect(screen.queryByTestId('invoker-terminal-planner-stream')).not.toBeInTheDocument();
+
+    submitPlanningText('second session request');
+    await waitFor(() => expect(mock.api.planningChatSend).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      mock.firePlanningChatStream({ sessionId: 'session-2', chunk: 'second raw stream' });
+    });
+
+    const secondPanel = await screen.findByTestId('invoker-terminal-planner-stream');
+    expect(secondPanel).toHaveTextContent('second raw stream');
+    expect(secondPanel).not.toHaveTextContent('first raw stream');
+
+    const sessionButtons = within(screen.getByTestId('planning-session-list')).getAllByRole('button');
+    fireEvent.click(sessionButtons[1]);
+
+    const firstPanel = await screen.findByTestId('invoker-terminal-planner-stream');
+    expect(firstPanel).toHaveTextContent('first raw stream');
+    expect(firstPanel).not.toHaveTextContent('second raw stream');
   });
 
   it('shows collapsed Thinking disclosure when reasoning is present', async () => {

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState, type ChangeEvent, type FormEvent, type KeyboardEvent } from 'react';
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent, type KeyboardEvent } from 'react';
 import { Terminal as XTermTerminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import type { TerminalSessionDescriptor } from '@invoker/contracts';
@@ -13,6 +13,11 @@ export interface InvokerTerminalLine {
 }
 
 export type PlanningTerminalMode = 'chat' | 'tmux';
+
+export interface InvokerTerminalPlanningStream {
+  text: string;
+  status: 'streaming' | 'failed';
+}
 
 interface PlanningPresetOptionView {
   key: string;
@@ -45,6 +50,7 @@ interface InvokerTerminalProps {
   presetOptions: PlanningPresetOptionView[];
   draftPlanAvailable: boolean;
   draftPlanSummary?: { name: string; taskCount: number; workflowCount?: number };
+  planningStream?: InvokerTerminalPlanningStream | null;
   submitError?: SubmitErrorView | null;
   readOnly?: boolean;
   expanded?: boolean;
@@ -270,6 +276,7 @@ export function InvokerTerminal({
   presetOptions,
   draftPlanAvailable,
   draftPlanSummary,
+  planningStream,
   submitError,
   readOnly = false,
   expanded = false,
@@ -330,7 +337,7 @@ export function InvokerTerminal({
     if (shouldFollowTranscript) {
       scrollTranscriptToBottom('line_change', lines.length);
     }
-  }, [lines.length, scrollTranscriptToBottom, shouldFollowTranscript]);
+  }, [lines.length, planningStream?.text, scrollTranscriptToBottom, shouldFollowTranscript]);
 
   useLayoutEffect(() => {
     const pending = pendingInputRef.current;
@@ -441,6 +448,61 @@ export function InvokerTerminal({
     }
   };
 
+  const transcriptContent = useMemo(() => (
+    <>
+      {lines.map((line) => {
+        const toneClass = line.tone === 'error'
+          ? 'text-destructive'
+          : line.tone === 'success'
+            ? 'text-emerald-400'
+            : line.tone === 'muted'
+              ? 'text-muted-foreground'
+              : line.role === 'assistant'
+                ? 'text-foreground'
+                : 'text-muted-foreground';
+        return (
+          <div key={line.id} className="space-y-1">
+            <div className="text-[11px] text-muted-foreground">{rolePrompt(line.role)}</div>
+            {line.reasoning ? (
+              <details
+                data-testid="invoker-terminal-thinking"
+                className="rounded-sm border border-border/60 bg-background/40 px-2 py-1 text-muted-foreground"
+              >
+                <summary className="cursor-pointer select-none text-[11px] text-muted-foreground">
+                  Thinking
+                </summary>
+                <div className="mt-1 whitespace-pre-wrap text-[12px] leading-5 text-muted-foreground">
+                  {line.reasoning}
+                </div>
+              </details>
+            ) : null}
+            <div className={`whitespace-pre-wrap ${toneClass}`}>{line.text}</div>
+          </div>
+        );
+      })}
+      {planningStream && planningStream.text ? (
+        <div
+          data-testid="invoker-terminal-planner-stream"
+          data-state={planningStream.status}
+          className={`rounded-sm border px-3 py-2 ${
+            planningStream.status === 'failed'
+              ? 'border-destructive/50 bg-destructive/10'
+              : 'border-border-strong bg-card/70'
+          }`}
+        >
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-[11px] text-muted-foreground">planner stream ›</div>
+            <div className={`text-[11px] ${planningStream.status === 'failed' ? 'text-destructive' : 'text-muted-foreground'}`}>
+              {planningStream.status === 'failed' ? 'failed' : 'live'}
+            </div>
+          </div>
+          <div className={`mt-2 whitespace-pre-wrap ${planningStream.status === 'failed' ? 'text-destructive' : 'text-foreground'}`}>
+            {planningStream.text}
+          </div>
+        </div>
+      ) : null}
+    </>
+  ), [lines, planningStream]);
   return (
     <section className="flex h-full min-h-0 flex-col bg-background">
       <div className="flex items-center justify-end gap-2 border-b border-border bg-background px-4 py-2.5">
@@ -525,36 +587,7 @@ export function InvokerTerminal({
             onScroll={handleTranscriptScroll}
             className="min-h-0 flex-1 space-y-3 overflow-y-auto bg-background px-4 py-4 font-mono text-[13px] leading-6"
           >
-            {lines.map((line) => {
-              const toneClass = line.tone === 'error'
-                ? 'text-destructive'
-                : line.tone === 'success'
-                  ? 'text-emerald-400'
-                  : line.tone === 'muted'
-                    ? 'text-muted-foreground'
-                    : line.role === 'assistant'
-                      ? 'text-foreground'
-                      : 'text-muted-foreground';
-              return (
-                <div key={line.id} className="space-y-1">
-                  <div className="text-[11px] text-muted-foreground">{rolePrompt(line.role)}</div>
-                  {line.reasoning ? (
-                    <details
-                      data-testid="invoker-terminal-thinking"
-                      className="rounded-sm border border-border/60 bg-background/40 px-2 py-1 text-muted-foreground"
-                    >
-                      <summary className="cursor-pointer select-none text-[11px] text-muted-foreground">
-                        Thinking
-                      </summary>
-                      <div className="mt-1 whitespace-pre-wrap text-[12px] leading-5 text-muted-foreground">
-                        {line.reasoning}
-                      </div>
-                    </details>
-                  ) : null}
-                  <div className={`whitespace-pre-wrap ${toneClass}`}>{line.text}</div>
-                </div>
-              );
-            })}
+            {transcriptContent}
           </div>
 
           {submitError && !readOnly && (

--- a/packages/ui/src/web/__tests__/web-invoker-client.test.ts
+++ b/packages/ui/src/web/__tests__/web-invoker-client.test.ts
@@ -76,6 +76,16 @@ describe('installWebInvoker', () => {
     expect(cb).toHaveBeenCalledWith(payload);
   });
 
+  it('onPlanningChatStream receives raw planner stream SSE payloads', () => {
+    installWebInvoker({});
+    const cb = vi.fn();
+    window.invoker.onPlanningChatStream(cb as never);
+    const es = FakeEventSource.instances[0];
+    const payload = { sessionId: 'session-1', chunk: 'raw planner text' };
+    es.fire('invoker:planning-chat-stream', payload);
+    expect(cb).toHaveBeenCalledWith(payload);
+  });
+
   it('approve POSTs the approve channel with args', async () => {
     fetchResult = undefined;
     installWebInvoker({});


### PR DESCRIPTION
## Summary

Planning chat now shows raw planner text in a temporary live panel while a turn is running.

When the final assistant reply lands, the panel disappears and the saved transcript stays final-only.

Failures keep partial raw text visible until the next send starts, so users can inspect what happened.

## Review Claim

The planning chat UI streams raw planner text in a temporary panel without changing the saved transcript model.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice consumes the live-text path from earlier slices and keeps raw text in transient renderer state only.

## Slice Rationale

Renderer activation lands last so reviewers can inspect the visible behavior on top of the already-added delivery path.

## Non-goals

- Does not persist raw planner text.
- Does not change planner command execution.
- Does not change draft submission behavior.

## Architecture

### Before

```mermaid
graph TD
    A["planning turn running"] --> B["busy transcript only"]
    C["final assistant reply"] --> D["normal transcript"]
```

### After

```mermaid
graph TD
    A["raw planner chunk"] --> B["temporary live panel"]
    C["final assistant reply"] --> D["normal transcript"]
    C --> E["live panel cleared"]
    F["planner failure"] --> G["live panel marked failed"]
```

## Visual Proof

[Planning stream panel transition video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-fa1081/planning-stream-panel-transition.webm)

The recording shows raw planner text appearing in the temporary live panel, then disappearing once the final assistant reply lands in the normal transcript.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx src/web/__tests__/web-invoker-client.test.ts`
- [x] `pnpm run test:all`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live streaming planner output to the planning terminal.
  * Streamed content is displayed per planning session and remains available when switching sessions.
  * Planner errors and failed streamed output remain visible for easier troubleshooting.
  * Streaming output is shown in both the standard terminal view and expanded overlay.

* **Bug Fixes**
  * Improved handling of streamed responses across concurrent or changing planning sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->