### PR TITLE
[Start Ready](1) Define start-ready IPC contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -262,6 +262,7 @@ export interface WorkerStatusEntry {
   policy: WorkerPolicyStatus;
   policyReason?: string;
   autoStarts: boolean;
+  desiredEnabled?: boolean;
   startable: boolean;
   stoppable: boolean;
   controlDisabledReason?: string;
@@ -556,6 +557,30 @@ export interface WorkflowMutationAcceptedResult {
   channel: string;
 }
 
+export interface StartReadyRequest {
+  recreateFailed?: boolean;
+  dryRun?: boolean;
+}
+
+export interface StartReadyPreview {
+  readyTaskIds: string[];
+  recoverableTaskIds: string[];
+  failedWorkflowIds: string[];
+  skipped: {
+    awaitingApproval: number;
+    reviewReady: number;
+    blocked: number;
+    failedTasks: number;
+  };
+}
+
+export interface StartReadyResult {
+  preview: StartReadyPreview;
+  started: TaskState[];
+  recreatedWorkflowIds: string[];
+  dryRun: boolean;
+}
+
 export interface WorkflowMutationFailedEvent {
   intentId: number;
   workflowId: string;
@@ -834,6 +859,10 @@ export const IpcChannels = {
   'invoker:start': {} as {
     request: [];
     response: TaskState[];
+  },
+  'invoker:start-ready': {} as {
+    request: [request?: StartReadyRequest];
+    response: StartReadyResult;
   },
   'invoker:resume-workflow': {} as {
     request: [];


### PR DESCRIPTION
## Summary

Defines the shared contract for start-ready recovery.

The IPC registry now has a typed start-ready request and result.

Worker status entries can also report persisted desired-enabled state.

## Review Claim

The reviewer is approving the typed contract that later slices use for start-ready recovery.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The new fields are additive. Existing callers can ignore `desiredEnabled`, and no runtime handler changes in this slice.

## Slice Rationale

This contract lands first so later slices can use the same typed surface without mixing schema review with runtime behavior.

## Non-goals

- This does not start tasks.
- This does not change worker behavior.
- This does not add UI controls.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 717a81992`
- Post-revert steps: None
- Data migration? No

</details>
