### PR TITLE
[GitHub Review ID Invariant](2) Normalize GitHub review IDs from PR URLs

### DIFF
--- a/packages/execution-engine/src/__tests__/repro-review-gate-logic-guards.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-review-gate-logic-guards.test.ts
@@ -95,7 +95,7 @@ describe('repro #1757: parseMakePrStackPublishResult normalizes/validates identi
     expect(out[1].id).toBe('b');
     expect(out[1].dependsOn).toEqual(['a']);
   });
-  it.fails('keeps GitHub provider ids aligned with the pull URL number', () => {
+  it('keeps GitHub provider ids aligned with the pull URL number', () => {
     const out = parseMakePrStackPublishResult(wrap([
       { id: 'a', url: 'https://github.com/owner/repo/pull/4261', providerId: 'github' },
       { id: 'b', url: 'https://github.com/owner/repo/pull/4279', providerId: 'github:4279', dependsOn: ['a'] },
@@ -103,7 +103,7 @@ describe('repro #1757: parseMakePrStackPublishResult normalizes/validates identi
     ]));
     expect(out.map((artifact) => artifact.providerId)).toEqual(['4261', '4279', '4284']);
   });
-  it.fails('fills in the GitHub pull number when the agent omits providerId', () => {
+  it('fills in the GitHub pull number when the agent omits providerId', () => {
     const out = parseMakePrStackPublishResult(wrap([
       { id: 'a', url: 'https://github.com/owner/repo/pull/4300' },
     ]));

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -374,6 +374,18 @@ export function buildMakePrStackPublishPrompt(args: {
   return lines.join('\n');
 }
 
+function parseGitHubPullRequestNumber(url: string): string | undefined {
+  const match = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/(\d+)(?:[/?#].*)?$/i.exec(url);
+  return match?.[1];
+}
+
+// GitHub-first for now: the public PR URL is the authoritative review-gate key.
+function normalizeReviewArtifactProviderId(url: string, providerId: string | undefined): string | undefined {
+  const githubPrNumber = parseGitHubPullRequestNumber(url);
+  if (githubPrNumber) return githubPrNumber;
+  return providerId;
+}
+
 export function parseMakePrStackPublishResult(raw: string): MakePrStackArtifactOutput[] {
   let parsed: unknown;
   try {
@@ -425,11 +437,14 @@ export function parseMakePrStackPublishResult(raw: string): MakePrStackArtifactO
         return dependency.trim();
       });
     ids.add(id);
+    const providerId = typeof record.providerId === 'string'
+      ? record.providerId.trim() || undefined
+      : undefined;
     records.push({
       id,
       title: typeof record.title === 'string' ? record.title : undefined,
       url,
-      providerId: typeof record.providerId === 'string' ? record.providerId : undefined,
+      providerId: normalizeReviewArtifactProviderId(url, providerId),
       branch: typeof record.branch === 'string' ? record.branch : undefined,
       baseBranch: typeof record.baseBranch === 'string' ? record.baseBranch : undefined,
       dependsOn: normalizedDependsOn,


### PR DESCRIPTION
## Summary

Makes GitHub PR URLs the source of truth for saved review-gate identifiers.

GitHub review-stack publishes now save the pull number from `/pull/<n>` even when the make-pr agent returns `github`, `github:<n>`, or a GraphQL node ID.

## Review Claim

GitHub review-stack artifacts always persist the PR number from the GitHub pull URL.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This only changes GitHub review-stack identifier normalization in `parseMakePrStackPublishResult` and promotes the earlier proof to active assertions.

## Slice Rationale

The behavior change follows the proof slice so the reviewer can verify the invariant before reading the normalization logic.

## Non-goals

- Does not change non-GitHub review providers.
- Does not repair already-persisted bad review IDs.
- Does not change merge-gate polling rules.

## Architecture

### Before

GitHub review-stack publishing trusted the agent-provided `providerId` string and copied it into merge-gate persistence unchanged.

### After

GitHub review-stack publishing derives the saved identifier from the pull URL first, so later review-gate writes and polls see one stable PR number format.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/repro-review-gate-logic-guards.test.ts src/__tests__/pr-authoring.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts -t "repro #1757|publishReviewStackWithMakePrSkill|make-pr stack publish body contract"`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/review-gate-github-providerid-fix.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 96c40e785f5711e1e6d3a0d09ab871295f0ffe05`
- Post-revert steps: None.
- Data migration? No

</details>
