### PR TITLE
[UI Responsiveness Guardrails Step 4](1) Narrow task hook helper surface

### DIFF
--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -55,18 +55,6 @@ function replaceWorkflowMapPreservingTaskBackedEntries(
   return next;
 }
 
-function workflowHasBackingTask(
-  tasks: Map<string, TaskState>,
-  workflowId: string,
-): boolean {
-  for (const task of tasks.values()) {
-    if (task.config.workflowId === workflowId) {
-      return true;
-    }
-  }
-  return false;
-}
-
 function countTasksByWorkflow(tasks: Map<string, TaskState>): Map<string, number> {
   const counts = new Map<string, number>();
   for (const task of tasks.values()) {


### PR DESCRIPTION
## Summary

The task hook now keeps only the maintained workflow-count path.

The old scan helper is no longer used after the count map became the guardrail path.

This keeps the renderer task update path smaller before the proof and chaos-gate slices.

## Review Claim

The task hook helper surface is narrowed to the maintained workflow-count path without changing task update behavior.

## Review Lane

refactor

## Review Unit

activation-surface

## Safety Invariant

The slice removes an unreferenced helper. The existing count map still decides whether task-backed workflow entries stay in the workflow map.

## Slice Rationale

This small hook-surface adjustment lands first so later proof and chaos-gate slices do not carry renderer helper churn.

## Non-goals

- No behavior change to task deltas, workflow selection, or graph rendering.
- Does not change UI performance budgets.
- Does not change the chaos matrix gate.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr4441.md --changed-files-file .tmp/pr4441-files.txt --diff-file .tmp/pr4441.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 82ec72d83`
- Post-revert steps: None.
- Data migration? No

</details>