### PR TITLE
[UI Responsiveness Guardrails Step 4](3) Require UI-stall chaos coverage

### DIFF
--- a/scripts/e2e-chaos/run-matrix.sh
+++ b/scripts/e2e-chaos/run-matrix.sh
@@ -75,6 +75,7 @@ lines = [line.strip() for line in os.environ["BASE_LINES"].splitlines() if line.
 high_risk = {
     "reset-race-coalesced",
     "timeout-deadlock-guard",
+    "retry-vs-recreate-window",
     "owner-autofix-intent",
     "owner-approve-delegated",
     "owner-reject-delegated",
@@ -240,6 +241,7 @@ fi
 echo ""
 echo "chaos matrix: $passed passed, $failed failed ($total total)"
 echo "ui-stall-relevant scenarios: $ui_stall_total"
+echo "ui-stall-required scenarios:${UI_STALL_REQUIRED_SCENARIOS//$'\n'/ }"
 echo "results jsonl: $RESULTS_FILE"
 
 if [ -z "$SCENARIO_FILTER" ]; then


### PR DESCRIPTION
## Summary

The chaos matrix now requires the retry-window UI-stall scenario.

The runner also prints the exact required UI-stall scenario set beside the summary output.

This keeps the gate policy separate from the hook refactor and the benchmark proof slice.

## Review Claim

The chaos matrix requires the retry-window scenario and emits the full UI-stall scenario set in logs.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The slice reuses the existing chaos matrix runner and scenario catalog. It only adjusts the required scenario set and output summary.

## Slice Rationale

This keeps the chaos gate policy separate from the renderer refactor and the Electron benchmark assertions.

## Non-goals

- Does not change production runtime behavior.
- Does not add a new chaos runner.
- Does not change the shell commands used by existing scenarios.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr4443.md --changed-files-file .tmp/pr4443-files.txt --diff-file .tmp/pr4443.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7c12a8751`
- Post-revert steps: None.
- Data migration? No

</details>
