### PR TITLE
[Stress chaos e2e](3) Add app storm harness and launch-slot proof

### DIFF
--- a/packages/app/e2e/storm-scale-responsiveness.spec.ts
+++ b/packages/app/e2e/storm-scale-responsiveness.spec.ts
@@ -1,0 +1,362 @@
+import { E2E_REPO_URL, expect, injectTaskStates, loadPlan, startPlan, test } from './fixtures/electron-app.js';
+import type { ElectronApplication, Page } from '@playwright/test';
+import { stringify as yamlStringify } from 'yaml';
+
+const ACK_BUDGET_MS = 200;
+const ACK_BUDGET_2X_MS = 400;
+const IPC_P95_BUDGET_MS = 200;
+const IPC_P95_BUDGET_2X_MS = 400;
+const IPC_MAX_BUDGET_MS = 250;
+const IPC_MAX_BUDGET_2X_MS = 500;
+const IPC_SAMPLE_INTERVAL_MS = 100;
+const IPC_WINDOW_MS = 8_000;
+const UPDATE_BURSTS = 10;
+const UPDATES_PER_BURST = 24;
+const UPDATE_BURST_DELAY_MS = 40;
+const STUCK_LAUNCH_AGE_MS = 12 * 60 * 1000;
+
+const SCALES = [
+  { name: '1x', workflowCount: 57, tasksPerWorkflow: 4, ackBudgetMs: ACK_BUDGET_MS, ipcP95BudgetMs: IPC_P95_BUDGET_MS, ipcMaxBudgetMs: IPC_MAX_BUDGET_MS },
+  { name: '2x', workflowCount: 114, tasksPerWorkflow: 4, ackBudgetMs: ACK_BUDGET_2X_MS, ipcP95BudgetMs: IPC_P95_BUDGET_2X_MS, ipcMaxBudgetMs: IPC_MAX_BUDGET_2X_MS },
+] as const;
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[Math.max(0, idx)]!;
+}
+
+async function measureAck(page: Page, action: () => Promise<void>, assertVisible: () => Promise<void>): Promise<number> {
+  const started = await page.evaluate(() => performance.now());
+  await action();
+  await assertVisible();
+  const ended = await page.evaluate(() => performance.now());
+  return ended - started;
+}
+
+
+async function seedStressScene(page: Page, scale: (typeof SCALES)[number]) {
+  const seeded = await page.evaluate(async (options) => {
+    if (!window.invoker.seedStressFixture) {
+      throw new Error('seedStressFixture is not exposed (NODE_ENV=test required)');
+    }
+    return window.invoker.seedStressFixture(options);
+  }, {
+    workflowCount: scale.workflowCount,
+    tasksPerWorkflow: scale.tasksPerWorkflow,
+  });
+  const hitch = await page.evaluate(async () => {
+    if (!window.invoker.seedMainProcessHitchFixture) {
+      throw new Error('seedMainProcessHitchFixture is not exposed (NODE_ENV=test required)');
+    }
+    return window.invoker.seedMainProcessHitchFixture();
+  });
+  expect(hitch.eventCount).toBeGreaterThanOrEqual(10_000);
+  await expect.poll(async () => {
+    const workflows = await page.evaluate(() => window.invoker.listWorkflows());
+    return workflows.length;
+  }, { timeout: 120_000 }).toBe(scale.workflowCount + 1);
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await page.locator('[data-testid^="workflow-node-"]:visible').first().waitFor({ state: 'visible', timeout: 30_000 });
+  return seeded as {
+    workflowCount: number;
+    taskCount: number;
+    running: number;
+    launching: number;
+    fixing: number;
+    pending: number;
+    failed: number;
+  };
+}
+
+async function sampleQueueStatus(page: Page) {
+  return page.evaluate(async () => window.invoker.getQueueStatus());
+}
+
+async function sampleWorkflowCount(page: Page): Promise<number> {
+  return page.evaluate(async () => (await window.invoker.listWorkflows()).length);
+}
+
+async function streamStormBursts(page: Page, taskIds: string[]): Promise<void> {
+  const phaseTemplates = ['running', 'launching', 'failed', 'pending'] as const;
+  for (let burst = 0; burst < UPDATE_BURSTS; burst += 1) {
+    const updates = Array.from({ length: UPDATES_PER_BURST }, (_, offset) => {
+      const taskId = taskIds[(burst * UPDATES_PER_BURST + offset) % taskIds.length]!;
+      const phase = phaseTemplates[(burst + offset) % phaseTemplates.length]!;
+      const now = new Date();
+      if (phase === 'running') {
+        return {
+          taskId,
+          changes: {
+            status: 'running',
+            execution: {
+              phase: 'executing',
+              startedAt: now,
+              lastHeartbeatAt: now,
+              error: undefined,
+              exitCode: undefined,
+              isFixingWithAI: false,
+            },
+          },
+        };
+      }
+      if (phase === 'launching') {
+        return {
+          taskId,
+          changes: {
+            status: 'pending',
+            execution: {
+              phase: 'launching',
+              launchStartedAt: now,
+              lastHeartbeatAt: now,
+              error: undefined,
+              exitCode: undefined,
+            },
+          },
+        };
+      }
+      if (phase === 'failed') {
+        return {
+          taskId,
+          changes: {
+            status: 'failed',
+            execution: {
+              phase: 'executing',
+              completedAt: now,
+              error: `storm burst ${burst}`,
+              exitCode: 1,
+              isFixingWithAI: false,
+            },
+          },
+        };
+      }
+      return {
+        taskId,
+        changes: {
+          status: 'pending',
+          execution: {
+            phase: undefined,
+            completedAt: undefined,
+            error: undefined,
+            exitCode: undefined,
+            isFixingWithAI: false,
+          },
+        },
+      };
+    });
+    await page.evaluate((burstUpdates) => {
+      if (!window.invoker.injectTaskStates) {
+        throw new Error('injectTaskStates is not exposed (NODE_ENV=test required)');
+      }
+      return window.invoker.injectTaskStates(burstUpdates);
+    }, updates);
+    await page.waitForTimeout(UPDATE_BURST_DELAY_MS);
+  }
+}
+
+async function stampedeWindow(electronApp: ElectronApplication): Promise<void> {
+  await electronApp.evaluate(({ BrowserWindow }) => {
+    const win = BrowserWindow.getAllWindows()[0];
+    if (!win) throw new Error('no BrowserWindow found');
+    win.hide();
+  });
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  await electronApp.evaluate(({ BrowserWindow }) => {
+    const win = BrowserWindow.getAllWindows()[0];
+    if (!win) throw new Error('no BrowserWindow found');
+    win.show();
+    win.focus();
+  });
+}
+
+async function recreateBurst(page: Page, limit = 10): Promise<void> {
+  await page.evaluate(async (burstLimit) => {
+    const workflows = await window.invoker.listWorkflows();
+    await Promise.allSettled(
+      workflows
+        .filter((workflow) => workflow.id !== 'wf-hitch-fat')
+        .slice(0, burstLimit)
+        .map((workflow) => window.invoker.recreateWorkflow(workflow.id)),
+    );
+  }, limit);
+}
+function buildReadyRootPlan() {
+  return {
+    name: 'Stress Ready Root',
+    repoUrl: E2E_REPO_URL,
+    onFinish: 'none' as const,
+    tasks: [
+      {
+        id: 'root',
+        description: 'Ready root',
+        command: 'echo ready-root',
+        dependencies: [] as string[],
+      },
+    ],
+  };
+}
+
+for (const scale of SCALES) {
+  test(`storm scale responsiveness stays correct under ${scale.name}`, async ({ page, electronApp }) => {
+    test.setTimeout(300_000);
+    const seeded = await seedStressScene(page, scale);
+    const initialQueue = await sampleQueueStatus(page);
+    expect(initialQueue.activeExecutionCount).toBe(seeded.running + seeded.fixing);
+    expect(initialQueue.activeExecutionCount).toBeLessThanOrEqual(initialQueue.runningCount);
+
+    const taskIds = await page.evaluate(async () => {
+      const result = await window.invoker.getTasks();
+      const tasks = Array.isArray(result) ? result : result.tasks;
+      return tasks.map((task: { id: string }) => task.id).filter((taskId: string) => !taskId.startsWith('wf-hitch-fat/'));
+    });
+    expect(taskIds.length).toBeGreaterThanOrEqual(scale.workflowCount * scale.tasksPerWorkflow);
+
+    const ipcSamples: number[] = [];
+    let sampling = true;
+    const sampler = (async () => {
+      const hardDeadline = Date.now() + IPC_WINDOW_MS + 20_000;
+      while (sampling && Date.now() < hardDeadline) {
+        const rtt = await page.evaluate(async () => {
+          const started = performance.now();
+          await Promise.all([
+            window.invoker.listWorkflows(),
+            window.invoker.getWorkerStatus(),
+            window.invoker.getQueueStatus(),
+          ]);
+          return performance.now() - started;
+        });
+        ipcSamples.push(rtt);
+        await page.waitForTimeout(IPC_SAMPLE_INTERVAL_MS);
+      }
+    })();
+
+    await page.getByTestId('sidebar-home').click();
+    const workflowNode = page
+      .locator('[data-testid^="workflow-node-"]:visible:not([data-testid="workflow-node-wf-hitch-fat"])')
+      .first();
+    await workflowNode.waitFor({ state: 'attached', timeout: 30_000 });
+    await workflowNode.dispatchEvent('click', { bubbles: true });
+    await expect(page.getByTestId('selected-workflow-mini-dag')).toBeVisible({ timeout: 15_000 });
+
+    const storm = (async () => {
+      await streamStormBursts(page, taskIds);
+      await recreateBurst(page);
+      await stampedeWindow(electronApp);
+      await streamStormBursts(page, taskIds.reverse());
+    })();
+
+    let ack = await measureAck(
+      page,
+      async () => { await page.getByTestId('sidebar-workers').click(); },
+      async () => {
+        await expect(page.getByTestId('worker-activity-card').or(page.getByText('Worker processes')).first()).toBeVisible({ timeout: scale.ackBudgetMs + 1500 });
+      },
+    );
+    expect(ack, `sidebar-workers ack ${ack}ms at ${scale.name}`).toBeLessThanOrEqual(scale.ackBudgetMs);
+
+    ack = await measureAck(
+      page,
+      async () => { await page.getByTestId('sidebar-home').click(); },
+      async () => {
+        await expect(page.getByTestId('workflow-graph-surface')).toBeVisible({ timeout: scale.ackBudgetMs + 1500 });
+      },
+    );
+    expect(ack, `sidebar-home ack ${ack}ms at ${scale.name}`).toBeLessThanOrEqual(scale.ackBudgetMs);
+
+    await storm;
+    sampling = false;
+    await sampler;
+
+    await expect.poll(async () => await sampleWorkflowCount(page), { timeout: 30_000 }).toBe(scale.workflowCount + 1);
+    await expect.poll(async () => await page.locator('[data-testid="selected-workflow-mini-dag"] .react-flow__node').count(), { timeout: 30_000 }).toBeGreaterThan(0);
+
+    const perf = await page.evaluate(async () => await window.invoker.getUiPerfStats());
+    expect(perf.maxRendererEventLoopLagMs).toBeLessThan(1000);
+    const postStormAck = await measureAck(
+      page,
+      async () => { await page.getByTestId('sidebar-workers').click(); },
+      async () => {
+        await expect(page.getByTestId('worker-activity-card').or(page.getByText('Worker processes')).first()).toBeVisible({ timeout: 30_000 });
+      },
+    );
+    expect(postStormAck, `post-storm sidebar-workers ack ${postStormAck}ms at ${scale.name}`).toBeLessThanOrEqual(scale.ackBudgetMs + 200);
+    await page.getByTestId('sidebar-home').click();
+    await expect(page.getByTestId('workflow-graph-surface')).toBeVisible({ timeout: 30_000 });
+    const finalQueue = await sampleQueueStatus(page);
+    expect(finalQueue.activeExecutionCount).toBeLessThanOrEqual(finalQueue.runningCount);
+
+    const sorted = [...ipcSamples].sort((a, b) => a - b);
+    const p95 = percentile(sorted, 95);
+    const max = sorted[sorted.length - 1] ?? 0;
+    expect(p95, `p95 IPC RTT ${p95.toFixed(1)}ms at ${scale.name}`).toBeLessThanOrEqual(scale.ipcP95BudgetMs);
+    expect(max, `max IPC RTT ${max.toFixed(1)}ms at ${scale.name}`).toBeLessThanOrEqual(scale.ipcMaxBudgetMs);
+  });
+}
+
+test('aged launching slots free capacity for a ready root', async ({ page }) => {
+  test.setTimeout(180_000);
+  const maxConcurrency = await page.evaluate(async () => (await window.invoker.getQueueStatus()).maxConcurrency);
+  const workflowCount = Math.max(2, maxConcurrency);
+  await page.evaluate(async (options) => {
+    if (!window.invoker.seedStressFixture) {
+      throw new Error('seedStressFixture is not exposed (NODE_ENV=test required)');
+    }
+    return window.invoker.seedStressFixture(options);
+  }, {
+    workflowCount,
+    tasksPerWorkflow: 4,
+    stuckLaunchingSlots: maxConcurrency,
+    launchAgeMs: STUCK_LAUNCH_AGE_MS,
+    nowIso: '2026-07-01T00:20:00.000Z',
+  });
+  await page.evaluate(async () => {
+    const result = await window.invoker.getTasks();
+    const tasks = Array.isArray(result) ? result : result.tasks;
+    const updates = tasks
+      .filter((task: any) => task.id.endsWith('/t0'))
+      .map((task: any) => ({
+        taskId: task.id,
+        changes: {
+          status: 'failed',
+          execution: {
+            phase: 'executing',
+            completedAt: new Date(),
+            error: 'clear running slot',
+            exitCode: 1,
+          },
+        },
+      }));
+    if (!window.invoker.injectTaskStates) {
+      throw new Error('injectTaskStates is not exposed (NODE_ENV=test required)');
+    }
+    await window.invoker.injectTaskStates(updates);
+  });
+
+  await loadPlan(page, buildReadyRootPlan());
+  await startPlan(page);
+
+  const rootTaskId = await page.evaluate(async () => {
+    const workflows = await window.invoker.listWorkflows();
+    const rootWorkflow = workflows.find((workflow) => workflow.name === 'Stress Ready Root');
+    if (!rootWorkflow) throw new Error('Root workflow missing');
+    const result = await window.invoker.getTasks();
+    const tasks = Array.isArray(result) ? result : result.tasks;
+    const rootTask = tasks.find((task: any) => task.config?.workflowId === rootWorkflow.id && task.description === 'Ready root');
+    if (!rootTask) throw new Error('Root task missing');
+    return rootTask.id as string;
+  });
+
+  await expect.poll(async () => {
+    await page.evaluate(() => window.invoker.start());
+    const status = await sampleQueueStatus(page);
+    return {
+      runningIds: status.running.map((task: { taskId: string }) => task.taskId),
+      queuedIds: status.queued.map((task: { taskId: string }) => task.taskId),
+    };
+  }, { timeout: 15_000 }).toMatchObject({
+    runningIds: expect.arrayContaining([rootTaskId]),
+  });
+
+  const queueStatus = await sampleQueueStatus(page);
+  expect(queueStatus.queued.map((task: { taskId: string }) => task.taskId)).not.toContain(rootTaskId);
+});

