### PR TITLE
[Godfile app step 2: extract renderer-task-feed](2) Wire main to renderer task-feed

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -129,7 +129,6 @@ import {
   type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 import { FileAndDbLogger } from './logger.js';
-import type { TaskOutputData } from './types.js';
 import {
   DEFAULT_SLACK_HARNESS_PRESETS,
   loadConfig,
@@ -217,10 +216,7 @@ import { runInvokerCliSetup } from './invoker-cli-setup.js';
 import { resolveBundledCliPath } from './cli-helper.js';
 import { buildAppMenuTemplate } from './app-menu.js';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
-import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from './delta-merge.js';
 import { CoalescedWorkflowMetadataPublisher } from './workflow-metadata-invalidation.js';
-import { WorkflowRollupProjection } from './workflow-rollup-projection.js';
-import { seedTaskCachesFromSnapshot } from './viewer-cache-hydration.js';
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
@@ -235,8 +231,6 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
-import { evaluateExecutingStall, taskNeedsExecutingStallCheck } from './executing-stall.js';
-
 
 import {
   buildFixWithAgentMutationArgs,
@@ -320,6 +314,10 @@ import {
   registerMainWindowActivateHandler,
   registerMainWindowSecondInstanceHandler,
 } from './window/window-lifecycle.js';
+import {
+  createRendererTaskFeed,
+  type RendererTaskFeedStopHandle,
+} from './window/renderer-task-feed.js';
 import { tryAcquireGuiInstanceLock, type GuiInstanceLock } from './gui-instance-lock.js';
 import { logProcessError } from './process-error-handling.js';
 
@@ -2050,10 +2048,8 @@ function createEmbeddedTerminalBackendFromConfig(
   // `activeExecutions` count now just reflects spawned execution
   // handles in `taskHandles`.
   const guiMutationHandlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
-  let dbPollInterval: ReturnType<typeof setInterval> | null = null;
-  let uiPerfLogInterval: ReturnType<typeof setInterval> | null = null;
-  const lastKnownTaskStates = new TaskSnapshotCache();
-  const workflowRollupProjection = new WorkflowRollupProjection();
+  let dbPollHandle: RendererTaskFeedStopHandle | null = null;
+  let activityPollHandle: RendererTaskFeedStopHandle | null = null;
   const deferredWorkflowLaunches = new Map<string, {
     timer: ReturnType<typeof setTimeout>;
     taskIds: string[];
@@ -2069,20 +2065,9 @@ function createEmbeddedTerminalBackendFromConfig(
       { module: 'ipc-delegate' },
     );
   };
-  const pendingOutputBuffers = new Map<string, string[]>();
-  const outputFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
   let workflowMetadataPublisher: CoalescedWorkflowMetadataPublisher | null = null;
-  let lastKnownWorkflowCount = 0;
   let startupWorkflowId: string | null = null;
   const startupWorkflowCache = createStartupWorkflowCache();
-  // In detached viewer mode the local DB is an empty in-memory copy. Workflow
-  // metadata for the bootstrap getter comes from the owner snapshot; task state
-  // is derived live from `lastKnownTaskStates` (kept current by deltas).
-  let detachedViewerWorkflows: unknown[] | null = null;
-  // While the detached viewer hydrates, owner deltas are buffered here and
-  // replayed after the cache is seeded, so an update arriving mid-hydration is
-  // not applied against an empty cache (quarantined and dropped).
-  let detachedDeltaBuffer: TaskDelta[] | null = null;
   let uiInteractive = false;
   let deferredStartupTriggered = false;
   const traceUiDeltaFlow = process.env.INVOKER_TRACE_UI_DELTA === '1';
@@ -2189,44 +2174,6 @@ function createEmbeddedTerminalBackendFromConfig(
     ts: new Date().toISOString(),
   });
 
-  const flushTaskOutput = (taskId: string): void => {
-    const timer = outputFlushTimers.get(taskId);
-    if (timer) {
-      clearTimeout(timer);
-      outputFlushTimers.delete(taskId);
-    }
-    const chunks = pendingOutputBuffers.get(taskId);
-    if (!chunks || chunks.length === 0) {
-      return;
-    }
-    pendingOutputBuffers.delete(taskId);
-    const data = chunks.join('');
-    if (traceTaskOutput) {
-      logger.info(`${taskId}: ${data.trimEnd()}`, { module: 'output' });
-    }
-    const outputData: TaskOutputData = { taskId, data };
-    messageBus.publish(Channels.TASK_OUTPUT, outputData);
-    try {
-      // Runner stream chunks land in the output spool only — task_output is
-      // reserved for explicit diagnostic writes (workflow actions, shutdown).
-      persistence.appendOutputChunk(taskId, data);
-    } catch (err) {
-      logger.error(`Failed to persist output for ${taskId}: ${err}`, { module: 'output' });
-    }
-  };
-
-  const enqueueTaskOutput = (taskId: string, data: string): void => {
-    const chunks = pendingOutputBuffers.get(taskId) ?? [];
-    chunks.push(data);
-    pendingOutputBuffers.set(taskId, chunks);
-    if (outputFlushTimers.has(taskId)) {
-      return;
-    }
-    const timer = setTimeout(() => flushTaskOutput(taskId), 100);
-    timer.unref?.();
-    outputFlushTimers.set(taskId, timer);
-  };
-
   const taskDeltaStream = createTaskDeltaStreamSequence();
   const getTaskDeltaStreamSequence = (): number => taskDeltaStream.current();
 
@@ -2246,35 +2193,34 @@ function createEmbeddedTerminalBackendFromConfig(
     onEvent: (event) => webBridge?.broadcast('invoker:task-graph-event', event),
   });
 
-  const publishTaskDeltaToRenderer = (delta: TaskDelta): void => {
-    const workflowRollups = workflowRollupProjection.applyDelta(delta);
-    taskGraphEventPublisher.publishDelta(delta, workflowRollups);
-  };
-
-  const applyTaskDeltaToOwnerCacheOrRecover = (delta: TaskDelta): TaskDelta[] => {
-    const { quarantined, accepted } = applyDelta(delta, lastKnownTaskStates);
-    if (quarantined.length === 0) {
-      return accepted ? [delta] : [];
-    }
-
-    const rendererDeltas: TaskDelta[] = [];
-    for (const taskId of quarantined) {
-      logger.info(`[gap-detect] quarantined task="${taskId}" — triggering authoritative reload`, { module: 'delta-merge' });
-      const { rendererDelta } = recoverQuarantinedTask(lastKnownTaskStates, taskId, {
-        loadTask: loadTaskByIdFromPersistence,
-        getMergeNode: (workflowId) => orchestrator.getMergeNode(workflowId),
-      });
-      if (rendererDelta) {
-        rendererDeltas.push(rendererDelta);
-      }
-    }
-    return rendererDeltas;
-  };
-
   const requestWorkflowMetadataPublish = (reason: string): void => {
     uiPerfStats.workflowMetadataPublishRequests += 1;
     workflowMetadataPublisher?.requestPublish(reason);
   };
+
+  const rendererTaskFeed = createRendererTaskFeed({
+    logger,
+    persistence,
+    messageBus,
+    orchestrator,
+    taskHandles,
+    taskGraphEventPublisher,
+    getMainWindow: () => mainWindow,
+    setStartupWorkflowId: (workflowId) => { startupWorkflowId = workflowId; },
+    requestWorkflowMetadataPublish,
+    scheduleAutoFix: (taskId) => scheduleAutoFix(taskId),
+    logAutoFixDebug: (taskId, phase, details) => logAutoFixDebug(taskId, phase, details),
+    uiPerfStats,
+    traceUiDeltaFlow,
+    traceDbPollPerTask,
+    traceTaskOutput,
+    executingStallTimeoutMs,
+    pollLaunchDispatcher: () => {
+      if (launchDispatcher) {
+        launchDispatcher.poll();
+      }
+    },
+  });
 
   const buildAutoFixQueueSnapshot = (taskId: string): Record<string, unknown> => {
     const workflowId = workflowIdForTaskArg(taskId);
@@ -2480,8 +2426,8 @@ function createEmbeddedTerminalBackendFromConfig(
       logger,
       messageBus,
       taskHandles,
-      enqueueTaskOutput,
-      flushTaskOutput,
+      enqueueTaskOutput: rendererTaskFeed.enqueueTaskOutput,
+      flushTaskOutput: rendererTaskFeed.flushTaskOutput,
       assertFatalExecutionCapacity,
       getTaskRunner: () => taskExecutor,
       setTaskRunner: (runner) => { taskExecutor = runner; },
@@ -2847,7 +2793,7 @@ function createEmbeddedTerminalBackendFromConfig(
       case 'invoker:stop-worker':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resume-workflow': {
-        const workflows = detachedViewerWorkflows ?? persistence.listWorkflows();
+        const workflows = rendererTaskFeed.getDetachedViewerWorkflows() ?? persistence.listWorkflows();
         const firstWorkflow = workflows[0] as { id?: unknown } | undefined;
         const workflowId = startupWorkflowId
           ?? (typeof firstWorkflow?.id === 'string' ? firstWorkflow.id : undefined);
@@ -3008,96 +2954,10 @@ function createEmbeddedTerminalBackendFromConfig(
     });
   }
 
-  function seedUiSnapshotCache(): void {
-    lastKnownWorkflowCount = persistence.listWorkflows().length;
-    seedTaskCachesFromSnapshot(orchestrator.getAllTasks(), { lastKnownTaskStates, workflowRollupProjection });
-  }
-
-  // Detached viewer: the local DB is empty, so seed the delta caches and
-  // bootstrap snapshot from the owner. Without this, the empty cache quarantines
-  // every `updated` delta for a task the viewer has not seen (dropping live
-  // updates), and bootstrap getters return nothing. Failures are non-fatal — the
-  // renderer's delegated reads still populate the view.
-  async function hydrateDetachedViewerFromOwner(): Promise<void> {
-    try {
-      const snapshot = await messageBus.request<{ kind: string }, { tasks?: TaskState[]; workflows?: unknown[] }>(
-        'headless.query',
-        { kind: 'tasks' },
-      );
-      const tasks = Array.isArray(snapshot?.tasks) ? snapshot.tasks : [];
-      const workflows = Array.isArray(snapshot?.workflows) ? snapshot.workflows : [];
-      detachedViewerWorkflows = workflows;
-      seedTaskCachesFromSnapshot(tasks, { lastKnownTaskStates, workflowRollupProjection });
-      lastKnownWorkflowCount = workflows.length;
-      startupWorkflowId = [...workflows]
-        .map((wf) => wf as { id?: string; updatedAt?: string; createdAt?: string })
-        .sort((left, right) => (Date.parse(right.updatedAt ?? '') || 0) - (Date.parse(left.updatedAt ?? '') || 0))[0]?.id ?? null;
-      logger.info(
-        `[init] Hydrated detached viewer from owner: ${tasks.length} tasks across ${workflows.length} workflows`,
-        { module: 'init' },
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.warn(`detached viewer hydration from owner failed; relying on delegated reads: ${message}`, { module: 'init' });
-    } finally {
-      // Resume direct delta processing and replay anything buffered during
-      // hydration (in arrival order). Always runs, so a hydration failure can
-      // never leave deltas buffered forever.
-      const buffered = detachedDeltaBuffer ?? [];
-      detachedDeltaBuffer = null;
-      for (const delta of buffered) processIncomingTaskDelta(delta);
-    }
-  }
-
-  // Current task states for the detached viewer's bootstrap getter, derived from
-  // the live delta cache so a renderer reload never sees the stale hydration
-  // snapshot.
-  function detachedViewerTasks(): TaskState[] {
-    return [...lastKnownTaskStates.keys()].map(
-      (taskId) => JSON.parse(lastKnownTaskStates.get(taskId) ?? '{}') as TaskState,
-    );
-  }
-
-  // Apply one owner task delta to the local cache and forward results to the
-  // renderer (and drive owner-side auto-fix). Extracted so the detached viewer
-  // can replay deltas that were buffered during hydration.
-  function processIncomingTaskDelta(d: TaskDelta): void {
-    uiPerfStats.mainDeltaToUi += 1;
-    if (traceUiDeltaFlow) {
-      logger.debug(`delta→ui: ${JSON.stringify(d)}`, { module: 'ui' });
-    }
-    const deltaTaskId = d.type === 'updated' || d.type === 'removed' ? d.taskId : undefined;
-    if (d.type === 'updated' && d.changes.status === 'failed') {
-      const cancellationError = shouldSkipAutoFixForError(d.changes.execution?.error);
-      const shouldAutoFixFromOrchestrator = orchestrator.shouldAutoFix(d.taskId);
-      logAutoFixDebug(d.taskId, 'delta-failed', {
-        shouldSkipForCancellation: cancellationError,
-        shouldAutoFixFromOrchestrator,
-      });
-      if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
-        logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
-        scheduleAutoFix(deltaTaskId);
-      } else if (deltaTaskId) {
-        logAutoFixDebug(deltaTaskId, 'delta-skip', {
-          reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
-          shouldSkipForCancellation: cancellationError,
-          shouldAutoFixFromOrchestrator,
-        });
-      }
-    }
-    for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(d)) {
-      publishTaskDeltaToRenderer(rendererDelta);
-    }
-  }
-
-  function loadTaskByIdFromPersistence(taskId: string): TaskState | undefined {
-    return persistence.loadTask(taskId);
-  }
-
   workflowMetadataPublisher = new CoalescedWorkflowMetadataPublisher({
     listWorkflows: () => persistence.listWorkflows(),
     publish: (workflows, stats) => {
-      lastKnownWorkflowCount = workflows.length;
+      rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
       uiPerfStats.workflowMetadataPublishes += 1;
       uiPerfStats.workflowMetadataCoalescedRequests += Math.max(0, stats.coalescedRequests - 1);
       if (stats.coalescedRequests > 1) {
@@ -3130,7 +2990,7 @@ function createEmbeddedTerminalBackendFromConfig(
   function bootstrapInitialWorkflowState(): void {
     const workflows = listWorkflowsByStartupRecency();
     startupWorkflowCache.set(workflows);
-    lastKnownWorkflowCount = workflows.length;
+    rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
     startupWorkflowId = workflows[0]?.id ?? null;
     if (!startupWorkflowId) {
       logger.info('[init] No workflows available for initial startup bootstrap', { module: 'init' });
@@ -3185,21 +3045,20 @@ function createEmbeddedTerminalBackendFromConfig(
   function publishOrchestratorSnapshotToRenderer(): void {
     const workflows = persistence.listWorkflows();
     const tasks = orchestrator.getAllTasks();
-    const previousTaskIds = new Set(lastKnownTaskStates.keys());
-    lastKnownTaskStates.clear();
-    workflowRollupProjection.replaceAll(tasks);
+    const previousTaskIds = new Set(rendererTaskFeed.listKnownTaskIds());
+    rendererTaskFeed.clearTaskSnapshots();
+    rendererTaskFeed.replaceWorkflowRollups(tasks);
     for (const task of tasks) {
-      const snapshot = JSON.stringify(task);
       previousTaskIds.delete(task.id);
-      lastKnownTaskStates.set(task.id, snapshot);
+      rendererTaskFeed.rememberTaskState(task);
       if (mainWindow && !mainWindow.isDestroyed()) {
-        publishTaskDeltaToRenderer({ type: 'created', task });
+        rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'created', task });
       }
     }
-    lastKnownWorkflowCount = workflows.length;
+    rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
     if (mainWindow && !mainWindow.isDestroyed()) {
       for (const removedTaskId of previousTaskIds) {
-        publishTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
+        rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
       }
       requestWorkflowMetadataPublish('orchestrator-snapshot');
     }
@@ -3308,175 +3167,7 @@ function createEmbeddedTerminalBackendFromConfig(
 
       setTimeout(() => {
         if (ownerMode) {
-          dbPollInterval = setInterval(() => {
-          if (!mainWindow || mainWindow.isDestroyed()) return;
-          try {
-            const workflows = persistence.listWorkflows();
-
-            if (workflows.length !== lastKnownWorkflowCount) {
-              const msg = `Workflow count changed: ${lastKnownWorkflowCount} → ${workflows.length}`;
-              logger.info(msg, { module: 'db-poll' });
-              try { persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
-              lastKnownWorkflowCount = workflows.length;
-              requestWorkflowMetadataPublish('db-poll-count');
-
-              orchestrator.syncAllFromDb();
-              logger.info(`Synced orchestrator for all ${workflows.length} workflows`, { module: 'db-poll' });
-            }
-
-            for (const wf of workflows) {
-              if (wf.status === 'completed' || wf.status === 'failed') continue;
-              const tasks = persistence.loadTasks(wf.id);
-              for (const loadedTask of tasks) {
-                let task = loadedTask;
-                const now = new Date();
-                const previousHeartbeat = parseExecutionDate(task.execution.lastHeartbeatAt);
-                const selectedAttempt = taskNeedsExecutingStallCheck(task) && task.execution.selectedAttemptId
-                  ? persistence.loadAttempt?.(task.execution.selectedAttemptId)
-                  : undefined;
-                const leaseExpiresAt = parseExecutionDate(selectedAttempt?.leaseExpiresAt);
-                const remoteHeartbeat = parseExecutionDate(task.execution.remoteHeartbeatAt);
-
-                if (task.status === 'running' || (task.status === 'pending' && task.execution.phase === 'launching')) {
-                  // CC.1: launch-stall watchdog removed. The
-                  // LaunchDispatcher's reapExpiredLeases /
-                  // abandonStuckLeases reapers (Phase B, CB.3) are the
-                  // sole recovery path for stalled launch claims.
-                  const executingStartedAt = parseExecutionDate(task.execution.startedAt);
-                  const executingAgeMs = executingStartedAt ? now.getTime() - executingStartedAt.getTime() : 0;
-                  const { heartbeatStale, leaseExpired, executingStalled, staleReason } = evaluateExecutingStall({
-                    now,
-                    phase: task.execution.phase,
-                    runnerKind: task.config.runnerKind,
-                    executingStartedAt,
-                    leaseExpiresAt,
-                    executorHeartbeatAt: previousHeartbeat,
-                    remoteHeartbeatAt: remoteHeartbeat,
-                    executingStallTimeoutMs,
-                  });
-
-                  if (executingStalled) {
-                    const selectedAttemptHeartbeat = parseExecutionDate(selectedAttempt?.lastHeartbeatAt);
-                    const executingError =
-                      `Execution stalled: task remained in running/executing for ${Math.floor(executingAgeMs / 1000)}s ` +
-                      `without a live execution handle and no completion signal from executor (${staleReason}).`;
-                    logger.info(
-                      `[executing-stall] detected task="${task.id}" phase=${task.execution.phase} executingAgeMs=${executingAgeMs} ` +
-                        `handlePresent=${taskHandles.has(task.id)} leaseExpired=${leaseExpired} heartbeatStale=${heartbeatStale} ` +
-                        `runnerKind=${task.config.runnerKind ?? 'none'} selectedAttemptId=${task.execution.selectedAttemptId ?? 'none'} ` +
-                        `attemptStatus=${selectedAttempt?.status ?? 'none'} executorHeartbeatAt=${previousHeartbeat?.toISOString() ?? 'none'} ` +
-                        `remoteHeartbeatAt=${remoteHeartbeat?.toISOString() ?? 'none'} attemptHeartbeatAt=${selectedAttemptHeartbeat?.toISOString() ?? 'none'} ` +
-                        `leaseExpiresAt=${leaseExpiresAt?.toISOString() ?? 'none'} launchStartedAt=${task.execution.launchStartedAt instanceof Date ? task.execution.launchStartedAt.toISOString() : task.execution.launchStartedAt ?? 'none'} ` +
-                        `launchCompletedAt=${task.execution.launchCompletedAt instanceof Date ? task.execution.launchCompletedAt.toISOString() : task.execution.launchCompletedAt ?? 'none'} ` +
-                        `startedAt=${executingStartedAt?.toISOString() ?? 'none'} completedAt=${task.execution.completedAt instanceof Date ? task.execution.completedAt.toISOString() : task.execution.completedAt ?? 'none'}`,
-                      { module: 'db-poll' },
-                    );
-                    const failedResponse: WorkResponse = {
-                      requestId: `executing-stall-${task.id}-${now.getTime()}`,
-                      actionId: task.id,
-                      attemptId: task.execution.selectedAttemptId,
-                      executionGeneration: task.execution.generation ?? 0,
-                      status: 'failed',
-                      outputs: {
-                        exitCode: 1,
-                        error: executingError,
-                        failureClass: 'liveness_stall',
-                      },
-                    };
-                    logger.error(`[executing-stall] forcing failure for "${task.id}": ${executingError}`, { module: 'db-poll' });
-                    if (persistence) {
-                      persistShutdownDiagnostic(task, persistence, {
-                        flushPendingOutput: flushTaskOutput,
-                        forcedStopReason: executingError,
-                        label: task.execution.phase === 'launching'
-                          ? 'Startup Failure Diagnostic'
-                          : 'Shutdown Diagnostic',
-                      });
-                    }
-                    orchestrator.handleWorkerResponse(failedResponse);
-                    continue;
-                  }
-                }
-
-                // Stalled-fix-session watchdog: a fix session whose owner died
-                // mid-fix (heartbeat stopped, attempt lease expired) is invisible
-                // to the running-task path above because its status is
-                // `fixing_with_ai`, not `running`. Evaluate it as an executing
-                // task; a live fix refreshes its lease every 30s via
-                // withAttemptHeartbeat, so only an orphaned one is ever stalled.
-                if (task.status === 'fixing_with_ai') {
-                  const fixStartedAt = parseExecutionDate(task.execution.startedAt);
-                  const { executingStalled, staleReason } = evaluateExecutingStall({
-                    now,
-                    phase: 'executing',
-                    runnerKind: task.config.runnerKind,
-                    executingStartedAt: fixStartedAt,
-                    leaseExpiresAt,
-                    executorHeartbeatAt: previousHeartbeat,
-                    remoteHeartbeatAt: remoteHeartbeat,
-                    executingStallTimeoutMs,
-                  });
-                  if (executingStalled) {
-                    const fixAgeMs = fixStartedAt ? now.getTime() - fixStartedAt.getTime() : 0;
-                    const reason =
-                      `Fix session stalled: task remained in fixing_with_ai for ${Math.floor(fixAgeMs / 1000)}s ` +
-                      `without a live fix handle (${staleReason}).`;
-                    logger.error(`[fix-session-stall] reclaiming "${task.id}": ${reason}`, { module: 'db-poll' });
-                    const outcome = orchestrator.reclaimStalledFixSession(task.id, {
-                      reason,
-                      expectedLineage: {
-                        taskId: task.id,
-                        selectedAttemptId: task.execution.selectedAttemptId,
-                        generation: task.execution.generation ?? 0,
-                      },
-                    });
-                    logger.info(
-                      `[fix-session-stall] reclaim outcome=${outcome} task="${task.id}" ` +
-                        `selectedAttemptId=${task.execution.selectedAttemptId ?? 'none'} ` +
-                        `leaseExpiresAt=${leaseExpiresAt?.toISOString() ?? 'none'}`,
-                      { module: 'db-poll' },
-                    );
-                    continue;
-                  }
-                }
-
-                const snapshot = JSON.stringify(task);
-                const prev = lastKnownTaskStates.get(task.id);
-                if (!prev) {
-                  if (traceDbPollPerTask) {
-                    const msg = `New task: ${task.id} (${task.status})`;
-                    logger.info(msg, { module: 'db-poll' });
-                    try { persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
-                  }
-                  lastKnownTaskStates.set(task.id, snapshot);
-                  uiPerfStats.dbPollCreated += 1;
-                  publishTaskDeltaToRenderer({ type: 'created', task });
-                } else if (prev !== snapshot) {
-                  if (traceDbPollPerTask) {
-                    const msg = `Task updated: ${task.id} (${task.status})`;
-                    logger.info(msg, { module: 'db-poll' });
-                    try { persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
-                  }
-                  lastKnownTaskStates.set(task.id, snapshot);
-                  uiPerfStats.dbPollUpdatedAsCreated += 1;
-                  publishTaskDeltaToRenderer({ type: 'created', task });
-                }
-              }
-            }
-            if (launchDispatcher) {
-              try {
-                launchDispatcher.poll();
-              } catch (err) {
-                logger.warn(
-                  `[launch-dispatcher] poll() failed: ${err instanceof Error ? err.message : String(err)}`,
-                  { module: 'db-poll' },
-                );
-              }
-            }
-          } catch {
-            // DB might be locked — skip this tick
-          }
-          }, 2000);
+          dbPollHandle = rendererTaskFeed.startDbPolling();
         }
 
       }, startupPollDelayMs).unref?.();
@@ -3793,30 +3484,13 @@ function createEmbeddedTerminalBackendFromConfig(
     // the db-poll doesn't re-emit deltas the messageBus already delivered.
     // Detached viewer: buffer owner deltas until hydration seeds the cache.
     if (!ownerMode) {
-      detachedDeltaBuffer = [];
+      rendererTaskFeed.beginDetachedViewerBuffering();
     }
     messageBus.subscribe(Channels.TASK_DELTA, (delta: unknown) => {
-      const d = delta as TaskDelta;
-      if (detachedDeltaBuffer) {
-        detachedDeltaBuffer.push(d);
-        return;
-      }
-      processIncomingTaskDelta(d);
+      rendererTaskFeed.receiveTaskDelta(delta as TaskDelta);
     });
 
-    uiPerfLogInterval = setInterval(() => {
-      const snapshot = {
-        ts: new Date().toISOString(),
-        metric: 'main_delta_flow',
-        ...uiPerfStats,
-      };
-      try {
-        persistence.writeActivityLog('ui-perf-main', 'info', JSON.stringify(snapshot));
-
-      } catch {
-        // DB might be locked
-      }
-    }, 10000);
+    activityPollHandle = rendererTaskFeed.startActivityPolling();
 
     messageBus.subscribe(Channels.TASK_OUTPUT, (data: unknown) => {
       if (mainWindow && !mainWindow.isDestroyed() && uiInteractive) {
@@ -3838,9 +3512,9 @@ function createEmbeddedTerminalBackendFromConfig(
 
     registerBootstrapStateIpc({
       ipcMain,
-      getTasks: () => (ownerMode ? orchestrator.getAllTasks() : detachedViewerTasks()),
+      getTasks: () => (ownerMode ? orchestrator.getAllTasks() : rendererTaskFeed.getDetachedViewerTasks()),
       getWorkflows: () =>
-        detachedViewerWorkflows ?? startupWorkflowCache.takeOrLoad(listWorkflowsByStartupRecency),
+        rendererTaskFeed.getDetachedViewerWorkflows() ?? startupWorkflowCache.takeOrLoad(listWorkflowsByStartupRecency),
       getInitialWorkflowId: () => startupWorkflowId,
       appStartedAtEpochMs: appProcessStartedAt,
       getTaskDeltaStreamSequence,
@@ -4001,7 +3675,7 @@ function createEmbeddedTerminalBackendFromConfig(
       const injectTaskStates = async (updates: Array<{ taskId: string; changes: TaskStateChanges }>): Promise<void> => {
         for (const { taskId, changes } of updates) {
           const before = orchestrator.getTask(taskId);
-          const previousSnapshot = lastKnownTaskStates.get(taskId);
+          const previousSnapshot = rendererTaskFeed.getTaskSnapshot(taskId);
           const previousTaskStateVersion = previousSnapshot
             ? (
                 (JSON.parse(previousSnapshot) as { taskStateVersion?: number }).taskStateVersion
@@ -4086,11 +3760,11 @@ function createEmbeddedTerminalBackendFromConfig(
 
       const allStarted = orchestrator.startExecution();
       const tasks = orchestrator.getAllTasks();
-      workflowRollupProjection.replaceAll(tasks);
+      rendererTaskFeed.replaceWorkflowRollups(tasks);
       for (const task of tasks) {
-        lastKnownTaskStates.set(task.id, JSON.stringify(task));
+        rendererTaskFeed.rememberTaskState(task);
         if (mainWindow && !mainWindow.isDestroyed()) {
-          publishTaskDeltaToRenderer({ type: 'created', task });
+          rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'created', task });
         }
       }
       logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${allStarted.length} started`, { module: 'ipc' });
@@ -4115,7 +3789,7 @@ function createEmbeddedTerminalBackendFromConfig(
           if (isTaskInFlightForForcedStop(task)) {
             logger.info(`stop — failing in-flight task "${task.id}" (${task.status})`, { module: 'ipc' });
             persistShutdownDiagnostic(task, persistence, {
-              flushPendingOutput: flushTaskOutput,
+              flushPendingOutput: rendererTaskFeed.flushTaskOutput,
               forcedStopReason: 'Stopped by user',
             });
             orchestrator.handleWorkerResponse({
@@ -4156,9 +3830,7 @@ function createEmbeddedTerminalBackendFromConfig(
       );
       rebuildTaskRunner();
       taskHandles.clear();
-      lastKnownTaskStates.clear();
-      workflowRollupProjection.clear();
-      lastKnownWorkflowCount = 0;
+      rendererTaskFeed.resetSnapshotState();
       requestWorkflowMetadataPublish('clear');
     });
 
@@ -4206,9 +3878,7 @@ function createEmbeddedTerminalBackendFromConfig(
       assertDeleteAllEnabled();
       await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       taskHandles.clear();
-      lastKnownTaskStates.clear();
-      workflowRollupProjection.clear();
-      lastKnownWorkflowCount = 0;
+      rendererTaskFeed.resetSnapshotState();
       requestWorkflowMetadataPublish('delete-all-workflows');
     });
 
@@ -4217,9 +3887,7 @@ function createEmbeddedTerminalBackendFromConfig(
       assertDeleteAllEnabled();
       await sharedDeleteAllWorkflowsBulk({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       taskHandles.clear();
-      lastKnownTaskStates.clear();
-      workflowRollupProjection.clear();
-      lastKnownWorkflowCount = 0;
+      rendererTaskFeed.resetSnapshotState();
       requestWorkflowMetadataPublish('delete-all-workflows-bulk');
     });
 
@@ -4882,7 +4550,7 @@ function createEmbeddedTerminalBackendFromConfig(
         throw err;
       }
       const workflows = persistence.listWorkflows();
-      lastKnownWorkflowCount = workflows.length;
+      rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
       requestWorkflowMetadataPublish('set-merge-mode');
     });
 
@@ -5344,9 +5012,9 @@ function createEmbeddedTerminalBackendFromConfig(
     );
 
     if (ownerMode) {
-      seedUiSnapshotCache();
+      rendererTaskFeed.seedUiSnapshotCache();
     } else {
-      await hydrateDetachedViewerFromOwner();
+      await rendererTaskFeed.hydrateDetachedViewerFromOwner();
     }
     createWindow();
     recordStartupMark('createWindow.end');
@@ -5402,8 +5070,8 @@ function createEmbeddedTerminalBackendFromConfig(
         if (apiServer) await apiServer.close().catch(() => {});
         embeddedTerminalManager.closeAll({ preserveForRestart: true });
         await workerRuntimeController?.stopAll();
-        if (dbPollInterval) clearInterval(dbPollInterval);
-        if (uiPerfLogInterval) clearInterval(uiPerfLogInterval);
+        dbPollHandle?.stop();
+        activityPollHandle?.stop();
         if (hourlyBackupInterval) {
           clearInterval(hourlyBackupInterval);
           hourlyBackupInterval = null;
@@ -5418,7 +5086,7 @@ function createEmbeddedTerminalBackendFromConfig(
             if (task.status === 'running' || task.status === 'fixing_with_ai') {
               if (persistence) {
                 persistShutdownDiagnostic(task, persistence, {
-                  flushPendingOutput: flushTaskOutput,
+                  flushPendingOutput: rendererTaskFeed.flushTaskOutput,
                   forcedStopReason: 'Application quit',
                 });
               }


### PR DESCRIPTION
## Summary

This switches `packages/app/src/main.ts` to call the new renderer task-feed module instead of running that code inline.

The behavior stays the same.

This slice is only the active `main.ts` routing change.

## Review Claim

Route renderer task-feed work from `packages/app/src/main.ts` into `createRendererTaskFeed(...)` without changing behavior.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

Pure delegation change. The renderer feed keeps the same IPC behavior, the same poll-loop shutdown path, and the same recovery contract. The focused renderer-feed regression tests still pass after this switch.

## Slice Rationale

After the new module exists, this slice can review only the active `main.ts` control-flow change.

## Non-goals

- No behavior change.
- No new IPC surface.
- No terminal or shutdown behavior changes.
- No delta-merge, flush-cadence, or detached-viewer behavior changes.

## Architecture

### Before

`packages/app/src/main.ts` ran the renderer task-feed pipeline inline.

### After

`packages/app/src/main.ts` routes that pipeline through `createRendererTaskFeed(...)`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/delta-merge.test.ts src/__tests__/viewer-cache-hydration.test.ts src/__tests__/workflow-rollup-projection.test.ts src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`

</details>

## Visual Proof

The checked-in UI snapshots below show the renderer task-feed surfaces that still render after the `main.ts` routing change.

`task-running` still shows a live running task in the graph.

![Running task graph still renders](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-ce75b2/task-running.png)

`task-panel` still shows the selected task inspector surface fed by the same pipeline.

![Task inspector still renders](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-ce75b2/task-panel.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 973e75a4`
- Post-revert steps: Re-run the focused vitest command above.
- Data migration? No.

</details>
