### PR TITLE
[Planning text stays readable](1) Wrap planning rail titles and previews

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3614,7 +3614,7 @@ export function App() {
               <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
               <div className="min-w-0 flex-1">
                 <div className="flex items-start justify-between gap-2">
-                  <div className="line-clamp-2 break-words text-sm font-medium" title={session.title}>
+                  <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
                     {session.title}
                   </div>
                   <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
@@ -3622,7 +3622,7 @@ export function App() {
                   </span>
                 </div>
                 <div
-                  className="mt-0.5 line-clamp-3 break-words font-mono text-[11px] leading-4 text-muted-foreground"
+                  className="mt-1 line-clamp-3 break-words font-mono text-[11px] leading-4 text-muted-foreground"
                   title={preview}
                 >
                   {preview}

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -796,10 +796,10 @@ describe('Invoker terminal (component)', () => {
     const expectedTitle = `${longPrompt.slice(0, 53).trimEnd()}…`;
     const title = within(rail).getByText(expectedTitle);
     const preview = within(rail).getByText(longReply);
-    expect(title).toHaveClass('line-clamp-2', 'break-words');
+    expect(title).toHaveClass('line-clamp-2', 'min-w-0', 'flex-1', 'break-words', 'leading-5');
     expect(title).not.toHaveClass('truncate');
     expect(title).toHaveAttribute('title', expectedTitle);
-    expect(preview).toHaveClass('line-clamp-3', 'break-words');
+    expect(preview).toHaveClass('mt-1', 'line-clamp-3', 'break-words');
     expect(preview).not.toHaveClass('truncate');
     expect(preview).toHaveAttribute('title', longReply);
     expect(screen.getByTestId('planning-session-rail')).toHaveClass('w-64', 'shrink-0');


### PR DESCRIPTION
## Summary

Planning text stays readable with the PR rebased onto `master` after the earlier wrapping implementation landed.

This keeps long planning titles and previews readable in the fixed Planning Terminal rail by tightening the title flex constraints and preserving the tooltip-backed wrapping behavior already on `master`.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1783372665113-2/fix-planning-text-clipping | Make planning text readable in the Planning Terminal rail | completed |
| wf-1783372665113-2/verify-planning-text-clipping | Verify planning text visibility and run the repo gate | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1783372665113-2/fix-planning-text-clipping — Make planning text readable in the Planning Terminal rail

Kept the planning session title flex-constrained with bounded line clamps so it shares the timestamp row predictably.

Kept the preview text wrapped across bounded lines with readable spacing inside the fixed rail.

### wf-1783372665113-2/verify-planning-text-clipping — Verify planning text visibility and run the repo gate

Updated the focused component regression so long rail titles and previews continue to assert the wrapping and spacing classes.

</details>

## Review Claim

Planning session rail titles and previews stay readable across bounded lines inside the existing fixed rail width.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the planning rail text presentation and its component regression coverage change; session data, selection, and planner behavior remain unchanged.

## Slice Rationale

The UI class change and regression coverage are one local readability claim, so reviewers can inspect the behavior and guard together.

## Non-goals

- No Planning Terminal navigation changes.
- No planner prompt or response changes.
- No sidebar width or persistence changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `git diff --check`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx`
- [x] `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx` (ran the full UI Vitest suite: 75 files, 743 tests)
- [x] `node scripts/validate-pr-body.mjs --body-file <(gh pr view 4270 --json body -q .body) --changed-files-file <(gh pr diff 4270 --name-only) --diff-file <(gh pr diff 4270 --patch)`

</details>

## Visual Proof

The restart walkthrough shows the Planning Terminal rail after restoring a drafted plan, with the long preview wrapping inside the rail instead of disappearing behind one-line truncation.

![Planning Terminal restart walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-49256e/planning-terminal-restart.gif)

The before capture shows the empty planning rail state used as the baseline for the restore proof.

![Planning Terminal restore before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-49256e/planning-terminal-restore-before.png)

The after capture shows the restored planning session with readable title and preview text in the rail.

![Planning Terminal restore after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-49256e/planning-terminal-restore-after.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 8f0f1f517e9dd7e30b0a950330e0503eb7377a93`
- Post-revert steps: Re-run the focused UI component test.
- Data migration? No.

</details>
