### PR TITLE
Planning Lag Step 3 Ui Perf Correlation And Proof (1) Correlate Planning Telemetry With Owner Ui Perf Stats

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -368,10 +368,21 @@ describe('headless-client', () => {
   it('delegates query ui-perf to a reachable owner endpoint', async () => {
     const bus = new LocalBus();
     bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
-    bus.onRequest('headless.query', async () => ({
-      maxRendererEventLoopLagMs: 123,
-      maxRendererLongTaskMs: 456,
-    }));
+    let queryPayload: Record<string, unknown> | undefined;
+    bus.onRequest('headless.query', async (payload: unknown) => {
+      queryPayload = payload as Record<string, unknown>;
+      return {
+        maxRendererEventLoopLagMs: 123,
+        maxRendererLongTaskMs: 456,
+        planningTypingLagReports: 2,
+        maxPlanningTypingLagMs: 78,
+        maxPlanningTypingLagContext: {
+          scenario: 'many-chats-many-messages-typing',
+          sessionCount: 6,
+          activeSurface: 'planning',
+        },
+      };
+    });
 
     const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     const runElectronHeadless = vi.fn(async () => 0);
@@ -384,7 +395,41 @@ describe('headless-client', () => {
 
     expect(exitCode).toBe(0);
     expect(runElectronHeadless).not.toHaveBeenCalled();
-    expect(stdout).toHaveBeenCalledWith('{"maxRendererEventLoopLagMs":123,"maxRendererLongTaskMs":456}\n');
+    expect(queryPayload?.kind).toBe('ui-perf');
+    expect(queryPayload?.reset).toBe(false);
+    expect(stdout).toHaveBeenCalledWith(
+      '{"maxRendererEventLoopLagMs":123,"maxRendererLongTaskMs":456,"planningTypingLagReports":2,"maxPlanningTypingLagMs":78,"maxPlanningTypingLagContext":{"scenario":"many-chats-many-messages-typing","sessionCount":6,"activeSurface":"planning"}}\n',
+    );
+    stdout.mockRestore();
+  });
+
+  it('delegates query ui-perf reset and honors delegated label output', async () => {
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    let queryPayload: Record<string, unknown> | undefined;
+    bus.onRequest('headless.query', async (payload: unknown) => {
+      queryPayload = payload as Record<string, unknown>;
+      return {
+        maxRendererEventLoopLagMs: 321,
+        maxRendererLongTaskMs: 654,
+        planningTypingLagReports: 1,
+        maxPlanningTypingLagMs: 987,
+      };
+    });
+
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const runElectronHeadless = vi.fn(async () => 0);
+
+    const exitCode = await runHeadlessClientCommand(['query', 'ui-perf', '--reset', '--output', 'label'], {
+      messageBus: bus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runElectronHeadless).not.toHaveBeenCalled();
+    expect(queryPayload).toEqual({ kind: 'ui-perf', reset: true });
+    expect(stdout).toHaveBeenCalledWith('321\n');
     stdout.mockRestore();
   });
 

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -6,6 +6,11 @@ import { SQLiteAdapter } from '@invoker/data-store';
 import type { MessageBus } from '@invoker/transport';
 import { LocalBus } from '@invoker/transport';
 import { TaskRunner } from '@invoker/execution-engine';
+import {
+  createUiPerfTelemetryStats,
+  recordUiPerfTelemetryReport,
+  resetUiPerfTelemetryStats,
+} from '../ui-perf-telemetry.js';
 
 /**
  * Tests for headless delegation and owner-boundary behavior.
@@ -97,14 +102,91 @@ describe('headless delegation enforcement', () => {
       expect(mockDeps.orchestrator.syncFromDb).toHaveBeenNthCalledWith(2, 'wf-2');
     });
 
-    it('allows query ui-perf in read-only mode', async () => {
+    it('allows query ui-perf in read-only mode with planning lag evidence', async () => {
+      const stats = createUiPerfTelemetryStats();
+      recordUiPerfTelemetryReport(stats, 'renderer_event_loop_lag', { lagMs: 12 });
+      recordUiPerfTelemetryReport(stats, 'renderer_long_task', { durationMs: 34 });
+      recordUiPerfTelemetryReport(stats, 'planning_typing_lag_baseline', {
+        scenario: 'many-chats-many-messages-typing',
+        sessionCount: 8,
+        transcriptSizeBytes: 12_345,
+        transcriptMessageCount: 80,
+        taskCount: 8,
+        workflowCount: 1,
+        activeSurface: 'planning',
+        activeState: 'dag:task_selected:terminal-collapsed',
+        targetName: 'edit-prompt-input',
+        lagMs: 56,
+      });
       mockDeps.getUiPerfStats = vi.fn(() => ({
+        ownerMode: 'local',
+        ts: '2026-07-13T00:00:00.000Z',
+        ...stats,
+      }));
+      mockDeps.resetUiPerfStats = vi.fn(() => resetUiPerfTelemetryStats(stats));
+      const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      let written = '';
+      try {
+        await expect(
+          runHeadless(['query', 'ui-perf', '--output', 'json'], mockDeps)
+        ).resolves.toBeUndefined();
+        written = stdout.mock.calls.map(([chunk]) => String(chunk)).join('');
+      } finally {
+        stdout.mockRestore();
+      }
+
+      expect(mockDeps.resetUiPerfStats).not.toHaveBeenCalled();
+      const payload = JSON.parse(written) as Record<string, unknown>;
+      expect(payload).toEqual(expect.objectContaining({
         maxRendererEventLoopLagMs: 12,
         maxRendererLongTaskMs: 34,
+        planningTypingLagReports: 1,
+        maxPlanningTypingLagMs: 56,
+        lastPlanningTypingLagMs: 56,
       }));
-      await expect(
-        runHeadless(['query', 'ui-perf', '--output', 'json'], mockDeps)
-      ).resolves.toBeUndefined();
+      expect(payload.maxPlanningTypingLagContext).toEqual(expect.objectContaining({
+        scenario: 'many-chats-many-messages-typing',
+        sessionCount: 8,
+        transcriptSizeBytes: 12_345,
+        transcriptMessageCount: 80,
+        activeSurface: 'planning',
+        activeState: 'dag:task_selected:terminal-collapsed',
+        targetName: 'edit-prompt-input',
+        lagMs: 56,
+      }));
+    });
+
+    it('resets query ui-perf stats only when --reset is supplied', async () => {
+      const stats = createUiPerfTelemetryStats();
+      recordUiPerfTelemetryReport(stats, 'planning_typing_lag_baseline', {
+        scenario: 'many-chats-many-messages-typing',
+        lagMs: 99,
+      });
+      mockDeps.getUiPerfStats = vi.fn(() => ({
+        ts: '2026-07-13T00:00:00.000Z',
+        ...stats,
+      }));
+      mockDeps.resetUiPerfStats = vi.fn(() => resetUiPerfTelemetryStats(stats));
+      const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      let written = '';
+      try {
+        await expect(
+          runHeadless(['query', 'ui-perf', '--reset', '--output', 'json'], mockDeps)
+        ).resolves.toBeUndefined();
+        written = stdout.mock.calls.map(([chunk]) => String(chunk)).join('');
+      } finally {
+        stdout.mockRestore();
+      }
+
+      expect(mockDeps.resetUiPerfStats).toHaveBeenCalledTimes(1);
+      const payload = JSON.parse(written) as Record<string, unknown>;
+      expect(payload).toEqual(expect.objectContaining({
+        planningTypingLagReports: 0,
+        maxPlanningTypingLagMs: 0,
+        lastPlanningTypingLagMs: 0,
+        maxPlanningTypingLagContext: null,
+        lastPlanningTypingLagContext: null,
+      }));
     });
 
     it('allows deprecated list command in read-only mode', async () => {

--- a/packages/app/src/__tests__/headless-query-capture.test.ts
+++ b/packages/app/src/__tests__/headless-query-capture.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { runHeadless, type HeadlessDeps } from '../headless.js';
+import {
+  createUiPerfTelemetryStats,
+  recordUiPerfTelemetryReport,
+} from '../ui-perf-telemetry.js';
+
+describe('headless query capture', () => {
+  it('captures planning ui-perf metrics in jsonl output without resetting stats', async () => {
+    const stats = createUiPerfTelemetryStats();
+    recordUiPerfTelemetryReport(stats, 'renderer_event_loop_lag', { lagMs: 11 });
+    recordUiPerfTelemetryReport(stats, 'planning_typing_lag_baseline', {
+      scenario: 'many-chats-many-messages-typing',
+      sessionCount: 4,
+      transcriptSizeBytes: 4096,
+      transcriptMessageCount: 40,
+      activeSurface: 'planning',
+      lagMs: 44,
+    });
+    const resetUiPerfStats = vi.fn();
+    const deps = {
+      getUiPerfStats: () => ({
+        ownerMode: 'local',
+        ts: '2026-07-13T00:00:00.000Z',
+        ...stats,
+      }),
+      resetUiPerfStats,
+    } as unknown as HeadlessDeps;
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    let written = '';
+    try {
+      await runHeadless(['query', 'ui-perf', '--output', 'jsonl'], deps);
+      written = stdout.mock.calls.map(([chunk]) => String(chunk)).join('');
+    } finally {
+      stdout.mockRestore();
+    }
+
+    expect(resetUiPerfStats).not.toHaveBeenCalled();
+    const payload = JSON.parse(written.trim()) as Record<string, unknown>;
+    expect(payload).toEqual(expect.objectContaining({
+      maxRendererEventLoopLagMs: 11,
+      planningTypingLagReports: 1,
+      maxPlanningTypingLagMs: 44,
+    }));
+    expect(payload.maxPlanningTypingLagContext).toEqual(expect.objectContaining({
+      scenario: 'many-chats-many-messages-typing',
+      sessionCount: 4,
+      transcriptSizeBytes: 4096,
+      transcriptMessageCount: 40,
+      activeSurface: 'planning',
+      lagMs: 44,
+    }));
+  });
+});

--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LocalBus } from '@invoker/transport';
+
+import { runHeadlessClientCommand } from '../headless-client.js';
+
+describe('owner read query', () => {
+  it('delegates ui-perf reads without resetting owner stats by default', async () => {
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    const queryPayloads: Array<Record<string, unknown>> = [];
+    bus.onRequest('headless.query', async (payload: unknown) => {
+      queryPayloads.push(payload as Record<string, unknown>);
+      return {
+        ownerMode: 'gui',
+        maxRendererEventLoopLagMs: 22,
+        maxRendererLongTaskMs: 33,
+        planningTypingLagReports: 1,
+        maxPlanningTypingLagMs: 55,
+        maxPlanningTypingLagContext: {
+          scenario: 'many-chats-many-messages-typing',
+          activeSurface: 'planning',
+        },
+      };
+    });
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    let written = '';
+    try {
+      const exitCode = await runHeadlessClientCommand(['query', 'ui-perf', '--output', 'json'], {
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(async () => {}),
+        runElectronHeadless: vi.fn(async () => 0),
+      });
+      expect(exitCode).toBe(0);
+      written = stdout.mock.calls.map(([chunk]) => String(chunk)).join('');
+    } finally {
+      stdout.mockRestore();
+    }
+
+    expect(queryPayloads).toEqual([{ kind: 'ui-perf', reset: false }]);
+    const payload = JSON.parse(written) as Record<string, unknown>;
+    expect(payload).toEqual(expect.objectContaining({
+      ownerMode: 'gui',
+      maxRendererEventLoopLagMs: 22,
+      maxRendererLongTaskMs: 33,
+      planningTypingLagReports: 1,
+      maxPlanningTypingLagMs: 55,
+    }));
+  });
+});

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -352,6 +352,22 @@ export function formatAsJsonl(items: unknown[]): string {
   return items.map(item => JSON.stringify(item)).join('\n');
 }
 
+export function formatUiPerfStats(
+  stats: Record<string, unknown>,
+  output: 'text' | 'label' | 'json' | 'jsonl' = 'text',
+): string {
+  switch (output) {
+    case 'label':
+      return String(stats.maxRendererEventLoopLagMs ?? 0);
+    case 'json':
+      return formatAsJson(stats);
+    case 'jsonl':
+      return formatAsJsonl([stats]);
+    default:
+      return JSON.stringify(stats, null, 2);
+  }
+}
+
 // ── Cost Formatters ─────────────────────────────────────────
 
 /**

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -27,6 +27,7 @@ import {
   isStandaloneCapable,
 } from './owner-endpoint.js';
 import { createOwnerResolver } from './owner-resolver.js';
+import { formatUiPerfStats } from './formatter.js';
 
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
@@ -174,7 +175,12 @@ async function delegateReadOnlyQuery(
       : 'Live owner is present but did not serve queue query');
   }
   if (isUiPerf) {
-    process.stdout.write(`${JSON.stringify(response)}\n`);
+    const outputIndex = args.indexOf('--output');
+    const output = outputIndex >= 0 ? args[outputIndex + 1] : undefined;
+    const format = output === 'label' || output === 'json' || output === 'jsonl'
+      ? output
+      : 'text';
+    process.stdout.write(`${formatUiPerfStats(response, format)}\n`);
     return true;
   }
   const outputIndex = args.indexOf('--output');

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -58,6 +58,7 @@ import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './work
 import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import type { RuntimeServices } from '@invoker/runtime-service';
+import { createUiPerfTelemetryStats } from './ui-perf-telemetry.js';
 
 export { bumpGenerationAndRecreate } from './workflow-actions.js';
 export {
@@ -383,7 +384,7 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
     formatWorkflowList, formatTaskStatus, formatWorkflowStatus,
     formatEventLog, formatQueueStatus, formatWorkflowStats,
     serializeWorkflow, serializeTask, serializeEvent,
-    formatAsLabel, formatAsJson, formatAsJsonl,
+    formatAsLabel, formatAsJson, formatAsJsonl, formatUiPerfStats,
   } = await import('./formatter.js');
 
   switch (subCommand) {
@@ -517,28 +518,9 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
       const stats = deps.getUiPerfStats?.() ?? {
         ownerMode: 'local',
         ts: new Date().toISOString(),
-        mainDeltaToUi: 0,
-        dbPollCreated: 0,
-        dbPollUpdatedAsCreated: 0,
-        dbPollUpdatedAsUpdated: 0,
-        rendererReports: 0,
-        maxRendererEventLoopLagMs: 0,
-        maxRendererLongTaskMs: 0,
+        ...createUiPerfTelemetryStats(),
       };
-      switch (flags.output) {
-        case 'label':
-          process.stdout.write(String((stats as Record<string, unknown>).maxRendererEventLoopLagMs ?? 0) + '\n');
-          break;
-        case 'json':
-          process.stdout.write(formatAsJson(stats) + '\n');
-          break;
-        case 'jsonl':
-          process.stdout.write(formatAsJsonl([stats]) + '\n');
-          break;
-        default:
-          process.stdout.write(`${JSON.stringify(stats, null, 2)}\n`);
-          break;
-      }
+      process.stdout.write(formatUiPerfStats(stats, flags.output) + '\n');
       break;
     }
     case 'stats': {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -160,6 +160,11 @@ import {
   buildActionGraphDiagnostics,
   resolveActionDiagnosticsStallThresholdMs,
 } from './action-graph-diagnostics.js';
+import {
+  createUiPerfTelemetryStats,
+  recordUiPerfTelemetryReport,
+  resetUiPerfTelemetryStats,
+} from './ui-perf-telemetry.js';
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
@@ -725,16 +730,7 @@ if (isHeadless) {
         commandService,
         getUiPerfStats: () => ({
           ts: new Date().toISOString(),
-          mainDeltaToUi: 0,
-          dbPollCreated: 0,
-          dbPollUpdatedAsCreated: 0,
-          dbPollUpdatedAsUpdated: 0,
-          rendererReports: 0,
-          maxRendererEventLoopLagMs: 0,
-          maxRendererHiddenEventLoopLagMs: 0,
-          maxRendererCumulativeLagMs: 0,
-          maxRendererTickDeltaMs: 0,
-          maxRendererLongTaskMs: 0,
+          ...createUiPerfTelemetryStats(),
         }),
         resetUiPerfStats: () => {},
         waitForApproval,
@@ -1212,18 +1208,7 @@ if (isHeadless) {
     process.env.INVOKER_EXECUTING_STALL_TIMEOUT_MS ?? '180000',
     10,
   ) || 180000;
-  const uiPerfStats = {
-    mainDeltaToUi: 0,
-    dbPollCreated: 0,
-    dbPollUpdatedAsCreated: 0,
-    dbPollUpdatedAsUpdated: 0,
-    rendererReports: 0,
-    maxRendererEventLoopLagMs: 0,
-    maxRendererHiddenEventLoopLagMs: 0,
-    maxRendererCumulativeLagMs: 0,
-    maxRendererTickDeltaMs: 0,
-    maxRendererLongTaskMs: 0,
-  };
+  const uiPerfStats = createUiPerfTelemetryStats();
   const startupMarks = new Map<string, number>();
   const startupPhaseDetails: Array<Record<string, unknown>> = [];
   const recordStartupMark = (phase: string, extra?: Record<string, unknown>): void => {
@@ -1270,16 +1255,7 @@ if (isHeadless) {
   };
 
   const resetUiPerfStats = (): void => {
-    uiPerfStats.mainDeltaToUi = 0;
-    uiPerfStats.dbPollCreated = 0;
-    uiPerfStats.dbPollUpdatedAsCreated = 0;
-    uiPerfStats.dbPollUpdatedAsUpdated = 0;
-    uiPerfStats.rendererReports = 0;
-    uiPerfStats.maxRendererEventLoopLagMs = 0;
-    uiPerfStats.maxRendererHiddenEventLoopLagMs = 0;
-    uiPerfStats.maxRendererCumulativeLagMs = 0;
-    uiPerfStats.maxRendererTickDeltaMs = 0;
-    uiPerfStats.maxRendererLongTaskMs = 0;
+    resetUiPerfTelemetryStats(uiPerfStats);
   };
 
   const getUiPerfStats = (): Record<string, unknown> => ({
@@ -3253,24 +3229,7 @@ if (isHeadless) {
         metric,
         ...(data ?? {}),
       };
-      if (metric === 'renderer_event_loop_lag' && typeof data?.lagMs === 'number') {
-        const hiddenOrUnfocused = data.visibilityState === 'hidden' || data.hasFocus === false;
-        if (hiddenOrUnfocused) {
-          uiPerfStats.maxRendererHiddenEventLoopLagMs = Math.max(uiPerfStats.maxRendererHiddenEventLoopLagMs, data.lagMs);
-        } else {
-          uiPerfStats.maxRendererEventLoopLagMs = Math.max(uiPerfStats.maxRendererEventLoopLagMs, data.lagMs);
-        }
-        if (typeof data.cumulativeLagMs === 'number') {
-          uiPerfStats.maxRendererCumulativeLagMs = Math.max(uiPerfStats.maxRendererCumulativeLagMs, data.cumulativeLagMs);
-        }
-        if (typeof data.tickDeltaMs === 'number') {
-          uiPerfStats.maxRendererTickDeltaMs = Math.max(uiPerfStats.maxRendererTickDeltaMs, data.tickDeltaMs);
-        }
-      }
-      if (metric === 'renderer_long_task' && typeof data?.durationMs === 'number') {
-        uiPerfStats.maxRendererLongTaskMs = Math.max(uiPerfStats.maxRendererLongTaskMs, data.durationMs);
-      }
-      uiPerfStats.rendererReports += 1;
+      recordUiPerfTelemetryReport(uiPerfStats, metric, data);
       try {
         persistence.writeActivityLog('ui-perf', 'info', JSON.stringify(payload));
       } catch {

--- a/packages/app/src/ui-perf-telemetry.ts
+++ b/packages/app/src/ui-perf-telemetry.ts
@@ -1,0 +1,137 @@
+export const PLANNING_TYPING_LAG_METRIC = 'planning_typing_lag_baseline';
+
+export interface UiPerfTelemetryStats {
+  mainDeltaToUi: number;
+  dbPollCreated: number;
+  dbPollUpdatedAsCreated: number;
+  dbPollUpdatedAsUpdated: number;
+  rendererReports: number;
+  maxRendererEventLoopLagMs: number;
+  maxRendererHiddenEventLoopLagMs: number;
+  maxRendererCumulativeLagMs: number;
+  maxRendererTickDeltaMs: number;
+  maxRendererLongTaskMs: number;
+  planningTypingLagReports: number;
+  maxPlanningTypingLagMs: number;
+  lastPlanningTypingLagMs: number;
+  maxPlanningTypingLagContext: Record<string, unknown> | null;
+  lastPlanningTypingLagContext: Record<string, unknown> | null;
+}
+
+const PLANNING_TYPING_LAG_CONTEXT_KEYS = [
+  'scenario',
+  'sessionCount',
+  'transcriptSizeBytes',
+  'transcriptMessageCount',
+  'taskCount',
+  'workflowCount',
+  'taskStatusCounts',
+  'activeSurface',
+  'activeState',
+  'viewMode',
+  'terminalDrawerState',
+  'selectionState',
+  'selectedTaskId',
+  'selectedWorkflowId',
+  'hasLoadedPlan',
+  'hasStarted',
+  'sequence',
+  'eventType',
+  'targetName',
+  'targetTagName',
+  'targetValueLength',
+  'targetReadOnly',
+  'targetDisabled',
+  'targetIsComposing',
+  'inputType',
+] as const;
+
+export function createUiPerfTelemetryStats(): UiPerfTelemetryStats {
+  return {
+    mainDeltaToUi: 0,
+    dbPollCreated: 0,
+    dbPollUpdatedAsCreated: 0,
+    dbPollUpdatedAsUpdated: 0,
+    rendererReports: 0,
+    maxRendererEventLoopLagMs: 0,
+    maxRendererHiddenEventLoopLagMs: 0,
+    maxRendererCumulativeLagMs: 0,
+    maxRendererTickDeltaMs: 0,
+    maxRendererLongTaskMs: 0,
+    planningTypingLagReports: 0,
+    maxPlanningTypingLagMs: 0,
+    lastPlanningTypingLagMs: 0,
+    maxPlanningTypingLagContext: null,
+    lastPlanningTypingLagContext: null,
+  };
+}
+
+export function resetUiPerfTelemetryStats(stats: UiPerfTelemetryStats): void {
+  Object.assign(stats, createUiPerfTelemetryStats());
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function planningTypingLagContext(
+  lagMs: number,
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  const context: Record<string, unknown> = { lagMs };
+  for (const key of PLANNING_TYPING_LAG_CONTEXT_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(data, key)) {
+      context[key] = data[key];
+    }
+  }
+  return context;
+}
+
+export function recordUiPerfTelemetryReport(
+  stats: UiPerfTelemetryStats,
+  metric: string,
+  data?: Record<string, unknown>,
+): void {
+  if (metric === 'renderer_event_loop_lag') {
+    const lagMs = finiteNumber(data?.lagMs);
+    if (lagMs !== undefined) {
+      const hiddenOrUnfocused = data?.visibilityState === 'hidden' || data?.hasFocus === false;
+      if (hiddenOrUnfocused) {
+        stats.maxRendererHiddenEventLoopLagMs = Math.max(stats.maxRendererHiddenEventLoopLagMs, lagMs);
+      } else {
+        stats.maxRendererEventLoopLagMs = Math.max(stats.maxRendererEventLoopLagMs, lagMs);
+      }
+    }
+    const cumulativeLagMs = finiteNumber(data?.cumulativeLagMs);
+    if (cumulativeLagMs !== undefined) {
+      stats.maxRendererCumulativeLagMs = Math.max(stats.maxRendererCumulativeLagMs, cumulativeLagMs);
+    }
+    const tickDeltaMs = finiteNumber(data?.tickDeltaMs);
+    if (tickDeltaMs !== undefined) {
+      stats.maxRendererTickDeltaMs = Math.max(stats.maxRendererTickDeltaMs, tickDeltaMs);
+    }
+  }
+
+  if (metric === 'renderer_long_task') {
+    const durationMs = finiteNumber(data?.durationMs);
+    if (durationMs !== undefined) {
+      stats.maxRendererLongTaskMs = Math.max(stats.maxRendererLongTaskMs, durationMs);
+    }
+  }
+
+  if (metric === PLANNING_TYPING_LAG_METRIC) {
+    const lagMs = finiteNumber(data?.lagMs);
+    if (lagMs !== undefined && data) {
+      const context = planningTypingLagContext(lagMs, data);
+      stats.planningTypingLagReports += 1;
+      stats.lastPlanningTypingLagMs = lagMs;
+      stats.lastPlanningTypingLagContext = context;
+      if (lagMs >= stats.maxPlanningTypingLagMs) {
+        stats.maxPlanningTypingLagMs = lagMs;
+        stats.maxPlanningTypingLagContext = context;
+      }
+    }
+  }
+
+  stats.rendererReports += 1;
+}


### PR DESCRIPTION
## Summary

Planning Lag Step 3 Ui Perf Correlation And Proof — 3 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1783567212570-19/implement-ui-perf-correlation-proof | Correlate planning telemetry with owner-level ui-perf query stats to prove root cause | completed |
| wf-1783567212570-19/verify-ui-perf-correlation-proof-app | Run focused app ui-perf query and delegation tests | completed (passed) |
| wf-1783567212570-19/verify-ui-perf-correlation-proof-ui | Re-run planning terminal suite to confirm no regression after telemetry wiring | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1783567212570-19/implement-ui-perf-correlation-proof — Correlate planning telemetry with owner-level ui-perf query stats to prove root cause
docs/context/inv-117/experiment-brief.md           | 222 +++++++++++++++++++++
 package.json                                       |   3 +
 packages/app/src/__tests__/headless-client.test.ts |  55 ++++-
 .../app/src/__tests__/headless-delegation.test.ts  |  90 ++++++++-
 .../src/__tests__/headless-query-capture.test.ts   |  55 +++++
 .../app/src/__tests__/owner-read-query.test.ts     |  49 +++++
 packages/app/src/formatter.ts                      |  16 ++
 packages/app/src/headless-client.ts                |   8 +-
 packages/app/src/headless.ts                       |  26 +--
 packages/app/src/main.ts                           |  59 +-----
 packages/app/src/ui-perf-telemetry.ts              | 137 +++++++++++++
 packages/ui/src/App.tsx                            | 214 +++++++++++++++++++-
 packages/ui/src/__tests__/helpers/mock-invoker.ts  |   1 +
 packages/ui/src/__tests__/plan-loading.test.tsx    |  86 +++++++-
 scripts/pr-body-rollout.mjs                        |  77 +++++++
 scripts/run-all-tests.sh                           |  72 +++++++
 scripts/test-pr-body-rollout.mjs                   |  87 ++++++++
 scripts/test-pr-body-validator.mjs                 |  31 +++
 scripts/validate-pr-body.mjs                       |  12 +-
 scripts/workspace-test.sh                          |   7 +
 20 files changed, 1218 insertions(+), 89 deletions(-)

### wf-1783567212570-19/verify-ui-perf-correlation-proof-app — Run focused app ui-perf query and delegation tests
docs/context/inv-117/experiment-brief.md           | 222 +++++++++++++++++++++
 package.json                                       |   3 +
 packages/app/src/__tests__/headless-client.test.ts |  55 ++++-
 .../app/src/__tests__/headless-delegation.test.ts  |  90 ++++++++-
 .../src/__tests__/headless-query-capture.test.ts   |  55 +++++
 .../app/src/__tests__/owner-read-query.test.ts     |  49 +++++
 packages/app/src/formatter.ts                      |  16 ++
 packages/app/src/headless-client.ts                |   8 +-
 packages/app/src/headless.ts                       |  26 +--
 packages/app/src/main.ts                           |  59 +-----
 packages/app/src/ui-perf-telemetry.ts              | 137 +++++++++++++
 packages/ui/src/App.tsx                            | 214 +++++++++++++++++++-
 packages/ui/src/__tests__/helpers/mock-invoker.ts  |   1 +
 packages/ui/src/__tests__/plan-loading.test.tsx    |  86 +++++++-
 scripts/pr-body-rollout.mjs                        |  77 +++++++
 scripts/run-all-tests.sh                           |  72 +++++++
 scripts/test-pr-body-rollout.mjs                   |  87 ++++++++
 scripts/test-pr-body-validator.mjs                 |  31 +++
 scripts/validate-pr-body.mjs                       |  12 +-
 scripts/workspace-test.sh                          |   7 +
 20 files changed, 1218 insertions(+), 89 deletions(-)

### wf-1783567212570-19/verify-ui-perf-correlation-proof-ui — Re-run planning terminal suite to confirm no regression after telemetry wiring
docs/context/inv-117/experiment-brief.md           | 222 +++++++++++++++++++++
 package.json                                       |   3 +
 packages/app/src/__tests__/headless-client.test.ts |  55 ++++-
 .../app/src/__tests__/headless-delegation.test.ts  |  90 ++++++++-
 .../src/__tests__/headless-query-capture.test.ts   |  55 +++++
 .../app/src/__tests__/owner-read-query.test.ts     |  49 +++++
 packages/app/src/formatter.ts                      |  16 ++
 packages/app/src/headless-client.ts                |   8 +-
 packages/app/src/headless.ts                       |  26 +--
 packages/app/src/main.ts                           |  59 +-----
 packages/app/src/ui-perf-telemetry.ts              | 137 +++++++++++++
 packages/ui/src/App.tsx                            | 214 +++++++++++++++++++-
 packages/ui/src/__tests__/helpers/mock-invoker.ts  |   1 +
 packages/ui/src/__tests__/plan-loading.test.tsx    |  86 +++++++-
 scripts/pr-body-rollout.mjs                        |  77 +++++++
 scripts/run-all-tests.sh                           |  72 +++++++
 scripts/test-pr-body-rollout.mjs                   |  87 ++++++++
 scripts/test-pr-body-validator.mjs                 |  31 +++
 scripts/validate-pr-body.mjs                       |  12 +-
 scripts/workspace-test.sh                          |   7 +
 20 files changed, 1218 insertions(+), 89 deletions(-)

</details>

## Review Claim

Approve the slice that correlates planning typing lag telemetry with owner-level ui-perf query stats.

## Review Lane

behavior

## Review Unit

planning-ui-perf-correlation

## Safety Invariant

This slice only records and formats ui-perf telemetry plus planning typing context. It does not change workflow execution, task persistence, or renderer state ownership.

## Slice Rationale

The telemetry correlation is the reviewable implementation unit. The app and planning terminal proof stay as dependent slices so reviewers can separate behavior from verification.

## Non-goals

This slice does not optimize the planning hot path, change the planning UI layout, alter workflow execution, or replace the Step 2 state isolation work.

## Architecture

### Before

The owner-level ui-perf query reported renderer lag counters, but planning typing lag context was not preserved in the queryable stats payload.

### After

Planning typing lag reports update max and last ui-perf fields with focused context, and owner read queries expose that evidence through the existing output formats.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-4406-body.tmp.md`
- [x] `mergify stack push --trunk origin/plan/planning-lag-step-2-hot-path-isolation --dry-run`
- [x] `mergify stack push --trunk origin/plan/planning-lag-step-2-hot-path-isolation --skip-rebase`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-client.test.ts src/__tests__/headless-delegation.test.ts src/__tests__/headless-query-capture.test.ts src/__tests__/owner-read-query.test.ts`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/plan-loading.test.tsx`

</details>

## Visual Proof

No screenshot delta exists here. This slice exposes planning typing lag evidence through headless ui-perf stats while keeping the visible planning terminal unchanged.

Focused proof: `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-client.test.ts src/__tests__/headless-delegation.test.ts src/__tests__/headless-query-capture.test.ts src/__tests__/owner-read-query.test.ts`

Reviewer cue: the ui-perf payload includes `planningTypingLagReports`, `maxPlanningTypingLagMs`, and focused planning context such as `activeSurface` and `activeState`.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, before merge close this PR and its dependent verification PRs together.
- Revert command: `git revert bdb81581` if the commit lands independently, or revert the GitHub merge commit after landing.
- Post-revert steps: Re-run the focused app ui-perf query tests before republishing Step 3.
- Data migration? No.

</details>
