### PR TITLE
[Inspector timeline](1) Show worker decisions beside task events

### DIFF
--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -731,9 +731,17 @@ describe('WorkflowInspector', () => {
     expect(screen.getByTestId('workflow-inspector-action-node')).toHaveTextContent('12000');
   });
 
-  it('shows task logs and filters by minimum level', async () => {
+  it('shows task timeline events and matching worker decisions', async () => {
     (window as unknown as {
-      invoker: { getEvents: (taskId: string, options: { limit: number }) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };
+      invoker: {
+        getEvents: (taskId: string, options: { limit: number }) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>>;
+        getWorkerDecisions: () => Promise<{
+          actions: Array<Record<string, unknown>>;
+          limit: number;
+          offset: number;
+          hasMore: boolean;
+        }>;
+      };
     }).invoker = {
       getEvents: vi.fn(async () => [
         {
@@ -755,6 +763,46 @@ describe('WorkflowInspector', () => {
           createdAt: '2025-01-01T00:00:01.000Z',
         },
       ]),
+      getWorkerDecisions: vi.fn(async () => ({
+        actions: [
+          {
+            id: 'wd-1',
+            workerKind: 'autofix',
+            actionType: 'fix-task',
+            workflowId: 'wf-1',
+            taskId: 'task-1',
+            subjectType: 'task',
+            subjectId: 'task-1',
+            externalKey: 'wf-1/task-1:g0:a1',
+            status: 'queued',
+            attemptCount: 1,
+            summary: 'Queued auto-fix with agent',
+            decision: 'act',
+            createdAt: '2025-01-01T00:00:04.000Z',
+            updatedAt: '2025-01-01T00:00:04.000Z',
+          },
+          {
+            id: 'wd-2',
+            workerKind: 'autofix',
+            actionType: 'fix-task',
+            workflowId: 'wf-1',
+            taskId: 'task-2',
+            subjectType: 'task',
+            subjectId: 'task-2',
+            externalKey: 'wf-1/task-2:g0:a1',
+            status: 'skipped',
+            attemptCount: 1,
+            summary: 'Skipped auto-fix',
+            reason: 'retry-budget-disabled',
+            decision: 'skip',
+            createdAt: '2025-01-01T00:00:05.000Z',
+            updatedAt: '2025-01-01T00:00:05.000Z',
+          },
+        ],
+        limit: 25,
+        offset: 0,
+        hasMore: false,
+      })),
     };
 
     try {
@@ -771,6 +819,8 @@ describe('WorkflowInspector', () => {
 
       await waitFor(() => expect(screen.getByText('Preparing review workspace')).toBeInTheDocument());
       expect(screen.getByText('Merge gate failed')).toBeInTheDocument();
+      await waitFor(() => expect(screen.getByText('Queued auto-fix with agent')).toBeInTheDocument());
+      expect(screen.queryByText('Skipped auto-fix')).not.toBeInTheDocument();
       expect(screen.queryByText('debug detail')).not.toBeInTheDocument();
 
       fireEvent.change(screen.getByTestId('task-log-level-select'), { target: { value: 'debug' } });

--- a/packages/ui/src/components/WorkerDecisionsSection.tsx
+++ b/packages/ui/src/components/WorkerDecisionsSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { WorkerActionSummary } from '../types.js';
 import { useWorkerDecisions } from '../hooks/useWorkerDecisions.js';
 import { displayWorkerTaskId, formatWorkerValue } from '../lib/worker-display.js';
@@ -11,25 +11,44 @@ function decisionClass(action: WorkerActionSummary): 'act' | 'skip' {
   return action.decision ?? (action.status === 'skipped' ? 'skip' : 'act');
 }
 
+function decisionTimestamp(action: WorkerActionSummary): string {
+  const value = action.completedAt ?? action.updatedAt ?? action.createdAt;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return '';
+  return new Date(parsed).toLocaleTimeString();
+}
+
+interface WorkerDecisionsSectionProps {
+  workerKind?: string;
+  workflowId?: string;
+  taskId?: string;
+  title?: string;
+  emptyText?: string;
+}
+
 export function WorkerDecisionsSection({
   workerKind,
   workflowId,
-}: {
-  workerKind: string;
-  workflowId?: string;
-}) {
+  taskId,
+  title = 'Decision timeline',
+  emptyText,
+}: WorkerDecisionsSectionProps) {
   const [filter, setFilter] = useState<DecisionFilter>('all');
   const [decisions] = useWorkerDecisions({
-    workerKind,
+    ...(workerKind ? { workerKind } : {}),
     ...(workflowId ? { workflowId } : {}),
     ...(filter === 'all' ? {} : { decision: filter }),
     limit: 25,
   });
+  const visibleDecisions = useMemo(
+    () => (taskId ? decisions.filter((decision) => decision.taskId === taskId || decision.subjectId === taskId) : decisions),
+    [decisions, taskId],
+  );
 
   return (
     <section className="rounded border border-border bg-card/60 p-3" data-testid="worker-decisions-section">
       <div className="flex items-center justify-between">
-        <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Decisions</h3>
+        <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">{title}</h3>
         <div className="flex gap-1">
           {FILTERS.map((value) => (
             <button
@@ -47,14 +66,15 @@ export function WorkerDecisionsSection({
           ))}
         </div>
       </div>
-      {decisions.length === 0 ? (
+      {visibleDecisions.length === 0 ? (
         <div className="mt-2 text-xs text-muted-foreground">
-          No {filter === 'all' ? '' : `${filter} `}decisions recorded yet.
+          {emptyText ?? `No ${filter === 'all' ? '' : `${filter} `}decisions recorded yet.`}
         </div>
       ) : (
         <ul className="mt-2 space-y-1">
-          {decisions.map((decision) => {
+          {visibleDecisions.map((decision) => {
             const cls = decisionClass(decision);
+            const timestamp = decisionTimestamp(decision);
             return (
               <li
                 key={decision.id}
@@ -75,6 +95,7 @@ export function WorkerDecisionsSection({
                   ) : (
                     <span className="truncate text-muted-foreground">{decision.subjectId}</span>
                   )}
+                  {timestamp ? <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">{timestamp}</span> : null}
                 </div>
                 {decision.reason ? <div className="mt-0.5 text-muted-foreground">reason: {decision.reason}</div> : null}
                 {decision.summary ? <div className="mt-0.5 text-muted-foreground">{decision.summary}</div> : null}

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -4,6 +4,7 @@ import { getEffectiveVisualStatus, getStatusColor } from '../lib/colors.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
 import { subscribeVisibilityAwarePoll } from '../hooks/visibilityAwarePoll.js';
 import { mutationFailureTitle } from '../lib/mutation-failure-display.js';
+import { WorkerDecisionsSection } from './WorkerDecisionsSection.js';
 import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, WorkflowMutationFailedEvent } from '@invoker/contracts';
 
 type MergeMode = 'manual' | 'automatic' | 'external_review';
@@ -403,7 +404,11 @@ export function WorkflowInspector({
   const logEntries = taskLogEvents.map(taskEventToLogEntry);
   const visibleLogEntries = logEntries
     .filter((entry) => LOG_LEVEL_RANK[entry.level] >= LOG_LEVEL_RANK[logLevelFilter]);
-
+  const selectedWorkflowId = workflow?.id ?? task?.config.workflowId;
+  const timelineDecisionTitle = task ? 'Worker decisions' : 'Workflow decisions';
+  const timelineDecisionEmptyText = task
+    ? 'No worker decisions for this task yet.'
+    : 'No workflow-level worker decisions recorded yet.';
   const savePrompt = () => {
     if (task && onEditPrompt && editPromptValue !== (task.config.prompt ?? '')) {
       onEditPrompt(task.id, editPromptValue);
@@ -799,68 +804,85 @@ export function WorkflowInspector({
           </section>
         )}
 
-        {task && (
+        {(task || selectedWorkflowId) && (
           <section className="rounded border border-border bg-secondary/70" data-testid="task-logs-section">
             <div className="flex items-center justify-between gap-3 px-3 py-2">
               <button
                 onClick={() => setShowLogs(!showLogs)}
                 className="text-left text-[11px] uppercase tracking-wide text-muted-foreground hover:text-foreground"
                 data-testid="task-logs-toggle"
-                data-sidebar-nav-item
-                data-sidebar-nav-order="80"
-                data-sidebar-expandable="true"
                 aria-expanded={showLogs}
               >
-                Logs {showLogs ? '▲' : '▼'}
+                Timeline {showLogs ? '▲' : '▼'}
               </button>
-              <label className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-muted-foreground">
-                Level
-                <select
-                  value={logLevelFilter}
-                  onChange={(event) => setLogLevelFilter(event.target.value as TaskLogLevel)}
-                  className="rounded border border-border-strong bg-muted px-2 py-1 text-xs normal-case text-foreground focus:border-border-strong focus:outline-none"
-                  data-testid="task-log-level-select"
-                >
-                  <option value="debug">Debug+</option>
-                  <option value="info">Info+</option>
-                  <option value="warn">Warn+</option>
-                  <option value="error">Error</option>
-                </select>
-              </label>
+              {task ? (
+                <label className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-muted-foreground">
+                  Level
+                  <select
+                    value={logLevelFilter}
+                    onChange={(event) => setLogLevelFilter(event.target.value as TaskLogLevel)}
+                    className="rounded border border-border-strong bg-muted px-2 py-1 text-xs normal-case text-foreground focus:border-border-strong focus:outline-none"
+                    data-testid="task-log-level-select"
+                  >
+                    <option value="debug">Debug+</option>
+                    <option value="info">Info+</option>
+                    <option value="warn">Warn+</option>
+                    <option value="error">Error</option>
+                  </select>
+                </label>
+              ) : null}
             </div>
             {showLogs && (
-              <div className="border-t border-border px-3 py-2">
-                {taskLogError && (
-                  <p className="mb-2 rounded border border-amber-800 bg-amber-950/30 px-2 py-1 text-xs text-amber-300" data-testid="task-log-error">
-                    {taskLogError}
-                  </p>
-                )}
-                {visibleLogEntries.length === 0 ? (
-                  <p className="text-xs text-muted-foreground">No logs at this level.</p>
-                ) : (
-                  <div className="space-y-2">
-                    {visibleLogEntries.slice(0, 20).map((entry) => (
-                      <div key={entry.id} className="rounded border border-border bg-card/60 p-2" data-testid="task-log-entry">
-                        <div className="flex items-start gap-2">
-                          <span className={`shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-semibold uppercase ${logLevelClass(entry.level)}`}>
-                            {entry.level}
-                          </span>
-                          <div className="min-w-0 flex-1">
-                            <div className="flex items-baseline justify-between gap-2">
-                              <p className="break-words text-xs text-foreground">{entry.message}</p>
-                              {entry.createdAt && (
-                                <span className="shrink-0 text-[10px] text-muted-foreground">{formatEventTime(entry.createdAt)}</span>
-                              )}
+              <div className="space-y-3 border-t border-border px-3 py-2">
+                <p className="text-xs text-muted-foreground">
+                  {task
+                    ? 'Task events first. Worker decisions below. This is the fastest way to see retries, skips, and AI fix attempts.'
+                    : 'Workflow-level worker decisions. Select a task for the event-by-event task timeline.'}
+                </p>
+                {task ? (
+                  <div>
+                    <div className="mb-2 text-[11px] uppercase tracking-wide text-muted-foreground">Task events</div>
+                    {taskLogError && (
+                      <p className="mb-2 rounded border border-amber-800 bg-amber-950/30 px-2 py-1 text-xs text-amber-300" data-testid="task-log-error">
+                        {taskLogError}
+                      </p>
+                    )}
+                    {visibleLogEntries.length === 0 ? (
+                      <p className="text-xs text-muted-foreground">No timeline entries at this level.</p>
+                    ) : (
+                      <div className="space-y-2">
+                        {visibleLogEntries.slice(0, 20).map((entry) => (
+                          <div key={entry.id} className="rounded border border-border bg-card/60 p-2" data-testid="task-log-entry">
+                            <div className="flex items-start gap-2">
+                              <span className={`shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-semibold uppercase ${logLevelClass(entry.level)}`}>
+                                {entry.level}
+                              </span>
+                              <div className="min-w-0 flex-1">
+                                <div className="flex items-baseline justify-between gap-2">
+                                  <p className="break-words text-xs text-foreground">{entry.message}</p>
+                                  {entry.createdAt && (
+                                    <span className="shrink-0 text-[10px] text-muted-foreground">{formatEventTime(entry.createdAt)}</span>
+                                  )}
+                                </div>
+                                {entry.detail && (
+                                  <code className="mt-1 block break-all text-[10px] text-muted-foreground">{entry.detail}</code>
+                                )}
+                              </div>
                             </div>
-                            {entry.detail && (
-                              <code className="mt-1 block break-all text-[10px] text-muted-foreground">{entry.detail}</code>
-                            )}
                           </div>
-                        </div>
+                        ))}
                       </div>
-                    ))}
+                    )}
                   </div>
-                )}
+                ) : null}
+                {selectedWorkflowId ? (
+                  <WorkerDecisionsSection
+                    workflowId={selectedWorkflowId}
+                    taskId={task?.id}
+                    title={timelineDecisionTitle}
+                    emptyText={timelineDecisionEmptyText}
+                  />
+                ) : null}
               </div>
             )}
           </section>


### PR DESCRIPTION
## Summary

The task inspector now calls this area **Timeline** and keeps task events with worker decisions in one place.

Before this, a failed task could show task output in one place and worker recovery state somewhere else, which made the sidebar hard to read.

This keeps the same worker and task data, but makes the timeline path clearer and puts the worker-decision block directly under task events.

## Review Claim

The inspector sidebar is now the single clear place to read task events and worker recovery state for a failed task.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

UI-only change. It still reads the same `getEvents` and `getWorkerDecisions` data and does not change worker policy, retries, or mutations.

## Slice Rationale

This keeps the fix to one sidebar clarity slice instead of mixing it with worker scheduling changes or a larger timeline rewrite.

## Non-goals

- Do not change autofix scheduling.
- Do not merge task events and worker decisions into one chronological list.
- Do not change backend contracts or persistence.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm exec vitest run src/__tests__/workflow-inspector.test.tsx src/__tests__/worker-decisions-section.test.tsx src/__tests__/worker-details-panel.test.tsx src/__tests__/keyboard-controls.test.tsx`

</details>

## Visual Proof

Task timeline now keeps task events and the worker-decision block in one inspector panel.

![Task timeline now keeps task events and the worker-decision block in one inspector panel.](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260714-57bb43/invoker-proof-timeline-after.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 39b547d`
- Post-revert steps: None
- Data migration? No

</details>
