### PR TITLE
[Terminal Double-Click Step 3 - Snapshot Replay Guard](1) Seed each terminal snapshot once

### DIFF
--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -651,7 +651,7 @@ describe('Terminal drawer (component)', () => {
     });
   });
 
-  it('does not duplicate the replay snapshot when the same session re-renders', async () => {
+  it('does not duplicate the replay snapshot when a live mounted session receives an updated descriptor', async () => {
     const session = makeTerminalSession('task-alpha', {
       outputSnapshot: 'replayed once\n',
     });
@@ -670,18 +670,48 @@ describe('Terminal drawer (component)', () => {
       expect(xtermMock.writeLog).toEqual(['replayed once\n']);
     });
 
+    act(() => {
+      mock.fireTerminalOutput({
+        sessionId: session.sessionId,
+        taskId: session.taskId,
+        data: 'live line\n',
+      });
+    });
+    await waitFor(() => {
+      expect(xtermMock.writeLog).toEqual(['replayed once\n', 'live line\n']);
+    });
+
     rerender(
       <TerminalDrawer
         state="partial"
         onCycle={vi.fn()}
-        sessions={[{ ...session }]}
+        sessions={[{ ...session, outputSnapshot: 'replayed once\nlive line\n' }]}
         activeSessionId={session.sessionId}
         onSelectSession={vi.fn()}
         onCloseSession={vi.fn()}
       />,
     );
 
-    expect(xtermMock.writeLog).toEqual(['replayed once\n']);
+    expect(xtermMock.writeLog).toEqual(['replayed once\n', 'live line\n']);
+
+    const newSession = makeTerminalSession('task-alpha', {
+      sessionId: 'mock-session-task-alpha-restarted',
+      outputSnapshot: 'new session replay\n',
+    });
+    rerender(
+      <TerminalDrawer
+        state="partial"
+        onCycle={vi.fn()}
+        sessions={[newSession]}
+        activeSessionId={newSession.sessionId}
+        onSelectSession={vi.fn()}
+        onCloseSession={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(xtermMock.writeLog).toEqual(['replayed once\n', 'live line\n', 'new session replay\n']);
+    });
   });
 
   it('keeps live output, input, resize, close, and tab selection intact without a preview row', async () => {

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -52,7 +52,6 @@ interface TerminalSessionPaneProps {
 
 type SeededOutputSnapshot = {
   sessionId: string;
-  snapshot: string;
   term: XTermTerminal;
 };
 
@@ -85,37 +84,42 @@ function seedTerminalOutputSnapshot(
   const outputSnapshot = session.outputSnapshot;
   const seededSnapshot = seededSnapshotRef.current;
   if (
-    outputSnapshot &&
-    (
-      !seededSnapshot ||
-      seededSnapshot.sessionId !== session.sessionId ||
-      seededSnapshot.snapshot !== outputSnapshot ||
-      seededSnapshot.term !== term
-    )
+    seededSnapshot &&
+    seededSnapshot.sessionId === session.sessionId &&
+    seededSnapshot.term === term
   ) {
-    try {
-      const startedAt = nowMs();
-      term.write(outputSnapshot);
-      seededSnapshotRef.current = {
-        sessionId: session.sessionId,
-        snapshot: outputSnapshot,
-        term,
-      };
-      reportTerminalPerf('embedded_terminal_snapshot_write', {
-        source,
-        durationMs: roundMs(nowMs() - startedAt),
-        bytes: byteLength(outputSnapshot),
-        chars: outputSnapshot.length,
-        sessionId: session.sessionId,
-        taskId: session.taskId,
-        status: session.status,
-      });
-    } catch (err) {
-      console.warn(
-        `Failed to seed output snapshot for terminal session ${session.sessionId}:`,
-        err,
-      );
-    }
+    return;
+  }
+
+  if (!outputSnapshot) {
+    seededSnapshotRef.current = {
+      sessionId: session.sessionId,
+      term,
+    };
+    return;
+  }
+
+  try {
+    const startedAt = nowMs();
+    term.write(outputSnapshot);
+    seededSnapshotRef.current = {
+      sessionId: session.sessionId,
+      term,
+    };
+    reportTerminalPerf('embedded_terminal_snapshot_write', {
+      source,
+      durationMs: roundMs(nowMs() - startedAt),
+      bytes: byteLength(outputSnapshot),
+      chars: outputSnapshot.length,
+      sessionId: session.sessionId,
+      taskId: session.taskId,
+      status: session.status,
+    });
+  } catch (err) {
+    console.warn(
+      `Failed to seed output snapshot for terminal session ${session.sessionId}:`,
+      err,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Terminal Double-Click Step 3 - Snapshot Replay Guard — 2 tasks completed, 0 failed, 0 closed, 0 not-run.

Mounted terminal panes now write restored output once for the current session identity.

A refreshed session descriptor no longer replays the same saved lines over live terminal output.

Focused drawer coverage keeps a new terminal identity able to restore its saved output.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1783561720145-5/harden-terminal-snapshot-reseed | Keep mounted sessions from replaying the same saved lines when snapshots refresh. | completed |
| wf-1783561720145-5/verify-terminal-restart-persistence-regression | Run focused UI restart persistence checks. | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1783561720145-5/harden-terminal-snapshot-reseed

packages/ui/src/__tests__/terminal-drawer.test.tsx | 36 +++++++++++-
packages/ui/src/components/TerminalDrawer.tsx      | 66 ++++++++++++----------
2 files changed, 68 insertions(+), 34 deletions(-)

### wf-1783561720145-5/verify-terminal-restart-persistence-regression

No file changes. Checks ran on the final tree.

</details>

## Review Claim

Approve that TerminalDrawer writes restored output once for a mounted terminal session, so refreshed snapshots do not replay the same saved lines over live terminal output.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The slice stays inside TerminalDrawer snapshot seeding and its focused terminal-drawer coverage. It does not change terminal session creation, workflow execution, or persistence writes.

## Slice Rationale

Step 2 already opens the existing terminal tab from the task card. This follow-up slice isolates the next user-visible bug: a mounted session should restore saved output once while a new session identity can still restore its saved output.

## Non-goals

- Does not change how double-click picks or opens a terminal session.
- Does not change terminal session persistence shape.
- Does not change terminal styling, tab layout, or drawer controls.
- Does not change planning terminal chat behavior.

## Architecture

### Before

```mermaid
graph TD
    A["TerminalDrawer receives a session descriptor update"] --> B["Seed guard compares session, terminal, and snapshot text"]
    B --> C["Changed snapshot text writes the saved output into the mounted xterm again"]
```

### After

```mermaid
graph TD
    A["TerminalDrawer receives a session descriptor update"] --> B["Seed guard compares terminal identity and session identity"]
    B --> C["Mounted identity returns without another replay write"]
    B --> D["A new session identity writes restored output once"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/ui test -- terminal-drawer`

</details>

## Visual Proof

Animated restart proof: the terminal state survives relaunch, and the restored session shows the pre-restart output without a second replay block.

![Terminal restart walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-55e734/planning-terminal-restart.gif)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 86ad9966`
- Post-revert steps: Re-run the focused terminal drawer component test and restart persistence checks.
- Data migration? No

</details>
