### PR TITLE
[Running Tab Flicker](1) Reproduce queue-skew blanking

### DIFF
--- a/packages/ui/src/__tests__/workflow-progress-surfaces.test.ts
+++ b/packages/ui/src/__tests__/workflow-progress-surfaces.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import type { QueueStatus } from '@invoker/contracts';
+import { makeUITask } from './helpers/mock-invoker.js';
+import { getRunningTaskEntries } from '../lib/workflow-progress-surfaces.js';
+import type { WorkflowMeta } from '../types.js';
+
+describe('workflow progress surfaces', () => {
+  it('repro: drops live running tasks when queue polling points at a missing task', () => {
+    const workflow: WorkflowMeta = {
+      id: 'wf-alpha',
+      name: 'Alpha',
+      status: 'running',
+    };
+    const alpha = makeUITask({
+      id: 'task-alpha',
+      description: 'First test task',
+      status: 'running',
+      workflowId: workflow.id,
+    });
+    const tasks = new Map([[alpha.id, alpha]]);
+    const workflows = new Map([[workflow.id, workflow]]);
+    const queueStatus: QueueStatus = {
+      maxConcurrency: 1,
+      runningCount: 1,
+      running: [{ taskId: 'ghost-task', description: 'Ghost task' }],
+      queued: [],
+    };
+
+    expect(getRunningTaskEntries(tasks, workflows, queueStatus)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

This adds a small repro for the Running tab blanking bug.

The bug came from queue polling winning over live task state. When queue data pointed at a missing task, the Running list went empty.

This test locks that bad case down before the fix changes it.

## Visual Proof

Reference surface only. This proof slice does not change UI behavior; the fix lands in the next PR.

![Reference Running surface for the queue-skew repro](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260714-97037a/running-surface-queue-skew.png)

## Review Claim

This slice proves the Running rail can blank when queue polling names a task that is missing from the live task map.

## Review Lane

proof

## Review Unit
proof

## Safety Invariant

This only adds one focused UI helper test. Product behavior is unchanged.

## Slice Rationale

The repro lands first so the next slice can flip one proven bad case instead of mixing evidence with the fix.

## Non-goals

- No UI behavior change.
- No queue or selection logic changes.
- No visual proof changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-progress-surfaces.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 04138e6d2`
- Post-revert steps: None.
- Data migration? No.

</details>
