### PR TITLE
[UI Responsiveness Guardrails Step 3](1) Add adverse-load performance budgets

### DIFF
--- a/packages/app/e2e/embedded-terminal-pty.spec.ts
+++ b/packages/app/e2e/embedded-terminal-pty.spec.ts
@@ -13,6 +13,17 @@ const TERMINAL_INPUT_BUDGET_MS = 100;
 const TERMINAL_OUTPUT_WRITE_BUDGET_MS = 250;
 const TERMINAL_RESIZE_BUDGET_MS = 250;
 const TERMINAL_TAB_SWITCH_WALL_BUDGET_MS = 1000;
+const TERMINAL_RENDERER_EVENT_LOOP_LAG_BUDGET_MS = 1000;
+const TERMINAL_RENDERER_LONG_TASK_BUDGET_MS = 1500;
+
+const TERMINAL_PRESSURE_BUDGETS = {
+  maxInputMs: TERMINAL_INPUT_BUDGET_MS,
+  maxOutputWriteMs: TERMINAL_OUTPUT_WRITE_BUDGET_MS,
+  maxResizeMs: TERMINAL_RESIZE_BUDGET_MS,
+  maxTabSwitchWallMs: TERMINAL_TAB_SWITCH_WALL_BUDGET_MS,
+  maxRendererEventLoopLagMs: TERMINAL_RENDERER_EVENT_LOOP_LAG_BUDGET_MS,
+  maxRendererLongTaskMs: TERMINAL_RENDERER_LONG_TASK_BUDGET_MS,
+};
 
 const CODEX_RESUME_PLAN = {
   name: 'Embedded PTY Resume',
@@ -84,6 +95,10 @@ function parseActivityPayload(message: string): Record<string, unknown> | null {
   } catch {
     return null;
   }
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
 }
 
 async function activityLogWatermark(page: Page): Promise<number> {
@@ -382,7 +397,6 @@ test.describe('Embedded terminal PTY', () => {
     await page.getByRole('tab', { name: /Terminal pressure alpha/i }).click();
     await expect(page.getByTestId(`terminal-tab-${fullAlphaTaskId}`)).toHaveAttribute('data-active', 'true');
     const switchWallMs = Date.now() - switchStartedAt;
-    expect(switchWallMs).toBeLessThanOrEqual(TERMINAL_TAB_SWITCH_WALL_BUDGET_MS);
 
     await page.getByRole('button', { name: 'Maximize terminal drawer' }).click();
     await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'maximized');
@@ -407,20 +421,40 @@ test.describe('Embedded terminal PTY', () => {
     const inputPayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_input');
     const outputPayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_output_write');
     const resizePayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_resize');
-    expect(attachPayloads.length).toBeGreaterThanOrEqual(2);
-    expect(inputPayloads.length).toBeGreaterThan(0);
-    expect(outputPayloads.length).toBeGreaterThan(0);
-    expect(resizePayloads.some((payload) => payload.source === 'active_session' && payload.taskId === fullAlphaTaskId)).toBe(true);
-    expect(Math.max(...inputPayloads.map((payload) => Number(payload.durationMs)))).toBeLessThanOrEqual(TERMINAL_INPUT_BUDGET_MS);
-    expect(Math.max(...outputPayloads.map((payload) => Number(payload.durationMs)))).toBeLessThanOrEqual(TERMINAL_OUTPUT_WRITE_BUDGET_MS);
-    expect(Math.max(...resizePayloads.map((payload) => Number(payload.durationMs)))).toBeLessThanOrEqual(TERMINAL_RESIZE_BUDGET_MS);
-
     const perf = await page.evaluate(async () => window.invoker.getUiPerfStats());
-    expect(Number(perf.embeddedTerminalAttachReports)).toBeGreaterThanOrEqual(2);
-    expect(Number(perf.embeddedTerminalInputReports)).toBeGreaterThan(0);
-    expect(Number(perf.embeddedTerminalOutputWriteReports)).toBeGreaterThan(0);
-    expect(Number(perf.maxEmbeddedTerminalInputMs)).toBeLessThanOrEqual(TERMINAL_INPUT_BUDGET_MS);
-    expect(Number(perf.maxEmbeddedTerminalOutputWriteMs)).toBeLessThanOrEqual(TERMINAL_OUTPUT_WRITE_BUDGET_MS);
-    expect(Number(perf.maxEmbeddedTerminalResizeMs)).toBeLessThanOrEqual(TERMINAL_RESIZE_BUDGET_MS);
+    const terminalEvidence = {
+      fullAlphaTaskId,
+      fullBetaTaskId,
+      switchWallMs,
+      attachPayloads,
+      inputPayloads,
+      outputPayloads,
+      resizePayloads,
+      perf,
+      budgets: TERMINAL_PRESSURE_BUDGETS,
+    };
+    console.log(`EMBEDDED_TERMINAL_PRESSURE_BENCH_RESULT=${JSON.stringify(terminalEvidence)}`);
+    const terminalEvidenceMessage = JSON.stringify(terminalEvidence);
+
+    expect(attachPayloads.length, terminalEvidenceMessage).toBeGreaterThanOrEqual(2);
+    expect(inputPayloads.length, terminalEvidenceMessage).toBeGreaterThan(0);
+    expect(outputPayloads.length, terminalEvidenceMessage).toBeGreaterThan(0);
+    expect(
+      resizePayloads.some((payload) => payload.source === 'active_session' && payload.taskId === fullAlphaTaskId),
+      terminalEvidenceMessage,
+    ).toBe(true);
+    expect(switchWallMs, terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_TAB_SWITCH_WALL_BUDGET_MS);
+    expect(Math.max(...inputPayloads.map((payload) => Number(payload.durationMs))), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_INPUT_BUDGET_MS);
+    expect(Math.max(...outputPayloads.map((payload) => Number(payload.durationMs))), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_OUTPUT_WRITE_BUDGET_MS);
+    expect(Math.max(...resizePayloads.map((payload) => Number(payload.durationMs))), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RESIZE_BUDGET_MS);
+
+    expect(Number(perf.embeddedTerminalAttachReports), terminalEvidenceMessage).toBeGreaterThanOrEqual(2);
+    expect(Number(perf.embeddedTerminalInputReports), terminalEvidenceMessage).toBeGreaterThan(0);
+    expect(Number(perf.embeddedTerminalOutputWriteReports), terminalEvidenceMessage).toBeGreaterThan(0);
+    expect(Number(perf.maxEmbeddedTerminalInputMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_INPUT_BUDGET_MS);
+    expect(Number(perf.maxEmbeddedTerminalOutputWriteMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_OUTPUT_WRITE_BUDGET_MS);
+    expect(Number(perf.maxEmbeddedTerminalResizeMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RESIZE_BUDGET_MS);
+    expect(numberOrZero(perf.maxRendererEventLoopLagMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RENDERER_EVENT_LOOP_LAG_BUDGET_MS);
+    expect(numberOrZero(perf.maxRendererLongTaskMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RENDERER_LONG_TASK_BUDGET_MS);
   });
 });

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -21,6 +21,17 @@ test.use({ guiOwnerMode: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'daemon' });
 const execFileAsync = promisify(execFile);
 const repoRoot = resolveRepoRoot(__dirname);
 const RESPONSIVE_INTERACTION_TIMEOUT_MS = 15000;
+const HEADLESS_DELEGATED_WORKFLOW_COUNT = 8;
+const MAX_RENDERER_EVENT_LOOP_LAG_MS = 1000;
+const MAX_RENDERER_LONG_TASK_MS = 1500;
+
+const HEADLESS_HERD_BUDGETS = {
+  maxInspectorToggleMs: RESPONSIVE_INTERACTION_TIMEOUT_MS,
+  delegatedWorkflowCount: HEADLESS_DELEGATED_WORKFLOW_COUNT,
+  minRetryCommandCount: HEADLESS_DELEGATED_WORKFLOW_COUNT + 1,
+  maxRendererEventLoopLagMs: MAX_RENDERER_EVENT_LOOP_LAG_MS,
+  maxRendererLongTaskMs: MAX_RENDERER_LONG_TASK_MS,
+};
 
 async function ensureHeadlessTestConfig(testDir: string): Promise<void> {
   await writeFile(path.join(testDir, 'e2e-config.json'), JSON.stringify({ autoFixRetries: 0 }), 'utf8');
@@ -67,18 +78,27 @@ function parseJsonStdout(stdout: string): Record<string, unknown> {
   return JSON.parse(line) as Record<string, unknown>;
 }
 
-async function assertInspectorToggleResponsive(page: Page, timeoutMs: number): Promise<void> {
+async function measureInspectorToggleResponsive(page: Page, timeoutMs: number, label: string): Promise<number> {
   const minimizeButton = page.getByLabel('Minimize inspector');
   const maximizeButton = page.getByLabel('Maximize inspector');
   const startedAt = Date.now();
-  await expect(async () => {
-    await minimizeButton.click();
-    await expect(maximizeButton).toBeVisible({ timeout: 1000 });
-    await maximizeButton.click();
-    await expect(minimizeButton).toBeVisible({ timeout: 1000 });
-  }).toPass({ timeout: timeoutMs });
-  const interactionMs = Date.now() - startedAt;
-  expect(interactionMs).toBeLessThan(timeoutMs);
+  try {
+    await expect(async () => {
+      await minimizeButton.click();
+      await expect(maximizeButton).toBeVisible({ timeout: 1000 });
+      await maximizeButton.click();
+      await expect(minimizeButton).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: timeoutMs });
+  } catch (err) {
+    console.log(`HEADLESS_THUNDERING_HERD_INTERACTION_FAILURE=${JSON.stringify({
+      label,
+      durationMs: Date.now() - startedAt,
+      timeoutMs,
+      error: err instanceof Error ? err.message : String(err),
+    })}`);
+    throw err;
+  }
+  return Date.now() - startedAt;
 }
 
 test.describe('Headless thundering herd', () => {
@@ -113,7 +133,7 @@ test.describe('Headless thundering herd', () => {
 
     const workflowIds = new Set<string>();
     workflowIds.add(currentWorkflowId);
-    for (let i = 0; i < 8; i += 1) {
+    for (let i = 0; i < HEADLESS_DELEGATED_WORKFLOW_COUNT; i += 1) {
       const result = await runHeadlessClient(testDir, ['run', planPath, '--no-track']);
       expectDelegated(result.stdout);
       // Use the workflow id echoed by this exact submission. Querying shared
@@ -125,32 +145,53 @@ test.describe('Headless thundering herd', () => {
 
     await page.waitForTimeout(500);
 
+    const retryBurstStartedAt = Date.now();
     const burst = Array.from(workflowIds).map((workflowId) =>
       runHeadlessClient(testDir, ['retry', workflowId, '--no-track']),
     );
 
-    const firstInteractionStartedAt = Date.now();
-    await assertInspectorToggleResponsive(page, RESPONSIVE_INTERACTION_TIMEOUT_MS);
-    expect(Date.now() - firstInteractionStartedAt).toBeLessThan(RESPONSIVE_INTERACTION_TIMEOUT_MS);
+    const firstInteractionMs = await measureInspectorToggleResponsive(
+      page,
+      RESPONSIVE_INTERACTION_TIMEOUT_MS,
+      'during_retry_burst',
+    );
 
     await page.waitForTimeout(1500);
 
-    const secondInteractionStartedAt = Date.now();
-    await assertInspectorToggleResponsive(page, RESPONSIVE_INTERACTION_TIMEOUT_MS);
-    expect(Date.now() - secondInteractionStartedAt).toBeLessThan(RESPONSIVE_INTERACTION_TIMEOUT_MS);
+    const secondInteractionMs = await measureInspectorToggleResponsive(
+      page,
+      RESPONSIVE_INTERACTION_TIMEOUT_MS,
+      'after_retry_burst',
+    );
 
     const retryResults = await Promise.all(burst);
+    const retryBurstWallMs = Date.now() - retryBurstStartedAt;
     for (const result of retryResults) {
       expectDelegated(result.stdout);
     }
 
     const perf = await page.evaluate(async () => await window.invoker.getUiPerfStats());
-    expect(perf.maxRendererEventLoopLagMs).toBeLessThan(1000);
-    expect(perf.maxRendererLongTaskMs).toBeLessThan(1500);
-
     const delegatedPerf = parseJsonStdout(
       (await runHeadlessClient(testDir, ['query', 'ui-perf', '--output', 'json'])).stdout,
     );
+    const evidence = {
+      workflowCount: workflowIds.size,
+      retryCommandCount: burst.length,
+      retryBurstWallMs,
+      firstInteractionMs,
+      secondInteractionMs,
+      perf,
+      delegatedPerf,
+      budgets: HEADLESS_HERD_BUDGETS,
+    };
+    console.log(`HEADLESS_THUNDERING_HERD_BENCH_RESULT=${JSON.stringify(evidence)}`);
+
+    const evidenceMessage = JSON.stringify(evidence);
+    expect(burst.length, evidenceMessage).toBeGreaterThanOrEqual(HEADLESS_DELEGATED_WORKFLOW_COUNT + 1);
+    expect(firstInteractionMs, evidenceMessage).toBeLessThanOrEqual(RESPONSIVE_INTERACTION_TIMEOUT_MS);
+    expect(secondInteractionMs, evidenceMessage).toBeLessThanOrEqual(RESPONSIVE_INTERACTION_TIMEOUT_MS);
+    expect(Number(perf.maxRendererEventLoopLagMs), evidenceMessage).toBeLessThanOrEqual(MAX_RENDERER_EVENT_LOOP_LAG_MS);
+    expect(Number(perf.maxRendererLongTaskMs), evidenceMessage).toBeLessThanOrEqual(MAX_RENDERER_LONG_TASK_MS);
     expect(delegatedPerf.ownerMode).toBe('standalone');
   });
 

--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -16,6 +16,25 @@ const PLANNING_PRESSURE_TURNS = 30;
 const PLANNING_INPUT_HANDLER_BUDGET_MS = 50;
 const PLANNING_INPUT_COMMIT_BUDGET_MS = 250;
 const PLANNING_INPUT_FILL_WALL_BUDGET_MS = 1500;
+const STARTUP_GRAPH_VISIBLE_AFTER_WINDOW_BUDGET_MS = 5000;
+const MAX_STARTUP_RENDERER_EVENT_LOOP_LAG_MS = 1000;
+const MAX_STARTUP_RENDERER_LONG_TASK_MS = 1500;
+const MAX_PLANNING_RENDERER_LONG_TASK_COUNT = 0;
+
+const STARTUP_NONEMPTY_BUDGETS = {
+  maxStartupMs: STARTUP_BUDGET_MS,
+  maxGraphVisibleAfterWindowMs: STARTUP_GRAPH_VISIBLE_AFTER_WINDOW_BUDGET_MS,
+  maxRendererEventLoopLagMs: MAX_STARTUP_RENDERER_EVENT_LOOP_LAG_MS,
+  maxRendererLongTaskMs: MAX_STARTUP_RENDERER_LONG_TASK_MS,
+};
+
+const PLANNING_PRESSURE_BUDGETS = {
+  pressureTurns: PLANNING_PRESSURE_TURNS,
+  maxInputHandlerMs: PLANNING_INPUT_HANDLER_BUDGET_MS,
+  maxInputCommitMs: PLANNING_INPUT_COMMIT_BUDGET_MS,
+  maxInputFillWallMs: PLANNING_INPUT_FILL_WALL_BUDGET_MS,
+  maxRendererLongTaskCount: MAX_PLANNING_RENDERER_LONG_TASK_COUNT,
+};
 
 async function launchElectronApp(testDir: string, extraEnv?: Record<string, string>) {
   const claudeMarker = path.join(repoRoot, 'scripts', 'e2e-dry-run', 'fixtures', 'claude-marker.sh');
@@ -95,6 +114,10 @@ function parseActivityPayload(message: string): Record<string, unknown> | null {
   } catch {
     return null;
   }
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
 }
 
 async function activityLogWatermark(page: Page): Promise<number> {
@@ -207,16 +230,32 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
           .map((entry) => entry.phase)
           .filter(Boolean),
       );
+      const graphVisibleAfterWindowMs = Number(graphVisible?.processElapsedMs) - Number(windowShow?.elapsedMs);
+      const startupEvidence = {
+        workflowCount,
+        tasksPerWorkflow,
+        expectedTaskCount,
+        elapsedMs,
+        graphVisibleAfterWindowMs,
+        taskCount: result.taskCount,
+        perf: result.perf,
+        startupEntries,
+        budgets: STARTUP_NONEMPTY_BUDGETS,
+      };
+      console.log(`STARTUP_NONEMPTY_BENCH_RESULT=${JSON.stringify(startupEvidence)}`);
+      const startupEvidenceMessage = JSON.stringify(startupEvidence);
 
-      expect(windowShow).toBeTruthy();
-      expect(graphVisible).toBeTruthy();
-      expect(taskGraphVisible).toBeTruthy();
-      expect(backgroundHydration).toBeUndefined();
-      expect(Number(graphVisible?.processElapsedMs) - Number(windowShow?.elapsedMs)).toBeLessThan(5000);
-      expect(Number(graphVisible?.nodeCount)).toBe(workflowCount);
-      expect(Number(taskGraphVisible?.nodeCount)).toBe(tasksPerWorkflow);
-      expect(elapsedMs).toBeLessThan(STARTUP_BUDGET_MS);
-      expect([...phaseNames]).toEqual(expect.arrayContaining([
+      expect(windowShow, startupEvidenceMessage).toBeTruthy();
+      expect(graphVisible, startupEvidenceMessage).toBeTruthy();
+      expect(taskGraphVisible, startupEvidenceMessage).toBeTruthy();
+      expect(backgroundHydration, startupEvidenceMessage).toBeUndefined();
+      expect(graphVisibleAfterWindowMs, startupEvidenceMessage).toBeLessThanOrEqual(STARTUP_GRAPH_VISIBLE_AFTER_WINDOW_BUDGET_MS);
+      expect(Number(graphVisible?.nodeCount), startupEvidenceMessage).toBe(workflowCount);
+      expect(Number(taskGraphVisible?.nodeCount), startupEvidenceMessage).toBe(tasksPerWorkflow);
+      expect(elapsedMs, startupEvidenceMessage).toBeLessThanOrEqual(STARTUP_BUDGET_MS);
+      expect(numberOrZero(result.perf.maxRendererEventLoopLagMs), startupEvidenceMessage).toBeLessThanOrEqual(MAX_STARTUP_RENDERER_EVENT_LOOP_LAG_MS);
+      expect(numberOrZero(result.perf.maxRendererLongTaskMs), startupEvidenceMessage).toBeLessThanOrEqual(MAX_STARTUP_RENDERER_LONG_TASK_MS);
+      expect([...phaseNames], startupEvidenceMessage).toEqual(expect.arrayContaining([
         'listWorkflowsByStartupRecency',
         'orchestrator.restore.full-snapshot',
         'sqlite.workflow-metadata.query',
@@ -226,8 +265,8 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
         'bootstrap-ipc.serialize-return',
       ]));
 
-      expect(result.taskCount).toBe(expectedTaskCount);
-      expect(result.perf.dbPollCreated).toBe(0);
+      expect(result.taskCount, startupEvidenceMessage).toBe(expectedTaskCount);
+      expect(result.perf.dbPollCreated, startupEvidenceMessage).toBe(0);
     } finally {
       await app.close();
     }
@@ -318,21 +357,37 @@ test('planning chat typing stays responsive with a large restored transcript', a
       const payloads = await uiPerfPayloadsSince(page, watermark);
       const inputChange = payloads.find((payload) => payload.metric === 'planning_chat_input_change' && payload.valueLength === typedText.length);
       const inputCommit = payloads.find((payload) => payload.metric === 'planning_chat_input_commit' && payload.valueLength === typedText.length);
-      expect(inputChange).toBeTruthy();
-      expect(inputCommit).toBeTruthy();
-      expect(Number(inputChange?.handlerDurationMs)).toBeLessThanOrEqual(PLANNING_INPUT_HANDLER_BUDGET_MS);
-      expect(Number(inputCommit?.durationMs)).toBeLessThanOrEqual(PLANNING_INPUT_COMMIT_BUDGET_MS);
-      expect(Number(inputCommit?.transcriptLineCount)).toBeGreaterThanOrEqual(PLANNING_PRESSURE_TURNS * 2);
-      expect(fillWallMs).toBeLessThanOrEqual(PLANNING_INPUT_FILL_WALL_BUDGET_MS);
-      expect(payloads.some((payload) => payload.metric === 'planning_chat_transcript_commit')).toBe(false);
-      expect(payloads.some((payload) => payload.metric === 'renderer_long_task')).toBe(false);
-
       const perf = await page.evaluate(async () => window.invoker.getUiPerfStats());
-      expect(Number(perf.planningChatInputChangeReports)).toBeGreaterThanOrEqual(1);
-      expect(Number(perf.planningChatInputCommitReports)).toBeGreaterThanOrEqual(1);
-      expect(Number(perf.maxPlanningChatInputHandlerMs)).toBeLessThanOrEqual(PLANNING_INPUT_HANDLER_BUDGET_MS);
-      expect(Number(perf.maxPlanningChatInputCommitMs)).toBeLessThanOrEqual(PLANNING_INPUT_COMMIT_BUDGET_MS);
-      expect(Number(perf.maxPlanningChatTranscriptLines)).toBeGreaterThanOrEqual(PLANNING_PRESSURE_TURNS * 2);
+      const transcriptCommitPayloads = payloads.filter((payload) => payload.metric === 'planning_chat_transcript_commit');
+      const longTaskPayloads = payloads.filter((payload) => payload.metric === 'renderer_long_task');
+      const planningEvidence = {
+        pressureTurns: PLANNING_PRESSURE_TURNS,
+        typedLength: typedText.length,
+        fillWallMs,
+        inputChange,
+        inputCommit,
+        transcriptCommitPayloads,
+        longTaskPayloads,
+        perf,
+        budgets: PLANNING_PRESSURE_BUDGETS,
+      };
+      console.log(`PLANNING_CHAT_PRESSURE_BENCH_RESULT=${JSON.stringify(planningEvidence)}`);
+      const planningEvidenceMessage = JSON.stringify(planningEvidence);
+
+      expect(inputChange, planningEvidenceMessage).toBeTruthy();
+      expect(inputCommit, planningEvidenceMessage).toBeTruthy();
+      expect(Number(inputChange?.handlerDurationMs), planningEvidenceMessage).toBeLessThanOrEqual(PLANNING_INPUT_HANDLER_BUDGET_MS);
+      expect(Number(inputCommit?.durationMs), planningEvidenceMessage).toBeLessThanOrEqual(PLANNING_INPUT_COMMIT_BUDGET_MS);
+      expect(Number(inputCommit?.transcriptLineCount), planningEvidenceMessage).toBeGreaterThanOrEqual(PLANNING_PRESSURE_TURNS * 2);
+      expect(fillWallMs, planningEvidenceMessage).toBeLessThanOrEqual(PLANNING_INPUT_FILL_WALL_BUDGET_MS);
+      expect(transcriptCommitPayloads.length, planningEvidenceMessage).toBe(0);
+      expect(longTaskPayloads.length, planningEvidenceMessage).toBeLessThanOrEqual(MAX_PLANNING_RENDERER_LONG_TASK_COUNT);
+
+      expect(Number(perf.planningChatInputChangeReports), planningEvidenceMessage).toBeGreaterThanOrEqual(1);
+      expect(Number(perf.planningChatInputCommitReports), planningEvidenceMessage).toBeGreaterThanOrEqual(1);
+      expect(Number(perf.maxPlanningChatInputHandlerMs), planningEvidenceMessage).toBeLessThanOrEqual(PLANNING_INPUT_HANDLER_BUDGET_MS);
+      expect(Number(perf.maxPlanningChatInputCommitMs), planningEvidenceMessage).toBeLessThanOrEqual(PLANNING_INPUT_COMMIT_BUDGET_MS);
+      expect(Number(perf.maxPlanningChatTranscriptLines), planningEvidenceMessage).toBeGreaterThanOrEqual(PLANNING_PRESSURE_TURNS * 2);
     } finally {
       await app.close();
     }

--- a/packages/app/e2e/ui-graph-drag-performance.spec.ts
+++ b/packages/app/e2e/ui-graph-drag-performance.spec.ts
@@ -14,6 +14,15 @@ const MIN_FRAME_COUNT = 35;
 const MAX_P95_FRAME_GAP_MS = 80;
 const MAX_FRAME_GAP_MS = 250;
 const MIN_TRANSFORM_CHANGES = 12;
+const MAX_FIRST_TRANSFORM_MS = 250;
+
+const DRAG_PERF_BUDGETS = {
+  minFrameCount: MIN_FRAME_COUNT,
+  maxP95FrameGapMs: MAX_P95_FRAME_GAP_MS,
+  maxFrameGapMs: MAX_FRAME_GAP_MS,
+  minTransformChanges: MIN_TRANSFORM_CHANGES,
+  maxFirstTransformMs: MAX_FIRST_TRANSFORM_MS,
+};
 
 interface DragPerfResult {
   frameCount: number;
@@ -21,6 +30,7 @@ interface DragPerfResult {
   p95FrameGapMs: number;
   transformChanges: number;
   transformChanged: boolean;
+  firstTransformMs: number | null;
   durationMs: number;
 }
 
@@ -125,8 +135,12 @@ async function recordDragPerformance(
       gaps.push(state.frames[i] - state.frames[i - 1]);
     }
     let transformChanges = 0;
+    let firstTransformMs: number | null = null;
     for (let i = 1; i < state.transforms.length; i += 1) {
-      if (state.transforms[i] !== state.transforms[i - 1]) transformChanges += 1;
+      if (state.transforms[i] !== state.transforms[i - 1]) {
+        transformChanges += 1;
+        firstTransformMs ??= state.frames[i] - state.startedAt;
+      }
     }
     const sorted = [...gaps].sort((a, b) => a - b);
     const p95Index = sorted.length === 0 ? 0 : Math.ceil(sorted.length * 0.95) - 1;
@@ -136,6 +150,7 @@ async function recordDragPerformance(
       p95FrameGapMs: sorted[p95Index] ?? 0,
       transformChanges,
       transformChanged: new Set(state.transforms).size > 1,
+      firstTransformMs,
       durationMs: state.finishedAt - state.startedAt,
     };
   });
@@ -177,12 +192,13 @@ async function streamTaskUpdatesDuringDrag(page: Page): Promise<number> {
 }
 
 function expectSmoothDrag(result: DragPerfResult): void {
-  expect(result.frameCount, JSON.stringify(result)).toBeGreaterThanOrEqual(MIN_FRAME_COUNT);
-  expect(result.p95FrameGapMs, JSON.stringify(result)).toBeLessThanOrEqual(MAX_P95_FRAME_GAP_MS);
-  expect(result.maxFrameGapMs, JSON.stringify(result)).toBeLessThanOrEqual(MAX_FRAME_GAP_MS);
-  if (result.transformChanged) {
-    expect(result.transformChanges, JSON.stringify(result)).toBeGreaterThanOrEqual(1);
-  }
+  const evidence = JSON.stringify({ ...result, budgets: DRAG_PERF_BUDGETS });
+  expect(result.frameCount, evidence).toBeGreaterThanOrEqual(MIN_FRAME_COUNT);
+  expect(result.p95FrameGapMs, evidence).toBeLessThanOrEqual(MAX_P95_FRAME_GAP_MS);
+  expect(result.maxFrameGapMs, evidence).toBeLessThanOrEqual(MAX_FRAME_GAP_MS);
+  expect(result.transformChanged, evidence).toBe(true);
+  expect(result.transformChanges, evidence).toBeGreaterThanOrEqual(MIN_TRANSFORM_CHANGES);
+  expect(result.firstTransformMs ?? Number.POSITIVE_INFINITY, evidence).toBeLessThanOrEqual(MAX_FIRST_TRANSFORM_MS);
 }
 
 test('workflow graph pan stays responsive under a large persisted graph', async ({ page }) => {
@@ -198,12 +214,7 @@ test('workflow graph pan stays responsive under a large persisted graph', async 
     ...result,
     workflowCount: WORKFLOW_COUNT,
     taskCount: WORKFLOW_COUNT * TASKS_PER_WORKFLOW,
-    thresholds: {
-      minFrameCount: MIN_FRAME_COUNT,
-      maxP95FrameGapMs: MAX_P95_FRAME_GAP_MS,
-      maxFrameGapMs: MAX_FRAME_GAP_MS,
-      minTransformChanges: MIN_TRANSFORM_CHANGES,
-    },
+    thresholds: DRAG_PERF_BUDGETS,
   })}`);
   expectSmoothDrag(result);
 });
@@ -228,12 +239,7 @@ test('workflow graph pan stays responsive while task updates arrive', async ({ p
     updateCount,
     updateBursts: UPDATE_BURSTS,
     updatesPerBurst: UPDATES_PER_BURST,
-    thresholds: {
-      minFrameCount: MIN_FRAME_COUNT,
-      maxP95FrameGapMs: MAX_P95_FRAME_GAP_MS,
-      maxFrameGapMs: MAX_FRAME_GAP_MS,
-      minTransformChanges: MIN_TRANSFORM_CHANGES,
-    },
+    thresholds: DRAG_PERF_BUDGETS,
   })}`);
   expect(updateCount).toBe(UPDATE_BURSTS * UPDATES_PER_BURST);
   expectSmoothDrag(result);


### PR DESCRIPTION
## Summary

Adds measured budgets to existing Electron responsiveness specs.

The specs now log JSON evidence for graph dragging, startup restore, planning input, delegated bursts, and terminal pressure.

Assertions now include renderer event loop lag, long tasks, first transform latency, and interaction wall time.

## Review Claim

Adverse load specs enforce explicit UI responsiveness budgets with raw evidence in logs.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The slice extends existing Electron E2E specs. It does not introduce a separate benchmark harness or production code path.

## Slice Rationale

This isolates measured adverse-load budgets before the matrix coverage policy. Reviewers can inspect benchmark assertions without runner policy changes.

## Non-goals

- Does not change production UI behavior.
- Does not introduce a new benchmark runner.
- Does not alter chaos matrix scenario selection.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test:e2e -- ui-graph-drag-performance.spec.ts headless-thundering-herd.spec.ts startup-nonempty-responsiveness.spec.ts embedded-terminal-pty.spec.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ui-responsiveness-step3-pr1.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run the targeted E2E command if the responsiveness gate is still required.
- Data migration? No

</details>
