### PR TITLE
[Automatic Merge Recovery](1) Tolerate no-op squash merges

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -3413,6 +3413,7 @@ describe('TaskRunner', () => {
       (executor as any).execGitReadonly = async (args: string[], cwd?: string) => {
         gitCalls.push(args);
         if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'base-sha';
         // diff --cached --quiet exits non-zero when there are staged changes
         if (args[0] === 'diff' && args.includes('--cached') && args.includes('--quiet')) {
           throw new Error('exit code 1');
@@ -3422,6 +3423,7 @@ describe('TaskRunner', () => {
       (executor as any).execGitIn = async (args: string[], _dir: string) => {
         gitCalls.push(args);
         if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'base-sha';
         // diff --cached --quiet exits non-zero when there are staged changes
         if (args[0] === 'diff' && args.includes('--cached') && args.includes('--quiet')) {
           throw new Error('exit code 1');
@@ -3443,7 +3445,7 @@ describe('TaskRunner', () => {
       // Should squash merge featureBranch into baseBranch using detached HEAD pattern (no rebase)
       const rebaseCall = gitCalls.find(c => c[0] === 'rebase');
       expect(rebaseCall).toBeUndefined();
-      const detachCall = gitCalls.find(c => c[0] === 'checkout' && c[1] === '--detach' && c[2] === 'master');
+      const detachCall = gitCalls.find(c => c[0] === 'checkout' && c[1] === '--detach' && c[2] === 'base-sha');
       expect(detachCall).toBeDefined();
       const squashCall = gitCalls.find(c => c[0] === 'merge' && c.includes('--squash') && c.includes('plan/feature'));
       expect(squashCall).toBeDefined();
@@ -4217,6 +4219,7 @@ console.log(JSON.stringify(out));
       (executor as any).execGitIn = async (args: string[], _dir: string) => {
         gitCalls.push(args);
         if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        if (args[0] === 'diff' && args[1] === '--cached' && args[2] === '--quiet') throw new Error('changes staged');
         return '';
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
@@ -4234,6 +4237,47 @@ console.log(JSON.stringify(out));
       // Squash commit pushed directly to origin from the clone
       const pushCall = gitCalls.find(c => c[0] === 'push' && c.includes('--force') && c.includes('origin') && c.some(a => a.startsWith('HEAD:refs/heads/')));
       expect(pushCall).toBeDefined();
+    });
+
+    it('approveMerge skips commit when squash merge is a no-op', async () => {
+      const persistence = {
+        loadWorkflow: () => ({
+          id: 'wf-1',
+          onFinish: 'merge',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          name: 'Test Workflow',
+        }),
+        updateTask: vi.fn(),
+        getWorkspacePath: () => null,
+      };
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: persistence as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+      });
+
+      const gitCalls: string[][] = [];
+      (executor as any).execGitReadonly = async (args: string[], cwd?: string) => {
+        gitCalls.push(args);
+        if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        return '';
+      };
+      (executor as any).execGitIn = async (args: string[], _dir: string) => {
+        gitCalls.push(args);
+        if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        return '';
+      };
+      (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
+      (executor as any).removeMergeWorktree = async () => {};
+
+      await executor.approveMerge('wf-1');
+
+      expect(gitCalls.find((c) => c[0] === 'merge' && c.includes('--squash') && c.includes('plan/feature'))).toBeDefined();
+      expect(gitCalls.find((c) => c[0] === 'diff' && c[1] === '--cached' && c[2] === '--quiet')).toBeDefined();
+      expect(gitCalls.find((c) => c[0] === 'commit')).toBeUndefined();
+      expect(gitCalls.find((c) => c[0] === 'push')).toBeUndefined();
     });
 
     it('approveMerge throws when workflow has no merge configured', async () => {

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -1035,15 +1035,22 @@ export async function approveMergeImpl(
         branchRepoUrl,
       );
       await execGitInMergeSafe(host, ['merge', '--squash', featureBranch], worktreeDir);
-      mergeTrace('GIT_COMMIT', { mergeMessage });
-      const commitBody = fullSummary ? `${mergeMessage}\n\n${fullSummary}` : mergeMessage;
-      await execGitInMergeSafe(host, ['commit', '-m', commitBody], worktreeDir);
-      // Push squash commit directly to origin (GitHub) from the clone
-      await execGitInMergeSafe(host, ['push', '--force', 'origin', `HEAD:refs/heads/${baseBranch}`], worktreeDir);
-      // Advance the baseBranch ref in the clone so subsequent operations see the updated base
-      const newHead = (await execGitInMergeSafe(host, ['rev-parse', 'HEAD'], worktreeDir)).trim();
-      await execGitInMergeSafe(host, ['update-ref', `refs/heads/${baseBranch}`, newHead], worktreeDir);
-      mergeTrace('SQUASH_MERGE_COMPLETE', { featureBranch, baseBranch });
+      const hasChanges = await execGitInMergeSafe(host, ['diff', '--cached', '--quiet'], worktreeDir)
+        .then(() => false)
+        .catch(() => true);
+      if (hasChanges) {
+        mergeTrace('GIT_COMMIT', { mergeMessage });
+        const commitBody = fullSummary ? `${mergeMessage}\n\n${fullSummary}` : mergeMessage;
+        await execGitInMergeSafe(host, ['commit', '-m', commitBody], worktreeDir);
+        // Push squash commit directly to origin (GitHub) from the clone
+        await execGitInMergeSafe(host, ['push', '--force', 'origin', `HEAD:refs/heads/${baseBranch}`], worktreeDir);
+        // Advance the baseBranch ref in the clone so subsequent operations see the updated base
+        const newHead = (await execGitInMergeSafe(host, ['rev-parse', 'HEAD'], worktreeDir)).trim();
+        await execGitInMergeSafe(host, ['update-ref', `refs/heads/${baseBranch}`, newHead], worktreeDir);
+        mergeTrace('SQUASH_MERGE_COMPLETE', { featureBranch, baseBranch });
+      } else {
+        mergeTrace('SQUASH_MERGE_NOOP', { featureBranch, baseBranch });
+      }
       console.log(`[merge] Approved: squash-merged ${featureBranch} into ${baseBranch}`);
     } catch (err) {
       mergeTrace('APPROVE_MERGE_ERROR', { workflowId, error: String(err) });
@@ -1665,6 +1672,7 @@ export async function consolidateAndMergeImpl(
     'consolidate-' + (workflowId ?? 'default'),
     repoUrlForMerge,
   );
+  const baseHead = (await execGitInMergeSafe(host, ['rev-parse', 'HEAD'], worktreeDir)).trim();
   console.log(`[merge] consolidateAndMerge: featureBranch=${featureBranch}, baseBranch=${baseBranch}, worktree=${worktreeDir}`);
 
   try {
@@ -1763,7 +1771,7 @@ export async function consolidateAndMergeImpl(
 
     if (onFinish === 'merge') {
       // Squash merge in the clone and push result directly to origin (GitHub)
-      await execGitInMergeSafe(host, ['checkout', '--detach', baseBranch], worktreeDir);
+      await execGitInMergeSafe(host, ['checkout', '--detach', baseHead], worktreeDir);
       await execGitInMergeSafe(host, ['merge', '--squash', featureBranch], worktreeDir);
       const hasChanges = await execGitInMergeSafe(host, ['diff', '--cached', '--quiet'], worktreeDir)
         .then(() => false)


### PR DESCRIPTION
## Summary

Automatic merge could stop on a clean squash. The merge path still fell through to `git commit`, and the gate failed.

This change fixes two bad path choices. Empty squashes now return early, and the final detach step uses the base commit already in the merge worktree.

## Review Claim

The automatic merge path takes the correct branch when the squash is empty or the base branch ref has changed.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only merge-runner branch selection changes. Normal squash merges still commit and push through the same route.

## Slice Rationale

The merge runner is the failing lower layer. Fixing its path decisions first keeps later worker automation changes small and easy to review.

## Non-goals

- No worker policy changes.
- No external-review PR flow changes.
- No UI or config changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts -t "executeMergeNode performs full merge|approveMerge performs the final merge step|approveMerge skips commit when squash merge is a no-op"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert bf234c02c`
- Post-revert steps: None.
- Data migration? No.

</details>
