### PR TITLE
[Planning Surface Tmux Step 2 In-Surface UI Mode](1) Add in-surface tmux mode

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -46,7 +46,7 @@ import { TerminalDrawer, type TerminalDrawerState } from './components/TerminalD
 import { LeftStatusColumn } from './components/LeftStatusColumn.js';
 import { BrowserTaskRow, BrowserWorkflowRow } from './components/BrowserListRows.js';
 import { useTheme } from './lib/theme.js';
-import { InvokerTerminal, type InvokerTerminalLine } from './components/InvokerTerminal.js';
+import { InvokerTerminal, type InvokerTerminalLine, type PlanningTerminalMode } from './components/InvokerTerminal.js';
 import { Toaster, toast } from 'sonner';
 import { Button } from './components/primitives/index.js';
 import { CommandPalette } from './components/CommandPalette.js';
@@ -125,7 +125,34 @@ type PlanningSessionView = Omit<InAppPlanningSessionSummary, 'messages'> & {
   input: string;
   busy: boolean;
   conversationKey: string;
+  mode: PlanningTerminalMode;
+  terminalSession?: TerminalSessionDescriptor | null;
+  terminalBusy?: boolean;
+  terminalError?: string | null;
 };
+
+function planningSessionFromSummary(
+  summary: InAppPlanningSessionSummary,
+  overrides: Partial<PlanningSessionView> = {},
+): PlanningSessionView {
+  return {
+    ...summary,
+    messages: summary.messages.map((line) => ({
+      id: line.id,
+      text: line.text,
+      role: line.role,
+      tone: line.tone,
+    })),
+    input: '',
+    busy: false,
+    conversationKey: summary.id,
+    mode: 'chat',
+    terminalSession: null,
+    terminalBusy: false,
+    terminalError: null,
+    ...overrides,
+  };
+}
 
 function makeInitialPlanningSession(now: string = new Date().toISOString()): PlanningSessionView {
   return {
@@ -140,6 +167,10 @@ function makeInitialPlanningSession(now: string = new Date().toISOString()): Pla
     createdAt: now,
     updatedAt: now,
     conversationKey: 'local-planning-session-1',
+    mode: 'chat',
+    terminalSession: null,
+    terminalBusy: false,
+    terminalError: null,
   };
 }
 
@@ -588,6 +619,10 @@ export function App() {
   const draftPlanSummary = activePlanningSession.draftPlanSummary;
   const activePlanningSessionBusy = activePlanningSession.busy;
   const activePlanningSessionSubmitted = activePlanningSession.status === 'submitted';
+  const activePlanningMode = activePlanningSession.mode ?? 'chat';
+  const activePlanningTerminalSession = activePlanningSession.terminalSession ?? null;
+  const activePlanningTerminalBusy = Boolean(activePlanningSession.terminalBusy);
+  const activePlanningTerminalError = activePlanningSession.terminalError ?? null;
   const [graphMaximized, setGraphMaximized] = useState(false);
   const { theme, toggleTheme } = useTheme();
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
@@ -743,6 +778,20 @@ export function App() {
             ? { ...session, status: 'exited', exitCode: event.exitCode }
             : session,
         ),
+      );
+      setPlanningSessions((prev) =>
+        prev.map((session) => (
+          session.terminalSession?.sessionId === event.sessionId
+            ? {
+                ...session,
+                terminalSession: {
+                  ...session.terminalSession,
+                  status: 'exited',
+                  exitCode: event.exitCode,
+                },
+              }
+            : session
+        )),
       );
     });
     return () => { unsubscribe?.(); };
@@ -2116,6 +2165,128 @@ export function App() {
     setSidebarSurface('planning');
   }, [selectedPlanningPresetKey]);
 
