### PR TITLE
[Execution Model Guard](2) Reject mismatched execution agent models

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { resolveInvokerConfigPath } from '@invoker/contracts';
 import {
   loadConfig,
+  resolveAutoFixExecutionModel,
   resolveConfigFilePath,
   resolveDefaultExecutionAgent,
   resolveDefaultTaskExecutionSettings,
@@ -169,6 +170,22 @@ describe('loadConfig', () => {
       executionModel: 'chatgpt-5.4',
     });
   });
+  it('only reuses the default model when auto-fix stays on the default agent', () => {
+    expect(resolveAutoFixExecutionModel({
+      autoFixAgent: 'omp',
+      defaultExecutionAgent: 'omp',
+      defaultExecutionModel: 'chatgpt-5.4',
+    })).toBe('chatgpt-5.4');
+    expect(resolveAutoFixExecutionModel({
+      autoFixAgent: 'codex',
+      defaultExecutionAgent: 'omp',
+      defaultExecutionModel: 'chatgpt-5.4',
+    })).toBeUndefined();
+    expect(resolveAutoFixExecutionModel({
+      defaultExecutionAgent: 'omp',
+      defaultExecutionModel: 'chatgpt-5.4',
+    })).toBeUndefined();
+  });
 
   it('reads conflict resolution settings from user config', () => {
     writeUserConfig({
@@ -333,6 +350,22 @@ describe('loadConfig', () => {
       },
     });
     expect(() => loadConfig()).toThrow('defaultExecution.executionModel requires defaultExecution.executionAgent');
+  });
+  it('rejects flat defaultExecutionModel without an agent', () => {
+    writeUserConfig({
+      defaultExecutionModel: 'claude',
+    });
+    expect(() => loadConfig()).toThrow('defaultExecutionModel requires defaultExecutionAgent');
+  });
+
+  it('rejects mismatched flat default execution pairs for builtin agents', () => {
+    writeUserConfig({
+      defaultExecutionAgent: 'codex',
+      defaultExecutionModel: 'claude',
+    });
+    expect(() => loadConfig()).toThrow(
+      'Execution model "claude" is not supported for execution agent "codex".',
+    );
   });
 
 

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -1,11 +1,31 @@
+import { assertExecutionModelSupported, registerBuiltinAgents } from '@invoker/execution-engine';
 import type { InvokerConfig } from './config.js';
 
+const builtinAgents = registerBuiltinAgents();
+
+function validateConfiguredModel(agentName: string | undefined, executionModel: string | undefined): void {
+  const normalizedAgent = agentName?.trim();
+  const normalizedModel = executionModel?.trim();
+  if (!normalizedAgent || !normalizedModel) return;
+  const agent = builtinAgents.get(normalizedAgent);
+  if (!agent) return;
+  assertExecutionModelSupported(agent, normalizedModel);
+}
+
 export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
-  const executionAgent = config.defaultExecution?.executionAgent;
-  const hasExecutionAgent = typeof executionAgent === 'string' && executionAgent.trim().length > 0;
-  if (config.defaultExecution?.executionModel !== undefined && !hasExecutionAgent) {
+  const nestedExecutionAgent = config.defaultExecution?.executionAgent;
+  const hasNestedExecutionAgent = typeof nestedExecutionAgent === 'string' && nestedExecutionAgent.trim().length > 0;
+  if (config.defaultExecution?.executionModel !== undefined && !hasNestedExecutionAgent) {
     throw new Error('defaultExecution.executionModel requires defaultExecution.executionAgent');
   }
 
+  const flatExecutionAgent = config.defaultExecutionAgent;
+  const hasFlatExecutionAgent = typeof flatExecutionAgent === 'string' && flatExecutionAgent.trim().length > 0;
+  if (config.defaultExecutionModel !== undefined && !hasFlatExecutionAgent) {
+    throw new Error('defaultExecutionModel requires defaultExecutionAgent');
+  }
+
+  validateConfiguredModel(config.defaultExecution?.executionAgent, config.defaultExecution?.executionModel);
+  validateConfiguredModel(config.defaultExecutionAgent, config.defaultExecutionModel);
   return config;
 }

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -413,6 +413,12 @@ export function resolveDefaultTaskExecutionSettings(config: InvokerConfig): Defa
     ...(configuredModel && configuredModel.length > 0 ? { executionModel: configuredModel } : {}),
   };
 }
