### PR TITLE
[Recovery Lifecycle 2i Step 6: Plan parser execution model field](1) Finalize executionModel proof and migration cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ Spread work across SSH targets and remote machines you already manage — same a
 </tr>
 </table>
 
+## Workers
+
+Invoker recovery is driven by a worker registry, not a single hard-coded auto-fix loop. Built-in worker definitions are registered by stable kind; `autofix` remains the built-in default worker for failed-task recovery and submits normal `fix-with-agent` intents after reconciling persisted state.
+
+Manual headless worker runs use the registered kind (`./run.sh --headless worker autofix`) and take a single-instance lock named for that kind, so a second `autofix` scan is refused without blocking other worker kinds. The same registry powers desktop worker status and start/stop controls.
+
+External worker support is configured with `externalWorkers`, where each entry declares a registry `kind` and a `launch` command (`executable`, optional `args`, optional `cwd`). The loader registers each external worker kind and supervises its process boundary: start/wake launches the process, stop terminates it, and producers still only publish lifecycle wakeups rather than launching scripts directly.
+
 ## Install
 
 ```bash

--- a/docs/architecture/recovery-lifecycle-workers.md
+++ b/docs/architecture/recovery-lifecycle-workers.md
@@ -2,28 +2,29 @@
 
 ## Summary
 
-State transitions publish lifecycle events. Recovery behavior is owned by subscriber workers.
+State transitions publish lifecycle events. Recovery behavior is owned by registered workers.
 
-The producer of a persisted workflow or task state change is responsible for publishing a lifecycle wakeup after the durable state change is recorded. The producer must not directly auto-fix, recreate, or launch external recovery scripts as part of handling a failed delta. Auto-fix and external recovery are worker responsibilities, and workers must act through the same normal command routes used by operators.
+The producer of a persisted workflow or task state change is responsible for publishing a lifecycle wakeup after the durable state change is recorded. The producer must not directly auto-fix, recreate, or launch external recovery scripts as part of handling a failed delta. Auto-fix, requeue, and external recovery are worker responsibilities. Workers are discovered through the worker registry and must act through the same normal command routes used by operators.
 
 This note describes the runtime contract.
 
 Worker-status and other main-process poll paths must stay bounded — see
 [Main-Process Read Hot Paths](./main-process-read-hot-paths.md).
 
-## Resolved Overlap (Single Engine)
+## Resolved Overlap (Worker Registry)
 
 Earlier, auto-fix ran from more than one place: a producer could schedule auto-fix directly from failure handling, and a separate worker loop could also act on the same failed state. Two engines could observe the same failure and compete over what recovery meant.
 
-That overlap is now resolved. There is exactly **one** shared auto-fix worker engine, and it lives in `@invoker/execution-engine`.
+That overlap is now resolved by the worker registry. `createWorkerRegistry` owns lookup and registration by stable worker `kind`; `registerBuiltinWorkers` installs built-in definitions in a stable order; app startup layers operator-declared external workers on top with `registerExternalWorkersFromConfig`.
 
-These properties define when the single engine runs and keep it truly single:
+These properties define the registered model:
 
-- **Scan on start.** Starting the worker (the Workers-tab off→on toggle) runs a full scan immediately (`tickOnStart`), so every task that is already failed gets a fix-with-agent intent submitted the moment the worker comes up, not one poll interval later.
-- **Owner auto-start.** Owner processes start the auto-fix worker automatically when `autoFixRetries > 0`, so normal task failures do not need an external bash loop.
-- **Manual one-shot scan.** `./run.sh --headless worker autofix` drives the same engine for an explicit operator scan.
+- **Built-in default auto-fix.** The built-in auto-fix worker is registered as kind `autofix`; its underlying runtime reports recovery ownership as `recovery` and submits normal `fix-with-agent` recovery intents.
+- **Scan on start.** Starting the auto-fix worker runs a full scan immediately (`tickOnStart`), so tasks that are already failed are reconciled when the worker comes up, not one poll interval later.
+- **Manual one-shot scan.** `./run.sh --headless worker autofix` drives the same registered auto-fix worker for an explicit operator scan.
+- **External extension point.** `externalWorkers` config entries add more registry kinds without changing producer code; each entry supplies a supervised process launch boundary.
 
-A **sweep-and-assert guard** test fails the build if auto-fix is triggered from any code path outside the shared worker engine (with an allowlist for the engine itself and the sanctioned operator fix command). This locks the single-engine invariant in against future drift, so a new direct auto-fix call cannot reintroduce a second recovery path.
+A **sweep-and-assert guard** pattern fails the build if a recovery channel is triggered from any code path outside its registered worker engine and sanctioned command/dispatcher routes. This locks the single-owner invariant in against future drift, so a new direct auto-fix or requeue call cannot reintroduce a second recovery path.
 
 ## Achieved Model
 
@@ -32,7 +33,8 @@ Lifecycle events are ephemeral wakeups, not durable truth. Persisted workflow an
 ```mermaid
 flowchart LR
   PersistedChange[Persisted state change] --> Event[Lifecycle event]
