### PR TITLE
[UI Responsiveness Guardrails Step 3](2) Add adverse-load performance budgets

### DIFF
--- a/packages/app/e2e/embedded-terminal-pty.spec.ts
+++ b/packages/app/e2e/embedded-terminal-pty.spec.ts
@@ -18,6 +18,7 @@ const TERMINAL_INPUT_BUDGET_MS = 100;
 const TERMINAL_OUTPUT_WRITE_BUDGET_MS = 250;
 const TERMINAL_RESIZE_BUDGET_MS = 250;
 const TERMINAL_TAB_SWITCH_WALL_BUDGET_MS = 1000;
+const TERMINAL_SESSION_UPSERT_BUDGET_MS = 250;
 const TERMINAL_RENDERER_EVENT_LOOP_LAG_BUDGET_MS = 1000;
 const TERMINAL_RENDERER_LONG_TASK_BUDGET_MS = 1500;
 
@@ -26,6 +27,7 @@ const TERMINAL_PRESSURE_BUDGETS = {
   maxOutputWriteMs: TERMINAL_OUTPUT_WRITE_BUDGET_MS,
   maxResizeMs: TERMINAL_RESIZE_BUDGET_MS,
   maxTabSwitchWallMs: TERMINAL_TAB_SWITCH_WALL_BUDGET_MS,
+  maxTerminalSessionUpsertMs: TERMINAL_SESSION_UPSERT_BUDGET_MS,
   maxRendererEventLoopLagMs: TERMINAL_RENDERER_EVENT_LOOP_LAG_BUDGET_MS,
   maxRendererLongTaskMs: TERMINAL_RENDERER_LONG_TASK_BUDGET_MS,
 };
