### PR TITLE
[Godfile app step 3: extract gui-mutation-handlers](4) Route main through GUI mutation handlers

### DIFF
--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -8,8 +8,12 @@ import type {
   InAppPlanningChatRequest,
   InAppPlanningCreateSessionRequest,
   InAppPlanningResetRequest,
+  InAppPlanningSetTerminalModeRequest,
+  InAppPlanningStreamEvent,
   InAppPlanningSubmitRequest,
   Logger,
+  StartReadyRequest,
+  StartReadyResult,
   WorkflowMutationAcceptedResult,
 } from '@invoker/contracts';
 import { ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
@@ -77,6 +81,7 @@ import {
   resetPlanningChat,
   restorePlanningChatSessions,
   sendPlanningChatMessage,
+  setPlanningChatTerminalMode,
   submitPlanningChatDraft,
 } from '../in-app-planner.js';
 import { seedMainProcessHitchFixture } from '../main-process-hitch-fixture.js';
@@ -86,6 +91,7 @@ import {
   AUTO_STARTED_OWNER_WORKER_KINDS,
   createLocalWorkerStatusSnapshot,
 } from '../worker-control.js';
+import { runStartReady } from '../start-ready.js';
 import type { WorkerRuntimeController } from '../worker-control.js';
 import { buildTaskGraphSnapshot } from '../web/task-graph-snapshot.js';
 import { collectSystemDiagnostics } from '../system-diagnostics.js';
@@ -210,6 +216,7 @@ export interface RegisterGuiMutationIpcHandlersContext extends GuiMutationTaskAc
   actions: GuiMutationTaskActions;
   planningChatSessions: ReturnType<typeof createInAppPlanningChatSessions>;
   planningCommandBuilder: ReturnType<typeof createPlanningCommandBuilderFromRegistry>;
+  emitPlanningChatStream: (event: InAppPlanningStreamEvent) => void;
   taskGraphEventPublisher: TaskGraphEventPublisher;
   loadTaskByIdFromPersistence: (taskId: string) => TaskState | undefined;
   markDaemonOwnerUnavailable: (reason: string) => void;
@@ -243,26 +250,6 @@ function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
     || task.status === 'fixing_with_ai'
     || (task.status === 'pending' && task.execution.phase === 'launching');
-}
-
-function isTaskRecoverableOnExplicitResume(task: TaskState): boolean {
-  if (task.status === 'running') return true;
-  if (task.status !== 'pending' || !task.execution.selectedAttemptId) return false;
-  if (task.execution.phase === 'launching') return true;
-
-  return Boolean(
-    task.execution.startedAt
-    || task.execution.launchStartedAt
-    || task.execution.launchCompletedAt
-    || task.execution.lastHeartbeatAt
-    || task.execution.workspacePath
-    || task.execution.agentSessionId
-    || task.execution.containerId
-    || task.execution.error
-    || task.execution.exitCode !== undefined
-    || task.execution.inputPrompt
-    || task.execution.pendingFixError,
-  );
 }
 
 export function createGuiMutationTaskActions(context: GuiMutationTaskActionsContext): GuiMutationTaskActions {
@@ -973,6 +960,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     actions,
     planningChatSessions,
     planningCommandBuilder,
+    emitPlanningChatStream,
     taskGraphEventPublisher,
     loadTaskByIdFromPersistence,
     markDaemonOwnerUnavailable,
@@ -1003,7 +991,6 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   };
   const ownerMode = getOwnerMode();
   const workerRuntimeController = getWorkerRuntimeController();
-  const launchDispatcher = context.getLaunchDispatcher();
   const workflowIdForTaskArg = actions.workflowIdForTaskArg;
   const workflowIdForTargetArg = actions.workflowIdForTargetArg;
   const performDeleteTask = actions.performDeleteTask;
@@ -1015,6 +1002,52 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   const performDetachWorkflow = actions.performDetachWorkflow;
   const performSharedApproveTask = actions.performSharedApproveTask;
   const executeFixWithAgentMutation = actions.executeFixWithAgentMutation;
