### PR TITLE
[Planning Surface Tmux Step 3 Persistence And Restart](1) Store planning terminal session state

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -428,6 +428,8 @@ export type InAppPlanningSessionStatus =
   | 'draft_ready'
   | 'submitted';
 
+export type PlanningTerminalMode = 'chat' | 'tmux';
+
 export interface InAppPlanningChatLine {
   id: number;
   role: 'user' | 'assistant' | 'system';
@@ -446,6 +448,12 @@ export interface InAppPlanningSessionSummary {
   draftPlanSummary?: InAppPlanningPlanSummary;
   submittedWorkflowId?: string;
   submittedPlanName?: string;
+  terminalMode?: PlanningTerminalMode;
+  terminalSessionId?: string;
+  terminalStatus?: 'running' | 'exited';
+  terminalExitCode?: number;
+  terminalOutputSnapshot?: string;
+  terminalUpdatedAt?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -513,6 +521,15 @@ export interface InAppPlanningResetRequest {
 }
 
 export type InAppPlanningResetResponse = { ok: true };
+
+export interface InAppPlanningSetTerminalModeRequest {
+  sessionId: string;
+  mode: PlanningTerminalMode;
+}
+
+export type InAppPlanningSetTerminalModeResponse =
+  | { ok: true }
+  | { ok: false; error: string };
 
 
 
@@ -781,6 +798,10 @@ export const IpcChannels = {
   'invoker:planning-chat-reset': {} as {
     request: [request: InAppPlanningResetRequest];
     response: InAppPlanningResetResponse;
+  },
+  'invoker:planning-chat-set-terminal-mode': {} as {
+    request: [request: InAppPlanningSetTerminalModeRequest];
+    response: InAppPlanningSetTerminalModeResponse;
   },
   'invoker:planning-terminal-open': {} as {
     request: [planningSessionId: string];

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -101,6 +101,8 @@ describe('SQLiteAdapter', () => {
       },
       submittedWorkflowId: 'wf-planning',
       submittedPlanName: 'README plan',
+      terminalMode: 'chat',
+      terminalOutputSnapshot: '',
       pendingResponse: true,
       createdAt: '2026-07-07T00:00:00.000Z',
       updatedAt: '2026-07-07T00:00:03.000Z',
@@ -419,6 +421,12 @@ describe('SQLiteAdapter', () => {
         'draft_plan_summary_json',
         'submitted_workflow_id',
         'submitted_plan_name',
+        'terminal_mode',
+        'terminal_session_id',
+        'terminal_status',
+        'terminal_exit_code',
+        'terminal_output_snapshot',
+        'terminal_updated_at',
         'pending_response',
         'created_at',
         'updated_at',
@@ -452,10 +460,44 @@ describe('SQLiteAdapter', () => {
       }
     });
 
+    it('round-trips planning tmux ownership across adapter reopen', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-planning-tmux-sessions-'));
+      const dbPath = join(dir, 'invoker.db');
+      try {
+        const first = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        first.upsertInAppPlanningSession(makePlanningSession('planning-tmux', {
+          terminalMode: 'tmux',
+          terminalSessionId: 'term-planning-tmux',
+          terminalStatus: 'running',
+          terminalExitCode: undefined,
+          terminalOutputSnapshot: 'tmux transcript\n',
+          terminalUpdatedAt: '2026-07-07T00:00:04.000Z',
+        }));
+        first.close();
+
+        const reopened = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        expect(reopened.loadInAppPlanningSession('planning-tmux')).toMatchObject({
+          terminalMode: 'tmux',
+          terminalSessionId: 'term-planning-tmux',
+          terminalStatus: 'running',
+          terminalOutputSnapshot: 'tmux transcript\n',
+          terminalUpdatedAt: '2026-07-07T00:00:04.000Z',
+        });
+        reopened.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('updates planning sessions and replaces visible messages', () => {
       adapter.upsertInAppPlanningSession(makePlanningSession('planning-1'));
       adapter.updateInAppPlanningSession('planning-1', {
         status: 'still_discussing',
+        terminalMode: 'tmux',
+        terminalSessionId: 'planning-terminal-1',
+        terminalStatus: 'running',
+        terminalOutputSnapshot: 'tmux output\n',
+        terminalUpdatedAt: '2026-07-07T00:00:04.500Z',
         messages: [{
           id: 7,
           role: 'system',
@@ -471,6 +513,11 @@ describe('SQLiteAdapter', () => {
       const loaded = adapter.loadInAppPlanningSession('planning-1');
       expect(loaded).toMatchObject({
         status: 'still_discussing',
+        terminalMode: 'tmux',
+        terminalSessionId: 'planning-terminal-1',
+        terminalStatus: 'running',
+        terminalOutputSnapshot: 'tmux output\n',
+        terminalUpdatedAt: '2026-07-07T00:00:04.500Z',
         messages: [{
           id: 7,
           role: 'system',

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -6,7 +6,7 @@
  */
 
 import type { TaskState, TaskStateChanges, PlanDefinition, Attempt, WorkflowDerivedStatus, WorkflowRollup, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency } from '@invoker/workflow-core';
-import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, SearchResultItem, SearchOptions } from '@invoker/contracts';
+import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
 
 
 export type ConversationMode = 'agent' | 'plan';
@@ -227,6 +227,12 @@ export interface InAppPlanningSessionRecord {
   draftPlanSummary?: InAppPlanningPlanSummary;
   submittedWorkflowId?: string;
   submittedPlanName?: string;
+  terminalMode?: PlanningTerminalMode;
+  terminalSessionId?: string;
+  terminalStatus?: 'running' | 'exited';
+  terminalExitCode?: number;
+  terminalOutputSnapshot?: string;
+  terminalUpdatedAt?: string;
   pendingResponse: boolean;
   createdAt: string;
   updatedAt: string;
@@ -240,6 +246,12 @@ export type InAppPlanningSessionPatch = Partial<Pick<
   | 'draftPlanSummary'
   | 'submittedWorkflowId'
   | 'submittedPlanName'
+  | 'terminalMode'
+  | 'terminalSessionId'
+  | 'terminalStatus'
+  | 'terminalExitCode'
+  | 'terminalOutputSnapshot'
+  | 'terminalUpdatedAt'
   | 'pendingResponse'
   | 'updatedAt'
 >>;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -30,7 +30,7 @@ import type {
   DetachedExternalDependency,
 } from '@invoker/workflow-core';
 import { DISPATCH_LEASE_MS } from '@invoker/contracts';
-import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, SearchResultItem, SearchOptions } from '@invoker/contracts';
+import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ExecutionResourceLeaseReleaseRow,
   LaunchDispatchInvalidationRow,
@@ -420,6 +420,12 @@ type InAppPlanningSessionRow = {
   draft_plan_summary_json?: unknown;
   submitted_workflow_id?: unknown;
   submitted_plan_name?: unknown;
+  terminal_mode?: unknown;
+  terminal_session_id?: unknown;
+  terminal_status?: unknown;
+  terminal_exit_code?: unknown;
+  terminal_output_snapshot?: unknown;
+  terminal_updated_at?: unknown;
   pending_response?: unknown;
   created_at?: unknown;
   updated_at?: unknown;
@@ -449,6 +455,14 @@ function isInAppPlanningSessionStatus(value: unknown): value is InAppPlanningSes
     || value === 'waiting_for_answer'
     || value === 'draft_ready'
     || value === 'submitted';
+}
+
+function isPlanningTerminalMode(value: unknown): value is PlanningTerminalMode {
+  return value === 'chat' || value === 'tmux';
+}
+
+function isPlanningTerminalStatus(value: unknown): value is 'running' | 'exited' | undefined {
+  return value === undefined || value === null || value === 'running' || value === 'exited';
 }
 
 function isInAppPlanningMessageRole(value: unknown): value is InAppPlanningChatLine['role'] {
@@ -1075,10 +1089,16 @@ export class SQLiteAdapter implements PersistenceAdapter {
           draft_plan_summary_json,
           submitted_workflow_id,
           submitted_plan_name,
+          terminal_mode,
+          terminal_session_id,
+          terminal_status,
+          terminal_exit_code,
+          terminal_output_snapshot,
+          terminal_updated_at,
           pending_response,
           created_at,
           updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(session_id) DO UPDATE SET
           title = excluded.title,
           preset_key = excluded.preset_key,
@@ -1086,6 +1106,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
           draft_plan_summary_json = excluded.draft_plan_summary_json,
           submitted_workflow_id = excluded.submitted_workflow_id,
           submitted_plan_name = excluded.submitted_plan_name,
+          terminal_mode = excluded.terminal_mode,
+          terminal_session_id = excluded.terminal_session_id,
+          terminal_status = excluded.terminal_status,
+          terminal_exit_code = excluded.terminal_exit_code,
+          terminal_output_snapshot = excluded.terminal_output_snapshot,
+          terminal_updated_at = excluded.terminal_updated_at,
           pending_response = excluded.pending_response,
           created_at = excluded.created_at,
           updated_at = excluded.updated_at`,
@@ -1097,6 +1123,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
           record.draftPlanSummary ? JSON.stringify(record.draftPlanSummary) : null,
           record.submittedWorkflowId ?? null,
           record.submittedPlanName ?? null,
+          record.terminalMode ?? 'chat',
+          record.terminalSessionId ?? null,
+          record.terminalStatus ?? null,
+          record.terminalExitCode ?? null,
+          record.terminalOutputSnapshot ?? '',
+          record.terminalUpdatedAt ?? null,
           record.pendingResponse ? 1 : 0,
           record.createdAt,
           record.updatedAt,
@@ -1147,6 +1179,30 @@ export class SQLiteAdapter implements PersistenceAdapter {
       if (Object.hasOwn(patch, 'submittedPlanName')) {
         setClauses.push('submitted_plan_name = ?');
         values.push(patch.submittedPlanName ?? null);
+      }
+      if (Object.hasOwn(patch, 'terminalMode')) {
+        setClauses.push('terminal_mode = ?');
+        values.push(patch.terminalMode ?? 'chat');
+      }
+      if (Object.hasOwn(patch, 'terminalSessionId')) {
+        setClauses.push('terminal_session_id = ?');
+        values.push(patch.terminalSessionId ?? null);
+      }
+      if (Object.hasOwn(patch, 'terminalStatus')) {
+        setClauses.push('terminal_status = ?');
+        values.push(patch.terminalStatus ?? null);
+      }
+      if (Object.hasOwn(patch, 'terminalExitCode')) {
+        setClauses.push('terminal_exit_code = ?');
+        values.push(patch.terminalExitCode ?? null);
+      }
+      if (Object.hasOwn(patch, 'terminalOutputSnapshot')) {
+        setClauses.push('terminal_output_snapshot = ?');
+        values.push(patch.terminalOutputSnapshot ?? '');
+      }
+      if (Object.hasOwn(patch, 'terminalUpdatedAt')) {
+        setClauses.push('terminal_updated_at = ?');
+        values.push(patch.terminalUpdatedAt ?? null);
       }
       if (Object.hasOwn(patch, 'pendingResponse')) {
         setClauses.push('pending_response = ?');
@@ -2247,6 +2303,17 @@ export class SQLiteAdapter implements PersistenceAdapter {
       if (!id || !title || !presetKey || !createdAt || !updatedAt || !isInAppPlanningSessionStatus(row.status)) {
         return undefined;
       }
+      const terminalMode = row.terminal_mode === undefined || row.terminal_mode === null
+        ? 'chat'
+        : isPlanningTerminalMode(row.terminal_mode)
+          ? row.terminal_mode
+          : undefined;
+      if (!terminalMode) {
+        return undefined;
+      }
+      if (!isPlanningTerminalStatus(row.terminal_status)) {
+        return undefined;
+      }
       if (
         row.status === 'submitted'
         && (
@@ -2291,6 +2358,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
         ...(draftPlanSummary ? { draftPlanSummary } : {}),
         ...(typeof row.submitted_workflow_id === 'string' ? { submittedWorkflowId: row.submitted_workflow_id } : {}),
         ...(typeof row.submitted_plan_name === 'string' ? { submittedPlanName: row.submitted_plan_name } : {}),
+        terminalMode,
+        ...(typeof row.terminal_session_id === 'string' ? { terminalSessionId: row.terminal_session_id } : {}),
+        ...(row.terminal_status ? { terminalStatus: row.terminal_status } : {}),
+        ...(typeof row.terminal_exit_code === 'number' ? { terminalExitCode: row.terminal_exit_code } : {}),
+        terminalOutputSnapshot: typeof row.terminal_output_snapshot === 'string' ? row.terminal_output_snapshot : '',
+        ...(typeof row.terminal_updated_at === 'string' ? { terminalUpdatedAt: row.terminal_updated_at } : {}),
         pendingResponse: row.pending_response === 1,
         createdAt,
         updatedAt,

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -178,6 +178,12 @@ export const SCHEMA_DDL = `
         draft_plan_summary_json TEXT CHECK (draft_plan_summary_json IS NULL OR json_valid(draft_plan_summary_json)),
         submitted_workflow_id TEXT,
         submitted_plan_name TEXT,
+        terminal_mode TEXT NOT NULL DEFAULT 'chat' CHECK (terminal_mode IN ('chat', 'tmux')),
+        terminal_session_id TEXT,
+        terminal_status TEXT CHECK (terminal_status IS NULL OR terminal_status IN ('running', 'exited')),
+        terminal_exit_code INTEGER,
+        terminal_output_snapshot TEXT NOT NULL DEFAULT '',
+        terminal_updated_at TEXT,
         pending_response INTEGER NOT NULL DEFAULT 0 CHECK (pending_response IN (0, 1)),
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
@@ -502,6 +508,12 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE attempts ADD COLUMN claimed_at TEXT',
   'ALTER TABLE attempts ADD COLUMN lease_expires_at TEXT',
   'ALTER TABLE tasks ADD COLUMN task_state_version INTEGER NOT NULL DEFAULT 1',
+  "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_mode TEXT NOT NULL DEFAULT 'chat' CHECK (terminal_mode IN ('chat', 'tmux'))",
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_session_id TEXT',
+  "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_status TEXT CHECK (terminal_status IS NULL OR terminal_status IN ('running', 'exited'))",
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
+  "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
 ];
 
 /**


### PR DESCRIPTION
## Summary

Planning Surface Tmux Step 3 Persistence And Restart stores the terminal state a planning session needs before restart behavior can use it.

Planning sessions now record terminal mode, session id, status, exit code, output snapshot, and update timestamps.

## Review Claim

Approve the planning terminal persistence contract and SQLite storage fields as the durable state for restart restoration.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The new columns have defaults, older databases migrate additively, and malformed terminal metadata causes the planning row to be ignored.

## Slice Rationale

This slice establishes the storage contract before any app process or UI behavior depends on restored planning terminal state.

## Non-goals

- This does not start or restore terminal processes.
- This does not change the planning terminal UI.
- This does not delete or rewrite existing planning messages.

## Architecture

### Before

Planning sessions persisted chat state, draft state, and submission state, but no terminal ownership or terminal snapshot metadata.

### After

Planning sessions persist terminal mode, terminal session linkage, terminal status, exit details, output snapshot, and terminal update time.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store test -- sqlite-adapter.test.ts`
- [x] `pnpm --filter @invoker/app test -- in-app-planner.test.ts`
- [x] `CAPTURE_VIDEO=1 pnpm --filter @invoker/ui build`
- [x] `CAPTURE_VIDEO=1 pnpm --filter @invoker/app build`
- [x] `CAPTURE_VIDEO=1 pnpm --filter @invoker/app test:e2e -- planning-terminal-restart-persistence.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, before dependent slices; after the stack lands, revert from the top of the stack down.
- Revert command: `git revert 8137eec1d959d6895ff6f66353b4744dcdbd7322`
- Post-revert steps: Revert dependent planning tmux restart slices first if they have landed.
- Data migration? Yes. Added SQLite columns may remain on existing databases, but reverted code ignores them.

</details>