@@ -434,6 +436,7 @@ test.describe('Embedded terminal PTY', () => {
     expect(Number(perf.maxEmbeddedTerminalInputMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_INPUT_BUDGET_MS);
     expect(Number(perf.maxEmbeddedTerminalOutputWriteMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_OUTPUT_WRITE_BUDGET_MS);
     expect(Number(perf.maxEmbeddedTerminalResizeMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RESIZE_BUDGET_MS);
+    expect(numberOrZero(perf.maxTerminalSessionUpsertMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_SESSION_UPSERT_BUDGET_MS);
     expect(numberOrZero(perf.maxRendererEventLoopLagMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RENDERER_EVENT_LOOP_LAG_BUDGET_MS);
     expect(numberOrZero(perf.maxRendererLongTaskMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RENDERER_LONG_TASK_BUDGET_MS);
   });

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -21,12 +21,15 @@ test.use({ guiOwnerMode: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'daemon' });
 const execFileAsync = promisify(execFile);
 const repoRoot = resolveRepoRoot(__dirname);
 const RESPONSIVE_INTERACTION_TIMEOUT_MS = 15000;
+const MAX_INSPECTOR_TOGGLE_MS = 5000;
 const HEADLESS_DELEGATED_WORKFLOW_COUNT = 8;
+const MAX_RETRY_BURST_WALL_MS = 120000;
 const MAX_RENDERER_EVENT_LOOP_LAG_MS = 1000;
 const MAX_RENDERER_LONG_TASK_MS = 1500;
 
 const HEADLESS_HERD_BUDGETS = {
-  maxInspectorToggleMs: RESPONSIVE_INTERACTION_TIMEOUT_MS,
+  maxInspectorToggleMs: MAX_INSPECTOR_TOGGLE_MS,
+  maxRetryBurstWallMs: MAX_RETRY_BURST_WALL_MS,
   delegatedWorkflowCount: HEADLESS_DELEGATED_WORKFLOW_COUNT,
   minRetryCommandCount: HEADLESS_DELEGATED_WORKFLOW_COUNT + 1,
   maxRendererEventLoopLagMs: MAX_RENDERER_EVENT_LOOP_LAG_MS,
@@ -188,8 +191,9 @@ test.describe('Headless thundering herd', () => {
 
     const evidenceMessage = JSON.stringify(evidence);
     expect(burst.length, evidenceMessage).toBeGreaterThanOrEqual(HEADLESS_DELEGATED_WORKFLOW_COUNT + 1);
-    expect(firstInteractionMs, evidenceMessage).toBeLessThanOrEqual(RESPONSIVE_INTERACTION_TIMEOUT_MS);
-    expect(secondInteractionMs, evidenceMessage).toBeLessThanOrEqual(RESPONSIVE_INTERACTION_TIMEOUT_MS);
+    expect(retryBurstWallMs, evidenceMessage).toBeLessThanOrEqual(MAX_RETRY_BURST_WALL_MS);
+    expect(firstInteractionMs, evidenceMessage).toBeLessThanOrEqual(MAX_INSPECTOR_TOGGLE_MS);
+    expect(secondInteractionMs, evidenceMessage).toBeLessThanOrEqual(MAX_INSPECTOR_TOGGLE_MS);
     expect(Number(perf.maxRendererEventLoopLagMs), evidenceMessage).toBeLessThanOrEqual(MAX_RENDERER_EVENT_LOOP_LAG_MS);
     expect(Number(perf.maxRendererLongTaskMs), evidenceMessage).toBeLessThanOrEqual(MAX_RENDERER_LONG_TASK_MS);
     expect(delegatedPerf.ownerMode).toBe('standalone');

--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -22,6 +22,8 @@ const PLANNING_PRESSURE_TURNS = 30;
 const PLANNING_INPUT_HANDLER_BUDGET_MS = 50;
 const PLANNING_INPUT_COMMIT_BUDGET_MS = 250;
 const PLANNING_INPUT_FILL_WALL_BUDGET_MS = 1500;
+const MAX_PLANNING_RENDERER_EVENT_LOOP_LAG_MS = 1000;
+const MAX_PLANNING_RENDERER_LONG_TASK_MS = 1500;
 const STARTUP_GRAPH_VISIBLE_AFTER_WINDOW_BUDGET_MS = 5000;
 const MAX_STARTUP_RENDERER_EVENT_LOOP_LAG_MS = 1000;
 const MAX_STARTUP_RENDERER_LONG_TASK_MS = 1500;
@@ -39,6 +41,8 @@ const PLANNING_PRESSURE_BUDGETS = {
   maxInputHandlerMs: PLANNING_INPUT_HANDLER_BUDGET_MS,
   maxInputCommitMs: PLANNING_INPUT_COMMIT_BUDGET_MS,
   maxInputFillWallMs: PLANNING_INPUT_FILL_WALL_BUDGET_MS,
+  maxRendererEventLoopLagMs: MAX_PLANNING_RENDERER_EVENT_LOOP_LAG_MS,
+  maxRendererLongTaskMs: MAX_PLANNING_RENDERER_LONG_TASK_MS,
   maxRendererLongTaskCount: MAX_PLANNING_RENDERER_LONG_TASK_COUNT,
 };
 
@@ -369,6 +373,8 @@ test('planning chat typing stays responsive with a large restored transcript', a
       expect(Number(perf.maxPlanningChatInputHandlerMs), planningEvidenceMessage).toBeLessThanOrEqual(PLANNING_INPUT_HANDLER_BUDGET_MS);
       expect(Number(perf.maxPlanningChatInputCommitMs), planningEvidenceMessage).toBeLessThanOrEqual(PLANNING_INPUT_COMMIT_BUDGET_MS);
       expect(Number(perf.maxPlanningChatTranscriptLines), planningEvidenceMessage).toBeGreaterThanOrEqual(PLANNING_PRESSURE_TURNS * 2);
+      expect(numberOrZero(perf.maxRendererEventLoopLagMs), planningEvidenceMessage).toBeLessThanOrEqual(MAX_PLANNING_RENDERER_EVENT_LOOP_LAG_MS);
+      expect(numberOrZero(perf.maxRendererLongTaskMs), planningEvidenceMessage).toBeLessThanOrEqual(MAX_PLANNING_RENDERER_LONG_TASK_MS);
     } finally {
       await app.close();
     }

--- a/packages/app/e2e/ui-graph-drag-performance.spec.ts
+++ b/packages/app/e2e/ui-graph-drag-performance.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, E2E_REPO_URL } from './fixtures/electron-app.js';
 import { stringify as yamlStringify } from 'yaml';
 import type { Page } from '@playwright/test';
+import { numberOrZero } from './fixtures/ui-perf.js';
 
 const WORKFLOW_COUNT = 50;
 const TASKS_PER_WORKFLOW = 8;
@@ -15,6 +16,9 @@ const MAX_P95_FRAME_GAP_MS = 80;
 const MAX_FRAME_GAP_MS = 250;
 const MIN_TRANSFORM_CHANGES = 12;
 const MAX_FIRST_TRANSFORM_MS = 250;
+const MAX_RENDERER_EVENT_LOOP_LAG_MS = 1000;
+const MAX_RENDERER_LONG_TASK_MS = 1500;
+const MAX_TASK_DELTA_BATCH_SIZE = 250;
 
 const DRAG_PERF_BUDGETS = {
   minFrameCount: MIN_FRAME_COUNT,
@@ -22,6 +26,9 @@ const DRAG_PERF_BUDGETS = {
   maxFrameGapMs: MAX_FRAME_GAP_MS,
   minTransformChanges: MIN_TRANSFORM_CHANGES,
   maxFirstTransformMs: MAX_FIRST_TRANSFORM_MS,
+  maxRendererEventLoopLagMs: MAX_RENDERER_EVENT_LOOP_LAG_MS,
+  maxRendererLongTaskMs: MAX_RENDERER_LONG_TASK_MS,
+  maxTaskDeltaBatchSize: MAX_TASK_DELTA_BATCH_SIZE,
 };
 
 interface DragPerfResult {
@@ -191,14 +198,17 @@ async function streamTaskUpdatesDuringDrag(page: Page): Promise<number> {
   return updateCount;
 }
 
-function expectSmoothDrag(result: DragPerfResult): void {
-  const evidence = JSON.stringify({ ...result, budgets: DRAG_PERF_BUDGETS });
+function expectSmoothDrag(result: DragPerfResult, perf: Record<string, unknown>): void {
+  const evidence = JSON.stringify({ ...result, perf, budgets: DRAG_PERF_BUDGETS });
   expect(result.frameCount, evidence).toBeGreaterThanOrEqual(MIN_FRAME_COUNT);
   expect(result.p95FrameGapMs, evidence).toBeLessThanOrEqual(MAX_P95_FRAME_GAP_MS);
   expect(result.maxFrameGapMs, evidence).toBeLessThanOrEqual(MAX_FRAME_GAP_MS);
   expect(result.transformChanged, evidence).toBe(true);
   expect(result.transformChanges, evidence).toBeGreaterThanOrEqual(MIN_TRANSFORM_CHANGES);
   expect(result.firstTransformMs ?? Number.POSITIVE_INFINITY, evidence).toBeLessThanOrEqual(MAX_FIRST_TRANSFORM_MS);
+  expect(numberOrZero(perf.maxRendererEventLoopLagMs), evidence).toBeLessThanOrEqual(MAX_RENDERER_EVENT_LOOP_LAG_MS);
+  expect(numberOrZero(perf.maxRendererLongTaskMs), evidence).toBeLessThanOrEqual(MAX_RENDERER_LONG_TASK_MS);
+  expect(numberOrZero(perf.maxTaskDeltaBatchSize), evidence).toBeLessThanOrEqual(MAX_TASK_DELTA_BATCH_SIZE);
 }
 
 test('workflow graph pan stays responsive under a large persisted graph', async ({ page }) => {
@@ -209,14 +219,16 @@ test('workflow graph pan stays responsive under a large persisted graph', async 
     '[data-testid="workflow-graph-react-flow"] .react-flow__pane',
     '[data-testid="workflow-graph-react-flow"] .react-flow__viewport',
   );
+  const perf = await page.evaluate(async () => await window.invoker.getUiPerfStats());
 
   console.log(`UI_GRAPH_DRAG_BENCH_RESULT=${JSON.stringify({
     ...result,
     workflowCount: WORKFLOW_COUNT,
     taskCount: WORKFLOW_COUNT * TASKS_PER_WORKFLOW,
+    perf,
     thresholds: DRAG_PERF_BUDGETS,
   })}`);
-  expectSmoothDrag(result);
+  expectSmoothDrag(result, perf);
 });
 
 test('workflow graph pan stays responsive while task updates arrive', async ({ page }) => {
@@ -231,6 +243,7 @@ test('workflow graph pan stays responsive while task updates arrive', async ({ p
       updateCount = await streamTaskUpdatesDuringDrag(page);
     },
   );
+  const perf = await page.evaluate(async () => await window.invoker.getUiPerfStats());
 
   console.log(`UI_GRAPH_DRAG_WITH_UPDATES_BENCH_RESULT=${JSON.stringify({
     ...result,
@@ -239,8 +252,10 @@ test('workflow graph pan stays responsive while task updates arrive', async ({ p
     updateCount,
     updateBursts: UPDATE_BURSTS,
     updatesPerBurst: UPDATES_PER_BURST,
+    perf,
     thresholds: DRAG_PERF_BUDGETS,
   })}`);
-  expect(updateCount).toBe(UPDATE_BURSTS * UPDATES_PER_BURST);
-  expectSmoothDrag(result);
+  const evidence = JSON.stringify({ ...result, updateCount, perf, budgets: DRAG_PERF_BUDGETS });
+  expect(updateCount, evidence).toBe(UPDATE_BURSTS * UPDATES_PER_BURST);
+  expectSmoothDrag(result, perf);
 });

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -67,10 +67,46 @@ function workflowHasBackingTask(
   return false;
 }
 
+function countTasksByWorkflow(tasks: Map<string, TaskState>): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const task of tasks.values()) {
+    const workflowId = task.config.workflowId;
+    if (!workflowId) continue;
+    counts.set(workflowId, (counts.get(workflowId) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function workflowHasBackingTaskCount(
+  taskCountsByWorkflow: Map<string, number>,
+  workflowId: string,
+): boolean {
+  return (taskCountsByWorkflow.get(workflowId) ?? 0) > 0;
+}
+
+function moveWorkflowTaskCount(
+  taskCountsByWorkflow: Map<string, number>,
+  beforeWorkflowId: string | undefined,
+  afterWorkflowId: string | undefined,
+): void {
+  if (beforeWorkflowId === afterWorkflowId) return;
+  if (beforeWorkflowId) {
+    const nextCount = (taskCountsByWorkflow.get(beforeWorkflowId) ?? 0) - 1;
+    if (nextCount > 0) {
+      taskCountsByWorkflow.set(beforeWorkflowId, nextCount);
+    } else {
+      taskCountsByWorkflow.delete(beforeWorkflowId);
+    }
+  }
+  if (afterWorkflowId) {
+    taskCountsByWorkflow.set(afterWorkflowId, (taskCountsByWorkflow.get(afterWorkflowId) ?? 0) + 1);
+  }
+}
+
 function applyWorkflowRollupPatches(
   previous: Map<string, WorkflowMeta>,
   patches: readonly WorkflowRollupPatch[],
-  tasks: Map<string, TaskState>,
+  taskCountsByWorkflow: Map<string, number>,
 ): Map<string, WorkflowMeta> {
   if (patches.length === 0) {
     return previous;
@@ -78,7 +114,7 @@ function applyWorkflowRollupPatches(
   const next = new Map(previous);
   for (const patch of patches) {
     if (patch.removed) {
-      if (!workflowHasBackingTask(tasks, patch.workflowId)) {
+      if (!workflowHasBackingTaskCount(taskCountsByWorkflow, patch.workflowId)) {
         next.delete(patch.workflowId);
       }
       continue;
@@ -336,9 +372,16 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
 
         const removedWorkflowIds: string[] = [];
         let hasAppliedTaskDelta = false;
+        let taskCountsByWorkflow: Map<string, number> | null = null;
+        const ensureTaskCountsByWorkflow = () => {
+          taskCountsByWorkflow ??= countTasksByWorkflow(nextTasks);
+          return taskCountsByWorkflow;
+        };
         for (const event of deltaEvents) {
           if (event.type !== 'delta') continue;
           const delta = event.delta;
+          const beforeTask = delta.type === 'created' ? undefined : nextTasks.get(delta.taskId);
+          const beforeWorkflowId = beforeTask?.config.workflowId;
           if (delta.type === 'updated' && !nextTasks.has(delta.taskId)) {
             if (traceTaskDeltas) {
               console.warn(
@@ -351,16 +394,30 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
             hasAppliedTaskDelta = true;
           }
           applyDeltaInPlace(nextTasks, delta);
-          for (const patch of event.workflowRollups) {
-            if (
-              patch.removed &&
-              nextWorkflows.has(patch.workflowId) &&
-              !workflowHasBackingTask(nextTasks, patch.workflowId)
-            ) {
-              removedWorkflowIds.push(patch.workflowId);
-            }
+          const afterTask = delta.type === 'removed'
+            ? undefined
+            : delta.type === 'created'
+              ? delta.task
+              : nextTasks.get(delta.taskId);
+          if (taskCountsByWorkflow) {
+            moveWorkflowTaskCount(taskCountsByWorkflow, beforeWorkflowId, afterTask?.config.workflowId);
           }
-          nextWorkflows = applyWorkflowRollupPatches(nextWorkflows, event.workflowRollups, nextTasks);
+          if (event.workflowRollups.length > 0) {
+            for (const patch of event.workflowRollups) {
+              if (
+                patch.removed &&
+                nextWorkflows.has(patch.workflowId) &&
+                !workflowHasBackingTaskCount(ensureTaskCountsByWorkflow(), patch.workflowId)
+              ) {
+                removedWorkflowIds.push(patch.workflowId);
+              }
+            }
+            nextWorkflows = applyWorkflowRollupPatches(
+              nextWorkflows,
+              event.workflowRollups,
+              ensureTaskCountsByWorkflow(),
+            );
+          }
         }
 
         if (!shouldRefreshWorkflows) {


### PR DESCRIPTION
## Summary

Adds measured budgets to existing Electron responsiveness specs.

The specs now log JSON evidence for graph dragging, planning input, delegated bursts, and terminal pressure.

Assertions now include renderer event loop lag, long tasks, first transform latency, and interaction wall time.

## Review Claim

Adverse-load specs enforce explicit UI responsiveness budgets with raw evidence in logs.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The slice extends existing Electron E2E specs. It does not introduce a separate benchmark harness or production code path.

## Slice Rationale

This isolates measured adverse-load budgets from the hot-path cache and chaos matrix policy. Reviewers can inspect benchmark assertions directly.

## Non-goals

- Does not change production UI behavior.
- Does not introduce a new benchmark runner.
- Does not alter chaos matrix scenario selection.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test:e2e -- ui-graph-drag-performance.spec.ts headless-thundering-herd.spec.ts startup-nonempty-responsiveness.spec.ts embedded-terminal-pty.spec.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ui-responsiveness-step3-pr2.md --changed-files-file /tmp/ui-responsiveness-step3-pr2-files.txt --diff-file /tmp/ui-responsiveness-step3-pr2.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run the targeted E2E command if the responsiveness gate is still required.
- Data migration? No

</details>
