### PR TITLE
[Planning text stays readable](1) Wrap planning rail text

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3080,6 +3080,7 @@ export function App() {
       <div className="space-y-0.5">
         {planningSessions.map((session) => {
           const selected = session.id === activePlanningSession.id;
+          const preview = previewPlanningMessage(session);
           return (
             <button
               key={session.id}
@@ -3090,13 +3091,18 @@ export function App() {
               <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
               <div className="min-w-0 flex-1">
                 <div className="flex items-start justify-between gap-2">
-                  <div className="truncate text-sm font-medium">{session.title}</div>
+                  <div className="line-clamp-2 break-words text-sm font-medium" title={session.title}>
+                    {session.title}
+                  </div>
                   <span className="shrink-0 font-mono text-[11px] text-muted-foreground">
                     {relativePlanningUpdatedAt(session.updatedAt)}
                   </span>
                 </div>
-                <div className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">
-                  {previewPlanningMessage(session)}
+                <div
+                  className="mt-0.5 line-clamp-3 break-words font-mono text-[11px] leading-4 text-muted-foreground"
+                  title={preview}
+                >
+                  {preview}
                 </div>
               </div>
             </button>

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -354,6 +354,41 @@ describe('Invoker terminal (component)', () => {
     expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('I can help draft that.');
   });
 
+  it('wraps long planning session rail titles and previews instead of clipping them to one line', async () => {
+    const longPrompt = 'Draft a very long planning session title that needs multiple readable wrapped lines in the fixed planning rail';
+    const longReply = [
+      'This planning preview should remain readable in the rail with several wrapped words,',
+      'including implementation details, verification notes, and follow-up context that used to be hidden by truncate.',
+    ].join(' ');
+    mock.api.planningChatSend = vi.fn(async () => ({
+      ok: true,
+      sessionId: 'session-1',
+      reply: longReply,
+      draftPlanAvailable: false,
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText(longPrompt);
+
+    const rail = screen.getByTestId('planning-session-list');
+    await waitFor(() => {
+      expect(within(rail).getByText(longReply)).toBeInTheDocument();
+    });
+
+    const expectedTitle = `${longPrompt.slice(0, 53).trimEnd()}…`;
+    const title = within(rail).getByText(expectedTitle);
+    const preview = within(rail).getByText(longReply);
+    expect(title).toHaveClass('line-clamp-2', 'break-words');
+    expect(title).not.toHaveClass('truncate');
+    expect(title).toHaveAttribute('title', expectedTitle);
+    expect(preview).toHaveClass('line-clamp-3', 'break-words');
+    expect(preview).not.toHaveClass('truncate');
+    expect(preview).toHaveAttribute('title', longReply);
+    expect(screen.getByTestId('planning-session-rail')).toHaveClass('w-64', 'shrink-0');
+  });
+
   it('keeps a new planning chat editable while another session is working', async () => {
     let resolveFirstSend: ((value: any) => void) | null = null;
     mock.api.planningChatSend = vi.fn((request: any) => {


### PR DESCRIPTION
## Summary

Planning text stays readable with both workflow tasks completed.

The Planning Terminal rail now wraps long session titles and previews inside the fixed rail width.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1783372665113-2/fix-planning-text-clipping | Make planning text readable in the Planning Terminal rail | completed |
| wf-1783372665113-2/verify-planning-text-clipping | Verify planning text visibility and run the repo gate | completed (passed) |

</details>

## Review Claim

Approve that Planning Terminal rail titles and previews wrap within the existing fixed rail width.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the rail item text classes changed. The fixed `w-64` rail width and planning session data stay unchanged.

## Slice Rationale

This slice pairs the visible rail behavior with the focused component assertion for the same rail rule.

## Non-goals

- Does not change planning session state, persistence, or message generation.
- Does not resize the Planning Terminal rail.
- Does not alter terminal transcript rendering or plan submission.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/app build`
- [x] `CAPTURE_MODE=after pnpm --filter @invoker/app test:e2e -- planning-text-stays-readable-proof.spec.ts`
- [x] `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx`
- [x] `node scripts/validate-pr-body.mjs --body-file .invoker-pr-body-planning-text.md --require-visual-proof --changed-files-file /tmp/planning-text-changed-files.txt --diff-file /tmp/planning-text.diff`

</details>

## Visual Proof

The fixed rail shows the long title wrapped over two visible lines and the assistant preview wrapped under it inside the selected planning session.

![Planning rail with wrapped long title and preview](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-68ccff/planning-text-stays-readable-rail.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d60856b1`
- Post-revert steps: None
- Data migration? No

</details>