--- a/packages/app/src/__tests__/dispatch-capacity-invariants.test.ts
+++ b/packages/app/src/__tests__/dispatch-capacity-invariants.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import {
+  DISPATCH_LEASE_MS,
+  LAUNCH_STUCK_ABANDON_MS,
+} from '@invoker/contracts';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator, type PlanDefinition, type TaskDelta, type TaskState } from '@invoker/workflow-core';
+import { LaunchDispatcher } from '../launch-dispatcher.js';
+import { taskNeedsExecutingStallCheck } from '../executing-stall.js';
+import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from '../delta-merge.js';
+import { WorkflowRollupProjection } from '../workflow-rollup-projection.js';
+
+function makeTask(
+  id: string,
+  workflowId: string,
+  status: TaskState['status'] = 'pending',
+  overrides: Partial<TaskState> = {},
+): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id,
+    description: `Task ${id}`,
+    status,
+    dependencies: [],
+    createdAt: new Date('2026-07-01T00:00:00.000Z'),
+    config: {
+      workflowId,
+      command: `echo ${id}`,
+      runnerKind: 'ssh',
+      poolId: 'mixed-local-ssh',
+      ...config,
+    },
+    execution: {
+      generation: 0,
+      ...execution,
+    },
+    taskStateVersion: 1,
+    ...rest,
+  } as TaskState;
+}
+
+function buildSingleTaskPlan(name: string, taskId: string): PlanDefinition {
+  return {
+    name,
+    tasks: [
+      {
+        id: taskId,
+        description: taskId,
+        command: `echo ${taskId}`,
+      },
+    ],
+  };
+}
+
+async function makeHarness(maxConcurrency = 4) {
+  const persistence = await SQLiteAdapter.create(':memory:');
+  const orchestrator = new Orchestrator({
+    persistence: persistence as any,
+    messageBus: new InMemoryBus(),
+    maxConcurrency,
+    deferRunningUntilLaunch: true,
+  });
+  const dispatcher = new LaunchDispatcher({
+    persistence,
+    orchestrator: {
+      prepareTaskForNewAttempt: (taskId, reason) => orchestrator.prepareTaskForNewAttempt(taskId, reason),
+      getTask: (taskId) => orchestrator.getTask(taskId),
+      startExecution: () => orchestrator.startExecution(),
+      syncFromDb: (workflowId) => orchestrator.syncFromDb(workflowId),
+      getTaskLaunchReadiness: (taskId) => orchestrator.getTaskLaunchReadiness(taskId),
+    },
+    ownerId: 'dispatch-invariants-owner',
+    maxLeasesPerPoll: maxConcurrency,
+  });
+  return { persistence, orchestrator, dispatcher };
+}
+
+function claimAllLaunches(persistence: SQLiteAdapter, count: number, nowIso: string) {
+  const claimed: Array<{ id: number; taskId: string; attemptId: string }> = [];
+  for (let i = 0; i < count; i += 1) {
+    const row = persistence.claimLaunchDispatchAtomic({
+      ownerId: 'dispatch-invariants-owner',
+      nowIso,
+    });
+    if (!row) {
+      throw new Error(`Expected leased dispatch row ${i + 1}/${count}`);
+    }
+    claimed.push({ id: row.id, taskId: row.taskId, attemptId: row.attemptId });
+  }
+  return claimed;
+}
+
+function latestTaskId(persistence: SQLiteAdapter) {
+  const taskId = persistence.getAllTaskIds().at(-1);
+  if (!taskId) {
+    throw new Error('Expected at least one task id');
+  }
+  return taskId;
+}
+
+function loadSingleTaskWorkflow(orchestrator: Orchestrator, persistence: SQLiteAdapter, name: string, taskId: string) {
+  orchestrator.loadPlan(buildSingleTaskPlan(name, taskId));
+  return latestTaskId(persistence);
+}
+
+
+function forceDispatchAge(
+  persistence: SQLiteAdapter,
+  dispatchId: number,
+  { enqueuedAt, fencedUntil }: { enqueuedAt: string; fencedUntil?: string },
+) {
+  const db = (persistence as any).db;
+  db.run(
+    `UPDATE task_launch_dispatch
+        SET enqueued_at = ?, fenced_until = ?, leased_at = ?, attempts_count = 1
+      WHERE id = ?`,
+    [enqueuedAt, fencedUntil ?? null, enqueuedAt, dispatchId],
+  );
+}
+
+describe('dispatch capacity invariants', () => {
+  const adapters: SQLiteAdapter[] = [];
+
+  afterEach(() => {
+    for (const adapter of adapters.splice(0)) {
+      adapter.close();
+    }
+  });
+
+  it('reports active executions separately from launching slots', async () => {
+    const { persistence, orchestrator } = await makeHarness(4);
+    adapters.push(persistence);
+    const now = new Date('2026-07-01T00:00:00.000Z');
+
+    for (let i = 0; i < 4; i += 1) {
+      loadSingleTaskWorkflow(orchestrator, persistence, `wf-${i}`, `task-${i}`);
+    }
+    orchestrator.startExecution();
+    const claimed = claimAllLaunches(persistence, 4, now.toISOString());
+    const runningRow = claimed[0]!;
+    expect(orchestrator.markTaskRunningAfterLaunch(runningRow.taskId, runningRow.attemptId, now)).toBe(true);
+
+    const status = orchestrator.getQueueStatus();
+    expect(status.runningCount).toBe(4);
+    expect(status.activeExecutionCount).toBe(1);
+    expect(status.launchingCount).toBe(3);
+    expect(status.running).toHaveLength(4);
+  });
+
+  it('abandons old launching slots by age and frees capacity for a ready root', async () => {
+    const { persistence, orchestrator, dispatcher } = await makeHarness(3);
+    adapters.push(persistence);
+    const now = new Date('2026-07-01T00:20:00.000Z');
+    const claimTime = new Date(now.getTime() - DISPATCH_LEASE_MS - 60_000);
+    const oldEnqueuedAt = new Date(now.getTime() - LAUNCH_STUCK_ABANDON_MS - 1_000).toISOString();
+
+    for (let i = 0; i < 2; i += 1) {
+      loadSingleTaskWorkflow(orchestrator, persistence, `stuck-${i}`, `stuck-${i}`);
+    }
+    orchestrator.startExecution();
+    const stuckRows = claimAllLaunches(persistence, 2, claimTime.toISOString());
+    for (const row of stuckRows) {
+      forceDispatchAge(persistence, row.id, {
+        enqueuedAt: oldEnqueuedAt,
+        fencedUntil: new Date(claimTime.getTime() + DISPATCH_LEASE_MS).toISOString(),
+      });
+    }
+
+    const rootTaskId = loadSingleTaskWorkflow(orchestrator, persistence, 'ready-root', 'root');
+
+    expect(dispatcher.abandonStuckLeases(now.toISOString())).toBe(2);
+    const abandoned = persistence.listLaunchDispatchesByState(['abandoned']);
+    expect(abandoned).toHaveLength(2);
+    const superseded = persistence.loadAttempts(stuckRows[0]!.taskId).find((attempt) => attempt.status === 'superseded');
+    expect(superseded).toBeDefined();
+
+    const started = orchestrator.startExecution();
+    expect(started.map((task) => task.id)).toContain(rootTaskId);
+    const rootTask = orchestrator.getTask(rootTaskId);
+    expect(rootTask?.execution.selectedAttemptId).toBeTruthy();
+    const rootDispatch = persistence.loadLaunchDispatchByAttempt(rootTask!.execution.selectedAttemptId!);
+    expect(rootDispatch?.state).toBe('enqueued');
+  });
+
+  it('abandons a stuck lease by age before max dispatch attempts but keeps recent leases', async () => {
+    const { persistence, orchestrator, dispatcher } = await makeHarness(2);
+    adapters.push(persistence);
+    const now = new Date('2026-07-01T00:20:00.000Z');
+    const claimTime = new Date(now.getTime() - DISPATCH_LEASE_MS - 60_000);
+
+    loadSingleTaskWorkflow(orchestrator, persistence, 'old', 'old');
+    loadSingleTaskWorkflow(orchestrator, persistence, 'recent', 'recent');
+    orchestrator.startExecution();
+
+    const claimed = claimAllLaunches(persistence, 2, claimTime.toISOString());
+    const oldRow = claimed.find((row) => row.taskId.endsWith('/old'));
+    const recentRow = claimed.find((row) => row.taskId.endsWith('/recent'));
+    expect(oldRow).toBeDefined();
+    expect(recentRow).toBeDefined();
+
+    forceDispatchAge(persistence, oldRow!.id, {
+      enqueuedAt: new Date(now.getTime() - LAUNCH_STUCK_ABANDON_MS - 1_000).toISOString(),
+      fencedUntil: new Date(claimTime.getTime() + DISPATCH_LEASE_MS).toISOString(),
+    });
+    forceDispatchAge(persistence, recentRow!.id, {
+      enqueuedAt: new Date(now.getTime() - 1_000).toISOString(),
+      fencedUntil: new Date(claimTime.getTime() + DISPATCH_LEASE_MS).toISOString(),
+    });
+
+    expect(dispatcher.abandonStuckLeases(now.toISOString())).toBe(1);
+    expect(persistence.loadLaunchDispatchById(oldRow!.id)?.state).toBe('abandoned');
+    expect(persistence.loadLaunchDispatchById(recentRow!.id)?.state).toBe('leased');
+  });
+
+  it('gates executing-stall checks to running, fixing, and pending+launching tasks', () => {
+    expect(taskNeedsExecutingStallCheck(makeTask('wf/t-running', 'wf', 'running'))).toBe(true);
+    expect(taskNeedsExecutingStallCheck(makeTask('wf/t-fixing', 'wf', 'fixing_with_ai'))).toBe(true);
+    expect(taskNeedsExecutingStallCheck(makeTask('wf/t-launching', 'wf', 'pending', {
+      execution: { phase: 'launching' } as any,
+    }))).toBe(true);
+    expect(taskNeedsExecutingStallCheck(makeTask('wf/t-pending', 'wf', 'pending'))).toBe(false);
+    expect(taskNeedsExecutingStallCheck(makeTask('wf/t-completed', 'wf', 'completed'))).toBe(false);
+    expect(taskNeedsExecutingStallCheck(makeTask('wf/t-failed', 'wf', 'failed'))).toBe(false);
+  });
+
+  it('keeps workflow rollups and quarantine recovery aligned through a delta burst', () => {
+    const cache = new TaskSnapshotCache();
+    const projection = new WorkflowRollupProjection();
+    const persisted = new Map<string, TaskState>([
+      ['wf-1/a', makeTask('wf-1/a', 'wf-1', 'running', { taskStateVersion: 1 })],
+      ['wf-2/b', makeTask('wf-2/b', 'wf-2', 'pending', { taskStateVersion: 1 })],
+    ]);
+
+    projection.replaceAll([...persisted.values()]);
+    for (const task of persisted.values()) {
+      cache.set(task.id, JSON.stringify(task));
+    }
+
+    const createDelta: TaskDelta = {
+      type: 'created',
+      task: makeTask('wf-3/c', 'wf-3', 'running', { taskStateVersion: 1 }),
+    };
+    persisted.set(createDelta.task.id, createDelta.task);
+    const createResult = applyDelta(createDelta, cache);
+    expect(createResult.accepted).toBe(true);
+    const createPatches = projection.applyDelta(createDelta);
+    expect(createPatches).toHaveLength(1);
+
+    const gapDelta: TaskDelta = {
+      type: 'updated',
+      taskId: 'wf-2/b',
+      changes: { status: 'running' },
+      previousTaskStateVersion: 4,
+      taskStateVersion: 5,
+    };
+    const gapResult = applyDelta(gapDelta, cache);
+    expect(gapResult.quarantined).toEqual(['wf-2/b']);
+    expect(cache.isQuarantined('wf-2/b')).toBe(true);
+
+    const removedDelta: TaskDelta = {
+      type: 'removed',
+      taskId: 'wf-3/c',
+      previousTaskStateVersion: 1,
+    };
+    persisted.delete('wf-3/c');
+    const removeResult = applyDelta(removedDelta, cache);
+    expect(removeResult.accepted).toBe(true);
+    const removePatches = projection.applyDelta(removedDelta);
+    expect(removePatches).toHaveLength(1);
+
+    const recovery = recoverQuarantinedTask(cache, 'wf-2/b', {
+      loadTask: (taskId) => persisted.get(taskId),
+      getMergeNode: () => undefined,
+    });
+    expect(recovery.rendererDelta).toEqual({ type: 'created', task: persisted.get('wf-2/b')! });
+    const recoveryPatches = projection.applyDelta(recovery.rendererDelta);
+    expect(recoveryPatches).toHaveLength(1);
+    expect(cache.isQuarantined('wf-2/b')).toBe(false);
+
+    const finalTasks = [...persisted.values()];
+    projection.replaceAll(finalTasks);
+    const workflowIds = new Set(finalTasks.map((task) => task.config.workflowId));
+    expect(workflowIds).toEqual(new Set(['wf-1', 'wf-2']));
+    expect(projection.patchFor('wf-1').rollup.countsByStatus.running).toBe(1);
+    expect(projection.patchFor('wf-2').rollup.countsByStatus.pending).toBe(1);
+  });
+});

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SQLiteAdapter } from '@invoker/data-store';
-import { DISPATCH_LEASE_MS, type Logger } from '@invoker/contracts';
+import { DISPATCH_LEASE_MS, LAUNCH_STUCK_ABANDON_MS, type Logger } from '@invoker/contracts';
 import { InMemoryBus } from '@invoker/test-kit';
 import { Orchestrator } from '@invoker/workflow-core';
 import { LaunchDispatcher } from '../launch-dispatcher.js';
