### PR TITLE
[Monkey Adverse](2) Fail orphaned in-flight tasks on owner boot

### DIFF
--- a/packages/app/src/__tests__/reconcile-orphaned-running-tasks.test.ts
+++ b/packages/app/src/__tests__/reconcile-orphaned-running-tasks.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TaskState } from '@invoker/workflow-core';
+
+import {
+  isTaskInFlightForForcedStop,
+  reconcileOrphanedInFlightTasksOnBoot,
+} from '../reconcile-orphaned-running-tasks.js';
+
+function makeTask(
+  id: string,
+  status: TaskState['status'],
+  execution: TaskState['execution'] = {},
+): TaskState {
+  return {
+    id,
+    description: id,
+    status,
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: 'wf-1' },
+    execution: { generation: 3, selectedAttemptId: 'attempt-1', ...execution },
+    taskStateVersion: 1,
+  } as TaskState;
+}
+
+describe('reconcileOrphanedInFlightTasksOnBoot', () => {
+  it('treats running, fixing_with_ai, and launching pending as in-flight', () => {
+    expect(isTaskInFlightForForcedStop(makeTask('a', 'running'))).toBe(true);
+    expect(isTaskInFlightForForcedStop(makeTask('b', 'fixing_with_ai'))).toBe(true);
+    expect(isTaskInFlightForForcedStop(makeTask('c', 'pending', { phase: 'launching' }))).toBe(true);
+    expect(isTaskInFlightForForcedStop(makeTask('d', 'pending'))).toBe(false);
+    expect(isTaskInFlightForForcedStop(makeTask('e', 'completed'))).toBe(false);
+  });
+
+  it('fails orphaned in-flight tasks with Application quit and writes a diagnostic', () => {
+    const running = makeTask('wf-1/slow-task', 'running');
+    const pending = makeTask('wf-1/ready', 'pending');
+    const handleWorkerResponse = vi.fn();
+    const appendTaskOutput = vi.fn();
+    const getOutputTail = vi.fn(() => []);
+
+    const failed = reconcileOrphanedInFlightTasksOnBoot({
+      orchestrator: {
+        getAllTasks: () => [running, pending],
+        handleWorkerResponse,
+      },
+      persistence: { getOutputTail, appendTaskOutput },
+    });
+
+    expect(failed.map((task) => task.id)).toEqual(['wf-1/slow-task']);
+    expect(handleWorkerResponse).toHaveBeenCalledTimes(1);
+    expect(handleWorkerResponse).toHaveBeenCalledWith({
+      requestId: 'boot-orphan-wf-1/slow-task',
+      actionId: 'wf-1/slow-task',
+      attemptId: 'attempt-1',
+      executionGeneration: 3,
+      status: 'failed',
+      outputs: { exitCode: 1, error: 'Application quit' },
+    });
+    expect(appendTaskOutput).toHaveBeenCalledTimes(1);
+    expect(String(appendTaskOutput.mock.calls[0]?.[1] ?? '')).toContain('Startup Orphan Diagnostic');
+    expect(String(appendTaskOutput.mock.calls[0]?.[1] ?? '')).toContain('forcedStopReason=Application quit');
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -126,6 +126,10 @@ import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutat
 import { submitWorkflowMutationOrAcknowledgeDeleted } from './workflow-mutation-submit.js';
 import type { WorkflowMutationContext } from './persisted-workflow-mutation-coordinator.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
+import {
+  isTaskInFlightForForcedStop,
+  reconcileOrphanedInFlightTasksOnBoot,
+} from './reconcile-orphaned-running-tasks.js';
 import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.js';
 import { dispatchStartedTasksWithGlobalTopup } from './global-topup.js';
 
@@ -266,12 +270,6 @@ function createRegisteredWorkerRegistry(): WorkerRegistry<WorkerRuntimeDependenc
 }
 
 
-
-function isTaskInFlightForForcedStop(task: TaskState): boolean {
-  return task.status === 'running'
-    || task.status === 'fixing_with_ai'
-    || (task.status === 'pending' && task.execution.phase === 'launching');
-}
 
 function isTaskRecoverableOnExplicitResume(task: TaskState): boolean {
   if (task.status === 'running') return true;
@@ -957,6 +955,19 @@ function startHeadlessMode(): void {
         readOnly: readOnlyMode,
         executionAgentRegistry: agentRegistry,
       });
+
+      if (!readOnlyMode && orchestrator && persistence) {
+        const orphaned = reconcileOrphanedInFlightTasksOnBoot({
+          orchestrator,
+          persistence,
+        });
+        if (orphaned.length > 0) {
+          logger.info(
+            `failed ${orphaned.length} orphaned in-flight task(s) left by a previous owner crash`,
+            { module: 'init', taskIds: orphaned.map((task) => task.id) },
+          );
+        }
+      }
 
       const headlessDeps: HeadlessDeps = {
         logger,
@@ -2796,13 +2807,25 @@ function createEmbeddedTerminalBackendFromConfig(
       });
     }
 
-    // Relaunch orphaned running tasks and start any pending-but-ready tasks.
+    // Fail orphaned in-flight tasks left by a previous crash, then start ready work.
     if (!ownerMode) {
       logger.info('follower mode startup: auto-run disabled', { module: 'init' });
-    } else if (invokerConfig.disableAutoRunOnStartup) {
-      logger.info('auto-run on startup disabled by config', { module: 'init' });
     } else {
-      orchestrator.startExecution();
+      const orphaned = reconcileOrphanedInFlightTasksOnBoot({
+        orchestrator,
+        persistence,
+      });
+      if (orphaned.length > 0) {
+        logger.info(
+          `failed ${orphaned.length} orphaned in-flight task(s) left by a previous owner crash`,
+          { module: 'init', taskIds: orphaned.map((task) => task.id) },
+        );
+      }
+      if (invokerConfig.disableAutoRunOnStartup) {
+        logger.info('auto-run on startup disabled by config', { module: 'init' });
+      } else {
+        orchestrator.startExecution();
+      }
     }
 
     const dbPath = path.join(resolveInvokerHomeRoot(), 'invoker.db');

--- a/packages/app/src/reconcile-orphaned-running-tasks.ts
+++ b/packages/app/src/reconcile-orphaned-running-tasks.ts
@@ -1,0 +1,64 @@
+import type { TaskState } from '@invoker/workflow-core';
+
+import {
+  persistShutdownDiagnostic,
+  type ShutdownDiagnosticDb,
+} from './shutdown-diagnostic.js';
+
+export function isTaskInFlightForForcedStop(task: TaskState): boolean {
+  return task.status === 'running'
+    || task.status === 'fixing_with_ai'
+    || (task.status === 'pending' && task.execution.phase === 'launching');
+}
+
+type BootReconcileOrchestrator = {
+  getAllTasks(): TaskState[];
+  handleWorkerResponse(response: {
+    requestId: string;
+    actionId: string;
+    attemptId?: string;
+    executionGeneration: number;
+    status: 'failed';
+    outputs: { exitCode: number; error: string };
+  }): unknown;
+};
+
+export type ReconcileOrphanedInFlightTasksOptions = {
+  orchestrator: BootReconcileOrchestrator;
+  persistence?: ShutdownDiagnosticDb | null;
+  reason?: string;
+};
+
+/**
+ * Fail durable in-flight tasks left behind when a previous owner died without
+ * before-quit cleanup (SIGKILL / crash). Mirrors graceful Application quit.
+ */
+export function reconcileOrphanedInFlightTasksOnBoot(
+  options: ReconcileOrphanedInFlightTasksOptions,
+): TaskState[] {
+  const reason = options.reason ?? 'Application quit';
+  const failed: TaskState[] = [];
+
+  for (const task of options.orchestrator.getAllTasks()) {
+    if (!isTaskInFlightForForcedStop(task)) continue;
+
+    if (options.persistence) {
+      persistShutdownDiagnostic(task, options.persistence, {
+        forcedStopReason: reason,
+        label: 'Startup Orphan Diagnostic',
+      });
+    }
+
+    options.orchestrator.handleWorkerResponse({
+      requestId: `boot-orphan-${task.id}`,
+      actionId: task.id,
+      attemptId: task.execution.selectedAttemptId,
+      executionGeneration: task.execution.generation ?? 0,
+      status: 'failed',
+      outputs: { exitCode: 1, error: reason },
+    });
+    failed.push(task);
+  }
+
+  return failed;
+}


### PR DESCRIPTION
## Summary

On owner boot, mark durable in-flight tasks left by a previous crash as failed.

This mirrors graceful Application quit handling that SIGKILL never performs, including the owner-serve surface.

## Review Claim

Approve marking orphaned running or fixing or launching tasks failed on owner boot with Application quit.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only touches tasks already marked in-flight with no live owner. Pending ready work still starts afterward.

## Slice Rationale

Behavior fix for the forced-kill repro. Kept separate from worker-action and mutation-intent recovery.

## Non-goals

Does not relaunch orphans, change stall watchdogs, or reconcile worker_actions.

## Architecture

### Before

```mermaid
graph TD
    A["owner SIGKILL"] --> B["task row stays running"]
    B --> C["owner relaunch"]
    C --> D["startExecution only"]
    D --> E["orphan remains running"]
```

### After

```mermaid
graph TD
    A["owner SIGKILL"] --> B["task row stays running"]
    B --> C["owner relaunch"]
    C --> D["reconcileOrphanedInFlightTasksOnBoot"]
    D --> E["fail with Application quit"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/reconcile-orphaned-running-tasks.test.ts`
- [ ] Manual owner forced-kill restart scenario

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8a333f3af656a9e76aab39fe899bc9a453b5949c`
- Post-revert steps: None
- Data migration? No

</details>
