### PR TITLE
[UI Responsiveness Guardrails Step 2](1) Add chat and terminal responsiveness guardrails

### DIFF
--- a/packages/app/e2e/embedded-terminal-pty.spec.ts
+++ b/packages/app/e2e/embedded-terminal-pty.spec.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import type { Page } from '@playwright/test';
 import {
   E2E_REPO_URL,
   expect,
@@ -7,6 +8,11 @@ import {
   loadPlan,
   test,
 } from './fixtures/electron-app.js';
+
+const TERMINAL_INPUT_BUDGET_MS = 100;
+const TERMINAL_OUTPUT_WRITE_BUDGET_MS = 250;
+const TERMINAL_RESIZE_BUDGET_MS = 250;
+const TERMINAL_TAB_SWITCH_WALL_BUDGET_MS = 1000;
 
 const CODEX_RESUME_PLAN = {
   name: 'Embedded PTY Resume',
@@ -51,6 +57,72 @@ const SCROLLBACK_PLAN = {
     },
   ],
 };
+
+const RESPONSIVE_TERMINAL_PLAN = {
+  name: 'Embedded PTY Responsiveness',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    {
+      id: 'terminal-pressure-alpha',
+      description: 'Terminal pressure alpha',
+      command: 'echo unused',
+      dependencies: [],
+    },
+    {
+      id: 'terminal-pressure-beta',
+      description: 'Terminal pressure beta',
+      command: 'echo unused',
+      dependencies: ['terminal-pressure-alpha'],
+    },
+  ],
+};
+
+function parseActivityPayload(message: string): Record<string, unknown> | null {
+  try {
+    return JSON.parse(message) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+async function activityLogWatermark(page: Page): Promise<number> {
+  const rows = await page.evaluate(async () => window.invoker.getActivityLogs(0, 100000));
+  return rows.at(-1)?.id ?? 0;
+}
+
+async function uiPerfPayloadsSince(page: Page, sinceId: number): Promise<Array<Record<string, unknown>>> {
+  const rows = await page.evaluate(async (watermark) => window.invoker.getActivityLogs(watermark, 5000), sinceId);
+  return rows
+    .filter((row) => row.source === 'ui-perf')
+    .map((row) => parseActivityPayload(row.message))
+    .filter((payload): payload is Record<string, unknown> => payload !== null);
+}
+
+async function resolveTaskId(page: Page, taskIdSuffix: string): Promise<string> {
+  const fullTaskId = await page.evaluate(async (suffix) => {
+    const result = await window.invoker.getTasks();
+    const tasks = Array.isArray(result) ? result : result.tasks;
+    return tasks.find((candidate: { id: string }) => candidate.id.endsWith(`/${suffix}`) || candidate.id.endsWith(suffix))?.id ?? null;
+  }, taskIdSuffix);
+  if (!fullTaskId) throw new Error(`${taskIdSuffix} was not loaded`);
+  return fullTaskId;
+}
+
+async function openTaskTerminalFromMiniDag(page: Page, taskIdSuffix: string): Promise<void> {
+  const taskNode = page
+    .getByTestId('selected-workflow-mini-dag')
+    .locator(`.react-flow__node[data-testid$="${taskIdSuffix}"]`)
+    .first();
+  const box = await taskNode.boundingBox();
+  if (!box) throw new Error(`${taskIdSuffix} task node has no bounding box`);
+  await taskNode.locator('> div').dispatchEvent('dblclick', {
+    bubbles: true,
+    cancelable: true,
+    clientX: box.x + box.width / 2,
+    clientY: box.y + box.height / 2,
+  });
+}
 
 test.describe('Embedded terminal PTY', () => {
   test('completed Codex resume terminal gets a real TTY in the drawer', async ({ page, testDir }) => {
@@ -257,5 +329,98 @@ test.describe('Embedded terminal PTY', () => {
       if (await firstLine.isVisible()) break;
     }
     await expect(firstLine).toBeVisible({ timeout: 10000 });
+  });
+
+  test('drawer interactions stay responsive while terminal output streams', async ({ page, testDir }) => {
+    await loadPlan(page, RESPONSIVE_TERMINAL_PLAN);
+    const alphaWorkspace = path.join(testDir, 'terminal-pressure-alpha-workspace');
+    const betaWorkspace = path.join(testDir, 'terminal-pressure-beta-workspace');
+    mkdirSync(alphaWorkspace, { recursive: true });
+    mkdirSync(betaWorkspace, { recursive: true });
+
+    await injectTaskStates(page, [
+      {
+        taskId: 'terminal-pressure-alpha',
+        changes: {
+          status: 'completed',
+          execution: {
+            workspacePath: alphaWorkspace,
+            completedAt: new Date('2025-01-01T00:00:00.000Z'),
+          },
+        },
+      },
+      {
+        taskId: 'terminal-pressure-beta',
+        changes: {
+          status: 'completed',
+          execution: {
+            workspacePath: betaWorkspace,
+            completedAt: new Date('2025-01-01T00:00:00.000Z'),
+          },
+        },
+      },
+    ]);
+
+    const fullAlphaTaskId = await resolveTaskId(page, 'terminal-pressure-alpha');
+    const fullBetaTaskId = await resolveTaskId(page, 'terminal-pressure-beta');
+    const watermark = await activityLogWatermark(page);
+
+    await openTaskTerminalFromMiniDag(page, 'terminal-pressure-alpha');
+    await expect(page.getByTestId('terminal-drawer-body')).toBeVisible({ timeout: 10000 });
+    const alphaPane = page.getByTestId(`terminal-pane-${fullAlphaTaskId}`);
+    await expect(alphaPane).toBeVisible();
+    await alphaPane.click();
+
+    await page.keyboard.type('for i in $(seq 1 140); do printf "term-live-%03d\\n" "$i"; done');
+    await page.keyboard.press('Enter');
+    await expect(alphaPane.getByText('term-live-140')).toBeVisible({ timeout: 10000 });
+
+    await openTaskTerminalFromMiniDag(page, 'terminal-pressure-beta');
+    await expect(page.getByTestId(`terminal-tab-${fullBetaTaskId}`)).toHaveAttribute('data-active', 'true', { timeout: 10000 });
+
+    const switchStartedAt = Date.now();
+    await page.getByRole('tab', { name: /Terminal pressure alpha/i }).click();
+    await expect(page.getByTestId(`terminal-tab-${fullAlphaTaskId}`)).toHaveAttribute('data-active', 'true');
+    const switchWallMs = Date.now() - switchStartedAt;
+    expect(switchWallMs).toBeLessThanOrEqual(TERMINAL_TAB_SWITCH_WALL_BUDGET_MS);
+
+    await page.getByRole('button', { name: 'Maximize terminal drawer' }).click();
+    await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'maximized');
+    const firstLine = alphaPane.getByText('term-live-001');
+    await expect(firstLine).not.toBeVisible();
+    await alphaPane.hover();
+    for (let index = 0; index < 12; index += 1) {
+      await page.mouse.wheel(0, -800);
+      if (await firstLine.isVisible()) break;
+    }
+    await expect(firstLine).toBeVisible({ timeout: 10000 });
+
+    await expect
+      .poll(async () => {
+        const payloads = await uiPerfPayloadsSince(page, watermark);
+        return payloads.filter((payload) => payload.metric === 'embedded_terminal_output_write').length;
+      }, { timeout: 5000 })
+      .toBeGreaterThan(0);
+
+    const payloads = await uiPerfPayloadsSince(page, watermark);
+    const attachPayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_attach');
+    const inputPayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_input');
+    const outputPayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_output_write');
+    const resizePayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_resize');
+    expect(attachPayloads.length).toBeGreaterThanOrEqual(2);
+    expect(inputPayloads.length).toBeGreaterThan(0);
+    expect(outputPayloads.length).toBeGreaterThan(0);
+    expect(resizePayloads.some((payload) => payload.source === 'active_session' && payload.taskId === fullAlphaTaskId)).toBe(true);
+    expect(Math.max(...inputPayloads.map((payload) => Number(payload.durationMs)))).toBeLessThanOrEqual(TERMINAL_INPUT_BUDGET_MS);
+    expect(Math.max(...outputPayloads.map((payload) => Number(payload.durationMs)))).toBeLessThanOrEqual(TERMINAL_OUTPUT_WRITE_BUDGET_MS);
+    expect(Math.max(...resizePayloads.map((payload) => Number(payload.durationMs)))).toBeLessThanOrEqual(TERMINAL_RESIZE_BUDGET_MS);
+
+    const perf = await page.evaluate(async () => window.invoker.getUiPerfStats());
+    expect(Number(perf.embeddedTerminalAttachReports)).toBeGreaterThanOrEqual(2);
+    expect(Number(perf.embeddedTerminalInputReports)).toBeGreaterThan(0);
+    expect(Number(perf.embeddedTerminalOutputWriteReports)).toBeGreaterThan(0);
+    expect(Number(perf.maxEmbeddedTerminalInputMs)).toBeLessThanOrEqual(TERMINAL_INPUT_BUDGET_MS);
+    expect(Number(perf.maxEmbeddedTerminalOutputWriteMs)).toBeLessThanOrEqual(TERMINAL_OUTPUT_WRITE_BUDGET_MS);
+    expect(Number(perf.maxEmbeddedTerminalResizeMs)).toBeLessThanOrEqual(TERMINAL_RESIZE_BUDGET_MS);
   });
 });

--- a/packages/app/e2e/embedded-terminal-spawn-failure.spec.ts
+++ b/packages/app/e2e/embedded-terminal-spawn-failure.spec.ts
@@ -71,5 +71,29 @@ test.describe('Embedded terminal spawn failure', () => {
     expect(dialogs[0]).toContain('Failed to start terminal session');
     expect(dialogs[0]).toContain('posix_spawnp failed');
     await expect(page.getByTestId('terminal-session-command')).toHaveCount(0);
+    await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
+    await expect(page.getByTestId('terminal-drawer-body')).toContainText('Open a terminal from a task to attach.');
+
+    await page.getByRole('button', { name: 'Maximize terminal drawer' }).click();
+    await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'maximized');
+    await page.getByRole('button', { name: 'Minimize terminal drawer' }).click();
+    await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'minimized');
+
+    const attachCount = await page.evaluate(async () => {
+      const rows = await window.invoker.getActivityLogs();
+      return rows
+        .filter((row) => row.source === 'ui-perf')
+        .map((row) => {
+          try {
+            return JSON.parse(row.message) as { metric?: string };
+          } catch {
+            return null;
+          }
+        })
+        .filter((payload): payload is { metric?: string } => payload !== null)
+        .filter((payload) => payload.metric === 'embedded_terminal_attach')
+        .length;
+    });
+    expect(attachCount).toBe(0);
   });
 });

