### PR TITLE
Add start-ready workflow trigger

### DIFF
--- a/packages/app/src/__tests__/gui-mutation-translation.test.ts
+++ b/packages/app/src/__tests__/gui-mutation-translation.test.ts
@@ -48,6 +48,7 @@ describe('GUI mutation translation', () => {
   it.each([
     'invoker:check-pr-statuses',
     'invoker:check-pr-status',
+    'invoker:start-ready',
   ])('routes %s to the owner GUI mutation handler', (channel) => {
     const translatorSource = getTranslatorSource();
     expect(translatorSource).toMatch(

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -741,6 +741,40 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(adapter.listWorkflowMutationIntents('wf-2')).toHaveLength(1);
   });
 
+  it('coalesces duplicate start-ready intents while queued', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
+
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async () => undefined,
+    );
+
+    const first = coordinator.submit(
+      'wf-1',
+      'normal',
+      'invoker:start-ready',
+      [{}],
+      { deferDrain: true },
+    );
+    const duplicates = Array.from({ length: 5 }, () =>
+      coordinator.submit(
+        'wf-1',
+        'normal',
+        'invoker:start-ready',
+        [{}],
+        { deferDrain: true },
+      ),
+    );
+
+    expect(new Set([first, ...duplicates])).toEqual(new Set([first]));
+    expect(adapter.listWorkflowMutationIntents('wf-1')).toHaveLength(1);
+  });
+
   it('requeues interrupted running workflow mutations on restart and drains persisted queued work', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);

--- a/packages/app/src/__tests__/start-ready.test.ts
+++ b/packages/app/src/__tests__/start-ready.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TaskState } from '@invoker/workflow-core';
+
+import { collectStartReadyPreview, runStartReady } from '../start-ready.js';
+
+function makeTask(
+  id: string,
+  status: TaskState['status'],
+  overrides: Partial<TaskState> = {},
+): TaskState {
+  return {
+    id,
+    description: id,
+    status,
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: id.split('/')[0] ?? 'wf-1' },
+    execution: {},
+    taskStateVersion: 1,
+    ...overrides,
+  } as TaskState;
+}
+
+function harness(initialTasks: TaskState[], readyTasks: TaskState[]) {
+  let tasks = [...initialTasks];
+  const orchestrator = {
+    syncAllFromDb: vi.fn(() => undefined),
+    getAllTasks: vi.fn(() => tasks),
+    getExecutableReadyTasks: vi.fn(() => readyTasks),
+    prepareTaskForNewAttempt: vi.fn((taskId: string) => {
+      tasks = tasks.map((task) => task.id === taskId
+        ? { ...task, status: 'pending' as TaskState['status'], execution: {} }
+        : task);
+      return tasks.find((task) => task.id === taskId) as TaskState;
+    }),
+    recreateWorkflow: vi.fn((workflowId: string) => {
+      const recreated = makeTask(`${workflowId}/recreated`, 'pending');
+      tasks = tasks.filter((task) => task.config.workflowId !== workflowId || task.status !== 'failed');
+      tasks.push(recreated);
+      readyTasks.push(recreated);
+      return [recreated];
+    }),
+    startExecution: vi.fn(() => [...readyTasks]),
+  };
+  return orchestrator;
+}
+
+describe('start-ready', () => {
+  it('previews ready, recoverable, failed, and gated work', () => {
+    const ready = makeTask('wf-1/ready', 'pending');
+    const recoverable = makeTask('wf-1/recoverable', 'pending', {
+      execution: { selectedAttemptId: 'attempt-1', phase: 'launching' },
+    });
+    const failed = makeTask('wf-2/failed', 'failed');
+    const approval = makeTask('wf-3/approval', 'awaiting_approval');
+    const blocked = makeTask('wf-4/blocked', 'blocked');
+    const orchestrator = harness([ready, recoverable, failed, approval, blocked], [ready]);
+
+    expect(collectStartReadyPreview(orchestrator)).toEqual({
+      readyTaskIds: ['wf-1/ready'],
+      recoverableTaskIds: ['wf-1/recoverable'],
+      failedWorkflowIds: ['wf-2'],
+      skipped: {
+        awaitingApproval: 1,
+        reviewReady: 0,
+        blocked: 1,
+        failedTasks: 1,
+      },
+    });
+  });
+
+  it('dry-run reports the preview without mutating work', () => {
+    const ready = makeTask('wf-1/ready', 'pending');
+    const recoverable = makeTask('wf-1/recoverable', 'running');
+    const orchestrator = harness([ready, recoverable], [ready]);
+
+    const result = runStartReady(orchestrator, { dryRun: true });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.started).toEqual([]);
+    expect(orchestrator.prepareTaskForNewAttempt).not.toHaveBeenCalled();
+    expect(orchestrator.startExecution).not.toHaveBeenCalled();
+  });
+
+  it('recovers interrupted claims and starts executable ready tasks', () => {
+    const ready = makeTask('wf-1/ready', 'pending');
+    const recoverable = makeTask('wf-1/recoverable', 'running');
+    const orchestrator = harness([ready, recoverable], [ready]);
+
+    const result = runStartReady(orchestrator);
+
+    expect(orchestrator.syncAllFromDb).toHaveBeenCalledTimes(1);
+    expect(orchestrator.prepareTaskForNewAttempt).toHaveBeenCalledWith('wf-1/recoverable', 'start_ready_recovery');
+    expect(orchestrator.startExecution).toHaveBeenCalledTimes(1);
+    expect(result.started.map((task) => task.id)).toEqual(['wf-1/ready']);
+  });
+
+  it('recreates failed workflows only when requested', () => {
+    const failed = makeTask('wf-1/failed', 'failed');
+    const orchestrator = harness([failed], []);
+
+    const result = runStartReady(orchestrator, { recreateFailed: true });
+
+    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(result.recreatedWorkflowIds).toEqual(['wf-1']);
+    expect(result.started.map((task) => task.id)).toEqual(['wf-1/recreated']);
+  });
+});

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -50,12 +50,29 @@ function runtime(kind: string): TestWorkerRuntime {
   };
 }
 
-function persistence() {
+function persistence(initialDesired: Record<string, boolean> = {}) {
+  const desired = new Map(Object.entries(initialDesired));
   return {
     listWorkerActions: vi.fn(() => []),
     listWorkflows: vi.fn(() => []),
     loadTasks: vi.fn(() => []),
     getEvents: vi.fn(() => []),
+    getEventsByTypes: vi.fn(() => []),
+    countEventsByTypes: vi.fn(() => []),
+    getWorkerDesiredState: vi.fn((workerKind: string) => (
+      desired.has(workerKind)
+        ? { workerKind, desiredEnabled: desired.get(workerKind) === true, updatedAt: '2026-01-01T00:00:00.000Z' }
+        : undefined
+    )),
+    setWorkerDesiredState: vi.fn((workerKind: string, desiredEnabled: boolean) => {
+      desired.set(workerKind, desiredEnabled);
+      return { workerKind, desiredEnabled, updatedAt: '2026-01-01T00:00:00.000Z' };
+    }),
+    listWorkerDesiredStates: vi.fn(() => Array.from(desired.entries()).map(([workerKind, desiredEnabled]) => ({
+      workerKind,
+      desiredEnabled,
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    }))),
   };
 }
 
@@ -72,9 +89,13 @@ function deps(): WorkerRuntimeDependencies {
   } as WorkerRuntimeDependencies;
 }
 
