### PR TITLE
[Planning Surface Tmux Step 3 Persistence And Restart](2) Restore planning tmux sessions on restart

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -2,13 +2,17 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { PlanConversation } from '../../../surfaces/src/index.ts';
 import {
   createInAppPlanningChatSessions,
+  createPlanningChatSession,
   createPlanningCommandBuilderFromRegistry,
   listInAppPlanningPresets,
+  listPlanningChatSessions,
   planFromGoal,
   resetPlanningChat,
   restorePlanningChatSessions,
   sendPlanningChatMessage,
+  setPlanningChatTerminalMode,
   submitPlanningChatDraft,
+  updatePlanningChatTerminalState,
   type LoadedGeneratedPlan,
 } from '../in-app-planner.js';
 import { ConversationRepository, SQLiteAdapter, type InAppPlanningSessionRecord } from '@invoker/data-store';
@@ -666,6 +670,97 @@ tasks:
     }
   });
 
+  it('restores persisted tmux mode and planning-owned terminal state', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const conversationRepo = new ConversationRepository(adapter);
+      const record: InAppPlanningSessionRecord = {
+        id: 'planning-tmux-restored',
+        title: 'Restored tmux plan',
+        presetKey: 'codex',
+        status: 'still_discussing',
+        messages: [
+          { id: 1, role: 'system', text: 'Ask Invoker what you want to build.', tone: 'muted', createdAt: '2026-07-07T00:00:00.000Z' },
+        ],
+        terminalMode: 'tmux',
+        terminalSessionId: 'term-planning-owned',
+        terminalStatus: 'running',
+        terminalOutputSnapshot: 'planner tmux output\n',
+        terminalUpdatedAt: '2026-07-07T00:00:03.000Z',
+        pendingResponse: false,
+        createdAt: '2026-07-07T00:00:00.000Z',
+        updatedAt: '2026-07-07T00:00:02.000Z',
+      };
+
+      const sessions = createInAppPlanningChatSessions();
+      await restorePlanningChatSessions([record], {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo,
+        planningSessionStore: adapter,
+      });
+
+      expect(sessions.get('planning-tmux-restored')).toMatchObject({
+        terminalMode: 'tmux',
+        terminalSessionId: 'term-planning-owned',
+        terminalStatus: 'running',
+        terminalOutputSnapshot: 'planner tmux output\n',
+      });
+      expect(listPlanningChatSessions({ sessions }).sessions[0]).toMatchObject({
+        terminalMode: 'tmux',
+        terminalSessionId: 'term-planning-owned',
+        terminalStatus: 'running',
+      });
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('persists planning terminal mode and snapshot updates without rewriting messages', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const sessions = createInAppPlanningChatSessions();
+      const created = await createPlanningChatSession({ title: 'Terminal state' }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        planningSessionStore: adapter,
+      });
+      if (!created.ok) throw new Error(created.error);
+
+      expect(setPlanningChatTerminalMode({
+        sessionId: created.session.id,
+        mode: 'tmux',
+      }, {
+        sessions,
+        planningSessionStore: adapter,
+      })).toEqual({ ok: true });
+      expect(updatePlanningChatTerminalState(created.session.id, {
+        terminalSessionId: 'term-planning-state',
+        terminalStatus: 'running',
+        terminalOutputSnapshot: 'hello from tmux\n',
+      }, {
+        sessions,
+        planningSessionStore: adapter,
+      })).toBe(true);
+
+      expect(adapter.loadInAppPlanningSession(created.session.id)).toMatchObject({
+        terminalMode: 'tmux',
+        terminalSessionId: 'term-planning-state',
+        terminalStatus: 'running',
+        terminalOutputSnapshot: 'hello from tmux\n',
+        messages: expect.arrayContaining([
+          expect.objectContaining({ role: 'system', text: 'Ask Invoker what you want to build.' }),
+        ]),
+      });
+    } finally {
+      adapter.close();
+    }
+  });
+
   it('rebuilds missing draft summaries from hidden planner state on restore', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     try {
@@ -740,6 +835,27 @@ tasks:
 
       expect(sessions.get('planning-submitted')?.messages).toHaveLength(1);
       expect(adapter.loadInAppPlanningSession('planning-submitted')?.pendingResponse).toBe(false);
+      expect(setPlanningChatTerminalMode({
+        sessionId: 'planning-submitted',
+        mode: 'tmux',
+      }, {
+        sessions,
+        planningSessionStore: adapter,
+      })).toEqual({ ok: true });
+      await expect(sendPlanningChatMessage({
+        sessionId: 'planning-submitted',
+        message: 'change it',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo: new ConversationRepository(adapter),
+        planningSessionStore: adapter,
+      })).resolves.toMatchObject({
+        ok: false,
+        error: 'This planning session was already submitted. Start a new planning chat for changes.',
+      });
     } finally {
       adapter.close();
     }

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -357,6 +357,8 @@ export class EmbeddedTerminalManager extends EventEmitter {
   restoreSpawnSession(seed: {
     sessionId: string;
     taskId: string;
+    kind?: EmbeddedTerminalSessionKind;
+    planningSessionId?: string;
     targetKey: string;
     spec: TerminalSpec;
     cwd: string;
@@ -381,7 +383,8 @@ export class EmbeddedTerminalManager extends EventEmitter {
     return this.registerSpawnSession({
       sessionId: seed.sessionId,
       taskId: seed.taskId,
-      kind: 'task',
+      kind: seed.kind ?? 'task',
+      planningSessionId: seed.planningSessionId,
       targetKey: seed.targetKey,
       spec: seed.spec,
       cwd: seed.cwd,

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -186,6 +186,17 @@ function appendSessionMessage(
   session.nextMessageId += 1;
   session.updatedAt = createdAt;
 }
+function clearStarterPromptIfUnused(session: InAppPlanningChatSession): void {
+  if (
+    session.messages.length === 1
+    && session.messages[0]?.role === 'system'
+    && session.messages[0]?.tone === 'muted'
+    && session.messages[0]?.text === 'Ask Invoker what you want to build.'
+  ) {
+    session.messages = [];
+    session.nextMessageId = 1;
+  }
+}
 
 function sessionToRecord(session: InAppPlanningChatSession, pendingResponse: boolean): InAppPlanningSessionRecord {
   return {
@@ -349,11 +360,17 @@ async function createSession(
     title: typeof request?.title === 'string' && request.title.trim() ? request.title.trim() : 'Untitled plan',
     presetKey,
     status: 'still_discussing',
-    messages: [],
+    messages: [{
+      id: 1,
+      role: 'system',
+      text: 'Ask Invoker what you want to build.',
+      tone: 'muted',
+      createdAt,
+    }],
     conversation: new PlanConversation(planConversationConfig(preset, deps, id)),
     createdAt,
     updatedAt: createdAt,
-    nextMessageId: 1,
+    nextMessageId: 2,
     terminalMode: 'chat',
     terminalOutputSnapshot: '',
   };
@@ -485,6 +502,7 @@ export async function sendPlanningChatMessage(
     const activeSession = session;
     const previousSend = activeSession.pendingSend ?? Promise.resolve();
     const turn = previousSend.then(async (): Promise<InAppPlanningChatResponse> => {
+      clearStarterPromptIfUnused(activeSession);
       appendSessionMessage(activeSession, 'user', message);
       if (activeSession.title === 'Untitled plan') {
         activeSession.title = titleFromMessage(message);

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -11,11 +11,14 @@ import type {
   InAppPlanningPlanSummary,
   InAppPlanningResetRequest,
   InAppPlanningResetResponse,
+  InAppPlanningSetTerminalModeRequest,
+  InAppPlanningSetTerminalModeResponse,
   InAppPlanningSessionStatus,
   InAppPlanningSessionSummary,
   InAppPlanningStreamEvent,
   InAppPlanningSubmitRequest,
   InAppPlanningSubmitResponse,
+  PlanningTerminalMode,
   PlanningPresetOption,
 } from '@invoker/contracts';
 import type {
@@ -62,6 +65,12 @@ export interface InAppPlanningChatSession {
   draftPlanText?: string;
   submittedWorkflowId?: string;
   submittedPlanName?: string;
+  terminalMode?: PlanningTerminalMode;
+  terminalSessionId?: string;
+  terminalStatus?: 'running' | 'exited';
+  terminalExitCode?: number;
+  terminalOutputSnapshot?: string;
+  terminalUpdatedAt?: string;
   createdAt: string;
   updatedAt: string;
   nextMessageId: number;
@@ -188,6 +197,12 @@ function sessionToRecord(session: InAppPlanningChatSession, pendingResponse: boo
     draftPlanSummary: session.draftPlanSummary,
     submittedWorkflowId: session.submittedWorkflowId,
     submittedPlanName: session.submittedPlanName,
+    terminalMode: session.terminalMode ?? 'chat',
+    terminalSessionId: session.terminalSessionId,
+    terminalStatus: session.terminalStatus,
+    terminalExitCode: session.terminalExitCode,
+    terminalOutputSnapshot: session.terminalOutputSnapshot ?? '',
+    terminalUpdatedAt: session.terminalUpdatedAt,
     pendingResponse,
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
@@ -205,6 +220,12 @@ function sessionToSummary(session: InAppPlanningChatSession): InAppPlanningSessi
     draftPlanSummary: session.draftPlanSummary,
     submittedWorkflowId: session.submittedWorkflowId,
     submittedPlanName: session.submittedPlanName,
+    terminalMode: session.terminalMode ?? 'chat',
+    terminalSessionId: session.terminalSessionId,
+    terminalStatus: session.terminalStatus,
+    terminalExitCode: session.terminalExitCode,
+    terminalOutputSnapshot: session.terminalOutputSnapshot ?? '',
+    terminalUpdatedAt: session.terminalUpdatedAt,
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
   };
@@ -333,6 +354,8 @@ async function createSession(
     createdAt,
     updatedAt: createdAt,
     nextMessageId: 1,
+    terminalMode: 'chat',
+    terminalOutputSnapshot: '',
   };
   deps.sessions.set(session.id, session);
   persistPlanningSession(session, deps.planningSessionStore, false);
@@ -612,6 +635,79 @@ export function resetPlanningChat(
   return { ok: true };
 }
 
+export function setPlanningChatTerminalMode(
+  request: InAppPlanningSetTerminalModeRequest,
+  deps: { sessions: InAppPlanningChatSessions; planningSessionStore?: InAppPlanningSessionStore },
+): InAppPlanningSetTerminalModeResponse {
+  const sessionId = typeof request?.sessionId === 'string' ? request.sessionId.trim() : '';
+  const session = sessionId ? deps.sessions.get(sessionId) : undefined;
+  if (!session) {
+    return { ok: false, error: 'No planning conversation yet.' };
+  }
+  if (request.mode !== 'chat' && request.mode !== 'tmux') {
+    return { ok: false, error: 'Unknown planning terminal mode.' };
+  }
+
+  const updatedAt = new Date().toISOString();
+  session.terminalMode = request.mode;
+  session.updatedAt = updatedAt;
+  deps.planningSessionStore?.updateInAppPlanningSession(session.id, {
+    terminalMode: request.mode,
+    updatedAt,
+  });
+  return { ok: true };
+}
+
+export interface PlanningChatTerminalStatePatch {
+  terminalMode?: PlanningTerminalMode;
+  terminalSessionId?: string;
+  terminalStatus?: 'running' | 'exited';
+  terminalExitCode?: number;
+  terminalOutputSnapshot?: string;
+  terminalUpdatedAt?: string;
+  touchSessionUpdatedAt?: boolean;
+}
+
+export function updatePlanningChatTerminalState(
+  sessionId: string,
+  patch: PlanningChatTerminalStatePatch,
+  deps: { sessions: InAppPlanningChatSessions; planningSessionStore?: InAppPlanningSessionStore },
+): boolean {
+  const session = deps.sessions.get(sessionId);
+  if (!session) return false;
+
+  const terminalUpdatedAt = patch.terminalUpdatedAt ?? new Date().toISOString();
+  const storePatch: InAppPlanningSessionPatch = { terminalUpdatedAt };
+  if (Object.hasOwn(patch, 'terminalMode')) {
+    session.terminalMode = patch.terminalMode;
+    storePatch.terminalMode = patch.terminalMode;
+  }
+  if (Object.hasOwn(patch, 'terminalSessionId')) {
+    session.terminalSessionId = patch.terminalSessionId;
+    storePatch.terminalSessionId = patch.terminalSessionId;
+  }
+  if (Object.hasOwn(patch, 'terminalStatus')) {
+    session.terminalStatus = patch.terminalStatus;
+    storePatch.terminalStatus = patch.terminalStatus;
+  }
+  if (Object.hasOwn(patch, 'terminalExitCode')) {
+    session.terminalExitCode = patch.terminalExitCode;
+    storePatch.terminalExitCode = patch.terminalExitCode;
+  }
+  if (Object.hasOwn(patch, 'terminalOutputSnapshot')) {
+    session.terminalOutputSnapshot = patch.terminalOutputSnapshot;
+    storePatch.terminalOutputSnapshot = patch.terminalOutputSnapshot;
+  }
+  session.terminalUpdatedAt = terminalUpdatedAt;
+  if (patch.touchSessionUpdatedAt) {
+    session.updatedAt = terminalUpdatedAt;
+    storePatch.updatedAt = terminalUpdatedAt;
+  }
+
+  deps.planningSessionStore?.updateInAppPlanningSession(session.id, storePatch);
+  return true;
+}
+
 export async function restorePlanningChatSessions(
   records: InAppPlanningSessionRecord[],
   deps: InAppPlannerDeps & {
@@ -644,6 +740,12 @@ export async function restorePlanningChatSessions(
       draftPlanSummary: record.draftPlanSummary,
       submittedWorkflowId: record.submittedWorkflowId,
       submittedPlanName: record.submittedPlanName,
+      terminalMode: record.terminalMode ?? 'chat',
+      terminalSessionId: record.terminalSessionId,
+      terminalStatus: record.terminalStatus,
+      terminalExitCode: record.terminalExitCode,
+      terminalOutputSnapshot: record.terminalOutputSnapshot ?? '',
+      terminalUpdatedAt: record.terminalUpdatedAt,
       createdAt: record.createdAt,
       updatedAt: record.updatedAt,
       nextMessageId,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2058,20 +2058,12 @@ function createEmbeddedTerminalBackendFromConfig(
       mainWindow.webContents.send('invoker:terminal-exit', payload);
     }
   });
-  embeddedTerminalManager.on('session-updated', (record) => {
-    if (record.kind !== 'planning' || !record.planningSessionId) return;
-    updatePlanningChatTerminalState(record.planningSessionId, {
-      terminalMode: 'tmux',
-      terminalSessionId: record.sessionId,
-      terminalStatus: record.status,
-      terminalExitCode: record.exitCode,
-      terminalOutputSnapshot: record.outputSnapshot,
-      terminalUpdatedAt: record.updatedAt,
-      touchSessionUpdatedAt: record.status !== 'running' || record.outputSnapshot.length === 0,
-    }, {
-      sessions: planningChatSessions,
-      planningSessionStore: ownerMode ? persistence : undefined,
-    });
+  const { restorePersistedPlanningTerminals } = bindPlanningTerminalSessionState({
+    embeddedTerminalManager,
+    logger,
+    planningChatSessions,
+    getPlanningSessionStore: () => (ownerMode ? persistence : undefined),
+    repoRoot,
   });
 
   const planningTerminalTargetKey = (planningSessionId: string): string => JSON.stringify({
@@ -5480,11 +5472,12 @@ function createEmbeddedTerminalBackendFromConfig(
         return { opened: false, reason: `Failed to start terminal session: ${reason}` };
       }
     });
-
     registerPlanningTerminalSessionIpcHandlers({
       ipcMain,
       embeddedTerminalManager,
       logger,
+      planningChatSessions,
+      getPlanningSessionStore: () => (ownerMode ? persistence : undefined),
       repoRoot,
     });
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -288,6 +288,7 @@ import {
   resetRendererUiPerfCounters,
 } from './renderer-ui-perf.js';
 import {
+  bindPlanningTerminalSessionState,
   registerPlanningTerminalSessionIpcHandlers,
   registerTerminalSessionIpcHandlers,
   registerTerminalSessionPersistence,
@@ -321,7 +322,6 @@ import {
   sendPlanningChatMessage,
   setPlanningChatTerminalMode,
   submitPlanningChatDraft,
-  updatePlanningChatTerminalState,
 } from './in-app-planner.js';
 import { discoverOwner, isStandaloneCapable } from './owner-endpoint.js';
 import {
@@ -2066,56 +2066,6 @@ function createEmbeddedTerminalBackendFromConfig(
     repoRoot,
   });
 
-  const planningTerminalTargetKey = (planningSessionId: string): string => JSON.stringify({
-    kind: 'planning',
-    planningSessionId,
-    taskId: `planning:${planningSessionId}`,
-    cwd: repoRoot,
-    command: null,
-    args: [],
-    linuxTerminalTail: null,
-    attach: null,
-  });
-
-  const restorePersistedPlanningTerminals = (): void => {
-    for (const session of planningChatSessions.values()) {
-      if (
-        session.terminalMode !== 'tmux'
-        || !session.terminalSessionId
-        || session.terminalStatus === 'exited'
-      ) {
-        continue;
-      }
-      try {
-        embeddedTerminalManager.restoreSpawnSession({
-          sessionId: session.terminalSessionId,
-          taskId: `planning:${session.id}`,
-          kind: 'planning',
-          planningSessionId: session.id,
-          targetKey: planningTerminalTargetKey(session.id),
-          spec: { cwd: repoRoot },
-          cwd: repoRoot,
-          createdAt: session.terminalUpdatedAt ?? session.updatedAt,
-          outputSnapshot: session.terminalOutputSnapshot ?? '',
-        });
-      } catch (err) {
-        logger.warn(
-          `planning terminal restore failed for session="${session.id}": ${err instanceof Error ? err.message : String(err)}`,
-          { module: 'planning-terminal' },
-        );
-        updatePlanningChatTerminalState(session.id, {
-          terminalMode: 'tmux',
-          terminalSessionId: session.terminalSessionId,
-          terminalStatus: 'exited',
-          terminalOutputSnapshot: session.terminalOutputSnapshot ?? '',
-          touchSessionUpdatedAt: true,
-        }, {
-          sessions: planningChatSessions,
-          planningSessionStore: ownerMode ? persistence : undefined,
-        });
-      }
-    }
-  };
   // CC.5: the legacy `launchingTasks` Set is gone. Per-attempt launch
   // state is tracked durably by `task_launch_dispatch` (Phase B); the
   // TaskRunner's internal `launchingAttemptIds` Set (CB.4) is the
@@ -5353,89 +5303,6 @@ function createEmbeddedTerminalBackendFromConfig(
     // (or selecting) an embedded session managed in the main process.
     // Headless `open-terminal` still routes to `openExternalTerminalForTask`
     // in `headless.ts` so existing CLI behaviour is preserved.
-    const planningTerminalOnly = (sessionId: string): { ok: true; planningSessionId: string } | { ok: false; reason: string } => {
-      const session = embeddedTerminalManager.get(sessionId);
-      if (!session) return { ok: false, reason: `Unknown session "${sessionId}".` };
-      if (session.kind !== 'planning') {
-        return { ok: false, reason: `Session "${sessionId}" is not a planning terminal session.` };
-      }
-      const planningSessionId = session.planningSessionId ?? '';
-      if (!planningSessionId || !planningChatSessions.has(planningSessionId)) {
-        return { ok: false, reason: `Session "${sessionId}" is not owned by a planning conversation.` };
-      }
-      return { ok: true, planningSessionId };
-    };
-
-    const planningTerminalWritable = (sessionId: string): { ok: true } | { ok: false; reason: string } => {
-      const allowed = planningTerminalOnly(sessionId);
-      if (!allowed.ok) return allowed;
-      if (!ownerMode) {
-        return { ok: false, reason: 'Planning terminal is read-only in this window.' };
-      }
-      const planningSession = planningChatSessions.get(allowed.planningSessionId);
-      if (planningSession?.status === 'submitted') {
-        return { ok: false, reason: 'This planning session was already submitted.' };
-      }
-      return { ok: true };
-    };
-
-    ipcMain.handle('invoker:planning-terminal-open', async (_event, planningSessionIdArg: string) => {
-      const planningSessionId = String(planningSessionIdArg ?? '').trim();
-      if (!planningSessionId) {
-        return { opened: false, reason: 'Planning session id is required.' };
-      }
-      if (!planningChatSessions.has(planningSessionId)) {
-        return { opened: false, reason: 'Planning conversation was not found.' };
-      }
-      logger.info(`invoked for planningSession="${planningSessionId}"`, { module: 'planning-terminal' });
-      try {
-        const session = embeddedTerminalManager.openOrReuse({
-          kind: 'planning',
-          taskId: `planning:${planningSessionId}`,
-          planningSessionId,
-          spec: { cwd: repoRoot },
-          cwd: repoRoot,
-        });
-        updatePlanningChatTerminalState(planningSessionId, {
-          terminalMode: 'tmux',
-          terminalSessionId: session.sessionId,
-          terminalStatus: session.status,
-          terminalExitCode: session.exitCode,
-          terminalOutputSnapshot: session.outputSnapshot ?? '',
-          touchSessionUpdatedAt: true,
-        }, {
-          sessions: planningChatSessions,
-          planningSessionStore: ownerMode ? persistence : undefined,
-        });
-        return { opened: true, session };
-      } catch (err) {
-        const reason = err instanceof Error ? err.message : String(err);
-        logger.warn(`planning terminal spawn failed for session="${planningSessionId}": ${reason}`, { module: 'planning-terminal' });
-        return { opened: false, reason: `Failed to start planning terminal session: ${reason}` };
-      }
-    });
-
-    ipcMain.handle('invoker:planning-terminal-list', async () => {
-      return embeddedTerminalManager.list().filter((session) => session.kind === 'planning');
-    });
-
-    ipcMain.handle('invoker:planning-terminal-write', async (_event, sessionId: string, data: string) => {
-      const allowed = planningTerminalWritable(sessionId);
-      if (!allowed.ok) return allowed;
-      return embeddedTerminalManager.write(sessionId, data);
-    });
-
-    ipcMain.handle('invoker:planning-terminal-resize', async (_event, sessionId: string, cols: number, rows: number) => {
-      const allowed = planningTerminalOnly(sessionId);
-      if (!allowed.ok) return allowed;
-      return embeddedTerminalManager.resize(sessionId, cols, rows);
-    });
-
-    ipcMain.handle('invoker:planning-terminal-close', async (_event, sessionId: string) => {
-      const allowed = planningTerminalOnly(sessionId);
-      if (!allowed.ok) return allowed;
-      return embeddedTerminalManager.close(sessionId);
-    });
     ipcMain.handle('invoker:open-terminal', async (_event, taskId: string) => {
       logger.info(`invoked for task="${taskId}"`, { module: 'open-terminal' });
       const liveHandle = taskHandles.get(taskId);

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -91,6 +91,7 @@ import type {
   InAppPlanningChatRequest,
   InAppPlanningResetRequest,
   InAppPlanningStreamEvent,
+  InAppPlanningSetTerminalModeRequest,
   InAppPlanningSubmitRequest,
   Logger,
   StartReadyRequest,
@@ -318,7 +319,9 @@ import {
   resetPlanningChat,
   restorePlanningChatSessions,
   sendPlanningChatMessage,
+  setPlanningChatTerminalMode,
   submitPlanningChatDraft,
+  updatePlanningChatTerminalState,
 } from './in-app-planner.js';
 import { discoverOwner, isStandaloneCapable } from './owner-endpoint.js';
 import {
@@ -1273,6 +1276,12 @@ function startHeadlessMode(): void {
               planningSessionStore: readOnlyMode ? undefined : persistence,
             });
           }
+          case 'invoker:planning-chat-set-terminal-mode': {
+            return setPlanningChatTerminalMode(payload.args[0] as InAppPlanningSetTerminalModeRequest, {
+              sessions: planningChatSessions,
+              planningSessionStore: readOnlyMode ? undefined : persistence,
+            });
+          }
           case 'invoker:load-plan': {
             const planText = String(payload.args[0] ?? '');
             await loadGeneratedPlan(planText);
@@ -2049,6 +2058,72 @@ function createEmbeddedTerminalBackendFromConfig(
       mainWindow.webContents.send('invoker:terminal-exit', payload);
     }
   });
+  embeddedTerminalManager.on('session-updated', (record) => {
+    if (record.kind !== 'planning' || !record.planningSessionId) return;
+    updatePlanningChatTerminalState(record.planningSessionId, {
+      terminalMode: 'tmux',
+      terminalSessionId: record.sessionId,
+      terminalStatus: record.status,
+      terminalExitCode: record.exitCode,
+      terminalOutputSnapshot: record.outputSnapshot,
+      terminalUpdatedAt: record.updatedAt,
+      touchSessionUpdatedAt: record.status !== 'running' || record.outputSnapshot.length === 0,
+    }, {
+      sessions: planningChatSessions,
+      planningSessionStore: ownerMode ? persistence : undefined,
+    });
+  });
+
+  const planningTerminalTargetKey = (planningSessionId: string): string => JSON.stringify({
+    kind: 'planning',
+    planningSessionId,
+    taskId: `planning:${planningSessionId}`,
+    cwd: repoRoot,
+    command: null,
+    args: [],
+    linuxTerminalTail: null,
+    attach: null,
+  });
+
+  const restorePersistedPlanningTerminals = (): void => {
+    for (const session of planningChatSessions.values()) {
+      if (
+        session.terminalMode !== 'tmux'
+        || !session.terminalSessionId
+        || session.terminalStatus === 'exited'
+      ) {
+        continue;
+      }
+      try {
+        embeddedTerminalManager.restoreSpawnSession({
+          sessionId: session.terminalSessionId,
+          taskId: `planning:${session.id}`,
+          kind: 'planning',
+          planningSessionId: session.id,
+          targetKey: planningTerminalTargetKey(session.id),
+          spec: { cwd: repoRoot },
+          cwd: repoRoot,
+          createdAt: session.terminalUpdatedAt ?? session.updatedAt,
+          outputSnapshot: session.terminalOutputSnapshot ?? '',
+        });
+      } catch (err) {
+        logger.warn(
+          `planning terminal restore failed for session="${session.id}": ${err instanceof Error ? err.message : String(err)}`,
+          { module: 'planning-terminal' },
+        );
+        updatePlanningChatTerminalState(session.id, {
+          terminalMode: 'tmux',
+          terminalSessionId: session.terminalSessionId,
+          terminalStatus: 'exited',
+          terminalOutputSnapshot: session.terminalOutputSnapshot ?? '',
+          touchSessionUpdatedAt: true,
+        }, {
+          sessions: planningChatSessions,
+          planningSessionStore: ownerMode ? persistence : undefined,
+        });
+      }
+    }
+  };
   // CC.5: the legacy `launchingTasks` Set is gone. Per-attempt launch
   // state is tracked durably by `task_launch_dispatch` (Phase B); the
   // TaskRunner's internal `launchingAttemptIds` Set (CB.4) is the
@@ -2835,6 +2910,7 @@ function createEmbeddedTerminalBackendFromConfig(
       case 'invoker:planning-chat-send':
       case 'invoker:planning-chat-submit':
       case 'invoker:planning-chat-reset':
+      case 'invoker:planning-chat-set-terminal-mode':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:load-plan':
         return { channel: 'headless.gui-mutation', request: payload };
@@ -3947,6 +4023,9 @@ function createEmbeddedTerminalBackendFromConfig(
       planningSessionStore: ownerMode ? persistence : undefined,
       onRawPlannerOutput: emitPlanningChatStream,
     });
+    if (ownerMode) {
+      restorePersistedPlanningTerminals();
+    }
     let testPlanFromGoalResponse: { planYaml: string; planName: string } | null = null;
     // Two variants: (1) a successful override that returns a canned reply +
     // plan YAML, or (2) an error injection that makes the wrapper throw the
@@ -4020,6 +4099,12 @@ function createEmbeddedTerminalBackendFromConfig(
     });
     registerGuiMutationHandler('invoker:planning-chat-reset', async (request: unknown) => {
       return resetPlanningChat(request as InAppPlanningResetRequest, {
+        sessions: planningChatSessions,
+        planningSessionStore: ownerMode ? persistence : undefined,
+      });
+    });
+    registerGuiMutationHandler('invoker:planning-chat-set-terminal-mode', async (request: unknown) => {
+      return setPlanningChatTerminalMode(request as InAppPlanningSetTerminalModeRequest, {
         sessions: planningChatSessions,
         planningSessionStore: ownerMode ? persistence : undefined,
       });
@@ -5276,6 +5361,89 @@ function createEmbeddedTerminalBackendFromConfig(
     // (or selecting) an embedded session managed in the main process.
     // Headless `open-terminal` still routes to `openExternalTerminalForTask`
     // in `headless.ts` so existing CLI behaviour is preserved.
+    const planningTerminalOnly = (sessionId: string): { ok: true; planningSessionId: string } | { ok: false; reason: string } => {
+      const session = embeddedTerminalManager.get(sessionId);
+      if (!session) return { ok: false, reason: `Unknown session "${sessionId}".` };
+      if (session.kind !== 'planning') {
+        return { ok: false, reason: `Session "${sessionId}" is not a planning terminal session.` };
+      }
+      const planningSessionId = session.planningSessionId ?? '';
+      if (!planningSessionId || !planningChatSessions.has(planningSessionId)) {
+        return { ok: false, reason: `Session "${sessionId}" is not owned by a planning conversation.` };
+      }
+      return { ok: true, planningSessionId };
+    };
+
+    const planningTerminalWritable = (sessionId: string): { ok: true } | { ok: false; reason: string } => {
+      const allowed = planningTerminalOnly(sessionId);
+      if (!allowed.ok) return allowed;
+      if (!ownerMode) {
+        return { ok: false, reason: 'Planning terminal is read-only in this window.' };
+      }
+      const planningSession = planningChatSessions.get(allowed.planningSessionId);
+      if (planningSession?.status === 'submitted') {
+        return { ok: false, reason: 'This planning session was already submitted.' };
+      }
+      return { ok: true };
+    };
+
+    ipcMain.handle('invoker:planning-terminal-open', async (_event, planningSessionIdArg: string) => {
+      const planningSessionId = String(planningSessionIdArg ?? '').trim();
+      if (!planningSessionId) {
+        return { opened: false, reason: 'Planning session id is required.' };
+      }
+      if (!planningChatSessions.has(planningSessionId)) {
+        return { opened: false, reason: 'Planning conversation was not found.' };
+      }
+      logger.info(`invoked for planningSession="${planningSessionId}"`, { module: 'planning-terminal' });
+      try {
+        const session = embeddedTerminalManager.openOrReuse({
+          kind: 'planning',
+          taskId: `planning:${planningSessionId}`,
+          planningSessionId,
+          spec: { cwd: repoRoot },
+          cwd: repoRoot,
+        });
+        updatePlanningChatTerminalState(planningSessionId, {
+          terminalMode: 'tmux',
+          terminalSessionId: session.sessionId,
+          terminalStatus: session.status,
+          terminalExitCode: session.exitCode,
+          terminalOutputSnapshot: session.outputSnapshot ?? '',
+          touchSessionUpdatedAt: true,
+        }, {
+          sessions: planningChatSessions,
+          planningSessionStore: ownerMode ? persistence : undefined,
+        });
+        return { opened: true, session };
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        logger.warn(`planning terminal spawn failed for session="${planningSessionId}": ${reason}`, { module: 'planning-terminal' });
+        return { opened: false, reason: `Failed to start planning terminal session: ${reason}` };
+      }
+    });
+
+    ipcMain.handle('invoker:planning-terminal-list', async () => {
+      return embeddedTerminalManager.list().filter((session) => session.kind === 'planning');
+    });
+
+    ipcMain.handle('invoker:planning-terminal-write', async (_event, sessionId: string, data: string) => {
+      const allowed = planningTerminalWritable(sessionId);
+      if (!allowed.ok) return allowed;
+      return embeddedTerminalManager.write(sessionId, data);
+    });
+
+    ipcMain.handle('invoker:planning-terminal-resize', async (_event, sessionId: string, cols: number, rows: number) => {
+      const allowed = planningTerminalOnly(sessionId);
+      if (!allowed.ok) return allowed;
+      return embeddedTerminalManager.resize(sessionId, cols, rows);
+    });
+
+    ipcMain.handle('invoker:planning-terminal-close', async (_event, sessionId: string) => {
+      const allowed = planningTerminalOnly(sessionId);
+      if (!allowed.ok) return allowed;
+      return embeddedTerminalManager.close(sessionId);
+    });
     ipcMain.handle('invoker:open-terminal', async (_event, taskId: string) => {
       logger.info(`invoked for task="${taskId}"`, { module: 'open-terminal' });
       const liveHandle = taskHandles.get(taskId);

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -15,6 +15,7 @@ import {
 export const TERMINAL_SESSION_UPSERT_COALESCE_MS = 250;
 
 type TerminalSessionRow = ReturnType<SQLiteAdapter['listTerminalSessions']>[number];
+type PlanningSessionStoreGetter = () => InAppPlanningSessionStore | undefined;
 
 interface PlanningTerminalLogger {
   info(message: string, context?: Record<string, unknown>): void;
@@ -278,21 +279,146 @@ function planningTerminalOnly(
   if (session.kind !== 'planning') {
     return { ok: false, reason: `Session "${sessionId}" is not a planning terminal session.` };
   }
+  const planningSessionId = session.planningSessionId ?? '';
+  if (!planningSessionId || !planningChatSessions.has(planningSessionId)) {
+    return { ok: false, reason: `Session "${sessionId}" is not owned by a planning conversation.` };
+  }
+  return { ok: true, planningSessionId };
+}
+
+function planningTerminalWritable(
+  embeddedTerminalManager: EmbeddedTerminalManager,
+  planningChatSessions: InAppPlanningChatSessions,
+  getPlanningSessionStore: PlanningSessionStoreGetter,
+  sessionId: string,
+): { ok: true } | { ok: false; reason: string } {
+  const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
+  if (!allowed.ok) return allowed;
+  if (!getPlanningSessionStore()) {
+    return { ok: false, reason: 'Planning terminal is read-only in this window.' };
+  }
+  const planningSession = planningChatSessions.get(allowed.planningSessionId);
+  if (planningSession?.status === 'submitted') {
+    return { ok: false, reason: 'This planning session was already submitted.' };
+  }
   return { ok: true };
+}
+
+function planningTerminalTargetKey(planningSessionId: string, repoRoot: string): string {
+  return JSON.stringify({
+    kind: 'planning',
+    planningSessionId,
+    taskId: `planning:${planningSessionId}`,
+    cwd: repoRoot,
+    command: null,
+    args: [],
+    linuxTerminalTail: null,
+    attach: null,
+  });
+}
+
+export function bindPlanningTerminalSessionState(deps: {
+  embeddedTerminalManager: EmbeddedTerminalManager;
+  logger: PlanningTerminalLogger;
+  planningChatSessions: InAppPlanningChatSessions;
+  getPlanningSessionStore: PlanningSessionStoreGetter;
+  repoRoot: string;
+}): { restorePersistedPlanningTerminals: () => void } {
+  const {
+    embeddedTerminalManager,
+    logger,
+    planningChatSessions,
+    getPlanningSessionStore,
+    repoRoot,
+  } = deps;
+
+  embeddedTerminalManager.on('session-updated', (record: TerminalSessionPersistenceRecord) => {
+    if (record.kind !== 'planning' || !record.planningSessionId) return;
+    updatePlanningChatTerminalState(record.planningSessionId, {
+      terminalMode: 'tmux',
+      terminalSessionId: record.sessionId,
+      terminalStatus: record.status,
+      terminalExitCode: record.exitCode,
+      terminalOutputSnapshot: record.outputSnapshot,
+      terminalUpdatedAt: record.updatedAt,
+      touchSessionUpdatedAt: record.status !== 'running' || record.outputSnapshot.length === 0,
+    }, {
+      sessions: planningChatSessions,
+      planningSessionStore: getPlanningSessionStore(),
+    });
+  });
+
+  const restorePersistedPlanningTerminals = (): void => {
+    for (const session of planningChatSessions.values()) {
+      if (
+        session.terminalMode !== 'tmux'
+        || !session.terminalSessionId
+        || session.terminalStatus === 'exited'
+      ) {
+        continue;
+      }
+      try {
+        embeddedTerminalManager.restoreSpawnSession({
+          sessionId: session.terminalSessionId,
+          taskId: `planning:${session.id}`,
+          kind: 'planning',
+          planningSessionId: session.id,
+          targetKey: planningTerminalTargetKey(session.id, repoRoot),
+          spec: { cwd: repoRoot },
+          cwd: repoRoot,
+          createdAt: session.terminalUpdatedAt ?? session.updatedAt,
+          outputSnapshot: session.terminalOutputSnapshot ?? '',
+        });
+      } catch (err) {
+        logger.warn(
+          `planning terminal restore failed for session="${session.id}": ${err instanceof Error ? err.message : String(err)}`,
+          { module: 'planning-terminal' },
+        );
+        updatePlanningChatTerminalState(session.id, {
+          terminalMode: 'tmux',
+          terminalSessionId: session.terminalSessionId,
+          terminalStatus: 'exited',
+          terminalOutputSnapshot: session.terminalOutputSnapshot ?? '',
+          touchSessionUpdatedAt: true,
+        }, {
+          sessions: planningChatSessions,
+          planningSessionStore: getPlanningSessionStore(),
+        });
+      }
+    }
+  };
+
+  return { restorePersistedPlanningTerminals };
 }
 
 export function registerPlanningTerminalSessionIpcHandlers(deps: {
   ipcMain: IpcMain;
   embeddedTerminalManager: EmbeddedTerminalManager;
   logger: PlanningTerminalLogger;
+  planningChatSessions: InAppPlanningChatSessions;
+  getPlanningSessionStore: PlanningSessionStoreGetter;
   repoRoot: string;
 }): void {
-  const { ipcMain, embeddedTerminalManager, logger, repoRoot } = deps;
+  const {
+    ipcMain,
+    embeddedTerminalManager,
+    logger,
+    planningChatSessions,
+    getPlanningSessionStore,
+    repoRoot,
+  } = deps;
 
   ipcMain.handle('invoker:planning-terminal-open', async (_event, planningSessionIdArg: string) => {
     const planningSessionId = String(planningSessionIdArg ?? '').trim();
     if (!planningSessionId) {
       return { opened: false, reason: 'Planning session id is required.' };
+    }
+    const planningSession = planningChatSessions.get(planningSessionId);
+    if (!planningSession) {
+      return { opened: false, reason: 'Planning conversation was not found.' };
+    }
+    if (planningSession.status === 'submitted') {
+      return { opened: false, reason: 'This planning session was already submitted.' };
     }
     logger.info(`invoked for planningSession="${planningSessionId}"`, { module: 'planning-terminal' });
     try {
@@ -302,6 +428,17 @@ export function registerPlanningTerminalSessionIpcHandlers(deps: {
         planningSessionId,
         spec: { cwd: repoRoot },
         cwd: repoRoot,
+      });
+      updatePlanningChatTerminalState(planningSessionId, {
+        terminalMode: 'tmux',
+        terminalSessionId: session.sessionId,
+        terminalStatus: session.status,
+        terminalExitCode: session.exitCode,
+        terminalOutputSnapshot: session.outputSnapshot ?? '',
+        touchSessionUpdatedAt: true,
+      }, {
+        sessions: planningChatSessions,
+        planningSessionStore: getPlanningSessionStore(),
       });
       return { opened: true, session };
     } catch (err) {
@@ -316,7 +453,12 @@ export function registerPlanningTerminalSessionIpcHandlers(deps: {
   });
 
   ipcMain.handle('invoker:planning-terminal-write', async (_event, sessionId: string, data: string) => {
-    const allowed = planningTerminalOnly(embeddedTerminalManager, sessionId);
+    const allowed = planningTerminalWritable(
+      embeddedTerminalManager,
+      planningChatSessions,
+      getPlanningSessionStore,
+      sessionId,
+    );
     if (!allowed.ok) return allowed;
     return embeddedTerminalManager.write(sessionId, data);
   });

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -10,6 +10,11 @@ import {
   type TerminalUiPerfReporter,
   type TerminalUiPerfSink,
 } from './terminal-ui-perf.js';
+import {
+  updatePlanningChatTerminalState,
+  type InAppPlanningChatSessions,
+  type InAppPlanningSessionStore,
+} from './in-app-planner.js';
 
 /** Coalesce running-session snapshot upserts so PTY output does not 1:1 SQLite-write on main. */
 export const TERMINAL_SESSION_UPSERT_COALESCE_MS = 250;
@@ -272,8 +277,9 @@ export function registerTerminalSessionIpcHandlers(deps: {
 
 function planningTerminalOnly(
   embeddedTerminalManager: EmbeddedTerminalManager,
+  planningChatSessions: InAppPlanningChatSessions,
   sessionId: string,
-): { ok: true } | { ok: false; reason: string } {
+): { ok: true; planningSessionId: string } | { ok: false; reason: string } {
   const session = embeddedTerminalManager.get(sessionId);
   if (!session) return { ok: false, reason: `Unknown session "${sessionId}".` };
   if (session.kind !== 'planning') {
@@ -464,13 +470,13 @@ export function registerPlanningTerminalSessionIpcHandlers(deps: {
   });
 
   ipcMain.handle('invoker:planning-terminal-resize', async (_event, sessionId: string, cols: number, rows: number) => {
-    const allowed = planningTerminalOnly(embeddedTerminalManager, sessionId);
+    const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
     if (!allowed.ok) return allowed;
     return embeddedTerminalManager.resize(sessionId, cols, rows);
   });
 
   ipcMain.handle('invoker:planning-terminal-close', async (_event, sessionId: string) => {
-    const allowed = planningTerminalOnly(embeddedTerminalManager, sessionId);
+    const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
     if (!allowed.ok) return allowed;
     return embeddedTerminalManager.close(sessionId);
   });

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -244,6 +244,8 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return { opened: false, reason: 'Planning terminals are not available in the web UI' };
       case 'invoker:planning-terminal-list':
         return [];
+      case 'invoker:planning-chat-set-terminal-mode':
+        return { ok: false, error: 'Planning tmux is not available in the web UI' };
       case 'invoker:planning-terminal-write':
       case 'invoker:planning-terminal-resize':
       case 'invoker:planning-terminal-close':


### PR DESCRIPTION
## Summary

Planning Surface Tmux Step 3 Persistence And Restart reconnects persisted planning terminal state during app startup.

The app now reattaches planning-owned terminal sessions and keeps terminal mode changes, output snapshots, and exit state synchronized.

## Review Claim

Approve the app-process routing that restores planning-owned tmux sessions and persists their live terminal state.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Restoration is limited to running planning sessions with stored terminal linkage, and write access remains owner-only and blocked after submission.

## Slice Rationale

This slice routes the stored state through the app process before the UI consumes restored sessions.

## Non-goals

- This does not alter the persisted schema introduced by the previous slice.
- This does not render restored terminal state in React.
- This does not change task-owned terminal behavior.

## Architecture

### Before

Startup restored planning chat sessions, while planning terminal sessions lived only in the current process lifetime.

### After

Startup restores planning chat sessions and recreates their running planning terminal descriptors before renderer hydration.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store test -- sqlite-adapter.test.ts`
- [x] `pnpm --filter @invoker/app test -- in-app-planner.test.ts`
- [x] `CAPTURE_VIDEO=1 pnpm --filter @invoker/ui build`
- [x] `CAPTURE_VIDEO=1 pnpm --filter @invoker/app build`
- [x] `CAPTURE_VIDEO=1 pnpm --filter @invoker/app test:e2e -- planning-terminal-restart-persistence.spec.ts`

</details>

## Visual Proof

Planning tmux restart walkthrough video: [planning tmux restart proof video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-81cfb2/planning-tmux-restart-proof.mp4)

The recording shows Add README in tmux mode before relaunch, then the same session restored directly into Planning tmux after relaunch.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, after reverting UI consumers that depend on this routing.
- Revert command: `git revert 2a9789dcad46246915577a76dc67de159f28336d`
- Post-revert steps: Revert the UI rehydration slice first if it has landed.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal mode switching for in-app planning chats, including chat and tmux modes.
  * Planning sessions now display and preserve terminal status, output, session details, and exit information.
  * Persisted planning terminals are restored when reopening eligible sessions.
  * Terminal actions are restricted for submitted or unauthorized planning sessions.
* **Bug Fixes**
  * Preserved planning terminal state and chat history consistently across updates and restores.
  * Added clear handling when tmux is unavailable in the web interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->