### PR TITLE
Fix Embedded Task Terminal Blank Rendering Step 3

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2704,7 +2704,7 @@ export function App() {
           dragHandleTestId="selected-workflow-mini-dag-drag-handle"
           title={`${displayedSelectedWorkflowGraph.workflow.name} task DAG`}
           boundsRef={graphSurfaceRef as unknown as RefObject<HTMLElement>}
-          contentClassName="h-[250px]"
+          contentClassName="min-h-0 h-[250px] overflow-hidden"
         >
           {graphBody}
         </FloatingGraphPanel>
@@ -2735,7 +2735,7 @@ export function App() {
       data-keyboard-region="workflowGraph"
       tabIndex={0}
       data-keyboard-active={keyboardRegion === 'workflowGraph' ? 'true' : 'false'}
-      className={`flex-1 relative overflow-hidden border-r border-border bg-background outline-none ${keyboardRegion === 'workflowGraph' ? 'ring-2 ring-inset ring-ring/50' : ''}`}
+      className={`relative min-h-0 flex-1 overflow-hidden border-r border-border bg-background outline-none ${keyboardRegion === 'workflowGraph' ? 'ring-2 ring-inset ring-ring/50' : ''}`}
       onClick={viewMode === 'dag' ? handleDagSurfaceClick : undefined}
     >
       {viewMode === 'queue' ? (
@@ -2787,7 +2787,7 @@ export function App() {
   );
 
   const renderGraphWorkspace = (title: string, subtitle: string, showMoreMenu: boolean): JSX.Element => (
-    <div className="flex-1 flex flex-col overflow-hidden">
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <div className="flex items-center justify-between border-b border-border bg-card/50 px-4 py-2">
         <div>
           <h2 className="text-sm font-semibold text-foreground">{title}</h2>
@@ -2928,7 +2928,7 @@ export function App() {
   const planningReadyCount = planningSessions.filter((session) => session.status === 'draft_ready').length;
 
   const renderPlanningTerminalSurface = (): JSX.Element => (
-    <div className="flex-1 flex overflow-hidden">
+    <div className="flex min-h-0 flex-1 overflow-hidden">
       <div data-testid="planning-session-rail" className="flex h-full w-64 shrink-0 flex-col border-r border-border bg-card">
         <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2.5">
           <div className="min-w-0">
@@ -3199,7 +3199,7 @@ export function App() {
 
 
       {/* Main content */}
-      <div className="flex-1 flex overflow-hidden">
+      <div className="flex min-h-0 flex-1 overflow-hidden">
         <LeftStatusColumn
           workflows={workflows}
           tasks={tasks}
@@ -3218,14 +3218,14 @@ export function App() {
           onToggleTheme={toggleTheme}
         />
 
-        <div className="flex-1 flex overflow-hidden">
-          <main className="flex-1 flex flex-col overflow-hidden bg-background">
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <main className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
             {sidebarSurface === 'home' ? (
               renderGraphWorkspace('Plan graph', homeSubtitle, true)
             ) : sidebarSurface === 'planning' ? (
               renderPlanningTerminalSurface()
             ) : (
-              <div className="flex-1 flex overflow-hidden">
+              <div className="flex min-h-0 flex-1 overflow-hidden">
                 {renderBrowserRail()}
                 {renderBrowserDetailWorkspace()}
               </div>

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -33,7 +33,12 @@ const xtermMock = vi.hoisted(() => {
     rows = 24;
     dataHandler: DataHandler | null = null;
     loadAddon = vi.fn();
-    open = vi.fn();
+    open = vi.fn((host: HTMLElement) => {
+      const terminalElement = document.createElement('div');
+      terminalElement.className = 'xterm';
+      terminalElement.textContent = 'mock terminal';
+      host.appendChild(terminalElement);
+    });
     write = vi.fn((data: string) => {
       writeLog.push(data);
     });
@@ -42,6 +47,7 @@ const xtermMock = vi.hoisted(() => {
       return { dispose: vi.fn() };
     });
     focus = vi.fn();
+    refresh = vi.fn();
     dispose = vi.fn();
 
     constructor() {
@@ -107,8 +113,18 @@ function makeTerminalSession(
     mode: 'spawn',
     attached: false,
     createdAt: new Date('2025-01-01T00:00:00Z').toISOString(),
+    outputSnapshot: `${taskId} ready\n`,
     ...overrides,
   };
+}
+
+async function expectPaneReady(taskId: string) {
+  const pane = screen.getByTestId(`terminal-pane-${taskId}`);
+  expect(pane).toBeVisible();
+  await waitFor(() => {
+    expect(pane.querySelector('.xterm')).not.toBeNull();
+  });
+  return pane;
 }
 
 async function selectWorkflow(): Promise<void> {
@@ -127,6 +143,10 @@ describe('Terminal drawer (component)', () => {
   beforeEach(() => {
     xtermMock.reset();
     mock = createMockInvoker();
+    mock.api.terminalResize = vi.fn(async () => ({ ok: true }));
+    mock.api.terminalWrite = vi.fn(async () => ({ ok: true }));
+    mock.api.terminalClose = vi.fn(async () => ({ ok: true }));
+    mock.api.terminalList = vi.fn(async () => []);
     mock.install();
   });
 
@@ -158,6 +178,83 @@ describe('Terminal drawer (component)', () => {
       expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
       expect(xtermMock.writeLog).toContain('restored before restart\n');
     });
+    await expectPaneReady('task-alpha');
+    await waitFor(() => {
+      expect(xtermMock.fitInstances[0]?.fit).toHaveBeenCalled();
+      expect(xtermMock.instances[0]?.refresh).toHaveBeenCalledWith(0, 23);
+      expect(mock.api.terminalResize).toHaveBeenCalledWith(restored.sessionId, 80, 24);
+    });
+  });
+
+  it('refits the active pane across partial and maximized drawer states', async () => {
+    const session = makeTerminalSession('task-alpha');
+    const props = {
+      onCycle: vi.fn(),
+      sessions: [session],
+      activeSessionId: session.sessionId,
+      onSelectSession: vi.fn(),
+      onCloseSession: vi.fn(),
+    };
+
+    const { rerender } = render(<TerminalDrawer state="minimized" {...props} />);
+    expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'minimized');
+    expect(screen.queryByTestId('terminal-drawer-body')).not.toBeInTheDocument();
+
+    rerender(<TerminalDrawer state="partial" {...props} />);
+    expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
+    expect(screen.getByTestId('terminal-drawer-body')).toHaveStyle({ height: '280px' });
+    expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
+    await expectPaneReady('task-alpha');
+    await waitFor(() => {
+      expect(xtermMock.fitInstances[0]?.fit).toHaveBeenCalled();
+      expect(xtermMock.instances[0]?.refresh).toHaveBeenCalledWith(0, 23);
+    });
+    const partialFitCalls = xtermMock.fitInstances[0].fit.mock.calls.length;
+    const partialRefreshCalls = xtermMock.instances[0].refresh.mock.calls.length;
+
+    rerender(<TerminalDrawer state="maximized" {...props} />);
+    expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'maximized');
+    expect(screen.getByTestId('terminal-drawer')).toHaveClass('fixed');
+    expect(screen.getByTestId('terminal-drawer-body')).toHaveClass('min-h-0', 'flex-1', 'overflow-hidden');
+    await expectPaneReady('task-alpha');
+    await waitFor(() => {
+      expect(xtermMock.fitInstances[0].fit.mock.calls.length).toBeGreaterThan(partialFitCalls);
+      expect(xtermMock.instances[0].refresh.mock.calls.length).toBeGreaterThan(partialRefreshCalls);
+      expect(xtermMock.instances[0]?.focus).toHaveBeenCalled();
+    });
+  });
+
+  it('refits the newly active pane when terminal tabs switch', async () => {
+    const alpha = makeTerminalSession('task-alpha');
+    const beta = makeTerminalSession('task-beta');
+    const props = {
+      state: 'partial' as const,
+      onCycle: vi.fn(),
+      sessions: [alpha, beta],
+      onSelectSession: vi.fn(),
+      onCloseSession: vi.fn(),
+    };
+
+    const { rerender } = render(<TerminalDrawer {...props} activeSessionId={alpha.sessionId} />);
+    await expectPaneReady('task-alpha');
+    const betaPane = screen.getByTestId('terminal-pane-task-beta');
+    expect(betaPane).not.toBeVisible();
+    expect(betaPane).toHaveStyle({ display: 'none' });
+    await waitFor(() => {
+      expect(betaPane.querySelector('.xterm')).not.toBeNull();
+      expect(xtermMock.fitInstances).toHaveLength(2);
+    });
+    const betaHiddenFitCalls = xtermMock.fitInstances[1].fit.mock.calls.length;
+    const betaHiddenRefreshCalls = xtermMock.instances[1].refresh.mock.calls.length;
+
+    rerender(<TerminalDrawer {...props} activeSessionId={beta.sessionId} />);
+    await expectPaneReady('task-beta');
+    expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'false');
+    expect(screen.getByTestId('terminal-tab-task-beta')).toHaveAttribute('data-active', 'true');
+    await waitFor(() => {
+      expect(xtermMock.fitInstances[1].fit.mock.calls.length).toBeGreaterThan(betaHiddenFitCalls);
+      expect(xtermMock.instances[1].refresh.mock.calls.length).toBeGreaterThan(betaHiddenRefreshCalls);
+    });
   });
 
   it('opens the drawer in the partial state (not maximized) when opening a terminal via double-click', async () => {
@@ -168,7 +265,6 @@ describe('Terminal drawer (component)', () => {
     fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
 
     await waitFor(() => {
-      // Partial drawer's next action is "Maximize".
       expect(screen.getByRole('button', { name: 'Maximize terminal drawer' })).toBeInTheDocument();
       expect(screen.getByTestId('terminal-drawer-body')).toBeInTheDocument();
       expect(screen.getByTestId('terminal-tab-task-alpha')).toBeInTheDocument();
@@ -176,7 +272,6 @@ describe('Terminal drawer (component)', () => {
     const drawer = screen.getByTestId('terminal-drawer');
     expect(drawer).toHaveAttribute('data-state', 'partial');
     expect(drawer).not.toHaveClass('fixed');
-    // Partial keeps today's 280px body height.
     expect(screen.getByTestId('terminal-drawer-body')).toHaveStyle({ height: '280px' });
     expect(mock.api.openTerminal).toHaveBeenCalledWith('task-alpha');
   });

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -143,10 +143,6 @@ describe('Terminal drawer (component)', () => {
   beforeEach(() => {
     xtermMock.reset();
     mock = createMockInvoker();
-    mock.api.terminalResize = vi.fn(async () => ({ ok: true }));
-    mock.api.terminalWrite = vi.fn(async () => ({ ok: true }));
-    mock.api.terminalClose = vi.fn(async () => ({ ok: true }));
-    mock.api.terminalList = vi.fn(async () => []);
     mock.install();
   });
 

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -663,8 +663,8 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
   return (
     <div
       ref={graphRootRef}
-      className="flex w-full flex-1"
-      style={{ minHeight: '300px', height: browserHeight }}
+      className="flex min-h-0 w-full flex-1 overflow-hidden"
+      style={{ height: browserHeight }}
     >
       <ReactFlow
         key={flowInstanceKey}

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -8,7 +8,7 @@
  * requiring a real terminal backing.
  */
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { Terminal as XTermTerminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import type { TerminalSessionDescriptor } from '@invoker/contracts';
@@ -46,6 +46,7 @@ interface TerminalDrawerProps {
 interface TerminalSessionPaneProps {
   session: TerminalSessionDescriptor;
   isActive: boolean;
+  drawerState: TerminalDrawerState;
   hasHeader: boolean;
 }
 
@@ -87,11 +88,62 @@ function seedTerminalOutputSnapshot(
   }
 }
 
-function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPaneProps): JSX.Element {
+function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: TerminalSessionPaneProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<XTermTerminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const seededSnapshotRef = useRef<SeededOutputSnapshot | null>(null);
+  const isActiveRef = useRef(isActive);
+  const fitFrameRef = useRef<number | null>(null);
+  const secondFitFrameRef = useRef<number | null>(null);
+
+  isActiveRef.current = isActive;
+
+  const clearScheduledFit = useCallback(() => {
+    if (fitFrameRef.current !== null) {
+      if (typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(fitFrameRef.current);
+      }
+      fitFrameRef.current = null;
+    }
+    if (secondFitFrameRef.current !== null) {
+      if (typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(secondFitFrameRef.current);
+      }
+      secondFitFrameRef.current = null;
+    }
+  }, []);
+
+  const fitVisibleTerminal = useCallback(() => {
+    if (!isActiveRef.current) return;
+    const term = termRef.current;
+    const fit = fitRef.current;
+    if (!term || !fit) return;
+    try {
+      fit.fit();
+      if (term.rows > 0) {
+        term.refresh?.(0, term.rows - 1);
+      }
+      void window.invoker?.terminalResize?.(session.sessionId, term.cols, term.rows);
+    } catch {
+      /* host has zero size, terminal disposed, or fit unsupported */
+    }
+  }, [session.sessionId]);
+
+  const scheduleFit = useCallback(() => {
+    clearScheduledFit();
+    fitVisibleTerminal();
+    if (typeof requestAnimationFrame !== 'function') return;
+
+    fitFrameRef.current = requestAnimationFrame(() => {
+      fitFrameRef.current = null;
+      fitVisibleTerminal();
+      secondFitFrameRef.current = requestAnimationFrame(() => {
+        secondFitFrameRef.current = null;
+        fitVisibleTerminal();
+      });
+    });
+  }, [clearScheduledFit, fitVisibleTerminal]);
 
   useEffect(() => {
     const host = containerRef.current;
@@ -133,35 +185,26 @@ function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPa
       }
     });
 
-    const tryFit = () => {
-      try {
-        fit.fit();
-        void window.invoker?.terminalResize?.(session.sessionId, term.cols, term.rows);
-      } catch {
-        /* host has zero size or fit unsupported */
-      }
-    };
-
-    const raf = typeof requestAnimationFrame === 'function'
-      ? requestAnimationFrame(tryFit)
-      : null;
-
     let resizeObserver: ResizeObserver | null = null;
     if (typeof ResizeObserver !== 'undefined') {
       try {
-        resizeObserver = new ResizeObserver(() => {
-          tryFit();
-        });
+        resizeObserver = new ResizeObserver(fitVisibleTerminal);
         resizeObserver.observe(host);
       } catch {
         resizeObserver = null;
       }
     }
+    if (isActiveRef.current) {
+      scheduleFit();
+      try {
+        term.focus();
+      } catch {
+        /* focus unsupported */
+      }
+    }
 
     return () => {
-      if (raf !== null && typeof cancelAnimationFrame === 'function') {
-        cancelAnimationFrame(raf);
-      }
+      clearScheduledFit();
       resizeObserver?.disconnect();
       inputDisposable.dispose();
       unsubscribeOutput?.();
@@ -173,7 +216,7 @@ function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPa
       termRef.current = null;
       fitRef.current = null;
     };
-  }, [session.sessionId]);
+  }, [clearScheduledFit, fitVisibleTerminal, scheduleFit, session.sessionId]);
 
   useEffect(() => {
     const term = termRef.current;
@@ -182,18 +225,19 @@ function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPa
   }, [session.outputSnapshot, session.sessionId]);
 
   useEffect(() => {
-    if (!isActive) return;
+    if (!isActive) {
+      clearScheduledFit();
+      return;
+    }
     const term = termRef.current;
-    const fit = fitRef.current;
-    if (!term || !fit) return;
+    if (!term) return;
     try {
-      fit.fit();
-      void window.invoker?.terminalResize?.(session.sessionId, term.cols, term.rows);
+      scheduleFit();
       term.focus();
     } catch {
       /* fit failed (e.g., hidden) */
     }
-  }, [isActive, session.sessionId]);
+  }, [clearScheduledFit, drawerState, hasHeader, isActive, scheduleFit, session.sessionId]);
 
   return (
     <div
@@ -320,6 +364,7 @@ export function TerminalDrawer({
               key={session.sessionId}
               session={session}
               isActive={session.sessionId === activeSessionId}
+              drawerState={state}
               hasHeader={Boolean(session.sessionId === activeSessionId && activeCommand)}
             />
           ))}

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -274,10 +274,10 @@ export function TerminalDrawer({
       className={
         isMaximized
           ? 'fixed inset-0 z-40 flex min-h-0 flex-col overflow-hidden border-t border-border bg-card'
-          : 'border-t border-border bg-card'
+          : 'shrink-0 border-t border-border bg-card'
       }
     >
-      <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+      <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
         <div
           role="tablist"
           data-testid="terminal-tab-strip"
@@ -340,7 +340,7 @@ export function TerminalDrawer({
       {showBody && (
         <div
           data-testid="terminal-drawer-body"
-          className={isMaximized ? 'relative min-h-0 flex-1 overflow-hidden bg-black' : 'relative overflow-hidden bg-black'}
+          className={isMaximized ? 'relative min-h-0 flex-1 overflow-hidden bg-black' : 'relative shrink-0 overflow-hidden bg-black'}
           style={isMaximized ? undefined : { height: DRAWER_BODY_HEIGHT_PX }}
         >
           {sessions.length === 0 && (

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -318,8 +318,7 @@ function WorkflowGraphInner({
   return (
     <div
       data-testid="workflow-graph-scroll"
-      className="h-full w-full overflow-hidden"
-      style={{ minHeight: '300px' }}
+      className="h-full min-h-0 w-full overflow-hidden"
     >
       <div ref={graphRootRef} data-testid="workflow-graph-react-flow" className="h-full w-full">
         <ReactFlow


### PR DESCRIPTION
## Summary

This keeps embedded terminal panes visible when the drawer shares vertical space with the workflow graph.

It also keeps long terminal output visible when the drawer is maximized.

## Review Claim

The reviewer is approving the terminal drawer layout behavior that gives the active xterm pane a measurable host height in partial and maximized states.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The slice only changes visible layout sizing around the graph and terminal drawer host. It does not change terminal session creation, task execution, or persisted output.

## Slice Rationale

This sits after the terminal fit lifecycle fix and covers the remaining blank rendering path: parent layout collapse. The focused checks stay with this slice because they assert the host-height behavior changed here.

## Non-goals

- No changes to terminal process spawning or attachment.
- No changes to task scheduling, executor routing, or workflow state.
- No changes to terminal command output semantics.
- No broad visual redesign of the graph, drawer, or inspector.

## Architecture

### Before

```mermaid
graph TD
    A["App flex containers keep implicit minimum heights"] --> B["Workflow graph reserves fixed minimum height"]
    B --> C["Terminal drawer competes for constrained vertical space"]
    C --> D["Active xterm pane can resolve to blank or clipped height"]
```

### After

```mermaid
graph TD
    A["App flex containers opt into min-height: 0"] --> B["Workflow graph and mini DAG shrink inside their hosts"]
    B --> C["Terminal drawer body keeps an explicit non-collapsing host"]
    C --> D["Active xterm pane has measurable height in partial and maximized states"]
```

## Visual Proof

Embedded tabbed terminal keeps the workflow graph visible and the active xterm pane nonblank:

![Embedded tabbed terminal proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-1c4dab/embedded-tabbed-terminal.png)

Maximized terminal drawer keeps long scrollback rendered in the full-height xterm host:

![Maximized terminal scrollback proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-1c4dab/maximized-terminal-scrollback-history.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/terminal-drawer.test.tsx`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-body-4281-candidate.md --changed-files-file /tmp/invoker-pr-body-4281-changed-files-current.txt --diff-file /tmp/invoker-pr-body-4281-current.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 92cf75f8617d323e3d109a2923c75f6c7d17fca5`
- Post-revert steps: Re-run the focused terminal drawer checks if the terminal lifecycle base remains in place.
- Data migration? No.

</details>