+export function resolveAutoFixExecutionModel(config: InvokerConfig): string | undefined {
+  const autoFixAgent = config.autoFixAgent?.trim();
+  if (!autoFixAgent) return undefined;
+  const defaults = resolveDefaultTaskExecutionSettings(config);
+  return autoFixAgent === defaults.executionAgent ? defaults.executionModel : undefined;
+}
 
 
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -133,6 +133,7 @@ import type { TaskOutputData } from './types.js';
 import {
   DEFAULT_SLACK_HARNESS_PRESETS,
   loadConfig,
+  resolveAutoFixExecutionModel,
   resolveConfigFileState,
   resolveDefaultTaskExecutionSettings,
   resolveEmbeddedTerminalBackendConfig,
@@ -235,7 +236,7 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
-import { evaluateExecutingStall, taskNeedsExecutingStallCheck } from './executing-stall.js';
+import { evaluateExecutingStall } from './executing-stall.js';
 
 
 import {
@@ -371,7 +372,7 @@ function buildRegisteredOwnerWorkerDeps(
       defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
       attemptLedger: autoFixAttemptLedger,
       getAutoFixAgent: () => invokerConfig.autoFixAgent,
-      getAutoFixExecutionModel: () => invokerConfig.defaultExecutionModel,
+      getAutoFixExecutionModel: () => resolveAutoFixExecutionModel(invokerConfig),
     },
     requeue: {
       stallRequeueRetries: invokerConfig.stallRequeueRetries,
@@ -3267,7 +3268,7 @@ function createEmbeddedTerminalBackendFromConfig(
               persistence,
               logger,
             });
-            taskGraphEventPublisher.publishSnapshot('refresh-task-graph', snapshot.tasks, snapshot.workflows, true);
+            taskGraphEventPublisher.publishSnapshot('refresh-task-graph', snapshot.tasks, snapshot.workflows);
           },
           deleteWorkflow: performDeleteWorkflow,
           detachWorkflow: performDetachWorkflow,
@@ -3331,7 +3332,7 @@ function createEmbeddedTerminalBackendFromConfig(
                 let task = loadedTask;
                 const now = new Date();
                 const previousHeartbeat = parseExecutionDate(task.execution.lastHeartbeatAt);
-                const selectedAttempt = taskNeedsExecutingStallCheck(task) && task.execution.selectedAttemptId
+                const selectedAttempt = task.execution.selectedAttemptId
                   ? persistence.loadAttempt?.(task.execution.selectedAttemptId)
                   : undefined;
                 const leaseExpiresAt = parseExecutionDate(selectedAttempt?.leaseExpiresAt);
@@ -3723,16 +3724,6 @@ function createEmbeddedTerminalBackendFromConfig(
           module: 'ipc-delegate',
         });
         return results;
-      });
-      messageBus.onRequest('headless.gui-mutation', async (req: unknown) => {
-        const payload = req as GuiMutationPayload;
-        const handler = guiMutationHandlers.get(payload.channel);
-        if (!handler) {
-          throw new Error(`No GUI mutation handler registered for channel: ${payload.channel}`);
-        }
-        const mutationArgs = Array.isArray(payload.args) ? payload.args : [];
-        logger.info(`headless.gui-mutation received channel=${payload.channel} mode=gui`, { module: 'ipc-delegate' });
-        return handler(...mutationArgs);
       });
       logger.info(`owner-ipc-ready ownerId=${workflowMutationOwnerId}`, { module: 'ipc-delegate' });
       recordStartupMark('owner-ipc-ready');
@@ -4178,7 +4169,6 @@ function createEmbeddedTerminalBackendFromConfig(
         ownerMode ? 'refresh-task-graph' : 'refresh-task-graph-delegated',
         snapshot.tasks,
         snapshot.workflows,
-        true,
       );
       recordStartupDuration('refresh-task-graph.return', startedAtMs, {
         taskCount: snapshot.tasks.length,

--- a/packages/execution-engine/src/__tests__/agent-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/agent-registry.test.ts
@@ -1,7 +1,34 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { AgentRegistry } from '../agent-registry.js';
 import { registerBuiltinAgents } from '../agents/index.js';
-import type { ExecutionAgent } from '../agent.js';
+import { assertExecutionModelSupported, type ExecutionAgent } from '../agent.js';
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawnSync: vi.fn(() => ({
+      status: 1,
+      stdout: '',
+      stderr: '',
+      output: [],
+      pid: 0,
+      signal: null,
+    })),
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(spawnSync).mockReset();
+  vi.mocked(spawnSync).mockReturnValue({
+    status: 1,
+    stdout: '',
+    stderr: '',
+    output: [],
+    pid: 0,
+    signal: null,
+  } as any);
+});
 
 function makeExecutionAgent(name: string, opts?: {
   bundledSkillRoot?: string;
@@ -68,6 +95,30 @@ describe('registerBuiltinAgents', () => {
       }),
     ]));
   });
