### PR TITLE
[Monkey Adverse](5) Prove orphaned mutation intents stay running on resume

### DIFF
--- a/packages/app/src/__tests__/repro-orphaned-mutation-intent-resume.test.ts
+++ b/packages/app/src/__tests__/repro-orphaned-mutation-intent-resume.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Repro: after owner crash, a mutation intent can stay `running` with no live
+ * lease. `resumePending()` only requeues expired leases today, so orphaned
+ * running intents never become `queued` and never drain.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { PersistedWorkflowMutationCoordinator } from '../persisted-workflow-mutation-coordinator.js';
+
+describe('orphaned workflow mutation intents on resumePending (repro)', () => {
+  const adapters: SQLiteAdapter[] = [];
+
+  afterEach(() => {
+    for (const adapter of adapters.splice(0)) {
+      adapter.close();
+    }
+  });
+
+  it('issue: resumePending leaves running intents without a lease stuck running', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    adapter.enqueueWorkflowMutationIntent('wf-1', 'mut', ['orphan'], 'normal');
+    const claimed = adapter.claimNextWorkflowMutationIntent('wf-1', 'dead-owner');
+    expect(claimed?.status).toBe('running');
+
+    let drained = 0;
+    const owner2 = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-2',
+      async () => {
+        drained += 1;
+      },
+    );
+
+    await owner2.resumePending();
+
+    expect(drained).toBe(0);
+    expect(adapter.listWorkflowMutationIntents('wf-1', ['running'])).toHaveLength(1);
+    expect(adapter.listWorkflowMutationIntents('wf-1', ['queued'])).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a unit repro where a running mutation intent has no lease.

resumePending previously ignored it, so the intent stayed stuck running.

## Review Claim

Approve that this test proves resumePending left lease-less running intents undrained.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

In-memory SQLite adapter only. No product change in this slice.

## Slice Rationale

Evidence before the resumePending orphan requeue fix.

## Non-goals

Does not change lease expiry handling or owner-serve boot wiring.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/repro-orphaned-mutation-intent-resume.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert cbc2bac55570a50c1820185579da4befeb4a04eb`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4413