### PR TITLE
[Recovery Lifecycle 2i Step 5: Registry guard, docs, full regression](1) Generalize the worker guard

### DIFF
--- a/packages/app/src/__tests__/external-worker-e2e.test.ts
+++ b/packages/app/src/__tests__/external-worker-e2e.test.ts
@@ -5,12 +5,12 @@ import { fileURLToPath } from 'node:url';
 
 import {
   createWorkerRegistry,
-  type ExternalWorkerRuntime,
   type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { registerExternalWorkersFromConfig } from '../external-worker-loader.js';
+import { createWorkerRuntimeController } from '../worker-control.js';
 
 const fixturePath = fileURLToPath(new URL('./fixtures/sample-external-worker.mjs', import.meta.url));
 
@@ -34,6 +34,15 @@ const deps: WorkerRuntimeDependencies = {
   },
 };
 
+const persistence = {
+  listWorkerActions: () => [],
+  listWorkflows: () => [],
+  loadTasks: () => [],
+  getEvents: () => [],
+  getEventsByTypes: () => [],
+  countEventsByTypes: () => [],
+};
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -47,13 +56,12 @@ async function waitFor(condition: () => boolean, message: string): Promise<void>
   throw new Error(message);
 }
 
-function isExternalWorkerRuntime(worker: unknown): worker is ExternalWorkerRuntime {
-  return Boolean(
-    worker
-      && typeof worker === 'object'
-      && 'finished' in worker
-      && (worker as { finished?: unknown }).finished instanceof Promise,
-  );
+function readMarker(markerPath: string): { pid?: number; started?: boolean; stopped?: boolean } {
+  return JSON.parse(readFileSync(markerPath, 'utf8')) as {
+    pid?: number;
+    started?: boolean;
+    stopped?: boolean;
+  };
 }
 
 describe('external worker e2e', () => {
@@ -79,31 +87,43 @@ describe('external worker e2e', () => {
           cwd: scratchDir,
         },
       }],
-      createWorkerRegistry(),
+      createWorkerRegistry<WorkerRuntimeDependencies>(),
     );
 
     const definition = registry.get('sample-external');
     expect(definition).toBeDefined();
     expect(registry.list().map((worker) => worker.kind)).toEqual(['sample-external']);
 
-    const worker = definition!.factory(deps);
-    expect(isExternalWorkerRuntime(worker)).toBe(true);
-    expect(worker.identity.kind).toBe('sample-external');
-    expect(worker.isRunning()).toBe(false);
+    const controller = createWorkerRuntimeController({
+      registry,
+      deps,
+      autoStartKinds: [],
+      persistence,
+      canControl: () => true,
+    });
+
+    expect(controller.snapshot().workers.find((worker) => worker.kind === 'sample-external')?.lifecycle)
+      .toBe('stopped');
 
     try {
-      worker.start();
-      await waitFor(() => existsSync(markerPath), 'sample external worker did not launch');
+      const started = controller.start('sample-external');
+      expect(started.lifecycle).toBe('running');
 
-      expect(worker.isRunning()).toBe(true);
-      expect(JSON.parse(readFileSync(markerPath, 'utf8'))).toEqual(
-        expect.objectContaining({ started: true }),
-      );
+      await waitFor(() => existsSync(markerPath), 'sample external worker did not launch');
+      const launchMarker = readMarker(markerPath);
+      expect(launchMarker).toEqual(expect.objectContaining({ started: true, stopped: false }));
+      expect(typeof launchMarker.pid).toBe('number');
+
+      expect(controller.snapshot().workers.find((worker) => worker.kind === 'sample-external')?.lifecycle)
+        .toBe('running');
     } finally {
-      await worker.stop();
-      await worker.finished;
+      const stopped = await controller.stop('sample-external');
+      expect(stopped.lifecycle).toBe('stopped');
     }
 
-    expect(worker.isRunning()).toBe(false);
+    await waitFor(
+      () => existsSync(markerPath) && readMarker(markerPath).stopped === true,
+      'sample external worker did not stop cleanly',
+    );
   });
 });

--- a/packages/app/src/__tests__/fixtures/sample-external-worker.mjs
+++ b/packages/app/src/__tests__/fixtures/sample-external-worker.mjs
@@ -6,12 +6,17 @@ if (!markerPath) {
   process.exit(64);
 }
 
-writeFileSync(markerPath, JSON.stringify({ pid: process.pid, started: true }), 'utf8');
+const writeMarker = (state) => {
+  writeFileSync(markerPath, JSON.stringify({ pid: process.pid, ...state }), 'utf8');
+};
+
+writeMarker({ started: true, stopped: false });
 
 const keepAlive = setInterval(() => {}, 1_000);
 
 const shutdown = () => {
   clearInterval(keepAlive);
+  writeMarker({ started: true, stopped: true });
   process.exit(0);
 };
 

