### PR TITLE
[Managed Worktree No Bootstrap](4) Stop threading provisioning through runner plumbing

### DIFF
--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -73,7 +73,6 @@ export type RemoteTargetDisplay = {
   port?: number;
   managedWorkspaces?: boolean;
   remoteInvokerHome?: string;
-  provisionCommand?: string;
   use_api_key?: boolean;
   secretsFile?: string;
   remoteHeartbeatIntervalSeconds?: number;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -178,7 +178,6 @@ export interface TaskRunnerConfig {
     port?: number;
     managedWorkspaces?: boolean;
     remoteInvokerHome?: string;
-    provisionCommand?: string;
     use_api_key?: boolean;
     secretsFile?: string;
     remoteHeartbeatIntervalSeconds?: number;
@@ -1681,7 +1680,6 @@ export class TaskRunner {
     port?: number;
     managedWorkspaces?: boolean;
     remoteInvokerHome?: string;
-    provisionCommand?: string;
     use_api_key?: boolean;
     secretsFile?: string;
     remoteHeartbeatIntervalSeconds?: number;


### PR DESCRIPTION
## Summary

This stops the runner plumbing from carrying a managed-worktree `provisionCommand`.

After the runtime change, that path was dead. The routing layer now matches the new checkout flow.

## Review Claim

Invoker no longer threads managed-worktree provisioning through the runner plumbing.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice only trims now-unused routing inputs after the runtime path already stopped consuming them.

## Slice Rationale

The runtime behavior changed first. This follow-up brings the surrounding routing surface into line with that behavior.

## Non-goals

- No runtime bootstrap behavior change.
- No user-facing docs change.
- No task-payload rewrite.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd ~/.invoker/worktrees/64a63486912a/experiment-wf-1783759502407-36-fix-managed-ssh-flutter-provision && pnpm run build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 7f876c05`
- Post-revert steps: Re-run `pnpm run build`.
- Data migration? No.

</details>