+
+  function publishOrchestratorSnapshotToRenderer(): void {
+    const workflows = persistence.listWorkflows();
+    const tasks = orchestrator.getAllTasks();
+    const previousTaskIds = new Set(rendererTaskFeed.listKnownTaskIds());
+    rendererTaskFeed.clearTaskSnapshots();
+    rendererTaskFeed.replaceWorkflowRollups(tasks);
+    for (const task of tasks) {
+      previousTaskIds.delete(task.id);
+      rendererTaskFeed.rememberTaskState(task);
+      if (mainWindowAvailable()) {
+        rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'created', task });
+      }
+    }
+    rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
+    if (mainWindowAvailable()) {
+      for (const removedTaskId of previousTaskIds) {
+        rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
+      }
+      requestWorkflowMetadataPublish('orchestrator-snapshot');
+    }
+  }
+
+  function executeStartReady(request: StartReadyRequest = {}): StartReadyResult {
+    const result = runStartReady(orchestrator, request);
+    if (!result.dryRun) {
+      publishOrchestratorSnapshotToRenderer();
+    }
+    logger.info(
+      `start-ready: ready=${result.preview.readyTaskIds.length} recoverable=${result.preview.recoverableTaskIds.length} failedWorkflows=${result.preview.failedWorkflowIds.length} recreated=${result.recreatedWorkflowIds.length} started=${result.started.length} dryRun=${result.dryRun ? 'true' : 'false'}`,
+      { module: 'ipc' },
+    );
+    const launchDispatcher = context.getLaunchDispatcher();
+    if (!result.dryRun && result.started.length > 0 && launchDispatcher) {
+      try {
+        launchDispatcher.poll();
+      } catch (err) {
+        logger.warn(
+          `start-ready: launch dispatcher poll failed: ${err instanceof Error ? err.message : String(err)}`,
+          { module: 'ipc' },
+        );
+      }
+    }
+    return result;
+  }
+
   function registerTaskScopedGuiMutationHandler<TResult = unknown>(
   channel: keyof typeof IpcChannels & string,
   resolveWorkflowId: (...args: unknown[]) => string | undefined,
@@ -1097,6 +1130,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     loadGeneratedPlan: loadGeneratedPlanPreview,
     conversationRepo: planningConversationRepo,
     planningSessionStore: ownerMode ? persistence : undefined,
+    onRawPlannerOutput: emitPlanningChatStream,
   });
   let testPlanFromGoalResponse: { planYaml: string; planName: string } | null = null;
   // Two variants: (1) a successful override that returns a canned reply +
@@ -1131,6 +1165,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       loadGeneratedPlan: loadGeneratedPlanPreview,
       conversationRepo: planningConversationRepo,
       planningSessionStore: ownerMode ? persistence : undefined,
+      onRawPlannerOutput: emitPlanningChatStream,
     });
   });
   registerGuiMutationHandler('invoker:planning-chat-list', async () => {
@@ -1155,6 +1190,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       conversationRepo: planningConversationRepo,
       planningSessionStore: ownerMode ? persistence : undefined,
       plannerReplyOverride,
+      onRawPlannerOutput: emitPlanningChatStream,
     });
   });
   registerGuiMutationHandler('invoker:planning-chat-submit', async (request: unknown) => {
@@ -1169,6 +1205,12 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   });
   registerGuiMutationHandler('invoker:planning-chat-reset', async (request: unknown) => {
     return resetPlanningChat(request as InAppPlanningResetRequest, {
+      sessions: planningChatSessions,
+      planningSessionStore: ownerMode ? persistence : undefined,
+    });
+  });
+  registerGuiMutationHandler('invoker:planning-chat-set-terminal-mode', async (request: unknown) => {
+    return setPlanningChatTerminalMode(request as InAppPlanningSetTerminalModeRequest, {
       sessions: planningChatSessions,
       planningSessionStore: ownerMode ? persistence : undefined,
     });
@@ -1246,40 +1288,20 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     return started;
   });
 