--- a/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
+++ b/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
@@ -59,28 +59,30 @@ describe('main-process read hot-path cost guards', () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'invoker-hotpath-'));
     adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
 
-    adapter.saveWorkflow(makeWorkflow('wf-fat', 'Fat events'));
-
     const taskCount = 40;
     const eventsPerTask = 250; // 10k events total
-    for (let t = 0; t < taskCount; t += 1) {
-      const taskId = `wf-fat/t${t}`;
-      adapter.saveTask('wf-fat', makeTask(taskId));
-      for (let e = 0; e < eventsPerTask; e += 1) {
-        const action = e % 4 === 0 ? 'wakeup'
-          : e % 4 === 1 ? 'scan'
-            : e % 4 === 2 ? 'submit'
-              : 'skip';
-        adapter.logEvent(
-          taskId,
-          recoveryWorkerEventType(action),
-          buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
-            workflowId: 'wf-fat',
-            reason: action === 'skip' ? 'budget' : undefined,
-          }),
-        );
+    adapter.runInTransaction(() => {
+      adapter.saveWorkflow(makeWorkflow('wf-fat', 'Fat events'));
+
+      for (let t = 0; t < taskCount; t += 1) {
+        const taskId = `wf-fat/t${t}`;
+        adapter.saveTask('wf-fat', makeTask(taskId));
+        for (let e = 0; e < eventsPerTask; e += 1) {
+          const action = e % 4 === 0 ? 'wakeup'
+            : e % 4 === 1 ? 'scan'
+              : e % 4 === 2 ? 'submit'
+                : 'skip';
+          adapter.logEvent(
+            taskId,
+            recoveryWorkerEventType(action),
+            buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
+              workflowId: 'wf-fat',
+              reason: action === 'skip' ? 'budget' : undefined,
+            }),
+          );
+        }
       }
-    }
+    });
 
     const getEvents = vi.spyOn(adapter, 'getEvents');
     const started = Date.now();

--- a/packages/app/src/main-process-hitch-fixture.ts
+++ b/packages/app/src/main-process-hitch-fixture.ts
@@ -54,59 +54,61 @@ function makeTask(id: string): TaskState {
 }
 
 export function seedMainProcessHitchFixture(
-  persistence: Pick<SQLiteAdapter, 'saveWorkflow' | 'saveTask' | 'logEvent' | 'upsertWorkerAction'>,
+  persistence: Pick<SQLiteAdapter, 'saveWorkflow' | 'saveTask' | 'logEvent' | 'upsertWorkerAction' | 'runInTransaction'>,
   options: MainProcessHitchFixtureOptions = {},
 ): MainProcessHitchFixtureResult {
   const taskCount = options.taskCount ?? DEFAULT_TASK_COUNT;
   const eventsPerTask = options.eventsPerTask ?? DEFAULT_EVENTS_PER_TASK;
   const actionsPerKind = options.actionsPerKind ?? DEFAULT_ACTIONS_PER_KIND;
   const workflowId = MAIN_PROCESS_HITCH_FIXTURE_WORKFLOW_ID;
-
-  persistence.saveWorkflow(makeWorkflow(workflowId, 'Main-process hitch fixture'));
-
-  for (let t = 0; t < taskCount; t += 1) {
-    const taskId = `${workflowId}/t${t}`;
-    persistence.saveTask(workflowId, makeTask(taskId));
-    for (let e = 0; e < eventsPerTask; e += 1) {
-      const action = e % 4 === 0 ? 'wakeup'
-        : e % 4 === 1 ? 'scan'
-          : e % 4 === 2 ? 'submit'
-            : 'skip';
-      persistence.logEvent(
-        taskId,
-        recoveryWorkerEventType(action),
-        buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
-          workflowId,
-          reason: action === 'skip' ? 'budget' : undefined,
-        }),
-      );
-    }
-  }
-
   let workerActionCount = 0;
