### PR TITLE
[UI Responsiveness Guardrails Step 3](1) Cache workflow rollup membership counts

### DIFF
--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -67,10 +67,46 @@ function workflowHasBackingTask(
   return false;
 }
 
+function countTasksByWorkflow(tasks: Map<string, TaskState>): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const task of tasks.values()) {
+    const workflowId = task.config.workflowId;
+    if (!workflowId) continue;
+    counts.set(workflowId, (counts.get(workflowId) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function workflowHasBackingTaskCount(
+  taskCountsByWorkflow: Map<string, number>,
+  workflowId: string,
+): boolean {
+  return (taskCountsByWorkflow.get(workflowId) ?? 0) > 0;
+}
+
+function moveWorkflowTaskCount(
+  taskCountsByWorkflow: Map<string, number>,
+  beforeWorkflowId: string | undefined,
+  afterWorkflowId: string | undefined,
+): void {
+  if (beforeWorkflowId === afterWorkflowId) return;
+  if (beforeWorkflowId) {
+    const nextCount = (taskCountsByWorkflow.get(beforeWorkflowId) ?? 0) - 1;
+    if (nextCount > 0) {
+      taskCountsByWorkflow.set(beforeWorkflowId, nextCount);
+    } else {
+      taskCountsByWorkflow.delete(beforeWorkflowId);
+    }
+  }
+  if (afterWorkflowId) {
+    taskCountsByWorkflow.set(afterWorkflowId, (taskCountsByWorkflow.get(afterWorkflowId) ?? 0) + 1);
+  }
+}
+
 function applyWorkflowRollupPatches(
   previous: Map<string, WorkflowMeta>,
   patches: readonly WorkflowRollupPatch[],
-  tasks: Map<string, TaskState>,
+  taskCountsByWorkflow: Map<string, number>,
 ): Map<string, WorkflowMeta> {
   if (patches.length === 0) {
     return previous;
@@ -78,7 +114,7 @@ function applyWorkflowRollupPatches(
   const next = new Map(previous);
   for (const patch of patches) {
     if (patch.removed) {
-      if (!workflowHasBackingTask(tasks, patch.workflowId)) {
+      if (!workflowHasBackingTaskCount(taskCountsByWorkflow, patch.workflowId)) {
         next.delete(patch.workflowId);
       }
       continue;
@@ -336,9 +372,16 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
 
         const removedWorkflowIds: string[] = [];
         let hasAppliedTaskDelta = false;
+        let taskCountsByWorkflow: Map<string, number> | null = null;
+        const ensureTaskCountsByWorkflow = () => {
+          taskCountsByWorkflow ??= countTasksByWorkflow(nextTasks);
+          return taskCountsByWorkflow;
+        };
         for (const event of deltaEvents) {
           if (event.type !== 'delta') continue;
           const delta = event.delta;
+          const beforeTask = delta.type === 'created' ? undefined : nextTasks.get(delta.taskId);
+          const beforeWorkflowId = beforeTask?.config.workflowId;
           if (delta.type === 'updated' && !nextTasks.has(delta.taskId)) {
             if (traceTaskDeltas) {
               console.warn(
@@ -351,16 +394,30 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
             hasAppliedTaskDelta = true;
           }
           applyDeltaInPlace(nextTasks, delta);
-          for (const patch of event.workflowRollups) {
-            if (
-              patch.removed &&
-              nextWorkflows.has(patch.workflowId) &&
-              !workflowHasBackingTask(nextTasks, patch.workflowId)
-            ) {
-              removedWorkflowIds.push(patch.workflowId);
-            }
+          const afterTask = delta.type === 'removed'
+            ? undefined
+            : delta.type === 'created'
+              ? delta.task
+              : nextTasks.get(delta.taskId);
+          if (taskCountsByWorkflow) {
+            moveWorkflowTaskCount(taskCountsByWorkflow, beforeWorkflowId, afterTask?.config.workflowId);
           }
-          nextWorkflows = applyWorkflowRollupPatches(nextWorkflows, event.workflowRollups, nextTasks);
+          if (event.workflowRollups.length > 0) {
+            for (const patch of event.workflowRollups) {
+              if (
+                patch.removed &&
+                nextWorkflows.has(patch.workflowId) &&
+                !workflowHasBackingTaskCount(ensureTaskCountsByWorkflow(), patch.workflowId)
+              ) {
+                removedWorkflowIds.push(patch.workflowId);
+              }
+            }
+            nextWorkflows = applyWorkflowRollupPatches(
+              nextWorkflows,
+              event.workflowRollups,
+              ensureTaskCountsByWorkflow(),
+            );
+          }
         }
 
         if (!shouldRefreshWorkflows) {


### PR DESCRIPTION
## Summary

Caches workflow membership counts while applying task deltas.

Removed workflow rollups no longer walk every task for each patch.

This keeps large graph update bursts within the measured renderer budgets added later in this stack.

## Review Claim

Workflow rollup deletion uses maintained task counts instead of repeated full task-map walks.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The slice only changes the internal membership check used while applying existing task deltas. It does not change task or workflow payloads.

## Slice Rationale

This local hot-path cache lands before the stricter budget gates so each later proof slice can run against stable update behavior.

## Non-goals

- Does not change workflow rollup semantics.
- Does not change IPC payload shapes.
- Does not add new UI surfaces.
- Does not tune chaos matrix policy.

## Visual Proof

![Planning and workflow graph surface after the hot-path cache](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260714-f62cb2/stacked-workflows.png)

The performance behavior is enforced by the focused Electron specs in the test plan; the screenshot anchors the affected planning and graph surface.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test:e2e -- ui-graph-drag-performance.spec.ts headless-thundering-herd.spec.ts startup-nonempty-responsiveness.spec.ts embedded-terminal-pty.spec.ts`
- [x] `pnpm run test:e2e-chaos`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ui-responsiveness-step3-pr1.md --require-visual-proof --changed-files-file /tmp/ui-responsiveness-step3-pr1-files.txt --diff-file /tmp/ui-responsiveness-step3-pr1.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run the targeted adverse-load E2E command if the responsiveness gate is still required.
- Data migration? No

</details>