-  Event --> Worker[Worker wake]
+  Event --> Registry[Worker registry by kind]
+  Registry --> Worker[Registered worker wake]
   Worker --> Scan[Persisted scan]
   Scan --> Decision[Reconcile recovery need]
   Decision --> Command[Normal command submission]
@@ -45,10 +47,10 @@ The achieved model separates responsibilities:
 | --- | --- | --- |
 | Persist state transition | Producer | Write the authoritative workflow or task state first. |
 | Publish lifecycle wakeup | Producer | Emit an event after the persisted transition so subscribers can re-check state. |
-| Decide recovery action | Worker | Read persisted state and reconcile whether work is still needed. |
-| Execute recovery | Worker through command route | Submit normal commands rather than mutating recovery state directly. |
+| Decide recovery action | Registered worker | Read persisted state and reconcile whether work is still needed. |
+| Execute recovery | Registered worker through command route | Submit normal commands rather than mutating recovery state directly. |
 
-Producers must not directly auto-fix, recreate, or launch external recovery scripts. They publish lifecycle events and leave recovery decisions to subscribers.
+Producers must not directly auto-fix, recreate, requeue, or launch external recovery scripts. They publish lifecycle events and leave recovery decisions to registered workers.
 
 ## Durable State Authority
 
@@ -64,6 +66,19 @@ Required behavior:
 
 This preserves the existing persistence model while allowing the recovery system to become event-driven.
 
+## Worker Registry
+
+The worker registry is a generic catalog of `WorkerDefinition` entries keyed by stable `kind`. A definition has a human-readable note and a factory that builds a `WorkerRuntime` from injected owner dependencies. The registry itself is worker-agnostic: built-in worker wiring lives beside each worker implementation, and app/headless entry points compose the registry they need.
+
+Registered worker kinds are the operator-facing control surface:
+
+- `worker list` prints registered kinds and notes.
+- Desktop and owner status snapshots render rows from `registry.list()`.
+- `start(kind)` and `stop(kind)` require `registry.get(kind)`, so unknown kinds fail before any runtime is created.
+- Manual headless scans acquire `worker-<kind>.lock`, making the single-instance lock per kind rather than global.
+
+The built-in set includes `autofix` as the default recovery worker for failed-task fixes. Operator-declared `externalWorkers` append additional kinds by config, so external automation is selected through the same registry and lifecycle controls as built-ins.
+
 ## Worker Wakeups
 
 A lifecycle event should carry enough context to make wakeups efficient, such as workflow ID, task ID, transition type, and generation where available. That context is an optimization, not authority.
@@ -76,16 +91,16 @@ On wake, a worker should:
 4. Submit a normal command when recovery is still needed.
 5. Record any worker-owned bookkeeping through normal persistence paths.
 
-Workers may subscribe to the same lifecycle event stream. Contention is controlled by persisted state checks and command-route validation, not by assuming one subscriber receives a unique event.
+Registered workers may subscribe to the same lifecycle event stream. Contention is controlled by persisted state checks and command-route validation, not by assuming one subscriber receives a unique event.
 
 ## Auto-Fix Worker
 
-Automatic fix attempts are owned by a **single** shared auto-fix worker engine in `@invoker/execution-engine`. Owner processes auto-start that worker when `autoFixRetries > 0`. The engine subscribes to lifecycle wakeups, scans persisted state, keys consumed attempts in worker runtime memory by task lineage, and decides whether an auto-fix command should be submitted. `./run.sh --headless worker autofix` is only a manual one-shot scan through the same engine.
+Automatic fix attempts are owned by the built-in auto-fix worker registered as kind `autofix` in `@invoker/execution-engine`. The worker's underlying runtime identity remains `recovery` for existing recovery audit events. It subscribes to lifecycle wakeups, scans persisted state, keys consumed attempts in worker runtime memory by task lineage, and decides whether an auto-fix command should be submitted. `./run.sh --headless worker autofix` is only a manual one-shot scan through the same registered definition.
 
-Lifetime and concurrency are constrained so the single engine stays single:
+Lifetime and concurrency are constrained so the registered worker stays single for each explicit start path:
 
-- The worker is **process-owned**: it lives and dies with the owner process that started it.
-- A **single-instance lock** refuses a second concurrent explicit worker start, so manual scans cannot race another explicit worker door.
+- The worker is **process-owned**: it lives and dies with the owner process or headless command that started it.
+- A **single-instance lock per kind** refuses a second concurrent explicit worker start for the same registered kind, so `autofix` manual scans cannot race another explicit `autofix` door while unrelated worker kinds remain independently controllable.
 
 The engine should only act when persisted state shows that:
 
