### PR TITLE
[Managed Worktree No Bootstrap](7) Document explicit repo bootstrap for managed worktrees

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -158,20 +158,19 @@ Minimal example:
       "user": "invoker",
       "sshKeyPath": "/home/you/.ssh/invoker_staging_a",
       "managedWorkspaces": true,
-      "remoteInvokerHome": "~/.invoker",
-      "provisionCommand": "pnpm install --frozen-lockfile"
+      "remoteInvokerHome": "~/.invoker"
     },
     "staging-b": {
       "host": "203.0.113.11",
       "user": "invoker",
       "sshKeyPath": "/home/you/.ssh/invoker_staging_b",
       "managedWorkspaces": true,
-      "remoteInvokerHome": "~/.invoker",
-      "provisionCommand": "pnpm install --frozen-lockfile"
+      "remoteInvokerHome": "~/.invoker"
     }
   }
 }
 ```
+Invoker does not run repo bootstrap automatically on managed SSH checkouts. If a repo needs setup such as `pnpm install` or `flutter pub get`, make the task command run that repo-owned step explicitly.
 
 `autoFixRetries` is a finite per-task cap. `3` means the worker keeps consumed attempts in process memory and can submit at most three auto-fix attempts for the same failed task lineage; `0` disables auto-fix workers.
 

--- a/docs/remote-ssh-targets.md
+++ b/docs/remote-ssh-targets.md
@@ -23,7 +23,6 @@ If you want to use a repo-specific config file, launch Invoker with `INVOKER_REP
       "sshKeyPath": "/home/user/.ssh/id_staging",
       "managedWorkspaces": true,
       "remoteInvokerHome": "~/.invoker",
