### PR TITLE
[Off-main UI Mutations](1) Route daemon GUI-only actions

### DIFF
--- a/packages/app/src/__tests__/gui-mutation-translation.test.ts
+++ b/packages/app/src/__tests__/gui-mutation-translation.test.ts
@@ -53,6 +53,8 @@ describe('GUI mutation translation', () => {
     'invoker:check-pr-statuses',
     'invoker:check-pr-status',
     'invoker:start-ready',
+    'invoker:select-experiment',
+    'invoker:edit-task-pool',
   ])('routes %s to the owner GUI mutation handler', (channel) => {
     const translatorSource = getTranslatorSource();
     expect(translatorSource).toMatch(

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -890,8 +890,7 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
           ? { channel: 'headless.exec', request: { args: ['reject', String(arg0)], noTrack: true } }
           : { channel: 'headless.exec', request: { args: ['reject', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:select-experiment':
-        if (Array.isArray(arg1)) return null;
-        return { channel: 'headless.exec', request: { args: ['select', String(arg0), String(arg1)], noTrack: true } };
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:retry-task':
         return { channel: 'headless.exec', request: { args: ['retry-task', String(arg0)], noTrack: true } };
       case 'invoker:cancel-task':
@@ -939,7 +938,7 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
       case 'invoker:edit-task-type':
         return { channel: 'headless.exec', request: { args: ['set', 'executor', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:edit-task-pool':
-        return null;
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:edit-task-agent':
         return { channel: 'headless.exec', request: { args: ['set', 'agent', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:edit-task-model':


### PR DESCRIPTION
## Summary

This repair keeps PR #4362's landed delegation slice aligned with current `master`.

`select-experiment` and `edit-task-pool` stay on `headless.gui-mutation` in the IPC translator that now owns GUI mutation delegation.

Beachball planning-chat lag delta is `0ms` by design because this repair changes no planning chat, benchmark harness, or beachball behavior.

## Review Claim

This PR changes only the daemon GUI mutation translator decision for `select-experiment` and `edit-task-pool`, keeping both on owner GUI mutation handling.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the translator outcomes for those two GUI-only actions and their focused regression check change. `packages/app/src/ipc/gui-mutation-handlers.ts` is a minimal conflict-only adjustment because current `master` owns that translator outside `main.ts`.

## Slice Rationale

The beachball stack cannot safely start until this Off-main UI Mutations root PR is healthy again.

## Non-goals

- No planning chat code.
- No benchmark harness.
- No beachball changes.
- No PR #4363 edits.
- No daemon startup, read-path, or owner-default changes.

## Architecture

### Before

Before this slice, `select-experiment` delegated through `headless.exec` and `edit-task-pool` returned `null`, so neither used owner GUI mutation handling.

### After

The translator keeps both GUI-only channels on `headless.gui-mutation`, letting the existing owner GUI mutation handler process them. No new delegation layer is added.

## Alternative Considerations

Putting the special case back in `main.ts` was rejected because current `master` owns this translator in `ipc/gui-mutation-handlers.ts`.

Adding beachball proof or planning-chat instrumentation here was rejected because this PR is only the stack-root repair.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/gui-mutation-translation.test.ts`

</details>

The requested wrapper command `pnpm --filter @invoker/app test -- --run src/__tests__/gui-mutation-translation.test.ts` was also run on July 28, 2026. The translator file passed inside that run, but the wrapper expanded to the full app Vitest suite and exited `1` on unrelated `main-process-read-hotpath-cost.test.ts` timing.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 537de82ff05286dbdcd9d296e1ecce1de11667c0`
- Post-revert steps: Rerun the focused translator test.
- Data migration? No.

</details>
