### PR TITLE
[Planning Terminal Attention Badge](1) Count attention-needed chats

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -666,6 +666,10 @@ export function App() {
   const activePlanningTerminalSession = activePlanningSession.terminalSession ?? null;
   const activePlanningTerminalBusy = Boolean(activePlanningSession.terminalBusy);
   const activePlanningTerminalError = activePlanningSession.terminalError ?? null;
+  const planningAttentionCount = useMemo(
+    () => planningSessions.filter((session) => planningNeedsAttention(session.status)).length,
+    [planningSessions],
+  );
 
   useEffect(() => {
     planningSessionsRef.current = planningSessions;
@@ -3736,6 +3740,7 @@ export function App() {
           queueStatus={queueStatus}
           workerStatus={workerStatus}
           planningSessionCount={planningSessions.length}
+          planningAttentionCount={planningAttentionCount}
           selectedSurface={sidebarSurface}
           collapsed={effectiveSidebarCollapsed}
           attentionTaskIdsWithFailures={attentionTaskIdsWithFailures}

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -51,6 +51,20 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
   });
+
+  it('hides the collapsed Planning Terminal badge for the idle initial chat', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
+
+    render(<App />);
+    act(() => window.dispatchEvent(new Event('resize')));
+
+    const sidebar = await screen.findByTestId('app-sidebar');
+    expect(sidebar.className).toContain('w-16');
+    expect(screen.getByTestId('sidebar-planning').textContent).toBe('');
+
+    Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
+  });
+
   it('opens worker status from the left panel', async () => {
     Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
     act(() => window.dispatchEvent(new Event('resize')));

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -442,6 +442,72 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
+  it('counts only attention-worthy planning sessions in the sidebar badge', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'idle-chat',
+          title: 'Idle chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+        }),
+        makePlanningSessionSummary({
+          id: 'draft-chat',
+          title: 'Draft ready chat',
+          status: 'draft_ready',
+          draftPlanAvailable: true,
+        }),
+        makePlanningSessionSummary({
+          id: 'waiting-chat',
+          title: 'Waiting chat',
+          status: 'waiting_for_answer',
+          draftPlanAvailable: false,
+        }),
+        makePlanningSessionSummary({
+          id: 'submitted-chat',
+          title: 'Submitted chat',
+          status: 'submitted',
+          draftPlanAvailable: false,
+        }),
+      ],
+    }));
+
+    render(<App />);
+
+    const planningButton = await screen.findByTestId('sidebar-planning');
+    await waitFor(() => {
+      expect(within(planningButton).getByText('2')).toBeInTheDocument();
+    });
+
+    fireEvent.click(planningButton);
+
+    expect(await screen.findByText('4 planning chats.')).toBeInTheDocument();
+    expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('4 chats');
+  });
+
+  it('keeps the Planning Terminal attention count unchanged when creating an idle chat', async () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
+    render(<App />);
+
+    const planningButton = await screen.findByTestId('sidebar-planning');
+    await waitFor(() => {
+      expect(within(planningButton).getByText('0')).toBeInTheDocument();
+    });
+
+    fireEvent.click(planningButton);
+
+    expect(await screen.findByText('1 planning chat.')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'New' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('2 planning chats.')).toBeInTheDocument();
+    });
+    expect(within(screen.getByTestId('sidebar-planning')).getByText('0')).toBeInTheDocument();
+    expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('2 chats');
+  });
+
   it('continues the same planning session', async () => {
     render(<App />);
     await openPlanningTerminal();

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -30,6 +30,7 @@ interface LeftStatusColumnProps {
   onSelectSurface: (surface: SidebarSurface) => void;
   onToggleCollapsed: () => void;
   planningSessionCount: number;
+  planningAttentionCount: number;
   onOpenSettings: () => void;
   theme: ThemeMode;
   onToggleTheme: () => void;
@@ -77,6 +78,7 @@ export function LeftStatusColumn({
   onSelectSurface,
   onToggleCollapsed,
   planningSessionCount,
+  planningAttentionCount,
   onOpenSettings,
   theme,
   onToggleTheme,
@@ -149,9 +151,9 @@ export function LeftStatusColumn({
         {collapsed ? (
           <div className="relative inline-flex h-9 w-9 items-center justify-center">
             <span><PlanningTerminalIcon className={ICON_CLASS} /></span>
-            {planningSessionCount > 0 && (
+            {planningAttentionCount > 0 && (
               <span className={`absolute -right-1 -top-1 rounded-full px-1.5 py-0.5 text-[10px] leading-none bg-background ${countClass('neutral')}`}>
-                {planningSessionCount}
+                {planningAttentionCount}
               </span>
             )}
           </div>
@@ -164,7 +166,7 @@ export function LeftStatusColumn({
               <span className="truncate">Planning Terminal</span>
             </span>
             <span className={`rounded-full px-2 py-0.5 text-[11px] ${countClass('neutral')}`}>
-              {planningSessionCount}
+              {planningAttentionCount}
             </span>
           </>
         )}


### PR DESCRIPTION
## Summary

Fix the Planning Terminal sidebar badge so it reports only planning conversations that require user attention, not every planning conversation. The existing UI already defines the attention contract in `planningNeedsAttention(status)`: `waiting_for_answer` and `draft_ready` count; `still_discussing`, `submitted`, and idle local chats do not.

This is one UI behavior slice in `packages/ui`: compute a planning attention count in `App`, pass it into `LeftStatusColumn`, keep the planning session rail's total-chat summary unchanged, and add focused component coverage around the sidebar badge. Because this targets Invoker itself, the resulting PR should use the normal Invoker external review gate and be published with Mergify Stacks after the branch is ready.


## Pipeline

| Time | Worker | Action | Status | Target | Summary |
| --- | --- | --- | --- | --- | --- |
| 2026-07-14T03:14:20.194Z | autofix | auto-retry | completed | wf-1783991966173-7/implement-planning-terminal-attention-badge | Worker action reconciled from completed intent on startup |
| 2026-07-14T03:14:20.199Z | autofix | auto-retry-cap | queued | wf-1783991966173-7/implement-planning-terminal-attention-badge | Durable per-task auto-fix retry counter |
| 2026-07-14T03:14:20.557Z | autofix | auto-fix | skipped | wf-1783991966173-7/implement-planning-terminal-attention-badge | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:14:20.558Z | autofix | auto-fix | skipped | wf-1783991966173-7/verify-planning-terminal-attention-badge | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:14:20.559Z | autofix | auto-fix | skipped | __merge__wf-1783991966173-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:14:21.405Z | autofix | auto-fix | skipped | wf-1783991966173-7/implement-planning-terminal-attention-badge | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:19:47.169Z | autofix | auto-fix | skipped | wf-1783991966173-7/verify-planning-terminal-attention-badge | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:20:51.115Z | autofix | auto-fix | skipped | __merge__wf-1783991966173-7 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T04:01:56.192Z | autofix | auto-retry | completed | __merge__wf-1783991966173-7 | Worker action reconciled from completed intent on startup |
| 2026-07-14T04:01:56.193Z | autofix | auto-retry-cap | queued | __merge__wf-1783991966173-7 | Durable per-task auto-fix retry counter |
| 2026-07-14T04:01:58.926Z | autofix | auto-fix | skipped | __merge__wf-1783991966173-7 | Skipped auto-fix: not-eligible (not-eligible) |

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/app-launch.test.tsx src/__tests__/invoker-terminal.test.tsx` — Run focused UI component tests for the Planning Terminal sidebar badge behavior.
Review claim: The focused UI tests prove the sidebar badge uses attention-needed planning conversations rather than total conversations.
Review lane: proof
Safety invariant: This task only executes existing Vitest test files in the `@invoker/ui` workspace.
Slice rationale: The verification is paired with the single UI behavior slice and uses the smallest Vitest invocation for the affected App/sidebar/terminal components.
Architectural effect: None; this task only validates the changed UI behavior.
Goal: Prove the Planning Terminal badge count behavior with deterministic component tests.
Motivation: The bug is visible in the React component layer, so focused Vitest coverage is faster and more targeted than a full Electron suite.
Alternative considerations: A full `pnpm run test:all` gate is unnecessary for this narrow badge presentation fix; manual inspection alone is insufficient.
Implementation details: Run the UI Vitest invocation from the repository root.
Non-goals: Do not edit files or broaden verification to unrelated package suites.
Layer: app_regression
Feature state: active
Files:
- packages/ui/src/__tests__/app-launch.test.tsx
- packages/ui/src/__tests__/invoker-terminal.test.tsx
Change types:
- packages/ui/src/__tests__/app-launch.test.tsx: none
- packages/ui/src/__tests__/invoker-terminal.test.tsx: none
Acceptance criteria:
- `pnpm --filter @invoker/ui exec vitest run src/__tests__/app-launch.test.tsx src/__tests__/invoker-terminal.test.tsx` exits 0.


</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>