-      "provisionCommand": "pnpm install --frozen-lockfile",
       "remoteHeartbeatIntervalSeconds": 30
     },
     "staging-server-b": {
@@ -33,12 +32,12 @@ If you want to use a repo-specific config file, launch Invoker with `INVOKER_REP
       "port": 22,
       "managedWorkspaces": true,
       "remoteInvokerHome": "~/.invoker",
-      "provisionCommand": "pnpm install --frozen-lockfile",
       "remoteHeartbeatIntervalSeconds": 30
     }
   }
 }
 ```
+Invoker does not run repo bootstrap automatically on managed SSH checkouts. If a repo needs setup such as `pnpm install` or `flutter pub get`, make the task command run that repo-owned step explicitly.
 
 ### Fields
 
@@ -50,12 +49,11 @@ If you want to use a repo-specific config file, launch Invoker with `INVOKER_REP
 | `port` | number | no | SSH port (default: 22) |
 | `managedWorkspaces` | boolean | no | When true, Invoker clones/fetches the repo and manages per-task worktrees on the remote host |
 | `remoteInvokerHome` | string | no | Base directory used by managed remote workspaces (default: `~/.invoker`) |
-| `provisionCommand` | string | no | Command run after worktree creation in managed mode |
 | `remoteHeartbeatIntervalSeconds` | number | no | Interval (seconds) for SSH remote workload heartbeat markers used by executing-stall detection (default: `30`) |
 
 ## Multiple SSH Targets
 
-You can configure as many remote targets as you want under `remoteTargets`. Each task picks one by `poolMemberId`.
+You can configure as many remote targets as you want under `remoteTargets`. Each task picks one with `poolId`.
 
 ```yaml
 name: "Run tasks on multiple remotes"
@@ -65,17 +63,15 @@ tasks:
   - id: check-a
     description: "Run tests on remote A"
     command: "pnpm test"
-    runnerKind: ssh
-    poolMemberId: staging-server
+    poolId: staging-server
 
   - id: check-b
     description: "Run tests on remote B"
     command: "pnpm test"
-    runnerKind: ssh
-    poolMemberId: staging-server-b
+    poolId: staging-server-b
 ```
 
-This is the supported way to run multiple SSH executors in one workflow: define multiple targets, then attach different tasks to different target IDs.
+This is the simplest way to target specific SSH machines: define multiple `remoteTargets`, then point each task at the target ID it should use. If you need queueing, load balancing, or mixed local/SSH routing, put those target IDs inside `executionPools` and use the pool name as `poolId` instead.
 
 ## Usage in Plans
 
@@ -89,31 +85,28 @@ tasks:
   - id: health-check
     description: "Verify staging server is reachable"
     command: "echo 'OK'; uptime; df -h"
-    runnerKind: ssh
-    poolMemberId: staging-server
+    poolId: staging-server
     dependencies: []
 
   - id: run-migrations
     description: "Run database migrations on staging"
     command: "cd /opt/app && ./migrate.sh"
-    runnerKind: ssh
-    poolMemberId: staging-server
+    poolId: staging-server
     dependencies:
       - health-check
 ```
 
 ### Task fields
 
-- `runnerKind: ssh` — selects the SSH executor
-- `poolMemberId: <id>` — references a key in `remoteTargets` config
+- `poolId: <id>` — references either a `remoteTargets` key directly or an `executionPools` key that contains SSH members
 
-Both fields are required for SSH tasks. The executor validates at runtime that the `poolMemberId` exists in config and throws a clear error if it's missing.
+The executor validates at runtime that the selected target or pool exists and resolves to an SSH-capable execution route.
 
 ## How It Works
 
-1. The plan parser reads `runnerKind` and `poolMemberId` from YAML and carries them through to `TaskConfig`.
-2. When `TaskRunner.selectExecutor()` sees `runnerKind: ssh`, it looks up the `poolMemberId` in the `remoteTargets` config map.
-3. An `SshExecutor` instance is created with the target's connection details.
+1. The plan parser reads `poolId` from YAML and stores it on the task config.
+2. At dispatch time, Invoker resolves that `poolId` either directly to a `remoteTargets` entry or to an `executionPools` member selection.
+3. An `SshExecutor` instance is created with the chosen target's connection details.
 4. The runner spawns: `ssh -i <keyPath> -p <port> -o StrictHostKeyChecking=accept-new -o BatchMode=yes user@host <command>`
 5. For `claude` action types, the Claude CLI command is shell-quoted and executed remotely.
 

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -247,13 +247,11 @@ export interface InvokerConfig {
     /**
      * Remote invoker home directory (e.g., ~/.invoker). Only used in managed mode.
      * Default: ~/.invoker
+     *
+     * Invoker does not run repo bootstrap automatically. If a repo needs hydration,
+     * make the task command run the repo-owned setup explicitly.
      */
     remoteInvokerHome?: string;
-    /**
-     * Optional provision command to run in the worktree after creation (e.g., pnpm install).
-     * Only used in managed mode. Default: pnpm install --frozen-lockfile
-     */
-    provisionCommand?: string;
     /**
      * When true, export agent API keys from the local secrets file into SSH task/fix
      * shells. Default false so remote Claude/Codex CLI account auth is preserved.


### PR DESCRIPTION
## Summary

This updates the managed SSH docs.

The examples now say Invoker does not bootstrap repos for tasks.

## Review Claim

The managed SSH docs now say that repo setup must run as an explicit repo step.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice changes prose only. Runtime behavior does not change.

## Slice Rationale

The user-facing docs now match the current examples and runtime behavior.

## Non-goals

- No runtime behavior change.
- No config-surface change.
- No task-payload rewrite.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd ~/.invoker/worktrees/64a63486912a/experiment-wf-1783759502407-36-fix-managed-ssh-flutter-provision && python3 - <<'PY'
from pathlib import Path
remote = Path('docs/remote-ssh-targets.md').read_text()
getting = Path('docs/getting-started.md').read_text()
assert 'repo bootstrap automatically' in remote
assert 'repo bootstrap automatically' in getting
assert 'provisionCommand' not in remote
print('docs-ok')
PY`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 79761f5c`
- Post-revert steps: None.
- Data migration? No.

</details>
