### PR TITLE
[Godfile app step 3: extract gui-mutation-handlers](2) Route main through gui mutation task actions

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -37,21 +37,7 @@ import * as path from 'node:path';
 import { existsSync, mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { config as loadDotenv } from 'dotenv';
-import {
-  computeGuiRuntimeStatus,
-  configureEarlyElectronApp,
-  createDaemonOwnerLossController,
-  formatGuiOwnerBootstrapFallbackMessage,
-  guiOwnerBootstrapTimeoutMs,
-  isMutationOwnerUnavailableError,
-  shouldTreatAsDaemonOwnerLoss,
-  registerGuiLifecycleHandlers,
-  resolveGuiOwnerPreference,
-  runElectronReadyBootstrap,
-  shouldRefreshGuiOwnerRoute,
-  startGuiModeBootstrap,
-  startMainProcessBootstrap,
-} from './bootstrap/app-bootstrap.js';
+import { computeGuiRuntimeStatus, configureEarlyElectronApp, createDaemonOwnerLossController, formatGuiOwnerBootstrapFallbackMessage, guiOwnerBootstrapTimeoutMs, isMutationOwnerUnavailableError, shouldTreatAsDaemonOwnerLoss, registerGuiLifecycleHandlers, resolveGuiOwnerPreference, runElectronReadyBootstrap, shouldRefreshGuiOwnerRoute, startGuiModeBootstrap, startMainProcessBootstrap } from './bootstrap/app-bootstrap.js';
 import { createStartupWorkflowCache } from './bootstrap/startup-workflow-cache.js';
 
 const enableTestCompositor = process.env.INVOKER_E2E_ENABLE_COMPOSITOR === '1' || Boolean(process.env.CAPTURE_MODE);
@@ -103,119 +89,32 @@ import type {
 import { ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
-import {
-  WorkspaceProbeAdapter,
-  ContainerProbeAdapter,
-  SessionProbeAdapter,
-  TerminalLauncherAdapter,
-} from '@invoker/runtime-adapters';
+import { WorkspaceProbeAdapter, ContainerProbeAdapter, SessionProbeAdapter, TerminalLauncherAdapter } from '@invoker/runtime-adapters';
 import { composeRuntimeServices, composeHeadlessStartup } from '@invoker/runtime-service';
 import type { RuntimeServices } from '@invoker/runtime-service';
 import type { MessageBus } from '@invoker/transport';
-import {
-  ExecutorRegistry, TaskRunner,
-  WorktreeExecutor,
-  CI_FAILURE_WORKER_KIND,
-  initializeShellEnvironment,
-  createAutoFixAttemptLedger,
-  createWorkerRegistry,
-  PR_STATUS_WORKER_KIND,
-  E2E_AUTOFIX_WORKER_KIND,
-  RESTART_TO_BRANCH_TRACE,
-  remoteFetchForPool,
-  DEFAULT_EXECUTION_AGENT,
-  registerBuiltinAgents,
-  registerBuiltinWorkers,
-  parseRequeueMutationArgs,
-  parseRequeueEscalateMutationArgs,
-  type AgentRegistry,
-  type WorkerRegistry,
-  type WorkerRuntimeDependencies,
-} from '@invoker/execution-engine';
+import { ExecutorRegistry, TaskRunner, WorktreeExecutor, CI_FAILURE_WORKER_KIND, initializeShellEnvironment, createAutoFixAttemptLedger, createWorkerRegistry, PR_STATUS_WORKER_KIND, E2E_AUTOFIX_WORKER_KIND, registerBuiltinAgents, registerBuiltinWorkers, parseRequeueMutationArgs, parseRequeueEscalateMutationArgs, type AgentRegistry, type WorkerRegistry, type WorkerRuntimeDependencies } from '@invoker/execution-engine';
 import { FileAndDbLogger } from './logger.js';
-import {
-  DEFAULT_SLACK_HARNESS_PRESETS,
-  loadConfig,
-  resolveConfigFileState,
-  resolveDefaultTaskExecutionSettings,
-  resolveEmbeddedTerminalBackendConfig,
-  resolvePrMaintenanceWorkerConfig,
-  type EmbeddedTerminalBackendConfig,
-  type InvokerConfig,
-} from './config.js';
-import {
-  resolveAutoApproveAIFixes,
-  resolveAutoFixRetries,
-} from './autofix-defaults.js';
-import {
-  DEFAULT_WORKTREE_MAX_CONCURRENCY,
-  assertExecutionCapacityInvariant,
-  resolveEffectiveMaxConcurrency,
-  shouldFatalOnExecutionCapacityOvercommit,
-} from './execution-capacity.js';
-import {
-  createHourlySnapshot,
-  resolveInvokerHomeRoot,
-} from './delete-all-snapshot.js';
+import { DEFAULT_SLACK_HARNESS_PRESETS, loadConfig, resolveAutoFixExecutionModel, resolveConfigFileState, resolveEmbeddedTerminalBackendConfig, resolvePrMaintenanceWorkerConfig, type EmbeddedTerminalBackendConfig, type InvokerConfig } from './config.js';
+import { resolveAutoApproveAIFixes, resolveAutoFixRetries } from './autofix-defaults.js';
+import { assertExecutionCapacityInvariant, resolveEffectiveMaxConcurrency, shouldFatalOnExecutionCapacityOvercommit } from './execution-capacity.js';
+import { createHourlySnapshot, resolveInvokerHomeRoot } from './delete-all-snapshot.js';
 import { openMainProcessDatabase } from './viewer-db-boundary.js';
-import {
-  isHeadlessMutatingCommand,
-  isHeadlessReadOnlyCommand,
-  resolveHeadlessTarget,
-  resolveHeadlessTargetWorkflowId,
-} from './headless-command-classification.js';
+import { isHeadlessMutatingCommand, isHeadlessReadOnlyCommand, resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import { backupPlan } from './plan-backup.js';
 // applyPlanDefinitionDefaults removed — parsePlan() applies defaults internally
 import { startApiServer, type ApiServer } from './api-server.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
-import {
-  runHeadless,
-  isDelegated,
-  tryDelegateRun,
-  tryDelegateResume,
-  resolveDelegationTimeoutMs,
-  tryDelegateExec,
-  tryDelegateQuery,
-  resolveAgentSession,
-  createHeadlessExecutor,
-  wireHeadlessApproveHook,
-  type HeadlessDeps,
-} from './headless.js';
+import { runHeadless, isDelegated, tryDelegateRun, tryDelegateResume, resolveDelegationTimeoutMs, tryDelegateExec, tryDelegateQuery, resolveAgentSession, createHeadlessExecutor, wireHeadlessApproveHook, type HeadlessDeps } from './headless.js';
 import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
-import {
-  startStandaloneLaunchDispatcher,
-  type StandaloneLaunchDispatcherController,
-} from './headless-standalone-launch-dispatcher.js';
-import {
-  approveTask as sharedApproveTask,
-  deleteAllWorkflows as sharedDeleteAllWorkflows,
-  deleteAllWorkflowsBulk as sharedDeleteAllWorkflowsBulk,
-  fixWithAgentAction,
-  rebaseRetry,
-  rebaseRecreate,
-  rejectTask as sharedRejectTask,
-  resolveConflictAction,
-  selectFailureRecoveryRoute,
-  selectExperiments as sharedSelectExperiments,
-  setWorkflowMergeMode,
-  StaleLineageError,
-} from './workflow-actions.js';
+import { startStandaloneLaunchDispatcher, type StandaloneLaunchDispatcherController } from './headless-standalone-launch-dispatcher.js';
+import { approveTask as sharedApproveTask, deleteAllWorkflows as sharedDeleteAllWorkflows, deleteAllWorkflowsBulk as sharedDeleteAllWorkflowsBulk, fixWithAgentAction, rejectTask as sharedRejectTask, selectExperiments as sharedSelectExperiments, StaleLineageError } from './workflow-actions.js';
 import { execSync } from 'node:child_process';
 import { resolveTaskTerminalSpec } from './open-terminal-for-task.js';
-import {
-  createBashTerminalBackend,
-  createPtyTerminalBackend,
-  EmbeddedTerminalManager,
-  type EmbeddedTerminalBackend,
-} from './embedded-terminal-manager.js';
+import { createBashTerminalBackend, createPtyTerminalBackend, EmbeddedTerminalManager, type EmbeddedTerminalBackend } from './embedded-terminal-manager.js';
 import { collectSystemDiagnostics } from './system-diagnostics.js';
 import { installBundledSkills, resolveBundledSkillsStatus } from './bundled-skills.js';
-import {
-  maybeAutoInstallCli,
-  resolveCliInstallerStatus,
-  updateInvokerCli,
-  type CliInstallerContext,
-} from './cli-installer.js';
+import { maybeAutoInstallCli, resolveCliInstallerStatus, updateInvokerCli, type CliInstallerContext } from './cli-installer.js';
 import { runInvokerCliSetup } from './invoker-cli-setup.js';
 import { resolveBundledCliPath } from './cli-helper.js';
 import { buildAppMenuTemplate } from './app-menu.js';
@@ -228,46 +127,23 @@ import { submitWorkflowMutationOrAcknowledgeDeleted } from './workflow-mutation-
 import type { WorkflowMutationContext } from './persisted-workflow-mutation-coordinator.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
 import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.js';
-import {
-  dispatchStartedTasksWithGlobalTopup,
-  executeGlobalTopup,
-  finalizeMutationWithGlobalTopup,
-  isDispatchableLaunch,
-} from './global-topup.js';
-import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
+import { dispatchStartedTasksWithGlobalTopup } from './global-topup.js';
 
-import {
-  buildFixWithAgentMutationArgs,
-  buildHeadlessFixArgs,
-  listOpenFixIntentsForTask,
-  parseFixWithAgentMutationArgs,
-  type ReviewGateCiContext,
-} from './auto-fix-intents.js';
+import { buildFixWithAgentMutationArgs, buildHeadlessFixArgs, listOpenFixIntentsForTask, parseFixWithAgentMutationArgs } from './auto-fix-intents.js';
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
-import { buildReviewGateQueryResponse } from './review-gate-query.js';
-import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
+import { createGuiMutationTaskActions } from './ipc/gui-mutation-handlers.js';
 import { answerOwnerHeadlessQuery, buildOwnerReadQueryHandlers } from './owner-read-query.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
-import {
-  AUTO_STARTED_OWNER_WORKER_KINDS,
-  createLocalWorkerStatusSnapshot,
-  createWorkerRuntimeController,
-  type WorkerRuntimeController,
-} from './worker-control.js';
+import { AUTO_STARTED_OWNER_WORKER_KINDS, createWorkerRuntimeController, type WorkerRuntimeController } from './worker-control.js';
 import { runStartReady } from './start-ready.js';
+import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
 import { startSurfaceEventRelay } from './surface-event-relay.js';
 import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
 import { buildWebInvokerDispatch } from './web/web-invoker-dispatch.js';
 import { startWebBridge, resolveWebUiDistDir, type WebBridge } from './web/web-bridge-server.js';
 import { resolveWebToken, resolveWebHost, resolveWebPort } from './web/start-web-surface.js';
-import {
-  createGuiMutationRegistrars,
-  registerBootstrapStateIpc,
-  type GuiMutationPayload,
-  type GuiMutationRegistrationContext,
-  type WorkflowScopedGuiMutationRegistrationContext,
-} from './ipc/ipc-registration.js';
+import { createGuiMutationRegistrars, registerBootstrapStateIpc, type GuiMutationPayload, type GuiMutationRegistrationContext, type WorkflowScopedGuiMutationRegistrationContext } from './ipc/ipc-registration.js';
 import { createTaskDeltaStreamSequence } from './task-delta-stream-sequence.js';
 import {
   createTerminalUiPerfCounters,
@@ -287,11 +163,7 @@ import {
   registerTerminalSessionPersistence,
 } from './terminal-session-ipc.js';
 import { startLifecycleEventBridge, type LifecycleEventBridge } from './lifecycle-event-bridge.js';
-import {
-  buildRecoveryWorkerAuditPayload,
-  classifyAutoFixRecoveryPhase,
-  recoveryWorkerEventType,
-} from './recovery-worker-observability.js';
+import { buildRecoveryWorkerAuditPayload, classifyAutoFixRecoveryPhase, recoveryWorkerEventType } from './recovery-worker-observability.js';
 import { seedMainProcessHitchFixture } from './main-process-hitch-fixture.js';
 import { seedStressFixture, type StressFixtureOptions } from './stress-fixture.js';
 import {
@@ -317,21 +189,9 @@ import {
   submitPlanningChatDraft,
 } from './in-app-planner.js';
 import { discoverOwner, isStandaloneCapable } from './owner-endpoint.js';
-import {
-  killRunningTaskExecution,
-  rebuildTaskRunner as rebuildTaskRunnerWiring,
-  requireWiredTaskRunner,
-  type TaskHandleMap,
-} from './execution/task-runner-wiring.js';
-import {
-  createMainWindow,
-  registerMainWindowActivateHandler,
-  registerMainWindowSecondInstanceHandler,
-} from './window/window-lifecycle.js';
-import {
-  createRendererTaskFeed,
-  type RendererTaskFeedStopHandle,
-} from './window/renderer-task-feed.js';
+import { killRunningTaskExecution, rebuildTaskRunner as rebuildTaskRunnerWiring, requireWiredTaskRunner, type TaskHandleMap } from './execution/task-runner-wiring.js';
+import { createMainWindow, registerMainWindowActivateHandler, registerMainWindowSecondInstanceHandler } from './window/window-lifecycle.js';
+import { createRendererTaskFeed, type RendererTaskFeedStopHandle } from './window/renderer-task-feed.js';
 import { tryAcquireGuiInstanceLock, type GuiInstanceLock } from './gui-instance-lock.js';
 import { logProcessError } from './process-error-handling.js';
 
@@ -383,7 +243,7 @@ function buildRegisteredOwnerWorkerDeps(
       defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
       attemptLedger: autoFixAttemptLedger,
       getAutoFixAgent: () => invokerConfig.autoFixAgent,
-      getAutoFixExecutionModel: () => invokerConfig.defaultExecutionModel,
+      getAutoFixExecutionModel: () => resolveAutoFixExecutionModel(invokerConfig),
     },
     requeue: {
       stallRequeueRetries: invokerConfig.stallRequeueRetries,
@@ -411,6 +271,26 @@ function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
     || task.status === 'fixing_with_ai'
     || (task.status === 'pending' && task.execution.phase === 'launching');
+}
+
+function isTaskRecoverableOnExplicitResume(task: TaskState): boolean {
+  if (task.status === 'running') return true;
+  if (task.status !== 'pending' || !task.execution.selectedAttemptId) return false;
+  if (task.execution.phase === 'launching') return true;
+
+  return Boolean(
+    task.execution.startedAt
+    || task.execution.launchStartedAt
+    || task.execution.launchCompletedAt
+    || task.execution.lastHeartbeatAt
+    || task.execution.workspacePath
+    || task.execution.agentSessionId
+    || task.execution.containerId
+    || task.execution.error
+    || task.execution.exitCode !== undefined
+    || task.execution.inputPrompt
+    || task.execution.pendingFixError,
+  );
 }
 
 declare const __BUILD_SHA__: string | undefined;
@@ -1538,11 +1418,6 @@ function startHeadlessMode(): void {
             return { ok: true };
           });
         }
-        if (!workflowMutationDispatcher.has('invoker:start-ready')) {
-          workflowMutationDispatcher.set('invoker:start-ready', async (requestArg: unknown) =>
-            runStartReady(orchestrator, requestArg as StartReadyRequest | undefined),
-          );
-        }
         if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
           workflowMutationDispatcher.set('invoker:fix-with-agent', async (...fixArgs: unknown[]) => {
             const { taskId, agentName, context } = parseFixWithAgentMutationArgs(fixArgs);
@@ -2104,19 +1979,18 @@ function createEmbeddedTerminalBackendFromConfig(
     dbPollCreated: 0,
     dbPollUpdatedAsCreated: 0,
     dbPollUpdatedAsUpdated: 0,
-    ...createRendererUiPerfCounters(),
+    rendererReports: 0,
+    maxRendererEventLoopLagMs: 0,
+    maxRendererHiddenEventLoopLagMs: 0,
+    maxRendererCumulativeLagMs: 0,
+    maxRendererTickDeltaMs: 0,
+    maxRendererLongTaskMs: 0,
     workflowMetadataPublishRequests: 0,
     workflowMetadataPublishes: 0,
     workflowMetadataCoalescedRequests: 0,
     largeTaskDeltaBatches: 0,
     maxTaskDeltaBatchSize: 0,
     ...createTerminalUiPerfCounters(),
-  };
-  const emitPlanningChatStream = (event: InAppPlanningStreamEvent): void => {
-    if (mainWindow && !mainWindow.isDestroyed() && uiInteractive) {
-      mainWindow.webContents.send('invoker:planning-chat-stream', event);
-    }
-    webBridge?.broadcast('invoker:planning-chat-stream', event);
   };
   const terminalUiPerf = createTerminalUiPerfReporter();
   const terminalUiPerfSink = createTerminalUiPerfSink(
@@ -2175,7 +2049,12 @@ function createEmbeddedTerminalBackendFromConfig(
     uiPerfStats.dbPollCreated = 0;
     uiPerfStats.dbPollUpdatedAsCreated = 0;
     uiPerfStats.dbPollUpdatedAsUpdated = 0;
-    resetRendererUiPerfCounters(uiPerfStats);
+    uiPerfStats.rendererReports = 0;
+    uiPerfStats.maxRendererEventLoopLagMs = 0;
+    uiPerfStats.maxRendererHiddenEventLoopLagMs = 0;
+    uiPerfStats.maxRendererCumulativeLagMs = 0;
+    uiPerfStats.maxRendererTickDeltaMs = 0;
+    uiPerfStats.maxRendererLongTaskMs = 0;
     uiPerfStats.workflowMetadataPublishRequests = 0;
     uiPerfStats.workflowMetadataPublishes = 0;
     uiPerfStats.workflowMetadataCoalescedRequests = 0;
@@ -2240,177 +2119,6 @@ function createEmbeddedTerminalBackendFromConfig(
     },
   });
 
-  const buildAutoFixQueueSnapshot = (taskId: string): Record<string, unknown> => {
-    const workflowId = workflowIdForTaskArg(taskId);
-    if (!workflowId) {
-      return {
-        workflowId: null,
-        openIntentCountForWorkflow: 0,
-        openFixIntentCountForWorkflow: 0,
-        openFixIntentCountForTask: 0,
-        openFixIntentForTask: false,
-        openFixIntentHead: null,
-        openFixIntentPreview: [],
-      };
-    }
-    const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
-    const openFixIntents = openIntents.filter((intent) => (
-      intent.channel === 'invoker:fix-with-agent' || intent.channel === 'headless.exec'
-    ));
-    const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
-    return {
-      workflowId,
-      openIntentCountForWorkflow: openIntents.length,
-      openFixIntentCountForWorkflow: openFixIntents.length,
-      openFixIntentCountForTask: openTaskFixIntents.length,
-      openFixIntentForTask: openTaskFixIntents.length > 0,
-      openFixIntentHead: openTaskFixIntents[0]
-        ? {
-          id: openTaskFixIntents[0].id,
-          status: openTaskFixIntents[0].status,
-          channel: openTaskFixIntents[0].channel,
-        }
-        : null,
-      openFixIntentPreview: openTaskFixIntents.slice(0, 5).map((intent) => ({
-        id: intent.id,
-        status: intent.status,
-        channel: intent.channel,
-      })),
-    };
-  };
-
-  const logAutoFixDebug = (
-    taskId: string,
-    phase: string,
-    details: Record<string, unknown> = {},
-  ): void => {
-    const task = orchestrator.getTask(taskId);
-    const payload = {
-      phase,
-      status: task?.status ?? 'missing',
-      ...buildAutoFixQueueSnapshot(taskId),
-      ...details,
-    };
-    persistence.logEvent?.(taskId, 'debug.auto-fix', payload);
-    const recoveryAction = classifyAutoFixRecoveryPhase(phase, payload);
-    if (recoveryAction) {
-      persistence.logEvent?.(
-        taskId,
-        recoveryWorkerEventType(recoveryAction),
-        buildRecoveryWorkerAuditPayload(recoveryAction, phase, payload),
-      );
-    }
-    logger.info(
-      `[auto-fix-debug] task="${taskId}" phase=${phase} payload=${JSON.stringify(payload)}`,
-      { module: 'auto-fix' },
-    );
-  };
-
-  const executeFixWithAgentMutation = async (
-    taskId: string,
-    agentName?: string,
-    source: 'ipc' | 'auto-fix' = 'ipc',
-    reviewGateContext?: ReviewGateCiContext,
-  ): Promise<TaskState[]> => {
-    const task = orchestrator.getTask(taskId);
-    if (!task) {
-      throw new Error(`Task ${taskId} not found`);
-    }
-    const savedError = task.execution.error ?? '';
-    const recoveryRoute = selectFailureRecoveryRoute(task, savedError);
-    logger.info(
-      `fix-with-agent: "${taskId}" agent=${agentName ?? DEFAULT_EXECUTION_AGENT} source=${source} route=${recoveryRoute.kind}`,
-      { module: 'ipc' },
-    );
-
-    const result = await fixWithAgentAction(
-      taskId,
-      {
-        logger,
-        orchestrator,
-        persistence,
-        commandService,
-        taskExecutor: requireTaskExecutor(),
-        mutationTiming: activeMutationContext?.mutationTiming,
-        autoApproveAIFixes: resolveAutoApproveAIFixes(invokerConfig),
-      },
-      {
-        agentName,
-        recoveryRoute,
-        recreateOutputLabel: source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI',
-        failureOutputLabel: source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Codex'}`,
-        reviewGateContext,
-        signal: activeMutationContext?.signal,
-      },
-    );
-    return result.started;
-  };
-
-  const scheduleAutoFix = (taskId: string): void => {
-    logAutoFixDebug(taskId, 'schedule-enter');
-    if (!workflowMutationCoordinator) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'no-workflow-mutation-coordinator' });
-      return;
-    }
-    if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'fix-handler-not-ready' });
-      return;
-    }
-    const workflowId = workflowIdForTaskArg(taskId);
-    if (!workflowId) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'workflow-not-found' });
-      return;
-    }
-    const shouldAutoFixNow = orchestrator.shouldAutoFix(taskId);
-    if (!shouldAutoFixNow) {
-      logAutoFixDebug(taskId, 'schedule-skip', {
-        reason: 'shouldAutoFix-false',
-        shouldAutoFix: shouldAutoFixNow,
-      });
-      return;
-    }
-    const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
-    const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
-    if (openTaskFixIntents.length > 0) {
-      logAutoFixDebug(taskId, 'schedule-skip', {
-        reason: 'already-queued-intent',
-        existingIntentIds: openTaskFixIntents.map((intent) => intent.id),
-      });
-      return;
-    }
-    const configuredAgent = loadConfig().autoFixAgent?.trim();
-    const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
-    logAutoFixDebug(taskId, 'schedule-enqueue');
-    logAutoFixDebug(taskId, 'schedule-enqueued');
-    void runWorkflowMutation(
-      workflowId,
-      'normal',
-      'invoker:fix-with-agent',
-      [taskId, selectedAgent],
-      async () => executeFixWithAgentMutation(taskId, selectedAgent, 'auto-fix'),
-    )
-      .then(() => {
-        logAutoFixDebug(taskId, 'schedule-dispatch-finished');
-      })
-      .catch((err) => {
-        if (err instanceof StaleLineageError) {
-          logger.info(`auto-fix discarded stale result for "${taskId}": ${err.message}`, { module: 'auto-fix' });
-          return;
-        }
-        logAutoFixDebug(taskId, 'schedule-dispatch-error', {
-          error: err instanceof Error ? err.stack ?? err.message : String(err),
-        });
-      });
-  };
-
-  const parseExecutionDate = (value: unknown): Date | undefined => {
-    if (!value) return undefined;
-    if (value instanceof Date) return value;
-    if (typeof value !== 'string') return undefined;
-    const parsed = new Date(value);
-    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
-  };
-
   function assertFatalExecutionCapacity(label: string): void {
     if (!shouldFatalOnExecutionCapacityOvercommit()) return;
     try {
@@ -2460,485 +2168,61 @@ function createEmbeddedTerminalBackendFromConfig(
       taskHandles,
     }, taskId);
   }