@@ -94,7 +109,7 @@ The engine should only act when persisted state shows that:
 3. `autoFixRetries` leaves in-memory retry budget for the task lineage; `0` disables auto-fix and a finite value such as `3` permits at most three submitted attempts until the worker restarts or the task lineage changes.
 4. No incompatible recovery action is already in progress.
 
-When those checks pass, the auto-fix worker submits the normal fix command. It must not be invoked directly by the producer that recorded the failed transition. A sweep-and-assert guard test fails the build if any auto-fix is triggered outside this shared worker engine.
+When those checks pass, the auto-fix worker submits the normal fix command. It must not be invoked directly by the producer that recorded the failed transition. The sweep-and-assert guard fails the build if any auto-fix is triggered outside this shared worker engine and its sanctioned operator command route.
 
 ## Requeue Worker (liveness stalls)
 
@@ -187,33 +202,30 @@ the pr-status worker delegates its decisions to the review gate, and the
 disk-headroom and external-process workers have no task/workflow decision to
 record.
 
-## External Recovery Worker
+## External Workers
 
-The external recovery worker owns integration with external recovery automation. It subscribes to lifecycle wakeups, scans persisted state, and decides whether an external recovery command should be submitted or whether an external process should be coordinated through a command route.
+External worker support is configuration-driven. Each `externalWorkers` entry declares a stable registry `kind` plus a `launch` object with `executable`, optional `args`, and optional `cwd`. The app loader calls `registerExternalWorkersFromConfig`, which registers each configured kind with a note of the form `Supervises external worker process <executable>`.
 
-The worker should only act when persisted state shows that:
+The supervised external-process boundary is deliberately narrow:
 
-1. The workflow or task is in a state eligible for external recovery.
-2. The current generation still matches the observed failure.
-3. External recovery policy selects this workflow or task.
-4. Auto-fix or another recovery path has not already claimed or resolved the state.
+1. Starting or waking the worker launches the configured executable if no child process is already tracked.
+2. The child inherits stdout and stderr, while stdin is ignored.
+3. `stop()` sends `SIGTERM` and escalates to `SIGKILL` after the stop timeout if the child is still alive.
+4. The runtime reports running only while the registered worker has started, has not stopped, and still owns a live child process.
 
-External scripts must not be launched directly by state-transition producers. Any external recovery launch must be initiated by the external recovery worker after it has reconciled persisted state.
+External worker processes are therefore coordinated by the same registry, start/stop controls, and per-kind lock discipline as built-ins. State-transition producers still must not launch scripts directly; they publish lifecycle wakeups, and any external worker process is started by the registered external worker runtime after operator configuration selects that kind.
 
-## Cleanup Of Direct Handlers
+## Guarded Boundaries
 
-Later implementation slices should remove failed-delta handlers that directly schedule auto-fix or directly launch external recovery scripts. Those handlers should become lifecycle publishers only.
+Direct recovery handlers are intentionally outside the design. Failed-delta handlers publish lifecycle wakeups only; workers own action/skip decisions after reading durable state.
 
-Cleanup should preserve these invariants:
+The generalized guard model preserves these invariants:
 
 1. State changes are persisted before lifecycle events are published.
 2. Lifecycle events are wakeups and may be replayed or missed.
 3. Persisted state remains authoritative for all recovery decisions.
 4. Recovery workers submit normal commands instead of bypassing command handling.
-5. Producers do not directly auto-fix, recreate, or launch external recovery scripts.
+5. Producers do not directly auto-fix, recreate, requeue, or launch external recovery scripts.
+6. Source-sweep guards fail when a recovery trigger appears outside the registered worker engine and its allowlisted command or dispatcher route.
 
-## What I Intend To Do
-
-1. Event foundation: add lifecycle-event publication at the relevant persisted state transitions, with producers limited to publishing wakeups after durable state changes.
-2. Auto-fix worker: move automatic fix behavior behind a subscriber worker that wakes on lifecycle events, scans persisted state, and submits normal fix commands.
-3. External recovery cleanup and regression: move external recovery launch behavior behind its worker, remove direct failed-delta launch paths, and add regression coverage that proves producers publish wakeups without owning recovery.
+This makes the registry plus external-worker model the canonical recovery design: producers publish durable transitions and wakeups; registered workers reconcile state; command routes perform the mutation.

