### PR TITLE
Document System Setup helper install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,19 @@ npm install -g @neko-catpital-labs/invoker-slack
 
 Or grab desktop builds and standalone binaries from [GitHub Releases](https://github.com/Neko-Catpital-Labs/Invoker/releases/latest). Full install, config, and source checkout steps: [Getting started](docs/getting-started.md).
 
+Packaged installs bundle the first-party Invoker AI helpers inside the app. Install helpers from System Setup or:
+
+```bash
+invoker-ui --install-skills
+```
+
+Then, in Codex, Claude, Cursor, or OMP, run:
+
+```text
+/invoker-plan-to-invoker "help me plan <change>"
+```
+
+The command plans first, writes `plans/invoker-handoff.md`, converts it to `plans/invoker-handoff.yaml`, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
 ## Docs
 
 - [Getting started](docs/getting-started.md) — prerequisites, install, config, quick start, troubleshooting
@@ -118,6 +131,7 @@ Or grab desktop builds and standalone binaries from [GitHub Releases](https://gi
 
 More: [local macOS release build](docs/local-macos-release-build.md), [remote SSH targets](docs/remote-ssh-targets.md), [Docker executor](docs/docker-executor.md), [web surface](docs/web-surface.md), [product story](docs/invoker-medium-article.md).
 
+If you need to turn a product or implementation plan into an Invoker workflow, install helpers from System Setup or `invoker-ui --install-skills`, then run `/invoker-plan-to-invoker "help me plan <change>"` in Codex, Claude, Cursor, or OMP. The command plans first, writes `plans/invoker-handoff.md`, converts it to `plans/invoker-handoff.yaml`, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
 ## License
 
 [Functional Source License, Version 1.1, ALv2 Future License](LICENSE) (SPDX: **FSL-1.1-ALv2**). Permitted use, competing use, and the future Apache License 2.0 grant are defined in the license file.


### PR DESCRIPTION
## Summary

The root README now includes the missing helper-install note.

Before this, the setup text was incomplete.

This updates only the README copy.

## Review Claim

The getting-started docs now include the missing helper-install note.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

README-only change. No code changed.

## Slice Rationale

This keeps the queue unblocker as one docs-only diff.

## Non-goals

- No code changes.
- No app behavior changes.
- No broader README rewrite.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Reviewed the updated README section locally.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 210f00eb2`
- Post-revert steps: None
- Data migration? No

</details>

## Files (1)

- README.md [MODIFIED] (+14 -0)
