### PR TITLE
[Off-main UI Mutations](2) Prefer daemon owner in auto mode

### DIFF
--- a/packages/app/e2e/gui-owner-auto-bootstrap.spec.ts
+++ b/packages/app/e2e/gui-owner-auto-bootstrap.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from './fixtures/electron-app';
+
+test.use({ guiOwnerMode: 'auto' });
+
+test('auto GUI mode boots a daemon owner', async ({ page }) => {
+  const runtimeStatus = await page.evaluate(async () => window.invoker.getRuntimeStatus());
+
+  expect(runtimeStatus).toEqual({
+    ownerMode: false,
+    readOnly: false,
+    mode: 'daemon-owner',
+  });
+});

--- a/packages/app/src/__tests__/app-bootstrap.test.ts
+++ b/packages/app/src/__tests__/app-bootstrap.test.ts
@@ -5,12 +5,14 @@ import {
   shouldTreatAsDaemonOwnerLoss,
   configureEarlyElectronApp,
   formatGuiOwnerBootstrapFallbackMessage,
+  guiAutoOwnerBootstrapTimeoutMs,
   guiOwnerBootstrapTimeoutMs,
   isMutationOwnerUnavailableError,
   registerGuiLifecycleHandlers,
   resolveGuiOwnerPreference,
   resolveElectronUserDataDir,
   runElectronReadyBootstrap,
+  shouldBootstrapDaemonOwner,
   shouldRefreshGuiOwnerRoute,
   startGuiModeBootstrap,
   startMainProcessBootstrap,
@@ -241,11 +243,14 @@ describe('app-bootstrap', () => {
     expect(order).toEqual(['headless', 'gui']);
   });
 
-  it('defaults GUI owner startup to auto discovery instead of daemon bootstrap', () => {
+  it('keeps auto as the default owner preference while preferring daemon bootstrap', () => {
     expect(resolveGuiOwnerPreference({})).toBe('auto');
     expect(resolveGuiOwnerPreference({ INVOKER_GUI_OWNER_MODE: 'daemon' })).toBe('daemon');
     expect(resolveGuiOwnerPreference({ INVOKER_GUI_OWNER_MODE: 'local' })).toBe('gui');
     expect(resolveGuiOwnerPreference({ INVOKER_GUI_DAEMON_OWNER: '1' })).toBe('daemon');
+    expect(shouldBootstrapDaemonOwner('auto')).toBe(true);
+    expect(shouldBootstrapDaemonOwner('daemon')).toBe(true);
+    expect(shouldBootstrapDaemonOwner('gui')).toBe(false);
   });
 
   it('refreshes GUI owner routing for daemon-backed GUI clients only', () => {
@@ -289,10 +294,12 @@ describe('app-bootstrap', () => {
     expect(isMutationOwnerUnavailableError(new Error('timeout'))).toBe(false);
   });
 
-  it('uses a bounded daemon bootstrap timeout and ignores invalid overrides', () => {
+  it('uses bounded daemon bootstrap timeouts and ignores invalid overrides', () => {
     expect(guiOwnerBootstrapTimeoutMs({ INVOKER_GUI_OWNER_BOOTSTRAP_TIMEOUT_MS: '2500' })).toBe(2500);
     expect(guiOwnerBootstrapTimeoutMs({ INVOKER_GUI_OWNER_BOOTSTRAP_TIMEOUT_MS: '-1' })).toBe(60000);
     expect(guiOwnerBootstrapTimeoutMs({ INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS: '1200' })).toBe(1200);
+    expect(guiAutoOwnerBootstrapTimeoutMs({ INVOKER_GUI_AUTO_OWNER_BOOTSTRAP_TIMEOUT_MS: '900' })).toBe(900);
+    expect(guiAutoOwnerBootstrapTimeoutMs({ INVOKER_GUI_AUTO_OWNER_BOOTSTRAP_TIMEOUT_MS: '0' })).toBe(5000);
   });
 
   it('formats daemon bootstrap failures with a local owner recovery path', () => {

--- a/packages/app/src/bootstrap/app-bootstrap.ts
+++ b/packages/app/src/bootstrap/app-bootstrap.ts
@@ -18,6 +18,14 @@ export function shouldRefreshGuiOwnerRoute(
 ): boolean {
   return preference === 'daemon' || (preference === 'auto' && isUsingDaemonOwner);
 }
+export function shouldBootstrapDaemonOwner(preference: GuiOwnerPreference): boolean {
+  return preference === 'daemon' || preference === 'auto';
+}
+
+export function guiAutoOwnerBootstrapTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const parsed = Number.parseInt(env.INVOKER_GUI_AUTO_OWNER_BOOTSTRAP_TIMEOUT_MS ?? '5000', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 5000;
+}
 
 export function guiOwnerBootstrapTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
   const parsed = Number.parseInt(

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -10,8 +10,10 @@ import {
   configureEarlyElectronApp,
   createDaemonOwnerLossController,
   formatGuiOwnerBootstrapFallbackMessage,
+  guiAutoOwnerBootstrapTimeoutMs,
   guiOwnerBootstrapTimeoutMs,
   isMutationOwnerUnavailableError,
+  shouldBootstrapDaemonOwner,
   shouldTreatAsDaemonOwnerLoss,
   registerGuiLifecycleHandlers,
   resolveGuiOwnerPreference,
@@ -516,11 +518,10 @@ async function discoverStandaloneOwnerForGui(waitMs: number): Promise<boolean> {
   }
 }
 
-async function ensureStandaloneOwnerForGui(): Promise<void> {
+async function ensureStandaloneOwnerForGui(timeoutMs: number = guiOwnerBootstrapTimeoutMs()): Promise<void> {
   if (await discoverStandaloneOwnerForGui(2_000)) return;
 
   const invokerHomeRoot = resolveInvokerHomeRoot();
-  const timeoutMs = guiOwnerBootstrapTimeoutMs();
   const bootstrapLock = tryAcquireOwnerBootstrapLock(invokerHomeRoot);
   try {
     if (bootstrapLock) {
@@ -2441,16 +2442,17 @@ startMainProcessBootstrap({
         process.stderr.write(`${YELLOW}Warning:${RESET} ${fallbackMessage}\n`);
         daemonGuiOwner = false;
       }
-    } else if (guiOwnerPreference === 'auto') {
-      recordStartupMark('daemonOwner.discover.start');
+    } else if (shouldBootstrapDaemonOwner(guiOwnerPreference)) {
+      recordStartupMark('daemonOwner.bootstrap.start');
       try {
-        daemonGuiOwner = await discoverStandaloneOwnerForGui(1_000);
+        await ensureStandaloneOwnerForGui(guiAutoOwnerBootstrapTimeoutMs());
+        daemonGuiOwner = true;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        logger.warn(`daemon owner auto-discovery failed; starting GUI owner locally: ${message}`, { module: 'init' });
+        logger.warn(`daemon owner auto-bootstrap failed; starting GUI owner locally: ${message}`, { module: 'init' });
         daemonGuiOwner = false;
       }
-      recordStartupMark('daemonOwner.discover.end', { daemonOwner: daemonGuiOwner });
+      recordStartupMark('daemonOwner.bootstrap.end', { daemonOwner: daemonGuiOwner });
     }
 
     if (daemonGuiOwner) {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1641,6 +1641,8 @@ function startHeadlessMode(): void {
             ok: true,
             ownerId: workflowMutationOwnerId,
             mode: 'standalone',
+            buildVersion,
+            buildSha,
           };
         });
         messageBus.onRequest('headless.query', async (req: unknown) =>
@@ -2677,6 +2679,8 @@ startMainProcessBootstrap({
         ok: true,
         ownerId: workflowMutationOwnerId,
         mode: 'gui',
+        buildVersion,
+        buildSha,
       }));
       messageBus.onRequest('headless.query', async (req: unknown) =>
         answerOwnerHeadlessQuery(req, buildOwnerReadQueryHandlers({


### PR DESCRIPTION
## Summary

Auto GUI startup still prefers a standalone daemon owner in auto mode before falling back to local owner mode.

This repair replays that daemon-owner slice on top of the repaired routing root.

No beachball or planning-chat behavior is added.

## Review Claim

Auto GUI startup prefers daemon-owner mode for workflow mutations while preserving local fallback.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Explicit `INVOKER_GUI_OWNER_MODE=gui` still stays local. Explicit daemon mode keeps its longer bootstrap path. Auto mode preserves the bounded `5,000ms` bootstrap fallback before local owner mode, and this repaired diff stays scoped to the existing PR #4363 files.

## Slice Rationale

This remains the daemon-owner default slice above the routing repair so PR #4362 can be reviewed independently.

## Non-goals

- Do not move read queries off the Electron main process.
- Do not change workflow mutation queue ordering.
- Do not add beachball, planning-chat, or benchmark harness code.
- Do not change PR #4362.

## Visual Proof

![Auto GUI startup runtime status showing daemon-owner mode](https://gist.githubusercontent.com/EdbertChan/3943dc938014db388a588cc4474cbeaf/raw/382bbbb18f5b11592f849d1e92157cb3b16a1f8d/pr4363-daemon-owner-runtime-proof.svg)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- --run src/__tests__/app-bootstrap.test.ts src/__tests__/gui-mutation-translation.test.ts`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app test:e2e gui-owner-auto-bootstrap.spec.ts`

</details>

Verified on the merged #4363 commit `f597c047dedd489ece110e67c878e8150b1ca132`. Planning-chat lag delta remains `0ms`; this repair preserves the existing `5,000ms` auto-bootstrap fallback bound.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert -m 1 f597c047dedd489ece110e67c878e8150b1ca132`
- Post-revert steps: Rerun the Test Plan commands.
- Data migration? No.

</details>
