### PR TITLE
[Planning Lag Step 3 Ui Perf Correlation And Proof](2) Expose planning typing stats through ui-perf queries

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -537,6 +537,12 @@ describe('headless-client', () => {
     bus.onRequest('headless.query', async () => ({
       maxRendererEventLoopLagMs: 123,
       maxRendererLongTaskMs: 456,
+      planningTypingLagReports: 3,
+      maxPlanningTypingLagMs: 41,
+      planningChatInputChangeReports: 2,
+      maxPlanningChatInputHandlerMs: 17,
+      planningChatInputCommitReports: 1,
+      maxPlanningChatInputCommitMs: 29,
     }));
 
     const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
@@ -550,9 +556,27 @@ describe('headless-client', () => {
 
     expect(exitCode).toBe(0);
     expect(runElectronHeadless).not.toHaveBeenCalled();
-    expect(stdout).toHaveBeenCalledWith('{"maxRendererEventLoopLagMs":123,"maxRendererLongTaskMs":456}\n');
+    expect(stdout).toHaveBeenCalledWith(
+      '{"maxRendererEventLoopLagMs":123,"maxRendererLongTaskMs":456,"planningTypingLagReports":3,"maxPlanningTypingLagMs":41,"planningChatInputChangeReports":2,"maxPlanningChatInputHandlerMs":17,"planningChatInputCommitReports":1,"maxPlanningChatInputCommitMs":29}\n',
+    );
     stdout.mockRestore();
   });
+
+  it('rejects query ui-perf --reset before delegating to the owner', async () => {
+    const bus = new LocalBus();
+    const queryHandler = vi.fn(async () => ({ maxRendererEventLoopLagMs: 1 }));
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    bus.onRequest('headless.query', queryHandler);
+
+    await expect(
+      runHeadlessClientCommand(['query', 'ui-perf', '--reset'], {
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(async () => {}),
+        runElectronHeadless: vi.fn(async () => 0),
+      }),
+    ).rejects.toThrow(/not a read-only query/);
+    expect(queryHandler).not.toHaveBeenCalled();
+  }, 30_000);
 
   it('does not silently fall back for query ui-perf when no owner endpoint is reachable', async () => {
     await expect(

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -102,13 +102,37 @@ describe('headless delegation enforcement', () => {
     });
 
     it('allows query ui-perf in read-only mode', async () => {
+      const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
       mockDeps.getUiPerfStats = vi.fn(() => ({
         maxRendererEventLoopLagMs: 12,
         maxRendererLongTaskMs: 34,
+        planningTypingLagReports: 1,
+        maxPlanningTypingLagMs: 11,
+        planningChatInputChangeReports: 1,
+        maxPlanningChatInputHandlerMs: 9,
+        planningChatInputCommitReports: 1,
+        maxPlanningChatInputCommitMs: 15,
       }));
-      await expect(
-        runHeadless(['query', 'ui-perf', '--output', 'json'], mockDeps)
-      ).resolves.toBeUndefined();
+      mockDeps.resetUiPerfStats = vi.fn();
+      try {
+        await expect(
+          runHeadless(['query', 'ui-perf', '--output', 'json'], mockDeps),
+        ).resolves.toBeUndefined();
+
+        expect(mockDeps.resetUiPerfStats).not.toHaveBeenCalled();
+        expect(JSON.parse(stdout.mock.calls[0][0] as string)).toMatchObject({
+          maxRendererEventLoopLagMs: 12,
+          maxRendererLongTaskMs: 34,
+          planningTypingLagReports: 1,
+          maxPlanningTypingLagMs: 11,
+          planningChatInputChangeReports: 1,
+          maxPlanningChatInputHandlerMs: 9,
+          planningChatInputCommitReports: 1,
+          maxPlanningChatInputCommitMs: 15,
+        });
+      } finally {
+        stdout.mockRestore();
+      }
     });
 
     it('prints direct action graph query JSON in read-only mode', async () => {

--- a/packages/app/src/__tests__/headless-query-capture.test.ts
+++ b/packages/app/src/__tests__/headless-query-capture.test.ts
@@ -108,8 +108,33 @@ describe('runReadOnlyHeadlessQueryToString', () => {
 
   it('still allows non-destructive `query ui-perf`', async () => {
     const resetUiPerfStats = vi.fn();
-    const deps = { ...makeQueryDeps(() => []), resetUiPerfStats, getUiPerfStats: () => ({ mainDeltaToUi: 1 }) };
-    await expect(runReadOnlyHeadlessQueryToString(['query', 'ui-perf'], deps)).resolves.toContain('mainDeltaToUi');
+    const deps = {
+      ...makeQueryDeps(() => []),
+      resetUiPerfStats,
+      getUiPerfStats: () => ({
+        mainDeltaToUi: 1,
+        maxRendererEventLoopLagMs: 12,
+        maxRendererLongTaskMs: 34,
+        planningTypingLagReports: 3,
+        maxPlanningTypingLagMs: 41,
+        planningChatInputChangeReports: 2,
+        maxPlanningChatInputHandlerMs: 17,
+        planningChatInputCommitReports: 1,
+        maxPlanningChatInputCommitMs: 29,
+      }),
+    };
+    const output = await runReadOnlyHeadlessQueryToString(['query', 'ui-perf', '--output', 'json'], deps);
+    expect(JSON.parse(output)).toMatchObject({
+      mainDeltaToUi: 1,
+      maxRendererEventLoopLagMs: 12,
+      maxRendererLongTaskMs: 34,
+      planningTypingLagReports: 3,
+      maxPlanningTypingLagMs: 41,
+      planningChatInputChangeReports: 2,
+      maxPlanningChatInputHandlerMs: 17,
+      planningChatInputCommitReports: 1,
+      maxPlanningChatInputCommitMs: 29,
+    });
     expect(resetUiPerfStats).not.toHaveBeenCalled();
   });
 

--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -9,7 +9,17 @@ function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQuer
   return {
     ownerModeLabel: 'gui',
     onActivity: vi.fn(),
-    getUiPerfStats: vi.fn(() => ({ mainDeltaToUi: 7 })),
+    getUiPerfStats: vi.fn(() => ({
+      mainDeltaToUi: 7,
+      maxRendererEventLoopLagMs: 12,
+      maxRendererLongTaskMs: 34,
+      planningTypingLagReports: 3,
+      maxPlanningTypingLagMs: 41,
+      planningChatInputChangeReports: 2,
+      maxPlanningChatInputHandlerMs: 17,
+      planningChatInputCommitReports: 1,
+      maxPlanningChatInputCommitMs: 29,
+    })),
     resetUiPerfStats: vi.fn(),
     getQueueStatus: vi.fn(() => ({ runningCount: 2 })),
     listWorkerActionHistory: vi.fn((request) => ({ workerKind: request.workerKind, actions: [], limit: request.limit ?? 20, offset: request.offset ?? 0, hasMore: false })),
@@ -36,7 +46,18 @@ function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQuer
 describe('answerOwnerReadQuery', () => {
   it('ui-perf merges the owner label with the stats; reset only when asked', () => {
     const h = makeHandlers({ ownerModeLabel: 'standalone' });
-    expect(answerOwnerReadQuery({ kind: 'ui-perf' }, h)).toEqual({ ownerMode: 'standalone', mainDeltaToUi: 7 });
+    expect(answerOwnerReadQuery({ kind: 'ui-perf' }, h)).toEqual({
+      ownerMode: 'standalone',
+      mainDeltaToUi: 7,
+      maxRendererEventLoopLagMs: 12,
+      maxRendererLongTaskMs: 34,
+      planningTypingLagReports: 3,
+      maxPlanningTypingLagMs: 41,
+      planningChatInputChangeReports: 2,
+      maxPlanningChatInputHandlerMs: 17,
+      planningChatInputCommitReports: 1,
+      maxPlanningChatInputCommitMs: 29,
+    });
     expect(h.resetUiPerfStats).not.toHaveBeenCalled();
     answerOwnerReadQuery({ kind: 'ui-perf', reset: true }, h);
     expect(h.resetUiPerfStats).toHaveBeenCalledTimes(1);

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -252,6 +252,9 @@ async function delegateReadOnlyQuery(
   if (!isUiPerf && !isQueue && !isActionGraph) {
     return delegateGenericReadQuery(args, bus, refreshMessageBus);
   }
+  if (isUiPerf && args.includes('--reset')) {
+    throw new Error('query ui-perf --reset is not a read-only query');
+  }
 
   // Use the resolver to wait for any reachable owner
   const resolver = createOwnerResolver(

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -27,6 +27,7 @@ import {
 import { resolveDefaultExecutionAgent } from './config.js';
 import { loadAllEventsPaged } from './load-all-events-paged.js';
 import { listWorkerDecisions, toWorkerActionSummary } from './worker-control.js';
+import { createRendererUiPerfCounters } from './renderer-ui-perf.js';
 import {
   collectRecoveryWorkerStatus,
   type RecoveryWorkerStatus,
@@ -294,9 +295,7 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
         dbPollCreated: 0,
         dbPollUpdatedAsCreated: 0,
         dbPollUpdatedAsUpdated: 0,
-        rendererReports: 0,
-        maxRendererEventLoopLagMs: 0,
-        maxRendererLongTaskMs: 0,
+        ...createRendererUiPerfCounters(),
       };
       switch (flags.output) {
         case 'label':

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -87,6 +87,7 @@ import {
 import { seedMainProcessHitchFixture } from '../main-process-hitch-fixture.js';
 import { seedStressFixture, type StressFixtureOptions } from '../stress-fixture.js';
 import { buildReviewGateQueryResponse } from '../review-gate-query.js';
+import { recordRendererUiPerfMetric, type RendererUiPerfCounters } from '../renderer-ui-perf.js';
 import {
   AUTO_STARTED_OWNER_WORKER_KINDS,
   createLocalWorkerStatusSnapshot,
@@ -224,14 +225,7 @@ export interface RegisterGuiMutationIpcHandlersContext extends GuiMutationTaskAc
   getTaskDeltaStreamSequence: () => number;
   computeRuntimeStatus: () => unknown;
   getUiPerfStats: () => Record<string, unknown>;
-  uiPerfStats: {
-    rendererReports: number;
-    maxRendererHiddenEventLoopLagMs: number;
-    maxRendererEventLoopLagMs: number;
-    maxRendererCumulativeLagMs: number;
-    maxRendererTickDeltaMs: number;
-    maxRendererLongTaskMs: number;
-  };
+  uiPerfStats: RendererUiPerfCounters;
   createRegisteredWorkerRegistry: () => WorkerRegistry<WorkerRuntimeDependencies>;
   buildCliInstallerContext: () => CliInstallerContext;
   resolveSetupCliPath: () => string;
@@ -1719,24 +1713,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     ) {
       logger.info(`ui metric ${metric} ${JSON.stringify(data ?? {})}`, { module: 'ui-state' });
     }
-    if (metric === 'renderer_event_loop_lag' && typeof data?.lagMs === 'number') {
-      const hiddenOrUnfocused = data.visibilityState === 'hidden' || data.hasFocus === false;
-      if (hiddenOrUnfocused) {
-        uiPerfStats.maxRendererHiddenEventLoopLagMs = Math.max(uiPerfStats.maxRendererHiddenEventLoopLagMs, data.lagMs);
-      } else {
-        uiPerfStats.maxRendererEventLoopLagMs = Math.max(uiPerfStats.maxRendererEventLoopLagMs, data.lagMs);
-      }
-      if (typeof data.cumulativeLagMs === 'number') {
-        uiPerfStats.maxRendererCumulativeLagMs = Math.max(uiPerfStats.maxRendererCumulativeLagMs, data.cumulativeLagMs);
-      }
-      if (typeof data.tickDeltaMs === 'number') {
-        uiPerfStats.maxRendererTickDeltaMs = Math.max(uiPerfStats.maxRendererTickDeltaMs, data.tickDeltaMs);
-      }
-    }
-    if (metric === 'renderer_long_task' && typeof data?.durationMs === 'number') {
-      uiPerfStats.maxRendererLongTaskMs = Math.max(uiPerfStats.maxRendererLongTaskMs, data.durationMs);
-    }
-    uiPerfStats.rendererReports += 1;
+    recordRendererUiPerfMetric(uiPerfStats, metric, data);
     try {
       persistence.writeActivityLog('ui-perf', 'info', JSON.stringify(payload));
     } catch {


### PR DESCRIPTION
## Summary

The headless ui-perf query now returns planning typing counters from the owner.

Read-only delegation keeps reset behavior out of delegated query calls.

## Review Claim

The headless ui-perf query surface includes planning typing counters without allowing reset through read-only delegation.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Read-only queries still avoid reset, and owner stats are read through the existing dependency boundary.

## Slice Rationale

This follows the counter slice so the owner and headless surfaces only consume existing fields.

## Non-goals

- Does not change counter math.
- Does not change task scheduling or workflow execution.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/renderer-ui-perf.test.ts src/__tests__/headless-client.test.ts src/__tests__/headless-delegation.test.ts src/__tests__/headless-query-capture.test.ts src/__tests__/owner-read-query.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/planning-lag-step3-pr2.md --changed-files-file /tmp/planning-lag-step3-pr2-files.txt --diff-file /tmp/planning-lag-step3-pr2.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this PR commit>`
- Post-revert steps: Re-run the focused headless ui-perf query tests if this owner query proof is still needed.
- Data migration? No

</details>