### PR TITLE
[PR CI scan](2) Add PR-number CI repair plumbing

### DIFF
--- a/packages/app/src/__tests__/review-gate-ci-repair-command.test.ts
+++ b/packages/app/src/__tests__/review-gate-ci-repair-command.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ReviewGateLookup } from '@invoker/data-store';
+import { createAutoFixAttemptLedger, type MergeGateApprovalStatus } from '@invoker/execution-engine';
+import type { TaskState } from '@invoker/workflow-core';
+
+import { repairReviewGateCiByPr } from '../review-gate-ci-repair-command.js';
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+function makeLookup(overrides: Partial<ReviewGateLookup> = {}): ReviewGateLookup {
+  return {
+    workflowId: 'wf-1',
+    mergeTaskId: 'wf-1/merge',
+    reviewId: '123',
+    reviewUrl: 'https://github.com/owner/repo/pull/123',
+    branch: 'feature/ci',
+    baseBranch: 'master',
+    workflowStatus: 'running',
+    workflowGeneration: 2,
+    mergeTaskStatus: 'review_ready',
+    selectedAttemptId: 'attempt-1',
+    ...overrides,
+  };
+}
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id: 'wf-1/merge',
+    description: 'merge',
+    status: 'review_ready',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: 'wf-1', isMergeNode: true, ...(config ?? {}) },
+    execution: {
+      generation: 2,
+      selectedAttemptId: 'attempt-1',
+      branch: 'feature/ci',
+      reviewGate: {
+        activeGeneration: 2,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [{
+          id: 'pr-123',
+          providerId: '123',
+          provider: 'github',
+          required: true,
+          status: 'open',
+          generation: 2,
+          headSha: 'sha-1',
+        }],
+      },
+      ...(execution ?? {}),
+    },
+    taskStateVersion: 10,
+    ...rest,
+  } as TaskState;
+}
+
+function makeCheckStatus(overrides: Partial<MergeGateApprovalStatus> = {}): MergeGateApprovalStatus {
+  return {
+    lifecycle: 'open',
+    rejected: false,
+    statusText: 'Awaiting review',
+    url: 'https://github.com/owner/repo/pull/123',
+    headSha: 'sha-1',
+    headRef: 'feature/ci',
+    mergeState: 'clean',
+    checks: {
+      state: 'failure',
+      failed: [{ name: 'types', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/1' }],
+    },
+    ...overrides,
+  };
+}
+
+describe('repairReviewGateCiByPr', () => {
+  it('returns unmapped when the PR has no local workflow', async () => {
+    const checkApproval = vi.fn();
+    const result = await repairReviewGateCiByPr('123', {
+      persistence: {
+        findReviewGateByPr: () => undefined,
+        loadTask: () => undefined,
+      },
+      repoRoot: '/repo',
+      policy: {
+        store: { loadTasks: () => [] },
+        submitter: { submit: vi.fn(() => 42) },
+        logger,
+        attemptLedger: createAutoFixAttemptLedger(),
+      },
+      mergeGateProvider: { checkApproval },
+    });
+
+    expect(result).toMatchObject({ status: 'unmapped', reason: 'no-local-workflow', prNumber: '123' });
+    expect(checkApproval).not.toHaveBeenCalled();
+  });
+
+  it('queues a CI repair when the mapped PR is red', async () => {
+    const submit = vi.fn(() => 42);
+    const checkApproval = vi.fn(async () => makeCheckStatus());
+    const result = await repairReviewGateCiByPr('123', {
+      persistence: {
+        findReviewGateByPr: () => makeLookup(),
+        loadTask: () => makeTask(),
+      },
+      repoRoot: '/repo',
+      policy: {
+        store: {
+          loadTasks: () => [makeTask()],
+          loadTask: () => makeTask(),
+          listWorkflowMutationIntents: () => [],
+          getWorkerAction: () => undefined,
+        },
+        submitter: { submit },
+        logger,
+        defaultAutoFixRetries: 2,
+        getAutoFixAgent: () => 'codex',
+        attemptLedger: createAutoFixAttemptLedger(),
+      },
+      mergeGateProvider: { checkApproval },
+      now: () => '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(checkApproval).toHaveBeenCalledWith({ identifier: '123', cwd: '/repo' });
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      status: 'queued',
+      reason: 'queued',
+      prNumber: '123',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+    });
+  });
+
+  it('skips mapped PRs whose checks are green', async () => {
+    const submit = vi.fn(() => 42);
+    const result = await repairReviewGateCiByPr('123', {
+      persistence: {
+        findReviewGateByPr: () => makeLookup(),
+        loadTask: () => makeTask(),
+      },
+      repoRoot: '/repo',
+      policy: {
+        store: {
+          loadTasks: () => [makeTask()],
+          loadTask: () => makeTask(),
+        },
+        submitter: { submit },
+        logger,
+        defaultAutoFixRetries: 2,
+        attemptLedger: createAutoFixAttemptLedger(),
+      },
+      mergeGateProvider: {
+        checkApproval: async () => makeCheckStatus({
+          checks: { state: 'success', failed: [] },
+        }),
+      },
+    });
+
+    expect(result).toMatchObject({ status: 'skipped', reason: 'checks-not-failing', prNumber: '123' });
+    expect(submit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -183,6 +183,7 @@ import {
   wireHeadlessApproveHook,
   type HeadlessDeps,
 } from './headless.js';
+import { parseReviewGatePrNumber, repairReviewGateCiByPr } from './review-gate-ci-repair-command.js';
 import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
 import {
   startStandaloneLaunchDispatcher,
@@ -1085,7 +1086,7 @@ function startHeadlessMode(): void {
         }
       }
 
-      const headlessDeps: HeadlessDeps = {
+      const headlessDeps = {
         logger,
         orchestrator, persistence, executorRegistry, messageBus,
         repoRoot, invokerConfig, initServices,
@@ -1104,9 +1105,22 @@ function startHeadlessMode(): void {
         executionAgentRegistry: agentRegistry,
         getBundledSkillsStatus,
         installBundledSkills: installPackagedSkills,
+        repairReviewGateCi: (prArg: string) => repairReviewGateCiByPr(prArg, {
+          persistence,
+          repoRoot,
+          policy: {
+            store: persistence,
+            submitter: { submit: submitRegisteredOwnerWorkerMutation },
+            logger,
+            defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
+            getAutoFixAgent: () => invokerConfig.autoFixAgent,
+            getAutoFixExecutionModel: () => resolveAutoFixExecutionModel(invokerConfig),
+            attemptLedger: autoFixAttemptLedger,
+          },
+        }),
         runtimeServices,
         appRootDir: __dirname,
-      };
+      } as HeadlessDeps;
 
       const createStandaloneTaskExecutor = (): TaskRunner => {
         const executor = createHeadlessExecutor(headlessDeps);
@@ -1498,6 +1512,8 @@ function startHeadlessMode(): void {
             case 'fix':
             case 'resolve-conflict':
               return { workflowId: standaloneWorkflowIdForTaskArg(arg0), priority: 'normal' };
+            case 'repair-review-gate-ci':
+              return { workflowId: standaloneWorkflowIdForReviewGatePrArg(arg0), priority: 'normal' };
             default:
               return { priority: 'normal' };
           }
@@ -1505,6 +1521,13 @@ function startHeadlessMode(): void {
 
         const standaloneWorkflowIdForTaskArg = (taskIdArg: unknown): string => {
           return resolveHeadlessTargetWorkflowId(taskIdArg, persistence);
+        };
+        const standaloneWorkflowIdForReviewGatePrArg = (prArg: unknown): string | undefined => {
+          const raw = prArg === undefined ? undefined : String(prArg);
+          if (!raw) return undefined;
+          const prNumber = parseReviewGatePrNumber(raw);
+          if (!prNumber) return undefined;
+          return persistence.findReviewGateByPr(prNumber)?.workflowId;
         };
 
         const runStandaloneWorkflowMutation = async <T>(
@@ -2387,8 +2410,21 @@ function createEmbeddedTerminalBackendFromConfig(
         );
         return;
       },
+      repairReviewGateCi: (prArg: string) => repairReviewGateCiByPr(prArg, {
+        persistence,
+        repoRoot,
+        policy: {
+          store: persistence,
+          submitter: { submit: submitRegisteredOwnerWorkerMutation },
+          logger,
+          defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
+          getAutoFixAgent: () => invokerConfig.autoFixAgent,
+          getAutoFixExecutionModel: () => resolveAutoFixExecutionModel(invokerConfig),
+          attemptLedger: autoFixAttemptLedger,
+        },
+      }),
       executionAgentRegistry: registerBuiltinAgents(),
-    });
+    } as HeadlessDeps);
     const { workflowId } = classifyHeadlessExecMutation(payload);
     logger.info(`executeHeadlessExec end args="${payload.args.join(' ')}" workflow="${workflowId ?? 'unknown'}"`, {
       module: 'ipc-delegate',
@@ -2400,6 +2436,14 @@ function createEmbeddedTerminalBackendFromConfig(
     const tasks = orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflowId);
     return { workflowId, tasks };
   }
+  function workflowIdForReviewGatePrArg(prArg: unknown): string | undefined {
+    const raw = prArg === undefined ? undefined : String(prArg);
+    if (!raw) return undefined;
+    const prNumber = parseReviewGatePrNumber(raw);
+    if (!prNumber) return undefined;
+    return persistence.findReviewGateByPr(prNumber)?.workflowId;
+  }
+
 
   function workflowIdForTargetArg(targetArg: unknown): string | undefined {
     if (targetArg === undefined) return undefined;
@@ -2460,6 +2504,8 @@ function createEmbeddedTerminalBackendFromConfig(
       case 'fix':
       case 'resolve-conflict':
         return { workflowId: workflowIdForTaskArg(arg0), priority: 'normal' };
+      case 'repair-review-gate-ci':
+        return { workflowId: workflowIdForReviewGatePrArg(arg0), priority: 'normal' };
       default:
         return { priority: 'normal' };
     }

--- a/packages/app/src/review-gate-ci-repair-command.ts
+++ b/packages/app/src/review-gate-ci-repair-command.ts
@@ -1,0 +1,143 @@
+import type { SQLiteAdapter } from '@invoker/data-store';
+import {
+  GitHubMergeGateProvider,
+  queueReviewGateCiRepair,
+  type MergeGateApprovalStatus,
+  type ReviewGateCiRepairPolicyOptions,
+} from '@invoker/execution-engine';
+
+export interface ReviewGateCiRepairCommandResult {
+  status: 'queued' | 'skipped' | 'unmapped';
+  reason: string;
+  message: string;
+  prNumber: string;
+  workflowId?: string;
+  taskId?: string;
+}
+
+export interface ReviewGateCiRepairCommandDeps {
+  persistence: Pick<SQLiteAdapter, 'findReviewGateByPr' | 'loadTask'>;
+  repoRoot: string;
+  policy: ReviewGateCiRepairPolicyOptions;
+  mergeGateProvider?: Pick<GitHubMergeGateProvider, 'checkApproval'>;
+  now?: () => string;
+}
+
+export function parseReviewGatePrNumber(prArg: string): string | null {
+  const fromUrl = prArg.match(/\/pull\/(\d+)/);
+  const bare = fromUrl?.[1] ?? prArg.replace(/^#/, '');
+  if (!/^\d+$/.test(bare)) return null;
+  return bare;
+}
+
+export async function repairReviewGateCiByPr(
+  prArg: string,
+  deps: ReviewGateCiRepairCommandDeps,
+): Promise<ReviewGateCiRepairCommandResult> {
+  const prNumber = parseReviewGatePrNumber(prArg);
+  if (!prNumber) {
+    throw new Error(`Could not parse a PR number from "${prArg}".`);
+  }
+  const lookup = deps.persistence.findReviewGateByPr(prNumber);
+  if (!lookup) {
+    return {
+      status: 'unmapped',
+      reason: 'no-local-workflow',
+      message: `No Invoker workflow found for PR ${prNumber}.`,
+      prNumber,
+    };
+  }
+
+  const mergeTask = deps.persistence.loadTask(lookup.mergeTaskId);
+  if (!mergeTask) {
+    return {
+      status: 'skipped',
+      reason: 'merge-task-missing',
+      message: `PR ${prNumber} maps to workflow ${lookup.workflowId}, but merge task ${lookup.mergeTaskId} is missing.`,
+      prNumber,
+      workflowId: lookup.workflowId,
+      taskId: lookup.mergeTaskId,
+    };
+  }
+
+  const provider = deps.mergeGateProvider ?? new GitHubMergeGateProvider();
+  const reviewId = lookup.reviewId?.trim() || prNumber;
+  const status = await provider.checkApproval({ identifier: reviewId, cwd: deps.repoRoot });
+  if (status.lifecycle !== 'open') {
+    return {
+      status: 'skipped',
+      reason: 'review-not-open',
+      message: `PR ${prNumber} is ${status.lifecycle}; no CI repair queued.`,
+      prNumber,
+      workflowId: lookup.workflowId,
+      taskId: mergeTask.id,
+    };
+  }
+  if (status.checks?.state !== 'failure' || status.checks.failed.length === 0) {
+    return {
+      status: 'skipped',
+      reason: 'checks-not-failing',
+      message: `PR ${prNumber} has no failing checks.`,
+      prNumber,
+      workflowId: lookup.workflowId,
+      taskId: mergeTask.id,
+    };
+  }
+
+  const createdAt = deps.now?.() ?? new Date().toISOString();
+  const generation = mergeTask.execution.generation ?? lookup.workflowGeneration ?? 0;
+  const attemptId = mergeTask.execution.selectedAttemptId ?? lookup.selectedAttemptId;
+  const result = await queueReviewGateCiRepair(deps.policy, {
+    eventKey: `review_gate.ci_failed|workflow:${lookup.workflowId}|task:${mergeTask.id}|scan:${prNumber}`,
+    kind: 'review_gate.ci_failed',
+    workflowId: lookup.workflowId,
+    taskId: mergeTask.id,
+    status: mergeTask.status,
+    taskStateVersion: mergeTask.taskStateVersion,
+    generation,
+    attemptId,
+    createdAt,
+    recoveryWakeup: {
+      eventKey: `review_gate.ci_failed|workflow:${lookup.workflowId}|task:${mergeTask.id}|scan:${prNumber}`,
+      eventKind: 'review_gate.ci_failed',
+      workflowId: lookup.workflowId,
+      taskId: mergeTask.id,
+      taskStateVersion: mergeTask.taskStateVersion,
+      generation,
+      attemptId,
+      createdAt,
+      reason: 'review_gate_failure',
+      authoritative: false,
+    },
+    reviewId,
+    reviewUrl: status.url,
+    headSha: status.headSha,
+    headRef: status.headRef,
+    branch: mergeTask.execution.branch ?? lookup.branch,
+    failedChecks: status.checks.failed,
+    statusText: reviewGateStatusText(status),
+  });
+
+  return result.decision === 'queued'
+    ? {
+      status: 'queued',
+      reason: result.reason,
+      message: `Queued CI repair for PR ${prNumber} on ${mergeTask.id}.`,
+      prNumber,
+      workflowId: lookup.workflowId,
+      taskId: mergeTask.id,
+    }
+    : {
+      status: 'skipped',
+      reason: result.reason,
+      message: `Skipped PR ${prNumber}: ${result.reason}.`,
+      prNumber,
+      workflowId: lookup.workflowId,
+      taskId: mergeTask.id,
+    };
+}
+
+function reviewGateStatusText(status: MergeGateApprovalStatus): string {
+  if (status.checks?.state === 'failure') return 'CI failed';
+  return status.statusText;
+}


### PR DESCRIPTION
## Summary

This adds the app-side plumbing for PR-number CI repair.

The bug was missing integration. Invoker could not take a PR number, map it to a merge task, re-read GitHub state, and hand that state to the shared repair path.

The fix adds that integration in the app layer and leaves surfaced callers for the next slice.

## Review Claim

Invoker can now translate one mapped PR number into the shared review-gate CI repair flow.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice only adds the app-side integration into the existing shared repair path.

## Slice Rationale

The routing layer has to exist before surfaced callers can invoke it.

## Non-goals

- No surfaced caller yet.
- No background PR scan yet.
- No UI changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/review-gate-ci-repair-command.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert f7a555e4a`
- Post-revert steps: None.
- Data migration? No.

</details>

## Files (4)

- packages/app/src/__tests__/review-gate-ci-repair-command.test.ts [ADDED] (+171 -0)
- packages/app/src/main.ts [MODIFIED] (+48 -0)
- packages/app/src/review-gate-ci-repair-command.ts [ADDED] (+138 -0)
- packages/execution-engine/src/review-gate-ci-repair.ts [MODIFIED] (+0 -1)

Depends-On: #4493

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a headless command to repair failing review-gate CI checks for a pull request.
  * Supports pull request numbers, `#number` references, and pull request URLs.
  * Queues a repair when failures are detected and reports clear queued, skipped, or unmapped outcomes.
  * Integrated review-gate CI repair with available execution workflows.

* **Tests**
  * Added coverage for unmapped pull requests, failing checks, and already-passing checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->