### PR TITLE
[Review Gate Recreate](2) Recreate workflows for merge conflict PRs

### DIFF
--- a/packages/app/src/__tests__/lifecycle-event-bridge.test.ts
+++ b/packages/app/src/__tests__/lifecycle-event-bridge.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../lifecycle-events.js';
 import {
   publishReviewGateCiFailedLifecycleEvent,
+  publishReviewGateMergeConflictLifecycleEvent,
   startLifecycleEventBridge,
 } from '../lifecycle-event-bridge.js';
 
@@ -305,6 +306,60 @@ describe('lifecycle event bridge', () => {
       attemptId: 'attempt-persisted',
     });
     expectRecoveryWakeup(events[0], { reason: 'review_gate_failure' });
+  });
+
+  it('publishes review-gate merge conflict wakeups with persisted task context', () => {
+    const bus = new LocalBus();
+    const events = collectLifecycleEvents(bus);
+    const task = makeTask({
+      id: 'wf-1/merge',
+      status: 'review_ready',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {
+        generation: 7,
+        selectedAttemptId: 'attempt-merge',
+        reviewId: '123',
+        branch: 'feature/merge-conflict',
+      },
+      taskStateVersion: 12,
+    });
+
+    const event = publishReviewGateMergeConflictLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'abc123',
+      headRef: 'feature/merge-conflict',
+      branch: 'feature/merge-conflict',
+      selectedAttemptId: 'attempt-merge',
+      generation: 7,
+      statusText: 'Awaiting review',
+    }, {
+      messageBus: bus,
+      getTask: () => task,
+      now: () => CREATED_AT_DATE,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toBe(event);
+    expect(events[0]).toMatchObject({
+      eventKey: 'review_gate.merge_conflict|workflow:wf-1|task:wf-1/merge|generation:7|attempt:attempt-merge|task-state:12|review:123:abc123',
+      kind: 'review_gate.merge_conflict',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      status: 'review_ready',
+      taskStateVersion: 12,
+      generation: 7,
+      attemptId: 'attempt-merge',
+      createdAt: CREATED_AT,
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'abc123',
+      statusText: 'Awaiting review',
+    });
+    expectRecoveryWakeup(events[0], { reason: 'review_gate_failure' });
+    expect(isWorkflowLifecycleEvent(events[0])).toBe(true);
   });
 
   it('unsubscribes cleanly', () => {

--- a/packages/app/src/__tests__/lifecycle-events.test.ts
+++ b/packages/app/src/__tests__/lifecycle-events.test.ts
@@ -4,6 +4,7 @@ import type { TaskDelta, TaskState } from '@invoker/workflow-core';
 import {
   buildLifecycleEventFromTaskDelta,
   buildReviewGateCiFailedLifecycleEvent,
+  buildReviewGateMergeConflictLifecycleEvent,
   buildTaskUpdatedLifecycleEvent,
   buildWorkflowWakeupLifecycleEvent,
   isTaskLifecycleEvent,
@@ -232,6 +233,42 @@ describe('lifecycle event helpers', () => {
     expect(event.failedChecks).toEqual([
       { name: 'test-all', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/runs/1' },
     ]);
+    expect(isWorkflowLifecycleEvent(event)).toBe(true);
+    expectRecoveryWakeup(event, { reason: 'review_gate_failure' });
+  });
+
+  it('builds review_gate.merge_conflict lifecycle wakeups', () => {
+    const event = buildReviewGateMergeConflictLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      status: 'review_ready',
+      taskStateVersion: 12,
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'abc123',
+      headRef: 'feature/merge-conflict',
+      branch: 'feature/merge-conflict',
+      statusText: 'Awaiting review',
+      generation: 7,
+      attemptId: 'attempt-merge',
+      createdAt: CREATED_AT_DATE,
+    });
+
+    expect(event).toMatchObject({
+      eventKey: 'review_gate.merge_conflict|workflow:wf-1|task:wf-1/merge|generation:7|attempt:attempt-merge|task-state:12|review:123:abc123',
+      kind: 'review_gate.merge_conflict',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      status: 'review_ready',
+      taskStateVersion: 12,
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'abc123',
+      generation: 7,
+      attemptId: 'attempt-merge',
+      createdAt: CREATED_AT,
+      statusText: 'Awaiting review',
+    });
     expect(isWorkflowLifecycleEvent(event)).toBe(true);
     expectRecoveryWakeup(event, { reason: 'review_gate_failure' });
   });

--- a/packages/app/src/__tests__/task-runner-wiring.test.ts
+++ b/packages/app/src/__tests__/task-runner-wiring.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TaskState } from '@invoker/workflow-core';
-import { publishReviewGateCiFailedLifecycleEvent } from '../lifecycle-event-bridge.js';
+import {
+  publishReviewGateCiFailedLifecycleEvent,
+  publishReviewGateMergeConflictLifecycleEvent,
+} from '../lifecycle-event-bridge.js';
 import { loadConfig, resolveSecretsFilePath } from '../config.js';
 import {
   killRunningTaskExecution,
@@ -45,6 +48,7 @@ vi.mock('@invoker/execution-engine', () => {
 
 vi.mock('../lifecycle-event-bridge.js', () => ({
   publishReviewGateCiFailedLifecycleEvent: vi.fn(),
+  publishReviewGateMergeConflictLifecycleEvent: vi.fn(),
 }));
 
 vi.mock('../config.js', () => ({
@@ -214,6 +218,12 @@ describe('task-runner-wiring', () => {
     const config = taskRunnerConstructor.mock.calls[0]?.[0] as any;
     await config.reviewGateCiFailurePublisher.publish({ taskId: 'merge-task' });
     expect(publishReviewGateCiFailedLifecycleEvent).toHaveBeenCalledWith(
+      { taskId: 'merge-task' },
+      expect.objectContaining({ messageBus: expect.any(Object), getTask: expect.any(Function) }),
+    );
+
+    await config.reviewGateMergeConflictPublisher.publish({ taskId: 'merge-task' });
+    expect(publishReviewGateMergeConflictLifecycleEvent).toHaveBeenCalledWith(
       { taskId: 'merge-task' },
       expect.objectContaining({ messageBus: expect.any(Object), getTask: expect.any(Function) }),
     );

--- a/packages/app/src/execution/task-runner-wiring.ts
+++ b/packages/app/src/execution/task-runner-wiring.ts
@@ -12,7 +12,10 @@ import {
 } from '@invoker/execution-engine';
 import type { Logger } from '@invoker/contracts';
 import { loadConfig, resolveDefaultTaskExecutionSettings, resolveSecretsFilePath, type InvokerConfig } from '../config.js';
-import { publishReviewGateCiFailedLifecycleEvent } from '../lifecycle-event-bridge.js';
+import {
+  publishReviewGateCiFailedLifecycleEvent,
+  publishReviewGateMergeConflictLifecycleEvent,
+} from '../lifecycle-event-bridge.js';
 
 export type TaskHandleMap = Map<string, { handle: ExecutorHandle; executor: Executor }>;
 
@@ -94,6 +97,14 @@ export function rebuildTaskRunner(deps: TaskRunnerWiringDeps): TaskRunner {
     reviewGateCiFailurePublisher: {
       publish: (trigger) => {
         publishReviewGateCiFailedLifecycleEvent(trigger, {
+          messageBus: deps.messageBus,
+          getTask: (taskId) => deps.orchestrator.getTask(taskId),
+        });
+      },
+    },
+    reviewGateMergeConflictPublisher: {
+      publish: (trigger) => {
+        publishReviewGateMergeConflictLifecycleEvent(trigger, {
           messageBus: deps.messageBus,
           getTask: (taskId) => deps.orchestrator.getTask(taskId),
         });

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -27,7 +27,10 @@ import {
 import { loadConfig, resolveSecretsFilePath, type InvokerConfig } from './config.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import { trackWorkflow } from './headless-watch.js';
-import { publishReviewGateCiFailedLifecycleEvent } from './lifecycle-event-bridge.js';
+import {
+  publishReviewGateCiFailedLifecycleEvent,
+  publishReviewGateMergeConflictLifecycleEvent,
+} from './lifecycle-event-bridge.js';
 import type { WorkflowCancelResult } from './workflow-preemption.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import type { RuntimeServices } from '@invoker/runtime-service';
@@ -158,6 +161,14 @@ export function createHeadlessExecutor(
     reviewGateCiFailurePublisher: {
       publish: (trigger) => {
         publishReviewGateCiFailedLifecycleEvent(trigger, {
+          messageBus: deps.messageBus,
+          getTask: (taskId) => deps.orchestrator.getTask(taskId),
+        });
+      },
+    },
+    reviewGateMergeConflictPublisher: {
+      publish: (trigger) => {
+        publishReviewGateMergeConflictLifecycleEvent(trigger, {
           messageBus: deps.messageBus,
           getTask: (taskId) => deps.orchestrator.getTask(taskId),
         });

--- a/packages/app/src/lifecycle-event-bridge.ts
+++ b/packages/app/src/lifecycle-event-bridge.ts
@@ -2,6 +2,7 @@ import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport'
 import type { TaskDelta, TaskState, TaskStatus } from '@invoker/workflow-core';
 import {
   buildReviewGateCiFailedLifecycleEvent,
+  buildReviewGateMergeConflictLifecycleEvent,
   buildTaskCreatedLifecycleEvent,
   buildTaskRemovedLifecycleEvent,
   buildTaskUpdatedLifecycleEvent,
@@ -44,6 +45,21 @@ export interface ReviewGateCiFailedWakeupInput {
   readonly selectedAttemptId?: string;
   readonly generation: number;
   readonly failedChecks: readonly ReviewGateFailedCheck[];
+  readonly statusText: string;
+}
+
+export interface ReviewGateMergeConflictWakeupInput {
+  readonly workflowId: string;
+  readonly taskId: string;
+  readonly status?: TaskStatus;
+  readonly taskStateVersion?: number;
+  readonly reviewId: string;
+  readonly reviewUrl: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
+  readonly branch?: string;
+  readonly selectedAttemptId?: string;
+  readonly generation: number;
   readonly statusText: string;
 }
 
@@ -94,6 +110,35 @@ export function publishReviewGateCiFailedLifecycleEvent(
     headRef: input.headRef,
     branch: input.branch,
     failedChecks: input.failedChecks,
+    statusText: input.statusText,
+    generation: input.generation,
+    attemptId,
+    createdAt: options.now?.(),
+  });
+  options.messageBus.publish(Channels.WORKFLOW_LIFECYCLE, event);
+  return event;
+}
+
+export function publishReviewGateMergeConflictLifecycleEvent(
+  input: ReviewGateMergeConflictWakeupInput,
+  options: Pick<LifecycleEventBridgeOptions, 'messageBus' | 'getTask' | 'now'>,
+): WorkflowLifecycleEvent | undefined {
+  const currentTask = options.getTask?.(input.taskId);
+  const status = input.status ?? currentTask?.status;
+  const taskStateVersion = input.taskStateVersion ?? currentTask?.taskStateVersion;
+  const attemptId = input.selectedAttemptId ?? currentTask?.execution.selectedAttemptId;
+  if (!status || taskStateVersion == null) return undefined;
+
+  const event = buildReviewGateMergeConflictLifecycleEvent({
+    workflowId: input.workflowId,
+    taskId: input.taskId,
+    status,
+    taskStateVersion,
+    reviewId: input.reviewId,
+    reviewUrl: input.reviewUrl,
+    headSha: input.headSha,
+    headRef: input.headRef,
+    branch: input.branch,
     statusText: input.statusText,
     generation: input.generation,
     attemptId,

--- a/packages/app/src/lifecycle-events.ts
+++ b/packages/app/src/lifecycle-events.ts
@@ -12,6 +12,7 @@ import {
   type TaskLifecycleEvent,
   type ReviewGateFailedCheck,
   type ReviewGateCiFailedLifecycleEvent,
+  type ReviewGateMergeConflictLifecycleEvent,
   type WorkflowWakeupLifecycleEvent,
   type RecoveryWorkerWakeupHint,
   type RecoveryWorkerWakeupReason,
@@ -30,12 +31,12 @@ export {
   type TaskLifecycleEvent,
   type ReviewGateFailedCheck,
   type ReviewGateCiFailedLifecycleEvent,
+  type ReviewGateMergeConflictLifecycleEvent,
   type WorkflowWakeupLifecycleEvent,
   type RecoveryWorkerWakeupHint,
   type RecoveryWorkerWakeupReason,
   type WorkflowWakeupReason,
 } from '@invoker/execution-engine';
-
 export interface LifecycleBuildOptions {
   readonly workflowId?: string;
   readonly previousStatus?: TaskStatus;
@@ -69,6 +70,19 @@ export interface ReviewGateCiFailedLifecycleEventInput extends LifecycleBuildOpt
   readonly headRef?: string;
   readonly branch?: string;
   readonly failedChecks: readonly ReviewGateFailedCheck[];
+  readonly statusText: string;
+}
+
+export interface ReviewGateMergeConflictLifecycleEventInput extends LifecycleBuildOptions {
+  readonly workflowId: string;
+  readonly taskId: string;
+  readonly status: TaskStatus;
+  readonly taskStateVersion: number;
+  readonly reviewId: string;
+  readonly reviewUrl: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
+  readonly branch?: string;
   readonly statusText: string;
 }
 
@@ -228,6 +242,52 @@ export function buildReviewGateCiFailedLifecycleEvent(
   };
 }
 
+export function buildReviewGateMergeConflictLifecycleEvent(
+  input: ReviewGateMergeConflictLifecycleEventInput,
+): ReviewGateMergeConflictLifecycleEvent {
+  const generation = input.generation ?? 0;
+  const createdAt = lifecycleCreatedAt(input.createdAt);
+  const eventKey = buildLifecycleEventKey({
+    kind: 'review_gate.merge_conflict',
+    workflowId: input.workflowId,
+    taskId: input.taskId,
+    taskStateVersion: input.taskStateVersion,
+    generation,
+    attemptId: input.attemptId,
+    discriminator: `review:${input.reviewId}:${input.headSha ?? 'no-head-sha'}`,
+  });
+
+  return {
+    eventKey,
+    kind: 'review_gate.merge_conflict',
+    workflowId: input.workflowId,
+    taskId: input.taskId,
+    status: input.status,
+    taskStateVersion: input.taskStateVersion,
+    generation,
+    ...(input.previousStatus ? { previousStatus: input.previousStatus } : {}),
+    ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+    createdAt,
+    recoveryWakeup: buildRecoveryWorkerWakeupHint({
+      eventKey,
+      eventKind: 'review_gate.merge_conflict',
+      workflowId: input.workflowId,
+      taskId: input.taskId,
+      taskStateVersion: input.taskStateVersion,
+      generation,
+      attemptId: input.attemptId,
+      createdAt,
+      reason: 'review_gate_failure',
+    }),
+    reviewId: input.reviewId,
+    reviewUrl: input.reviewUrl,
+    ...(input.headSha ? { headSha: input.headSha } : {}),
+    ...(input.headRef ? { headRef: input.headRef } : {}),
+    ...(input.branch ? { branch: input.branch } : {}),
+    statusText: input.statusText,
+  };
+}
+
 export function buildWorkflowWakeupLifecycleEvent(
   input: WorkflowWakeupLifecycleEventInput,
 ): WorkflowWakeupLifecycleEvent {
@@ -327,6 +387,12 @@ export function isWorkflowLifecycleEvent(value: unknown): value is WorkflowLifec
         && typeof value.reviewId === 'string'
         && typeof value.reviewUrl === 'string'
         && Array.isArray(value.failedChecks)
+        && typeof value.statusText === 'string';
+    case 'review_gate.merge_conflict':
+      return typeof value.taskId === 'string'
+        && typeof value.status === 'string'
+        && typeof value.reviewId === 'string'
+        && typeof value.reviewUrl === 'string'
         && typeof value.statusText === 'string';
     case 'workflow.wakeup':
       return value.reason === 'startup_reconcile'

--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -573,6 +573,7 @@ describe('GitHubMergeGateProvider', () => {
       expect(result.headSha).toBe('abc123');
       expect(result.headRef).toBe('feature/red-ci');
       expect(result.mergeState).toBe('clean');
+      expect(result.hasMergeConflict).toBe(false);
       expect(result.checks).toEqual({
         state: 'failure',
         failed: [
@@ -590,6 +591,58 @@ describe('GitHubMergeGateProvider', () => {
           },
         ],
       });
+    });
+
+    it('marks only DIRTY merge state as a merge conflict signal', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'OPEN',
+            reviewDecision: null,
+            url: 'https://github.com/owner/repo/pull/5',
+            headRefOid: 'dirty123',
+            headRefName: 'feature/conflict',
+            mergeStateStatus: 'DIRTY',
+            statusCheckRollup: [],
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '5', cwd: '/tmp/repo' });
+
+      expect(result.mergeState).toBe('dirty');
+      expect(result.hasMergeConflict).toBe(true);
+    });
+
+    it('does not treat BEHIND merge state as a merge conflict signal', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'OPEN',
+            reviewDecision: null,
+            url: 'https://github.com/owner/repo/pull/6',
+            headRefOid: 'behind123',
+            headRefName: 'feature/behind',
+            mergeStateStatus: 'BEHIND',
+            statusCheckRollup: [],
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '6', cwd: '/tmp/repo' });
+
+      expect(result.mergeState).toBe('dirty');
+      expect(result.hasMergeConflict).toBe(false);
     });
   });
 });

--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -8,12 +8,20 @@ import {
   autoFixAttemptLedgerKeyFromLifecycleEvent,
   createAutoFixAttemptLedger,
 } from '../auto-fix-attempt-ledger.js';
-import type { ReviewGateCiFailedLifecycleEvent } from '../lifecycle-events.js';
+import type {
+  ReviewGateCiFailedLifecycleEvent,
+  ReviewGateMergeConflictLifecycleEvent,
+} from '../lifecycle-events.js';
 import {
   CI_FAILURE_WORKER_KIND,
   ciFailureActionKey,
   createCiFailureTick,
 } from '../workers/ci-failure-worker.js';
+import {
+  createReviewGateMergeConflictTick,
+  REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
+  reviewGateMergeConflictActionKey,
+} from '../workers/review-gate-merge-conflict-worker.js';
 import {
   DEFAULT_PR_STATUS_WORKER_INTERVAL_MS,
   createPrStatusWorker,
@@ -98,6 +106,41 @@ function makeEvent(overrides: Partial<ReviewGateCiFailedLifecycleEvent> = {}): R
   };
 }
 
+function makeMergeConflictEvent(
+  overrides: Partial<ReviewGateMergeConflictLifecycleEvent> = {},
+): ReviewGateMergeConflictLifecycleEvent {
+  return {
+    eventKey: 'review_gate.merge_conflict|workflow:wf-1|task:wf-1/merge',
+    kind: 'review_gate.merge_conflict',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/merge',
+    status: 'review_ready',
+    taskStateVersion: 10,
+    generation: 2,
+    attemptId: 'attempt-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    recoveryWakeup: {
+      eventKey: 'review_gate.merge_conflict|workflow:wf-1|task:wf-1/merge',
+      eventKind: 'review_gate.merge_conflict',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      taskStateVersion: 10,
+      generation: 2,
+      attemptId: 'attempt-1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      reason: 'review_gate_failure',
+      authoritative: false,
+    },
+    reviewId: '123',
+    reviewUrl: 'https://github.com/owner/repo/pull/123',
+    headSha: 'sha-1',
+    headRef: 'feature/ci',
+    branch: 'feature/ci',
+    statusText: 'Awaiting review',
+    ...overrides,
+  };
+}
+
 function toRecord(write: WorkerActionWrite): WorkerActionRecord {
   const now = '2026-01-01T00:00:00.000Z';
   return {
@@ -133,6 +176,32 @@ function makeHarness(task = makeTask()) {
   };
   const attemptLedger = createAutoFixAttemptLedger();
   return { actions, store, submit, attemptLedger };
+}
+
+function makeRebaseRecreateHarness(task = makeTask()) {
+  const tasks = new Map<string, TaskState>([[task.id, task]]);
+  const actions = new Map<string, WorkerActionRecord>();
+  const submit = vi.fn((workflowId: string, priority: WorkflowMutationPriority, channel: string, args: unknown[]) => {
+    expect(workflowId).toBe('wf-1');
+    expect(priority).toBe('high');
+    expect(channel).toBe('invoker:rebase-recreate');
+    expect(args).toEqual(['wf-1']);
+    return 99;
+  });
+  const store = {
+    loadTasks: vi.fn((workflowId: string) => workflowId === 'wf-1' ? Array.from(tasks.values()) : []),
+    loadTask: vi.fn((taskId: string) => tasks.get(taskId)),
+    listWorkflowMutationIntents: vi.fn(() => []),
+    getWorkerAction: vi.fn((workerKind: string, externalKey: string) => actions.get(`${workerKind}:${externalKey}`)),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+      const existing = actions.get(`${write.workerKind}:${write.externalKey}`);
+      const saved = toRecord({ ...write, id: existing?.id ?? write.id, createdAt: existing?.createdAt });
+      actions.set(`${write.workerKind}:${write.externalKey}`, saved);
+      return saved;
+    }),
+    logEvent: vi.fn(),
+  };
+  return { actions, store, submit };
 }
 
 describe('PR status and CI failure workers', () => {
@@ -251,6 +320,76 @@ describe('PR status and CI failure workers', () => {
     });
   });
 
+
+  it('queues workflow rebase-recreate for review-gate merge conflict events', async () => {
+    const event = makeMergeConflictEvent();
+    const harness = makeRebaseRecreateHarness();
+    const tick = createReviewGateMergeConflictTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      drainEvents: () => [event],
+    });
+
+    await tick({ identity: { kind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    expect(harness.actions.get(`${REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND}:${reviewGateMergeConflictActionKey(event)}`)).toMatchObject({
+      workerKind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
+      actionType: 'rebase-recreate-review-gate-conflict',
+      status: 'queued',
+      intentId: '99',
+      externalKey: reviewGateMergeConflictActionKey(event),
+    });
+  });
+
+  it('dedupes repeated merge conflict events for the same review head', async () => {
+    const event = makeMergeConflictEvent();
+    const harness = makeRebaseRecreateHarness();
+    const tick = createReviewGateMergeConflictTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      drainEvents: () => [event, makeMergeConflictEvent()],
+    });
+
+    await tick({ identity: { kind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips stale merge conflict events when the PR head changed before submit', async () => {
+    const event = makeMergeConflictEvent();
+    const task = makeTask({
+      execution: {
+        reviewGate: {
+          activeGeneration: 2,
+          completion: { required: 'all', status: 'approved' },
+          artifacts: [{
+            id: 'pr-123',
+            providerId: '123',
+            required: true,
+            status: 'open',
+            generation: 2,
+            headSha: 'sha-2',
+          }],
+        },
+      },
+    });
+    const harness = makeRebaseRecreateHarness(task);
+    const tick = createReviewGateMergeConflictTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      drainEvents: () => [event],
+    });
+
+    await tick({ identity: { kind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
+
+    expect(harness.submit).not.toHaveBeenCalled();
+    expect(harness.actions.get(`${REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND}:${reviewGateMergeConflictActionKey(event)}`)).toBeUndefined();
+    expect(harness.store.upsertWorkerAction).not.toHaveBeenCalled();
+  });
   it('rejects stale CI failure events when the PR head changed before submit', async () => {
     const event = makeEvent();
     const task = makeTask({

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -5396,6 +5396,77 @@ console.log(JSON.stringify(out));
         );
       });
 
+      it('publishes review-gate merge conflict wakeups for open PR conflicts', async () => {
+        const task = makeTask({
+          id: 'merge-conflict',
+          status: 'review_ready',
+          config: { workflowId: 'wf-merge-conflict', isMergeNode: true },
+          execution: {
+            generation: 4,
+            selectedAttemptId: 'attempt-merge',
+            reviewId: 'owner/repo#303',
+            branch: 'feature/conflict',
+            reviewGate: {
+              activeGeneration: 4,
+              completion: { required: 'all', status: 'approved' as const },
+              artifacts: [{
+                id: 'pr-303',
+                providerId: 'owner/repo#303',
+                required: true,
+                status: 'open' as const,
+                generation: 4,
+                headSha: 'abc123',
+              }],
+            },
+          },
+          taskStateVersion: 13,
+        });
+        const reviewGateMergeConflictPublisher = { publish: vi.fn().mockResolvedValue(undefined) };
+        const orchestrator = {
+          getTask: (id: string) => (id === task.id ? task : undefined),
+          getAllTasks: () => [task],
+          approve: vi.fn(),
+          recordTaskHeartbeat: vi.fn(),
+        };
+        const persistence = { updateTask: vi.fn() };
+        const mergeGateProvider = {
+          checkApproval: vi.fn().mockResolvedValue({
+            lifecycle: 'open',
+            rejected: false,
+            statusText: 'Awaiting review',
+            url: 'https://github.com/owner/repo/pull/303',
+            headSha: 'abc123',
+            headRef: 'feature/conflict',
+            mergeState: 'dirty',
+            hasMergeConflict: true,
+          }),
+        };
+
+        const executor = new TaskRunner({
+          orchestrator: orchestrator as any,
+          persistence: persistence as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          cwd: '/runner-base-cwd',
+          mergeGateProvider: mergeGateProvider as any,
+          reviewGateMergeConflictPublisher: reviewGateMergeConflictPublisher as any,
+        });
+
+        await executor.checkMergeGateStatuses();
+
+        expect(reviewGateMergeConflictPublisher.publish).toHaveBeenCalledWith({
+          taskId: 'merge-conflict',
+          workflowId: 'wf-merge-conflict',
+          reviewId: 'owner/repo#303',
+          reviewUrl: 'https://github.com/owner/repo/pull/303',
+          headSha: 'abc123',
+          headRef: 'feature/conflict',
+          branch: 'feature/conflict',
+          selectedAttemptId: 'attempt-merge',
+          generation: 4,
+          statusText: 'Awaiting review',
+        });
+      });
+
       it('polls all current reviewGate artifacts and approves only after every required artifact is approved', async () => {
         const downstream = makeTask({ id: 'downstream-after-stack', status: 'running' });
         const reviewGate = {

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -8,6 +8,7 @@ import { registerDiskHeadroomWorker } from './workers/disk-headroom-worker.js';
 import { registerPrMaintenanceWorkers } from './workers/pr-maintenance-workers.js';
 import { registerPrStatusWorker } from './workers/pr-status-worker.js';
 import { registerRequeueWorker } from './workers/requeue-worker.js';
+import { registerReviewGateMergeConflictWorker } from './workers/review-gate-merge-conflict-worker.js';
 import { registerWorkflowResumeWorker } from './workers/workflow-resume-worker.js';
 
 /** Register every built-in worker in the stable built-in order. */
@@ -19,6 +20,7 @@ export function registerBuiltinWorkers(
   registerWorkflowResumeWorker(registry);
   registerPrStatusWorker(registry);
   registerCiFailureWorker(registry);
+  registerReviewGateMergeConflictWorker(registry);
   registerDiskHeadroomWorker(registry);
   registerAutoApproveWorker(registry);
   registerPrMaintenanceWorkers(registry);

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -152,6 +152,7 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       headSha: data.headRefOid,
       headRef: data.headRefName,
       mergeState: normalizeMergeState(data.mergeStateStatus),
+      hasMergeConflict: data.mergeStateStatus === 'DIRTY',
       checks: summarizeStatusChecks(data.statusCheckRollup),
     };
   }

--- a/packages/execution-engine/src/lifecycle-events.ts
+++ b/packages/execution-engine/src/lifecycle-events.ts
@@ -19,6 +19,7 @@ export const WORKFLOW_LIFECYCLE_EVENT_KINDS = [
   'task.needs_input',
   'task.removed',
   'review_gate.ci_failed',
+  'review_gate.merge_conflict',
   'workflow.wakeup',
 ] as const;
 
@@ -91,6 +92,18 @@ export interface ReviewGateCiFailedLifecycleEvent extends WorkflowLifecycleEvent
   readonly statusText: string;
 }
 
+export interface ReviewGateMergeConflictLifecycleEvent extends WorkflowLifecycleEventBase {
+  readonly kind: 'review_gate.merge_conflict';
+  readonly taskId: string;
+  readonly status: TaskStatus;
+  readonly reviewId: string;
+  readonly reviewUrl: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
+  readonly branch?: string;
+  readonly statusText: string;
+}
+
 export interface WorkflowWakeupLifecycleEvent extends WorkflowLifecycleEventBase {
   readonly kind: 'workflow.wakeup';
   readonly reason: WorkflowWakeupReason;
@@ -100,6 +113,7 @@ export interface WorkflowWakeupLifecycleEvent extends WorkflowLifecycleEventBase
 export type WorkflowLifecycleEvent =
   | TaskLifecycleEvent
   | ReviewGateCiFailedLifecycleEvent
+  | ReviewGateMergeConflictLifecycleEvent
   | WorkflowWakeupLifecycleEvent;
 
 export type WorkflowWakeupReason =

--- a/packages/execution-engine/src/merge-gate-provider.ts
+++ b/packages/execution-engine/src/merge-gate-provider.ts
@@ -47,6 +47,7 @@ export interface MergeGateApprovalStatus {
   headSha?: string;
   headRef?: string;
   mergeState?: 'clean' | 'dirty' | 'unknown';
+  hasMergeConflict?: boolean;
   checks?: MergeGateCheckSummary;
 }
 

--- a/packages/execution-engine/src/task-runner-review-gate.ts
+++ b/packages/execution-engine/src/task-runner-review-gate.ts
@@ -3,8 +3,8 @@
  *
  * Owns the poll loop that reconciles each merge-node task's review artifacts
  * against the merge-gate provider, maps provider lifecycle → artifact status,
- * completes approved gates, closes reviews on teardown, and publishes CI-failure
- * lifecycle triggers.
+ * completes approved gates, closes reviews on teardown, and publishes
+ * review-gate failure lifecycle triggers.
  *
  * Stateful functions take a {@link TaskRunnerReviewGateHost} — a
  * `Pick<TaskRunner, …>` — as their first parameter, so the type-only import of
@@ -14,9 +14,8 @@
  * this module; the same-named `TaskRunner` methods are thin delegates that route
  * through `gitPlumbing`-style namespace calls.
  *
- * The `ReviewGateCiFailureTrigger` / `ReviewGateCiFailureLifecyclePublisher`
- * declarations live here (their owning cluster) and stay barrel-visible via the
- * package index re-export.
+ * The review-gate failure trigger/publisher declarations live here (their
+ * owning cluster) and stay barrel-visible via the package index re-export.
  */
 
 import type { TaskState } from '@invoker/workflow-core';
@@ -46,11 +45,29 @@ export interface ReviewGateCiFailureLifecyclePublisher {
   publish(trigger: ReviewGateCiFailureTrigger): void | Promise<void>;
 }
 
+export interface ReviewGateMergeConflictTrigger {
+  taskId: string;
+  workflowId: string;
+  reviewId: string;
+  reviewUrl: string;
+  headSha?: string;
+  headRef?: string;
+  branch?: string;
+  selectedAttemptId?: string;
+  generation: number;
+  statusText: string;
+}
+
+export interface ReviewGateMergeConflictLifecyclePublisher {
+  publish(trigger: ReviewGateMergeConflictTrigger): void | Promise<void>;
+}
+
 /**
  * Subset of {@link TaskRunner} the review-gate polling family reads. Picked from
  * `TaskRunner` (not hand-written) so the host stays locked to the runner's real
- * member types. `reviewGateCiFailureInFlight` is single-cluster-owned: it lives
- * here as an `@internal` runner field and is picked into this host.
+ * `reviewGateCiFailureInFlight` and `reviewGateMergeConflictInFlight` are
+ * single-cluster-owned: they live here as `@internal` runner fields and are
+ * picked into this host.
  */
 export type TaskRunnerReviewGateHost = Pick<
   TaskRunner,
@@ -64,6 +81,8 @@ export type TaskRunnerReviewGateHost = Pick<
   // Review-gate cluster state
   | 'reviewGateCiFailurePublisher'
   | 'reviewGateCiFailureInFlight'
+  | 'reviewGateMergeConflictPublisher'
+  | 'reviewGateMergeConflictInFlight'
 >;
 
 export async function closeWorkflowReview(
@@ -254,6 +273,7 @@ export async function pollMergeGateTask(
         host.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
       } else if (status.lifecycle === 'open') {
         await maybePublishReviewGateCiFailure(host, current!, status, providerId);
+        await maybePublishReviewGateMergeConflict(host, current!, status, providerId);
       }
       continue;
     }
@@ -269,6 +289,7 @@ export async function pollMergeGateTask(
       host.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
     } else if (status.lifecycle === 'open') {
       await maybePublishReviewGateCiFailure(host, current!, status, providerId);
+      await maybePublishReviewGateMergeConflict(host, current!, status, providerId);
     }
   }
 }
@@ -338,5 +359,42 @@ export async function maybePublishReviewGateCiFailure(
     });
   } finally {
     host.reviewGateCiFailureInFlight.delete(key);
+  }
+}
+
+export async function maybePublishReviewGateMergeConflict(
+  host: TaskRunnerReviewGateHost,
+  task: TaskState,
+  status: MergeGateApprovalStatus,
+  reviewId: string = task.execution.reviewId ?? '',
+): Promise<void> {
+  if (!host.reviewGateMergeConflictPublisher) return;
+  if (!task.config.workflowId || !reviewId) return;
+  if (!status.hasMergeConflict) return;
+
+  const key = [
+    task.id,
+    task.execution.selectedAttemptId ?? 'no-attempt',
+    task.execution.generation ?? 0,
+    status.headSha ?? 'no-head-sha',
+  ].join(':');
+  if (host.reviewGateMergeConflictInFlight.has(key)) return;
+
+  host.reviewGateMergeConflictInFlight.add(key);
+  try {
+    await host.reviewGateMergeConflictPublisher.publish({
+      taskId: task.id,
+      workflowId: task.config.workflowId,
+      reviewId,
+      reviewUrl: status.url,
+      headSha: status.headSha,
+      headRef: status.headRef,
+      branch: task.execution.branch,
+      selectedAttemptId: task.execution.selectedAttemptId,
+      generation: task.execution.generation ?? 0,
+      statusText: status.statusText,
+    });
+  } finally {
+    host.reviewGateMergeConflictInFlight.delete(key);
   }
 }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -66,7 +66,10 @@ import { buildWorkRequest } from './task-runner-prepare.js';
 import { dispatchExecutor } from './task-runner-dispatch.js';
 import { wireCompletion } from './task-runner-finalize.js';
 import * as reviewGate from './task-runner-review-gate.js';
-import type { ReviewGateCiFailureLifecyclePublisher } from './task-runner-review-gate.js';
+import type {
+  ReviewGateCiFailureLifecyclePublisher,
+  ReviewGateMergeConflictLifecyclePublisher,
+} from './task-runner-review-gate.js';
 import {
   poolMemberKey,
   selectPoolMember,
@@ -163,6 +166,7 @@ export interface TaskRunnerConfig {
   mergeGateProvider?: MergeGateProvider;
   reviewProviderRegistry?: ReviewProviderRegistry;
   reviewGateCiFailurePublisher?: ReviewGateCiFailureLifecyclePublisher;
+  reviewGateMergeConflictPublisher?: ReviewGateMergeConflictLifecyclePublisher;
   /**
    * Provider that returns remote SSH targets keyed by target ID.
    * Called at task-execution time so config file changes take effect on retry.
@@ -217,6 +221,9 @@ export class TaskRunner {
   /** @internal */ reviewProviderRegistry?: ReviewProviderRegistry;
   /** @internal */ reviewGateCiFailurePublisher?: ReviewGateCiFailureLifecyclePublisher;
   /** @internal */ reviewGateCiFailureInFlight = new Set<string>();
+  /** @internal */ reviewGateMergeConflictPublisher?: ReviewGateMergeConflictLifecyclePublisher;
+  /** @internal */ reviewGateMergeConflictInFlight = new Set<string>();
+
   /** @internal */ getRemoteTargets: () => Record<string, RemoteTargetDisplay>;
   /** @internal */ getExecutionPools: () => Record<string, ExecutionPoolConfig>;
   private getExecutionDefaults: () => { executionAgent?: string; executionModel?: string };
@@ -332,6 +339,7 @@ export class TaskRunner {
     this.mergeGateProvider = config.mergeGateProvider;
     this.reviewProviderRegistry = config.reviewProviderRegistry;
     this.reviewGateCiFailurePublisher = config.reviewGateCiFailurePublisher;
+    this.reviewGateMergeConflictPublisher = config.reviewGateMergeConflictPublisher;
     this.getRemoteTargets = config.remoteTargetsProvider ?? (() => ({}));
     this.getExecutionPools = config.executionPoolsProvider ?? (() => ({}));
     this.getExecutionDefaults = config.executionDefaultsProvider ?? (() => ({}));

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -16,6 +16,10 @@ import type { PrMaintenanceWorkerConfig } from './workers/pr-maintenance-workers
 import type { E2eAutoFixWorkerConfig } from './workers/e2e-autofix-worker.js';
 import type { DiskHeadroomWorkerConfig } from './workers/disk-headroom-worker.js';
 import type { PrStatusReviewGate } from './workers/pr-status-worker.js';
+import type {
+  ReviewGateMergeConflictWorkerStore,
+  ReviewGateMergeConflictWorkerSubmitter,
+} from './workers/review-gate-merge-conflict-worker.js';
 import type { RequeueWorkerConfig, RequeueWorkerSubmitter } from './workers/requeue-worker.js';
 import type {
   WorkflowResumeWorkerConfig,
@@ -26,9 +30,18 @@ import type {
 /** Dependencies injected into a built-in worker factory when its runtime is built. */
 export interface WorkerRuntimeDependencies {
   /** Persisted workflow/task state accessor. */
-  store: AutoFixRecoveryStore & CiFailureWorkerStore & AutoApproveWorkerStore & WorkflowResumeWorkerStore;
+  store: AutoFixRecoveryStore
+    & CiFailureWorkerStore
+    & AutoApproveWorkerStore
+    & ReviewGateMergeConflictWorkerStore
+    & WorkflowResumeWorkerStore;
   /** Action-output channel used to submit follow-up mutation intents. */
-  submitter: AutoFixRecoverySubmitter & CiFailureWorkerSubmitter & RequeueWorkerSubmitter & AutoApproveWorkerSubmitter & WorkflowResumeWorkerSubmitter;
+  submitter: AutoFixRecoverySubmitter
+    & CiFailureWorkerSubmitter
+    & RequeueWorkerSubmitter
+    & AutoApproveWorkerSubmitter
+    & ReviewGateMergeConflictWorkerSubmitter
+    & WorkflowResumeWorkerSubmitter;
   /** Operator logger. */
   logger: Logger;
   /** Optional bus that turns lifecycle events into immediate wakeups. */

--- a/packages/execution-engine/src/workers/review-gate-merge-conflict-worker.ts
+++ b/packages/execution-engine/src/workers/review-gate-merge-conflict-worker.ts
@@ -1,0 +1,496 @@
+import type { Logger } from '@invoker/contracts';
+import type {
+  WorkerActionRecord,
+  WorkerActionStatus,
+  WorkerActionWrite,
+  WorkflowMutationIntent,
+  WorkflowMutationIntentStatus,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
+import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
+import type { TaskState } from '@invoker/workflow-core';
+
+import {
+  isReviewGateCiContextStale,
+  type ReviewGateCiContext,
+  type ReviewGateLineageFields,
+} from '../auto-fix-intents.js';
+import type {
+  ReviewGateMergeConflictLifecycleEvent,
+  WorkflowLifecycleEvent,
+} from '../lifecycle-events.js';
+import { recordWorkerDecisionRow } from '../worker-decision-ledger.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND = 'review-gate-merge-conflict';
+export const DEFAULT_REVIEW_GATE_MERGE_CONFLICT_WORKER_INTERVAL_MS = 60_000;
+
+const REBASE_RECREATE_CHANNEL = 'invoker:rebase-recreate';
+const REVIEW_GATE_MERGE_CONFLICT_ACTION_TYPE = 'rebase-recreate-review-gate-conflict';
+const NO_HEAD_SHA = 'no-head';
+
+type ReviewGateMergeConflictActionStatus = WorkerActionStatus;
+
+type HeadlessExecPayload = {
+  args?: unknown[];
+};
+
+export interface ReviewGateMergeConflictWorkerStore {
+  loadTasks(workflowId: string): TaskState[];
+  loadTask?(taskId: string): TaskState | undefined;
+  listWorkflowMutationIntents?(
+    workflowId?: string,
+    statuses?: WorkflowMutationIntentStatus[],
+  ): WorkflowMutationIntent[];
+  getWorkerAction?(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
+  upsertWorkerAction?(action: WorkerActionWrite): WorkerActionRecord;
+  logEvent?(taskId: string, eventType: string, payload?: unknown): void;
+}
+
+export interface ReviewGateMergeConflictWorkerSubmitter {
+  submit(
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: typeof REBASE_RECREATE_CHANNEL,
+    args: unknown[],
+    options?: { deferDrain?: boolean },
+  ): number;
+}
+
+export interface ReviewGateMergeConflictWorkerPolicyOptions {
+  store: ReviewGateMergeConflictWorkerStore;
+  submitter: ReviewGateMergeConflictWorkerSubmitter;
+  logger: Logger;
+  drainEvents?: () => ReviewGateMergeConflictLifecycleEvent[];
+}
+
+export interface ReviewGateMergeConflictWorkerOptions {
+  logger: Logger;
+  instanceId?: string;
+  intervalMs?: number;
+  installSignalHandlers?: boolean;
+  reviewGateMergeConflict?: Omit<ReviewGateMergeConflictWorkerPolicyOptions, 'logger' | 'drainEvents'>;
+  tickOnStart?: boolean;
+  messageBus?: MessageBus;
+  onTick?: WorkerTick;
+}
+
+export function registerReviewGateMergeConflictWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
+    note: 'Queues workflow rebase-recreate when a review-gate PR reports merge conflicts.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createReviewGateMergeConflictWorker({
+        logger: deps.logger,
+        messageBus: deps.messageBus,
+        reviewGateMergeConflict: {
+          store: deps.store,
+          submitter: deps.submitter,
+        },
+      }),
+  });
+  return registry;
+}
+
+export function reviewGateMergeConflictActionKey(event: Pick<
+  ReviewGateMergeConflictLifecycleEvent,
+  'taskId' | 'reviewId' | 'headSha'
+>): string {
+  return [
+    'review-gate-merge-conflict',
+    event.taskId,
+    event.reviewId,
+    event.headSha ?? NO_HEAD_SHA,
+  ].join(':');
+}
+
+function getHeadlessExecArgs(intent: WorkflowMutationIntent): unknown[] {
+  if (intent.channel !== 'headless.exec') {
+    return [];
+  }
+  const payload = intent.args[0] as HeadlessExecPayload | undefined;
+  return Array.isArray(payload?.args) ? payload.args : [];
+}
+
+function isWorkflowRecreateIntentForWorkflow(intent: WorkflowMutationIntent, workflowId: string): boolean {
+  if (intent.channel === REBASE_RECREATE_CHANNEL || intent.channel === 'invoker:recreate-workflow') {
+    return typeof intent.args[0] === 'string' && intent.args[0] === workflowId;
+  }
+
+  const args = getHeadlessExecArgs(intent);
+  return (args[0] === 'rebase-recreate' || args[0] === 'recreate')
+    && typeof args[1] === 'string'
+    && args[1] === workflowId;
+}
+
+function listOpenWorkflowRecreateIntents(
+  intents: WorkflowMutationIntent[],
+  workflowId: string,
+): WorkflowMutationIntent[] {
+  return intents.filter((intent) => isWorkflowRecreateIntentForWorkflow(intent, workflowId));
+}
+
+function loadTaskForEvent(
+  event: ReviewGateMergeConflictLifecycleEvent,
+  options: ReviewGateMergeConflictWorkerPolicyOptions,
+): TaskState | undefined {
+  const direct = options.store.loadTask?.(event.taskId);
+  if (direct) return direct;
+  return options.store.loadTasks(event.workflowId).find((task) => task.id === event.taskId);
+}
+
+function currentReviewGateLineage(task: TaskState, reviewId: string): ReviewGateLineageFields {
+  const gate = task.execution.reviewGate;
+  const artifact = gate?.artifacts.find((candidate) =>
+    candidate.generation === gate.activeGeneration
+    && candidate.status !== 'discarded'
+    && !candidate.discardedAt
+    && candidate.providerId === reviewId,
+  );
+  return {
+    reviewId: artifact?.providerId ?? task.execution.reviewId,
+    generation: task.execution.generation ?? 0,
+    selectedAttemptId: task.execution.selectedAttemptId,
+    branch: task.execution.branch,
+    headSha: artifact?.headSha,
+  };
+}
+
+function reviewGateContextFromEvent(event: ReviewGateMergeConflictLifecycleEvent): ReviewGateCiContext {
+  return {
+    reviewId: event.reviewId,
+    generation: event.generation,
+    selectedAttemptId: event.attemptId,
+    branch: event.branch,
+    headSha: event.headSha,
+  };
+}
+
+function staleReasonForEvent(
+  event: ReviewGateMergeConflictLifecycleEvent,
+  task: TaskState,
+): { stale: false } | { stale: true; reason: string; details: Record<string, unknown> } {
+  if (task.config.workflowId !== event.workflowId) {
+    return {
+      stale: true,
+      reason: 'workflow-changed',
+      details: { currentWorkflowId: task.config.workflowId ?? null },
+    };
+  }
+  if (task.status !== 'review_ready' && task.status !== 'awaiting_approval') {
+    return {
+      stale: true,
+      reason: 'status-changed',
+      details: { currentStatus: task.status },
+    };
+  }
+
+  const context = reviewGateContextFromEvent(event);
+  const current = currentReviewGateLineage(task, event.reviewId);
+  if (!isReviewGateCiContextStale(context, current)) {
+    return { stale: false };
+  }
+
+  if (current.reviewId !== event.reviewId) {
+    return {
+      stale: true,
+      reason: 'review-changed',
+      details: { currentReviewId: current.reviewId ?? null },
+    };
+  }
+  if ((current.generation ?? 0) !== event.generation) {
+    return {
+      stale: true,
+      reason: 'generation-changed',
+      details: { currentGeneration: current.generation ?? 0 },
+    };
+  }
+  if (current.selectedAttemptId !== event.attemptId) {
+    return {
+      stale: true,
+      reason: 'selected-attempt-changed',
+      details: { currentSelectedAttemptId: current.selectedAttemptId ?? null },
+    };
+  }
+  if (current.headSha !== event.headSha) {
+    return {
+      stale: true,
+      reason: 'head-sha-changed',
+      details: { currentHeadSha: current.headSha ?? null },
+    };
+  }
+  return {
+    stale: true,
+    reason: 'branch-changed',
+    details: { currentBranch: current.branch ?? null },
+  };
+}
+
+function isOpenOrCompletedActionStatus(status: string): boolean {
+  return status === 'queued'
+    || status === 'pending'
+    || status === 'running'
+    || status === 'needs_input'
+    || status === 'review_ready'
+    || status === 'completed';
+}
+
+function recordReviewGateMergeConflictAction(
+  options: ReviewGateMergeConflictWorkerPolicyOptions,
+  event: ReviewGateMergeConflictLifecycleEvent,
+  status: ReviewGateMergeConflictActionStatus,
+  summary: string,
+  payload: Record<string, unknown> = {},
+  intentId?: number | string,
+): WorkerActionRecord | undefined {
+  return recordWorkerDecisionRow(options.store, {
+    workerKind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
+    actionType: REVIEW_GATE_MERGE_CONFLICT_ACTION_TYPE,
+    externalKey: reviewGateMergeConflictActionKey(event),
+    subjectType: 'review',
+    subjectId: event.reviewId,
+    workflowId: event.workflowId,
+    taskId: event.taskId,
+    status,
+    summary,
+    intentId,
+    incrementAttempt: status === 'queued' || status === 'failed',
+    payload: {
+      reviewId: event.reviewId,
+      reviewUrl: event.reviewUrl,
+      headSha: event.headSha ?? null,
+      headRef: event.headRef ?? null,
+      branch: event.branch ?? null,
+      generation: event.generation,
+      selectedAttemptId: event.attemptId ?? null,
+      taskStateVersion: event.taskStateVersion ?? null,
+      ...payload,
+    },
+  });
+}
+
+function logReviewGateMergeConflictEvent(
+  options: ReviewGateMergeConflictWorkerPolicyOptions,
+  event: ReviewGateMergeConflictLifecycleEvent,
+  phase: string,
+  details: Record<string, unknown>,
+): void {
+  const payload = {
+    phase,
+    worker: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
+    workflowId: event.workflowId,
+    reviewId: event.reviewId,
+    headSha: event.headSha ?? null,
+    generation: event.generation,
+    selectedAttemptId: event.attemptId ?? null,
+    ...details,
+  };
+  options.store.logEvent?.(event.taskId, 'debug.review-gate-merge-conflict-worker', payload);
+  options.logger.debug?.(`[worker:${REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND}] ${phase}`, {
+    module: 'review-gate-merge-conflict-worker',
+    taskId: event.taskId,
+    ...payload,
+  });
+}
+
+function listOpenRecreateIntentsForEvent(
+  options: ReviewGateMergeConflictWorkerPolicyOptions,
+  event: ReviewGateMergeConflictLifecycleEvent,
+): WorkflowMutationIntent[] {
+  const open = options.store.listWorkflowMutationIntents?.(event.workflowId, ['queued', 'running']) ?? [];
+  return listOpenWorkflowRecreateIntents(open, event.workflowId);
+}
+
+function shouldSkipExistingAction(
+  options: ReviewGateMergeConflictWorkerPolicyOptions,
+  event: ReviewGateMergeConflictLifecycleEvent,
+): boolean {
+  const externalKey = reviewGateMergeConflictActionKey(event);
+  const existing = options.store.getWorkerAction?.(REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND, externalKey);
+  if (!existing) return false;
+  if (isOpenOrCompletedActionStatus(existing.status)) {
+    logReviewGateMergeConflictEvent(options, event, 'review-gate-merge-conflict-skip', {
+      reason: 'already-recorded',
+      existingStatus: existing.status,
+      intentId: existing.intentId ?? null,
+    });
+    return true;
+  }
+  return false;
+}
+
+function firstLine(text: string | undefined): string | undefined {
+  const trimmed = text?.trim();
+  if (!trimmed) return undefined;
+  return trimmed.split('\n', 1)[0];
+}
+
+function reconcileFinishedIntentAction(
+  options: ReviewGateMergeConflictWorkerPolicyOptions,
+  event: ReviewGateMergeConflictLifecycleEvent,
+): void {
+  const externalKey = reviewGateMergeConflictActionKey(event);
+  const existing = options.store.getWorkerAction?.(REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND, externalKey);
+  if (!existing || !existing.intentId) return;
+  if (existing.status !== 'queued' && existing.status !== 'pending' && existing.status !== 'running') return;
+
+  const terminalIntents = options.store.listWorkflowMutationIntents?.(event.workflowId, ['completed', 'failed']) ?? [];
+  const intent = terminalIntents.find((candidate) => String(candidate.id) === existing.intentId);
+  if (!intent) return;
+
+  const now = new Date().toISOString();
+  const status: WorkerActionStatus = intent.status === 'completed' ? 'completed' : 'failed';
+  const summary = status === 'completed'
+    ? 'Workflow rebase-recreate intent completed'
+    : `Workflow rebase-recreate intent failed: ${firstLine(intent.error) ?? 'unknown error'}`;
+  const payload = existing.payload && typeof existing.payload === 'object'
+    ? { ...(existing.payload as Record<string, unknown>) }
+    : {};
+  options.store.upsertWorkerAction?.({
+    ...existing,
+    status,
+    summary,
+    payload: {
+      ...payload,
+      reconciledIntentStatus: intent.status,
+      intentError: intent.error ?? null,
+    },
+    updatedAt: now,
+    completedAt: now,
+  });
+  logReviewGateMergeConflictEvent(options, event, 'review-gate-merge-conflict-intent-reconciled', {
+    intentId: existing.intentId,
+    intentStatus: intent.status,
+    actionStatus: status,
+  });
+}
+
+async function handleReviewGateMergeConflictEvent(
+  options: ReviewGateMergeConflictWorkerPolicyOptions,
+  event: ReviewGateMergeConflictLifecycleEvent,
+): Promise<void> {
+  const task = loadTaskForEvent(event, options);
+  if (!task) {
+    logReviewGateMergeConflictEvent(options, event, 'review-gate-merge-conflict-skip', { reason: 'task-not-found' });
+    return;
+  }
+
+  reconcileFinishedIntentAction(options, event);
+
+  if (shouldSkipExistingAction(options, event)) return;
+
+  const stale = staleReasonForEvent(event, task);
+  if (stale.stale) {
+    logReviewGateMergeConflictEvent(options, event, 'review-gate-merge-conflict-stale', {
+      reason: stale.reason,
+      ...stale.details,
+    });
+    return;
+  }
+
+  const openRecreateIntents = listOpenRecreateIntentsForEvent(options, event);
+  if (openRecreateIntents.length > 0) {
+    const intentId = openRecreateIntents[0]?.id;
+    recordReviewGateMergeConflictAction(options, event, 'queued', 'Workflow rebase-recreate already queued for review gate', {
+      reason: 'already-queued-intent',
+      existingIntentIds: openRecreateIntents.map((intent) => intent.id),
+    }, intentId);
+    logReviewGateMergeConflictEvent(options, event, 'review-gate-merge-conflict-skip', {
+      reason: 'already-queued-intent',
+      existingIntentIds: openRecreateIntents.map((intent) => intent.id),
+    });
+    return;
+  }
+
+  const intentId = options.submitter.submit(event.workflowId, 'high', REBASE_RECREATE_CHANNEL, [event.workflowId]);
+  recordReviewGateMergeConflictAction(
+    options,
+    event,
+    'queued',
+    'Queued workflow rebase-recreate for review-gate merge conflict',
+    { channel: REBASE_RECREATE_CHANNEL },
+    intentId,
+  );
+  logReviewGateMergeConflictEvent(options, event, 'review-gate-merge-conflict-submitted', {
+    intentId,
+    channel: REBASE_RECREATE_CHANNEL,
+  });
+}
+
+export function createReviewGateMergeConflictTick(options: ReviewGateMergeConflictWorkerPolicyOptions): WorkerTick {
+  return async () => {
+    const events = options.drainEvents?.() ?? [];
+    const seen = new Set<string>();
+    for (const event of events) {
+      const externalKey = reviewGateMergeConflictActionKey(event);
+      if (seen.has(externalKey)) continue;
+      seen.add(externalKey);
+      await handleReviewGateMergeConflictEvent(options, event);
+    }
+  };
+}
+
+function isReviewGateMergeConflictEvent(event: WorkflowLifecycleEvent): event is ReviewGateMergeConflictLifecycleEvent {
+  return event.kind === 'review_gate.merge_conflict';
+}
+
+export function createReviewGateMergeConflictWorker(
+  options: ReviewGateMergeConflictWorkerOptions,
+): WorkerRuntime {
+  const pendingEvents: ReviewGateMergeConflictLifecycleEvent[] = [];
+  let lifecycleUnsubscribe: Unsubscribe | undefined;
+  const onTick = options.onTick ?? (
+    options.reviewGateMergeConflict
+      ? createReviewGateMergeConflictTick({
+        ...options.reviewGateMergeConflict,
+        logger: options.logger,
+        drainEvents: () => pendingEvents.splice(0),
+      })
+      : (() => {})
+  );
+  const runtime = createWorkerRuntime({
+    kind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_REVIEW_GATE_MERGE_CONFLICT_WORKER_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick,
+  });
+
+  if (!options.messageBus || !options.reviewGateMergeConflict || options.onTick) {
+    return runtime;
+  }
+
+  const start = (): void => {
+    if (!lifecycleUnsubscribe) {
+      lifecycleUnsubscribe = options.messageBus?.subscribe<WorkflowLifecycleEvent>(
+        Channels.WORKFLOW_LIFECYCLE,
+        (event) => {
+          if (!isReviewGateMergeConflictEvent(event)) return;
+          pendingEvents.push(event);
+          runtime.wake('wake');
+        },
+      );
+    }
+    runtime.start();
+  };
+  const stop = async (): Promise<void> => {
+    lifecycleUnsubscribe?.();
+    lifecycleUnsubscribe = undefined;
+    await runtime.stop();
+  };
+
+  return {
+    identity: runtime.identity,
+    start,
+    wake: runtime.wake,
+    tick: runtime.tick,
+    stop,
+    isRunning: runtime.isRunning,
+  };
+}


### PR DESCRIPTION
## Summary

This slice turns the new review-gate merge-conflict event into a workflow rebase-and-recreate action.

The bug was that even after review-gate polling could see a merge conflict, no worker acted on it. Conflicted PRs still fell back to task-level repair paths or manual cleanup.

The fix adds a dedicated worker that watches `review_gate.merge_conflict`, checks the current review and head lineage, and queues `invoker:rebase-recreate` once per workflow head.

## Review Claim

Reviewers are approving that review-gate merge conflicts now queue workflow rebase-recreate instead of task-level repair.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The worker only acts on the current review and head lineage and skips when a workflow recreate is already queued or running.

## Slice Rationale

The mutation policy is separate from the signal plumbing so reviewers can verify the action choice without re-reading the provider and bridge changes.

## Non-goals

- No change to normal CI-failure auto-fix.
- No change to manual `rebase-recreate` commands.
- No UI behavior change.

## Architecture

### Before

`review_gate.merge_conflict` existed only as a lifecycle event. No worker subscribed to it, so merge-conflicted PRs still depended on task-level repair or manual intervention.

### After

A new `review-gate-merge-conflict` worker subscribes to `review_gate.merge_conflict` and submits the existing workflow-scoped `invoker:rebase-recreate` mutation. It does not create a task-level fix intent.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/github-merge-gate-provider.test.ts src/__tests__/task-runner.test.ts src/__tests__/pr-ci-workers.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert a638ff89a`
- Post-revert steps: None.
- Data migration? No.

</details>

Depends-On: #4361