+  const handlePlanningModeChange = useCallback(async (mode: PlanningTerminalMode) => {
+    const sourceSession = activePlanningSession;
+    if (mode === 'chat') {
+      updatePlanningSessionById(sourceSession.id, (session) => ({ ...session, mode: 'chat' }));
+      return;
+    }
+    if (sourceSession.mode === 'tmux' && (sourceSession.terminalBusy || sourceSession.terminalSession)) {
+      return;
+    }
+
+    updatePlanningSessionById(sourceSession.id, (session) => ({
+      ...session,
+      mode: 'tmux',
+      terminalBusy: !session.terminalSession,
+      terminalError: null,
+    }));
+
+    let targetSessionId = sourceSession.id;
+    let terminalSession = sourceSession.terminalSession ?? null;
+
+    if (sourceSession.id.startsWith('local-')) {
+      if (!invoker?.planningChatCreate) {
+        updatePlanningSessionById(sourceSession.id, (session) => ({
+          ...session,
+          terminalBusy: false,
+          terminalError: 'Planner is not available.',
+        }));
+        return;
+      }
+
+      try {
+        const result = await invoker.planningChatCreate({
+          presetKey: sourceSession.presetKey || selectedPlanningPresetKey || undefined,
+          title: sourceSession.title,
+        });
+        if (!result.ok) {
+          updatePlanningSessionById(sourceSession.id, (session) => ({
+            ...session,
+            terminalBusy: false,
+            terminalError: result.error,
+          }));
+          return;
+        }
+
+        targetSessionId = result.session.id;
+        terminalSession = null;
+        setPlanningSessions((prev) => prev.map((session) => (
+          session.id === sourceSession.id
+            ? planningSessionFromSummary(result.session, {
+                input: session.input,
+                busy: false,
+                mode: 'tmux',
+                terminalBusy: true,
+                terminalError: null,
+              })
+            : session
+        )));
+        setActivePlanningSessionId((currentSessionId) => (
+          currentSessionId === sourceSession.id ? targetSessionId : currentSessionId
+        ));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to create a planning session.';
+        updatePlanningSessionById(sourceSession.id, (session) => ({
+          ...session,
+          terminalBusy: false,
+          terminalError: message,
+        }));
+        return;
+      }
+    }
+
+    if (terminalSession) {
+      updatePlanningSessionById(targetSessionId, (session) => ({
+        ...session,
+        terminalBusy: false,
+        terminalError: null,
+      }));
+      return;
+    }
+
+    if (!invoker?.planningTerminalOpen) {
+      updatePlanningSessionById(targetSessionId, (session) => ({
+        ...session,
+        terminalBusy: false,
+        terminalError: 'Planning tmux is not available.',
+      }));
+      return;
+    }
+
+    try {
+      const result = await invoker.planningTerminalOpen(targetSessionId);
+      if (result.opened && result.session) {
+        updatePlanningSessionById(targetSessionId, (session) => ({
+          ...session,
+          mode: 'tmux',
+          terminalSession: result.session,
+          terminalBusy: false,
+          terminalError: null,
+          updatedAt: new Date().toISOString(),
+        }));
+      } else {
+        updatePlanningSessionById(targetSessionId, (session) => ({
+          ...session,
+          terminalBusy: false,
+          terminalError: result.reason ?? 'Failed to open planning tmux.',
+        }));
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to open planning tmux.';
+      updatePlanningSessionById(targetSessionId, (session) => ({
+        ...session,
+        terminalBusy: false,
+        terminalError: message,
+      }));
+    }
+  }, [
+    activePlanningSession,
+    invoker,
+    selectedPlanningPresetKey,
+    updatePlanningSessionById,
+  ]);
+
 
   const handleStop = useCallback(async () => {
     if (!invoker) return;
@@ -2970,10 +3141,15 @@ export function App() {
             draftPlanSummary={draftPlanSummary}
             submitError={planningSubmitError}
             readOnly={activePlanningSessionSubmitted}
+            mode={activePlanningMode}
+            terminalSession={activePlanningTerminalSession}
+            terminalBusy={activePlanningTerminalBusy}
+            terminalError={activePlanningTerminalError}
             onValueChange={setPlanningInput}
             onSubmit={() => void handlePlanningSubmit()}
             onSubmitDraft={() => void handlePlanningSubmitDraft()}
             onPresetChange={setSelectedPlanningPresetKey}
+            onModeChange={(mode) => void handlePlanningModeChange(mode)}
             onExpand={() => setPlanningTerminalExpanded(true)}
           />
         </div>
@@ -3303,11 +3479,16 @@ export function App() {
             draftPlanSummary={draftPlanSummary}
             submitError={planningSubmitError}
             expanded
+            mode={activePlanningMode}
+            terminalSession={activePlanningTerminalSession}
+            terminalBusy={activePlanningTerminalBusy}
+            terminalError={activePlanningTerminalError}
             onValueChange={setPlanningInput}
             readOnly={activePlanningSessionSubmitted}
             onSubmit={() => void handlePlanningSubmit()}
             onSubmitDraft={() => void handlePlanningSubmitDraft()}
             onPresetChange={setSelectedPlanningPresetKey}
+            onModeChange={(mode) => void handlePlanningModeChange(mode)}
             onExpand={() => setPlanningTerminalExpanded(true)}
             onCloseExpanded={() => setPlanningTerminalExpanded(false)}
           />

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -1,4 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { Terminal as XTermTerminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
+import type { TerminalSessionDescriptor } from '@invoker/contracts';
 import { Button } from './primitives/index.js';
 
 export interface InvokerTerminalLine {
@@ -8,6 +11,8 @@ export interface InvokerTerminalLine {
   reasoning?: string;
   tone?: 'muted' | 'error' | 'success';
 }
+
+export type PlanningTerminalMode = 'chat' | 'tmux';
 
 interface PlanningPresetOptionView {
   key: string;
@@ -31,10 +36,15 @@ interface InvokerTerminalProps {
   submitError?: SubmitErrorView | null;
   readOnly?: boolean;
   expanded?: boolean;
+  mode?: PlanningTerminalMode;
+  terminalSession?: TerminalSessionDescriptor | null;
+  terminalBusy?: boolean;
+  terminalError?: string | null;
   onValueChange: (value: string) => void;
   onSubmit: () => void;
   onSubmitDraft: () => void;
   onPresetChange: (presetKey: string) => void;
+  onModeChange?: (mode: PlanningTerminalMode) => void;
   onExpand: () => void;
   onCloseExpanded?: () => void;
   onCollapse?: () => void;
@@ -52,6 +62,192 @@ function rolePrompt(role: InvokerTerminalLine['role']): string {
   return 'system ›';
 }
 
+type SeededOutputSnapshot = {
+  sessionId: string;
+  snapshot: string;
+  term: XTermTerminal;
+};
+
+function seedTerminalOutputSnapshot(
+  term: XTermTerminal,
+  session: TerminalSessionDescriptor,
+  seededSnapshotRef: { current: SeededOutputSnapshot | null },
+): void {
+  const outputSnapshot = session.outputSnapshot;
+  const seededSnapshot = seededSnapshotRef.current;
+  if (
+    outputSnapshot &&
+    (
+      !seededSnapshot ||
+      seededSnapshot.sessionId !== session.sessionId ||
+      seededSnapshot.snapshot !== outputSnapshot ||
+      seededSnapshot.term !== term
+    )
+  ) {
+    try {
+      term.write(outputSnapshot);
+      seededSnapshotRef.current = {
+        sessionId: session.sessionId,
+        snapshot: outputSnapshot,
+        term,
+      };
+    } catch (err) {
+      console.warn(
+        `Failed to seed output snapshot for planning terminal session ${session.sessionId}:`,
+        err,
+      );
+    }
+  }
+}
+
+interface PlanningTmuxPaneProps {
+  session: TerminalSessionDescriptor | null;
+  busy: boolean;
+  error?: string | null;
+}
+
+function PlanningTmuxPane({ session, busy, error }: PlanningTmuxPaneProps): JSX.Element {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const termRef = useRef<XTermTerminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const seededSnapshotRef = useRef<SeededOutputSnapshot | null>(null);
+
+  useEffect(() => {
+    const host = containerRef.current;
+    if (!host || !session) return;
+
+    let term: XTermTerminal;
+    let fit: FitAddon;
+    try {
+      term = new XTermTerminal({
+        fontSize: 12,
+        fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+        cursorBlink: true,
+        convertEol: false,
+        scrollback: 5000,
+        theme: { background: '#0b0f1a', foreground: '#e5e7eb' },
+      });
+      fit = new FitAddon();
+      term.loadAddon(fit);
+      term.open(host);
+    } catch {
+      return;
+    }
+    termRef.current = term;
+    fitRef.current = fit;
+
+    seedTerminalOutputSnapshot(term, session, seededSnapshotRef);
+
+    const inputDisposable = term.onData((data) => {
+      void window.invoker?.planningTerminalWrite?.(session.sessionId, data);
+    });
+
+    const subscribeToOutput = window.__INVOKER_TEST_ON_TERMINAL_OUTPUT__ ?? window.invoker?.onTerminalOutput;
+    const unsubscribeOutput = subscribeToOutput?.((event) => {
+      if (event.sessionId !== session.sessionId) return;
+      try {
+        term.write(event.data);
+      } catch {
+        /* terminal disposed */
+      }
+    });
+
+    const tryFit = () => {
+      try {
+        fit.fit();
+        void window.invoker?.planningTerminalResize?.(session.sessionId, term.cols, term.rows);
+      } catch {
+        /* host has zero size or fit unsupported */
+      }
+    };
+
+    const raf = typeof requestAnimationFrame === 'function'
+      ? requestAnimationFrame(tryFit)
+      : null;
+
+    let resizeObserver: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== 'undefined') {
+      try {
+        resizeObserver = new ResizeObserver(() => {
+          tryFit();
+        });
+        resizeObserver.observe(host);
+      } catch {
+        resizeObserver = null;
+      }
+    }
+
+    return () => {
+      if (raf !== null && typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(raf);
+      }
+      resizeObserver?.disconnect();
+      inputDisposable.dispose();
+      unsubscribeOutput?.();
+      try {
+        term.dispose();
+      } catch {
+        /* already disposed */
+      }
+      termRef.current = null;
+      fitRef.current = null;
+    };
+  }, [session?.sessionId]);
+
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term || !session) return;
+    seedTerminalOutputSnapshot(term, session, seededSnapshotRef);
+  }, [session?.outputSnapshot, session?.sessionId]);
+
+  useEffect(() => {
+    const term = termRef.current;
+    const fit = fitRef.current;
+    if (!term || !fit || !session) return;
+    try {
+      fit.fit();
+      void window.invoker?.planningTerminalResize?.(session.sessionId, term.cols, term.rows);
+      term.focus();
+    } catch {
+      /* fit failed (e.g., hidden) */
+    }
+  }, [session?.sessionId]);
+
+  return (
+    <div className="relative min-h-0 flex-1 overflow-hidden bg-black">
+      {!session && (
+        <div
+          data-testid="invoker-terminal-tmux-placeholder"
+          className="absolute inset-0 flex items-center justify-center px-4 text-center font-mono text-xs text-muted-foreground"
+        >
+          {error || (busy ? 'Starting tmux session…' : 'No tmux session attached.')}
+        </div>
+      )}
+      {session && (
+        <div
+          ref={containerRef}
+          data-testid="invoker-terminal-tmux-pane"
+          data-session-id={session.sessionId}
+          className="absolute inset-0 overflow-hidden"
+        />
+      )}
+      {session?.status === 'exited' && (
+        <div className="absolute right-3 top-3 rounded-sm border border-border bg-card px-2 py-1 font-mono text-[11px] text-amber-300">
+          exited{typeof session.exitCode === 'number' ? ` ${session.exitCode}` : ''}
+        </div>
+      )}
+      {session && error && (
+        <div
+          data-testid="invoker-terminal-tmux-error"
+          className="absolute bottom-3 left-3 right-3 rounded-sm border border-destructive/40 bg-card px-3 py-2 font-mono text-xs text-destructive"
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function InvokerTerminal({
   lines,
   busy,
@@ -63,10 +259,15 @@ export function InvokerTerminal({
   submitError,
   readOnly = false,
   expanded = false,
+  mode = 'chat',
+  terminalSession = null,
+  terminalBusy = false,
+  terminalError = null,
   onValueChange,
   onSubmit,
   onSubmitDraft,
   onPresetChange,
+  onModeChange,
   onExpand,
   onCloseExpanded,
   onCollapse,
@@ -100,10 +301,10 @@ export function InvokerTerminal({
   }, []);
 
   useEffect(() => {
-    if (!busy && !readOnly) {
+    if (mode === 'chat' && !busy && !readOnly) {
       inputRef.current?.focus();
     }
-  }, [busy, readOnly]);
+  }, [busy, mode, readOnly]);
 
   const focusComposer = (): void => {
     inputRef.current?.focus();
@@ -113,10 +314,40 @@ export function InvokerTerminal({
     <section className="flex h-full min-h-0 flex-col bg-background">
       <div className="flex items-center justify-end gap-2 border-b border-border bg-background px-4 py-2.5">
         <div className="flex shrink-0 items-center gap-2">
-          {busy && (
+          {onModeChange && (
+            <div
+              role="tablist"
+              aria-label="Planning mode"
+              data-testid="invoker-terminal-mode-toggle"
+              className="inline-flex overflow-hidden rounded-sm border border-border"
+            >
+              <button
+                type="button"
+                role="tab"
+                aria-selected={mode === 'chat'}
+                onClick={() => onModeChange('chat')}
+                className={`px-2.5 py-1 text-xs ${mode === 'chat' ? 'bg-secondary text-foreground' : 'text-muted-foreground hover:bg-secondary/60 hover:text-foreground'}`}
+              >
+                Chat
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={mode === 'tmux'}
+                onClick={() => onModeChange('tmux')}
+                className={`border-l border-border px-2.5 py-1 text-xs ${mode === 'tmux' ? 'bg-secondary text-foreground' : 'text-muted-foreground hover:bg-secondary/60 hover:text-foreground'}`}
+              >
+                tmux
+              </button>
+            </div>
+          )}
+          {mode === 'chat' && busy && (
             <span className="font-mono text-[11px] text-muted-foreground">working…</span>
           )}
-          {readOnly && (
+          {mode === 'tmux' && terminalBusy && (
+            <span className="font-mono text-[11px] text-muted-foreground">starting…</span>
+          )}
+          {mode === 'chat' && readOnly && (
             <span className="font-mono text-[11px] text-muted-foreground">submitted</span>
           )}
           {expanded ? (
@@ -153,163 +384,169 @@ export function InvokerTerminal({
         </div>
       </div>
 
-      <div
-        ref={transcriptRef}
-        data-testid="invoker-terminal-transcript"
-        onScroll={handleTranscriptScroll}
-        className="min-h-0 flex-1 space-y-3 overflow-y-auto bg-background px-4 py-4 font-mono text-[13px] leading-6"
-      >
-        {lines.map((line) => {
-          const toneClass = line.tone === 'error'
-            ? 'text-destructive'
-            : line.tone === 'success'
-              ? 'text-emerald-400'
-              : line.tone === 'muted'
-                ? 'text-muted-foreground'
-                : line.role === 'assistant'
-                  ? 'text-foreground'
-                  : 'text-muted-foreground';
-          return (
-            <div key={line.id} className="space-y-1">
-              <div className="text-[11px] text-muted-foreground">{rolePrompt(line.role)}</div>
-              {line.reasoning ? (
-                <details
-                  data-testid="invoker-terminal-thinking"
-                  className="rounded-sm border border-border/60 bg-background/40 px-2 py-1 text-muted-foreground"
-                >
-                  <summary className="cursor-pointer select-none text-[11px] text-muted-foreground">
-                    Thinking
-                  </summary>
-                  <div className="mt-1 whitespace-pre-wrap text-[12px] leading-5 text-muted-foreground">
-                    {line.reasoning}
-                  </div>
-                </details>
-              ) : null}
-              <div className={`whitespace-pre-wrap ${toneClass}`}>{line.text}</div>
-            </div>
-          );
-        })}
-      </div>
-
-      {submitError && !readOnly && (
-        <div
-          data-testid="invoker-terminal-submit-error"
-          className="sticky bottom-0 z-10 border-t border-destructive/40 bg-background px-4 py-3 text-destructive-foreground"
-        >
-          <div className="text-sm font-medium text-destructive">{submitError.title}</div>
-          <div className="mt-2 whitespace-pre-wrap font-mono text-xs leading-5 text-destructive/90">{submitError.message}</div>
-          <div className="mt-3 flex flex-wrap gap-2">
-            {draftPlanAvailable && (
-              <button
-                type="button"
-                onClick={onSubmitDraft}
-                disabled={busy}
-                className="rounded-sm bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground hover:bg-destructive/85 disabled:cursor-wait disabled:opacity-50"
-              >
-                Retry submit
-              </button>
-            )}
-            <button
-              type="button"
-              onClick={focusComposer}
-              className="rounded-sm border border-border px-3 py-1.5 text-xs text-muted-foreground hover:border-border-strong hover:text-foreground"
-            >
-              Keep chatting
-            </button>
-            <button
-              type="button"
-              onClick={() => void navigator.clipboard?.writeText(submitError.message)}
-              className="rounded-sm border border-border px-3 py-1.5 text-xs text-muted-foreground hover:border-border-strong hover:text-foreground"
-            >
-              Copy error
-            </button>
-          </div>
-        </div>
-      )}
-
-      {draftPlanAvailable && !readOnly && (
-        <div
-          data-testid="invoker-terminal-ready-bar"
-          className="sticky bottom-0 z-10 border-t border-border bg-background px-4 py-3 text-sm text-foreground"
-        >
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <span className="font-mono text-xs text-muted-foreground">
-              {draftPlanSummary
-                ? `draft ready · "${draftPlanSummary.name}" · ${draftPlanSummary.workflowCount && draftPlanSummary.workflowCount > 1 ? `${draftPlanSummary.workflowCount} workflows` : `${draftPlanSummary.taskCount} step${draftPlanSummary.taskCount === 1 ? '' : 's'}`}`
-                : 'draft ready'}
-            </span>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={onSubmitDraft}
-                disabled={busy}
-                className="rounded-sm bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-50"
-              >
-                Submit to Invoker
-              </button>
-              <button
-                type="button"
-                onClick={focusComposer}
-                className="rounded-sm border border-border px-3 py-1.5 text-xs text-muted-foreground hover:border-border-strong hover:text-foreground"
-              >
-                Keep chatting
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      <form
-        className="border-t border-border bg-background px-4 py-3"
-        onSubmit={(event) => {
-          event.preventDefault();
-          if (!value.trim() || busy || readOnly) return;
-          onSubmit();
-        }}
-      >
-        <div className="flex items-start gap-2">
-          <span className="mt-2.5 shrink-0 font-mono text-xs text-muted-foreground" aria-hidden="true">›</span>
-          <textarea
-            ref={inputRef}
-            data-testid="invoker-terminal-input"
-            value={value}
-            disabled={busy || readOnly}
-            rows={expanded ? 8 : 3}
-            onChange={(event) => onValueChange(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing && !busy && !readOnly && value.trim()) {
-                event.preventDefault();
-                onSubmit();
-              }
-            }}
-            placeholder={readOnly ? 'This planning session was already submitted.' : 'Describe the change, ask questions, or say “draft the full plan”.'}
-            className="min-h-20 w-full resize-none border-0 bg-transparent py-2 font-mono text-[13px] leading-6 text-foreground outline-none placeholder:text-muted-foreground focus:ring-0 disabled:cursor-wait"
-          />
-        </div>
-        <div className="mt-2 flex flex-wrap items-center justify-between gap-3">
-          <label className="flex items-center gap-2 font-mono text-xs text-muted-foreground">
-            <span>ai</span>
-            <select
-              data-testid="invoker-terminal-harness"
-              value={selectedPresetKey}
-              onChange={(event) => onPresetChange(event.target.value)}
-              disabled={readOnly}
-              className="rounded-sm border border-border bg-background px-2 py-1 text-xs text-foreground outline-none hover:border-border-strong focus:border-ring"
-            >
-              {presetOptions.map((option) => (
-                <option key={option.key} value={option.key}>{option.label}</option>
-              ))}
-            </select>
-          </label>
-          <Button
-            type="submit"
-            size="sm"
-            disabled={busy || readOnly || !value.trim()}
+      {mode === 'tmux' ? (
+        <PlanningTmuxPane session={terminalSession} busy={terminalBusy} error={terminalError} />
+      ) : (
+        <>
+          <div
+            ref={transcriptRef}
+            data-testid="invoker-terminal-transcript"
+            onScroll={handleTranscriptScroll}
+            className="min-h-0 flex-1 space-y-3 overflow-y-auto bg-background px-4 py-4 font-mono text-[13px] leading-6"
           >
-            Send
-          </Button>
-        </div>
-      </form>
+            {lines.map((line) => {
+              const toneClass = line.tone === 'error'
+                ? 'text-destructive'
+                : line.tone === 'success'
+                  ? 'text-emerald-400'
+                  : line.tone === 'muted'
+                    ? 'text-muted-foreground'
+                    : line.role === 'assistant'
+                      ? 'text-foreground'
+                      : 'text-muted-foreground';
+              return (
+                <div key={line.id} className="space-y-1">
+                  <div className="text-[11px] text-muted-foreground">{rolePrompt(line.role)}</div>
+                  {line.reasoning ? (
+                    <details
+                      data-testid="invoker-terminal-thinking"
+                      className="rounded-sm border border-border/60 bg-background/40 px-2 py-1 text-muted-foreground"
+                    >
+                      <summary className="cursor-pointer select-none text-[11px] text-muted-foreground">
+                        Thinking
+                      </summary>
+                      <div className="mt-1 whitespace-pre-wrap text-[12px] leading-5 text-muted-foreground">
+                        {line.reasoning}
+                      </div>
+                    </details>
+                  ) : null}
+                  <div className={`whitespace-pre-wrap ${toneClass}`}>{line.text}</div>
+                </div>
+              );
+            })}
+          </div>
+
+          {submitError && !readOnly && (
+            <div
+              data-testid="invoker-terminal-submit-error"
+              className="sticky bottom-0 z-10 border-t border-destructive/40 bg-background px-4 py-3 text-destructive-foreground"
+            >
+              <div className="text-sm font-medium text-destructive">{submitError.title}</div>
+              <div className="mt-2 whitespace-pre-wrap font-mono text-xs leading-5 text-destructive/90">{submitError.message}</div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {draftPlanAvailable && (
+                  <button
+                    type="button"
+                    onClick={onSubmitDraft}
+                    disabled={busy}
+                    className="rounded-sm bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground hover:bg-destructive/85 disabled:cursor-wait disabled:opacity-50"
+                  >
+                    Retry submit
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={focusComposer}
+                  className="rounded-sm border border-border px-3 py-1.5 text-xs text-muted-foreground hover:border-border-strong hover:text-foreground"
+                >
+                  Keep chatting
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void navigator.clipboard?.writeText(submitError.message)}
+                  className="rounded-sm border border-border px-3 py-1.5 text-xs text-muted-foreground hover:border-border-strong hover:text-foreground"
+                >
+                  Copy error
+                </button>
+              </div>
+            </div>
+          )}
+
+          {draftPlanAvailable && !readOnly && (
+            <div
+              data-testid="invoker-terminal-ready-bar"
+              className="sticky bottom-0 z-10 border-t border-border bg-background px-4 py-3 text-sm text-foreground"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <span className="font-mono text-xs text-muted-foreground">
+                  {draftPlanSummary
+                    ? `draft ready · "${draftPlanSummary.name}" · ${draftPlanSummary.workflowCount && draftPlanSummary.workflowCount > 1 ? `${draftPlanSummary.workflowCount} workflows` : `${draftPlanSummary.taskCount} step${draftPlanSummary.taskCount === 1 ? '' : 's'}`}`
+                    : 'draft ready'}
+                </span>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={onSubmitDraft}
+                    disabled={busy}
+                    className="rounded-sm bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-50"
+                  >
+                    Submit to Invoker
+                  </button>
+                  <button
+                    type="button"
+                    onClick={focusComposer}
+                    className="rounded-sm border border-border px-3 py-1.5 text-xs text-muted-foreground hover:border-border-strong hover:text-foreground"
+                  >
+                    Keep chatting
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <form
+            className="border-t border-border bg-background px-4 py-3"
+            onSubmit={(event) => {
+              event.preventDefault();
+              if (!value.trim() || busy || readOnly) return;
+              onSubmit();
+            }}
+          >
+            <div className="flex items-start gap-2">
+              <span className="mt-2.5 shrink-0 font-mono text-xs text-muted-foreground" aria-hidden="true">›</span>
+              <textarea
+                ref={inputRef}
+                data-testid="invoker-terminal-input"
+                value={value}
+                disabled={busy || readOnly}
+                rows={expanded ? 8 : 3}
+                onChange={(event) => onValueChange(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing && !busy && !readOnly && value.trim()) {
+                    event.preventDefault();
+                    onSubmit();
+                  }
+                }}
+                placeholder={readOnly ? 'This planning session was already submitted.' : 'Describe the change, ask questions, or say “draft the full plan”.'}
+                className="min-h-20 w-full resize-none border-0 bg-transparent py-2 font-mono text-[13px] leading-6 text-foreground outline-none placeholder:text-muted-foreground focus:ring-0 disabled:cursor-wait"
+              />
+            </div>
+            <div className="mt-2 flex flex-wrap items-center justify-between gap-3">
+              <label className="flex items-center gap-2 font-mono text-xs text-muted-foreground">
+                <span>ai</span>
+                <select
+                  data-testid="invoker-terminal-harness"
+                  value={selectedPresetKey}
+                  onChange={(event) => onPresetChange(event.target.value)}
+                  disabled={readOnly}
+                  className="rounded-sm border border-border bg-background px-2 py-1 text-xs text-foreground outline-none hover:border-border-strong focus:border-ring"
+                >
+                  {presetOptions.map((option) => (
+                    <option key={option.key} value={option.key}>{option.label}</option>
+                  ))}
+                </select>
+              </label>
+              <Button
+                type="submit"
+                size="sm"
+                disabled={busy || readOnly || !value.trim()}
+              >
+                Send
+              </Button>
+            </div>
+          </form>
+        </>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

Planning Surface Tmux Step 2 In-Surface UI Mode - 2 tasks completed, 0 failed, 0 closed

This exposes a chat/tmux switch inside the planning surface.

The tmux pane now renders inside the planning work area for the active planning session.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1783564216054-12/implement-planning-tmux-ui-mode | Add chat/tmux mode toggle and render tmux inside the planning blue surface | completed |
| wf-1783564216054-12/verify-planning-tmux-ui-mode | Run focused UI tests for planning and terminal rendering behavior | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1783564216054-12/implement-planning-tmux-ui-mode - Add chat/tmux mode toggle and render tmux inside the planning blue surface

```text
packages/ui/src/App.tsx                        | 184 ++++++++-
packages/ui/src/components/InvokerTerminal.tsx | 551 ++++++++++++++++++-------
2 files changed, 578 insertions(+), 157 deletions(-)
```

### wf-1783564216054-12/verify-planning-tmux-ui-mode - Run focused UI tests for planning and terminal rendering behavior

No source changes. Verification passed on the implementation slice.

</details>

## Review Claim

Approve exposing an in-surface tmux mode for planning while leaving chat mode as the default.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The slice changes only planning UI files. Existing task-terminal drawer behavior remains outside the diff.

## Slice Rationale

This is the UI activation slice for the planning terminal capability already present in the base branch.

## Non-goals

- Does not change task-terminal drawer behavior.
- Does not change planning session persistence.
- Does not change IPC contracts or backend terminal lifecycle.

## Architecture

### Before

```mermaid
graph TD
    A["Planning surface"] --> B["Chat transcript"]
    A --> C["Bottom task terminal drawer"]
```

### After

```mermaid
graph TD
    A["Planning surface"] --> B["Chat mode"]
    A --> C["Tmux mode"]
    C --> D["Attached planning terminal session"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx`
- [x] `pnpm --filter @invoker/ui build`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-step2-pr-body.md --require-visual-proof --changed-files-file /tmp/invoker-step2-changed-files.txt --diff-file /tmp/invoker-step2.diff`

</details>

## Visual Proof

![Planning tmux mode rendered inside the planning surface](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-af6c0c/invoker-planning-tmux-mode-proof.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e298544645b82a477fdd020c156061937dd99918`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Chat/tmux mode switcher for planning sessions.
  * Added an embedded terminal experience for planning sessions, including live output, keyboard input, resizing, and full-screen viewing.
  * Added status indicators for terminal activity and connection errors.
  * Automatically preserves terminal state when switching between planning sessions.

* **Bug Fixes**
  * Improved terminal cleanup and session handling when a planning terminal exits or changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->