### PR TITLE
[Stress chaos e2e](2) Tighten core launch-slot accounting

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -195,6 +195,8 @@ export interface TaskHistoryEntry extends TaskState {
 export interface QueueStatus {
   maxConcurrency: number;
   runningCount: number;
+  activeExecutionCount?: number;
+  launchingCount?: number;
   running: Array<{ taskId: string; description: string }>;
   queued: Array<{ taskId: string; priority: number; description: string }>;
 }
@@ -1157,6 +1159,25 @@ export const IpcTestOnlyChannels = {
       taskCount: number;
       eventCount: number;
       workerActionCount: number;
+    };
+  },
+  'invoker:seed-stress-fixture': {} as {
+    request: [options?: {
+      workflowCount?: number;
+      tasksPerWorkflow?: number;
+      eventsPerTask?: number;
+      nowIso?: string;
+      stuckLaunchingSlots?: number;
+      launchAgeMs?: number;
+    }];
+    response: {
+      workflowCount: number;
+      taskCount: number;
+      running: number;
+      launching: number;
+      fixing: number;
+      pending: number;
+      failed: number;
     };
   },
 } as const;

--- a/packages/contracts/src/launch-timeouts.ts
+++ b/packages/contracts/src/launch-timeouts.ts
@@ -13,5 +13,6 @@
 export const ATTEMPT_LEASE_MS = 20 * 60 * 1000;
 
 export const DISPATCH_LEASE_MS = 12 * 60 * 1000;
+export const LAUNCH_STUCK_ABANDON_MS = DISPATCH_LEASE_MS;
 
 export const DISPATCH_MAX_ATTEMPTS = 3;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -2943,16 +2943,24 @@ export class SQLiteAdapter implements PersistenceAdapter {
   listAbandonableLaunchDispatchLeases(options: {
     nowIso?: string;
     maxAttempts: number;
+    maxLaunchAgeMs?: number;
   }): TaskLaunchDispatch[] {
     const now = options.nowIso ?? new Date().toISOString();
+    const maxLaunchAgeMs = options.maxLaunchAgeMs;
+    const ageCutoff = maxLaunchAgeMs === undefined
+      ? null
+      : new Date(new Date(now).getTime() - maxLaunchAgeMs).toISOString();
     const rows = this.queryAll(
       `SELECT * FROM task_launch_dispatch
          WHERE state = 'leased'
            AND fenced_until IS NOT NULL
            AND fenced_until < ?
-           AND attempts_count >= ?
+           AND (
+             attempts_count >= ?
+             OR (? IS NOT NULL AND enqueued_at <= ?)
+           )
          ORDER BY id ASC`,
-      [now, options.maxAttempts],
+      [now, options.maxAttempts, ageCutoff, ageCutoff],
     );
     return rows.map((row) => this.rowToTaskLaunchDispatch(row));
   }

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -3672,6 +3672,8 @@ export class Orchestrator {
   getQueueStatus(options?: { refresh?: boolean }): {
     maxConcurrency: number;
     runningCount: number;
+    activeExecutionCount: number;
+    launchingCount: number;
     running: Array<{ taskId: string; attemptId?: string; description: string }>;
     queued: Array<{ taskId: string; priority: number; description: string }>;
   } {
@@ -3720,9 +3722,14 @@ export class Orchestrator {
       })
       .sort((a, b) => (b.priority - a.priority) || (a.createdAt - b.createdAt));
 
+    const activeExecutionCount = activeAttempts.filter(({ task }) =>
+      task.status === 'running' || task.status === 'fixing_with_ai',
+    ).length;
     return {
       maxConcurrency: this.maxConcurrency,
       runningCount: activeAttempts.length,
+      activeExecutionCount,
+      launchingCount: activeAttempts.length - activeExecutionCount,
       running: activeAttempts.map(({ task, attemptId }) => ({
         taskId: task.id,
         attemptId,


### PR DESCRIPTION
## Summary

This tightens the core queue read so executing work and launching slots are counted separately.

It also makes an old leased launch row abandonable after one dispatch lease instead of waiting for the longer lease window.

## Review Claim

Core queue accounting now reports executing versus launching work separately, and the abandon query now catches leased launches older than one dispatch lease.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`runningCount` keeps its old meaning as occupied slots, and the age check only widens the existing abandon query for leased rows that are already past their fence.

## Slice Rationale

The queue-read change and the lease-age check are one core scheduling seam, so they stay together ahead of the app wiring.

## Non-goals

No app wiring, no storm harness, and no ci policy changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd ~/Documents/GitHub/Invoker-ui-regressions && pnpm --filter @invoker/app test`
- [ ] `cd ~/Documents/GitHub/Invoker-ui-regressions && pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 547125f83`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4242