### PR TITLE
[Monkey Adverse](11) Gate test workflow IDs on INVOKER_TEST_WORKFLOW_IDS

### DIFF
--- a/packages/workflow-core/src/__tests__/repro-test-workflow-id-env.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-test-workflow-id-env.test.ts
@@ -1,8 +1,8 @@
 /**
- * Repro: NODE_ENV=test alone rewrites workflow IDs to wf-test-N, which breaks
- * chaos/overload extractors that require wf-<digits>-<digits>.
+ * Workflow test IDs are gated on INVOKER_TEST_WORKFLOW_IDS=1 so chaos runs can
+ * keep NODE_ENV=test without breaking wf-<ms>-<n> extractors.
  */
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { Orchestrator, type OrchestratorPersistence, type PlanDefinition } from '../orchestrator.js';
 import type { Attempt, TaskState } from '../task-types.js';
 
@@ -29,13 +29,24 @@ const bus = {
   disconnect() {},
 };
 
-describe('nextWorkflowId NODE_ENV=test rewrite (repro)', () => {
+function loadOneWorkflowId(): string {
+  const orchestrator = new Orchestrator({
+    persistence: new MiniPersistence(),
+    messageBus: bus as never,
+    maxConcurrency: 1,
+  });
+  const plan: PlanDefinition = {
+    name: 'id-shape',
+    onFinish: 'none',
+    tasks: [{ id: 't1', description: 't', command: 'true' }],
+  };
+  orchestrator.loadPlan(plan);
+  return orchestrator.getWorkflowIds()[0]!;
+}
+
+describe('nextWorkflowId INVOKER_TEST_WORKFLOW_IDS gate', () => {
   const previousNodeEnv = process.env.NODE_ENV;
   const previousTestIds = process.env.INVOKER_TEST_WORKFLOW_IDS;
-
-  beforeEach(() => {
-    delete process.env.INVOKER_TEST_WORKFLOW_IDS;
-  });
 
   afterEach(() => {
     if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
@@ -44,22 +55,15 @@ describe('nextWorkflowId NODE_ENV=test rewrite (repro)', () => {
     else process.env.INVOKER_TEST_WORKFLOW_IDS = previousTestIds;
   });
 
-  it('issue: NODE_ENV=test alone produces wf-test-* workflow ids', () => {
+  it('fixed: NODE_ENV=test alone uses production-shaped workflow ids', () => {
+    delete process.env.INVOKER_TEST_WORKFLOW_IDS;
     process.env.NODE_ENV = 'test';
+    expect(loadOneWorkflowId()).toMatch(/^wf-\d+-\d+$/);
+  });
 
-    const orchestrator = new Orchestrator({
-      persistence: new MiniPersistence(),
-      messageBus: bus as never,
-      maxConcurrency: 1,
-    });
-    const plan: PlanDefinition = {
-      name: 'id-shape',
-      onFinish: 'none',
-      tasks: [{ id: 't1', description: 't', command: 'true' }],
-    };
-    orchestrator.loadPlan(plan);
-    const workflowId = orchestrator.getWorkflowIds()[0];
-
-    expect(workflowId).toMatch(/^wf-test-\d+$/);
+  it('fixed: INVOKER_TEST_WORKFLOW_IDS=1 yields wf-test-* ids', () => {
+    process.env.INVOKER_TEST_WORKFLOW_IDS = '1';
+    process.env.NODE_ENV = 'production';
+    expect(loadOneWorkflowId()).toMatch(/^wf-test-\d+$/);
   });
 });

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -181,7 +181,7 @@ function isReplaceableAttemptStatus(status: Attempt['status']): boolean {
 
 function nextWorkflowId(): string {
   workflowCounter += 1;
-  if (process.env.NODE_ENV === 'test') return `wf-test-${workflowCounter}`;
+  if (process.env.INVOKER_TEST_WORKFLOW_IDS === '1') return `wf-test-${workflowCounter}`;
   return `wf-${Date.now()}-${workflowCounter}`;
 }
 

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -6,6 +6,9 @@ const maxWorkers = process.env.INVOKER_VITEST_MAX_WORKERS
 
 export default defineConfig({
   test: {
+    env: {
+      INVOKER_TEST_WORKFLOW_IDS: '1',
+    },
     exclude: ['**/node_modules/**', '**/dist/**'],
     globals: true,
     // App plan-parser tests call git ls-remote (execSync timeout 10s); Vitest default 5s flakes.


### PR DESCRIPTION
## Summary

nextWorkflowId uses wf-test-* only when INVOKER_TEST_WORKFLOW_IDS=1.

Vitest sets that flag so unit tests stay stable while chaos can keep production-shaped IDs under NODE_ENV=test.

## Review Claim

Approve gating deterministic test workflow IDs on INVOKER_TEST_WORKFLOW_IDS instead of NODE_ENV alone.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Default vitest still gets wf-test IDs via explicit env. Chaos runs keep production IDs by omitting the flag.

## Slice Rationale

Behavior fix for the NODE_ENV rewrite repro. E2E launch env updates are the next slice.

## Non-goals

Does not change chaos extractor regexes or Playwright launch env in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/repro-test-workflow-id-env.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c5d59de62`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4419