### PR TITLE
[Monkey Adverse](6) Requeue orphaned mutation intents on resumePending

### DIFF
--- a/packages/app/src/__tests__/repro-orphaned-mutation-intent-resume.test.ts
+++ b/packages/app/src/__tests__/repro-orphaned-mutation-intent-resume.test.ts
@@ -1,7 +1,6 @@
 /**
  * Repro: after owner crash, a mutation intent can stay `running` with no live
- * lease. `resumePending()` only requeues expired leases today, so orphaned
- * running intents never become `queued` and never drain.
+ * lease. Fixed: `resumePending()` also requeues orphaned running intents.
  */
 import { afterEach, describe, expect, it } from 'vitest';
 import { SQLiteAdapter } from '@invoker/data-store';
@@ -16,7 +15,7 @@ describe('orphaned workflow mutation intents on resumePending (repro)', () => {
     }
   });
 
-  it('issue: resumePending leaves running intents without a lease stuck running', async () => {
+  it('fixed: resumePending requeues and drains running intents without a lease', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({
@@ -41,8 +40,8 @@ describe('orphaned workflow mutation intents on resumePending (repro)', () => {
 
     await owner2.resumePending();
 
-    expect(drained).toBe(0);
-    expect(adapter.listWorkflowMutationIntents('wf-1', ['running'])).toHaveLength(1);
-    expect(adapter.listWorkflowMutationIntents('wf-1', ['queued'])).toHaveLength(0);
+    expect(drained).toBe(1);
+    expect(adapter.listWorkflowMutationIntents('wf-1', ['running', 'queued'])).toHaveLength(0);
+    expect(adapter.listWorkflowMutationIntents('wf-1', ['completed'])).toHaveLength(1);
   });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1784,6 +1784,14 @@ function startHeadlessMode(): void {
             setLatestTaskExecutor: (executor) => { latestTaskExecutor = executor; },
           });
         }
+
+        void recoverWorkflowMutationsOnStartup({
+          ownerMode: true,
+          persistence,
+          workflowMutationCoordinator: workflowMutationCoordinator ?? undefined,
+          logger,
+          maybeDelayResume: maybeDelayWorkflowResumeForTest,
+        });
       }
 
       await runHeadless(cliArgs, headlessDeps);

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -238,6 +238,7 @@ export class PersistedWorkflowMutationCoordinator {
 
   async resumePending(): Promise<void> {
     this.persistence.requeueExpiredWorkflowMutationLeases();
+    this.persistence.requeueOrphanedWorkflowMutationIntents();
     const workflowIds = Array.from(
       new Set(
       this.persistence.listWorkflowMutationIntents(undefined, ['queued']).map((intent) => intent.workflowId),


### PR DESCRIPTION
## Summary

resumePending now returns running intents that lack an active lease to the queued state.

Owner-serve also recovers pending mutations on boot like the GUI path.

## Review Claim

Approve requeueing orphaned running mutation intents during resumePending and owner-serve boot recovery.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only requeues intents already without a live lease. Live leases remain exclusive.

## Slice Rationale

Behavior fix for the orphaned-intent repro. Separate from worker action sweeping.

## Non-goals

Does not change mutation dispatch semantics or foreign-key tolerance for absent workflows.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/repro-orphaned-mutation-intent-resume.test.ts src/__tests__/workflow-mutation-startup.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 51760c64bcb37f61fe0e8674466e853553f60b80`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4414