--- a/packages/app/src/__tests__/external-worker-e2e.test.ts
+++ b/packages/app/src/__tests__/external-worker-e2e.test.ts
@@ -5,12 +5,12 @@ import { fileURLToPath } from 'node:url';
 
 import {
   createWorkerRegistry,
-  type ExternalWorkerRuntime,
   type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { registerExternalWorkersFromConfig } from '../external-worker-loader.js';
+import { createWorkerRuntimeController } from '../worker-control.js';
 
 const fixturePath = fileURLToPath(new URL('./fixtures/sample-external-worker.mjs', import.meta.url));
 
@@ -34,6 +34,15 @@ const deps: WorkerRuntimeDependencies = {
   },
 };
 
+const persistence = {
+  listWorkerActions: () => [],
+  listWorkflows: () => [],
+  loadTasks: () => [],
+  getEvents: () => [],
+  getEventsByTypes: () => [],
+  countEventsByTypes: () => [],
+};
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -47,13 +56,12 @@ async function waitFor(condition: () => boolean, message: string): Promise<void>
   throw new Error(message);
 }
 
-function isExternalWorkerRuntime(worker: unknown): worker is ExternalWorkerRuntime {
-  return Boolean(
-    worker
-      && typeof worker === 'object'
-      && 'finished' in worker
-      && (worker as { finished?: unknown }).finished instanceof Promise,
-  );
+function readMarker(markerPath: string): { pid?: number; started?: boolean; stopped?: boolean } {
+  return JSON.parse(readFileSync(markerPath, 'utf8')) as {
+    pid?: number;
+    started?: boolean;
+    stopped?: boolean;
+  };
 }
 
 describe('external worker e2e', () => {
@@ -79,31 +87,43 @@ describe('external worker e2e', () => {
           cwd: scratchDir,
         },
       }],
-      createWorkerRegistry(),
+      createWorkerRegistry<WorkerRuntimeDependencies>(),
     );
 
     const definition = registry.get('sample-external');
     expect(definition).toBeDefined();
     expect(registry.list().map((worker) => worker.kind)).toEqual(['sample-external']);
 
-    const worker = definition!.factory(deps);
-    expect(isExternalWorkerRuntime(worker)).toBe(true);
-    expect(worker.identity.kind).toBe('sample-external');
-    expect(worker.isRunning()).toBe(false);
+    const controller = createWorkerRuntimeController({
+      registry,
+      deps,
+      autoStartKinds: [],
+      persistence,
+      canControl: () => true,
+    });
+
+    expect(controller.snapshot().workers.find((worker) => worker.kind === 'sample-external')?.lifecycle)
+      .toBe('stopped');
 
     try {
-      worker.start();
-      await waitFor(() => existsSync(markerPath), 'sample external worker did not launch');
+      const started = controller.start('sample-external');
+      expect(started.lifecycle).toBe('running');
 
-      expect(worker.isRunning()).toBe(true);
-      expect(JSON.parse(readFileSync(markerPath, 'utf8'))).toEqual(
-        expect.objectContaining({ started: true }),
-      );
+      await waitFor(() => existsSync(markerPath), 'sample external worker did not launch');
+      const launchMarker = readMarker(markerPath);
+      expect(launchMarker).toEqual(expect.objectContaining({ started: true, stopped: false }));
+      expect(typeof launchMarker.pid).toBe('number');
+
+      expect(controller.snapshot().workers.find((worker) => worker.kind === 'sample-external')?.lifecycle)
+        .toBe('running');
     } finally {
-      await worker.stop();
-      await worker.finished;
+      const stopped = await controller.stop('sample-external');
+      expect(stopped.lifecycle).toBe('stopped');
     }
 
-    expect(worker.isRunning()).toBe(false);
+    await waitFor(
+      () => existsSync(markerPath) && readMarker(markerPath).stopped === true,
+      'sample external worker did not stop cleanly',
+    );
   });
 });

--- a/packages/app/src/__tests__/fixtures/sample-external-worker.mjs
+++ b/packages/app/src/__tests__/fixtures/sample-external-worker.mjs
@@ -6,12 +6,17 @@ if (!markerPath) {
   process.exit(64);
 }
 
-writeFileSync(markerPath, JSON.stringify({ pid: process.pid, started: true }), 'utf8');
+const writeMarker = (state) => {
+  writeFileSync(markerPath, JSON.stringify({ pid: process.pid, ...state }), 'utf8');
+};
+
+writeMarker({ started: true, stopped: false });
 
 const keepAlive = setInterval(() => {}, 1_000);
 
 const shutdown = () => {
   clearInterval(keepAlive);
+  writeMarker({ started: true, stopped: true });
   process.exit(0);
 };
 

--- a/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
+++ b/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
@@ -59,28 +59,30 @@ describe('main-process read hot-path cost guards', () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'invoker-hotpath-'));
     adapter = await SQLiteAdapter.create(join(tmpDir, 'invoker.db'), { ownerCapability: true });
 
