### PR TITLE
[PR CI scan](5) Surface PR CI scan worker in Workers UI

### DIFF
--- a/packages/ui/src/__tests__/queue-view.test.tsx
+++ b/packages/ui/src/__tests__/queue-view.test.tsx
@@ -321,6 +321,14 @@ describe('QueueView', () => {
           startable: false,
           stoppable: true,
         }),
+        makeWorker({
+          kind: 'pr-ci-failure-scan',
+          note: 'Scans mapped PRs for failing CI.',
+          lifecycle: 'running',
+          autoStarts: true,
+          startable: false,
+          stoppable: true,
+        }),
       ]),
     );
 
@@ -331,13 +339,15 @@ describe('QueueView', () => {
       'worker-row-ci-failure',
       'worker-row-coderabbit-address',
       'worker-row-pr-conflict-rebase',
+      'worker-row-pr-ci-failure-scan',
     ]);
-    expect(screen.queryByText('Worker processes (5)')).not.toBeInTheDocument();
+    expect(screen.getByText('Worker processes (6)')).toBeInTheDocument();
     expect(screen.getByText('Autofix')).toBeInTheDocument();
     expect(screen.getByText('PR status')).toBeInTheDocument();
     expect(screen.getByText('CI failure repair')).toBeInTheDocument();
     expect(screen.getByText('Coderabbit Address')).toBeInTheDocument();
     expect(screen.getByText('Pr Conflict Rebase')).toBeInTheDocument();
+    expect(screen.getByText('PR CI scan')).toBeInTheDocument();
   });
 
   it('shows disabled Autofix and CI rows when policy is disabled', () => {

--- a/packages/ui/src/__tests__/queue-view.test.tsx
+++ b/packages/ui/src/__tests__/queue-view.test.tsx
@@ -341,7 +341,7 @@ describe('QueueView', () => {
       'worker-row-pr-conflict-rebase',
       'worker-row-pr-ci-failure-scan',
     ]);
-    expect(screen.getByText('Worker processes (6)')).toBeInTheDocument();
+    expect(screen.queryByText('Worker processes (6)')).not.toBeInTheDocument();
     expect(screen.getByText('Autofix')).toBeInTheDocument();
     expect(screen.getByText('PR status')).toBeInTheDocument();
     expect(screen.getByText('CI failure repair')).toBeInTheDocument();

--- a/packages/ui/src/__tests__/worker-details-panel.test.tsx
+++ b/packages/ui/src/__tests__/worker-details-panel.test.tsx
@@ -125,6 +125,18 @@ describe('WorkerDetailsPanel', () => {
     expect(screen.getByText('PR status')).toBeInTheDocument();
     expect(screen.getByText('No persisted PR status actions. This worker updates review gates directly.')).toBeInTheDocument();
   });
+  it('shows PR CI scan copy when no actions are persisted', () => {
+    renderPanel(makeWorker({
+      kind: 'pr-ci-failure-scan',
+      note: 'Scans mapped PRs for failing CI.',
+      recentActions: [],
+    }));
+
+    expect(screen.getByTestId('worker-details-title')).toHaveTextContent('PR CI scan');
+    expect(screen.getByText('Idle. Scans mapped PRs for failing CI and queues repairs.')).toBeInTheDocument();
+    expect(screen.getByText('No PR CI scan runs recorded yet.')).toBeInTheDocument();
+  });
+
   it('shows coderabbit-address as a built-in worker when no actions are persisted', () => {
     renderPanel(makeWorker({
       kind: 'coderabbit-address',

--- a/packages/ui/src/lib/worker-display.ts
+++ b/packages/ui/src/lib/worker-display.ts
@@ -98,6 +98,13 @@ export function getWorkerDisplayCopy(kind: string): WorkerDisplayCopy {
       noActionText: 'No CI repair actions recorded yet.',
     };
   }
+  if (kind === 'pr-ci-failure-scan') {
+    return {
+      name: 'PR CI scan',
+      idleText: 'Idle. Scans mapped PRs for failing CI and queues repairs.',
+      noActionText: 'No PR CI scan runs recorded yet.',
+    };
+  }
   if (kind === 'e2e-autofix') {
     return {
       name: 'Daily e2e auto-fix',


### PR DESCRIPTION
## Summary

This teaches the Workers surface how to name and describe the new maintenance worker.

The bug was visibility. The background worker existed, but the UI had no worker-specific label or empty-state copy for it.

The fix adds the new worker name, idle text, and no-action copy, plus UI tests that keep the row visible in the Workers pane and details panel.

## Review Claim

The Workers surface now renders a dedicated row and copy for the new maintenance worker instead of falling back to generic worker text.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice only changes worker presentation text and the tests around that presentation.

## Slice Rationale

The UI copy is separate from the scheduled worker logic so the background-scheduling slice stays reviewable on its own.

## Non-goals

- No scheduling changes.
- No repair-policy changes.
- No new backend worker behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/queue-view.test.tsx src/__tests__/worker-details-panel.test.tsx`
- [x] `pnpm run check:types`

</details>

## Visual Proof

Walkthrough video: the Workers badge moves from 10 to 11 processes after the new row lands.

[Workers before/after video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-fde413/pr4332-workers-before-after.mp4)

Workers pane before the UI copy slice: the Workers badge shows 10 processes and there is no dedicated row for the new maintenance worker.

![Before: workers pane without the new maintenance worker row](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-fde413/pr4324-workers-before.png)

Workers pane after the UI copy slice: the Workers badge shows 11 processes.

![After: workers pane with the new maintenance worker row](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-fde413/pr4324-workers-after.png)

Focused new row: the Worker Processes pane shows the dedicated row with its idle copy.

![After: dedicated worker row and idle copy](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-fde413/pr4324-workers-row-after.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 5099ce214`
- Post-revert steps: None.
- Data migration? No.

</details>

Depends-On: #4331