+  it('prefers Codex models discovered from the CLI', () => {
+    vi.mocked(spawnSync).mockReturnValueOnce({
+      status: 0,
+      stdout: JSON.stringify({
+        models: [
+          { slug: 'gpt-5.5', display_name: 'GPT-5.5' },
+          { slug: 'gpt-5.4-mini', display_name: 'GPT-5.4 Mini' },
+          { slug: 'gpt-5.5', display_name: 'Duplicate GPT-5.5' },
+        ],
+      }),
+      stderr: '',
+      output: [],
+      pid: 1,
+      signal: null,
+    } as any);
+
+    const codexAgent = registerBuiltinAgents().getOrThrow('codex');
+
+    expect(codexAgent.supportedModels).toEqual([
+      { id: 'gpt-5.5', label: 'GPT-5.5' },
+      { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
+    ]);
+    expect(() => assertExecutionModelSupported(codexAgent, 'gpt-5.5')).not.toThrow();
+  });
 
 
   it('registers cursor, omp, and codex planning agents', () => {
@@ -130,6 +181,29 @@ describe('AgentRegistry', () => {
   it('still throws for real unknown execution agent names', () => {
     expect(() => registry.getOrThrow('cluade')).toThrow(
       'No execution agent registered with name "cluade". Available: [claude, codex]',
+    );
+  });
+  it('accepts versioned OpenAI-style models for codex', () => {
+    const codexAgent = registerBuiltinAgents().getOrThrow('codex');
+    expect(() => assertExecutionModelSupported(codexAgent, 'gpt-5.1-codex-max')).not.toThrow();
+  });
+
+  it('rejects clearly foreign models for codex', () => {
+    const codexAgent = registerBuiltinAgents().getOrThrow('codex');
+    expect(() => assertExecutionModelSupported(codexAgent, 'claude')).toThrow(
+      'Execution model "claude" is not supported for execution agent "codex".',
+    );
+  });
+  it('accepts Claude aliases and versioned Claude model ids', () => {
+    const claudeAgent = registerBuiltinAgents().getOrThrow('claude');
+    expect(() => assertExecutionModelSupported(claudeAgent, 'sonnet')).not.toThrow();
+    expect(() => assertExecutionModelSupported(claudeAgent, 'anthropic/claude-opus-4-8-20260528')).not.toThrow();
+  });
+
+  it('rejects plain claude as an execution model for Claude', () => {
+    const claudeAgent = registerBuiltinAgents().getOrThrow('claude');
+    expect(() => assertExecutionModelSupported(claudeAgent, 'claude')).toThrow(
+      'Execution model "claude" is not supported for execution agent "claude".',
     );
   });
 

--- a/packages/execution-engine/src/__tests__/plan-execution-agents.test.ts
+++ b/packages/execution-engine/src/__tests__/plan-execution-agents.test.ts
@@ -1,14 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { assertPlanExecutionAgentsRegistered } from '../plan-execution-agents.js';
-import { AgentRegistry } from '../agent-registry.js';
-import { ClaudeExecutionAgent } from '../agents/claude-execution-agent.js';
-import { CodexExecutionAgent } from '../agents/codex-execution-agent.js';
+import { registerBuiltinAgents } from '../agents/index.js';
 
-function makeRegistry(): AgentRegistry {
-  const registry = new AgentRegistry();
-  registry.registerExecution(new ClaudeExecutionAgent());
-  registry.registerExecution(new CodexExecutionAgent());
-  return registry;
+function makeRegistry() {
+  return registerBuiltinAgents();
 }
 
 describe('assertPlanExecutionAgentsRegistered', () => {
@@ -73,5 +68,22 @@ describe('assertPlanExecutionAgentsRegistered', () => {
       tasks: [{ id: 'a', executionAgent: '  claude  ' }],
     };
     expect(() => assertPlanExecutionAgentsRegistered(plan, makeRegistry())).not.toThrow();
+  });
+  it('rejects incompatible executionModel values for the selected agent', () => {
+    const plan = {
+      tasks: [{ id: 'a', executionAgent: 'codex', executionModel: 'claude' }],
+    };
+    expect(() => assertPlanExecutionAgentsRegistered(plan, makeRegistry())).toThrow(
+      /Task "a" Execution model "claude" is not supported for execution agent "codex"/,
+    );
+  });
+
+  it('rejects incompatible executionModel values for the default codex agent', () => {
+    const plan = {
+      tasks: [{ id: 'a', executionModel: 'claude' }],
+    };
+    expect(() => assertPlanExecutionAgentsRegistered(plan, makeRegistry())).toThrow(
+      /Task "a" Execution model "claude" is not supported for execution agent "codex"/,
+    );
   });
 });

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -12,6 +12,7 @@ import type { WorkResponse, Logger } from '@invoker/contracts';
 import { EventEmitter } from 'events';
 import { buildCanonicalPrBody, validateCanonicalPrBody } from '../pr-authoring.js';
 import type { PrAuthoringContext } from '../pr-authoring.js';
+import { registerBuiltinAgents } from '../agents/index.js';
 
 /**
  * Creates a mock executor that auto-completes on start().
@@ -231,6 +232,19 @@ describe('TaskRunner', () => {
       outputs: { exitCode: 0 },
     });
     await done;
+  });
+  it('rejects incompatible fix models before spawning the agent', async () => {
+    const runner = new TaskRunner({
+      orchestrator: { getTask: () => undefined, handleWorkerResponse: vi.fn() } as any,
+      persistence: { updateTask: vi.fn() } as any,
+      executorRegistry: { getDefault: vi.fn(), get: vi.fn(), getAll: vi.fn(() => []) } as any,
+      executionAgentRegistry: registerBuiltinAgents(),
+      cwd: '/tmp',
+    });
+
+    expect(() => runner.spawnAgentFix('Fix the bug', '/tmp', 'codex', 'claude')).toThrow(
+      'Execution model "claude" is not supported for execution agent "codex".',
+    );
   });
 
   it('sends attemptId and executionGeneration in work requests and preserves them in responses', async () => {

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -5,10 +5,13 @@ import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { PersistedTaskMeta } from '../executor.js';
 import type { Writable, Readable } from 'node:stream';
 
-// Mock child_process before importing WorktreeExecutor
-vi.mock('node:child_process', () => ({
-  spawn: vi.fn(),
-}));
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
@@ -20,6 +23,7 @@ import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync } from 'node:fs';
 import { WorktreeExecutor, computeContentHash } from '../worktree-executor.js';
 import { BaseExecutor } from '../base-executor.js';
+import { registerBuiltinAgents } from '../agents/index.js';
 
 const mockedSpawn = vi.mocked(spawn);
 
@@ -1062,6 +1066,32 @@ describe('WorktreeExecutor', () => {
       });
 
       await expect(executor.start(request)).rejects.toThrow();
+    });
+  });
+
+  describe('agent registry validation', () => {
+    it('rejects incompatible executionModel values before spawning the agent', async () => {
+      const executorWithRegistry = new WorktreeExecutor({
+        cacheDir: '/fake/cache',
+        worktreeBaseDir: '/fake/worktrees',
+        agentRegistry: registerBuiltinAgents(),
+      });
+      mockPool(executorWithRegistry);
+      setupSpawnMock();
+
+      const request = makeRequest({
+        actionType: 'ai_task',
+        inputs: {
+          prompt: 'test prompt',
+          executionAgent: 'codex',
+          executionModel: 'claude',
+        },
+      });
+
+      await expect(executorWithRegistry.start(request)).rejects.toThrow(
+        'Execution model "claude" is not supported for execution agent "codex".',
+      );
+      expect(mockedSpawn.mock.calls.some(([cmd]) => cmd === 'codex')).toBe(false);
     });
   });
 

--- a/packages/execution-engine/src/agent.ts
+++ b/packages/execution-engine/src/agent.ts
@@ -1,13 +1,3 @@
-/**
- * ExecutionAgent / PlanningAgent — Pluggable AI agent interfaces.
- *
- * Executors own the spawn lifecycle (stdio, exit handling, worktree/container setup).
- * Agents only provide command specs. This keeps the abstraction thin:
- * agents say *what* to run, executors decide *how* to run it.
- */
-
-// ── Execution Agent ──────────────────────────────────────────
-
 export interface AgentCommandSpec {
   cmd: string;
   args: string[];
@@ -29,28 +19,13 @@ export const DEFAULT_EXECUTION_AGENT = 'codex';
 export interface ExecutionAgent {
   readonly name: string;
   readonly stdinMode: 'ignore' | 'pipe';
-  /** Tail command for Linux terminal launch (e.g. 'exec_bash' or 'pause'). */
   readonly linuxTerminalTail?: 'exec_bash' | 'pause';
-
-  /**
-   * Root directory where this agent's bundled skills are installed.
-   * Example: ~/.claude/skills for the Claude agent.
-   * Undefined when the agent has no bundled skill support.
-   */
   readonly bundledSkillRoot?: string;
-
-  /**
-   * Skill names this agent bundles (e.g. ['make-pr']).
-   * The registry uses this list for capability-based lookup.
-   * Each name corresponds to a subdirectory `invoker-{name}` under bundledSkillRoot.
-   */
   readonly bundledSkills?: readonly string[];
-  /** Curated built-in model choices for this harness. Values must be CLI-compatible. */
   readonly supportedModels?: readonly ExecutionModelOption[];
-
+  supportsModel?(executionModel: string): boolean;
   buildCommand(fullPrompt: string, options?: AgentCommandBuildOptions): AgentCommandSpec;
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] };
-  /** Build a command spec for a fix/conflict-resolution prompt. */
   buildFixCommand?(prompt: string, options?: AgentCommandBuildOptions): AgentCommandSpec;
   getContainerRequirements?(): {
     mounts: Array<{ hostPath: string; containerPath: string; readonly?: boolean }>;
@@ -58,7 +33,18 @@ export interface ExecutionAgent {
   };
 }
 
-// ── Planning Agent ───────────────────────────────────────────
+export function assertExecutionModelSupported(
+  agent: Pick<ExecutionAgent, 'name' | 'supportedModels' | 'supportsModel'>,
+  executionModel: string | null | undefined,
+): void {
+  const normalizedModel = executionModel?.trim();
+  if (!normalizedModel) return;
+  if (agent.supportedModels?.some((candidate) => candidate.id === normalizedModel)) return;
+  if (agent.supportsModel?.(normalizedModel)) return;
+  const supported = agent.supportedModels?.map((candidate) => candidate.id) ?? [];
+  const hint = supported.length > 0 ? ` Known models: [${supported.join(', ')}].` : '';
+  throw new Error(`Execution model "${normalizedModel}" is not supported for execution agent "${agent.name}".${hint}`);
+}
 
 export interface PlanningAgent {
   readonly name: string;

--- a/packages/execution-engine/src/agents/claude-execution-agent.ts
+++ b/packages/execution-engine/src/agents/claude-execution-agent.ts
@@ -1,24 +1,13 @@
-/**
- * ClaudeExecutionAgent — ExecutionAgent implementation for Anthropic's Claude CLI.
- *
- * Extracted from BaseExecutor.buildClaudeArgs() / prepareClaudeSession().
- * Agents provide command specs; executors own the spawn lifecycle.
- */
-
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions, ExecutionModelOption } from '../agent.js';
+
 export interface ClaudeExecutionAgentConfig {
-  /** Command to invoke the Claude CLI. Default: 'claude'. */
   command?: string;
-  /** Override command used specifically for fix flows. Default: INVOKER_CLAUDE_FIX_COMMAND or `command`. */
   fixCommand?: string;
-  /** Path to the Claude config directory on the host. Default: ~/.claude. */
   configDir?: string;
-  /** Home directory inside Docker containers. Default: '/home/invoker'. */
   containerHomePath?: string;
-  /** ANTHROPIC_API_KEY. Falls back to process.env.ANTHROPIC_API_KEY. */
   apiKey?: string;
 }
 
@@ -27,6 +16,10 @@ const CLAUDE_SUPPORTED_MODELS: readonly ExecutionModelOption[] = [
   { id: 'opus', label: 'Claude Opus' },
   { id: 'haiku', label: 'Claude Haiku' },
 ];
+
+function normalizeClaudeModel(executionModel: string): string {
+  return executionModel.trim().toLowerCase().replace(/^anthropic[/:]/, '');
+}
 
 export class ClaudeExecutionAgent implements ExecutionAgent {
   readonly name = 'claude';
@@ -68,6 +61,13 @@ export class ClaudeExecutionAgent implements ExecutionAgent {
       args: ['--session-id', sessionId, ...this.buildModelArgs(options.executionModel), '-p', prompt, '--dangerously-skip-permissions'],
       sessionId,
     };
+  }
+  supportsModel(executionModel: string): boolean {
+    const normalized = normalizeClaudeModel(executionModel);
+    return normalized === 'sonnet'
+      || normalized === 'opus'
+      || normalized === 'haiku'
+      || /^claude-(sonnet|opus|haiku)(?:-|$)/.test(normalized);
   }
 
   private buildModelArgs(executionModel?: string): string[] {

--- a/packages/execution-engine/src/agents/codex-execution-agent.ts
+++ b/packages/execution-engine/src/agents/codex-execution-agent.ts
@@ -1,40 +1,62 @@
-/**
- * CodexExecutionAgent — ExecutionAgent implementation for OpenAI Codex CLI.
- *
- * Agents provide command specs; executors own the spawn lifecycle.
- *
- * Known issue: `codex exec --json` exits 0 when the agent turn completes,
- * NOT when the task succeeds. Codex can fail to verify its fix (e.g. EPERM
- * blocking test execution) and still exit 0. Callers that check only the
- * exit code will treat an unverified fix as successful.
- */
-
+import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions, ExecutionModelOption } from '../agent.js';
+
 export interface CodexExecutionAgentConfig {
-  /** Command to invoke the Codex CLI. Default: 'codex'. */
   command?: string;
-  /**
-   * Run in full-auto mode (sandboxed workspace-write + on-request approvals).
-   * Ignored when bypassApprovalsAndSandbox is true.
-   */
   fullAuto?: boolean;
-  /**
-   * Run without Codex sandbox/approval gating.
-   * Default: true (Invoker already isolates work in managed workspaces).
-   */
   bypassApprovalsAndSandbox?: boolean;
 }
 
-const CODEX_SUPPORTED_MODELS: readonly ExecutionModelOption[] = [
+const CODEX_MODEL_DISCOVERY_TIMEOUT_MS = 3_000;
+const CODEX_MODEL_CACHE_MS = 5 * 60_000;
+
+const CODEX_FALLBACK_MODELS: readonly ExecutionModelOption[] = [
+  { id: 'gpt-5.5', label: 'GPT-5.5' },
+  { id: 'gpt-5.5-pro', label: 'GPT-5.5 Pro' },
+  { id: 'gpt-5.4', label: 'GPT-5.4' },
+  { id: 'gpt-5.4-pro', label: 'GPT-5.4 Pro' },
+  { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
+  { id: 'gpt-5.4-nano', label: 'GPT-5.4 Nano' },
+  { id: 'gpt-5.3', label: 'GPT-5.3' },
+  { id: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
+  { id: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
+  { id: 'gpt-5.2', label: 'GPT-5.2' },
+  { id: 'gpt-5.2-codex', label: 'GPT-5.2 Codex' },
+  { id: 'gpt-5.1', label: 'GPT-5.1' },
+  { id: 'gpt-5.1-codex', label: 'GPT-5.1 Codex' },
+  { id: 'gpt-5.1-codex-max', label: 'GPT-5.1 Codex Max' },
   { id: 'gpt-5', label: 'GPT-5' },
   { id: 'gpt-5-codex', label: 'GPT-5 Codex' },
-  { id: 'gpt-5-mini', label: 'GPT-5 Mini' },
-  { id: 'o3', label: 'o3' },
-  { id: 'o4-mini', label: 'o4-mini' },
 ];
+
+function normalizeCodexModelId(model: string): string {
+  return model.trim().toLowerCase();
+}
+
+function parseDiscoveredCodexModels(stdout: string): ExecutionModelOption[] {
+  try {
+    const parsed = JSON.parse(stdout) as {
+      models?: Array<{ slug?: string; display_name?: string }>;
+    };
+    const models: ExecutionModelOption[] = [];
+    const seen = new Set<string>();
+    for (const entry of parsed.models ?? []) {
+      const id = entry.slug?.trim();
+      const label = entry.display_name?.trim();
+      if (!id || !label) continue;
+      const key = normalizeCodexModelId(id);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      models.push({ id, label });
+    }
+    return models;
+  } catch {
+    return [];
+  }
+}
 
 export class CodexExecutionAgent implements ExecutionAgent {
   readonly name = 'codex';
@@ -42,11 +64,11 @@ export class CodexExecutionAgent implements ExecutionAgent {
   readonly linuxTerminalTail = 'exec_bash' as const;
   readonly bundledSkillRoot: string;
   readonly bundledSkills = ['make-pr'] as const;
-  readonly supportedModels = CODEX_SUPPORTED_MODELS;
 
   private readonly command: string;
   private readonly fullAuto: boolean;
   private readonly bypassApprovalsAndSandbox: boolean;
+  private supportedModelCache?: { expiresAt: number; models: readonly ExecutionModelOption[] };
 
   constructor(config: CodexExecutionAgentConfig = {}) {
     this.command = config.command ?? 'codex';
@@ -54,6 +76,10 @@ export class CodexExecutionAgent implements ExecutionAgent {
     this.fullAuto = config.fullAuto ?? true;
     this.bundledSkillRoot = join(homedir(), '.codex', 'skills');
   }
+  get supportedModels(): readonly ExecutionModelOption[] {
+    return this.getSupportedModels();
+  }
+
 
   buildCommand(fullPrompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
     const sessionId = randomUUID();
@@ -78,6 +104,36 @@ export class CodexExecutionAgent implements ExecutionAgent {
     else if (this.fullAuto) args.push('--full-auto');
     args.push(...this.buildModelArgs(options.executionModel), prompt);
     return { cmd: this.command, args, sessionId };
+  }
+  supportsModel(executionModel: string): boolean {
+    const normalized = normalizeCodexModelId(executionModel);
+    return this.getSupportedModels().some((candidate) => normalizeCodexModelId(candidate.id) === normalized);
+  }
+  private getSupportedModels(): readonly ExecutionModelOption[] {
+    const cached = this.supportedModelCache;
+    const now = Date.now();
+    if (cached && cached.expiresAt > now) {
+      return cached.models;
+    }
+    const discovered = this.discoverSupportedModels();
+    const models = discovered.length > 0 ? discovered : CODEX_FALLBACK_MODELS;
+    this.supportedModelCache = {
+      expiresAt: now + CODEX_MODEL_CACHE_MS,
+      models,
+    };
+    return models;
+  }
+
+  private discoverSupportedModels(): readonly ExecutionModelOption[] {
+    const result = spawnSync(this.command, ['debug', 'models'], {
+      encoding: 'utf8',
+      timeout: CODEX_MODEL_DISCOVERY_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+    });
+    if (result.error || result.status !== 0) {
+      return [];
+    }
+    return parseDiscoveredCodexModels(result.stdout);
   }
 
   private buildModelArgs(executionModel?: string): string[] {

--- a/packages/execution-engine/src/agents/kimi-execution-agent.ts
+++ b/packages/execution-engine/src/agents/kimi-execution-agent.ts
@@ -52,6 +52,10 @@ export class KimiExecutionAgent implements ExecutionAgent {
       sessionId,
     };
   }
+  supportsModel(executionModel: string): boolean {
+    const normalized = executionModel.trim().toLowerCase();
+    return normalized.includes('kimi') || normalized.includes('moonshot');
+  }
 
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] } {
     return { cmd: this.command, args: ['--session', sessionId] };

--- a/packages/execution-engine/src/agents/omp-execution-agent.ts
+++ b/packages/execution-engine/src/agents/omp-execution-agent.ts
@@ -70,6 +70,9 @@ export class OmpExecutionAgent implements ExecutionAgent {
       sessionId,
     };
   }
+  supportsModel(_executionModel: string): boolean {
+    return true;
+  }
 
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] } {
     return { cmd: this.command, args: ['--session-dir', this.sessionDir(sessionId), '--continue'] };

--- a/packages/execution-engine/src/agents/qwen-execution-agent.ts
+++ b/packages/execution-engine/src/agents/qwen-execution-agent.ts
@@ -59,6 +59,9 @@ export class QwenExecutionAgent implements ExecutionAgent {
       sessionId,
     };
   }
+  supportsModel(executionModel: string): boolean {
+    return executionModel.trim().toLowerCase().includes('qwen');
+  }
 
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] } {
     return { cmd: this.command, args: ['--resume', sessionId] };

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -5,7 +5,7 @@ import type { Executor, ExecutorHandle, PersistedTaskMeta, TerminalSpec, Unsubsc
 import { bashPreserveOrReset, bashMergeUpstreams, bashFetchNodeRemotes, parsePreserveResult, parseMergeError } from './branch-utils.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
 import type { AgentRegistry } from './agent-registry.js';
-import { DEFAULT_EXECUTION_AGENT } from './agent.js';
+import { assertExecutionModelSupported, DEFAULT_EXECUTION_AGENT } from './agent.js';
 import { checkStaleness } from './git-staleness-detector.js';
 import { assertNotGitConfigMutation, ensureRemoteUrl } from './git-config-mutation.js';
 import { childProcessHasExited, terminateChildProcessGroup } from './process-utils.js';
@@ -926,6 +926,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
       if (opts?.agentRegistry) {
         const agentName = request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
         const agent = opts.agentRegistry.getOrThrow(agentName);
+        assertExecutionModelSupported(agent, request.inputs.executionModel);
         const fullPrompt = this.buildFullPrompt(request);
         const spec = agent.buildCommand(fullPrompt, { executionModel: request.inputs.executionModel });
         return { cmd: spec.cmd, args: spec.args, agentSessionId: spec.sessionId, fullPrompt: spec.fullPrompt };

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -15,7 +15,7 @@ import type { Orchestrator } from '@invoker/workflow-core';
 import { OrchestratorError, OrchestratorErrorCode, parseMergeConflictError } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { buildAgentExitFailureDetail, cleanElectronEnv, resolveExecutableOnCurrentPath } from './process-utils.js';
-import { DEFAULT_EXECUTION_AGENT, type ExecutionAgent } from './agent.js';
+import { assertExecutionModelSupported, DEFAULT_EXECUTION_AGENT, type ExecutionAgent } from './agent.js';
 import type { SessionDriver } from './session-driver.js';
 import type { AgentRegistry } from './agent-registry.js';
 import { buildWorktreeListScript, createSshRemoteScriptError } from './ssh-git-exec.js';
@@ -756,6 +756,7 @@ export function spawnAgentFixViaRegistry(
   driver?: SessionDriver,
   executionModel?: string,
 ): Promise<{ stdout: string; sessionId: string }> {
+  assertExecutionModelSupported(agent, executionModel);
   const promptTransport = materializeLocalPrompt(prompt);
   const spec = agent.buildFixCommand?.(promptTransport.effectivePrompt, { executionModel });
   if (!spec) {

--- a/packages/execution-engine/src/plan-execution-agents.ts
+++ b/packages/execution-engine/src/plan-execution-agents.ts
@@ -2,14 +2,16 @@
  * Plan validation helper — verifies all executionAgent names in a plan are registered.
  */
 
+import { DEFAULT_EXECUTION_AGENT, assertExecutionModelSupported } from './agent.js';
 import type { AgentRegistry } from './agent-registry.js';
 
 interface PlanWithAgents {
-  tasks: Array<{ id: string; executionAgent?: string }>;
+  tasks: Array<{ id: string; executionAgent?: string; executionModel?: string }>;
 }
 
 /**
- * Validate that every task's `executionAgent` (if set) is registered in the agent registry.
+ * Validate that every task's `executionAgent` (if set) is registered in the agent registry,
+ * and that any configured `executionModel` matches the effective execution agent.
  * Throws with a descriptive error listing available agents if validation fails.
  */
 export function assertPlanExecutionAgentsRegistered(
@@ -22,6 +24,13 @@ export function assertPlanExecutionAgentsRegistered(
     const agent = task.executionAgent?.trim();
     if (agent && !registry.get(agent)) {
       errors.push(`Task "${task.id}" references unknown executionAgent "${agent}"`);
+      continue;
+    }
+    const effectiveAgent = agent || DEFAULT_EXECUTION_AGENT;
+    try {
+      assertExecutionModelSupported(registry.getOrThrow(effectiveAgent), task.executionModel);
+    } catch (err) {
+      errors.push(`Task "${task.id}" ${(err as Error).message}`);
     }
   }
   if (errors.length > 0) {

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -11,7 +11,7 @@ import { planManagedWorktree } from './managed-worktree-controller.js';
 import { findManagedWorktreeForBranch, abbrevRefMatchesBranch } from './worktree-discovery.js';
 import { DEFAULT_WORKTREE_PROVISION_COMMAND } from './default-worktree-provision-command.js';
 import type { AgentRegistry } from './agent-registry.js';
-import { DEFAULT_EXECUTION_AGENT } from './agent.js';
+import { assertExecutionModelSupported, DEFAULT_EXECUTION_AGENT } from './agent.js';
 import { computeRepoUrlHash, sanitizeBranchForPath } from './git-utils.js';
 import { isWorkspaceCleanupEnabled } from './workspace-cleanup-policy.js';
 import { buildSshConnectionArgs } from './ssh-transport-options.js';
@@ -423,8 +423,9 @@ ${runProvisionSection}stop_bootstrap_heartbeat
       bench('SshExecutor.payload.built', { command: true });
     } else if (request.actionType === 'ai_task') {
       if (this.agentRegistry) {
-        const agentName = request.inputs.executionAgent ?? 'claude';
+        const agentName = request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
         const agent = this.agentRegistry.getOrThrow(agentName);
+        assertExecutionModelSupported(agent, request.inputs.executionModel);
         const fullPrompt = this.buildFullPrompt(request);
         const spec = agent.buildCommand(fullPrompt, { executionModel: request.inputs.executionModel });
         agentSessionId = spec.sessionId;

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -4520,6 +4520,27 @@ describe('Orchestrator', () => {
       expect(persisted).toBeDefined();
       expect(persisted?.task.config.executionAgent).toBe('codex');
     });
+    it('clears executionModel when the execution agent changes', () => {
+      orchestrator.loadPlan({
+        name: 'edit-agent-clears-model',
+        tasks: [{
+          id: 't1',
+          description: 'Task 1',
+          command: 'echo old',
+          executionAgent: 'claude',
+          executionModel: 'opus',
+        }],
+      });
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 't1', status: 'failed', outputs: { exitCode: 1, error: 'oops' } }),
+      );
+
+      orchestrator.editTaskAgent('t1', 'codex');
+
+      expect(orchestrator.getTask('t1')?.config.executionAgent).toBe('codex');
+      expect(orchestrator.getTask('t1')?.config.executionModel).toBeUndefined();
+    });
 
     it('idempotence — two consecutive agent edits trigger two cancel-first cycles and two generation bumps', () => {
       orchestrator.loadPlan({

--- a/packages/workflow-core/src/orchestrator/task-edits.ts
+++ b/packages/workflow-core/src/orchestrator/task-edits.ts
@@ -203,7 +203,16 @@ export function editTaskAgentImpl(host: TaskEditHost, taskId: string, agentName:
     host.cancelTask(taskId);
   }
 
-  const agentChanges: TaskStateChanges = { config: { executionAgent: agentName } };
+  const normalizedAgent = agentName.trim();
+  const preservedExecutionModel = task.config.executionAgent?.trim() === normalizedAgent
+    ? task.config.executionModel
+    : undefined;
+  const agentChanges: TaskStateChanges = {
+    config: {
+      executionAgent: agentName,
+      executionModel: preservedExecutionModel,
+    },
+  };
   const agentBefore = host.stateGetTask(taskId)!;
   const agentUpdated = host.writeAndSync(taskId, agentChanges);
   const agentDelta: TaskDelta = host.buildUpdateDelta(agentBefore, agentUpdated, agentChanges);


### PR DESCRIPTION
## Summary

This stops invalid agent/model pairs before Invoker launches work.

The bug let Codex keep Claude-flavored model strings. That failed late, after plan setup or remote launch had already started.

This slice validates the pair at config load, plan load, executor launch, fix spawn, and task agent edits.

## Review Claim

Invoker now rejects incompatible execution agent/model pairs at every launch path, and clears stale model overrides when the agent changes.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

All changed paths only gate already-invalid combinations. Valid agent/model pairs still flow through the same launch code and CLI arguments.

## Slice Rationale

The helper lands first. This slice only wires that classifier through the places that used to forward bad pairs unchanged.

## Non-goals

- Expanding the supported model catalog.
- Changing how valid models are passed to harness CLIs.
- Adding any UI behavior or proof assets.

## Architecture

### Before

```mermaid
graph TD
    A["Config and task edits kept any executionModel string"]
    B["Plan load and executor launch forwarded the pair unchanged"]
    C["The remote harness rejected the bad pair late"]
    A --> B --> C
```

### After

```mermaid
graph TD
    A["The shared helper classifies which models belong to each agent"]
    B["Config, plan, executor, and fix entry points reject bad pairs early"]
    C["Task agent edits clear stale model overrides on agent change"]
    A --> B
    A --> C
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && node_modules/.bin/vitest run src/__tests__/config.test.ts`
- [x] `cd packages/execution-engine && node_modules/.bin/vitest run src/__tests__/plan-execution-agents.test.ts src/__tests__/task-runner.test.ts src/__tests__/worktree-executor.test.ts`
- [x] `cd packages/workflow-core && node_modules/.bin/vitest run src/__tests__/orchestrator.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
