### PR TITLE
fix: avoid duplicate taskId in CI repair debug log

### DIFF
--- a/packages/execution-engine/src/review-gate-ci-repair.ts
+++ b/packages/execution-engine/src/review-gate-ci-repair.ts
@@ -277,7 +277,6 @@ function logCiFailureWorkerEvent(
   options.store.logEvent?.(event.taskId, 'debug.ci-failure-worker', payload);
   options.logger.debug?.(`[worker:${CI_FAILURE_WORKER_KIND}] ${phase}`, {
     module: 'review-gate-ci-repair',
-    taskId: event.taskId,
     ...payload,
   });
 }

--- a/packages/execution-engine/src/review-gate-ci-repair.ts
+++ b/packages/execution-engine/src/review-gate-ci-repair.ts
@@ -277,6 +277,7 @@ function logCiFailureWorkerEvent(
   options.store.logEvent?.(event.taskId, 'debug.ci-failure-worker', payload);
   options.logger.debug?.(`[worker:${CI_FAILURE_WORKER_KIND}] ${phase}`, {
     module: 'review-gate-ci-repair',
+    taskId: event.taskId,
     ...payload,
   });
 }

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -7,6 +7,7 @@ import type {
   AutoFixRecoverySubmitter,
   AutoFixWorkerConfig,
 } from './auto-fix-recovery.js';
+import type { ReviewGateCiRepairStore, ReviewGateCiRepairSubmitter } from './review-gate-ci-repair.js';
 import type { CiFailureWorkerStore, CiFailureWorkerSubmitter } from './workers/ci-failure-worker.js';
 import type {
   AutoApproveWorkerStore,
@@ -34,6 +35,7 @@ export interface WorkerRuntimeDependencies {
   /** Persisted workflow/task state accessor. */
   store: AutoFixRecoveryStore
     & CiFailureWorkerStore
+    & ReviewGateCiRepairStore
     & AutoApproveWorkerStore
     & ReviewGateMergeConflictWorkerStore
     & WorkflowResumeWorkerStore
@@ -41,6 +43,7 @@ export interface WorkerRuntimeDependencies {
   /** Action-output channel used to submit follow-up mutation intents. */
   submitter: AutoFixRecoverySubmitter
     & CiFailureWorkerSubmitter
+    & ReviewGateCiRepairSubmitter
     & RequeueWorkerSubmitter
     & AutoApproveWorkerSubmitter
     & ReviewGateMergeConflictWorkerSubmitter


### PR DESCRIPTION
Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #4493