### PR TITLE
[Review Gate Recreate](1c) Wire merge conflict publisher into headless task runners

### DIFF
--- a/packages/app/src/__tests__/lifecycle-event-bridge.test.ts
+++ b/packages/app/src/__tests__/lifecycle-event-bridge.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../lifecycle-events.js';
 import {
   publishReviewGateCiFailedLifecycleEvent,
+  publishReviewGateMergeConflictLifecycleEvent,
   startLifecycleEventBridge,
 } from '../lifecycle-event-bridge.js';
 
@@ -305,6 +306,60 @@ describe('lifecycle event bridge', () => {
       attemptId: 'attempt-persisted',
     });
     expectRecoveryWakeup(events[0], { reason: 'review_gate_failure' });
+  });
+
+  it('publishes review-gate merge conflict wakeups with persisted task context', () => {
+    const bus = new LocalBus();
+    const events = collectLifecycleEvents(bus);
+    const task = makeTask({
+      id: 'wf-1/merge',
+      status: 'review_ready',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {
+        generation: 7,
+        selectedAttemptId: 'attempt-merge',
+        reviewId: '123',
+        branch: 'feature/merge-conflict',
+      },
+      taskStateVersion: 12,
+    });
+
+    const event = publishReviewGateMergeConflictLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'abc123',
+      headRef: 'feature/merge-conflict',
+      branch: 'feature/merge-conflict',
+      selectedAttemptId: 'attempt-merge',
+      generation: 7,
+      statusText: 'Awaiting review',
+    }, {
+      messageBus: bus,
+      getTask: () => task,
+      now: () => CREATED_AT_DATE,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toBe(event);
+    expect(events[0]).toMatchObject({
+      eventKey: 'review_gate.merge_conflict|workflow:wf-1|task:wf-1/merge|generation:7|attempt:attempt-merge|task-state:12|review:123:abc123',
+      kind: 'review_gate.merge_conflict',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      status: 'review_ready',
+      taskStateVersion: 12,
+      generation: 7,
+      attemptId: 'attempt-merge',
+      createdAt: CREATED_AT,
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'abc123',
+      statusText: 'Awaiting review',
+    });
+    expectRecoveryWakeup(events[0], { reason: 'review_gate_failure' });
+    expect(isWorkflowLifecycleEvent(events[0])).toBe(true);
   });
 
   it('unsubscribes cleanly', () => {

--- a/packages/app/src/__tests__/lifecycle-events.test.ts
+++ b/packages/app/src/__tests__/lifecycle-events.test.ts
@@ -4,6 +4,7 @@ import type { TaskDelta, TaskState } from '@invoker/workflow-core';
 import {
   buildLifecycleEventFromTaskDelta,
   buildReviewGateCiFailedLifecycleEvent,
+  buildReviewGateMergeConflictLifecycleEvent,
   buildTaskUpdatedLifecycleEvent,
   buildWorkflowWakeupLifecycleEvent,
   isTaskLifecycleEvent,
@@ -232,6 +233,42 @@ describe('lifecycle event helpers', () => {
     expect(event.failedChecks).toEqual([
       { name: 'test-all', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/runs/1' },
     ]);
+    expect(isWorkflowLifecycleEvent(event)).toBe(true);
+    expectRecoveryWakeup(event, { reason: 'review_gate_failure' });
+  });
+
+  it('builds review_gate.merge_conflict lifecycle wakeups', () => {
+    const event = buildReviewGateMergeConflictLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      status: 'review_ready',
+      taskStateVersion: 12,
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'abc123',
+      headRef: 'feature/merge-conflict',
+      branch: 'feature/merge-conflict',
+      statusText: 'Awaiting review',
+      generation: 7,
+      attemptId: 'attempt-merge',
+      createdAt: CREATED_AT_DATE,
+    });
+
+    expect(event).toMatchObject({
+      eventKey: 'review_gate.merge_conflict|workflow:wf-1|task:wf-1/merge|generation:7|attempt:attempt-merge|task-state:12|review:123:abc123',
+      kind: 'review_gate.merge_conflict',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      status: 'review_ready',
+      taskStateVersion: 12,
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'abc123',
+      generation: 7,
+      attemptId: 'attempt-merge',
+      createdAt: CREATED_AT,
+      statusText: 'Awaiting review',
+    });
     expect(isWorkflowLifecycleEvent(event)).toBe(true);
     expectRecoveryWakeup(event, { reason: 'review_gate_failure' });
   });

--- a/packages/app/src/__tests__/task-runner-wiring.test.ts
+++ b/packages/app/src/__tests__/task-runner-wiring.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TaskState } from '@invoker/workflow-core';
-import { publishReviewGateCiFailedLifecycleEvent } from '../lifecycle-event-bridge.js';
+import {
+  publishReviewGateCiFailedLifecycleEvent,
+  publishReviewGateMergeConflictLifecycleEvent,
+} from '../lifecycle-event-bridge.js';
 import { loadConfig, resolveSecretsFilePath } from '../config.js';
 import {
   killRunningTaskExecution,
@@ -45,6 +48,7 @@ vi.mock('@invoker/execution-engine', () => {
 
 vi.mock('../lifecycle-event-bridge.js', () => ({
   publishReviewGateCiFailedLifecycleEvent: vi.fn(),
+  publishReviewGateMergeConflictLifecycleEvent: vi.fn(),
 }));
 
 vi.mock('../config.js', () => ({
@@ -214,6 +218,12 @@ describe('task-runner-wiring', () => {
     const config = taskRunnerConstructor.mock.calls[0]?.[0] as any;
     await config.reviewGateCiFailurePublisher.publish({ taskId: 'merge-task' });
     expect(publishReviewGateCiFailedLifecycleEvent).toHaveBeenCalledWith(
+      { taskId: 'merge-task' },
+      expect.objectContaining({ messageBus: expect.any(Object), getTask: expect.any(Function) }),
+    );
+
+    await config.reviewGateMergeConflictPublisher.publish({ taskId: 'merge-task' });
+    expect(publishReviewGateMergeConflictLifecycleEvent).toHaveBeenCalledWith(
       { taskId: 'merge-task' },
       expect.objectContaining({ messageBus: expect.any(Object), getTask: expect.any(Function) }),
     );

--- a/packages/app/src/execution/task-runner-wiring.ts
+++ b/packages/app/src/execution/task-runner-wiring.ts
@@ -12,7 +12,10 @@ import {
 } from '@invoker/execution-engine';
 import type { Logger } from '@invoker/contracts';
 import { loadConfig, resolveDefaultTaskExecutionSettings, resolveSecretsFilePath, type InvokerConfig } from '../config.js';
-import { publishReviewGateCiFailedLifecycleEvent } from '../lifecycle-event-bridge.js';
+import {
+  publishReviewGateCiFailedLifecycleEvent,
+  publishReviewGateMergeConflictLifecycleEvent,
+} from '../lifecycle-event-bridge.js';
 
 export type TaskHandleMap = Map<string, { handle: ExecutorHandle; executor: Executor }>;
 
@@ -94,6 +97,14 @@ export function rebuildTaskRunner(deps: TaskRunnerWiringDeps): TaskRunner {
     reviewGateCiFailurePublisher: {
       publish: (trigger) => {
         publishReviewGateCiFailedLifecycleEvent(trigger, {
+          messageBus: deps.messageBus,
+          getTask: (taskId) => deps.orchestrator.getTask(taskId),
+        });
+      },
+    },
+    reviewGateMergeConflictPublisher: {
+      publish: (trigger) => {
+        publishReviewGateMergeConflictLifecycleEvent(trigger, {
           messageBus: deps.messageBus,
           getTask: (taskId) => deps.orchestrator.getTask(taskId),
         });

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -27,7 +27,10 @@ import {
 import { loadConfig, resolveSecretsFilePath, type InvokerConfig } from './config.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import { trackWorkflow } from './headless-watch.js';
-import { publishReviewGateCiFailedLifecycleEvent } from './lifecycle-event-bridge.js';
+import {
+  publishReviewGateCiFailedLifecycleEvent,
+  publishReviewGateMergeConflictLifecycleEvent,
+} from './lifecycle-event-bridge.js';
 import type { WorkflowCancelResult } from './workflow-preemption.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import type { RuntimeServices } from '@invoker/runtime-service';
@@ -158,6 +161,14 @@ export function createHeadlessExecutor(
     reviewGateCiFailurePublisher: {
       publish: (trigger) => {
         publishReviewGateCiFailedLifecycleEvent(trigger, {
+          messageBus: deps.messageBus,
+          getTask: (taskId) => deps.orchestrator.getTask(taskId),
+        });
+      },
+    },
+    reviewGateMergeConflictPublisher: {
+      publish: (trigger) => {
+        publishReviewGateMergeConflictLifecycleEvent(trigger, {
           messageBus: deps.messageBus,
           getTask: (taskId) => deps.orchestrator.getTask(taskId),
         });

--- a/packages/app/src/lifecycle-event-bridge.ts
+++ b/packages/app/src/lifecycle-event-bridge.ts
@@ -2,6 +2,7 @@ import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport'
 import type { TaskDelta, TaskState, TaskStatus } from '@invoker/workflow-core';
 import {
   buildReviewGateCiFailedLifecycleEvent,
+  buildReviewGateMergeConflictLifecycleEvent,
   buildTaskCreatedLifecycleEvent,
   buildTaskRemovedLifecycleEvent,
   buildTaskUpdatedLifecycleEvent,
@@ -44,6 +45,21 @@ export interface ReviewGateCiFailedWakeupInput {
   readonly selectedAttemptId?: string;
   readonly generation: number;
   readonly failedChecks: readonly ReviewGateFailedCheck[];
+  readonly statusText: string;
+}
+
+export interface ReviewGateMergeConflictWakeupInput {
+  readonly workflowId: string;
+  readonly taskId: string;
+  readonly status?: TaskStatus;
+  readonly taskStateVersion?: number;
+  readonly reviewId: string;
+  readonly reviewUrl: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
+  readonly branch?: string;
+  readonly selectedAttemptId?: string;
+  readonly generation: number;
   readonly statusText: string;
 }
 
@@ -94,6 +110,35 @@ export function publishReviewGateCiFailedLifecycleEvent(
     headRef: input.headRef,
     branch: input.branch,
     failedChecks: input.failedChecks,
+    statusText: input.statusText,
+    generation: input.generation,
+    attemptId,
+    createdAt: options.now?.(),
+  });
+  options.messageBus.publish(Channels.WORKFLOW_LIFECYCLE, event);
+  return event;
+}
+
+export function publishReviewGateMergeConflictLifecycleEvent(
+  input: ReviewGateMergeConflictWakeupInput,
+  options: Pick<LifecycleEventBridgeOptions, 'messageBus' | 'getTask' | 'now'>,
+): WorkflowLifecycleEvent | undefined {
+  const currentTask = options.getTask?.(input.taskId);
+  const status = input.status ?? currentTask?.status;
+  const taskStateVersion = input.taskStateVersion ?? currentTask?.taskStateVersion;
+  const attemptId = input.selectedAttemptId ?? currentTask?.execution.selectedAttemptId;
+  if (!status || taskStateVersion == null) return undefined;
+
+  const event = buildReviewGateMergeConflictLifecycleEvent({
+    workflowId: input.workflowId,
+    taskId: input.taskId,
+    status,
+    taskStateVersion,
+    reviewId: input.reviewId,
+    reviewUrl: input.reviewUrl,
+    headSha: input.headSha,
+    headRef: input.headRef,
+    branch: input.branch,
     statusText: input.statusText,
     generation: input.generation,
     attemptId,

--- a/packages/app/src/lifecycle-events.ts
+++ b/packages/app/src/lifecycle-events.ts
@@ -12,6 +12,7 @@ import {
   type TaskLifecycleEvent,
   type ReviewGateFailedCheck,
   type ReviewGateCiFailedLifecycleEvent,
+  type ReviewGateMergeConflictLifecycleEvent,
   type WorkflowWakeupLifecycleEvent,
   type RecoveryWorkerWakeupHint,
   type RecoveryWorkerWakeupReason,
@@ -30,12 +31,12 @@ export {
   type TaskLifecycleEvent,
   type ReviewGateFailedCheck,
   type ReviewGateCiFailedLifecycleEvent,
+  type ReviewGateMergeConflictLifecycleEvent,
   type WorkflowWakeupLifecycleEvent,
   type RecoveryWorkerWakeupHint,
   type RecoveryWorkerWakeupReason,
   type WorkflowWakeupReason,
 } from '@invoker/execution-engine';
-
 export interface LifecycleBuildOptions {
   readonly workflowId?: string;
   readonly previousStatus?: TaskStatus;
@@ -69,6 +70,19 @@ export interface ReviewGateCiFailedLifecycleEventInput extends LifecycleBuildOpt
   readonly headRef?: string;
   readonly branch?: string;
   readonly failedChecks: readonly ReviewGateFailedCheck[];
+  readonly statusText: string;
+}
+
+export interface ReviewGateMergeConflictLifecycleEventInput extends LifecycleBuildOptions {
+  readonly workflowId: string;
+  readonly taskId: string;
+  readonly status: TaskStatus;
+  readonly taskStateVersion: number;
+  readonly reviewId: string;
+  readonly reviewUrl: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
+  readonly branch?: string;
   readonly statusText: string;
 }
 
@@ -228,6 +242,52 @@ export function buildReviewGateCiFailedLifecycleEvent(
   };
 }
 
+export function buildReviewGateMergeConflictLifecycleEvent(
+  input: ReviewGateMergeConflictLifecycleEventInput,
+): ReviewGateMergeConflictLifecycleEvent {
+  const generation = input.generation ?? 0;
+  const createdAt = lifecycleCreatedAt(input.createdAt);
+  const eventKey = buildLifecycleEventKey({
+    kind: 'review_gate.merge_conflict',
+    workflowId: input.workflowId,
+    taskId: input.taskId,
+    taskStateVersion: input.taskStateVersion,
+    generation,
+    attemptId: input.attemptId,
+    discriminator: `review:${input.reviewId}:${input.headSha ?? 'no-head-sha'}`,
+  });
+
+  return {
+    eventKey,
+    kind: 'review_gate.merge_conflict',
+    workflowId: input.workflowId,
+    taskId: input.taskId,
+    status: input.status,
+    taskStateVersion: input.taskStateVersion,
+    generation,
+    ...(input.previousStatus ? { previousStatus: input.previousStatus } : {}),
+    ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+    createdAt,
+    recoveryWakeup: buildRecoveryWorkerWakeupHint({
+      eventKey,
+      eventKind: 'review_gate.merge_conflict',
+      workflowId: input.workflowId,
+      taskId: input.taskId,
+      taskStateVersion: input.taskStateVersion,
+      generation,
+      attemptId: input.attemptId,
+      createdAt,
+      reason: 'review_gate_failure',
+    }),
+    reviewId: input.reviewId,
+    reviewUrl: input.reviewUrl,
+    ...(input.headSha ? { headSha: input.headSha } : {}),
+    ...(input.headRef ? { headRef: input.headRef } : {}),
+    ...(input.branch ? { branch: input.branch } : {}),
+    statusText: input.statusText,
+  };
+}
+
 export function buildWorkflowWakeupLifecycleEvent(
   input: WorkflowWakeupLifecycleEventInput,
 ): WorkflowWakeupLifecycleEvent {
@@ -327,6 +387,12 @@ export function isWorkflowLifecycleEvent(value: unknown): value is WorkflowLifec
         && typeof value.reviewId === 'string'
         && typeof value.reviewUrl === 'string'
         && Array.isArray(value.failedChecks)
+        && typeof value.statusText === 'string';
+    case 'review_gate.merge_conflict':
+      return typeof value.taskId === 'string'
+        && typeof value.status === 'string'
+        && typeof value.reviewId === 'string'
+        && typeof value.reviewUrl === 'string'
         && typeof value.statusText === 'string';
     case 'workflow.wakeup':
       return value.reason === 'startup_reconcile'

--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -573,6 +573,7 @@ describe('GitHubMergeGateProvider', () => {
       expect(result.headSha).toBe('abc123');
       expect(result.headRef).toBe('feature/red-ci');
       expect(result.mergeState).toBe('clean');
+      expect(result.hasMergeConflict).toBe(false);
       expect(result.checks).toEqual({
         state: 'failure',
         failed: [
@@ -590,6 +591,58 @@ describe('GitHubMergeGateProvider', () => {
           },
         ],
       });
+    });
+
+    it('marks only DIRTY merge state as a merge conflict signal', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'OPEN',
+            reviewDecision: null,
+            url: 'https://github.com/owner/repo/pull/5',
+            headRefOid: 'dirty123',
+            headRefName: 'feature/conflict',
+            mergeStateStatus: 'DIRTY',
+            statusCheckRollup: [],
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '5', cwd: '/tmp/repo' });
+
+      expect(result.mergeState).toBe('dirty');
+      expect(result.hasMergeConflict).toBe(true);
+    });
+
+    it('does not treat BEHIND merge state as a merge conflict signal', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'OPEN',
+            reviewDecision: null,
+            url: 'https://github.com/owner/repo/pull/6',
+            headRefOid: 'behind123',
+            headRefName: 'feature/behind',
+            mergeStateStatus: 'BEHIND',
+            statusCheckRollup: [],
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '6', cwd: '/tmp/repo' });
+
+      expect(result.mergeState).toBe('dirty');
+      expect(result.hasMergeConflict).toBe(false);
     });
   });
 });

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -5396,6 +5396,77 @@ console.log(JSON.stringify(out));
         );
       });
 
+      it('publishes review-gate merge conflict wakeups for open PR conflicts', async () => {
+        const task = makeTask({
+          id: 'merge-conflict',
+          status: 'review_ready',
+          config: { workflowId: 'wf-merge-conflict', isMergeNode: true },
+          execution: {
+            generation: 4,
+            selectedAttemptId: 'attempt-merge',
+            reviewId: 'owner/repo#303',
+            branch: 'feature/conflict',
+            reviewGate: {
+              activeGeneration: 4,
+              completion: { required: 'all', status: 'approved' as const },
+              artifacts: [{
+                id: 'pr-303',
+                providerId: 'owner/repo#303',
+                required: true,
+                status: 'open' as const,
+                generation: 4,
+                headSha: 'abc123',
+              }],
+            },
+          },
+          taskStateVersion: 13,
+        });
+        const reviewGateMergeConflictPublisher = { publish: vi.fn().mockResolvedValue(undefined) };
+        const orchestrator = {
+          getTask: (id: string) => (id === task.id ? task : undefined),
+          getAllTasks: () => [task],
+          approve: vi.fn(),
+          recordTaskHeartbeat: vi.fn(),
+        };
+        const persistence = { updateTask: vi.fn() };
+        const mergeGateProvider = {
+          checkApproval: vi.fn().mockResolvedValue({
+            lifecycle: 'open',
+            rejected: false,
+            statusText: 'Awaiting review',
+            url: 'https://github.com/owner/repo/pull/303',
+            headSha: 'abc123',
+            headRef: 'feature/conflict',
+            mergeState: 'dirty',
+            hasMergeConflict: true,
+          }),
+        };
+
+        const executor = new TaskRunner({
+          orchestrator: orchestrator as any,
+          persistence: persistence as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          cwd: '/runner-base-cwd',
+          mergeGateProvider: mergeGateProvider as any,
+          reviewGateMergeConflictPublisher: reviewGateMergeConflictPublisher as any,
+        });
+
+        await executor.checkMergeGateStatuses();
+
+        expect(reviewGateMergeConflictPublisher.publish).toHaveBeenCalledWith({
+          taskId: 'merge-conflict',
+          workflowId: 'wf-merge-conflict',
+          reviewId: 'owner/repo#303',
+          reviewUrl: 'https://github.com/owner/repo/pull/303',
+          headSha: 'abc123',
+          headRef: 'feature/conflict',
+          branch: 'feature/conflict',
+          selectedAttemptId: 'attempt-merge',
+          generation: 4,
+          statusText: 'Awaiting review',
+        });
+      });
+
       it('polls all current reviewGate artifacts and approves only after every required artifact is approved', async () => {
         const downstream = makeTask({ id: 'downstream-after-stack', status: 'running' });
         const reviewGate = {

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -152,6 +152,7 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       headSha: data.headRefOid,
       headRef: data.headRefName,
       mergeState: normalizeMergeState(data.mergeStateStatus),
+      hasMergeConflict: data.mergeStateStatus === 'DIRTY',
       checks: summarizeStatusChecks(data.statusCheckRollup),
     };
   }

--- a/packages/execution-engine/src/lifecycle-events.ts
+++ b/packages/execution-engine/src/lifecycle-events.ts
@@ -19,6 +19,7 @@ export const WORKFLOW_LIFECYCLE_EVENT_KINDS = [
   'task.needs_input',
   'task.removed',
   'review_gate.ci_failed',
+  'review_gate.merge_conflict',
   'workflow.wakeup',
 ] as const;
 
@@ -91,6 +92,18 @@ export interface ReviewGateCiFailedLifecycleEvent extends WorkflowLifecycleEvent
   readonly statusText: string;
 }
 
+export interface ReviewGateMergeConflictLifecycleEvent extends WorkflowLifecycleEventBase {
+  readonly kind: 'review_gate.merge_conflict';
+  readonly taskId: string;
+  readonly status: TaskStatus;
+  readonly reviewId: string;
+  readonly reviewUrl: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
+  readonly branch?: string;
+  readonly statusText: string;
+}
+
 export interface WorkflowWakeupLifecycleEvent extends WorkflowLifecycleEventBase {
   readonly kind: 'workflow.wakeup';
   readonly reason: WorkflowWakeupReason;
@@ -100,6 +113,7 @@ export interface WorkflowWakeupLifecycleEvent extends WorkflowLifecycleEventBase
 export type WorkflowLifecycleEvent =
   | TaskLifecycleEvent
   | ReviewGateCiFailedLifecycleEvent
+  | ReviewGateMergeConflictLifecycleEvent
   | WorkflowWakeupLifecycleEvent;
 
 export type WorkflowWakeupReason =

--- a/packages/execution-engine/src/merge-gate-provider.ts
+++ b/packages/execution-engine/src/merge-gate-provider.ts
@@ -47,6 +47,7 @@ export interface MergeGateApprovalStatus {
   headSha?: string;
   headRef?: string;
   mergeState?: 'clean' | 'dirty' | 'unknown';
+  hasMergeConflict?: boolean;
   checks?: MergeGateCheckSummary;
 }
 

--- a/packages/execution-engine/src/task-runner-review-gate.ts
+++ b/packages/execution-engine/src/task-runner-review-gate.ts
@@ -3,8 +3,8 @@
  *
  * Owns the poll loop that reconciles each merge-node task's review artifacts
  * against the merge-gate provider, maps provider lifecycle → artifact status,
- * completes approved gates, closes reviews on teardown, and publishes CI-failure
- * lifecycle triggers.
+ * completes approved gates, closes reviews on teardown, and publishes
+ * review-gate failure lifecycle triggers.
  *
  * Stateful functions take a {@link TaskRunnerReviewGateHost} — a
  * `Pick<TaskRunner, …>` — as their first parameter, so the type-only import of
@@ -14,9 +14,8 @@
  * this module; the same-named `TaskRunner` methods are thin delegates that route
  * through `gitPlumbing`-style namespace calls.
  *
- * The `ReviewGateCiFailureTrigger` / `ReviewGateCiFailureLifecyclePublisher`
- * declarations live here (their owning cluster) and stay barrel-visible via the
- * package index re-export.
+ * The review-gate failure trigger/publisher declarations live here (their
+ * owning cluster) and stay barrel-visible via the package index re-export.
  */
 
 import type { TaskState } from '@invoker/workflow-core';
@@ -46,11 +45,29 @@ export interface ReviewGateCiFailureLifecyclePublisher {
   publish(trigger: ReviewGateCiFailureTrigger): void | Promise<void>;
 }
 
+export interface ReviewGateMergeConflictTrigger {
+  taskId: string;
+  workflowId: string;
+  reviewId: string;
+  reviewUrl: string;
+  headSha?: string;
+  headRef?: string;
+  branch?: string;
+  selectedAttemptId?: string;
+  generation: number;
+  statusText: string;
+}
+
+export interface ReviewGateMergeConflictLifecyclePublisher {
+  publish(trigger: ReviewGateMergeConflictTrigger): void | Promise<void>;
+}
+
 /**
  * Subset of {@link TaskRunner} the review-gate polling family reads. Picked from
  * `TaskRunner` (not hand-written) so the host stays locked to the runner's real
- * member types. `reviewGateCiFailureInFlight` is single-cluster-owned: it lives
- * here as an `@internal` runner field and is picked into this host.
+ * `reviewGateCiFailureInFlight` and `reviewGateMergeConflictInFlight` are
+ * single-cluster-owned: they live here as `@internal` runner fields and are
+ * picked into this host.
  */
 export type TaskRunnerReviewGateHost = Pick<
   TaskRunner,
@@ -64,6 +81,8 @@ export type TaskRunnerReviewGateHost = Pick<
   // Review-gate cluster state
   | 'reviewGateCiFailurePublisher'
   | 'reviewGateCiFailureInFlight'
+  | 'reviewGateMergeConflictPublisher'
+  | 'reviewGateMergeConflictInFlight'
 >;
 
 export async function closeWorkflowReview(
@@ -254,6 +273,7 @@ export async function pollMergeGateTask(
         host.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
       } else if (status.lifecycle === 'open') {
         await maybePublishReviewGateCiFailure(host, current!, status, providerId);
+        await maybePublishReviewGateMergeConflict(host, current!, status, providerId);
       }
       continue;
     }
@@ -269,6 +289,7 @@ export async function pollMergeGateTask(
       host.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
     } else if (status.lifecycle === 'open') {
       await maybePublishReviewGateCiFailure(host, current!, status, providerId);
+      await maybePublishReviewGateMergeConflict(host, current!, status, providerId);
     }
   }
 }
@@ -338,5 +359,42 @@ export async function maybePublishReviewGateCiFailure(
     });
   } finally {
     host.reviewGateCiFailureInFlight.delete(key);
+  }
+}
+
+export async function maybePublishReviewGateMergeConflict(
+  host: TaskRunnerReviewGateHost,
+  task: TaskState,
+  status: MergeGateApprovalStatus,
+  reviewId: string = task.execution.reviewId ?? '',
+): Promise<void> {
+  if (!host.reviewGateMergeConflictPublisher) return;
+  if (!task.config.workflowId || !reviewId) return;
+  if (!status.hasMergeConflict) return;
+
+  const key = [
+    task.id,
+    task.execution.selectedAttemptId ?? 'no-attempt',
+    task.execution.generation ?? 0,
+    status.headSha ?? 'no-head-sha',
+  ].join(':');
+  if (host.reviewGateMergeConflictInFlight.has(key)) return;
+
+  host.reviewGateMergeConflictInFlight.add(key);
+  try {
+    await host.reviewGateMergeConflictPublisher.publish({
+      taskId: task.id,
+      workflowId: task.config.workflowId,
+      reviewId,
+      reviewUrl: status.url,
+      headSha: status.headSha,
+      headRef: status.headRef,
+      branch: task.execution.branch,
+      selectedAttemptId: task.execution.selectedAttemptId,
+      generation: task.execution.generation ?? 0,
+      statusText: status.statusText,
+    });
+  } finally {
+    host.reviewGateMergeConflictInFlight.delete(key);
   }
 }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -66,7 +66,10 @@ import { buildWorkRequest } from './task-runner-prepare.js';
 import { dispatchExecutor } from './task-runner-dispatch.js';
 import { wireCompletion } from './task-runner-finalize.js';
 import * as reviewGate from './task-runner-review-gate.js';
-import type { ReviewGateCiFailureLifecyclePublisher } from './task-runner-review-gate.js';
+import type {
+  ReviewGateCiFailureLifecyclePublisher,
+  ReviewGateMergeConflictLifecyclePublisher,
+} from './task-runner-review-gate.js';
 import {
   poolMemberKey,
   selectPoolMember,
@@ -163,6 +166,7 @@ export interface TaskRunnerConfig {
   mergeGateProvider?: MergeGateProvider;
   reviewProviderRegistry?: ReviewProviderRegistry;
   reviewGateCiFailurePublisher?: ReviewGateCiFailureLifecyclePublisher;
+  reviewGateMergeConflictPublisher?: ReviewGateMergeConflictLifecyclePublisher;
   /**
    * Provider that returns remote SSH targets keyed by target ID.
    * Called at task-execution time so config file changes take effect on retry.
@@ -217,6 +221,9 @@ export class TaskRunner {
   /** @internal */ reviewProviderRegistry?: ReviewProviderRegistry;
   /** @internal */ reviewGateCiFailurePublisher?: ReviewGateCiFailureLifecyclePublisher;
   /** @internal */ reviewGateCiFailureInFlight = new Set<string>();
+  /** @internal */ reviewGateMergeConflictPublisher?: ReviewGateMergeConflictLifecyclePublisher;
+  /** @internal */ reviewGateMergeConflictInFlight = new Set<string>();
+
   /** @internal */ getRemoteTargets: () => Record<string, RemoteTargetDisplay>;
   /** @internal */ getExecutionPools: () => Record<string, ExecutionPoolConfig>;
   private getExecutionDefaults: () => { executionAgent?: string; executionModel?: string };
@@ -332,6 +339,7 @@ export class TaskRunner {
     this.mergeGateProvider = config.mergeGateProvider;
     this.reviewProviderRegistry = config.reviewProviderRegistry;
     this.reviewGateCiFailurePublisher = config.reviewGateCiFailurePublisher;
+    this.reviewGateMergeConflictPublisher = config.reviewGateMergeConflictPublisher;
     this.getRemoteTargets = config.remoteTargetsProvider ?? (() => ({}));
     this.getExecutionPools = config.executionPoolsProvider ?? (() => ({}));
     this.getExecutionDefaults = config.executionDefaultsProvider ?? (() => ({}));


### PR DESCRIPTION
## Summary

This slice wires the merge-conflict publisher into the headless task-runner builder.

The bug was that the headless-owned `TaskRunner` builder still only forwarded `review_gate.ci_failed` into the lifecycle bridge.

The fix updates `headless-shared` so headless runners also inject the merge-conflict publisher.

## Review Claim

Reviewers are approving that headless task-runner construction now forwards review-gate merge-conflict events into the lifecycle bridge.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice only changes headless task-runner construction. It does not change desktop wiring or worker policy.

## Slice Rationale

The headless entrypoint wiring is separate from the desktop builder so each surface can be checked on its own.

## Non-goals

- No desktop builder change.
- No provider change.
- No worker behavior change.

## Architecture

### Before

`headless-shared` only injected `reviewGateCiFailurePublisher`, so headless-created runners dropped merge-conflict callbacks.

### After

`headless-shared` now injects both review-gate publishers during headless task-runner construction.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 341fe6cd8`
- Post-revert steps: None.
- Data migration? No.

</details>

Depends-On: #4358