--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -12,6 +12,10 @@ import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-re
 
 const repoRoot = resolveRepoRoot(__dirname);
 const STARTUP_BUDGET_MS = 12000;
+const PLANNING_PRESSURE_TURNS = 30;
+const PLANNING_INPUT_HANDLER_BUDGET_MS = 50;
+const PLANNING_INPUT_COMMIT_BUDGET_MS = 250;
+const PLANNING_INPUT_FILL_WALL_BUDGET_MS = 1500;
 
 async function launchElectronApp(testDir: string, extraEnv?: Record<string, string>) {
   const claudeMarker = path.join(repoRoot, 'scripts', 'e2e-dry-run', 'fixtures', 'claude-marker.sh');
@@ -70,6 +74,12 @@ function buildPlan(index: number) {
   };
 }
 
+function buildPlanningPressureReply(): string {
+  return Array.from({ length: 60 }, (_, index) => (
+    `planning pressure reply line ${String(index + 1).padStart(2, '0')} keeps realistic transcript output in the renderer.`
+  )).join('\n');
+}
+
 async function waitForWorkflowGraphVisible(page: Page, timeoutMs: number): Promise<number> {
   const startedAt = Date.now();
   await page.locator('[data-testid^="workflow-node-"]:visible').first().waitFor({
@@ -85,6 +95,19 @@ function parseActivityPayload(message: string): Record<string, unknown> | null {
   } catch {
     return null;
   }
+}
+
+async function activityLogWatermark(page: Page): Promise<number> {
+  const rows = await page.evaluate(async () => window.invoker.getActivityLogs(0, 100000));
+  return rows.at(-1)?.id ?? 0;
+}
+
+async function uiPerfPayloadsSince(page: Page, sinceId: number): Promise<Array<Record<string, unknown>>> {
+  const rows = await page.evaluate(async (watermark) => window.invoker.getActivityLogs(watermark, 5000), sinceId);
+  return rows
+    .filter((row) => row.source === 'ui-perf')
+    .map((row) => parseActivityPayload(row.message))
+    .filter((payload): payload is Record<string, unknown> => payload !== null);
 }
 
 async function dragGraphAndAssertViewportMoves(page: Page): Promise<void> {
@@ -205,6 +228,111 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
 
       expect(result.taskCount).toBe(expectedTaskCount);
       expect(result.perf.dbPollCreated).toBe(0);
+    } finally {
+      await app.close();
+    }
+  } finally {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});
+
+test('planning chat typing stays responsive with a large restored transcript', async () => {
+  const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-planning-chat-pressure-'));
+  try {
+    const app = await launchElectronApp(testDir, {
+      INVOKER_TEST_RESUME_PENDING_DELAY_MS: '15000',
+    });
+    try {
+      const page = await app.firstWindow({ timeout: STARTUP_BUDGET_MS });
+      await page.waitForLoadState('domcontentloaded');
+      await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10_000 });
+      await page.evaluate(async () => {
+        await window.invoker.clear();
+        await window.invoker.deleteAllWorkflows();
+      });
+
+      const planYaml = yamlStringify(buildPlan(901));
+      await page.evaluate(async ({ yaml, reply }) => {
+        await window.invoker.setTestPlanningChatResponse?.({
+          planYaml: yaml,
+          planName: 'Planning Pressure Plan',
+          reply,
+        });
+      }, { yaml: planYaml, reply: buildPlanningPressureReply() });
+
+      let sessionId: string | undefined;
+      for (let index = 0; index < PLANNING_PRESSURE_TURNS; index += 1) {
+        const response = await page.evaluate(async ({ currentSessionId, message }) => {
+          return window.invoker.planningChatSend({
+            ...(currentSessionId ? { sessionId: currentSessionId } : {}),
+            message,
+            presetKey: 'codex',
+          });
+        }, {
+          currentSessionId: sessionId,
+          message: `pressure request ${index + 1}`,
+        });
+        expect(response.ok).toBe(true);
+        if (!response.ok) throw new Error(response.error);
+        sessionId = response.sessionId;
+      }
+      expect(sessionId).toBeTruthy();
+
+      await page.reload();
+      await page.waitForLoadState('domcontentloaded');
+      await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10_000 });
+      await page.getByTestId('sidebar-planning').click();
+      await expect(page.getByTestId('invoker-terminal-input')).toBeVisible({ timeout: 10000 });
+      await expect(page.getByTestId('invoker-terminal-transcript')).toContainText(
+        `pressure request ${PLANNING_PRESSURE_TURNS}`,
+        { timeout: 10000 },
+      );
+      await expect
+        .poll(async () => {
+          const payloads = await uiPerfPayloadsSince(page, 0);
+          return payloads.some((payload) =>
+            payload.metric === 'planning_chat_transcript_commit'
+            && Number(payload.lineCount) >= PLANNING_PRESSURE_TURNS * 2,
+          );
+        }, { timeout: 5000 })
+        .toBe(true);
+
+      const watermark = await activityLogWatermark(page);
+      const typedText = 'keep typing responsive while the transcript is large';
+      const fillStartedAt = Date.now();
+      await page.getByTestId('invoker-terminal-input').fill(typedText);
+      await expect(page.getByTestId('invoker-terminal-input')).toHaveValue(typedText);
+      const fillWallMs = Date.now() - fillStartedAt;
+
+      await expect
+        .poll(async () => {
+          const payloads = await uiPerfPayloadsSince(page, watermark);
+          return payloads.some((payload) =>
+            payload.metric === 'planning_chat_input_commit'
+            && payload.valueLength === typedText.length
+            && Number(payload.transcriptLineCount) >= PLANNING_PRESSURE_TURNS * 2,
+          );
+        }, { timeout: 5000 })
+        .toBe(true);
+
+      const payloads = await uiPerfPayloadsSince(page, watermark);
+      const inputChange = payloads.find((payload) => payload.metric === 'planning_chat_input_change' && payload.valueLength === typedText.length);
+      const inputCommit = payloads.find((payload) => payload.metric === 'planning_chat_input_commit' && payload.valueLength === typedText.length);
+      expect(inputChange).toBeTruthy();
+      expect(inputCommit).toBeTruthy();
+      expect(Number(inputChange?.handlerDurationMs)).toBeLessThanOrEqual(PLANNING_INPUT_HANDLER_BUDGET_MS);
+      expect(Number(inputCommit?.durationMs)).toBeLessThanOrEqual(PLANNING_INPUT_COMMIT_BUDGET_MS);
+      expect(Number(inputCommit?.transcriptLineCount)).toBeGreaterThanOrEqual(PLANNING_PRESSURE_TURNS * 2);
+      expect(fillWallMs).toBeLessThanOrEqual(PLANNING_INPUT_FILL_WALL_BUDGET_MS);
+      expect(payloads.some((payload) => payload.metric === 'planning_chat_transcript_commit')).toBe(false);
+      expect(payloads.some((payload) => payload.metric === 'renderer_long_task')).toBe(false);
+
+      const perf = await page.evaluate(async () => window.invoker.getUiPerfStats());
+      expect(Number(perf.planningChatInputChangeReports)).toBeGreaterThanOrEqual(1);
+      expect(Number(perf.planningChatInputCommitReports)).toBeGreaterThanOrEqual(1);
+      expect(Number(perf.maxPlanningChatInputHandlerMs)).toBeLessThanOrEqual(PLANNING_INPUT_HANDLER_BUDGET_MS);
+      expect(Number(perf.maxPlanningChatInputCommitMs)).toBeLessThanOrEqual(PLANNING_INPUT_COMMIT_BUDGET_MS);
+      expect(Number(perf.maxPlanningChatTranscriptLines)).toBeGreaterThanOrEqual(PLANNING_PRESSURE_TURNS * 2);
     } finally {
       await app.close();
     }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -170,6 +170,21 @@ function makeInitialPlanningSession(now: string = new Date().toISOString()): Pla
   };
 }
 
