### PR TITLE
[Monkey Adverse](4) Sweep terminal worker actions on owner startup

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -128,6 +128,7 @@ import {
   registerBuiltinWorkers,
   parseRequeueMutationArgs,
   parseRequeueEscalateMutationArgs,
+  reconcileTerminalWorkerActionsOnStartup,
   type AgentRegistry,
   type WorkerRegistry,
   type WorkerRuntimeDependencies,
@@ -1765,6 +1766,13 @@ function startHeadlessMode(): void {
           autoFixRetries: resolveAutoFixRetries(invokerConfig),
           canControl: () => !readOnlyMode,
         });
+        const reconciledWorkerActions = reconcileTerminalWorkerActionsOnStartup(persistence);
+        if (reconciledWorkerActions > 0) {
+          logger.info(
+            `reconciled ${reconciledWorkerActions} terminal worker action(s) on startup`,
+            { module: 'init' },
+          );
+        }
         workerRuntimeController.startAutoStartedWorkers();
 
         // Owner discovery and exec handlers must exist before dispatch polling starts.
@@ -3518,6 +3526,13 @@ function createEmbeddedTerminalBackendFromConfig(
         autoFixRetries: resolveAutoFixRetries(invokerConfig),
         canControl: () => ownerMode,
       });
+      const reconciledWorkerActions = reconcileTerminalWorkerActionsOnStartup(persistence);
+      if (reconciledWorkerActions > 0) {
+        logger.info(
+          `reconciled ${reconciledWorkerActions} terminal worker action(s) on startup`,
+          { module: 'init' },
+        );
+      }
     }
 
     // Fail orphaned in-flight tasks left by a previous crash, then start ready work.

--- a/packages/execution-engine/src/__tests__/reconcile-terminal-worker-actions.test.ts
+++ b/packages/execution-engine/src/__tests__/reconcile-terminal-worker-actions.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { WorkerActionRecord, WorkerActionWrite, WorkflowMutationIntent } from '@invoker/data-store';
+
+import { reconcileTerminalWorkerActionsOnStartup } from '../reconcile-terminal-worker-actions.js';
+
+function toRecord(write: WorkerActionWrite): WorkerActionRecord {
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? '2026-01-01T00:00:00.000Z',
+    updatedAt: write.updatedAt ?? '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('reconcileTerminalWorkerActionsOnStartup', () => {
+  it('leaves open intents untouched and reconciles failed intents', () => {
+    const actions = new Map<string, WorkerActionRecord>();
+    actions.set('a', toRecord({
+      id: 'a',
+      workerKind: 'ci-failure',
+      actionType: 'fix-ci-failure',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/t',
+      subjectType: 'review',
+      subjectId: '1',
+      externalKey: 'a',
+      status: 'queued',
+      intentId: '1',
+    }));
+    actions.set('b', toRecord({
+      id: 'b',
+      workerKind: 'ci-failure',
+      actionType: 'fix-ci-failure',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/t2',
+      subjectType: 'review',
+      subjectId: '2',
+      externalKey: 'b',
+      status: 'queued',
+      intentId: '2',
+    }));
+
+    const intents: WorkflowMutationIntent[] = [
+      {
+        id: 1,
+        workflowId: 'wf-1',
+        channel: 'invoker:fix-with-agent',
+        args: [],
+        priority: 'normal',
+        status: 'running',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+      {
+        id: 2,
+        workflowId: 'wf-1',
+        channel: 'invoker:fix-with-agent',
+        args: [],
+        priority: 'normal',
+        status: 'failed',
+        error: 'boom\nstack',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    ];
+
+    const store = {
+      listWorkerActions: (filters?: { status?: string }) =>
+        Array.from(actions.values()).filter((row) => !filters?.status || row.status === filters.status),
+      listWorkflowMutationIntents: (_workflowId?: string, statuses?: Array<'completed' | 'failed' | 'running' | 'queued'>) =>
+        intents.filter((intent) => !statuses || statuses.includes(intent.status)),
+      upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+        const saved = toRecord(write);
+        actions.set(write.id, saved);
+        return saved;
+      }),
+    };
+
+    expect(reconcileTerminalWorkerActionsOnStartup(store)).toBe(1);
+    expect(actions.get('a')?.status).toBe('queued');
+    expect(actions.get('b')).toMatchObject({
+      status: 'failed',
+      summary: 'Worker action reconciled from failed intent on startup: boom',
+    });
+  });
+});

--- a/packages/execution-engine/src/__tests__/repro-worker-action-stuck-queued-after-restart.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-worker-action-stuck-queued-after-restart.test.ts
@@ -4,8 +4,8 @@
  * ci-failure-worker only runs when a lifecycle event is drained — a cold start
  * with no wake event leaves the UI showing a forever-queued repair.
  *