@@ -467,9 +467,9 @@ describe('LaunchDispatcher', () => {
       const pastIso = new Date(Date.now() - 60_000).toISOString();
       (adapter as any).db.run(
         `UPDATE task_launch_dispatch
-           SET state = 'leased', fenced_until = ?, attempts_count = 1
+           SET state = 'leased', fenced_until = ?, attempts_count = 1, enqueued_at = ?
          WHERE id = ?`,
-        [pastIso, underAttemptRow.id],
+        [pastIso, new Date().toISOString(), underAttemptRow.id],
       );
 
       const prepare = vi.fn();
@@ -487,9 +487,12 @@ describe('LaunchDispatcher', () => {
         generation: 0,
       });
       const pastIso = new Date(Date.now() - 60_000).toISOString();
+      const recentEnqueuedAt = new Date().toISOString();
       (adapter as any).db.run(
-        `UPDATE task_launch_dispatch SET state = 'leased', dispatch_owner = 'owner-x', fenced_until = ? WHERE id = ?`,
-        [pastIso, row.id],
+        `UPDATE task_launch_dispatch
+           SET state = 'leased', dispatch_owner = 'owner-x', fenced_until = ?, attempts_count = 1, enqueued_at = ?
+         WHERE id = ?`,
+        [pastIso, recentEnqueuedAt, row.id],
       );
 
       const dispatcher = new LaunchDispatcher({
@@ -498,6 +501,31 @@ describe('LaunchDispatcher', () => {
       });
       dispatcher.poll();
       expect(adapter.loadLaunchDispatchById(row.id)?.state).toBe('enqueued');
+    });
+    it('poll() abandons age-stale launching leases before reaping them back to enqueued', () => {
+      seed();
+      const row = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-r/t1',
+        attemptId: 'attempt-aged',
+        workflowId: 'wf-r',
+        generation: 0,
+      });
+      const now = new Date('2026-07-01T00:20:00.000Z');
+      const pastIso = new Date(now.getTime() - 60_000).toISOString();
+      const enqueuedAtIso = new Date(now.getTime() - LAUNCH_STUCK_ABANDON_MS - 1_000).toISOString();
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch
+           SET state = 'leased', dispatch_owner = 'owner-x', fenced_until = ?, attempts_count = 1, enqueued_at = ?
+         WHERE id = ?`,
+        [pastIso, enqueuedAtIso, row.id],
+      );
+
+      const prepare = vi.fn();
+      const { dispatcher } = dispatcherWithOrchestrator({ prepareTaskForNewAttempt: prepare });
+      dispatcher.poll();
+
+      expect(adapter.loadLaunchDispatchById(row.id)?.state).toBe('abandoned');
+      expect(prepare).toHaveBeenCalledWith('wf-r/t1', 'launch-dispatch-abandoned');
     });
   });
 

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -283,6 +283,8 @@ export function formatWorkerDecisions(actions: WorkerActionSummary[]): string {
 export function formatQueueStatus(status: {
   maxConcurrency: number;
   runningCount: number;
+  activeExecutionCount: number;
+  launchingCount: number;
   running: Array<{ taskId: string; description: string }>;
   queued: Array<{ taskId: string; priority: number; description: string }>;
 }): string {
@@ -290,12 +292,11 @@ export function formatQueueStatus(status: {
 
   // Concurrency header
   lines.push(
-    `${BOLD}Concurrency:${RESET} ${status.runningCount} / ${status.maxConcurrency} running`,
+    `${BOLD}Concurrency:${RESET} running=${status.activeExecutionCount} launching=${status.launchingCount} slots=${status.runningCount}/${status.maxConcurrency} queued=${status.queued.length}`,
   );
   lines.push('');
 
-  // Running section
-  lines.push(`${BOLD}${YELLOW}Running (${status.running.length}):${RESET}`);
+  lines.push(`${BOLD}${YELLOW}Active slots (${status.running.length}):${RESET}`);
   if (status.running.length === 0) {
     lines.push(`${DIM}  (none)${RESET}`);
   } else {

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -10,7 +10,7 @@
 import type { SQLiteAdapter, TaskLaunchDispatch } from '@invoker/data-store';
 import type { LaunchOutboxAck } from '@invoker/execution-engine';
 import type { TaskLaunchReadiness, TaskState } from '@invoker/workflow-core';
-import { DISPATCH_MAX_ATTEMPTS, type Logger } from '@invoker/contracts';
+import { DISPATCH_MAX_ATTEMPTS, LAUNCH_STUCK_ABANDON_MS, type Logger } from '@invoker/contracts';
 
 
 export type LaunchDispatcherPersistence = Pick<
@@ -102,14 +102,15 @@ export class LaunchDispatcher {
   /**
    * Single dispatcher tick:
    *
-   *   1. Reap any leased rows whose dispatch lease expired.
-   *   2. Abandon expired rows that exhausted their retry budget.
+   *   1. Abandon leased rows that are out of retries or have sat in
+   *      launch long enough to be treated as stuck.
+   *   2. Reap any remaining leased rows whose dispatch lease expired.
    *   3. Top up ready tasks into the durable launch outbox.
    *   4. Lease and dispatch enqueued rows.
    */
   poll(): void {
-    this.reapExpiredLeases();
     this.abandonStuckLeases();
+    this.reapExpiredLeases();
     this.topUpReadyLaunches();
     this.dispatchActive();
   }
@@ -297,16 +298,18 @@ export class LaunchDispatcher {
   }
 
   /**
-   * For every `leased` row whose fence has expired AND whose
-   * attempts_count has reached `maxAttempts`, transition it to
-   * `abandoned`, ask the orchestrator to prepare a fresh attempt, and
-   * emit a real `task.failed` event with a concrete error message.
+   * For every `leased` row whose fence has expired AND that either
+   * exhausted its retry budget or sat in launching past
+   * `LAUNCH_STUCK_ABANDON_MS`, transition it to `abandoned`, ask the
+   * orchestrator to prepare a fresh attempt, and emit a real
+   * `task.failed` event with a concrete error message.
    * Returns the number of rows abandoned.
    */
   abandonStuckLeases(nowIso?: string): number {
     const candidates = this.persistence.listAbandonableLaunchDispatchLeases({
       nowIso,
       maxAttempts: this.maxAttempts,
+      maxLaunchAgeMs: LAUNCH_STUCK_ABANDON_MS,
     });
     if (candidates.length === 0) return 0;
     let abandoned = 0;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -288,6 +288,7 @@ import {
   recoveryWorkerEventType,
 } from './recovery-worker-observability.js';
 import { seedMainProcessHitchFixture } from './main-process-hitch-fixture.js';
+import { seedStressFixture, type StressFixtureOptions } from './stress-fixture.js';
 import {
   executeNoTrackHeadlessBatch,
   type HeadlessBatchExecRequest,
@@ -1339,6 +1340,15 @@ function startHeadlessMode(): void {
               throw new Error('seed-main-process-hitch-fixture is only available in tests');
             }
             const seeded = seedMainProcessHitchFixture(persistence);
+            orchestrator.syncAllFromDb();
+            return seeded;
+          }
+          case 'invoker:seed-stress-fixture': {
+            if (process.env.NODE_ENV !== 'test') {
+              throw new Error('seed-stress-fixture is only available in tests');
+            }
+            const options = payload.args[0] as StressFixtureOptions | undefined;
+            const seeded = seedStressFixture(persistence, options);
             orchestrator.syncAllFromDb();
             return seeded;
           }
@@ -3725,6 +3735,16 @@ function createEmbeddedTerminalBackendFromConfig(
         });
         return results;
       });
+      messageBus.onRequest('headless.gui-mutation', async (req: unknown) => {
+        const payload = req as GuiMutationPayload;
+        const handler = guiMutationHandlers.get(payload.channel);
+        if (!handler) {
+          throw new Error(`No GUI mutation handler registered for channel: ${payload.channel}`);
+        }
+        const mutationArgs = Array.isArray(payload.args) ? payload.args : [];
+        logger.info(`headless.gui-mutation received channel=${payload.channel} mode=gui`, { module: 'ipc-delegate' });
+        return handler(...mutationArgs);
+      });
       logger.info(`owner-ipc-ready ownerId=${workflowMutationOwnerId}`, { module: 'ipc-delegate' });
       recordStartupMark('owner-ipc-ready');
     }
@@ -4011,16 +4031,10 @@ function createEmbeddedTerminalBackendFromConfig(
         }
         orchestrator.syncAllFromDb();
       };
-      ipcMain.handle(
+      registerGuiMutationHandler(
         'invoker:inject-task-states',
-        async (_event, updates: Array<{ taskId: string; changes: TaskStateChanges }>) => {
-          if (!ownerMode) {
-            await messageBus.request('headless.gui-mutation', {
-              channel: 'invoker:inject-task-states',
-              args: [updates],
-            } satisfies GuiMutationPayload);
-            return;
-          }
+        async (updatesArg: unknown) => {
+          const updates = updatesArg as Array<{ taskId: string; changes: TaskStateChanges }>;
           await injectTaskStates(updates);
         },
       );
@@ -4042,14 +4056,14 @@ function createEmbeddedTerminalBackendFromConfig(
           testPlanningChatResponse = response;
         },
       );
-      ipcMain.handle('invoker:seed-main-process-hitch-fixture', async () => {
-        if (!ownerMode) {
-          return await messageBus.request('headless.gui-mutation', {
-            channel: 'invoker:seed-main-process-hitch-fixture',
-            args: [],
-          } satisfies GuiMutationPayload);
-        }
+      registerGuiMutationHandler('invoker:seed-main-process-hitch-fixture', async () => {
         const seeded = seedMainProcessHitchFixture(persistence);
+        orchestrator.syncAllFromDb();
+        return seeded;
+      });
+      registerGuiMutationHandler('invoker:seed-stress-fixture', async (optionsArg: unknown) => {
+        const options = optionsArg as StressFixtureOptions | undefined;
+        const seeded = seedStressFixture(persistence, options);
         orchestrator.syncAllFromDb();
         return seeded;
       });

--- a/packages/app/src/stress-fixture.ts
+++ b/packages/app/src/stress-fixture.ts
@@ -1,0 +1,279 @@
+import type { SQLiteAdapter, Workflow } from '@invoker/data-store';
+import { ATTEMPT_LEASE_MS, DISPATCH_LEASE_MS, LAUNCH_STUCK_ABANDON_MS } from '@invoker/contracts';
+import { createAttempt, type TaskState } from '@invoker/workflow-core';
+import {
+  buildRecoveryWorkerAuditPayload,
+  recoveryWorkerEventType,
+} from './recovery-worker-observability.js';
+
+const DEFAULT_NOW_ISO = '2026-07-01T00:00:00.000Z';
+const DEFAULT_WORKFLOW_COUNT = 57;
+const DEFAULT_TASKS_PER_WORKFLOW = 4;
+const DEFAULT_EVENTS_PER_TASK = 0;
+
+type PersistedTaskState = Omit<TaskState, 'status' | 'config' | 'execution'> & {
+  status: TaskState['status'];
+  config: TaskState['config'] & {
+    workflowId?: string;
+    runnerKind?: string;
+    poolId?: string;
+  };
+  execution: TaskState['execution'] & {
+    phase?: 'launching' | 'executing';
+    launchStartedAt?: Date;
+    launchCompletedAt?: Date;
+  };
+};
+
+export interface StressFixtureOptions {
+  workflowCount?: number;
+  tasksPerWorkflow?: number;
+  eventsPerTask?: number;
+  nowIso?: string;
+  stuckLaunchingSlots?: number;
+  launchAgeMs?: number;
+}
+
+export interface StressFixtureResult {
+  workflowCount: number;
+  taskCount: number;
+  running: number;
+  launching: number;
+  fixing: number;
+  pending: number;
+  failed: number;
+}
+
+function makeWorkflow(id: string, name: string, nowIso: string): Workflow {
+  return {
+    id,
+    name,
+    status: 'running',
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  };
+}
+
+function makeBaseTask(id: string, workflowId: string, now: Date): PersistedTaskState {
+  return {
+    id,
+    description: `Task ${id}`,
+    status: 'pending',
+    dependencies: [],
+    createdAt: now,
+    config: {
+      workflowId,
+      runnerKind: 'ssh',
+      poolId: 'mixed-local-ssh',
+    },
+    execution: {
+      generation: 0,
+    },
+    taskStateVersion: 1,
+  };
+}
+
+function addRecoveryEvents(
+  persistence: Pick<SQLiteAdapter, 'logEvent'>,
+  taskId: string,
+  workflowId: string,
+  eventsPerTask: number,
+): void {
+  for (let e = 0; e < eventsPerTask; e += 1) {
+    const action = e % 4 === 0
+      ? 'wakeup'
+      : e % 4 === 1
+        ? 'scan'
+        : e % 4 === 2
+          ? 'submit'
+          : 'skip';
+    persistence.logEvent(
+      taskId,
+      recoveryWorkerEventType(action),
+      buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
+        workflowId,
+        reason: action === 'skip' ? 'budget' : undefined,
+      }),
+    );
+  }
+}
+
+function withLeasedAttempt(taskId: string, status: 'claimed' | 'running', now: Date) {
+  return createAttempt(taskId, {
+    status,
+    claimedAt: now,
+    startedAt: status === 'running' ? now : undefined,
+    lastHeartbeatAt: now,
+    leaseExpiresAt: new Date(now.getTime() + ATTEMPT_LEASE_MS),
+  });
+}
+function backdateDispatchRow(
+  persistence: Pick<SQLiteAdapter, 'enqueueLaunchDispatch' | 'claimLaunchDispatchAtomic'>,
+  dispatchId: number,
+  enqueuedAt: string,
+  fencedUntil: string,
+): void {
+  const db = (persistence as unknown as { db: { run: (sql: string, params: unknown[]) => void } }).db;
+  db.run(
+    `UPDATE task_launch_dispatch
+        SET enqueued_at = ?, leased_at = ?, fenced_until = ?, attempts_count = 1
+      WHERE id = ?`,
+    [enqueuedAt, enqueuedAt, fencedUntil, dispatchId],
+  );
+}
+
+function seedStuckLaunchingDispatch(
+  persistence: Pick<SQLiteAdapter, 'enqueueLaunchDispatch' | 'claimLaunchDispatchAtomic'>,
+  workflowId: string,
+  taskId: string,
+  attemptId: string,
+  now: Date,
+  launchAgeMs: number,
+): void {
+  const claimTime = new Date(now.getTime() - DISPATCH_LEASE_MS - 60_000);
+  const dispatch = persistence.enqueueLaunchDispatch({
+    taskId,
+    attemptId,
+    workflowId,
+    generation: 0,
+  });
+  persistence.claimLaunchDispatchAtomic({
+    ownerId: 'stress-fixture-owner',
+    nowIso: claimTime.toISOString(),
+  });
+  backdateDispatchRow(
+    persistence,
+    dispatch.id,
+    new Date(now.getTime() - launchAgeMs - 1_000).toISOString(),
+    new Date(claimTime.getTime() + DISPATCH_LEASE_MS).toISOString(),
+  );
+}
+
+
+function classifyState(taskIndex: number): 'running' | 'launching' | 'fixing' | 'pending' | 'failed' {
+  if (taskIndex % 10 === 9) {
+    return 'failed';
+  }
+  switch (taskIndex % 4) {
+    case 0:
+      return 'running';
+    case 1:
+      return 'launching';
+    case 2:
+      return 'fixing';
+    default:
+      return 'pending';
+  }
+}
+
+export function seedStressFixture(
+  persistence: Pick<
+    SQLiteAdapter,
+    | 'saveWorkflow'
+    | 'saveTask'
+    | 'saveAttempt'
+    | 'logEvent'
+    | 'enqueueLaunchDispatch'
+    | 'claimLaunchDispatchAtomic'
+  >,
+  options: StressFixtureOptions = {},
+): StressFixtureResult {
+  const workflowCount = options.workflowCount ?? DEFAULT_WORKFLOW_COUNT;
+  const tasksPerWorkflow = options.tasksPerWorkflow ?? DEFAULT_TASKS_PER_WORKFLOW;
+  const eventsPerTask = options.eventsPerTask ?? DEFAULT_EVENTS_PER_TASK;
+  const stuckLaunchingSlots = options.stuckLaunchingSlots ?? 0;
+  const launchAgeMs = options.launchAgeMs ?? LAUNCH_STUCK_ABANDON_MS;
+  const nowIso = options.nowIso ?? DEFAULT_NOW_ISO;
+  const now = new Date(nowIso);
+  const result: StressFixtureResult = {
+    workflowCount,
+    taskCount: workflowCount * tasksPerWorkflow,
+    running: 0,
+    launching: 0,
+    fixing: 0,
+    pending: 0,
+    failed: 0,
+  };
+  let seededStuckLaunchingSlots = 0;
+
+
+  for (let workflowIndex = 0; workflowIndex < workflowCount; workflowIndex += 1) {
+    const workflowId = `wf-stress-${workflowIndex}`;
+    persistence.saveWorkflow(makeWorkflow(workflowId, `Stress workflow ${workflowIndex}`, nowIso));
+    for (let taskIndex = 0; taskIndex < tasksPerWorkflow; taskIndex += 1) {
+      const taskId = `${workflowId}/t${taskIndex}`;
+      const task = makeBaseTask(taskId, workflowId, now);
+      switch (classifyState(taskIndex)) {
+        case 'running': {
+          const attempt = withLeasedAttempt(taskId, 'running', now);
+          task.status = 'running';
+          task.execution = {
+            ...task.execution,
+            phase: 'executing',
+            startedAt: now,
+            lastHeartbeatAt: now,
+            selectedAttemptId: attempt.id,
+          };
+          persistence.saveTask(workflowId, task);
+          persistence.saveAttempt(attempt);
+          result.running += 1;
+          break;
+        }
+        case 'launching': {
+          const attempt = withLeasedAttempt(taskId, 'claimed', now);
+          task.execution = {
+            ...task.execution,
+            phase: 'launching',
+            launchStartedAt: now,
+            lastHeartbeatAt: now,
+            selectedAttemptId: attempt.id,
+          };
+          persistence.saveTask(workflowId, task);
+          persistence.saveAttempt(attempt);
+          if (seededStuckLaunchingSlots < stuckLaunchingSlots) {
+            seedStuckLaunchingDispatch(
+              persistence,
+              workflowId,
+              taskId,
+              attempt.id,
+              now,
+              launchAgeMs,
+            );
+            seededStuckLaunchingSlots += 1;
+          }
+          result.launching += 1;
+          break;
+        }
+        case 'fixing': {
+          const attempt = withLeasedAttempt(taskId, 'running', now);
+          task.status = 'fixing_with_ai';
+          task.execution = {
+            ...task.execution,
+            phase: 'executing',
+            startedAt: now,
+            lastHeartbeatAt: now,
+            isFixingWithAI: true,
+            agentSessionId: `${taskId}-session`,
+            agentName: 'stress-agent',
+            selectedAttemptId: attempt.id,
+          };
+          persistence.saveTask(workflowId, task);
+          persistence.saveAttempt(attempt);
+          result.fixing += 1;
+          break;
+        }
+        case 'failed':
+          task.status = 'failed';
+          result.failed += 1;
+          break;
+        case 'pending':
+          result.pending += 1;
+          break;
+      }
+      persistence.saveTask(workflowId, task);
+      addRecoveryEvents(persistence, taskId, workflowId, eventsPerTask);
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

This wires the queue-truth fields and the stress-seeding path through the app surfaces.

It also adds the large storm scenarios that drive the real app through churn, spikes, and stampedes.

## Review Claim

The app now carries the storm harness, reports executing and launching counts, and runs the large storm scenarios through the real app path.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The core lease rule already landed in the prior slice. This slice only wires that core behavior through app entry points and the app-side storm harness.

## Slice Rationale

The app wiring, the stress seeder, and the large storm scenarios all depend on the same app control path, so they stay together after the core scheduler change.

## Non-goals

No core lease-query changes and no ci policy changes.

## Visual Proof

![After the seeded storm, the Home surface still shows a populated workflow rail and a visible selected-workflow mini DAG.](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-43da14/storm-after-home.png)

![After the same storm, switching to Workers still renders the worker activity surface instead of wedging or blanking.](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-43da14/storm-after-workers.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd ~/Documents/GitHub/Invoker-ui-regressions && pnpm --filter @invoker/app test`
- [ ] `cd ~/Documents/GitHub/Invoker-ui-regressions/packages/app && pnpm test:e2e storm-scale-responsiveness.spec.ts`
- [ ] `cd ~/Documents/GitHub/Invoker-ui-regressions && pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f9e40552b`
- Post-revert steps: None
- Data migration? No

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Queue status now provides clearer concurrency information, including active work, launching tasks, available capacity, and queued totals.
  - Active work is labeled more accurately in queue displays.

- **Reliability**
  - Improved handling of stalled task launches so capacity can be recovered and ready work can proceed.
  - Strengthened queue, workflow, and recovery consistency under heavy workloads.

- **Testing**
  - Added comprehensive end-to-end and integration coverage for responsiveness, dispatch capacity, queue behavior, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->