### PR TITLE
Fit the workflow graph when Home returns from browser surfaces

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2246,6 +2246,14 @@ export function App() {
     setInspectorCollapsed((prev) => !prev);
   }, [autoCollapseInspector]);
 
+  const navigateHomeAndFitWorkflowGraph = useCallback((reason: string) => {
+    cameraSuppressedRef.current = false;
+    setSidebarSurface('home');
+    setInspectorManualOpen(false);
+    setViewMode('dag');
+    issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason });
+  }, [issueCameraCommand]);
+
   const handleSelectSidebarSurface = useCallback((nextSurface: SidebarSurface) => {
     setGraphActionsMenuOpen(false);
     reportUiNavigation(window.invoker?.reportUiPerf, {
@@ -2262,16 +2270,15 @@ export function App() {
       setViewMode('queue');
       return;
     }
-    setViewMode('dag');
     if (nextSurface === 'home') {
-      setSidebarSurface('home');
-      setInspectorManualOpen(false);
+      navigateHomeAndFitWorkflowGraph('sidebar-home');
       return;
     }
+    setViewMode('dag');
     setSidebarSurface(nextSurface);
     setInspectorManualOpen(false);
     setStatusFilters(new Set<WorkflowStatus>());
-  }, [sidebarSurface, viewMode]);
+  }, [navigateHomeAndFitWorkflowGraph, sidebarSurface, viewMode]);
 
   const handleDismissBrowserSurface = useCallback(() => {
     setGraphActionsMenuOpen(false);
@@ -2282,10 +2289,8 @@ export function App() {
       viewMode,
       dismiss: true,
     });
-    setSidebarSurface('home');
-    setInspectorManualOpen(false);
-    setViewMode('dag');
-  }, [sidebarSurface, viewMode]);
+    navigateHomeAndFitWorkflowGraph('browser-return-home');
+  }, [navigateHomeAndFitWorkflowGraph, sidebarSurface, viewMode]);
 
   // ── Task actions ──────────────────────────────────────────
   const handleProvideInput = useCallback(

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -146,4 +146,21 @@ describe('Browser-surface camera (component)', () => {
     expect(setCenterMock).not.toHaveBeenCalled();
     expect(fitViewMock).not.toHaveBeenCalled();
   });
+  it('clicking the left-nav home icon returns to the workflow graph and fits the whole graph', async () => {
+    mock.setTasks(tasks, workflows);
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId('sidebar-workflows'));
+    await screen.findByTestId('selected-workflow-mini-dag');
+    await settleCamera();
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+
+    await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
+    await flushFrames(4);
+
+    expect(fitViewMock).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Clicking the left rail Home icon now returns to the Home graph and fits the full workflow graph back into view.

The bug was simple. The icon changed the surface, but it did not trigger a graph fit. The viewport could stay stuck on the browser view and look blank.

The fix uses one shared Home-return helper so both return paths switch back to Home and re-fit the workflow graph.

## Review Claim

The Home return paths now re-fit the full workflow graph instead of only switching views.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This only changes the visible Home return behavior. It reuses the existing workflow camera fit behavior and does not change graph layout or task updates.

## Slice Rationale

This is one local UI behavior. Keeping the fix and the regression proof together makes the reviewer check one Home return flow in one place.

## Non-goals

- No change to workflow browser filtering.
- No change to task-DAG camera behavior.
- No change to workflow graph layout.

## Architecture

### Before

The Home-return handlers switched the UI back to Home, but they could leave the workflow camera where the browser view had it.

### After

Both Home-return handlers call `navigateHomeAndFitWorkflowGraph(reason)`. That helper clears temporary camera suppression, switches to Home DAG view, and issues a workflow-graph fit.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/browser-surface-camera-resnap.test.tsx src/__tests__/app-launch.test.tsx src/__tests__/timeline-view-e2e.test.tsx`
- [x] `bash scripts/ui-visual-proof.sh capture-after --spec e2e/home-fit-workflow-graph-proof.spec.ts --output-dir /tmp/home-fit-graph-proof`

</details>

## Visual Proof

Primary proof is the walkthrough video. It shows the app on the Workflows browser view, then the left rail Home icon click, then the full workflow graph back on screen.

- Video: [left rail Home returns to the full workflow graph](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-f34033/walkthrough.webm)
- Screenshot: ![Home graph fit after clicking the left rail Home icon](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-f34033/sidebar-home-fit-workflow-graph.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 543e15f13`
- Post-revert steps: None.
- Data migration? No.

</details>
