### PR TITLE
[Execution Model Guard](1) Add execution-agent model compatibility helper

### DIFF
--- a/packages/execution-engine/src/__tests__/agent-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/agent-registry.test.ts
@@ -1,7 +1,34 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { AgentRegistry } from '../agent-registry.js';
 import { registerBuiltinAgents } from '../agents/index.js';
-import type { ExecutionAgent } from '../agent.js';
+import { assertExecutionModelSupported, type ExecutionAgent } from '../agent.js';
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawnSync: vi.fn(() => ({
+      status: 1,
+      stdout: '',
+      stderr: '',
+      output: [],
+      pid: 0,
+      signal: null,
+    })),
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(spawnSync).mockReset();
+  vi.mocked(spawnSync).mockReturnValue({
+    status: 1,
+    stdout: '',
+    stderr: '',
+    output: [],
+    pid: 0,
+    signal: null,
+  } as any);
+});
 
 function makeExecutionAgent(name: string, opts?: {
   bundledSkillRoot?: string;
@@ -68,6 +95,30 @@ describe('registerBuiltinAgents', () => {
       }),
     ]));
   });
+  it('prefers Codex models discovered from the CLI', () => {
+    vi.mocked(spawnSync).mockReturnValueOnce({
+      status: 0,
+      stdout: JSON.stringify({
+        models: [
+          { slug: 'gpt-5.5', display_name: 'GPT-5.5' },
+          { slug: 'gpt-5.4-mini', display_name: 'GPT-5.4 Mini' },
+          { slug: 'gpt-5.5', display_name: 'Duplicate GPT-5.5' },
+        ],
+      }),
+      stderr: '',
+      output: [],
+      pid: 1,
+      signal: null,
+    } as any);
+
+    const codexAgent = registerBuiltinAgents().getOrThrow('codex');
+
+    expect(codexAgent.supportedModels).toEqual([
+      { id: 'gpt-5.5', label: 'GPT-5.5' },
+      { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
+    ]);
+    expect(() => assertExecutionModelSupported(codexAgent, 'gpt-5.5')).not.toThrow();
+  });
 
 
   it('registers cursor, omp, and codex planning agents', () => {
@@ -130,6 +181,29 @@ describe('AgentRegistry', () => {
   it('still throws for real unknown execution agent names', () => {
     expect(() => registry.getOrThrow('cluade')).toThrow(
       'No execution agent registered with name "cluade". Available: [claude, codex]',
+    );
+  });
+  it('accepts versioned OpenAI-style models for codex', () => {
+    const codexAgent = registerBuiltinAgents().getOrThrow('codex');
+    expect(() => assertExecutionModelSupported(codexAgent, 'gpt-5.1-codex-max')).not.toThrow();
+  });
+
+  it('rejects clearly foreign models for codex', () => {
+    const codexAgent = registerBuiltinAgents().getOrThrow('codex');
+    expect(() => assertExecutionModelSupported(codexAgent, 'claude')).toThrow(
+      'Execution model "claude" is not supported for execution agent "codex".',
+    );
+  });
+  it('accepts Claude aliases and versioned Claude model ids', () => {
+    const claudeAgent = registerBuiltinAgents().getOrThrow('claude');
+    expect(() => assertExecutionModelSupported(claudeAgent, 'sonnet')).not.toThrow();
+    expect(() => assertExecutionModelSupported(claudeAgent, 'anthropic/claude-opus-4-8-20260528')).not.toThrow();
+  });
+
+  it('rejects plain claude as an execution model for Claude', () => {
+    const claudeAgent = registerBuiltinAgents().getOrThrow('claude');
+    expect(() => assertExecutionModelSupported(claudeAgent, 'claude')).toThrow(
+      'Execution model "claude" is not supported for execution agent "claude".',
     );
   });
 

--- a/packages/execution-engine/src/agent.ts
+++ b/packages/execution-engine/src/agent.ts
@@ -1,13 +1,3 @@
-/**
- * ExecutionAgent / PlanningAgent — Pluggable AI agent interfaces.
- *
- * Executors own the spawn lifecycle (stdio, exit handling, worktree/container setup).
- * Agents only provide command specs. This keeps the abstraction thin:
- * agents say *what* to run, executors decide *how* to run it.
- */
-
-// ── Execution Agent ──────────────────────────────────────────
-
 export interface AgentCommandSpec {
   cmd: string;
   args: string[];
@@ -29,28 +19,13 @@ export const DEFAULT_EXECUTION_AGENT = 'codex';
 export interface ExecutionAgent {
   readonly name: string;
   readonly stdinMode: 'ignore' | 'pipe';
-  /** Tail command for Linux terminal launch (e.g. 'exec_bash' or 'pause'). */
   readonly linuxTerminalTail?: 'exec_bash' | 'pause';
-
-  /**
-   * Root directory where this agent's bundled skills are installed.
-   * Example: ~/.claude/skills for the Claude agent.
-   * Undefined when the agent has no bundled skill support.
-   */
   readonly bundledSkillRoot?: string;
-
-  /**
-   * Skill names this agent bundles (e.g. ['make-pr']).
-   * The registry uses this list for capability-based lookup.
-   * Each name corresponds to a subdirectory `invoker-{name}` under bundledSkillRoot.
-   */
   readonly bundledSkills?: readonly string[];
-  /** Curated built-in model choices for this harness. Values must be CLI-compatible. */
   readonly supportedModels?: readonly ExecutionModelOption[];
-
+  supportsModel?(executionModel: string): boolean;
   buildCommand(fullPrompt: string, options?: AgentCommandBuildOptions): AgentCommandSpec;
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] };
-  /** Build a command spec for a fix/conflict-resolution prompt. */
   buildFixCommand?(prompt: string, options?: AgentCommandBuildOptions): AgentCommandSpec;
   getContainerRequirements?(): {
     mounts: Array<{ hostPath: string; containerPath: string; readonly?: boolean }>;
@@ -58,7 +33,18 @@ export interface ExecutionAgent {
   };
 }
 
-// ── Planning Agent ───────────────────────────────────────────
+export function assertExecutionModelSupported(
+  agent: Pick<ExecutionAgent, 'name' | 'supportedModels' | 'supportsModel'>,
+  executionModel: string | null | undefined,
+): void {
+  const normalizedModel = executionModel?.trim();
+  if (!normalizedModel) return;
+  if (agent.supportedModels?.some((candidate) => candidate.id === normalizedModel)) return;
+  if (agent.supportsModel?.(normalizedModel)) return;
+  const supported = agent.supportedModels?.map((candidate) => candidate.id) ?? [];
+  const hint = supported.length > 0 ? ` Known models: [${supported.join(', ')}].` : '';
+  throw new Error(`Execution model "${normalizedModel}" is not supported for execution agent "${agent.name}".${hint}`);
+}
 
 export interface PlanningAgent {
   readonly name: string;

--- a/packages/execution-engine/src/agents/claude-execution-agent.ts
+++ b/packages/execution-engine/src/agents/claude-execution-agent.ts
@@ -1,24 +1,13 @@
-/**
- * ClaudeExecutionAgent — ExecutionAgent implementation for Anthropic's Claude CLI.
- *
- * Extracted from BaseExecutor.buildClaudeArgs() / prepareClaudeSession().
- * Agents provide command specs; executors own the spawn lifecycle.
- */
-
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions, ExecutionModelOption } from '../agent.js';
+
 export interface ClaudeExecutionAgentConfig {
-  /** Command to invoke the Claude CLI. Default: 'claude'. */
   command?: string;
-  /** Override command used specifically for fix flows. Default: INVOKER_CLAUDE_FIX_COMMAND or `command`. */
   fixCommand?: string;
-  /** Path to the Claude config directory on the host. Default: ~/.claude. */
   configDir?: string;
-  /** Home directory inside Docker containers. Default: '/home/invoker'. */
   containerHomePath?: string;
-  /** ANTHROPIC_API_KEY. Falls back to process.env.ANTHROPIC_API_KEY. */
   apiKey?: string;
 }
 
@@ -27,6 +16,10 @@ const CLAUDE_SUPPORTED_MODELS: readonly ExecutionModelOption[] = [
   { id: 'opus', label: 'Claude Opus' },
   { id: 'haiku', label: 'Claude Haiku' },
 ];
+
+function normalizeClaudeModel(executionModel: string): string {
+  return executionModel.trim().toLowerCase().replace(/^anthropic[/:]/, '');
+}
 
 export class ClaudeExecutionAgent implements ExecutionAgent {
   readonly name = 'claude';
@@ -68,6 +61,13 @@ export class ClaudeExecutionAgent implements ExecutionAgent {
       args: ['--session-id', sessionId, ...this.buildModelArgs(options.executionModel), '-p', prompt, '--dangerously-skip-permissions'],
       sessionId,
     };
+  }
+  supportsModel(executionModel: string): boolean {
+    const normalized = normalizeClaudeModel(executionModel);
+    return normalized === 'sonnet'
+      || normalized === 'opus'
+      || normalized === 'haiku'
+      || /^claude-(sonnet|opus|haiku)(?:-|$)/.test(normalized);
   }
 
   private buildModelArgs(executionModel?: string): string[] {

--- a/packages/execution-engine/src/agents/codex-execution-agent.ts
+++ b/packages/execution-engine/src/agents/codex-execution-agent.ts
@@ -1,40 +1,62 @@
-/**
- * CodexExecutionAgent — ExecutionAgent implementation for OpenAI Codex CLI.
- *
- * Agents provide command specs; executors own the spawn lifecycle.
- *
- * Known issue: `codex exec --json` exits 0 when the agent turn completes,
- * NOT when the task succeeds. Codex can fail to verify its fix (e.g. EPERM
- * blocking test execution) and still exit 0. Callers that check only the
- * exit code will treat an unverified fix as successful.
- */
-
+import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions, ExecutionModelOption } from '../agent.js';
+
 export interface CodexExecutionAgentConfig {
-  /** Command to invoke the Codex CLI. Default: 'codex'. */
   command?: string;
-  /**
-   * Run in full-auto mode (sandboxed workspace-write + on-request approvals).
-   * Ignored when bypassApprovalsAndSandbox is true.
-   */
   fullAuto?: boolean;
-  /**
-   * Run without Codex sandbox/approval gating.
-   * Default: true (Invoker already isolates work in managed workspaces).
-   */
   bypassApprovalsAndSandbox?: boolean;
 }
 
-const CODEX_SUPPORTED_MODELS: readonly ExecutionModelOption[] = [
+const CODEX_MODEL_DISCOVERY_TIMEOUT_MS = 3_000;
+const CODEX_MODEL_CACHE_MS = 5 * 60_000;
+
+const CODEX_FALLBACK_MODELS: readonly ExecutionModelOption[] = [
+  { id: 'gpt-5.5', label: 'GPT-5.5' },
+  { id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro' },
+  { id: 'gpt-5.4', label: 'GPT-5.4' },
+  { id: 'gpt-5.4-pro', label: 'GPT-5.4 Pro' },
+  { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
+  { id: 'gpt-5.4-nano', label: 'GPT-5.4 Nano' },
+  { id: 'gpt-5.3', label: 'GPT-5.3' },
+  { id: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
+  { id: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
+  { id: 'gpt-5.2', label: 'GPT-5.2' },
+  { id: 'gpt-5.2-codex', label: 'GPT-5.2 Codex' },
+  { id: 'gpt-5.1', label: 'GPT-5.1' },
+  { id: 'gpt-5.1-codex', label: 'GPT-5.1 Codex' },
+  { id: 'gpt-5.1-codex-max', label: 'GPT-5.1 Codex Max' },
   { id: 'gpt-5', label: 'GPT-5' },
   { id: 'gpt-5-codex', label: 'GPT-5 Codex' },
-  { id: 'gpt-5-mini', label: 'GPT-5 Mini' },
-  { id: 'o3', label: 'o3' },
-  { id: 'o4-mini', label: 'o4-mini' },
 ];
+
+function normalizeCodexModelId(model: string): string {
+  return model.trim().toLowerCase();
+}
+
+function parseDiscoveredCodexModels(stdout: string): ExecutionModelOption[] {
+  try {
+    const parsed = JSON.parse(stdout) as {
+      models?: Array<{ slug?: string; display_name?: string }>;
+    };
+    const models: ExecutionModelOption[] = [];
+    const seen = new Set<string>();
+    for (const entry of parsed.models ?? []) {
+      const id = entry.slug?.trim();
+      const label = entry.display_name?.trim();
+      if (!id || !label) continue;
+      const key = normalizeCodexModelId(id);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      models.push({ id, label });
+    }
+    return models;
+  } catch {
+    return [];
+  }
+}
 
 export class CodexExecutionAgent implements ExecutionAgent {
   readonly name = 'codex';
@@ -42,11 +64,11 @@ export class CodexExecutionAgent implements ExecutionAgent {
   readonly linuxTerminalTail = 'exec_bash' as const;
   readonly bundledSkillRoot: string;
   readonly bundledSkills = ['make-pr'] as const;
-  readonly supportedModels = CODEX_SUPPORTED_MODELS;
 
   private readonly command: string;
   private readonly fullAuto: boolean;
   private readonly bypassApprovalsAndSandbox: boolean;
+  private supportedModelCache?: { expiresAt: number; models: readonly ExecutionModelOption[] };
 
   constructor(config: CodexExecutionAgentConfig = {}) {
     this.command = config.command ?? 'codex';
@@ -54,6 +76,10 @@ export class CodexExecutionAgent implements ExecutionAgent {
     this.fullAuto = config.fullAuto ?? true;
     this.bundledSkillRoot = join(homedir(), '.codex', 'skills');
   }
+  get supportedModels(): readonly ExecutionModelOption[] {
+    return this.getSupportedModels();
+  }
+
 
   buildCommand(fullPrompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
     const sessionId = randomUUID();
@@ -78,6 +104,36 @@ export class CodexExecutionAgent implements ExecutionAgent {
     else if (this.fullAuto) args.push('--full-auto');
     args.push(...this.buildModelArgs(options.executionModel), prompt);
     return { cmd: this.command, args, sessionId };
+  }
+  supportsModel(executionModel: string): boolean {
+    const normalized = normalizeCodexModelId(executionModel);
+    return this.getSupportedModels().some((candidate) => normalizeCodexModelId(candidate.id) === normalized);
+  }
+  private getSupportedModels(): readonly ExecutionModelOption[] {
+    const cached = this.supportedModelCache;
+    const now = Date.now();
+    if (cached && cached.expiresAt > now) {
+      return cached.models;
+    }
+    const discovered = this.discoverSupportedModels();
+    const models = discovered.length > 0 ? discovered : CODEX_FALLBACK_MODELS;
+    this.supportedModelCache = {
+      expiresAt: now + CODEX_MODEL_CACHE_MS,
+      models,
+    };
+    return models;
+  }
+
+  private discoverSupportedModels(): readonly ExecutionModelOption[] {
+    const result = spawnSync(this.command, ['debug', 'models'], {
+      encoding: 'utf8',
+      timeout: CODEX_MODEL_DISCOVERY_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+    });
+    if (result.error || result.status !== 0) {
+      return [];
+    }
+    return parseDiscoveredCodexModels(result.stdout);
   }
 
   private buildModelArgs(executionModel?: string): string[] {

--- a/packages/execution-engine/src/agents/kimi-execution-agent.ts
+++ b/packages/execution-engine/src/agents/kimi-execution-agent.ts
@@ -52,6 +52,10 @@ export class KimiExecutionAgent implements ExecutionAgent {
       sessionId,
     };
   }
+  supportsModel(executionModel: string): boolean {
+    const normalized = executionModel.trim().toLowerCase();
+    return normalized.includes('kimi') || normalized.includes('moonshot');
+  }
 
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] } {
     return { cmd: this.command, args: ['--session', sessionId] };

--- a/packages/execution-engine/src/agents/omp-execution-agent.ts
+++ b/packages/execution-engine/src/agents/omp-execution-agent.ts
@@ -70,6 +70,9 @@ export class OmpExecutionAgent implements ExecutionAgent {
       sessionId,
     };
   }
+  supportsModel(_executionModel: string): boolean {
+    return true;
+  }
 
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] } {
     return { cmd: this.command, args: ['--session-dir', this.sessionDir(sessionId), '--continue'] };

--- a/packages/execution-engine/src/agents/qwen-execution-agent.ts
+++ b/packages/execution-engine/src/agents/qwen-execution-agent.ts
@@ -59,6 +59,9 @@ export class QwenExecutionAgent implements ExecutionAgent {
       sessionId,
     };
   }
+  supportsModel(executionModel: string): boolean {
+    return executionModel.trim().toLowerCase().includes('qwen');
+  }
 
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] } {
     return { cmd: this.command, args: ['--resume', sessionId] };


### PR DESCRIPTION
## Summary

This adds one shared way for each execution harness to say which model names belong to it.

The bug fix needs one source of truth. Without it, each caller would guess differently.

This slice adds the helper and the per-agent match rules, but does not reject anything yet.

## Review Claim

The execution engine now has one reusable agent/model compatibility helper with harness-owned matching rules.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

This slice is behavior-neutral. Production call sites do not use the new helper yet, and the only runtime edits are agent metadata methods.

## Slice Rationale

This is the foundation slice. It lets the next PR wire one classifier through config and launch paths without re-arguing the matching rules at each call site.

## Non-goals

- No behavior change.
- Rejecting invalid config or task settings.
- Changing any CLI arguments sent to execution harnesses.
- Changing task mutation behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && node_modules/.bin/vitest run src/__tests__/agent-registry.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