- * This test freezes that durable stuck state. The follow-up fix adds a startup
- * sweep that folds terminal intents into open action rows before workers tick.
+ * Fixed behavior: `reconcileTerminalWorkerActionsOnStartup` folds terminal
+ * intents into open action rows before workers tick.
  */
 import { describe, expect, it, vi } from 'vitest';
 
@@ -16,6 +16,7 @@ import type {
   WorkflowMutationIntentStatus,
 } from '@invoker/data-store';
 
+import { reconcileTerminalWorkerActionsOnStartup } from '../reconcile-terminal-worker-actions.js';
 import { CI_FAILURE_WORKER_KIND, ciFailureActionKey } from '../workers/ci-failure-worker.js';
 
 function toRecord(write: WorkerActionWrite): WorkerActionRecord {
@@ -29,36 +30,12 @@ function toRecord(write: WorkerActionWrite): WorkerActionRecord {
 }
 
 describe('worker action stuck queued after terminal intent (startup gap)', () => {
-  it('issue: queued action remains queued after restart when no tick drains events', () => {
+  it('fixed: startup sweep marks queued actions completed when their intent is terminal', () => {
     const externalKey = ciFailureActionKey({
-      eventKey: 'review_gate.ci_failed|workflow:wf-1|task:wf-1/merge',
-      kind: 'review_gate.ci_failed',
-      workflowId: 'wf-1',
       taskId: 'wf-1/merge',
-      status: 'review_ready',
-      taskStateVersion: 10,
-      generation: 2,
-      attemptId: 'attempt-1',
-      createdAt: '2026-01-01T00:00:00.000Z',
-      recoveryWakeup: {
-        eventKey: 'review_gate.ci_failed|workflow:wf-1|task:wf-1/merge',
-        eventKind: 'review_gate.ci_failed',
-        workflowId: 'wf-1',
-        taskId: 'wf-1/merge',
-        taskStateVersion: 10,
-        generation: 2,
-        attemptId: 'attempt-1',
-        createdAt: '2026-01-01T00:00:00.000Z',
-        reason: 'review_gate_failure',
-        authoritative: false,
-      },
       reviewId: '123',
-      reviewUrl: 'https://github.com/owner/repo/pull/123',
       headSha: 'sha-1',
-      headRef: 'feature/ci',
-      branch: 'feature/ci',
       failedChecks: [{ name: 'PR Body', conclusion: 'CANCELLED', detailsUrl: 'https://example.test/1' }],
-      statusText: 'Awaiting review',
     });
 
     const actions = new Map<string, WorkerActionRecord>();
@@ -87,7 +64,6 @@ describe('worker action stuck queued after terminal intent (startup gap)', () =>
       createdAt: '2026-01-01T00:00:00.000Z',
     }];
 
-    // Simulate cold restart: persistence still has the rows, but no worker tick ran.
     const store = {
       listWorkerActions: vi.fn((filters?: { status?: string }) =>
         Array.from(actions.values()).filter((row) => !filters?.status || row.status === filters.status),
@@ -95,15 +71,22 @@ describe('worker action stuck queued after terminal intent (startup gap)', () =>
       listWorkflowMutationIntents: vi.fn((_workflowId?: string, statuses?: WorkflowMutationIntentStatus[]) =>
         intents.filter((intent) => !statuses || statuses.includes(intent.status)),
       ),
-      upsertWorkerAction: vi.fn(),
+      upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+        const saved = toRecord(write);
+        actions.set(`${write.workerKind}:${write.externalKey}`, saved);
+        return saved;
+      }),
     };
 
-    const open = store.listWorkerActions({ status: 'queued' });
-    expect(open).toHaveLength(1);
-    expect(open[0]?.intentId).toBe('27908');
-    expect(store.listWorkflowMutationIntents('wf-1', ['completed', 'failed'])[0]?.status).toBe('completed');
-    // Without a startup sweep, nothing folds the terminal intent into the action.
-    expect(store.upsertWorkerAction).not.toHaveBeenCalled();
-    expect(actions.get(`${CI_FAILURE_WORKER_KIND}:${externalKey}`)?.status).toBe('queued');
+    const reconciled = reconcileTerminalWorkerActionsOnStartup(store, new Date('2026-01-02T00:00:00.000Z'));
+
+    expect(reconciled).toBe(1);
+    expect(store.upsertWorkerAction).toHaveBeenCalledTimes(1);
+    expect(actions.get(`${CI_FAILURE_WORKER_KIND}:${externalKey}`)).toMatchObject({
+      status: 'completed',
+      summary: 'Worker action reconciled from completed intent on startup',
+      completedAt: '2026-01-02T00:00:00.000Z',
+    });
+    expect(store.listWorkerActions({ status: 'queued' })).toHaveLength(0);
   });
 });

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -69,6 +69,7 @@ export * from './workers/pr-maintenance-workers.js';
 export * from './workers/e2e-autofix-worker.js';
 export * from './workers/requeue-worker.js';
 export * from './workers/workflow-resume-worker.js';
+export * from './reconcile-terminal-worker-actions.js';
 export * from './requeue-attempt-ledger.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-attempt-ledger.js';

--- a/packages/execution-engine/src/reconcile-terminal-worker-actions.ts
+++ b/packages/execution-engine/src/reconcile-terminal-worker-actions.ts
@@ -1,0 +1,85 @@
+import type {
+  WorkerActionListFilters,
+  WorkerActionRecord,
+  WorkerActionStatus,
+  WorkerActionWrite,
+  WorkflowMutationIntent,
+  WorkflowMutationIntentStatus,
+} from '@invoker/data-store';
+
+export type TerminalWorkerActionReconcileStore = {
+  listWorkerActions(filters?: WorkerActionListFilters): WorkerActionRecord[];
+  listWorkflowMutationIntents?(
+    workflowId?: string,
+    statuses?: WorkflowMutationIntentStatus[],
+  ): WorkflowMutationIntent[];
+  upsertWorkerAction?(action: WorkerActionWrite): WorkerActionRecord;
+};
+
+const OPEN_STATUSES: WorkerActionStatus[] = ['queued', 'pending', 'running'];
+
+function firstLine(value: string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  const line = value.split('\n').map((part) => part.trim()).find(Boolean);
+  return line || undefined;
+}
+
+/**
+ * Fold terminal mutation-intent outcomes into open worker_actions rows.
+ *
+ * Tick-time workers only reconcile when they drain a lifecycle event. After
+ * owner SIGKILL mid-tick, a queued action can outlive a completed/failed
+ * intent until this startup sweep runs.
+ */
+export function reconcileTerminalWorkerActionsOnStartup(
+  store: TerminalWorkerActionReconcileStore,
+  now: Date = new Date(),
+): number {
+  if (!store.upsertWorkerAction || !store.listWorkflowMutationIntents) {
+    return 0;
+  }
+
+  const seen = new Set<string>();
+  const open: WorkerActionRecord[] = [];
+  for (const status of OPEN_STATUSES) {
+    for (const action of store.listWorkerActions({ status })) {
+      if (seen.has(action.id)) continue;
+      seen.add(action.id);
+      open.push(action);
+    }
+  }
+
+  let reconciled = 0;
+  const nowIso = now.toISOString();
+  for (const action of open) {
+    if (!action.intentId) continue;
+    const terminalIntents = store.listWorkflowMutationIntents(action.workflowId, ['completed', 'failed']);
+    const intent = terminalIntents.find((candidate) => String(candidate.id) === action.intentId);
+    if (!intent) continue;
+
+    const status: WorkerActionStatus = intent.status === 'completed' ? 'completed' : 'failed';
+    const summary = status === 'completed'
+      ? 'Worker action reconciled from completed intent on startup'
+      : `Worker action reconciled from failed intent on startup: ${firstLine(intent.error) ?? 'unknown error'}`;
+    const payload = action.payload && typeof action.payload === 'object'
+      ? { ...(action.payload as Record<string, unknown>) }
+      : {};
+
+    store.upsertWorkerAction({
+      ...action,
+      status,
+      summary,
+      payload: {
+        ...payload,
+        reconciledIntentStatus: intent.status,
+        reconciledAtStartup: true,
+        intentError: intent.error ?? null,
+      },
+      updatedAt: nowIso,
+      completedAt: nowIso,
+    });
+    reconciled += 1;
+  }
+
+  return reconciled;
+}


### PR DESCRIPTION
## Summary

Before auto-started workers tick, persist terminal intent outcomes onto open worker_actions rows.

This ends forever-queued repairs left after SIGKILL mid-tick by updating durable action status.

## Review Claim

Approve startup reconcile of open worker actions whose linked mutation intents are terminal.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only closes actions that already have a terminal intent. Open intents stay queued.

## Slice Rationale

Behavior fix for the stuck-queued repro. Separate from task-orphan and mutation-intent recovery.

## Non-goals

Does not change tick-time ci-failure policy beyond sharing the same terminal-intent fold.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/reconcile-terminal-worker-actions.test.ts src/__tests__/repro-worker-action-stuck-queued-after-restart.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9cf69411810b61d5fbf68e5dc2ee4a3c84836c41`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Worker actions left queued, pending, or running after a restart are now automatically reconciled with their completed or failed workflow operations.
  * Reconciled actions receive the appropriate final status, summary, completion time, and relevant error details.
  * Prevents worker actions from remaining stuck after terminal workflow operations.

* **Tests**
  * Added coverage for startup reconciliation, including completed and failed workflow outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->