### PR TITLE
[Land Stack Failure Hardening](1) Use REST issue labels for admin-bypass

### DIFF
--- a/scripts/land-stack.mjs
+++ b/scripts/land-stack.mjs
@@ -147,6 +147,10 @@ function gh(args) {
   return execFileSync('gh', args, { encoding: 'utf8' });
 }
 
+function addLabel(prNumber, label) {
+  gh(['api', '--method', 'POST', `repos/{owner}/{repo}/issues/${prNumber}/labels`, '-f', `labels[]=${label}`]);
+}
+
 function fetchPr(num) {
   const out = gh(['pr', 'view', String(num), '--json',
     'number,headRefOid,headRefName,baseRefName,state,mergeStateStatus,reviewDecision']);
@@ -287,7 +291,7 @@ function main() {
   console.log(`\nExecuting: adding 'admin-bypass' to ${targets.length} verified PR(s), bottom-to-top.`);
   for (const pr of targets) {
     console.log(`  PR #${pr.number} (head ${short(pr.headRefOid)}, base ${pr.baseRefName})`);
-    gh(['pr', 'edit', String(pr.number), '--add-label', 'admin-bypass']);
+    addLabel(pr.number, 'admin-bypass');
   }
   console.log(`Queued ${targets.length} PR(s) as one stack unit.`);
 }

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 import sys
 from typing import Mapping, Sequence
+from urllib.parse import quote
 
 try:
     from .mergify_admin_requeue_model import (
@@ -88,12 +89,20 @@ class GhClient:
         subprocess.run(["gh", "pr", "comment", str(number), "--repo", repo, "--body", body], check=True, text=True, capture_output=True)
 
     def edit_label(self, repo: str, number: int, add: str | None = None, remove: str | None = None) -> None:
-        args = ["gh", "pr", "edit", str(number), "--repo", repo]
         if add:
-            args.extend(["--add-label", add])
+            subprocess.run(
+                ["gh", "api", "--method", "POST", f"repos/{repo}/issues/{number}/labels", "-f", f"labels[]={add}"],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
         if remove:
-            args.extend(["--remove-label", remove])
-        subprocess.run(args, check=True, text=True, capture_output=True)
+            subprocess.run(
+                ["gh", "api", "--method", "DELETE", f"repos/{repo}/issues/{number}/labels/{quote(remove, safe='')}"],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
 
     def resolve_review_thread(self, thread_id: str) -> None:
         query = "mutation($threadId:ID!) { resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } } }"

--- a/scripts/test-land-stack.mjs
+++ b/scripts/test-land-stack.mjs
@@ -152,7 +152,7 @@ if (process.argv[2] === 'pr' && process.argv[3] === 'list') {
   process.stdout.write(JSON.stringify(Object.values(prs)));
   process.exit(0);
 }
-if (process.argv[2] === 'pr' && process.argv[3] === 'edit') {
+if (process.argv[2] === 'api') {
   fs.appendFileSync(log, process.argv.slice(2).join(' ') + '\\n');
   process.exit(0);
 }
@@ -183,8 +183,8 @@ test('execute labels every verified PR bottom-to-top', () => {
   const { res, edits } = runCli(['2174', '2175']);
   assert.equal(res.status, 0, `${res.stdout}\n${res.stderr}`);
   assert.deepEqual(edits, [
-    'pr edit 2174 --add-label admin-bypass',
-    'pr edit 2175 --add-label admin-bypass',
+    'api --method POST repos/{owner}/{repo}/issues/2174/labels -f labels[]=admin-bypass',
+    'api --method POST repos/{owner}/{repo}/issues/2175/labels -f labels[]=admin-bypass',
   ]);
 });
 

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import sys
 import unittest
+from unittest import mock
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -201,6 +202,45 @@ class SnapshotFromDetail(unittest.TestCase):
         self.assertEqual(snap.latest_mergify.state, "dequeued")
         self.assertEqual(snap.latest_mergify.head_sha, HEAD)
 
+
+class GhClientLabelEdit(unittest.TestCase):
+    def test_add_label_uses_rest_issue_labels_endpoint(self):
+        client = s.GhClient()
+        with mock.patch("mergify_admin_requeue_snapshot.subprocess.run") as run:
+            client.edit_label("Neko-Catpital-Labs/Invoker", 4157, add="admin-bypass")
+
+        run.assert_called_once_with(
+            [
+                "gh",
+                "api",
+                "--method",
+                "POST",
+                "repos/Neko-Catpital-Labs/Invoker/issues/4157/labels",
+                "-f",
+                "labels[]=admin-bypass",
+            ],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_remove_label_uses_rest_issue_labels_endpoint(self):
+        client = s.GhClient()
+        with mock.patch("mergify_admin_requeue_snapshot.subprocess.run") as run:
+            client.edit_label("Neko-Catpital-Labs/Invoker", 4157, remove="merge-hold")
+
+        run.assert_called_once_with(
+            [
+                "gh",
+                "api",
+                "--method",
+                "DELETE",
+                "repos/Neko-Catpital-Labs/Invoker/issues/4157/labels/merge-hold",
+            ],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Landing a stack was failing after the stack check passed.

The queue step still used `gh pr edit`, and that path now trips GitHub's old Projects Classic GraphQL field.

This slice uses the REST issue-label endpoint in both landing paths, so verified stacks still queue.

## Review Claim

The land-stack queue path now uses GitHub's REST issue-label API instead of the broken `gh pr edit` path.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This only changes how Invoker writes the same label after the existing stack guard has already verified the PR order and SHAs.

## Slice Rationale

The broken GitHub label write is the first failure mode in the landing flow, and it can be reviewed without the later app-side recovery guard.

## Non-goals

- Does not relax the stack-number, SHA, or branch-name guard.
- Does not change SSH routing.
- Does not change merge-gate recovery behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-land-stack.mjs`
- [x] `python3 scripts/test_mergify_admin_requeue_snapshot.py`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/land-stack-failure-hardening-pr1.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert dbb0adb32`
- Post-revert steps: None
- Data migration? No

</details>