+function planningSessionSummaryToView(session: InAppPlanningSessionSummary): PlanningSessionView {
+  return {
+    ...session,
+    messages: session.messages.map((line) => ({
+      id: line.id,
+      text: line.text,
+      role: line.role,
+      ...(line.tone ? { tone: line.tone } : {}),
+    })),
+    input: '',
+    busy: false,
+    conversationKey: session.id,
+  };
+}
+
 function planningNeedsAttention(status: InAppPlanningSessionStatus): boolean {
   return status === 'waiting_for_answer' || status === 'draft_ready';
 }
@@ -597,6 +612,7 @@ export function App() {
   const [planName, setPlanName] = useState<string | null>(null);
   const [planningSessions, setPlanningSessions] = useState<PlanningSessionView[]>(() => [makeInitialPlanningSession()]);
   const [activePlanningSessionId, setActivePlanningSessionId] = useState('local-planning-session-1');
+  const planningSessionsRef = useRef(planningSessions);
   const nextPlanningSessionLocalIdRef = useRef(2);
   const nextTerminalLineIdRef = useRef(1);
   const [planningPresetOptions, setPlanningPresetOptions] = useState<Array<{ key: string; label: string; isDefault?: boolean }>>([]);
@@ -619,6 +635,10 @@ export function App() {
   const activePlanningTerminalSession = activePlanningSession.terminalSession ?? null;
   const activePlanningTerminalBusy = Boolean(activePlanningSession.terminalBusy);
   const activePlanningTerminalError = activePlanningSession.terminalError ?? null;
+
+  useEffect(() => {
+    planningSessionsRef.current = planningSessions;
+  }, [planningSessions]);
   const [graphMaximized, setGraphMaximized] = useState(false);
   const { theme, toggleTheme } = useTheme();
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
@@ -740,9 +760,36 @@ export function App() {
       .catch(() => {
         setPlanningPresetOptions([{ key: 'codex', label: 'Codex', isDefault: true }]);
         setSelectedPlanningPresetKey('codex');
-      });
+    });
     refreshSystemDiagnostics();
   }, [refreshSystemDiagnostics]);
