### PR TITLE
[UI Responsiveness Guardrails Step 2](1) Initialize renderer perf counters through helper

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -153,7 +153,6 @@ import {
 } from './terminal-ui-perf.js';
 import {
   createRendererUiPerfCounters,
-  recordRendererUiPerfMetric,
   resetRendererUiPerfCounters,
 } from './renderer-ui-perf.js';
 import {
@@ -1979,17 +1978,12 @@ function createEmbeddedTerminalBackendFromConfig(
     dbPollCreated: 0,
     dbPollUpdatedAsCreated: 0,
     dbPollUpdatedAsUpdated: 0,
-    rendererReports: 0,
-    maxRendererEventLoopLagMs: 0,
-    maxRendererHiddenEventLoopLagMs: 0,
-    maxRendererCumulativeLagMs: 0,
-    maxRendererTickDeltaMs: 0,
-    maxRendererLongTaskMs: 0,
     workflowMetadataPublishRequests: 0,
     workflowMetadataPublishes: 0,
     workflowMetadataCoalescedRequests: 0,
     largeTaskDeltaBatches: 0,
     maxTaskDeltaBatchSize: 0,
+    ...createRendererUiPerfCounters(),
     ...createTerminalUiPerfCounters(),
   };
   const terminalUiPerf = createTerminalUiPerfReporter();
@@ -2049,17 +2043,12 @@ function createEmbeddedTerminalBackendFromConfig(
     uiPerfStats.dbPollCreated = 0;
     uiPerfStats.dbPollUpdatedAsCreated = 0;
     uiPerfStats.dbPollUpdatedAsUpdated = 0;
-    uiPerfStats.rendererReports = 0;
-    uiPerfStats.maxRendererEventLoopLagMs = 0;
-    uiPerfStats.maxRendererHiddenEventLoopLagMs = 0;
-    uiPerfStats.maxRendererCumulativeLagMs = 0;
-    uiPerfStats.maxRendererTickDeltaMs = 0;
-    uiPerfStats.maxRendererLongTaskMs = 0;
     uiPerfStats.workflowMetadataPublishRequests = 0;
     uiPerfStats.workflowMetadataPublishes = 0;
     uiPerfStats.workflowMetadataCoalescedRequests = 0;
     uiPerfStats.largeTaskDeltaBatches = 0;
     uiPerfStats.maxTaskDeltaBatchSize = 0;
+    resetRendererUiPerfCounters(uiPerfStats);
     resetTerminalUiPerfCounters(uiPerfStats);
     terminalUiPerf.reset();
   };


### PR DESCRIPTION
## Summary

Renderer performance counters now start from the shared counter factory in the main process.

Resetting UI performance stats also routes through the same shared reset helper.

## Review Claim

Main-process UI performance stats route renderer counter initialization and reset through the shared renderer counter helpers.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only counter construction and reset wiring change here. Runtime metric interpretation stays in the existing IPC handler for the next slice.

## Slice Rationale

This slice keeps counter lifetime routing separate from the IPC report handler so each side can be reviewed locally.

## Non-goals

- No changes to visible chat or terminal controls.
- No changes to renderer metric names or persistence records.
- No change to terminal UI performance counters.

## Architecture

### Before

The main process listed the renderer counter fields inline and reset those fields one by one.

### After

The main process gets renderer counter defaults from `createRendererUiPerfCounters()` and resets them with `resetRendererUiPerfCounters()`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- renderer-ui-perf`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ui-responsiveness-step2-pr1.md --require-visual-proof --changed-files-file /tmp/ui-responsiveness-step2-pr1-files.txt --diff-file /tmp/ui-responsiveness-step2-pr1.diff`

</details>

## Visual Proof

![Invoker graph rendering with renderer counter lifetime wiring](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260714-fe81be/neutral-chrome-home-graph.png)

The graph renders with the current UI performance wiring. Counter aggregation is not visible, so the focused test covers the measured behavior.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 47c366aacfe226df5e1badedbc63650946d31e11`
- Post-revert steps: Re-run `pnpm --filter @invoker/app test -- renderer-ui-perf`
- Data migration? No

</details>
