### PR TITLE
[Recovery Lifecycle 2i Step 4: External worker plugin loader](2) Prove worker-door lifecycle

### DIFF
--- a/packages/app/src/__tests__/external-worker-e2e.test.ts
+++ b/packages/app/src/__tests__/external-worker-e2e.test.ts
@@ -5,12 +5,12 @@ import { fileURLToPath } from 'node:url';
 
 import {
   createWorkerRegistry,
-  type ExternalWorkerRuntime,
   type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { registerExternalWorkersFromConfig } from '../external-worker-loader.js';
+import { createWorkerRuntimeController } from '../worker-control.js';
 
 const fixturePath = fileURLToPath(new URL('./fixtures/sample-external-worker.mjs', import.meta.url));
 
@@ -34,6 +34,15 @@ const deps: WorkerRuntimeDependencies = {
   },
 };
 
+const persistence = {
+  listWorkerActions: () => [],
+  listWorkflows: () => [],
+  loadTasks: () => [],
+  getEvents: () => [],
+  getEventsByTypes: () => [],
+  countEventsByTypes: () => [],
+};
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -47,13 +56,12 @@ async function waitFor(condition: () => boolean, message: string): Promise<void>
   throw new Error(message);
 }
 
-function isExternalWorkerRuntime(worker: unknown): worker is ExternalWorkerRuntime {
-  return Boolean(
-    worker
-      && typeof worker === 'object'
-      && 'finished' in worker
-      && (worker as { finished?: unknown }).finished instanceof Promise,
-  );
+function readMarker(markerPath: string): { pid?: number; started?: boolean; stopped?: boolean } {
+  return JSON.parse(readFileSync(markerPath, 'utf8')) as {
+    pid?: number;
+    started?: boolean;
+    stopped?: boolean;
+  };
 }
 
 describe('external worker e2e', () => {
@@ -79,31 +87,43 @@ describe('external worker e2e', () => {
           cwd: scratchDir,
         },
       }],
-      createWorkerRegistry(),
+      createWorkerRegistry<WorkerRuntimeDependencies>(),
     );
 
     const definition = registry.get('sample-external');
     expect(definition).toBeDefined();
     expect(registry.list().map((worker) => worker.kind)).toEqual(['sample-external']);
 
-    const worker = definition!.factory(deps);
-    expect(isExternalWorkerRuntime(worker)).toBe(true);
-    expect(worker.identity.kind).toBe('sample-external');
-    expect(worker.isRunning()).toBe(false);
+    const controller = createWorkerRuntimeController({
+      registry,
+      deps,
+      autoStartKinds: [],
+      persistence,
+      canControl: () => true,
+    });
+
+    expect(controller.snapshot().workers.find((worker) => worker.kind === 'sample-external')?.lifecycle)
+      .toBe('stopped');
 
     try {
-      worker.start();
-      await waitFor(() => existsSync(markerPath), 'sample external worker did not launch');
+      const started = controller.start('sample-external');
+      expect(started.lifecycle).toBe('running');
 
-      expect(worker.isRunning()).toBe(true);
-      expect(JSON.parse(readFileSync(markerPath, 'utf8'))).toEqual(
-        expect.objectContaining({ started: true }),
-      );
+      await waitFor(() => existsSync(markerPath), 'sample external worker did not launch');
+      const launchMarker = readMarker(markerPath);
+      expect(launchMarker).toEqual(expect.objectContaining({ started: true, stopped: false }));
+      expect(typeof launchMarker.pid).toBe('number');
+
+      expect(controller.snapshot().workers.find((worker) => worker.kind === 'sample-external')?.lifecycle)
+        .toBe('running');
     } finally {
-      await worker.stop();
-      await worker.finished;
+      const stopped = await controller.stop('sample-external');
+      expect(stopped.lifecycle).toBe('stopped');
     }
 
-    expect(worker.isRunning()).toBe(false);
+    await waitFor(
+      () => existsSync(markerPath) && readMarker(markerPath).stopped === true,
+      'sample external worker did not stop cleanly',
+    );
   });
 });

--- a/packages/app/src/__tests__/fixtures/sample-external-worker.mjs
+++ b/packages/app/src/__tests__/fixtures/sample-external-worker.mjs
@@ -6,12 +6,17 @@ if (!markerPath) {
   process.exit(64);
 }
 