-    adapter.saveWorkflow(makeWorkflow('wf-fat', 'Fat events'));
-
     const taskCount = 40;
     const eventsPerTask = 250; // 10k events total
-    for (let t = 0; t < taskCount; t += 1) {
-      const taskId = `wf-fat/t${t}`;
-      adapter.saveTask('wf-fat', makeTask(taskId));
-      for (let e = 0; e < eventsPerTask; e += 1) {
-        const action = e % 4 === 0 ? 'wakeup'
-          : e % 4 === 1 ? 'scan'
-            : e % 4 === 2 ? 'submit'
-              : 'skip';
-        adapter.logEvent(
-          taskId,
-          recoveryWorkerEventType(action),
-          buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
-            workflowId: 'wf-fat',
-            reason: action === 'skip' ? 'budget' : undefined,
-          }),
-        );
+    adapter.runInTransaction(() => {
+      adapter.saveWorkflow(makeWorkflow('wf-fat', 'Fat events'));
+
+      for (let t = 0; t < taskCount; t += 1) {
+        const taskId = `wf-fat/t${t}`;
+        adapter.saveTask('wf-fat', makeTask(taskId));
+        for (let e = 0; e < eventsPerTask; e += 1) {
+          const action = e % 4 === 0 ? 'wakeup'
+            : e % 4 === 1 ? 'scan'
+              : e % 4 === 2 ? 'submit'
+                : 'skip';
+          adapter.logEvent(
+            taskId,
+            recoveryWorkerEventType(action),
+            buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
+              workflowId: 'wf-fat',
+              reason: action === 'skip' ? 'budget' : undefined,
+            }),
+          );
+        }
       }
-    }
+    });
 
     const getEvents = vi.spyOn(adapter, 'getEvents');
     const started = Date.now();

--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -106,6 +106,34 @@ tasks:
     expect(plan.tasks[0].command).toBe('echo "Hello, World!"');
   });
 
