### PR TITLE
[Godfile app step 2: extract renderer-task-feed](1) Extract renderer task-feed pipeline

### DIFF
--- a/packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts
+++ b/packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts
@@ -6,8 +6,10 @@
  * lines in ~/.invoker/invoker.log with no intervening recovery, after which
  * the selected workflow's mini-DAG renders blank until the user reloads.
  *
- * Owner-side root cause (current production code at
- * packages/app/src/main.ts:2896–2904):
+ * Owner-side recovery now lives in
+ * packages/app/src/window/renderer-task-feed.ts:158–176. Before
+ * `recoverQuarantinedTask` extracted the contract, the equivalent inline loop
+ * looked like:
  *
  *   const { quarantined } = applyDelta(d, lastKnownTaskStates);
  *   for (const taskId of quarantined) {
@@ -72,9 +74,10 @@ function makeMergeNode(workflowId: string, taskStateVersion: number): TaskState 
 
 /**
  * Faithful mirror of the production main-process recovery loop
- * (packages/app/src/main.ts:2896–2906): apply the delta, then for each
- * quarantined id, run the shared `recoverQuarantinedTask` helper and
- * collect every renderer delta it returns.
+ * (packages/app/src/window/renderer-task-feed.ts:158–176 and :231–256):
+ * apply the delta, then for each quarantined id, run the shared
+ * `recoverQuarantinedTask` helper and collect every renderer delta it
+ * returns.
  *
  * Pre-fix, this file used a `simulateLegacyRecoveryLoop` that inlined the
  * old buggy code (no orchestrator fallback, silent delete on persistence

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -129,7 +129,6 @@ import {
   type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 import { FileAndDbLogger } from './logger.js';
-import type { TaskOutputData } from './types.js';
 import {
   DEFAULT_SLACK_HARNESS_PRESETS,
   loadConfig,
@@ -217,10 +216,7 @@ import { runInvokerCliSetup } from './invoker-cli-setup.js';
 import { resolveBundledCliPath } from './cli-helper.js';
 import { buildAppMenuTemplate } from './app-menu.js';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
-import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from './delta-merge.js';
 import { CoalescedWorkflowMetadataPublisher } from './workflow-metadata-invalidation.js';
-import { WorkflowRollupProjection } from './workflow-rollup-projection.js';
-import { seedTaskCachesFromSnapshot } from './viewer-cache-hydration.js';
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
@@ -235,8 +231,6 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
-import { evaluateExecutingStall, taskNeedsExecutingStallCheck } from './executing-stall.js';
-
 
 import {
   buildFixWithAgentMutationArgs,
@@ -320,6 +314,10 @@ import {
   registerMainWindowActivateHandler,
   registerMainWindowSecondInstanceHandler,
 } from './window/window-lifecycle.js';
+import {
+  createRendererTaskFeed,
+  type RendererTaskFeedStopHandle,
+} from './window/renderer-task-feed.js';
 import { tryAcquireGuiInstanceLock, type GuiInstanceLock } from './gui-instance-lock.js';
 import { logProcessError } from './process-error-handling.js';
 
@@ -2050,10 +2048,8 @@ function createEmbeddedTerminalBackendFromConfig(
   // `activeExecutions` count now just reflects spawned execution
   // handles in `taskHandles`.
   const guiMutationHandlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
-  let dbPollInterval: ReturnType<typeof setInterval> | null = null;
-  let uiPerfLogInterval: ReturnType<typeof setInterval> | null = null;
-  const lastKnownTaskStates = new TaskSnapshotCache();
-  const workflowRollupProjection = new WorkflowRollupProjection();
+  let dbPollHandle: RendererTaskFeedStopHandle | null = null;
+  let activityPollHandle: RendererTaskFeedStopHandle | null = null;
   const deferredWorkflowLaunches = new Map<string, {
     timer: ReturnType<typeof setTimeout>;
     taskIds: string[];
@@ -2069,20 +2065,9 @@ function createEmbeddedTerminalBackendFromConfig(
       { module: 'ipc-delegate' },
     );
   };
-  const pendingOutputBuffers = new Map<string, string[]>();
-  const outputFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
   let workflowMetadataPublisher: CoalescedWorkflowMetadataPublisher | null = null;
-  let lastKnownWorkflowCount = 0;
   let startupWorkflowId: string | null = null;
   const startupWorkflowCache = createStartupWorkflowCache();
-  // In detached viewer mode the local DB is an empty in-memory copy. Workflow
-  // metadata for the bootstrap getter comes from the owner snapshot; task state
-  // is derived live from `lastKnownTaskStates` (kept current by deltas).
-  let detachedViewerWorkflows: unknown[] | null = null;
-  // While the detached viewer hydrates, owner deltas are buffered here and
-  // replayed after the cache is seeded, so an update arriving mid-hydration is
-  // not applied against an empty cache (quarantined and dropped).
-  let detachedDeltaBuffer: TaskDelta[] | null = null;
   let uiInteractive = false;
   let deferredStartupTriggered = false;
   const traceUiDeltaFlow = process.env.INVOKER_TRACE_UI_DELTA === '1';
@@ -2189,44 +2174,6 @@ function createEmbeddedTerminalBackendFromConfig(
     ts: new Date().toISOString(),
   });
 
-  const flushTaskOutput = (taskId: string): void => {
-    const timer = outputFlushTimers.get(taskId);
-    if (timer) {
-      clearTimeout(timer);
-      outputFlushTimers.delete(taskId);
-    }
-    const chunks = pendingOutputBuffers.get(taskId);
-    if (!chunks || chunks.length === 0) {
-      return;
-    }
-    pendingOutputBuffers.delete(taskId);
-    const data = chunks.join('');
-    if (traceTaskOutput) {
-      logger.info(`${taskId}: ${data.trimEnd()}`, { module: 'output' });
-    }
-    const outputData: TaskOutputData = { taskId, data };
-    messageBus.publish(Channels.TASK_OUTPUT, outputData);
-    try {
-      // Runner stream chunks land in the output spool only — task_output is
-      // reserved for explicit diagnostic writes (workflow actions, shutdown).
-      persistence.appendOutputChunk(taskId, data);
-    } catch (err) {
-      logger.error(`Failed to persist output for ${taskId}: ${err}`, { module: 'output' });
-    }
-  };
-
-  const enqueueTaskOutput = (taskId: string, data: string): void => {
-    const chunks = pendingOutputBuffers.get(taskId) ?? [];
-    chunks.push(data);
-    pendingOutputBuffers.set(taskId, chunks);
-    if (outputFlushTimers.has(taskId)) {
-      return;
-    }
-    const timer = setTimeout(() => flushTaskOutput(taskId), 100);
-    timer.unref?.();
-    outputFlushTimers.set(taskId, timer);
-  };
-
   const taskDeltaStream = createTaskDeltaStreamSequence();
   const getTaskDeltaStreamSequence = (): number => taskDeltaStream.current();
 
@@ -2246,35 +2193,34 @@ function createEmbeddedTerminalBackendFromConfig(
     onEvent: (event) => webBridge?.broadcast('invoker:task-graph-event', event),
   });
 
-  const publishTaskDeltaToRenderer = (delta: TaskDelta): void => {
-    const workflowRollups = workflowRollupProjection.applyDelta(delta);
-    taskGraphEventPublisher.publishDelta(delta, workflowRollups);
-  };
-
-  const applyTaskDeltaToOwnerCacheOrRecover = (delta: TaskDelta): TaskDelta[] => {
-    const { quarantined, accepted } = applyDelta(delta, lastKnownTaskStates);
-    if (quarantined.length === 0) {
-      return accepted ? [delta] : [];
-    }
-
-    const rendererDeltas: TaskDelta[] = [];
-    for (const taskId of quarantined) {
-      logger.info(`[gap-detect] quarantined task="${taskId}" — triggering authoritative reload`, { module: 'delta-merge' });
-      const { rendererDelta } = recoverQuarantinedTask(lastKnownTaskStates, taskId, {
-        loadTask: loadTaskByIdFromPersistence,
-        getMergeNode: (workflowId) => orchestrator.getMergeNode(workflowId),
-      });
-      if (rendererDelta) {
-        rendererDeltas.push(rendererDelta);
-      }
-    }
-    return rendererDeltas;
-  };
-
   const requestWorkflowMetadataPublish = (reason: string): void => {
     uiPerfStats.workflowMetadataPublishRequests += 1;
     workflowMetadataPublisher?.requestPublish(reason);
   };
+
+  const rendererTaskFeed = createRendererTaskFeed({
+    logger,
+    persistence,
+    messageBus,
+    orchestrator,
+    taskHandles,
+    taskGraphEventPublisher,
+    getMainWindow: () => mainWindow,
+    setStartupWorkflowId: (workflowId) => { startupWorkflowId = workflowId; },
+    requestWorkflowMetadataPublish,
+    scheduleAutoFix: (taskId) => scheduleAutoFix(taskId),
+    logAutoFixDebug: (taskId, phase, details) => logAutoFixDebug(taskId, phase, details),
+    uiPerfStats,
+    traceUiDeltaFlow,
+    traceDbPollPerTask,
+    traceTaskOutput,
+    executingStallTimeoutMs,
+    pollLaunchDispatcher: () => {
+      if (launchDispatcher) {
+        launchDispatcher.poll();
+      }
+    },
+  });
 
   const buildAutoFixQueueSnapshot = (taskId: string): Record<string, unknown> => {
     const workflowId = workflowIdForTaskArg(taskId);
@@ -2480,8 +2426,8 @@ function createEmbeddedTerminalBackendFromConfig(
       logger,
       messageBus,
       taskHandles,
-      enqueueTaskOutput,
-      flushTaskOutput,
+      enqueueTaskOutput: rendererTaskFeed.enqueueTaskOutput,
+      flushTaskOutput: rendererTaskFeed.flushTaskOutput,
       assertFatalExecutionCapacity,
       getTaskRunner: () => taskExecutor,
       setTaskRunner: (runner) => { taskExecutor = runner; },
@@ -2847,7 +2793,7 @@ function createEmbeddedTerminalBackendFromConfig(
       case 'invoker:stop-worker':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resume-workflow': {
-        const workflows = detachedViewerWorkflows ?? persistence.listWorkflows();
+        const workflows = rendererTaskFeed.getDetachedViewerWorkflows() ?? persistence.listWorkflows();
         const firstWorkflow = workflows[0] as { id?: unknown } | undefined;
         const workflowId = startupWorkflowId
           ?? (typeof firstWorkflow?.id === 'string' ? firstWorkflow.id : undefined);
@@ -3008,96 +2954,10 @@ function createEmbeddedTerminalBackendFromConfig(
     });
   }
 
-  function seedUiSnapshotCache(): void {
-    lastKnownWorkflowCount = persistence.listWorkflows().length;
-    seedTaskCachesFromSnapshot(orchestrator.getAllTasks(), { lastKnownTaskStates, workflowRollupProjection });
-  }
-
-  // Detached viewer: the local DB is empty, so seed the delta caches and
-  // bootstrap snapshot from the owner. Without this, the empty cache quarantines
-  // every `updated` delta for a task the viewer has not seen (dropping live
-  // updates), and bootstrap getters return nothing. Failures are non-fatal — the
-  // renderer's delegated reads still populate the view.
-  async function hydrateDetachedViewerFromOwner(): Promise<void> {
-    try {
-      const snapshot = await messageBus.request<{ kind: string }, { tasks?: TaskState[]; workflows?: unknown[] }>(
-        'headless.query',
-        { kind: 'tasks' },
-      );
-      const tasks = Array.isArray(snapshot?.tasks) ? snapshot.tasks : [];
-      const workflows = Array.isArray(snapshot?.workflows) ? snapshot.workflows : [];
-      detachedViewerWorkflows = workflows;
-      seedTaskCachesFromSnapshot(tasks, { lastKnownTaskStates, workflowRollupProjection });
-      lastKnownWorkflowCount = workflows.length;
-      startupWorkflowId = [...workflows]
-        .map((wf) => wf as { id?: string; updatedAt?: string; createdAt?: string })
-        .sort((left, right) => (Date.parse(right.updatedAt ?? '') || 0) - (Date.parse(left.updatedAt ?? '') || 0))[0]?.id ?? null;
-      logger.info(
-        `[init] Hydrated detached viewer from owner: ${tasks.length} tasks across ${workflows.length} workflows`,
-        { module: 'init' },
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.warn(`detached viewer hydration from owner failed; relying on delegated reads: ${message}`, { module: 'init' });
-    } finally {
-      // Resume direct delta processing and replay anything buffered during
-      // hydration (in arrival order). Always runs, so a hydration failure can
-      // never leave deltas buffered forever.
-      const buffered = detachedDeltaBuffer ?? [];
-      detachedDeltaBuffer = null;
-      for (const delta of buffered) processIncomingTaskDelta(delta);
-    }
-  }
-
-  // Current task states for the detached viewer's bootstrap getter, derived from
-  // the live delta cache so a renderer reload never sees the stale hydration
-  // snapshot.
-  function detachedViewerTasks(): TaskState[] {
-    return [...lastKnownTaskStates.keys()].map(
-      (taskId) => JSON.parse(lastKnownTaskStates.get(taskId) ?? '{}') as TaskState,
-    );
-  }
-
-  // Apply one owner task delta to the local cache and forward results to the
-  // renderer (and drive owner-side auto-fix). Extracted so the detached viewer
-  // can replay deltas that were buffered during hydration.
-  function processIncomingTaskDelta(d: TaskDelta): void {
-    uiPerfStats.mainDeltaToUi += 1;
-    if (traceUiDeltaFlow) {
-      logger.debug(`delta→ui: ${JSON.stringify(d)}`, { module: 'ui' });
-    }
-    const deltaTaskId = d.type === 'updated' || d.type === 'removed' ? d.taskId : undefined;
-    if (d.type === 'updated' && d.changes.status === 'failed') {
-      const cancellationError = shouldSkipAutoFixForError(d.changes.execution?.error);
-      const shouldAutoFixFromOrchestrator = orchestrator.shouldAutoFix(d.taskId);
-      logAutoFixDebug(d.taskId, 'delta-failed', {
-        shouldSkipForCancellation: cancellationError,
-        shouldAutoFixFromOrchestrator,
-      });
-      if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
-        logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
-        scheduleAutoFix(deltaTaskId);
-      } else if (deltaTaskId) {
-        logAutoFixDebug(deltaTaskId, 'delta-skip', {
-          reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
-          shouldSkipForCancellation: cancellationError,
-          shouldAutoFixFromOrchestrator,
-        });
-      }
-    }
-    for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(d)) {
-      publishTaskDeltaToRenderer(rendererDelta);
-    }
-  }
-
-  function loadTaskByIdFromPersistence(taskId: string): TaskState | undefined {
-    return persistence.loadTask(taskId);
-  }
-
   workflowMetadataPublisher = new CoalescedWorkflowMetadataPublisher({
     listWorkflows: () => persistence.listWorkflows(),
     publish: (workflows, stats) => {
-      lastKnownWorkflowCount = workflows.length;
+      rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
       uiPerfStats.workflowMetadataPublishes += 1;
       uiPerfStats.workflowMetadataCoalescedRequests += Math.max(0, stats.coalescedRequests - 1);
       if (stats.coalescedRequests > 1) {
@@ -3130,7 +2990,7 @@ function createEmbeddedTerminalBackendFromConfig(
   function bootstrapInitialWorkflowState(): void {
     const workflows = listWorkflowsByStartupRecency();
     startupWorkflowCache.set(workflows);
-    lastKnownWorkflowCount = workflows.length;
+    rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
     startupWorkflowId = workflows[0]?.id ?? null;
     if (!startupWorkflowId) {
       logger.info('[init] No workflows available for initial startup bootstrap', { module: 'init' });
@@ -3185,21 +3045,20 @@ function createEmbeddedTerminalBackendFromConfig(
   function publishOrchestratorSnapshotToRenderer(): void {
     const workflows = persistence.listWorkflows();
     const tasks = orchestrator.getAllTasks();
-    const previousTaskIds = new Set(lastKnownTaskStates.keys());
-    lastKnownTaskStates.clear();
-    workflowRollupProjection.replaceAll(tasks);
+    const previousTaskIds = new Set(rendererTaskFeed.listKnownTaskIds());
+    rendererTaskFeed.clearTaskSnapshots();
+    rendererTaskFeed.replaceWorkflowRollups(tasks);
     for (const task of tasks) {
-      const snapshot = JSON.stringify(task);
       previousTaskIds.delete(task.id);
-      lastKnownTaskStates.set(task.id, snapshot);
+      rendererTaskFeed.rememberTaskState(task);
       if (mainWindow && !mainWindow.isDestroyed()) {
-        publishTaskDeltaToRenderer({ type: 'created', task });
+        rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'created', task });
       }
     }
-    lastKnownWorkflowCount = workflows.length;
+    rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
     if (mainWindow && !mainWindow.isDestroyed()) {
       for (const removedTaskId of previousTaskIds) {
-        publishTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
+        rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
       }
       requestWorkflowMetadataPublish('orchestrator-snapshot');
     }
@@ -3308,175 +3167,7 @@ function createEmbeddedTerminalBackendFromConfig(
 
       setTimeout(() => {
         if (ownerMode) {
-          dbPollInterval = setInterval(() => {
-          if (!mainWindow || mainWindow.isDestroyed()) return;
-          try {
-            const workflows = persistence.listWorkflows();
-
-            if (workflows.length !== lastKnownWorkflowCount) {
-              const msg = `Workflow count changed: ${lastKnownWorkflowCount} → ${workflows.length}`;
-              logger.info(msg, { module: 'db-poll' });
-              try { persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
-              lastKnownWorkflowCount = workflows.length;
-              requestWorkflowMetadataPublish('db-poll-count');
-
-              orchestrator.syncAllFromDb();
-              logger.info(`Synced orchestrator for all ${workflows.length} workflows`, { module: 'db-poll' });
-            }
-
-            for (const wf of workflows) {
-              if (wf.status === 'completed' || wf.status === 'failed') continue;
-              const tasks = persistence.loadTasks(wf.id);
-              for (const loadedTask of tasks) {
-                let task = loadedTask;
-                const now = new Date();
-                const previousHeartbeat = parseExecutionDate(task.execution.lastHeartbeatAt);
-                const selectedAttempt = taskNeedsExecutingStallCheck(task) && task.execution.selectedAttemptId
-                  ? persistence.loadAttempt?.(task.execution.selectedAttemptId)
-                  : undefined;
-                const leaseExpiresAt = parseExecutionDate(selectedAttempt?.leaseExpiresAt);
-                const remoteHeartbeat = parseExecutionDate(task.execution.remoteHeartbeatAt);
-
-                if (task.status === 'running' || (task.status === 'pending' && task.execution.phase === 'launching')) {
-                  // CC.1: launch-stall watchdog removed. The
-                  // LaunchDispatcher's reapExpiredLeases /
-                  // abandonStuckLeases reapers (Phase B, CB.3) are the
-                  // sole recovery path for stalled launch claims.
-                  const executingStartedAt = parseExecutionDate(task.execution.startedAt);
-                  const executingAgeMs = executingStartedAt ? now.getTime() - executingStartedAt.getTime() : 0;
-                  const { heartbeatStale, leaseExpired, executingStalled, staleReason } = evaluateExecutingStall({
-                    now,
-                    phase: task.execution.phase,
-                    runnerKind: task.config.runnerKind,
-                    executingStartedAt,
-                    leaseExpiresAt,
-                    executorHeartbeatAt: previousHeartbeat,
-                    remoteHeartbeatAt: remoteHeartbeat,
-                    executingStallTimeoutMs,
-                  });
-
-                  if (executingStalled) {
-                    const selectedAttemptHeartbeat = parseExecutionDate(selectedAttempt?.lastHeartbeatAt);
-                    const executingError =
-                      `Execution stalled: task remained in running/executing for ${Math.floor(executingAgeMs / 1000)}s ` +
-                      `without a live execution handle and no completion signal from executor (${staleReason}).`;
-                    logger.info(
-                      `[executing-stall] detected task="${task.id}" phase=${task.execution.phase} executingAgeMs=${executingAgeMs} ` +
-                        `handlePresent=${taskHandles.has(task.id)} leaseExpired=${leaseExpired} heartbeatStale=${heartbeatStale} ` +
-                        `runnerKind=${task.config.runnerKind ?? 'none'} selectedAttemptId=${task.execution.selectedAttemptId ?? 'none'} ` +
-                        `attemptStatus=${selectedAttempt?.status ?? 'none'} executorHeartbeatAt=${previousHeartbeat?.toISOString() ?? 'none'} ` +
-                        `remoteHeartbeatAt=${remoteHeartbeat?.toISOString() ?? 'none'} attemptHeartbeatAt=${selectedAttemptHeartbeat?.toISOString() ?? 'none'} ` +
-                        `leaseExpiresAt=${leaseExpiresAt?.toISOString() ?? 'none'} launchStartedAt=${task.execution.launchStartedAt instanceof Date ? task.execution.launchStartedAt.toISOString() : task.execution.launchStartedAt ?? 'none'} ` +
-                        `launchCompletedAt=${task.execution.launchCompletedAt instanceof Date ? task.execution.launchCompletedAt.toISOString() : task.execution.launchCompletedAt ?? 'none'} ` +
-                        `startedAt=${executingStartedAt?.toISOString() ?? 'none'} completedAt=${task.execution.completedAt instanceof Date ? task.execution.completedAt.toISOString() : task.execution.completedAt ?? 'none'}`,
-                      { module: 'db-poll' },
-                    );
-                    const failedResponse: WorkResponse = {
-                      requestId: `executing-stall-${task.id}-${now.getTime()}`,
-                      actionId: task.id,
-                      attemptId: task.execution.selectedAttemptId,
-                      executionGeneration: task.execution.generation ?? 0,
-                      status: 'failed',
-                      outputs: {
-                        exitCode: 1,
-                        error: executingError,
-                        failureClass: 'liveness_stall',
-                      },
-                    };
-                    logger.error(`[executing-stall] forcing failure for "${task.id}": ${executingError}`, { module: 'db-poll' });
-                    if (persistence) {
-                      persistShutdownDiagnostic(task, persistence, {
-                        flushPendingOutput: flushTaskOutput,
-                        forcedStopReason: executingError,
-                        label: task.execution.phase === 'launching'
-                          ? 'Startup Failure Diagnostic'
-                          : 'Shutdown Diagnostic',
-                      });
-                    }
-                    orchestrator.handleWorkerResponse(failedResponse);
-                    continue;
-                  }
-                }
-
-                // Stalled-fix-session watchdog: a fix session whose owner died
-                // mid-fix (heartbeat stopped, attempt lease expired) is invisible
-                // to the running-task path above because its status is
-                // `fixing_with_ai`, not `running`. Evaluate it as an executing
-                // task; a live fix refreshes its lease every 30s via
-                // withAttemptHeartbeat, so only an orphaned one is ever stalled.
-                if (task.status === 'fixing_with_ai') {
-                  const fixStartedAt = parseExecutionDate(task.execution.startedAt);
-                  const { executingStalled, staleReason } = evaluateExecutingStall({
-                    now,
-                    phase: 'executing',
-                    runnerKind: task.config.runnerKind,
-                    executingStartedAt: fixStartedAt,
-                    leaseExpiresAt,
-                    executorHeartbeatAt: previousHeartbeat,
-                    remoteHeartbeatAt: remoteHeartbeat,
-                    executingStallTimeoutMs,
-                  });
-                  if (executingStalled) {
-                    const fixAgeMs = fixStartedAt ? now.getTime() - fixStartedAt.getTime() : 0;
-                    const reason =
-                      `Fix session stalled: task remained in fixing_with_ai for ${Math.floor(fixAgeMs / 1000)}s ` +
-                      `without a live fix handle (${staleReason}).`;
-                    logger.error(`[fix-session-stall] reclaiming "${task.id}": ${reason}`, { module: 'db-poll' });
-                    const outcome = orchestrator.reclaimStalledFixSession(task.id, {
-                      reason,
-                      expectedLineage: {
-                        taskId: task.id,
-                        selectedAttemptId: task.execution.selectedAttemptId,
-                        generation: task.execution.generation ?? 0,
-                      },
-                    });
-                    logger.info(
-                      `[fix-session-stall] reclaim outcome=${outcome} task="${task.id}" ` +
-                        `selectedAttemptId=${task.execution.selectedAttemptId ?? 'none'} ` +
-                        `leaseExpiresAt=${leaseExpiresAt?.toISOString() ?? 'none'}`,
-                      { module: 'db-poll' },
-                    );
-                    continue;
-                  }
-                }
-
-                const snapshot = JSON.stringify(task);
-                const prev = lastKnownTaskStates.get(task.id);
-                if (!prev) {
-                  if (traceDbPollPerTask) {
-                    const msg = `New task: ${task.id} (${task.status})`;
-                    logger.info(msg, { module: 'db-poll' });
-                    try { persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
-                  }
-                  lastKnownTaskStates.set(task.id, snapshot);
-                  uiPerfStats.dbPollCreated += 1;
-                  publishTaskDeltaToRenderer({ type: 'created', task });
-                } else if (prev !== snapshot) {
-                  if (traceDbPollPerTask) {
-                    const msg = `Task updated: ${task.id} (${task.status})`;
-                    logger.info(msg, { module: 'db-poll' });
-                    try { persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
-                  }
-                  lastKnownTaskStates.set(task.id, snapshot);
-                  uiPerfStats.dbPollUpdatedAsCreated += 1;
-                  publishTaskDeltaToRenderer({ type: 'created', task });
-                }
-              }
-            }
-            if (launchDispatcher) {
-              try {
-                launchDispatcher.poll();
-              } catch (err) {
-                logger.warn(
-                  `[launch-dispatcher] poll() failed: ${err instanceof Error ? err.message : String(err)}`,
-                  { module: 'db-poll' },
-                );
-              }
-            }
-          } catch {
-            // DB might be locked — skip this tick
-          }
-          }, 2000);
+          dbPollHandle = rendererTaskFeed.startDbPolling();
         }
 
       }, startupPollDelayMs).unref?.();
@@ -3793,30 +3484,13 @@ function createEmbeddedTerminalBackendFromConfig(
     // the db-poll doesn't re-emit deltas the messageBus already delivered.
     // Detached viewer: buffer owner deltas until hydration seeds the cache.
     if (!ownerMode) {
-      detachedDeltaBuffer = [];
+      rendererTaskFeed.beginDetachedViewerBuffering();
     }
     messageBus.subscribe(Channels.TASK_DELTA, (delta: unknown) => {
-      const d = delta as TaskDelta;
-      if (detachedDeltaBuffer) {
-        detachedDeltaBuffer.push(d);
-        return;
-      }
-      processIncomingTaskDelta(d);
+      rendererTaskFeed.receiveTaskDelta(delta as TaskDelta);
     });
 
-    uiPerfLogInterval = setInterval(() => {
-      const snapshot = {
-        ts: new Date().toISOString(),
-        metric: 'main_delta_flow',
-        ...uiPerfStats,
-      };
-      try {
-        persistence.writeActivityLog('ui-perf-main', 'info', JSON.stringify(snapshot));
-
-      } catch {
-        // DB might be locked
-      }
-    }, 10000);
+    activityPollHandle = rendererTaskFeed.startActivityPolling();
 
     messageBus.subscribe(Channels.TASK_OUTPUT, (data: unknown) => {
       if (mainWindow && !mainWindow.isDestroyed() && uiInteractive) {
@@ -3838,9 +3512,9 @@ function createEmbeddedTerminalBackendFromConfig(
 
     registerBootstrapStateIpc({
       ipcMain,
-      getTasks: () => (ownerMode ? orchestrator.getAllTasks() : detachedViewerTasks()),
+      getTasks: () => (ownerMode ? orchestrator.getAllTasks() : rendererTaskFeed.getDetachedViewerTasks()),
       getWorkflows: () =>
-        detachedViewerWorkflows ?? startupWorkflowCache.takeOrLoad(listWorkflowsByStartupRecency),
+        rendererTaskFeed.getDetachedViewerWorkflows() ?? startupWorkflowCache.takeOrLoad(listWorkflowsByStartupRecency),
       getInitialWorkflowId: () => startupWorkflowId,
       appStartedAtEpochMs: appProcessStartedAt,
       getTaskDeltaStreamSequence,
@@ -4001,7 +3675,7 @@ function createEmbeddedTerminalBackendFromConfig(
       const injectTaskStates = async (updates: Array<{ taskId: string; changes: TaskStateChanges }>): Promise<void> => {
         for (const { taskId, changes } of updates) {
           const before = orchestrator.getTask(taskId);
-          const previousSnapshot = lastKnownTaskStates.get(taskId);
+          const previousSnapshot = rendererTaskFeed.getTaskSnapshot(taskId);
           const previousTaskStateVersion = previousSnapshot
             ? (
                 (JSON.parse(previousSnapshot) as { taskStateVersion?: number }).taskStateVersion
@@ -4086,11 +3760,11 @@ function createEmbeddedTerminalBackendFromConfig(
 
       const allStarted = orchestrator.startExecution();
       const tasks = orchestrator.getAllTasks();
-      workflowRollupProjection.replaceAll(tasks);
+      rendererTaskFeed.replaceWorkflowRollups(tasks);
       for (const task of tasks) {
-        lastKnownTaskStates.set(task.id, JSON.stringify(task));
+        rendererTaskFeed.rememberTaskState(task);
         if (mainWindow && !mainWindow.isDestroyed()) {
-          publishTaskDeltaToRenderer({ type: 'created', task });
+          rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'created', task });
         }
       }
       logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${allStarted.length} started`, { module: 'ipc' });
@@ -4115,7 +3789,7 @@ function createEmbeddedTerminalBackendFromConfig(
           if (isTaskInFlightForForcedStop(task)) {
             logger.info(`stop — failing in-flight task "${task.id}" (${task.status})`, { module: 'ipc' });
             persistShutdownDiagnostic(task, persistence, {
-              flushPendingOutput: flushTaskOutput,
+              flushPendingOutput: rendererTaskFeed.flushTaskOutput,
               forcedStopReason: 'Stopped by user',
             });
             orchestrator.handleWorkerResponse({
@@ -4156,9 +3830,7 @@ function createEmbeddedTerminalBackendFromConfig(
       );
       rebuildTaskRunner();
       taskHandles.clear();
-      lastKnownTaskStates.clear();
-      workflowRollupProjection.clear();
-      lastKnownWorkflowCount = 0;
+      rendererTaskFeed.resetSnapshotState();
       requestWorkflowMetadataPublish('clear');
     });
 
@@ -4206,9 +3878,7 @@ function createEmbeddedTerminalBackendFromConfig(
       assertDeleteAllEnabled();
       await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       taskHandles.clear();
-      lastKnownTaskStates.clear();
-      workflowRollupProjection.clear();
-      lastKnownWorkflowCount = 0;
+      rendererTaskFeed.resetSnapshotState();
       requestWorkflowMetadataPublish('delete-all-workflows');
     });
 
@@ -4217,9 +3887,7 @@ function createEmbeddedTerminalBackendFromConfig(
       assertDeleteAllEnabled();
       await sharedDeleteAllWorkflowsBulk({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       taskHandles.clear();
-      lastKnownTaskStates.clear();
-      workflowRollupProjection.clear();
-      lastKnownWorkflowCount = 0;
+      rendererTaskFeed.resetSnapshotState();
       requestWorkflowMetadataPublish('delete-all-workflows-bulk');
     });
 
@@ -4882,7 +4550,7 @@ function createEmbeddedTerminalBackendFromConfig(
         throw err;
       }
       const workflows = persistence.listWorkflows();
-      lastKnownWorkflowCount = workflows.length;
+      rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
       requestWorkflowMetadataPublish('set-merge-mode');
     });
 
@@ -5344,9 +5012,9 @@ function createEmbeddedTerminalBackendFromConfig(
     );
 
     if (ownerMode) {
-      seedUiSnapshotCache();
+      rendererTaskFeed.seedUiSnapshotCache();
     } else {
-      await hydrateDetachedViewerFromOwner();
+      await rendererTaskFeed.hydrateDetachedViewerFromOwner();
     }
     createWindow();
     recordStartupMark('createWindow.end');
@@ -5402,8 +5070,8 @@ function createEmbeddedTerminalBackendFromConfig(
         if (apiServer) await apiServer.close().catch(() => {});
         embeddedTerminalManager.closeAll({ preserveForRestart: true });
         await workerRuntimeController?.stopAll();
-        if (dbPollInterval) clearInterval(dbPollInterval);
-        if (uiPerfLogInterval) clearInterval(uiPerfLogInterval);
+        dbPollHandle?.stop();
+        activityPollHandle?.stop();
         if (hourlyBackupInterval) {
           clearInterval(hourlyBackupInterval);
           hourlyBackupInterval = null;
@@ -5418,7 +5086,7 @@ function createEmbeddedTerminalBackendFromConfig(
             if (task.status === 'running' || task.status === 'fixing_with_ai') {
               if (persistence) {
                 persistShutdownDiagnostic(task, persistence, {
-                  flushPendingOutput: flushTaskOutput,
+                  flushPendingOutput: rendererTaskFeed.flushTaskOutput,
                   forcedStopReason: 'Application quit',
                 });
               }

--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -1,0 +1,496 @@
+import type { BrowserWindow } from 'electron';
+import type { Logger, WorkResponse } from '@invoker/contracts';
+import type { Workflow } from '@invoker/data-store';
+import { Channels, type MessageBus } from '@invoker/transport';
+import type { TaskDelta, TaskState } from '@invoker/workflow-core';
+import { shouldSkipAutoFixForError } from '../auto-fix-gating.js';
+import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from '../delta-merge.js';
+import { evaluateExecutingStall, taskNeedsExecutingStallCheck } from '../executing-stall.js';
+import { persistShutdownDiagnostic, type ShutdownDiagnosticDb } from '../shutdown-diagnostic.js';
+import type { TaskGraphEventPublisher } from '../task-graph-event-publisher.js';
+import type { TaskOutputData } from '../types.js';
+import { seedTaskCachesFromSnapshot } from '../viewer-cache-hydration.js';
+import { WorkflowRollupProjection } from '../workflow-rollup-projection.js';
+
+export type RendererTaskFeedTimer = NodeJS.Timeout;
+
+export interface RendererTaskFeedStopHandle {
+  stop(): void;
+}
+
+export interface RendererTaskFeedAttempt {
+  leaseExpiresAt?: unknown;
+  lastHeartbeatAt?: unknown;
+  status?: string;
+}
+
+export interface RendererTaskFeedPersistence extends ShutdownDiagnosticDb {
+  listWorkflows(): Workflow[];
+  loadTasks(workflowId: string): TaskState[];
+  loadTask(taskId: string): TaskState | undefined;
+  loadAttempt?(attemptId: string): RendererTaskFeedAttempt | undefined;
+  writeActivityLog(source: string, level: string, message: string): void;
+  appendOutputChunk(taskId: string, data: string): void;
+}
+
+export interface RendererTaskFeedOrchestrator {
+  getAllTasks(): TaskState[];
+  getMergeNode(workflowId: string): TaskState | undefined;
+  shouldAutoFix(taskId: string): boolean;
+  syncAllFromDb(): void;
+  handleWorkerResponse(response: WorkResponse): void;
+  reclaimStalledFixSession(
+    taskId: string,
+    options: {
+      reason: string;
+      expectedLineage: {
+        taskId: string;
+        selectedAttemptId: string | undefined;
+        generation: number;
+      };
+    },
+  ): unknown;
+}
+
+export interface RendererTaskFeedUiPerfStats {
+  mainDeltaToUi: number;
+  dbPollCreated: number;
+  dbPollUpdatedAsCreated: number;
+  workflowMetadataPublishes: number;
+  workflowMetadataCoalescedRequests: number;
+  [key: string]: number;
+}
+
+export interface RendererTaskFeedDeps {
+  logger: Logger;
+  persistence: RendererTaskFeedPersistence;
+  messageBus: Pick<MessageBus, 'publish' | 'request'>;
+  orchestrator: RendererTaskFeedOrchestrator;
+  taskHandles: { has(taskId: string): boolean };
+  taskGraphEventPublisher: Pick<TaskGraphEventPublisher, 'publishDelta'>;
+  getMainWindow: () => BrowserWindow | null;
+  setStartupWorkflowId: (workflowId: string | null) => void;
+  requestWorkflowMetadataPublish: (reason: string) => void;
+  scheduleAutoFix: (taskId: string) => void;
+  logAutoFixDebug: (taskId: string, phase: string, details?: Record<string, unknown>) => void;
+  uiPerfStats: RendererTaskFeedUiPerfStats;
+  traceUiDeltaFlow: boolean;
+  traceDbPollPerTask: boolean;
+  traceTaskOutput: boolean;
+  executingStallTimeoutMs: number;
+  pollLaunchDispatcher: () => void;
+}
+
+export interface RendererTaskFeed {
+  enqueueTaskOutput(taskId: string, data: string): void;
+  flushTaskOutput(taskId: string): void;
+  seedUiSnapshotCache(): void;
+  hydrateDetachedViewerFromOwner(): Promise<void>;
+  getDetachedViewerTasks(): TaskState[];
+  getDetachedViewerWorkflows(): unknown[] | null;
+  publishTaskDeltaToRenderer(delta: TaskDelta): void;
+  getLastKnownWorkflowCount(): number;
+  setLastKnownWorkflowCount(count: number): void;
+  getTaskSnapshot(taskId: string): string | undefined;
+  listKnownTaskIds(): string[];
+  clearTaskSnapshots(): void;
+  replaceWorkflowRollups(tasks: TaskState[]): void;
+  rememberTaskState(task: TaskState): void;
+  resetSnapshotState(): void;
+  beginDetachedViewerBuffering(): void;
+  receiveTaskDelta(delta: TaskDelta): void;
+  startDbPolling(): RendererTaskFeedStopHandle;
+  startActivityPolling(): RendererTaskFeedStopHandle;
+}
+
+export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTaskFeed {
+  const lastKnownTaskStates = new TaskSnapshotCache();
+  const workflowRollupProjection = new WorkflowRollupProjection();
+  const pendingOutputBuffers = new Map<string, string[]>();
+  const outputFlushTimers = new Map<string, RendererTaskFeedTimer>();
+  let lastKnownWorkflowCount = 0;
+  let detachedViewerWorkflows: unknown[] | null = null;
+  let detachedDeltaBuffer: TaskDelta[] | null = null;
+
+  const flushTaskOutput = (taskId: string): void => {
+    const timer = outputFlushTimers.get(taskId);
+    if (timer) {
+      clearTimeout(timer);
+      outputFlushTimers.delete(taskId);
+    }
+    const chunks = pendingOutputBuffers.get(taskId);
+    if (!chunks || chunks.length === 0) {
+      return;
+    }
+    pendingOutputBuffers.delete(taskId);
+    const data = chunks.join('');
+    if (deps.traceTaskOutput) {
+      deps.logger.info(`${taskId}: ${data.trimEnd()}`, { module: 'output' });
+    }
+    const outputData: TaskOutputData = { taskId, data };
+    deps.messageBus.publish(Channels.TASK_OUTPUT, outputData);
+    try {
+      // Runner stream chunks land in the output spool only — task_output is
+      // reserved for explicit diagnostic writes (workflow actions, shutdown).
+      deps.persistence.appendOutputChunk(taskId, data);
+    } catch (err) {
+      deps.logger.error(`Failed to persist output for ${taskId}: ${err}`, { module: 'output' });
+    }
+  };
+
+  const enqueueTaskOutput = (taskId: string, data: string): void => {
+    const chunks = pendingOutputBuffers.get(taskId) ?? [];
+    chunks.push(data);
+    pendingOutputBuffers.set(taskId, chunks);
+    if (outputFlushTimers.has(taskId)) {
+      return;
+    }
+    const timer = setTimeout(() => flushTaskOutput(taskId), 100);
+    timer.unref?.();
+    outputFlushTimers.set(taskId, timer);
+  };
+
+  const publishTaskDeltaToRenderer = (delta: TaskDelta): void => {
+    const workflowRollups = workflowRollupProjection.applyDelta(delta);
+    deps.taskGraphEventPublisher.publishDelta(delta, workflowRollups);
+  };
+
+  const applyTaskDeltaToOwnerCacheOrRecover = (delta: TaskDelta): TaskDelta[] => {
+    const { quarantined, accepted } = applyDelta(delta, lastKnownTaskStates);
+    if (quarantined.length === 0) {
+      return accepted ? [delta] : [];
+    }
+
+    const rendererDeltas: TaskDelta[] = [];
+    for (const taskId of quarantined) {
+      deps.logger.info(`[gap-detect] quarantined task="${taskId}" — triggering authoritative reload`, { module: 'delta-merge' });
+      const { rendererDelta } = recoverQuarantinedTask(lastKnownTaskStates, taskId, {
+        loadTask: (recoveryTaskId) => deps.persistence.loadTask(recoveryTaskId),
+        getMergeNode: (workflowId) => deps.orchestrator.getMergeNode(workflowId),
+      });
+      if (rendererDelta) {
+        rendererDeltas.push(rendererDelta);
+      }
+    }
+    return rendererDeltas;
+  };
+
+  const seedUiSnapshotCache = (): void => {
+    lastKnownWorkflowCount = deps.persistence.listWorkflows().length;
+    seedTaskCachesFromSnapshot(deps.orchestrator.getAllTasks(), { lastKnownTaskStates, workflowRollupProjection });
+  };
+
+  // Detached viewer: the local DB is empty, so seed the delta caches and
+  // bootstrap snapshot from the owner. Without this, the empty cache quarantines
+  // every `updated` delta for a task the viewer has not seen (dropping live
+  // updates), and bootstrap getters return nothing. Failures are non-fatal — the
+  // renderer's delegated reads still populate the view.
+  const hydrateDetachedViewerFromOwner = async (): Promise<void> => {
+    try {
+      const snapshot = await deps.messageBus.request<{ kind: string }, { tasks?: TaskState[]; workflows?: unknown[] }>(
+        'headless.query',
+        { kind: 'tasks' },
+      );
+      const tasks = Array.isArray(snapshot?.tasks) ? snapshot.tasks : [];
+      const workflows = Array.isArray(snapshot?.workflows) ? snapshot.workflows : [];
+      detachedViewerWorkflows = workflows;
+      seedTaskCachesFromSnapshot(tasks, { lastKnownTaskStates, workflowRollupProjection });
+      lastKnownWorkflowCount = workflows.length;
+      deps.setStartupWorkflowId(
+        [...workflows]
+          .map((wf) => wf as { id?: string; updatedAt?: string; createdAt?: string })
+          .sort((left, right) => (Date.parse(right.updatedAt ?? '') || 0) - (Date.parse(left.updatedAt ?? '') || 0))[0]?.id ?? null,
+      );
+      deps.logger.info(
+        `[init] Hydrated detached viewer from owner: ${tasks.length} tasks across ${workflows.length} workflows`,
+        { module: 'init' },
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      deps.logger.warn(`detached viewer hydration from owner failed; relying on delegated reads: ${message}`, { module: 'init' });
+    } finally {
+      // Resume direct delta processing and replay anything buffered during
+      // hydration (in arrival order). Always runs, so a hydration failure can
+      // never leave deltas buffered forever.
+      const buffered = detachedDeltaBuffer ?? [];
+      detachedDeltaBuffer = null;
+      for (const delta of buffered) processIncomingTaskDelta(delta);
+    }
+  };
+
+  // Current task states for the detached viewer's bootstrap getter, derived from
+  // the live delta cache so a renderer reload never sees the stale hydration
+  // snapshot.
+  const getDetachedViewerTasks = (): TaskState[] => [...lastKnownTaskStates.keys()].map(
+    (taskId) => JSON.parse(lastKnownTaskStates.get(taskId) ?? '{}') as TaskState,
+  );
+
+  // Apply one owner task delta to the local cache and forward results to the
+  // renderer (and drive owner-side auto-fix). Extracted so the detached viewer
+  // can replay deltas that were buffered during hydration.
+  const processIncomingTaskDelta = (delta: TaskDelta): void => {
+    deps.uiPerfStats.mainDeltaToUi += 1;
+    if (deps.traceUiDeltaFlow) {
+      deps.logger.debug(`delta→ui: ${JSON.stringify(delta)}`, { module: 'ui' });
+    }
+    const deltaTaskId = delta.type === 'updated' || delta.type === 'removed' ? delta.taskId : undefined;
+    if (delta.type === 'updated' && delta.changes.status === 'failed') {
+      const cancellationError = shouldSkipAutoFixForError(delta.changes.execution?.error);
+      const shouldAutoFixFromOrchestrator = deps.orchestrator.shouldAutoFix(delta.taskId);
+      deps.logAutoFixDebug(delta.taskId, 'delta-failed', {
+        shouldSkipForCancellation: cancellationError,
+        shouldAutoFixFromOrchestrator,
+      });
+      if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
+        deps.logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
+        deps.scheduleAutoFix(deltaTaskId);
+      } else if (deltaTaskId) {
+        deps.logAutoFixDebug(deltaTaskId, 'delta-skip', {
+          reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
+          shouldSkipForCancellation: cancellationError,
+          shouldAutoFixFromOrchestrator,
+        });
+      }
+    }
+    for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(delta)) {
+      publishTaskDeltaToRenderer(rendererDelta);
+    }
+  };
+
+  const parseExecutionDate = (value: unknown): Date | undefined => {
+    if (!value) return undefined;
+    if (value instanceof Date) return value;
+    if (typeof value !== 'string') return undefined;
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+  };
+
+  const startDbPolling = (): RendererTaskFeedStopHandle => {
+    const interval = setInterval(() => {
+      const mainWindow = deps.getMainWindow();
+      if (!mainWindow || mainWindow.isDestroyed()) return;
+      try {
+        const workflows = deps.persistence.listWorkflows();
+
+        if (workflows.length !== lastKnownWorkflowCount) {
+          const msg = `Workflow count changed: ${lastKnownWorkflowCount} → ${workflows.length}`;
+          deps.logger.info(msg, { module: 'db-poll' });
+          try { deps.persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
+          lastKnownWorkflowCount = workflows.length;
+          deps.requestWorkflowMetadataPublish('db-poll-count');
+
+          deps.orchestrator.syncAllFromDb();
+          deps.logger.info(`Synced orchestrator for all ${workflows.length} workflows`, { module: 'db-poll' });
+        }
+
+        for (const workflow of workflows) {
+          if (workflow.status === 'completed' || workflow.status === 'failed') continue;
+          const tasks = deps.persistence.loadTasks(workflow.id);
+          for (const loadedTask of tasks) {
+            const task = loadedTask;
+            const now = new Date();
+            const previousHeartbeat = parseExecutionDate(task.execution.lastHeartbeatAt);
+            const selectedAttempt = taskNeedsExecutingStallCheck(task) && task.execution.selectedAttemptId
+              ? deps.persistence.loadAttempt?.(task.execution.selectedAttemptId)
+              : undefined;
+            const leaseExpiresAt = parseExecutionDate(selectedAttempt?.leaseExpiresAt);
+            const remoteHeartbeat = parseExecutionDate(task.execution.remoteHeartbeatAt);
+
+            if (task.status === 'running' || (task.status === 'pending' && task.execution.phase === 'launching')) {
+              // CC.1: launch-stall watchdog removed. The
+              // LaunchDispatcher's reapExpiredLeases /
+              // abandonStuckLeases reapers (Phase B, CB.3) are the
+              // sole recovery path for stalled launch claims.
+              const executingStartedAt = parseExecutionDate(task.execution.startedAt);
+              const executingAgeMs = executingStartedAt ? now.getTime() - executingStartedAt.getTime() : 0;
+              const { heartbeatStale, leaseExpired, executingStalled, staleReason } = evaluateExecutingStall({
+                now,
+                phase: task.execution.phase,
+                runnerKind: task.config.runnerKind,
+                executingStartedAt,
+                leaseExpiresAt,
+                executorHeartbeatAt: previousHeartbeat,
+                remoteHeartbeatAt: remoteHeartbeat,
+                executingStallTimeoutMs: deps.executingStallTimeoutMs,
+              });
+
+              if (executingStalled) {
+                const selectedAttemptHeartbeat = parseExecutionDate(selectedAttempt?.lastHeartbeatAt);
+                const executingError =
+                  `Execution stalled: task remained in running/executing for ${Math.floor(executingAgeMs / 1000)}s ` +
+                  `without a live execution handle and no completion signal from executor (${staleReason}).`;
+                deps.logger.info(
+                  `[executing-stall] detected task="${task.id}" phase=${task.execution.phase} executingAgeMs=${executingAgeMs} ` +
+                    `handlePresent=${deps.taskHandles.has(task.id)} leaseExpired=${leaseExpired} heartbeatStale=${heartbeatStale} ` +
+                    `runnerKind=${task.config.runnerKind ?? 'none'} selectedAttemptId=${task.execution.selectedAttemptId ?? 'none'} ` +
+                    `attemptStatus=${selectedAttempt?.status ?? 'none'} executorHeartbeatAt=${previousHeartbeat?.toISOString() ?? 'none'} ` +
+                    `remoteHeartbeatAt=${remoteHeartbeat?.toISOString() ?? 'none'} attemptHeartbeatAt=${selectedAttemptHeartbeat?.toISOString() ?? 'none'} ` +
+                    `leaseExpiresAt=${leaseExpiresAt?.toISOString() ?? 'none'} launchStartedAt=${task.execution.launchStartedAt instanceof Date ? task.execution.launchStartedAt.toISOString() : task.execution.launchStartedAt ?? 'none'} ` +
+                    `launchCompletedAt=${task.execution.launchCompletedAt instanceof Date ? task.execution.launchCompletedAt.toISOString() : task.execution.launchCompletedAt ?? 'none'} ` +
+                    `startedAt=${executingStartedAt?.toISOString() ?? 'none'} completedAt=${task.execution.completedAt instanceof Date ? task.execution.completedAt.toISOString() : task.execution.completedAt ?? 'none'}`,
+                  { module: 'db-poll' },
+                );
+                const failedResponse: WorkResponse = {
+                  requestId: `executing-stall-${task.id}-${now.getTime()}`,
+                  actionId: task.id,
+                  attemptId: task.execution.selectedAttemptId,
+                  executionGeneration: task.execution.generation ?? 0,
+                  status: 'failed',
+                  outputs: {
+                    exitCode: 1,
+                    error: executingError,
+                    failureClass: 'liveness_stall',
+                  },
+                };
+                deps.logger.error(`[executing-stall] forcing failure for "${task.id}": ${executingError}`, { module: 'db-poll' });
+                persistShutdownDiagnostic(task, deps.persistence, {
+                  flushPendingOutput: flushTaskOutput,
+                  forcedStopReason: executingError,
+                  label: task.execution.phase === 'launching'
+                    ? 'Startup Failure Diagnostic'
+                    : 'Shutdown Diagnostic',
+                });
+                deps.orchestrator.handleWorkerResponse(failedResponse);
+                continue;
+              }
+            }
+
+            // Stalled-fix-session watchdog: a fix session whose owner died
+            // mid-fix (heartbeat stopped, attempt lease expired) is invisible
+            // to the running-task path above because its status is
+            // `fixing_with_ai`, not `running`. Evaluate it as an executing
+            // task; a live fix refreshes its lease every 30s via
+            // withAttemptHeartbeat, so only an orphaned one is ever stalled.
+            if (task.status === 'fixing_with_ai') {
+              const fixStartedAt = parseExecutionDate(task.execution.startedAt);
+              const { executingStalled, staleReason } = evaluateExecutingStall({
+                now,
+                phase: 'executing',
+                runnerKind: task.config.runnerKind,
+                executingStartedAt: fixStartedAt,
+                leaseExpiresAt,
+                executorHeartbeatAt: previousHeartbeat,
+                remoteHeartbeatAt: remoteHeartbeat,
+                executingStallTimeoutMs: deps.executingStallTimeoutMs,
+              });
+              if (executingStalled) {
+                const fixAgeMs = fixStartedAt ? now.getTime() - fixStartedAt.getTime() : 0;
+                const reason =
+                  `Fix session stalled: task remained in fixing_with_ai for ${Math.floor(fixAgeMs / 1000)}s ` +
+                  `without a live fix handle (${staleReason}).`;
+                deps.logger.error(`[fix-session-stall] reclaiming "${task.id}": ${reason}`, { module: 'db-poll' });
+                const outcome = deps.orchestrator.reclaimStalledFixSession(task.id, {
+                  reason,
+                  expectedLineage: {
+                    taskId: task.id,
+                    selectedAttemptId: task.execution.selectedAttemptId,
+                    generation: task.execution.generation ?? 0,
+                  },
+                });
+                deps.logger.info(
+                  `[fix-session-stall] reclaim outcome=${outcome} task="${task.id}" ` +
+                    `selectedAttemptId=${task.execution.selectedAttemptId ?? 'none'} ` +
+                    `leaseExpiresAt=${leaseExpiresAt?.toISOString() ?? 'none'}`,
+                  { module: 'db-poll' },
+                );
+                continue;
+              }
+            }
+
+            const snapshot = JSON.stringify(task);
+            const previous = lastKnownTaskStates.get(task.id);
+            if (!previous) {
+              if (deps.traceDbPollPerTask) {
+                const msg = `New task: ${task.id} (${task.status})`;
+                deps.logger.info(msg, { module: 'db-poll' });
+                try { deps.persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
+              }
+              lastKnownTaskStates.set(task.id, snapshot);
+              deps.uiPerfStats.dbPollCreated += 1;
+              publishTaskDeltaToRenderer({ type: 'created', task });
+            } else if (previous !== snapshot) {
+              if (deps.traceDbPollPerTask) {
+                const msg = `Task updated: ${task.id} (${task.status})`;
+                deps.logger.info(msg, { module: 'db-poll' });
+                try { deps.persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
+              }
+              lastKnownTaskStates.set(task.id, snapshot);
+              deps.uiPerfStats.dbPollUpdatedAsCreated += 1;
+              publishTaskDeltaToRenderer({ type: 'created', task });
+            }
+          }
+        }
+        try {
+          deps.pollLaunchDispatcher();
+        } catch (err) {
+          deps.logger.warn(
+            `[launch-dispatcher] poll() failed: ${err instanceof Error ? err.message : String(err)}`,
+            { module: 'db-poll' },
+          );
+        }
+      } catch {
+        // DB might be locked — skip this tick
+      }
+    }, 2000);
+
+    return {
+      stop() {
+        clearInterval(interval);
+      },
+    };
+  };
+
+  const startActivityPolling = (): RendererTaskFeedStopHandle => {
+    const interval = setInterval(() => {
+      const snapshot = {
+        ts: new Date().toISOString(),
+        metric: 'main_delta_flow',
+        ...deps.uiPerfStats,
+      };
+      try {
+        deps.persistence.writeActivityLog('ui-perf-main', 'info', JSON.stringify(snapshot));
+
+      } catch {
+        // DB might be locked
+      }
+    }, 10000);
+
+    return {
+      stop() {
+        clearInterval(interval);
+      },
+    };
+  };
+
+  return {
+    enqueueTaskOutput,
+    flushTaskOutput,
+    seedUiSnapshotCache,
+    hydrateDetachedViewerFromOwner,
+    getDetachedViewerTasks,
+    getDetachedViewerWorkflows: () => detachedViewerWorkflows,
+    publishTaskDeltaToRenderer,
+    getLastKnownWorkflowCount: () => lastKnownWorkflowCount,
+    setLastKnownWorkflowCount: (count) => { lastKnownWorkflowCount = count; },
+    getTaskSnapshot: (taskId) => lastKnownTaskStates.get(taskId),
+    listKnownTaskIds: () => [...lastKnownTaskStates.keys()],
+    clearTaskSnapshots: () => { lastKnownTaskStates.clear(); },
+    replaceWorkflowRollups: (tasks) => { workflowRollupProjection.replaceAll(tasks); },
+    rememberTaskState: (task) => { lastKnownTaskStates.set(task.id, JSON.stringify(task)); },
+    resetSnapshotState: () => {
+      lastKnownTaskStates.clear();
+      workflowRollupProjection.clear();
+      lastKnownWorkflowCount = 0;
+    },
+    beginDetachedViewerBuffering: () => { detachedDeltaBuffer = []; },
+    receiveTaskDelta: (delta) => {
+      if (detachedDeltaBuffer) {
+        detachedDeltaBuffer.push(delta);
+        return;
+      }
+      processIncomingTaskDelta(delta);
+    },
+    startDbPolling,
+    startActivityPolling,
+  };
+}


### PR DESCRIPTION
Review claim: The output-buffering/task-delta/viewer-hydration pipeline and the db/activity poll loops move from main.ts to window/renderer-task-feed.ts owning their state block; behavior unchanged.
Review lane: refactor
Safety invariant: Pure move slice. The delta pipeline is pinned by delta-merge.test.ts (which mirrors the main-process loop), viewer-cache-hydration.test.ts, workflow-rollup-projection.test.ts, and the synthetic-merge quarantine repro; poll loops return stop() handles so the shutdown path keeps clearing them.
Slice rationale: One extraction per slice per the review-compression convention; this is slice 2 of the app decomposition chain and touches nothing else.
Architectural effect: main.ts delegates the renderer feed to window/renderer-task-feed.ts (the window/ sibling of window-lifecycle.ts); the module owns lastKnownTaskStates, workflowRollupProjection, pendingOutputBuffers, outputFlushTimers, detachedDeltaBuffer, detachedViewerWorkflows, lastKnownWorkflowCount, lastActivityLogId and exposes getters for registerBootstrapStateIpc. No dependency direction change.
Goal:
Create window/renderer-task-feed.ts owning the renderer delta/output pipeline and the two poll loops.
Motivation:
packages/app/src/main.ts is 5,039 lines; extracting the renderer task-feed pipeline (output buffering, delta publication, viewer hydration, poll loops) relocates ~460 lines along the established seam so future changes review in isolation.
Alternative considerations:
- Split delta pipeline and poll loops into two modules (rejected: the poll loops read and write the same state block; one seam, one claim).
- Keep state in main.ts and pass every field by getter (rejected: the block is exclusively owned by this cluster; ownership transfer is the smaller interface).
Implementation details:
- Create packages/app/src/window/renderer-task-feed.ts exporting createRendererTaskFeed(deps) following the window-lifecycle.ts deps convention (getMainWindow, provider getters, recordStartupMark hooks).
- Move from main.ts: flushTaskOutput (1948-1973), enqueueTaskOutput (1974-1985), the taskGraphEventPublisher wiring (1990-2004), publishTaskDeltaToRenderer (2005-2008), applyTaskDeltaToOwnerCacheOrRecover (2010-2029), requestWorkflowMetadataPublish (2030-2033), seedUiSnapshotCache (2709-2712), hydrateDetachedViewerFromOwner (2719-2751), detachedViewerTasks (2753-2758), processIncomingTaskDelta (2761-2770), loadTaskByIdFromPersistence (2771-2773), listWorkflowsByStartupRecency (2794-2806), bootstrapInitialWorkflowState (2808-2861), publishOrchestratorSnapshotToRenderer (2862-2884), and the db-poll/activity-poll bodies from startDeferredStartupWork (2982-3117) as startDbPolling/startActivityPolling returning stop() functions.
- The module owns the renderer-feed state block and provides the getters registerBootstrapStateIpc needs (main.ts line 3451) plus the TASK_DELTA/TASK_OUTPUT feed wiring (3405-3439).
- Deps carry getMainWindow, isUiInteractive, getOrchestrator, getPersistence, getMessageBus, getOwnerMode, taskDeltaStream, uiPerfStats/recordStartupMark hooks, and a logger getter; singletons are read through getters at call time.
- Refresh the outdated main.ts line citations in packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts comments so they point at the new module.
Non-goals:
- No IPC mutation-handler moves (next slice); no terminal or shutdown moves.
- No change to delta merge semantics, flush cadence, or detached-viewer recovery behavior.
Layer: app_bridge
Feature state: active
Files:
- packages/app/src/main.ts
- packages/app/src/window/renderer-task-feed.ts
- packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts
Change types:
- packages/app/src/main.ts: modify
- packages/app/src/window/renderer-task-feed.ts: create
- packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts: test-only
Acceptance criteria:
- pnpm --filter @invoker/app exec vitest run src/__tests__/delta-merge.test.ts src/__tests__/viewer-cache-hydration.test.ts src/__tests__/workflow-rollup-projection.test.ts src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts exits 0.
- main.ts no longer declares the renderer-feed state block; shutdown clears polls via stop() handles.

Solution:
  Move the renderer task-feed pipeline (output buffering, delta publication, viewer hydration, poll loops) out of packages/app/src/main.ts into packages/app/src/window/renderer-task-feed.ts; behavior unchanged.
Review claim: The output-buffering/task-delta/viewer-hydration pipeline and the db/activity poll loops move from main.ts to window/renderer-task-feed.ts owning their state block; behavior unchanged.
Review lane: refactor
Safety invariant: Pure move slice. The delta pipeline is pinned by delta-merge.test.ts (which mirrors the main-process loop), viewer-cache-hydration.test.ts, workflow-rollup-projection.test.ts, and the synthetic-merge quarantine repro; poll loops return stop() handles so the shutdown path keeps clearing them.
Slice rationale: One extraction per slice per the review-compression convention; this is slice 2 of the app decomposition chain and touches nothing else.
Architectural effect: main.ts delegates the renderer feed to window/renderer-task-feed.ts (the window/ sibling of window-lifecycle.ts); the module owns lastKnownTaskStates, workflowRollupProjection, pendingOutputBuffers, outputFlushTimers, detachedDeltaBuffer, detachedViewerWorkflows, lastKnownWorkflowCount, lastActivityLogId and exposes getters for registerBootstrapStateIpc. No dependency direction change.
Goal:
Create window/renderer-task-feed.ts owning the renderer delta/output pipeline and the two poll loops.
Motivation:
packages/app/src/main.ts is 5,039 lines; extracting the renderer task-feed pipeline (output buffering, delta publication, viewer hydration, poll loops) relocates ~460 lines along the established seam so future changes review in isolation.
Alternative considerations:
- Split delta pipeline and poll loops into two modules (rejected: the poll loops read and write the same state block; one seam, one claim).
- Keep state in main.ts and pass every field by getter (rejected: the block is exclusively owned by this cluster; ownership transfer is the smaller interface).
Implementation details:
- Create packages/app/src/window/renderer-task-feed.ts exporting createRendererTaskFeed(deps) following the window-lifecycle.ts deps convention (getMainWindow, provider getters, recordStartupMark hooks).
- Move from main.ts: flushTaskOutput (1948-1973), enqueueTaskOutput (1974-1985), the taskGraphEventPublisher wiring (1990-2004), publishTaskDeltaToRenderer (2005-2008), applyTaskDeltaToOwnerCacheOrRecover (2010-2029), requestWorkflowMetadataPublish (2030-2033), seedUiSnapshotCache (2709-2712), hydrateDetachedViewerFromOwner (2719-2751), detachedViewerTasks (2753-2758), processIncomingTaskDelta (2761-2770), loadTaskByIdFromPersistence (2771-2773), listWorkflowsByStartupRecency (2794-2806), bootstrapInitialWorkflowState (2808-2861), publishOrchestratorSnapshotToRenderer (2862-2884), and the db-poll/activity-poll bodies from startDeferredStartupWork (2982-3117) as startDbPolling/startActivityPolling returning stop() functions.
- The module owns the renderer-feed state block and provides the getters registerBootstrapStateIpc needs (main.ts line 3451) plus the TASK_DELTA/TASK_OUTPUT feed wiring (3405-3439).
- Deps carry getMainWindow, isUiInteractive, getOrchestrator, getPersistence, getMessageBus, getOwnerMode, taskDeltaStream, uiPerfStats/recordStartupMark hooks, and a logger getter; singletons are read through getters at call time.
- Refresh the outdated main.ts line citations in packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts comments so they point at the new module.
Non-goals:
- No IPC mutation-handler moves (next slice); no terminal or shutdown moves.
- No change to delta merge semantics, flush cadence, or detached-viewer recovery behavior.
Layer: app_bridge
Feature state: active
Files:
- packages/app/src/main.ts
- packages/app/src/window/renderer-task-feed.ts
- packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts
Change types:
- packages/app/src/main.ts: modify
- packages/app/src/window/renderer-task-feed.ts: create
- packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts: test-only
Acceptance criteria:
- pnpm --filter @invoker/app exec vitest run src/__tests__/delta-merge.test.ts src/__tests__/viewer-cache-hydration.test.ts src/__tests__/workflow-rollup-projection.test.ts src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts exits 0.
- main.ts no longer declares the renderer-feed state block; shutdown clears polls via stop() handles.