### PR TITLE
[Managed Worktree No Bootstrap](5) Stop exposing the setup hook in CLI config

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -87,7 +87,6 @@ type CliRuntimeConfig = {
     port?: number;
     managedWorkspaces?: boolean;
     remoteInvokerHome?: string;
-    provisionCommand?: string;
     use_api_key?: boolean;
     secretsFile?: string;
     remoteHeartbeatIntervalSeconds?: number;


### PR DESCRIPTION
## Summary

This updates the CLI-facing config shape.

The managed-worktree setup hook is no longer listed there.

## Review Claim

The CLI-facing config shape no longer includes a managed-worktree setup hook.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice changes one exposed CLI-facing field only. Executor behavior is unchanged.

## Slice Rationale

The lower layers already changed. This follow-up makes the exposed CLI-facing shape match them.

## Non-goals

- No executor behavior change.
- No app-config guidance change.
- No docs change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd ~/.invoker/worktrees/64a63486912a/experiment-wf-1783759502407-36-fix-managed-ssh-flutter-provision && pnpm run build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 38630ed2`
- Post-revert steps: Re-run `pnpm run build`.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the deprecated provisioning command option from remote target configuration.
  * Existing CLI runtime behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->