### PR TITLE
Allow inspector prompt tasks to change harness and model

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
-import type { ActionGraphNode, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
+import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
 import { reportUiNavigation } from './lib/report-ui-navigation.js';
@@ -589,7 +589,8 @@ export function App() {
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [remoteTargets, setRemoteTargets] = useState<string[]>([]);
   const [executionPools, setExecutionPools] = useState<string[]>([]);
-  const [executionAgents, setExecutionAgents] = useState<string[]>([]);
+  const [executionHarnesses, setExecutionHarnesses] = useState<ExecutionHarnessOption[]>([]);
+  const [executionDefaults, setExecutionDefaults] = useState<ExecutionDefaults | null>(null);
   const [statusFilters, setStatusFilters] = useState<Set<WorkflowStatus>>(new Set());
   const [runtimeStatus, setRuntimeStatus] = useState<RuntimeStatus | null>(
     () => (typeof window !== 'undefined' ? window.__INVOKER_BOOTSTRAP__?.runtimeStatus ?? null : null),
@@ -684,7 +685,8 @@ export function App() {
   useEffect(() => {
     window.invoker?.getRemoteTargets?.().then(setRemoteTargets).catch(() => {});
     window.invoker?.getExecutionPools?.().then(setExecutionPools).catch(() => {});
-    window.invoker?.getExecutionAgents?.().then(setExecutionAgents).catch(() => {});
+    window.invoker?.getExecutionHarnesses?.().then(setExecutionHarnesses).catch(() => {});
+    window.invoker?.getExecutionDefaults?.().then(setExecutionDefaults).catch(() => {});
     window.invoker?.getRuntimeStatus?.().then(setRuntimeStatus).catch(() => {});
     window.invoker?.getPlanningPresets?.()
       .then((options) => {
@@ -2393,6 +2395,18 @@ export function App() {
     },
     [invoker, trackAcceptedMutation],
   );
+  const handleEditModel = useCallback(
+    async (taskId: string, executionModel: string | null) => {
+      if (!invoker) return;
+      try {
+        const result = await invoker.editTaskModel(taskId, executionModel);
+        trackAcceptedMutation(result);
+      } catch (err) {
+        notifyMutationError('Failed to edit task model:', err);
+      }
+    },
+    [invoker, trackAcceptedMutation],
+  );
 
   const handleSetExternalGatePolicies = useCallback(
     async (taskId: string, updates: ExternalGatePolicyUpdate[]) => {
@@ -3232,7 +3246,10 @@ export function App() {
                   advancedExpanded={advancedMetadataExpanded}
                   remoteTargets={remoteTargets}
                   executionPools={executionPools}
-                  executionAgents={executionAgents}
+                  executionHarnesses={executionHarnesses}
+                  executionDefaults={executionDefaults}
+                  onEditAgent={handleEditAgent}
+                  onEditModel={handleEditModel}
                   onApprove={openApprovalModal}
                   onReject={openRejectModal}
                   onSetMergeBranch={handleSetMergeBranch}

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -217,10 +217,28 @@ export function createMockInvoker(
     editTaskPrompt: vi.fn(async () => accepted('invoker:edit-task-prompt')),
     editTaskPool: vi.fn(async () => accepted('invoker:edit-task-pool')),
     editTaskAgent: vi.fn(async () => accepted('invoker:edit-task-agent')),
+    editTaskModel: vi.fn(async () => accepted('invoker:edit-task-model')),
     setTaskExternalGatePolicies: vi.fn(async () => accepted('invoker:set-task-external-gate-policies')),
     getRemoteTargets: vi.fn(async () => []),
     getExecutionPools: vi.fn(async () => ['mixed-local-ssh', 'pnpm-ssh']),
-    getExecutionAgents: vi.fn(async () => ['claude', 'codex']),
+    getExecutionHarnesses: vi.fn(async () => [
+      {
+        name: 'claude',
+        supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }],
+      },
+      {
+        name: 'codex',
+        supportedModels: [{ id: 'gpt-5-codex', label: 'GPT-5 Codex' }],
+      },
+      {
+        name: 'omp',
+        supportedModels: [
+          { id: 'chatgpt-5.4', label: 'ChatGPT 5.4' },
+          { id: 'openai/gpt-5-codex', label: 'OpenAI GPT-5 Codex' },
+        ],
+      },
+    ]),
+    getExecutionDefaults: vi.fn(async () => ({ executionAgent: 'codex' })),
     getRuntimeStatus: vi.fn(async () => runtimeStatus),
     getSystemDiagnostics: vi.fn(async () => ({
       platform: 'linux',

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -93,6 +93,47 @@ describe('Task interaction (component)', () => {
       expect(screen.getByTestId('prompt-command-display')).toHaveTextContent('exit 1');
     });
   });
+  it('lets prompt tasks change harness and model from the inspector', async () => {
+    const promptTask = makeUITask({
+      id: 'task-ai',
+      description: 'AI task',
+      status: 'pending',
+      workflowId: 'wf-a',
+      prompt: 'Write a test',
+      config: {
+        workflowId: 'wf-a',
+        prompt: 'Write a test',
+        executionAgent: 'omp',
+      },
+    });
+    vi.mocked(mock.api.getExecutionDefaults).mockResolvedValue({
+      executionAgent: 'omp',
+      executionModel: 'chatgpt-5.4',
+    });
+
+    render(<App />);
+    act(() => mock.setTasks([promptTask], workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
+    });
+
+    fireEvent.click(await screen.findByTestId('rf__node-task-ai'));
+    await waitFor(() => {
+      expect(screen.getByTestId('execution-agent-select')).toBeInTheDocument();
+      expect(screen.getByTestId('execution-model-select')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId('execution-agent-select'), { target: { value: 'codex' } });
+    await waitFor(() => {
+      expect(mock.api.editTaskAgent).toHaveBeenCalledWith('task-ai', 'codex');
+    });
+
+    fireEvent.change(screen.getByTestId('execution-model-select'), { target: { value: 'openai/gpt-5-codex' } });
+    await waitFor(() => {
+      expect(mock.api.editTaskModel).toHaveBeenCalledWith('task-ai', 'openai/gpt-5-codex');
+    });
+  });
 
   it('clicking a task expands a minimized inspector', async () => {
     render(<App />);

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -506,7 +506,10 @@ describe('WorkflowInspector', () => {
       <WorkflowInspector
         workflow={workflow}
         task={makeTask()}
-        executionAgents={['claude', 'codex']}
+        executionHarnesses={[
+          { name: 'claude', supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }] },
+          { name: 'codex', supportedModels: [{ id: 'gpt-5-codex', label: 'GPT-5 Codex' }] },
+        ]}
         collapsed={false}
         advancedExpanded={false}
         onEditAgent={onEditAgent}
@@ -517,6 +520,38 @@ describe('WorkflowInspector', () => {
 
     fireEvent.change(screen.getByTestId('execution-agent-select'), { target: { value: 'claude' } });
     expect(onEditAgent).toHaveBeenCalledWith('task-1', 'claude');
+  });
+
+  it('renders the default model label and edits the selected model', () => {
+    const onEditModel = vi.fn();
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={makeTask({
+          status: 'pending',
+          config: { workflowId: 'wf-1', prompt: 'Fix failing tests', executionAgent: 'omp' },
+        })}
+        executionHarnesses={[
+          {
+            name: 'omp',
+            supportedModels: [
+              { id: 'chatgpt-5.4', label: 'ChatGPT 5.4' },
+              { id: 'openai/gpt-5-codex', label: 'OpenAI GPT-5 Codex' },
+            ],
+          },
+        ]}
+        executionDefaults={{ executionAgent: 'omp', executionModel: 'chatgpt-5.4' }}
+        collapsed={false}
+        advancedExpanded={false}
+        onEditModel={onEditModel}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('option', { name: 'Default (ChatGPT 5.4)' })).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId('execution-model-select'), { target: { value: 'openai/gpt-5-codex' } });
+    expect(onEditModel).toHaveBeenCalledWith('task-1', 'openai/gpt-5-codex');
   });
 
   it('double-click edits prompt and saves through callback', () => {

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -3,7 +3,7 @@ import type { ReviewGateArtifact, ReviewGateQueryResponse, TaskState, WorkflowMe
 import { getEffectiveVisualStatus, getStatusColor } from '../lib/colors.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
 import { subscribeVisibilityAwarePoll } from '../hooks/visibilityAwarePoll.js';
-import type { ActionGraphNode } from '@invoker/contracts';
+import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption } from '@invoker/contracts';
 
 type MergeMode = 'manual' | 'automatic' | 'external_review';
 type TaskLogLevel = 'debug' | 'info' | 'warn' | 'error';
@@ -140,13 +140,15 @@ interface WorkflowInspectorProps {
   reviewGate?: ReviewGateQueryResponse | null;
   remoteTargets?: string[];
   executionPools?: string[];
-  executionAgents?: string[];
+  executionHarnesses?: ExecutionHarnessOption[];
+  executionDefaults?: ExecutionDefaults | null;
   actionNode?: ActionGraphNode | null;
   collapsed: boolean;
   advancedExpanded: boolean;
   onEditType?: (taskId: string, runnerKind: string, poolMemberId?: string) => void;
   onEditPool?: (taskId: string, poolId: string) => void;
   onEditAgent?: (taskId: string, agentName: string) => void;
+  onEditModel?: (taskId: string, executionModel: string | null) => void;
   onEditPrompt?: (taskId: string, newPrompt: string) => void;
   onEditCommand?: (taskId: string, newCommand: string) => void;
   onApprove?: (task: TaskState) => void;
@@ -245,12 +247,14 @@ export function WorkflowInspector({
   workflowTasks,
   reviewGate,
   executionPools,
-  executionAgents,
+  executionHarnesses,
+  executionDefaults,
   actionNode,
   collapsed,
   advancedExpanded,
   onEditPool,
   onEditAgent,
+  onEditModel,
   onEditPrompt,
   onEditCommand,
   onApprove,
@@ -344,12 +348,30 @@ export function WorkflowInspector({
   const nodeTitle = task?.description ?? workflowTitle ?? 'No node selected';
   const showsWorkflowMergeDetails = Boolean(!task && workflow?.id && workflow.onFinish === 'pull_request');
   const isMergeNode = Boolean((task?.config.isMergeNode || showsWorkflowMergeDetails) && workflow?.id);
-  const currentAgent = task?.config.executionAgent ?? task?.execution.agentName ?? 'claude';
+  const currentAgent = task?.config.executionAgent ?? task?.execution.agentName ?? executionDefaults?.executionAgent ?? 'codex';
+  const selectedHarness = useMemo(
+    () => executionHarnesses?.find((harness) => harness.name === currentAgent) ?? null,
+    [currentAgent, executionHarnesses],
+  );
+  const currentModel = task?.config.executionModel ?? '';
   const agentOptions = useMemo(() => {
-    const names = new Set(executionAgents ?? []);
+    const names = new Set((executionHarnesses ?? []).map((harness) => harness.name));
     names.add(currentAgent);
     return [...names].filter(Boolean);
-  }, [currentAgent, executionAgents]);
+  }, [currentAgent, executionHarnesses]);
+  const modelOptions = useMemo(() => {
+    const models = new Map((selectedHarness?.supportedModels ?? []).map((model) => [model.id, model]));
+    if (currentModel && !models.has(currentModel)) {
+      models.set(currentModel, { id: currentModel, label: currentModel });
+    }
+    return [...models.values()];
+  }, [currentModel, selectedHarness]);
+  const defaultModelLabel = useMemo(() => {
+    if (currentAgent !== executionDefaults?.executionAgent || !executionDefaults.executionModel) return 'Default';
+    const label = selectedHarness?.supportedModels.find((model) => model.id === executionDefaults.executionModel)?.label
+      ?? executionDefaults.executionModel;
+    return `Default (${label})`;
+  }, [currentAgent, executionDefaults, selectedHarness]);
   const poolOptions = useMemo(() => {
     const ids = new Set(executionPools ?? []);
     if (task?.config.poolId) ids.add(task.config.poolId);
@@ -600,6 +622,25 @@ export function WorkflowInspector({
               >
                 {agentOptions.map((agentName) => (
                   <option key={agentName} value={agentName}>{capitalize(agentName)}</option>
+                ))}
+              </select>
+            </label>
+          </section>
+        )}
+        {task?.config.prompt && onEditModel && modelOptions.length > 0 && (
+          <section className="rounded border border-border bg-secondary/70 p-3">
+            <label className="flex items-center justify-between gap-3">
+              <span className="text-xs uppercase tracking-wide text-muted-foreground">AI Model</span>
+              <select
+                value={currentModel}
+                onChange={(event) => onEditModel(task.id, event.target.value || null)}
+                disabled={isTaskBusy}
+                className="min-w-0 max-w-[190px] rounded border border-border-strong bg-muted px-2 py-1 text-xs text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                data-testid="execution-model-select"
+              >
+                <option value="">{defaultModelLabel}</option>
+                {modelOptions.map((model) => (
+                  <option key={model.id} value={model.id}>{model.label}</option>
                 ))}
               </select>
             </label>

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -89,6 +89,7 @@ export interface TaskConfig {
   readonly poolMemberId?: string;
   readonly isMergeNode?: boolean;
   readonly executionAgent?: string;
+  readonly executionModel?: string;
   readonly autoFixRetries?: number;
   readonly summary?: string;
   readonly problem?: string;


### PR DESCRIPTION
## Summary

Prompt tasks in the inspector can now change both the AI harness and the AI model.

The UI already had the edit endpoints, but the inspector never got the edit callbacks.

It also still called the wrong harness endpoint, so OMP and model changes were unreachable from the app.

This wires the inspector to harness metadata and task defaults, then adds the missing model dropdown and app-level tests for the full edit path.

## Review Claim

The task inspector now lets prompt tasks switch to OMP and choose a model, using the existing task edit IPC with no backend changes.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This stays inside `packages/ui`: the backend mutation surface was already present, and the new controls only call the existing `editTaskAgent` and `editTaskModel` requests.

## Slice Rationale

The bug lived in one inspector path: wrong harness loading plus missing inspector edit wiring. Fixing both together keeps one user-visible claim and avoids a half-wired selector.

## Non-goals

- No task-runner or IPC contract changes.
- No command-task harness/model UI.
- No TaskPanel parity work for the unused legacy component.

## Architecture

### Before

`App` used the old `getExecutionAgents` endpoint and did not pass task edit callbacks into `WorkflowInspector`.

`WorkflowInspector` could show prompt text, but it had no live harness control and no model control.

### After

`App` now uses `getExecutionHarnesses` and `getExecutionDefaults`, then passes that data and the existing edit requests into `WorkflowInspector`.

`WorkflowInspector` resolves the current harness from task config, runtime agent name, and defaults, then renders both selectors from the harness metadata.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-inspector.test.tsx src/__tests__/task-interaction.test.tsx`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && cd packages/app && CAPTURE_MODE=after CAPTURE_VIDEO=1 npx playwright test e2e/visual-proof-omp-codex.spec.ts`

</details>

## Visual Proof

Walkthrough video — loads the prompt task, opens the inspector, and shows the harness/model controls in place.

[Walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-1f85b9/omp-codex-task-inspector-after.webm)

Before — the prompt task inspector shows the prompt body only; there is no harness or model control.

![Before — prompt task inspector without harness or model selectors](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-1f85b9/omp-codex-task-inspector-before.png)

After — the same prompt task inspector shows an Omp harness selector and a model selector.

![After — prompt task inspector with harness and model selectors](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-1f85b9/omp-codex-task-inspector-after.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 2fa528815`
- Post-revert steps: None.
- Data migration? No.

</details>
