### PR TITLE
[Recovery Lifecycle 2i Step 4: External worker plugin loader](1) Batch app-suite fixture seeding

### DIFF
--- a/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
+++ b/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
@@ -59,28 +59,30 @@ describe('main-process read hot-path cost guards', () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'invoker-hotpath-'));
     adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
 
-    adapter.saveWorkflow(makeWorkflow('wf-fat', 'Fat events'));
-
     const taskCount = 40;
     const eventsPerTask = 250; // 10k events total
-    for (let t = 0; t < taskCount; t += 1) {
-      const taskId = `wf-fat/t${t}`;
-      adapter.saveTask('wf-fat', makeTask(taskId));
-      for (let e = 0; e < eventsPerTask; e += 1) {
-        const action = e % 4 === 0 ? 'wakeup'
-          : e % 4 === 1 ? 'scan'
-            : e % 4 === 2 ? 'submit'
-              : 'skip';
-        adapter.logEvent(
-          taskId,
-          recoveryWorkerEventType(action),
-          buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
-            workflowId: 'wf-fat',
-            reason: action === 'skip' ? 'budget' : undefined,
-          }),
-        );
+    adapter.runInTransaction(() => {
+      adapter.saveWorkflow(makeWorkflow('wf-fat', 'Fat events'));
+
+      for (let t = 0; t < taskCount; t += 1) {
+        const taskId = `wf-fat/t${t}`;
+        adapter.saveTask('wf-fat', makeTask(taskId));
+        for (let e = 0; e < eventsPerTask; e += 1) {
+          const action = e % 4 === 0 ? 'wakeup'
+            : e % 4 === 1 ? 'scan'
+              : e % 4 === 2 ? 'submit'
+                : 'skip';
+          adapter.logEvent(
+            taskId,
+            recoveryWorkerEventType(action),
+            buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
+              workflowId: 'wf-fat',
+              reason: action === 'skip' ? 'budget' : undefined,
+            }),
+          );
+        }
       }
-    }
+    });
 
     const getEvents = vi.spyOn(adapter, 'getEvents');
     const started = Date.now();

--- a/packages/app/src/main-process-hitch-fixture.ts
+++ b/packages/app/src/main-process-hitch-fixture.ts
@@ -54,59 +54,61 @@ function makeTask(id: string): TaskState {
 }
 
 export function seedMainProcessHitchFixture(
-  persistence: Pick<SQLiteAdapter, 'saveWorkflow' | 'saveTask' | 'logEvent' | 'upsertWorkerAction'>,
+  persistence: Pick<SQLiteAdapter, 'saveWorkflow' | 'saveTask' | 'logEvent' | 'upsertWorkerAction' | 'runInTransaction'>,
   options: MainProcessHitchFixtureOptions = {},
 ): MainProcessHitchFixtureResult {
   const taskCount = options.taskCount ?? DEFAULT_TASK_COUNT;
   const eventsPerTask = options.eventsPerTask ?? DEFAULT_EVENTS_PER_TASK;
   const actionsPerKind = options.actionsPerKind ?? DEFAULT_ACTIONS_PER_KIND;
   const workflowId = MAIN_PROCESS_HITCH_FIXTURE_WORKFLOW_ID;
-
-  persistence.saveWorkflow(makeWorkflow(workflowId, 'Main-process hitch fixture'));
-
-  for (let t = 0; t < taskCount; t += 1) {
-    const taskId = `${workflowId}/t${t}`;
-    persistence.saveTask(workflowId, makeTask(taskId));
-    for (let e = 0; e < eventsPerTask; e += 1) {
-      const action = e % 4 === 0 ? 'wakeup'
-        : e % 4 === 1 ? 'scan'
-          : e % 4 === 2 ? 'submit'
-            : 'skip';
-      persistence.logEvent(
-        taskId,
-        recoveryWorkerEventType(action),
-        buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
-          workflowId,
-          reason: action === 'skip' ? 'budget' : undefined,
-        }),
-      );
-    }
-  }
-
   let workerActionCount = 0;
