### PR TITLE
Fix Embedded Task Terminal Blank Rendering Step 2

### DIFF
--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -35,6 +35,7 @@ const xtermMock = vi.hoisted(() => {
       return { dispose: vi.fn() };
     });
     focus = vi.fn();
+    refresh = vi.fn();
     dispose = vi.fn();
 
     constructor() {
@@ -182,6 +183,12 @@ describe('Terminal drawer rendering regressions', () => {
     expect(screen.getByTestId('terminal-drawer-body')).toHaveStyle({ height: '280px' });
     expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
     await expectPaneReady('task-alpha');
+    await waitFor(() => {
+      expect(xtermMock.fitInstances[0]?.fit).toHaveBeenCalled();
+      expect(xtermMock.instances[0]?.refresh).toHaveBeenCalledWith(0, 23);
+    });
+    const partialFitCalls = xtermMock.fitInstances[0].fit.mock.calls.length;
+    const partialRefreshCalls = xtermMock.instances[0].refresh.mock.calls.length;
 
     rerender(<TerminalDrawer state="maximized" {...props} />);
     expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'maximized');
@@ -191,7 +198,8 @@ describe('Terminal drawer rendering regressions', () => {
     await expectPaneReady('task-alpha');
 
     await waitFor(() => {
-      expect(xtermMock.fitInstances[0]?.fit).toHaveBeenCalled();
+      expect(xtermMock.fitInstances[0].fit.mock.calls.length).toBeGreaterThan(partialFitCalls);
+      expect(xtermMock.instances[0].refresh.mock.calls.length).toBeGreaterThan(partialRefreshCalls);
       expect(xtermMock.instances[0]?.focus).toHaveBeenCalled();
     });
   });
@@ -214,6 +222,12 @@ describe('Terminal drawer rendering regressions', () => {
     expect(betaPane).toHaveStyle({ display: 'none' });
     expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
     expect(screen.getByTestId('terminal-tab-task-beta')).toHaveAttribute('data-active', 'false');
+    await waitFor(() => {
+      expect(betaPane.querySelector('.xterm')).not.toBeNull();
+      expect(xtermMock.fitInstances).toHaveLength(2);
+    });
+    const betaHiddenFitCalls = xtermMock.fitInstances[1].fit.mock.calls.length;
+    const betaHiddenRefreshCalls = xtermMock.instances[1].refresh.mock.calls.length;
 
     rerender(<TerminalDrawer {...props} activeSessionId={beta.sessionId} />);
     expect(alphaPane).not.toBeVisible();
@@ -221,6 +235,28 @@ describe('Terminal drawer rendering regressions', () => {
     await expectPaneReady('task-beta');
     expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'false');
     expect(screen.getByTestId('terminal-tab-task-beta')).toHaveAttribute('data-active', 'true');
+    await waitFor(() => {
+      expect(xtermMock.fitInstances[1].fit.mock.calls.length).toBeGreaterThan(betaHiddenFitCalls);
+      expect(xtermMock.instances[1].refresh.mock.calls.length).toBeGreaterThan(betaHiddenRefreshCalls);
+    });
+  });
+
+  it('fits restored terminal sessions on initial drawer mount', async () => {
+    const session = makeTerminalSession('task-alpha');
+    (mock.api.terminalList as ReturnType<typeof vi.fn>).mockResolvedValue([session]);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
+      expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
+    });
+    await expectPaneReady('task-alpha');
+    await waitFor(() => {
+      expect(xtermMock.fitInstances[0]?.fit).toHaveBeenCalled();
+      expect(xtermMock.instances[0]?.refresh).toHaveBeenCalledWith(0, 23);
+      expect(mock.api.terminalResize).toHaveBeenCalledWith(session.sessionId, 80, 24);
+    });
   });
 
   it('returns to an already-open terminal tab with the correct active pane', async () => {

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type { Terminal as XTermTerminal } from 'xterm';
 import type { FitAddon } from 'xterm-addon-fit';
 import 'xterm/css/xterm.css';
@@ -53,6 +53,7 @@ interface TerminalDrawerProps {
 interface TerminalSessionPaneProps {
   session: TerminalSessionDescriptor;
   isActive: boolean;
+  drawerState: TerminalDrawerState;
   hasHeader: boolean;
 }
 
@@ -127,11 +128,62 @@ function seedTerminalOutputSnapshot(
   }
 }
 
-function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPaneProps): JSX.Element {
+function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: TerminalSessionPaneProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<XTermTerminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const seededSnapshotRef = useRef<SeededOutputSnapshot | null>(null);
+  const isActiveRef = useRef(isActive);
+  const fitFrameRef = useRef<number | null>(null);
+  const secondFitFrameRef = useRef<number | null>(null);
+
+  isActiveRef.current = isActive;
+
+  const clearScheduledFit = useCallback(() => {
+    if (fitFrameRef.current !== null) {
+      if (typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(fitFrameRef.current);
+      }
+      fitFrameRef.current = null;
+    }
+    if (secondFitFrameRef.current !== null) {
+      if (typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(secondFitFrameRef.current);
+      }
+      secondFitFrameRef.current = null;
+    }
+  }, []);
+
+  const fitVisibleTerminal = useCallback(() => {
+    if (!isActiveRef.current) return;
+    const term = termRef.current;
+    const fit = fitRef.current;
+    if (!term || !fit) return;
+    try {
+      fit.fit();
+      if (term.rows > 0) {
+        term.refresh?.(0, term.rows - 1);
+      }
+      void terminalApi().terminalResize?.(session.sessionId, term.cols, term.rows);
+    } catch {
+      /* host has zero size, terminal disposed, or fit unsupported */
+    }
+  }, [session.sessionId]);
+
+  const scheduleFit = useCallback(() => {
+    clearScheduledFit();
+    fitVisibleTerminal();
+    if (typeof requestAnimationFrame !== 'function') return;
+
+    fitFrameRef.current = requestAnimationFrame(() => {
+      fitFrameRef.current = null;
+      fitVisibleTerminal();
+      secondFitFrameRef.current = requestAnimationFrame(() => {
+        secondFitFrameRef.current = null;
+        fitVisibleTerminal();
+      });
+    });
+  }, [clearScheduledFit, fitVisibleTerminal]);
 
   useEffect(() => {
     const host = containerRef.current;
@@ -188,27 +240,17 @@ function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPa
         }
       });
 
-      const tryFit = () => {
-        try {
-          fit.fit();
-          void terminalApi().terminalResize?.(session.sessionId, term.cols, term.rows);
-        } catch {
-          /* host has zero size or fit unsupported */
-        }
-      };
-
-      const raf = typeof requestAnimationFrame === 'function' ? requestAnimationFrame(tryFit) : null;
       let resizeObserver: ResizeObserver | null = null;
       if (typeof ResizeObserver !== 'undefined') {
         try {
-          resizeObserver = new ResizeObserver(tryFit);
+          resizeObserver = new ResizeObserver(fitVisibleTerminal);
           resizeObserver.observe(host);
         } catch {
           resizeObserver = null;
         }
       }
-      if (isActive) {
-        tryFit();
+      if (isActiveRef.current) {
+        scheduleFit();
         try {
           term.focus();
         } catch {
@@ -217,9 +259,7 @@ function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPa
       }
 
       cleanup = () => {
-        if (raf !== null && typeof cancelAnimationFrame === 'function') {
-          cancelAnimationFrame(raf);
-        }
+        clearScheduledFit();
         resizeObserver?.disconnect();
         inputDisposable.dispose();
         unsubscribeOutput?.();
@@ -237,7 +277,7 @@ function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPa
       disposed = true;
       cleanup?.();
     };
-  }, [session.sessionId]);
+  }, [clearScheduledFit, fitVisibleTerminal, scheduleFit, session.sessionId]);
 
   useEffect(() => {
     const term = termRef.current;
@@ -246,18 +286,19 @@ function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPa
   }, [session.outputSnapshot, session.sessionId]);
 
   useEffect(() => {
-    if (!isActive) return;
+    if (!isActive) {
+      clearScheduledFit();
+      return;
+    }
     const term = termRef.current;
-    const fit = fitRef.current;
-    if (!term || !fit) return;
+    if (!term) return;
     try {
-      fit.fit();
-      void terminalApi().terminalResize?.(session.sessionId, term.cols, term.rows);
+      scheduleFit();
       term.focus();
     } catch {
       /* fit failed */
     }
-  }, [isActive, session.sessionId]);
+  }, [drawerState, hasHeader, isActive, scheduleFit, session.sessionId]);
 
   return (
     <div
@@ -385,6 +426,7 @@ export function TerminalDrawer({
               key={session.sessionId}
               session={session}
               isActive={session.sessionId === activeSessionId}
+              drawerState={state}
               hasHeader={Boolean(session.sessionId === activeSessionId && activeCommand)}
             />
           ))}


