### PR TITLE
[Review Gate CI Substate](1) Persist review-gate CI substate data

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -125,6 +125,14 @@ export interface WorkResponseOutputs {
   /** Typed review-gate artifact state produced by merge-gate style actions. */
   reviewGate?: ReviewGateState;
 }
+export type ReviewGateSubstate =
+  | 'review_open'
+  | 'ci_pending'
+  | 'ci_failing'
+  | 'merge_conflict'
+  | 'fix_pending'
+  | 'ready_to_land';
+
 
 export interface ReviewGateQueryResponse {
   workflowId: string;
@@ -133,6 +141,7 @@ export interface ReviewGateQueryResponse {
   activeGeneration: number | null;
   completion: { required: 'all'; status: 'approved' };
   ready: boolean;
+  substate?: ReviewGateSubstate | null;
   artifacts: ReviewGateArtifact[];
   discardedArtifacts: ReviewGateArtifact[];
   edges: Array<{ from: string; to: string }>;

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -141,6 +141,13 @@ export type ReviewGateArtifactStatus =
   | 'discarded'
   | 'unknown';
 
+export interface MergeGateFailedCheck {
+  readonly name: string;
+  readonly conclusion?: string;
+  readonly detailsUrl?: string;
+  readonly summary?: string;
+}
+
 export interface ReviewGateArtifact {
   readonly id: string;
   readonly title?: string;
@@ -154,6 +161,9 @@ export interface ReviewGateArtifact {
   readonly required: boolean;
   readonly status: ReviewGateArtifactStatus;
   readonly rawStatus?: string;
+  readonly checksState?: 'pending' | 'success' | 'failure';
+  readonly failedChecks?: readonly MergeGateFailedCheck[];
+  readonly mergeState?: 'clean' | 'dirty' | 'unknown';
   readonly dependsOn?: readonly string[];
   readonly generation: number;
   readonly createdAt?: string;


### PR DESCRIPTION
## Summary

This slice adds typed review-gate fields to the shared stored artifact shapes.

It also adds the shared `substate` field to the shared types used by later slices.

## Review Claim

Add typed review-gate metadata fields to the shared type contracts, including the new `substate` field.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This slice changes shared type contracts only. It does not change merge publication, approval, polling, or operator surfaces.

## Slice Rationale

The later slices need these shared fields first. Landing the type contract alone keeps the base slice small and easy to trust.

## Non-goals

- Do not change pull-request lifecycle behavior yet.
- Do not change CI repair behavior yet.
- Do not change any operator-facing output yet.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 92fe95fe8`
- Post-revert steps: None
- Data migration? No

</details>