-  for (const workerKind of ACTION_WORKER_KINDS) {
-    for (let i = 0; i < actionsPerKind; i += 1) {
-      const taskId = `${workflowId}/t${i % Math.max(taskCount, 1)}`;
-      const write: WorkerActionWrite = {
-        id: `wa-hitch-${workerKind}-${i}`,
-        workerKind,
-        actionType: 'hitch-fixture',
-        workflowId,
-        taskId,
-        subjectType: 'task',
-        subjectId: taskId,
-        externalKey: `hitch:${workerKind}:${i}`,
-        status: i % 5 === 0 ? 'skipped' : 'completed',
-        attemptCount: 1,
-        summary: `Hitch fixture ${workerKind} ${i}`,
-        payload: { reason: i % 5 === 0 ? 'budget' : 'ok' },
-        createdAt: `2026-07-01T00:00:${String(i % 60).padStart(2, '0')}.000Z`,
-        updatedAt: `2026-07-01T00:01:${String(i % 60).padStart(2, '0')}.000Z`,
-      };
-      persistence.upsertWorkerAction(write);
-      workerActionCount += 1;
+
+  persistence.runInTransaction(() => {
+    persistence.saveWorkflow(makeWorkflow(workflowId, 'Main-process hitch fixture'));
+
+    for (let t = 0; t < taskCount; t += 1) {
+      const taskId = `${workflowId}/t${t}`;
+      persistence.saveTask(workflowId, makeTask(taskId));
+      for (let e = 0; e < eventsPerTask; e += 1) {
+        const action = e % 4 === 0 ? 'wakeup'
+          : e % 4 === 1 ? 'scan'
+            : e % 4 === 2 ? 'submit'
+              : 'skip';
+        persistence.logEvent(
+          taskId,
+          recoveryWorkerEventType(action),
+          buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
+            workflowId,
+            reason: action === 'skip' ? 'budget' : undefined,
+          }),
+        );
+      }
     }
-  }
+
+    for (const workerKind of ACTION_WORKER_KINDS) {
+      for (let i = 0; i < actionsPerKind; i += 1) {
+        const taskId = `${workflowId}/t${i % Math.max(taskCount, 1)}`;
+        const write: WorkerActionWrite = {
+          id: `wa-hitch-${workerKind}-${i}`,
+          workerKind,
+          actionType: 'hitch-fixture',
+          workflowId,
+          taskId,
+          subjectType: 'task',
+          subjectId: taskId,
+          externalKey: `hitch:${workerKind}:${i}`,
+          status: i % 5 === 0 ? 'skipped' : 'completed',
+          attemptCount: 1,
+          summary: `Hitch fixture ${workerKind} ${i}`,
+          payload: { reason: i % 5 === 0 ? 'budget' : 'ok' },
+          createdAt: `2026-07-01T00:00:${String(i % 60).padStart(2, '0')}.000Z`,
+          updatedAt: `2026-07-01T00:01:${String(i % 60).padStart(2, '0')}.000Z`,
+        };
+        persistence.upsertWorkerAction(write);
+        workerActionCount += 1;
+      }
+    }
+  });
 
   return {
     workflowId,


### PR DESCRIPTION
## Summary

Main-process hitch fixtures now seed their fat workflow data inside one SQLite transaction.

This keeps the app suite from spending review time on repeated setup writes while exercising the same fixture contents.

## Review Claim

The main-process hitch fixture seeds the same workflow data in one SQLite transaction.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The transaction wraps only test fixture seeding; it does not change queried rows or production launch behavior.

## Slice Rationale

This support slice keeps the external-worker app-suite gate practical without mixing with the worker-door lifecycle proof.

## Non-goals

This slice does not change external-worker runtime behavior.

It does not change main-process read cost assertions or query behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/external-worker-e2e.test.ts src/__tests__/main-process-read-hotpath-cost.test.ts`
- [x] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5c5095fc`
- Post-revert steps: None
- Data migration? No

</details>
