### PR TITLE
[Worker Registration Step 5: PR Summary, Operator Surface, and Final Gate](1) Add PR summary refresh worker core

### DIFF
--- a/packages/app/src/__tests__/pr-summary-refresh-worker.test.ts
+++ b/packages/app/src/__tests__/pr-summary-refresh-worker.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+import {
+  buildPrSummaryBody,
+  createPrSummaryRefreshTick,
+  PR_SUMMARY_REFRESH_WORKER_KIND,
+  type PrSummaryRefreshCandidate,
+  type PrSummaryRefreshWorkerStore,
+} from '@invoker/execution-engine';
+
+const TICK_CONTEXT = {
+  identity: { kind: PR_SUMMARY_REFRESH_WORKER_KIND, instanceId: 'test' },
+  reason: 'manual' as const,
+  tickNumber: 1,
+  signal: new AbortController().signal,
+};
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id: 'wf-1/build',
+    description: 'Build project',
+    status: 'completed',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: {
+      workflowId: 'wf-1',
+      command: 'pnpm test',
+      ...(config ?? {}),
+    },
+    execution: {
+      generation: 1,
+      ...(execution ?? {}),
+    },
+    taskStateVersion: 1,
+    ...rest,
+  };
+}
+
+function makeMergeTask(): TaskState {
+  return makeTask({
+    id: 'wf-1/__merge__',
+    description: 'Merge gate',
+    status: 'review_ready',
+    config: {
+      workflowId: 'wf-1',
+      isMergeNode: true,
+      runnerKind: 'merge',
+      summary: 'Merged workflow work.',
+    },
+    execution: {
+      generation: 2,
+      workspacePath: '/repo',
+      reviewGate: {
+        activeGeneration: 2,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [{
+          id: 'review-123',
+          providerId: '123',
+          provider: 'github',
+          url: 'https://github.com/acme/repo/pull/123',
+          required: true,
+          status: 'open',
+          generation: 2,
+        }],
+      },
+    },
+  });
+}
+
+function makeAction(overrides: Partial<WorkerActionRecord> = {}): WorkerActionRecord {
+  return {
+    id: 'ci-failure:key',
+    workerKind: 'ci-failure',
+    actionType: 'fix-ci-failure',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/build',
+    subjectType: 'review',
+    subjectId: '123',
+    externalKey: 'ci-failure:key',
+    status: 'completed',
+    attemptCount: 1,
+    summary: 'Submitted CI repair.',
+    payload: {},
+    createdAt: '2026-01-01T00:01:00.000Z',
+    updatedAt: '2026-01-01T00:01:00.000Z',
+    completedAt: '2026-01-01T00:01:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeStore(tasks: TaskState[], actions: WorkerActionRecord[] = []): {
+  store: PrSummaryRefreshWorkerStore;
+  savedActions: Map<string, WorkerActionRecord>;
+} {
+  const savedActions = new Map(actions.map((action) => [`${action.workerKind}:${action.externalKey}`, action]));
+  const store: PrSummaryRefreshWorkerStore = {
+    listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+    loadWorkflow: vi.fn(() => ({
+      id: 'wf-1',
+      name: 'Worker summary workflow',
+      description: 'Reviewers can see what Invoker did.',
+    })),
+    loadTasks: vi.fn(() => tasks),
+    listWorkerActions: vi.fn((filters = {}) => [...savedActions.values()]
+      .filter((action) => !filters.workflowId || action.workflowId === filters.workflowId)
+      .filter((action) => !filters.workerKind || action.workerKind === filters.workerKind)
+      .slice(0, filters.limit ?? undefined)),
+    getWorkerAction: vi.fn((workerKind: string, externalKey: string) =>
+      savedActions.get(`${workerKind}:${externalKey}`)),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+      const key = `${write.workerKind}:${write.externalKey}`;
+      const existing = savedActions.get(key);
+      const saved: WorkerActionRecord = {
+        id: write.id,
+        workerKind: write.workerKind,
+        actionType: write.actionType,
+        workflowId: write.workflowId,
+        taskId: write.taskId,
+        subjectType: write.subjectType,
+        subjectId: write.subjectId,
+        externalKey: write.externalKey,
+        status: write.status,
+        attemptCount: write.attemptCount ?? existing?.attemptCount ?? 0,
+        summary: write.summary,
+        payload: write.payload,
+        createdAt: existing?.createdAt ?? write.createdAt ?? '2026-01-01T00:02:00.000Z',
+        updatedAt: write.updatedAt ?? '2026-01-01T00:02:00.000Z',
+        completedAt: write.completedAt,
+      };
+      savedActions.set(key, saved);
+      return saved;
+    }),
+    logEvent: vi.fn(),
+  };
+  return { store, savedActions };
+}
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+describe('pr-summary-refresh worker', () => {
+  it('updates changed PR bodies with canonical pipeline rows and records action state', async () => {
+    const mergeTask = makeMergeTask();
+    const { store, savedActions } = makeStore([makeTask(), mergeTask], [makeAction()]);
+    const provider = {
+      name: 'github',
+      getReviewBody: vi.fn(async () => 'old body'),
+      updateReviewBody: vi.fn(async () => undefined),
+    };
+
+    await createPrSummaryRefreshTick({
+      logger,
+      store,
+      provider,
+    })(TICK_CONTEXT);
+
+    expect(provider.updateReviewBody).toHaveBeenCalledTimes(1);
+    const body = provider.updateReviewBody.mock.calls[0]?.[0]?.body ?? '';
+    expect(body).toContain('## Pipeline');
+    expect(body).toContain('| 2026-01-01T00:01:00.000Z | ci-failure | fix-ci-failure | completed | wf-1/build | Submitted CI repair. |');
+    expect(body).toContain('- [x] `pnpm test` — Build project');
+
+    const refreshAction = [...savedActions.values()].find((action) =>
+      action.workerKind === PR_SUMMARY_REFRESH_WORKER_KIND);
+    expect(refreshAction).toMatchObject({
+      status: 'completed',
+      taskId: 'wf-1/__merge__',
+      summary: 'Updated PR body with Invoker pipeline summary',
+    });
+    expect(store.logEvent).toHaveBeenCalledWith(
+      'wf-1/__merge__',
+      'task.worker_action',
+      expect.objectContaining({
+        workerKind: PR_SUMMARY_REFRESH_WORKER_KIND,
+        actionType: 'refresh-pr-summary',
+        status: 'completed',
+      }),
+    );
+  });
+
+  it('skips provider updates when the live body already matches', async () => {
+    const mergeTask = makeMergeTask();
+    const { store, savedActions } = makeStore([makeTask(), mergeTask], [makeAction()]);
+    const candidate: PrSummaryRefreshCandidate = {
+      workflowId: 'wf-1',
+      mergeTask,
+      artifact: mergeTask.execution.reviewGate!.artifacts[0]!,
+    };
+    const currentBody = buildPrSummaryBody(candidate, store);
+    const provider = {
+      name: 'github',
+      getReviewBody: vi.fn(async () => `${currentBody}\n`),
+      updateReviewBody: vi.fn(async () => undefined),
+    };
+
+    const tick = createPrSummaryRefreshTick({
+      logger,
+      store,
+      provider,
+    });
+
+    await tick(TICK_CONTEXT);
+
+    expect(provider.updateReviewBody).not.toHaveBeenCalled();
+    const refreshAction = [...savedActions.values()].find((action) =>
+      action.workerKind === PR_SUMMARY_REFRESH_WORKER_KIND);
+    expect(refreshAction).toMatchObject({
+      status: 'skipped',
+      summary: 'PR body already includes current Invoker pipeline summary',
+    });
+    expect(refreshAction?.payload).toMatchObject({ reason: 'body-current' });
+    expect(store.logEvent).toHaveBeenCalledTimes(1);
+
+    await tick({ ...TICK_CONTEXT, tickNumber: 2 });
+
+    expect(provider.updateReviewBody).not.toHaveBeenCalled();
+    expect(store.logEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -93,7 +93,7 @@ import { WorkspaceProbeAdapter, ContainerProbeAdapter, SessionProbeAdapter, Term
 import { composeRuntimeServices, composeHeadlessStartup } from '@invoker/runtime-service';
 import type { RuntimeServices } from '@invoker/runtime-service';
 import type { MessageBus } from '@invoker/transport';
-import { ExecutorRegistry, TaskRunner, WorktreeExecutor, CI_FAILURE_WORKER_KIND, initializeShellEnvironment, createAutoFixAttemptLedger, createWorkerRegistry, PR_STATUS_WORKER_KIND, E2E_AUTOFIX_WORKER_KIND, registerBuiltinAgents, registerBuiltinWorkers, parseRequeueMutationArgs, parseRequeueEscalateMutationArgs, type AgentRegistry, type WorkerRegistry, type WorkerRuntimeDependencies } from '@invoker/execution-engine';
+import { ExecutorRegistry, TaskRunner, WorktreeExecutor, CI_FAILURE_WORKER_KIND, initializeShellEnvironment, createAutoFixAttemptLedger, createWorkerRegistry, GitHubMergeGateProvider, PR_STATUS_WORKER_KIND, E2E_AUTOFIX_WORKER_KIND, registerBuiltinAgents, registerBuiltinWorkers, parseRequeueMutationArgs, parseRequeueEscalateMutationArgs, type AgentRegistry, type WorkerRegistry, type WorkerRuntimeDependencies } from '@invoker/execution-engine';
 import { FileAndDbLogger } from './logger.js';
 import { DEFAULT_SLACK_HARNESS_PRESETS, loadConfig, resolveAutoFixExecutionModel, resolveConfigFileState, resolveEmbeddedTerminalBackendConfig, resolvePrMaintenanceWorkerConfig, type EmbeddedTerminalBackendConfig, type InvokerConfig } from './config.js';
 import { resolveAutoApproveAIFixes, resolveAutoFixRetries } from './autofix-defaults.js';
@@ -239,6 +239,7 @@ function buildRegisteredOwnerWorkerDeps(
     reviewGate: {
       checkMergeGateStatuses,
     },
+    mergeGateProvider: new GitHubMergeGateProvider(),
     autoFix: {
       defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
       attemptLedger: autoFixAttemptLedger,

--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -34,6 +34,36 @@ describe('GitHubMergeGateProvider', () => {
     process.env = originalEnv;
   });
 
+  describe('updateReviewBody', () => {
+    it('updates the PR body through a temporary body file', async () => {
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'origin') {
+          return mockSpawnResult('https://github.com/owner/repo.git', 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      await provider.updateReviewBody({
+        identifier: '42',
+        cwd: '/tmp/repo',
+        body: '## Summary\n\nUpdated body',
+      });
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'gh',
+        [
+          'pr', 'edit', '42',
+          '--repo', 'owner/repo',
+          '--body-file', expect.stringContaining('body.md'),
+        ],
+        expect.objectContaining({ cwd: '/tmp/repo' }),
+      );
+    });
+  });
+
   describe('createReview', () => {
     it('targets origin repository when creating merge-gate PRs', async () => {
       const { spawn } = await import('node:child_process');

--- a/packages/execution-engine/src/__tests__/pr-authoring.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-authoring.test.ts
@@ -110,6 +110,40 @@ describe('buildCanonicalPrBody', () => {
     expect(body).toContain(visualProof);
   });
 
+  it('renders worker action pipeline rows in chronological order', () => {
+    const body = buildCanonicalPrBody({
+      title: 'Refresh PR summary',
+      workflowSummary: 'Show Invoker pipeline work.',
+      structuredContext: {
+        tasks: [],
+        workerActions: [
+          {
+            workerKind: 'ci-failure',
+            actionType: 'fix-ci-failure',
+            status: 'completed',
+            taskId: 'wf-1/repair',
+            summary: 'Submitted CI repair.',
+            createdAt: '2026-01-01T00:02:00.000Z',
+          },
+          {
+            workerKind: 'autofix',
+            actionType: 'auto-fix',
+            status: 'skipped',
+            taskId: 'wf-1/build',
+            reason: 'retry-budget-exhausted',
+            createdAt: '2026-01-01T00:01:00.000Z',
+          },
+        ],
+      },
+    });
+
+    expect(body).toContain('## Pipeline');
+    const first = body.indexOf('| 2026-01-01T00:01:00.000Z | autofix | auto-fix | skipped | wf-1/build | (retry-budget-exhausted) |');
+    const second = body.indexOf('| 2026-01-01T00:02:00.000Z | ci-failure | fix-ci-failure | completed | wf-1/repair | Submitted CI repair. |');
+    expect(first).toBeGreaterThan(-1);
+    expect(second).toBeGreaterThan(first);
+  });
+
   it('canonical body passes validation', () => {
     const body = buildCanonicalPrBody({
       title: 'Anything',

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -17,8 +17,10 @@ import {
   PR_CONFLICT_REBASE_WORKER_KIND,
 } from '../workers/pr-maintenance-workers.js';
 import { PR_STATUS_WORKER_KIND } from '../workers/pr-status-worker.js';
+import { PR_SUMMARY_REFRESH_WORKER_KIND } from '../workers/pr-summary-refresh-worker.js';
 import { DISK_HEADROOM_WORKER_KIND } from '../workers/disk-headroom-worker.js';
 import { REQUEUE_WORKER_KIND } from '../workers/requeue-worker.js';
+import { REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND } from '../workers/review-gate-merge-conflict-worker.js';
 import { WORKFLOW_RESUME_WORKER_KIND } from '../workers/workflow-resume-worker.js';
 import { E2E_AUTOFIX_WORKER_KIND } from '../workers/e2e-autofix-worker.js';
 
@@ -71,7 +73,9 @@ describe('worker registry', () => {
       REQUEUE_WORKER_KIND,
       WORKFLOW_RESUME_WORKER_KIND,
       PR_STATUS_WORKER_KIND,
+      PR_SUMMARY_REFRESH_WORKER_KIND,
       CI_FAILURE_WORKER_KIND,
+      REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
       DISK_HEADROOM_WORKER_KIND,
       AUTO_APPROVE_WORKER_KIND,
       CODERABBIT_ADDRESS_WORKER_KIND,
@@ -82,7 +86,9 @@ describe('worker registry', () => {
     expect(registry.get(REQUEUE_WORKER_KIND)).toBeDefined();
     expect(registry.get(WORKFLOW_RESUME_WORKER_KIND)).toBeDefined();
     expect(registry.get(PR_STATUS_WORKER_KIND)).toBeDefined();
+    expect(registry.get(PR_SUMMARY_REFRESH_WORKER_KIND)).toBeDefined();
     expect(registry.get(CI_FAILURE_WORKER_KIND)).toBeDefined();
+    expect(registry.get(REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND)).toBeDefined();
     expect(registry.get(DISK_HEADROOM_WORKER_KIND)).toBeDefined();
     expect(registry.get(AUTO_APPROVE_WORKER_KIND)).toBeDefined();
     expect(registry.get(CODERABBIT_ADDRESS_WORKER_KIND)).toBeDefined();
@@ -111,6 +117,8 @@ describe('worker registry', () => {
     const registry = registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>());
 
     expect(registry.get(PR_STATUS_WORKER_KIND)?.factory(deps()).identity.kind).toBe(PR_STATUS_WORKER_KIND);
+    expect(registry.get(PR_SUMMARY_REFRESH_WORKER_KIND)?.factory(deps()).identity.kind)
+      .toBe(PR_SUMMARY_REFRESH_WORKER_KIND);
     expect(registry.get(CI_FAILURE_WORKER_KIND)?.factory(deps()).identity.kind).toBe(CI_FAILURE_WORKER_KIND);
     expect(registry.get(CODERABBIT_ADDRESS_WORKER_KIND)?.factory(deps()).identity.kind)
       .toBe(CODERABBIT_ADDRESS_WORKER_KIND);

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -6,6 +6,7 @@ import { registerCiFailureWorker } from './workers/ci-failure-worker.js';
 import { registerE2eAutoFixWorker } from './workers/e2e-autofix-worker.js';
 import { registerDiskHeadroomWorker } from './workers/disk-headroom-worker.js';
 import { registerPrMaintenanceWorkers } from './workers/pr-maintenance-workers.js';
+import { registerPrSummaryRefreshWorker } from './workers/pr-summary-refresh-worker.js';
 import { registerPrStatusWorker } from './workers/pr-status-worker.js';
 import { registerRequeueWorker } from './workers/requeue-worker.js';
 import { registerReviewGateMergeConflictWorker } from './workers/review-gate-merge-conflict-worker.js';
@@ -19,6 +20,7 @@ export function registerBuiltinWorkers(
   registerRequeueWorker(registry);
   registerWorkflowResumeWorker(registry);
   registerPrStatusWorker(registry);
+  registerPrSummaryRefreshWorker(registry);
   registerCiFailureWorker(registry);
   registerReviewGateMergeConflictWorker(registry);
   registerDiskHeadroomWorker(registry);

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -1,4 +1,7 @@
 import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
 import { killProcessGroup, SIGKILL_TIMEOUT_MS } from './process-utils.js';
 import type {
@@ -102,6 +105,27 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       '--jq', '.body',
     ], cwd));
     return stdout.trim();
+  }
+
+  async updateReviewBody(opts: {
+    identifier: string;
+    cwd: string;
+    body: string;
+  }): Promise<void> {
+    const { identifier, cwd, body } = opts;
+    const targetRepo = await this.resolveTargetRepo(cwd);
+    const tempDir = mkdtempSync(join(tmpdir(), 'invoker-pr-body-'));
+    const bodyPath = join(tempDir, 'body.md');
+    try {
+      writeFileSync(bodyPath, body, 'utf8');
+      await retryTransientGitHubCli(() => this.exec('gh', [
+        'pr', 'edit', identifier,
+        '--repo', targetRepo,
+        '--body-file', bodyPath,
+      ], cwd));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   }
 
   async checkApproval(opts: {

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -57,6 +57,7 @@ export * from './worker-lock.js';
 export * from './builtin-workers.js';
 export * from './auto-fix-recovery.js';
 export * from './workers/pr-status-worker.js';
+export * from './workers/pr-summary-refresh-worker.js';
 export * from './workers/ci-failure-worker.js';
 export * from './workers/auto-approve-worker.js';
 export * from './workers/disk-headroom-worker.js';

--- a/packages/execution-engine/src/merge-gate-provider.ts
+++ b/packages/execution-engine/src/merge-gate-provider.ts
@@ -21,6 +21,12 @@ export interface MergeGateCloseReviewOptions {
   cwd: string;
 }
 
+export interface MergeGateUpdateReviewBodyOptions {
+  identifier: string;
+  cwd: string;
+  body: string;
+}
+
 export interface MergeGateCheckSummary {
   state: 'pending' | 'success' | 'failure';
   failed: MergeGateFailedCheck[];
@@ -71,4 +77,7 @@ export interface MergeGateProvider {
 
   /** Read the live PR body as published on the provider (e.g. GitHub). */
   getReviewBody?(opts: { identifier: string; cwd: string }): Promise<string>;
+
+  /** Replace the live PR body as published on the provider (e.g. GitHub). */
+  updateReviewBody?(opts: MergeGateUpdateReviewBodyOptions): Promise<void>;
 }

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -33,6 +33,21 @@ export interface PrAuthoringTaskEntry {
   fileChangeSummary?: string;
 }
 
+/** Durable worker action evidence rendered into the PR pipeline summary. */
+export interface PrAuthoringWorkerActionEntry {
+  workerKind: string;
+  actionType: string;
+  status: string;
+  subjectType?: string;
+  subjectId?: string;
+  workflowId?: string;
+  taskId?: string;
+  summary?: string;
+  reason?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
 /**
  * Structured context that supplements the free-form `workflowSummary` string
  * with machine-readable evidence for PR body authoring.
@@ -46,6 +61,8 @@ export interface PrAuthoringContext {
   workflowDescription?: string;
   /** Per-task entries with verification evidence. */
   tasks: PrAuthoringTaskEntry[];
+  /** Durable worker decisions/actions that explain Invoker pipeline activity. */
+  workerActions?: PrAuthoringWorkerActionEntry[];
   /** Visual-proof markdown block (screenshots / video walkthrough). */
   visualProofMarkdown?: string;
 }
@@ -478,6 +495,69 @@ export function parseMakePrStackPublishResult(raw: string): MakePrStackArtifactO
   return records;
 }
 
+function markdownTableCell(value: string | undefined): string {
+  const normalized = (value ?? '').replace(/\s+/g, ' ').trim();
+  if (!normalized) return '-';
+  return normalized.replaceAll('\\', '\\\\').replaceAll('|', '\\|');
+}
+
+function workerActionTimestamp(action: PrAuthoringWorkerActionEntry): string {
+  return action.createdAt ?? action.updatedAt ?? '';
+}
+
+function workerActionTarget(action: PrAuthoringWorkerActionEntry): string {
+  if (action.taskId) return action.taskId;
+  if (action.workflowId && action.subjectId && action.subjectId !== action.workflowId) {
+    return `${action.workflowId}/${action.subjectId}`;
+  }
+  return action.subjectId ?? action.workflowId ?? '-';
+}
+
+function compareWorkerActionsByTime(
+  a: PrAuthoringWorkerActionEntry,
+  b: PrAuthoringWorkerActionEntry,
+): number {
+  const aTime = workerActionTimestamp(a);
+  const bTime = workerActionTimestamp(b);
+  const aMs = Date.parse(aTime);
+  const bMs = Date.parse(bTime);
+  if (Number.isFinite(aMs) && Number.isFinite(bMs) && aMs !== bMs) return aMs - bMs;
+  return aTime.localeCompare(bTime)
+    || a.workerKind.localeCompare(b.workerKind)
+    || a.actionType.localeCompare(b.actionType)
+    || workerActionTarget(a).localeCompare(workerActionTarget(b));
+}
+
+function renderPipelineSection(workerActions: readonly PrAuthoringWorkerActionEntry[]): string[] {
+  const lines: string[] = [];
+  lines.push('## Pipeline');
+  lines.push('');
+
+  if (workerActions.length === 0) {
+    lines.push('_No worker actions recorded._');
+    lines.push('');
+    return lines;
+  }
+
+  lines.push('| Time | Worker | Action | Status | Target | Summary |');
+  lines.push('| --- | --- | --- | --- | --- | --- |');
+  for (const action of [...workerActions].sort(compareWorkerActionsByTime)) {
+    const summary = action.reason
+      ? `${action.summary ?? ''}${action.summary ? ' ' : ''}(${action.reason})`
+      : action.summary;
+    lines.push([
+      markdownTableCell(workerActionTimestamp(action)),
+      markdownTableCell(action.workerKind),
+      markdownTableCell(action.actionType),
+      markdownTableCell(action.status),
+      markdownTableCell(workerActionTarget(action)),
+      markdownTableCell(summary),
+    ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+  }
+  lines.push('');
+  return lines;
+}
+
 /**
  * Build a deterministic canonical PR body from structured context.
  * Used as the no-AI escape hatch when all agent-authored attempts fail.
@@ -498,6 +578,10 @@ export function buildCanonicalPrBody(args: {
     lines.push(args.workflowSummary.trim());
   }
   lines.push('');
+
+  if (args.structuredContext?.workerActions !== undefined) {
+    lines.push(...renderPipelineSection(args.structuredContext.workerActions));
+  }
 
   // ## Test Plan — content collapsed per the canonical schema.
   lines.push('## Test Plan');
@@ -612,6 +696,24 @@ export function buildMakePrPrompt(args: {
     if (ctx.visualProofMarkdown) {
       lines.push('Visual proof (include verbatim in PR body if present):');
       lines.push(ctx.visualProofMarkdown);
+      lines.push('');
+    }
+
+    if (ctx.workerActions !== undefined) {
+      lines.push('Pipeline worker actions (render as a ## Pipeline table in chronological order):');
+      if (ctx.workerActions.length === 0) {
+        lines.push('- No worker actions recorded.');
+      } else {
+        for (const action of [...ctx.workerActions].sort(compareWorkerActionsByTime)) {
+          const target = workerActionTarget(action);
+          const when = workerActionTimestamp(action) || 'unknown-time';
+          const summary = action.summary ? ` — ${action.summary}` : '';
+          const reason = action.reason ? ` (${action.reason})` : '';
+          lines.push(
+            `- ${when} ${action.workerKind}/${action.actionType} ${action.status} target=${target}${summary}${reason}`,
+          );
+        }
+      }
       lines.push('');
     }
   }

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@invoker/contracts';
 import type { MessageBus } from '@invoker/transport';
 
+import type { MergeGateProvider } from './merge-gate-provider.js';
 import type {
   AutoFixRecoveryStore,
   AutoFixRecoverySubmitter,
@@ -26,6 +27,7 @@ import type {
   WorkflowResumeWorkerStore,
   WorkflowResumeWorkerSubmitter,
 } from './workers/workflow-resume-worker.js';
+import type { PrSummaryRefreshWorkerStore } from './workers/pr-summary-refresh-worker.js';
 
 /** Dependencies injected into a built-in worker factory when its runtime is built. */
 export interface WorkerRuntimeDependencies {
@@ -34,7 +36,8 @@ export interface WorkerRuntimeDependencies {
     & CiFailureWorkerStore
     & AutoApproveWorkerStore
     & ReviewGateMergeConflictWorkerStore
-    & WorkflowResumeWorkerStore;
+    & WorkflowResumeWorkerStore
+    & PrSummaryRefreshWorkerStore;
   /** Action-output channel used to submit follow-up mutation intents. */
   submitter: AutoFixRecoverySubmitter
     & CiFailureWorkerSubmitter
@@ -48,6 +51,8 @@ export interface WorkerRuntimeDependencies {
   messageBus?: MessageBus;
   /** Review-gate polling surface owned by the task runner. */
   reviewGate?: PrStatusReviewGate;
+  /** Provider IO surface for workers that need to update published reviews. */
+  mergeGateProvider?: MergeGateProvider;
   /** Auto-fix tuning shared by workers that submit fix intents. */
   autoFix?: AutoFixWorkerConfig;
   /** Requeue worker tuning (stall requeue budget / backoff). */

--- a/packages/execution-engine/src/workers/pr-summary-refresh-worker.ts
+++ b/packages/execution-engine/src/workers/pr-summary-refresh-worker.ts
@@ -1,0 +1,375 @@
+import { createHash } from 'node:crypto';
+
+import type { Logger } from '@invoker/contracts';
+import type {
+  WorkerActionListFilters,
+  WorkerActionRecord,
+  WorkerActionStatus,
+} from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+import type { MergeGateProvider } from '../merge-gate-provider.js';
+import {
+  buildCanonicalPrBody,
+  type PrAuthoringContext,
+  type PrAuthoringTaskEntry,
+  type PrAuthoringWorkerActionEntry,
+} from '../pr-authoring.js';
+import { recordWorkerDecisionRow, type WorkerDecisionStore } from '../worker-decision-ledger.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const PR_SUMMARY_REFRESH_WORKER_KIND = 'pr-summary-refresh';
+export const DEFAULT_PR_SUMMARY_REFRESH_WORKER_INTERVAL_MS = 60_000;
+
+const PR_SUMMARY_REFRESH_ACTION_TYPE = 'refresh-pr-summary';
+
+type ReviewGateState = NonNullable<TaskState['execution']['reviewGate']>;
+type ReviewGateArtifact = ReviewGateState['artifacts'][number];
+
+export interface PrSummaryRefreshWorkerStore extends WorkerDecisionStore {
+  listWorkflows(): ReadonlyArray<{ id: string }>;
+  loadWorkflow?(workflowId: string): { id: string; name?: string; description?: string } | undefined;
+  loadTasks(workflowId: string): TaskState[];
+  listWorkerActions?(filters?: WorkerActionListFilters): WorkerActionRecord[];
+  logEvent?(taskId: string, eventType: string, payload?: unknown): void;
+}
+
+export interface PrSummaryRefreshWorkerOptions {
+  logger: Logger;
+  instanceId?: string;
+  intervalMs?: number;
+  installSignalHandlers?: boolean;
+  tickOnStart?: boolean;
+  store: PrSummaryRefreshWorkerStore;
+  provider?: Pick<MergeGateProvider, 'name' | 'getReviewBody' | 'updateReviewBody'>;
+  onTick?: WorkerTick;
+}
+
+export interface PrSummaryRefreshCandidate {
+  workflowId: string;
+  mergeTask: TaskState;
+  artifact: ReviewGateArtifact;
+}
+
+/** Register the built-in PR summary refresh worker. */
+export function registerPrSummaryRefreshWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: PR_SUMMARY_REFRESH_WORKER_KIND,
+    note: 'Refreshes published PR bodies with the canonical Invoker pipeline summary.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createPrSummaryRefreshWorker({
+        logger: deps.logger,
+        store: deps.store,
+        provider: deps.mergeGateProvider,
+      }),
+  });
+  return registry;
+}
+
+export function createPrSummaryRefreshWorker(options: PrSummaryRefreshWorkerOptions): WorkerRuntime {
+  return createWorkerRuntime({
+    kind: PR_SUMMARY_REFRESH_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_PR_SUMMARY_REFRESH_WORKER_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick: options.onTick ?? createPrSummaryRefreshTick(options),
+  });
+}
+
+export function createPrSummaryRefreshTick(options: PrSummaryRefreshWorkerOptions): WorkerTick {
+  return async () => {
+    const candidates = listPrSummaryRefreshCandidates(options.store);
+    if (candidates.length === 0) {
+      options.logger.debug?.('[worker:pr-summary-refresh] no merge review tasks found', {
+        module: 'pr-summary-refresh-worker',
+      });
+      return;
+    }
+
+    for (const candidate of candidates) {
+      await refreshCandidate(candidate, options);
+    }
+  };
+}
+
+export function listPrSummaryRefreshCandidates(
+  store: Pick<PrSummaryRefreshWorkerStore, 'listWorkflows' | 'loadTasks'>,
+): PrSummaryRefreshCandidate[] {
+  const candidates: PrSummaryRefreshCandidate[] = [];
+  for (const workflow of store.listWorkflows()) {
+    const tasks = store.loadTasks(workflow.id);
+    for (const mergeTask of tasks) {
+      if (!mergeTask.config.isMergeNode) continue;
+      for (const artifact of activeReviewArtifacts(mergeTask)) {
+        candidates.push({ workflowId: workflow.id, mergeTask, artifact });
+      }
+    }
+  }
+  return candidates;
+}
+
+function activeReviewArtifacts(task: TaskState): ReviewGateArtifact[] {
+  const gate = task.execution.reviewGate;
+  if (gate) {
+    return gate.artifacts.filter((artifact) =>
+      artifact.generation === gate.activeGeneration
+      && artifact.status !== 'discarded'
+      && !artifact.discardedAt
+      && Boolean(artifact.providerId),
+    );
+  }
+
+  if (!task.execution.reviewId && !task.execution.reviewUrl) return [];
+  return [{
+    id: task.execution.reviewId ?? 'review',
+    providerId: task.execution.reviewId,
+    url: task.execution.reviewUrl,
+    provider: task.execution.reviewProviderId,
+    required: true,
+    status: 'open',
+    generation: task.execution.generation ?? 0,
+  }];
+}
+
+async function refreshCandidate(
+  candidate: PrSummaryRefreshCandidate,
+  options: PrSummaryRefreshWorkerOptions,
+): Promise<void> {
+  const reviewId = candidate.artifact.providerId;
+  const cwd = candidate.mergeTask.execution.workspacePath;
+  const externalKey = prSummaryRefreshExternalKey(candidate);
+
+  if (!reviewId) {
+    recordRefreshAction(options, candidate, 'skipped', 'Missing review provider id', {
+      reason: 'missing-review-id',
+      externalKey,
+    });
+    return;
+  }
+  if (!cwd) {
+    recordRefreshAction(options, candidate, 'skipped', 'Missing review workspace path', {
+      reason: 'missing-workspace-path',
+      externalKey,
+    });
+    return;
+  }
+  if (!options.provider?.getReviewBody || !options.provider.updateReviewBody) {
+    recordRefreshAction(options, candidate, 'skipped', 'Review provider cannot refresh PR bodies', {
+      reason: 'provider-unavailable',
+      externalKey,
+    });
+    return;
+  }
+
+  try {
+    const body = buildPrSummaryBody(candidate, options.store);
+    const current = await options.provider.getReviewBody({ identifier: reviewId, cwd });
+    const bodyHash = sha256(body);
+    if (normalizeBodyForCompare(current) === normalizeBodyForCompare(body)) {
+      recordRefreshAction(options, candidate, 'skipped', 'PR body already includes current Invoker pipeline summary', {
+        reason: 'body-current',
+        externalKey,
+        bodyHash,
+      });
+      return;
+    }
+
+    await options.provider.updateReviewBody({ identifier: reviewId, cwd, body });
+    recordRefreshAction(options, candidate, 'completed', 'Updated PR body with Invoker pipeline summary', {
+      externalKey,
+      bodyHash,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    options.logger.error?.('[worker:pr-summary-refresh] failed to refresh PR body', {
+      module: 'pr-summary-refresh-worker',
+      workflowId: candidate.workflowId,
+      taskId: candidate.mergeTask.id,
+      reviewId,
+      err,
+    });
+    recordRefreshAction(options, candidate, 'failed', 'Failed to update PR body with Invoker pipeline summary', {
+      reason: 'update-failed',
+      error: message,
+      externalKey,
+    });
+  }
+}
+
+export function buildPrSummaryBody(
+  candidate: PrSummaryRefreshCandidate,
+  store: Pick<PrSummaryRefreshWorkerStore, 'loadWorkflow' | 'loadTasks' | 'listWorkerActions'>,
+): string {
+  const workflow = store.loadWorkflow?.(candidate.workflowId);
+  const tasks = store.loadTasks(candidate.workflowId);
+  const structuredContext = buildPrSummaryAuthoringContext(candidate.workflowId, workflow, tasks, store);
+  const summary = workflow?.description
+    ?? candidate.mergeTask.config.summary
+    ?? candidate.mergeTask.description
+    ?? `Workflow ${candidate.workflowId}`;
+  return buildCanonicalPrBody({
+    title: workflow?.name ?? candidate.mergeTask.description,
+    workflowSummary: summary,
+    structuredContext,
+  });
+}
+
+function buildPrSummaryAuthoringContext(
+  workflowId: string,
+  workflow: { name?: string; description?: string } | undefined,
+  tasks: readonly TaskState[],
+  store: Pick<PrSummaryRefreshWorkerStore, 'listWorkerActions'>,
+): PrAuthoringContext {
+  return {
+    workflowName: workflow?.name,
+    workflowDescription: workflow?.description,
+    tasks: tasks
+      .filter((task) => !task.config.isMergeNode)
+      .map(taskToPrEntry),
+    workerActions: workerActionsForWorkflow(workflowId, store),
+  };
+}
+
+function taskToPrEntry(task: TaskState): PrAuthoringTaskEntry {
+  return {
+    taskId: task.id,
+    description: task.description,
+    status: task.status === 'completed' ? 'completed' : task.status === 'failed' ? 'failed' : 'skipped',
+    ...(task.config.command ? { command: task.config.command } : {}),
+  };
+}
+
+function workerActionsForWorkflow(
+  workflowId: string,
+  store: Pick<PrSummaryRefreshWorkerStore, 'listWorkerActions'>,
+): PrAuthoringWorkerActionEntry[] {
+  return (store.listWorkerActions?.({ workflowId }) ?? [])
+    .filter((action) => action.workerKind !== PR_SUMMARY_REFRESH_WORKER_KIND)
+    .map((action) => {
+      const reason = reasonFromPayload(action.payload);
+      return {
+        workerKind: action.workerKind,
+        actionType: action.actionType,
+        status: action.status,
+        subjectType: action.subjectType,
+        subjectId: action.subjectId,
+        ...(action.workflowId ? { workflowId: action.workflowId } : {}),
+        ...(action.taskId ? { taskId: action.taskId } : {}),
+        ...(action.summary ? { summary: action.summary } : {}),
+        ...(reason ? { reason } : {}),
+        createdAt: action.createdAt,
+        updatedAt: action.updatedAt,
+      };
+    });
+}
+
+function reasonFromPayload(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return undefined;
+  const reason = (payload as Record<string, unknown>).reason;
+  return typeof reason === 'string' && reason.trim() ? reason : undefined;
+}
+
+function recordRefreshAction(
+  options: PrSummaryRefreshWorkerOptions,
+  candidate: PrSummaryRefreshCandidate,
+  status: WorkerActionStatus,
+  summary: string,
+  payload: Record<string, unknown>,
+): WorkerActionRecord | undefined {
+  const externalKey = typeof payload.externalKey === 'string'
+    ? payload.externalKey
+    : prSummaryRefreshExternalKey(candidate);
+  const existing = options.store.getWorkerAction?.(PR_SUMMARY_REFRESH_WORKER_KIND, externalKey);
+  const action = recordWorkerDecisionRow(options.store, {
+    workerKind: PR_SUMMARY_REFRESH_WORKER_KIND,
+    actionType: PR_SUMMARY_REFRESH_ACTION_TYPE,
+    externalKey,
+    subjectType: 'review',
+    subjectId: candidate.artifact.providerId ?? candidate.artifact.id,
+    workflowId: candidate.workflowId,
+    taskId: candidate.mergeTask.id,
+    status,
+    summary,
+    reason: typeof payload.reason === 'string' ? payload.reason : undefined,
+    incrementAttempt: status === 'completed' || status === 'failed',
+    payload: {
+      reviewId: candidate.artifact.providerId ?? null,
+      reviewUrl: candidate.artifact.url ?? null,
+      artifactId: candidate.artifact.id,
+      generation: candidate.artifact.generation,
+      provider: candidate.artifact.provider ?? null,
+      ...payload,
+      externalKey: undefined,
+    },
+  });
+  if (shouldLogTaskWorkerAction(existing, action)) {
+    logTaskWorkerAction(options.store, candidate.mergeTask.id, action, {
+      workerKind: PR_SUMMARY_REFRESH_WORKER_KIND,
+      actionType: PR_SUMMARY_REFRESH_ACTION_TYPE,
+      status,
+      summary,
+      externalKey,
+      reason: typeof payload.reason === 'string' ? payload.reason : undefined,
+      reviewId: candidate.artifact.providerId ?? null,
+      reviewUrl: candidate.artifact.url ?? null,
+    });
+  }
+  return action;
+}
+
+function shouldLogTaskWorkerAction(
+  existing: WorkerActionRecord | undefined,
+  action: WorkerActionRecord | undefined,
+): boolean {
+  if (!action) return true;
+  if (!existing) return true;
+  return existing.status !== action.status
+    || existing.summary !== action.summary
+    || existing.attemptCount !== action.attemptCount
+    || reasonFromPayload(existing.payload) !== reasonFromPayload(action.payload);
+}
+
+function logTaskWorkerAction(
+  store: Pick<PrSummaryRefreshWorkerStore, 'logEvent'>,
+  taskId: string,
+  action: WorkerActionRecord | undefined,
+  fallback: Record<string, unknown>,
+): void {
+  store.logEvent?.(taskId, 'task.worker_action', {
+    ...fallback,
+    ...(action ? {
+      id: action.id,
+      workerKind: action.workerKind,
+      actionType: action.actionType,
+      status: action.status,
+      summary: action.summary,
+      attemptCount: action.attemptCount,
+      createdAt: action.createdAt,
+      updatedAt: action.updatedAt,
+      completedAt: action.completedAt ?? null,
+    } : {}),
+  });
+}
+
+function prSummaryRefreshExternalKey(candidate: PrSummaryRefreshCandidate): string {
+  return [
+    'pr-summary-refresh',
+    candidate.mergeTask.id,
+    candidate.artifact.providerId ?? candidate.artifact.id,
+    `g${candidate.artifact.generation}`,
+  ].join(':');
+}
+
+function normalizeBodyForCompare(body: string): string {
+  return body.replace(/\r\n/g, '\n').trimEnd();
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}


### PR DESCRIPTION
## Summary

This wires the PR summary refresh worker into the app and merge-gate provider path.

It renders Pipeline body text from saved worker actions and only calls GitHub when the published body is out of date.

## Review Claim

The refresh worker is registered end to end and routes PR body updates through the merge-gate provider without launching agents.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The worker reads saved workflow state, merge-gate state, and worker action records. It only calls the provider when the freshly rendered body differs from the live body.

## Slice Rationale

This is the worker and provider routing later slices read from when they surface the same worker action history.

## Non-goals

- Do not add worker relay behavior.
- Do not add a visual worker graph.
- Do not change task timeline rendering in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --dir packages/execution-engine exec vitest run src/__tests__/pr-authoring.test.ts src/__tests__/github-merge-gate-provider.test.ts src/__tests__/worker-registry.test.ts`
- [x] `pnpm --dir packages/app exec vitest run src/__tests__/pr-summary-refresh-worker.test.ts src/__tests__/worker-control.test.ts src/__tests__/formatter.test.ts`

</details>

## Visual Proof

Worker action history is visible in the operator surfaces after the refresh route is wired through the app.

![Worker action history visible in the operator surfaces](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260714-2b23fa/worker-decisions-panel.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert beff1974`
- Post-revert steps: None.
- Data migration? No.

</details>
