### PR TITLE
[Start Ready](2) Add start-ready runtime path

### DIFF
--- a/packages/app/src/__tests__/gui-mutation-translation.test.ts
+++ b/packages/app/src/__tests__/gui-mutation-translation.test.ts
@@ -48,6 +48,7 @@ describe('GUI mutation translation', () => {
   it.each([
     'invoker:check-pr-statuses',
     'invoker:check-pr-status',
+    'invoker:start-ready',
   ])('routes %s to the owner GUI mutation handler', (channel) => {
     const translatorSource = getTranslatorSource();
     expect(translatorSource).toMatch(

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -741,6 +741,40 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(adapter.listWorkflowMutationIntents('wf-2')).toHaveLength(1);
   });
 
+  it('coalesces duplicate start-ready intents while queued', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
+
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async () => undefined,
+    );
+
+    const first = coordinator.submit(
+      'wf-1',
+      'normal',
+      'invoker:start-ready',
+      [{}],
+      { deferDrain: true },
+    );
+    const duplicates = Array.from({ length: 5 }, () =>
+      coordinator.submit(
+        'wf-1',
+        'normal',
+        'invoker:start-ready',
+        [{}],
+        { deferDrain: true },
+      ),
+    );
+
+    expect(new Set([first, ...duplicates])).toEqual(new Set([first]));
+    expect(adapter.listWorkflowMutationIntents('wf-1')).toHaveLength(1);
+  });
+
   it('requeues interrupted running workflow mutations on restart and drains persisted queued work', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);

--- a/packages/app/src/__tests__/start-ready.test.ts
+++ b/packages/app/src/__tests__/start-ready.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TaskState } from '@invoker/workflow-core';
+
+import { collectStartReadyPreview, runStartReady } from '../start-ready.js';
+
+function makeTask(
+  id: string,
+  status: TaskState['status'],
+  overrides: Partial<TaskState> = {},
+): TaskState {
+  return {
+    id,
+    description: id,
+    status,
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: id.split('/')[0] ?? 'wf-1' },
+    execution: {},
+    taskStateVersion: 1,
+    ...overrides,
+  } as TaskState;
+}
+
+function harness(initialTasks: TaskState[], readyTasks: TaskState[]) {
+  let tasks = [...initialTasks];
+  const orchestrator = {
+    syncAllFromDb: vi.fn(() => undefined),
+    getAllTasks: vi.fn(() => tasks),
+    getExecutableReadyTasks: vi.fn(() => readyTasks),
+    prepareTaskForNewAttempt: vi.fn((taskId: string) => {
+      tasks = tasks.map((task) => task.id === taskId
+        ? { ...task, status: 'pending' as TaskState['status'], execution: {} }
+        : task);
+      return tasks.find((task) => task.id === taskId) as TaskState;
+    }),
+    recreateWorkflow: vi.fn((workflowId: string) => {
+      const recreated = makeTask(`${workflowId}/recreated`, 'pending');
+      tasks = tasks.filter((task) => task.config.workflowId !== workflowId || task.status !== 'failed');
+      tasks.push(recreated);
+      readyTasks.push(recreated);
+      return [recreated];
+    }),
+    startExecution: vi.fn(() => [...readyTasks]),
+  };
+  return orchestrator;
+}
+
+describe('start-ready', () => {
+  it('previews ready, recoverable, failed, and gated work', () => {
+    const ready = makeTask('wf-1/ready', 'pending');
+    const recoverable = makeTask('wf-1/recoverable', 'pending', {
+      execution: { selectedAttemptId: 'attempt-1', phase: 'launching' },
+    });
+    const failed = makeTask('wf-2/failed', 'failed');
+    const approval = makeTask('wf-3/approval', 'awaiting_approval');
+    const blocked = makeTask('wf-4/blocked', 'blocked');
+    const orchestrator = harness([ready, recoverable, failed, approval, blocked], [ready]);
+
+    expect(collectStartReadyPreview(orchestrator)).toEqual({
+      readyTaskIds: ['wf-1/ready'],
+      recoverableTaskIds: ['wf-1/recoverable'],
+      failedWorkflowIds: ['wf-2'],
+      skipped: {
+        awaitingApproval: 1,
+        reviewReady: 0,
+        blocked: 1,
+        failedTasks: 1,
+      },
+    });
+  });
+
+  it('dry-run reports the preview without mutating work', () => {
+    const ready = makeTask('wf-1/ready', 'pending');
+    const recoverable = makeTask('wf-1/recoverable', 'running');
+    const orchestrator = harness([ready, recoverable], [ready]);
+
+    const result = runStartReady(orchestrator, { dryRun: true });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.started).toEqual([]);
+    expect(orchestrator.prepareTaskForNewAttempt).not.toHaveBeenCalled();
+    expect(orchestrator.startExecution).not.toHaveBeenCalled();
+  });
+
+  it('recovers interrupted claims and starts executable ready tasks', () => {
+    const ready = makeTask('wf-1/ready', 'pending');
+    const recoverable = makeTask('wf-1/recoverable', 'running');
+    const orchestrator = harness([ready, recoverable], [ready]);
+
+    const result = runStartReady(orchestrator);
+
+    expect(orchestrator.syncAllFromDb).toHaveBeenCalledTimes(1);
+    expect(orchestrator.prepareTaskForNewAttempt).toHaveBeenCalledWith('wf-1/recoverable', 'start_ready_recovery');
+    expect(orchestrator.startExecution).toHaveBeenCalledTimes(1);
+    expect(result.started.map((task) => task.id)).toEqual(['wf-1/ready']);
+  });
+
+  it('recreates failed workflows only when requested', () => {
+    const failed = makeTask('wf-1/failed', 'failed');
+    const orchestrator = harness([failed], []);
+
+    const result = runStartReady(orchestrator, { recreateFailed: true });
+
+    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(result.recreatedWorkflowIds).toEqual(['wf-1']);
+    expect(result.started.map((task) => task.id)).toEqual(['wf-1/recreated']);
+  });
+});

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -50,12 +50,29 @@ function runtime(kind: string): TestWorkerRuntime {
   };
 }
 