-writeFileSync(markerPath, JSON.stringify({ pid: process.pid, started: true }), 'utf8');
+const writeMarker = (state) => {
+  writeFileSync(markerPath, JSON.stringify({ pid: process.pid, ...state }), 'utf8');
+};
+
+writeMarker({ started: true, stopped: false });
 
 const keepAlive = setInterval(() => {}, 1_000);
 
 const shutdown = () => {
   clearInterval(keepAlive);
+  writeMarker({ started: true, stopped: true });
   process.exit(0);
 };
 

--- a/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
+++ b/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
@@ -59,28 +59,30 @@ describe('main-process read hot-path cost guards', () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'invoker-hotpath-'));
     adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
 
-    adapter.saveWorkflow(makeWorkflow('wf-fat', 'Fat events'));
-
     const taskCount = 40;
     const eventsPerTask = 250; // 10k events total
-    for (let t = 0; t < taskCount; t += 1) {
-      const taskId = `wf-fat/t${t}`;
-      adapter.saveTask('wf-fat', makeTask(taskId));
-      for (let e = 0; e < eventsPerTask; e += 1) {
-        const action = e % 4 === 0 ? 'wakeup'
-          : e % 4 === 1 ? 'scan'
-            : e % 4 === 2 ? 'submit'
-              : 'skip';
-        adapter.logEvent(
-          taskId,
-          recoveryWorkerEventType(action),
-          buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
-            workflowId: 'wf-fat',
-            reason: action === 'skip' ? 'budget' : undefined,
-          }),
-        );
+    adapter.runInTransaction(() => {
+      adapter.saveWorkflow(makeWorkflow('wf-fat', 'Fat events'));
+
+      for (let t = 0; t < taskCount; t += 1) {
+        const taskId = `wf-fat/t${t}`;
+        adapter.saveTask('wf-fat', makeTask(taskId));
+        for (let e = 0; e < eventsPerTask; e += 1) {
+          const action = e % 4 === 0 ? 'wakeup'
+            : e % 4 === 1 ? 'scan'
+              : e % 4 === 2 ? 'submit'
+                : 'skip';
+          adapter.logEvent(
+            taskId,
+            recoveryWorkerEventType(action),
+            buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
+              workflowId: 'wf-fat',
+              reason: action === 'skip' ? 'budget' : undefined,
+            }),
+          );
+        }
       }
-    }
+    });
 
     const getEvents = vi.spyOn(adapter, 'getEvents');
     const started = Date.now();

--- a/packages/app/src/main-process-hitch-fixture.ts
+++ b/packages/app/src/main-process-hitch-fixture.ts
@@ -54,59 +54,61 @@ function makeTask(id: string): TaskState {
 }
 
 export function seedMainProcessHitchFixture(
-  persistence: Pick<SQLiteAdapter, 'saveWorkflow' | 'saveTask' | 'logEvent' | 'upsertWorkerAction'>,
+  persistence: Pick<SQLiteAdapter, 'saveWorkflow' | 'saveTask' | 'logEvent' | 'upsertWorkerAction' | 'runInTransaction'>,
   options: MainProcessHitchFixtureOptions = {},
 ): MainProcessHitchFixtureResult {
   const taskCount = options.taskCount ?? DEFAULT_TASK_COUNT;
   const eventsPerTask = options.eventsPerTask ?? DEFAULT_EVENTS_PER_TASK;
   const actionsPerKind = options.actionsPerKind ?? DEFAULT_ACTIONS_PER_KIND;
   const workflowId = MAIN_PROCESS_HITCH_FIXTURE_WORKFLOW_ID;
-
-  persistence.saveWorkflow(makeWorkflow(workflowId, 'Main-process hitch fixture'));
-
-  for (let t = 0; t < taskCount; t += 1) {
-    const taskId = `${workflowId}/t${t}`;
-    persistence.saveTask(workflowId, makeTask(taskId));
-    for (let e = 0; e < eventsPerTask; e += 1) {
-      const action = e % 4 === 0 ? 'wakeup'
-        : e % 4 === 1 ? 'scan'
-          : e % 4 === 2 ? 'submit'
-            : 'skip';
-      persistence.logEvent(
-        taskId,
-        recoveryWorkerEventType(action),
-        buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
-          workflowId,
-          reason: action === 'skip' ? 'budget' : undefined,
-        }),
-      );
-    }
-  }
-
   let workerActionCount = 0;