-
-  /** Cancel a task and cascade-kill all downstream DAG dependents. Shared by IPC, headless, and API. */
-  async function performCancelTask(taskId: string): Promise<{ cancelled: string[]; runningCancelled: string[] }> {
-    const envelope = makeEnvelope('cancel-task', 'ui', 'task', { taskId });
-    const cmdResult = await commandService.cancelTask(envelope);
-    if (!cmdResult.ok) throw CommandError.fromResult(cmdResult.error);
-    for (const id of cmdResult.data.runningCancelled) {
-      await killRunningTask(id);
+  const requireTaskExecutor = (): TaskRunner => {
+    if (!taskExecutor) {
+      throw new Error('Task runner is not initialized');
     }
-    return cmdResult.data;
-  }
+    return taskExecutor;
+  };
 
-  async function performDeleteTask(taskId: string): Promise<void> {
-    logger.info(`performDeleteTask begin task="${taskId}"`, { module: 'kill' });
-    const task = orchestrator.getTask(taskId);
-    const workflowId = task?.config.workflowId;
-    if (task && (task.status === 'running' || task.status === 'fixing_with_ai')) {
-      await killRunningTask(task.id);
-    }
-    if (workflowId) {
-      await requireTaskExecutor().closeWorkflowReview(workflowId);
-    }
-    const envelope = makeEnvelope('delete-task', 'ui', 'task', { taskId });
-    const result = await commandService.deleteTask(envelope);
-    if (!result.ok) throw CommandError.fromResult(result.error);
-    remoteFetchForPool.enabled = false;
-    try {
-      await dispatchStartedTasksWithGlobalTopup({
-        orchestrator,
-        taskExecutor: requireTaskExecutor(),
-        logger,
-        context: 'ipc.delete-task',
-        started: result.data,
-        scopedTaskIds: result.data.map((startedTask) => startedTask.id),
-        mutationTiming: activeMutationContext?.mutationTiming,
-      });
-    } finally {
-      remoteFetchForPool.enabled = true;
-    }
-    requestWorkflowMetadataPublish('delete-task');
-    logger.info(`performDeleteTask end task="${taskId}"`, { module: 'kill' });
-  }
-
-  /** Cancel all active tasks in a workflow and kill any running processes. */
-  async function performCancelWorkflow(workflowId: string): Promise<{ cancelled: string[]; runningCancelled: string[] }> {
-    logger.info(`performCancelWorkflow begin workflow="${workflowId}"`, { module: 'kill' });
-    const envelope = makeEnvelope('cancel-workflow', 'ui', 'workflow', { workflowId });
-    const cmdResult = await commandService.cancelWorkflow(envelope);
-    if (!cmdResult.ok) throw CommandError.fromResult(cmdResult.error);
-    logger.info(
-      `performCancelWorkflow commandService complete workflow="${workflowId}" cancelled=${cmdResult.data.cancelled.length} runningCancelled=${cmdResult.data.runningCancelled.length}`,
-      { module: 'kill' },
-    );
-    for (const id of cmdResult.data.runningCancelled) {
-      logger.info(`performCancelWorkflow killing running task "${id}"`, { module: 'kill' });
-      await killRunningTask(id);
-    }
-    logger.info(`performCancelWorkflow end workflow="${workflowId}"`, { module: 'kill' });
-    return cmdResult.data;
-  }
-
-  async function performDeleteWorkflow(workflowId: string): Promise<void> {
-    logger.info(`performDeleteWorkflow begin workflow="${workflowId}"`, { module: 'kill' });
-    // Kill all running tasks belonging to the workflow (process management is outside orchestrator scope)
-    const allTasks = orchestrator.getAllTasks();
-    const workflowTasks = allTasks.filter(
-      (t) =>
-        t.config.workflowId === workflowId &&
-        (t.status === 'running' || t.status === 'fixing_with_ai'),
-    );
-    for (const task of workflowTasks) {
-      await killRunningTask(task.id);
-    }
-    await requireTaskExecutor().closeWorkflowReview(workflowId);
-    // Serialized via CommandService: DB delete + memory clear + scheduler cleanup + removal deltas
-    const envelope = makeEnvelope('delete-workflow', 'ui', 'workflow', { workflowId });
-    const result = await commandService.deleteWorkflow(envelope);
-    if (!result.ok) throw new Error(result.error.message);
-    requestWorkflowMetadataPublish('delete-workflow');
-    logger.info(`performDeleteWorkflow end workflow="${workflowId}"`, { module: 'kill' });
-  }
-
-  async function performDetachWorkflow(workflowId: string, upstreamWorkflowId: string): Promise<void> {
-    logger.info(`performDetachWorkflow begin workflow="${workflowId}" upstream="${upstreamWorkflowId}"`, { module: 'kill' });
-    const envelope = makeEnvelope('detach-workflow', 'ui', 'workflow', { workflowId, upstreamWorkflowId });
-    const result = await commandService.detachWorkflow(envelope);
-    if (!result.ok) throw new Error(result.error.message);
-    logger.info(`performDetachWorkflow end workflow="${workflowId}" upstream="${upstreamWorkflowId}"`, { module: 'kill' });
-    requestWorkflowMetadataPublish('detach-workflow');
-  }
-
-  /** Orchestrator error codes that preemption treats as benign (cancel is best-effort). */
-  const preemptSkipCodes: ReadonlySet<string> = new Set([
-    OrchestratorErrorCode.TASK_NOT_FOUND,
-    OrchestratorErrorCode.TASK_ALREADY_TERMINAL,
-    OrchestratorErrorCode.WORKFLOW_NOT_FOUND,
-  ]);
-
-  async function preemptTaskSubgraph(taskId: string): Promise<void> {
-    try {
-      await performCancelTask(taskId);
-    } catch (err) {
-      if (err instanceof CommandError && preemptSkipCodes.has(err.code)) {
-        logger.info(`preemptTaskSubgraph skipped for "${taskId}": ${err.message}`, { module: 'ipc' });
-        return;
-      }
-      throw err;
-    }
-  }
-
-  async function preemptWorkflowExecution(workflowId: string): Promise<WorkflowCancelResult> {
-    try {
-      logger.info(`preemptWorkflowExecution begin for "${workflowId}"`, { module: 'ipc' });
-      const result = await performCancelWorkflow(workflowId);
-      logger.info(`preemptWorkflowExecution end for "${workflowId}"`, { module: 'ipc' });
-      return result;
-    } catch (err) {
-      if (err instanceof CommandError && preemptSkipCodes.has(err.code)) {
-        logger.info(`preemptWorkflowExecution skipped for "${workflowId}": ${err.message}`, { module: 'ipc' });
-        return { cancelled: [], runningCancelled: [] };
-      }
-      throw err;
-    }
-  }
-
-  function requireTaskExecutor(): TaskRunner {
-    return requireWiredTaskRunner(() => taskExecutor);
-  }
   const loadTaskByIdFromPersistence = (taskId: string): TaskState | undefined =>
     persistence.loadTask(taskId);
 
-
-  async function executeHeadlessRun(payload: HeadlessRunMutationPayload): Promise<{ workflowId: string; tasks: TaskState[] }> {
-    const { applyConfiguredPlanDefaults, parsePlanFile } = await import('./plan-parser.js');
-    const plan = applyConfiguredPlanDefaults(await parsePlanFile(payload.planPath));
-    taskHandles.clear();
-    backupPlan(plan, undefined, logger);
-    const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
-    orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
-    const workflowId = orchestrator.getWorkflowIds().find(id => !wfIdsBefore.has(id))!;
-    const started = orchestrator.startExecution();
-    logger.info(`started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
-    const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
-    return { workflowId, tasks };
-  }
-
-  async function executeHeadlessResume(payload: HeadlessResumeMutationPayload): Promise<{ workflowId: string; tasks: TaskState[] }> {
-    const { workflowId } = payload;
-
-    const allStarted = orchestrator.resumeWorkflow(workflowId);
-    const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
-    return { workflowId, tasks };
-  }
-
-  async function executeHeadlessExec(payload: HeadlessExecMutationPayload): Promise<unknown> {
-    logger.info(`executeHeadlessExec begin args="${payload.args.join(' ')}" noTrack=${payload.noTrack ? 'true' : 'false'}`, {
-      module: 'ipc-delegate',
-    });
-    const headlessCommand = String(payload.args[0] ?? '');
-    const headlessTarget = String(payload.args[1] ?? '');
-    const resolvedHeadlessTarget = resolveHeadlessTarget(headlessTarget, persistence);
-    if (
-      (headlessCommand === 'recreate' || headlessCommand === 'retry')
-      && resolvedHeadlessTarget.kind === 'workflow'
-    ) {
-      cancelDeferredWorkflowLaunch(resolvedHeadlessTarget.workflowId, `headless.${headlessCommand}`);
-    }
-    await runHeadless(payload.args, {
-      logger,
-      orchestrator, persistence, executorRegistry, messageBus,
-      commandService,
-      repoRoot, invokerConfig, initServices,
-      signal: activeMutationContext?.signal,
-      mutationTiming: activeMutationContext?.mutationTiming,
-      cancelTask: (taskId: string) => performCancelTask(taskId),
-      cancelWorkflow: (workflowId: string) => performCancelWorkflow(workflowId),
-      waitForApproval: payload.waitForApproval,
-      noTrack: payload.noTrack,
-      preemptTaskSubgraph: (taskId: string) => preemptTaskSubgraph(taskId),
-      preemptWorkflowExecution: (workflowId: string) => preemptWorkflowExecution(workflowId),
-      deferRunnableTasks: (tasks: TaskState[], workflowId?: string) => {
-        const filteredTasks = tasks;
-        const crossWorkflowTasks = workflowId
-          ? tasks.filter((task) => task.config.workflowId !== workflowId)
-          : [];
-        if (crossWorkflowTasks.length > 0) {
-          logger.info(
-            `deferRunnableTasks dispatching cross-workflow runnable tasks for workflow="${workflowId}": ${crossWorkflowTasks.map((task) => `${task.id}(${task.config.workflowId ?? 'unknown'})`).join(', ')}`,
-            { module: 'ipc-delegate' },
-          );
-        }
-        if (filteredTasks.length === 0) {
-          return;
-        }
-        logger.info(
-          `deferRunnableTasks accepted by launch outbox workflow="${workflowId ?? 'unknown'}" count=${filteredTasks.length}`,
-          { module: 'ipc-delegate' },
-        );
-        return;
-      },
-      executionAgentRegistry: registerBuiltinAgents(),
-    });
-    const { workflowId } = classifyHeadlessExecMutation(payload);
-    logger.info(`executeHeadlessExec end args="${payload.args.join(' ')}" workflow="${workflowId ?? 'unknown'}"`, {
-      module: 'ipc-delegate',
-    });
-    if (!workflowId) {
-      return { ok: true };
-    }
-    orchestrator.syncFromDb(workflowId);
-    const tasks = orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflowId);
-    return { workflowId, tasks };
-  }
-
-  function workflowIdForTargetArg(targetArg: unknown): string | undefined {
-    if (targetArg === undefined) return undefined;
-    return resolveHeadlessTargetWorkflowId(targetArg, persistence);
-  }
-
-  function workflowIdForTaskArg(taskIdArg: unknown): string | undefined {
-    return workflowIdForTargetArg(taskIdArg);
-  }
-
-  function classifyHeadlessExecMutation(payload: HeadlessExecMutationPayload): {
-    workflowId?: string;
-    priority: WorkflowMutationPriority;
-  } {
-    const [command, arg0] = payload.args;
-    if (!command) return { priority: 'normal' };
-
-    switch (command) {
-      case 'set': {
-        const [, subCommand, targetArg] = payload.args;
-        switch (subCommand) {
-          case 'workflow':
-          case 'merge-mode':
-            return { workflowId: targetArg === undefined ? undefined : String(targetArg), priority: 'high' };
-          case 'command':
-          case 'prompt':
-          case 'executor':
-          case 'agent':
-          case 'fix-prompt':
-          case 'fix-context':
-          case 'gate-policy':
-          case 'task':
-            return { workflowId: workflowIdForTaskArg(targetArg), priority: 'high' };
-          default:
-            return { priority: 'normal' };
-        }
-      }
-      case 'resume':
-      case 'retry':
-        return { workflowId: workflowIdForTargetArg(arg0), priority: 'high' };
-      case 'recreate':
-      case 'cancel-workflow':
-      case 'delete':
-      case 'delete-workflow':
-      case 'detach-workflow':
-        return { workflowId: arg0, priority: 'high' };
-      case 'rebase-retry':
-      case 'rebase-recreate':
-        return { workflowId: workflowIdForTargetArg(arg0), priority: 'high' };
-      case 'cancel':
-      case 'retry-task':
-      case 'recreate-task':
-      case 'delete-task':
-        return { workflowId: workflowIdForTaskArg(arg0), priority: 'high' };
-      case 'approve':
-      case 'reject':
-      case 'select':
-      case 'fix':
-      case 'resolve-conflict':
-        return { workflowId: workflowIdForTaskArg(arg0), priority: 'normal' };
-      default:
-        return { priority: 'normal' };
-    }
-  }
-
-  async function runWorkflowMutation<T>(
-    workflowId: string | undefined,
-    priority: WorkflowMutationPriority,
-    channel: string,
-    args: unknown[],
-    op: () => Promise<T>,
-  ): Promise<T> {
-    if (!workflowId) return op();
-    if (!workflowMutationCoordinator) {
-      throw new Error('Workflow mutation coordinator is unavailable');
-    }
-    if (!workflowMutationDispatcher.has(channel)) {
-      throw new Error(`No workflow mutation dispatcher registered for ${channel}`);
-    }
-    return workflowMutationCoordinator.enqueue<T>(workflowId, priority, channel, args);
-  }
-
-  function submitWorkflowMutation(
-    workflowId: string | undefined,
-    priority: WorkflowMutationPriority,
-    channel: string,
-    args: unknown[],
-  ): WorkflowMutationAcceptedResult {
-    if (!workflowId) throw new Error(`Could not resolve workflow for ${channel}`);
-    if (!workflowMutationCoordinator) throw new Error('Workflow mutation coordinator is unavailable');
-    if (!workflowMutationDispatcher.has(channel)) {
-      throw new Error(`No workflow mutation dispatcher registered for ${channel}`);
-    }
-    return submitWorkflowMutationOrAcknowledgeDeleted(workflowId, priority, channel, args, {
-      coordinator: workflowMutationCoordinator,
-      workflowExists: (id) => Boolean(persistence.loadWorkflow(id)),
-      logger,
-    });
-  }
-
-  function registerTaskScopedGuiMutationHandler<TResult = unknown>(
-    channel: keyof typeof IpcChannels & string,
-    resolveWorkflowId: (...args: unknown[]) => string | undefined,
-    priority: WorkflowMutationPriority,
-    handler: (...args: unknown[]) => Promise<TResult>,
-  ): void {
-    workflowMutationDispatcher.set(channel, (...args: unknown[]) => handler(...args));
-    registerGuiMutationHandler(channel, async (...args: unknown[]) => (
-      submitWorkflowMutation(resolveWorkflowId(...args), priority, channel, args)
-    ));
-  }
-
-  function translateGuiMutationToHeadless(payload: GuiMutationPayload):
-    | { channel: 'headless.gui-mutation'; request: GuiMutationPayload }
-    | { channel: 'headless.run'; request: HeadlessRunMutationPayload }
-    | { channel: 'headless.resume'; request: HeadlessResumeMutationPayload }
-    | { channel: 'headless.exec'; request: HeadlessExecMutationPayload }
-    | null {
-    const [arg0, arg1, arg2] = payload.args;
-    switch (payload.channel) {
-      case 'invoker:planning-chat-create':
-      case 'invoker:planning-chat-list':
-      case 'invoker:plan-from-goal':
-      case 'invoker:planning-chat-send':
-      case 'invoker:planning-chat-submit':
-      case 'invoker:planning-chat-reset':
-      case 'invoker:planning-chat-set-terminal-mode':
-        return { channel: 'headless.gui-mutation', request: payload };
-      case 'invoker:load-plan':
-        return { channel: 'headless.gui-mutation', request: payload };
-      case 'invoker:start':
-        return { channel: 'headless.gui-mutation', request: payload };
-      case 'invoker:start-ready':
-        return { channel: 'headless.gui-mutation', request: payload };
-      case 'invoker:stop':
-        return { channel: 'headless.gui-mutation', request: payload };
-      case 'invoker:clear':
-        return { channel: 'headless.gui-mutation', request: payload };
-      case 'invoker:start-worker':
-        return { channel: 'headless.gui-mutation', request: payload };
-      case 'invoker:stop-worker':
-        return { channel: 'headless.gui-mutation', request: payload };
-      case 'invoker:resume-workflow': {
-        const workflows = rendererTaskFeed.getDetachedViewerWorkflows() ?? persistence.listWorkflows();
-        const firstWorkflow = workflows[0] as { id?: unknown } | undefined;
-        const workflowId = startupWorkflowId
-          ?? (typeof firstWorkflow?.id === 'string' ? firstWorkflow.id : undefined);
-        if (!workflowId) return null;
-        return { channel: 'headless.resume', request: { workflowId } };
-      }
-      case 'invoker:delete-all-workflows':
-        return { channel: 'headless.exec', request: { args: ['delete-all'] } };
-      case 'invoker:delete-all-workflows-bulk':
-        return { channel: 'headless.exec', request: { args: ['delete-all'] } };
-      case 'invoker:delete-task':
-        return { channel: 'headless.exec', request: { args: ['delete-task', String(arg0)], noTrack: true } };
-      case 'invoker:delete-workflow':
-        return { channel: 'headless.exec', request: { args: ['delete', String(arg0)], noTrack: true } };
-      case 'invoker:detach-workflow':
-        return { channel: 'headless.exec', request: { args: ['detach-workflow', String(arg0), String(arg1)], noTrack: true } };
-      case 'invoker:provide-input':
-        return { channel: 'headless.exec', request: { args: ['input', String(arg0), String(arg1)], noTrack: true } };
-      case 'invoker:approve':
-        return { channel: 'headless.exec', request: { args: ['approve', String(arg0)], noTrack: true } };
-      case 'invoker:reject':
-        return arg1 === undefined
-          ? { channel: 'headless.exec', request: { args: ['reject', String(arg0)], noTrack: true } }
-          : { channel: 'headless.exec', request: { args: ['reject', String(arg0), String(arg1)], noTrack: true } };
-      case 'invoker:select-experiment':
-        if (Array.isArray(arg1)) return null;
-        return { channel: 'headless.exec', request: { args: ['select', String(arg0), String(arg1)], noTrack: true } };
-      case 'invoker:restart-task':
-        return { channel: 'headless.exec', request: { args: ['retry-task', String(arg0)], noTrack: true } };
-      case 'invoker:cancel-task':
-        return { channel: 'headless.exec', request: { args: ['cancel', String(arg0)], noTrack: true } };
-      case 'invoker:cancel-workflow':
-        return { channel: 'headless.exec', request: { args: ['cancel-workflow', String(arg0)], noTrack: true } };
-      case 'invoker:recreate-workflow':
-        return { channel: 'headless.exec', request: { args: ['recreate', String(arg0)], noTrack: true } };
-      case 'invoker:recreate-task':
-        return { channel: 'headless.exec', request: { args: ['recreate-task', String(arg0)], noTrack: true } };
-      case 'invoker:recreate-downstream':
-        return { channel: 'headless.exec', request: { args: ['recreate-downstream', String(arg0)], noTrack: true } };
-      case 'invoker:retry-workflow':
-        return { channel: 'headless.exec', request: { args: ['retry', String(arg0)], noTrack: true } };
-      case 'invoker:rebase-retry':
-        return { channel: 'headless.exec', request: { args: ['rebase-retry', String(arg0)], noTrack: true } };
-      case 'invoker:rebase-recreate':
-        return { channel: 'headless.exec', request: { args: ['rebase-recreate', String(arg0)], noTrack: true } };
-      case 'invoker:set-merge-branch':
-        return { channel: 'headless.gui-mutation', request: payload };
-      case 'invoker:set-merge-mode':
-        return { channel: 'headless.exec', request: { args: ['set', 'merge-mode', String(arg0), String(arg1)], noTrack: true } };
-      case 'invoker:approve-merge': {
-        const workflowId = String(arg0);
-        const mergeTask = persistence.loadTasks(workflowId).find((task) => task.config.isMergeNode);
-        if (!mergeTask) return null;
-        return { channel: 'headless.exec', request: { args: ['approve', mergeTask.id], noTrack: true } };
-      }
-      case 'invoker:check-pr-statuses':
-        return { channel: 'headless.gui-mutation', request: payload };
-      case 'invoker:check-pr-status':
-        return { channel: 'headless.gui-mutation', request: payload };
-      case 'invoker:resolve-conflict':
-        return arg1 === undefined
-          ? { channel: 'headless.exec', request: { args: ['resolve-conflict', String(arg0)], noTrack: true } }
-          : { channel: 'headless.exec', request: { args: ['resolve-conflict', String(arg0), String(arg1)], noTrack: true } };
-      case 'invoker:fix-with-agent': {
-        const { taskId, agentName, context } = parseFixWithAgentMutationArgs(payload.args);
-        return { channel: 'headless.exec', request: { args: buildHeadlessFixArgs(taskId, agentName, context), noTrack: true } };
-      }
-      case 'invoker:edit-task-command':
-        return { channel: 'headless.exec', request: { args: ['set', 'command', String(arg0), String(arg1)], noTrack: true } };
-      case 'invoker:edit-task-prompt':
-        return { channel: 'headless.exec', request: { args: ['set', 'prompt', String(arg0), String(arg1)], noTrack: true } };
-      case 'invoker:edit-task-type':
-        return { channel: 'headless.exec', request: { args: ['set', 'executor', String(arg0), String(arg1)], noTrack: true } };
-      case 'invoker:edit-task-pool':
-        return null;
-      case 'invoker:edit-task-agent':
-        return { channel: 'headless.exec', request: { args: ['set', 'agent', String(arg0), String(arg1)], noTrack: true } };
-      case 'invoker:edit-task-model':
-        return { channel: 'headless.exec', request: { args: ['set', 'model', String(arg0), arg1 == null ? '' : String(arg1)], noTrack: true } };
-      case 'invoker:set-task-external-gate-policies': {
-        const taskId = String(arg0);
-        const updates = Array.isArray(arg1) ? arg1 as Array<{ workflowId: string; taskId?: string; gatePolicy: 'completed' | 'review_ready' }> : [];
-        if (updates.length !== 1) return null;
-        const update = updates[0];
-        if (!update) return null;
-        const args = ['set', 'gate-policy', taskId, update.workflowId];
-        if (update.taskId) args.push(update.taskId);
-        args.push(update.gatePolicy);
-        return { channel: 'headless.exec', request: { args, noTrack: true } };
-      }
-      case 'invoker:replace-task':
-        return {
-          channel: 'headless.exec',
-          request: { args: ['replace-task', String(arg0), JSON.stringify(Array.isArray(arg1) ? arg1 : [])], noTrack: true },
-        };
-      default:
-        return null;
-    }
-  }
-
-  async function performSharedApproveTask(
-    taskId: string,
-    source: 'ui' | 'surface' | 'api',
-    scope: 'task' | 'workflow' = 'task',
-  ): Promise<{ started: TaskState[] }> {
-    const envelope = makeEnvelope('approve', source === 'api' ? 'surface' : source, scope, { taskId });
-    return sharedApproveTask(taskId, {
-      orchestrator,
-      taskExecutor: requireTaskExecutor(),
-      approve: async (approvedTaskId) => {
-        const result = await commandService.approve({ ...envelope, payload: { taskId: approvedTaskId } });
-        if (!result.ok) throw new Error(result.error.message);
-        return result.data;
-      },
-      resumeAfterFixApproval: async (approvedTaskId) => {
-        const result = await commandService.resumeTaskAfterFixApproval({ ...envelope, payload: { taskId: approvedTaskId } });
-        if (!result.ok) throw new Error(result.error.message);
-        return result.data;
-      },
-    });
-  }
-
+  const guiMutationTaskActions = createGuiMutationTaskActions({
+    logger,
+    persistence,
+    messageBus,
+    executorRegistry,
+    agentRegistry,
+    repoRoot,
+    invokerConfig,
+    effectiveMaxConcurrency,
+    taskHandles,
+    getOrchestrator: () => orchestrator,
+    setOrchestrator: (value) => { orchestrator = value; },
+    getCommandService: () => commandService,
+    setCommandService: (value) => { commandService = value; },
+    getWorkflowMutationCoordinator: () => workflowMutationCoordinator,
+    workflowMutationDispatcher,
+    getActiveMutationContext: () => activeMutationContext,
+    getRendererTaskFeed: () => rendererTaskFeed,
+    getStartupWorkflowId: () => startupWorkflowId,
+    getLaunchDispatcher: () => launchDispatcher,
+    requireTaskExecutor,
+    getTaskExecutor: () => taskExecutor,
+    rebuildTaskRunner,
+    initServices,
+    requestWorkflowMetadataPublish,
+    cancelDeferredWorkflowLaunch,
+    killRunningTask,
+    buildCommandServiceInvalidationDeps,
+  });
+  const {
+    scheduleAutoFix,
+    logAutoFixDebug,
+    performDeleteWorkflow,
+    performDetachWorkflow,
+    performSharedApproveTask,
+    executeHeadlessRun,
+    executeHeadlessResume,
+    executeHeadlessExec,
+    classifyHeadlessExecMutation,
+    translateGuiMutationToHeadless,
+    submitWorkflowMutation,
+    runWorkflowMutation,
+    workflowIdForTaskArg,
+    workflowIdForTargetArg,
+  } = guiMutationTaskActions;
   const guiMutationRegistrationContext = {
     ipcMain,
     getOwnerMode: () => ownerMode,
@@ -2955,13 +2239,18 @@ function createEmbeddedTerminalBackendFromConfig(
     submitWorkflowMutation,
   };
 
-  const {
-    registerGuiMutationHandler,
-    registerWorkflowScopedGuiMutationHandler,
-  } = createGuiMutationRegistrars(
+  const guiMutationRegistrars = createGuiMutationRegistrars(
     guiMutationRegistrationContext,
     workflowScopedGuiMutationRegistrationContext,
   );
+  const { registerGuiMutationHandler } = guiMutationRegistrars;
+
+  const emitPlanningChatStream = (event: InAppPlanningStreamEvent): void => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('invoker:planning-chat-stream', event);
+    }
+    webBridge?.broadcast('invoker:planning-chat-stream', event);
+  };
 
   function createWindow(): void {
     createMainWindow({
@@ -3086,7 +2375,6 @@ function createEmbeddedTerminalBackendFromConfig(
       requestWorkflowMetadataPublish('orchestrator-snapshot');
     }
   }
-
   function executeStartReady(request: StartReadyRequest = {}): StartReadyResult {
     const result = runStartReady(orchestrator, request);
     if (!result.dryRun) {
@@ -3171,7 +2459,7 @@ function createEmbeddedTerminalBackendFromConfig(
               persistence,
               logger,
             });
-            taskGraphEventPublisher.publishSnapshot('refresh-task-graph', snapshot.tasks, snapshot.workflows, true);
+            taskGraphEventPublisher.publishSnapshot('refresh-task-graph', snapshot.tasks, snapshot.workflows);
           },
           deleteWorkflow: performDeleteWorkflow,
           detachWorkflow: performDetachWorkflow,
@@ -3355,9 +2643,6 @@ function createEmbeddedTerminalBackendFromConfig(
       workflowMutationDispatcher.set('headless.exec', async (payloadArg: unknown) => {
         return executeHeadlessExec(payloadArg as HeadlessExecMutationPayload);
       });
-      workflowMutationDispatcher.set('invoker:start-ready', async (requestArg: unknown) =>
-        executeStartReady(requestArg as StartReadyRequest | undefined),
-      );
       workflowMutationDispatcher.set('api:approve-task', async (taskIdArg: unknown) => {
         await performSharedApproveTask(String(taskIdArg), 'api');
       });
@@ -3906,1063 +3191,6 @@ function createEmbeddedTerminalBackendFromConfig(
       recordStartupDuration,
       getTaskDeltaStreamSequence,
     });
-
-    registerGuiMutationHandler('invoker:delete-all-workflows', async () => {
-      logger.info('delete-all-workflows', { module: 'ipc' });
-      assertDeleteAllEnabled();
-      await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
-      taskHandles.clear();
-      rendererTaskFeed.resetSnapshotState();
-      requestWorkflowMetadataPublish('delete-all-workflows');
-    });
-
-    registerGuiMutationHandler('invoker:delete-all-workflows-bulk', async () => {
-      logger.info('delete-all-workflows-bulk', { module: 'ipc' });
-      assertDeleteAllEnabled();
-      await sharedDeleteAllWorkflowsBulk({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
-      taskHandles.clear();
-      rendererTaskFeed.resetSnapshotState();
-      requestWorkflowMetadataPublish('delete-all-workflows-bulk');
-    });
-
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:delete-task',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'high',
-      async (taskIdArg: unknown) => {
-        const taskId = String(taskIdArg);
-        logger.info(`delete-task: "${taskId}"`, { module: 'ipc' });
-        try {
-          await performDeleteTask(taskId);
-        } catch (err) {
-          logger.error(`delete-task failed: ${err}`, { module: 'ipc' });
-          throw err;
-        }
-      },
-    );
-
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:delete-workflow',
-      (workflowIdArg: unknown) => String(workflowIdArg),
-      'high',
-      async (workflowIdArg: unknown) => {
-        const workflowId = String(workflowIdArg);
-        logger.info(`delete-workflow: "${workflowId}"`, { module: 'ipc' });
-        try {
-          await performDeleteWorkflow(workflowId);
-        } catch (err) {
-          logger.error(`delete-workflow failed: ${err}`, { module: 'ipc' });
-          throw err;
-        }
-      },
-    );
-
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:detach-workflow',
-      (workflowIdArg: unknown) => String(workflowIdArg),
-      'high',
-      async (workflowIdArg: unknown, upstreamWorkflowIdArg: unknown) => {
-        const workflowId = String(workflowIdArg);
-        const upstreamWorkflowId = String(upstreamWorkflowIdArg);
-        logger.info(
-          `detach-workflow: workflow="${workflowId}" upstream="${upstreamWorkflowId}"`,
-          { module: 'ipc' },
-        );
-        try {
-          await performDetachWorkflow(workflowId, upstreamWorkflowId);
-        } catch (err) {
-          logger.error(`detach-workflow failed: ${err}`, { module: 'ipc' });
-          throw err;
-        }
-      },
-    );
-
-    registerTaskScopedGuiMutationHandler(
-      'invoker:provide-input',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'normal',
-      async (taskIdArg: unknown, inputArg: unknown) => {
-      const taskId = String(taskIdArg);
-      const input = String(inputArg);
-      const envelope = makeEnvelope('provide-input', 'ui', 'task', { taskId, input });
-      const result = await commandService.provideInput(envelope);
-      if (!result.ok) throw new Error(result.error.message);
-    });
-
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:approve',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'normal',
-      async (taskIdArg: unknown) => {
-      const taskId = String(taskIdArg);
-      logger.info(`approve: "${taskId}"`, { module: 'ipc' });
-      const { started } = await performSharedApproveTask(taskId, 'ui');
-      logger.info(`approve: commandService returned ${started.length} started tasks: [${started.map(t => `${t.id}(${t.status})`).join(', ')}]`, { module: 'ipc' });
-      await finalizeMutationWithGlobalTopup({
-        orchestrator,
-        taskExecutor: requireTaskExecutor(),
-        logger,
-        context: 'ipc.approve',
-        started,
-        mutationTiming: activeMutationContext?.mutationTiming,
-        scopedTaskIds: [taskId],
-      });
-      },
-    );
-
-    registerTaskScopedGuiMutationHandler(
-      'invoker:reject',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'normal',
-      async (taskIdArg: unknown, reasonArg?: unknown) => {
-      const taskId = String(taskIdArg);
-      const reason = reasonArg === undefined ? undefined : String(reasonArg);
-      const envelope = makeEnvelope('reject', 'ui', 'task', { taskId, reason });
-      const result = await commandService.reject(envelope);
-      if (!result.ok) throw new Error(result.error.message);
-    });
-
-    registerTaskScopedGuiMutationHandler(
-      'invoker:select-experiment',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'normal',
-      async (taskIdArg: unknown, experimentIdArg: unknown) => {
-      const taskId = String(taskIdArg);
-      const experimentId = experimentIdArg as string | string[];
-      const ids = Array.isArray(experimentId) ? experimentId : [experimentId];
-      logger.info(`select-experiment: "${taskId}" experimentIds=${JSON.stringify(ids)}`, { module: 'ipc' });
-      try {
-        if (ids.length === 1) {
-          // Single-select: serialized via CommandService
-          const envelope = makeEnvelope('select-experiment', 'ui', 'task', { taskId, experimentId: ids[0] });
-          const result = await commandService.selectExperiment(envelope);
-          if (!result.ok) throw new Error(result.error.message);
-        } else {
-          // Multi-select: needs taskExecutor for branch merge, stays in workflow-actions
-          await sharedSelectExperiments(taskId, ids, { orchestrator, taskExecutor: requireTaskExecutor() });
-        }
-      } catch (err) {
-        logger.error(`select-experiment failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-    });
-
-    // `invoker:restart-task` IPC channel — the channel name is kept
-    // for UI compatibility (renaming would require coordinated UI
-    // changes, deferred to a follow-up). The handler now routes
-    // through `commandService.retryTask` per Step 13's vocabulary
-    // cleanup so the UI's "Restart" context-menu action keeps its
-    // historical retry-class semantics (preserves
-    // branch/workspacePath lineage). The channel itself carries an
-    // `@deprecated` marker in `packages/contracts/src/ipc-channels.ts`.
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:restart-task',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'high',
-      async (taskIdArg: unknown) => {
-      const taskId = String(taskIdArg);
-      logger.info(`restart-task → retry-task (Step 13 vocabulary): "${taskId}"`, { module: 'ipc' });
-      try {
-        await preemptTaskSubgraph(taskId);
-        const envelope = makeEnvelope('retry-task', 'ui', 'task', { taskId });
-        const result = await commandService.retryTask(envelope);
-        if (!result.ok) throw new Error(result.error.message);
-        const started = result.data;
-        logger.info(
-          `${RESTART_TO_BRANCH_TRACE} ipc invoker:restart-task after commandService.retryTask: count=${started.length} [${started.map((t) => `${t.id}(${t.status})`).join(', ')}]`,
-          { module: 'ipc' },
-        );
-        const runnable = started.filter(isDispatchableLaunch);
-        logger.info(
-          `${RESTART_TO_BRANCH_TRACE} ipc invoker:restart-task runnable=${runnable.length} [${runnable.map((t) => t.id).join(', ') || '(none)'}] → taskExecutor.executeTasks`,
-          { module: 'ipc' },
-        );
-        await dispatchStartedTasksWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.restart-task',
-          started,
-          scopedTaskIds: [taskId],
-        });
-      } catch (err) {
-        logger.error(`restart-task failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-      },
-    );
-
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:cancel-task',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'high',
-      async (taskIdArg: unknown) => {
-      const taskId = String(taskIdArg);
-      logger.info(`cancel-task: "${taskId}"`, { module: 'ipc' });
-      try {
-        const result = await performCancelTask(taskId);
-        await finalizeMutationWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.cancel-task',
-          mutationTiming: activeMutationContext?.mutationTiming,
-        });
-        return result;
-      } catch (err) {
-        logger.error(`cancel-task failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-      },
-    );
-
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:cancel-workflow',
-      (workflowIdArg: unknown) => String(workflowIdArg),
-      'high',
-      async (workflowIdArg: unknown) => {
-      const workflowId = String(workflowIdArg);
-      logger.info(`cancel-workflow: "${workflowId}"`, { module: 'ipc' });
-      try {
-        const result = await preemptWorkflowBeforeMutation(workflowId, {
-          preemptWorkflowExecution,
-          logger,
-          context: 'ipc.cancel-workflow',
-          mutationTiming: activeMutationContext?.mutationTiming,
-        });
-        await finalizeMutationWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.cancel-workflow',
-          mutationTiming: activeMutationContext?.mutationTiming,
-        });
-        return result;
-      } catch (err) {
-        logger.error(`cancel-workflow failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-      },
-    );
-
-    registerGuiMutationHandler('invoker:start-worker', async (kindArg: unknown) => {
-      if (!workerRuntimeController) {
-        throw new Error('Worker runtime controller is unavailable');
-      }
-      return workerRuntimeController.start(String(kindArg));
-    });
-
-    registerGuiMutationHandler('invoker:stop-worker', async (kindArg: unknown) => {
-      if (!workerRuntimeController) {
-        throw new Error('Worker runtime controller is unavailable');
-      }
-      return workerRuntimeController.stop(String(kindArg));
-    });
-
-    ipcMain.handle('invoker:get-queue-status', () => {
-      return orchestrator.getQueueStatus();
-    });
-    ipcMain.handle('invoker:get-worker-status', async () => {
-      if (!ownerMode) {
-        try {
-          const delegated = await messageBus.request<{ kind: string }, { workerStatus?: unknown }>(
-            'headless.query',
-            { kind: 'worker-status' },
-          );
-          if (delegated && typeof delegated === 'object' && 'workerStatus' in delegated) {
-            return delegated.workerStatus;
-          }
-        } catch (err) {
-          if (isMutationOwnerUnavailableError(err)) markDaemonOwnerUnavailable(err instanceof Error ? err.message : String(err));
-          logger.warn(
-            `get-worker-status owner delegation failed; falling back to local read-only snapshot: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-            { module: 'ipc' },
-          );
-        }
-        return createLocalWorkerStatusSnapshot({
-          registry: createRegisteredWorkerRegistry(),
-          persistence,
-          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
-        });
-      }
-      return workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
-        registry: createRegisteredWorkerRegistry(),
-        persistence,
-        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
-      });
-    });
-
-
-    ipcMain.handle('invoker:get-action-graph', async () => {
-      if (!ownerMode) {
-        try {
-          return await messageBus.request('headless.query', { kind: 'action-graph' });
-        } catch (err) {
-          if (isMutationOwnerUnavailableError(err)) markDaemonOwnerUnavailable(err instanceof Error ? err.message : String(err));
-          logger.warn(
-            `get-action-graph owner delegation failed; falling back to local read-only snapshot: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-            { module: 'ipc' },
-          );
-        }
-      }
-      return buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig });
-    });
-
-    ipcMain.handle('invoker:report-ui-perf', (_event, metric: string, data?: Record<string, unknown>) => {
-      const payload = {
-        ts: new Date().toISOString(),
-        metric,
-        ...(data ?? {}),
-      };
-      if (
-        metric === 'startup_bootstrap_state' ||
-        metric === 'startup_snapshot_applied' ||
-        metric === 'startup_snapshot_skipped_bootstrap_complete' ||
-        metric === 'startup_workflow_graph_visible' ||
-        metric === 'ui_delta_stream_gap_detected' ||
-        (metric === 'useTasks_snapshot_replace' && data?.workflowCount === 0)
-      ) {
-        logger.info(`ui metric ${metric} ${JSON.stringify(data ?? {})}`, { module: 'ui-state' });
-      }
-      recordRendererUiPerfMetric(uiPerfStats, metric, data);
-      try {
-        persistence.writeActivityLog('ui-perf', 'info', JSON.stringify(payload));
-      } catch {
-        // DB might be locked
-      }
-    });
-
-    ipcMain.handle('invoker:get-ui-perf-stats', () => ({
-      ...getUiPerfStats(),
-    }));
-
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:recreate-workflow',
-      (workflowIdArg: unknown) => String(workflowIdArg),
-      'high',
-      async (workflowIdArg: unknown) => {
-      const workflowId = String(workflowIdArg);
-      cancelDeferredWorkflowLaunch(workflowId, 'ipc.recreate-workflow');
-      logger.info(`recreate-workflow: "${workflowId}"`, { module: 'ipc' });
-      try {
-        await preemptWorkflowBeforeMutation(workflowId, {
-          preemptWorkflowExecution,
-          logger,
-          context: 'ipc.recreate-workflow',
-          mutationTiming: activeMutationContext?.mutationTiming,
-        });
-        const recreateWfEnvelope = makeEnvelope('recreate-workflow', 'ui', 'workflow', { workflowId });
-        const recreateWfResult = activeMutationContext?.mutationTiming
-          ? await activeMutationContext.mutationTiming.span(
-            'main.ipc.recreate-workflow.commandService.recreateWorkflow',
-            undefined,
-            () => commandService.recreateWorkflow(recreateWfEnvelope),
-          )
-          : await commandService.recreateWorkflow(recreateWfEnvelope);
-        if (!recreateWfResult.ok) throw new Error(recreateWfResult.error.message);
-        const started = recreateWfResult.data;
-        remoteFetchForPool.enabled = false;
-        try {
-          await dispatchStartedTasksWithGlobalTopup({
-            orchestrator,
-            taskExecutor: requireTaskExecutor(),
-            logger,
-            context: 'ipc.recreate-workflow',
-            started,
-            scopedWorkflowId: workflowId,
-            mutationTiming: activeMutationContext?.mutationTiming,
-          });
-        } finally {
-          remoteFetchForPool.enabled = true;
-        }
-      } catch (err) {
-        logger.error(`recreate-workflow failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-      },
-    );
-
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:recreate-task',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'high',
-      async (taskIdArg: unknown) => {
-      const taskId = String(taskIdArg);
-      logger.info(`recreate-task: "${taskId}"`, { module: 'ipc' });
-      try {
-        if (activeMutationContext?.mutationTiming) {
-          await activeMutationContext.mutationTiming.span(
-            'main.ipc.recreate-task.preemptTaskSubgraph',
-            { taskId },
-            () => preemptTaskSubgraph(taskId),
-          );
-        } else {
-          await preemptTaskSubgraph(taskId);
-        }
-        const recreateTaskEnvelope = makeEnvelope('recreate-task', 'ui', 'task', { taskId });
-        const recreateTaskResult = activeMutationContext?.mutationTiming
-          ? await activeMutationContext.mutationTiming.span(
-            'main.ipc.recreate-task.commandService.recreateTask',
-            { taskId },
-            () => commandService.recreateTask(recreateTaskEnvelope),
-          )
-          : await commandService.recreateTask(recreateTaskEnvelope);
-        if (!recreateTaskResult.ok) throw new Error(recreateTaskResult.error.message);
-        const started = recreateTaskResult.data;
-        remoteFetchForPool.enabled = false;
-        try {
-          await dispatchStartedTasksWithGlobalTopup({
-            orchestrator,
-            taskExecutor: requireTaskExecutor(),
-            logger,
-            context: 'ipc.recreate-task',
-            started,
-            scopedTaskIds: [taskId],
-            mutationTiming: activeMutationContext?.mutationTiming,
-          });
-        } finally {
-          remoteFetchForPool.enabled = true;
-        }
-      } catch (err) {
-        logger.error(`recreate-task failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-      },
-    );
-
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:recreate-downstream',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'high',
-      async (taskIdArg: unknown) => {
-      const taskId = String(taskIdArg);
-      logger.info(`recreate-downstream: "${taskId}"`, { module: 'ipc' });
-      try {
-        if (activeMutationContext?.mutationTiming) {
-          await activeMutationContext.mutationTiming.span(
-            'main.ipc.recreate-downstream.preemptTaskSubgraph',
-            { taskId },
-            () => preemptTaskSubgraph(taskId),
-          );
-        } else {
-          await preemptTaskSubgraph(taskId);
-        }
-        const recreateDownstreamEnvelope = makeEnvelope('recreate-downstream', 'ui', 'task', { taskId });
-        const recreateDownstreamResult = activeMutationContext?.mutationTiming
-          ? await activeMutationContext.mutationTiming.span(
-            'main.ipc.recreate-downstream.commandService.recreateDownstream',
-            { taskId },
-            () => commandService.recreateDownstream(recreateDownstreamEnvelope),
-          )
-          : await commandService.recreateDownstream(recreateDownstreamEnvelope);
-        if (!recreateDownstreamResult.ok) throw new Error(recreateDownstreamResult.error.message);
-        const started = recreateDownstreamResult.data;
-        remoteFetchForPool.enabled = false;
-        try {
-          await dispatchStartedTasksWithGlobalTopup({
-            orchestrator,
-            taskExecutor: requireTaskExecutor(),
-            logger,
-            context: 'ipc.recreate-downstream',
-            started,
-            scopedTaskIds: [taskId],
-            mutationTiming: activeMutationContext?.mutationTiming,
-          });
-        } finally {
-          remoteFetchForPool.enabled = true;
-        }
-      } catch (err) {
-        logger.error(`recreate-downstream failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-      },
-    );
-
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:retry-workflow',
-      (workflowIdArg: unknown) => String(workflowIdArg),
-      'high',
-      async (workflowIdArg: unknown) => {
-      const workflowId = String(workflowIdArg);
-      cancelDeferredWorkflowLaunch(workflowId, 'ipc.retry-workflow');
-      logger.info(`retry-workflow: "${workflowId}"`, { module: 'ipc' });
-      try {
-        await preemptWorkflowBeforeMutation(workflowId, {
-          preemptWorkflowExecution,
-          logger,
-          context: 'ipc.retry-workflow',
-          mutationTiming: activeMutationContext?.mutationTiming,
-        });
-        const envelope = makeEnvelope('retry-workflow', 'ui', 'workflow', { workflowId });
-        const result = activeMutationContext?.mutationTiming
-          ? await activeMutationContext.mutationTiming.span(
-            'main.ipc.retry-workflow.commandService.retryWorkflow',
-            undefined,
-            () => commandService.retryWorkflow(envelope),
-          )
-          : await commandService.retryWorkflow(envelope);
-        if (!result.ok) throw new Error(result.error.message);
-        remoteFetchForPool.enabled = false;
-        try {
-          await dispatchStartedTasksWithGlobalTopup({
-            orchestrator,
-            taskExecutor: requireTaskExecutor(),
-            logger,
-            context: 'ipc.retry-workflow',
-            started: result.data,
-            scopedWorkflowId: workflowId,
-            mutationTiming: activeMutationContext?.mutationTiming,
-          });
-        } finally {
-          remoteFetchForPool.enabled = true;
-        }
-      } catch (err) {
-        logger.error(`retry-workflow failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-      },
-    );
-
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:rebase-retry',
-      (targetArg: unknown) => workflowIdForTargetArg(targetArg),
-      'high',
-      async (targetArg: unknown) => {
-      const target = String(targetArg);
-      const workflowId = workflowIdForTargetArg(targetArg);
-      if (!workflowId) {
-        throw new Error(`Could not resolve workflow for rebase-retry target "${target}"`);
-      }
-      logger.info(`rebase-retry: "${target}"`, { module: 'ipc' });
-      try {
-        await preemptWorkflowBeforeMutation(workflowId, {
-          preemptWorkflowExecution,
-          logger,
-          context: 'ipc.rebase-retry',
-          mutationTiming: activeMutationContext?.mutationTiming,
-        });
-        const started = await rebaseRetry(target, {
-          logger,
-          orchestrator,
-          persistence,
-          commandService,
-          repoRoot,
-          taskExecutor: requireTaskExecutor(),
-          mutationTiming: activeMutationContext?.mutationTiming,
-        });
-        await dispatchStartedTasksWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.rebase-retry',
-          started,
-          scopedWorkflowId: workflowId,
-          mutationTiming: activeMutationContext?.mutationTiming,
-        });
-      } catch (err) {
-        logger.error(`rebase-retry failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-      },
-    );
-
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:rebase-recreate',
-      (targetArg: unknown) => workflowIdForTargetArg(targetArg),
-      'high',
-      async (targetArg: unknown) => {
-      const target = String(targetArg);
-      const workflowId = workflowIdForTargetArg(targetArg);
-      if (!workflowId) {
-        throw new Error(`Could not resolve workflow for rebase-recreate target "${target}"`);
-      }
-      cancelDeferredWorkflowLaunch(workflowId, 'ipc.rebase-recreate');
-      logger.info(`rebase-recreate: "${target}"`, { module: 'ipc' });
-      try {
-        await preemptWorkflowBeforeMutation(workflowId, {
-          preemptWorkflowExecution,
-          logger,
-          context: 'ipc.rebase-recreate',
-          mutationTiming: activeMutationContext?.mutationTiming,
-        });
-        const started = await rebaseRecreate(target, {
-          logger,
-          orchestrator,
-          persistence,
-          commandService,
-          repoRoot,
-          taskExecutor: requireTaskExecutor(),
-          mutationTiming: activeMutationContext?.mutationTiming,
-        });
-        await dispatchStartedTasksWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.rebase-recreate',
-          started,
-          scopedWorkflowId: workflowId,
-          mutationTiming: activeMutationContext?.mutationTiming,
-        });
-      } catch (err) {
-        logger.error(`rebase-recreate failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-      },
-    );
-
-    registerTaskScopedGuiMutationHandler(
-      'invoker:set-merge-branch',
-      (workflowIdArg: unknown) => String(workflowIdArg),
-      'normal',
-      async (workflowIdArg: unknown, baseBranchArg: unknown) => {
-      const workflowId = String(workflowIdArg);
-      const baseBranch = String(baseBranchArg);
-      logger.info(`set-merge-branch: workflow="${workflowId}" → "${baseBranch}"`, { module: 'ipc' });
-      try {
-        persistence.updateWorkflow(workflowId, { baseBranch });
-
-        const tasks = persistence.loadTasks(workflowId);
-        const mergeTask = tasks.find(t => t.config.isMergeNode);
-        if (mergeTask) {
-          const envelope = makeEnvelope('set-merge-branch', 'ui', 'task', { taskId: mergeTask.id });
-          const result = await commandService.retryTask(envelope);
-          if (!result.ok) throw new Error(result.error.message);
-          const started = result.data;
-          await dispatchStartedTasksWithGlobalTopup({
-            orchestrator,
-            taskExecutor: requireTaskExecutor(),
-            logger,
-            context: 'ipc.set-merge-branch',
-            started,
-            scopedTaskIds: [mergeTask.id],
-          });
-        }
-        requestWorkflowMetadataPublish('set-merge-branch');
-      } catch (err) {
-        logger.error(`set-merge-branch failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-    });
-
-    registerTaskScopedGuiMutationHandler(
-      'invoker:set-merge-mode',
-      (workflowIdArg: unknown) => String(workflowIdArg),
-      'normal',
-      async (workflowIdArg: unknown, mergeModeArg: unknown) => {
-      const workflowId = String(workflowIdArg);
-      const mergeMode = String(mergeModeArg);
-      logger.info(`set-merge-mode: workflow="${workflowId}" → "${mergeMode}"`, { module: 'ipc' });
-      try {
-        await setWorkflowMergeMode(workflowId, mergeMode, {
-          orchestrator,
-          persistence,
-          taskExecutor: requireTaskExecutor(),
-        });
-      } catch (err) {
-        logger.error(`set-merge-mode failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-      const workflows = persistence.listWorkflows();
-      rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
-      requestWorkflowMetadataPublish('set-merge-mode');
-    });
-
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:approve-merge',
-      (workflowIdArg: unknown) => String(workflowIdArg),
-      'normal',
-      async (workflowIdArg: unknown) => {
-      const workflowId = String(workflowIdArg);
-      logger.info(`approve-merge: "${workflowId}"`, { module: 'ipc' });
-      try {
-        const mergeTask = orchestrator.getMergeNode(workflowId);
-        if (!mergeTask) throw new Error(`No merge node for workflow ${workflowId}`);
-        const { started } = await performSharedApproveTask(mergeTask.id, 'ui', 'workflow');
-        await finalizeMutationWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.approve-merge',
-          started,
-          mutationTiming: activeMutationContext?.mutationTiming,
-          scopedWorkflowId: workflowId,
-        });
-      } catch (err) {
-        logger.error(`approve-merge failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-      },
-    );
-
-    registerGuiMutationHandler('invoker:check-pr-statuses', async () => {
-      logger.info('check-pr-statuses', { module: 'ipc' });
-      await requireTaskExecutor().checkMergeGateStatuses();
-    });
-
-    registerGuiMutationHandler('invoker:check-pr-status', async () => {
-      const tasks = orchestrator.getAllTasks();
-      const awaitingMergeGates = tasks.filter(
-        t => t.config.isMergeNode && (t.status === 'review_ready' || t.status === 'awaiting_approval')
-      );
-      await Promise.all(
-        awaitingMergeGates.map(t => requireTaskExecutor().checkPrApprovalNow(t.id))
-      );
-    });
-
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:resolve-conflict',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'normal',
-      async (taskIdArg: unknown, agentNameArg?: unknown) => {
-      const taskId = String(taskIdArg);
-      const agentName = agentNameArg === undefined ? undefined : String(agentNameArg);
-      logger.info(
-        `resolve-conflict: "${taskId}" agent=${agentName ?? DEFAULT_EXECUTION_AGENT} source=ipc route=resolveConflictAction`,
-        { module: 'ipc' },
-      );
-      try {
-        const result = await resolveConflictAction(taskId, {
-          orchestrator,
-          persistence,
-          taskExecutor: requireTaskExecutor(),
-          autoApproveAIFixes: resolveAutoApproveAIFixes(invokerConfig),
-        }, agentName, activeMutationContext?.signal);
-        await finalizeMutationWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.resolve-conflict',
-          started: result.started,
-          mutationTiming: activeMutationContext?.mutationTiming,
-          scopedTaskIds: [taskId],
-        });
-      } catch (err) {
-        if (err instanceof StaleLineageError) {
-          logger.info(`resolve-conflict discarded stale result for "${taskId}": ${err.message}`, { module: 'ipc' });
-          return;
-        }
-        await finalizeMutationWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.resolve-conflict.failure',
-          mutationTiming: activeMutationContext?.mutationTiming,
-        });
-        logger.error(`resolve-conflict failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-      },
-    );
-
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:fix-with-agent',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'normal',
-      async (...fixArgs: unknown[]) => {
-      const { taskId, agentName, context } = parseFixWithAgentMutationArgs(fixArgs);
-      const source = context.autoFix ? 'auto-fix' : 'ipc';
-      try {
-        const started = await executeFixWithAgentMutation(
-          taskId,
-          agentName,
-          source,
-          context.reviewGateContext,
-        );
-        await finalizeMutationWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: source === 'auto-fix' ? 'ipc.fix-with-agent.auto-fix' : 'ipc.fix-with-agent',
-          started,
-          mutationTiming: activeMutationContext?.mutationTiming,
-          scopedTaskIds: [taskId],
-        });
-      } catch (err) {
-        if (err instanceof StaleLineageError) {
-          logger.info(`fix-with-agent discarded stale result for "${taskId}": ${err.message}`, { module: 'ipc' });
-          return;
-        }
-        await finalizeMutationWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.fix-with-agent.failure',
-          mutationTiming: activeMutationContext?.mutationTiming,
-        });
-        logger.error(`fix-with-agent failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-      },
-    );
-
-    registerTaskScopedGuiMutationHandler(
-      'invoker:edit-task-command',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'normal',
-      async (taskIdArg: unknown, newCommandArg: unknown) => {
-      const taskId = String(taskIdArg);
-      const newCommand = String(newCommandArg);
-      logger.info(`edit-task-command: "${taskId}" → "${newCommand}"`, { module: 'ipc' });
-      try {
-        const envelope = makeEnvelope('edit-task-command', 'ui', 'task', { taskId, newCommand });
-        const result = await commandService.editTaskCommand(envelope);
-        if (!result.ok) throw new Error(result.error.message);
-        await dispatchStartedTasksWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.edit-task-command',
-          started: result.data,
-          scopedTaskIds: [taskId],
-        });
-      } catch (err) {
-        logger.error(`edit-task-command failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-    });
-
-    registerTaskScopedGuiMutationHandler(
-      'invoker:edit-task-prompt',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'normal',
-      async (taskIdArg: unknown, newPromptArg: unknown) => {
-      const taskId = String(taskIdArg);
-      const newPrompt = String(newPromptArg);
-      logger.info(`edit-task-prompt: "${taskId}" → "${newPrompt}"`, { module: 'ipc' });
-      try {
-        const envelope = makeEnvelope('edit-task-prompt', 'ui', 'task', { taskId, newPrompt });
-        const result = await commandService.editTaskPrompt(envelope);
-        if (!result.ok) throw new Error(result.error.message);
-        await dispatchStartedTasksWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.edit-task-prompt',
-          started: result.data,
-          scopedTaskIds: [taskId],
-        });
-      } catch (err) {
-        logger.error(`edit-task-prompt failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-    });
-
-    registerTaskScopedGuiMutationHandler(
-      'invoker:edit-task-type',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'normal',
-      async (taskIdArg: unknown, runnerKindArg: unknown, poolMemberIdArg?: unknown) => {
-      const taskId = String(taskIdArg);
-      const runnerKind = String(runnerKindArg);
-      const poolMemberId = poolMemberIdArg === undefined ? undefined : String(poolMemberIdArg);
-      logger.info(`edit-task-type: "${taskId}" → "${runnerKind}" poolMemberId=${poolMemberId ?? 'none'}`, { module: 'ipc' });
-      try {
-        const envelope = makeEnvelope('edit-task-type', 'ui', 'task', { taskId, runnerKind, poolMemberId });
-        const result = await commandService.editTaskType(envelope);
-        if (!result.ok) throw new Error(result.error.message);
-        await dispatchStartedTasksWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.edit-task-type',
-          started: result.data,
-          scopedTaskIds: [taskId],
-        });
-      } catch (err) {
-        logger.error(`edit-task-type failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-    });
-
-    registerTaskScopedGuiMutationHandler(
-      'invoker:edit-task-pool',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'normal',
-      async (taskIdArg: unknown, poolIdArg: unknown) => {
-      const taskId = String(taskIdArg);
-      const poolId = String(poolIdArg);
-      logger.info(`edit-task-pool: "${taskId}" → "${poolId}"`, { module: 'ipc' });
-      try {
-        const envelope = makeEnvelope('edit-task-pool', 'ui', 'task', { taskId, poolId });
-        const result = await commandService.editTaskPool(envelope);
-        if (!result.ok) throw new Error(result.error.message);
-        await dispatchStartedTasksWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.edit-task-pool',
-          started: result.data,
-          scopedTaskIds: [taskId],
-        });
-      } catch (err) {
-        logger.error(`edit-task-pool failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-    });
-
-    registerTaskScopedGuiMutationHandler(
-      'invoker:edit-task-agent',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'normal',
-      async (taskIdArg: unknown, agentNameArg: unknown) => {
-      const taskId = String(taskIdArg);
-      const agentName = String(agentNameArg);
-      logger.info(`edit-task-agent: "${taskId}" → "${agentName}"`, { module: 'ipc' });
-      try {
-        const envelope = makeEnvelope('edit-task-agent', 'ui', 'task', { taskId, agentName });
-        const result = await commandService.editTaskAgent(envelope);
-        if (!result.ok) throw new Error(result.error.message);
-        await dispatchStartedTasksWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.edit-task-agent',
-          started: result.data,
-          scopedTaskIds: [taskId],
-        });
-      } catch (err) {
-        logger.error(`edit-task-agent failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-    });
-    registerTaskScopedGuiMutationHandler(
-      'invoker:edit-task-model',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'normal',
-      async (taskIdArg: unknown, executionModelArg: unknown) => {
-      const taskId = String(taskIdArg);
-      const executionModel = typeof executionModelArg === 'string' ? executionModelArg : null;
-      logger.info(`edit-task-model: "${taskId}" → "${executionModel ?? ''}"`, { module: 'ipc' });
-      try {
-        const envelope = makeEnvelope('edit-task-model', 'ui', 'task', { taskId, executionModel });
-        const result = await commandService.editTaskModel(envelope);
-        if (!result.ok) throw new Error(result.error.message);
-        await dispatchStartedTasksWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.edit-task-model',
-          started: result.data,
-          scopedTaskIds: [taskId],
-        });
-      } catch (err) {
-        logger.error(`edit-task-model failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-    });
-
-
-    registerTaskScopedGuiMutationHandler(
-      'invoker:set-task-external-gate-policies',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'normal',
-      async (taskIdArg: unknown, updatesArg: unknown) => {
-        const taskId = String(taskIdArg);
-        const updates = updatesArg as Array<{ workflowId: string; taskId?: string; gatePolicy: 'completed' | 'review_ready' }>;
-        logger.info(`set-task-external-gate-policies: "${taskId}" updates=${updates.length}`, { module: 'ipc' });
-        try {
-          const envelope = makeEnvelope('set-gate-policies', 'ui', 'task', { taskId, updates });
-          const result = await commandService.setTaskExternalGatePolicies(envelope);
-          if (!result.ok) throw new Error(result.error.message);
-          await dispatchStartedTasksWithGlobalTopup({
-            orchestrator,
-            taskExecutor: requireTaskExecutor(),
-            logger,
-            context: 'ipc.set-task-external-gate-policies',
-            started: result.data,
-            scopedTaskIds: [taskId],
-          });
-        } catch (err) {
-          logger.error(`set-task-external-gate-policies failed: ${err}`, { module: 'ipc' });
-          throw err;
-        }
-      },
-    );
-
-    ipcMain.handle('invoker:get-remote-targets', () => {
-      return Object.keys(loadConfig().remoteTargets ?? {});
-    });
-
-    ipcMain.handle('invoker:get-execution-harnesses', () => {
-      return agentRegistry.listExecutionHarnesses();
-    });
-
-    ipcMain.handle('invoker:get-planning-presets', () => listInAppPlanningPresets(loadConfig()));
-
-    ipcMain.handle('invoker:get-execution-defaults', () => {
-      return resolveDefaultTaskExecutionSettings(loadConfig());
-    });
-
-    ipcMain.handle('invoker:get-runtime-status', () => computeRuntimeStatus());
-
-    ipcMain.handle('invoker:get-system-diagnostics', () => {
-      return collectSystemDiagnostics({
-        appVersion: app.getVersion(),
-        isPackaged: app.isPackaged,
-        platform: process.platform,
-        arch: process.arch,
-        bundledSkills: getBundledSkillsStatus(),
-        cliInstaller: resolveCliInstallerStatus(buildCliInstallerContext()),
-        config: resolveConfigFileState(),
-        presets: invokerConfig.slackHarnessPresets ?? DEFAULT_SLACK_HARNESS_PRESETS,
-        defaultPreset: invokerConfig.defaultSlackHarnessPreset ?? 'cursor+claude',
-      });
-    });
-
-    ipcMain.handle('invoker:get-bundled-skills-status', () => {
-      return getBundledSkillsStatus();
-    });
-
-    ipcMain.handle('invoker:install-bundled-skills', (_event, mode = 'install') => {
-      return installPackagedSkills(mode);
-    });
-
-    ipcMain.handle('invoker:update-invoker-cli', () => {
-      return updateInvokerCli(buildCliInstallerContext());
-    });
-    ipcMain.handle('invoker:run-invoker-cli-setup', (_event, request) => {
-      return runInvokerCliSetup(request, {
-        cliPath: resolveSetupCliPath(),
-        updateCli: () => updateInvokerCli(buildCliInstallerContext()),
-        installBundledSkills: installPackagedSkills,
-      });
-    });
-
-
-    registerTaskScopedGuiMutationHandler(
-      'invoker:replace-task',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'high',
-      async (taskIdArg: unknown, replacementTasksArg: unknown) => {
-      const taskId = String(taskIdArg);
-      const replacementTasks = replacementTasksArg as unknown[];
-      logger.info(`replace-task: "${taskId}" with ${replacementTasks.length} replacement(s)`, { module: 'ipc' });
-      try {
-        const envelope = makeEnvelope('replace-task', 'ui', 'task', {
-          taskId,
-          replacementTasks: replacementTasks as TaskReplacementDef[],
-        });
-        const result = await commandService.replaceTask(envelope);
-        if (!result.ok) throw new Error(result.error.message);
-        await dispatchStartedTasksWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.replace-task',
-          started: result.data,
-          scopedTaskIds: [taskId, ...result.data.map((task) => task.id)],
-        });
-        return result.data;
-      } catch (err) {
-        logger.error(`replace-task failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-    });
-
     // ── DB Polling — detect external workflow changes ───
     ipcMain.handle('invoker:get-activity-logs', (_event, sinceId?: number, limit?: number) => {
       return persistence.getActivityLogs(sinceId ?? 0, limit ?? 2000);


### PR DESCRIPTION
## Summary

This slice switches `main.ts` to get GUI mutation task actions from `createGuiMutationTaskActions(...)`.

`main.ts` drops the copied helper bodies while keeping the existing channel registrations and planning surfaces intact.

## Review Claim

`main.ts` can route GUI mutation task actions through `ipc/gui-mutation-handlers.ts` without changing public channels.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

The previous slice already added the shared module and guards. This diff is deletions plus the main-process wiring, and the pinned suites passed.

## Slice Rationale

The shared task-action module and the live `main.ts` handoff are separate review questions. This slice limits review to the `main.ts` routing change.

## Non-goals

- No owner-delegation bus handler moves.
- No standalone headless-serve moves.
- No terminal IPC moves.
- No handler-table rewrite, channel rename, or no behavior change; public channels stay unchanged.

## Architecture

### Before

`main.ts` defined the GUI mutation task-action helpers inline alongside the IPC registrations.

### After

`main.ts` builds `createGuiMutationTaskActions(...)` once, then reuses the returned helpers from the shared module while keeping the existing registrations in place.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/gui-mutation-translation.test.ts src/__tests__/ipc-registration.test.ts src/__tests__/no-manual-dispatch.test.ts src/__tests__/workflow-mutation-submit.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4992d88d5`
- Post-revert steps: None
- Data migration? No

</details>