### PR TITLE
[Godfile app step 2: extract renderer-task-feed](1) Route renderer task-feed wiring

### DIFF
--- a/packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts
+++ b/packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts
@@ -6,8 +6,10 @@
  * lines in ~/.invoker/invoker.log with no intervening recovery, after which
  * the selected workflow's mini-DAG renders blank until the user reloads.
  *
- * Owner-side root cause (current production code at
- * packages/app/src/main.ts:2896–2904):
+ * Owner-side recovery now lives in
+ * packages/app/src/renderer-task-feed.ts:169–177. Before
+ * `recoverQuarantinedTask` extracted the contract, the equivalent inline loop
+ * looked like:
  *
  *   const { quarantined } = applyDelta(d, lastKnownTaskStates);
  *   for (const taskId of quarantined) {
@@ -72,9 +74,10 @@ function makeMergeNode(workflowId: string, taskStateVersion: number): TaskState 
 
 /**
  * Faithful mirror of the production main-process recovery loop
- * (packages/app/src/main.ts:2896–2906): apply the delta, then for each
- * quarantined id, run the shared `recoverQuarantinedTask` helper and
- * collect every renderer delta it returns.
+ * (packages/app/src/renderer-task-feed.ts:169–177 and :232–257):
+ * apply the delta, then for each quarantined id, run the shared
+ * `recoverQuarantinedTask` helper and collect every renderer delta it
+ * returns.
  *
  * Pre-fix, this file used a `simulateLegacyRecoveryLoop` that inlined the
  * old buggy code (no orchestrator fallback, silent delete on persistence

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -129,7 +129,6 @@ import {
   type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 import { FileAndDbLogger } from './logger.js';
-import type { TaskOutputData } from './types.js';
 import {
   DEFAULT_SLACK_HARNESS_PRESETS,
   loadConfig,
@@ -217,10 +216,7 @@ import { runInvokerCliSetup } from './invoker-cli-setup.js';
 import { resolveBundledCliPath } from './cli-helper.js';
 import { buildAppMenuTemplate } from './app-menu.js';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
-import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from './delta-merge.js';
 import { CoalescedWorkflowMetadataPublisher } from './workflow-metadata-invalidation.js';
-import { WorkflowRollupProjection } from './workflow-rollup-projection.js';
-import { seedTaskCachesFromSnapshot } from './viewer-cache-hydration.js';
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
@@ -235,8 +231,6 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
-import { evaluateExecutingStall, taskNeedsExecutingStallCheck } from './executing-stall.js';
-
 
 import {
   buildFixWithAgentMutationArgs,
@@ -320,6 +314,10 @@ import {
   registerMainWindowActivateHandler,
   registerMainWindowSecondInstanceHandler,
 } from './window/window-lifecycle.js';
+import {
+  createRendererTaskFeed,
+  type RendererTaskFeedStopHandle,
+} from './renderer-task-feed.js';
 import { tryAcquireGuiInstanceLock, type GuiInstanceLock } from './gui-instance-lock.js';
 import { logProcessError } from './process-error-handling.js';
 
@@ -2050,10 +2048,8 @@ function createEmbeddedTerminalBackendFromConfig(
   // `activeExecutions` count now just reflects spawned execution
   // handles in `taskHandles`.
   const guiMutationHandlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
-  let dbPollInterval: ReturnType<typeof setInterval> | null = null;
-  let uiPerfLogInterval: ReturnType<typeof setInterval> | null = null;
-  const lastKnownTaskStates = new TaskSnapshotCache();
-  const workflowRollupProjection = new WorkflowRollupProjection();
+  let dbPollHandle: RendererTaskFeedStopHandle | null = null;
+  let activityPollHandle: RendererTaskFeedStopHandle | null = null;
   const deferredWorkflowLaunches = new Map<string, {
     timer: ReturnType<typeof setTimeout>;
     taskIds: string[];
@@ -2069,20 +2065,9 @@ function createEmbeddedTerminalBackendFromConfig(
       { module: 'ipc-delegate' },
     );
   };
-  const pendingOutputBuffers = new Map<string, string[]>();
-  const outputFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
   let workflowMetadataPublisher: CoalescedWorkflowMetadataPublisher | null = null;
-  let lastKnownWorkflowCount = 0;
   let startupWorkflowId: string | null = null;
   const startupWorkflowCache = createStartupWorkflowCache();
-  // In detached viewer mode the local DB is an empty in-memory copy. Workflow
-  // metadata for the bootstrap getter comes from the owner snapshot; task state
-  // is derived live from `lastKnownTaskStates` (kept current by deltas).
-  let detachedViewerWorkflows: unknown[] | null = null;
-  // While the detached viewer hydrates, owner deltas are buffered here and
-  // replayed after the cache is seeded, so an update arriving mid-hydration is
-  // not applied against an empty cache (quarantined and dropped).
-  let detachedDeltaBuffer: TaskDelta[] | null = null;
   let uiInteractive = false;
   let deferredStartupTriggered = false;
   const traceUiDeltaFlow = process.env.INVOKER_TRACE_UI_DELTA === '1';
@@ -2189,44 +2174,6 @@ function createEmbeddedTerminalBackendFromConfig(
     ts: new Date().toISOString(),
   });
 
-  const flushTaskOutput = (taskId: string): void => {
-    const timer = outputFlushTimers.get(taskId);
-    if (timer) {
-      clearTimeout(timer);
-      outputFlushTimers.delete(taskId);
-    }
-    const chunks = pendingOutputBuffers.get(taskId);
-    if (!chunks || chunks.length === 0) {
-      return;
-    }
-    pendingOutputBuffers.delete(taskId);
-    const data = chunks.join('');
-    if (traceTaskOutput) {
-      logger.info(`${taskId}: ${data.trimEnd()}`, { module: 'output' });
-    }
-    const outputData: TaskOutputData = { taskId, data };
-    messageBus.publish(Channels.TASK_OUTPUT, outputData);
-    try {
-      // Runner stream chunks land in the output spool only — task_output is
-      // reserved for explicit diagnostic writes (workflow actions, shutdown).
-      persistence.appendOutputChunk(taskId, data);
-    } catch (err) {
-      logger.error(`Failed to persist output for ${taskId}: ${err}`, { module: 'output' });
-    }
-  };
-
-  const enqueueTaskOutput = (taskId: string, data: string): void => {
-    const chunks = pendingOutputBuffers.get(taskId) ?? [];
-    chunks.push(data);
-    pendingOutputBuffers.set(taskId, chunks);
-    if (outputFlushTimers.has(taskId)) {
-      return;
-    }
-    const timer = setTimeout(() => flushTaskOutput(taskId), 100);
-    timer.unref?.();
-    outputFlushTimers.set(taskId, timer);
-  };
-
   const taskDeltaStream = createTaskDeltaStreamSequence();
   const getTaskDeltaStreamSequence = (): number => taskDeltaStream.current();
 
@@ -2246,35 +2193,34 @@ function createEmbeddedTerminalBackendFromConfig(
     onEvent: (event) => webBridge?.broadcast('invoker:task-graph-event', event),
   });
 
-  const publishTaskDeltaToRenderer = (delta: TaskDelta): void => {
-    const workflowRollups = workflowRollupProjection.applyDelta(delta);
-    taskGraphEventPublisher.publishDelta(delta, workflowRollups);
-  };
-
-  const applyTaskDeltaToOwnerCacheOrRecover = (delta: TaskDelta): TaskDelta[] => {
-    const { quarantined, accepted } = applyDelta(delta, lastKnownTaskStates);
-    if (quarantined.length === 0) {
-      return accepted ? [delta] : [];
-    }
-
-    const rendererDeltas: TaskDelta[] = [];
-    for (const taskId of quarantined) {
-      logger.info(`[gap-detect] quarantined task="${taskId}" — triggering authoritative reload`, { module: 'delta-merge' });
-      const { rendererDelta } = recoverQuarantinedTask(lastKnownTaskStates, taskId, {
-        loadTask: loadTaskByIdFromPersistence,
-        getMergeNode: (workflowId) => orchestrator.getMergeNode(workflowId),
-      });
-      if (rendererDelta) {
-        rendererDeltas.push(rendererDelta);
-      }
-    }
-    return rendererDeltas;
-  };
-
   const requestWorkflowMetadataPublish = (reason: string): void => {
     uiPerfStats.workflowMetadataPublishRequests += 1;
     workflowMetadataPublisher?.requestPublish(reason);
   };
+
+  const rendererTaskFeed = createRendererTaskFeed({
+    logger,
+    getPersistence: () => persistence,
+    getMessageBus: () => messageBus,
+    getOrchestrator: () => orchestrator,
+    taskHandles,
+    taskGraphEventPublisher,
+    getMainWindow: () => mainWindow,
+    setStartupWorkflowId: (workflowId) => { startupWorkflowId = workflowId; },
+    requestWorkflowMetadataPublish,
+    scheduleAutoFix: (taskId) => scheduleAutoFix(taskId),
+    logAutoFixDebug: (taskId, phase, details) => logAutoFixDebug(taskId, phase, details),
+    uiPerfStats,
+    traceUiDeltaFlow,
+    traceDbPollPerTask,
+    traceTaskOutput,
+    executingStallTimeoutMs,
+    pollLaunchDispatcher: () => {
+      if (launchDispatcher) {
+        launchDispatcher.poll();
+      }
+    },
+  });
 
   const buildAutoFixQueueSnapshot = (taskId: string): Record<string, unknown> => {
     const workflowId = workflowIdForTaskArg(taskId);
@@ -2480,8 +2426,8 @@ function createEmbeddedTerminalBackendFromConfig(
       logger,
       messageBus,
       taskHandles,
-      enqueueTaskOutput,
-      flushTaskOutput,
+      enqueueTaskOutput: rendererTaskFeed.enqueueTaskOutput,
+      flushTaskOutput: rendererTaskFeed.flushTaskOutput,
       assertFatalExecutionCapacity,
       getTaskRunner: () => taskExecutor,
       setTaskRunner: (runner) => { taskExecutor = runner; },
@@ -2847,7 +2793,7 @@ function createEmbeddedTerminalBackendFromConfig(
       case 'invoker:stop-worker':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resume-workflow': {
-        const workflows = detachedViewerWorkflows ?? persistence.listWorkflows();
+        const workflows = rendererTaskFeed.getDetachedViewerWorkflows() ?? persistence.listWorkflows();
         const firstWorkflow = workflows[0] as { id?: unknown } | undefined;
         const workflowId = startupWorkflowId
           ?? (typeof firstWorkflow?.id === 'string' ? firstWorkflow.id : undefined);
@@ -3008,96 +2954,10 @@ function createEmbeddedTerminalBackendFromConfig(
     });
   }
 
-  function seedUiSnapshotCache(): void {
-    lastKnownWorkflowCount = persistence.listWorkflows().length;
-    seedTaskCachesFromSnapshot(orchestrator.getAllTasks(), { lastKnownTaskStates, workflowRollupProjection });
-  }
-
-  // Detached viewer: the local DB is empty, so seed the delta caches and
-  // bootstrap snapshot from the owner. Without this, the empty cache quarantines
-  // every `updated` delta for a task the viewer has not seen (dropping live
-  // updates), and bootstrap getters return nothing. Failures are non-fatal — the
-  // renderer's delegated reads still populate the view.
-  async function hydrateDetachedViewerFromOwner(): Promise<void> {
-    try {
-      const snapshot = await messageBus.request<{ kind: string }, { tasks?: TaskState[]; workflows?: unknown[] }>(
-        'headless.query',
-        { kind: 'tasks' },
-      );
-      const tasks = Array.isArray(snapshot?.tasks) ? snapshot.tasks : [];
-      const workflows = Array.isArray(snapshot?.workflows) ? snapshot.workflows : [];
-      detachedViewerWorkflows = workflows;
-      seedTaskCachesFromSnapshot(tasks, { lastKnownTaskStates, workflowRollupProjection });
-      lastKnownWorkflowCount = workflows.length;
-      startupWorkflowId = [...workflows]
-        .map((wf) => wf as { id?: string; updatedAt?: string; createdAt?: string })
-        .sort((left, right) => (Date.parse(right.updatedAt ?? '') || 0) - (Date.parse(left.updatedAt ?? '') || 0))[0]?.id ?? null;
-      logger.info(
-        `[init] Hydrated detached viewer from owner: ${tasks.length} tasks across ${workflows.length} workflows`,
-        { module: 'init' },
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.warn(`detached viewer hydration from owner failed; relying on delegated reads: ${message}`, { module: 'init' });
-    } finally {
-      // Resume direct delta processing and replay anything buffered during
-      // hydration (in arrival order). Always runs, so a hydration failure can
-      // never leave deltas buffered forever.
-      const buffered = detachedDeltaBuffer ?? [];
-      detachedDeltaBuffer = null;
-      for (const delta of buffered) processIncomingTaskDelta(delta);
-    }
-  }
-
-  // Current task states for the detached viewer's bootstrap getter, derived from
-  // the live delta cache so a renderer reload never sees the stale hydration
-  // snapshot.
-  function detachedViewerTasks(): TaskState[] {
-    return [...lastKnownTaskStates.keys()].map(
-      (taskId) => JSON.parse(lastKnownTaskStates.get(taskId) ?? '{}') as TaskState,
-    );
-  }
-
-  // Apply one owner task delta to the local cache and forward results to the
-  // renderer (and drive owner-side auto-fix). Extracted so the detached viewer
-  // can replay deltas that were buffered during hydration.
-  function processIncomingTaskDelta(d: TaskDelta): void {
-    uiPerfStats.mainDeltaToUi += 1;
-    if (traceUiDeltaFlow) {
-      logger.debug(`delta→ui: ${JSON.stringify(d)}`, { module: 'ui' });
-    }
-    const deltaTaskId = d.type === 'updated' || d.type === 'removed' ? d.taskId : undefined;
-    if (d.type === 'updated' && d.changes.status === 'failed') {
-      const cancellationError = shouldSkipAutoFixForError(d.changes.execution?.error);
-      const shouldAutoFixFromOrchestrator = orchestrator.shouldAutoFix(d.taskId);
-      logAutoFixDebug(d.taskId, 'delta-failed', {
-        shouldSkipForCancellation: cancellationError,
-        shouldAutoFixFromOrchestrator,
-      });
-      if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
-        logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
-        scheduleAutoFix(deltaTaskId);
-      } else if (deltaTaskId) {
-        logAutoFixDebug(deltaTaskId, 'delta-skip', {
-          reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
-          shouldSkipForCancellation: cancellationError,
-          shouldAutoFixFromOrchestrator,
-        });
-      }
-    }
-    for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(d)) {
-      publishTaskDeltaToRenderer(rendererDelta);
-    }
-  }
-
-  function loadTaskByIdFromPersistence(taskId: string): TaskState | undefined {
-    return persistence.loadTask(taskId);
-  }
-
   workflowMetadataPublisher = new CoalescedWorkflowMetadataPublisher({
     listWorkflows: () => persistence.listWorkflows(),
     publish: (workflows, stats) => {
-      lastKnownWorkflowCount = workflows.length;
+      rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
       uiPerfStats.workflowMetadataPublishes += 1;
       uiPerfStats.workflowMetadataCoalescedRequests += Math.max(0, stats.coalescedRequests - 1);
       if (stats.coalescedRequests > 1) {
@@ -3130,7 +2990,7 @@ function createEmbeddedTerminalBackendFromConfig(
   function bootstrapInitialWorkflowState(): void {
     const workflows = listWorkflowsByStartupRecency();
     startupWorkflowCache.set(workflows);
-    lastKnownWorkflowCount = workflows.length;
+    rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
     startupWorkflowId = workflows[0]?.id ?? null;
     if (!startupWorkflowId) {
       logger.info('[init] No workflows available for initial startup bootstrap', { module: 'init' });
@@ -3185,21 +3045,20 @@ function createEmbeddedTerminalBackendFromConfig(
   function publishOrchestratorSnapshotToRenderer(): void {
     const workflows = persistence.listWorkflows();
     const tasks = orchestrator.getAllTasks();
-    const previousTaskIds = new Set(lastKnownTaskStates.keys());
-    lastKnownTaskStates.clear();
-    workflowRollupProjection.replaceAll(tasks);
+    const previousTaskIds = new Set(rendererTaskFeed.listKnownTaskIds());
+    rendererTaskFeed.clearTaskSnapshots();
+    rendererTaskFeed.replaceWorkflowRollups(tasks);
     for (const task of tasks) {
-      const snapshot = JSON.stringify(task);
       previousTaskIds.delete(task.id);
-      lastKnownTaskStates.set(task.id, snapshot);
+      rendererTaskFeed.rememberTaskState(task);
       if (mainWindow && !mainWindow.isDestroyed()) {
-        publishTaskDeltaToRenderer({ type: 'created', task });
+        rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'created', task });
       }
     }
-    lastKnownWorkflowCount = workflows.length;
+    rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
     if (mainWindow && !mainWindow.isDestroyed()) {
       for (const removedTaskId of previousTaskIds) {
-        publishTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
+        rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
       }
       requestWorkflowMetadataPublish('orchestrator-snapshot');
     }
@@ -3308,175 +3167,7 @@ function createEmbeddedTerminalBackendFromConfig(
 
       setTimeout(() => {
         if (ownerMode) {
-          dbPollInterval = setInterval(() => {
-          if (!mainWindow || mainWindow.isDestroyed()) return;
-          try {
-            const workflows = persistence.listWorkflows();
-
-            if (workflows.length !== lastKnownWorkflowCount) {
-              const msg = `Workflow count changed: ${lastKnownWorkflowCount} → ${workflows.length}`;
-              logger.info(msg, { module: 'db-poll' });
-              try { persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
-              lastKnownWorkflowCount = workflows.length;
-              requestWorkflowMetadataPublish('db-poll-count');
-
-              orchestrator.syncAllFromDb();
-              logger.info(`Synced orchestrator for all ${workflows.length} workflows`, { module: 'db-poll' });
-            }
-
-            for (const wf of workflows) {
-              if (wf.status === 'completed' || wf.status === 'failed') continue;
-              const tasks = persistence.loadTasks(wf.id);
-              for (const loadedTask of tasks) {
-                let task = loadedTask;
-                const now = new Date();
-                const previousHeartbeat = parseExecutionDate(task.execution.lastHeartbeatAt);
-                const selectedAttempt = taskNeedsExecutingStallCheck(task) && task.execution.selectedAttemptId
-                  ? persistence.loadAttempt?.(task.execution.selectedAttemptId)
-                  : undefined;
-                const leaseExpiresAt = parseExecutionDate(selectedAttempt?.leaseExpiresAt);
-                const remoteHeartbeat = parseExecutionDate(task.execution.remoteHeartbeatAt);
-
-                if (task.status === 'running' || (task.status === 'pending' && task.execution.phase === 'launching')) {
-                  // CC.1: launch-stall watchdog removed. The
-                  // LaunchDispatcher's reapExpiredLeases /
-                  // abandonStuckLeases reapers (Phase B, CB.3) are the
-                  // sole recovery path for stalled launch claims.
-                  const executingStartedAt = parseExecutionDate(task.execution.startedAt);
-                  const executingAgeMs = executingStartedAt ? now.getTime() - executingStartedAt.getTime() : 0;
-                  const { heartbeatStale, leaseExpired, executingStalled, staleReason } = evaluateExecutingStall({
-                    now,
-                    phase: task.execution.phase,
-                    runnerKind: task.config.runnerKind,
-                    executingStartedAt,
-                    leaseExpiresAt,
-                    executorHeartbeatAt: previousHeartbeat,
-                    remoteHeartbeatAt: remoteHeartbeat,
-                    executingStallTimeoutMs,
-                  });
-
-                  if (executingStalled) {
-                    const selectedAttemptHeartbeat = parseExecutionDate(selectedAttempt?.lastHeartbeatAt);
-                    const executingError =
-                      `Execution stalled: task remained in running/executing for ${Math.floor(executingAgeMs / 1000)}s ` +
-                      `without a live execution handle and no completion signal from executor (${staleReason}).`;
-                    logger.info(
-                      `[executing-stall] detected task="${task.id}" phase=${task.execution.phase} executingAgeMs=${executingAgeMs} ` +
-                        `handlePresent=${taskHandles.has(task.id)} leaseExpired=${leaseExpired} heartbeatStale=${heartbeatStale} ` +
-                        `runnerKind=${task.config.runnerKind ?? 'none'} selectedAttemptId=${task.execution.selectedAttemptId ?? 'none'} ` +
-                        `attemptStatus=${selectedAttempt?.status ?? 'none'} executorHeartbeatAt=${previousHeartbeat?.toISOString() ?? 'none'} ` +
-                        `remoteHeartbeatAt=${remoteHeartbeat?.toISOString() ?? 'none'} attemptHeartbeatAt=${selectedAttemptHeartbeat?.toISOString() ?? 'none'} ` +
-                        `leaseExpiresAt=${leaseExpiresAt?.toISOString() ?? 'none'} launchStartedAt=${task.execution.launchStartedAt instanceof Date ? task.execution.launchStartedAt.toISOString() : task.execution.launchStartedAt ?? 'none'} ` +
-                        `launchCompletedAt=${task.execution.launchCompletedAt instanceof Date ? task.execution.launchCompletedAt.toISOString() : task.execution.launchCompletedAt ?? 'none'} ` +
-                        `startedAt=${executingStartedAt?.toISOString() ?? 'none'} completedAt=${task.execution.completedAt instanceof Date ? task.execution.completedAt.toISOString() : task.execution.completedAt ?? 'none'}`,
-                      { module: 'db-poll' },
-                    );
-                    const failedResponse: WorkResponse = {
-                      requestId: `executing-stall-${task.id}-${now.getTime()}`,
-                      actionId: task.id,
-                      attemptId: task.execution.selectedAttemptId,
-                      executionGeneration: task.execution.generation ?? 0,
-                      status: 'failed',
-                      outputs: {
-                        exitCode: 1,
-                        error: executingError,
-                        failureClass: 'liveness_stall',
-                      },
-                    };
-                    logger.error(`[executing-stall] forcing failure for "${task.id}": ${executingError}`, { module: 'db-poll' });
-                    if (persistence) {
-                      persistShutdownDiagnostic(task, persistence, {
-                        flushPendingOutput: flushTaskOutput,
-                        forcedStopReason: executingError,
-                        label: task.execution.phase === 'launching'
-                          ? 'Startup Failure Diagnostic'
-                          : 'Shutdown Diagnostic',
-                      });
-                    }
-                    orchestrator.handleWorkerResponse(failedResponse);
-                    continue;
-                  }
-                }
-
-                // Stalled-fix-session watchdog: a fix session whose owner died
-                // mid-fix (heartbeat stopped, attempt lease expired) is invisible
-                // to the running-task path above because its status is
-                // `fixing_with_ai`, not `running`. Evaluate it as an executing
-                // task; a live fix refreshes its lease every 30s via
-                // withAttemptHeartbeat, so only an orphaned one is ever stalled.
-                if (task.status === 'fixing_with_ai') {
-                  const fixStartedAt = parseExecutionDate(task.execution.startedAt);
-                  const { executingStalled, staleReason } = evaluateExecutingStall({
-                    now,
-                    phase: 'executing',
-                    runnerKind: task.config.runnerKind,
-                    executingStartedAt: fixStartedAt,
-                    leaseExpiresAt,
-                    executorHeartbeatAt: previousHeartbeat,
-                    remoteHeartbeatAt: remoteHeartbeat,
-                    executingStallTimeoutMs,
-                  });
-                  if (executingStalled) {
-                    const fixAgeMs = fixStartedAt ? now.getTime() - fixStartedAt.getTime() : 0;
-                    const reason =
-                      `Fix session stalled: task remained in fixing_with_ai for ${Math.floor(fixAgeMs / 1000)}s ` +
-                      `without a live fix handle (${staleReason}).`;
-                    logger.error(`[fix-session-stall] reclaiming "${task.id}": ${reason}`, { module: 'db-poll' });
-                    const outcome = orchestrator.reclaimStalledFixSession(task.id, {
-                      reason,
-                      expectedLineage: {
-                        taskId: task.id,
-                        selectedAttemptId: task.execution.selectedAttemptId,
-                        generation: task.execution.generation ?? 0,
-                      },
-                    });
-                    logger.info(
-                      `[fix-session-stall] reclaim outcome=${outcome} task="${task.id}" ` +
-                        `selectedAttemptId=${task.execution.selectedAttemptId ?? 'none'} ` +
-                        `leaseExpiresAt=${leaseExpiresAt?.toISOString() ?? 'none'}`,
-                      { module: 'db-poll' },
-                    );
-                    continue;
-                  }
-                }
-
-                const snapshot = JSON.stringify(task);
-                const prev = lastKnownTaskStates.get(task.id);
-                if (!prev) {
-                  if (traceDbPollPerTask) {
-                    const msg = `New task: ${task.id} (${task.status})`;
-                    logger.info(msg, { module: 'db-poll' });
-                    try { persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
-                  }
-                  lastKnownTaskStates.set(task.id, snapshot);
-                  uiPerfStats.dbPollCreated += 1;
-                  publishTaskDeltaToRenderer({ type: 'created', task });
-                } else if (prev !== snapshot) {
-                  if (traceDbPollPerTask) {
-                    const msg = `Task updated: ${task.id} (${task.status})`;
-                    logger.info(msg, { module: 'db-poll' });
-                    try { persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
-                  }
-                  lastKnownTaskStates.set(task.id, snapshot);
-                  uiPerfStats.dbPollUpdatedAsCreated += 1;
-                  publishTaskDeltaToRenderer({ type: 'created', task });
-                }
-              }
-            }
-            if (launchDispatcher) {
-              try {
-                launchDispatcher.poll();
-              } catch (err) {
-                logger.warn(
-                  `[launch-dispatcher] poll() failed: ${err instanceof Error ? err.message : String(err)}`,
-                  { module: 'db-poll' },
-                );
-              }
-            }
-          } catch {
-            // DB might be locked — skip this tick
-          }
-          }, 2000);
+          dbPollHandle = rendererTaskFeed.startDbPolling();
         }
 
       }, startupPollDelayMs).unref?.();
@@ -3793,30 +3484,13 @@ function createEmbeddedTerminalBackendFromConfig(
     // the db-poll doesn't re-emit deltas the messageBus already delivered.
     // Detached viewer: buffer owner deltas until hydration seeds the cache.
     if (!ownerMode) {
-      detachedDeltaBuffer = [];
+      rendererTaskFeed.beginDetachedViewerBuffering();
     }
     messageBus.subscribe(Channels.TASK_DELTA, (delta: unknown) => {
-      const d = delta as TaskDelta;
-      if (detachedDeltaBuffer) {
-        detachedDeltaBuffer.push(d);
-        return;
-      }
-      processIncomingTaskDelta(d);
+      rendererTaskFeed.receiveTaskDelta(delta as TaskDelta);
     });
 
-    uiPerfLogInterval = setInterval(() => {
-      const snapshot = {
-        ts: new Date().toISOString(),
-        metric: 'main_delta_flow',
-        ...uiPerfStats,
-      };
-      try {
-        persistence.writeActivityLog('ui-perf-main', 'info', JSON.stringify(snapshot));
-
-      } catch {
-        // DB might be locked
-      }
-    }, 10000);
+    activityPollHandle = rendererTaskFeed.startActivityPolling();
 
     messageBus.subscribe(Channels.TASK_OUTPUT, (data: unknown) => {
       if (mainWindow && !mainWindow.isDestroyed() && uiInteractive) {
@@ -3838,9 +3512,9 @@ function createEmbeddedTerminalBackendFromConfig(
 
     registerBootstrapStateIpc({
       ipcMain,
-      getTasks: () => (ownerMode ? orchestrator.getAllTasks() : detachedViewerTasks()),
+      getTasks: () => (ownerMode ? orchestrator.getAllTasks() : rendererTaskFeed.getDetachedViewerTasks()),
       getWorkflows: () =>
-        detachedViewerWorkflows ?? startupWorkflowCache.takeOrLoad(listWorkflowsByStartupRecency),
+        rendererTaskFeed.getDetachedViewerWorkflows() ?? startupWorkflowCache.takeOrLoad(listWorkflowsByStartupRecency),
       getInitialWorkflowId: () => startupWorkflowId,
       appStartedAtEpochMs: appProcessStartedAt,
       getTaskDeltaStreamSequence,
@@ -4001,7 +3675,7 @@ function createEmbeddedTerminalBackendFromConfig(
       const injectTaskStates = async (updates: Array<{ taskId: string; changes: TaskStateChanges }>): Promise<void> => {
         for (const { taskId, changes } of updates) {
           const before = orchestrator.getTask(taskId);
-          const previousSnapshot = lastKnownTaskStates.get(taskId);
+          const previousSnapshot = rendererTaskFeed.getTaskSnapshot(taskId);
           const previousTaskStateVersion = previousSnapshot
             ? (
                 (JSON.parse(previousSnapshot) as { taskStateVersion?: number }).taskStateVersion
@@ -4086,11 +3760,11 @@ function createEmbeddedTerminalBackendFromConfig(
 
       const allStarted = orchestrator.startExecution();
       const tasks = orchestrator.getAllTasks();
-      workflowRollupProjection.replaceAll(tasks);
+      rendererTaskFeed.replaceWorkflowRollups(tasks);
       for (const task of tasks) {
-        lastKnownTaskStates.set(task.id, JSON.stringify(task));
+        rendererTaskFeed.rememberTaskState(task);
         if (mainWindow && !mainWindow.isDestroyed()) {
-          publishTaskDeltaToRenderer({ type: 'created', task });
+          rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'created', task });
         }
       }
       logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${allStarted.length} started`, { module: 'ipc' });
@@ -4115,7 +3789,7 @@ function createEmbeddedTerminalBackendFromConfig(
           if (isTaskInFlightForForcedStop(task)) {
             logger.info(`stop — failing in-flight task "${task.id}" (${task.status})`, { module: 'ipc' });
             persistShutdownDiagnostic(task, persistence, {
-              flushPendingOutput: flushTaskOutput,
+              flushPendingOutput: rendererTaskFeed.flushTaskOutput,
               forcedStopReason: 'Stopped by user',
             });
             orchestrator.handleWorkerResponse({
@@ -4156,9 +3830,7 @@ function createEmbeddedTerminalBackendFromConfig(
       );
       rebuildTaskRunner();
       taskHandles.clear();
-      lastKnownTaskStates.clear();
-      workflowRollupProjection.clear();
-      lastKnownWorkflowCount = 0;
+      rendererTaskFeed.resetSnapshotState();
       requestWorkflowMetadataPublish('clear');
     });
 
@@ -4192,7 +3864,7 @@ function createEmbeddedTerminalBackendFromConfig(
       persistence,
       getOrchestrator: () => orchestrator,
       agentRegistry,
-      loadTaskByIdFromPersistence,
+      loadTaskByIdFromPersistence: rendererTaskFeed.loadTaskByIdFromPersistence,
       resolveAgentSession,
       getOwnerMode: () => ownerMode,
       getMessageBus: () => messageBus,
@@ -4206,9 +3878,7 @@ function createEmbeddedTerminalBackendFromConfig(
       assertDeleteAllEnabled();
       await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       taskHandles.clear();
-      lastKnownTaskStates.clear();
-      workflowRollupProjection.clear();
-      lastKnownWorkflowCount = 0;
+      rendererTaskFeed.resetSnapshotState();
       requestWorkflowMetadataPublish('delete-all-workflows');
     });
 
@@ -4217,9 +3887,7 @@ function createEmbeddedTerminalBackendFromConfig(
       assertDeleteAllEnabled();
       await sharedDeleteAllWorkflowsBulk({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       taskHandles.clear();
-      lastKnownTaskStates.clear();
-      workflowRollupProjection.clear();
-      lastKnownWorkflowCount = 0;
+      rendererTaskFeed.resetSnapshotState();
       requestWorkflowMetadataPublish('delete-all-workflows-bulk');
     });
 
@@ -4882,7 +4550,7 @@ function createEmbeddedTerminalBackendFromConfig(
         throw err;
       }
       const workflows = persistence.listWorkflows();
-      lastKnownWorkflowCount = workflows.length;
+      rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
       requestWorkflowMetadataPublish('set-merge-mode');
     });
 
@@ -5344,9 +5012,9 @@ function createEmbeddedTerminalBackendFromConfig(
     );
 
     if (ownerMode) {
-      seedUiSnapshotCache();
+      rendererTaskFeed.seedUiSnapshotCache();
     } else {
-      await hydrateDetachedViewerFromOwner();
+      await rendererTaskFeed.hydrateDetachedViewerFromOwner();
     }
     createWindow();
     recordStartupMark('createWindow.end');
@@ -5402,8 +5070,8 @@ function createEmbeddedTerminalBackendFromConfig(
         if (apiServer) await apiServer.close().catch(() => {});
         embeddedTerminalManager.closeAll({ preserveForRestart: true });
         await workerRuntimeController?.stopAll();
-        if (dbPollInterval) clearInterval(dbPollInterval);
-        if (uiPerfLogInterval) clearInterval(uiPerfLogInterval);
+        dbPollHandle?.stop();
+        activityPollHandle?.stop();
         if (hourlyBackupInterval) {
           clearInterval(hourlyBackupInterval);
           hourlyBackupInterval = null;
@@ -5418,7 +5086,7 @@ function createEmbeddedTerminalBackendFromConfig(
             if (task.status === 'running' || task.status === 'fixing_with_ai') {
               if (persistence) {
                 persistShutdownDiagnostic(task, persistence, {
-                  flushPendingOutput: flushTaskOutput,
+                  flushPendingOutput: rendererTaskFeed.flushTaskOutput,
                   forcedStopReason: 'Application quit',
                 });
               }

--- a/packages/app/src/renderer-task-feed.ts
+++ b/packages/app/src/renderer-task-feed.ts
@@ -1,0 +1,501 @@
+import type { BrowserWindow } from 'electron';
+import type { Logger, WorkResponse } from '@invoker/contracts';
+import type { Workflow } from '@invoker/data-store';
+import { Channels, type MessageBus } from '@invoker/transport';
+import type { TaskDelta, TaskState } from '@invoker/workflow-core';
+import { shouldSkipAutoFixForError } from '../auto-fix-gating.js';
+import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from '../delta-merge.js';
+import { evaluateExecutingStall, taskNeedsExecutingStallCheck } from '../executing-stall.js';
+import { persistShutdownDiagnostic, type ShutdownDiagnosticDb } from '../shutdown-diagnostic.js';
+import type { TaskGraphEventPublisher } from '../task-graph-event-publisher.js';
+import type { TaskOutputData } from '../types.js';
+import { seedTaskCachesFromSnapshot } from '../viewer-cache-hydration.js';
+import { WorkflowRollupProjection } from '../workflow-rollup-projection.js';
+
+export type RendererTaskFeedTimer = NodeJS.Timeout;
+
+export interface RendererTaskFeedStopHandle {
+  stop(): void;
+}
+
+export interface RendererTaskFeedAttempt {
+  leaseExpiresAt?: unknown;
+  lastHeartbeatAt?: unknown;
+  status?: string;
+}
+
+export interface RendererTaskFeedPersistence extends ShutdownDiagnosticDb {
+  listWorkflows(): Workflow[];
+  loadTasks(workflowId: string): TaskState[];
+  loadTask(taskId: string): TaskState | undefined;
+  loadAttempt?(attemptId: string): RendererTaskFeedAttempt | undefined;
+  writeActivityLog(source: string, level: string, message: string): void;
+  appendOutputChunk(taskId: string, data: string): void;
+}
+
+export interface RendererTaskFeedOrchestrator {
+  getAllTasks(): TaskState[];
+  getMergeNode(workflowId: string): TaskState | undefined;
+  shouldAutoFix(taskId: string): boolean;
+  syncAllFromDb(): void;
+  handleWorkerResponse(response: WorkResponse): void;
+  reclaimStalledFixSession(
+    taskId: string,
+    options: {
+      reason: string;
+      expectedLineage: {
+        taskId: string;
+        selectedAttemptId: string | undefined;
+        generation: number;
+      };
+    },
+  ): unknown;
+}
+
+export interface RendererTaskFeedUiPerfStats {
+  mainDeltaToUi: number;
+  dbPollCreated: number;
+  dbPollUpdatedAsCreated: number;
+  workflowMetadataPublishes: number;
+  workflowMetadataCoalescedRequests: number;
+  [key: string]: number;
+}
+
+export interface RendererTaskFeedDeps {
+  logger: Logger;
+  getPersistence: () => RendererTaskFeedPersistence;
+  getMessageBus: () => Pick<MessageBus, 'publish' | 'request'>;
+  getOrchestrator: () => RendererTaskFeedOrchestrator;
+  taskHandles: { has(taskId: string): boolean };
+  taskGraphEventPublisher: Pick<TaskGraphEventPublisher, 'publishDelta'>;
+  getMainWindow: () => BrowserWindow | null;
+  setStartupWorkflowId: (workflowId: string | null) => void;
+  requestWorkflowMetadataPublish: (reason: string) => void;
+  scheduleAutoFix: (taskId: string) => void;
+  logAutoFixDebug: (taskId: string, phase: string, details?: Record<string, unknown>) => void;
+  uiPerfStats: RendererTaskFeedUiPerfStats;
+  traceUiDeltaFlow: boolean;
+  traceDbPollPerTask: boolean;
+  traceTaskOutput: boolean;
+  executingStallTimeoutMs: number;
+  pollLaunchDispatcher: () => void;
+}
+
+export interface RendererTaskFeed {
+  enqueueTaskOutput(taskId: string, data: string): void;
+  flushTaskOutput(taskId: string): void;
+  seedUiSnapshotCache(): void;
+  hydrateDetachedViewerFromOwner(): Promise<void>;
+  getDetachedViewerTasks(): TaskState[];
+  getDetachedViewerWorkflows(): unknown[] | null;
+  publishTaskDeltaToRenderer(delta: TaskDelta): void;
+  getLastKnownWorkflowCount(): number;
+  setLastKnownWorkflowCount(count: number): void;
+  getTaskSnapshot(taskId: string): string | undefined;
+  listKnownTaskIds(): string[];
+  clearTaskSnapshots(): void;
+  replaceWorkflowRollups(tasks: TaskState[]): void;
+  rememberTaskState(task: TaskState): void;
+  resetSnapshotState(): void;
+  beginDetachedViewerBuffering(): void;
+  receiveTaskDelta(delta: TaskDelta): void;
+  startDbPolling(): RendererTaskFeedStopHandle;
+  startActivityPolling(): RendererTaskFeedStopHandle;
+  loadTaskByIdFromPersistence(taskId: string): TaskState | undefined;
+}
+
+export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTaskFeed {
+  const lastKnownTaskStates = new TaskSnapshotCache();
+  const workflowRollupProjection = new WorkflowRollupProjection();
+  const pendingOutputBuffers = new Map<string, string[]>();
+  const outputFlushTimers = new Map<string, RendererTaskFeedTimer>();
+  let lastKnownWorkflowCount = 0;
+  let detachedViewerWorkflows: unknown[] | null = null;
+  let detachedDeltaBuffer: TaskDelta[] | null = null;
+  const getPersistence = (): RendererTaskFeedPersistence => deps.getPersistence();
+  const getMessageBus = (): Pick<MessageBus, 'publish' | 'request'> => deps.getMessageBus();
+  const getOrchestrator = (): RendererTaskFeedOrchestrator => deps.getOrchestrator();
+
+  const flushTaskOutput = (taskId: string): void => {
+    const timer = outputFlushTimers.get(taskId);
+    if (timer) {
+      clearTimeout(timer);
+      outputFlushTimers.delete(taskId);
+    }
+    const chunks = pendingOutputBuffers.get(taskId);
+    if (!chunks || chunks.length === 0) {
+      return;
+    }
+    pendingOutputBuffers.delete(taskId);
+    const data = chunks.join('');
+    if (deps.traceTaskOutput) {
+      deps.logger.info(`${taskId}: ${data.trimEnd()}`, { module: 'output' });
+    }
+    const outputData: TaskOutputData = { taskId, data };
+    getMessageBus().publish(Channels.TASK_OUTPUT, outputData);
+    try {
+      // Runner stream chunks land in the output spool only — task_output is
+      // reserved for explicit diagnostic writes (workflow actions, shutdown).
+      getPersistence().appendOutputChunk(taskId, data);
+    } catch (err) {
+      deps.logger.error(`Failed to persist output for ${taskId}: ${err}`, { module: 'output' });
+    }
+  };
+
+  const enqueueTaskOutput = (taskId: string, data: string): void => {
+    const chunks = pendingOutputBuffers.get(taskId) ?? [];
+    chunks.push(data);
+    pendingOutputBuffers.set(taskId, chunks);
+    if (outputFlushTimers.has(taskId)) {
+      return;
+    }
+    const timer = setTimeout(() => flushTaskOutput(taskId), 100);
+    timer.unref?.();
+    outputFlushTimers.set(taskId, timer);
+  };
+
+  const publishTaskDeltaToRenderer = (delta: TaskDelta): void => {
+    const workflowRollups = workflowRollupProjection.applyDelta(delta);
+    deps.taskGraphEventPublisher.publishDelta(delta, workflowRollups);
+  };
+
+  const applyTaskDeltaToOwnerCacheOrRecover = (delta: TaskDelta): TaskDelta[] => {
+    const { quarantined, accepted } = applyDelta(delta, lastKnownTaskStates);
+    if (quarantined.length === 0) {
+      return accepted ? [delta] : [];
+    }
+
+    const rendererDeltas: TaskDelta[] = [];
+    for (const taskId of quarantined) {
+      deps.logger.info(`[gap-detect] quarantined task="${taskId}" — triggering authoritative reload`, { module: 'delta-merge' });
+      const { rendererDelta } = recoverQuarantinedTask(lastKnownTaskStates, taskId, {
+        loadTask: (recoveryTaskId) => getPersistence().loadTask(recoveryTaskId),
+        getMergeNode: (workflowId) => getOrchestrator().getMergeNode(workflowId),
+      });
+      if (rendererDelta) {
+        rendererDeltas.push(rendererDelta);
+      }
+    }
+    return rendererDeltas;
+  };
+
+  const seedUiSnapshotCache = (): void => {
+    lastKnownWorkflowCount = getPersistence().listWorkflows().length;
+    seedTaskCachesFromSnapshot(getOrchestrator().getAllTasks(), { lastKnownTaskStates, workflowRollupProjection });
+  };
+
+  // Detached viewer: the local DB is empty, so seed the delta caches and
+  // bootstrap snapshot from the owner. Without this, the empty cache quarantines
+  // every `updated` delta for a task the viewer has not seen (dropping live
+  // updates), and bootstrap getters return nothing. Failures are non-fatal — the
+  // renderer's delegated reads still populate the view.
+  const hydrateDetachedViewerFromOwner = async (): Promise<void> => {
+    try {
+      const snapshot = await getMessageBus().request<{ kind: string }, { tasks?: TaskState[]; workflows?: unknown[] }>(
+        'headless.query',
+        { kind: 'tasks' },
+      );
+      const tasks = Array.isArray(snapshot?.tasks) ? snapshot.tasks : [];
+      const workflows = Array.isArray(snapshot?.workflows) ? snapshot.workflows : [];
+      detachedViewerWorkflows = workflows;
+      seedTaskCachesFromSnapshot(tasks, { lastKnownTaskStates, workflowRollupProjection });
+      lastKnownWorkflowCount = workflows.length;
+      deps.setStartupWorkflowId(
+        [...workflows]
+          .map((wf) => wf as { id?: string; updatedAt?: string; createdAt?: string })
+          .sort((left, right) => (Date.parse(right.updatedAt ?? '') || 0) - (Date.parse(left.updatedAt ?? '') || 0))[0]?.id ?? null,
+      );
+      deps.logger.info(
+        `[init] Hydrated detached viewer from owner: ${tasks.length} tasks across ${workflows.length} workflows`,
+        { module: 'init' },
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      deps.logger.warn(`detached viewer hydration from owner failed; relying on delegated reads: ${message}`, { module: 'init' });
+    } finally {
+      // Resume direct delta processing and replay anything buffered during
+      // hydration (in arrival order). Always runs, so a hydration failure can
+      // never leave deltas buffered forever.
+      const buffered = detachedDeltaBuffer ?? [];
+      detachedDeltaBuffer = null;
+      for (const delta of buffered) processIncomingTaskDelta(delta);
+    }
+  };
+
+  // Current task states for the detached viewer's bootstrap getter, derived from
+  // the live delta cache so a renderer reload never sees the stale hydration
+  // snapshot.
+  const getDetachedViewerTasks = (): TaskState[] => [...lastKnownTaskStates.keys()].map(
+    (taskId) => JSON.parse(lastKnownTaskStates.get(taskId) ?? '{}') as TaskState,
+  );
+
+  // Apply one owner task delta to the local cache and forward results to the
+  // renderer (and drive owner-side auto-fix). Extracted so the detached viewer
+  // can replay deltas that were buffered during hydration.
+  const processIncomingTaskDelta = (delta: TaskDelta): void => {
+    deps.uiPerfStats.mainDeltaToUi += 1;
+    if (deps.traceUiDeltaFlow) {
+      deps.logger.debug(`delta→ui: ${JSON.stringify(delta)}`, { module: 'ui' });
+    }
+    const deltaTaskId = delta.type === 'updated' || delta.type === 'removed' ? delta.taskId : undefined;
+    if (delta.type === 'updated' && delta.changes.status === 'failed') {
+      const cancellationError = shouldSkipAutoFixForError(delta.changes.execution?.error);
+      const shouldAutoFixFromOrchestrator = getOrchestrator().shouldAutoFix(delta.taskId);
+      deps.logAutoFixDebug(delta.taskId, 'delta-failed', {
+        shouldSkipForCancellation: cancellationError,
+        shouldAutoFixFromOrchestrator,
+      });
+      if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
+        deps.logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
+        deps.scheduleAutoFix(deltaTaskId);
+      } else if (deltaTaskId) {
+        deps.logAutoFixDebug(deltaTaskId, 'delta-skip', {
+          reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
+          shouldSkipForCancellation: cancellationError,
+          shouldAutoFixFromOrchestrator,
+        });
+      }
+    }
+    for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(delta)) {
+      publishTaskDeltaToRenderer(rendererDelta);
+    }
+  };
+
+  const parseExecutionDate = (value: unknown): Date | undefined => {
+    if (!value) return undefined;
+    if (value instanceof Date) return value;
+    if (typeof value !== 'string') return undefined;
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+  };
+
+  const startDbPolling = (): RendererTaskFeedStopHandle => {
+    const interval = setInterval(() => {
+      const mainWindow = deps.getMainWindow();
+      if (!mainWindow || mainWindow.isDestroyed()) return;
+      try {
+        const workflows = getPersistence().listWorkflows();
+
+        if (workflows.length !== lastKnownWorkflowCount) {
+          const msg = `Workflow count changed: ${lastKnownWorkflowCount} → ${workflows.length}`;
+          deps.logger.info(msg, { module: 'db-poll' });
+          try { getPersistence().writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
+          lastKnownWorkflowCount = workflows.length;
+          deps.requestWorkflowMetadataPublish('db-poll-count');
+
+          getOrchestrator().syncAllFromDb();
+          deps.logger.info(`Synced orchestrator for all ${workflows.length} workflows`, { module: 'db-poll' });
+        }
+
+        for (const workflow of workflows) {
+          if (workflow.status === 'completed' || workflow.status === 'failed') continue;
+          const tasks = getPersistence().loadTasks(workflow.id);
+          for (const loadedTask of tasks) {
+            const task = loadedTask;
+            const now = new Date();
+            const previousHeartbeat = parseExecutionDate(task.execution.lastHeartbeatAt);
+            const selectedAttempt = taskNeedsExecutingStallCheck(task) && task.execution.selectedAttemptId
+              ? getPersistence().loadAttempt?.(task.execution.selectedAttemptId)
+              : undefined;
+            const leaseExpiresAt = parseExecutionDate(selectedAttempt?.leaseExpiresAt);
+            const remoteHeartbeat = parseExecutionDate(task.execution.remoteHeartbeatAt);
+
+            if (task.status === 'running' || (task.status === 'pending' && task.execution.phase === 'launching')) {
+              // CC.1: launch-stall watchdog removed. The
+              // LaunchDispatcher's reapExpiredLeases /
+              // abandonStuckLeases reapers (Phase B, CB.3) are the
+              // sole recovery path for stalled launch claims.
+              const executingStartedAt = parseExecutionDate(task.execution.startedAt);
+              const executingAgeMs = executingStartedAt ? now.getTime() - executingStartedAt.getTime() : 0;
+              const { heartbeatStale, leaseExpired, executingStalled, staleReason } = evaluateExecutingStall({
+                now,
+                phase: task.execution.phase,
+                runnerKind: task.config.runnerKind,
+                executingStartedAt,
+                leaseExpiresAt,
+                executorHeartbeatAt: previousHeartbeat,
+                remoteHeartbeatAt: remoteHeartbeat,
+                executingStallTimeoutMs: deps.executingStallTimeoutMs,
+              });
+
+              if (executingStalled) {
+                const selectedAttemptHeartbeat = parseExecutionDate(selectedAttempt?.lastHeartbeatAt);
+                const executingError =
+                  `Execution stalled: task remained in running/executing for ${Math.floor(executingAgeMs / 1000)}s ` +
+                  `without a live execution handle and no completion signal from executor (${staleReason}).`;
+                deps.logger.info(
+                  `[executing-stall] detected task="${task.id}" phase=${task.execution.phase} executingAgeMs=${executingAgeMs} ` +
+                    `handlePresent=${deps.taskHandles.has(task.id)} leaseExpired=${leaseExpired} heartbeatStale=${heartbeatStale} ` +
+                    `runnerKind=${task.config.runnerKind ?? 'none'} selectedAttemptId=${task.execution.selectedAttemptId ?? 'none'} ` +
+                    `attemptStatus=${selectedAttempt?.status ?? 'none'} executorHeartbeatAt=${previousHeartbeat?.toISOString() ?? 'none'} ` +
+                    `remoteHeartbeatAt=${remoteHeartbeat?.toISOString() ?? 'none'} attemptHeartbeatAt=${selectedAttemptHeartbeat?.toISOString() ?? 'none'} ` +
+                    `leaseExpiresAt=${leaseExpiresAt?.toISOString() ?? 'none'} launchStartedAt=${task.execution.launchStartedAt instanceof Date ? task.execution.launchStartedAt.toISOString() : task.execution.launchStartedAt ?? 'none'} ` +
+                    `launchCompletedAt=${task.execution.launchCompletedAt instanceof Date ? task.execution.launchCompletedAt.toISOString() : task.execution.launchCompletedAt ?? 'none'} ` +
+                    `startedAt=${executingStartedAt?.toISOString() ?? 'none'} completedAt=${task.execution.completedAt instanceof Date ? task.execution.completedAt.toISOString() : task.execution.completedAt ?? 'none'}`,
+                  { module: 'db-poll' },
+                );
+                const failedResponse: WorkResponse = {
+                  requestId: `executing-stall-${task.id}-${now.getTime()}`,
+                  actionId: task.id,
+                  attemptId: task.execution.selectedAttemptId,
+                  executionGeneration: task.execution.generation ?? 0,
+                  status: 'failed',
+                  outputs: {
+                    exitCode: 1,
+                    error: executingError,
+                    failureClass: 'liveness_stall',
+                  },
+                };
+                deps.logger.error(`[executing-stall] forcing failure for "${task.id}": ${executingError}`, { module: 'db-poll' });
+                persistShutdownDiagnostic(task, getPersistence(), {
+                  flushPendingOutput: flushTaskOutput,
+                  forcedStopReason: executingError,
+                  label: task.execution.phase === 'launching'
+                    ? 'Startup Failure Diagnostic'
+                    : 'Shutdown Diagnostic',
+                });
+                getOrchestrator().handleWorkerResponse(failedResponse);
+                continue;
+              }
+            }
+
+            // Stalled-fix-session watchdog: a fix session whose owner died
+            // mid-fix (heartbeat stopped, attempt lease expired) is invisible
+            // to the running-task path above because its status is
+            // `fixing_with_ai`, not `running`. Evaluate it as an executing
+            // task; a live fix refreshes its lease every 30s via
+            // withAttemptHeartbeat, so only an orphaned one is ever stalled.
+            if (task.status === 'fixing_with_ai') {
+              const fixStartedAt = parseExecutionDate(task.execution.startedAt);
+              const { executingStalled, staleReason } = evaluateExecutingStall({
+                now,
+                phase: 'executing',
+                runnerKind: task.config.runnerKind,
+                executingStartedAt: fixStartedAt,
+                leaseExpiresAt,
+                executorHeartbeatAt: previousHeartbeat,
+                remoteHeartbeatAt: remoteHeartbeat,
+                executingStallTimeoutMs: deps.executingStallTimeoutMs,
+              });
+              if (executingStalled) {
+                const fixAgeMs = fixStartedAt ? now.getTime() - fixStartedAt.getTime() : 0;
+                const reason =
+                  `Fix session stalled: task remained in fixing_with_ai for ${Math.floor(fixAgeMs / 1000)}s ` +
+                  `without a live fix handle (${staleReason}).`;
+                deps.logger.error(`[fix-session-stall] reclaiming "${task.id}": ${reason}`, { module: 'db-poll' });
+                const outcome = getOrchestrator().reclaimStalledFixSession(task.id, {
+                  reason,
+                  expectedLineage: {
+                    taskId: task.id,
+                    selectedAttemptId: task.execution.selectedAttemptId,
+                    generation: task.execution.generation ?? 0,
+                  },
+                });
+                deps.logger.info(
+                  `[fix-session-stall] reclaim outcome=${outcome} task="${task.id}" ` +
+                    `selectedAttemptId=${task.execution.selectedAttemptId ?? 'none'} ` +
+                    `leaseExpiresAt=${leaseExpiresAt?.toISOString() ?? 'none'}`,
+                  { module: 'db-poll' },
+                );
+                continue;
+              }
+            }
+
+            const snapshot = JSON.stringify(task);
+            const previous = lastKnownTaskStates.get(task.id);
+            if (!previous) {
+              if (deps.traceDbPollPerTask) {
+                const msg = `New task: ${task.id} (${task.status})`;
+                deps.logger.info(msg, { module: 'db-poll' });
+                try { getPersistence().writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
+              }
+              lastKnownTaskStates.set(task.id, snapshot);
+              deps.uiPerfStats.dbPollCreated += 1;
+              publishTaskDeltaToRenderer({ type: 'created', task });
+            } else if (previous !== snapshot) {
+              if (deps.traceDbPollPerTask) {
+                const msg = `Task updated: ${task.id} (${task.status})`;
+                deps.logger.info(msg, { module: 'db-poll' });
+                try { getPersistence().writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
+              }
+              lastKnownTaskStates.set(task.id, snapshot);
+              deps.uiPerfStats.dbPollUpdatedAsCreated += 1;
+              publishTaskDeltaToRenderer({ type: 'created', task });
+            }
+          }
+        }
+        try {
+          deps.pollLaunchDispatcher();
+        } catch (err) {
+          deps.logger.warn(
+            `[launch-dispatcher] poll() failed: ${err instanceof Error ? err.message : String(err)}`,
+            { module: 'db-poll' },
+          );
+        }
+      } catch {
+        // DB might be locked — skip this tick
+      }
+    }, 2000);
+
+    return {
+      stop() {
+        clearInterval(interval);
+      },
+    };
+  };
+
+  const startActivityPolling = (): RendererTaskFeedStopHandle => {
+    const interval = setInterval(() => {
+      const snapshot = {
+        ts: new Date().toISOString(),
+        metric: 'main_delta_flow',
+        ...deps.uiPerfStats,
+      };
+      try {
+        getPersistence().writeActivityLog('ui-perf-main', 'info', JSON.stringify(snapshot));
+
+      } catch {
+        // DB might be locked
+      }
+    }, 10000);
+
+    return {
+      stop() {
+        clearInterval(interval);
+      },
+    };
+  };
+
+  return {
+    enqueueTaskOutput,
+    flushTaskOutput,
+    seedUiSnapshotCache,
+    hydrateDetachedViewerFromOwner,
+    loadTaskByIdFromPersistence: (taskId) => getPersistence().loadTask(taskId),
+    getDetachedViewerTasks,
+    getDetachedViewerWorkflows: () => detachedViewerWorkflows,
+    publishTaskDeltaToRenderer,
+    getLastKnownWorkflowCount: () => lastKnownWorkflowCount,
+    setLastKnownWorkflowCount: (count) => { lastKnownWorkflowCount = count; },
+    getTaskSnapshot: (taskId) => lastKnownTaskStates.get(taskId),
+    listKnownTaskIds: () => [...lastKnownTaskStates.keys()],
+    clearTaskSnapshots: () => { lastKnownTaskStates.clear(); },
+    replaceWorkflowRollups: (tasks) => { workflowRollupProjection.replaceAll(tasks); },
+    rememberTaskState: (task) => { lastKnownTaskStates.set(task.id, JSON.stringify(task)); },
+    resetSnapshotState: () => {
+      lastKnownTaskStates.clear();
+      workflowRollupProjection.clear();
+      lastKnownWorkflowCount = 0;
+    },
+    beginDetachedViewerBuffering: () => { detachedDeltaBuffer = []; },
+    receiveTaskDelta: (delta) => {
+      if (detachedDeltaBuffer) {
+        detachedDeltaBuffer.push(delta);
+        return;
+      }
+      processIncomingTaskDelta(delta);
+    },
+    startDbPolling,
+    startActivityPolling,
+  };
+}


### PR DESCRIPTION
## Summary

This slice relocates the renderer task-feed wiring from `main.ts` into `renderer-task-feed.ts`.

The bug was in the startup wiring, not the UI behavior. The new module read startup services too early, so the app window crashed before render.

The fix keeps the new module, but reads persistence, message bus, and orchestrator through getters at call time. The renderer still behaves the same.

## Review Claim

Keep the renderer task-feed wiring in `renderer-task-feed.ts`, with unchanged renderer behavior.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

Pure wiring relocation. The renderer task delta cache, viewer hydration path, and poll-loop behavior stay pinned by focused Vitest coverage and focused UI proof.

## Slice Rationale

One renderer feed cluster per slice. Keeping output buffering, task deltas, and poll wakeups together avoids temporary cross-module plumbing.

## Non-goals

- No behavior change.
- No IPC mutation handler changes.
- No terminal backend changes.
- No change to delta merge semantics, flush cadence, or detached-viewer recovery behavior.

## Architecture

### Before

`main.ts` handled renderer task output buffering, delta publication, detached-viewer hydration, and the DB/activity poll loops directly.

### After

`main.ts` now calls `renderer-task-feed.ts` for that renderer feed cluster, and the module reads live services through getter hooks when each path runs.

```mermaid
flowchart LR
  M["main.ts"] --> WL["window/window-lifecycle.ts"]
  M --> RTF["renderer-task-feed.ts"]
  RTF --> R["renderer updates via webContents.send"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec -- vitest run src/__tests__/delta-merge.test.ts src/__tests__/viewer-cache-hydration.test.ts src/__tests__/workflow-rollup-projection.test.ts src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts`
- [x] `cd packages/app && CAPTURE_MODE=after CAPTURE_VIDEO=1 npx playwright test e2e/visual-proof.spec.ts -g "task running$|task complete$|task panel$"`

</details>

## Visual Proof

Running state still reaches the renderer after the wiring relocation.

![Running workflow card still shows the active task state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-05c750/task-running.png)

Completed state still rolls forward through the same renderer feed.

![Completed upstream task still updates inside the workflow mini-DAG](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-05c750/task-complete.png)

Task details still hydrate the command panel from the new renderer feed module.

![Task inspector still shows the command and logs for the selected task](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-05c750/task-panel.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 97b7abae`
- Post-revert steps: Re-run the focused Vitest command to confirm the renderer feed returned to the previous location cleanly.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved synchronization of task and workflow updates in the app.
  - Detached task views now hydrate more reliably and retain updates received during loading.
  - Task output updates are delivered and saved more consistently.
  - Enhanced recovery for interrupted or stalled task executions helps keep status information accurate.
  - Database and activity monitoring now provide more dependable updates to the interface.

- **Bug Fixes**
  - Resolved a synchronization issue that could cause synthetic merge tasks to enter a quarantine loop or display incorrect created/removed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->