### PR TITLE
[Deferred Startup Reconcile](3) Flip startup reconcile regression tests green

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3534,34 +3534,42 @@ function createEmbeddedTerminalBackendFromConfig(
         autoFixRetries: resolveAutoFixRetries(invokerConfig),
         canControl: () => ownerMode,
       });
-      const reconciledWorkerActions = reconcileTerminalWorkerActionsOnStartup(persistence);
-      if (reconciledWorkerActions > 0) {
-        logger.info(
-          `reconciled ${reconciledWorkerActions} terminal worker action(s) on startup`,
-          { module: 'init' },
-        );
-      }
     }
 
     // Fail orphaned in-flight tasks left by a previous crash, then start ready work.
     if (!ownerMode) {
       logger.info('follower mode startup: auto-run disabled', { module: 'init' });
     } else {
-      const orphaned = reconcileOrphanedInFlightTasksOnBoot({
-        orchestrator,
-        persistence,
-      });
-      if (orphaned.length > 0) {
-        logger.info(
-          `failed ${orphaned.length} orphaned in-flight task(s) left by a previous owner crash`,
-          { module: 'init', taskIds: orphaned.map((task) => task.id) },
-        );
-      }
-      if (invokerConfig.disableAutoRunOnStartup) {
-        logger.info('auto-run on startup disabled by config', { module: 'init' });
-      } else {
-        orchestrator.startExecution();
-      }
+      setTimeout(() => {
+        if (!ownerMode) return;
+        try {
+          const reconciledWorkerActions = reconcileTerminalWorkerActionsOnStartup(persistence);
+          if (reconciledWorkerActions > 0) {
+            logger.info(
+              `reconciled ${reconciledWorkerActions} terminal worker action(s) on startup`,
+              { module: 'init' },
+            );
+          }
+          const orphaned = reconcileOrphanedInFlightTasksOnBoot({
+            orchestrator,
+            persistence,
+          });
+          if (orphaned.length > 0) {
+            logger.info(
+              `failed ${orphaned.length} orphaned in-flight task(s) left by a previous owner crash`,
+              { module: 'init', taskIds: orphaned.map((task) => task.id) },
+            );
+          }
+          if (invokerConfig.disableAutoRunOnStartup) {
+            logger.info('auto-run on startup disabled by config', { module: 'init' });
+          } else {
+            orchestrator.startExecution();
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          logger.error(`deferred owner startup maintenance failed: ${message}`, { module: 'init' });
+        }
+      }, 0);
     }
 
     const dbPath = path.join(resolveInvokerHomeRoot(), 'invoker.db');

--- a/packages/execution-engine/src/__tests__/reconcile-terminal-worker-actions.test.ts
+++ b/packages/execution-engine/src/__tests__/reconcile-terminal-worker-actions.test.ts
@@ -82,4 +82,45 @@ describe('reconcileTerminalWorkerActionsOnStartup', () => {
       summary: 'Worker action reconciled from failed intent on startup: boom',
     });
   });
+
+  it('preserves store method binding when listing terminal intents', () => {
+    const actions = new Map<string, WorkerActionRecord>([
+      ['a', toRecord({
+        id: 'a',
+        workerKind: 'ci-failure',
+        actionType: 'fix-ci-failure',
+        workflowId: 'wf-1',
+        taskId: 'wf-1/t',
+        subjectType: 'review',
+        subjectId: '1',
+        externalKey: 'a',
+        status: 'queued',
+        intentId: '9',
+      })],
+    ]);
+    const store = {
+      listWorkerActions: () => Array.from(actions.values()),
+      listWorkflowMutationIntents(workflowId?: string) {
+        expect(this).toBe(store);
+        expect(workflowId).toBe('wf-1');
+        return [{
+          id: 9,
+          workflowId: 'wf-1',
+          channel: 'invoker:fix-with-agent',
+          args: [],
+          priority: 'normal' as const,
+          status: 'completed' as const,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        }];
+      },
+      upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+        const saved = toRecord(write);
+        actions.set(write.id, saved);
+        return saved;
+      }),
+    };
+
+    expect(reconcileTerminalWorkerActionsOnStartup(store)).toBe(1);
+    expect(actions.get('a')?.status).toBe('completed');
+  });
 });

--- a/packages/execution-engine/src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
@@ -47,7 +47,7 @@ describe('repro: deferred startup reconcile method binding', () => {
     );
   });
 
