### PR TITLE
[UI Responsiveness Guardrails Step 3](2) Require UI-stall chaos coverage

### DIFF
--- a/packages/app/e2e/embedded-terminal-pty.spec.ts
+++ b/packages/app/e2e/embedded-terminal-pty.spec.ts
@@ -13,6 +13,17 @@ const TERMINAL_INPUT_BUDGET_MS = 100;
 const TERMINAL_OUTPUT_WRITE_BUDGET_MS = 250;
 const TERMINAL_RESIZE_BUDGET_MS = 250;
 const TERMINAL_TAB_SWITCH_WALL_BUDGET_MS = 1000;
+const TERMINAL_RENDERER_EVENT_LOOP_LAG_BUDGET_MS = 1000;
+const TERMINAL_RENDERER_LONG_TASK_BUDGET_MS = 1500;
+
+const TERMINAL_PRESSURE_BUDGETS = {
+  maxInputMs: TERMINAL_INPUT_BUDGET_MS,
+  maxOutputWriteMs: TERMINAL_OUTPUT_WRITE_BUDGET_MS,
+  maxResizeMs: TERMINAL_RESIZE_BUDGET_MS,
+  maxTabSwitchWallMs: TERMINAL_TAB_SWITCH_WALL_BUDGET_MS,
+  maxRendererEventLoopLagMs: TERMINAL_RENDERER_EVENT_LOOP_LAG_BUDGET_MS,
+  maxRendererLongTaskMs: TERMINAL_RENDERER_LONG_TASK_BUDGET_MS,
+};
 
 const CODEX_RESUME_PLAN = {
   name: 'Embedded PTY Resume',
@@ -84,6 +95,10 @@ function parseActivityPayload(message: string): Record<string, unknown> | null {
   } catch {
     return null;
   }
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
 }
 
 async function activityLogWatermark(page: Page): Promise<number> {
@@ -382,7 +397,6 @@ test.describe('Embedded terminal PTY', () => {
     await page.getByRole('tab', { name: /Terminal pressure alpha/i }).click();
     await expect(page.getByTestId(`terminal-tab-${fullAlphaTaskId}`)).toHaveAttribute('data-active', 'true');
     const switchWallMs = Date.now() - switchStartedAt;
-    expect(switchWallMs).toBeLessThanOrEqual(TERMINAL_TAB_SWITCH_WALL_BUDGET_MS);
 
     await page.getByRole('button', { name: 'Maximize terminal drawer' }).click();
     await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'maximized');
@@ -407,20 +421,40 @@ test.describe('Embedded terminal PTY', () => {
     const inputPayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_input');
     const outputPayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_output_write');
     const resizePayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_resize');
-    expect(attachPayloads.length).toBeGreaterThanOrEqual(2);
-    expect(inputPayloads.length).toBeGreaterThan(0);
-    expect(outputPayloads.length).toBeGreaterThan(0);
-    expect(resizePayloads.some((payload) => payload.source === 'active_session' && payload.taskId === fullAlphaTaskId)).toBe(true);
-    expect(Math.max(...inputPayloads.map((payload) => Number(payload.durationMs)))).toBeLessThanOrEqual(TERMINAL_INPUT_BUDGET_MS);
-    expect(Math.max(...outputPayloads.map((payload) => Number(payload.durationMs)))).toBeLessThanOrEqual(TERMINAL_OUTPUT_WRITE_BUDGET_MS);
-    expect(Math.max(...resizePayloads.map((payload) => Number(payload.durationMs)))).toBeLessThanOrEqual(TERMINAL_RESIZE_BUDGET_MS);
-
     const perf = await page.evaluate(async () => window.invoker.getUiPerfStats());
-    expect(Number(perf.embeddedTerminalAttachReports)).toBeGreaterThanOrEqual(2);
-    expect(Number(perf.embeddedTerminalInputReports)).toBeGreaterThan(0);
-    expect(Number(perf.embeddedTerminalOutputWriteReports)).toBeGreaterThan(0);
-    expect(Number(perf.maxEmbeddedTerminalInputMs)).toBeLessThanOrEqual(TERMINAL_INPUT_BUDGET_MS);
-    expect(Number(perf.maxEmbeddedTerminalOutputWriteMs)).toBeLessThanOrEqual(TERMINAL_OUTPUT_WRITE_BUDGET_MS);
-    expect(Number(perf.maxEmbeddedTerminalResizeMs)).toBeLessThanOrEqual(TERMINAL_RESIZE_BUDGET_MS);
+    const terminalEvidence = {
+      fullAlphaTaskId,
+      fullBetaTaskId,
+      switchWallMs,
+      attachPayloads,
+      inputPayloads,
+      outputPayloads,
+      resizePayloads,
+      perf,
+      budgets: TERMINAL_PRESSURE_BUDGETS,
+    };
+    console.log(`EMBEDDED_TERMINAL_PRESSURE_BENCH_RESULT=${JSON.stringify(terminalEvidence)}`);
+    const terminalEvidenceMessage = JSON.stringify(terminalEvidence);
+
+    expect(attachPayloads.length, terminalEvidenceMessage).toBeGreaterThanOrEqual(2);
+    expect(inputPayloads.length, terminalEvidenceMessage).toBeGreaterThan(0);
+    expect(outputPayloads.length, terminalEvidenceMessage).toBeGreaterThan(0);
+    expect(
+      resizePayloads.some((payload) => payload.source === 'active_session' && payload.taskId === fullAlphaTaskId),
+      terminalEvidenceMessage,
+    ).toBe(true);
+    expect(switchWallMs, terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_TAB_SWITCH_WALL_BUDGET_MS);
+    expect(Math.max(...inputPayloads.map((payload) => Number(payload.durationMs))), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_INPUT_BUDGET_MS);
+    expect(Math.max(...outputPayloads.map((payload) => Number(payload.durationMs))), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_OUTPUT_WRITE_BUDGET_MS);
+    expect(Math.max(...resizePayloads.map((payload) => Number(payload.durationMs))), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RESIZE_BUDGET_MS);
+
+    expect(Number(perf.embeddedTerminalAttachReports), terminalEvidenceMessage).toBeGreaterThanOrEqual(2);
+    expect(Number(perf.embeddedTerminalInputReports), terminalEvidenceMessage).toBeGreaterThan(0);
+    expect(Number(perf.embeddedTerminalOutputWriteReports), terminalEvidenceMessage).toBeGreaterThan(0);
+    expect(Number(perf.maxEmbeddedTerminalInputMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_INPUT_BUDGET_MS);
+    expect(Number(perf.maxEmbeddedTerminalOutputWriteMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_OUTPUT_WRITE_BUDGET_MS);
+    expect(Number(perf.maxEmbeddedTerminalResizeMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RESIZE_BUDGET_MS);
+    expect(numberOrZero(perf.maxRendererEventLoopLagMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RENDERER_EVENT_LOOP_LAG_BUDGET_MS);
+    expect(numberOrZero(perf.maxRendererLongTaskMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RENDERER_LONG_TASK_BUDGET_MS);
   });
 });

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -21,6 +21,17 @@ test.use({ guiOwnerMode: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'daemon' });
 const execFileAsync = promisify(execFile);
 const repoRoot = resolveRepoRoot(__dirname);
 const RESPONSIVE_INTERACTION_TIMEOUT_MS = 15000;
+const HEADLESS_DELEGATED_WORKFLOW_COUNT = 8;
+const MAX_RENDERER_EVENT_LOOP_LAG_MS = 1000;
+const MAX_RENDERER_LONG_TASK_MS = 1500;
+
+const HEADLESS_HERD_BUDGETS = {
+  maxInspectorToggleMs: RESPONSIVE_INTERACTION_TIMEOUT_MS,
+  delegatedWorkflowCount: HEADLESS_DELEGATED_WORKFLOW_COUNT,
+  minRetryCommandCount: HEADLESS_DELEGATED_WORKFLOW_COUNT + 1,
+  maxRendererEventLoopLagMs: MAX_RENDERER_EVENT_LOOP_LAG_MS,
+  maxRendererLongTaskMs: MAX_RENDERER_LONG_TASK_MS,
+};
 
 async function ensureHeadlessTestConfig(testDir: string): Promise<void> {
   await writeFile(path.join(testDir, 'e2e-config.json'), JSON.stringify({ autoFixRetries: 0 }), 'utf8');
@@ -67,18 +78,27 @@ function parseJsonStdout(stdout: string): Record<string, unknown> {
   return JSON.parse(line) as Record<string, unknown>;
 }
 
-async function assertInspectorToggleResponsive(page: Page, timeoutMs: number): Promise<void> {
+async function measureInspectorToggleResponsive(page: Page, timeoutMs: number, label: string): Promise<number> {
   const minimizeButton = page.getByLabel('Minimize inspector');
   const maximizeButton = page.getByLabel('Maximize inspector');
   const startedAt = Date.now();
-  await expect(async () => {
-    await minimizeButton.click();
-    await expect(maximizeButton).toBeVisible({ timeout: 1000 });
-    await maximizeButton.click();
-    await expect(minimizeButton).toBeVisible({ timeout: 1000 });
-  }).toPass({ timeout: timeoutMs });
-  const interactionMs = Date.now() - startedAt;
-  expect(interactionMs).toBeLessThan(timeoutMs);
+  try {
+    await expect(async () => {
+      await minimizeButton.click();
+      await expect(maximizeButton).toBeVisible({ timeout: 1000 });
+      await maximizeButton.click();
+      await expect(minimizeButton).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: timeoutMs });
+  } catch (err) {
+    console.log(`HEADLESS_THUNDERING_HERD_INTERACTION_FAILURE=${JSON.stringify({
+      label,
+      durationMs: Date.now() - startedAt,
+      timeoutMs,
+      error: err instanceof Error ? err.message : String(err),
+    })}`);
+    throw err;
+  }
+  return Date.now() - startedAt;
 }
 
 test.describe('Headless thundering herd', () => {
@@ -113,7 +133,7 @@ test.describe('Headless thundering herd', () => {
 
     const workflowIds = new Set<string>();
     workflowIds.add(currentWorkflowId);
-    for (let i = 0; i < 8; i += 1) {
+    for (let i = 0; i < HEADLESS_DELEGATED_WORKFLOW_COUNT; i += 1) {
       const result = await runHeadlessClient(testDir, ['run', planPath, '--no-track']);
       expectDelegated(result.stdout);
       // Use the workflow id echoed by this exact submission. Querying shared
@@ -125,32 +145,53 @@ test.describe('Headless thundering herd', () => {
 
     await page.waitForTimeout(500);
 
+    const retryBurstStartedAt = Date.now();
     const burst = Array.from(workflowIds).map((workflowId) =>
       runHeadlessClient(testDir, ['retry', workflowId, '--no-track']),
     );
 
-    const firstInteractionStartedAt = Date.now();
-    await assertInspectorToggleResponsive(page, RESPONSIVE_INTERACTION_TIMEOUT_MS);
-    expect(Date.now() - firstInteractionStartedAt).toBeLessThan(RESPONSIVE_INTERACTION_TIMEOUT_MS);
+    const firstInteractionMs = await measureInspectorToggleResponsive(
+      page,
+      RESPONSIVE_INTERACTION_TIMEOUT_MS,
+      'during_retry_burst',
+    );
 
     await page.waitForTimeout(1500);
 
-    const secondInteractionStartedAt = Date.now();
-    await assertInspectorToggleResponsive(page, RESPONSIVE_INTERACTION_TIMEOUT_MS);
-    expect(Date.now() - secondInteractionStartedAt).toBeLessThan(RESPONSIVE_INTERACTION_TIMEOUT_MS);
+    const secondInteractionMs = await measureInspectorToggleResponsive(
+      page,
+      RESPONSIVE_INTERACTION_TIMEOUT_MS,
+      'after_retry_burst',
+    );
 
     const retryResults = await Promise.all(burst);
+    const retryBurstWallMs = Date.now() - retryBurstStartedAt;
     for (const result of retryResults) {
       expectDelegated(result.stdout);
     }
 
     const perf = await page.evaluate(async () => await window.invoker.getUiPerfStats());
-    expect(perf.maxRendererEventLoopLagMs).toBeLessThan(1000);
-    expect(perf.maxRendererLongTaskMs).toBeLessThan(1500);
-
     const delegatedPerf = parseJsonStdout(
       (await runHeadlessClient(testDir, ['query', 'ui-perf', '--output', 'json'])).stdout,
     );
+    const evidence = {
+      workflowCount: workflowIds.size,
+      retryCommandCount: burst.length,
+      retryBurstWallMs,
+      firstInteractionMs,
+      secondInteractionMs,
+      perf,
+      delegatedPerf,
+      budgets: HEADLESS_HERD_BUDGETS,
+    };
+    console.log(`HEADLESS_THUNDERING_HERD_BENCH_RESULT=${JSON.stringify(evidence)}`);
+
+    const evidenceMessage = JSON.stringify(evidence);
+    expect(burst.length, evidenceMessage).toBeGreaterThanOrEqual(HEADLESS_DELEGATED_WORKFLOW_COUNT + 1);
+    expect(firstInteractionMs, evidenceMessage).toBeLessThanOrEqual(RESPONSIVE_INTERACTION_TIMEOUT_MS);
+    expect(secondInteractionMs, evidenceMessage).toBeLessThanOrEqual(RESPONSIVE_INTERACTION_TIMEOUT_MS);
+    expect(Number(perf.maxRendererEventLoopLagMs), evidenceMessage).toBeLessThanOrEqual(MAX_RENDERER_EVENT_LOOP_LAG_MS);
+    expect(Number(perf.maxRendererLongTaskMs), evidenceMessage).toBeLessThanOrEqual(MAX_RENDERER_LONG_TASK_MS);
     expect(delegatedPerf.ownerMode).toBe('standalone');
   });
 

--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -16,6 +16,25 @@ const PLANNING_PRESSURE_TURNS = 30;
 const PLANNING_INPUT_HANDLER_BUDGET_MS = 50;
 const PLANNING_INPUT_COMMIT_BUDGET_MS = 250;
 const PLANNING_INPUT_FILL_WALL_BUDGET_MS = 1500;
+const STARTUP_GRAPH_VISIBLE_AFTER_WINDOW_BUDGET_MS = 5000;
+const MAX_STARTUP_RENDERER_EVENT_LOOP_LAG_MS = 1000;
+const MAX_STARTUP_RENDERER_LONG_TASK_MS = 1500;
+const MAX_PLANNING_RENDERER_LONG_TASK_COUNT = 0;
+
+const STARTUP_NONEMPTY_BUDGETS = {
+  maxStartupMs: STARTUP_BUDGET_MS,
+  maxGraphVisibleAfterWindowMs: STARTUP_GRAPH_VISIBLE_AFTER_WINDOW_BUDGET_MS,
+  maxRendererEventLoopLagMs: MAX_STARTUP_RENDERER_EVENT_LOOP_LAG_MS,
+  maxRendererLongTaskMs: MAX_STARTUP_RENDERER_LONG_TASK_MS,
+};
+
+const PLANNING_PRESSURE_BUDGETS = {
+  pressureTurns: PLANNING_PRESSURE_TURNS,
+  maxInputHandlerMs: PLANNING_INPUT_HANDLER_BUDGET_MS,
+  maxInputCommitMs: PLANNING_INPUT_COMMIT_BUDGET_MS,
+  maxInputFillWallMs: PLANNING_INPUT_FILL_WALL_BUDGET_MS,
+  maxRendererLongTaskCount: MAX_PLANNING_RENDERER_LONG_TASK_COUNT,
+};
 
 async function launchElectronApp(testDir: string, extraEnv?: Record<string, string>) {
   const claudeMarker = path.join(repoRoot, 'scripts', 'e2e-dry-run', 'fixtures', 'claude-marker.sh');
@@ -95,6 +114,10 @@ function parseActivityPayload(message: string): Record<string, unknown> | null {
   } catch {
     return null;
   }
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
 }
 
 async function activityLogWatermark(page: Page): Promise<number> {
@@ -207,16 +230,32 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
           .map((entry) => entry.phase)
           .filter(Boolean),
       );
+      const graphVisibleAfterWindowMs = Number(graphVisible?.processElapsedMs) - Number(windowShow?.elapsedMs);
+      const startupEvidence = {
+        workflowCount,
+        tasksPerWorkflow,
+        expectedTaskCount,
+        elapsedMs,
+        graphVisibleAfterWindowMs,
+        taskCount: result.taskCount,
+        perf: result.perf,
+        startupEntries,
+        budgets: STARTUP_NONEMPTY_BUDGETS,
+      };
+      console.log(`STARTUP_NONEMPTY_BENCH_RESULT=${JSON.stringify(startupEvidence)}`);
+      const startupEvidenceMessage = JSON.stringify(startupEvidence);
 
-      expect(windowShow).toBeTruthy();
-      expect(graphVisible).toBeTruthy();
-      expect(taskGraphVisible).toBeTruthy();
-      expect(backgroundHydration).toBeUndefined();
-      expect(Number(graphVisible?.processElapsedMs) - Number(windowShow?.elapsedMs)).toBeLessThan(5000);
-      expect(Number(graphVisible?.nodeCount)).toBe(workflowCount);
-      expect(Number(taskGraphVisible?.nodeCount)).toBe(tasksPerWorkflow);
-      expect(elapsedMs).toBeLessThan(STARTUP_BUDGET_MS);
-      expect([...phaseNames]).toEqual(expect.arrayContaining([
+      expect(windowShow, startupEvidenceMessage).toBeTruthy();
+      expect(graphVisible, startupEvidenceMessage).toBeTruthy();
+      expect(taskGraphVisible, startupEvidenceMessage).toBeTruthy();
+      expect(backgroundHydration, startupEvidenceMessage).toBeUndefined();
+      expect(graphVisibleAfterWindowMs, startupEvidenceMessage).toBeLessThanOrEqual(STARTUP_GRAPH_VISIBLE_AFTER_WINDOW_BUDGET_MS);
+      expect(Number(graphVisible?.nodeCount), startupEvidenceMessage).toBe(workflowCount);
+      expect(Number(taskGraphVisible?.nodeCount), startupEvidenceMessage).toBe(tasksPerWorkflow);
+      expect(elapsedMs, startupEvidenceMessage).toBeLessThanOrEqual(STARTUP_BUDGET_MS);
+      expect(numberOrZero(result.perf.maxRendererEventLoopLagMs), startupEvidenceMessage).toBeLessThanOrEqual(MAX_STARTUP_RENDERER_EVENT_LOOP_LAG_MS);
+      expect(numberOrZero(result.perf.maxRendererLongTaskMs), startupEvidenceMessage).toBeLessThanOrEqual(MAX_STARTUP_RENDERER_LONG_TASK_MS);
+      expect([...phaseNames], startupEvidenceMessage).toEqual(expect.arrayContaining([
         'listWorkflowsByStartupRecency',
         'orchestrator.restore.full-snapshot',
         'sqlite.workflow-metadata.query',
@@ -226,8 +265,8 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
         'bootstrap-ipc.serialize-return',
       ]));
 
-      expect(result.taskCount).toBe(expectedTaskCount);
-      expect(result.perf.dbPollCreated).toBe(0);
+      expect(result.taskCount, startupEvidenceMessage).toBe(expectedTaskCount);
+      expect(result.perf.dbPollCreated, startupEvidenceMessage).toBe(0);
     } finally {
       await app.close();
     }
@@ -318,21 +357,37 @@ test('planning chat typing stays responsive with a large restored transcript', a
       const payloads = await uiPerfPayloadsSince(page, watermark);
       const inputChange = payloads.find((payload) => payload.metric === 'planning_chat_input_change' && payload.valueLength === typedText.length);
       const inputCommit = payloads.find((payload) => payload.metric === 'planning_chat_input_commit' && payload.valueLength === typedText.length);
-      expect(inputChange).toBeTruthy();
-      expect(inputCommit).toBeTruthy();
-      expect(Number(inputChange?.handlerDurationMs)).toBeLessThanOrEqual(PLANNING_INPUT_HANDLER_BUDGET_MS);
-      expect(Number(inputCommit?.durationMs)).toBeLessThanOrEqual(PLANNING_INPUT_COMMIT_BUDGET_MS);
-      expect(Number(inputCommit?.transcriptLineCount)).toBeGreaterThanOrEqual(PLANNING_PRESSURE_TURNS * 2);
-      expect(fillWallMs).toBeLessThanOrEqual(PLANNING_INPUT_FILL_WALL_BUDGET_MS);
-      expect(payloads.some((payload) => payload.metric === 'planning_chat_transcript_commit')).toBe(false);
-      expect(payloads.some((payload) => payload.metric === 'renderer_long_task')).toBe(false);
-
       const perf = await page.evaluate(async () => window.invoker.getUiPerfStats());
-      expect(Number(perf.planningChatInputChangeReports)).toBeGreaterThanOrEqual(1);
-      expect(Number(perf.planningChatInputCommitReports)).toBeGreaterThanOrEqual(1);
-      expect(Number(perf.maxPlanningChatInputHandlerMs)).toBeLessThanOrEqual(PLANNING_INPUT_HANDLER_BUDGET_MS);
-      expect(Number(perf.maxPlanningChatInputCommitMs)).toBeLessThanOrEqual(PLANNING_INPUT_COMMIT_BUDGET_MS);
-      expect(Number(perf.maxPlanningChatTranscriptLines)).toBeGreaterThanOrEqual(PLANNING_PRESSURE_TURNS * 2);
+      const transcriptCommitPayloads = payloads.filter((payload) => payload.metric === 'planning_chat_transcript_commit');
+      const longTaskPayloads = payloads.filter((payload) => payload.metric === 'renderer_long_task');
+      const planningEvidence = {
+        pressureTurns: PLANNING_PRESSURE_TURNS,
+        typedLength: typedText.length,
+        fillWallMs,
+        inputChange,
+        inputCommit,
+        transcriptCommitPayloads,
+        longTaskPayloads,
+        perf,
+        budgets: PLANNING_PRESSURE_BUDGETS,
+      };
+      console.log(`PLANNING_CHAT_PRESSURE_BENCH_RESULT=${JSON.stringify(planningEvidence)}`);
+      const planningEvidenceMessage = JSON.stringify(planningEvidence);
+
+      expect(inputChange, planningEvidenceMessage).toBeTruthy();
+      expect(inputCommit, planningEvidenceMessage).toBeTruthy();
+      expect(Number(inputChange?.handlerDurationMs), planningEvidenceMessage).toBeLessThanOrEqual(PLANNING_INPUT_HANDLER_BUDGET_MS);
+      expect(Number(inputCommit?.durationMs), planningEvidenceMessage).toBeLessThanOrEqual(PLANNING_INPUT_COMMIT_BUDGET_MS);
+      expect(Number(inputCommit?.transcriptLineCount), planningEvidenceMessage).toBeGreaterThanOrEqual(PLANNING_PRESSURE_TURNS * 2);
+      expect(fillWallMs, planningEvidenceMessage).toBeLessThanOrEqual(PLANNING_INPUT_FILL_WALL_BUDGET_MS);
+      expect(transcriptCommitPayloads.length, planningEvidenceMessage).toBe(0);
+      expect(longTaskPayloads.length, planningEvidenceMessage).toBeLessThanOrEqual(MAX_PLANNING_RENDERER_LONG_TASK_COUNT);
+
+      expect(Number(perf.planningChatInputChangeReports), planningEvidenceMessage).toBeGreaterThanOrEqual(1);
+      expect(Number(perf.planningChatInputCommitReports), planningEvidenceMessage).toBeGreaterThanOrEqual(1);
+      expect(Number(perf.maxPlanningChatInputHandlerMs), planningEvidenceMessage).toBeLessThanOrEqual(PLANNING_INPUT_HANDLER_BUDGET_MS);
+      expect(Number(perf.maxPlanningChatInputCommitMs), planningEvidenceMessage).toBeLessThanOrEqual(PLANNING_INPUT_COMMIT_BUDGET_MS);
+      expect(Number(perf.maxPlanningChatTranscriptLines), planningEvidenceMessage).toBeGreaterThanOrEqual(PLANNING_PRESSURE_TURNS * 2);
     } finally {
       await app.close();
     }

--- a/packages/app/e2e/ui-graph-drag-performance.spec.ts
+++ b/packages/app/e2e/ui-graph-drag-performance.spec.ts
@@ -14,6 +14,15 @@ const MIN_FRAME_COUNT = 35;
 const MAX_P95_FRAME_GAP_MS = 80;
 const MAX_FRAME_GAP_MS = 250;
 const MIN_TRANSFORM_CHANGES = 12;
+const MAX_FIRST_TRANSFORM_MS = 250;
+
+const DRAG_PERF_BUDGETS = {
+  minFrameCount: MIN_FRAME_COUNT,
+  maxP95FrameGapMs: MAX_P95_FRAME_GAP_MS,
+  maxFrameGapMs: MAX_FRAME_GAP_MS,
+  minTransformChanges: MIN_TRANSFORM_CHANGES,
+  maxFirstTransformMs: MAX_FIRST_TRANSFORM_MS,
+};
 
 interface DragPerfResult {
   frameCount: number;
@@ -21,6 +30,7 @@ interface DragPerfResult {
   p95FrameGapMs: number;
   transformChanges: number;
   transformChanged: boolean;
+  firstTransformMs: number | null;
   durationMs: number;
 }
 
@@ -125,8 +135,12 @@ async function recordDragPerformance(
       gaps.push(state.frames[i] - state.frames[i - 1]);
     }
     let transformChanges = 0;
+    let firstTransformMs: number | null = null;
     for (let i = 1; i < state.transforms.length; i += 1) {
-      if (state.transforms[i] !== state.transforms[i - 1]) transformChanges += 1;
+      if (state.transforms[i] !== state.transforms[i - 1]) {
+        transformChanges += 1;
+        firstTransformMs ??= state.frames[i] - state.startedAt;
+      }
     }
     const sorted = [...gaps].sort((a, b) => a - b);
     const p95Index = sorted.length === 0 ? 0 : Math.ceil(sorted.length * 0.95) - 1;
@@ -136,6 +150,7 @@ async function recordDragPerformance(
       p95FrameGapMs: sorted[p95Index] ?? 0,
       transformChanges,
       transformChanged: new Set(state.transforms).size > 1,
+      firstTransformMs,
       durationMs: state.finishedAt - state.startedAt,
     };
   });
@@ -177,12 +192,13 @@ async function streamTaskUpdatesDuringDrag(page: Page): Promise<number> {
 }
 
 function expectSmoothDrag(result: DragPerfResult): void {
-  expect(result.frameCount, JSON.stringify(result)).toBeGreaterThanOrEqual(MIN_FRAME_COUNT);
-  expect(result.p95FrameGapMs, JSON.stringify(result)).toBeLessThanOrEqual(MAX_P95_FRAME_GAP_MS);
-  expect(result.maxFrameGapMs, JSON.stringify(result)).toBeLessThanOrEqual(MAX_FRAME_GAP_MS);
-  if (result.transformChanged) {
-    expect(result.transformChanges, JSON.stringify(result)).toBeGreaterThanOrEqual(1);
-  }
+  const evidence = JSON.stringify({ ...result, budgets: DRAG_PERF_BUDGETS });
+  expect(result.frameCount, evidence).toBeGreaterThanOrEqual(MIN_FRAME_COUNT);
+  expect(result.p95FrameGapMs, evidence).toBeLessThanOrEqual(MAX_P95_FRAME_GAP_MS);
+  expect(result.maxFrameGapMs, evidence).toBeLessThanOrEqual(MAX_FRAME_GAP_MS);
+  expect(result.transformChanged, evidence).toBe(true);
+  expect(result.transformChanges, evidence).toBeGreaterThanOrEqual(MIN_TRANSFORM_CHANGES);
+  expect(result.firstTransformMs ?? Number.POSITIVE_INFINITY, evidence).toBeLessThanOrEqual(MAX_FIRST_TRANSFORM_MS);
 }
 
 test('workflow graph pan stays responsive under a large persisted graph', async ({ page }) => {
@@ -198,12 +214,7 @@ test('workflow graph pan stays responsive under a large persisted graph', async 
     ...result,
     workflowCount: WORKFLOW_COUNT,
     taskCount: WORKFLOW_COUNT * TASKS_PER_WORKFLOW,
-    thresholds: {
-      minFrameCount: MIN_FRAME_COUNT,
-      maxP95FrameGapMs: MAX_P95_FRAME_GAP_MS,
-      maxFrameGapMs: MAX_FRAME_GAP_MS,
-      minTransformChanges: MIN_TRANSFORM_CHANGES,
-    },
+    thresholds: DRAG_PERF_BUDGETS,
   })}`);
   expectSmoothDrag(result);
 });
@@ -228,12 +239,7 @@ test('workflow graph pan stays responsive while task updates arrive', async ({ p
     updateCount,
     updateBursts: UPDATE_BURSTS,
     updatesPerBurst: UPDATES_PER_BURST,
-    thresholds: {
-      minFrameCount: MIN_FRAME_COUNT,
-      maxP95FrameGapMs: MAX_P95_FRAME_GAP_MS,
-      maxFrameGapMs: MAX_FRAME_GAP_MS,
-      minTransformChanges: MIN_TRANSFORM_CHANGES,
-    },
+    thresholds: DRAG_PERF_BUDGETS,
   })}`);
   expect(updateCount).toBe(UPDATE_BURSTS * UPDATES_PER_BURST);
   expectSmoothDrag(result);

--- a/scripts/e2e-chaos/run-matrix.sh
+++ b/scripts/e2e-chaos/run-matrix.sh
@@ -16,6 +16,15 @@ case "$GIT_DIR" in
 esac
 RESULT_ROOT="${INVOKER_CHAOS_RESULT_ROOT:-$GIT_DIR/invoker-chaos/$RUN_ID}"
 RESULTS_FILE="${INVOKER_CHAOS_RESULTS_FILE:-$RESULT_ROOT/results.jsonl}"
+UI_STALL_REQUIRED_SCENARIOS="
+reset-race-coalesced
+timeout-deadlock-guard
+retry-vs-recreate-window
+owner-autofix-intent
+owner-approve-delegated
+owner-reject-delegated
+stale-late-completion-both
+"
 
 mkdir -p "$RESULT_ROOT/logs"
 : > "$RESULTS_FILE"
@@ -36,18 +45,18 @@ run_with_timeout() {
 
 catalog() {
   cat <<'EOF'
-fix-approve-standalone|headless-standalone|single|task_failed|approve|autofix_manual|none|bash __ROOT__/scripts/e2e-dry-run/cases/case-1.5-fix-approve.sh
-fix-reject-standalone|headless-standalone|single|task_failed|reject|autofix_manual|none|bash __ROOT__/scripts/e2e-dry-run/cases/case-1.6-fix-reject.sh
-manual-approve-standalone|headless-standalone|single|awaiting_approval|approve|off|none|bash __ROOT__/scripts/e2e-dry-run/cases/case-1.7-manual-approve.sh
-manual-reject-standalone|headless-standalone|single|awaiting_approval|reject|off|none|bash __ROOT__/scripts/e2e-dry-run/cases/case-1.8-manual-reject.sh
-cancel-downstream-standalone|headless-standalone|sequential|running_task|cancel_task|off|overlap|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.10-cancel-downstream.sh
-reset-race-coalesced|headless-standalone|fan-in|failed_upstream|recreate_vs_rebase|off|overlap|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.13-rebase-recreate-coalesced.sh
-timeout-deadlock-guard|headless-standalone|single|owner_timeout_guard|rebase_and_retry|off|timeout_window|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.14-standalone-timeout-deadlock-guard.sh
-retry-vs-recreate-window|headless-standalone|single|late_reset_window|retry_vs_recreate|off|five_second_window|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh
-owner-autofix-intent|gui-owner|single|task_failed|autofix_enqueue|autofix_retry_1|none|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh
-owner-approve-delegated|gui-owner|single|awaiting_approval|approve|off|delegated|bash __ROOT__/scripts/e2e-chaos/cases/case-owner-approve-delegated.sh
-owner-reject-delegated|gui-owner|single|awaiting_approval|reject|off|delegated|bash __ROOT__/scripts/e2e-chaos/cases/case-owner-reject-delegated.sh
-stale-late-completion-both|gui-owner|sequential|stale_worker_response|recreate_and_retry_task|off|late_completion|bash __ROOT__/scripts/repro/repro-stale-late-completion-after-reset.sh --mode=both --expect-fixed
+fix-approve-standalone|headless-standalone|single|task_failed|approve|autofix_manual|none|none|bash __ROOT__/scripts/e2e-dry-run/cases/case-1.5-fix-approve.sh
+fix-reject-standalone|headless-standalone|single|task_failed|reject|autofix_manual|none|none|bash __ROOT__/scripts/e2e-dry-run/cases/case-1.6-fix-reject.sh
+manual-approve-standalone|headless-standalone|single|awaiting_approval|approve|off|none|none|bash __ROOT__/scripts/e2e-dry-run/cases/case-1.7-manual-approve.sh
+manual-reject-standalone|headless-standalone|single|awaiting_approval|reject|off|none|none|bash __ROOT__/scripts/e2e-dry-run/cases/case-1.8-manual-reject.sh
+cancel-downstream-standalone|headless-standalone|sequential|running_task|cancel_task|off|overlap|task-delta-overlap|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.10-cancel-downstream.sh
+reset-race-coalesced|headless-standalone|fan-in|failed_upstream|recreate_vs_rebase|off|overlap|delta-reset-coalescing|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.13-rebase-recreate-coalesced.sh
+timeout-deadlock-guard|headless-standalone|single|owner_timeout_guard|rebase_and_retry|off|timeout_window|owner-timeout-liveness|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.14-standalone-timeout-deadlock-guard.sh
+retry-vs-recreate-window|headless-standalone|single|late_reset_window|retry_vs_recreate|off|five_second_window|retry-burst-race|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh
+owner-autofix-intent|gui-owner|single|task_failed|autofix_enqueue|autofix_retry_1|none|gui-owner-autofix|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh
+owner-approve-delegated|gui-owner|single|awaiting_approval|approve|off|delegated|gui-owner-delegation|bash __ROOT__/scripts/e2e-chaos/cases/case-owner-approve-delegated.sh
+owner-reject-delegated|gui-owner|single|awaiting_approval|reject|off|delegated|gui-owner-delegation|bash __ROOT__/scripts/e2e-chaos/cases/case-owner-reject-delegated.sh
+stale-late-completion-both|gui-owner|sequential|stale_worker_response|recreate_and_retry_task|off|late_completion|late-completion-delta-flow|bash __ROOT__/scripts/repro/repro-stale-late-completion-after-reset.sh --mode=both --expect-fixed
 EOF
 }
 
@@ -74,8 +83,8 @@ high_risk = {
 
 entries = []
 for line in lines:
-    parts = line.split("|", 7)
-    if len(parts) != 8:
+    parts = line.split("|", 8)
+    if len(parts) != 9:
         raise SystemExit(f"invalid scenario line: {line}")
     entries.append(parts)
 
@@ -104,10 +113,12 @@ record_result() {
   local recovery_action="$5"
   local auto_fix_policy="$6"
   local race_profile="$7"
-  local log_file="$8"
-  local exit_code="$9"
-  local duration_ms="${10}"
-  python3 - "$RESULTS_FILE" "$scenario_id" "$SEED" "$surface_mode" "$topology" "$failure_mode" "$recovery_action" "$auto_fix_policy" "$race_profile" "$log_file" "$exit_code" "$duration_ms" <<'PY'
+  local ui_stall_profile="$8"
+  local log_file="$9"
+  local exit_code="${10}"
+  local duration_ms="${11}"
+  local case_timeout_seconds="${12}"
+  python3 - "$RESULTS_FILE" "$scenario_id" "$SEED" "$surface_mode" "$topology" "$failure_mode" "$recovery_action" "$auto_fix_policy" "$race_profile" "$ui_stall_profile" "$log_file" "$exit_code" "$duration_ms" "$case_timeout_seconds" <<'PY'
 import json
 import pathlib
 import re
@@ -123,9 +134,11 @@ import sys
     recovery_action,
     auto_fix_policy,
     race_profile,
+    ui_stall_profile,
     log_file,
     exit_code,
     duration_ms,
+    case_timeout_seconds,
 ) = sys.argv[1:]
 
 text = pathlib.Path(log_file).read_text(encoding="utf-8", errors="ignore")
@@ -142,6 +155,8 @@ record = {
     "recoveryAction": recovery_action,
     "autoFixPolicy": auto_fix_policy,
     "raceProfile": race_profile,
+    "uiStallRelevant": ui_stall_profile != "none",
+    "uiStallProfile": ui_stall_profile,
     "result": result,
     "hangDetected": hang_detected,
     "staleRunningTasks": "FAIL: found stale running task" in text,
@@ -150,6 +165,9 @@ record = {
     "workflowIds": workflow_ids,
     "exitCode": int(exit_code),
     "durationMs": int(duration_ms),
+    "thresholds": {
+        "caseTimeoutSeconds": int(case_timeout_seconds),
+    },
     "logFile": log_file,
 }
 with open(results_file, "a", encoding="utf-8") as fh:
@@ -163,18 +181,28 @@ echo "==> chaos results: $RESULTS_FILE"
 total=0
 passed=0
 failed=0
+ui_stall_total=0
+ui_stall_seen=""
 
-while IFS=$'\t' read -r scenario_id surface_mode topology failure_mode recovery_action auto_fix_policy race_profile command; do
+while IFS=$'\t' read -r scenario_id surface_mode topology failure_mode recovery_action auto_fix_policy race_profile ui_stall_profile command; do
   [ -n "$scenario_id" ] || continue
   if [ -n "$SCENARIO_FILTER" ] && [[ "$scenario_id" != *"$SCENARIO_FILTER"* ]]; then
     continue
   fi
 
   total=$((total + 1))
+  if [ "$ui_stall_profile" != "none" ]; then
+    ui_stall_total=$((ui_stall_total + 1))
+    base_scenario_id="${scenario_id%@repeat*}"
+    case " $ui_stall_seen " in
+      *" $base_scenario_id "*) ;;
+      *) ui_stall_seen="$ui_stall_seen $base_scenario_id" ;;
+    esac
+  fi
   log_file="$RESULT_ROOT/logs/${scenario_id//[^A-Za-z0-9._-]/_}.log"
   echo ""
   echo "======== $scenario_id ========"
-  echo "surface=$surface_mode topology=$topology failure=$failure_mode recovery=$recovery_action autofix=$auto_fix_policy race=$race_profile"
+  echo "surface=$surface_mode topology=$topology failure=$failure_mode recovery=$recovery_action autofix=$auto_fix_policy race=$race_profile ui_stall=$ui_stall_profile"
   echo "command=$command"
 
   start_ms="$(python3 - <<'PY'
@@ -194,7 +222,7 @@ PY
   duration_ms=$((end_ms - start_ms))
 
   cat "$log_file"
-  record_result "$scenario_id" "$surface_mode" "$topology" "$failure_mode" "$recovery_action" "$auto_fix_policy" "$race_profile" "$log_file" "$exit_code" "$duration_ms"
+  record_result "$scenario_id" "$surface_mode" "$topology" "$failure_mode" "$recovery_action" "$auto_fix_policy" "$race_profile" "$ui_stall_profile" "$log_file" "$exit_code" "$duration_ms" "$CASE_TIMEOUT_SECONDS"
 
   if [ "$exit_code" -eq 0 ]; then
     passed=$((passed + 1))
@@ -211,7 +239,22 @@ fi
 
 echo ""
 echo "chaos matrix: $passed passed, $failed failed ($total total)"
+echo "ui-stall-relevant scenarios: $ui_stall_total"
 echo "results jsonl: $RESULTS_FILE"
+
+if [ -z "$SCENARIO_FILTER" ]; then
+  missing_ui_stall=""
+  for required_scenario in $UI_STALL_REQUIRED_SCENARIOS; do
+    case " $ui_stall_seen " in
+      *" $required_scenario "*) ;;
+      *) missing_ui_stall="$missing_ui_stall $required_scenario" ;;
+    esac
+  done
+  if [ -n "$missing_ui_stall" ]; then
+    echo "FAILED: chaos matrix omitted UI-stall-relevant scenario(s):$missing_ui_stall" >&2
+    exit 1
+  fi
+fi
 
 if [ "$failed" -ne 0 ]; then
   exit 1


### PR DESCRIPTION
## Summary

Adds UI-stall relevance metadata to the existing chaos matrix.

The runner now records stall profiles, case timeouts, and required scenario coverage in the results stream.

Full matrix runs fail when unfiltered coverage omits required owner, delegation, retry, or late-completion scenarios.

## Review Claim

The chaos matrix now requires the owner, delegation, retry, and late-completion scenarios that matter for UI-stall coverage.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The slice reuses the existing chaos matrix runner and scenario catalog. It only adds metadata, evidence fields, and an unfiltered coverage guard.

## Slice Rationale

This keeps chaos gate policy separate from the Electron benchmark assertions. Reviewers can inspect the matrix contract without E2E spec changes.

## Non-goals

- Does not change production runtime behavior.
- Does not add a new chaos runner.
- Does not change the shell commands used by existing scenarios.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run test:e2e-chaos`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ui-responsiveness-step3-pr2.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run `pnpm run test:e2e-chaos` if the chaos gate is still required.
- Data migration? No

</details>