+  registerGuiMutationHandler('invoker:start-ready', async (requestArg: unknown) => {
+    return executeStartReady(requestArg as StartReadyRequest | undefined);
+  });
+
   registerGuiMutationHandler('invoker:resume-workflow', async () => {
     const workflows = persistence.listWorkflows();
     if (workflows.length === 0) {
       logger.info('resume-workflow: no workflows found', { module: 'ipc' });
       return null;
     }
-    orchestrator.syncAllFromDb();
-
-    const tasksToRecover = orchestrator.getAllTasks().filter(isTaskRecoverableOnExplicitResume);
-    for (const task of tasksToRecover) {
-      orchestrator.prepareTaskForNewAttempt(task.id, 'resume_workflow_recovery');
-    }
-
-    const allStarted = orchestrator.startExecution();
+    const result = executeStartReady({});
     const tasks = orchestrator.getAllTasks();
-    rendererTaskFeed.replaceWorkflowRollups(tasks);
-    for (const task of tasks) {
-      rendererTaskFeed.rememberTaskState(task);
-      if (mainWindowAvailable()) {
-        rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'created', task });
-      }
-    }
-    logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${allStarted.length} started`, { module: 'ipc' });
-    if (allStarted.length > 0 && launchDispatcher) {
-      try {
-        launchDispatcher.poll();
-      } catch (err) {
-        logger.warn(
-          `resume-workflow: launch dispatcher poll failed: ${err instanceof Error ? err.message : String(err)}`,
-          { module: 'ipc' },
-        );
-      }
-    }
-    return { workflow: workflows[0], taskCount: tasks.length, startedCount: allStarted.length };
+    logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${result.started.length} started`, { module: 'ipc' });
+    return { workflow: workflows[0], taskCount: tasks.length, startedCount: result.started.length };
   });
 
   registerGuiMutationHandler('invoker:stop', async () => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -70,21 +70,15 @@ import {
   resolveRepoRoot,
 } from '@invoker/contracts';
 import type {
-  ActionGraphResponse,
   BundledSkillsInstallMode,
   InAppPlanRequest,
   InAppPlanningCreateSessionRequest,
   InAppPlanningChatRequest,
   InAppPlanningResetRequest,
-  InAppPlanningStreamEvent,
   InAppPlanningSetTerminalModeRequest,
   InAppPlanningSubmitRequest,
   Logger,
-  StartReadyRequest,
-  StartReadyResult,
-  WorkflowMeta,
   WorkflowMutationAcceptedResult,
-  WorkResponse,
 } from '@invoker/contracts';
 import { ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
 import type { SQLiteAdapter } from '@invoker/data-store';
@@ -114,8 +108,7 @@ import { resolveTaskTerminalSpec } from './open-terminal-for-task.js';
 import { createBashTerminalBackend, createPtyTerminalBackend, EmbeddedTerminalManager, type EmbeddedTerminalBackend } from './embedded-terminal-manager.js';
 import { collectSystemDiagnostics } from './system-diagnostics.js';
 import { installBundledSkills, resolveBundledSkillsStatus } from './bundled-skills.js';
-import { maybeAutoInstallCli, resolveCliInstallerStatus, updateInvokerCli, type CliInstallerContext } from './cli-installer.js';
-import { runInvokerCliSetup } from './invoker-cli-setup.js';
+import { maybeAutoInstallCli, updateInvokerCli, type CliInstallerContext } from './cli-installer.js';
 import { resolveBundledCliPath } from './cli-helper.js';
 import { buildAppMenuTemplate } from './app-menu.js';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
@@ -132,12 +125,10 @@ import { dispatchStartedTasksWithGlobalTopup } from './global-topup.js';
 import { buildFixWithAgentMutationArgs, buildHeadlessFixArgs, listOpenFixIntentsForTask, parseFixWithAgentMutationArgs } from './auto-fix-intents.js';
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
-import { createGuiMutationTaskActions } from './ipc/gui-mutation-handlers.js';
+import { createGuiMutationTaskActions, registerGuiMutationIpcHandlers } from './ipc/gui-mutation-handlers.js';
 import { answerOwnerHeadlessQuery, buildOwnerReadQueryHandlers } from './owner-read-query.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 import { AUTO_STARTED_OWNER_WORKER_KINDS, createWorkerRuntimeController, type WorkerRuntimeController } from './worker-control.js';
-import { runStartReady } from './start-ready.js';
-import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
 import { startSurfaceEventRelay } from './surface-event-relay.js';
 import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
 import { buildWebInvokerDispatch } from './web/web-invoker-dispatch.js';
@@ -179,7 +170,6 @@ import {
   createInAppPlanningChatSessions,
   createPlanningChatSession,
   createPlanningCommandBuilderFromRegistry,
-  listInAppPlanningPresets,
   listPlanningChatSessions,
   planFromGoal as planFromGoalInApp,
   resetPlanningChat,
@@ -2220,8 +2210,6 @@ function createEmbeddedTerminalBackendFromConfig(
     translateGuiMutationToHeadless,
     submitWorkflowMutation,
     runWorkflowMutation,
-    workflowIdForTaskArg,
-    workflowIdForTargetArg,
   } = guiMutationTaskActions;
   const guiMutationRegistrationContext = {
     ipcMain,
@@ -2243,14 +2231,6 @@ function createEmbeddedTerminalBackendFromConfig(
     guiMutationRegistrationContext,
     workflowScopedGuiMutationRegistrationContext,
   );
-  const { registerGuiMutationHandler } = guiMutationRegistrars;
-
-  const emitPlanningChatStream = (event: InAppPlanningStreamEvent): void => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('invoker:planning-chat-stream', event);
-    }
-    webBridge?.broadcast('invoker:planning-chat-stream', event);
-  };
 
   function createWindow(): void {
     createMainWindow({
@@ -2352,49 +2332,6 @@ function createEmbeddedTerminalBackendFromConfig(
       taskCount: orchestrator.getAllTasks().length,
       workflowCount: workflows.length,
     });
-  }
-
-  function publishOrchestratorSnapshotToRenderer(): void {
-    const workflows = persistence.listWorkflows();
-    const tasks = orchestrator.getAllTasks();
-    const previousTaskIds = new Set(rendererTaskFeed.listKnownTaskIds());
-    rendererTaskFeed.clearTaskSnapshots();
-    rendererTaskFeed.replaceWorkflowRollups(tasks);
-    for (const task of tasks) {
-      previousTaskIds.delete(task.id);
-      rendererTaskFeed.rememberTaskState(task);
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'created', task });
-      }
-    }
-    rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      for (const removedTaskId of previousTaskIds) {
-        rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
-      }
-      requestWorkflowMetadataPublish('orchestrator-snapshot');
-    }
-  }
-  function executeStartReady(request: StartReadyRequest = {}): StartReadyResult {
-    const result = runStartReady(orchestrator, request);
-    if (!result.dryRun) {
-      publishOrchestratorSnapshotToRenderer();
-    }
-    logger.info(
-      `start-ready: ready=${result.preview.readyTaskIds.length} recoverable=${result.preview.recoverableTaskIds.length} failedWorkflows=${result.preview.failedWorkflowIds.length} recreated=${result.recreatedWorkflowIds.length} started=${result.started.length} dryRun=${result.dryRun ? 'true' : 'false'}`,
-      { module: 'ipc' },
-    );
-    if (!result.dryRun && result.started.length > 0 && launchDispatcher) {
-      try {
-        launchDispatcher.poll();
-      } catch (err) {
-        logger.warn(
-          `start-ready: launch dispatcher poll failed: ${err instanceof Error ? err.message : String(err)}`,
-          { module: 'ipc' },
-        );
-      }
-    }
-    return result;
   }
 
   function startDeferredStartupWork(): void {
@@ -2853,349 +2790,39 @@ function createEmbeddedTerminalBackendFromConfig(
       getTaskDeltaStreamSequence,
       recordStartupDuration,
     });
