### PR TITLE
[Monkey Adverse](12) Set INVOKER_TEST_WORKFLOW_IDS in e2e launches

### DIFF
--- a/packages/app/e2e/embedded-terminal-restart-persistence.spec.ts
+++ b/packages/app/e2e/embedded-terminal-restart-persistence.spec.ts
@@ -48,6 +48,7 @@ async function launchApp(paths: { dbDir: string; userDataDir: string; ipcSocketP
     env: {
       ...process.env,
       NODE_ENV: 'test',
+          INVOKER_TEST_WORKFLOW_IDS: '1',
       INVOKER_USER_DATA_DIR: paths.userDataDir,
       INVOKER_DISABLE_SLACK: '1',
       TZ: 'UTC',

--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -158,6 +158,7 @@ exit 64
       env: {
         ...process.env,
         NODE_ENV: 'test',
+        INVOKER_TEST_WORKFLOW_IDS: '1',
         INVOKER_DISABLE_SLACK: '1',
         TZ: 'UTC',
         INVOKER_GUI_OWNER_MODE: (forceReadOnlyStatus || forceConnectionLostStatus) ? 'gui' : guiOwnerMode,

--- a/packages/app/e2e/gap-recovery-bench.spec.ts
+++ b/packages/app/e2e/gap-recovery-bench.spec.ts
@@ -44,6 +44,7 @@ async function launchElectronApp(testDir: string, extraEnv?: Record<string, stri
     env: {
       ...process.env,
       NODE_ENV: 'test',
+          INVOKER_TEST_WORKFLOW_IDS: '1',
       INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
       INVOKER_DB_DIR: testDir,
       INVOKER_IPC_SOCKET: ipcSocketPath,

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -46,6 +46,7 @@ function headlessTestEnv(testDir: string): NodeJS.ProcessEnv {
   return {
     ...process.env,
     NODE_ENV: 'test',
+          INVOKER_TEST_WORKFLOW_IDS: '1',
     TZ: 'UTC',
     INVOKER_DB_DIR: testDir,
     INVOKER_IPC_SOCKET: ipcSocketPath,

--- a/packages/app/e2e/launching-stall-watchdog.spec.ts
+++ b/packages/app/e2e/launching-stall-watchdog.spec.ts
@@ -55,6 +55,7 @@ base.describe('Launch stall watchdog', () => {
         env: {
           ...process.env,
           NODE_ENV: 'test',
+          INVOKER_TEST_WORKFLOW_IDS: '1',
           INVOKER_GUI_OWNER_MODE: 'gui',
           INVOKER_DB_DIR: testDir,
           INVOKER_IPC_SOCKET: ipcSocketPath,
@@ -164,6 +165,7 @@ base.describe('Launch stall watchdog', () => {
         env: {
           ...process.env,
           NODE_ENV: 'test',
+          INVOKER_TEST_WORKFLOW_IDS: '1',
           INVOKER_GUI_OWNER_MODE: 'gui',
           INVOKER_DB_DIR: testDir,
           INVOKER_IPC_SOCKET: ipcSocketPath,

--- a/packages/app/e2e/orphan-relaunch.spec.ts
+++ b/packages/app/e2e/orphan-relaunch.spec.ts
@@ -70,6 +70,7 @@ base.describe('Orphan task relaunch on restart', () => {
         env: {
           ...process.env,
           NODE_ENV: 'test',
+          INVOKER_TEST_WORKFLOW_IDS: '1',
           INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
           INVOKER_DB_DIR: testDir,
           INVOKER_ALLOW_DELETE_ALL: '1',

--- a/packages/app/e2e/planning-terminal-restart-persistence.spec.ts
+++ b/packages/app/e2e/planning-terminal-restart-persistence.spec.ts
@@ -46,6 +46,7 @@ async function launchApp(paths: { dbDir: string; userDataDir: string; ipcSocketP
     env: {
       ...process.env,
       NODE_ENV: 'test',
+          INVOKER_TEST_WORKFLOW_IDS: '1',
       INVOKER_USER_DATA_DIR: paths.userDataDir,
       INVOKER_DISABLE_SLACK: '1',
       TZ: 'UTC',

--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -74,6 +74,7 @@ async function launchElectronApp(testDir: string, extraEnv?: Record<string, stri
     env: {
       ...process.env,
       NODE_ENV: 'test',
+          INVOKER_TEST_WORKFLOW_IDS: '1',
       INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
       INVOKER_DB_DIR: testDir,
       INVOKER_IPC_SOCKET: ipcSocketPath,

--- a/packages/app/e2e/startup-window-liveness.spec.ts
+++ b/packages/app/e2e/startup-window-liveness.spec.ts
@@ -41,6 +41,7 @@ test('GUI renderer becomes ready while the test window stays invisible', async (
       env: {
         ...process.env,
         NODE_ENV: 'test',
+          INVOKER_TEST_WORKFLOW_IDS: '1',
         INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
         INVOKER_DB_DIR: testDir,
         INVOKER_IPC_SOCKET: ipcSocketPath,

--- a/packages/app/e2e/task-new-attempt-reset.spec.ts
+++ b/packages/app/e2e/task-new-attempt-reset.spec.ts
@@ -76,6 +76,7 @@ async function launchApp(testDir: string, configPath: string): Promise<{ app: El
     env: {
       ...process.env,
       NODE_ENV: 'test',
+          INVOKER_TEST_WORKFLOW_IDS: '1',
       TZ: 'UTC',
       INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'daemon',
       INVOKER_DB_DIR: testDir,


### PR DESCRIPTION
## Summary

Set `INVOKER_TEST_WORKFLOW_IDS=1` in Playwright e2e launches so specs keep deterministic `wf-test-*` workflow IDs after the NODE_ENV gate change in #4420.

## Review Claim

Approve wiring INVOKER_TEST_WORKFLOW_IDS into shared e2e launch fixtures and affected Playwright specs.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only test launch paths set the flag; production-shaped chaos runs still omit it.

## Slice Rationale

E2E follow-up to #4420. Keeps monkey-adverse Playwright repros on stable workflow IDs without reverting the vitest gate.

## Non-goals

Does not change workflow ID generation logic or vitest env defaults.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec playwright test e2e/startup-window-liveness.spec.ts --grep @smoke` (or CI e2e-proof shard)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