-  for (const workerKind of ACTION_WORKER_KINDS) {
-    for (let i = 0; i < actionsPerKind; i += 1) {
-      const taskId = `${workflowId}/t${i % Math.max(taskCount, 1)}`;
-      const write: WorkerActionWrite = {
-        id: `wa-hitch-${workerKind}-${i}`,
-        workerKind,
-        actionType: 'hitch-fixture',
-        workflowId,
-        taskId,
-        subjectType: 'task',
-        subjectId: taskId,
-        externalKey: `hitch:${workerKind}:${i}`,
-        status: i % 5 === 0 ? 'skipped' : 'completed',
-        attemptCount: 1,
-        summary: `Hitch fixture ${workerKind} ${i}`,
-        payload: { reason: i % 5 === 0 ? 'budget' : 'ok' },
-        createdAt: `2026-07-01T00:00:${String(i % 60).padStart(2, '0')}.000Z`,
-        updatedAt: `2026-07-01T00:01:${String(i % 60).padStart(2, '0')}.000Z`,
-      };
-      persistence.upsertWorkerAction(write);
-      workerActionCount += 1;
+
+  persistence.runInTransaction(() => {
+    persistence.saveWorkflow(makeWorkflow(workflowId, 'Main-process hitch fixture'));
+
+    for (let t = 0; t < taskCount; t += 1) {
+      const taskId = `${workflowId}/t${t}`;
+      persistence.saveTask(workflowId, makeTask(taskId));
+      for (let e = 0; e < eventsPerTask; e += 1) {
+        const action = e % 4 === 0 ? 'wakeup'
+          : e % 4 === 1 ? 'scan'
+            : e % 4 === 2 ? 'submit'
+              : 'skip';
+        persistence.logEvent(
+          taskId,
+          recoveryWorkerEventType(action),
+          buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
+            workflowId,
+            reason: action === 'skip' ? 'budget' : undefined,
+          }),
+        );
+      }
     }
-  }
+
+    for (const workerKind of ACTION_WORKER_KINDS) {
+      for (let i = 0; i < actionsPerKind; i += 1) {
+        const taskId = `${workflowId}/t${i % Math.max(taskCount, 1)}`;
+        const write: WorkerActionWrite = {
+          id: `wa-hitch-${workerKind}-${i}`,
+          workerKind,
+          actionType: 'hitch-fixture',
+          workflowId,
+          taskId,
+          subjectType: 'task',
+          subjectId: taskId,
+          externalKey: `hitch:${workerKind}:${i}`,
+          status: i % 5 === 0 ? 'skipped' : 'completed',
+          attemptCount: 1,
+          summary: `Hitch fixture ${workerKind} ${i}`,
+          payload: { reason: i % 5 === 0 ? 'budget' : 'ok' },
+          createdAt: `2026-07-01T00:00:${String(i % 60).padStart(2, '0')}.000Z`,
+          updatedAt: `2026-07-01T00:01:${String(i % 60).padStart(2, '0')}.000Z`,
+        };
+        persistence.upsertWorkerAction(write);
+        workerActionCount += 1;
+      }
+    }
+  });
 
   return {
     workflowId,


### PR DESCRIPTION
## Summary

The sample external-worker check now uses the worker runtime controller instead of constructing the runtime directly.

It starts the configured kind through the registry-backed door, waits for launch, stops it, and verifies the process wrote a stop marker.

## Review Claim

An end-to-end test proves a configured external worker starts and stops through the worker runtime controller.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The slice changes only the sample external-worker test and fixture, so product behavior is unchanged.

## Slice Rationale

The loader already exists on master; this slice tightens the end-to-end proof without reopening the config or loader changes.

## Non-goals

This slice does not change external-worker registration or launch code.

It does not change built-in worker behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/external-worker-e2e.test.ts src/__tests__/main-process-read-hotpath-cost.test.ts`
- [x] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7b64d05c`
- Post-revert steps: None
- Data migration? No

</details>
