### PR TITLE
[Deferred Startup Reconcile](4) Add production Start ready click repro harness

### DIFF
--- a/packages/app/e2e/global-teardown.ts
+++ b/packages/app/e2e/global-teardown.ts
@@ -1,11 +1,11 @@
 import { execFileSync } from 'node:child_process';
-import { rmSync } from 'node:fs';
+import { existsSync, rmSync } from 'node:fs';
 import * as path from 'node:path';
 import { E2E_BROWSER_REGISTRY_ENV } from './fixtures/browser-process-registry.js';
 
 export default async function globalTeardown(): Promise<void> {
   const registryPath = process.env[E2E_BROWSER_REGISTRY_ENV];
-  if (!registryPath) return;
+  if (!registryPath || !existsSync(registryPath)) return;
 
   const repoRoot = path.resolve(__dirname, '..', '..', '..');
   const cleanupScript = path.join(repoRoot, 'scripts', 'cleanup-orphaned-automation-chrome.mjs');

--- a/packages/app/e2e/start-ready-production-click.spec.ts
+++ b/packages/app/e2e/start-ready-production-click.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * Repro: clicking "Start ready work" must not crash Invoker against the
+ * production ~/.invoker database.
+ *
+ * Run only via scripts/repro/repro-start-ready-production-click.sh
+ * (sets INVOKER_REPRO_PRODUCTION_DB=1).
+ */
+import { _electron as electron, expect, test } from '@playwright/test';
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const MAIN_JS = path.resolve(__dirname, '..', 'dist', 'main.js');
+const INVOKER_LOG = path.join(process.env.HOME ?? '', '.invoker', 'invoker.log');
+const USE_PRODUCTION_DB = process.env.INVOKER_REPRO_PRODUCTION_DB === '1';
+
+function logWatermark(): string {
+  return new Date().toISOString();
+}
+
+function uncaughtExceptionsSince(watermark: string): string[] {
+  if (!fs.existsSync(INVOKER_LOG)) return [];
+  try {
+    const out = execSync(
+      `rg "uncaughtException" ${JSON.stringify(INVOKER_LOG)} | tail -100`,
+      { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+    );
+    return out.split('\n').filter((line) => {
+      if (!line.includes('uncaughtException')) return false;
+      const match = line.match(/"time":"([^"]+)"/);
+      return Boolean(match && match[1] >= watermark);
+    });
+  } catch {
+    return [];
+  }
+}
+
+test.describe('Start ready production click survival', () => {
+  if (!USE_PRODUCTION_DB) return;
+
+  test('clicking Start ready work keeps Electron alive', async () => {
+    const watermark = logWatermark();
+    const electronApp = await electron.launch({
+      args: [MAIN_JS],
+      env: {
+        ...process.env,
+        ELECTRON_ENABLE_LOGGING: '1',
+        INVOKER_E2E_ENABLE_COMPOSITOR: '1',
+      },
+    });
+
+    try {
+      const page = await electronApp.firstWindow({ timeout: 90_000 });
+      await page.waitForLoadState('domcontentloaded');
+      await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 60_000 });
+
+      const startButton = page.getByTestId('rail-start-ready');
+      await expect(startButton).toBeVisible({ timeout: 60_000 });
+      await startButton.click();
+
+      await page.waitForFunction(() => {
+        const button = document.querySelector('[data-testid="rail-start-ready"]') as HTMLButtonElement | null;
+        return button !== null && !button.disabled;
+      }, null, { timeout: 120_000 });
+
+      await page.waitForTimeout(5_000);
+      const tasks = await page.evaluate(async () => {
+        const result = await window.invoker.getTasks();
+        return Array.isArray(result) ? result.length : result.tasks.length;
+      });
+      expect(tasks).toBeGreaterThan(0);
+
+      const pid = electronApp.process()?.pid;
+      expect(pid).toBeTruthy();
+      if (pid) {
+        execSync(`kill -0 ${pid}`);
+      }
+
+      const crashes = uncaughtExceptionsSince(watermark);
+      expect(crashes, `uncaught exceptions after click:\n${crashes.join('\n')}`).toEqual([]);
+    } finally {
+      await electronApp.close();
+    }
+  });
+});

--- a/scripts/repro/repro-start-ready-production-click.sh
+++ b/scripts/repro/repro-start-ready-production-click.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Repro: clicking "Start ready work" crashed Invoker after deferred startup
+# reconcile began calling SQLite adapter methods without `this` binding.
+#
+# Observed in ~/.invoker/invoker.log:
+#   uncaughtException: TypeError: Cannot read properties of undefined (reading 'queryAll')
+#     at listWorkflowMutationIntents
+#     at reconcileTerminalWorkerActionsOnStartup
+#     at Timeout._onTimeout (deferred owner startup maintenance)
+#
+# Fixed behavior:
+#   reconcileTerminalWorkerActionsOnStartup binds store methods before calling
+#   them, and deferred startup maintenance is wrapped in try/catch so a reconcile
+#   failure cannot take down the GUI owner.
+#
+# This script:
+#   1. Runs the unit repro proving the unbound-method failure mode
+#   2. Builds the app
+#   3. Launches the real Electron UI against ~/.invoker
+#   4. Playwright clicks [data-testid="rail-start-ready"]
+#   5. Asserts the process stays alive with no new uncaughtException log lines
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] 1/3 unit repro: unbound listWorkflowMutationIntents crashes without bind"
+pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
+
+echo "[repro] 2/3 build app + ui"
+pnpm --filter @invoker/ui build >/dev/null
+pnpm --filter @invoker/app build >/dev/null
+
+echo "[repro] 3/3 production GUI click: Start ready work"
+bash "$ROOT/scripts/kill-all-electron.sh" >/dev/null 2>&1 || true
+sleep 1
+
+INVOKER_REPRO_PRODUCTION_DB=1 pnpm --filter @invoker/app exec playwright test \
+  e2e/start-ready-production-click.spec.ts
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

This slice adds a production-database Playwright repro for the Start ready work crash.

The harness launches Electron against `~/.invoker`, clicks `[data-testid="rail-start-ready"]`, and asserts the owner stays alive with no new `uncaughtException` log lines.

A shell repro script runs the unit proof, builds the app, and executes the click repro end to end.

## Review Claim

Approve the production Start ready click repro harness that guards the deferred startup reconcile fix.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The Playwright spec registers its test only when `INVOKER_REPRO_PRODUCTION_DB=1`, so CI and default e2e runs skip it.

The repro script is manual-only tooling under `scripts/repro/`.

## Slice Rationale

Behavior and unit proof landed in earlier slices.

This slice adds the integration repro reviewers can rerun against a real large owner database.

## Non-goals

- No reconcile implementation changes
- No additional GUI behavior changes

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-start-ready-production-click.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4551