### PR TITLE
[GitHub Review ID Invariant](1) Add pending proof for GitHub review ID drift

### DIFF
--- a/packages/execution-engine/src/__tests__/repro-review-gate-logic-guards.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-review-gate-logic-guards.test.ts
@@ -95,6 +95,20 @@ describe('repro #1757: parseMakePrStackPublishResult normalizes/validates identi
     expect(out[1].id).toBe('b');
     expect(out[1].dependsOn).toEqual(['a']);
   });
+  it.fails('keeps GitHub provider ids aligned with the pull URL number', () => {
+    const out = parseMakePrStackPublishResult(wrap([
+      { id: 'a', url: 'https://github.com/owner/repo/pull/4261', providerId: 'github' },
+      { id: 'b', url: 'https://github.com/owner/repo/pull/4279', providerId: 'github:4279', dependsOn: ['a'] },
+      { id: 'c', url: 'https://github.com/owner/repo/pull/4284', providerId: 'PR_kwXYZ', dependsOn: ['b'] },
+    ]));
+    expect(out.map((artifact) => artifact.providerId)).toEqual(['4261', '4279', '4284']);
+  });
+  it.fails('fills in the GitHub pull number when the agent omits providerId', () => {
+    const out = parseMakePrStackPublishResult(wrap([
+      { id: 'a', url: 'https://github.com/owner/repo/pull/4300' },
+    ]));
+    expect(out[0]?.providerId).toBe('4300');
+  });
 });
 
 // ── #1811: mapReviewGateArtifactStatus ───────────────────


### PR DESCRIPTION
## Summary

Adds pending regression proof for GitHub review-gate IDs drifting away from their PR URLs.

The new cases lock the bad `github`, `github:<n>`, and `PR_kw...` shapes without changing runtime behavior yet.

## Review Claim

The parser now has pending proof that GitHub review IDs drift from the PR URL today.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds pending tests in the existing repro guard file. Production code stays unchanged.

## Slice Rationale

The proof lands before the fix so reviewers can see the broken GitHub identifier shapes in isolation.

## Non-goals

- Does not change how review-gate artifacts are parsed.
- Does not repair already-persisted bad review IDs.
- Does not change worker polling behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/repro-review-gate-logic-guards.test.ts -t "repro #1757"`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/review-gate-github-providerid-proof.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5da7ed8dbc9094e09da22231f1f0112cfb25da31`
- Post-revert steps: None.
- Data migration? No

</details>