-    async function loadGeneratedPlanPreview(
-      planText: string,
-      options?: { preserveTaskHandles?: boolean; logLabel?: string },
-    ): Promise<{ planName: string; workflowId: string; workflowIds?: string[]; workflowCount?: number }> {
-      const { applyConfiguredPlanDefaults, parsePlanSubmissionBundle } = await import('./plan-parser.js');
-      const submission = parsePlanSubmissionBundle(planText);
-      const existingWorkflowIds = new Set(persistence.listWorkflows().map((workflow) => workflow.id));
-      const loadedWorkflowIds: string[] = [];
-      let upstream: { workflowId: string; featureBranch: string } | undefined;
-      logger.info(
-        `${options?.logLabel ?? 'plan-from-goal'}: loading "${submission.name}" (${submission.plans.length} workflow${submission.plans.length === 1 ? '' : 's'})`,
-        { module: 'ipc' },
-      );
-      if (!options?.preserveTaskHandles) {
-        taskHandles.clear();
-      }
-
-      for (const parsedPlan of submission.plans) {
-        let plan = applyConfiguredPlanDefaults(parsedPlan);
-        if (upstream) {
-          plan = {
-            ...plan,
-            baseBranch: upstream.featureBranch,
-            externalDependencies: [
-              ...(plan.externalDependencies ?? []),
-              {
-                workflowId: upstream.workflowId,
-                taskId: '__merge__',
-                requiredStatus: 'completed',
-                gatePolicy: 'review_ready',
-              } as const,
-            ],
-          };
-        }
-        backupPlan(plan, undefined, logger);
-        orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
-        const workflow = persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
-        if (!workflow) {
-          throw new Error('Loaded plan did not create a workflow.');
-        }
-        existingWorkflowIds.add(workflow.id);
-        loadedWorkflowIds.push(workflow.id);
-        upstream = { workflowId: workflow.id, featureBranch: workflow.featureBranch ?? plan.featureBranch ?? plan.baseBranch ?? 'main' };
-      }
-
-      const workflowId = loadedWorkflowIds[loadedWorkflowIds.length - 1];
-      if (!workflowId) {
-        throw new Error('Loaded plan did not create a workflow.');
-      }
-      return {
-        planName: submission.name,
-        workflowId,
-        workflowIds: loadedWorkflowIds,
-        workflowCount: loadedWorkflowIds.length,
-      };
-    }
-
-    const planningConversationRepo = new ConversationRepository(persistence, {
-      info: (message) => logger.info(message, { module: 'planning-chat' }),
-      warn: (message) => logger.warn(message, { module: 'planning-chat' }),
-      error: (message) => logger.error(message, { module: 'planning-chat' }),
-    });
-    await restorePlanningChatSessions(persistence.listInAppPlanningSessions(), {
-      config: invokerConfig,
-      workingDir: repoRoot,
-      sessions: planningChatSessions,
-      planningCommandBuilder,
-      loadGeneratedPlan: loadGeneratedPlanPreview,
-      conversationRepo: planningConversationRepo,
-      planningSessionStore: ownerMode ? persistence : undefined,
-      onRawPlannerOutput: emitPlanningChatStream,
-    });
-    if (ownerMode) {
-      restorePersistedPlanningTerminals();
-    }
-    let testPlanFromGoalResponse: { planYaml: string; planName: string } | null = null;
-    // Two variants: (1) a successful override that returns a canned reply +
-    // plan YAML, or (2) an error injection that makes the wrapper throw the
-    // given message. The error variant lets visual-proof specs render the
-    // exhausted-retry error path without spawning a real planner subprocess.
-    let testPlanningChatResponse:
-      | { planYaml: string; planName: string; reply?: string }
-      | { throwError: string }
-      | null = null;
-
-
-    registerGuiMutationHandler('invoker:plan-from-goal', async (...args: unknown[]) => {
-      if (process.env.NODE_ENV === 'test' && testPlanFromGoalResponse) {
-        const loaded = await loadGeneratedPlanPreview(testPlanFromGoalResponse.planYaml);
-        return { ok: true, planName: testPlanFromGoalResponse.planName, workflowId: loaded.workflowId, workflowIds: loaded.workflowIds, workflowCount: loaded.workflowCount };
-      }
-      return planFromGoalInApp(args[0] as InAppPlanRequest, {
-        config: invokerConfig,
-        workingDir: repoRoot,
-        loadGeneratedPlan: loadGeneratedPlanPreview,
-        planningCommandBuilder,
-        conversationRepo: planningConversationRepo,
-      });
-    });
-    registerGuiMutationHandler('invoker:planning-chat-create', async (request: unknown) => {
-      return createPlanningChatSession(request as InAppPlanningCreateSessionRequest | undefined, {
-        config: invokerConfig,
-        workingDir: repoRoot,
-        sessions: planningChatSessions,
-        planningCommandBuilder,
-        loadGeneratedPlan: loadGeneratedPlanPreview,
-        conversationRepo: planningConversationRepo,
-        planningSessionStore: ownerMode ? persistence : undefined,
-        onRawPlannerOutput: emitPlanningChatStream,
-      });
-    });
-    registerGuiMutationHandler('invoker:planning-chat-list', async () => {
-      return listPlanningChatSessions({ sessions: planningChatSessions });
-    });
-    registerGuiMutationHandler('invoker:planning-chat-send', async (request: unknown) => {
-      const planningChatResponseOverride = process.env.NODE_ENV === 'test' ? testPlanningChatResponse : null;
-      const plannerReplyOverride = planningChatResponseOverride
-        ? async (): Promise<string> => {
-          if ('throwError' in planningChatResponseOverride) {
-            throw new Error(planningChatResponseOverride.throwError);
-          }
-          return `${planningChatResponseOverride.reply ?? 'Draft plan ready.'}\n\n\`\`\`yaml\n${planningChatResponseOverride.planYaml}\n\`\`\``;
-        }
-        : undefined;
-      return sendPlanningChatMessage(request as InAppPlanningChatRequest, {
-        config: invokerConfig,
-        workingDir: repoRoot,
-        sessions: planningChatSessions,
-        planningCommandBuilder,
-        loadGeneratedPlan: loadGeneratedPlanPreview,
-        conversationRepo: planningConversationRepo,
-        planningSessionStore: ownerMode ? persistence : undefined,
-        plannerReplyOverride,
-        onRawPlannerOutput: emitPlanningChatStream,
-      });
-    });
-    registerGuiMutationHandler('invoker:planning-chat-submit', async (request: unknown) => {
-      return submitPlanningChatDraft(request as InAppPlanningSubmitRequest, {
-        sessions: planningChatSessions,
-        loadGeneratedPlan: (planText) => loadGeneratedPlanPreview(planText, {
-          preserveTaskHandles: true,
-          logLabel: 'planning-chat-submit',
-        }),
-        planningSessionStore: ownerMode ? persistence : undefined,
-      });
-    });
-    registerGuiMutationHandler('invoker:planning-chat-reset', async (request: unknown) => {
-      return resetPlanningChat(request as InAppPlanningResetRequest, {
-        sessions: planningChatSessions,
-        planningSessionStore: ownerMode ? persistence : undefined,
-      });
-    });
-    registerGuiMutationHandler('invoker:planning-chat-set-terminal-mode', async (request: unknown) => {
-      return setPlanningChatTerminalMode(request as InAppPlanningSetTerminalModeRequest, {
-        sessions: planningChatSessions,
-        planningSessionStore: ownerMode ? persistence : undefined,
-      });
-    });
-    registerGuiMutationHandler('invoker:load-plan', async (planTextArg: unknown) => {
-      const planText = String(planTextArg);
-      await loadGeneratedPlanPreview(planText, { logLabel: 'load-plan' });
-    });
-
-    if (process.env.NODE_ENV === 'test') {
-      const injectTaskStates = async (updates: Array<{ taskId: string; changes: TaskStateChanges }>): Promise<void> => {
-        for (const { taskId, changes } of updates) {
-          const before = orchestrator.getTask(taskId);
-          const previousSnapshot = rendererTaskFeed.getTaskSnapshot(taskId);
-          const previousTaskStateVersion = previousSnapshot
-            ? (
-                (JSON.parse(previousSnapshot) as { taskStateVersion?: number }).taskStateVersion
-                ?? before?.taskStateVersion
-                ?? 1
-              )
-            : (before?.taskStateVersion ?? 0);
-          persistence.updateTask(taskId, changes);
-          messageBus.publish(Channels.TASK_DELTA, {
-            type: 'updated',
-            taskId,
-            changes,
-            previousTaskStateVersion,
-            taskStateVersion: previousTaskStateVersion + 1,
-          } satisfies TaskDelta);
-        }
-        orchestrator.syncAllFromDb();
-      };
-      registerGuiMutationHandler(
-        'invoker:inject-task-states',
-        async (updatesArg: unknown) => {
-          const updates = updatesArg as Array<{ taskId: string; changes: TaskStateChanges }>;
-          await injectTaskStates(updates);
-        },
-      );
-      ipcMain.handle(
-        'invoker:set-test-plan-from-goal-response',
-        async (_event, response: { planYaml: string; planName: string } | null) => {
-          testPlanFromGoalResponse = response;
-        },
-      );
-      ipcMain.handle(
-        'invoker:set-test-planning-chat-response',
-        async (
-          _event,
-          response:
-            | { planYaml: string; planName: string; reply?: string }
-            | { throwError: string }
-            | null,
-        ) => {
-          testPlanningChatResponse = response;
-        },
-      );
-      registerGuiMutationHandler('invoker:seed-main-process-hitch-fixture', async () => {
-        const seeded = seedMainProcessHitchFixture(persistence);
-        orchestrator.syncAllFromDb();
-        return seeded;
-      });
-      registerGuiMutationHandler('invoker:seed-stress-fixture', async (optionsArg: unknown) => {
-        const options = optionsArg as StressFixtureOptions | undefined;
-        const seeded = seedStressFixture(persistence, options);
-        orchestrator.syncAllFromDb();
-        return seeded;
-      });
-    }
-
-    registerGuiMutationHandler('invoker:start', async () => {
-      logger.info('start', { module: 'ipc' });
-      const started = orchestrator.startExecution();
-      logger.info(`startExecution returned ${started.length} tasks: [${started.map(t => t.id).join(', ')}]`, { module: 'ipc' });
-      return started;
-    });
-
-    registerGuiMutationHandler('invoker:start-ready', async (requestArg: unknown) => {
-      return executeStartReady(requestArg as StartReadyRequest | undefined);
-    });
-
-    registerGuiMutationHandler('invoker:resume-workflow', async () => {
-      const workflows = persistence.listWorkflows();
-      if (workflows.length === 0) {
-        logger.info('resume-workflow: no workflows found', { module: 'ipc' });
-        return null;
-      }
-      const result = executeStartReady({});
-      const tasks = orchestrator.getAllTasks();
-      logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${result.started.length} started`, { module: 'ipc' });
-      return { workflow: workflows[0], taskCount: tasks.length, startedCount: result.started.length };
-    });
-
-    registerGuiMutationHandler('invoker:stop', async () => {
-      logger.info('stop — destroying all executors', { module: 'ipc' });
-      const failInFlightTasks = (): void => {
-        const allTasks = orchestrator.getAllTasks();
-        for (const task of allTasks) {
-          if (isTaskInFlightForForcedStop(task)) {
-            logger.info(`stop — failing in-flight task "${task.id}" (${task.status})`, { module: 'ipc' });
-            persistShutdownDiagnostic(task, persistence, {
-              flushPendingOutput: rendererTaskFeed.flushTaskOutput,
-              forcedStopReason: 'Stopped by user',
-            });
-            orchestrator.handleWorkerResponse({
-              requestId: `stop-${task.id}`,
-              actionId: task.id,
-              attemptId: task.execution.selectedAttemptId,
-              executionGeneration: task.execution.generation ?? 0,
-              status: 'failed',
-              outputs: { exitCode: 1, error: 'Stopped by user' },
-            });
-          }
-        }
-      };
-      failInFlightTasks();
-      await Promise.all(executorRegistry.getAll().map(f => f.destroyAll()));
-      failInFlightTasks();
-    });
-
-    registerGuiMutationHandler('invoker:clear', async () => {
-      logger.info('clear — stopping all tasks and resetting DAG', { module: 'ipc' });
-      await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
-      await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
-
-      orchestrator = new Orchestrator({
-        persistence,
-        messageBus,
-        taskRepository: new SqliteTaskRepository(persistence),
-        maxConcurrency: effectiveMaxConcurrency,
-        defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
-        executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
-        defaultPoolId: invokerConfig.defaultPoolId,
-        availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
-        deferRunningUntilLaunch: true,
-      });
-      commandService = new CommandService(
-        orchestrator,
-        buildCommandServiceInvalidationDeps(),
-      );
-      rebuildTaskRunner();
-      taskHandles.clear();
-      rendererTaskFeed.resetSnapshotState();
-      requestWorkflowMetadataPublish('clear');
-    });
-
-
-    ipcMain.handle('invoker:refresh-task-graph', async () => {
-      const startedAtMs = Date.now();
-      const snapshot = await resolveRefreshTaskGraphSnapshot({
-        ownerMode,
-        messageBus,
-        resolveInvokerHomeRoot,
-        orchestrator,
-        persistence,
-        logger,
-      });
-
-      taskGraphEventPublisher.publishSnapshot(
-        ownerMode ? 'refresh-task-graph' : 'refresh-task-graph-delegated',
-        snapshot.tasks,
-        snapshot.workflows,
-        true,
-      );
-      recordStartupDuration('refresh-task-graph.return', startedAtMs, {
-        taskCount: snapshot.tasks.length,
-        workflowCount: snapshot.workflows.length,
-        streamSequence: getTaskDeltaStreamSequence(),
-      });
-    });
-    registerReadOnlyIpcHandlers({
-      ipcMain,
-      logger,
-      persistence,
+    await registerGuiMutationIpcHandlers({
+      ipcMain, app, logger, persistence, messageBus, executorRegistry, agentRegistry,
+      repoRoot, invokerConfig, effectiveMaxConcurrency, taskHandles,
       getOrchestrator: () => orchestrator,
-      agentRegistry,
-      loadTaskByIdFromPersistence,
-      resolveAgentSession,
-      getOwnerMode: () => ownerMode,
-      getMessageBus: () => messageBus,
-      onMutationOwnerUnavailable: markDaemonOwnerUnavailable,
-      recordStartupDuration,
-      getTaskDeltaStreamSequence,
+      setOrchestrator: (value) => { orchestrator = value; },
+      getCommandService: () => commandService,
+      setCommandService: (value) => { commandService = value; },
+      getWorkflowMutationCoordinator: () => workflowMutationCoordinator,
+      workflowMutationDispatcher,
+      getActiveMutationContext: () => activeMutationContext,
+      getRendererTaskFeed: () => rendererTaskFeed,
+      getStartupWorkflowId: () => startupWorkflowId,
+      getLaunchDispatcher: () => launchDispatcher,
+      requireTaskExecutor, getTaskExecutor: () => taskExecutor, rebuildTaskRunner, initServices,
+      requestWorkflowMetadataPublish, cancelDeferredWorkflowLaunch, killRunningTask,
+      buildCommandServiceInvalidationDeps,
+      getMainWindow: () => mainWindow, getOwnerMode: () => ownerMode,
+      getWorkerRuntimeController: () => workerRuntimeController,
+      registrars: guiMutationRegistrars, actions: guiMutationTaskActions,
+      planningChatSessions, planningCommandBuilder,
+      emitPlanningChatStream: (event) => {
+        if (mainWindow && !mainWindow.isDestroyed()) mainWindow.webContents.send('invoker:planning-chat-stream', event);
+        webBridge?.broadcast('invoker:planning-chat-stream', event);
+      },
+      taskGraphEventPublisher, loadTaskByIdFromPersistence, markDaemonOwnerUnavailable,
+      recordStartupDuration, getTaskDeltaStreamSequence, computeRuntimeStatus, getUiPerfStats,
+      uiPerfStats, createRegisteredWorkerRegistry, buildCliInstallerContext,
+      resolveSetupCliPath, getBundledSkillsStatus, installPackagedSkills,
     });
-    // ── DB Polling — detect external workflow changes ───
-    ipcMain.handle('invoker:get-activity-logs', (_event, sinceId?: number, limit?: number) => {
-      return persistence.getActivityLogs(sinceId ?? 0, limit ?? 2000);
-    });
+    if (ownerMode) restorePersistedPlanningTerminals();
 
+    ipcMain.handle('invoker:get-activity-logs', (_event, sinceId?: number, limit?: number) =>
+      persistence.getActivityLogs(sinceId ?? 0, limit ?? 2000));
     // ── Embedded terminal session manager (GUI) ─────────────────
     // GUI `invoker:open-terminal` keeps users inside Invoker by opening
     // (or selecting) an embedded session managed in the main process.


### PR DESCRIPTION
## Summary

This slice routes GUI bootstrap mutation registration through `registerGuiMutationIpcHandlers(...)`.

`main.ts` now passes the same process dependencies into the handler module.

The channel names stay unchanged while owner delegation, activity logs, and terminal IPC stay in `main.ts`.

## Review Claim

`main.ts` can route the live GUI mutation registration path through `ipc/gui-mutation-handlers.ts` without changing public IPC behavior.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

The previous slice prepared the complete handler module. This slice only changes the GUI bootstrap handoff, and the focused GUI mutation suites pass.

## Slice Rationale

The handler module surface and the live bootstrap routing are separate review questions. This slice limits review to the runtime handoff.

## Non-goals

- No owner-delegation bus handler moves.
- No terminal IPC moves.
- No activity-log handler moves.
- No channel renames or new IPC channels.
- No behavior change; public IPC behavior stays unchanged.

## Architecture

### Before

`main.ts` registered the live GUI mutation handlers inline during GUI bootstrap.

Planning chat stream emission and start-ready snapshot publication sat beside those registration bodies.

### After

`main.ts` passes the mutation dependencies into `registerGuiMutationIpcHandlers(...)`.

`ipc/gui-mutation-handlers.ts` owns the mutation registration path and calls back through context getters for mutable process state.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/gui-mutation-translation.test.ts src/__tests__/ipc-registration.test.ts src/__tests__/no-manual-dispatch.test.ts src/__tests__/workflow-mutation-submit.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a43ad57a2bdc8a6db10df26988db3c67f8efaef9`
- Post-revert steps: None
- Data migration? No

</details>
