### PR TITLE
[Monkey Adverse](8) Prove retry/recreate FK failures for missing workflows

### DIFF
--- a/packages/app/src/__tests__/workflow-mutation-submit.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-submit.test.ts
@@ -102,6 +102,43 @@ describe('submitWorkflowMutationOrAcknowledgeDeleted', () => {
     )).toThrow(error);
   });
 
+
+  it('issue: headless retry for a missing workflow still throws FOREIGN KEY', () => {
+    const error = makeForeignKeyError();
+    const submit = vi.fn(() => {
+      throw error;
+    });
+
+    expect(() => submitWorkflowMutationOrAcknowledgeDeleted(
+      'wf-missing',
+      'high',
+      'headless.exec',
+      [{ args: ['retry', 'wf-missing'] }],
+      {
+        coordinator: { submit },
+        workflowExists: () => false,
+      },
+    )).toThrow(error);
+  });
+
+  it('issue: headless recreate for a missing workflow still throws FOREIGN KEY', () => {
+    const error = makeForeignKeyError();
+    const submit = vi.fn(() => {
+      throw error;
+    });
+
+    expect(() => submitWorkflowMutationOrAcknowledgeDeleted(
+      'wf-missing',
+      'high',
+      'headless.exec',
+      [{ args: ['recreate', 'wf-missing'] }],
+      {
+        coordinator: { submit },
+        workflowExists: () => false,
+      },
+    )).toThrow(error);
+  });
+
   it('still propagates foreign-key failures for non-delete mutations', () => {
     const error = makeForeignKeyError();
     const submit = vi.fn(() => {


### PR DESCRIPTION
## Summary

Extends mutation helper tests to show workflow re-run and recreate still throw FOREIGN KEY when the workflow is gone.

That matches erase-all races observed in monkey runs.

## Review Claim

Approve documenting that re-run and recreate are not yet idempotent for missing workflows.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only assertions of current throw behavior.

## Slice Rationale

Evidence before making re-run and recreate tolerate missing workflows like workflow erasure.

## Non-goals

Does not change the mutation helper behavior yet.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/workflow-mutation-submit.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f00c7d99524cc750864110c91fc5c4a0c6df4b8b`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4416