### PR TITLE
[Review Gate CI Substate](3) Surface review-gate substates

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -397,6 +397,7 @@ describe('GET /api/workflows/:id/review-gate', () => {
       mergeTaskId: null,
       status: null,
       ready: false,
+      substate: null,
       artifacts: [],
       discardedArtifacts: [],
       edges: [],

--- a/packages/app/src/__tests__/headless-query-review-gate.test.ts
+++ b/packages/app/src/__tests__/headless-query-review-gate.test.ts
@@ -23,6 +23,32 @@ const record: ReviewGateLookup = {
   mergeTaskStatus: 'running',
   selectedAttemptId: 'wf-42/__merge__wf-42-attempt-1',
 };
+const reviewGateTasks = [{
+  id: '__merge__wf-42',
+  description: 'Review gate for wf-42',
+  status: 'review_ready',
+  dependencies: [],
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  config: { workflowId: 'wf-42', isMergeNode: true },
+  execution: {
+    generation: 2,
+    reviewId: '999',
+    reviewUrl: 'https://github.com/owner/repo/pull/999',
+    reviewGate: {
+      activeGeneration: 2,
+      completion: { required: 'all', status: 'approved' as const },
+      artifacts: [{
+        id: '999',
+        providerId: '999',
+        required: true,
+        status: 'open' as const,
+        generation: 2,
+        checksState: 'pending' as const,
+      }],
+    },
+  },
+}] as any[];
+
 
 describe('headless query review-gate', () => {
   let mockDeps: HeadlessDeps;
@@ -37,7 +63,10 @@ describe('headless query review-gate', () => {
       persistence: {
         readOnly: true,
         findReviewGateByPr,
+        loadWorkflow: vi.fn(() => ({ id: 'wf-42', name: 'Workflow 42' })),
+        loadTasks: vi.fn(() => reviewGateTasks),
       } as unknown as SQLiteAdapter,
+
       commandService: {} as unknown as CommandService,
       executorRegistry: {} as unknown as HeadlessDeps['executorRegistry'],
       messageBus: new LocalBus() as MessageBus,
@@ -92,11 +121,12 @@ describe('headless query review-gate', () => {
     await runHeadless(['query', 'review-gate', '123456', '--output', 'jsonl'], mockDeps);
     expect((stdoutSpy.mock.calls[0][0] as string).trim()).toBe('');
   });
-  it('prints a human text line by default and a clear miss message', async () => {
+  it('prints a human text line by default with the derived review substate and a clear miss message', async () => {
     await runHeadless(['query', 'review-gate', '999'], mockDeps);
     const line = stdoutSpy.mock.calls[0][0] as string;
     expect(line).toContain('wf-42');
     expect(line).toContain('running');
+    expect(line).toContain('substate=ci_pending');
     expect(line).not.toContain('{');
 
     stdoutSpy.mockClear();

--- a/packages/app/src/__tests__/ipc-read-handlers.test.ts
+++ b/packages/app/src/__tests__/ipc-read-handlers.test.ts
@@ -118,6 +118,7 @@ describe('registerReadOnlyIpcHandlers', () => {
         { from: 'runtime', to: 'ui' },
       ],
       ready: false,
+      substate: 'review_open',
     });
   });
 

--- a/packages/app/src/__tests__/review-gate-status-worker.test.ts
+++ b/packages/app/src/__tests__/review-gate-status-worker.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-
+import { Channels } from '@invoker/transport';
+import type { TaskState } from '@invoker/workflow-core';
 import { startReviewGateStatusWorker } from '../review-gate-status-worker.js';
+import { startSurfaceEventRelay } from '../surface-event-relay.js';
+
 
 const logger = {
   info: vi.fn(),
@@ -9,6 +12,50 @@ const logger = {
   debug: vi.fn(),
   trace: vi.fn(),
 };
+
+function createRelayBus() {
+  const handlers = new Map<string, (payload: unknown) => void>();
+  return {
+    bus: {
+      publish: vi.fn(),
+      subscribe: vi.fn((channel: string, handler: (payload: unknown) => void) => {
+        handlers.set(channel, handler);
+        return () => handlers.delete(channel);
+      }),
+    },
+    emit(channel: string, payload: unknown) {
+      handlers.get(channel)?.(payload);
+    },
+  };
+}
+
+function makeReviewGateTask(overrides: Partial<TaskState['execution']> = {}): TaskState {
+  return {
+    id: '__merge__wf-1',
+    description: 'Review gate for wf-1',
+    status: 'review_ready',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: 'wf-1', isMergeNode: true },
+    execution: {
+      generation: 0,
+      reviewId: 'owner/repo#1',
+      reviewUrl: 'https://github.com/owner/repo/pull/1',
+      reviewGate: {
+        activeGeneration: 0,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [{
+          id: 'owner/repo#1',
+          providerId: 'owner/repo#1',
+          required: true,
+          status: 'open',
+          generation: 0,
+        }],
+      },
+      ...overrides,
+    },
+  } as TaskState;
+}
 
 describe('review-gate status worker', () => {
   afterEach(() => {
@@ -128,5 +175,68 @@ describe('review-gate status worker', () => {
     worker?.stop();
     await vi.advanceTimersByTimeAsync(3000);
     expect(checkMergeGateStatuses).not.toHaveBeenCalled();
+  });
+  it.each([
+    ['review_open', makeReviewGateTask(), 'review open'],
+    ['ci_pending', makeReviewGateTask({
+      reviewGate: {
+        activeGeneration: 0,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [{ id: 'owner/repo#1', providerId: 'owner/repo#1', required: true, status: 'open', generation: 0, checksState: 'pending' }],
+      },
+    }), 'CI pending'],
+    ['ci_failing', makeReviewGateTask({
+      reviewGate: {
+        activeGeneration: 0,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [{ id: 'owner/repo#1', providerId: 'owner/repo#1', required: true, status: 'open', generation: 0, checksState: 'failure' }],
+      },
+    }), 'CI failing'],
+    ['merge_conflict', makeReviewGateTask({
+      reviewGate: {
+        activeGeneration: 0,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [{ id: 'owner/repo#1', providerId: 'owner/repo#1', required: true, status: 'open', generation: 0, mergeState: 'dirty' }],
+      },
+    }), 'merge conflict'],
+    ['fix_pending', makeReviewGateTask({ pendingFixError: 'lint failed' }), 'fix pending approval'],
+    ['ready_to_land', makeReviewGateTask({
+      reviewGate: {
+        activeGeneration: 0,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [{ id: 'owner/repo#1', providerId: 'owner/repo#1', required: true, status: 'open', generation: 0, checksState: 'success' }],
+      },
+    }), 'ready to land'],
+  ])('emits workflow progress review state for %s', async (_name, mergeTask, expected) => {
+    vi.useFakeTimers();
+    const relay = createRelayBus();
+    const stop = startSurfaceEventRelay({
+      messageBus: relay.bus as any,
+      persistence: {
+        loadTasks: vi.fn(() => [mergeTask]),
+        loadWorkflow: vi.fn(() => ({ id: 'wf-1', name: 'Workflow 1' })),
+      },
+      orchestrator: {
+        getWorkflowStatus: vi.fn(() => ({ total: 1, completed: 0 })),
+      } as any,
+      logWarn: vi.fn(),
+    });
+
+    relay.emit(Channels.TASK_DELTA, {
+      type: 'updated',
+      taskId: mergeTask.id,
+      changes: { status: mergeTask.status },
+      taskStateVersion: 1,
+      previousTaskStateVersion: 0,
+    });
+    await vi.advanceTimersByTimeAsync(2500);
+
+    expect(relay.bus.publish).toHaveBeenCalledWith(
+      Channels.SURFACE_EVENT,
+      expect.objectContaining({
+        progress: expect.objectContaining({ reviewState: expected }),
+      }),
+    );
+    stop();
   });
 });

--- a/packages/app/src/__tests__/task-runner-wiring.test.ts
+++ b/packages/app/src/__tests__/task-runner-wiring.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TaskState } from '@invoker/workflow-core';
-import {
-  publishReviewGateCiFailedLifecycleEvent,
-  publishReviewGateMergeConflictLifecycleEvent,
-} from '../lifecycle-event-bridge.js';
+import { publishReviewGateCiFailedLifecycleEvent } from '../lifecycle-event-bridge.js';
 import { loadConfig, resolveSecretsFilePath } from '../config.js';
 import {
   killRunningTaskExecution,
@@ -48,7 +45,6 @@ vi.mock('@invoker/execution-engine', () => {
 
 vi.mock('../lifecycle-event-bridge.js', () => ({
   publishReviewGateCiFailedLifecycleEvent: vi.fn(),
-  publishReviewGateMergeConflictLifecycleEvent: vi.fn(),
 }));
 
 vi.mock('../config.js', () => ({
@@ -195,8 +191,9 @@ describe('task-runner-wiring', () => {
     };
     const persistence = {
       updateTask: vi.fn(),
-      loadWorkflow: vi.fn(() => ({ mergeMode: 'local' })),
+      loadWorkflow: vi.fn(() => ({ onFinish: 'merge', mergeMode: 'manual' })),
     };
+
 
     rebuildTaskRunner({
       orchestrator: orchestrator as any,
@@ -222,12 +219,6 @@ describe('task-runner-wiring', () => {
       expect.objectContaining({ messageBus: expect.any(Object), getTask: expect.any(Function) }),
     );
 
-    await config.reviewGateMergeConflictPublisher.publish({ taskId: 'merge-task' });
-    expect(publishReviewGateMergeConflictLifecycleEvent).toHaveBeenCalledWith(
-      { taskId: 'merge-task' },
-      expect.objectContaining({ messageBus: expect.any(Object), getTask: expect.any(Function) }),
-    );
-
     const approveHook = orchestrator.setBeforeApproveHook.mock.calls[0]?.[0];
     const mergeTask = {
       config: { isMergeNode: true, workflowId: 'wf-1' },
@@ -236,7 +227,11 @@ describe('task-runner-wiring', () => {
     await approveHook(mergeTask);
     expect(currentRunner.approveMerge).toHaveBeenCalledWith('wf-1');
 
-    persistence.loadWorkflow.mockReturnValueOnce({ mergeMode: 'external_review' });
+    persistence.loadWorkflow.mockReturnValueOnce({ onFinish: 'pull_request', mergeMode: 'manual' });
+    await approveHook(mergeTask);
+    expect(currentRunner.approveMerge).toHaveBeenCalledTimes(1);
+
+    persistence.loadWorkflow.mockReturnValueOnce({ onFinish: 'merge', mergeMode: 'external_review' });
     await approveHook(mergeTask);
     expect(currentRunner.approveMerge).toHaveBeenCalledTimes(1);
   });

--- a/packages/app/src/execution/task-runner-wiring.ts
+++ b/packages/app/src/execution/task-runner-wiring.ts
@@ -12,10 +12,7 @@ import {
 } from '@invoker/execution-engine';
 import type { Logger } from '@invoker/contracts';
 import { loadConfig, resolveDefaultTaskExecutionSettings, resolveSecretsFilePath, type InvokerConfig } from '../config.js';
-import {
-  publishReviewGateCiFailedLifecycleEvent,
-  publishReviewGateMergeConflictLifecycleEvent,
-} from '../lifecycle-event-bridge.js';
+import { publishReviewGateCiFailedLifecycleEvent } from '../lifecycle-event-bridge.js';
 
 export type TaskHandleMap = Map<string, { handle: ExecutorHandle; executor: Executor }>;
 
@@ -71,11 +68,15 @@ export function wireTaskRunnerApproveHook(deps: Pick<
   'orchestrator' | 'persistence' | 'getTaskRunner'
 >): void {
   deps.orchestrator.setBeforeApproveHook(async (task: TaskState) => {
-    if (task.config.isMergeNode && task.config.workflowId && task.execution.pendingFixError === undefined) {
-      const workflow = deps.persistence.loadWorkflow(task.config.workflowId);
-      if (workflow?.mergeMode === 'external_review') return;
-      await requireWiredTaskRunner(deps.getTaskRunner).approveMerge(task.config.workflowId);
-    }
+    if (!task.config.isMergeNode || !task.config.workflowId) return;
+    if (task.execution.pendingFixError !== undefined) return;
+
+    const workflow = deps.persistence.loadWorkflow(task.config.workflowId);
+    if (!workflow) return;
+    if (workflow.onFinish !== 'merge') return;
+    if (workflow.mergeMode === 'external_review') return;
+
+    await requireWiredTaskRunner(deps.getTaskRunner).approveMerge(task.config.workflowId);
   });
 }
 
@@ -97,14 +98,6 @@ export function rebuildTaskRunner(deps: TaskRunnerWiringDeps): TaskRunner {
     reviewGateCiFailurePublisher: {
       publish: (trigger) => {
         publishReviewGateCiFailedLifecycleEvent(trigger, {
-          messageBus: deps.messageBus,
-          getTask: (taskId) => deps.orchestrator.getTask(taskId),
-        });
-      },
-    },
-    reviewGateMergeConflictPublisher: {
-      publish: (trigger) => {
-        publishReviewGateMergeConflictLifecycleEvent(trigger, {
           messageBus: deps.messageBus,
           getTask: (taskId) => deps.orchestrator.getTask(taskId),
         });

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -16,6 +16,8 @@ import type { AgentSessionData, NormalizedCostEvent } from '@invoker/contracts';
 import { AUTO_FIX_WORKER_KIND, type AgentRegistry } from '@invoker/execution-engine';
 import type { CostGroupDimension } from './cost-rollup.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
+import { buildReviewGateQueryResponse } from './review-gate-query.js';
+
 import {
   type HeadlessDeps,
   type QueryFlags,
@@ -177,11 +179,20 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
         case 'label': writeOut(`${record?.workflowId ?? ''}\n`); break;
         case 'json':  writeOut(formatAsJson(record ?? {}) + '\n'); break;
         case 'jsonl': writeOut(formatAsJsonl(record ? [record] : []) + '\n'); break;
-        default:      writeOut(
-          record
-            ? `${record.workflowId}\t${record.reviewId ?? prNumber}\t${record.workflowStatus}\tgen=${record.workflowGeneration}\t${record.branch ?? ''}\n`
-            : `No Invoker workflow found for PR ${prNumber}.\n`,
-        ); break;
+        default:      if (!record) {
+          writeOut(`No Invoker workflow found for PR ${prNumber}.\n`);
+          break;
+        }
+        {
+          const workflow = deps.persistence.loadWorkflow(record.workflowId);
+          const tasks = deps.persistence.loadTasks(record.workflowId);
+          const gate = buildReviewGateQueryResponse({ workflowId: record.workflowId, workflow, tasks });
+          const substate = gate.substate ?? 'null';
+          writeOut(
+            `${record.workflowId}\t${record.reviewId ?? prNumber}\t${record.workflowStatus}\tgen=${record.workflowGeneration}\tsubstate=${substate}\t${record.branch ?? ''}\n`,
+          );
+        }
+        break;
       }
       break;
     }

--- a/packages/app/src/review-gate-query.ts
+++ b/packages/app/src/review-gate-query.ts
@@ -20,6 +20,25 @@ function scalarArtifact(task: TaskState): ReviewGateArtifact | null {
   };
 }
 
+function deriveReviewGateSubstate(
+  mergeTask: TaskState,
+  requiredArtifacts: readonly ReviewGateArtifact[],
+): ReviewGateQueryResponse['substate'] {
+  if (mergeTask.execution.pendingFixError !== undefined) return 'fix_pending';
+  if (requiredArtifacts.some((artifact) => artifact.mergeState === 'dirty')) return 'merge_conflict';
+  if (requiredArtifacts.some((artifact) => artifact.checksState === 'failure')) return 'ci_failing';
+  if (requiredArtifacts.some((artifact) => artifact.checksState === 'pending')) return 'ci_pending';
+  if (
+    requiredArtifacts.length > 0
+    && requiredArtifacts.every((artifact) => artifact.status === 'open')
+    && requiredArtifacts.every((artifact) => artifact.checksState === 'success')
+  ) {
+    return 'ready_to_land';
+  }
+  if (requiredArtifacts.length > 0) return 'review_open';
+  return null;
+}
+
 export function buildReviewGateQueryResponse(args: {
   workflowId: string;
   workflow: unknown | undefined;
@@ -34,6 +53,7 @@ export function buildReviewGateQueryResponse(args: {
       activeGeneration: null,
       completion,
       ready: false,
+      substate: null,
       artifacts: [],
       discardedArtifacts: [],
       edges: [],
@@ -62,6 +82,7 @@ export function buildReviewGateQueryResponse(args: {
 
   const requiredArtifacts = artifacts.filter((artifact) => artifact.required);
   const ready = requiredArtifacts.length > 0 && requiredArtifacts.every((artifact) => artifact.status === 'approved');
+  const substate = deriveReviewGateSubstate(mergeTask, requiredArtifacts);
   const edges = artifacts.length < 2
     ? []
     : artifacts.slice(0, -1).map((artifact, index) => ({
@@ -76,6 +97,7 @@ export function buildReviewGateQueryResponse(args: {
     activeGeneration,
     completion,
     ready,
+    substate,
     artifacts,
     discardedArtifacts,
     edges,

--- a/packages/app/src/surface-event-relay.ts
+++ b/packages/app/src/surface-event-relay.ts
@@ -42,6 +42,25 @@ function workflowIdFromTaskId(taskId: string): string | undefined {
  * Start relaying workflow-progress surface events on the IPC bus.
  * Returns a stop function that unsubscribes and clears pending timers.
  */
+function reviewStateLabel(substate: ReturnType<typeof buildReviewGateQueryResponse>['substate']): string | undefined {
+  switch (substate) {
+    case 'review_open':
+      return 'review open';
+    case 'ci_pending':
+      return 'CI pending';
+    case 'ci_failing':
+      return 'CI failing';
+    case 'merge_conflict':
+      return 'merge conflict';
+    case 'fix_pending':
+      return 'fix pending approval';
+    case 'ready_to_land':
+      return 'ready to land';
+    default:
+      return undefined;
+  }
+}
+
 export function startSurfaceEventRelay(deps: SurfaceEventRelayDeps): () => void {
   const { messageBus, persistence, orchestrator } = deps;
   const progressTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -53,9 +72,7 @@ export function startSurfaceEventRelay(deps: SurfaceEventRelayDeps): () => void 
     const percentComplete = counts.total > 0 ? Math.round((counts.completed / counts.total) * 100) : 0;
     const gate = buildReviewGateQueryResponse({ workflowId, workflow, tasks });
     const prUrl = gate.artifacts.find((artifact) => artifact.url)?.url;
-    const reviewState = gate.mergeTaskId
-      ? (gate.ready ? 'review ready' : (gate.status ?? undefined))
-      : undefined;
+    const reviewState = gate.mergeTaskId ? reviewStateLabel(gate.substate) : undefined;
     const event = {
       type: 'workflow_progress' as const,
       progress: {

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -125,6 +125,14 @@ export interface WorkResponseOutputs {
   /** Typed review-gate artifact state produced by merge-gate style actions. */
   reviewGate?: ReviewGateState;
 }
+export type ReviewGateSubstate =
+  | 'review_open'
+  | 'ci_pending'
+  | 'ci_failing'
+  | 'merge_conflict'
+  | 'fix_pending'
+  | 'ready_to_land';
+
 
 export interface ReviewGateQueryResponse {
   workflowId: string;
@@ -133,6 +141,7 @@ export interface ReviewGateQueryResponse {
   activeGeneration: number | null;
   completion: { required: 'all'; status: 'approved' };
   ready: boolean;
+  substate?: ReviewGateSubstate | null;
   artifacts: ReviewGateArtifact[];
   discardedArtifacts: ReviewGateArtifact[];
   edges: Array<{ from: string; to: string }>;

--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -8,24 +8,18 @@ import {
   autoFixAttemptLedgerKeyFromLifecycleEvent,
   createAutoFixAttemptLedger,
 } from '../auto-fix-attempt-ledger.js';
-import type {
-  ReviewGateCiFailedLifecycleEvent,
-  ReviewGateMergeConflictLifecycleEvent,
-} from '../lifecycle-events.js';
+import type { ReviewGateCiFailedLifecycleEvent } from '../lifecycle-events.js';
 import {
   CI_FAILURE_WORKER_KIND,
   ciFailureActionKey,
   createCiFailureTick,
 } from '../workers/ci-failure-worker.js';
-import {
-  createReviewGateMergeConflictTick,
-  REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
-  reviewGateMergeConflictActionKey,
-} from '../workers/review-gate-merge-conflict-worker.js';
+import { maybePublishReviewGateCiFailure } from '../task-runner-review-gate.js';
 import {
   DEFAULT_PR_STATUS_WORKER_INTERVAL_MS,
   createPrStatusWorker,
 } from '../workers/pr-status-worker.js';
+
 
 const logger = {
   info: vi.fn(),
@@ -106,41 +100,6 @@ function makeEvent(overrides: Partial<ReviewGateCiFailedLifecycleEvent> = {}): R
   };
 }
 
-function makeMergeConflictEvent(
-  overrides: Partial<ReviewGateMergeConflictLifecycleEvent> = {},
-): ReviewGateMergeConflictLifecycleEvent {
-  return {
-    eventKey: 'review_gate.merge_conflict|workflow:wf-1|task:wf-1/merge',
-    kind: 'review_gate.merge_conflict',
-    workflowId: 'wf-1',
-    taskId: 'wf-1/merge',
-    status: 'review_ready',
-    taskStateVersion: 10,
-    generation: 2,
-    attemptId: 'attempt-1',
-    createdAt: '2026-01-01T00:00:00.000Z',
-    recoveryWakeup: {
-      eventKey: 'review_gate.merge_conflict|workflow:wf-1|task:wf-1/merge',
-      eventKind: 'review_gate.merge_conflict',
-      workflowId: 'wf-1',
-      taskId: 'wf-1/merge',
-      taskStateVersion: 10,
-      generation: 2,
-      attemptId: 'attempt-1',
-      createdAt: '2026-01-01T00:00:00.000Z',
-      reason: 'review_gate_failure',
-      authoritative: false,
-    },
-    reviewId: '123',
-    reviewUrl: 'https://github.com/owner/repo/pull/123',
-    headSha: 'sha-1',
-    headRef: 'feature/ci',
-    branch: 'feature/ci',
-    statusText: 'Awaiting review',
-    ...overrides,
-  };
-}
-
 function toRecord(write: WorkerActionWrite): WorkerActionRecord {
   const now = '2026-01-01T00:00:00.000Z';
   return {
@@ -176,32 +135,6 @@ function makeHarness(task = makeTask()) {
   };
   const attemptLedger = createAutoFixAttemptLedger();
   return { actions, store, submit, attemptLedger };
-}
-
-function makeRebaseRecreateHarness(task = makeTask()) {
-  const tasks = new Map<string, TaskState>([[task.id, task]]);
-  const actions = new Map<string, WorkerActionRecord>();
-  const submit = vi.fn((workflowId: string, priority: WorkflowMutationPriority, channel: string, args: unknown[]) => {
-    expect(workflowId).toBe('wf-1');
-    expect(priority).toBe('high');
-    expect(channel).toBe('invoker:rebase-recreate');
-    expect(args).toEqual(['wf-1']);
-    return 99;
-  });
-  const store = {
-    loadTasks: vi.fn((workflowId: string) => workflowId === 'wf-1' ? Array.from(tasks.values()) : []),
-    loadTask: vi.fn((taskId: string) => tasks.get(taskId)),
-    listWorkflowMutationIntents: vi.fn(() => []),
-    getWorkerAction: vi.fn((workerKind: string, externalKey: string) => actions.get(`${workerKind}:${externalKey}`)),
-    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
-      const existing = actions.get(`${write.workerKind}:${write.externalKey}`);
-      const saved = toRecord({ ...write, id: existing?.id ?? write.id, createdAt: existing?.createdAt });
-      actions.set(`${write.workerKind}:${write.externalKey}`, saved);
-      return saved;
-    }),
-    logEvent: vi.fn(),
-  };
-  return { actions, store, submit };
 }
 
 describe('PR status and CI failure workers', () => {
@@ -320,76 +253,6 @@ describe('PR status and CI failure workers', () => {
     });
   });
 
-
-  it('queues workflow rebase-recreate for review-gate merge conflict events', async () => {
-    const event = makeMergeConflictEvent();
-    const harness = makeRebaseRecreateHarness();
-    const tick = createReviewGateMergeConflictTick({
-      store: harness.store,
-      submitter: { submit: harness.submit },
-      logger,
-      drainEvents: () => [event],
-    });
-
-    await tick({ identity: { kind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
-
-    expect(harness.submit).toHaveBeenCalledTimes(1);
-    expect(harness.actions.get(`${REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND}:${reviewGateMergeConflictActionKey(event)}`)).toMatchObject({
-      workerKind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
-      actionType: 'rebase-recreate-review-gate-conflict',
-      status: 'queued',
-      intentId: '99',
-      externalKey: reviewGateMergeConflictActionKey(event),
-    });
-  });
-
-  it('dedupes repeated merge conflict events for the same review head', async () => {
-    const event = makeMergeConflictEvent();
-    const harness = makeRebaseRecreateHarness();
-    const tick = createReviewGateMergeConflictTick({
-      store: harness.store,
-      submitter: { submit: harness.submit },
-      logger,
-      drainEvents: () => [event, makeMergeConflictEvent()],
-    });
-
-    await tick({ identity: { kind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
-
-    expect(harness.submit).toHaveBeenCalledTimes(1);
-  });
-
-  it('skips stale merge conflict events when the PR head changed before submit', async () => {
-    const event = makeMergeConflictEvent();
-    const task = makeTask({
-      execution: {
-        reviewGate: {
-          activeGeneration: 2,
-          completion: { required: 'all', status: 'approved' },
-          artifacts: [{
-            id: 'pr-123',
-            providerId: '123',
-            required: true,
-            status: 'open',
-            generation: 2,
-            headSha: 'sha-2',
-          }],
-        },
-      },
-    });
-    const harness = makeRebaseRecreateHarness(task);
-    const tick = createReviewGateMergeConflictTick({
-      store: harness.store,
-      submitter: { submit: harness.submit },
-      logger,
-      drainEvents: () => [event],
-    });
-
-    await tick({ identity: { kind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
-
-    expect(harness.submit).not.toHaveBeenCalled();
-    expect(harness.actions.get(`${REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND}:${reviewGateMergeConflictActionKey(event)}`)).toBeUndefined();
-    expect(harness.store.upsertWorkerAction).not.toHaveBeenCalled();
-  });
   it('rejects stale CI failure events when the PR head changed before submit', async () => {
     const event = makeEvent();
     const task = makeTask({
@@ -425,5 +288,30 @@ describe('PR status and CI failure workers', () => {
     // decision row. Only meaningful skips (e.g. retry-budget-exhausted) persist.
     expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toBeUndefined();
     expect(harness.store.upsertWorkerAction).not.toHaveBeenCalled();
+  });
+  it('does not publish a CI repair intent for pending checks or merge-conflict-only polls', async () => {
+    const publish = vi.fn();
+    const host = {
+      reviewGateCiFailurePublisher: { publish },
+      reviewGateCiFailureInFlight: new Set<string>(),
+    } as any;
+    const task = makeTask();
+
+    await maybePublishReviewGateCiFailure(host, task, {
+      lifecycle: 'open',
+      rejected: false,
+      statusText: 'Checks pending',
+      url: 'https://github.com/owner/repo/pull/123',
+      checks: { state: 'pending', failed: [] },
+    }, '123');
+    await maybePublishReviewGateCiFailure(host, task, {
+      lifecycle: 'open',
+      rejected: false,
+      statusText: 'Merge conflict',
+      url: 'https://github.com/owner/repo/pull/123',
+      mergeState: 'dirty',
+    }, '123');
+
+    expect(publish).not.toHaveBeenCalled();
   });
 });

--- a/packages/execution-engine/src/__tests__/review-gate-poll-heartbeat-db.test.ts
+++ b/packages/execution-engine/src/__tests__/review-gate-poll-heartbeat-db.test.ts
@@ -36,6 +36,27 @@ function reviewGateTask(id: string, reviewId: string, status: TaskState['status'
     },
   } as TaskState;
 }
+function structuredReviewGateTask(id: string, reviewId: string, status: TaskState['status']): TaskState {
+  return {
+    ...reviewGateTask(id, reviewId, status),
+    execution: {
+      ...reviewGateTask(id, reviewId, status).execution,
+      reviewGate: {
+        activeGeneration: 1,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [{
+          id: reviewId,
+          providerId: reviewId,
+          provider: 'stub-github',
+          required: true,
+          status: 'open',
+          generation: 1,
+        }],
+      },
+    },
+  } as TaskState;
+}
+
 
 function stubMergeGateProvider(overrides: Partial<MergeGateApprovalStatus> = {}): MergeGateProvider {
   return {
@@ -99,6 +120,40 @@ describe('pollMergeGateTask → SQLite heartbeat persistence', () => {
     expect(heartbeatMs).toBeGreaterThanOrEqual(beforePoll);
     expect(heartbeatMs).toBeLessThanOrEqual(afterPoll);
     expect(heartbeatMs).toBeGreaterThan(before.getTime());
+  });
+  it('persists checksState failedChecks and mergeState onto an open review artifact', async () => {
+    const task = structuredReviewGateTask('merge-health', 'foo/bar#303', 'review_ready');
+    adapter.saveTask(WORKFLOW.id, task);
+    orchestrator.syncFromDb(WORKFLOW.id);
+
+    const runner = new TaskRunner({
+      orchestrator,
+      persistence: adapter,
+      executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+      cwd: '/runner-base-cwd',
+      mergeGateProvider: stubMergeGateProvider({
+        statusText: 'Checks failing',
+        mergeState: 'dirty',
+        checks: {
+          state: 'failure',
+          failed: [{ name: 'lint', conclusion: 'FAILURE', detailsUrl: 'https://ci.example/lint' }],
+        },
+      }),
+    });
+
+    await runner.checkMergeGateStatuses();
+
+    const persisted = adapter.loadTasks(WORKFLOW.id).find((candidate) => candidate.id === task.id)!;
+    expect(persisted.execution.reviewGate?.artifacts).toEqual([
+      expect.objectContaining({
+        id: 'foo/bar#303',
+        status: 'open',
+        rawStatus: 'Checks failing',
+        checksState: 'failure',
+        failedChecks: [{ name: 'lint', conclusion: 'FAILURE', detailsUrl: 'https://ci.example/lint' }],
+        mergeState: 'dirty',
+      }),
+    ]);
   });
 
   it('checkPrApprovalNow advances lastHeartbeatAt for a review_ready task in SQLite', async () => {

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2755,7 +2755,7 @@ describe('TaskRunner', () => {
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
     });
 
-    it('pull_request mode: calls execPr and persists reviewUrl', async () => {
+    it('pull_request mode: republishes through createReview and returns to review_ready', async () => {
       const completedTask = makeTask({
         id: 't1',
         status: 'completed',
@@ -2763,7 +2763,7 @@ describe('TaskRunner', () => {
         execution: { branch: 'invoker/t1' },
       });
 
-      const { executor, mergeTask, orchestrator, persistence } = setupPublishAfterFix({
+      const { executor, mergeTask, orchestrator, persistence, mergeGateProvider } = setupPublishAfterFix({
         mergeMode: 'manual',
         onFinish: 'pull_request',
         featureBranch: 'plan/feature',
@@ -2778,11 +2778,33 @@ describe('TaskRunner', () => {
         workflowSummary: '## Summary',
         cwd: '/tmp/gate-clone',
       }));
-      expect((executor as any).execPr).toHaveBeenCalledWith('master', 'plan/feature', 'Test Workflow', '## Summary\n\nPublished body', '/tmp/gate-clone');
-      expect(persistence.updateTask).toHaveBeenCalledWith('__merge__wf-pub', expect.objectContaining({
-        execution: expect.objectContaining({ reviewUrl: 'https://github.com/owner/repo/pull/100' }),
+      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(expect.objectContaining({
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        title: 'Test Workflow',
+        cwd: '/tmp/gate-clone',
+        body: '## Summary\n\nPublished body',
       }));
-      expect(orchestrator.setTaskReviewReady).toHaveBeenCalled();
+      expect((executor as any).execPr).not.toHaveBeenCalled();
+      expect(persistence.updateTask).not.toHaveBeenCalledWith('__merge__wf-pub', expect.objectContaining({
+        execution: expect.objectContaining({ reviewUrl: expect.any(String) }),
+      }));
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-pub', expect.objectContaining({
+        execution: expect.objectContaining({
+          branch: 'plan/feature',
+          reviewUrl: 'https://github.com/owner/repo/pull/99',
+          reviewId: 'owner/repo#99',
+          reviewStatus: 'Awaiting review',
+          reviewGate: expect.objectContaining({
+            activeGeneration: 0,
+            artifacts: [expect.objectContaining({
+              providerId: 'owner/repo#99',
+              status: 'open',
+              generation: 0,
+            })],
+          }),
+        }),
+      }), expect.objectContaining({ generation: 0 }));
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
     });
 

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -4422,23 +4422,43 @@ console.log(JSON.stringify(out));
       consolidateSpy.mockRestore();
     });
 
-    it('approveMerge with onFinish=pull_request persists PR URL', async () => {
+    it('executeMergeNode with onFinish=pull_request parks in review_ready with a typed review gate', async () => {
+      const allTasks = [
+        makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),
+      ];
+      const orchestrator = {
+        getTask: (id: string) => allTasks.find(t => t.id === id),
+        getAllTasks: () => allTasks,
+        handleWorkerResponse: vi.fn(() => []),
+        setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
+      };
       const persistence = {
         loadWorkflow: () => ({
           id: 'wf-1',
           onFinish: 'pull_request',
+          mergeMode: 'manual',
           baseBranch: 'master',
           featureBranch: 'plan/feature',
           name: 'Test Workflow',
         }),
         updateTask: vi.fn(),
-        getWorkspacePath: () => null,
+      };
+      const mergeGateProvider = {
+        name: 'github',
+        createReview: vi.fn().mockResolvedValue({
+          url: 'https://github.com/owner/repo/pull/55',
+          identifier: 'owner/repo#55',
+        }),
       };
       const executor = new TaskRunner({
-        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        orchestrator: orchestrator as any,
         persistence: persistence as any,
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
         cwd: '/tmp',
+        mergeGateProvider: mergeGateProvider as any,
+        callbacks: { onComplete: vi.fn() },
       });
 
       (executor as any).execGitReadonly = async (args: string[], cwd?: string) => {
@@ -4456,39 +4476,55 @@ console.log(JSON.stringify(out));
         sessionId: 'sess-pr-1',
         agentName: 'codex',
       });
-      (executor as any).execPr = vi.fn().mockResolvedValue('https://github.com/owner/repo/pull/55');
+      (executor as any).execPr = vi.fn();
 
-      const logSpy = vi.spyOn(console, 'log');
+      const mergeTask = makeTask({
+        id: '__merge__wf-1',
+        status: 'running',
+        dependencies: ['t1'],
+        config: { isMergeNode: true, workflowId: 'wf-1' },
+      });
 
-      await executor.approveMerge('wf-1');
+      await (executor as any).executeMergeNode(mergeTask);
 
-      // Should push + create PR (with clone dir as cwd)
       expect((executor as any).authorPrBodyWithSkill).toHaveBeenCalledWith(expect.objectContaining({
         title: 'Test Workflow',
         baseBranch: 'master',
         featureBranch: 'plan/feature',
         cwd: '/tmp/mock-wt',
       }));
-      expect((executor as any).execPr).toHaveBeenCalledWith('master', 'plan/feature', 'Test Workflow', '## Summary\n\nAuthored body', '/tmp/mock-wt');
-
-      // Should persist the PR URL on the merge task
-      expect(persistence.updateTask).toHaveBeenCalledWith(
+      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(expect.objectContaining({
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        title: 'Test Workflow',
+        cwd: '/tmp/mock-wt',
+        body: '## Summary\n\nAuthored body',
+      }));
+      expect((executor as any).execPr).not.toHaveBeenCalled();
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith(
         '__merge__wf-1',
         expect.objectContaining({
-          config: expect.objectContaining({ summary: expect.any(String) }),
-          execution: { reviewUrl: 'https://github.com/owner/repo/pull/55' },
+          execution: expect.objectContaining({
+            reviewUrl: 'https://github.com/owner/repo/pull/55',
+            reviewId: 'owner/repo#55',
+            reviewStatus: 'Awaiting review',
+            reviewGate: expect.objectContaining({
+              activeGeneration: 0,
+              artifacts: [expect.objectContaining({
+                providerId: 'owner/repo#55',
+                status: 'open',
+                generation: 0,
+              })],
+            }),
+          }),
         }),
+        expect.objectContaining({ generation: 0 }),
       );
-
-      // Should log the PR URL
-      expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining('https://github.com/owner/repo/pull/55'),
-      );
-
-      logSpy.mockRestore();
+      expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
     });
 
-    it('automatic merge with onFinish=pull_request persists PR URL', async () => {
+
+    it('automatic merge with onFinish=pull_request reuses typed review publication instead of execPr', async () => {
       const allTasks = [
         makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),
       ];
@@ -4496,6 +4532,9 @@ console.log(JSON.stringify(out));
         getTask: (id: string) => allTasks.find(t => t.id === id),
         getAllTasks: () => allTasks,
         handleWorkerResponse: vi.fn(() => []),
+        setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -4508,12 +4547,20 @@ console.log(JSON.stringify(out));
         }),
         updateTask: vi.fn(),
       };
+      const mergeGateProvider = {
+        name: 'github',
+        createReview: vi.fn().mockResolvedValue({
+          url: 'https://github.com/owner/repo/pull/77',
+          identifier: 'owner/repo#77',
+        }),
+      };
       const onComplete = vi.fn();
       const executor = new TaskRunner({
         orchestrator: orchestrator as any,
         persistence: persistence as any,
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
         cwd: '/tmp',
+        mergeGateProvider: mergeGateProvider as any,
         callbacks: { onComplete },
       });
 
@@ -4532,7 +4579,7 @@ console.log(JSON.stringify(out));
         sessionId: 'sess-pr-2',
         agentName: 'codex',
       });
-      (executor as any).execPr = vi.fn().mockResolvedValue('https://github.com/owner/repo/pull/77');
+      (executor as any).execPr = vi.fn();
 
       const mergeTask = makeTask({
         id: '__merge__wf-1',
@@ -4543,21 +4590,28 @@ console.log(JSON.stringify(out));
 
       await (executor as any).executeMergeNode(mergeTask);
 
-      // Should persist the PR URL via the final updateTask call
-      expect(persistence.updateTask).toHaveBeenCalledWith(
+      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
+        expect.objectContaining({ body: '## Summary\n\nAuto authored body' }),
+      );
+      expect((executor as any).execPr).not.toHaveBeenCalled();
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith(
         '__merge__wf-1',
         expect.objectContaining({
           execution: expect.objectContaining({
             reviewUrl: 'https://github.com/owner/repo/pull/77',
+            reviewGate: expect.objectContaining({
+              artifacts: [expect.objectContaining({ providerId: 'owner/repo#77' })],
+            }),
           }),
         }),
+        expect.objectContaining({ generation: 0 }),
       );
 
-      // Should complete successfully
-      expect(orchestrator.handleWorkerResponse).toHaveBeenCalledWith(
+      expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalledWith(
         expect.objectContaining({ status: 'completed' }),
       );
     });
+
 
     it('executeMergeNode passes authored body to createReview in external_review mode', async () => {
       const allTasks = [
@@ -4704,7 +4758,7 @@ console.log(JSON.stringify(out));
       );
     });
 
-    it('approveMerge passes summary body to execPr for pull_request onFinish', async () => {
+    it('approveMerge with onFinish=pull_request does not publish a second review', async () => {
       const persistence = {
         loadWorkflow: () => ({
           id: 'wf-1',
@@ -4723,39 +4777,16 @@ console.log(JSON.stringify(out));
         cwd: '/tmp',
       });
 
-      (executor as any).execGitReadonly = async (args: string[], cwd?: string) => {
-        if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
-        return '';
-      };
-      (executor as any).execGitIn = async (args: string[], _dir: string) => {
-        if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
-        return '';
-      };
-      (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
-      (executor as any).removeMergeWorktree = async () => {};
-      (executor as any).buildMergeSummary = vi.fn().mockResolvedValue('## Summary\nApprove summary');
-      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
-        body: '## Summary\n\nApprove authored body',
-        sessionId: 'sess-pr-3',
-        agentName: 'codex',
-      });
-      (executor as any).execPr = vi.fn().mockResolvedValue('https://github.com/owner/repo/pull/88');
+      (executor as any).createMergeWorktree = vi.fn();
+      (executor as any).authorPrBodyWithSkill = vi.fn();
+      (executor as any).execPr = vi.fn();
 
       await executor.approveMerge('wf-1');
 
-      expect((executor as any).authorPrBodyWithSkill).toHaveBeenCalledWith(expect.objectContaining({
-        title: 'Test Workflow',
-        workflowSummary: '## Summary\nApprove summary',
-      }));
-      expect((executor as any).execPr).toHaveBeenCalledWith(
-        'master', 'plan/feature', 'Test Workflow', '## Summary\n\nApprove authored body', '/tmp/mock-wt',
-      );
-      expect(persistence.updateTask).toHaveBeenCalledWith(
-        '__merge__wf-1',
-        expect.objectContaining({
-          config: expect.objectContaining({ summary: '## Summary\nApprove summary' }),
-        }),
-      );
+      expect((executor as any).createMergeWorktree).not.toHaveBeenCalled();
+      expect((executor as any).authorPrBodyWithSkill).not.toHaveBeenCalled();
+      expect((executor as any).execPr).not.toHaveBeenCalled();
+      expect(persistence.updateTask).not.toHaveBeenCalled();
     });
   });
 
@@ -5394,77 +5425,6 @@ console.log(JSON.stringify(out));
           'manual-heartbeat',
           expect.objectContaining({ source: 'executor' }),
         );
-      });
-
-      it('publishes review-gate merge conflict wakeups for open PR conflicts', async () => {
-        const task = makeTask({
-          id: 'merge-conflict',
-          status: 'review_ready',
-          config: { workflowId: 'wf-merge-conflict', isMergeNode: true },
-          execution: {
-            generation: 4,
-            selectedAttemptId: 'attempt-merge',
-            reviewId: 'owner/repo#303',
-            branch: 'feature/conflict',
-            reviewGate: {
-              activeGeneration: 4,
-              completion: { required: 'all', status: 'approved' as const },
-              artifacts: [{
-                id: 'pr-303',
-                providerId: 'owner/repo#303',
-                required: true,
-                status: 'open' as const,
-                generation: 4,
-                headSha: 'abc123',
-              }],
-            },
-          },
-          taskStateVersion: 13,
-        });
-        const reviewGateMergeConflictPublisher = { publish: vi.fn().mockResolvedValue(undefined) };
-        const orchestrator = {
-          getTask: (id: string) => (id === task.id ? task : undefined),
-          getAllTasks: () => [task],
-          approve: vi.fn(),
-          recordTaskHeartbeat: vi.fn(),
-        };
-        const persistence = { updateTask: vi.fn() };
-        const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
-            lifecycle: 'open',
-            rejected: false,
-            statusText: 'Awaiting review',
-            url: 'https://github.com/owner/repo/pull/303',
-            headSha: 'abc123',
-            headRef: 'feature/conflict',
-            mergeState: 'dirty',
-            hasMergeConflict: true,
-          }),
-        };
-
-        const executor = new TaskRunner({
-          orchestrator: orchestrator as any,
-          persistence: persistence as any,
-          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
-          cwd: '/runner-base-cwd',
-          mergeGateProvider: mergeGateProvider as any,
-          reviewGateMergeConflictPublisher: reviewGateMergeConflictPublisher as any,
-        });
-
-        await executor.checkMergeGateStatuses();
-
-        expect(reviewGateMergeConflictPublisher.publish).toHaveBeenCalledWith({
-          taskId: 'merge-conflict',
-          workflowId: 'wf-merge-conflict',
-          reviewId: 'owner/repo#303',
-          reviewUrl: 'https://github.com/owner/repo/pull/303',
-          headSha: 'abc123',
-          headRef: 'feature/conflict',
-          branch: 'feature/conflict',
-          selectedAttemptId: 'attempt-merge',
-          generation: 4,
-          statusText: 'Awaiting review',
-        });
       });
 
       it('polls all current reviewGate artifacts and approves only after every required artifact is approved', async () => {
@@ -6932,7 +6892,7 @@ console.log(JSON.stringify(out));
       expect(mergeAbort).toBeDefined();
     });
 
-    it('appends visual proof markdown when runVisualProofCapture returns content', async () => {
+    it('leaves pull_request visual proof capture to the caller instead of consolidateAndMerge', async () => {
       const tasks = new Map<string, TaskState>();
       tasks.set('t1', makeTask({
         id: 't1', status: 'completed',
@@ -6973,19 +6933,18 @@ console.log(JSON.stringify(out));
         sessionId: 'sess-pr-5',
         agentName: 'codex',
       });
-      (executor as any).execPr = vi.fn().mockResolvedValue('https://example.com/pr');
 
       await executor.consolidateAndMerge(
         'pull_request', 'master', 'plan/test', 'wf-1', 'Test', ['t1'],
         'original body', true,
       );
 
-      expect((executor as any).runVisualProofCapture).toHaveBeenCalledWith(
-        'master', 'plan/test', expect.any(String), undefined,
-      );
+      expect((executor as any).runVisualProofCapture).not.toHaveBeenCalled();
+      expect((executor as any).authorPrBodyWithSkill).not.toHaveBeenCalled();
     });
 
-    it('proceeds normally when runVisualProofCapture returns undefined', async () => {
+
+    it('still succeeds when pull_request visual proof is delegated to the caller', async () => {
       const tasks = new Map<string, TaskState>();
       tasks.set('t1', makeTask({
         id: 't1', status: 'completed',
@@ -7021,20 +6980,15 @@ console.log(JSON.stringify(out));
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).runVisualProofCapture = vi.fn().mockResolvedValue(undefined);
-      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
-        body: '## Summary\n\nAuthored consolidate body',
-        sessionId: 'sess-pr-6',
-        agentName: 'codex',
-      });
-      (executor as any).execPr = vi.fn().mockResolvedValue('https://example.com/pr');
+      (executor as any).authorPrBodyWithSkill = vi.fn();
 
-      // Should not throw
       await executor.consolidateAndMerge(
         'pull_request', 'master', 'plan/test', 'wf-1', 'Test', ['t1'],
         'original body', true,
       );
 
-      expect((executor as any).runVisualProofCapture).toHaveBeenCalled();
+      expect((executor as any).runVisualProofCapture).not.toHaveBeenCalled();
+      expect((executor as any).authorPrBodyWithSkill).not.toHaveBeenCalled();
     });
 
     it('skips visual proof when visualProof is false', async () => {

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -327,6 +327,123 @@ async function authorPrBodyForMerge(
   );
   return authored.body;
 }
+async function publishReviewArtifactsForMerge(host: MergeRunnerHost, args: {
+  workflowId?: string;
+  mergeNodeTaskId: string;
+  workflowName: string;
+  baseBranch: string;
+  featureBranch: string;
+  workflowSummary: string;
+  cwd: string;
+  expectedGeneration: number;
+  repoUrl?: string;
+  reviewGate?: ReviewGateState;
+}): Promise<{
+  reviewUrl?: string;
+  reviewId?: string;
+  reviewStatus: 'Awaiting review';
+  reviewGate: ReviewGateState;
+}> {
+  if (isInvokerRepoUrl(args.repoUrl)) {
+    if (!host.publishReviewStackWithMakePrSkill) {
+      throw new Error('make-pr skill is required to publish Invoker review stacks');
+    }
+    logTaskProgress(host, args.mergeNodeTaskId, 'info', 'Publishing review stack with make-pr agent', {
+      featureBranch: args.featureBranch,
+    });
+    const published = await host.publishReviewStackWithMakePrSkill({
+      workflowId: args.workflowId,
+      mergeNodeTaskId: args.mergeNodeTaskId,
+      title: args.workflowName,
+      baseBranch: args.baseBranch,
+      featureBranch: args.featureBranch,
+      workflowSummary: args.workflowSummary,
+      cwd: args.cwd,
+      reviewGate: args.reviewGate,
+    });
+    logTaskProgress(host, args.mergeNodeTaskId, 'info', 'Review stack published', {
+      agentName: published.agentName,
+      artifactCount: published.artifacts.length,
+      reviewUrl: published.artifacts[0]?.url,
+    });
+    const artifacts = published.artifacts.map((artifact) => ({
+      ...artifact,
+      baseBranch: artifact.baseBranch ?? args.baseBranch,
+      required: artifact.required ?? true,
+      status: artifact.status ?? 'open' as const,
+      generation: artifact.generation ?? args.expectedGeneration,
+    }));
+    const reviewGate = {
+      activeGeneration: args.expectedGeneration,
+      completion: { required: 'all' as const, status: 'approved' as const },
+      artifacts,
+    };
+    const firstArtifact = artifacts[0];
+    console.log(
+      `[merge] Published Invoker review stack via ${published.agentName} skill`,
+    );
+    return {
+      reviewUrl: firstArtifact?.url,
+      reviewId: firstArtifact?.providerId,
+      reviewStatus: 'Awaiting review',
+      reviewGate,
+    };
+  }
+
+  if (!host.mergeGateProvider) {
+    throw new Error('merge review publication requires a configured review provider');
+  }
+
+  logTaskProgress(host, args.mergeNodeTaskId, 'info', 'Authoring PR body', {
+    featureBranch: args.featureBranch,
+  });
+  const structuredContext = args.workflowId
+    ? await buildPrAuthoringContext(host, args.workflowId)
+    : undefined;
+  const prBody = await authorPrBodyForMerge(host, {
+    workflowId: args.workflowId,
+    mergeNodeTaskId: args.mergeNodeTaskId,
+    title: args.workflowName,
+    baseBranch: args.baseBranch,
+    featureBranch: args.featureBranch,
+    workflowSummary: args.workflowSummary,
+    structuredContext,
+    cwd: args.cwd,
+    repoUrl: args.repoUrl,
+  });
+
+  logTaskProgress(host, args.mergeNodeTaskId, 'info', 'Creating review PR', {
+    featureBranch: args.featureBranch,
+  });
+  const result = await host.mergeGateProvider.createReview({
+    baseBranch: args.baseBranch,
+    featureBranch: args.featureBranch,
+    title: args.workflowName,
+    cwd: args.cwd,
+    body: prBody,
+  });
+  logTaskProgress(host, args.mergeNodeTaskId, 'info', 'Review PR created', {
+    reviewUrl: result.url,
+    reviewId: result.identifier,
+  });
+  console.log(`[merge] Created GitHub PR: ${result.url}`);
+
+  return {
+    reviewUrl: result.url,
+    reviewId: result.identifier,
+    reviewStatus: 'Awaiting review',
+    reviewGate: buildSingleArtifactReviewGate({
+      expectedGeneration: args.expectedGeneration,
+      title: args.workflowName,
+      url: result.url,
+      providerId: result.identifier,
+      provider: host.mergeGateProvider.name,
+      branch: args.featureBranch,
+      baseBranch: args.baseBranch,
+      nowIso: new Date().toISOString(),
+    }),
+  };
+}
 
 /**
  * Build structured PR-authoring context from workflow tasks.
@@ -659,7 +776,7 @@ export async function runMergeGateActionImpl(
   }
 
   if (featureBranch && (onFinish !== 'none' || mergeMode === 'external_review')) {
-    const effectiveOnFinish = mergeMode === 'automatic' ? onFinish : 'none';
+    const effectiveOnFinish = mergeMode === 'automatic' && onFinish !== 'pull_request' ? onFinish : 'none';
     try {
       logTaskProgress(host, task.id, 'info', 'Collecting completed task branches', {
         featureBranch,
@@ -669,7 +786,7 @@ export async function runMergeGateActionImpl(
         baseBranch,
         mergeMode === 'external_review' || onFinish === 'pull_request',
       );
-      reviewUrl = await host.consolidateAndMerge(
+      await host.consolidateAndMerge(
         effectiveOnFinish,
         baseBranch,
         featureBranch,
@@ -681,7 +798,7 @@ export async function runMergeGateActionImpl(
         baseCheckoutRef,
         task.id,
       );
-      if (mergeMode === 'manual') {
+      if (mergeMode === 'manual' && onFinish !== 'pull_request') {
         mergeTrace('GATE_WS_PATH_MANUAL_AWAIT', { taskId: task.id, gateWorkspacePath: gateWorkspacePath ?? null });
         console.log(
           `[merge-gate-workspace] setTaskReviewReady path=manual branch consolidate ` +
@@ -702,15 +819,7 @@ export async function runMergeGateActionImpl(
           },
         };
       }
-      if (mergeMode === 'external_review') {
-        const invokerReviewStack = isInvokerRepoUrl(workflow?.repoUrl);
-        if (!invokerReviewStack && !host.mergeGateProvider) {
-          throw new Error('mergeMode is "external_review" but no review provider configured');
-        }
-
-        // The PR branch is pushed from the separate consolidation clone above.
-        // Fetch it into the persistent gate workspace and check it out before
-        // persisting the workspace handoff used by review terminals.
+      if (mergeMode === 'external_review' || onFinish === 'pull_request') {
         logTaskProgress(host, task.id, 'info', 'Checking out review branch in gate workspace', {
           featureBranch,
         });
@@ -718,116 +827,40 @@ export async function runMergeGateActionImpl(
 
         const expectedGeneration = task.execution.generation ?? 0;
         let fullSummary = summary;
-        let vpMarkdownCapture: string | undefined;
         if (visualProof && host.runVisualProofCapture) {
           const slug = (featureBranch ?? 'workflow').replace(/\//g, '-');
           const vpMarkdown = await host.runVisualProofCapture(baseBranch, featureBranch!, slug, workflow?.repoUrl);
           if (vpMarkdown) {
-            vpMarkdownCapture = vpMarkdown;
             fullSummary = (summary ?? '') + '\n\n' + vpMarkdown;
           }
         }
 
-        let reviewGate: ReviewGateState;
-        if (invokerReviewStack) {
-          if (!host.publishReviewStackWithMakePrSkill) {
-            throw new Error('make-pr skill is required to publish Invoker review stacks');
-          }
-          logTaskProgress(host, task.id, 'info', 'Publishing review stack with make-pr agent', {
-            featureBranch,
-          });
-          const published = await host.publishReviewStackWithMakePrSkill({
-            workflowId,
-            mergeNodeTaskId: task.id,
-            title: workflow?.name ?? 'Workflow',
-            baseBranch,
-            featureBranch: featureBranch!,
-            workflowSummary: fullSummary ?? '',
-            cwd: gateWorkspacePath!,
-          });
-          logTaskProgress(host, task.id, 'info', 'Review stack published', {
-            agentName: published.agentName,
-            artifactCount: published.artifacts.length,
-            reviewUrl: published.artifacts[0]?.url,
-          });
-          const artifacts = published.artifacts.map((artifact) => ({
-            ...artifact,
-            baseBranch: artifact.baseBranch ?? baseBranch,
-            required: true,
-            status: 'open' as const,
-            generation: expectedGeneration,
-          }));
-          reviewGate = {
-            activeGeneration: expectedGeneration,
-            completion: { required: 'all', status: 'approved' },
-            artifacts,
-          };
-          const firstArtifact = artifacts[0];
-          reviewUrl = firstArtifact?.url;
-          reviewId = firstArtifact?.providerId;
-          reviewStatus = 'Awaiting review';
-          console.log(
-            `[merge] Published Invoker review stack via ${published.agentName} skill`,
-          );
-        } else {
-          // Route through shared PR-authoring helper for consistent PR bodies.
-          logTaskProgress(host, task.id, 'info', 'Authoring PR body', {
-            featureBranch,
-          });
-          const structuredCtx = workflowId
-            ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture)
-            : undefined;
-          const prBody = await authorPrBodyForMerge(host, {
-            workflowId,
-            mergeNodeTaskId: task.id,
-            title: workflow?.name ?? 'Workflow',
-            baseBranch,
-            featureBranch: featureBranch!,
-            workflowSummary: fullSummary ?? '',
-            structuredContext: structuredCtx,
-            cwd: gateWorkspacePath!,
-            repoUrl: workflow?.repoUrl,
-          });
+        const published = await publishReviewArtifactsForMerge(host, {
+          workflowId,
+          mergeNodeTaskId: task.id,
+          workflowName: workflow?.name ?? 'Workflow',
+          baseBranch,
+          featureBranch,
+          workflowSummary: fullSummary ?? '',
+          cwd: gateWorkspacePath!,
+          expectedGeneration,
+          repoUrl: workflow?.repoUrl,
+          reviewGate: task.execution.reviewGate,
+        });
+        reviewUrl = published.reviewUrl;
+        reviewId = published.reviewId;
+        reviewStatus = published.reviewStatus;
+        const reviewGate = published.reviewGate;
 
-          // Create PR via provider (consolidation already done above).
-          // Use the gate clone dir so gh CLI resolves the correct GitHub remote.
-          logTaskProgress(host, task.id, 'info', 'Creating review PR', {
-            featureBranch,
-          });
-          const result = await host.mergeGateProvider!.createReview({
-            baseBranch,
-            featureBranch,
-            title: workflow?.name ?? 'Workflow',
-            cwd: gateWorkspacePath!,
-            body: prBody,
-          });
-          logTaskProgress(host, task.id, 'info', 'Review PR created', {
-            reviewUrl: result.url,
-            reviewId: result.identifier,
-          });
-          console.log(`[merge] Created GitHub PR: ${result.url}`);
-
-          reviewUrl = result.url;
-          reviewId = result.identifier;
-          reviewStatus = 'Awaiting review';
-          reviewGate = buildSingleArtifactReviewGate({
-            expectedGeneration,
-            title: workflow?.name ?? 'Workflow',
-            url: result.url,
-            providerId: result.identifier,
-            provider: host.mergeGateProvider!.name,
-            branch: featureBranch,
-            baseBranch,
-            nowIso: new Date().toISOString(),
-          });
-        }
-        mergeTrace('GATE_WS_PATH_EXTERNAL_REVIEW_AWAIT', {
+        mergeTrace('GATE_WS_PATH_REVIEW_PUBLISH_AWAIT', {
           taskId: task.id,
           gateWorkspacePath: gateWorkspacePath ?? null,
           reviewUrl,
+          onFinish,
+          mergeMode,
         });
         console.log(
-          `[merge-gate-workspace] setTaskReviewReady path=external_review ` +
+          `[merge-gate-workspace] setTaskReviewReady path=review_publish ` +
             `task=${task.id} gateWorkspacePath=${gateWorkspacePath ?? 'NULL'}`,
         );
         response = {
@@ -883,15 +916,16 @@ export async function runMergeGateActionImpl(
       };
     }
   } else {
-    if (mergeMode === 'manual' || mergeMode === 'external_review') {
+    if (mergeMode === 'manual' || mergeMode === 'external_review' || onFinish === 'pull_request') {
       mergeTrace('GATE_WS_PATH_NO_CONSOLIDATE_AWAIT', {
         taskId: task.id,
         gateWorkspacePath: gateWorkspacePath ?? null,
         mergeMode,
+        onFinish,
       });
       console.log(
         `[merge-gate-workspace] setTaskReviewReady path=no_consolidate_branch ` +
-          `task=${task.id} gateWorkspacePath=${gateWorkspacePath ?? 'NULL'} mergeMode=${mergeMode}`,
+          `task=${task.id} gateWorkspacePath=${gateWorkspacePath ?? 'NULL'} mergeMode=${mergeMode} onFinish=${onFinish}`,
       );
       response = {
         requestId: `merge-${task.id}`,
@@ -900,13 +934,13 @@ export async function runMergeGateActionImpl(
         status: 'review_ready',
         outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined },
       };
-        return {
-          response,
-          taskChanges: {
-            config: { summary },
-            execution: { branch: featureBranch ?? undefined, workspacePath: gateWorkspacePath },
-          },
-        };
+      return {
+        response,
+        taskChanges: {
+          config: { summary },
+          execution: { branch: featureBranch ?? undefined, workspacePath: gateWorkspacePath },
+        },
+      };
     }
     response = {
       requestId: `merge-${task.id}`,
@@ -1006,17 +1040,15 @@ export async function approveMergeImpl(
   const summary = await host.buildMergeSummary(workflowId);
   let fullSummary = summary;
   const visualProof = workflow.visualProof ?? false;
-  let vpMarkdownCapture: string | undefined;
   if (visualProof && host.runVisualProofCapture) {
     const slug = (featureBranch ?? 'workflow').replace(/\//g, '-');
     const vpMarkdown = await host.runVisualProofCapture(baseBranch, featureBranch!, slug, workflow.repoUrl);
     if (vpMarkdown) {
-      vpMarkdownCapture = vpMarkdown;
       fullSummary = summary + '\n\n' + vpMarkdown;
     }
   }
-  const structuredContext = await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture);
   const mergeMessage = workflow.name ?? 'Workflow';
+
 
   // Clean up the persistent gate worktree created by executeMergeNodeImpl
   const mergeTaskId = `__merge__${workflowId}`;
@@ -1049,36 +1081,6 @@ export async function approveMergeImpl(
       mergeTrace('APPROVE_MERGE_ERROR', { workflowId, error: String(err) });
       try { await execGitInMergeSafe(host, ['merge', '--abort'], worktreeDir); } catch { /* no merge in progress */ }
       throw err;
-    } finally {
-      await host.removeMergeWorktree(worktreeDir);
-      if (gateWorktreePath) {
-        await host.removeMergeWorktree(gateWorktreePath);
-      }
-    }
-  } else if (onFinish === 'pull_request') {
-    const worktreeDir = await host.createMergeWorktree(featureBranch, 'approve-pr-' + workflowId, workflow.repoUrl);
-    try {
-      mergeTrace('GIT_PUSH', { featureBranch, worktreeDir });
-      // Push feature branch directly to origin (GitHub) from the clone
-      await pushFeatureBranchWithRefLockRetry(host, worktreeDir, featureBranch);
-      const prBody = await authorPrBodyForMerge(host, {
-        workflowId,
-        mergeNodeTaskId: mergeTaskId,
-        title: mergeMessage,
-        baseBranch,
-        featureBranch,
-        workflowSummary: fullSummary ?? '',
-        structuredContext,
-        cwd: worktreeDir,
-        repoUrl: workflow.repoUrl,
-      });
-      const reviewUrl = await host.execPr(baseBranch, featureBranch, mergeMessage, prBody, worktreeDir);
-      mergeTrace('PR_CREATED', { featureBranch, baseBranch, reviewUrl });
-      console.log(`[merge] Approved: created pull request ${reviewUrl}`);
-      host.persistence.updateTask(mergeTaskId, {
-        config: { summary },
-        execution: { reviewUrl },
-      });
     } finally {
       await host.removeMergeWorktree(worktreeDir);
       if (gateWorktreePath) {
@@ -1318,123 +1320,37 @@ export async function publishAfterFixImpl(
     await pushFeatureBranchWithRefLockRetry(host, consolidateDir, featureBranch);
 
     let fullSummary = summary;
-    let vpMarkdownCapture2: string | undefined;
     if (visualProof && host.runVisualProofCapture) {
       const slug = featureBranch.replace(/\//g, '-');
       const vpMarkdown = await host.runVisualProofCapture(baseBranch, featureBranch, slug, workflow?.repoUrl);
       if (vpMarkdown) {
-        vpMarkdownCapture2 = vpMarkdown;
         fullSummary = (summary ?? '') + '\n\n' + vpMarkdown;
       }
     }
 
-    if (mergeMode === 'external_review') {
-      const invokerReviewStack = isInvokerRepoUrl(workflow?.repoUrl);
-      if (!invokerReviewStack && !host.mergeGateProvider) {
-        throw new Error('mergeMode is "external_review" but no review provider configured');
-      }
-
-      const expectedGeneration = task.execution.generation ?? 0;
-      let reviewUrl: string | undefined;
-      let reviewId: string | undefined;
-      let reviewGate: ReviewGateState;
-      if (invokerReviewStack) {
-        if (!host.publishReviewStackWithMakePrSkill) {
-          throw new Error('make-pr skill is required to publish Invoker review stacks');
-        }
-        logTaskProgress(host, task.id, 'info', 'Publishing review stack with make-pr agent', {
-          featureBranch,
-        });
-        const published = await host.publishReviewStackWithMakePrSkill({
-          workflowId,
-          mergeNodeTaskId: task.id,
-          title: workflow?.name ?? 'Workflow',
-          baseBranch,
-          featureBranch,
-          workflowSummary: fullSummary ?? '',
-          cwd: consolidateDir,
-        });
-        logTaskProgress(host, task.id, 'info', 'Review stack published', {
-          agentName: published.agentName,
-          artifactCount: published.artifacts.length,
-          reviewUrl: published.artifacts[0]?.url,
-        });
-        const artifacts = published.artifacts.map((artifact) => ({
-          ...artifact,
-          baseBranch: artifact.baseBranch ?? baseBranch,
-          required: true,
-          status: 'open' as const,
-          generation: expectedGeneration,
-        }));
-        reviewGate = {
-          activeGeneration: expectedGeneration,
-          completion: { required: 'all', status: 'approved' },
-          artifacts,
-        };
-        reviewUrl = artifacts[0]?.url;
-        reviewId = artifacts[0]?.providerId;
-        console.log(
-          `[merge] Post-fix: published Invoker review stack via ${published.agentName} skill`,
-        );
-      } else {
-        // Route through shared PR-authoring helper for consistent PR bodies.
-        logTaskProgress(host, task.id, 'info', 'Authoring PR body', {
-          featureBranch,
-        });
-        const structuredCtxReview = workflowId
-          ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture2)
-          : undefined;
-        const prBodyReview = await authorPrBodyForMerge(host, {
-          workflowId,
-          mergeNodeTaskId: task.id,
-          title: workflow?.name ?? 'Workflow',
-          baseBranch,
-          featureBranch,
-          workflowSummary: fullSummary ?? '',
-          structuredContext: structuredCtxReview,
-          cwd: consolidateDir,
-          repoUrl: workflow?.repoUrl,
-        });
-
-        logTaskProgress(host, task.id, 'info', 'Creating review PR', {
-          featureBranch,
-        });
-        const result = await host.mergeGateProvider!.createReview({
-          baseBranch,
-          featureBranch,
-          title: workflow?.name ?? 'Workflow',
-          cwd: consolidateDir,
-          body: prBodyReview,
-        });
-        logTaskProgress(host, task.id, 'info', 'Review PR created', {
-          reviewUrl: result.url,
-          reviewId: result.identifier,
-        });
-        console.log(`[merge] Post-fix: created/updated GitHub PR: ${result.url}`);
-
-        reviewUrl = result.url;
-        reviewId = result.identifier;
-        reviewGate = buildSingleArtifactReviewGate({
-          expectedGeneration,
-          title: workflow?.name ?? 'Workflow',
-          url: result.url,
-          providerId: result.identifier,
-          provider: host.mergeGateProvider!.name,
-          branch: featureBranch,
-          baseBranch,
-          nowIso: new Date().toISOString(),
-        });
-      }
+    if (mergeMode === 'external_review' || onFinish === 'pull_request') {
+      const published = await publishReviewArtifactsForMerge(host, {
+        workflowId,
+        mergeNodeTaskId: task.id,
+        workflowName: workflow?.name ?? 'Workflow',
+        baseBranch,
+        featureBranch,
+        workflowSummary: fullSummary ?? '',
+        cwd: consolidateDir,
+        expectedGeneration: task.execution.generation ?? 0,
+        repoUrl: workflow?.repoUrl,
+        reviewGate: task.execution.reviewGate,
+      });
 
       setMergeGateReviewReady(host, task.id, {
         config: { runnerKind: 'worktree', summary },
         execution: {
           branch: featureBranch,
           workspacePath: gateWorkspacePath,
-          reviewUrl,
-          reviewId,
-          reviewStatus: 'Awaiting review',
-          reviewGate,
+          reviewUrl: published.reviewUrl,
+          reviewId: published.reviewId,
+          reviewStatus: published.reviewStatus,
+          reviewGate: published.reviewGate,
           fixedIntegrationSha: undefined,
           fixedIntegrationRecordedAt: undefined,
           fixedIntegrationSource: undefined,
@@ -1445,30 +1361,6 @@ export async function publishAfterFixImpl(
       });
       await startReviewReadyDependents(host);
       return;
-    }
-
-    // manual mode with pull_request onFinish
-    if (onFinish === 'pull_request') {
-      const structuredCtx = workflowId
-        ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture2)
-        : undefined;
-      const prBody = await authorPrBodyForMerge(host, {
-        workflowId,
-        mergeNodeTaskId: task.id,
-        title: workflow?.name ?? 'Workflow',
-        baseBranch,
-        featureBranch,
-        workflowSummary: fullSummary ?? '',
-        structuredContext: structuredCtx,
-        cwd: consolidateDir,
-        repoUrl: workflow?.repoUrl,
-      });
-      const reviewUrl = await host.execPr(baseBranch, featureBranch, workflow?.name ?? 'Workflow', prBody, consolidateDir);
-      console.log(`[merge] Post-fix: created pull request ${reviewUrl}`);
-      updateMergeGateMetadataIfCurrent(host, task.id, {
-        config: { summary },
-        execution: { reviewUrl },
-      }, captureMergeGateLineage(task));
     }
 
     setMergeGateReviewReady(host, task.id, {
@@ -1751,14 +1643,6 @@ export async function consolidateAndMergeImpl(
     // in the finally block, so without this push the branch would be lost.
     await pushFeatureBranchWithRefLockRetry(host, worktreeDir, featureBranch);
 
-    if (visualProof && onFinish === 'pull_request' && host.runVisualProofCapture) {
-      const slug = (featureBranch ?? 'workflow').replace(/\//g, '-');
-      const vpMarkdown = await host.runVisualProofCapture(baseBranch, featureBranch, slug, repoUrlForMerge);
-      if (vpMarkdown) {
-        body = (body ? body + '\n\n' : '') + vpMarkdown;
-      }
-    }
-
     const mergeMessage = workflowName ?? 'Workflow';
 
     if (onFinish === 'merge') {
@@ -1779,27 +1663,9 @@ export async function consolidateAndMergeImpl(
       } else {
         console.log(`[merge] No changes to commit — ${baseBranch} already up-to-date with ${featureBranch}`);
       }
-    } else if (onFinish === 'pull_request') {
-      // Push feature branch directly to origin (GitHub) from the clone
-      await pushFeatureBranchWithRefLockRetry(host, worktreeDir, featureBranch);
-      const structuredCtx3 = workflowId
-        ? await buildPrAuthoringContext(host, workflowId)
-        : undefined;
-      const prBody = await authorPrBodyForMerge(host, {
-        workflowId,
-        mergeNodeTaskId,
-        title: workflowName ?? 'Workflow',
-        baseBranch,
-        featureBranch,
-        workflowSummary: body ?? '',
-        structuredContext: structuredCtx3,
-        cwd: worktreeDir,
-        repoUrl: repoUrlForMerge,
-      });
-      const reviewUrl = await host.execPr(baseBranch, featureBranch, workflowName ?? 'Workflow', prBody, worktreeDir);
-      console.log(`[merge] Created pull request: ${reviewUrl}`);
-      return reviewUrl;
     }
+    return undefined;
+
   } catch (err) {
     console.error(`[merge] consolidateAndMerge FAILED: ${err instanceof Error ? err.message : String(err)}`);
     try { await execGitInMergeSafe(host, ['merge', '--abort'], worktreeDir); } catch { /* no merge in progress */ }

--- a/packages/execution-engine/src/task-runner-review-gate.ts
+++ b/packages/execution-engine/src/task-runner-review-gate.ts
@@ -3,8 +3,8 @@
  *
  * Owns the poll loop that reconciles each merge-node task's review artifacts
  * against the merge-gate provider, maps provider lifecycle → artifact status,
- * completes approved gates, closes reviews on teardown, and publishes
- * review-gate failure lifecycle triggers.
+ * completes approved gates, closes reviews on teardown, and publishes CI-failure
+ * lifecycle triggers.
  *
  * Stateful functions take a {@link TaskRunnerReviewGateHost} — a
  * `Pick<TaskRunner, …>` — as their first parameter, so the type-only import of
@@ -14,8 +14,9 @@
  * this module; the same-named `TaskRunner` methods are thin delegates that route
  * through `gitPlumbing`-style namespace calls.
  *
- * The review-gate failure trigger/publisher declarations live here (their
- * owning cluster) and stay barrel-visible via the package index re-export.
+ * The `ReviewGateCiFailureTrigger` / `ReviewGateCiFailureLifecyclePublisher`
+ * declarations live here (their owning cluster) and stay barrel-visible via the
+ * package index re-export.
  */
 
 import type { TaskState } from '@invoker/workflow-core';
@@ -44,10 +45,11 @@ export interface ReviewGateCiFailureTrigger {
 export interface ReviewGateCiFailureLifecyclePublisher {
   publish(trigger: ReviewGateCiFailureTrigger): void | Promise<void>;
 }
-
 export interface ReviewGateMergeConflictTrigger {
   taskId: string;
   workflowId: string;
+  status?: TaskState['status'];
+  taskStateVersion?: number;
   reviewId: string;
   reviewUrl: string;
   headSha?: string;
@@ -62,12 +64,12 @@ export interface ReviewGateMergeConflictLifecyclePublisher {
   publish(trigger: ReviewGateMergeConflictTrigger): void | Promise<void>;
 }
 
+
 /**
  * Subset of {@link TaskRunner} the review-gate polling family reads. Picked from
  * `TaskRunner` (not hand-written) so the host stays locked to the runner's real
- * `reviewGateCiFailureInFlight` and `reviewGateMergeConflictInFlight` are
- * single-cluster-owned: they live here as `@internal` runner fields and are
- * picked into this host.
+ * member types. `reviewGateCiFailureInFlight` is single-cluster-owned: it lives
+ * here as an `@internal` runner field and is picked into this host.
  */
 export type TaskRunnerReviewGateHost = Pick<
   TaskRunner,
@@ -81,8 +83,6 @@ export type TaskRunnerReviewGateHost = Pick<
   // Review-gate cluster state
   | 'reviewGateCiFailurePublisher'
   | 'reviewGateCiFailureInFlight'
-  | 'reviewGateMergeConflictPublisher'
-  | 'reviewGateMergeConflictInFlight'
 >;
 
 export async function closeWorkflowReview(
@@ -194,17 +194,25 @@ export function updateReviewGateArtifact(
       ) {
         return artifact;
       }
-      const next: ReviewGateArtifact = {
+      return {
         ...artifact,
         status: mappedStatus,
+        checksState: status.checks?.state,
+        ...(status.checks
+          ? { failedChecks: status.checks.failed }
+          : mappedStatus !== 'open'
+            ? { failedChecks: undefined }
+            : {}),
+        ...(status.mergeState !== undefined
+          ? { mergeState: status.mergeState }
+          : mappedStatus !== 'open'
+            ? { mergeState: undefined }
+            : {}),
+        ...(mappedStatus === 'open' ? { rawStatus: status.statusText } : {}),
         ...(status.headSha ? { headSha: status.headSha } : {}),
         ...(status.headRef ? { headRef: status.headRef } : {}),
         updatedAt: new Date().toISOString(),
       };
-      if (mappedStatus === 'open') {
-        return { ...next, rawStatus: status.statusText };
-      }
-      return next;
     }),
   };
 }
@@ -273,7 +281,6 @@ export async function pollMergeGateTask(
         host.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
       } else if (status.lifecycle === 'open') {
         await maybePublishReviewGateCiFailure(host, current!, status, providerId);
-        await maybePublishReviewGateMergeConflict(host, current!, status, providerId);
       }
       continue;
     }
@@ -289,7 +296,6 @@ export async function pollMergeGateTask(
       host.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
     } else if (status.lifecycle === 'open') {
       await maybePublishReviewGateCiFailure(host, current!, status, providerId);
-      await maybePublishReviewGateMergeConflict(host, current!, status, providerId);
     }
   }
 }
@@ -359,42 +365,5 @@ export async function maybePublishReviewGateCiFailure(
     });
   } finally {
     host.reviewGateCiFailureInFlight.delete(key);
-  }
-}
-
-export async function maybePublishReviewGateMergeConflict(
-  host: TaskRunnerReviewGateHost,
-  task: TaskState,
-  status: MergeGateApprovalStatus,
-  reviewId: string = task.execution.reviewId ?? '',
-): Promise<void> {
-  if (!host.reviewGateMergeConflictPublisher) return;
-  if (!task.config.workflowId || !reviewId) return;
-  if (!status.hasMergeConflict) return;
-
-  const key = [
-    task.id,
-    task.execution.selectedAttemptId ?? 'no-attempt',
-    task.execution.generation ?? 0,
-    status.headSha ?? 'no-head-sha',
-  ].join(':');
-  if (host.reviewGateMergeConflictInFlight.has(key)) return;
-
-  host.reviewGateMergeConflictInFlight.add(key);
-  try {
-    await host.reviewGateMergeConflictPublisher.publish({
-      taskId: task.id,
-      workflowId: task.config.workflowId,
-      reviewId,
-      reviewUrl: status.url,
-      headSha: status.headSha,
-      headRef: status.headRef,
-      branch: task.execution.branch,
-      selectedAttemptId: task.execution.selectedAttemptId,
-      generation: task.execution.generation ?? 0,
-      statusText: status.statusText,
-    });
-  } finally {
-    host.reviewGateMergeConflictInFlight.delete(key);
   }
 }

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -279,9 +279,11 @@ describe('WorkflowInspector', () => {
           activeGeneration: 0,
           completion: { required: 'all', status: 'approved' },
           ready: false,
+          substate: null,
           artifacts: [],
           discardedArtifacts: [],
           edges: [],
+
         }}
         collapsed={false}
         advancedExpanded={false}
@@ -306,12 +308,14 @@ describe('WorkflowInspector', () => {
           activeGeneration: 0,
           completion: { required: 'all', status: 'approved' },
           ready: false,
+          substate: null,
           artifacts: [
             { id: 'contracts', title: 'Define contracts', url: 'https://example.test/contracts', required: true, status: 'open', generation: 0 },
             { id: 'runtime', title: 'Wire runtime', url: 'https://example.test/runtime', required: true, status: 'open', generation: 0 },
           ],
           discardedArtifacts: [],
           edges: [],
+
         }}
         collapsed={false}
         advancedExpanded={false}
@@ -325,6 +329,50 @@ describe('WorkflowInspector', () => {
       'Wire runtime',
     ]);
   });
+  it('renders artifact detail lines from typed review metadata', () => {
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready' }}
+        task={null}
+        reviewGate={{
+          workflowId: 'wf-1',
+          mergeTaskId: '__merge__wf-1',
+          status: 'review_ready',
+          activeGeneration: 0,
+          completion: { required: 'all', status: 'approved' },
+          ready: false,
+          substate: 'ci_failing',
+          artifacts: [
+            { id: 'conflict', title: 'Conflict', url: 'https://example.test/conflict', required: true, status: 'open', generation: 0, mergeState: 'dirty' },
+            {
+              id: 'checks',
+              title: 'Checks',
+              url: 'https://example.test/checks',
+              required: true,
+              status: 'open',
+              generation: 0,
+              checksState: 'failure',
+              failedChecks: [{ name: 'lint' }, { name: 'unit' }],
+            },
+            { id: 'pending', title: 'Pending', url: 'https://example.test/pending', required: true, status: 'open', generation: 0, checksState: 'pending' },
+            { id: 'passing', title: 'Passing', url: 'https://example.test/passing', required: true, status: 'open', generation: 0, checksState: 'success' },
+          ],
+          discardedArtifacts: [],
+          edges: [],
+        }}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Merge conflict')).toBeInTheDocument();
+    expect(screen.getByText('lint, unit')).toBeInTheDocument();
+    expect(screen.getByText('Checks pending')).toBeInTheDocument();
+    expect(screen.getByText('Checks passing')).toBeInTheDocument();
+  });
+
 
   it('renders a linear pull request stack with connectors', () => {
     render(
@@ -338,6 +386,7 @@ describe('WorkflowInspector', () => {
           activeGeneration: 0,
           completion: { required: 'all', status: 'approved' },
           ready: false,
+          substate: null,
           artifacts: [
             { id: 'contracts', title: 'Contracts', url: 'https://example.test/contracts', required: true, status: 'approved', generation: 0 },
             { id: 'runtime', title: 'Runtime', url: 'https://example.test/runtime', required: true, status: 'open', generation: 0, dependsOn: ['contracts'] },
@@ -345,6 +394,7 @@ describe('WorkflowInspector', () => {
           ],
           discardedArtifacts: [],
           edges: [{ from: 'contracts', to: 'runtime' }, { from: 'runtime', to: 'ui' }],
+
         }}
         collapsed={false}
         advancedExpanded={false}
@@ -374,6 +424,7 @@ describe('WorkflowInspector', () => {
           activeGeneration: 1,
           completion: { required: 'all', status: 'approved' },
           ready: false,
+          substate: null,
           artifacts: [
             { id: 'runtime', title: 'Runtime', url: 'https://example.test/runtime', required: true, status: 'open', generation: 1 },
           ],

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -225,6 +225,17 @@ function getMergeNodeReviewUrl(
 function artifactLabel(artifact: ReviewGateArtifact): string {
   return artifact.title || artifact.url || (artifact.providerId ? `#${artifact.providerId}` : artifact.id);
 }
+function artifactDetail(artifact: ReviewGateArtifact): string | null {
+  if (artifact.mergeState === 'dirty') return 'Merge conflict';
+  if (artifact.checksState === 'failure') {
+    const failedChecks = artifact.failedChecks?.map((check) => check.name).filter(Boolean) ?? [];
+    return failedChecks.length > 0 ? failedChecks.join(', ') : null;
+  }
+  if (artifact.checksState === 'pending') return 'Checks pending';
+  if (artifact.checksState === 'success' && artifact.status === 'open') return 'Checks passing';
+  return null;
+}
+
 
 function ReviewGateStackSection({ reviewGate }: { reviewGate: ReviewGateQueryResponse }): JSX.Element {
   const artifacts = reviewGate.artifacts;
@@ -262,6 +273,11 @@ function ReviewGateStackSection({ reviewGate }: { reviewGate: ReviewGateQueryRes
                   <div className="text-foreground">{artifactLabel(artifact)}</div>
                 )}
                 <div className="mt-1 text-[11px] text-muted-foreground">{formatStatus(artifact.status)}</div>
+                {artifactDetail(artifact) && (
+                  <div className="mt-1 text-[11px] text-muted-foreground">
+                    {artifactDetail(artifact)}
+                  </div>
+                )}
               </div>
             </li>
           ))}

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -2202,6 +2202,53 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(downstreamTaskId)!.config.externalDependencies ?? []).toEqual(taskDepsBefore);
       expect(persistence.events.map((event) => event.eventType)).not.toContain('workflow.external_dependency_policy_updated');
     });
+    it('treats pull-request publication as review_ready, not completed, for downstream gate policies', () => {
+      orchestrator.loadPlan({
+        name: 'publish-pr-workflow',
+        tasks: [{ id: 'publish-pr', description: 'Publish pull request' }],
+      });
+      const prereqTaskId = sid(orchestrator, 0, 'publish-pr');
+      const prereqWfId = prereqTaskId.split('/')[0]!;
+      const prereqMergeId = `__merge__${prereqWfId}`;
+
+      orchestrator.loadPlan({
+        name: 'workflow-waits-for-published-pr',
+        tasks: [
+          {
+            id: 'review-leaf',
+            description: 'needs upstream published PR only',
+            externalDependencies: [{ workflowId: prereqWfId, gatePolicy: 'review_ready' }],
+          },
+        ],
+      });
+      const reviewLeafId = sid(orchestrator, 1, 'review-leaf');
+
+      orchestrator.loadPlan({
+        name: 'workflow-waits-for-upstream-completion',
+        tasks: [
+          {
+            id: 'strict-leaf',
+            description: 'needs upstream workflow completion',
+            externalDependencies: [{ workflowId: prereqWfId, gatePolicy: 'completed' }],
+          },
+        ],
+      });
+      const strictLeafId = sid(orchestrator, 2, 'strict-leaf');
+
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(makeResponse({ actionId: prereqTaskId, status: 'completed' }));
+      orchestrator.setTaskReviewReady(prereqMergeId, {
+        execution: {
+          reviewId: 'owner/repo#229',
+          reviewUrl: 'https://github.com/owner/repo/pull/229',
+          reviewStatus: 'Awaiting review',
+        },
+      });
+
+      expect(orchestrator.getTask(reviewLeafId)!.status).toBe('running');
+      expect(orchestrator.getTask(strictLeafId)!.status).toBe('pending');
+    });
+
 
     it('approved merge-gate dependency keeps downstream pending when upstream is awaiting_approval', () => {
       orchestrator.loadPlan({

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -141,6 +141,13 @@ export type ReviewGateArtifactStatus =
   | 'discarded'
   | 'unknown';
 
+export interface MergeGateFailedCheck {
+  readonly name: string;
+  readonly conclusion?: string;
+  readonly detailsUrl?: string;
+  readonly summary?: string;
+}
+
 export interface ReviewGateArtifact {
   readonly id: string;
   readonly title?: string;
@@ -154,6 +161,9 @@ export interface ReviewGateArtifact {
   readonly required: boolean;
   readonly status: ReviewGateArtifactStatus;
   readonly rawStatus?: string;
+  readonly checksState?: 'pending' | 'success' | 'failure';
+  readonly failedChecks?: readonly MergeGateFailedCheck[];
+  readonly mergeState?: 'clean' | 'dirty' | 'unknown';
   readonly dependsOn?: readonly string[];
   readonly generation: number;
   readonly createdAt?: string;


### PR DESCRIPTION
## Summary

This slice exposes the review substate on operator-facing surfaces.

It updates the headless review-gate output and the inspector stack so operators can see check failures and merge conflicts directly.

## Review Claim

Expose the review substate on the operator-facing review surfaces, and show artifact-level check or conflict details in the inspector.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice only changes operator-facing surfaces. It does not change merge execution, review polling, or background fix-worker flow.

## Slice Rationale

After the earlier slices land, the remaining work is to show the new state on the surfaces people use to inspect review gates.

## Non-goals

- Do not change merge execution logic.
- Do not change review polling behavior.
- Do not add new automation on merge conflicts.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/headless-query-review-gate.test.ts`
- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/workflow-inspector.test.tsx`
- [x] `pnpm run check:types`

</details>

## Visual Proof

The inspector stack now shows artifact details directly in the review rows.

![Review gate stack with failed-check names and merge-conflict detail](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260714-6ccdcb/review-gate-substates-after.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 25d0835b8`
- Post-revert steps: None
- Data migration? No

</details>
