### PR TITLE
[Inspector timeline](2) Tone down timeline event styling

### DIFF
--- a/packages/ui/src/components/WorkerDecisionsSection.tsx
+++ b/packages/ui/src/components/WorkerDecisionsSection.tsx
@@ -17,6 +17,10 @@ function decisionTimestamp(action: WorkerActionSummary): string {
   if (!Number.isFinite(parsed)) return '';
   return new Date(parsed).toLocaleTimeString();
 }
+function decisionLabelClass(decision: 'act' | 'skip'): string {
+  return decision === 'skip' ? 'text-amber-300' : 'text-emerald-300';
+}
+
 
 interface WorkerDecisionsSectionProps {
   workerKind?: string;
@@ -46,7 +50,7 @@ export function WorkerDecisionsSection({
   );
 
   return (
-    <section className="rounded border border-border bg-card/60 p-3" data-testid="worker-decisions-section">
+    <section className="pt-3" data-testid="worker-decisions-section">
       <div className="flex items-center justify-between">
         <h3 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">{title}</h3>
         <div className="flex gap-1">
@@ -71,22 +75,18 @@ export function WorkerDecisionsSection({
           {emptyText ?? `No ${filter === 'all' ? '' : `${filter} `}decisions recorded yet.`}
         </div>
       ) : (
-        <ul className="mt-2 space-y-1">
-          {visibleDecisions.map((decision) => {
+        <ul className="mt-2">
+          {visibleDecisions.map((decision, index) => {
             const cls = decisionClass(decision);
             const timestamp = decisionTimestamp(decision);
             return (
               <li
                 key={decision.id}
                 data-testid="worker-decision-row"
-                className="rounded border border-border/80 bg-background/40 px-2 py-1 text-xs"
+                className={`${index === 0 ? '' : 'border-t border-border/40'} py-2 text-xs`}
               >
                 <div className="flex items-center gap-2">
-                  <span
-                    className={`rounded px-1 py-0.5 text-[10px] font-semibold uppercase ${
-                      cls === 'skip' ? 'bg-amber-900/50 text-amber-200' : 'bg-emerald-900/50 text-emerald-200'
-                    }`}
-                  >
+                  <span className={`shrink-0 text-[10px] font-medium uppercase ${decisionLabelClass(cls)}`}>
                     {cls}
                   </span>
                   <span className="text-muted-foreground">{formatWorkerValue(decision.status)}</span>
@@ -97,8 +97,8 @@ export function WorkerDecisionsSection({
                   )}
                   {timestamp ? <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">{timestamp}</span> : null}
                 </div>
-                {decision.reason ? <div className="mt-0.5 text-muted-foreground">reason: {decision.reason}</div> : null}
-                {decision.summary ? <div className="mt-0.5 text-muted-foreground">{decision.summary}</div> : null}
+                {decision.reason ? <div className="mt-1 text-muted-foreground">reason: {decision.reason}</div> : null}
+                {decision.summary ? <div className="mt-1 text-foreground/85">{decision.summary}</div> : null}
               </li>
             );
           })}

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -119,14 +119,14 @@ function workspaceRecreateNoticeFromEvent(event: TaskAuditEvent): WorkspaceRecre
 function logLevelClass(level: TaskLogLevel): string {
   switch (level) {
     case 'error':
-      return 'bg-red-900/40 text-red-300 border-red-800';
+      return 'text-red-300';
     case 'warn':
-      return 'bg-amber-900/40 text-amber-300 border-amber-800';
+      return 'text-amber-300';
     case 'debug':
-      return 'bg-slate-800 text-slate-300 border-slate-700';
+      return 'text-slate-300';
     case 'info':
     default:
-      return 'bg-secondary/70 text-foreground border-border-strong';
+      return 'text-muted-foreground';
   }
 }
 
@@ -850,11 +850,15 @@ export function WorkflowInspector({
                     {visibleLogEntries.length === 0 ? (
                       <p className="text-xs text-muted-foreground">No timeline entries at this level.</p>
                     ) : (
-                      <div className="space-y-2">
-                        {visibleLogEntries.slice(0, 20).map((entry) => (
-                          <div key={entry.id} className="rounded border border-border bg-card/60 p-2" data-testid="task-log-entry">
+                      <div className="space-y-0">
+                        {visibleLogEntries.slice(0, 20).map((entry, index) => (
+                          <div
+                            key={entry.id}
+                            className={`${index === 0 ? '' : 'border-t border-border/40'} py-2`}
+                            data-testid="task-log-entry"
+                          >
                             <div className="flex items-start gap-2">
-                              <span className={`shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-semibold uppercase ${logLevelClass(entry.level)}`}>
+                              <span className={`shrink-0 pt-0.5 text-[10px] font-medium uppercase ${logLevelClass(entry.level)}`}>
                                 {entry.level}
                               </span>
                               <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Summary

The timeline panel now uses one quiet list style instead of separate dark cards for each event row.

Before this, each task event and worker decision looked like its own boxed panel, which made the inspector feel louder than the rest of the sidebar.

This keeps the same timeline panel and filters, but lowers the contrast and uses simple divided rows.

## Review Claim

The timeline surface now looks calmer and less flashy without changing what the sidebar shows.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

UI-only change. It only adjusts classes in `WorkflowInspector` and `WorkerDecisionsSection`. No data loading, worker logic, or mutations changed.

## Slice Rationale

This keeps the styling cleanup separate from the earlier timeline structure change, so the visual pass can be reviewed on its own.

## Non-goals

- Do not change which events appear.
- Do not change worker decision filtering.
- Do not merge timeline rows into one new data model.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm exec vitest run src/__tests__/workflow-inspector.test.tsx src/__tests__/worker-decisions-section.test.tsx src/__tests__/worker-details-panel.test.tsx src/__tests__/keyboard-controls.test.tsx`

</details>

## Visual Proof

The timeline now uses one quieter list container instead of a stack of separate event cards.

![The timeline now uses one quieter list container instead of a stack of separate event cards.](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260714-528813/invoker-proof-timeline-boring2.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert cf41bc9`
- Post-revert steps: None
- Data migration? No

</details>
