### PR TITLE
[Managed Worktree No Bootstrap](1) Add no-provision managed worktree regressions

### DIFF
--- a/packages/execution-engine/src/__tests__/default-worktree-provision-command.test.ts
+++ b/packages/execution-engine/src/__tests__/default-worktree-provision-command.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_WORKTREE_PROVISION_COMMAND } from '../default-worktree-provision-command.js';
+
+describe('DEFAULT_WORKTREE_PROVISION_COMMAND', () => {
+  it.skip('stays empty so managed worktrees never auto-provision repos', () => {
+    expect(DEFAULT_WORKTREE_PROVISION_COMMAND).toBe('');
+    expect(DEFAULT_WORKTREE_PROVISION_COMMAND.trim()).toBe('');
+  });
+});

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -1235,6 +1235,44 @@ describe('SshExecutor entry lifecycle', () => {
     proc.emit('close', 0, null);
     await new Promise((r) => setTimeout(r, 50));
   });
+  it.skip('managed mode skips implicit provisioning and still reaches a Flutter payload', async () => {
+    const ssh2 = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+      remoteInvokerHome: '~/.invoker',
+    }) as any;
+
+    vi.spyOn(ssh2, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return '__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=abc123def456abc123def456abc123def456abc1';
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      return '';
+    });
+    vi.spyOn(ssh2, 'setupTaskBranch').mockResolvedValue(undefined);
+
+    await ssh2.start(makeRequest({
+      actionType: 'command',
+      inputs: {
+        command: "printf 'ok\\n' > .invoker-flutter-bootstrap-ran",
+        description: 'test',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    }));
+
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+    expect(proc).toBeDefined();
+    const writeMock = (proc.stdin as any).write as ReturnType<typeof vi.fn>;
+    const script = writeMock.mock.calls[0]![0] as string;
+    expect(script).not.toContain('PROVISION_PATH="$STAGING_DIR/provision.sh"');
+    expect(script).toContain('"$RUNNER_PATH" "$PAYLOAD_PATH"');
+
+    proc.emit('close', 0, null);
+    await new Promise((r) => setTimeout(r, 50));
+  });
 
   it('changes managed branch and worktree when request lifecycleTag changes, as recreate does', async () => {
     const ssh2 = new SshExecutor({

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -354,6 +354,18 @@ describe('WorktreeExecutor', () => {
 
     taskProcess.emit('close', 0, null);
   });
+  it.skip('does not run implicit provisioning before spawning the task process', async () => {
+    const { taskProcess } = setupSpawnMock();
+
+    await executor.start(makeRequest());
+
+    const bootstrapCall = mockedSpawn.mock.calls.find(
+      ([cmd, args]) => cmd === '/bin/bash' && (args as string[])?.[1]?.includes('pnpm install'),
+    );
+    expect(bootstrapCall).toBeUndefined();
+
+    taskProcess.emit('close', 0, null);
+  });
 
   it('completion captures branch and commit hash in summary', async () => {
     const { taskProcess } = setupSpawnMock();


### PR DESCRIPTION
## Summary

This adds focused skipped regressions for managed worktrees that should no longer auto-run repo setup.

The checks stay skipped in this slice so the proof lands before the runtime change.

## Review Claim

Invoker now has focused skipped regressions for the no-bootstrap managed-worktree behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes tests only. Runtime behavior stays unchanged.

## Slice Rationale

The next slice changes executor behavior. This proof lands first so the reviewer sees the intended behavior before the implementation flips it on.

## Non-goals

- No runtime behavior change.
- No config surface change.
- No docs change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd ~/.invoker/worktrees/64a63486912a/experiment-wf-1783759502407-36-fix-managed-ssh-flutter-provision/packages/execution-engine && pnpm exec vitest run src/__tests__/default-worktree-provision-command.test.ts src/__tests__/worktree-executor.test.ts src/__tests__/ssh-executor.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert c4b97740`
- Post-revert steps: None.
- Data migration? No.

</details>