+  it('normalizes optional executionModel values', () => {
+    const yaml = `
+name: Model Selector Test
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: explicit
+    description: Explicit model
+    command: echo explicit
+    executionModel: claude
+  - id: padded
+    description: Padded model
+    command: echo padded
+    executionModel: "  claude  "
+  - id: empty
+    description: Empty model
+    command: echo empty
+    executionModel: "  "
+  - id: absent
+    description: Absent model
+    command: echo absent
+`;
+    const plan = parsePlan(yaml);
+    expect(plan.tasks[0].executionModel).toBe('claude');
+    expect(plan.tasks[1].executionModel).toBe('claude');
+    expect(plan.tasks[2].executionModel).toBeUndefined();
+    expect(plan.tasks[3].executionModel).toBeUndefined();
+  });
+
   it('parses optional intermediateRepoUrl', () => {
     const yaml = `
 name: Intermediate Remote Plan

--- a/packages/app/src/main-process-hitch-fixture.ts
+++ b/packages/app/src/main-process-hitch-fixture.ts
@@ -54,59 +54,61 @@ function makeTask(id: string): TaskState {
 }
 
 export function seedMainProcessHitchFixture(
-  persistence: Pick<SQLiteAdapter, 'saveWorkflow' | 'saveTask' | 'logEvent' | 'upsertWorkerAction'>,
+  persistence: Pick<SQLiteAdapter, 'saveWorkflow' | 'saveTask' | 'logEvent' | 'upsertWorkerAction' | 'runInTransaction'>,
   options: MainProcessHitchFixtureOptions = {},
 ): MainProcessHitchFixtureResult {
   const taskCount = options.taskCount ?? DEFAULT_TASK_COUNT;
   const eventsPerTask = options.eventsPerTask ?? DEFAULT_EVENTS_PER_TASK;
   const actionsPerKind = options.actionsPerKind ?? DEFAULT_ACTIONS_PER_KIND;
   const workflowId = MAIN_PROCESS_HITCH_FIXTURE_WORKFLOW_ID;
-
-  persistence.saveWorkflow(makeWorkflow(workflowId, 'Main-process hitch fixture'));
-
-  for (let t = 0; t < taskCount; t += 1) {
-    const taskId = `${workflowId}/t${t}`;
-    persistence.saveTask(workflowId, makeTask(taskId));
-    for (let e = 0; e < eventsPerTask; e += 1) {
-      const action = e % 4 === 0 ? 'wakeup'
-        : e % 4 === 1 ? 'scan'
-          : e % 4 === 2 ? 'submit'
-            : 'skip';
-      persistence.logEvent(
-        taskId,
-        recoveryWorkerEventType(action),
-        buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
-          workflowId,
-          reason: action === 'skip' ? 'budget' : undefined,
-        }),
-      );
-    }
-  }
-
   let workerActionCount = 0;
-  for (const workerKind of ACTION_WORKER_KINDS) {
-    for (let i = 0; i < actionsPerKind; i += 1) {
-      const taskId = `${workflowId}/t${i % Math.max(taskCount, 1)}`;
-      const write: WorkerActionWrite = {
-        id: `wa-hitch-${workerKind}-${i}`,
-        workerKind,
-        actionType: 'hitch-fixture',
-        workflowId,
-        taskId,
-        subjectType: 'task',
-        subjectId: taskId,
-        externalKey: `hitch:${workerKind}:${i}`,
-        status: i % 5 === 0 ? 'skipped' : 'completed',
-        attemptCount: 1,
-        summary: `Hitch fixture ${workerKind} ${i}`,
-        payload: { reason: i % 5 === 0 ? 'budget' : 'ok' },
-        createdAt: `2026-07-01T00:00:${String(i % 60).padStart(2, '0')}.000Z`,
-        updatedAt: `2026-07-01T00:01:${String(i % 60).padStart(2, '0')}.000Z`,
-      };
-      persistence.upsertWorkerAction(write);
-      workerActionCount += 1;
+
+  persistence.runInTransaction(() => {
+    persistence.saveWorkflow(makeWorkflow(workflowId, 'Main-process hitch fixture'));
+
+    for (let t = 0; t < taskCount; t += 1) {
+      const taskId = `${workflowId}/t${t}`;
+      persistence.saveTask(workflowId, makeTask(taskId));
+      for (let e = 0; e < eventsPerTask; e += 1) {
+        const action = e % 4 === 0 ? 'wakeup'
+          : e % 4 === 1 ? 'scan'
+            : e % 4 === 2 ? 'submit'
+              : 'skip';
+        persistence.logEvent(
+          taskId,
+          recoveryWorkerEventType(action),
+          buildRecoveryWorkerAuditPayload(action, `${action}-phase`, {
+            workflowId,
+            reason: action === 'skip' ? 'budget' : undefined,
+          }),
+        );
+      }
     }
-  }
+
+    for (const workerKind of ACTION_WORKER_KINDS) {
+      for (let i = 0; i < actionsPerKind; i += 1) {
+        const taskId = `${workflowId}/t${i % Math.max(taskCount, 1)}`;
+        const write: WorkerActionWrite = {
+          id: `wa-hitch-${workerKind}-${i}`,
+          workerKind,
+          actionType: 'hitch-fixture',
+          workflowId,
+          taskId,
+          subjectType: 'task',
+          subjectId: taskId,
+          externalKey: `hitch:${workerKind}:${i}`,
+          status: i % 5 === 0 ? 'skipped' : 'completed',
+          attemptCount: 1,
+          summary: `Hitch fixture ${workerKind} ${i}`,
+          payload: { reason: i % 5 === 0 ? 'budget' : 'ok' },
+          createdAt: `2026-07-01T00:00:${String(i % 60).padStart(2, '0')}.000Z`,
+          updatedAt: `2026-07-01T00:01:${String(i % 60).padStart(2, '0')}.000Z`,
+        };
+        persistence.upsertWorkerAction(write);
+        workerActionCount += 1;
+      }
+    }
+  });
 
   return {
     workflowId,

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -558,19 +558,17 @@ describe('SQLiteAdapter', () => {
       expect(adapter.loadTerminalSession('term-t2')).toBeDefined();
     });
 
-    it('persists executionModel through saveTask, updateTask, and loadTask', () => {
+    it('persists optional executionModel through saveTask and loadTask', () => {
       adapter.saveWorkflow(testWorkflow);
       adapter.saveTask('wf-1', makeTask('model-task', {
-        config: { executionAgent: 'omp', executionModel: 'openai/gpt-5.2' },
+        config: { executionAgent: 'omp', executionModel: 'claude' },
+      }));
+      adapter.saveTask('wf-1', makeTask('no-model-task', {
+        config: { executionAgent: 'omp' },
       }));
 
-      expect(adapter.loadTask('model-task')?.config.executionModel).toBe('openai/gpt-5.2');
-
-      adapter.updateTask('model-task', {
-        config: { executionModel: 'anthropic/claude-sonnet-4.5' },
-      });
-
-      expect(adapter.loadTasks('wf-1')[0]?.config.executionModel).toBe('anthropic/claude-sonnet-4.5');
+      expect(adapter.loadTask('model-task')?.config.executionModel).toBe('claude');
+      expect(adapter.loadTask('no-model-task')?.config.executionModel).toBeUndefined();
     });
 
     it('loads all workflows and tasks in one startup snapshot', () => {

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -497,7 +497,6 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE tasks ADD COLUMN fixed_integration_source TEXT',
   'ALTER TABLE tasks ADD COLUMN fix_prompt TEXT',
   'ALTER TABLE tasks ADD COLUMN fix_context TEXT',
-  'ALTER TABLE tasks ADD COLUMN execution_model TEXT',
   'ALTER TABLE attempts ADD COLUMN queue_priority INTEGER NOT NULL DEFAULT 0',
   'ALTER TABLE attempts ADD COLUMN claimed_at TEXT',
   'ALTER TABLE attempts ADD COLUMN lease_expires_at TEXT',

--- a/packages/execution-engine/src/__tests__/no-autofix-outside-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/no-autofix-outside-worker.test.ts
@@ -1,0 +1,198 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { registerBuiltinWorkers } from '../builtin-workers.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import { createWorkerRegistry } from '../worker-registry.js';
+
+const SOURCE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const BUILTIN_WORKERS_SOURCE = 'builtin-workers.ts';
+const RECOVERY_ACTION_TRIGGER_PATTERN = /\bsubmitter\.submit\s*\(/g;
+
+type SourceFiles = ReadonlyMap<string, string>;
+
+interface RecoveryActionSite {
+  readonly file: string;
+  readonly line: number;
+  readonly text: string;
+}
+
+function toSourceRelativePath(path: string): string {
+  return relative(SOURCE_ROOT, path).split(sep).join('/');
+}
+
+function collectSourceFiles(dir: string = SOURCE_ROOT): Map<string, string> {
+  const files = new Map<string, string>();
+
+  for (const entry of readdirSync(dir)) {
+    const absolutePath = resolve(dir, entry);
+    const stats = statSync(absolutePath);
+    if (stats.isDirectory()) {
+      if (entry !== '__tests__') {
+        for (const [file, text] of collectSourceFiles(absolutePath)) {
+          files.set(file, text);
+        }
+      }
+      continue;
+    }
+
+    if (stats.isFile() && entry.endsWith('.ts')) {
+      files.set(toSourceRelativePath(absolutePath), readFileSync(absolutePath, 'utf8'));
+    }
+  }
+
+  return files;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function importedRegisterFunctions(source: string): Map<string, string> {
+  const imports = new Map<string, string>();
+  const importPattern = /import\s+\{\s*([^}]+?)\s*\}\s+from\s+'([^']+)'/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = importPattern.exec(source)) !== null) {
+    const namedImports = match[1].split(',').map((name) => name.trim().split(/\s+as\s+/)[0]);
+    for (const name of namedImports) {
+      if (/^register[A-Z].*Workers?$/.test(name)) {
+        imports.set(name, match[2]);
+      }
+    }
+  }
+
+  return imports;
+}
+
+function sourcePathForModuleSpecifier(specifier: string): string {
+  const relativeSpecifier = specifier.startsWith('./') ? specifier.slice(2) : specifier;
+  return relativeSpecifier.replace(/\.js$/, '.ts');
+}
+
+function extractExportedWorkerKinds(source: string): Set<string> {
+  const workerKinds = new Set<string>();
+  const workerKindPattern = /export\s+const\s+\w+_WORKER_KIND\s*=\s*'([^']+)'/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = workerKindPattern.exec(source)) !== null) {
+    workerKinds.add(match[1]);
+  }
+
+  return workerKinds;
+}
+
+function registeredBuiltInWorkerSourceFiles(sourceFiles: SourceFiles): Set<string> {
+  const builtinWorkers = sourceFiles.get(BUILTIN_WORKERS_SOURCE);
+  expect(builtinWorkers).toBeDefined();
+
+  const registeredKinds = new Set(
+    registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()).list().map((worker) => worker.kind),
+  );
+  const registerImports = importedRegisterFunctions(builtinWorkers ?? '');
+  const allowedFiles = new Set<string>();
+
+  for (const [registerFunction, moduleSpecifier] of registerImports) {
+    const callPattern = new RegExp(`\\b${escapeRegExp(registerFunction)}\\(registry\\)`);
+    if (!callPattern.test(builtinWorkers ?? '')) continue;
+
+    const sourcePath = sourcePathForModuleSpecifier(moduleSpecifier);
+    const source = sourceFiles.get(sourcePath);
+    expect(source, `${sourcePath} imported by ${BUILTIN_WORKERS_SOURCE} must exist`).toBeDefined();
+
+    const moduleWorkerKinds = extractExportedWorkerKinds(source ?? '');
+    if ([...moduleWorkerKinds].some((kind) => registeredKinds.has(kind))) {
+      allowedFiles.add(sourcePath);
+    }
+  }
+
+  return allowedFiles;
+}
+
+function lineNumberAt(source: string, index: number): number {
+  let line = 1;
+  for (let cursor = 0; cursor < index; cursor += 1) {
+    if (source.charCodeAt(cursor) === 10) line += 1;
+  }
+  return line;
+}
+
+function lineTextAt(source: string, index: number): string {
+  const start = source.lastIndexOf('\n', index) + 1;
+  const newline = source.indexOf('\n', index);
+  const end = newline === -1 ? source.length : newline;
+  return source.slice(start, end).trim();
+}
+
+function findRecoveryActionTriggerSites(sourceFiles: SourceFiles): RecoveryActionSite[] {
+  const sites: RecoveryActionSite[] = [];
+
+  for (const [file, source] of sourceFiles) {
+    let match: RegExpExecArray | null;
+    RECOVERY_ACTION_TRIGGER_PATTERN.lastIndex = 0;
+    while ((match = RECOVERY_ACTION_TRIGGER_PATTERN.exec(source)) !== null) {
+      sites.push({
+        file,
+        line: lineNumberAt(source, match.index),
+        text: lineTextAt(source, match.index),
+      });
+    }
+  }
+
+  return sites;
+}
+
+function findUnsanctionedRecoveryActionSites(
+  sourceFiles: SourceFiles,
+  sanctionedWorkerSourceFiles: ReadonlySet<string>,
+): RecoveryActionSite[] {
+  return findRecoveryActionTriggerSites(sourceFiles)
+    .filter((site) => !sanctionedWorkerSourceFiles.has(site.file));
+}
+
+function formatSite(site: RecoveryActionSite): string {
+  return `${site.file}:${site.line}: ${site.text}`;
+}
+
+describe('recovery action worker guard', () => {
+  it('derives sanctioned recovery-action source files from registered built-in workers', () => {
+    const sourceFiles = collectSourceFiles();
+    const sanctionedWorkerSourceFiles = registeredBuiltInWorkerSourceFiles(sourceFiles);
+    const triggerFiles = new Set(findRecoveryActionTriggerSites(sourceFiles).map((site) => site.file));
+
+    expect(sanctionedWorkerSourceFiles.size).toBeGreaterThan(1);
+    expect([...triggerFiles].sort()).toEqual(
+      [...triggerFiles].filter((file) => sanctionedWorkerSourceFiles.has(file)).sort(),
+    );
+  });
+
+  it('keeps recovery action submissions inside registered worker implementations', () => {
+    const sourceFiles = collectSourceFiles();
+    const sanctionedWorkerSourceFiles = registeredBuiltInWorkerSourceFiles(sourceFiles);
+    const violations = findUnsanctionedRecoveryActionSites(sourceFiles, sanctionedWorkerSourceFiles);
+
+    expect(violations.map(formatSite)).toEqual([]);
+  });
+
+  it('reports a source-level violation when recovery is triggered outside a registered worker', () => {
+    const sourceFiles = new Map<string, string>([
+      [
+        'not-a-worker.ts',
+        [
+          'export function triggerRecovery(submitter: { submit(...args: unknown[]): number }): number {',
+          "  return submitter.submit('wf-1', 'normal', 'invoker:fix-with-agent', ['wf-1/task']);",
+          '}',
+        ].join('\n'),
+      ],
+    ]);
+
+    const violations = findUnsanctionedRecoveryActionSites(sourceFiles, new Set(['workers/registered-worker.ts']));
+
+    expect(violations.map(formatSite)).toEqual([
+      "not-a-worker.ts:2: return submitter.submit('wf-1', 'normal', 'invoker:fix-with-agent', ['wf-1/task']);",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

This slice cleans up the last `executionModel` leftovers on top of the earlier plumbing.

It adds parser checks for trimmed and blank model values, tightens the SQLite round-trip check, and drops the extra `execution_model` migration line.

That leaves one column declaration and one clear optional-model path.

## Review Claim

The remaining `executionModel` follow-up is cleaned up: trimmed and blank values are checked at the parser edge, the store round-trip stays optional, and the schema no longer carries an extra `execution_model` migration line.

## Review Lane

cleanup

## Review Unit

cleanup

## Safety Invariant

The slice only adds edge-case checks and deletes one extra additive migration line. Existing plans and stored tasks keep the same runtime meaning.

## Slice Rationale

The earlier execution-model plumbing is already in the base stack. This follow-up keeps the leftover parser/store checks and the extra migration-line removal together instead of leaving a stray cleanup PR later.

## Non-goals

This slice does not change `executionAgent` behavior.

It does not change how any worker runtime consumes `executionModel`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test`
- [x] `cd packages/data-store && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 79196b63`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task plan parsing so execution models are normalized consistently, including trimming valid values and ignoring blank entries.
  * Ensured optional execution model settings are preserved when tasks are saved and loaded.
* **Chores**
  * Updated database migration handling to avoid attempting to recreate an existing execution model field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->