### PR TITLE
[Crash Orphan Preservation](3) Surface preserved crash actions

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3973,6 +3973,8 @@ export function App() {
                   onEditCommand={handleEditCommand}
                   onApprove={openApprovalModal}
                   onReject={openRejectModal}
+                  onRestartTask={handleRestartTask}
+                  onRecreateTask={handleRecreateTask}
                   onSetMergeBranch={handleSetMergeBranch}
                   onSetMergeMode={handleSetMergeMode}
                   onToggleCollapsed={handleToggleInspectorCollapsed}

--- a/packages/ui/src/__tests__/context-menu.test.ts
+++ b/packages/ui/src/__tests__/context-menu.test.ts
@@ -36,6 +36,25 @@ describe('ContextMenu getMenuItems', () => {
       expect(items[0].variant).toBe('primary');
       expect(items[0].action).toBe('onOpenTerminal');
     });
+    it('crash-preserved running task prioritizes restart and disables terminal reopen', () => {
+      const task = makeTask({
+        status: 'running',
+        execution: { crashPreservedAt: new Date('2026-07-13T01:02:03.000Z') },
+      });
+      const items = getMenuItems(task);
+
+      expect(items[0]).toMatchObject({
+        label: 'Restart Task',
+        enabled: true,
+        action: 'onRestart',
+        variant: 'primary',
+      });
+      expect(items[1]).toMatchObject({
+        label: 'Open Terminal',
+        enabled: false,
+        action: 'onOpenTerminal',
+      });
+    });
 
     it('pending task: first item is "Restart Task" (primary)', () => {
       const task = makeTask({ status: 'pending' });
@@ -163,12 +182,23 @@ describe('ContextMenu getMenuItems', () => {
       expect(restartItem?.enabled).toBe(true);
     });
 
-    it('disables restart for running tasks', () => {
+    it('disables restart for ordinary running tasks', () => {
       const task = makeTask({ status: 'running' });
       const items = getMenuItems(task);
 
       const restartItem = items.find((item) => item.id === 'restart');
       expect(restartItem?.enabled).toBe(false);
+    });
+
+    it('re-enables restart for running tasks preserved after a crash', () => {
+      const task = makeTask({
+        status: 'running',
+        execution: { crashPreservedAt: new Date('2026-07-13T01:02:03.000Z') },
+      });
+      const items = getMenuItems(task);
+
+      const restartItem = items.find((item) => item.id === 'restart');
+      expect(restartItem?.enabled).toBe(true);
     });
   });
 

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -754,6 +754,39 @@ describe('WorkflowInspector', () => {
       'Approval blocked: capability mismatch',
     );
   });
+  it('surfaces crash-preserved inspection actions for orphaned running tasks', () => {
+    const onRestartTask = vi.fn();
+    const onRecreateTask = vi.fn();
+    const task = makeTask({
+      status: 'running',
+      execution: {
+        crashPreservedAt: new Date('2026-07-13T01:02:03.000Z'),
+        crashPreservedOwnerPid: 46301,
+        crashPreservedReportPath: '/tmp/Electron-46301.ips',
+        crashPreservedDiagnosticSummary: 'previous owner pid=46301; no matching crash report found',
+      },
+    });
+
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={task}
+        collapsed={false}
+        advancedExpanded={false}
+        onRestartTask={onRestartTask}
+        onRecreateTask={onRecreateTask}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('inspector-crash-preserved')).toHaveTextContent('Preserved after crash');
+    expect(screen.getByTestId('inspector-crash-preserved')).toHaveTextContent('Previous owner PID: 46301');
+    fireEvent.click(screen.getByRole('button', { name: 'Restart Task' }));
+    expect(onRestartTask).toHaveBeenCalledWith('task-1');
+    fireEvent.click(screen.getByRole('button', { name: 'Recreate from Task' }));
+    expect(onRecreateTask).toHaveBeenCalledWith('task-1');
+  });
 
   it('shows selected action graph node details', () => {
     render(

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -183,6 +183,8 @@ interface WorkflowInspectorProps {
   onEditCommand?: (taskId: string, newCommand: string) => void;
   onApprove?: (task: TaskState) => void;
   onReject?: (task: TaskState) => void;
+  onRestartTask?: (taskId: string) => void;
+  onRecreateTask?: (taskId: string) => void;
   onSetMergeBranch?: (workflowId: string, baseBranch: string) => Promise<void>;
   onSetMergeMode?: (workflowId: string, mergeMode: MergeMode) => Promise<void>;
   onToggleCollapsed: () => void;
@@ -306,6 +308,8 @@ export function WorkflowInspector({
   onEditCommand,
   onApprove,
   onReject,
+  onRestartTask,
+  onRecreateTask,
   onSetMergeBranch,
   onSetMergeMode,
   onToggleCollapsed,
@@ -425,6 +429,8 @@ export function WorkflowInspector({
     return [...ids].filter(Boolean);
   }, [executionPools, task?.config.poolId]);
   const isTaskBusy = task?.status === 'running' || task?.status === 'fixing_with_ai';
+  const isCrashPreserved = Boolean(task?.execution.crashPreservedAt);
+  const crashPreservedSummary = task?.execution.crashPreservedDiagnosticSummary;
   const hasPrompt = task?.config.prompt !== undefined;
   const hasCommand = task?.config.command !== undefined;
   const hasExecutableContent = Boolean(hasPrompt || hasCommand);
@@ -549,6 +555,48 @@ export function WorkflowInspector({
               <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-amber-100">
                 {task.execution.pendingFixError}
               </pre>
+            </div>
+          )}
+          {isCrashPreserved && task && (
+            <div
+              data-testid="inspector-crash-preserved"
+              className="mt-3 rounded border border-amber-500/40 bg-amber-950/40 p-3"
+            >
+              <h3 className="text-[11px] uppercase tracking-wide text-amber-200">Preserved after crash</h3>
+              <p className="mt-1 text-xs text-amber-100 break-words">
+                Invoker kept this task unchanged after the previous owner died so the state stays inspectable.
+              </p>
+              {task.execution.crashPreservedOwnerPid !== undefined && (
+                <p className="mt-2 text-[11px] text-amber-300">
+                  Previous owner PID: {task.execution.crashPreservedOwnerPid}
+                </p>
+              )}
+              {task.execution.crashPreservedReportPath && (
+                <p className="mt-1 text-[11px] text-amber-300 break-all">
+                  Crash report: {task.execution.crashPreservedReportPath}
+                </p>
+              )}
+              {crashPreservedSummary && (
+                <p className="mt-2 text-[11px] text-amber-200 break-words">
+                  {crashPreservedSummary}
+                </p>
+              )}
+              <div className="mt-3 flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => onRestartTask?.(task.id)}
+                  className="flex-1 rounded bg-amber-500 px-3 py-2 text-xs font-medium text-black transition-colors hover:bg-amber-400"
+                >
+                  Restart Task
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onRecreateTask?.(task.id)}
+                  className="flex-1 rounded border border-amber-400 px-3 py-2 text-xs font-medium text-amber-100 transition-colors hover:bg-amber-900/40"
+                >
+                  Recreate from Task
+                </button>
+              </div>
             </div>
           )}
           {showApprovalActions && task && (

--- a/packages/ui/src/lib/context-menu-items.ts
+++ b/packages/ui/src/lib/context-menu-items.ts
@@ -36,8 +36,9 @@ export function getMenuItems(
   const { agents = ['claude', 'codex'] } = options;
   const items: MenuItem[] = [];
 
-  const canRestart = task.status !== 'running';
-  const canOpenTerminal = !isExperimentSpawnPivotTask(task);
+  const isCrashPreserved = Boolean(task.execution.crashPreservedAt);
+  const canRestart = task.status !== 'running' || isCrashPreserved;
+  const canOpenTerminal = !isExperimentSpawnPivotTask(task) && !isCrashPreserved;
   const canFix = task.status === 'failed';
   const canCancel = task.status !== 'completed' && task.status !== 'stale';
 
@@ -57,21 +58,38 @@ export function getMenuItems(
 
   // ── Task actions (grouped) ────────────────────────────────────
   if (task.status === 'running') {
-    items.push({
-      id: 'open-terminal',
-      label: 'Open Terminal',
-      enabled: canOpenTerminal,
-      action: 'onOpenTerminal',
-      variant: !canFix ? 'primary' : 'default',
-      separator: 'task',
-    });
+    if (isCrashPreserved) {
+      items.push({
+        id: 'restart',
+        label: 'Restart Task',
+        enabled: canRestart,
+        action: 'onRestart',
+        variant: !canFix ? 'primary' : 'default',
+        separator: 'task',
+      });
+      items.push({
+        id: 'open-terminal',
+        label: 'Open Terminal',
+        enabled: canOpenTerminal,
+        action: 'onOpenTerminal',
+      });
+    } else {
+      items.push({
+        id: 'open-terminal',
+        label: 'Open Terminal',
+        enabled: canOpenTerminal,
+        action: 'onOpenTerminal',
+        variant: !canFix ? 'primary' : 'default',
+        separator: 'task',
+      });
 
-    items.push({
-      id: 'restart',
-      label: 'Restart Task',
-      enabled: canRestart,
-      action: 'onRestart',
-    });
+      items.push({
+        id: 'restart',
+        label: 'Restart Task',
+        enabled: canRestart,
+        action: 'onRestart',
+      });
+    }
   } else if (task.status === 'pending') {
     items.push({
       id: 'restart',


### PR DESCRIPTION
## Summary

Once crash-preserved tasks stop mutating in the background, the UI needs to tell the user what happened and what safe next step to take.

This adds an inspector notice and re-enables the existing restart and recreate actions for crash-preserved running tasks.

## Review Claim

Crash-preserved running tasks are clearly labeled in the inspector, and the user can restart or recreate them from that preserved state.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice only reads crash-preservation metadata and routes existing restart and recreate actions. It does not invent new backend mutation paths.

## Slice Rationale

The runtime fix makes preserved tasks intentional. This follow-up slice makes that preserved state understandable and actionable for the person looking at it.

## Non-goals

- No persistence changes
- No startup reconciliation changes
- No terminal recovery changes

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `git diff --check upstream/master...HEAD`
- [x] `node scripts/validate-pr-body.mjs --body-file <tmp>/body.md --changed-files-file <tmp>/changed-files.txt --diff-file <tmp>/pr.diff`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/context-menu.test.ts src/__tests__/workflow-inspector.test.tsx -t "crash-preserved|Preserved after crash|Restart visibility|Status-adaptive ordering"`
- [x] `pnpm --filter @invoker/ui run build`

</details>


## Visual Proof

The inspector now shows that the running task was preserved after a crash and offers the existing recovery actions directly in that panel.
![Crash-preserved inspector state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-9fb51d/crash-preserved-inspector-after.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert e21a53ca`
- Post-revert steps: None.
- Data migration? No.

</details>

