### PR TITLE
[PR CI scan](4) Add periodic mapped PR CI scan worker

### DIFF
--- a/packages/app/src/__tests__/headless-pr-maintenance.test.ts
+++ b/packages/app/src/__tests__/headless-pr-maintenance.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import {
   CODERABBIT_ADDRESS_WORKER_KIND,
+  PR_CI_FAILURE_SCAN_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
 } from '@invoker/execution-engine';
 import { runHeadless } from '../headless.js';
@@ -90,12 +91,22 @@ describe('headless worker PR-maintenance', () => {
     expect(readFileSync(join(repoRoot, 'rebase.marker'), 'utf8')).toBe('rebase-token');
     expect(stdout).toContain(`${PR_CONFLICT_REBASE_WORKER_KIND} worker scan completed.`);
   });
+  it('runs the pr-ci-failure-scan worker one-shot with the threaded config', async () => {
+    writeCronScript(repoRoot, 'packages/execution-engine/scripts/cron-pr-ci-failure.sh', 'pr-ci.marker');
 
-  it('lists both PR-maintenance worker kinds from the manual entrypoint', async () => {
+    await runHeadless(['worker', PR_CI_FAILURE_SCAN_WORKER_KIND], makeWorkerDeps(repoRoot, 'scan-token') as never);
+
+    expect(readFileSync(join(repoRoot, 'pr-ci.marker'), 'utf8')).toBe('scan-token');
+    expect(stdout).toContain(`${PR_CI_FAILURE_SCAN_WORKER_KIND} worker scan completed.`);
+  });
+
+
+  it('lists all PR-maintenance worker kinds from the manual entrypoint', async () => {
     await runHeadless(['worker', 'list'], { invokerConfig: {} } as never);
 
     expect(stdout).toContain('Worker kinds');
     expect(stdout).toContain(CODERABBIT_ADDRESS_WORKER_KIND);
     expect(stdout).toContain(PR_CONFLICT_REBASE_WORKER_KIND);
+    expect(stdout).toContain(PR_CI_FAILURE_SCAN_WORKER_KIND);
   });
 });

--- a/packages/app/src/__tests__/registered-owner-workers.test.ts
+++ b/packages/app/src/__tests__/registered-owner-workers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   CODERABBIT_ADDRESS_WORKER_KIND,
+  PR_CI_FAILURE_SCAN_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
   createWorkerRegistry,
   registerBuiltinWorkers,
@@ -96,7 +97,7 @@ describe('registered owner PR-maintenance worker dependencies', () => {
     expect(deps.prMaintenance).toEqual({ intervalMs: 90000, shell: '/bin/bash' });
   });
 