-  for (const workerKind of ACTION_WORKER_KINDS) {
-    for (let i = 0; i < actionsPerKind; i += 1) {
-      const taskId = `${workflowId}/t${i % Math.max(taskCount, 1)}`;
-      const write: WorkerActionWrite = {
-        id: `wa-hitch-${workerKind}-${i}`,
-        workerKind,
-        actionType: 'hitch-fixture',
-        workflowId,
-        taskId,
-        subjectType: 'task',
-        subjectId: taskId,
-        externalKey: `hitch:${workerKind}:${i}`,
-        status: i % 5 === 0 ? 'skipped' : 'completed',
-        attemptCount: 1,
-        summary: `Hitch fixture ${workerKind} ${i}`,
-        payload: { reason: i % 5 === 0 ? 'budget' : 'ok' },
-        createdAt: `2026-07-01T00:00:${String(i % 60).padStart(2, '0')}.000Z`,
-        updatedAt: `2026-07-01T00:01:${String(i % 60).padStart(2, '0')}.000Z`,
-      };
-      persistence.upsertWorkerAction(write);
-      workerActionCount += 1;
+
+  persistence.runInTransaction(() => {
+    persistence.saveWorkflow(makeWorkflow(workflowId, 'Main-process hitch fixture'));
+
+    for (let t = 0; t < taskCount; t += 1) {
+      const taskId = `${workflowId}/t${t}`;
+      persistence.saveTask(workflowId, makeTask(taskId));
+      for (let e = 0; e < eventsPerTask; e += 1) {
+        const action = e % 4 === 0 ? 'wakeup'
+          : e % 4 === 1 ? 'scan'
+            : e % 4 === 2 ? 'submit'
+              : 'skip';
+        persistence.logEvent(
+          taskId,
+          recoveryWorkerEventType(action),
+          buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
+            workflowId,
+            reason: action === 'skip' ? 'budget' : undefined,
+          }),
+        );
+      }
     }
-  }
+
+    for (const workerKind of ACTION_WORKER_KINDS) {
+      for (let i = 0; i < actionsPerKind; i += 1) {
+        const taskId = `${workflowId}/t${i % Math.max(taskCount, 1)}`;
+        const write: WorkerActionWrite = {
+          id: `wa-hitch-${workerKind}-${i}`,
+          workerKind,
+          actionType: 'hitch-fixture',
+          workflowId,
+          taskId,
+          subjectType: 'task',
+          subjectId: taskId,
+          externalKey: `hitch:${workerKind}:${i}`,
+          status: i % 5 === 0 ? 'skipped' : 'completed',
+          attemptCount: 1,
+          summary: `Hitch fixture ${workerKind} ${i}`,
+          payload: { reason: i % 5 === 0 ? 'budget' : 'ok' },
+          createdAt: `2026-07-01T00:00:${String(i % 60).padStart(2, '0')}.000Z`,
+          updatedAt: `2026-07-01T00:01:${String(i % 60).padStart(2, '0')}.000Z`,
+        };
+        persistence.upsertWorkerAction(write);
+        workerActionCount += 1;
+      }
+    }
+  });
 
   return {
     workflowId,

--- a/packages/execution-engine/src/__tests__/no-autofix-outside-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/no-autofix-outside-worker.test.ts
@@ -1,0 +1,198 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { registerBuiltinWorkers } from '../builtin-workers.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import { createWorkerRegistry } from '../worker-registry.js';
+
+const SOURCE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const BUILTIN_WORKERS_SOURCE = 'builtin-workers.ts';
+const RECOVERY_ACTION_TRIGGER_PATTERN = /\bsubmitter\.submit\s*\(/g;
+
+type SourceFiles = ReadonlyMap<string, string>;
+
+interface RecoveryActionSite {
+  readonly file: string;
+  readonly line: number;
+  readonly text: string;
+}
+
+function toSourceRelativePath(path: string): string {
+  return relative(SOURCE_ROOT, path).split(sep).join('/');
+}
+
+function collectSourceFiles(dir: string = SOURCE_ROOT): Map<string, string> {
+  const files = new Map<string, string>();
+
+  for (const entry of readdirSync(dir)) {
+    const absolutePath = resolve(dir, entry);
+    const stats = statSync(absolutePath);
+    if (stats.isDirectory()) {
+      if (entry !== '__tests__') {
+        for (const [file, text] of collectSourceFiles(absolutePath)) {
+          files.set(file, text);
+        }
+      }
+      continue;
+    }
+
+    if (stats.isFile() && entry.endsWith('.ts')) {
+      files.set(toSourceRelativePath(absolutePath), readFileSync(absolutePath, 'utf8'));
+    }
+  }
+
+  return files;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function importedRegisterFunctions(source: string): Map<string, string> {
+  const imports = new Map<string, string>();
+  const importPattern = /import\s+\{\s*([^}]+?)\s*\}\s+from\s+'([^']+)'/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = importPattern.exec(source)) !== null) {
+    const namedImports = match[1].split(',').map((name) => name.trim().split(/\s+as\s+/)[0]);
+    for (const name of namedImports) {
+      if (/^register[A-Z].*Workers?$/.test(name)) {
+        imports.set(name, match[2]);
+      }
+    }
+  }
+
+  return imports;
+}
+
+function sourcePathForModuleSpecifier(specifier: string): string {
+  const relativeSpecifier = specifier.startsWith('./') ? specifier.slice(2) : specifier;
+  return relativeSpecifier.replace(/\.js$/, '.ts');
+}
+
+function extractExportedWorkerKinds(source: string): Set<string> {
+  const workerKinds = new Set<string>();
+  const workerKindPattern = /export\s+const\s+\w+_WORKER_KIND\s*=\s*'([^']+)'/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = workerKindPattern.exec(source)) !== null) {
+    workerKinds.add(match[1]);
+  }
+
+  return workerKinds;
+}
+
+function registeredBuiltInWorkerSourceFiles(sourceFiles: SourceFiles): Set<string> {
+  const builtinWorkers = sourceFiles.get(BUILTIN_WORKERS_SOURCE);
+  expect(builtinWorkers).toBeDefined();
+
+  const registeredKinds = new Set(
+    registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()).list().map((worker) => worker.kind),
+  );
+  const registerImports = importedRegisterFunctions(builtinWorkers ?? '');
+  const allowedFiles = new Set<string>();
+
+  for (const [registerFunction, moduleSpecifier] of registerImports) {
+    const callPattern = new RegExp(`\\b${escapeRegExp(registerFunction)}\\(registry\\)`);
+    if (!callPattern.test(builtinWorkers ?? '')) continue;
+
+    const sourcePath = sourcePathForModuleSpecifier(moduleSpecifier);
+    const source = sourceFiles.get(sourcePath);
+    expect(source, `${sourcePath} imported by ${BUILTIN_WORKERS_SOURCE} must exist`).toBeDefined();
+
+    const moduleWorkerKinds = extractExportedWorkerKinds(source ?? '');
+    if ([...moduleWorkerKinds].some((kind) => registeredKinds.has(kind))) {
+      allowedFiles.add(sourcePath);
+    }
+  }
+
+  return allowedFiles;
+}
+
+function lineNumberAt(source: string, index: number): number {
+  let line = 1;
+  for (let cursor = 0; cursor < index; cursor += 1) {
+    if (source.charCodeAt(cursor) === 10) line += 1;
+  }
+  return line;
+}
+
+function lineTextAt(source: string, index: number): string {
+  const start = source.lastIndexOf('\n', index) + 1;
+  const newline = source.indexOf('\n', index);
+  const end = newline === -1 ? source.length : newline;
+  return source.slice(start, end).trim();
+}
+
+function findRecoveryActionTriggerSites(sourceFiles: SourceFiles): RecoveryActionSite[] {
+  const sites: RecoveryActionSite[] = [];
+
+  for (const [file, source] of sourceFiles) {
+    let match: RegExpExecArray | null;
+    RECOVERY_ACTION_TRIGGER_PATTERN.lastIndex = 0;
+    while ((match = RECOVERY_ACTION_TRIGGER_PATTERN.exec(source)) !== null) {
+      sites.push({
+        file,
+        line: lineNumberAt(source, match.index),
+        text: lineTextAt(source, match.index),
+      });
+    }
+  }
+
+  return sites;
+}
+
+function findUnsanctionedRecoveryActionSites(
+  sourceFiles: SourceFiles,
+  sanctionedWorkerSourceFiles: ReadonlySet<string>,
+): RecoveryActionSite[] {
+  return findRecoveryActionTriggerSites(sourceFiles)
+    .filter((site) => !sanctionedWorkerSourceFiles.has(site.file));
+}
+
+function formatSite(site: RecoveryActionSite): string {
+  return `${site.file}:${site.line}: ${site.text}`;
+}
+
+describe('recovery action worker guard', () => {
+  it('derives sanctioned recovery-action source files from registered built-in workers', () => {
+    const sourceFiles = collectSourceFiles();
+    const sanctionedWorkerSourceFiles = registeredBuiltInWorkerSourceFiles(sourceFiles);
+    const triggerFiles = new Set(findRecoveryActionTriggerSites(sourceFiles).map((site) => site.file));
+
+    expect(sanctionedWorkerSourceFiles.size).toBeGreaterThan(1);
+    expect([...triggerFiles].sort()).toEqual(
+      [...triggerFiles].filter((file) => sanctionedWorkerSourceFiles.has(file)).sort(),
+    );
+  });
+
+  it('keeps recovery action submissions inside registered worker implementations', () => {
+    const sourceFiles = collectSourceFiles();
+    const sanctionedWorkerSourceFiles = registeredBuiltInWorkerSourceFiles(sourceFiles);
+    const violations = findUnsanctionedRecoveryActionSites(sourceFiles, sanctionedWorkerSourceFiles);
+
+    expect(violations.map(formatSite)).toEqual([]);
+  });
+
+  it('reports a source-level violation when recovery is triggered outside a registered worker', () => {
+    const sourceFiles = new Map<string, string>([
+      [
+        'not-a-worker.ts',
+        [
+          'export function triggerRecovery(submitter: { submit(...args: unknown[]): number }): number {',
+          "  return submitter.submit('wf-1', 'normal', 'invoker:fix-with-agent', ['wf-1/task']);",
+          '}',
+        ].join('\n'),
+      ],
+    ]);
+
+    const violations = findUnsanctionedRecoveryActionSites(sourceFiles, new Set(['workers/registered-worker.ts']));
+
+    expect(violations.map(formatSite)).toEqual([
+      "not-a-worker.ts:2: return submitter.submit('wf-1', 'normal', 'invoker:fix-with-agent', ['wf-1/task']);",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Lock in the registry model. Generalize the 2h sweep-and-assert guard so it allows recovery actions only through a registered worker (not only the single auto-fix worker), update the architecture doc and README to the registry plus external-worker model, and run the full repository suite as the terminal gate.

This is the terminal workflow of the 2i stack. Its final task runs the full repository suite and depends on the guard slice.

Review claim: The guard proves recovery actions only happen through a registered worker, and the docs describe the registry plus external-worker model.
Safety invariant: The guard inspects source and the docs change Markdown only; neither changes runtime recovery behavior.
Architectural effect: The single-engine invariant becomes a registered-worker invariant, recorded as the canonical recovery design.

Invoker-on-Invoker note: after implementation branches are ready, publish the resulting stack with Mergify Stacks.


## Pipeline

| Time | Worker | Action | Status | Target | Summary |
| --- | --- | --- | --- | --- | --- |
| 2026-07-08T23:50:39.485Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-08T23:50:39.490Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-08T23:50:39.491Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-08T23:50:39.853Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-08T23:50:40.788Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-08T23:50:40.804Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-08T23:50:40.948Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-08T23:50:40.968Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:24:38.080Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:24:38.138Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:24:38.138Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:24:38.139Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:45:08.523Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:45:08.582Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:45:08.583Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:45:08.585Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:12:59.353Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:12:59.414Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:12:59.415Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:12:59.416Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:35:48.039Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:35:48.092Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:35:48.092Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:35:48.093Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:47:57.497Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:47:57.552Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:47:57.553Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:47:57.554Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:16:02.298Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:16:02.357Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:16:02.357Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:16:02.358Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:42:43.653Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:42:43.758Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:42:43.759Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:42:43.759Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:59:42.318Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:59:42.378Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:59:42.378Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:59:42.379Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:07:23.100Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:07:23.183Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:07:23.184Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:07:23.184Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:16:44.670Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:16:44.746Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:16:44.746Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:16:44.747Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:37:39.645Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:37:39.764Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:37:39.765Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:37:39.765Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:48:32.118Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:48:32.200Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:48:32.201Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:48:32.202Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:00:05.339Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:00:05.421Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:00:05.422Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:00:05.422Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:08:37.385Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:08:37.455Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:08:37.456Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:08:37.457Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:15:15.654Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:15:15.765Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:15:15.766Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:15:15.767Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:25:22.154Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:25:22.229Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:25:22.229Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:25:22.230Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:31:55.504Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:31:55.629Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:31:55.630Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:31:55.631Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:41:32.485Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:41:32.558Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:41:32.558Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:41:32.559Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:48:44.635Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:48:44.716Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:48:44.717Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:48:44.718Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:55:14.672Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:55:14.782Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:55:14.783Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:55:14.784Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:01:22.928Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:01:23.070Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:01:23.071Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:01:23.072Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:10:41.981Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:10:42.139Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:10:42.140Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:10:42.141Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:16:32.340Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:16:32.415Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:16:32.415Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:16:32.416Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:51:06.460Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:51:06.529Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:51:06.530Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:51:06.530Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:59:06.479Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:59:06.556Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:59:06.557Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:59:06.557Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:06:33.255Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:06:33.416Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:06:33.418Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:06:33.419Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:23:10.468Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:23:10.594Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:23:10.595Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:23:10.596Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:30:27.695Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:30:27.878Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:30:27.879Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:30:27.880Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:39:47.458Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:39:47.528Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:39:47.529Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:39:47.529Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:46:18.480Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:46:18.631Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:46:18.636Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:46:18.636Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:56:46.313Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:56:46.379Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:56:46.380Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:56:46.380Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:05:20.945Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:05:21.020Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:05:21.020Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:05:21.021Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:12:04.548Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:12:04.617Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:12:04.617Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:12:04.618Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:21:25.213Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:21:25.285Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:21:25.285Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:21:25.286Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T08:13:27.473Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:13:27.545Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:13:27.546Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:13:27.547Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:21:09.630Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:21:09.703Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:21:09.704Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:21:09.705Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:39:23.038Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:39:23.118Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:39:23.119Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:39:23.119Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:59:01.003Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:59:01.085Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:59:01.086Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:59:01.089Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:06:15.770Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:06:15.771Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:06:15.771Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:06:15.772Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:51:20.543Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:51:20.576Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:51:20.581Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:51:20.582Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:52:31.032Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:52:31.036Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:52:31.037Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:52:31.038Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:53:35.248Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:53:35.252Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:53:35.253Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:53:35.254Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:54:53.032Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:54:53.034Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:54:53.035Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:54:53.036Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:56:18.792Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:56:18.795Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:56:18.798Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:56:18.801Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:57:46.242Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:57:46.243Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:57:46.253Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:57:46.254Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:59:07.551Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:59:07.552Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:59:07.553Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T03:59:07.554Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:01:12.788Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:01:12.789Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:01:12.791Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:01:12.792Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:03:42.959Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:03:42.960Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:03:42.961Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:03:42.963Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:06:24.620Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:06:24.622Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:06:24.623Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:06:24.625Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:08:30.882Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:08:30.895Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:08:30.896Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:08:30.896Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:09:57.084Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:09:57.085Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:09:57.086Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:09:57.088Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:13:33.038Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:13:33.039Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:13:33.039Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:13:33.040Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:15:13.849Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:15:13.850Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:15:13.851Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:15:13.852Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:16:14.179Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:16:14.182Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:16:14.183Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:16:14.188Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:17:16.968Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:17:16.969Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:17:16.971Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:17:16.972Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:18:36.756Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:18:36.757Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:18:36.759Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:18:36.764Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:20:13.925Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:20:13.926Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:20:13.928Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:20:13.929Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:21:56.258Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:21:56.259Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:21:56.260Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:21:56.261Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:23:30.332Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:23:30.337Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:23:30.343Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:23:30.345Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:25:41.159Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:25:41.162Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:25:41.163Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:25:41.180Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:27:56.355Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:27:56.366Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:27:56.390Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:27:56.449Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:29:00.032Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:29:00.044Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:29:00.045Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:29:00.047Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:30:05.971Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:30:05.973Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:30:05.974Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:30:05.976Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:32:24.042Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:32:24.044Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:32:24.044Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:32:24.046Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:33:48.146Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:33:48.148Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:33:48.150Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:33:48.151Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:36:58.013Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:36:58.017Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:36:58.019Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:36:58.021Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:39:04.345Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:39:04.348Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:39:04.349Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:39:04.350Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:40:24.991Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:40:24.994Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:40:24.995Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:40:24.995Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:49:31.239Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:49:31.242Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:49:31.259Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:49:31.261Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:50:53.395Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:50:53.397Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:50:53.399Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:50:53.400Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:52:19.847Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:52:19.848Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:52:19.851Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:52:19.852Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:54:28.418Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:54:28.422Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:54:28.424Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:54:28.429Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:57:27.362Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:57:27.364Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:57:27.393Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:57:27.395Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:59:13.242Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:59:13.243Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:59:13.244Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:59:13.245Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:01:38.031Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:01:38.032Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:01:38.033Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:01:38.034Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:04:12.103Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:04:12.105Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:04:12.109Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:04:12.110Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:06:01.197Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:06:01.198Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:06:01.199Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:06:01.199Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:07:59.237Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:07:59.239Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:07:59.240Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:07:59.241Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:09:31.148Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:09:31.150Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:09:31.151Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:09:31.153Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:10:41.679Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:10:41.681Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:10:41.682Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:10:41.692Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:12:08.983Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:12:08.984Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:12:08.985Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:12:08.986Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:13:33.710Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:13:33.711Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:13:33.712Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:13:33.713Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:15:15.330Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:15:15.333Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:15:15.342Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:15:15.344Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:16:24.471Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:16:24.472Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:16:24.472Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:16:24.473Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:17:27.981Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:17:27.982Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:17:27.983Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:17:27.984Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:19:18.159Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:19:18.160Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:19:18.161Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:19:18.161Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:20:50.139Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:20:50.140Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:20:50.141Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:20:50.142Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:22:12.665Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:22:12.667Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:22:12.668Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:22:12.669Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:23:42.074Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:23:42.076Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:23:42.077Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:23:42.078Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:24:43.535Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:24:43.536Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:24:43.537Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:24:43.537Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:26:08.905Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:26:08.906Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:26:08.907Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:26:08.907Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:27:54.107Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:27:54.108Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:27:54.109Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:27:54.110Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:29:11.455Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:29:11.456Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:29:11.457Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:29:11.458Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:30:59.664Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:30:59.665Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:30:59.666Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:30:59.668Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:32:09.023Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:32:09.024Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:32:09.025Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:32:09.026Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:33:16.147Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:33:16.148Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:33:16.149Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:33:16.150Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:34:49.809Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:34:49.813Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:34:49.814Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:34:49.815Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:38:35.291Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:38:35.293Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:38:35.294Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:38:35.295Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:40:15.025Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:40:15.026Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:40:15.027Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:40:15.027Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:42:00.586Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:42:00.587Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:42:00.588Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:42:00.588Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:44:25.248Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:44:25.250Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:44:25.251Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:44:25.252Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:46:56.815Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:46:56.816Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:46:56.817Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:46:56.818Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:48:00.320Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:48:00.321Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:48:00.322Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:48:00.323Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:49:15.050Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:49:15.051Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:49:15.052Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:49:15.053Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:50:22.823Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:50:22.824Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:50:22.826Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:50:22.827Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:52:52.840Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:52:52.843Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:52:52.845Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:52:52.846Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:54:06.060Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:54:06.065Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:54:06.065Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:54:06.066Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:00:42.639Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:00:42.640Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:00:42.640Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:00:42.641Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:02:02.852Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:02:02.853Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:02:02.854Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:02:02.854Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:03:19.555Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:03:19.560Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:03:19.578Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:03:19.581Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:04:38.230Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:04:38.231Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:04:38.232Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:04:38.233Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:05:45.964Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:05:45.965Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:05:45.966Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:05:45.967Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:07:27.075Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:07:27.076Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:07:27.077Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:07:27.078Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:08:30.199Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:08:30.200Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:08:30.201Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:08:30.201Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:10:25.105Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:10:25.109Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:10:25.122Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:10:25.124Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:11:26.813Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:11:26.814Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:11:26.815Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:11:26.816Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:12:48.858Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:12:48.859Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:12:48.860Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:12:48.861Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:14:03.960Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:14:03.961Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:14:03.962Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:14:03.963Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:15:33.980Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:15:33.981Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:15:33.982Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:15:33.983Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:17:40.974Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:17:40.975Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:17:40.976Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:17:40.977Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:18:57.284Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:18:57.285Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:18:57.286Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:18:57.287Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:26:12.530Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:26:12.532Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:26:12.533Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:26:12.534Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:27:29.956Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:27:29.957Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:27:29.958Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:27:29.959Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:29:15.392Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:29:15.393Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:29:15.394Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:29:15.395Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:30:58.941Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:30:58.942Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:30:58.944Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:30:58.945Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:32:12.495Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:32:12.505Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:32:12.506Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:32:12.507Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:34:33.356Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:34:33.357Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:34:33.358Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:34:33.359Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:37:47.341Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:37:47.342Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:37:47.343Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:37:47.344Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:38:54.372Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:38:54.378Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:38:54.379Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:38:54.380Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:39:59.047Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:39:59.048Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:39:59.049Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:39:59.049Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:41:30.408Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:41:30.409Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:41:30.410Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:41:30.411Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:42:30.774Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:42:30.775Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:42:30.776Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:42:30.778Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:43:31.216Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:43:31.217Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:43:31.218Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:43:31.219Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:44:43.159Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:44:43.160Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:44:43.161Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:44:43.161Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:46:27.082Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:46:27.122Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:46:27.125Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:46:27.126Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:47:46.104Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:47:46.105Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:47:46.108Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:47:46.109Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:49:02.594Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:49:02.679Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:49:02.681Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:49:02.692Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:52:05.500Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:52:05.502Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:52:05.502Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:52:05.506Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:53:25.295Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:53:25.296Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:53:25.297Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:53:25.299Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:56:55.708Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:56:55.709Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:56:55.709Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:56:55.710Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:58:15.639Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:58:15.640Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:58:15.641Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:58:15.642Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:59:16.982Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:59:16.983Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:59:16.984Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:59:16.986Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:00:39.517Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:00:39.517Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:00:39.518Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:00:39.519Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:02:25.896Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:02:25.906Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:02:25.907Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:02:25.908Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:04:22.398Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:04:22.399Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:04:22.400Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:04:22.401Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:05:37.135Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:05:37.187Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:05:37.192Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:05:37.195Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:06:38.633Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:06:38.640Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:06:38.660Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:06:38.678Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:08:08.268Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:08:08.270Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:08:08.271Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:08:08.272Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:09:58.802Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:09:58.803Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:09:58.804Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:09:58.804Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:11:12.611Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:11:12.612Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:11:12.613Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:11:12.614Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:12:29.818Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:12:29.820Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:12:29.821Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:12:29.822Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:13:36.427Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:13:36.428Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:13:36.429Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:13:36.429Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:14:36.656Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:14:36.657Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:14:36.658Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:14:36.684Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:16:51.275Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:16:51.276Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:16:51.277Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:16:51.277Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:21:25.629Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:21:25.630Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:21:25.631Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:21:25.632Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:23:37.495Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:23:37.496Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:23:37.497Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:23:37.498Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:26:38.988Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:26:38.989Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:26:39.003Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:26:39.005Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:31:33.234Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:31:33.234Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:31:33.235Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:31:33.237Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:34:04.553Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:34:04.554Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:34:04.583Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:34:04.584Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:37:29.414Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:37:29.415Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:37:29.416Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:37:29.417Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:42:05.238Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:42:05.239Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:42:05.240Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:42:05.240Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:19:45.162Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:19:45.179Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:19:45.179Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:19:45.413Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:19:45.414Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:19:45.415Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:19:45.416Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:19:45.911Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:19:45.927Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:20:53.586Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:20:53.587Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:20:53.588Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:20:53.589Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:22:22.877Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:22:22.878Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:22:22.879Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:22:22.879Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:23:44.523Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:23:44.523Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:23:44.524Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:23:44.526Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:25:01.645Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:25:01.646Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:25:01.646Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:25:01.647Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:37:00.183Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:37:00.183Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:37:00.184Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:37:00.185Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:38:01.768Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:38:01.769Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:38:01.770Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:38:01.771Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:39:12.597Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:39:12.598Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:39:12.598Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:39:12.599Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:40:37.603Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:40:37.604Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:40:37.605Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:40:37.606Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:41:39.408Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:41:39.409Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:41:39.410Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:41:39.411Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:42:49.883Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:42:49.884Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:42:49.885Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:42:49.886Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:44:12.082Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:44:12.083Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:44:12.084Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:44:12.085Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:45:13.334Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:45:13.335Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:45:13.336Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:45:13.337Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:46:13.838Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:46:13.839Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:46:13.840Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:46:13.841Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:47:29.263Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:47:29.264Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:47:29.265Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:47:29.266Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:48:34.502Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:48:34.502Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:48:34.507Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:48:34.509Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:50:04.962Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:50:04.963Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:50:04.964Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:50:04.965Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:51:16.742Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:51:16.750Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:51:16.751Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:51:16.751Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:52:17.223Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:52:17.224Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:52:17.225Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:52:17.226Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:53:22.050Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:53:22.051Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:53:22.052Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:53:22.067Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:54:49.077Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:54:49.079Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:54:49.080Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:54:49.081Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:55:50.994Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:55:50.995Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:55:50.996Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:55:50.996Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:57:04.541Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:57:04.542Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:57:04.543Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:57:04.544Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:58:12.187Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:58:12.188Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:58:12.189Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:58:12.190Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:59:24.309Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:59:24.310Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:59:24.311Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:59:24.312Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:00:25.474Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:00:25.475Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:00:25.476Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:00:25.476Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:01:35.457Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:01:35.458Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:01:35.459Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:01:35.460Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:02:48.107Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:02:48.108Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:02:48.109Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:02:48.110Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:03:48.761Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:03:48.762Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:03:48.763Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:03:48.763Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:05:00.434Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:05:00.435Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:05:00.436Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:05:00.437Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:06:11.223Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:06:11.224Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:06:11.225Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:06:11.236Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:07:11.888Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:07:11.889Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:07:11.890Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:07:11.891Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:08:42.490Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:08:42.499Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:08:42.500Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:08:42.501Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:10:12.420Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:10:12.421Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:10:12.422Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:10:12.422Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:11:24.409Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:11:24.413Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:11:24.414Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:11:24.416Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:13:55.531Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:13:55.532Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:13:55.533Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:13:55.534Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:15:20.976Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:15:20.977Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:15:20.978Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:15:20.979Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:16:55.376Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:16:55.377Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:16:55.378Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:16:55.379Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:18:39.278Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:18:39.279Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:18:39.280Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:18:39.281Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:22:19.754Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:22:19.755Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:22:19.755Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:22:19.756Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:25:54.328Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:25:54.329Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:25:54.330Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:25:54.330Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:28:07.651Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:28:07.652Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:28:07.653Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:28:07.654Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:30:21.530Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:30:21.532Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:30:21.534Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:30:21.535Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:32:48.224Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:32:48.225Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:32:48.226Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:32:48.227Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:35:17.471Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:35:17.472Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:35:17.473Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:35:17.474Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:38:34.774Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:38:34.775Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:38:34.776Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:38:34.777Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:41:03.455Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:41:03.456Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:41:03.457Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:41:03.458Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:43:27.163Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:43:27.164Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:43:27.165Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:43:27.166Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:45:38.000Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:45:38.000Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:45:38.002Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:45:38.003Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:47:34.573Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:47:34.574Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:47:34.575Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:47:34.576Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:50:00.526Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:50:00.527Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:50:00.528Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:50:00.529Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:51:18.917Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:51:18.918Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:51:18.918Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:51:18.919Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:52:54.241Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:52:54.241Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:52:54.242Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:52:54.243Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:54:37.522Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:54:37.523Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:54:37.524Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:54:37.525Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:55:44.551Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:55:44.552Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:55:44.554Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:55:44.557Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:57:47.065Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:57:47.066Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:57:47.067Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:57:47.068Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:59:54.363Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:59:54.365Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:59:54.366Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:59:54.367Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:01:06.498Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:01:06.500Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:01:06.501Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:01:06.502Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:02:45.358Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:02:45.359Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:02:45.381Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:02:45.383Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:04:06.347Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:04:06.348Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:04:06.349Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:04:06.350Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:06:08.662Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:06:08.663Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:06:08.663Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:06:08.664Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:08:45.272Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:08:45.272Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:08:45.285Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:08:45.286Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:10:20.290Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:10:20.291Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:10:20.292Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:10:20.292Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:11:35.056Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:11:35.057Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:11:35.058Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:11:35.059Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T11:09:29.965Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T11:09:29.966Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T11:09:29.967Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T11:09:29.967Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T17:13:07.741Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-13T08:28:43.088Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-13T08:28:43.338Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-13T08:28:43.597Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-13T08:57:56.964Z | autofix | auto-fix | skipped | wf-1782282120289-7/generalize-worker-guard | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-13T08:57:56.964Z | autofix | auto-fix | skipped | wf-1782282120289-7/update-recovery-worker-docs | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-13T09:11:10.737Z | autofix | auto-fix | skipped | wf-1782282120289-7/full-regression | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-13T09:11:59.120Z | autofix | auto-fix | skipped | __merge__wf-1782282120289-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-13T17:06:52.001Z | autofix | auto-retry-cap | queued | __merge__wf-1782282120289-7 | Durable per-task auto-fix retry counter |
| 2026-07-13T17:06:52.001Z | ci-failure | fix-ci-failure | completed | __merge__wf-1782282120289-7 | CI repair intent completed |
| 2026-07-13T17:06:52.704Z | ci-failure | fix-ci-failure | completed | __merge__wf-1782282120289-7 | CI repair intent completed |

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `echo hello` — Layer: e2e_regression
Feature state: active
Review claim: The full repository suite passes with the complete 2i registry and external-worker stack in place.
Review lane: proof
Safety invariant: This task only runs the repository suite as the terminal gate; it changes no product code.
Slice rationale: The full-suite run is the single terminal gate for the whole 2i stack, separate from the focused per-slice proofs.
Architectural effect: None; this is the terminal verification gate.
Goal: Run the full repository suite as the terminal gate for the 2i stack.
Motivation: The 2i stack spans several packages and adds external-process supervision, so a full run is risk-justified as the terminal gate.
Alternative considerations: A focused command was rejected for the terminal gate because the stack crosses package boundaries and adds new process supervision.
Implementation details: Run the full repository suite after the guard slice.
Non-goals: Does not change product code; the per-slice proofs already cover focused behavior.
Acceptance criteria:
- pnpm run test:all exits 0.


</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>