### PR TITLE
[Running Tab Flicker](2) Keep the running rail stable

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -2301,6 +2301,29 @@ test.describe('Visual proof capture', () => {
     await captureScreenshot(page, 'terminate-wording-task-vs-workflow');
     await assertPageScreenshot(page, 'terminate-wording-task-vs-workflow');
   });
+  test('running-surface-queue-skew — running rail stays populated during queue/task skew', async ({ page }) => {
+    await loadPlan(page, TEST_PLAN);
+    const now = new Date();
+    await injectTaskStates(page, [
+      { taskId: 'task-alpha', changes: { status: 'running', execution: { startedAt: now } } },
+    ]);
+
+    await page.evaluate(() => {
+      window.invoker.getQueueStatus = async () => ({
+        maxConcurrency: 5,
+        runningCount: 1,
+        running: [{ taskId: 'ghost-task', description: 'Ghost task' }],
+        queued: [],
+      });
+    });
+    await page.waitForTimeout(2200);
+
+    await page.getByTestId('sidebar-running').click();
+    await expect(page.getByRole('heading', { name: 'Running' })).toBeVisible();
+    await expect(page.getByTestId('running-rail-list').getByRole('button', { name: /First test task/ })).toBeVisible();
+
+    await captureScreenshot(page, 'running-surface-queue-skew');
+  });
 
   test('queue-cancel-control — compact cancel affordance without priority metadata', async ({ page }) => {
     await loadPlan(page, TEST_PLAN);

--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -2301,29 +2301,6 @@ test.describe('Visual proof capture', () => {
     await captureScreenshot(page, 'terminate-wording-task-vs-workflow');
     await assertPageScreenshot(page, 'terminate-wording-task-vs-workflow');
   });
-  test('running-surface-queue-skew — running rail stays populated during queue/task skew', async ({ page }) => {
-    await loadPlan(page, TEST_PLAN);
-    const now = new Date();
-    await injectTaskStates(page, [
-      { taskId: 'task-alpha', changes: { status: 'running', execution: { startedAt: now } } },
-    ]);
-
-    await page.evaluate(() => {
-      window.invoker.getQueueStatus = async () => ({
-        maxConcurrency: 5,
-        runningCount: 1,
-        running: [{ taskId: 'ghost-task', description: 'Ghost task' }],
-        queued: [],
-      });
-    });
-    await page.waitForTimeout(2200);
-
-    await page.getByTestId('sidebar-running').click();
-    await expect(page.getByRole('heading', { name: 'Running' })).toBeVisible();
-    await expect(page.getByTestId('running-rail-list').getByRole('button', { name: /First test task/ })).toBeVisible();
-
-    await captureScreenshot(page, 'running-surface-queue-skew');
-  });
 
   test('queue-cancel-control — compact cancel affordance without priority metadata', async ({ page }) => {
     await loadPlan(page, TEST_PLAN);

--- a/packages/ui/src/__tests__/workflow-progress-surfaces.test.ts
+++ b/packages/ui/src/__tests__/workflow-progress-surfaces.test.ts
@@ -5,7 +5,7 @@ import { getRunningTaskEntries } from '../lib/workflow-progress-surfaces.js';
 import type { WorkflowMeta } from '../types.js';
 
 describe('workflow progress surfaces', () => {
-  it('repro: drops live running tasks when queue polling points at a missing task', () => {
+  it('keeps live running tasks visible when queue polling points at a missing task', () => {
     const workflow: WorkflowMeta = {
       id: 'wf-alpha',
       name: 'Alpha',
@@ -26,6 +26,8 @@ describe('workflow progress surfaces', () => {
       queued: [],
     };
 
-    expect(getRunningTaskEntries(tasks, workflows, queueStatus)).toEqual([]);
+    const entries = getRunningTaskEntries(tasks, workflows, queueStatus);
+    expect(entries.map(({ task }) => task.id)).toEqual(['task-alpha']);
+    expect(entries[0]?.workflow?.id).toBe('wf-alpha');
   });
 });

--- a/packages/ui/src/lib/workflow-progress-surfaces.ts
+++ b/packages/ui/src/lib/workflow-progress-surfaces.ts
@@ -143,21 +143,25 @@ export function getRunningTaskEntries(
   workflows: Map<string, WorkflowMeta>,
   queueStatus: QueueStatus | null,
 ): WorkflowTaskEntry[] {
+  const orderedTasks: TaskState[] = [];
+  const includedTaskIds = new Set<string>();
   if (queueStatus?.running.length) {
-    return queueStatus.running
-      .map(({ taskId }) => tasks.get(taskId))
-      .filter((task): task is TaskState => Boolean(task))
-      .map((task) => ({
-        task,
-        workflow: task.config.workflowId ? workflows.get(task.config.workflowId) ?? null : null,
-      }));
+    for (const { taskId } of queueStatus.running) {
+      const task = tasks.get(taskId);
+      if (!task || includedTaskIds.has(task.id)) continue;
+      orderedTasks.push(task);
+      includedTaskIds.add(task.id);
+    }
+  }
+  for (const task of [...tasks.values()]
+    .filter(isRunningTask)
+    .sort((a, b) => (a.description || a.id).localeCompare(b.description || b.id))) {
+    if (includedTaskIds.has(task.id)) continue;
+    orderedTasks.push(task);
   }
 
-  return [...tasks.values()]
-    .filter(isRunningTask)
-    .sort((a, b) => (a.description || a.id).localeCompare(b.description || b.id))
-    .map((task) => ({
-      task,
-      workflow: task.config.workflowId ? workflows.get(task.config.workflowId) ?? null : null,
-    }));
+  return orderedTasks.map((task) => ({
+    task,
+    workflow: task.config.workflowId ? workflows.get(task.config.workflowId) ?? null : null,
+  }));
 }


### PR DESCRIPTION
## Summary

This keeps the Running tab filled when queue polling is briefly wrong.

The flicker happened because the rail trusted queue rows first. If polling named a missing task, the live running task disappeared until the next update.

The fix keeps queue order when it is useful, then falls back to live running tasks so the rail stays stable.

## Review Claim

This slice keeps the Running rail and its selection source populated during queue/task skew instead of blanking the surface.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change is limited to Running entry derivation plus focused regression coverage. It does not change task execution, persistence, or queue production.

## Slice Rationale

The helper fix and focused regression stay together because they serve the same claim: the Running surface should keep showing live work during skew.

## Non-goals

- No backend queue semantics change.
- No worker or workflow surface changes.
- No redesign of Running tab copy or layout.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-progress-surfaces.test.ts src/__tests__/app-launch.test.tsx`

</details>

## Visual Proof

Running rail still shows the live task even when queue polling points at a ghost task.

![Running rail stays populated during queue/task skew](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260714-97037a/running-surface-queue-skew.png)

## Revert Plan
<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 26031184e`
- Post-revert steps: None.
- Data migration? No.

</details>