-  it.fails('queries terminal intents once per workflow during startup reconcile', () => {
+  it('queries terminal intents once per workflow during startup reconcile', () => {
     const actions = [
       toRecord(buildQueuedAction('a', '9')),
       toRecord(buildQueuedAction('b', '9')),

--- a/packages/execution-engine/src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store';
+
+import { reconcileTerminalWorkerActionsOnStartup } from '../reconcile-terminal-worker-actions.js';
+
+function toRecord(write: WorkerActionWrite): WorkerActionRecord {
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? '2026-01-01T00:00:00.000Z',
+    updatedAt: write.updatedAt ?? '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function buildQueuedAction(id: string, intentId: string): WorkerActionWrite {
+  return {
+    id,
+    workerKind: 'ci-failure',
+    actionType: 'fix-ci-failure',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/t',
+    subjectType: 'review',
+    subjectId: '1',
+    externalKey: id,
+    status: 'queued',
+    intentId,
+  };
+}
+
+describe('repro: deferred startup reconcile method binding', () => {
+  it('fails like production when listWorkflowMutationIntents is extracted without bind', () => {
+    const store = {
+      listWorkflowMutationIntents(workflowId?: string) {
+        if (!workflowId) return [];
+        return this.queryAll(workflowId);
+      },
+      queryAll(workflowId: string) {
+        return workflowId === 'wf-1'
+          ? [{ id: 9, workflowId: 'wf-1', channel: 'x', args: [], priority: 'normal', status: 'completed', createdAt: 't' }]
+          : [];
+      },
+    };
+    const unboundList = store.listWorkflowMutationIntents;
+    expect(() => unboundList('wf-1', ['completed', 'failed'])).toThrow(
+      /Cannot read properties of undefined \(reading 'queryAll'\)/,
+    );
+  });
+
+  it.fails('queries terminal intents once per workflow during startup reconcile', () => {
+    const actions = [
+      toRecord(buildQueuedAction('a', '9')),
+      toRecord(buildQueuedAction('b', '9')),
+    ];
+    const listWorkflowMutationIntents = vi.fn((workflowId?: string) => {
+      expect(workflowId).toBe('wf-1');
+      return [{
+        id: 9,
+        workflowId: 'wf-1',
+        channel: 'invoker:fix-with-agent',
+        args: [],
+        priority: 'normal' as const,
+        status: 'completed' as const,
+        createdAt: '2026-01-01T00:00:00.000Z',
+      }];
+    });
+    const store = {
+      listWorkerActions: () => actions,
+      listWorkflowMutationIntents,
+      upsertWorkerAction: vi.fn((write: WorkerActionWrite) => toRecord(write)),
+    };
+
+    expect(reconcileTerminalWorkerActionsOnStartup(store)).toBe(2);
+    expect(listWorkflowMutationIntents).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/execution-engine/src/reconcile-terminal-worker-actions.ts
+++ b/packages/execution-engine/src/reconcile-terminal-worker-actions.ts
@@ -38,6 +38,8 @@ export function reconcileTerminalWorkerActionsOnStartup(
   if (!store.upsertWorkerAction || !store.listWorkflowMutationIntents) {
     return 0;
   }
+  const upsertWorkerAction = store.upsertWorkerAction.bind(store);
+  const listTerminalIntents = store.listWorkflowMutationIntents.bind(store);
 
   const seen = new Set<string>();
   const open: WorkerActionRecord[] = [];
@@ -51,10 +53,23 @@ export function reconcileTerminalWorkerActionsOnStartup(
 
   let reconciled = 0;
   const nowIso = now.toISOString();
+  const terminalIntentsByWorkflow = new Map<string, Map<string, WorkflowMutationIntent>>();
+  const resolveTerminalIntent = (
+    workflowId: string,
+    intentId: string,
+  ): WorkflowMutationIntent | undefined => {
+    let intentsById = terminalIntentsByWorkflow.get(workflowId);
+    if (!intentsById) {
+      const terminalIntents = listTerminalIntents(workflowId, ['completed', 'failed']);
+      intentsById = new Map(terminalIntents.map((candidate) => [String(candidate.id), candidate]));
+      terminalIntentsByWorkflow.set(workflowId, intentsById);
+    }
+    return intentsById.get(intentId);
+  };
+
   for (const action of open) {
-    if (!action.intentId) continue;
-    const terminalIntents = store.listWorkflowMutationIntents(action.workflowId, ['completed', 'failed']);
-    const intent = terminalIntents.find((candidate) => String(candidate.id) === action.intentId);
+    if (!action.intentId || !action.workflowId) continue;
+    const intent = resolveTerminalIntent(action.workflowId, action.intentId);
     if (!intent) continue;
 
     const status: WorkerActionStatus = intent.status === 'completed' ? 'completed' : 'failed';
@@ -65,7 +80,7 @@ export function reconcileTerminalWorkerActionsOnStartup(
       ? { ...(action.payload as Record<string, unknown>) }
       : {};
 
-    store.upsertWorkerAction({
+    upsertWorkerAction({
       ...action,
       status,
       summary,


### PR DESCRIPTION
## Summary

This slice flips the deferred startup reconcile regression tests from pending to passing.

The binding regression in `reconcile-terminal-worker-actions.test.ts` now asserts store methods keep their receiver.

The per-workflow intent cache repro now passes against the slice (2) reconcile implementation.

## Review Claim

Approve turning the startup reconcile regression tests green after the behavior fix.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only updates tests. Runtime startup behavior shipped in slice (2).

## Slice Rationale

Slice (1) documents the regressions as pending proof.

Slice (2) lands the behavior fix without mixed proof files.

This slice connects the proof to the fix.

## Non-goals

- No production code changes
- No Playwright harness in this slice

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/reconcile-terminal-worker-actions.test.ts src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4549