### PR TITLE
[Stress chaos e2e](1) Add contracts for stress seeding and queue truth

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -195,6 +195,8 @@ export interface TaskHistoryEntry extends TaskState {
 export interface QueueStatus {
   maxConcurrency: number;
   runningCount: number;
+  activeExecutionCount?: number;
+  launchingCount?: number;
   running: Array<{ taskId: string; description: string }>;
   queued: Array<{ taskId: string; priority: number; description: string }>;
 }
@@ -1157,6 +1159,25 @@ export const IpcTestOnlyChannels = {
       taskCount: number;
       eventCount: number;
       workerActionCount: number;
+    };
+  },
+  'invoker:seed-stress-fixture': {} as {
+    request: [options?: {
+      workflowCount?: number;
+      tasksPerWorkflow?: number;
+      eventsPerTask?: number;
+      nowIso?: string;
+      stuckLaunchingSlots?: number;
+      launchAgeMs?: number;
+    }];
+    response: {
+      workflowCount: number;
+      taskCount: number;
+      running: number;
+      launching: number;
+      fixing: number;
+      pending: number;
+      failed: number;
     };
   },
 } as const;

--- a/packages/contracts/src/launch-timeouts.ts
+++ b/packages/contracts/src/launch-timeouts.ts
@@ -13,5 +13,6 @@
 export const ATTEMPT_LEASE_MS = 20 * 60 * 1000;
 
 export const DISPATCH_LEASE_MS = 12 * 60 * 1000;
+export const LAUNCH_STUCK_ABANDON_MS = DISPATCH_LEASE_MS;
 
 export const DISPATCH_MAX_ATTEMPTS = 3;


### PR DESCRIPTION
## Summary

This adds the contract fields that distinguish executing work from launching slots in queue reads.

It also adds the shared stuck-launch age constant and the stress-seeding request shape used by later slices.

## Review Claim

The contract now carries queue-truth fields, a stuck-launch age constant, and a production-shape stress-seeding request.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Only contract files change. No caller behavior changes in this slice.

## Slice Rationale

The later scheduler and CI slices both depend on these names and literals, so the shared contract lands first.

## Non-goals

No dispatcher behavior, no queue formatting, and no ci policy changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd ~/Documents/GitHub/Invoker-ui-regressions && pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3550b270c`
- Post-revert steps: None
- Data migration? No

</details>