### PR DESCRIPTION
## Summary

Fix Embedded Task Terminal Blank Rendering Step 2 — 2 tasks completed, 0 failed, 0 closed, 0 skipped

Active embedded task terminals could reopen with restored output but no measured xterm geometry.

This keeps the active pane fitted after output restore, tab activation, and drawer layout measurement so the terminal paints instead of staying blank.

## Review Claim

Approve that `TerminalDrawer` schedules fit and resize work when restored output, active-tab changes, or drawer measurements make the visible xterm pane paintable.

## Review Lane

behavior

## Review Unit

terminal-drawer-fit-lifecycle

## Safety Invariant

The PR diff against Step 1 is limited to `TerminalDrawer.tsx` and its focused drawer tests. It does not change task execution, session persistence, IPC payloads, or backend output delivery.

## Slice Rationale

Step 1 covered the broader blank-pane regression surface.

This slice changes only the active terminal fit path so review can stay local to xterm sizing and pane activation.

## Non-goals

- Does not change terminal session creation, closing, or output streaming.
- Does not change task execution, orchestration, or persistence.
- Does not change non-terminal drawer views.

## Visual Proof

The failure is a transition-sensitive xterm paint issue. Static screenshots do not prove the intermediate resize timing.

The deterministic drawer test restores terminal output, switches tabs, and asserts the active pane receives resize calls after layout settles.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/terminal-drawer.test.tsx` - 4 tests passed.
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp-pr-4276-body.md` - passed.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert fd7f9b68acdbf4156eddc20ca5fa81bf04d76460`
- Post-revert steps: None
- Data migration? No

</details>