-function persistence() {
+function persistence(initialDesired: Record<string, boolean> = {}) {
+  const desired = new Map(Object.entries(initialDesired));
   return {
     listWorkerActions: vi.fn(() => []),
     listWorkflows: vi.fn(() => []),
     loadTasks: vi.fn(() => []),
     getEvents: vi.fn(() => []),
+    getEventsByTypes: vi.fn(() => []),
+    countEventsByTypes: vi.fn(() => []),
+    getWorkerDesiredState: vi.fn((workerKind: string) => (
+      desired.has(workerKind)
+        ? { workerKind, desiredEnabled: desired.get(workerKind) === true, updatedAt: '2026-01-01T00:00:00.000Z' }
+        : undefined
+    )),
+    setWorkerDesiredState: vi.fn((workerKind: string, desiredEnabled: boolean) => {
+      desired.set(workerKind, desiredEnabled);
+      return { workerKind, desiredEnabled, updatedAt: '2026-01-01T00:00:00.000Z' };
+    }),
+    listWorkerDesiredStates: vi.fn(() => Array.from(desired.entries()).map(([workerKind, desiredEnabled]) => ({
+      workerKind,
+      desiredEnabled,
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    }))),
   };
 }
 
@@ -72,9 +89,13 @@ function deps(): WorkerRuntimeDependencies {
   } as WorkerRuntimeDependencies;
 }
 
