### PR TITLE
[Automatic Merge Recovery](2) Re-accept review-ready merge gates

### DIFF
--- a/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
@@ -71,11 +71,17 @@ function wakeup(overrides: Partial<RecoveryWorkerWakeupHint> = {}): RecoveryWork
   };
 }
 
-function makeStore(tasks: TaskState[], openIntents: WorkflowMutationIntent[] = []) {
+function makeStore(
+  tasks: TaskState[],
+  openIntents: WorkflowMutationIntent[] = [],
+  workflows: Array<{ id: string; mergeMode?: string | null; onFinish?: string | null }> = [{ id: 'wf-1' }],
+) {
+  const workflowMap = new Map(workflows.map((workflow) => [workflow.id, workflow]));
   const actions = new Map<string, WorkerActionRecord>();
   const writes: WorkerActionWrite[] = [];
   const store: AutoApproveWorkerStore = {
-    listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+    listWorkflows: vi.fn(() => workflows.map(({ id }) => ({ id }))),
+    loadWorkflow: vi.fn((workflowId: string) => workflowMap.get(workflowId)),
     loadTasks: vi.fn(() => tasks),
     loadTask: vi.fn((taskId: string) => tasks.find((candidate) => candidate.id === taskId)),
     listWorkflowMutationIntents: vi.fn(() => openIntents),
@@ -140,6 +146,38 @@ describe('autoapprove worker', () => {
 
     expect(collectValidatedAutoApproveCandidates({ store, submitter: { submit: vi.fn() }, logger, enabled: true }, [candidate()])).toEqual([]);
     expect(writes[0]).toMatchObject({ status: 'skipped', summary: 'Skipped AI fix approval: review-ready-ambiguous' });
+  });
+  it('scans review-ready automatic merge gates', () => {
+    const reviewReadyGate = task({
+      status: 'review_ready',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: { pendingFixError: undefined },
+    });
+    const { store } = makeStore([reviewReadyGate], [], [{ id: 'wf-1', mergeMode: 'automatic', onFinish: 'merge' }]);
+
+    expect(listAutoApproveScanCandidates({ store })).toEqual([
+      expect.objectContaining({ taskId: 'wf-1/task-1', workflowId: 'wf-1', generation: 1, taskStateVersion: 4 }),
+    ]);
+  });
+
+  it('submits review-ready automatic merge gates for approval', async () => {
+    const reviewReadyGate = task({
+      status: 'review_ready',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: { pendingFixError: undefined },
+    });
+    const { store, writes } = makeStore([reviewReadyGate], [], [{ id: 'wf-1', mergeMode: 'automatic', onFinish: 'merge' }]);
+    const submitter = { submit: vi.fn(() => 42) };
+
+    await createAutoApproveTick({ store, submitter, logger, enabled: true })({
+      identity: { kind: 'autoapprove', instanceId: 'test' },
+      reason: 'manual',
+      tickNumber: 1,
+      signal: new AbortController().signal,
+    });
+
+    expect(submitter.submit).toHaveBeenCalledWith('wf-1', 'normal', 'invoker:approve', ['wf-1/task-1']);
+    expect(writes[0]).toMatchObject({ status: 'queued', summary: 'Queued AI fix approval' });
   });
 
   it('skips stale workflow, generation, task-state version, and attempt snapshots', () => {

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -3413,6 +3413,7 @@ describe('TaskRunner', () => {
       (executor as any).execGitReadonly = async (args: string[], cwd?: string) => {
         gitCalls.push(args);
         if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'base-sha';
         // diff --cached --quiet exits non-zero when there are staged changes
         if (args[0] === 'diff' && args.includes('--cached') && args.includes('--quiet')) {
           throw new Error('exit code 1');
@@ -3422,6 +3423,7 @@ describe('TaskRunner', () => {
       (executor as any).execGitIn = async (args: string[], _dir: string) => {
         gitCalls.push(args);
         if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'base-sha';
         // diff --cached --quiet exits non-zero when there are staged changes
         if (args[0] === 'diff' && args.includes('--cached') && args.includes('--quiet')) {
           throw new Error('exit code 1');
@@ -3443,7 +3445,7 @@ describe('TaskRunner', () => {
       // Should squash merge featureBranch into baseBranch using detached HEAD pattern (no rebase)
       const rebaseCall = gitCalls.find(c => c[0] === 'rebase');
       expect(rebaseCall).toBeUndefined();
-      const detachCall = gitCalls.find(c => c[0] === 'checkout' && c[1] === '--detach' && c[2] === 'master');
+      const detachCall = gitCalls.find(c => c[0] === 'checkout' && c[1] === '--detach' && c[2] === 'base-sha');
       expect(detachCall).toBeDefined();
       const squashCall = gitCalls.find(c => c[0] === 'merge' && c.includes('--squash') && c.includes('plan/feature'));
       expect(squashCall).toBeDefined();
@@ -4217,6 +4219,7 @@ console.log(JSON.stringify(out));
       (executor as any).execGitIn = async (args: string[], _dir: string) => {
         gitCalls.push(args);
         if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        if (args[0] === 'diff' && args[1] === '--cached' && args[2] === '--quiet') throw new Error('changes staged');
         return '';
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
@@ -4234,6 +4237,47 @@ console.log(JSON.stringify(out));
       // Squash commit pushed directly to origin from the clone
       const pushCall = gitCalls.find(c => c[0] === 'push' && c.includes('--force') && c.includes('origin') && c.some(a => a.startsWith('HEAD:refs/heads/')));
       expect(pushCall).toBeDefined();
+    });
+
+    it('approveMerge skips commit when squash merge is a no-op', async () => {
+      const persistence = {
+        loadWorkflow: () => ({
+          id: 'wf-1',
+          onFinish: 'merge',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          name: 'Test Workflow',
+        }),
+        updateTask: vi.fn(),
+        getWorkspacePath: () => null,
+      };
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: persistence as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+      });
+
+      const gitCalls: string[][] = [];
+      (executor as any).execGitReadonly = async (args: string[], cwd?: string) => {
+        gitCalls.push(args);
+        if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        return '';
+      };
+      (executor as any).execGitIn = async (args: string[], _dir: string) => {
+        gitCalls.push(args);
+        if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        return '';
+      };
+      (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
+      (executor as any).removeMergeWorktree = async () => {};
+
+      await executor.approveMerge('wf-1');
+
+      expect(gitCalls.find((c) => c[0] === 'merge' && c.includes('--squash') && c.includes('plan/feature'))).toBeDefined();
+      expect(gitCalls.find((c) => c[0] === 'diff' && c[1] === '--cached' && c[2] === '--quiet')).toBeDefined();
+      expect(gitCalls.find((c) => c[0] === 'commit')).toBeUndefined();
+      expect(gitCalls.find((c) => c[0] === 'push')).toBeUndefined();
     });
 
     it('approveMerge throws when workflow has no merge configured', async () => {

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -1035,15 +1035,22 @@ export async function approveMergeImpl(
         branchRepoUrl,
       );
       await execGitInMergeSafe(host, ['merge', '--squash', featureBranch], worktreeDir);
-      mergeTrace('GIT_COMMIT', { mergeMessage });
-      const commitBody = fullSummary ? `${mergeMessage}\n\n${fullSummary}` : mergeMessage;
-      await execGitInMergeSafe(host, ['commit', '-m', commitBody], worktreeDir);
-      // Push squash commit directly to origin (GitHub) from the clone
-      await execGitInMergeSafe(host, ['push', '--force', 'origin', `HEAD:refs/heads/${baseBranch}`], worktreeDir);
-      // Advance the baseBranch ref in the clone so subsequent operations see the updated base
-      const newHead = (await execGitInMergeSafe(host, ['rev-parse', 'HEAD'], worktreeDir)).trim();
-      await execGitInMergeSafe(host, ['update-ref', `refs/heads/${baseBranch}`, newHead], worktreeDir);
-      mergeTrace('SQUASH_MERGE_COMPLETE', { featureBranch, baseBranch });
+      const hasChanges = await execGitInMergeSafe(host, ['diff', '--cached', '--quiet'], worktreeDir)
+        .then(() => false)
+        .catch(() => true);
+      if (hasChanges) {
+        mergeTrace('GIT_COMMIT', { mergeMessage });
+        const commitBody = fullSummary ? `${mergeMessage}\n\n${fullSummary}` : mergeMessage;
+        await execGitInMergeSafe(host, ['commit', '-m', commitBody], worktreeDir);
+        // Push squash commit directly to origin (GitHub) from the clone
+        await execGitInMergeSafe(host, ['push', '--force', 'origin', `HEAD:refs/heads/${baseBranch}`], worktreeDir);
+        // Advance the baseBranch ref in the clone so subsequent operations see the updated base
+        const newHead = (await execGitInMergeSafe(host, ['rev-parse', 'HEAD'], worktreeDir)).trim();
+        await execGitInMergeSafe(host, ['update-ref', `refs/heads/${baseBranch}`, newHead], worktreeDir);
+        mergeTrace('SQUASH_MERGE_COMPLETE', { featureBranch, baseBranch });
+      } else {
+        mergeTrace('SQUASH_MERGE_NOOP', { featureBranch, baseBranch });
+      }
       console.log(`[merge] Approved: squash-merged ${featureBranch} into ${baseBranch}`);
     } catch (err) {
       mergeTrace('APPROVE_MERGE_ERROR', { workflowId, error: String(err) });
@@ -1665,6 +1672,7 @@ export async function consolidateAndMergeImpl(
     'consolidate-' + (workflowId ?? 'default'),
     repoUrlForMerge,
   );
+  const baseHead = (await execGitInMergeSafe(host, ['rev-parse', 'HEAD'], worktreeDir)).trim();
   console.log(`[merge] consolidateAndMerge: featureBranch=${featureBranch}, baseBranch=${baseBranch}, worktree=${worktreeDir}`);
 
   try {
@@ -1763,7 +1771,7 @@ export async function consolidateAndMergeImpl(
 
     if (onFinish === 'merge') {
       // Squash merge in the clone and push result directly to origin (GitHub)
-      await execGitInMergeSafe(host, ['checkout', '--detach', baseBranch], worktreeDir);
+      await execGitInMergeSafe(host, ['checkout', '--detach', baseHead], worktreeDir);
       await execGitInMergeSafe(host, ['merge', '--squash', featureBranch], worktreeDir);
       const hasChanges = await execGitInMergeSafe(host, ['diff', '--cached', '--quiet'], worktreeDir)
         .then(() => false)

--- a/packages/execution-engine/src/workers/auto-approve-worker.ts
+++ b/packages/execution-engine/src/workers/auto-approve-worker.ts
@@ -24,6 +24,7 @@ type AutoApproveActionStatus = WorkerActionStatus;
 
 export interface AutoApproveWorkerStore {
   listWorkflows(): ReadonlyArray<{ id: string }>;
+  loadWorkflow?(workflowId: string): { mergeMode?: string | null; onFinish?: string | null } | undefined;
   loadTasks(workflowId: string): TaskState[];
   loadTask?(taskId: string): TaskState | undefined;
   listWorkflowMutationIntents?(
@@ -136,14 +137,27 @@ function candidateFromTask(task: TaskState): AutoApproveCandidate | undefined {
   return { ...ref, source: 'scan' };
 }
 
+function shouldAutoApproveReviewReadyTask(
+  options: Pick<AutoApproveWorkerPolicyOptions, 'store'>,
+  task: TaskState,
+): boolean {
+  if (!task.config.isMergeNode) return false;
+  const workflowId = workflowIdForTask(task);
+  if (!workflowId) return false;
+  const workflow = options.store.loadWorkflow?.(workflowId);
+  if (!workflow) return false;
+  return (workflow.mergeMode ?? 'manual') === 'automatic' && (workflow.onFinish ?? 'none') === 'merge';
+}
+
 export function listAutoApproveScanCandidates(
   options: Pick<AutoApproveWorkerPolicyOptions, 'store'>,
 ): AutoApproveCandidate[] {
   const candidates: AutoApproveCandidate[] = [];
   for (const workflow of options.store.listWorkflows()) {
     for (const task of options.store.loadTasks(workflow.id)) {
-      if (task.status !== 'awaiting_approval') continue;
-      if (task.execution.pendingFixError === undefined) continue;
+      const awaitingApprovalFix = task.status === 'awaiting_approval' && task.execution.pendingFixError !== undefined;
+      const reviewReadyAutomaticGate = task.status === 'review_ready' && shouldAutoApproveReviewReadyTask(options, task);
+      if (!awaitingApprovalFix && !reviewReadyAutomaticGate) continue;
       const candidate = candidateFromTask(task);
       if (candidate) candidates.push(candidate);
     }
@@ -360,16 +374,19 @@ function validateAutoApproveCandidate(
   }
 
   if (latest.status === 'review_ready') {
-    skipAutoApproveCandidate(options, candidate, 'review-ready-ambiguous');
-    return undefined;
-  }
-  if (latest.status !== 'awaiting_approval') {
-    skipAutoApproveCandidate(options, candidate, 'status-changed', { status: latest.status });
-    return undefined;
-  }
-  if (latest.execution.pendingFixError === undefined) {
-    skipAutoApproveCandidate(options, candidate, 'no-pending-fix');
-    return undefined;
+    if (!shouldAutoApproveReviewReadyTask(options, latest)) {
+      skipAutoApproveCandidate(options, candidate, 'review-ready-ambiguous');
+      return undefined;
+    }
+  } else {
+    if (latest.status !== 'awaiting_approval') {
+      skipAutoApproveCandidate(options, candidate, 'status-changed', { status: latest.status });
+      return undefined;
+    }
+    if (latest.execution.pendingFixError === undefined) {
+      skipAutoApproveCandidate(options, candidate, 'no-pending-fix');
+      return undefined;
+    }
   }
 
   if (hasAlreadyRecordedAction(options, candidate)) return undefined;


### PR DESCRIPTION
## Summary

Automatic merge gates could reach `review_ready` and still stall. The worker stopped before sending them back through the approve route.

This change routes review-ready automatic merge gates through the same approve path already used for fix-session continuations. Manual and PR-review gates stay on their current path.

## Review Claim

Review-ready automatic merge gates follow the auto-approve route again.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only route selection changes for review-ready merge nodes from automatic-merge workflows. The downstream approve path is unchanged.

## Slice Rationale

This sits above the merge-runner fix. Once the merge path is safe, the worker can reopen the blocked route in its own slice.

## Non-goals

- No merge-runner changes.
- No external-review PR flow changes.
- No UI or config changes.

## Architecture

### Before

The worker stopped at `review_ready`, so automatic merge gates never got back onto the approve route.

### After

The worker routes review-ready merge nodes from automatic-merge workflows back onto that existing approve route.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/auto-approve-worker.test.ts -t "autoapprove worker"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 7c62a144b`
- Post-revert steps: None.
- Data migration? No.

</details>
