### PR TITLE
[Terminal Double-Click Step 3 - Snapshot Replay Guard](1) Harden terminal snapshot replay guard

### DIFF
--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -426,6 +426,53 @@ describe('Terminal drawer (component)', () => {
     expect(xtermMock.writeLog).toEqual(['replayed once\n']);
   });
 
+  it('does not replay a refreshed restored snapshot into the same live mounted session', async () => {
+    const session = makeTerminalSession('task-alpha', {
+      outputSnapshot: 'restored before restart\n',
+    });
+
+    const { rerender } = render(
+      <TerminalDrawer
+        state="partial"
+        onCycle={vi.fn()}
+        sessions={[session]}
+        activeSessionId={session.sessionId}
+        onSelectSession={vi.fn()}
+        onCloseSession={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(xtermMock.instances).toHaveLength(1);
+      expect(xtermMock.writeLog).toEqual(['restored before restart\n']);
+    });
+
+    act(() => {
+      mock.fireTerminalOutput({
+        sessionId: session.sessionId,
+        taskId: session.taskId,
+        data: 'after restart\n',
+      });
+    });
+    await waitFor(() => {
+      expect(xtermMock.writeLog).toEqual(['restored before restart\n', 'after restart\n']);
+    });
+
+    await act(async () => {
+      rerender(
+        <TerminalDrawer
+          state="partial"
+          onCycle={vi.fn()}
+          sessions={[{ ...session, outputSnapshot: 'restored before restart\nafter restart\n' }]}
+          activeSessionId={session.sessionId}
+          onSelectSession={vi.fn()}
+          onCloseSession={vi.fn()}
+        />,
+      );
+    });
+
+    expect(xtermMock.writeLog).toEqual(['restored before restart\n', 'after restart\n']);
+  });
+
   it('keeps live output, input, resize, close, and tab selection intact without a preview row', async () => {
     (mock.api.openTerminal as ReturnType<typeof vi.fn>).mockImplementation(async (taskId: string) => ({
       opened: true,

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -51,7 +51,6 @@ interface TerminalSessionPaneProps {
 
 type SeededOutputSnapshot = {
   sessionId: string;
-  snapshot: string;
   term: XTermTerminal;
 };
 
@@ -63,27 +62,32 @@ function seedTerminalOutputSnapshot(
   const outputSnapshot = session.outputSnapshot;
   const seededSnapshot = seededSnapshotRef.current;
   if (
-    outputSnapshot &&
-    (
-      !seededSnapshot ||
-      seededSnapshot.sessionId !== session.sessionId ||
-      seededSnapshot.snapshot !== outputSnapshot ||
-      seededSnapshot.term !== term
-    )
+    seededSnapshot &&
+    seededSnapshot.sessionId === session.sessionId &&
+    seededSnapshot.term === term
   ) {
-    try {
-      term.write(outputSnapshot);
-      seededSnapshotRef.current = {
-        sessionId: session.sessionId,
-        snapshot: outputSnapshot,
-        term,
-      };
-    } catch (err) {
-      console.warn(
-        `Failed to seed output snapshot for terminal session ${session.sessionId}:`,
-        err,
-      );
-    }
+    return;
+  }
+
+  if (!outputSnapshot) {
+    seededSnapshotRef.current = {
+      sessionId: session.sessionId,
+      term,
+    };
+    return;
+  }
+
+  try {
+    term.write(outputSnapshot);
+    seededSnapshotRef.current = {
+      sessionId: session.sessionId,
+      term,
+    };
+  } catch (err) {
+    console.warn(
+      `Failed to seed output snapshot for terminal session ${session.sessionId}:`,
+      err,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Terminal panes now seed each restored output snapshot only once per mounted xterm session.

Refreshed session descriptors keep the live terminal stream intact without writing historical lines back into the pane.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1783561720145-5/harden-terminal-snapshot-reseed | Prevent repeated replay lines when an already-mounted session receives snapshot updates. | completed |
| wf-1783561720145-5/verify-terminal-restart-persistence-regression | Run focused UI and restart persistence regression checks. | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1783561720145-5/harden-terminal-snapshot-reseed

packages/ui/src/__tests__/terminal-drawer.test.tsx | 47 ++++++++++++++++++++++
packages/ui/src/components/TerminalDrawer.tsx      | 46 +++++++++++----------
2 files changed, 72 insertions(+), 21 deletions(-)

### wf-1783561720145-5/verify-terminal-restart-persistence-regression

No file changes. The task reran the focused UI regression surface and passed.

</details>

## Review Claim

Approve TerminalDrawer's mount-local snapshot guard for restored terminal output.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change only affects snapshot seeding for an already-mounted terminal pane. Live output, input, resize, close, and tab selection paths stay covered.

## Slice Rationale

This slice keeps the terminal pane behavior change with the focused regression that proves the replay stream does not repeat.

## Non-goals

- Does not alter open-terminal IPC session creation.
- Does not change terminal tab selection, input forwarding, resize, or close behavior.
- Does not change persisted terminal snapshot storage.

## Architecture

### Before

```mermaid
graph TD
    A["Mounted terminal session receives a refreshed descriptor"] --> B["Snapshot text is compared"]
    B --> C["Changed snapshot text can be written into the same xterm instance"]
```

### After

```mermaid
graph TD
    A["Mounted terminal session receives a refreshed descriptor"] --> B["Mounted xterm instance is recognized"]
    B --> C["Historical snapshot seeding is skipped for that mounted pane"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/ui test -- terminal-drawer.test.tsx`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/terminal-step3-pr-body.md --require-visual-proof`

</details>

## Visual Proof

Restart walkthrough: the Planning Terminal remains visible across the relaunch sequence while the restored state stays stable.

[planning terminal restart walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-a7765e/planning-terminal-restart.gif)

Before restore capture:

![Planning Terminal before restore](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-a7765e/planning-terminal-restore-before.png)

After restore capture:

![Planning Terminal after restore](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-a7765e/planning-terminal-restore-after.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert d3d06980`
- Post-revert steps: Rerun `pnpm --filter @invoker/ui test -- terminal-drawer.test.tsx`.
- Data migration? No.

</details>