-  it('builds both PR-maintenance workers from the owner deps without starting them', () => {
+  it('builds all PR-maintenance workers from the owner deps without starting them', () => {
     const registry = registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>());
     const deps = buildOwnerWorkerDeps({
       prMaintenance: { enabled: true, intervalMs: 90000 },
@@ -104,10 +105,13 @@ describe('registered owner PR-maintenance worker dependencies', () => {
 
     const coderabbit = registry.get(CODERABBIT_ADDRESS_WORKER_KIND)?.factory(deps);
     const rebase = registry.get(PR_CONFLICT_REBASE_WORKER_KIND)?.factory(deps);
+    const ciScan = registry.get(PR_CI_FAILURE_SCAN_WORKER_KIND)?.factory(deps);
 
     expect(coderabbit?.identity.kind).toBe(CODERABBIT_ADDRESS_WORKER_KIND);
     expect(coderabbit?.isRunning()).toBe(false);
     expect(rebase?.identity.kind).toBe(PR_CONFLICT_REBASE_WORKER_KIND);
     expect(rebase?.isRunning()).toBe(false);
+    expect(ciScan?.identity.kind).toBe(PR_CI_FAILURE_SCAN_WORKER_KIND);
+    expect(ciScan?.isRunning()).toBe(false);
   });
 });

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -5,6 +5,7 @@ import {
   CODERABBIT_ADDRESS_WORKER_KIND,
   E2E_AUTOFIX_WORKER_KIND,
   createWorkerRegistry,
+  PR_CI_FAILURE_SCAN_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
   PR_SUMMARY_REFRESH_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
@@ -116,6 +117,7 @@ function controller(
   register(CI_FAILURE_WORKER_KIND, 'Repairs failed CI.');
   register(CODERABBIT_ADDRESS_WORKER_KIND, 'Addresses CodeRabbit review comments.');
   register(PR_CONFLICT_REBASE_WORKER_KIND, 'Rebases conflicted pull requests.');
+  register(PR_CI_FAILURE_SCAN_WORKER_KIND, 'Scans mapped PRs for failing CI.');
   register(WORKFLOW_RESUME_WORKER_KIND, 'Resumes incomplete workflows.');
   register(E2E_AUTOFIX_WORKER_KIND, 'Runs the extended e2e battery on a schedule.');
   register('external-preview', 'External preview worker.');
@@ -145,6 +147,7 @@ describe('createWorkerRuntimeController', () => {
     expect(snapshot.workers.find((worker) => worker.kind === CI_FAILURE_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === CODERABBIT_ADDRESS_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === PR_CONFLICT_REBASE_WORKER_KIND)?.lifecycle).toBe('running');
+    expect(snapshot.workers.find((worker) => worker.kind === PR_CI_FAILURE_SCAN_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === WORKFLOW_RESUME_WORKER_KIND)?.lifecycle).toBe('stopped');
     expect(snapshot.workers.find((worker) => worker.kind === WORKFLOW_RESUME_WORKER_KIND)?.startable).toBe(true);
     expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)?.lifecycle).toBe('stopped');
@@ -245,6 +248,7 @@ describe('createWorkerRuntimeController', () => {
       CI_FAILURE_WORKER_KIND,
       CODERABBIT_ADDRESS_WORKER_KIND,
       PR_CONFLICT_REBASE_WORKER_KIND,
+      PR_CI_FAILURE_SCAN_WORKER_KIND,
     ] as const) {
       expect(setup.controller.start(kind)).toMatchObject({
         kind,

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -18,6 +18,7 @@ import {
   DISK_HEADROOM_WORKER_KIND,
   E2E_AUTOFIX_WORKER_KIND,
   PR_SUMMARY_REFRESH_WORKER_KIND,
+  PR_CI_FAILURE_SCAN_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
   REQUEUE_WORKER_KIND,
@@ -26,8 +27,6 @@ import {
   type WorkerRuntime,
   type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
-
-
 import { collectRecoveryWorkerStatus } from './recovery-worker-observability.js';
 
 export const AUTO_STARTED_OWNER_WORKER_KINDS = [
@@ -39,6 +38,7 @@ export const AUTO_STARTED_OWNER_WORKER_KINDS = [
   AUTO_APPROVE_WORKER_KIND,
   CODERABBIT_ADDRESS_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
+  PR_CI_FAILURE_SCAN_WORKER_KIND,
 ] as const;
 
 export interface WorkerRuntimeController {
@@ -170,6 +170,7 @@ const BUILT_IN_WORKER_KINDS = new Set<string>([
   CODERABBIT_ADDRESS_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
   WORKFLOW_RESUME_WORKER_KIND,
+  PR_CI_FAILURE_SCAN_WORKER_KIND,
 ]);
 
 export function createWorkerRuntimeController(options: {

--- a/packages/execution-engine/scripts/cron-pr-ci-failure.sh
+++ b/packages/execution-engine/scripts/cron-pr-ci-failure.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=scripts/cron-pr-lib.sh
+source "$(dirname "$0")/cron-pr-lib.sh"
+
+cron_lock
+
+prs_json="$(gh_json pr list --repo "$TARGET_REPO" --state open \
+  --json number,mergeable,mergeStateStatus --limit 100)" || {
+  log_line "could not list PRs; exiting"
+  exit 0
+}
+
+failures=0
+processed=0
+while IFS= read -r pr; do
+  [ -z "$pr" ] && continue
+  num="$(jq -r '.number' <<<"$pr")"
+  mergeable="$(jq -r '.mergeable // ""' <<<"$pr")"
+  merge_state="$(jq -r '.mergeStateStatus // ""' <<<"$pr")"
+
+  if [ "$merge_state" = "DIRTY" ] || [ "$mergeable" = "CONFLICTING" ]; then
+    log_line "PR #$num: skip conflicted PR; rebase worker owns it"
+    continue
+  fi
+
+  if ! output="$(headless_mutation repair-review-gate-ci "$num" 2>&1)"; then
+    failures=1
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      log_line "PR #$num: $line"
+    done <<<"$output"
+    continue
+  fi
+
+  processed=$((processed + 1))
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    log_line "PR #$num: $line"
+  done <<<"$output"
+done < <(jq -c '.[]' <<<"$prs_json")
+
+log_line "PR CI scan processed $processed open PRs"
+[ "$failures" -eq 0 ]

--- a/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS,
   PR_CONFLICT_REBASE_WORKER_KIND,
   createCoderabbitAddressWorker,
+  createPrCiFailureScanWorker,
   createPrConflictRebaseWorker,
   type PrMaintenanceLockProbeOptions,
 } from '../workers/pr-maintenance-workers.js';
@@ -164,6 +165,26 @@ describe('PR maintenance workers', () => {
     expect(spawnHarness.calls[0]).toEqual(expect.objectContaining({
       command: 'bash',
       args: [resolve(repoRoot, 'scripts/cron-pr-conflict-rebase.sh')],
+      options: expect.objectContaining({ cwd: repoRoot }),
+    }));
+  });
+  it('spawns the PR CI scan shell entrypoint', async () => {
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness();
+    const worker = createPrCiFailureScanWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => ({ held: false }),
+      installSignalHandlers: false,
+    });
+
+    await worker.tick();
+
+    expect(spawnHarness.calls[0]).toEqual(expect.objectContaining({
+      command: 'bash',
+      args: [resolve(repoRoot, 'packages/execution-engine/scripts/cron-pr-ci-failure.sh')],
       options: expect.objectContaining({ cwd: repoRoot }),
     }));
   });

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -14,6 +14,7 @@ import { CI_FAILURE_WORKER_KIND } from '../workers/ci-failure-worker.js';
 import { AUTO_APPROVE_WORKER_KIND } from '../workers/auto-approve-worker.js';
 import {
   CODERABBIT_ADDRESS_WORKER_KIND,
+  PR_CI_FAILURE_SCAN_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
 } from '../workers/pr-maintenance-workers.js';
 import { PR_STATUS_WORKER_KIND } from '../workers/pr-status-worker.js';
@@ -80,6 +81,7 @@ describe('worker registry', () => {
       AUTO_APPROVE_WORKER_KIND,
       CODERABBIT_ADDRESS_WORKER_KIND,
       PR_CONFLICT_REBASE_WORKER_KIND,
+      PR_CI_FAILURE_SCAN_WORKER_KIND,
       E2E_AUTOFIX_WORKER_KIND,
     ]);
     expect(registry.get(AUTO_FIX_WORKER_KIND)).toBeDefined();

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -14,11 +14,13 @@ import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../wor
 
 export const CODERABBIT_ADDRESS_WORKER_KIND = 'coderabbit-address';
 export const PR_CONFLICT_REBASE_WORKER_KIND = 'pr-conflict-rebase';
+export const PR_CI_FAILURE_SCAN_WORKER_KIND = 'pr-ci-failure-scan';
 export const DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS = 5 * 60_000;
 
 export type PrMaintenanceWorkerKind =
   | typeof CODERABBIT_ADDRESS_WORKER_KIND
-  | typeof PR_CONFLICT_REBASE_WORKER_KIND;
+  | typeof PR_CONFLICT_REBASE_WORKER_KIND
+  | typeof PR_CI_FAILURE_SCAN_WORKER_KIND;
 
 type EnvOverrides = Record<string, string | undefined>;
 
@@ -39,13 +41,18 @@ const PR_CONFLICT_REBASE_ENTRYPOINT: PrMaintenanceEntrypoint = {
   scriptRelativePath: 'scripts/cron-pr-conflict-rebase.sh',
   note: 'Runs the PR conflict rebase-recreate cron entrypoint under worker scheduling.',
 };
+const PR_CI_FAILURE_SCAN_ENTRYPOINT: PrMaintenanceEntrypoint = {
+  kind: PR_CI_FAILURE_SCAN_WORKER_KIND,
+  scriptRelativePath: 'packages/execution-engine/scripts/cron-pr-ci-failure.sh',
+  note: 'Runs the mapped-PR CI scan cron entrypoint under worker scheduling.',
+};
 
 export interface PrMaintenanceWorkerConfig {
   /** Repository root that owns the shell scripts. Defaults to the current Invoker repo root. */
   repoRoot?: string;
   /** Environment overrides passed to the shell entrypoint. `undefined` removes a variable. */
   env?: EnvOverrides;
-  /** Poll cadence for both PR-maintenance workers. Defaults to five minutes. */
+  /** Poll cadence for PR-maintenance workers. Defaults to five minutes. */
   intervalMs?: number;
   /** Shared cron lock path. Defaults to the shell script's `INVOKER_PR_CRON_LOCK` behavior. */
   lockPath?: string;
@@ -86,12 +93,13 @@ export interface PrMaintenanceTickOptions extends PrMaintenanceWorkerConfig {
   lockProbe?: PrMaintenanceLockProbe;
 }
 
-/** Register both built-in PR-maintenance workers in cron job order. */
+/** Register built-in PR-maintenance workers in cron job order. */
 export function registerPrMaintenanceWorkers(
   registry: WorkerRegistry<WorkerRuntimeDependencies>,
 ): WorkerRegistry<WorkerRuntimeDependencies> {
   registerCoderabbitAddressWorker(registry);
   registerPrConflictRebaseWorker(registry);
+  registerPrCiFailureScanWorker(registry);
   return registry;
 }
 
@@ -126,6 +134,22 @@ export function registerPrConflictRebaseWorker(
   });
   return registry;
 }
+export function registerPrCiFailureScanWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: PR_CI_FAILURE_SCAN_WORKER_KIND,
+    note: PR_CI_FAILURE_SCAN_ENTRYPOINT.note,
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createPrCiFailureScanWorker({
+        logger: deps.logger,
+        ...deps.prMaintenance,
+        store: deps.store,
+      }),
+  });
+  return registry;
+}
+
 
 export function createCoderabbitAddressWorker(options: PrMaintenanceWorkerOptions): WorkerRuntime {
   return createPrMaintenanceWorker(CODERABBIT_ADDRESS_ENTRYPOINT, options);
@@ -134,6 +158,10 @@ export function createCoderabbitAddressWorker(options: PrMaintenanceWorkerOption
 export function createPrConflictRebaseWorker(options: PrMaintenanceWorkerOptions): WorkerRuntime {
   return createPrMaintenanceWorker(PR_CONFLICT_REBASE_ENTRYPOINT, options);
 }
+export function createPrCiFailureScanWorker(options: PrMaintenanceWorkerOptions): WorkerRuntime {
+  return createPrMaintenanceWorker(PR_CI_FAILURE_SCAN_ENTRYPOINT, options);
+}
+
 
 export function createPrMaintenanceTick(options: PrMaintenanceTickOptions): WorkerTick {
   return async (ctx) => {


### PR DESCRIPTION
## Summary

This adds periodic wakeups for mapped review-gate CI recovery.

The bug was missed wakeups. Review-gate CI could stay untouched after owner restarts because nothing woke the existing recovery flow back up.

The fix adds a PR-maintenance loop and keeps conflicted PRs on the existing rebase path.

## Review Claim

Invoker now has periodic wakeups that can re-run mapped review-gate CI recovery after restarts.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new loop only wakes existing recovery work. It does not add a second repair implementation.

## Slice Rationale

The wakeup loop comes after the shared repair path and the earlier PR-number plumbing because it depends on both.

## Non-goals

- No repair attempt for unmapped PRs.
- No new CI fix logic.
- No UI copy changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/pr-maintenance-workers.test.ts src/__tests__/worker-registry.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-pr-maintenance.test.ts src/__tests__/registered-owner-workers.test.ts src/__tests__/worker-control.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 1fa338bfc`
- Post-revert steps: None.
- Data migration? No.

</details>

## Files (8)

- packages/app/src/__tests__/headless-pr-maintenance.test.ts [MODIFIED] (+12 -1)
- packages/app/src/__tests__/registered-owner-workers.test.ts [MODIFIED] (+5 -1)
- packages/app/src/__tests__/worker-control.test.ts [MODIFIED] (+4 -0)
- packages/app/src/worker-control.ts [MODIFIED] (+3 -2)
- packages/execution-engine/scripts/cron-pr-ci-failure.sh [ADDED] (+45 -0)
- packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts [MODIFIED] (+21 -0)
- packages/execution-engine/src/__tests__/worker-registry.test.ts [MODIFIED] (+2 -0)
- packages/execution-engine/src/workers/pr-maintenance-workers.ts [MODIFIED] (+31 -3)

Depends-On: #4334