### PR TITLE
[Planning Surface Tmux Step 2 In-Surface UI Mode](1) Keep tmux mode isolated from chat draft controls

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -616,6 +616,9 @@ export function App() {
   const activePlanningSessionBusy = activePlanningSession.busy;
   const activePlanningSessionSubmitted = activePlanningSession.status === 'submitted';
   const activePlanningMode = activePlanningSession.mode ?? 'chat';
+  const activePlanningDraftPlanAvailable = activePlanningMode === 'chat' && draftPlanAvailable;
+  const activePlanningDraftPlanSummary = activePlanningMode === 'chat' ? draftPlanSummary : undefined;
+  const activePlanningSubmitError = activePlanningMode === 'chat' ? planningSubmitError : null;
   const activePlanningTerminalSession = activePlanningSession.terminalSession ?? null;
   const activePlanningTerminalBusy = Boolean(activePlanningSession.terminalBusy);
   const activePlanningTerminalError = activePlanningSession.terminalError ?? null;
@@ -2021,6 +2024,7 @@ export function App() {
   }, [invoker]);
 
   const handlePlanningSubmitDraft = useCallback(async () => {
+    if (activePlanningMode !== 'chat') return;
     if (!planningSessionId) {
       setPlanningSubmitError({ title: 'Plan could not be submitted', message: 'No planning conversation yet.' });
       appendTerminalLine('Plan could not be submitted:\nNo planning conversation yet.', 'system', 'error');
@@ -2073,7 +2077,7 @@ export function App() {
       setPlanningSubmitError({ title: 'Plan could not be submitted', message });
       appendTerminalLine(`Plan could not be submitted:\n${message}`, 'system', 'error');
     }
-  }, [appendTerminalLine, invoker, planningSessionId, refreshTaskGraph, updatePlanningSessionById]);
+  }, [activePlanningMode, appendTerminalLine, invoker, planningSessionId, refreshTaskGraph, updatePlanningSessionById]);
 
   const handlePlanningSubmit = useCallback(async () => {
     const input = planningInput.trim();
@@ -3160,9 +3164,9 @@ export function App() {
             value={planningInput}
             selectedPresetKey={selectedPlanningPresetKey}
             presetOptions={planningPresetOptions}
-            draftPlanAvailable={draftPlanAvailable}
-            draftPlanSummary={draftPlanSummary}
-            submitError={planningSubmitError}
+            draftPlanAvailable={activePlanningDraftPlanAvailable}
+            draftPlanSummary={activePlanningDraftPlanSummary}
+            submitError={activePlanningSubmitError}
             readOnly={activePlanningSessionSubmitted}
             mode={activePlanningMode}
             terminalSession={activePlanningTerminalSession}
@@ -3467,9 +3471,9 @@ export function App() {
             value={planningInput}
             selectedPresetKey={selectedPlanningPresetKey}
             presetOptions={planningPresetOptions}
-            draftPlanAvailable={draftPlanAvailable}
-            draftPlanSummary={draftPlanSummary}
-            submitError={planningSubmitError}
+            draftPlanAvailable={activePlanningDraftPlanAvailable}
+            draftPlanSummary={activePlanningDraftPlanSummary}
+            submitError={activePlanningSubmitError}
             expanded
             mode={activePlanningMode}
             terminalSession={activePlanningTerminalSession}

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -10,6 +10,65 @@ vi.mock('@xyflow/react', async () => {
   return createReactFlowMock();
 });
 
+const xtermMock = vi.hoisted(() => {
+  type DataHandler = (data: string) => void;
+
+  const instances: MockTerminal[] = [];
+  const fitInstances: MockFitAddon[] = [];
+  const writeLog: string[] = [];
+
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    dataHandler: DataHandler | null = null;
+    loadAddon = vi.fn();
+    open = vi.fn((host: HTMLElement) => {
+      const terminalElement = document.createElement('div');
+      terminalElement.className = 'xterm';
+      terminalElement.textContent = 'mock planning terminal';
+      host.appendChild(terminalElement);
+    });
+    write = vi.fn((data: string) => {
+      writeLog.push(data);
+    });
+    onData = vi.fn((cb: DataHandler) => {
+      this.dataHandler = cb;
+      return { dispose: vi.fn() };
+    });
+    focus = vi.fn();
+    refresh = vi.fn();
+    dispose = vi.fn();
+
+    constructor() {
+      instances.push(this);
+    }
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+
+    constructor() {
+      fitInstances.push(this);
+    }
+  }
+
+  return {
+    Terminal: MockTerminal,
+    FitAddon: MockFitAddon,
+    instances,
+    fitInstances,
+    writeLog,
+    reset: () => {
+      instances.length = 0;
+      fitInstances.length = 0;
+      writeLog.length = 0;
+    },
+  };
+});
+
+vi.mock('xterm', () => ({ Terminal: xtermMock.Terminal }));
+vi.mock('xterm-addon-fit', () => ({ FitAddon: xtermMock.FitAddon }));
+
 // Dynamic imports are required so modules see the hoisted @xyflow/react mock.
 const { App } = await import('../App.js');
 const { InvokerTerminal } = await import('../components/InvokerTerminal.js');
@@ -18,6 +77,7 @@ describe('Invoker terminal (component)', () => {
   let mock: MockInvoker;
 
   beforeEach(() => {
+    xtermMock.reset();
     mock = createMockInvoker();
     mock.install();
   });
@@ -178,6 +238,49 @@ describe('Invoker terminal (component)', () => {
     fireEvent.click(screen.getByTestId('sidebar-planning'));
     expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review it, then Run.');
     expect(mock.api.start).not.toHaveBeenCalled();
+  });
+
+  it('renders planning tmux inside the planning surface and hides draft submit controls', async () => {
+    mock.api.planningChatSend = vi.fn(async () => ({
+      ok: true,
+      sessionId: 'session-1',
+      reply: 'Here is the plan.',
+      draftPlanAvailable: true,
+      draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First', 'Second'] },
+    })) as any;
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft the full plan');
+    await screen.findByTestId('invoker-terminal-ready-bar');
+
+    fireEvent.click(screen.getByRole('tab', { name: 'tmux' }));
+
+    const tmuxPane = await screen.findByTestId('invoker-terminal-tmux-pane');
+    expect(tmuxPane).toHaveAttribute('data-session-id', 'mock-planning-terminal-session-1');
+    expect(screen.getByTestId('planning-session-rail')).toBeInTheDocument();
+    expect(screen.queryByTestId('terminal-drawer')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Submit to Invoker' })).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(mock.api.planningTerminalOpen).toHaveBeenCalledWith('session-1');
+      expect(xtermMock.instances).toHaveLength(1);
+    });
+
+    mock.fireTerminalOutput({
+      sessionId: 'mock-planning-terminal-session-1',
+      taskId: 'planning:session-1',
+      kind: 'planning',
+      planningSessionId: 'session-1',
+      data: 'draft ready from tmux output\n',
+    });
+    await waitFor(() => {
+      expect(xtermMock.writeLog).toContain('draft ready from tmux output\n');
+    });
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Chat' }));
+    expect(screen.getByTestId('invoker-terminal-transcript')).not.toHaveTextContent('draft ready from tmux output');
   });
 
   it('shows stacked workflow counts and submit messaging', async () => {

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -111,10 +111,58 @@ function PlanningTmuxPane({ session, busy, error }: PlanningTmuxPaneProps): JSX.
   const termRef = useRef<XTermTerminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const seededSnapshotRef = useRef<SeededOutputSnapshot | null>(null);
+  const fitFrameRef = useRef<number | null>(null);
+  const secondFitFrameRef = useRef<number | null>(null);
+  const sessionId = session?.sessionId ?? null;
+
+  const clearScheduledFit = useCallback(() => {
+    if (fitFrameRef.current !== null) {
+      if (typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(fitFrameRef.current);
+      }
+      fitFrameRef.current = null;
+    }
+    if (secondFitFrameRef.current !== null) {
+      if (typeof cancelAnimationFrame === 'function') {
+        cancelAnimationFrame(secondFitFrameRef.current);
+      }
+      secondFitFrameRef.current = null;
+    }
+  }, []);
+
+  const fitVisibleTerminal = useCallback(() => {
+    const term = termRef.current;
+    const fit = fitRef.current;
+    if (!term || !fit || !sessionId) return;
+    try {
+      fit.fit();
+      if (term.rows > 0) {
+        term.refresh?.(0, term.rows - 1);
+      }
+      void window.invoker?.planningTerminalResize?.(sessionId, term.cols, term.rows);
+    } catch {
+      /* host has zero size, terminal disposed, or fit unsupported */
+    }
+  }, [sessionId]);
+
+  const scheduleFit = useCallback(() => {
+    clearScheduledFit();
+    fitVisibleTerminal();
+    if (typeof requestAnimationFrame !== 'function') return;
+
+    fitFrameRef.current = requestAnimationFrame(() => {
+      fitFrameRef.current = null;
+      fitVisibleTerminal();
+      secondFitFrameRef.current = requestAnimationFrame(() => {
+        secondFitFrameRef.current = null;
+        fitVisibleTerminal();
+      });
+    });
+  }, [clearScheduledFit, fitVisibleTerminal]);
 
   useEffect(() => {
     const host = containerRef.current;
-    if (!host || !session) return;
+    if (!host || !session || !sessionId) return;
 
     let term: XTermTerminal;
     let fit: FitAddon;
@@ -139,12 +187,12 @@ function PlanningTmuxPane({ session, busy, error }: PlanningTmuxPaneProps): JSX.
     seedTerminalOutputSnapshot(term, session, seededSnapshotRef);
 
     const inputDisposable = term.onData((data) => {
-      void window.invoker?.planningTerminalWrite?.(session.sessionId, data);
+      void window.invoker?.planningTerminalWrite?.(sessionId, data);
     });
 
     const subscribeToOutput = window.__INVOKER_TEST_ON_TERMINAL_OUTPUT__ ?? window.invoker?.onTerminalOutput;
     const unsubscribeOutput = subscribeToOutput?.((event) => {
-      if (event.sessionId !== session.sessionId) return;
+      if (event.sessionId !== sessionId) return;
       try {
         term.write(event.data);
       } catch {
@@ -152,35 +200,24 @@ function PlanningTmuxPane({ session, busy, error }: PlanningTmuxPaneProps): JSX.
       }
     });
 
-    const tryFit = () => {
-      try {
-        fit.fit();
-        void window.invoker?.planningTerminalResize?.(session.sessionId, term.cols, term.rows);
-      } catch {
-        /* host has zero size or fit unsupported */
-      }
-    };
-
-    const raf = typeof requestAnimationFrame === 'function'
-      ? requestAnimationFrame(tryFit)
-      : null;
-
     let resizeObserver: ResizeObserver | null = null;
     if (typeof ResizeObserver !== 'undefined') {
       try {
-        resizeObserver = new ResizeObserver(() => {
-          tryFit();
-        });
+        resizeObserver = new ResizeObserver(scheduleFit);
         resizeObserver.observe(host);
       } catch {
         resizeObserver = null;
       }
     }
+    scheduleFit();
+    try {
+      term.focus();
+    } catch {
+      /* focus unsupported */
+    }
 
     return () => {
-      if (raf !== null && typeof cancelAnimationFrame === 'function') {
-        cancelAnimationFrame(raf);
-      }
+      clearScheduledFit();
       resizeObserver?.disconnect();
       inputDisposable.dispose();
       unsubscribeOutput?.();
@@ -192,7 +229,7 @@ function PlanningTmuxPane({ session, busy, error }: PlanningTmuxPaneProps): JSX.
       termRef.current = null;
       fitRef.current = null;
     };
-  }, [session?.sessionId]);
+  }, [clearScheduledFit, scheduleFit, sessionId]);
 
   useEffect(() => {
     const term = termRef.current;
@@ -202,16 +239,14 @@ function PlanningTmuxPane({ session, busy, error }: PlanningTmuxPaneProps): JSX.
 
   useEffect(() => {
     const term = termRef.current;
-    const fit = fitRef.current;
-    if (!term || !fit || !session) return;
+    if (!term || !session) return;
     try {
-      fit.fit();
-      void window.invoker?.planningTerminalResize?.(session.sessionId, term.cols, term.rows);
+      scheduleFit();
       term.focus();
     } catch {
       /* fit failed (e.g., hidden) */
     }
-  }, [session?.sessionId]);
+  }, [scheduleFit, session?.sessionId]);
 
   return (
     <div className="relative min-h-0 flex-1 overflow-hidden bg-black">
@@ -309,6 +344,7 @@ export function InvokerTerminal({
   const focusComposer = (): void => {
     inputRef.current?.focus();
   };
+  const draftSubmitAvailable = mode === 'chat' && draftPlanAvailable;
 
   return (
     <section className="flex h-full min-h-0 flex-col bg-background">
@@ -434,7 +470,7 @@ export function InvokerTerminal({
               <div className="text-sm font-medium text-destructive">{submitError.title}</div>
               <div className="mt-2 whitespace-pre-wrap font-mono text-xs leading-5 text-destructive/90">{submitError.message}</div>
               <div className="mt-3 flex flex-wrap gap-2">
-                {draftPlanAvailable && (
+                {draftSubmitAvailable && (
                   <button
                     type="button"
                     onClick={onSubmitDraft}
@@ -462,7 +498,7 @@ export function InvokerTerminal({
             </div>
           )}
 
-          {draftPlanAvailable && !readOnly && (
+          {draftSubmitAvailable && !readOnly && (
             <div
               data-testid="invoker-terminal-ready-bar"
               className="sticky bottom-0 z-10 border-t border-border bg-background px-4 py-3 text-sm text-foreground"


### PR DESCRIPTION
## Summary

Planning Surface Tmux Step 2 In-Surface UI Mode - 2 tasks completed, 0 failed, 0 closed

The planning surface now keeps tmux mode separate from chat-only draft state.

This prevents chat-only draft controls and error banners from appearing over the embedded tmux pane.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1783564216054-12/implement-planning-tmux-ui-mode | Add chat/tmux mode toggle and render tmux inside the planning blue surface | completed |
| wf-1783564216054-12/verify-planning-tmux-ui-mode | Run focused UI tests for planning and terminal rendering behavior | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1783564216054-12/implement-planning-tmux-ui-mode - Add chat/tmux mode toggle and render tmux inside the planning blue surface

```text
packages/ui/src/App.tsx                          |  18 ++--
packages/ui/src/__tests__/invoker-terminal.test.tsx | 103 +++++++++++++++++++++
packages/ui/src/components/InvokerTerminal.tsx   |  96 +++++++++++++------
3 files changed, 180 insertions(+), 37 deletions(-)
```

### wf-1783564216054-12/verify-planning-tmux-ui-mode - Run focused UI tests for planning and terminal rendering behavior

No source changes. Verification passed on the implementation slice.

</details>

## Review Claim

Approve isolating chat draft affordances from planning tmux mode while preserving the in-surface terminal.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The slice is limited to planning UI state gating, terminal fit timing, and a focused component test.

Task terminal drawer behavior and backend handlers are outside this slice.

## Slice Rationale

This follow-up keeps the Step 2 UI review local after the base in-surface tmux activation landed.

The verification task produced no source diff, so it is recorded in this body rather than published as an empty stack slice.

## Non-goals

- Does not change task-terminal drawer behavior.
- Does not change planning session persistence.
- Does not change IPC contracts or backend terminal lifecycle.

## Architecture

### Before

```mermaid
graph TD
    A["Planning session draft state"] --> B["InvokerTerminal props"]
    B --> C["Chat draft controls"]
    B --> D["Tmux pane"]
```

### After

```mermaid
graph TD
    A["Planning session draft state"] --> B["Active planning mode gate"]
    B --> C["Chat mode receives draft controls"]
    B --> D["Tmux mode receives only terminal state"]
    D --> E["Scheduled fit and resize"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx`
- [x] `pnpm --filter @invoker/ui build`
- [x] `bash scripts/ui-visual-proof.sh capture-after --spec tmp-planning-tmux-proof.spec.ts --output-dir /tmp/invoker-step2-visual-proof`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-step2-pr-body.md --require-visual-proof --changed-files-file /tmp/invoker-step2-changed-files.txt --diff-file /tmp/invoker-step2.diff`

</details>

## Visual Proof

![Planning tmux tab rendered inside the planning surface without chat draft submit controls](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-f9aeb9/planning-tmux-mode-no-draft-controls.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ab5de94cfbe10407821664b9d99b425868cf58a3`
- Post-revert steps: None
- Data migration? No

</details>