-function controller(autoStartKinds: readonly string[] = AUTO_STARTED_OWNER_WORKER_KINDS) {
+function controller(
+  autoStartKinds: readonly string[] = AUTO_STARTED_OWNER_WORKER_KINDS,
+  desiredState: Record<string, boolean> = {},
+) {
   const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
   const runtimes = new Map<string, TestWorkerRuntime[]>();
+  const store = persistence(desiredState);
   const register = (kind: string, note: string, runtimeKind = kind) => {
     registry.register({
       kind,
@@ -99,11 +120,12 @@ function controller(autoStartKinds: readonly string[] = AUTO_STARTED_OWNER_WORKE
 
   return {
     runtimes,
+    persistence: store,
     controller: createWorkerRuntimeController({
       registry,
       deps: deps(),
       autoStartKinds,
-      persistence: persistence() as never,
+      persistence: store as never,
       canControl: () => true,
     }),
   };
@@ -124,6 +146,43 @@ describe('createWorkerRuntimeController', () => {
     expect(snapshot.workers.find((worker) => worker.kind === WORKFLOW_RESUME_WORKER_KIND)?.startable).toBe(true);
     expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)?.lifecycle).toBe('stopped');
     expect(snapshot.workers.find((worker) => worker.kind === 'external-preview')?.lifecycle).toBe('stopped');
+  });
+
+  it('restores saved desired worker states over built-in launch defaults', () => {
+    const setup = controller(AUTO_STARTED_OWNER_WORKER_KINDS, {
+      [PR_STATUS_WORKER_KIND]: false,
+      [WORKFLOW_RESUME_WORKER_KIND]: true,
+    });
+
+    setup.controller.startAutoStartedWorkers();
+    const snapshot = setup.controller.snapshot();
+
+    expect(snapshot.workers.find((worker) => worker.kind === PR_STATUS_WORKER_KIND)).toMatchObject({
+      lifecycle: 'stopped',
+      desiredEnabled: false,
+      autoStarts: false,
+    });
+    expect(snapshot.workers.find((worker) => worker.kind === WORKFLOW_RESUME_WORKER_KIND)).toMatchObject({
+      lifecycle: 'running',
+      desiredEnabled: true,
+      autoStarts: true,
+    });
+    expect(setup.persistence.setWorkerDesiredState).not.toHaveBeenCalled();
+  });
+
+  it('persists manual worker enable and disable state', async () => {
+    const setup = controller();
+
+    setup.controller.start(WORKFLOW_RESUME_WORKER_KIND);
+    await setup.controller.stop(WORKFLOW_RESUME_WORKER_KIND);
+
+    expect(setup.persistence.setWorkerDesiredState).toHaveBeenNthCalledWith(1, WORKFLOW_RESUME_WORKER_KIND, true);
+    expect(setup.persistence.setWorkerDesiredState).toHaveBeenNthCalledWith(2, WORKFLOW_RESUME_WORKER_KIND, false);
+    expect(setup.controller.snapshot().workers.find((worker) => worker.kind === WORKFLOW_RESUME_WORKER_KIND)).toMatchObject({
+      lifecycle: 'stopped',
+      desiredEnabled: false,
+      autoStarts: false,
+    });
   });
 
   it('auto-starts e2e-autofix only when its kind is in autoStartKinds', () => {

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -32,6 +32,7 @@ export const HEADLESS_COMMANDS = [
   { name: 'install-skills', kind: 'special' },
   { name: 'watch', kind: 'read' },
   { name: 'run', kind: 'write' },
+  { name: 'start-ready', kind: 'write' },
   { name: 'resume', kind: 'write' },
   { name: 'retry', kind: 'write' },
   { name: 'retry-task', kind: 'write' },

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -8,7 +8,7 @@
  * command-family modules — keeping the import graph acyclic.
  */
 
-import { makeEnvelope } from '@invoker/contracts';
+import { makeEnvelope, type StartReadyRequest } from '@invoker/contracts';
 import type { TaskState } from '@invoker/workflow-core';
 import {
   remoteFetchForPool,
@@ -48,6 +48,7 @@ import {
   preemptTaskSubgraph,
   preemptWorkflowExecution,
 } from './headless-shared.js';
+import { runStartReady } from './start-ready.js';
 
 export async function headlessWatch(workflowId: string | undefined, deps: HeadlessDeps): Promise<void> {
   const workflows = deps.persistence.listWorkflows();
@@ -210,6 +211,72 @@ export async function headlessResume(
 
   await api.close().catch(() => {});
   await webSurface?.close().catch(() => {});
+}
+
+function parseStartReadyArgs(args: string[], inheritedNoTrack: boolean | undefined): {
+  request: StartReadyRequest;
+  noTrack: boolean;
+} {
+  const request: StartReadyRequest = {};
+  let noTrack = inheritedNoTrack ?? false;
+  for (const arg of args) {
+    switch (arg) {
+      case '--dry-run':
+        request.dryRun = true;
+        break;
+      case '--recreate-failed':
+        request.recreateFailed = true;
+        break;
+      case '--no-track':
+        noTrack = true;
+        break;
+      default:
+        throw new Error(`Unknown start-ready option "${arg}". Usage: --headless start-ready [--dry-run] [--recreate-failed] [--no-track]`);
+    }
+  }
+  return { request, noTrack };
+}
+
+export async function headlessStartReady(args: string[], deps: HeadlessDeps): Promise<void> {
+  const { request, noTrack } = parseStartReadyArgs(args, deps.noTrack);
+  const result = runStartReady(deps.orchestrator, request);
+  const runnable = result.started.filter(isDispatchableLaunch);
+  const preview = result.preview;
+
+  const modeLabel = request.recreateFailed ? 'Start and recreate failed' : 'Start ready work';
+  process.stdout.write(`${modeLabel}: ${result.dryRun ? 'preview' : 'submitted'}\n`);
+  process.stdout.write(`  ready: ${preview.readyTaskIds.length}\n`);
+  process.stdout.write(`  recoverable: ${preview.recoverableTaskIds.length}\n`);
+  process.stdout.write(`  failed workflows: ${preview.failedWorkflowIds.length}\n`);
+  process.stdout.write(`  recreated workflows: ${result.recreatedWorkflowIds.length}\n`);
+  process.stdout.write(`  started: ${runnable.length}\n`);
+
+  if (result.dryRun || runnable.length === 0) {
+    return;
+  }
+
+  if (noTrack) {
+    if (deps.deferRunnableTasks) {
+      deps.deferRunnableTasks(runnable);
+    } else {
+      const taskExecutor = createHeadlessExecutor(deps);
+      const launch = setTimeout(() => {
+        void taskExecutor.executeTasks(runnable).catch((err) => {
+          deps.logger.error(
+            `background no-track start-ready failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+            { module: 'headless' },
+          );
+        });
+      }, 25);
+      launch.unref?.();
+    }
+    process.stdout.write('[headless] --no-track enabled: start-ready accepted; exiting without tracking.\n');
+    return;
+  }
+
+  const taskExecutor = createHeadlessExecutor(deps);
+  wireHeadlessApproveHook(deps, taskExecutor);
+  await taskExecutor.executeTasks(runnable);
 }
 
 export async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Promise<void> {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -76,6 +76,7 @@ import { headlessQuery, headlessQuerySelect, renderWorkerStatus } from './headle
 export { resolveAgentSession } from './headless-query-list.js';
 import {
   headlessRun,
+  headlessStartReady,
   headlessResume,
   headlessWatch,
   headlessRetryWorkflow,
@@ -267,6 +268,9 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
     // ── Execute (unchanged) ──
     case 'run':
       await headlessRun(args[1], deps, deps.waitForApproval, deps.noTrack);
+      break;
+    case 'start-ready':
+      await headlessStartReady(args.slice(1), deps);
       break;
     case 'resume':
       await headlessResume(args[1], deps, deps.waitForApproval, deps.noTrack);
@@ -530,6 +534,8 @@ ${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
 ${BOLD}Execute:${RESET}
   watch [<workflowId>]                                Watch workflow status until settled or Ctrl-C
   run <plan.yaml>                                     Load and execute plan
+  start-ready [--dry-run] [--recreate-failed] [--no-track]
+                                                      Start pending work that is ready to execute
   resume <id>                                         Resume incomplete workflow
   retry <workflowId>                                  Retry workflow: rerun failed, keep completed
   retry-task <taskId>                                 Retry a single failed/stuck task
@@ -929,4 +935,3 @@ async function headlessSetTaskMetadata(
   );
   process.stdout.write(`Updated task "${result.id}" ${result.fieldPath} → ${JSON.stringify(result.value)}\n`);
 }
-

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -92,6 +92,8 @@ import type {
   InAppPlanningResetRequest,
   InAppPlanningSubmitRequest,
   Logger,
+  StartReadyRequest,
+  StartReadyResult,
   WorkflowMeta,
   WorkflowMutationAcceptedResult,
   WorkResponse,
@@ -258,6 +260,7 @@ import {
   createWorkerRuntimeController,
   type WorkerRuntimeController,
 } from './worker-control.js';
+import { runStartReady } from './start-ready.js';
 import { startSurfaceEventRelay } from './surface-event-relay.js';
 import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
 import { buildWebInvokerDispatch } from './web/web-invoker-dispatch.js';
@@ -407,26 +410,6 @@ function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
     || task.status === 'fixing_with_ai'
     || (task.status === 'pending' && task.execution.phase === 'launching');
-}
-
-function isTaskRecoverableOnExplicitResume(task: TaskState): boolean {
-  if (task.status === 'running') return true;
-  if (task.status !== 'pending' || !task.execution.selectedAttemptId) return false;
-  if (task.execution.phase === 'launching') return true;
-
-  return Boolean(
-    task.execution.startedAt
-    || task.execution.launchStartedAt
-    || task.execution.launchCompletedAt
-    || task.execution.lastHeartbeatAt
-    || task.execution.workspacePath
-    || task.execution.agentSessionId
-    || task.execution.containerId
-    || task.execution.error
-    || task.execution.exitCode !== undefined
-    || task.execution.inputPrompt
-    || task.execution.pendingFixError,
-  );
 }
 
 declare const __BUILD_SHA__: string | undefined;
@@ -1547,6 +1530,11 @@ function startHeadlessMode(): void {
             });
             return { ok: true };
           });
+        }
+        if (!workflowMutationDispatcher.has('invoker:start-ready')) {
+          workflowMutationDispatcher.set('invoker:start-ready', async (requestArg: unknown) =>
+            runStartReady(orchestrator, requestArg as StartReadyRequest | undefined),
+          );
         }
         if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
           workflowMutationDispatcher.set('invoker:fix-with-agent', async (...fixArgs: unknown[]) => {
@@ -2845,6 +2833,8 @@ function createEmbeddedTerminalBackendFromConfig(
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:start':
         return { channel: 'headless.gui-mutation', request: payload };
+      case 'invoker:start-ready':
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:stop':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:clear':
@@ -3210,6 +3200,28 @@ function createEmbeddedTerminalBackendFromConfig(
       }
       requestWorkflowMetadataPublish('orchestrator-snapshot');
     }
+  }
+
+  function executeStartReady(request: StartReadyRequest = {}): StartReadyResult {
+    const result = runStartReady(orchestrator, request);
+    if (!result.dryRun) {
+      publishOrchestratorSnapshotToRenderer();
+    }
+    logger.info(
+      `start-ready: ready=${result.preview.readyTaskIds.length} recoverable=${result.preview.recoverableTaskIds.length} failedWorkflows=${result.preview.failedWorkflowIds.length} recreated=${result.recreatedWorkflowIds.length} started=${result.started.length} dryRun=${result.dryRun ? 'true' : 'false'}`,
+      { module: 'ipc' },
+    );
+    if (!result.dryRun && result.started.length > 0 && launchDispatcher) {
+      try {
+        launchDispatcher.poll();
+      } catch (err) {
+        logger.warn(
+          `start-ready: launch dispatcher poll failed: ${err instanceof Error ? err.message : String(err)}`,
+          { module: 'ipc' },
+        );
+      }
+    }
+    return result;
   }
 
   function startDeferredStartupWork(): void {
@@ -3626,6 +3638,9 @@ function createEmbeddedTerminalBackendFromConfig(
       workflowMutationDispatcher.set('headless.exec', async (payloadArg: unknown) => {
         return executeHeadlessExec(payloadArg as HeadlessExecMutationPayload);
       });
+      workflowMutationDispatcher.set('invoker:start-ready', async (requestArg: unknown) =>
+        executeStartReady(requestArg as StartReadyRequest | undefined),
+      );
       workflowMutationDispatcher.set('api:approve-task', async (taskIdArg: unknown) => {
         await performSharedApproveTask(String(taskIdArg), 'api');
       });
@@ -4072,40 +4087,20 @@ function createEmbeddedTerminalBackendFromConfig(
       return started;
     });
 
+    registerGuiMutationHandler('invoker:start-ready', async (requestArg: unknown) => {
+      return executeStartReady(requestArg as StartReadyRequest | undefined);
+    });
+
     registerGuiMutationHandler('invoker:resume-workflow', async () => {
       const workflows = persistence.listWorkflows();
       if (workflows.length === 0) {
         logger.info('resume-workflow: no workflows found', { module: 'ipc' });
         return null;
       }
-      orchestrator.syncAllFromDb();
-
-      const tasksToRecover = orchestrator.getAllTasks().filter(isTaskRecoverableOnExplicitResume);
-      for (const task of tasksToRecover) {
-        orchestrator.prepareTaskForNewAttempt(task.id, 'resume_workflow_recovery');
-      }
-
-      const allStarted = orchestrator.startExecution();
+      const result = executeStartReady({});
       const tasks = orchestrator.getAllTasks();
-      workflowRollupProjection.replaceAll(tasks);
-      for (const task of tasks) {
-        lastKnownTaskStates.set(task.id, JSON.stringify(task));
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          publishTaskDeltaToRenderer({ type: 'created', task });
-        }
-      }
-      logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${allStarted.length} started`, { module: 'ipc' });
-      if (allStarted.length > 0 && launchDispatcher) {
-        try {
-          launchDispatcher.poll();
-        } catch (err) {
-          logger.warn(
-            `resume-workflow: launch dispatcher poll failed: ${err instanceof Error ? err.message : String(err)}`,
-            { module: 'ipc' },
-          );
-        }
-      }
-      return { workflow: workflows[0], taskCount: tasks.length, startedCount: allStarted.length };
+      logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${result.started.length} started`, { module: 'ipc' });
+      return { workflow: workflows[0], taskCount: tasks.length, startedCount: result.started.length };
     });
 
     registerGuiMutationHandler('invoker:stop', async () => {

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -213,6 +213,9 @@ export class PersistedWorkflowMutationCoordinator {
   }
 
   private coalescibleRetryKey(channel: string, args: unknown[]): string | null {
+    if (channel === 'invoker:start-ready') {
+      return 'start-ready';
+    }
     if (channel === 'invoker:retry-workflow') {
       const target = typeof args[0] === 'string' ? args[0] : '';
       return /^wf-[^/]+$/.test(target) ? `retry-workflow:${target}` : null;
@@ -224,6 +227,9 @@ export class PersistedWorkflowMutationCoordinator {
     const rawArgs = Array.isArray(payload?.args) ? payload.args : [];
     const command = typeof rawArgs[0] === 'string' ? rawArgs[0] : '';
     const target = typeof rawArgs[1] === 'string' ? rawArgs[1] : '';
+    if (command === 'start-ready') {
+      return 'start-ready';
+    }
     if (command !== 'retry' || !/^wf-[^/]+$/.test(target)) {
       return null;
     }

--- a/packages/app/src/start-ready.ts
+++ b/packages/app/src/start-ready.ts
@@ -1,0 +1,115 @@
+import type {
+  StartReadyPreview,
+  StartReadyRequest,
+  StartReadyResult,
+} from '@invoker/contracts';
+import type { Orchestrator, TaskState } from '@invoker/workflow-core';
+
+type StartReadyOrchestrator = Pick<
+  Orchestrator,
+  | 'syncAllFromDb'
+  | 'getAllTasks'
+  | 'getExecutableReadyTasks'
+  | 'prepareTaskForNewAttempt'
+  | 'recreateWorkflow'
+  | 'startExecution'
+>;
+
+export function isTaskRecoverableOnExplicitResume(task: TaskState): boolean {
+  if (task.status === 'running') return true;
+  if (task.status !== 'pending' || !task.execution.selectedAttemptId) return false;
+  if (task.execution.phase === 'launching') return true;
+
+  return Boolean(
+    task.execution.startedAt
+    || task.execution.launchStartedAt
+    || task.execution.launchCompletedAt
+    || task.execution.lastHeartbeatAt
+    || task.execution.workspacePath
+    || task.execution.agentSessionId
+    || task.execution.containerId
+    || task.execution.error
+    || task.execution.exitCode !== undefined
+    || task.execution.inputPrompt
+    || task.execution.pendingFixError,
+  );
+}
+
+function uniqueWorkflowIds(tasks: readonly TaskState[]): string[] {
+  const ids = new Set<string>();
+  for (const task of tasks) {
+    if (task.config.workflowId) ids.add(task.config.workflowId);
+  }
+  return Array.from(ids);
+}
+
+function uniqueTasks(tasks: readonly TaskState[]): TaskState[] {
+  const seen = new Set<string>();
+  const result: TaskState[] = [];
+  for (const task of tasks) {
+    const attemptId = task.execution.selectedAttemptId?.trim();
+    const key = attemptId ? `${task.id}:${attemptId}` : task.id;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(task);
+  }
+  return result;
+}
+
+export function collectStartReadyPreview(orchestrator: StartReadyOrchestrator): StartReadyPreview {
+  const tasks = orchestrator.getAllTasks();
+  const readyTasks = orchestrator.getExecutableReadyTasks();
+  const recoverableTasks = tasks.filter(isTaskRecoverableOnExplicitResume);
+  const failedTasks = tasks.filter((task) => task.status === 'failed');
+
+  return {
+    readyTaskIds: readyTasks.map((task) => task.id),
+    recoverableTaskIds: recoverableTasks.map((task) => task.id),
+    failedWorkflowIds: uniqueWorkflowIds(failedTasks),
+    skipped: {
+      awaitingApproval: tasks.filter((task) => task.status === 'awaiting_approval').length,
+      reviewReady: tasks.filter((task) => task.status === 'review_ready').length,
+      blocked: tasks.filter((task) => task.status === 'blocked' || task.status === 'needs_input').length,
+      failedTasks: failedTasks.length,
+    },
+  };
+}
+
+export function runStartReady(
+  orchestrator: StartReadyOrchestrator,
+  request: StartReadyRequest = {},
+): StartReadyResult {
+  orchestrator.syncAllFromDb();
+  const preview = collectStartReadyPreview(orchestrator);
+  if (request.dryRun) {
+    return {
+      preview,
+      started: [],
+      recreatedWorkflowIds: [],
+      dryRun: true,
+    };
+  }
+
+  const started: TaskState[] = [];
+  const recreatedWorkflowIds: string[] = [];
+  if (request.recreateFailed) {
+    for (const workflowId of preview.failedWorkflowIds) {
+      started.push(...orchestrator.recreateWorkflow(workflowId));
+      recreatedWorkflowIds.push(workflowId);
+    }
+  }
+
+  const recoverableTasks = orchestrator.getAllTasks().filter(isTaskRecoverableOnExplicitResume);
+  for (const task of recoverableTasks) {
+    orchestrator.prepareTaskForNewAttempt(task.id, 'start_ready_recovery');
+  }
+
+  started.push(...orchestrator.startExecution());
+
+  return {
+    preview,
+    started: uniqueTasks(started),
+    recreatedWorkflowIds,
+    dryRun: false,
+  };
+}

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -258,6 +258,7 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       case 'invoker:replace-task':
       case 'invoker:load-plan':
       case 'invoker:start':
+      case 'invoker:start-ready':
       case 'invoker:stop':
       case 'invoker:clear':
       case 'invoker:resume-workflow':

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -20,6 +20,7 @@ import {
   PR_CONFLICT_REBASE_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
   REQUEUE_WORKER_KIND,
+  WORKFLOW_RESUME_WORKER_KIND,
   type WorkerRegistry,
   type WorkerRuntime,
   type WorkerRuntimeDependencies,
@@ -40,7 +41,7 @@ export const AUTO_STARTED_OWNER_WORKER_KINDS = [
 
 export interface WorkerRuntimeController {
   startAutoStartedWorkers(): void;
-  start(kind: string): WorkerStatusEntry;
+  start(kind: string, options?: { persistDesiredState?: boolean }): WorkerStatusEntry;
   stop(kind: string): Promise<WorkerStatusEntry>;
   stopAll(): Promise<void>;
   snapshot(): WorkerStatusSnapshot;
@@ -49,7 +50,7 @@ export interface WorkerRuntimeController {
 type WorkerStatusPersistence = Pick<
   SQLiteAdapter,
   'listWorkerActions' | 'listWorkflows' | 'loadTasks' | 'getEvents' | 'getEventsByTypes' | 'countEventsByTypes'
->;
+> & Partial<Pick<SQLiteAdapter, 'getWorkerDesiredState' | 'setWorkerDesiredState' | 'listWorkerDesiredStates'>>;
 
 const DEFAULT_WORKER_ACTION_HISTORY_LIMIT = 20;
 const MAX_WORKER_ACTION_HISTORY_LIMIT = 100;
@@ -165,6 +166,7 @@ const BUILT_IN_WORKER_KINDS = new Set<string>([
   AUTO_APPROVE_WORKER_KIND,
   CODERABBIT_ADDRESS_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
+  WORKFLOW_RESUME_WORKER_KIND,
 ]);
 
 export function createWorkerRuntimeController(options: {
@@ -187,17 +189,24 @@ export function createWorkerRuntimeController(options: {
     return definition;
   };
 
+  const desiredEnabledForKind = (kind: string): boolean => {
+    const saved = options.persistence.getWorkerDesiredState?.(kind);
+    return saved?.desiredEnabled ?? options.autoStartKinds.includes(kind);
+  };
+
   const rowForKind = (kind: string): WorkerStatusEntry => {
     const definition = options.registry.get(kind);
     if (!definition) {
       throw new Error(`Unknown worker kind: "${kind}"`);
     }
+    const desiredEnabled = desiredEnabledForKind(kind);
     return buildWorkerStatusEntry({
       definitionKind: definition.kind,
       note: definition.note,
       handle: handles.get(kind),
       stoppedAt: stoppedAtByKind.get(kind),
-      autoStarts: options.autoStartKinds.includes(kind),
+      autoStarts: desiredEnabled,
+      desiredEnabled,
       policy: policyForKind(kind),
       persistence: options.persistence,
       canControl: options.canControl(),
@@ -220,14 +229,17 @@ export function createWorkerRuntimeController(options: {
 
   return {
     startAutoStartedWorkers(): void {
-      for (const kind of options.autoStartKinds) {
-        if (!options.registry.get(kind)) continue;
-        this.start(kind);
+      for (const definition of options.registry.list()) {
+        if (!desiredEnabledForKind(definition.kind)) continue;
+        this.start(definition.kind, { persistDesiredState: false });
       }
     },
 
-    start(kind: string): WorkerStatusEntry {
+    start(kind: string, optionsArg?: { persistDesiredState?: boolean }): WorkerStatusEntry {
       const definition = requireDefinition(kind);
+      if (optionsArg?.persistDesiredState !== false) {
+        options.persistence.setWorkerDesiredState?.(kind, true);
+      }
 
       const existing = handles.get(kind);
       if (existing) {
@@ -249,6 +261,7 @@ export function createWorkerRuntimeController(options: {
     },
     async stop(kind: string): Promise<WorkerStatusEntry> {
       requireDefinition(kind);
+      options.persistence.setWorkerDesiredState?.(kind, false);
       const handle = handles.get(kind);
       if (!handle) {
         return rowForKind(kind);
@@ -282,15 +295,20 @@ export function createLocalWorkerStatusSnapshot(options: {
     : undefined;
   return {
     generatedAt: new Date().toISOString(),
-    workers: options.registry.list().map((definition) => buildWorkerStatusEntry({
-      definitionKind: definition.kind,
-      note: definition.note,
-      autoStarts: options.autoStartKinds.includes(definition.kind),
-      policy: 'unknown',
-      persistence: options.persistence,
-      canControl: false,
-      recovery: definition.kind === AUTO_FIX_WORKER_KIND ? recovery : undefined,
-    })),
+    workers: options.registry.list().map((definition) => {
+      const desiredEnabled = options.persistence.getWorkerDesiredState?.(definition.kind)?.desiredEnabled
+        ?? options.autoStartKinds.includes(definition.kind);
+      return buildWorkerStatusEntry({
+        definitionKind: definition.kind,
+        note: definition.note,
+        autoStarts: desiredEnabled,
+        desiredEnabled,
+        policy: 'unknown',
+        persistence: options.persistence,
+        canControl: false,
+        recovery: definition.kind === AUTO_FIX_WORKER_KIND ? recovery : undefined,
+      });
+    }),
   };
 }
 
@@ -301,6 +319,7 @@ function buildWorkerStatusEntry(args: {
   handle?: RuntimeHandle;
   stoppedAt?: string;
   autoStarts: boolean;
+  desiredEnabled: boolean;
   policy: WorkerPolicyStatus;
   persistence: WorkerStatusPersistence;
   canControl: boolean;
@@ -318,6 +337,7 @@ function buildWorkerStatusEntry(args: {
     lifecycle,
     policy: args.policy,
     autoStarts: args.autoStarts,
+    desiredEnabled: args.desiredEnabled,
     startable: lifecycle !== 'running' && args.policy !== 'disabled' && args.canControl,
     stoppable: lifecycle === 'running' && args.canControl,
     ...(controlDisabledReason ? { controlDisabledReason } : {}),

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -262,6 +262,7 @@ export interface WorkerStatusEntry {
   policy: WorkerPolicyStatus;
   policyReason?: string;
   autoStarts: boolean;
+  desiredEnabled?: boolean;
   startable: boolean;
   stoppable: boolean;
   controlDisabledReason?: string;
@@ -556,6 +557,30 @@ export interface WorkflowMutationAcceptedResult {
   channel: string;
 }
 
+export interface StartReadyRequest {
+  recreateFailed?: boolean;
+  dryRun?: boolean;
+}
+
+export interface StartReadyPreview {
+  readyTaskIds: string[];
+  recoverableTaskIds: string[];
+  failedWorkflowIds: string[];
+  skipped: {
+    awaitingApproval: number;
+    reviewReady: number;
+    blocked: number;
+    failedTasks: number;
+  };
+}
+
+export interface StartReadyResult {
+  preview: StartReadyPreview;
+  started: TaskState[];
+  recreatedWorkflowIds: string[];
+  dryRun: boolean;
+}
+
 export interface WorkflowMutationFailedEvent {
   intentId: number;
   workflowId: string;
@@ -834,6 +859,10 @@ export const IpcChannels = {
   'invoker:start': {} as {
     request: [];
     response: TaskState[];
+  },
+  'invoker:start-ready': {} as {
+    request: [request?: StartReadyRequest];
+    response: StartReadyResult;
   },
   'invoker:resume-workflow': {} as {
     request: [];

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -697,6 +697,11 @@ describe('SQLiteAdapter', () => {
         'workflows.id:CASCADE',
         'tasks.id:CASCADE',
       ]));
+      expect(tableColumns(adapter, 'worker_desired_states')).toEqual(expect.arrayContaining([
+        'worker_kind',
+        'desired_enabled',
+        'updated_at',
+      ]));
     });
 
     it('does not create auto_fix_attempts on fresh task tables', () => {
@@ -859,6 +864,26 @@ describe('SQLiteAdapter', () => {
 
       expect(adapter.listWorkerActions({ decision: 'skip' }).map((action) => action.id)).toEqual(['wa-skip']);
       expect(adapter.listWorkerActions({ decision: 'act' }).map((action) => action.id)).toEqual(['wa-done', 'wa-act']);
+    });
+
+    it('persists worker desired states', () => {
+      expect(adapter.getWorkerDesiredState('workflow-resume')).toBeUndefined();
+
+      expect(adapter.setWorkerDesiredState('workflow-resume', true)).toMatchObject({
+        workerKind: 'workflow-resume',
+        desiredEnabled: true,
+      });
+      expect(adapter.getWorkerDesiredState('workflow-resume')).toMatchObject({
+        workerKind: 'workflow-resume',
+        desiredEnabled: true,
+      });
+
+      adapter.setWorkerDesiredState('workflow-resume', false);
+      adapter.setWorkerDesiredState('pr-status', true);
+      expect(adapter.listWorkerDesiredStates()).toEqual([
+        expect.objectContaining({ workerKind: 'pr-status', desiredEnabled: true }),
+        expect.objectContaining({ workerKind: 'workflow-resume', desiredEnabled: false }),
+      ]);
     });
   });
 

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -164,6 +164,12 @@ export interface WorkerActionRecord {
   completedAt?: string;
 }
 
+export interface WorkerDesiredStateRecord {
+  workerKind: string;
+  desiredEnabled: boolean;
+  updatedAt: string;
+}
+
 export interface WorkerActionWrite {
   /** Insert-only row id. Updates are keyed by workerKind/externalKey and reject a different id. */
   id: string;
@@ -301,6 +307,9 @@ export interface PersistenceAdapter {
   getWorkerAction(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
   upsertWorkerAction(action: WorkerActionWrite): WorkerActionRecord;
   listWorkerActions(filters?: WorkerActionListFilters): WorkerActionRecord[];
+  getWorkerDesiredState(workerKind: string): WorkerDesiredStateRecord | undefined;
+  setWorkerDesiredState(workerKind: string, desiredEnabled: boolean): WorkerDesiredStateRecord;
+  listWorkerDesiredStates(): WorkerDesiredStateRecord[];
 
   // Conversations (Slack thread-based)
   saveConversation(conversation: Conversation): void;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -47,6 +47,7 @@ import type {
   WorkerActionListFilters,
   WorkerActionRecord,
   WorkerActionWrite,
+  WorkerDesiredStateRecord,
   TerminalSessionPatch,
   TerminalSessionRecord,
   InAppPlanningSessionPatch,
@@ -1720,6 +1721,38 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return rows.map((row) => this.rowToWorkerAction(row));
   }
 
+  getWorkerDesiredState(workerKind: string): WorkerDesiredStateRecord | undefined {
+    const row = this.queryOne(
+      'SELECT worker_kind, desired_enabled, updated_at FROM worker_desired_states WHERE worker_kind = ?',
+      [workerKind],
+    );
+    return row ? this.rowToWorkerDesiredState(row) : undefined;
+  }
+
+  setWorkerDesiredState(workerKind: string, desiredEnabled: boolean): WorkerDesiredStateRecord {
+    const updatedAt = new Date().toISOString();
+    this.execRun(
+      `INSERT INTO worker_desired_states (worker_kind, desired_enabled, updated_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(worker_kind) DO UPDATE SET
+         desired_enabled = excluded.desired_enabled,
+         updated_at = excluded.updated_at`,
+      [workerKind, desiredEnabled ? 1 : 0, updatedAt],
+    );
+    const saved = this.getWorkerDesiredState(workerKind);
+    if (!saved) {
+      throw new Error(`Failed to persist worker desired state for ${workerKind}`);
+    }
+    return saved;
+  }
+
+  listWorkerDesiredStates(): WorkerDesiredStateRecord[] {
+    const rows = this.queryAll(
+      'SELECT worker_kind, desired_enabled, updated_at FROM worker_desired_states ORDER BY worker_kind ASC',
+    );
+    return rows.map((row) => this.rowToWorkerDesiredState(row));
+  }
+
   // ── Queries ─────────────────────────────────────────
 
   getSelectedExperiment(taskId: string): string | null {
@@ -3192,6 +3225,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   private rowToWorkerAction(row: Record<string, unknown>): WorkerActionRecord {
     return mapRowToWorkerAction(row);
+  }
+
+  private rowToWorkerDesiredState(row: Record<string, unknown>): WorkerDesiredStateRecord {
+    return {
+      workerKind: String(row.worker_kind),
+      desiredEnabled: Number(row.desired_enabled) !== 0,
+      updatedAt: String(row.updated_at),
+    };
   }
 
   private requeueWorkflowMutationLease(workflowId: string): void {

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -380,6 +380,12 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_worker_actions_kind_updated
         ON worker_actions(worker_kind, updated_at DESC, id);
 
+      CREATE TABLE IF NOT EXISTS worker_desired_states (
+        worker_kind TEXT PRIMARY KEY,
+        desired_enabled INTEGER NOT NULL,
+        updated_at TEXT DEFAULT (datetime('now'))
+      );
+
       CREATE TABLE IF NOT EXISTS execution_resource_leases (
         resource_key TEXT NOT NULL,
         resource_type TEXT NOT NULL,
@@ -530,6 +536,11 @@ export const POST_MIGRATION_STATEMENTS = [
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_task_updated ON worker_actions(task_id, updated_at)',
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_workflow_status ON worker_actions(workflow_id, worker_kind, status)',
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_kind_updated ON worker_actions(worker_kind, updated_at DESC, id)',
+  `CREATE TABLE IF NOT EXISTS worker_desired_states (
+    worker_kind TEXT PRIMARY KEY,
+    desired_enabled INTEGER NOT NULL,
+    updated_at TEXT DEFAULT (datetime('now'))
+  )`,
   'DROP INDEX IF EXISTS idx_task_launch_dispatch_active_attempt',
   `
       CREATE UNIQUE INDEX IF NOT EXISTS idx_task_launch_dispatch_active_attempt

--- a/packages/execution-engine/src/__tests__/workflow-resume-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/workflow-resume-worker.test.ts
@@ -107,12 +107,12 @@ function harness(options: HarnessOptions = {}) {
 }
 
 describe('workflow resume worker tick', () => {
-  it('submits a retry for a workflow that has any non-terminal task', async () => {
+  it('submits start-ready for a workflow that has ready pending work', async () => {
     const h = harness({
       workflows: [
         {
           id: 'wf-1',
-          tasks: [makeTask({ status: 'running' as TaskState['status'] })],
+          tasks: [makeTask({ status: 'pending' as TaskState['status'] })],
         },
       ],
     });
@@ -122,7 +122,47 @@ describe('workflow resume worker tick', () => {
     expect(workflowId).toBe('wf-1');
     expect(priority).toBe('normal');
     expect(channel).toBe(WORKFLOW_RESUME_COMMAND_CHANNEL);
-    expect(args).toEqual(['wf-1']);
+    expect(args).toEqual([{}]);
+  });
+
+  it('skips pending work whose local dependencies are not completed', async () => {
+    const h = harness({
+      workflows: [
+        {
+          id: 'wf-1',
+          tasks: [
+            makeTask({ id: 'wf-1/a', status: 'running' as TaskState['status'] }),
+            makeTask({
+              id: 'wf-1/b',
+              status: 'pending' as TaskState['status'],
+              dependencies: ['wf-1/a'],
+            }),
+          ],
+        },
+      ],
+    });
+    await h.tick(POLL_CTX);
+    expect(h.submit).not.toHaveBeenCalled();
+  });
+
+  it('submits pending work when local dependencies are completed', async () => {
+    const h = harness({
+      workflows: [
+        {
+          id: 'wf-1',
+          tasks: [
+            makeTask({ id: 'wf-1/a', status: 'completed' as TaskState['status'] }),
+            makeTask({
+              id: 'wf-1/b',
+              status: 'pending' as TaskState['status'],
+              dependencies: ['wf-1/a'],
+            }),
+          ],
+        },
+      ],
+    });
+    await h.tick(POLL_CTX);
+    expect(h.submit).toHaveBeenCalledTimes(1);
   });
 
   it('skips workflows whose tasks are all terminal', async () => {
@@ -182,7 +222,7 @@ describe('workflow resume worker tick', () => {
     expect(h.submit).not.toHaveBeenCalled();
   });
 
-  it('still resumes a workflow with actionable pending work alongside a failed task', async () => {
+  it('still submits start-ready for pending work alongside a failed task', async () => {
     const h = harness({
       workflows: [
         {
@@ -270,7 +310,7 @@ describe('workflow resume worker tick', () => {
       'recovery.worker.submit',
       expect.objectContaining({
         worker: 'workflow-resume',
-        phase: 'retry-workflow',
+        phase: 'start-ready',
         workflowId: 'wf-1',
         channel: WORKFLOW_RESUME_COMMAND_CHANNEL,
         intentId: expect.any(Number),

--- a/packages/execution-engine/src/workers/workflow-resume-worker.ts
+++ b/packages/execution-engine/src/workers/workflow-resume-worker.ts
@@ -14,18 +14,10 @@ import type { WorkerRegistry } from '../worker-registry.js';
 
 export const WORKFLOW_RESUME_WORKER_KIND = 'workflow-resume';
 
-export const WORKFLOW_RESUME_COMMAND_CHANNEL = 'invoker:retry-workflow';
+export const WORKFLOW_RESUME_COMMAND_CHANNEL = 'invoker:start-ready';
 
 const DEFAULT_WORKFLOW_RESUME_POLL_INTERVAL_MS = 60_000;
 export const DEFAULT_WORKFLOW_RESUME_COOLDOWN_MS = 60_000;
-
-const TERMINAL_TASK_STATUSES: ReadonlySet<TaskState['status']> = new Set<TaskState['status']>([
-  'completed' as TaskState['status'],
-  'review_ready' as TaskState['status'],
-  'failed' as TaskState['status'],
-  'closed' as TaskState['status'],
-  'stale' as TaskState['status'],
-]);
 
 export interface WorkflowResumeWorkerStore {
   listWorkflows(): ReadonlyArray<{ id: string }>;
@@ -77,11 +69,18 @@ export function createWorkflowResumeCooldownLedger(): WorkflowResumeCooldownLedg
   };
 }
 
-function isWorkflowIncomplete(store: WorkflowResumeWorkerStore, workflowId: string): boolean {
+function hasLocallyReadyPendingTask(store: WorkflowResumeWorkerStore, workflowId: string): boolean {
   const tasks = store.loadTasks(workflowId);
   if (tasks.length === 0) return false;
+  const tasksById = new Map(tasks.map((task) => [task.id, task]));
   for (const task of tasks) {
-    if (!TERMINAL_TASK_STATUSES.has(task.status)) return true;
+    if (task.status !== 'pending') continue;
+    const dependencies = task.dependencies ?? [];
+    const localDependenciesSatisfied = dependencies.every((dependencyId) => {
+      const dependency = tasksById.get(dependencyId);
+      return dependency === undefined || dependency.status === 'completed';
+    });
+    if (localDependenciesSatisfied) return true;
   }
   return false;
 }
@@ -95,10 +94,10 @@ function collectWakeupWorkflowIds(hints: RecoveryWorkerWakeupHint[]): string[] {
   return Array.from(seen);
 }
 
-function listAllIncompleteWorkflowIds(store: WorkflowResumeWorkerStore): string[] {
+function listAllWorkflowsWithReadyPendingTasks(store: WorkflowResumeWorkerStore): string[] {
   const targets: string[] = [];
   for (const workflow of store.listWorkflows()) {
-    if (isWorkflowIncomplete(store, workflow.id)) {
+    if (hasLocallyReadyPendingTask(store, workflow.id)) {
       targets.push(workflow.id);
     }
   }
@@ -114,8 +113,8 @@ export function createWorkflowResumeTick(options: WorkflowResumeWorkerPolicyOpti
     const wakeupWorkflowIds = collectWakeupWorkflowIds(wakeups);
 
     const candidateIds = wakeupWorkflowIds.length > 0 && ctx.reason === 'wake'
-      ? wakeupWorkflowIds.filter((id) => isWorkflowIncomplete(options.store, id))
-      : listAllIncompleteWorkflowIds(options.store);
+      ? wakeupWorkflowIds.filter((id) => hasLocallyReadyPendingTask(options.store, id))
+      : listAllWorkflowsWithReadyPendingTasks(options.store);
 
     const submitted = new Set<string>();
     for (const workflowId of candidateIds) {
@@ -134,17 +133,17 @@ export function createWorkflowResumeTick(options: WorkflowResumeWorkerPolicyOpti
         workflowId,
         'normal',
         WORKFLOW_RESUME_COMMAND_CHANNEL,
-        [workflowId],
+        [{}],
       );
       options.ledger.markSubmitted(workflowId, nowMs + cooldownMs);
       options.store.logEvent?.(workflowId, 'recovery.worker.submit', {
         worker: WORKFLOW_RESUME_WORKER_KIND,
-        phase: 'retry-workflow',
+        phase: 'start-ready',
         workflowId,
         intentId,
         channel: WORKFLOW_RESUME_COMMAND_CHANNEL,
       });
-      options.logger.info(`[worker:${WORKFLOW_RESUME_WORKER_KIND}] submitted retry for incomplete workflow`, {
+      options.logger.info(`[worker:${WORKFLOW_RESUME_WORKER_KIND}] submitted start-ready for pending work`, {
         module: 'workflow-resume-worker',
         workflowId,
         intentId,
@@ -225,7 +224,7 @@ export function registerWorkflowResumeWorker(
 ): WorkerRegistry<WorkerRuntimeDependencies> {
   registry.register({
     kind: WORKFLOW_RESUME_WORKER_KIND,
-    note: 'Submits retry-workflow intents for workflows that have any non-terminal task.',
+    note: 'Submits start-ready intents when workflows have pending work ready to launch.',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
       createWorkflowResumeWorker({
         logger: deps.logger,

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
-import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
+import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, StartReadyRequest, StartReadyResult, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
 import { reportUiNavigation } from './lib/report-ui-navigation.js';
@@ -45,6 +45,7 @@ import { useTheme } from './lib/theme.js';
 import { InvokerTerminal, type InvokerTerminalLine, type PlanningTerminalMode } from './components/InvokerTerminal.js';
 import { Toaster, toast } from 'sonner';
 import { Button } from './components/primitives/index.js';
+import { ChevronDownIcon, PlayIcon } from './components/icons/index.js';
 import { CommandPalette } from './components/CommandPalette.js';
 import {
   getAttentionTaskEntries,
@@ -115,6 +116,10 @@ function notifyMutationError(rawTitle: string, err: unknown): void {
   const title = rawTitle.replace(/[:\s]+$/, '');
   const description = err instanceof Error ? err.message : typeof err === 'string' ? err : undefined;
   toast.error(title, description ? { description } : undefined);
+}
+
+function formatCount(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
 }
 type PlanningSessionView = Omit<InAppPlanningSessionSummary, 'messages'> & {
   messages: InvokerTerminalLine[];
@@ -580,6 +585,7 @@ export function App() {
   );
   const graphSurfaceRef = useRef<HTMLDivElement>(null);
   const graphActionsMenuRef = useRef<HTMLDivElement>(null);
+  const startReadyMenuRef = useRef<HTMLDivElement>(null);
   const lastGoodSelectedWorkflowGraphRef = useRef<SelectedWorkflowGraphSnapshot | null>(null);
   const contextMenuTaskRef = useRef<TaskState | null>(null);
   const [sidebarSurface, setSidebarSurface] = useState<SidebarSurface>('home');
@@ -655,6 +661,9 @@ export function App() {
   const [activeTerminalSessionId, setActiveTerminalSessionId] = useState<string | null>(null);
   const [workflowContextMenu, setWorkflowContextMenu] = useState<WorkflowContextMenuState | null>(null);
   const [graphActionsMenuOpen, setGraphActionsMenuOpen] = useState(false);
+  const [startReadyMenuOpen, setStartReadyMenuOpen] = useState(false);
+  const [startReadyBusy, setStartReadyBusy] = useState(false);
+  const [startReadyPreview, setStartReadyPreview] = useState<StartReadyResult | null>(null);
   // Transient, user-visible outcome line for a confirmed workflow detach.
   const [detachNotice, setDetachNotice] = useState<string | null>(null);
   const [keyboardRegion, setKeyboardRegion] = useState<KeyboardRegion>('workflowGraph');
@@ -2020,6 +2029,63 @@ export function App() {
     }
   }, [invoker]);
 
+  const handleStartReadyAction = useCallback(async (
+    request: StartReadyRequest = {},
+  ): Promise<StartReadyResult | null> => {
+    if (!invoker?.startReady) return null;
+    setStartReadyBusy(true);
+    setStartReadyMenuOpen(false);
+    try {
+      const result = await invoker.startReady(request);
+      if (!result.dryRun) {
+        await refreshTaskGraph();
+        void refreshActionGraph();
+        if (result.started.length > 0) setHasStarted(true);
+        if (result.started.length > 0 || result.recreatedWorkflowIds.length > 0) {
+          const descriptionParts = [
+            result.recreatedWorkflowIds.length > 0
+              ? formatCount(result.recreatedWorkflowIds.length, 'workflow')
+              : null,
+            result.preview.recoverableTaskIds.length > 0
+              ? formatCount(result.preview.recoverableTaskIds.length, 'recovered task')
+              : null,
+          ].filter(Boolean);
+          toast.success(
+            `Started ${formatCount(result.started.length, 'task')}`,
+            descriptionParts.length > 0 ? { description: descriptionParts.join(' · ') } : undefined,
+          );
+        } else {
+          toast('No ready work to start');
+        }
+      }
+      return result;
+    } catch (err) {
+      notifyMutationError('Failed to start ready work:', err);
+      return null;
+    } finally {
+      setStartReadyBusy(false);
+    }
+  }, [invoker, refreshActionGraph, refreshTaskGraph]);
+
+  const handleStartReadyPreview = useCallback(async () => {
+    if (!invoker?.startReady) return;
+    setStartReadyBusy(true);
+    setStartReadyMenuOpen(false);
+    try {
+      const result = await invoker.startReady({ dryRun: true, recreateFailed: true });
+      setStartReadyPreview(result);
+    } catch (err) {
+      notifyMutationError('Failed to preview ready work:', err);
+    } finally {
+      setStartReadyBusy(false);
+    }
+  }, [invoker]);
+
+  const handleConfirmStartAndRecreateFailed = useCallback(async () => {
+    const result = await handleStartReadyAction({ recreateFailed: true });
+    if (result) setStartReadyPreview(null);
+  }, [handleStartReadyAction]);
+
   const handlePlanningSubmitDraft = useCallback(async () => {
     if (!planningSessionId) {
       setPlanningSubmitError({ title: 'Plan could not be submitted', message: 'No planning conversation yet.' });
@@ -2377,6 +2443,7 @@ export function App() {
 
   const showStart = hasLoadedPlan && !hasStarted;
   const showStop = hasStarted && !allSettled;
+  const showStartReadyControl = hasLoadedPlan || tasks.size > 0 || workflows.size > 0;
   const showEmptyGraphTutorial = sidebarSurface === 'home' && !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
   const autoCollapseSidebar = viewportWidth < 1440;
   const effectiveSidebarCollapsed = sidebarCollapsed ?? autoCollapseSidebar;
@@ -2391,14 +2458,17 @@ export function App() {
     }
   }, [autoCollapseInspector, sidebarSurface]);
   useEffect(() => {
-    if (!graphActionsMenuOpen) return undefined;
+    if (!graphActionsMenuOpen && !startReadyMenuOpen) return undefined;
     const handlePointerDown = (event: PointerEvent) => {
       if (graphActionsMenuRef.current?.contains(event.target as Node)) return;
+      if (startReadyMenuRef.current?.contains(event.target as Node)) return;
       setGraphActionsMenuOpen(false);
+      setStartReadyMenuOpen(false);
     };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         setGraphActionsMenuOpen(false);
+        setStartReadyMenuOpen(false);
       }
     };
     document.addEventListener('pointerdown', handlePointerDown);
@@ -2407,7 +2477,7 @@ export function App() {
       document.removeEventListener('pointerdown', handlePointerDown);
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [graphActionsMenuOpen]);
+  }, [graphActionsMenuOpen, startReadyMenuOpen]);
 
   const selectViewMode = useCallback((nextView: 'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph') => {
     setGraphActionsMenuOpen(false);
@@ -2754,6 +2824,46 @@ export function App() {
         >
           Stop
         </button>
+      )}
+      {showStartReadyControl && (
+        <div ref={startReadyMenuRef} className="relative inline-flex">
+          <button
+            type="button"
+            data-testid="rail-start-ready"
+            onClick={() => void handleStartReadyAction()}
+            disabled={startReadyBusy}
+            className="inline-flex h-8 items-center gap-1.5 rounded-l border border-emerald-600 bg-emerald-700 px-3 text-xs font-medium text-white hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <PlayIcon className="h-3.5 w-3.5" />
+            {startReadyBusy ? 'Starting…' : 'Start ready work'}
+          </button>
+          <button
+            type="button"
+            aria-label="Start ready options"
+            aria-expanded={startReadyMenuOpen}
+            data-testid="rail-start-ready-menu"
+            onClick={() => setStartReadyMenuOpen((open) => !open)}
+            disabled={startReadyBusy}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-r border-y border-r border-emerald-600 bg-emerald-800 text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <ChevronDownIcon className="h-3.5 w-3.5" />
+          </button>
+          {startReadyMenuOpen && (
+            <div
+              data-testid="rail-start-ready-options"
+              className="absolute right-0 top-10 z-30 w-56 rounded-lg border border-border bg-card p-1 shadow-xl"
+            >
+              <button
+                type="button"
+                data-testid="rail-start-ready-recreate-failed"
+                onClick={() => void handleStartReadyPreview()}
+                className="block w-full rounded px-3 py-2 text-left text-xs text-foreground hover:bg-secondary"
+              >
+                Start and recreate failed…
+              </button>
+            </div>
+          )}
+        </div>
       )}
       <button
         type="button"
@@ -3586,6 +3696,59 @@ export function App() {
                   <span className="truncate text-xs text-muted-foreground">{result.subtitle}</span>
                 </button>
               ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {startReadyPreview && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="start-ready-preview-title"
+          data-testid="start-ready-preview-dialog"
+          className="fixed inset-0 z-40 flex items-start justify-center bg-black/45 px-4 pt-[16vh]"
+          onClick={() => setStartReadyPreview(null)}
+        >
+          <div
+            className="w-full max-w-md rounded-lg border border-border bg-background shadow-2xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="border-b border-border px-4 py-3">
+              <h2 id="start-ready-preview-title" className="text-sm font-semibold text-foreground">Start and recreate failed</h2>
+            </div>
+            <div className="space-y-2 px-4 py-4 text-sm">
+              {([
+                ['Ready tasks', startReadyPreview.preview.readyTaskIds.length],
+                ['Recoverable tasks', startReadyPreview.preview.recoverableTaskIds.length],
+                ['Failed workflows', startReadyPreview.preview.failedWorkflowIds.length],
+                ['Awaiting approval', startReadyPreview.preview.skipped.awaitingApproval],
+                ['Review ready', startReadyPreview.preview.skipped.reviewReady],
+                ['Blocked', startReadyPreview.preview.skipped.blocked],
+              ] as Array<[string, number]>).map(([label, value]) => (
+                <div key={label} className="flex items-center justify-between gap-4">
+                  <span className="text-muted-foreground">{label}</span>
+                  <span className="font-medium text-foreground">{value}</span>
+                </div>
+              ))}
+            </div>
+            <div className="flex justify-end gap-2 border-t border-border px-4 py-3">
+              <button
+                type="button"
+                className="rounded border border-border px-3 py-1.5 text-xs text-muted-foreground hover:bg-secondary"
+                onClick={() => setStartReadyPreview(null)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                data-testid="start-ready-preview-confirm"
+                disabled={startReadyBusy}
+                className="rounded bg-emerald-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-60"
+                onClick={() => void handleConfirmStartAndRecreateFailed()}
+              >
+                {startReadyBusy ? 'Starting…' : 'Start and recreate'}
+              </button>
             </div>
           </div>
         </div>

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -18,7 +18,7 @@ import type {
   TaskConfig,
   TaskExecution,
 } from '../../types.js';
-import type { ActionGraphResponse, InAppPlanningSessionSummary, RuntimeStatus, TerminalOutputEvent, WorkerStatusEntry, WorkerStatusSnapshot, WorkflowMutationAcceptedResult, WorkflowMutationFailedEvent } from '@invoker/contracts';
+import type { ActionGraphResponse, InAppPlanningSessionSummary, RuntimeStatus, StartReadyResult, TerminalOutputEvent, WorkerStatusEntry, WorkerStatusSnapshot, WorkflowMutationAcceptedResult, WorkflowMutationFailedEvent } from '@invoker/contracts';
 
 export interface MockInvoker {
   /** The mock InvokerAPI object installed on window.invoker. */
@@ -342,6 +342,22 @@ export function createMockInvoker(
       runtimeStatusCallbacks.add(cb);
       return () => { runtimeStatusCallbacks.delete(cb); };
     }),
+    startReady: vi.fn(async () => ({
+      preview: {
+        readyTaskIds: [],
+        recoverableTaskIds: [],
+        failedWorkflowIds: [],
+        skipped: {
+          awaitingApproval: 0,
+          reviewReady: 0,
+          blocked: 0,
+          failedTasks: 0,
+        },
+      },
+      started: [],
+      recreatedWorkflowIds: [],
+      dryRun: false,
+    } satisfies StartReadyResult)),
     resumeWorkflow: vi.fn(async () => null),
     listWorkflows: vi.fn(async () => workflowSnapshot),
     loadWorkflow: vi.fn(async () => ({ workflow: {}, tasks: [] })),

--- a/packages/ui/src/__tests__/queue-view.test.tsx
+++ b/packages/ui/src/__tests__/queue-view.test.tsx
@@ -336,7 +336,7 @@ describe('QueueView', () => {
 
     expect(within(screen.getByTestId('worker-row-autofix')).getByText('Disabled · autoFixRetries=0')).toBeInTheDocument();
     expect(within(screen.getByTestId('worker-row-ci-failure')).getByText('Disabled · autoFixRetries=0')).toBeInTheDocument();
-    expect(within(screen.getByTestId('worker-row-ci-failure')).getByText('Auto-starts')).toBeInTheDocument();
+    expect(within(screen.getByTestId('worker-row-ci-failure')).getByText('Starts on launch')).toBeInTheDocument();
   });
 
   it('calls start worker for a stopped row', () => {
@@ -352,7 +352,7 @@ describe('QueueView', () => {
       ]),
     );
 
-    fireEvent.click(within(screen.getByTestId('worker-row-autofix')).getByRole('button', { name: 'Start process' }));
+    fireEvent.click(within(screen.getByTestId('worker-row-autofix')).getByRole('button', { name: 'Enable worker' }));
     expect(onStartWorker).toHaveBeenCalledWith('autofix');
   });
 
@@ -369,7 +369,7 @@ describe('QueueView', () => {
       ]),
     );
 
-    fireEvent.click(within(screen.getByTestId('worker-row-ci-failure')).getByRole('button', { name: 'Stop process' }));
+    fireEvent.click(within(screen.getByTestId('worker-row-ci-failure')).getByRole('button', { name: 'Disable worker' }));
     expect(onStopWorker).toHaveBeenCalledWith('ci-failure');
   });
 
@@ -388,7 +388,7 @@ describe('QueueView', () => {
       true,
     );
 
-    const start = within(screen.getByTestId('worker-row-autofix')).getByRole('button', { name: 'Start process' });
+    const start = within(screen.getByTestId('worker-row-autofix')).getByRole('button', { name: 'Enable worker' });
     expect(start).toBeDisabled();
     expect(start).toHaveAttribute('title', 'Read-only window');
   });

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -42,8 +42,8 @@ function activityExplanation(worker: WorkerStatusEntry, lifecycle: string): stri
   const action = getActiveWorkerAction(worker);
   if (action) return `Active work: ${formatWorkerValue(action.actionType)} · ${formatWorkerValue(action.status)}`;
   if (lifecycle === 'running') return getWorkerDisplayCopy(worker.kind).idleText;
-  if (lifecycle === 'exited') return 'Process exited. Start it to create a fresh runtime.';
-  return 'Process stopped. Start it to listen for work.';
+  if (lifecycle === 'exited') return 'Process exited. Enable it to create a fresh runtime.';
+  return 'Worker disabled. Enable it to listen for work.';
 }
 
 export function WorkerActivityCard({
@@ -99,7 +99,7 @@ export function WorkerActivityCard({
     <div data-testid="worker-activity-card">
       <div className="mb-4">
         <h3 className="text-lg font-semibold text-foreground">Worker processes ({snapshot?.workers.length ?? 0})</h3>
-        <div className="mt-1 text-sm text-muted-foreground">Process status is separate from queue work. A running process can be idle.</div>
+        <div className="mt-1 text-sm text-muted-foreground">Enabled workers are restored on launch. A running process can be idle.</div>
       </div>
 
       {!snapshot ? (
@@ -114,6 +114,7 @@ export function WorkerActivityCard({
             const pending = Boolean(pendingByKind[worker.kind]);
             const isControlDisabled = Boolean(disabledTitle) || pending;
             const selected = selectedWorkerKind === worker.kind;
+            const launchesOnStart = worker.desiredEnabled ?? worker.autoStarts;
             const footer = worker.kind === 'pr-status'
               ? 'No queue task is expected for this worker.'
               : selected
@@ -158,9 +159,9 @@ export function WorkerActivityCard({
                           {formatWorkerValue(worker.policy)}{worker.policyReason ? ` · ${worker.policyReason}` : ''}
                         </span>
                       )}
-                      {worker.autoStarts && (
+                      {launchesOnStart && (
                         <span className="rounded-full border border-border-strong bg-accent/30 px-2 py-0.5 text-[11px] text-muted-foreground">
-                          Auto-starts
+                          Starts on launch
                         </span>
                       )}
                     </div>
@@ -193,7 +194,7 @@ export function WorkerActivityCard({
                       });
                     }}
                   >
-                    {pending ? (showStart ? 'Starting…' : 'Stopping…') : showStart ? 'Start process' : 'Stop process'}
+                    {pending ? (showStart ? 'Enabling…' : 'Disabling…') : showStart ? 'Enable worker' : 'Disable worker'}
                   </button>
                 </div>
               </div>

--- a/packages/ui/src/components/icons/index.tsx
+++ b/packages/ui/src/components/icons/index.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from 'react';
 import {
   AlertTriangle,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   Clock,
@@ -10,6 +11,7 @@ import {
   GitPullRequest,
   Layers,
   Moon,
+  Play,
   Settings,
   Sun,
   TerminalSquare,
@@ -40,6 +42,8 @@ export const SettingsIcon = withDefaults(Settings);
 export const InvokerIcon = withDefaults(Compass);
 export const ChevronLeftIcon = withDefaults(ChevronLeft);
 export const ChevronRightIcon = withDefaults(ChevronRight);
+export const ChevronDownIcon = withDefaults(ChevronDown);
+export const PlayIcon = withDefaults(Play);
 export const GitPullRequestIcon = withDefaults(GitPullRequest);
 export const GitMergeIcon = withDefaults(GitMerge);
 export const SunIcon = withDefaults(Sun);

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1379,9 +1379,7 @@ export class Orchestrator {
     this.pruneLaunchDeferrals();
 
     const activeAttempts = this.countActivePersistedAttempts();
-    const readyTasks = this.stateMachine
-      .getReadyTasks()
-      .filter((task) => this.getExternalDependencyBlocker(task) === undefined);
+    const readyTasks = this.getExecutableReadyTasks();
     this.logger.info('[orchestrator] startExecution', {
       ready: readyTasks.length,
       active: activeAttempts,
@@ -2957,6 +2955,12 @@ export class Orchestrator {
 
   getReadyTasks(): TaskState[] {
     return this.stateMachine.getReadyTasks();
+  }
+
+  getExecutableReadyTasks(): TaskState[] {
+    return this.stateMachine
+      .getReadyTasks()
+      .filter((task) => this.getExternalDependencyBlocker(task) === undefined);
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds one recovery action for ready Invoker work.

The primary UI action starts tasks that can run now.

The adjacent dropdown previews a broader recovery that also recreates failed work before execution.

The existing workflow resume worker now asks for the same start-ready action when pending work becomes locally runnable.

Worker enablement now persists as desired state, so toggles survive restart instead of being rebuilt from defaults.

## Review Claim

The reviewer is approving one start-ready recovery affordance shared by the UI, headless command, and workflow resume worker.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The default action only starts ready tasks that can run now. Failed-work recreation remains behind the dropdown preview and an explicit confirmation.

## Slice Rationale

This ships as one user-facing recovery affordance because the UI button, CLI command, IPC surface, and worker trigger must agree on the same semantics.

## Non-goals

- This does not automatically recreate failed work from the worker.
- This does not change review-gate approval behavior.
- This does not change worker execution limits.
- This does not make web clients mutate workflows.

## Architecture

### Before

```mermaid
graph TD
    A["UI resume action"] --> B["resume workflow IPC"]
    C["workflow resume worker"] --> B
    D["worker toggles"] --> E["process-local default state"]
```

### After

```mermaid
graph TD
    A["Start ready UI action"] --> B["start-ready IPC"]
    C["start-ready CLI command"] --> B
    D["workflow resume worker"] --> B
    B --> E["shared start-ready planner"]
    F["worker toggles"] --> G["persisted desired state"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm exec vitest run src/__tests__/start-ready.test.ts src/__tests__/worker-control.test.ts src/__tests__/gui-mutation-translation.test.ts src/__tests__/persisted-workflow-mutation-coordinator.test.ts` from `packages/app`
- [x] `pnpm exec vitest run src/__tests__/workflow-resume-worker.test.ts` from `packages/execution-engine`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sqlite-adapter.test.ts`
- [x] `pnpm exec vitest run src/__tests__/queue-view.test.tsx` from `packages/ui`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/ui build`
- [x] `bash scripts/ui-visual-proof.sh capture-after --spec start-ready-visual-proof.spec.ts --output-dir /tmp/start-ready-pr-proof`

</details>

## Visual Proof

The walkthrough shows the new start-ready split button, its dropdown option, and the recreate preview dialog.

[start-ready walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260714-933de7/walkthrough.webm)

The dropdown screenshot shows `Start ready work` as the primary action and `Start and recreate failed...` in the adjacent menu.

![start ready dropdown](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260714-933de7/start-ready-dropdown.png)

The confirmation screenshot shows the dry-run preview counts before failed work is recreated.

![start ready recreate preview](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260714-933de7/start-ready-recreate-preview.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d6b6392e0`
- Post-revert steps: None
- Data migration? Yes. The `worker_desired_states` table can remain unused after revert.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Start ready work” controls with previews, dry-run support, recovery, and optional failed-workflow recreation.
  * Added the `start-ready` headless command and workflow automation.
  * Workers now remember enabled/disabled preferences and display “Starts on launch” status.
  * Updated worker controls with clearer Enable/Disable actions and status messaging.

* **Bug Fixes**
  * Start-ready processing now skips tasks with incomplete dependencies and coalesces duplicate requests.
  * Resume processing now targets actionable pending work more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->