### PR TITLE
[Workflow Gate Policy](1) Default upstream stack gates to review_ready

### DIFF
--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -282,7 +282,7 @@ tasks:
 `;
     const plan = parsePlan(yaml);
     expect(plan.externalDependencies).toEqual([
-      { workflowId: 'wf-123', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
+      { workflowId: 'wf-123', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'review_ready' },
     ]);
   });
 
@@ -326,7 +326,7 @@ tasks:
 `;
     const plan = parsePlan(yaml);
     expect(plan.externalDependencies).toEqual([
-      { workflowId: 'wf-123', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
+      { workflowId: 'wf-123', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'review_ready' },
     ]);
     expect(plan.tasks[0].externalDependencies).toBeUndefined();
     expect(plan.tasks[1].externalDependencies).toBeUndefined();

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1169,7 +1169,7 @@ function startHeadlessMode(): void {
                   workflowId: upstream.workflowId,
                   taskId: '__merge__',
                   requiredStatus: 'completed',
-                  gatePolicy: 'completed',
+                  gatePolicy: 'review_ready',
                 } as const,
               ],
             };
@@ -3886,7 +3886,7 @@ function createEmbeddedTerminalBackendFromConfig(
                 workflowId: upstream.workflowId,
                 taskId: '__merge__',
                 requiredStatus: 'completed',
-                gatePolicy: 'completed',
+                gatePolicy: 'review_ready',
               } as const,
             ],
           };

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -205,7 +205,7 @@ function parseExternalDependencies(
       );
     }
     const taskId = dep.taskId?.trim() || '__merge__';
-    const defaultGatePolicy: 'completed' | 'review_ready' = taskId === '__merge__' ? 'completed' : 'review_ready';
+    const defaultGatePolicy: 'completed' | 'review_ready' = 'review_ready';
     return {
       workflowId: dep.workflowId,
       taskId,


### PR DESCRIPTION
## Summary

Stacked plans were defaulting upstream merge-gate blockers to `completed`, so downstream work stayed blocked even after the upstream PR was already review ready.

This changes the default to `review_ready` everywhere we create or parse that dependency, so new stacks start the next step as soon as the upstream review gate is ready.

## Review Claim

New stacked workflow dependencies default to `review_ready` instead of `completed` when they point at an upstream merge gate.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant
Only merge-gate defaulting changes here. Existing plans that already spell out `gatePolicy` keep their current behavior.

## Slice Rationale

The default blocker policy is one behavior change. Keeping it separate makes it easy to review without mixing in unrelated UI work.

## Non-goals

- No workflow gate editor in the UI yet.
- No queue or scheduler changes.
- No camera or graph behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/plan-parser.test.ts -t "defaults externalDependencies without taskId to upstream merge gate|parses top-level externalDependencies onto the workflow only"`

</details>

## Visual Proof

Stacked workflow submission still renders the upstream and downstream workflows as one reviewable chain after the default gate-policy change.

![Stacked workflows remain connected after submission](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-910dfe/review-ready-default-stack.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 5c3f6f2c6`
- Post-revert steps: None.
- Data migration? No.

</details>
