### PR TITLE
[Monkey Adverse](9) Tolerate missing-workflow FK on retry and recreate

### DIFF
--- a/packages/app/src/__tests__/workflow-mutation-submit.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-submit.test.ts
@@ -103,13 +103,10 @@ describe('submitWorkflowMutationOrAcknowledgeDeleted', () => {
   });
 
 
-  it('issue: headless retry for a missing workflow still throws FOREIGN KEY', () => {
-    const error = makeForeignKeyError();
-    const submit = vi.fn(() => {
-      throw error;
-    });
+  it('fixed: headless retry for a missing workflow is accepted without queueing', () => {
+    const submit = vi.fn(() => 42);
 
-    expect(() => submitWorkflowMutationOrAcknowledgeDeleted(
+    const result = submitWorkflowMutationOrAcknowledgeDeleted(
       'wf-missing',
       'high',
       'headless.exec',
@@ -118,28 +115,59 @@ describe('submitWorkflowMutationOrAcknowledgeDeleted', () => {
         coordinator: { submit },
         workflowExists: () => false,
       },
-    )).toThrow(error);
+    );
+
+    expect(result.intentId).toBe(0);
+    expect(result.accepted).toBe(true);
+    expect(submit).not.toHaveBeenCalled();
   });
 
-  it('issue: headless recreate for a missing workflow still throws FOREIGN KEY', () => {
-    const error = makeForeignKeyError();
+  it('fixed: headless recreate FK race is accepted when the workflow is gone', () => {
     const submit = vi.fn(() => {
-      throw error;
+      throw makeForeignKeyError();
     });
+    let exists = true;
 
-    expect(() => submitWorkflowMutationOrAcknowledgeDeleted(
+    const result = submitWorkflowMutationOrAcknowledgeDeleted(
       'wf-missing',
       'high',
       'headless.exec',
       [{ args: ['recreate', 'wf-missing'] }],
       {
         coordinator: { submit },
-        workflowExists: () => false,
+        workflowExists: () => {
+          const current = exists;
+          exists = false;
+          return current;
+        },
       },
-    )).toThrow(error);
+    );
+
+    expect(result.intentId).toBe(0);
+    expect(result.accepted).toBe(true);
+    expect(submit).toHaveBeenCalledTimes(1);
   });
 
-  it('still propagates foreign-key failures for non-delete mutations', () => {
+  it('fixed: invoker retry-workflow for a missing workflow is accepted without queueing', () => {
+    const submit = vi.fn(() => 42);
+
+    const result = submitWorkflowMutationOrAcknowledgeDeleted(
+      'wf-missing',
+      'high',
+      'invoker:retry-workflow',
+      ['wf-missing'],
+      {
+        coordinator: { submit },
+        workflowExists: () => false,
+      },
+    );
+
+    expect(result.intentId).toBe(0);
+    expect(result.accepted).toBe(true);
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it('still propagates foreign-key failures for non-idempotent mutations', () => {
     const error = makeForeignKeyError();
     const submit = vi.fn(() => {
       throw error;
@@ -148,8 +176,8 @@ describe('submitWorkflowMutationOrAcknowledgeDeleted', () => {
     expect(() => submitWorkflowMutationOrAcknowledgeDeleted(
       'wf-missing',
       'high',
-      'invoker:retry-workflow',
-      ['wf-missing'],
+      'invoker:fix-with-agent',
+      ['wf-missing/task', 'codex'],
       {
         coordinator: { submit },
         workflowExists: () => false,

--- a/packages/app/src/workflow-mutation-submit.ts
+++ b/packages/app/src/workflow-mutation-submit.ts
@@ -18,18 +18,38 @@ export interface SubmitWorkflowMutationOptions {
   deferDrain?: boolean;
 }
 
-function isMissingWorkflowDelete(channel: string, workflowId: string, args: unknown[]): boolean {
-  if (channel === 'invoker:delete-workflow') {
+const MISSING_WORKFLOW_IDEMPOTENT_COMMANDS = new Set([
+  'delete',
+  'delete-workflow',
+  'retry',
+  'recreate',
+  'retry-task',
+  'recreate-task',
+]);
+
+function headlessExecCommand(args: unknown[]): string | undefined {
+  const payload = args[0] as { args?: unknown[] } | undefined;
+  const command = payload?.args?.[0];
+  return typeof command === 'string' ? command : undefined;
+}
+
+function isMissingWorkflowIdempotentMutation(channel: string, workflowId: string, args: unknown[]): boolean {
+  if (
+    channel === 'invoker:delete-workflow'
+    || channel === 'invoker:retry-workflow'
+    || channel === 'invoker:recreate-workflow'
+  ) {
     return args[0] === workflowId;
   }
   if (channel !== 'headless.exec') {
     return false;
   }
   const payload = args[0] as { args?: unknown[] } | undefined;
-  const command = payload?.args?.[0];
-  return Array.isArray(payload?.args)
-    && (command === 'delete' || command === 'delete-workflow')
-    && payload.args[1] === workflowId;
+  const command = headlessExecCommand(args);
+  if (!command || !MISSING_WORKFLOW_IDEMPOTENT_COMMANDS.has(command)) {
+    return false;
+  }
+  return Array.isArray(payload?.args) && payload.args[1] === workflowId;
 }
 
 function isForeignKeyConstraintError(error: unknown): boolean {
@@ -39,12 +59,12 @@ function isForeignKeyConstraintError(error: unknown): boolean {
     || sqliteError.message.includes('FOREIGN KEY constraint failed');
 }
 
-function acceptedAlreadyDeleted(
+function acceptedMissingWorkflow(
   workflowId: string,
   channel: string,
   logger?: Pick<Logger, 'info'>,
 ): WorkflowMutationAcceptedResult {
-  logger?.info(`delete-workflow ignored missing workflow="${workflowId}"`, { module: 'workflow-mutation' });
+  logger?.info(`ignored missing workflow="${workflowId}" for channel=${channel}`, { module: 'workflow-mutation' });
   return { ok: true, accepted: true, intentId: 0, workflowId, channel };
 }
 
@@ -55,8 +75,8 @@ export function submitWorkflowMutationOrAcknowledgeDeleted(
   args: unknown[],
   options: SubmitWorkflowMutationOptions,
 ): WorkflowMutationAcceptedResult {
-  if (isMissingWorkflowDelete(channel, workflowId, args) && !options.workflowExists(workflowId)) {
-    return acceptedAlreadyDeleted(workflowId, channel, options.logger);
+  if (isMissingWorkflowIdempotentMutation(channel, workflowId, args) && !options.workflowExists(workflowId)) {
+    return acceptedMissingWorkflow(workflowId, channel, options.logger);
   }
 
   try {
@@ -66,11 +86,11 @@ export function submitWorkflowMutationOrAcknowledgeDeleted(
     return { ok: true, accepted: true, intentId, workflowId, channel };
   } catch (error) {
     if (
-      isMissingWorkflowDelete(channel, workflowId, args)
+      isMissingWorkflowIdempotentMutation(channel, workflowId, args)
       && isForeignKeyConstraintError(error)
       && !options.workflowExists(workflowId)
     ) {
-      return acceptedAlreadyDeleted(workflowId, channel, options.logger);
+      return acceptedMissingWorkflow(workflowId, channel, options.logger);
     }
     throw error;
   }


### PR DESCRIPTION
## Summary

Treat workflow re-run and recreate like workflow erasure when the workflow is already missing.

FK races during erase-all become accepted no-ops instead of hard failures after a failed mutation attempt.

## Review Claim

Approve treating missing-workflow re-run and recreate as accepted no-ops instead of throwing FOREIGN KEY.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only idempotent workflow-level mutations are covered. Fix-with-agent and other mutations still throw.

## Slice Rationale

Behavior fix for the FK repro. Kept separate from mutation resume recovery.

## Non-goals

Does not serialize erase-all against all mutations or change SQLite schema.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/workflow-mutation-submit.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 91756cbf9ece1399d9843b0f26df718a206526eb`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4417