### PR TITLE
[UI Responsiveness Guardrails Step 2](2) Record renderer perf reports in IPC helper

### DIFF
--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -81,6 +81,7 @@ import {
 } from '../in-app-planner.js';
 import { seedMainProcessHitchFixture } from '../main-process-hitch-fixture.js';
 import { seedStressFixture, type StressFixtureOptions } from '../stress-fixture.js';
+import { recordRendererUiPerfMetric, type RendererUiPerfCounters } from '../renderer-ui-perf.js';
 import { buildReviewGateQueryResponse } from '../review-gate-query.js';
 import {
   AUTO_STARTED_OWNER_WORKER_KINDS,
@@ -217,14 +218,7 @@ export interface RegisterGuiMutationIpcHandlersContext extends GuiMutationTaskAc
   getTaskDeltaStreamSequence: () => number;
   computeRuntimeStatus: () => unknown;
   getUiPerfStats: () => Record<string, unknown>;
-  uiPerfStats: {
-    rendererReports: number;
-    maxRendererHiddenEventLoopLagMs: number;
-    maxRendererEventLoopLagMs: number;
-    maxRendererCumulativeLagMs: number;
-    maxRendererTickDeltaMs: number;
-    maxRendererLongTaskMs: number;
-  };
+  uiPerfStats: RendererUiPerfCounters;
   createRegisteredWorkerRegistry: () => WorkerRegistry<WorkerRuntimeDependencies>;
   buildCliInstallerContext: () => CliInstallerContext;
   resolveSetupCliPath: () => string;
@@ -1697,24 +1691,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     ) {
       logger.info(`ui metric ${metric} ${JSON.stringify(data ?? {})}`, { module: 'ui-state' });
     }
-    if (metric === 'renderer_event_loop_lag' && typeof data?.lagMs === 'number') {
-      const hiddenOrUnfocused = data.visibilityState === 'hidden' || data.hasFocus === false;
-      if (hiddenOrUnfocused) {
-        uiPerfStats.maxRendererHiddenEventLoopLagMs = Math.max(uiPerfStats.maxRendererHiddenEventLoopLagMs, data.lagMs);
-      } else {
-        uiPerfStats.maxRendererEventLoopLagMs = Math.max(uiPerfStats.maxRendererEventLoopLagMs, data.lagMs);
-      }
-      if (typeof data.cumulativeLagMs === 'number') {
-        uiPerfStats.maxRendererCumulativeLagMs = Math.max(uiPerfStats.maxRendererCumulativeLagMs, data.cumulativeLagMs);
-      }
-      if (typeof data.tickDeltaMs === 'number') {
-        uiPerfStats.maxRendererTickDeltaMs = Math.max(uiPerfStats.maxRendererTickDeltaMs, data.tickDeltaMs);
-      }
-    }
-    if (metric === 'renderer_long_task' && typeof data?.durationMs === 'number') {
-      uiPerfStats.maxRendererLongTaskMs = Math.max(uiPerfStats.maxRendererLongTaskMs, data.durationMs);
-    }
-    uiPerfStats.rendererReports += 1;
+    recordRendererUiPerfMetric(uiPerfStats, metric, data);
     try {
       persistence.writeActivityLog('ui-perf', 'info', JSON.stringify(payload));
     } catch {


### PR DESCRIPTION
## Summary

Renderer UI performance reports now use the shared recorder in the IPC handler.

The activity log payload still records each metric while chat and terminal counters use the shared aggregation rules.

## Review Claim

The IPC surface exposes renderer UI performance reports through the shared recorder without changing persistence.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The handler still writes the same activity log payload. Counter aggregation is delegated to the tested helper.

## Slice Rationale

This slice is only the IPC surface that exposes reports. The lower counter lifetime work lives in the previous PR.

## Non-goals

- No changes to visible chat or terminal controls.
- No changes to metric names or activity-log records.
- No changes to counter initialization.

## Architecture

### Before

The IPC handler updated renderer counters inline before writing the activity log.

### After

The IPC handler calls `recordRendererUiPerfMetric()` and then writes the same activity log payload.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- renderer-ui-perf`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ui-responsiveness-step2-pr2.md --changed-files-file /tmp/ui-responsiveness-step2-pr2-files.txt --diff-file /tmp/ui-responsiveness-step2-pr2.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 6ae2f359896688385877fe2865e9b14fee48e3b7`
- Post-revert steps: Re-run `pnpm --filter @invoker/app test -- renderer-ui-perf`
- Data migration? No

</details>