-function controller(autoStartKinds: readonly string[] = AUTO_STARTED_OWNER_WORKER_KINDS) {
+function controller(
+  autoStartKinds: readonly string[] = AUTO_STARTED_OWNER_WORKER_KINDS,
+  desiredState: Record<string, boolean> = {},
+) {
   const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
   const runtimes = new Map<string, TestWorkerRuntime[]>();
+  const store = persistence(desiredState);
   const register = (kind: string, note: string, runtimeKind = kind) => {
     registry.register({
       kind,
@@ -99,11 +120,12 @@ function controller(autoStartKinds: readonly string[] = AUTO_STARTED_OWNER_WORKE
 
   return {
     runtimes,
+    persistence: store,
     controller: createWorkerRuntimeController({
       registry,
       deps: deps(),
       autoStartKinds,
-      persistence: persistence() as never,
+      persistence: store as never,
       canControl: () => true,
     }),
   };
@@ -124,6 +146,43 @@ describe('createWorkerRuntimeController', () => {
     expect(snapshot.workers.find((worker) => worker.kind === WORKFLOW_RESUME_WORKER_KIND)?.startable).toBe(true);
     expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)?.lifecycle).toBe('stopped');
     expect(snapshot.workers.find((worker) => worker.kind === 'external-preview')?.lifecycle).toBe('stopped');
+  });
+
+  it('restores saved desired worker states over built-in launch defaults', () => {
+    const setup = controller(AUTO_STARTED_OWNER_WORKER_KINDS, {
+      [PR_STATUS_WORKER_KIND]: false,
+      [WORKFLOW_RESUME_WORKER_KIND]: true,
+    });
+
+    setup.controller.startAutoStartedWorkers();
+    const snapshot = setup.controller.snapshot();
+
+    expect(snapshot.workers.find((worker) => worker.kind === PR_STATUS_WORKER_KIND)).toMatchObject({
+      lifecycle: 'stopped',
+      desiredEnabled: false,
+      autoStarts: false,
+    });
+    expect(snapshot.workers.find((worker) => worker.kind === WORKFLOW_RESUME_WORKER_KIND)).toMatchObject({
+      lifecycle: 'running',
+      desiredEnabled: true,
+      autoStarts: true,
+    });
+    expect(setup.persistence.setWorkerDesiredState).not.toHaveBeenCalled();
+  });
+
+  it('persists manual worker enable and disable state', async () => {
+    const setup = controller();
+
+    setup.controller.start(WORKFLOW_RESUME_WORKER_KIND);
+    await setup.controller.stop(WORKFLOW_RESUME_WORKER_KIND);
+
+    expect(setup.persistence.setWorkerDesiredState).toHaveBeenNthCalledWith(1, WORKFLOW_RESUME_WORKER_KIND, true);
+    expect(setup.persistence.setWorkerDesiredState).toHaveBeenNthCalledWith(2, WORKFLOW_RESUME_WORKER_KIND, false);
+    expect(setup.controller.snapshot().workers.find((worker) => worker.kind === WORKFLOW_RESUME_WORKER_KIND)).toMatchObject({
+      lifecycle: 'stopped',
+      desiredEnabled: false,
+      autoStarts: false,
+    });
   });
 
   it('auto-starts e2e-autofix only when its kind is in autoStartKinds', () => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -92,6 +92,8 @@ import type {
   InAppPlanningResetRequest,
   InAppPlanningSubmitRequest,
   Logger,
+  StartReadyRequest,
+  StartReadyResult,
   WorkflowMeta,
   WorkflowMutationAcceptedResult,
   WorkResponse,
@@ -258,6 +260,7 @@ import {
   createWorkerRuntimeController,
   type WorkerRuntimeController,
 } from './worker-control.js';
+import { runStartReady } from './start-ready.js';
 import { startSurfaceEventRelay } from './surface-event-relay.js';
 import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
 import { buildWebInvokerDispatch } from './web/web-invoker-dispatch.js';
@@ -407,26 +410,6 @@ function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
     || task.status === 'fixing_with_ai'
     || (task.status === 'pending' && task.execution.phase === 'launching');
-}
-
-function isTaskRecoverableOnExplicitResume(task: TaskState): boolean {
-  if (task.status === 'running') return true;
-  if (task.status !== 'pending' || !task.execution.selectedAttemptId) return false;
-  if (task.execution.phase === 'launching') return true;
-
-  return Boolean(
-    task.execution.startedAt
-    || task.execution.launchStartedAt
-    || task.execution.launchCompletedAt
-    || task.execution.lastHeartbeatAt
-    || task.execution.workspacePath
-    || task.execution.agentSessionId
-    || task.execution.containerId
-    || task.execution.error
-    || task.execution.exitCode !== undefined
-    || task.execution.inputPrompt
-    || task.execution.pendingFixError,
-  );
 }
 
 declare const __BUILD_SHA__: string | undefined;
@@ -1547,6 +1530,11 @@ function startHeadlessMode(): void {
             });
             return { ok: true };
           });
+        }
+        if (!workflowMutationDispatcher.has('invoker:start-ready')) {
+          workflowMutationDispatcher.set('invoker:start-ready', async (requestArg: unknown) =>
+            runStartReady(orchestrator, requestArg as StartReadyRequest | undefined),
+          );
         }
         if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
           workflowMutationDispatcher.set('invoker:fix-with-agent', async (...fixArgs: unknown[]) => {
@@ -2845,6 +2833,8 @@ function createEmbeddedTerminalBackendFromConfig(
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:start':
         return { channel: 'headless.gui-mutation', request: payload };
+      case 'invoker:start-ready':
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:stop':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:clear':
@@ -3210,6 +3200,28 @@ function createEmbeddedTerminalBackendFromConfig(
       }
       requestWorkflowMetadataPublish('orchestrator-snapshot');
     }
+  }
+
+  function executeStartReady(request: StartReadyRequest = {}): StartReadyResult {
+    const result = runStartReady(orchestrator, request);
+    if (!result.dryRun) {
+      publishOrchestratorSnapshotToRenderer();
+    }
+    logger.info(
+      `start-ready: ready=${result.preview.readyTaskIds.length} recoverable=${result.preview.recoverableTaskIds.length} failedWorkflows=${result.preview.failedWorkflowIds.length} recreated=${result.recreatedWorkflowIds.length} started=${result.started.length} dryRun=${result.dryRun ? 'true' : 'false'}`,
+      { module: 'ipc' },
+    );
+    if (!result.dryRun && result.started.length > 0 && launchDispatcher) {
+      try {
+        launchDispatcher.poll();
+      } catch (err) {
+        logger.warn(
+          `start-ready: launch dispatcher poll failed: ${err instanceof Error ? err.message : String(err)}`,
+          { module: 'ipc' },
+        );
+      }
+    }
+    return result;
   }
 
   function startDeferredStartupWork(): void {
@@ -3626,6 +3638,9 @@ function createEmbeddedTerminalBackendFromConfig(
       workflowMutationDispatcher.set('headless.exec', async (payloadArg: unknown) => {
         return executeHeadlessExec(payloadArg as HeadlessExecMutationPayload);
       });
+      workflowMutationDispatcher.set('invoker:start-ready', async (requestArg: unknown) =>
+        executeStartReady(requestArg as StartReadyRequest | undefined),
+      );
       workflowMutationDispatcher.set('api:approve-task', async (taskIdArg: unknown) => {
         await performSharedApproveTask(String(taskIdArg), 'api');
       });
@@ -4072,40 +4087,20 @@ function createEmbeddedTerminalBackendFromConfig(
       return started;
     });
 
+    registerGuiMutationHandler('invoker:start-ready', async (requestArg: unknown) => {
+      return executeStartReady(requestArg as StartReadyRequest | undefined);
+    });
+
     registerGuiMutationHandler('invoker:resume-workflow', async () => {
       const workflows = persistence.listWorkflows();
       if (workflows.length === 0) {
         logger.info('resume-workflow: no workflows found', { module: 'ipc' });
         return null;
       }
-      orchestrator.syncAllFromDb();
-
-      const tasksToRecover = orchestrator.getAllTasks().filter(isTaskRecoverableOnExplicitResume);
-      for (const task of tasksToRecover) {
-        orchestrator.prepareTaskForNewAttempt(task.id, 'resume_workflow_recovery');
-      }
-
-      const allStarted = orchestrator.startExecution();
+      const result = executeStartReady({});
       const tasks = orchestrator.getAllTasks();
-      workflowRollupProjection.replaceAll(tasks);
-      for (const task of tasks) {
-        lastKnownTaskStates.set(task.id, JSON.stringify(task));
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          publishTaskDeltaToRenderer({ type: 'created', task });
-        }
-      }
-      logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${allStarted.length} started`, { module: 'ipc' });
-      if (allStarted.length > 0 && launchDispatcher) {
-        try {
-          launchDispatcher.poll();
-        } catch (err) {
-          logger.warn(
-            `resume-workflow: launch dispatcher poll failed: ${err instanceof Error ? err.message : String(err)}`,
-            { module: 'ipc' },
-          );
-        }
-      }
-      return { workflow: workflows[0], taskCount: tasks.length, startedCount: allStarted.length };
+      logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${result.started.length} started`, { module: 'ipc' });
+      return { workflow: workflows[0], taskCount: tasks.length, startedCount: result.started.length };
     });
 
     registerGuiMutationHandler('invoker:stop', async () => {

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -213,6 +213,9 @@ export class PersistedWorkflowMutationCoordinator {
   }
 
   private coalescibleRetryKey(channel: string, args: unknown[]): string | null {
+    if (channel === 'invoker:start-ready') {
+      return 'start-ready';
+    }
     if (channel === 'invoker:retry-workflow') {
       const target = typeof args[0] === 'string' ? args[0] : '';
       return /^wf-[^/]+$/.test(target) ? `retry-workflow:${target}` : null;
@@ -224,6 +227,9 @@ export class PersistedWorkflowMutationCoordinator {
     const rawArgs = Array.isArray(payload?.args) ? payload.args : [];
     const command = typeof rawArgs[0] === 'string' ? rawArgs[0] : '';
     const target = typeof rawArgs[1] === 'string' ? rawArgs[1] : '';
+    if (command === 'start-ready') {
+      return 'start-ready';
+    }
     if (command !== 'retry' || !/^wf-[^/]+$/.test(target)) {
       return null;
     }

--- a/packages/app/src/start-ready.ts
+++ b/packages/app/src/start-ready.ts
@@ -1,0 +1,115 @@
+import type {
+  StartReadyPreview,
+  StartReadyRequest,
+  StartReadyResult,
+} from '@invoker/contracts';
+import type { Orchestrator, TaskState } from '@invoker/workflow-core';
+
+type StartReadyOrchestrator = Pick<
+  Orchestrator,
+  | 'syncAllFromDb'
+  | 'getAllTasks'
+  | 'getExecutableReadyTasks'
+  | 'prepareTaskForNewAttempt'
+  | 'recreateWorkflow'
+  | 'startExecution'
+>;
+
+export function isTaskRecoverableOnExplicitResume(task: TaskState): boolean {
+  if (task.status === 'running') return true;
+  if (task.status !== 'pending' || !task.execution.selectedAttemptId) return false;
+  if (task.execution.phase === 'launching') return true;
+
+  return Boolean(
+    task.execution.startedAt
+    || task.execution.launchStartedAt
+    || task.execution.launchCompletedAt
+    || task.execution.lastHeartbeatAt
+    || task.execution.workspacePath
+    || task.execution.agentSessionId
+    || task.execution.containerId
+    || task.execution.error
+    || task.execution.exitCode !== undefined
+    || task.execution.inputPrompt
+    || task.execution.pendingFixError,
+  );
+}
+
+function uniqueWorkflowIds(tasks: readonly TaskState[]): string[] {
+  const ids = new Set<string>();
+  for (const task of tasks) {
+    if (task.config.workflowId) ids.add(task.config.workflowId);
+  }
+  return Array.from(ids);
+}
+
+function uniqueTasks(tasks: readonly TaskState[]): TaskState[] {
+  const seen = new Set<string>();
+  const result: TaskState[] = [];
+  for (const task of tasks) {
+    const attemptId = task.execution.selectedAttemptId?.trim();
+    const key = attemptId ? `${task.id}:${attemptId}` : task.id;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(task);
+  }
+  return result;
+}
+
+export function collectStartReadyPreview(orchestrator: StartReadyOrchestrator): StartReadyPreview {
+  const tasks = orchestrator.getAllTasks();
+  const readyTasks = orchestrator.getExecutableReadyTasks();
+  const recoverableTasks = tasks.filter(isTaskRecoverableOnExplicitResume);
+  const failedTasks = tasks.filter((task) => task.status === 'failed');
+
+  return {
+    readyTaskIds: readyTasks.map((task) => task.id),
+    recoverableTaskIds: recoverableTasks.map((task) => task.id),
+    failedWorkflowIds: uniqueWorkflowIds(failedTasks),
+    skipped: {
+      awaitingApproval: tasks.filter((task) => task.status === 'awaiting_approval').length,
+      reviewReady: tasks.filter((task) => task.status === 'review_ready').length,
+      blocked: tasks.filter((task) => task.status === 'blocked' || task.status === 'needs_input').length,
+      failedTasks: failedTasks.length,
+    },
+  };
+}
+
+export function runStartReady(
+  orchestrator: StartReadyOrchestrator,
+  request: StartReadyRequest = {},
+): StartReadyResult {
+  orchestrator.syncAllFromDb();
+  const preview = collectStartReadyPreview(orchestrator);
+  if (request.dryRun) {
+    return {
+      preview,
+      started: [],
+      recreatedWorkflowIds: [],
+      dryRun: true,
+    };
+  }
+
+  const started: TaskState[] = [];
+  const recreatedWorkflowIds: string[] = [];
+  if (request.recreateFailed) {
+    for (const workflowId of preview.failedWorkflowIds) {
+      started.push(...orchestrator.recreateWorkflow(workflowId));
+      recreatedWorkflowIds.push(workflowId);
+    }
+  }
+
+  const recoverableTasks = orchestrator.getAllTasks().filter(isTaskRecoverableOnExplicitResume);
+  for (const task of recoverableTasks) {
+    orchestrator.prepareTaskForNewAttempt(task.id, 'start_ready_recovery');
+  }
+
+  started.push(...orchestrator.startExecution());
+
+  return {
+    preview,
+    started: uniqueTasks(started),
+    recreatedWorkflowIds,
+    dryRun: false,
+  };
+}

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -258,6 +258,7 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       case 'invoker:replace-task':
       case 'invoker:load-plan':
       case 'invoker:start':
+      case 'invoker:start-ready':
       case 'invoker:stop':
       case 'invoker:clear':
       case 'invoker:resume-workflow':

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -20,6 +20,7 @@ import {
   PR_CONFLICT_REBASE_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
   REQUEUE_WORKER_KIND,
+  WORKFLOW_RESUME_WORKER_KIND,
   type WorkerRegistry,
   type WorkerRuntime,
   type WorkerRuntimeDependencies,
@@ -40,7 +41,7 @@ export const AUTO_STARTED_OWNER_WORKER_KINDS = [
 
 export interface WorkerRuntimeController {
   startAutoStartedWorkers(): void;
-  start(kind: string): WorkerStatusEntry;
+  start(kind: string, options?: { persistDesiredState?: boolean }): WorkerStatusEntry;
   stop(kind: string): Promise<WorkerStatusEntry>;
   stopAll(): Promise<void>;
   snapshot(): WorkerStatusSnapshot;
@@ -49,7 +50,7 @@ export interface WorkerRuntimeController {
 type WorkerStatusPersistence = Pick<
   SQLiteAdapter,
   'listWorkerActions' | 'listWorkflows' | 'loadTasks' | 'getEvents' | 'getEventsByTypes' | 'countEventsByTypes'
->;
+> & Partial<Pick<SQLiteAdapter, 'getWorkerDesiredState' | 'setWorkerDesiredState' | 'listWorkerDesiredStates'>>;
 
 const DEFAULT_WORKER_ACTION_HISTORY_LIMIT = 20;
 const MAX_WORKER_ACTION_HISTORY_LIMIT = 100;
@@ -165,6 +166,7 @@ const BUILT_IN_WORKER_KINDS = new Set<string>([
   AUTO_APPROVE_WORKER_KIND,
   CODERABBIT_ADDRESS_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
+  WORKFLOW_RESUME_WORKER_KIND,
 ]);
 
 export function createWorkerRuntimeController(options: {
@@ -187,17 +189,24 @@ export function createWorkerRuntimeController(options: {
     return definition;
   };
 
+  const desiredEnabledForKind = (kind: string): boolean => {
+    const saved = options.persistence.getWorkerDesiredState?.(kind);
+    return saved?.desiredEnabled ?? options.autoStartKinds.includes(kind);
+  };
+
   const rowForKind = (kind: string): WorkerStatusEntry => {
     const definition = options.registry.get(kind);
     if (!definition) {
       throw new Error(`Unknown worker kind: "${kind}"`);
     }
+    const desiredEnabled = desiredEnabledForKind(kind);
     return buildWorkerStatusEntry({
       definitionKind: definition.kind,
       note: definition.note,
       handle: handles.get(kind),
       stoppedAt: stoppedAtByKind.get(kind),
-      autoStarts: options.autoStartKinds.includes(kind),
+      autoStarts: desiredEnabled,
+      desiredEnabled,
       policy: policyForKind(kind),
       persistence: options.persistence,
       canControl: options.canControl(),
@@ -220,14 +229,17 @@ export function createWorkerRuntimeController(options: {
 
   return {
     startAutoStartedWorkers(): void {
-      for (const kind of options.autoStartKinds) {
-        if (!options.registry.get(kind)) continue;
-        this.start(kind);
+      for (const definition of options.registry.list()) {
+        if (!desiredEnabledForKind(definition.kind)) continue;
+        this.start(definition.kind, { persistDesiredState: false });
       }
     },
 
-    start(kind: string): WorkerStatusEntry {
+    start(kind: string, optionsArg?: { persistDesiredState?: boolean }): WorkerStatusEntry {
       const definition = requireDefinition(kind);
+      if (optionsArg?.persistDesiredState !== false) {
+        options.persistence.setWorkerDesiredState?.(kind, true);
+      }
 
       const existing = handles.get(kind);
       if (existing) {
@@ -249,6 +261,7 @@ export function createWorkerRuntimeController(options: {
     },
     async stop(kind: string): Promise<WorkerStatusEntry> {
       requireDefinition(kind);
+      options.persistence.setWorkerDesiredState?.(kind, false);
       const handle = handles.get(kind);
       if (!handle) {
         return rowForKind(kind);
@@ -282,15 +295,20 @@ export function createLocalWorkerStatusSnapshot(options: {
     : undefined;
   return {
     generatedAt: new Date().toISOString(),
-    workers: options.registry.list().map((definition) => buildWorkerStatusEntry({
-      definitionKind: definition.kind,
-      note: definition.note,
-      autoStarts: options.autoStartKinds.includes(definition.kind),
-      policy: 'unknown',
-      persistence: options.persistence,
-      canControl: false,
-      recovery: definition.kind === AUTO_FIX_WORKER_KIND ? recovery : undefined,
-    })),
+    workers: options.registry.list().map((definition) => {
+      const desiredEnabled = options.persistence.getWorkerDesiredState?.(definition.kind)?.desiredEnabled
+        ?? options.autoStartKinds.includes(definition.kind);
+      return buildWorkerStatusEntry({
+        definitionKind: definition.kind,
+        note: definition.note,
+        autoStarts: desiredEnabled,
+        desiredEnabled,
+        policy: 'unknown',
+        persistence: options.persistence,
+        canControl: false,
+        recovery: definition.kind === AUTO_FIX_WORKER_KIND ? recovery : undefined,
+      });
+    }),
   };
 }
 
@@ -301,6 +319,7 @@ function buildWorkerStatusEntry(args: {
   handle?: RuntimeHandle;
   stoppedAt?: string;
   autoStarts: boolean;
+  desiredEnabled: boolean;
   policy: WorkerPolicyStatus;
   persistence: WorkerStatusPersistence;
   canControl: boolean;
@@ -318,6 +337,7 @@ function buildWorkerStatusEntry(args: {
     lifecycle,
     policy: args.policy,
     autoStarts: args.autoStarts,
+    desiredEnabled: args.desiredEnabled,
     startable: lifecycle !== 'running' && args.policy !== 'disabled' && args.canControl,
     stoppable: lifecycle === 'running' && args.canControl,
     ...(controlDisabledReason ? { controlDisabledReason } : {}),

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -262,6 +262,7 @@ export interface WorkerStatusEntry {
   policy: WorkerPolicyStatus;
   policyReason?: string;
   autoStarts: boolean;
+  desiredEnabled?: boolean;
   startable: boolean;
   stoppable: boolean;
   controlDisabledReason?: string;
@@ -556,6 +557,30 @@ export interface WorkflowMutationAcceptedResult {
   channel: string;
 }
 
+export interface StartReadyRequest {
+  recreateFailed?: boolean;
+  dryRun?: boolean;
+}
+
+export interface StartReadyPreview {
+  readyTaskIds: string[];
+  recoverableTaskIds: string[];
+  failedWorkflowIds: string[];
+  skipped: {
+    awaitingApproval: number;
+    reviewReady: number;
+    blocked: number;
+    failedTasks: number;
+  };
+}
+
+export interface StartReadyResult {
+  preview: StartReadyPreview;
+  started: TaskState[];
+  recreatedWorkflowIds: string[];
+  dryRun: boolean;
+}
+
 export interface WorkflowMutationFailedEvent {
   intentId: number;
   workflowId: string;
@@ -834,6 +859,10 @@ export const IpcChannels = {
   'invoker:start': {} as {
     request: [];
     response: TaskState[];
+  },
+  'invoker:start-ready': {} as {
+    request: [request?: StartReadyRequest];
+    response: StartReadyResult;
   },
   'invoker:resume-workflow': {} as {
     request: [];

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -697,6 +697,11 @@ describe('SQLiteAdapter', () => {
         'workflows.id:CASCADE',
         'tasks.id:CASCADE',
       ]));
+      expect(tableColumns(adapter, 'worker_desired_states')).toEqual(expect.arrayContaining([
+        'worker_kind',
+        'desired_enabled',
+        'updated_at',
+      ]));
     });
 
     it('does not create auto_fix_attempts on fresh task tables', () => {
@@ -859,6 +864,26 @@ describe('SQLiteAdapter', () => {
 
       expect(adapter.listWorkerActions({ decision: 'skip' }).map((action) => action.id)).toEqual(['wa-skip']);
       expect(adapter.listWorkerActions({ decision: 'act' }).map((action) => action.id)).toEqual(['wa-done', 'wa-act']);
+    });
+
+    it('persists worker desired states', () => {
+      expect(adapter.getWorkerDesiredState('workflow-resume')).toBeUndefined();
+
+      expect(adapter.setWorkerDesiredState('workflow-resume', true)).toMatchObject({
+        workerKind: 'workflow-resume',
+        desiredEnabled: true,
+      });
+      expect(adapter.getWorkerDesiredState('workflow-resume')).toMatchObject({
+        workerKind: 'workflow-resume',
+        desiredEnabled: true,
+      });
+
+      adapter.setWorkerDesiredState('workflow-resume', false);
+      adapter.setWorkerDesiredState('pr-status', true);
+      expect(adapter.listWorkerDesiredStates()).toEqual([
+        expect.objectContaining({ workerKind: 'pr-status', desiredEnabled: true }),
+        expect.objectContaining({ workerKind: 'workflow-resume', desiredEnabled: false }),
+      ]);
     });
   });
 

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -164,6 +164,12 @@ export interface WorkerActionRecord {
   completedAt?: string;
 }
 
+export interface WorkerDesiredStateRecord {
+  workerKind: string;
+  desiredEnabled: boolean;
+  updatedAt: string;
+}
+
 export interface WorkerActionWrite {
   /** Insert-only row id. Updates are keyed by workerKind/externalKey and reject a different id. */
   id: string;
@@ -301,6 +307,9 @@ export interface PersistenceAdapter {
   getWorkerAction(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
   upsertWorkerAction(action: WorkerActionWrite): WorkerActionRecord;
   listWorkerActions(filters?: WorkerActionListFilters): WorkerActionRecord[];
+  getWorkerDesiredState(workerKind: string): WorkerDesiredStateRecord | undefined;
+  setWorkerDesiredState(workerKind: string, desiredEnabled: boolean): WorkerDesiredStateRecord;
+  listWorkerDesiredStates(): WorkerDesiredStateRecord[];
 
   // Conversations (Slack thread-based)
   saveConversation(conversation: Conversation): void;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -47,6 +47,7 @@ import type {
   WorkerActionListFilters,
   WorkerActionRecord,
   WorkerActionWrite,
+  WorkerDesiredStateRecord,
   TerminalSessionPatch,
   TerminalSessionRecord,
   InAppPlanningSessionPatch,
@@ -1720,6 +1721,38 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return rows.map((row) => this.rowToWorkerAction(row));
   }
 
+  getWorkerDesiredState(workerKind: string): WorkerDesiredStateRecord | undefined {
+    const row = this.queryOne(
+      'SELECT worker_kind, desired_enabled, updated_at FROM worker_desired_states WHERE worker_kind = ?',
+      [workerKind],
+    );
+    return row ? this.rowToWorkerDesiredState(row) : undefined;
+  }
+
+  setWorkerDesiredState(workerKind: string, desiredEnabled: boolean): WorkerDesiredStateRecord {
+    const updatedAt = new Date().toISOString();
+    this.execRun(
+      `INSERT INTO worker_desired_states (worker_kind, desired_enabled, updated_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(worker_kind) DO UPDATE SET
+         desired_enabled = excluded.desired_enabled,
+         updated_at = excluded.updated_at`,
+      [workerKind, desiredEnabled ? 1 : 0, updatedAt],
+    );
+    const saved = this.getWorkerDesiredState(workerKind);
+    if (!saved) {
+      throw new Error(`Failed to persist worker desired state for ${workerKind}`);
+    }
+    return saved;
+  }
+
+  listWorkerDesiredStates(): WorkerDesiredStateRecord[] {
+    const rows = this.queryAll(
+      'SELECT worker_kind, desired_enabled, updated_at FROM worker_desired_states ORDER BY worker_kind ASC',
+    );
+    return rows.map((row) => this.rowToWorkerDesiredState(row));
+  }
+
   // ── Queries ─────────────────────────────────────────
 
   getSelectedExperiment(taskId: string): string | null {
@@ -3192,6 +3225,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   private rowToWorkerAction(row: Record<string, unknown>): WorkerActionRecord {
     return mapRowToWorkerAction(row);
+  }
+
+  private rowToWorkerDesiredState(row: Record<string, unknown>): WorkerDesiredStateRecord {
+    return {
+      workerKind: String(row.worker_kind),
+      desiredEnabled: Number(row.desired_enabled) !== 0,
+      updatedAt: String(row.updated_at),
+    };
   }
 
   private requeueWorkflowMutationLease(workflowId: string): void {

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -380,6 +380,12 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_worker_actions_kind_updated
         ON worker_actions(worker_kind, updated_at DESC, id);
 
+      CREATE TABLE IF NOT EXISTS worker_desired_states (
+        worker_kind TEXT PRIMARY KEY,
+        desired_enabled INTEGER NOT NULL,
+        updated_at TEXT DEFAULT (datetime('now'))
+      );
+
       CREATE TABLE IF NOT EXISTS execution_resource_leases (
         resource_key TEXT NOT NULL,
         resource_type TEXT NOT NULL,
@@ -530,6 +536,11 @@ export const POST_MIGRATION_STATEMENTS = [
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_task_updated ON worker_actions(task_id, updated_at)',
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_workflow_status ON worker_actions(workflow_id, worker_kind, status)',
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_kind_updated ON worker_actions(worker_kind, updated_at DESC, id)',
+  `CREATE TABLE IF NOT EXISTS worker_desired_states (
+    worker_kind TEXT PRIMARY KEY,
+    desired_enabled INTEGER NOT NULL,
+    updated_at TEXT DEFAULT (datetime('now'))
+  )`,
   'DROP INDEX IF EXISTS idx_task_launch_dispatch_active_attempt',
   `
       CREATE UNIQUE INDEX IF NOT EXISTS idx_task_launch_dispatch_active_attempt

--- a/packages/execution-engine/src/__tests__/workflow-resume-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/workflow-resume-worker.test.ts
@@ -107,12 +107,12 @@ function harness(options: HarnessOptions = {}) {
 }
 
 describe('workflow resume worker tick', () => {
-  it('submits a retry for a workflow that has any non-terminal task', async () => {
+  it('submits start-ready for a workflow that has ready pending work', async () => {
     const h = harness({
       workflows: [
         {
           id: 'wf-1',
-          tasks: [makeTask({ status: 'running' as TaskState['status'] })],
+          tasks: [makeTask({ status: 'pending' as TaskState['status'] })],
         },
       ],
     });
@@ -122,7 +122,47 @@ describe('workflow resume worker tick', () => {
     expect(workflowId).toBe('wf-1');
     expect(priority).toBe('normal');
     expect(channel).toBe(WORKFLOW_RESUME_COMMAND_CHANNEL);
-    expect(args).toEqual(['wf-1']);
+    expect(args).toEqual([{}]);
+  });
+
+  it('skips pending work whose local dependencies are not completed', async () => {
+    const h = harness({
+      workflows: [
+        {
+          id: 'wf-1',
+          tasks: [
+            makeTask({ id: 'wf-1/a', status: 'running' as TaskState['status'] }),
+            makeTask({
+              id: 'wf-1/b',
+              status: 'pending' as TaskState['status'],
+              dependencies: ['wf-1/a'],
+            }),
+          ],
+        },
+      ],
+    });
+    await h.tick(POLL_CTX);
+    expect(h.submit).not.toHaveBeenCalled();
+  });
+
+  it('submits pending work when local dependencies are completed', async () => {
+    const h = harness({
+      workflows: [
+        {
+          id: 'wf-1',
+          tasks: [
+            makeTask({ id: 'wf-1/a', status: 'completed' as TaskState['status'] }),
+            makeTask({
+              id: 'wf-1/b',
+              status: 'pending' as TaskState['status'],
+              dependencies: ['wf-1/a'],
+            }),
+          ],
+        },
+      ],
+    });
+    await h.tick(POLL_CTX);
+    expect(h.submit).toHaveBeenCalledTimes(1);
   });
 
   it('skips workflows whose tasks are all terminal', async () => {
@@ -182,7 +222,7 @@ describe('workflow resume worker tick', () => {
     expect(h.submit).not.toHaveBeenCalled();
   });
 
-  it('still resumes a workflow with actionable pending work alongside a failed task', async () => {
+  it('still submits start-ready for pending work alongside a failed task', async () => {
     const h = harness({
       workflows: [
         {
@@ -270,7 +310,7 @@ describe('workflow resume worker tick', () => {
       'recovery.worker.submit',
       expect.objectContaining({
         worker: 'workflow-resume',
-        phase: 'retry-workflow',
+        phase: 'start-ready',
         workflowId: 'wf-1',
         channel: WORKFLOW_RESUME_COMMAND_CHANNEL,
         intentId: expect.any(Number),

--- a/packages/execution-engine/src/workers/workflow-resume-worker.ts
+++ b/packages/execution-engine/src/workers/workflow-resume-worker.ts
@@ -14,18 +14,10 @@ import type { WorkerRegistry } from '../worker-registry.js';
 
 export const WORKFLOW_RESUME_WORKER_KIND = 'workflow-resume';
 
-export const WORKFLOW_RESUME_COMMAND_CHANNEL = 'invoker:retry-workflow';
+export const WORKFLOW_RESUME_COMMAND_CHANNEL = 'invoker:start-ready';
 
 const DEFAULT_WORKFLOW_RESUME_POLL_INTERVAL_MS = 60_000;
 export const DEFAULT_WORKFLOW_RESUME_COOLDOWN_MS = 60_000;
-
-const TERMINAL_TASK_STATUSES: ReadonlySet<TaskState['status']> = new Set<TaskState['status']>([
-  'completed' as TaskState['status'],
-  'review_ready' as TaskState['status'],
-  'failed' as TaskState['status'],
-  'closed' as TaskState['status'],
-  'stale' as TaskState['status'],
-]);
 
 export interface WorkflowResumeWorkerStore {
   listWorkflows(): ReadonlyArray<{ id: string }>;
@@ -77,11 +69,18 @@ export function createWorkflowResumeCooldownLedger(): WorkflowResumeCooldownLedg
   };
 }
 
-function isWorkflowIncomplete(store: WorkflowResumeWorkerStore, workflowId: string): boolean {
+function hasLocallyReadyPendingTask(store: WorkflowResumeWorkerStore, workflowId: string): boolean {
   const tasks = store.loadTasks(workflowId);
   if (tasks.length === 0) return false;
+  const tasksById = new Map(tasks.map((task) => [task.id, task]));
   for (const task of tasks) {
-    if (!TERMINAL_TASK_STATUSES.has(task.status)) return true;
+    if (task.status !== 'pending') continue;
+    const dependencies = task.dependencies ?? [];
+    const localDependenciesSatisfied = dependencies.every((dependencyId) => {
+      const dependency = tasksById.get(dependencyId);
+      return dependency === undefined || dependency.status === 'completed';
+    });
+    if (localDependenciesSatisfied) return true;
   }
   return false;
 }
@@ -95,10 +94,10 @@ function collectWakeupWorkflowIds(hints: RecoveryWorkerWakeupHint[]): string[] {
   return Array.from(seen);
 }
 
-function listAllIncompleteWorkflowIds(store: WorkflowResumeWorkerStore): string[] {
+function listAllWorkflowsWithReadyPendingTasks(store: WorkflowResumeWorkerStore): string[] {
   const targets: string[] = [];
   for (const workflow of store.listWorkflows()) {
-    if (isWorkflowIncomplete(store, workflow.id)) {
+    if (hasLocallyReadyPendingTask(store, workflow.id)) {
       targets.push(workflow.id);
     }
   }
@@ -114,8 +113,8 @@ export function createWorkflowResumeTick(options: WorkflowResumeWorkerPolicyOpti
     const wakeupWorkflowIds = collectWakeupWorkflowIds(wakeups);
 
     const candidateIds = wakeupWorkflowIds.length > 0 && ctx.reason === 'wake'
-      ? wakeupWorkflowIds.filter((id) => isWorkflowIncomplete(options.store, id))
-      : listAllIncompleteWorkflowIds(options.store);
+      ? wakeupWorkflowIds.filter((id) => hasLocallyReadyPendingTask(options.store, id))
+      : listAllWorkflowsWithReadyPendingTasks(options.store);
 
     const submitted = new Set<string>();
     for (const workflowId of candidateIds) {
@@ -134,17 +133,17 @@ export function createWorkflowResumeTick(options: WorkflowResumeWorkerPolicyOpti
         workflowId,
         'normal',
         WORKFLOW_RESUME_COMMAND_CHANNEL,
-        [workflowId],
+        [{}],
       );
       options.ledger.markSubmitted(workflowId, nowMs + cooldownMs);
       options.store.logEvent?.(workflowId, 'recovery.worker.submit', {
         worker: WORKFLOW_RESUME_WORKER_KIND,
-        phase: 'retry-workflow',
+        phase: 'start-ready',
         workflowId,
         intentId,
         channel: WORKFLOW_RESUME_COMMAND_CHANNEL,
       });
-      options.logger.info(`[worker:${WORKFLOW_RESUME_WORKER_KIND}] submitted retry for incomplete workflow`, {
+      options.logger.info(`[worker:${WORKFLOW_RESUME_WORKER_KIND}] submitted start-ready for pending work`, {
         module: 'workflow-resume-worker',
         workflowId,
         intentId,
@@ -225,7 +224,7 @@ export function registerWorkflowResumeWorker(
 ): WorkerRegistry<WorkerRuntimeDependencies> {
   registry.register({
     kind: WORKFLOW_RESUME_WORKER_KIND,
-    note: 'Submits retry-workflow intents for workflows that have any non-terminal task.',
+    note: 'Submits start-ready intents when workflows have pending work ready to launch.',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
       createWorkflowResumeWorker({
         logger: deps.logger,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1379,9 +1379,7 @@ export class Orchestrator {
     this.pruneLaunchDeferrals();
 
     const activeAttempts = this.countActivePersistedAttempts();
-    const readyTasks = this.stateMachine
-      .getReadyTasks()
-      .filter((task) => this.getExternalDependencyBlocker(task) === undefined);
+    const readyTasks = this.getExecutableReadyTasks();
     this.logger.info('[orchestrator] startExecution', {
       ready: readyTasks.length,
       active: activeAttempts,
@@ -2957,6 +2955,12 @@ export class Orchestrator {
 
   getReadyTasks(): TaskState[] {
     return this.stateMachine.getReadyTasks();
+  }
+
+  getExecutableReadyTasks(): TaskState[] {
+    return this.stateMachine
+      .getReadyTasks()
+      .filter((task) => this.getExternalDependencyBlocker(task) === undefined);
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds the shared runtime path for start-ready recovery.

The runtime collects ready work that can run now and recoverable interrupted attempts.

Failed workflow recreation remains opt-in and is only performed when the caller asks for it.

The workflow resume worker now uses this runtime path when pending work has completed local prerequisites.

Worker desired-enabled state is stored in SQLite and restored on launch.

## Review Claim

The reviewer is approving the runtime behavior behind start-ready recovery.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The automatic worker path only starts ready work. Failed workflow recreation still requires an explicit caller option.

## Slice Rationale

This is separated from surfaces so runtime semantics can be reviewed independently.

## Non-goals

- This does not add new UI controls.
- This does not add a new headless entry point.
- This does not change review-gate approval behavior.

## Architecture

### Before

```mermaid
graph TD
    A["workflow resume worker"] --> B["resume workflow IPC"]
    C["worker toggles"] --> D["launch default state"]
```

### After

```mermaid
graph TD
    A["workflow resume worker"] --> B["start-ready IPC"]
    B --> C["shared start-ready runtime"]
    D["worker toggles"] --> E["persisted desired state"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm exec vitest run src/__tests__/start-ready.test.ts src/__tests__/worker-control.test.ts src/__tests__/gui-mutation-translation.test.ts src/__tests__/persisted-workflow-mutation-coordinator.test.ts` from `packages/app`
- [x] `pnpm exec vitest run src/__tests__/workflow-resume-worker.test.ts` from `packages/execution-engine`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sqlite-adapter.test.ts`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app build`

</details>

## Visual Proof

The runtime slice changes the Electron owner path used by the final surface. The walkthrough exercises that owner path in the built app.

[start-ready walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260714-933de7/walkthrough.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c546a8211`
- Post-revert steps: None
- Data migration? Yes. The `worker_desired_states` table can remain unused after revert.

</details>
