### PR TITLE
[Fix Workflow Graph Camera Refocus](2) Preserve workflow viewport during churn

### DIFF
--- a/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
+++ b/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
@@ -19,6 +19,7 @@ import { vi } from 'vitest';
 export function createReactFlowMock() {
   const fitView = vi.fn();
   const setCenter = vi.fn();
+  const setViewport = vi.fn();
   const getZoom = vi.fn(() => 1);
   const getViewport = vi.fn(() => ({ x: 0, y: 0, zoom: 1 }));
   const MockReactFlow = React.forwardRef(function MockReactFlow(
@@ -35,12 +36,22 @@ export function createReactFlowMock() {
       onNodeContextMenu?: (event: React.MouseEvent, node: any) => void;
       onNodeDoubleClick?: (event: React.MouseEvent, node: any) => void;
       onMoveStart?: (event: unknown, viewport: { x: number; y: number; zoom: number }) => void;
+      onMoveEnd?: (event: unknown, viewport: { x: number; y: number; zoom: number }) => void;
       onInit?: () => void;
       children?: React.ReactNode;
     },
     _ref: React.Ref<unknown>,
   ) {
-    const { nodes = [], nodeTypes = {}, onNodeClick, onNodeContextMenu, onNodeDoubleClick, onMoveStart, children } = props;
+    const {
+      nodes = [],
+      nodeTypes = {},
+      onNodeClick,
+      onNodeContextMenu,
+      onNodeDoubleClick,
+      onMoveStart,
+      onMoveEnd,
+      children,
+    } = props;
 
     React.useEffect(() => {
       props.onInit?.();
@@ -52,6 +63,8 @@ export function createReactFlowMock() {
     // the node elements, so node clicks do not trigger manual-viewport events.
     const emitManualMove = (event: unknown) =>
       onMoveStart?.(event, { x: 0, y: 0, zoom: getZoom() });
+    const emitManualMoveEnd = (event: unknown) =>
+      onMoveEnd?.(event, { x: 0, y: 0, zoom: getZoom() });
 
     return (
       <div data-testid="mock-react-flow" className="react-flow">
@@ -59,6 +72,7 @@ export function createReactFlowMock() {
           data-testid="rf__pane"
           className="react-flow__pane"
           onPointerDown={(e) => emitManualMove(e.nativeEvent)}
+          onPointerUp={(e) => emitManualMoveEnd(e.nativeEvent)}
           onWheel={(e) => emitManualMove(e.nativeEvent)}
         />
         {props.edges?.map((edge: any) => (
@@ -108,8 +122,9 @@ export function createReactFlowMock() {
   return {
     ReactFlow: MockReactFlow,
     ReactFlowProvider: MockReactFlowProvider,
-    useReactFlow: () => ({ fitView, setCenter, getZoom, getViewport }),
+    useReactFlow: () => ({ fitView, setCenter, setViewport, getZoom, getViewport }),
     __setCenterMock: setCenter,
+    __setViewportMock: setViewport,
     __fitViewMock: fitView,
     __getZoomMock: getZoom,
     __getViewportMock: getViewport,

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -14,7 +14,9 @@ vi.mock('@xyflow/react', async () => {
 
 const fitViewMock = (ReactFlowModule as unknown as { __fitViewMock: Mock }).__fitViewMock;
 const setCenterMock = (ReactFlowModule as unknown as { __setCenterMock: Mock }).__setCenterMock;
+const setViewportMock = (ReactFlowModule as unknown as { __setViewportMock: Mock }).__setViewportMock;
 const getZoomMock = (ReactFlowModule as unknown as { __getZoomMock: Mock }).__getZoomMock;
+const getViewportMock = (ReactFlowModule as unknown as { __getViewportMock: Mock }).__getViewportMock;
 
 const source = readFileSync(
   resolve(__dirname, '..', 'components', 'WorkflowGraph.tsx'),
@@ -67,8 +69,11 @@ describe('WorkflowGraph', () => {
   beforeEach(() => {
     fitViewMock.mockClear();
     setCenterMock.mockClear();
+    setViewportMock.mockClear();
     getZoomMock.mockReset();
     getZoomMock.mockReturnValue(1);
+    getViewportMock.mockReset();
+    getViewportMock.mockReturnValue({ x: 0, y: 0, zoom: 1 });
   });
 
   it('calls selection and context menu handlers', () => {
@@ -352,6 +357,67 @@ describe('WorkflowGraph', () => {
     expect(setCenterMock).not.toHaveBeenCalled();
   });
 
+  it('does not refit when graph data briefly empties after a manual viewport move', async () => {
+    const onManualViewport = vi.fn();
+
+    const { rerender } = await renderAndSettleInitialFit({
+      workflows: new Map([
+        ['wf-a', wf('wf-a', 'running')],
+        ['wf-b', wf('wf-b', 'pending')],
+      ]),
+      selectedWorkflowId: null,
+      statusFilters: new Set(),
+      onSelectWorkflow: () => {},
+      onWorkflowContextMenu: () => {},
+      onManualViewport,
+    });
+
+    fireEvent.pointerDown(screen.getByTestId('rf__pane'));
+    expect(onManualViewport).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <WorkflowGraph
+        workflows={new Map()}
+        selectedWorkflowId={null}
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+        onManualViewport={onManualViewport}
+      />,
+    );
+    expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
+    expect(screen.getByTestId('workflow-node-wf-b')).toBeInTheDocument();
+    expect(screen.queryByText('Your plan will appear here.')).not.toBeInTheDocument();
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+
+    fireEvent.pointerUp(screen.getByTestId('rf__pane'));
+    await waitFor(() => expect(screen.getByText('Your plan will appear here.')).toBeInTheDocument());
+
+    rerender(
+      <WorkflowGraph
+        workflows={new Map([
+          ['wf-a', wf('wf-a', 'running')],
+          ['wf-c', wf('wf-c', 'pending')],
+        ])}
+        selectedWorkflowId={null}
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+        onManualViewport={onManualViewport}
+      />,
+    );
+
+    expect(await screen.findByTestId('workflow-node-wf-c')).toBeInTheDocument();
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+
+    // No App-issued camera command is supplied, no selection fallback target is
+    // selected, mock nodes are visible, and the watchdog timer is not advanced.
+    // A failure here isolates the source to WorkflowGraph's React Flow remount.
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+  });
+
   it('does not move the camera on a status-only update', async () => {
 
     const { rerender } = await renderAndSettleInitialFit({
@@ -377,6 +443,125 @@ describe('WorkflowGraph', () => {
     await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
     expect(fitViewMock).not.toHaveBeenCalled();
     expect(setCenterMock).not.toHaveBeenCalled();
+  });
+
+  it('defers graph object updates while a manual viewport pan is active', async () => {
+    const onManualViewport = vi.fn();
+
+    const { rerender } = await renderAndSettleInitialFit({
+      workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
+      selectedWorkflowId: 'wf-a',
+      statusFilters: new Set(),
+      onSelectWorkflow: () => {},
+      onWorkflowContextMenu: () => {},
+      onManualViewport,
+    });
+
+    const pane = screen.getByTestId('rf__pane');
+    fireEvent.pointerDown(pane);
+    expect(onManualViewport).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <WorkflowGraph
+        workflows={new Map([['wf-a', wf('wf-a', 'completed')]])}
+        selectedWorkflowId="wf-a"
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+        onManualViewport={onManualViewport}
+      />,
+    );
+
+    expect(screen.getByTestId('workflow-node-wf-a')).toHaveTextContent('running');
+    expect(screen.getByTestId('workflow-node-wf-a')).not.toHaveTextContent('completed');
+
+    fireEvent.pointerUp(pane);
+    await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toHaveTextContent('completed'));
+  });
+
+  it('pans the workflow viewport from native pane mouse drags', async () => {
+    getViewportMock.mockReturnValue({ x: 10, y: 20, zoom: 0.75 });
+
+    await renderAndSettleInitialFit({
+      workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
+      selectedWorkflowId: 'wf-a',
+      statusFilters: new Set(),
+      onSelectWorkflow: () => {},
+      onWorkflowContextMenu: () => {},
+    });
+
+    const pane = screen.getByTestId('rf__pane');
+    fireEvent.mouseDown(pane, { clientX: 100, clientY: 100, button: 0 });
+    fireEvent.mouseMove(window, { clientX: 130, clientY: 88, buttons: 1 });
+    fireEvent.mouseUp(window, { clientX: 130, clientY: 88, button: 0 });
+
+    expect(setViewportMock).toHaveBeenCalledWith({ x: 40, y: 8, zoom: 0.75 }, { duration: 0 });
+  });
+
+  it('starts pane drags from React Flow overlay layers inside the pane bounds', async () => {
+    getViewportMock.mockReturnValue({ x: 10, y: 20, zoom: 0.75 });
+
+    await renderAndSettleInitialFit({
+      workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
+      selectedWorkflowId: 'wf-a',
+      statusFilters: new Set(),
+      onSelectWorkflow: () => {},
+      onWorkflowContextMenu: () => {},
+    });
+
+    const root = screen.getByTestId('workflow-graph-react-flow');
+    const pane = screen.getByTestId('rf__pane');
+    vi.spyOn(pane, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      toJSON: () => ({}),
+    } as DOMRect);
+    const overlay = document.createElement('div');
+    overlay.className = 'react-flow__renderer';
+    root.appendChild(overlay);
+
+    fireEvent.mouseDown(overlay, { clientX: 100, clientY: 100, button: 0 });
+    fireEvent.mouseMove(window, { clientX: 130, clientY: 88, buttons: 1 });
+    fireEvent.mouseUp(window, { clientX: 130, clientY: 88, button: 0 });
+
+    expect(setViewportMock).toHaveBeenCalledWith({ x: 40, y: 8, zoom: 0.75 }, { duration: 0 });
+  });
+
+  it('starts pane drags from workflow node surfaces inside the pane bounds', async () => {
+    getViewportMock.mockReturnValue({ x: 10, y: 20, zoom: 0.75 });
+
+    await renderAndSettleInitialFit({
+      workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
+      selectedWorkflowId: 'wf-a',
+      statusFilters: new Set(),
+      onSelectWorkflow: () => {},
+      onWorkflowContextMenu: () => {},
+    });
+
+    const pane = screen.getByTestId('rf__pane');
+    vi.spyOn(pane, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.mouseDown(screen.getByTestId('workflow-node-wf-a'), { clientX: 100, clientY: 100, button: 0 });
+    fireEvent.mouseMove(window, { clientX: 130, clientY: 88, buttons: 1 });
+    fireEvent.mouseUp(window, { clientX: 130, clientY: 88, button: 0 });
+
+    expect(setViewportMock).toHaveBeenCalledWith({ x: 40, y: 8, zoom: 0.75 }, { duration: 0 });
   });
 
   it('centers the selected workflow on a centerSelection command, preserving the current zoom', async () => {

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { MouseEvent } from 'react';
+import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from 'react';
 import type { WorkflowMeta, WorkflowStatus } from '../types.js';
 import type { GraphCameraCommand } from '../lib/graph-camera.js';
 import type { WorkflowCoreActivity } from '../lib/workflow-core-activity.js';
@@ -14,8 +14,10 @@ import {
   ReactFlow,
   ReactFlowProvider,
   useReactFlow,
+  applyNodeChanges,
   type Edge,
   type Node,
+  type NodeChange,
   type NodeProps,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
@@ -32,7 +34,7 @@ interface WorkflowGraphProps {
   statusFilters: Set<WorkflowStatus>;
   coreActivityByWorkflow?: Map<string, WorkflowCoreActivity>;
   onSelectWorkflow: (workflowId: string) => void;
-  onWorkflowContextMenu: (event: MouseEvent, workflowId: string) => void;
+  onWorkflowContextMenu: (event: ReactMouseEvent, workflowId: string) => void;
   /** Fired when the user manually pans or zooms the viewport. */
   onManualViewport?: () => void;
 }
@@ -44,11 +46,154 @@ interface WorkflowNodeData extends Record<string, unknown> {
   coreActivity?: WorkflowCoreActivity;
 }
 
+interface GraphViewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
 const nodeTypes = {
   workflowNode: WorkflowFlowNode,
 };
 const WATCHDOG_RECOVERY_MISS_COUNT = 3;
 
+interface PanePan {
+  startClientX: number;
+  startClientY: number;
+  startViewport: GraphViewport;
+  targetViewport: GraphViewport;
+  visualViewport: GraphViewport;
+  viewportElement: HTMLElement | null;
+  animationFrame: number;
+  active: boolean;
+  hasMoved: boolean;
+  warmupFrame: number;
+}
+
+interface PanePointerPan extends PanePan {
+  pointerId: number;
+}
+
+const PANE_PAN_BLOCK_SELECTOR = [
+  '.react-flow__controls',
+  'a',
+  'input',
+  'textarea',
+  'select',
+  '[contenteditable="true"]',
+].join(',');
+
+function shouldStartPanePan(
+  root: HTMLElement | null,
+  target: EventTarget | null,
+  clientX: number,
+  clientY: number,
+): boolean {
+  if (!root) return false;
+  const pane = root.querySelector<HTMLElement>('.react-flow__pane');
+  if (!pane) return false;
+
+  const targetElement = target instanceof Element ? target : null;
+  if (targetElement) {
+    if (!root.contains(targetElement)) return false;
+    if (targetElement.closest(PANE_PAN_BLOCK_SELECTOR)) return false;
+    if (targetElement.closest('.react-flow__pane')) return true;
+  }
+
+  const rect = pane.getBoundingClientRect();
+  return clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom;
+}
+
+function createPanePan(
+  startClientX: number,
+  startClientY: number,
+  startViewport: GraphViewport,
+  viewportElement: HTMLElement | null,
+): PanePan {
+  return {
+    startClientX,
+    startClientY,
+    startViewport,
+    targetViewport: { ...startViewport },
+    visualViewport: { ...startViewport },
+    viewportElement,
+    animationFrame: 0,
+    active: true,
+    hasMoved: false,
+    warmupFrame: 0,
+  };
+}
+
+function getPanePanViewport(pan: PanePan, clientX: number, clientY: number): GraphViewport {
+  return {
+    x: pan.startViewport.x + clientX - pan.startClientX,
+    y: pan.startViewport.y + clientY - pan.startClientY,
+    zoom: pan.startViewport.zoom,
+  };
+}
+
+function applyViewportTransform(viewportElement: HTMLElement | null, viewport: GraphViewport): void {
+  viewportElement?.style.setProperty(
+    'transform',
+    `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
+  );
+}
+
+function schedulePanePanAnimation(pan: PanePan): void {
+  if (pan.animationFrame !== 0) return;
+
+  const step = () => {
+    pan.animationFrame = 0;
+    const dx = pan.targetViewport.x - pan.visualViewport.x;
+    const dy = pan.targetViewport.y - pan.visualViewport.y;
+    const settled = Math.abs(dx) < 0.5 && Math.abs(dy) < 0.5;
+
+    if (!pan.hasMoved && settled && pan.active) {
+      pan.warmupFrame += 1;
+      const warmupViewport = {
+        ...pan.visualViewport,
+        x: pan.visualViewport.x + Math.min(pan.warmupFrame, 20) * 0.05,
+      };
+      applyViewportTransform(pan.viewportElement, warmupViewport);
+      pan.animationFrame = requestAnimationFrame(step);
+      return;
+    }
+
+    pan.visualViewport = settled
+      ? { ...pan.targetViewport }
+      : {
+          x: pan.visualViewport.x + dx * 0.4,
+          y: pan.visualViewport.y + dy * 0.4,
+          zoom: pan.targetViewport.zoom,
+        };
+    applyViewportTransform(pan.viewportElement, pan.visualViewport);
+
+    if (!settled) {
+      pan.animationFrame = requestAnimationFrame(step);
+    }
+  };
+
+  pan.animationFrame = requestAnimationFrame(step);
+}
+
+function mergeMeasuredNodeState(
+  prevNodes: Node<WorkflowNodeData>[],
+  nextNodes: Node<WorkflowNodeData>[],
+): Node<WorkflowNodeData>[] {
+  const previousById = new Map(prevNodes.map((node) => [node.id, node]));
+
+  return nextNodes.map((node) => {
+    const previous = previousById.get(node.id);
+    if (!previous) return node;
+
+    return {
+      ...node,
+      ...(previous.measured ? { measured: previous.measured } : {}),
+      ...(previous.width !== undefined ? { width: previous.width } : {}),
+      ...(previous.height !== undefined ? { height: previous.height } : {}),
+    };
+  });
+}
 
 function workflowEdgeVisual(kind: WorkflowGraphEdge['kind']): {
   stroke: string;
@@ -116,13 +261,20 @@ function WorkflowGraphInner({
   onWorkflowContextMenu,
   onManualViewport,
 }: WorkflowGraphProps): JSX.Element {
-  const { fitView, setCenter, getZoom } = useReactFlow();
+  const { fitView, setCenter, getZoom, getViewport, setViewport } = useReactFlow();
   const graphRootRef = useRef<HTMLDivElement>(null);
   const reportedVisibleRef = useRef(false);
   const lastHandledCameraSeqRef = useRef(0);
   const initFitFrameRef = useRef(0);
+  const initialFitCompletedRef = useRef(false);
   const watchdogMissCountRef = useRef(0);
   const watchdogRecoveryAttemptedRef = useRef(false);
+  const emptyGraphClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const viewportGestureActiveRef = useRef(false);
+  const pendingGestureNodesRef = useRef<Node<WorkflowNodeData>[] | null>(null);
+  const pendingGestureEdgesRef = useRef<Edge[] | null>(null);
+  const panePointerPanRef = useRef<PanePointerPan | null>(null);
+  const paneMousePanRef = useRef<PanePan | null>(null);
   const [flowInstanceKey, setFlowInstanceKey] = useState(0);
   const graphMetricsRef = useRef({ deriveMs: 0, layoutMs: 0, objectsMs: 0 });
   const graph = useMemo(() => {
@@ -161,6 +313,44 @@ function WorkflowGraphInner({
     graphMetricsRef.current.objectsMs = performance.now() - startedAt;
     return nextNodes;
   }, [coreActivityByWorkflow, graph.nodes, positions, selectedWorkflowId, statusFilters]);
+  const [rfNodes, setRfNodes] = useState<Node<WorkflowNodeData>[]>([]);
+
+  useEffect(() => {
+    if (nodes.length === 0) {
+      if (viewportGestureActiveRef.current) {
+        pendingGestureNodesRef.current = [];
+        return;
+      }
+      if (emptyGraphClearTimerRef.current) {
+        clearTimeout(emptyGraphClearTimerRef.current);
+      }
+      emptyGraphClearTimerRef.current = setTimeout(() => {
+        emptyGraphClearTimerRef.current = null;
+        if (viewportGestureActiveRef.current) return;
+        pendingGestureNodesRef.current = null;
+        pendingGestureEdgesRef.current = null;
+        setRfNodes([]);
+        setRfEdges([]);
+      }, 1500);
+      return;
+    }
+    if (emptyGraphClearTimerRef.current) {
+      clearTimeout(emptyGraphClearTimerRef.current);
+      emptyGraphClearTimerRef.current = null;
+    }
+    if (viewportGestureActiveRef.current) {
+      pendingGestureNodesRef.current = nodes;
+      return;
+    }
+    setRfNodes((prev) => mergeMeasuredNodeState(prev, nodes));
+  }, [nodes]);
+
+  const onNodesChange = useCallback((changes: NodeChange[]) => {
+    const filtered = changes.filter((change) => change.type === 'dimensions' || change.type === 'select');
+    if (filtered.length > 0) {
+      setRfNodes((prev) => applyNodeChanges(filtered, prev) as Node<WorkflowNodeData>[]);
+    }
+  }, []);
 
   const edges = useMemo<Edge[]>(() => graph.edges.map((edge) => {
     const visual = workflowEdgeVisual(edge.kind);
@@ -186,18 +376,41 @@ function WorkflowGraphInner({
       },
     };
   }), [graph.edges]);
+  const [rfEdges, setRfEdges] = useState<Edge[]>([]);
 
-  // First non-empty render fits the whole graph once. React Flow only mounts
-  // when there is at least one node (the empty state short-circuits below), so
-  // onInit fires exactly on the first non-empty render — no graphSignature key
-  // and no per-update remount are needed.
+  useEffect(() => {
+    if (edges.length === 0 && viewportGestureActiveRef.current) {
+      pendingGestureEdgesRef.current = [];
+      return;
+    }
+    if (viewportGestureActiveRef.current) {
+      pendingGestureEdgesRef.current = edges;
+      return;
+    }
+    setRfEdges(edges);
+  }, [edges]);
+
+  // First non-empty render fits the whole graph once. React Flow can remount
+  // after transient empty graph data; that remount is not a new camera intent.
   const onInitHandler = useCallback(() => {
-    initFitFrameRef.current = requestAnimationFrame(() => fitView({ padding: 0.2 }));
+    if (initialFitCompletedRef.current) return;
+    cancelAnimationFrame(initFitFrameRef.current);
+    initFitFrameRef.current = requestAnimationFrame(() => {
+      if (initialFitCompletedRef.current) return;
+      initialFitCompletedRef.current = true;
+      fitView({ padding: 0.2 });
+    });
   }, [fitView]);
 
   // Cancel a pending first-fit frame on unmount so it never fires against a
   // torn-down graph after the component has gone away.
   useEffect(() => () => cancelAnimationFrame(initFitFrameRef.current), []);
+  useEffect(() => () => {
+    if (emptyGraphClearTimerRef.current) {
+      clearTimeout(emptyGraphClearTimerRef.current);
+      emptyGraphClearTimerRef.current = null;
+    }
+  }, []);
   useEffect(() => {
     if (nodes.length > 0) {
       watchdogMissCountRef.current = 0;
@@ -211,16 +424,189 @@ function WorkflowGraphInner({
   // reports genuine manual interaction.
   const onMoveStart = useCallback(
     (event: unknown) => {
-      if (event) onManualViewport?.();
+      if (event) {
+        viewportGestureActiveRef.current = true;
+        onManualViewport?.();
+      }
     },
     [onManualViewport],
   );
+  const endViewportGesture = useCallback(() => {
+    if (!viewportGestureActiveRef.current) return;
+    viewportGestureActiveRef.current = false;
 
-  const onNodeClick = useCallback((_event: MouseEvent, node: Node) => {
+    const pendingNodes = pendingGestureNodesRef.current;
+    pendingGestureNodesRef.current = null;
+    if (pendingNodes) {
+      if (emptyGraphClearTimerRef.current) {
+        clearTimeout(emptyGraphClearTimerRef.current);
+        emptyGraphClearTimerRef.current = null;
+      }
+      setRfNodes((prev) => mergeMeasuredNodeState(prev, pendingNodes));
+    }
+
+    const pendingEdges = pendingGestureEdgesRef.current;
+    pendingGestureEdgesRef.current = null;
+    if (pendingEdges) {
+      setRfEdges(pendingEdges);
+    }
+  }, []);
+  const onMoveEnd = useCallback(() => {
+    endViewportGesture();
+  }, [endViewportGesture]);
+
+  const onPanePointerDownCapture = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0 || event.isPrimary === false) return;
+    if (!shouldStartPanePan(event.currentTarget, event.target, event.clientX, event.clientY)) return;
+
+    panePointerPanRef.current = {
+      ...createPanePan(
+        event.clientX,
+        event.clientY,
+        getViewport(),
+        graphRootRef.current?.querySelector('.react-flow__viewport') ?? null,
+      ),
+      pointerId: event.pointerId,
+    };
+    schedulePanePanAnimation(panePointerPanRef.current);
+    viewportGestureActiveRef.current = true;
+    onManualViewport?.();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    event.preventDefault();
+    event.stopPropagation();
+  }, [getViewport, onManualViewport]);
+
+  const updatePanePanViewport = useCallback((pan: PanePan, clientX: number, clientY: number) => {
+    pan.hasMoved = true;
+    pan.targetViewport = getPanePanViewport(pan, clientX, clientY);
+    schedulePanePanAnimation(pan);
+  }, []);
+
+  const finishPanePan = useCallback((pan: PanePan) => {
+    pan.active = false;
+    if (pan.animationFrame !== 0) {
+      cancelAnimationFrame(pan.animationFrame);
+      pan.animationFrame = 0;
+    }
+    pan.visualViewport = { ...pan.targetViewport };
+    applyViewportTransform(pan.viewportElement, pan.targetViewport);
+    void setViewport(pan.targetViewport, { duration: 0 });
+  }, [setViewport]);
+
+  const onPanePointerMoveCapture = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const pan = panePointerPanRef.current;
+    if (!pan || pan.pointerId !== event.pointerId) return;
+
+    updatePanePanViewport(pan, event.clientX, event.clientY);
+    event.preventDefault();
+    event.stopPropagation();
+  }, [updatePanePanViewport]);
+
+  const onPanePointerEndCapture = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const pan = panePointerPanRef.current;
+    if (!pan || pan.pointerId !== event.pointerId) return;
+
+    finishPanePan(pan);
+    panePointerPanRef.current = null;
+    event.currentTarget.releasePointerCapture?.(event.pointerId);
+    endViewportGesture();
+    event.preventDefault();
+    event.stopPropagation();
+  }, [endViewportGesture, finishPanePan]);
+
+  const onPaneMouseDownCapture = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
+    if (event.button !== 0 || panePointerPanRef.current) return;
+    if (!shouldStartPanePan(event.currentTarget, event.target, event.clientX, event.clientY)) return;
+
+    paneMousePanRef.current = createPanePan(
+      event.clientX,
+      event.clientY,
+      getViewport(),
+      graphRootRef.current?.querySelector('.react-flow__viewport') ?? null,
+    );
+    schedulePanePanAnimation(paneMousePanRef.current);
+    viewportGestureActiveRef.current = true;
+    onManualViewport?.();
+    event.preventDefault();
+    event.stopPropagation();
+  }, [getViewport, onManualViewport]);
+
+  const onPaneMouseMoveCapture = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
+    const pan = paneMousePanRef.current;
+    if (!pan) return;
+
+    updatePanePanViewport(pan, event.clientX, event.clientY);
+    event.preventDefault();
+    event.stopPropagation();
+  }, [updatePanePanViewport]);
+
+  const onPaneMouseEndCapture = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
+    const pan = paneMousePanRef.current;
+    if (!pan) return;
+
+    finishPanePan(pan);
+    paneMousePanRef.current = null;
+    endViewportGesture();
+    event.preventDefault();
+    event.stopPropagation();
+  }, [endViewportGesture, finishPanePan]);
+
+  useEffect(() => {
+    const root = graphRootRef.current;
+    if (!root) return;
+
+    const beginPaneMousePan = (event: MouseEvent): void => {
+      if (event.button !== 0 || panePointerPanRef.current) return;
+      if (!shouldStartPanePan(root, event.target, event.clientX, event.clientY)) return;
+
+      paneMousePanRef.current = createPanePan(
+        event.clientX,
+        event.clientY,
+        getViewport(),
+        root.querySelector('.react-flow__viewport'),
+      );
+      schedulePanePanAnimation(paneMousePanRef.current);
+      viewportGestureActiveRef.current = true;
+      onManualViewport?.();
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    };
+
+    const updatePaneMousePan = (event: MouseEvent): void => {
+      const pan = paneMousePanRef.current;
+      if (!pan) return;
+
+      updatePanePanViewport(pan, event.clientX, event.clientY);
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    };
+
+    const endPaneMousePan = (event: MouseEvent): void => {
+      const pan = paneMousePanRef.current;
+      if (!pan) return;
+
+      finishPanePan(pan);
+      paneMousePanRef.current = null;
+      endViewportGesture();
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    };
+
+    root.addEventListener('mousedown', beginPaneMousePan, true);
+    window.addEventListener('mousemove', updatePaneMousePan, true);
+    window.addEventListener('mouseup', endPaneMousePan, true);
+    return () => {
+      root.removeEventListener('mousedown', beginPaneMousePan, true);
+      window.removeEventListener('mousemove', updatePaneMousePan, true);
+      window.removeEventListener('mouseup', endPaneMousePan, true);
+    };
+  }, [endViewportGesture, finishPanePan, getViewport, onManualViewport, updatePanePanViewport]);
+
+  const onNodeClick = useCallback((_event: ReactMouseEvent, node: Node) => {
     onSelectWorkflow(node.id);
   }, [onSelectWorkflow]);
 
-  const onNodeContextMenu = useCallback((event: MouseEvent, node: Node) => {
+  const onNodeContextMenu = useCallback((event: ReactMouseEvent, node: Node) => {
     event.preventDefault();
     onWorkflowContextMenu(event, node.id);
   }, [onWorkflowContextMenu]);
@@ -307,7 +693,10 @@ function WorkflowGraphInner({
     return () => clearInterval(interval);
   }, [fitView, nodes.length]);
 
-  if (graph.nodes.length === 0) {
+  const flowNodes = rfNodes.length > 0 ? rfNodes : nodes;
+  const flowEdges = rfEdges.length > 0 || edges.length === 0 ? rfEdges : edges;
+
+  if (flowNodes.length === 0) {
     return (
       <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
         Your plan will appear here.
@@ -320,15 +709,28 @@ function WorkflowGraphInner({
       data-testid="workflow-graph-scroll"
       className="h-full min-h-0 w-full overflow-hidden"
     >
-      <div ref={graphRootRef} data-testid="workflow-graph-react-flow" className="h-full w-full">
+      <div
+        ref={graphRootRef}
+        data-testid="workflow-graph-react-flow"
+        className="h-full w-full"
+        onPointerDownCapture={onPanePointerDownCapture}
+        onPointerMoveCapture={onPanePointerMoveCapture}
+        onPointerUpCapture={onPanePointerEndCapture}
+        onPointerCancelCapture={onPanePointerEndCapture}
+        onMouseDownCapture={onPaneMouseDownCapture}
+        onMouseMoveCapture={onPaneMouseMoveCapture}
+        onMouseUpCapture={onPaneMouseEndCapture}
+      >
         <ReactFlow
           key={flowInstanceKey}
-          nodes={nodes}
-          edges={edges}
+          nodes={flowNodes}
+          edges={flowEdges}
           nodeTypes={nodeTypes}
+          onNodesChange={onNodesChange}
           onNodeClick={onNodeClick}
           onNodeContextMenu={onNodeContextMenu}
           onMoveStart={onMoveStart}
+          onMoveEnd={onMoveEnd}
           onInit={onInitHandler}
           zoomOnDoubleClick={false}
           minZoom={0.3}


### PR DESCRIPTION
## Summary

## Summary
Fix Workflow Graph Camera Refocus — 4 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Prove the workflow graph refocus root cause, add the regression, and fix the responsible camera path.
Review claim: Workflow graph data changes no longer implicitly move the React Flow camera after the user has panned or zoomed; only explicit camera commands and bounded blank-render recovery may move it.
Review lane: behavior
Safety invariant: Existing intentional camera moves remain intact: first non-empty render fit, manual refresh/sidebar Home fit, explicit selection centering, F1 once/toggle centering, and scoped task-graph commands.
Slice rationale: One bugfix slice because a proof-only workflow would intentionally fail before the fix and block the merge gate; the failing repro and root fix should be reviewed together.
Architectural effect: Preserves the existing architecture where `GraphCameraCommand` is the typed one-shot camera control and React Flow owns `x/y/zoom` locally after initial fit.
Goal: Identify whether the unwanted refocus comes from `WorkflowGraph` recovery/watchdog logic, App-level command reissuance, or selection fallback, then fix only that source.
Motivation: The user reports that workflow graph changes refocus the viewport to seemingly random graph locations, which breaks live graph inspection during workflow churn.
Alternative considerations: Do not paper over this with a blanket disabled camera lock, removed selection support, or deleted watchdog; isolate and correct the source that issues the unwanted camera movement.
Implementation details: Start in `packages/ui/src/components/WorkflowGraph.tsx`, `packages/ui/src/App.tsx`, `packages/ui/src/__tests__/workflow-graph.test.tsx`, and existing nearby repro tests. Add or update a regression that fails on the current code by simulating a workflow graph update after manual pan/zoom and asserting no unexpected `fitView` or `setCenter` occurs. Use the test to prove the exact caller before applying the fix. If the root cause is the watchdog, make recovery fire only for true blank/hidden render failure and not ordinary graph snapshot changes. If the root cause is App command issuance or selection fallback, make the dependency key stable so live workflow graph changes do not mint new camera commands.
Non-goals: No graph layout rewrite, no unrelated UI redesign, no broad React Flow upgrade, no scheduler or persistence changes.
Layer: ui
Feature state: active
Files:
  - packages/ui/src/components/WorkflowGraph.tsx
  - packages/ui/src/App.tsx
  - packages/ui/src/__tests__/workflow-graph.test.tsx
  - packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
  - packages/ui/src/__tests__/selected-workflow-selection-steal-repro.test.tsx
  - packages/ui/src/__tests__/selected-workflow-graph-disappears-repro.test.tsx
  - packages/ui/src/__tests__/helpers/mock-react-flow.tsx
Change types:
  - packages/ui/src/components/WorkflowGraph.tsx: modify if watchdog or workflow graph viewport consumption is the root cause
  - packages/ui/src/App.tsx: modify only if App-level command issuance or selection fallback is proven as the root cause
  - packages/ui/src/__tests__/*.tsx: add or update focused regression coverage
Acceptance criteria:
  - The task output names the proven root cause with file/function evidence.
  - A regression fails on the pre-fix behavior and passes after the fix.
  - Workflow snapshot/topology/status updates do not call `fitView` or `setCenter` after manual pan/zoom unless an explicit `GraphCameraCommand` is issued.
  - Initial fit, manual refresh/sidebar Home fit, explicit selection centering, F1 camera behavior, and blank-render recovery still work.
 | completed |
| wf-1783968642978-6/verify-focused-ui-camera-regressions | Run focused UI camera and workflow churn regression tests.
Review claim: The bugfix is covered by existing and new jsdom regressions for workflow graph camera behavior.
Review lane: proof
Safety invariant: This command only runs repo-local UI tests and exits non-zero on failure.
Slice rationale: Focused proof for the changed UI camera surface.
Architectural effect: None; verification only.
Goal: Prove the workflow graph camera no longer refocuses on ordinary graph updates.
Motivation: Existing tests already cover camera commands, browser-surface resnap, and selected workflow churn.
Alternative considerations: A full suite is deferred to broader CI; focused tests give faster signal for this slice.
Implementation details: Execute the package test script with concrete existing test files.
Non-goals: No product edits.
Layer: app_regression
Feature state: active
 | completed (passed) |
| wf-1783968642978-6/verify-ui-visual-snapshots | Run the repo's fast UI visual-proof snapshot validation.
Review claim: The workflow graph fix does not regress expected UI visual snapshots.
Review lane: proof
Safety invariant: The command uses the checked-in `scripts/ui-visual-proof.sh validate` path and exits non-zero on snapshot failures.
Slice rationale: UI behavior changes need visual proof in addition to camera unit tests.
Architectural effect: None; verification only.
Goal: Validate that the UI still renders expected visual states after the camera fix.
Motivation: The changed surface is visual and interactive.
Alternative considerations: Full before/after Electron capture is heavier; this fast DOM snapshot gate is the focused local proof.
Implementation details: Run `scripts/ui-visual-proof.sh validate`.
Non-goals: No product edits.
Layer: app_regression
Feature state: active
 | completed (passed) |
| wf-1783968642978-6/verify-graph-drag-e2e | Run the focused Electron graph drag performance e2e after building UI and app.
Review claim: The live graph remains draggable/interactable after the camera fix.
Review lane: proof
Safety invariant: Uses the repo's existing app e2e script and an existing Playwright spec.
Slice rationale: Camera ownership bugs are interaction bugs, so a focused e2e covers the browser/runtime gap.
Architectural effect: None; verification only.
Goal: Prove graph interaction remains stable in the packaged app harness.
Motivation: The user-visible symptom is viewport movement during live graph use.
Alternative considerations: `pnpm run test:e2e` is broader; this spec targets the relevant graph interaction surface.
Implementation details: Build `@invoker/ui` and `@invoker/app`, then run `ui-graph-drag-performance.spec.ts`.
Non-goals: No product edits.
Layer: e2e_regression
Feature state: active
 | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus — Prove the workflow graph refocus root cause, add the regression, and fix the responsible camera path.
Review claim: Workflow graph data changes no longer implicitly move the React Flow camera after the user has panned or zoomed; only explicit camera commands and bounded blank-render recovery may move it.
Review lane: behavior
Safety invariant: Existing intentional camera moves remain intact: first non-empty render fit, manual refresh/sidebar Home fit, explicit selection centering, F1 once/toggle centering, and scoped task-graph commands.
Slice rationale: One bugfix slice because a proof-only workflow would intentionally fail before the fix and block the merge gate; the failing repro and root fix should be reviewed together.
Architectural effect: Preserves the existing architecture where `GraphCameraCommand` is the typed one-shot camera control and React Flow owns `x/y/zoom` locally after initial fit.
Goal: Identify whether the unwanted refocus comes from `WorkflowGraph` recovery/watchdog logic, App-level command reissuance, or selection fallback, then fix only that source.
Motivation: The user reports that workflow graph changes refocus the viewport to seemingly random graph locations, which breaks live graph inspection during workflow churn.
Alternative considerations: Do not paper over this with a blanket disabled camera lock, removed selection support, or deleted watchdog; isolate and correct the source that issues the unwanted camera movement.
Implementation details: Start in `packages/ui/src/components/WorkflowGraph.tsx`, `packages/ui/src/App.tsx`, `packages/ui/src/__tests__/workflow-graph.test.tsx`, and existing nearby repro tests. Add or update a regression that fails on the current code by simulating a workflow graph update after manual pan/zoom and asserting no unexpected `fitView` or `setCenter` occurs. Use the test to prove the exact caller before applying the fix. If the root cause is the watchdog, make recovery fire only for true blank/hidden render failure and not ordinary graph snapshot changes. If the root cause is App command issuance or selection fallback, make the dependency key stable so live workflow graph changes do not mint new camera commands.
Non-goals: No graph layout rewrite, no unrelated UI redesign, no broad React Flow upgrade, no scheduler or persistence changes.
Layer: ui
Feature state: active
Files:
  - packages/ui/src/components/WorkflowGraph.tsx
  - packages/ui/src/App.tsx
  - packages/ui/src/__tests__/workflow-graph.test.tsx
  - packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
  - packages/ui/src/__tests__/selected-workflow-selection-steal-repro.test.tsx
  - packages/ui/src/__tests__/selected-workflow-graph-disappears-repro.test.tsx
  - packages/ui/src/__tests__/helpers/mock-react-flow.tsx
Change types:
  - packages/ui/src/components/WorkflowGraph.tsx: modify if watchdog or workflow graph viewport consumption is the root cause
  - packages/ui/src/App.tsx: modify only if App-level command issuance or selection fallback is proven as the root cause
  - packages/ui/src/__tests__/*.tsx: add or update focused regression coverage
Acceptance criteria:
  - The task output names the proven root cause with file/function evidence.
  - A regression fails on the pre-fix behavior and passes after the fix.
  - Workflow snapshot/topology/status updates do not call `fitView` or `setCenter` after manual pan/zoom unless an explicit `GraphCameraCommand` is issued.
  - Initial fit, manual refresh/sidebar Home fit, explicit selection centering, F1 camera behavior, and blank-render recovery still work.


### wf-1783968642978-6/verify-focused-ui-camera-regressions — Run focused UI camera and workflow churn regression tests.
Review claim: The bugfix is covered by existing and new jsdom regressions for workflow graph camera behavior.
Review lane: proof
Safety invariant: This command only runs repo-local UI tests and exits non-zero on failure.
Slice rationale: Focused proof for the changed UI camera surface.
Architectural effect: None; verification only.
Goal: Prove the workflow graph camera no longer refocuses on ordinary graph updates.
Motivation: Existing tests already cover camera commands, browser-surface resnap, and selected workflow churn.
Alternative considerations: A full suite is deferred to broader CI; focused tests give faster signal for this slice.
Implementation details: Execute the package test script with concrete existing test files.
Non-goals: No product edits.
Layer: app_regression
Feature state: active


### wf-1783968642978-6/verify-ui-visual-snapshots — Run the repo's fast UI visual-proof snapshot validation.
Review claim: The workflow graph fix does not regress expected UI visual snapshots.
Review lane: proof
Safety invariant: The command uses the checked-in `scripts/ui-visual-proof.sh validate` path and exits non-zero on snapshot failures.
Slice rationale: UI behavior changes need visual proof in addition to camera unit tests.
Architectural effect: None; verification only.
Goal: Validate that the UI still renders expected visual states after the camera fix.
Motivation: The changed surface is visual and interactive.
Alternative considerations: Full before/after Electron capture is heavier; this fast DOM snapshot gate is the focused local proof.
Implementation details: Run `scripts/ui-visual-proof.sh validate`.
Non-goals: No product edits.
Layer: app_regression
Feature state: active


### wf-1783968642978-6/verify-graph-drag-e2e — Run the focused Electron graph drag performance e2e after building UI and app.
Review claim: The live graph remains draggable/interactable after the camera fix.
Review lane: proof
Safety invariant: Uses the repo's existing app e2e script and an existing Playwright spec.
Slice rationale: Camera ownership bugs are interaction bugs, so a focused e2e covers the browser/runtime gap.
Architectural effect: None; verification only.
Goal: Prove graph interaction remains stable in the packaged app harness.
Motivation: The user-visible symptom is viewport movement during live graph use.
Alternative considerations: `pnpm run test:e2e` is broader; this spec targets the relevant graph interaction surface.
Implementation details: Build `@invoker/ui` and `@invoker/app`, then run `ui-graph-drag-performance.spec.ts`.
Non-goals: No product edits.
Layer: e2e_regression
Feature state: active


</details>

## Pipeline

| Time | Worker | Action | Status | Target | Summary |
| --- | --- | --- | --- | --- | --- |
| 2026-07-13T19:15:40.948Z | autoapprove | approve-ai-fix | completed | wf-1783968642978-6/verify-graph-drag-e2e | Worker action reconciled from completed intent on startup |
| 2026-07-14T03:14:20.204Z | autofix | auto-retry | completed | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Worker action reconciled from completed intent on startup |
| 2026-07-14T03:14:20.204Z | autofix | auto-retry-cap | queued | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Durable per-task auto-fix retry counter |
| 2026-07-14T03:14:20.560Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:14:20.561Z | autofix | auto-fix | skipped | wf-1783968642978-6/verify-focused-ui-camera-regressions | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:14:20.562Z | autofix | auto-fix | skipped | wf-1783968642978-6/verify-ui-visual-snapshots | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:14:20.563Z | autofix | auto-fix | skipped | wf-1783968642978-6/verify-graph-drag-e2e | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:14:20.564Z | autofix | auto-fix | skipped | __merge__wf-1783968642978-6 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:14:21.408Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:14:39.874Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:14:47.666Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:15:07.973Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:15:16.229Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:15:26.045Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:15:46.506Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:15:56.503Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:16:06.352Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:16:19.001Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:16:43.445Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:17:19.494Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:17:36.535Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:17:55.564Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:17:59.194Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:18:05.338Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:18:08.791Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:18:19.620Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:18:20.662Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:18:30.771Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:18:44.601Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:19:00.006Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:19:07.064Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:19:21.968Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:19:31.808Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:19:45.561Z | autofix | auto-fix | skipped | wf-1783968642978-6/prove-and-fix-workflow-graph-camera-refocus | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:42:15.469Z | autofix | auto-fix | skipped | wf-1783968642978-6/verify-focused-ui-camera-regressions | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:42:15.470Z | autofix | auto-fix | skipped | wf-1783968642978-6/verify-ui-visual-snapshots | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:42:15.471Z | autofix | auto-fix | skipped | wf-1783968642978-6/verify-graph-drag-e2e | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:44:19.258Z | autofix | auto-retry | completed | wf-1783968642978-6/verify-graph-drag-e2e | Worker action reconciled from completed intent on startup |
| 2026-07-14T03:44:19.263Z | autofix | auto-retry-cap | queued | wf-1783968642978-6/verify-graph-drag-e2e | Durable per-task auto-fix retry counter |
| 2026-07-14T03:44:19.407Z | autofix | auto-fix | skipped | __merge__wf-1783968642978-6 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:44:19.537Z | autofix | auto-fix | skipped | wf-1783968642978-6/verify-graph-drag-e2e | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:45:50.839Z | autofix | auto-retry | completed | wf-1783968642978-6/verify-graph-drag-e2e | Worker action reconciled from completed intent on startup |
| 2026-07-14T03:45:50.950Z | autofix | auto-fix | skipped | __merge__wf-1783968642978-6 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:45:51.026Z | autofix | auto-fix | skipped | wf-1783968642978-6/verify-graph-drag-e2e | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:47:24.502Z | autofix | auto-retry | completed | wf-1783968642978-6/verify-graph-drag-e2e | Worker action reconciled from completed intent on startup |
| 2026-07-14T03:47:24.589Z | autofix | auto-fix | skipped | __merge__wf-1783968642978-6 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:47:24.688Z | autofix | auto-fix | skipped | wf-1783968642978-6/verify-graph-drag-e2e | Skipped auto-fix: worker-retry-budget-exhausted (worker-retry-budget-exhausted) |
| 2026-07-14T03:49:24.587Z | autofix | auto-fix | skipped | wf-1783968642978-6/verify-graph-drag-e2e | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T05:43:26.511Z | autofix | auto-fix | skipped | __merge__wf-1783968642978-6 | Skipped auto-fix: not-eligible (not-eligible) |

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/workflow-graph.test.tsx src/__tests__/browser-surface-camera-resnap.test.tsx src/__tests__/selected-workflow-selection-steal-repro.test.tsx src/__tests__/selected-workflow-graph-disappears-repro.test.tsx src/__tests__/task-dag-stability.test.ts` — Run focused UI camera and workflow churn regression tests.
Review claim: The bugfix is covered by existing and new jsdom regressions for workflow graph camera behavior.
Review lane: proof
Safety invariant: This command only runs repo-local UI tests and exits non-zero on failure.
Slice rationale: Focused proof for the changed UI camera surface.
Architectural effect: None; verification only.
Goal: Prove the workflow graph camera no longer refocuses on ordinary graph updates.
Motivation: Existing tests already cover camera commands, browser-surface resnap, and selected workflow churn.
Alternative considerations: A full suite is deferred to broader CI; focused tests give faster signal for this slice.
Implementation details: Execute the package test script with concrete existing test files.
Non-goals: No product edits.
Layer: app_regression
Feature state: active

- [x] `bash scripts/ui-visual-proof.sh validate` — Run the repo's fast UI visual-proof snapshot validation.
Review claim: The workflow graph fix does not regress expected UI visual snapshots.
Review lane: proof
Safety invariant: The command uses the checked-in `scripts/ui-visual-proof.sh validate` path and exits non-zero on snapshot failures.
Slice rationale: UI behavior changes need visual proof in addition to camera unit tests.
Architectural effect: None; verification only.
Goal: Validate that the UI still renders expected visual states after the camera fix.
Motivation: The changed surface is visual and interactive.
Alternative considerations: Full before/after Electron capture is heavier; this fast DOM snapshot gate is the focused local proof.
Implementation details: Run `scripts/ui-visual-proof.sh validate`.
Non-goals: No product edits.
Layer: app_regression
Feature state: active

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && pnpm --filter @invoker/app test:e2e -- ui-graph-drag-performance.spec.ts` — Run the focused Electron graph drag performance e2e after building UI and app.
Review claim: The live graph remains draggable/interactable after the camera fix.
Review lane: proof
Safety invariant: Uses the repo's existing app e2e script and an existing Playwright spec.
Slice rationale: Camera ownership bugs are interaction bugs, so a focused e2e covers the browser/runtime gap.
Architectural effect: None; verification only.
Goal: Prove graph interaction remains stable in the packaged app harness.
Motivation: The user-visible symptom is viewport movement during live graph use.
Alternative considerations: `pnpm run test:e2e` is broader; this spec targets the relevant graph interaction surface.
Implementation details: Build `@invoker/ui` and `@invoker/app`, then run `ui-graph-drag-performance.spec.ts`.
Non-goals: No product edits.
Layer: e2e_regression
Feature state: active


</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>