+
+  useEffect(() => {
+    let cancelled = false;
+    window.invoker?.planningChatList?.()
+      .then((response) => {
+        if (cancelled || !response.ok || response.sessions.length === 0) return;
+        const currentSessions = planningSessionsRef.current;
+        const first = currentSessions[0];
+        const onlyInitialPlaceholder = currentSessions.length === 1
+          && first?.id === 'local-planning-session-1'
+          && first.input === ''
+          && first.messages.every((line) => line.role === 'system');
+        if (!onlyInitialPlaceholder) return;
+        const restored = response.sessions.map(planningSessionSummaryToView);
+        const maxLineId = restored.reduce((max, session) => (
+          Math.max(max, ...session.messages.map((line) => line.id))
+        ), 1);
+        nextTerminalLineIdRef.current = Math.max(nextTerminalLineIdRef.current, maxLineId + 1);
+        setPlanningSessions(restored);
+        setActivePlanningSessionId(restored[0]?.id ?? 'local-planning-session-1');
+        setSelectedPlanningPresetKey((current) => current || restored[0]?.presetKey || current);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     window.invoker?.terminalList?.().then((list) => {

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { vi } from 'vitest';
-import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import { useState } from 'react';
+import { createMockInvoker, makePlanningSessionSummary, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { WorkflowMeta } from '../types.js';
 
 vi.mock('@xyflow/react', async () => {
@@ -13,6 +14,9 @@ vi.mock('@xyflow/react', async () => {
 // Dynamic imports are required so modules see the hoisted @xyflow/react mock.
 const { App } = await import('../App.js');
 const { InvokerTerminal } = await import('../components/InvokerTerminal.js');
+
+const COMPONENT_INPUT_HANDLER_BUDGET_MS = 16;
+const COMPONENT_INPUT_COMMIT_BUDGET_MS = 50;
 
 describe('Invoker terminal (component)', () => {
   let mock: MockInvoker;
@@ -69,6 +73,14 @@ describe('Invoker terminal (component)', () => {
     expect(screen.getByTestId('invoker-terminal-input')).toBeEnabled();
   });
 
+  function lastPerfPayload(metric: string): Record<string, any> {
+    const payload = vi.mocked(mock.api.reportUiPerf).mock.calls
+      .filter(([name]) => name === metric)
+      .map(([, data]) => data as Record<string, any>)
+      .at(-1);
+    if (!payload) throw new Error(`Missing ${metric} perf payload`);
+    return payload;
+  }
   it('generates a planning reply from plain language', async () => {
     render(<App />);
     await openPlanningTerminal();
@@ -190,6 +202,120 @@ describe('Invoker terminal (component)', () => {
           lastLineRole: 'assistant',
         }),
       );
+    });
+  });
+
+  it('keeps typing responsive under a large existing transcript', async () => {
+    const largeTranscript = Array.from({ length: 360 }, (_, index) => ({
+      id: index + 1,
+      text: `pressure transcript line ${index + 1}: ${'renderer output '.repeat(12)}`,
+      role: index % 2 === 0 ? 'user' as const : 'assistant' as const,
+    }));
+
+    function Harness(): JSX.Element {
+      const [value, setValue] = useState('');
+      return (
+        <InvokerTerminal
+          activeConversationKey="large-chat"
+          lines={largeTranscript}
+          busy={false}
+          value={value}
+          selectedPresetKey="codex"
+          presetOptions={[{ key: 'codex', label: 'Codex' }]}
+          draftPlanAvailable={false}
+          onValueChange={setValue}
+          onSubmit={vi.fn()}
+          onSubmitDraft={vi.fn()}
+          onPresetChange={vi.fn()}
+          onExpand={vi.fn()}
+        />
+      );
+    }
+
+    render(<Harness />);
+    vi.mocked(mock.api.reportUiPerf).mockClear();
+
+    const nextValue = 'tighten terminal responsiveness assertions';
+    const input = screen.getByTestId('invoker-terminal-input');
+    fireEvent.change(input, { target: { value: nextValue } });
+
+    await waitFor(() => expect(input).toHaveValue(nextValue));
+    await waitFor(() => {
+      expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+        'planning_chat_input_commit',
+        expect.objectContaining({
+          valueLength: nextValue.length,
+          previousValueLength: 0,
+          conversationKey: 'large-chat',
+          transcriptLineCount: largeTranscript.length,
+        }),
+      );
+    });
+
+    const changePayload = lastPerfPayload('planning_chat_input_change');
+    expect(changePayload.handlerDurationMs).toBeLessThanOrEqual(COMPONENT_INPUT_HANDLER_BUDGET_MS);
+    expect(changePayload.transcriptLineCount).toBe(largeTranscript.length);
+
+    const commitPayload = lastPerfPayload('planning_chat_input_commit');
+    expect(commitPayload.durationMs).toBeLessThanOrEqual(COMPONENT_INPUT_COMMIT_BUDGET_MS);
+    expect(commitPayload.transcriptLineCount).toBe(largeTranscript.length);
+
+    const transcriptCommitsAfterTyping = vi.mocked(mock.api.reportUiPerf).mock.calls
+      .filter(([metric]) => metric === 'planning_chat_transcript_commit');
+    expect(transcriptCommitsAfterTyping).toHaveLength(0);
+  });
+
+  it('hydrates restored planning chats and keeps the restored session editable', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'saved-pressure-chat',
+          title: 'Saved pressure chat',
+          status: 'still_discussing',
+          presetKey: 'codex',
+          messages: [
+            {
+              id: 1,
+              role: 'system',
+              text: 'Ask Invoker what you want to build.',
+              tone: 'muted',
+              createdAt: '2026-07-07T00:00:00.000Z',
+            },
+            {
+              id: 2,
+              role: 'user',
+              text: 'Keep this restored transcript editable',
+              createdAt: '2026-07-07T00:00:01.000Z',
+            },
+            {
+              id: 3,
+              role: 'assistant',
+              text: 'The restored transcript is ready.',
+              createdAt: '2026-07-07T00:00:02.000Z',
+            },
+          ],
+          draftPlanAvailable: false,
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('The restored transcript is ready.');
+    });
+    expect(screen.getByTestId('invoker-terminal-input')).toBeEnabled();
+
+    submitPlanningText('continue the restored session');
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        sessionId: 'saved-pressure-chat',
+        message: 'continue the restored session',
+        presetKey: 'codex',
+      });
     });
   });
 

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -594,6 +594,7 @@ describe('Terminal drawer (component)', () => {
 
     render(<Harness />);
     await waitFor(() => expect(xtermMock.instances).toHaveLength(2));
+    const initialWriteCount = xtermMock.writeLog.length;
     vi.mocked(mock.api.reportUiPerf).mockClear();
 
     act(() => {
@@ -606,7 +607,7 @@ describe('Terminal drawer (component)', () => {
       }
     });
 
-    await waitFor(() => expect(xtermMock.writeLog).toHaveLength(80));
+    await waitFor(() => expect(xtermMock.writeLog).toHaveLength(initialWriteCount + 80));
     expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
 
     fireEvent.click(screen.getByRole('tab', { name: /Beta description/i }));

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -12,6 +12,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
+import { useState } from 'react';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { WorkflowMeta } from '../types.js';
 import type { TerminalSessionDescriptor } from '@invoker/contracts';
@@ -86,6 +87,8 @@ vi.mock('xterm-addon-fit', () => ({ FitAddon: xtermMock.FitAddon }));
 
 const { App } = await import('../App.js');
 const { TerminalDrawer } = await import('../components/TerminalDrawer.js');
+
+const COMPONENT_TERMINAL_INTERACTION_BUDGET_MS = 50;
 
 const workflows: WorkflowMeta[] = [{ id: 'wf-a', name: 'Workflow A', status: 'completed' }];
 const taskAlpha = makeUITask({
@@ -555,6 +558,92 @@ describe('Terminal drawer (component)', () => {
           sessionId: session.sessionId,
           taskId: session.taskId,
           bytes: 'live line\n'.length,
+          active: true,
+        }),
+      );
+    });
+  });
+
+  it('keeps live output, input, and tab switching responsive under terminal pressure', async () => {
+    const alpha = makeTerminalSession('task-alpha', {
+      command: 'sh',
+      args: ['-lc', 'alpha'],
+    });
+    const beta = makeTerminalSession('task-beta', {
+      command: 'sh',
+      args: ['-lc', 'beta'],
+    });
+
+    function Harness(): JSX.Element {
+      const [activeSessionId, setActiveSessionId] = useState(alpha.sessionId);
+      return (
+        <TerminalDrawer
+          state="partial"
+          onCycle={vi.fn()}
+          sessions={[alpha, beta]}
+          activeSessionId={activeSessionId}
+          onSelectSession={setActiveSessionId}
+          onCloseSession={vi.fn()}
+          taskLabels={new Map([
+            [alpha.taskId, 'Alpha description'],
+            [beta.taskId, 'Beta description'],
+          ])}
+        />
+      );
+    }
+
+    render(<Harness />);
+    await waitFor(() => expect(xtermMock.instances).toHaveLength(2));
+    vi.mocked(mock.api.reportUiPerf).mockClear();
+
+    act(() => {
+      for (let index = 0; index < 80; index += 1) {
+        mock.fireTerminalOutput({
+          sessionId: alpha.sessionId,
+          taskId: alpha.taskId,
+          data: `alpha pressure output ${index}\n`,
+        });
+      }
+    });
+
+    await waitFor(() => expect(xtermMock.writeLog).toHaveLength(80));
+    expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
+
+    fireEvent.click(screen.getByRole('tab', { name: /Beta description/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-tab-task-beta')).toHaveAttribute('data-active', 'true');
+    });
+
+    act(() => {
+      xtermMock.instances[1]?.emitData('printf beta\n');
+    });
+    expect(mock.api.terminalWrite).toHaveBeenCalledWith(beta.sessionId, 'printf beta\n');
+
+    const outputPayloads = vi.mocked(mock.api.reportUiPerf).mock.calls
+      .filter(([metric]) => metric === 'embedded_terminal_output_write')
+      .map(([, data]) => data as Record<string, any>);
+    expect(outputPayloads).toHaveLength(80);
+    expect(Math.max(...outputPayloads.map((payload) => payload.durationMs))).toBeLessThanOrEqual(COMPONENT_TERMINAL_INTERACTION_BUDGET_MS);
+    expect(outputPayloads.every((payload) => payload.active === true)).toBe(true);
+
+    const inputPayload = vi.mocked(mock.api.reportUiPerf).mock.calls
+      .filter(([metric]) => metric === 'embedded_terminal_input')
+      .map(([, data]) => data as Record<string, any>)
+      .at(-1);
+    expect(inputPayload).toEqual(expect.objectContaining({
+      sessionId: beta.sessionId,
+      taskId: beta.taskId,
+      active: true,
+    }));
+    expect(inputPayload?.durationMs).toBeLessThanOrEqual(COMPONENT_TERMINAL_INTERACTION_BUDGET_MS);
+
+    await waitFor(() => {
+      expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+        'embedded_terminal_resize',
+        expect.objectContaining({
+          source: 'active_session',
+          sessionId: beta.sessionId,
+          taskId: beta.taskId,
           active: true,
         }),
       );

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ChangeEvent, type FormEvent, type KeyboardEvent } from 'react';
+import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState, type ChangeEvent, type FormEvent, type KeyboardEvent } from 'react';
 import { Terminal as XTermTerminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import type { TerminalSessionDescriptor } from '@invoker/contracts';

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -147,33 +147,43 @@ function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: Term
     }
   }, []);
 
-  const fitVisibleTerminal = useCallback(() => {
+  const fitVisibleTerminal = useCallback((source: 'active_session' | 'resize_observer' | 'followup_frame') => {
     if (!isActiveRef.current) return;
     const term = termRef.current;
     const fit = fitRef.current;
     if (!term || !fit) return;
     try {
+      const startedAt = nowMs();
       fit.fit();
       if (term.rows > 0) {
         term.refresh?.(0, term.rows - 1);
       }
       void window.invoker?.terminalResize?.(session.sessionId, term.cols, term.rows);
+      reportTerminalPerf('embedded_terminal_resize', {
+        source,
+        durationMs: roundMs(nowMs() - startedAt),
+        sessionId: session.sessionId,
+        taskId: session.taskId,
+        cols: term.cols,
+        rows: term.rows,
+        active: isActiveRef.current,
+      });
     } catch {
       /* host has zero size, terminal disposed, or fit unsupported */
     }
-  }, [session.sessionId]);
+  }, [session.sessionId, session.taskId]);
 
-  const scheduleFit = useCallback(() => {
+  const scheduleFit = useCallback((source: 'active_session' | 'resize_observer') => {
     clearScheduledFit();
-    fitVisibleTerminal();
+    fitVisibleTerminal(source);
     if (typeof requestAnimationFrame !== 'function') return;
 
     fitFrameRef.current = requestAnimationFrame(() => {
       fitFrameRef.current = null;
-      fitVisibleTerminal();
+      fitVisibleTerminal('followup_frame');
       secondFitFrameRef.current = requestAnimationFrame(() => {
         secondFitFrameRef.current = null;
-        fitVisibleTerminal();
+        fitVisibleTerminal('followup_frame');
       });
     });
   }, [clearScheduledFit, fitVisibleTerminal]);
@@ -253,14 +263,14 @@ function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: Term
     let resizeObserver: ResizeObserver | null = null;
     if (typeof ResizeObserver !== 'undefined') {
       try {
-        resizeObserver = new ResizeObserver(fitVisibleTerminal);
+        resizeObserver = new ResizeObserver(() => scheduleFit('resize_observer'));
         resizeObserver.observe(host);
       } catch {
         resizeObserver = null;
       }
     }
     if (isActiveRef.current) {
-      scheduleFit();
+      scheduleFit('active_session');
       try {
         term.focus();
       } catch {
@@ -297,7 +307,7 @@ function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: Term
     const term = termRef.current;
     if (!term) return;
     try {
-      scheduleFit();
+      scheduleFit('active_session');
       term.focus();
     } catch {
       /* fit failed (e.g., hidden) */


### PR DESCRIPTION
## Summary

UI Responsiveness Guardrails Step 2 - 2 tasks completed, 0 failed, 0 closed, 0 bypassed

This adds direct guardrails for chat typing and embedded terminal interactions under pressure.

It keeps the checks in the existing renderer and Electron suites.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1783387742385-17/add-interactive-chat-and-terminal-regressions | Planning-chat typing and embedded-terminal interactions stay responsive under realistic transcript and output pressure. | completed |
| wf-1783387742385-17/verify-interactive-chat-and-terminal-regressions | The chat and terminal responsiveness slice passes the repo's existing UI and Electron test runners. | completed (passed) |

</details>

## Review Claim

Planning-chat typing and embedded-terminal interactions stay responsive under realistic transcript and output pressure.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The slice extends existing UI component and Electron E2E coverage and keeps production changes local to the planning chat and terminal path.

## Slice Rationale

The reported freeze is an interaction problem, so this slice covers typing, opening, tab switching, scrollback, live output, and drawer controls on the surfaces users touch.

## Non-goals

- It does not redesign the planning terminal, terminal drawer, or task graph.
- It does not add a separate performance harness or logging system.
- It does not change workflow execution semantics.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test`
- [x] `pnpm --filter @invoker/app test:e2e`

</details>

## Visual Proof

![Planning chat remains usable with a restored draft ready for submission.](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-beb614/planning-terminal-restore-after.png)

![Embedded terminal drawer remains usable while a completed resume session is open.](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-beb614/completed-ssh-terminal-resume.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f2656c37`
- Post-revert steps: None
- Data migration? No

</details>
