### PR TITLE
[Workflow Graph Home Fit](1) Fit the workflow graph when Home returns from browser surfaces

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2246,6 +2246,14 @@ export function App() {
     setInspectorCollapsed((prev) => !prev);
   }, [autoCollapseInspector]);
 
+  const navigateHomeAndFitWorkflowGraph = useCallback((reason: string) => {
+    cameraSuppressedRef.current = false;
+    setSidebarSurface('home');
+    setInspectorManualOpen(false);
+    setViewMode('dag');
+    issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason });
+  }, [issueCameraCommand]);
+
   const handleSelectSidebarSurface = useCallback((nextSurface: SidebarSurface) => {
     setGraphActionsMenuOpen(false);
     reportUiNavigation(window.invoker?.reportUiPerf, {
@@ -2262,16 +2270,15 @@ export function App() {
       setViewMode('queue');
       return;
     }
-    setViewMode('dag');
     if (nextSurface === 'home') {
-      setSidebarSurface('home');
-      setInspectorManualOpen(false);
+      navigateHomeAndFitWorkflowGraph('sidebar-home');
       return;
     }
+    setViewMode('dag');
     setSidebarSurface(nextSurface);
     setInspectorManualOpen(false);
     setStatusFilters(new Set<WorkflowStatus>());
-  }, [sidebarSurface, viewMode]);
+  }, [navigateHomeAndFitWorkflowGraph, sidebarSurface, viewMode]);
 
   const handleDismissBrowserSurface = useCallback(() => {
     setGraphActionsMenuOpen(false);
@@ -2282,10 +2289,8 @@ export function App() {
       viewMode,
       dismiss: true,
     });
-    setSidebarSurface('home');
-    setInspectorManualOpen(false);
-    setViewMode('dag');
-  }, [sidebarSurface, viewMode]);
+    navigateHomeAndFitWorkflowGraph('browser-return-home');
+  }, [navigateHomeAndFitWorkflowGraph, sidebarSurface, viewMode]);
 
   // ── Task actions ──────────────────────────────────────────
   const handleProvideInput = useCallback(

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -20,14 +20,33 @@ import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vite
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { WorkflowMeta } from '../types.js';
+import type { GraphCameraCommand } from '../lib/graph-camera.js';
 import * as ReactFlowModule from '@xyflow/react';
 
 // vitest hoists vi.mock above imports and its factory cannot close over
 // top-level bindings, so the mock module is loaded dynamically here — a test
 // module-loading boundary, the sanctioned exception to static-import-only.
+const workflowGraphSpy = vi.hoisted(() => ({
+  commands: [] as Array<GraphCameraCommand | null | undefined>,
+  reset() {
+    this.commands.length = 0;
+  },
+}));
+
 vi.mock('@xyflow/react', async () => {
   const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
   return createReactFlowMock();
+});
+
+vi.mock('../components/WorkflowGraph.js', async () => {
+  const actual = await vi.importActual<typeof import('../components/WorkflowGraph.js')>('../components/WorkflowGraph.js');
+  return {
+    ...actual,
+    WorkflowGraph(props: Parameters<typeof actual.WorkflowGraph>[0]) {
+      workflowGraphSpy.commands.push(props.cameraCommand);
+      return actual.WorkflowGraph(props);
+    },
+  };
 });
 
 const fitViewMock = (ReactFlowModule as unknown as { __fitViewMock: Mock }).__fitViewMock;
@@ -100,6 +119,7 @@ describe('Browser-surface camera (component)', () => {
     setCenterMock.mockClear();
     getZoomMock.mockReset();
     getZoomMock.mockReturnValue(1);
+    workflowGraphSpy.reset();
   });
 
   afterEach(() => {
@@ -146,7 +166,7 @@ describe('Browser-surface camera (component)', () => {
     expect(setCenterMock).not.toHaveBeenCalled();
     expect(fitViewMock).not.toHaveBeenCalled();
   });
-  it('clicking the left-nav home icon returns to the workflow graph and fits the whole graph', async () => {
+  it('clicking the left-nav home icon returns to the workflow graph and issues the Home fit command', async () => {
     mock.setTasks(tasks, workflows);
     render(<App />);
 
@@ -155,10 +175,19 @@ describe('Browser-surface camera (component)', () => {
     await settleCamera();
     fitViewMock.mockClear();
     setCenterMock.mockClear();
+    workflowGraphSpy.reset();
 
     fireEvent.click(screen.getByTestId('sidebar-home'));
 
     await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
+    await waitFor(() => {
+      const matchingCommands = workflowGraphSpy.commands.filter((command): command is GraphCameraCommand => (
+        command?.kind === 'fitInitial'
+        && command.scope === 'workflow'
+        && command.reason === 'sidebar-home'
+      ));
+      expect(matchingCommands.length).toBeGreaterThan(0);
+    });
     await flushFrames(4);
 
     expect(fitViewMock).toHaveBeenCalled();

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -146,4 +146,21 @@ describe('Browser-surface camera (component)', () => {
     expect(setCenterMock).not.toHaveBeenCalled();
     expect(fitViewMock).not.toHaveBeenCalled();
   });
+  it('clicking the left-nav home icon returns to the workflow graph and fits the whole graph', async () => {
+    mock.setTasks(tasks, workflows);
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId('sidebar-workflows'));
+    await screen.findByTestId('selected-workflow-mini-dag');
+    await settleCamera();
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+
+    await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
+    await flushFrames(4);
+
+    expect(fitViewMock).toHaveBeenCalled();
+  });
 });

--- a/scripts/repro/repro-coderabbit-pr4241-sidebar-home-fit-command.sh
+++ b/scripts/repro/repro-coderabbit-pr4241-sidebar-home-fit-command.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CodeRabbit PR #4241 (discussion r3566839020): the Home-return regression test
+# only asserted react-flow fitView(), which WorkflowGraph can trigger on mount
+# even if App stops issuing the explicit sidebar-home fitInitial command.
+#
+# The focused regression clicks the left-rail Home icon from the Workflows
+# browser surface and asserts WorkflowGraph received a workflow-scoped
+# fitInitial command with reason sidebar-home.
+#   - Buggy code omits the command -> vitest fails -> repro exits non-zero.
+#   - Fixed code issues the command -> vitest passes -> repro exits zero.
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/invoker-pr4241-sidebar-home-fit.XXXXXX.log")"
+trap 'rm -f "$LOG_FILE"' EXIT
+
+echo "[repro] PR #4241: sidebar Home must issue a workflow fitInitial command."
+
+if pnpm -C "$REPO_ROOT" --filter @invoker/ui exec vitest run \
+  src/__tests__/browser-surface-camera-resnap.test.tsx \
+  -t "clicking the left-nav home icon returns to the workflow graph and issues the Home fit command" \
+  >"$LOG_FILE" 2>&1; then
+  echo "[repro] PASS: sidebar Home sent WorkflowGraph the workflow fitInitial command with reason sidebar-home."
+  exit 0
+else
+  status=$?
+  echo "[repro] FAIL: sidebar Home returned home without proving the explicit workflow fitInitial command."
+  cat "$LOG_FILE"
+  exit "$status"
+fi


### PR DESCRIPTION
## Summary

Clicking the left rail Home icon now returns to the Home graph and fits the full workflow graph back into view.

The bug was simple. The icon changed the surface, but it did not trigger a graph fit. The viewport could stay stuck on the browser view and look blank.

The fix uses one shared Home-return helper so both return paths switch back to Home and re-fit the workflow graph.

## Review Claim

The Home return paths now re-fit the full workflow graph instead of only switching views.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This only changes the visible Home return behavior. It reuses the existing workflow camera fit behavior and does not change graph layout or task updates.

## Slice Rationale

This is one local UI behavior. Keeping the fix and the regression proof together makes the reviewer check one Home return flow in one place.

## Non-goals

- No change to workflow browser filtering.
- No change to task-DAG camera behavior.
- No change to workflow graph layout.

## Architecture

### Before

The Home-return handlers switched the UI back to Home, but they could leave the workflow camera where the browser view had it.

### After

Both Home-return handlers call `navigateHomeAndFitWorkflowGraph(reason)`. That helper clears temporary camera suppression, switches to Home DAG view, and issues a workflow-graph fit.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/browser-surface-camera-resnap.test.tsx src/__tests__/app-launch.test.tsx src/__tests__/timeline-view-e2e.test.tsx`
- [x] `bash scripts/ui-visual-proof.sh capture-after --spec e2e/home-fit-workflow-graph-proof.spec.ts --output-dir /tmp/home-fit-graph-proof`

</details>

## Visual Proof

Primary proof is the walkthrough video. It shows the app on the Workflows browser view, then the left rail Home icon click, then the full workflow graph back on screen.

- Video: [left rail Home returns to the full workflow graph](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-02d6d3/walkthrough.webm)
- Screenshot: ![Home graph fit after clicking the left rail Home icon](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-02d6d3/sidebar-home-fit-workflow-graph.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 543e15f13`
- Post-revert steps: None.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Returning home from the browser or sidebar now consistently restores the workflow graph view.
  * The graph automatically fits to display the full workflow after returning home.
  * Improved camera state reset behavior when navigating back to the workflow graph.

* **Tests**
  * Added regression coverage for camera refocusing when returning home.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->