### PR TITLE
[Monkey Adverse](3) Prove queued worker actions survive restart without sweep

### DIFF
--- a/packages/app/src/__tests__/reconcile-orphaned-running-tasks.test.ts
+++ b/packages/app/src/__tests__/reconcile-orphaned-running-tasks.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TaskState } from '@invoker/workflow-core';
+
+import {
+  isTaskInFlightForForcedStop,
+  reconcileOrphanedInFlightTasksOnBoot,
+} from '../reconcile-orphaned-running-tasks.js';
+
+function makeTask(
+  id: string,
+  status: TaskState['status'],
+  execution: TaskState['execution'] = {},
+): TaskState {
+  return {
+    id,
+    description: id,
+    status,
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: 'wf-1' },
+    execution: { generation: 3, selectedAttemptId: 'attempt-1', ...execution },
+    taskStateVersion: 1,
+  } as TaskState;
+}
+
+describe('reconcileOrphanedInFlightTasksOnBoot', () => {
+  it('treats running, fixing_with_ai, and launching pending as in-flight', () => {
+    expect(isTaskInFlightForForcedStop(makeTask('a', 'running'))).toBe(true);
+    expect(isTaskInFlightForForcedStop(makeTask('b', 'fixing_with_ai'))).toBe(true);
+    expect(isTaskInFlightForForcedStop(makeTask('c', 'pending', { phase: 'launching' }))).toBe(true);
+    expect(isTaskInFlightForForcedStop(makeTask('d', 'pending'))).toBe(false);
+    expect(isTaskInFlightForForcedStop(makeTask('e', 'completed'))).toBe(false);
+  });
+
+  it('fails orphaned in-flight tasks with Application quit and writes a diagnostic', () => {
+    const running = makeTask('wf-1/slow-task', 'running');
+    const pending = makeTask('wf-1/ready', 'pending');
+    const handleWorkerResponse = vi.fn();
+    const appendTaskOutput = vi.fn();
+    const getOutputTail = vi.fn(() => []);
+
+    const failed = reconcileOrphanedInFlightTasksOnBoot({
+      orchestrator: {
+        getAllTasks: () => [running, pending],
+        handleWorkerResponse,
+      },
+      persistence: { getOutputTail, appendTaskOutput },
+    });
+
+    expect(failed.map((task) => task.id)).toEqual(['wf-1/slow-task']);
+    expect(handleWorkerResponse).toHaveBeenCalledTimes(1);
+    expect(handleWorkerResponse).toHaveBeenCalledWith({
+      requestId: 'boot-orphan-wf-1/slow-task',
+      actionId: 'wf-1/slow-task',
+      attemptId: 'attempt-1',
+      executionGeneration: 3,
+      status: 'failed',
+      outputs: { exitCode: 1, error: 'Application quit' },
+    });
+    expect(appendTaskOutput).toHaveBeenCalledTimes(1);
+    expect(String(appendTaskOutput.mock.calls[0]?.[1] ?? '')).toContain('Startup Orphan Diagnostic');
+    expect(String(appendTaskOutput.mock.calls[0]?.[1] ?? '')).toContain('forcedStopReason=Application quit');
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -126,6 +126,10 @@ import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutat
 import { submitWorkflowMutationOrAcknowledgeDeleted } from './workflow-mutation-submit.js';
 import type { WorkflowMutationContext } from './persisted-workflow-mutation-coordinator.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
+import {
+  isTaskInFlightForForcedStop,
+  reconcileOrphanedInFlightTasksOnBoot,
+} from './reconcile-orphaned-running-tasks.js';
 import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.js';
 import { dispatchStartedTasksWithGlobalTopup } from './global-topup.js';
 
@@ -266,12 +270,6 @@ function createRegisteredWorkerRegistry(): WorkerRegistry<WorkerRuntimeDependenc
 }
 
 
-
-function isTaskInFlightForForcedStop(task: TaskState): boolean {
-  return task.status === 'running'
-    || task.status === 'fixing_with_ai'
-    || (task.status === 'pending' && task.execution.phase === 'launching');
-}
 
 function isTaskRecoverableOnExplicitResume(task: TaskState): boolean {
   if (task.status === 'running') return true;
@@ -957,6 +955,19 @@ function startHeadlessMode(): void {
         readOnly: readOnlyMode,
         executionAgentRegistry: agentRegistry,
       });
+
+      if (!readOnlyMode && orchestrator && persistence) {
+        const orphaned = reconcileOrphanedInFlightTasksOnBoot({
+          orchestrator,
+          persistence,
+        });
+        if (orphaned.length > 0) {
+          logger.info(
+            `failed ${orphaned.length} orphaned in-flight task(s) left by a previous owner crash`,
+            { module: 'init', taskIds: orphaned.map((task) => task.id) },
+          );
+        }
+      }
 
       const headlessDeps: HeadlessDeps = {
         logger,
@@ -2796,13 +2807,25 @@ function createEmbeddedTerminalBackendFromConfig(
       });
     }
 
-    // Relaunch orphaned running tasks and start any pending-but-ready tasks.
+    // Fail orphaned in-flight tasks left by a previous crash, then start ready work.
     if (!ownerMode) {
       logger.info('follower mode startup: auto-run disabled', { module: 'init' });
-    } else if (invokerConfig.disableAutoRunOnStartup) {
-      logger.info('auto-run on startup disabled by config', { module: 'init' });
     } else {
-      orchestrator.startExecution();
+      const orphaned = reconcileOrphanedInFlightTasksOnBoot({
+        orchestrator,
+        persistence,
+      });
+      if (orphaned.length > 0) {
+        logger.info(
+          `failed ${orphaned.length} orphaned in-flight task(s) left by a previous owner crash`,
+          { module: 'init', taskIds: orphaned.map((task) => task.id) },
+        );
+      }
+      if (invokerConfig.disableAutoRunOnStartup) {
+        logger.info('auto-run on startup disabled by config', { module: 'init' });
+      } else {
+        orchestrator.startExecution();
+      }
     }
 
     const dbPath = path.join(resolveInvokerHomeRoot(), 'invoker.db');

--- a/packages/app/src/reconcile-orphaned-running-tasks.ts
+++ b/packages/app/src/reconcile-orphaned-running-tasks.ts
@@ -1,0 +1,64 @@
+import type { TaskState } from '@invoker/workflow-core';
+
+import {
+  persistShutdownDiagnostic,
+  type ShutdownDiagnosticDb,
+} from './shutdown-diagnostic.js';
+
+export function isTaskInFlightForForcedStop(task: TaskState): boolean {
+  return task.status === 'running'
+    || task.status === 'fixing_with_ai'
+    || (task.status === 'pending' && task.execution.phase === 'launching');
+}
+
+type BootReconcileOrchestrator = {
+  getAllTasks(): TaskState[];
+  handleWorkerResponse(response: {
+    requestId: string;
+    actionId: string;
+    attemptId?: string;
+    executionGeneration: number;
+    status: 'failed';
+    outputs: { exitCode: number; error: string };
+  }): unknown;
+};
+
+export type ReconcileOrphanedInFlightTasksOptions = {
+  orchestrator: BootReconcileOrchestrator;
+  persistence?: ShutdownDiagnosticDb | null;
+  reason?: string;
+};
+
+/**
+ * Fail durable in-flight tasks left behind when a previous owner died without
+ * before-quit cleanup (SIGKILL / crash). Mirrors graceful Application quit.
+ */
+export function reconcileOrphanedInFlightTasksOnBoot(
+  options: ReconcileOrphanedInFlightTasksOptions,
+): TaskState[] {
+  const reason = options.reason ?? 'Application quit';
+  const failed: TaskState[] = [];
+
+  for (const task of options.orchestrator.getAllTasks()) {
+    if (!isTaskInFlightForForcedStop(task)) continue;
+
+    if (options.persistence) {
+      persistShutdownDiagnostic(task, options.persistence, {
+        forcedStopReason: reason,
+        label: 'Startup Orphan Diagnostic',
+      });
+    }
+
+    options.orchestrator.handleWorkerResponse({
+      requestId: `boot-orphan-${task.id}`,
+      actionId: task.id,
+      attemptId: task.execution.selectedAttemptId,
+      executionGeneration: task.execution.generation ?? 0,
+      status: 'failed',
+      outputs: { exitCode: 1, error: reason },
+    });
+    failed.push(task);
+  }
+
+  return failed;
+}

--- a/packages/execution-engine/src/__tests__/repro-worker-action-stuck-queued-after-restart.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-worker-action-stuck-queued-after-restart.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Repro: after owner SIGKILL mid-tick, a worker_actions row can stay `queued`
+ * while its linked mutation intent is already terminal. Tick-time reconcile in
+ * ci-failure-worker only runs when a lifecycle event is drained — a cold start
+ * with no wake event leaves the UI showing a forever-queued repair.
+ *
+ * This test freezes that durable stuck state. The follow-up fix adds a startup
+ * sweep that folds terminal intents into open action rows before workers tick.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  WorkerActionRecord,
+  WorkerActionWrite,
+  WorkflowMutationIntent,
+  WorkflowMutationIntentStatus,
+} from '@invoker/data-store';
+
+import { CI_FAILURE_WORKER_KIND, ciFailureActionKey } from '../workers/ci-failure-worker.js';
+
+function toRecord(write: WorkerActionWrite): WorkerActionRecord {
+  const now = '2026-01-01T00:00:00.000Z';
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? now,
+    updatedAt: write.updatedAt ?? now,
+  };
+}
+
+describe('worker action stuck queued after terminal intent (startup gap)', () => {
+  it('issue: queued action remains queued after restart when no tick drains events', () => {
+    const externalKey = ciFailureActionKey({
+      eventKey: 'review_gate.ci_failed|workflow:wf-1|task:wf-1/merge',
+      kind: 'review_gate.ci_failed',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      status: 'review_ready',
+      taskStateVersion: 10,
+      generation: 2,
+      attemptId: 'attempt-1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      recoveryWakeup: {
+        eventKey: 'review_gate.ci_failed|workflow:wf-1|task:wf-1/merge',
+        eventKind: 'review_gate.ci_failed',
+        workflowId: 'wf-1',
+        taskId: 'wf-1/merge',
+        taskStateVersion: 10,
+        generation: 2,
+        attemptId: 'attempt-1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        reason: 'review_gate_failure',
+        authoritative: false,
+      },
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'sha-1',
+      headRef: 'feature/ci',
+      branch: 'feature/ci',
+      failedChecks: [{ name: 'PR Body', conclusion: 'CANCELLED', detailsUrl: 'https://example.test/1' }],
+      statusText: 'Awaiting review',
+    });
+
+    const actions = new Map<string, WorkerActionRecord>();
+    actions.set(`${CI_FAILURE_WORKER_KIND}:${externalKey}`, toRecord({
+      id: `${CI_FAILURE_WORKER_KIND}:${externalKey}`,
+      workerKind: CI_FAILURE_WORKER_KIND,
+      actionType: 'fix-ci-failure',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      subjectType: 'review',
+      subjectId: '123',
+      externalKey,
+      status: 'queued',
+      attemptCount: 1,
+      intentId: '27908',
+      summary: 'Queued CI repair with agent',
+    }));
+
+    const intents: WorkflowMutationIntent[] = [{
+      id: 27908,
+      workflowId: 'wf-1',
+      channel: 'invoker:fix-with-agent',
+      args: [],
+      priority: 'normal',
+      status: 'completed',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    }];
+
+    // Simulate cold restart: persistence still has the rows, but no worker tick ran.
+    const store = {
+      listWorkerActions: vi.fn((filters?: { status?: string }) =>
+        Array.from(actions.values()).filter((row) => !filters?.status || row.status === filters.status),
+      ),
+      listWorkflowMutationIntents: vi.fn((_workflowId?: string, statuses?: WorkflowMutationIntentStatus[]) =>
+        intents.filter((intent) => !statuses || statuses.includes(intent.status)),
+      ),
+      upsertWorkerAction: vi.fn(),
+    };
+
+    const open = store.listWorkerActions({ status: 'queued' });
+    expect(open).toHaveLength(1);
+    expect(open[0]?.intentId).toBe('27908');
+    expect(store.listWorkflowMutationIntents('wf-1', ['completed', 'failed'])[0]?.status).toBe('completed');
+    // Without a startup sweep, nothing folds the terminal intent into the action.
+    expect(store.upsertWorkerAction).not.toHaveBeenCalled();
+    expect(actions.get(`${CI_FAILURE_WORKER_KIND}:${externalKey}`)?.status).toBe('queued');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a unit repro that freezes a queued ci-failure action whose intent is already completed.

It shows the stuck state survives a cold restart when no worker tick runs.

## Review Claim

Approve that this test documents the startup gap for terminal intent vs queued worker actions.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only harness with in-memory maps. No product behavior change.

## Slice Rationale

Evidence before the startup sweep. Separates proof from the fix that folds intents into actions.

## Non-goals

Does not add the startup sweep or change tick-time reconcile.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/repro-worker-action-stuck-queued-after-restart.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert bf2e1365d014b91edab6532209e4162a0f4ea01c`
- Post-revert steps: None
- Data migration? No

</details>
