### PR TITLE
[Workflow Graph Left Click](1) Restore workflow selection on left click

### DIFF
--- a/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
+++ b/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
@@ -66,6 +66,31 @@ export function createReactFlowMock() {
     const emitManualMoveEnd = (event: unknown) =>
       onMoveEnd?.(event, { x: 0, y: 0, zoom: getZoom() });
 
+    const nodeElements = nodes.map((node) => {
+      const NodeComponent = nodeTypes[node.type ?? ''];
+      return (
+        <div
+          key={node.id}
+          data-testid={`rf__node-${node.id}`}
+          data-x={(node as { position?: { x?: number } }).position?.x}
+          data-y={(node as { position?: { y?: number } }).position?.y}
+          className="react-flow__node"
+          onClick={(e) => onNodeClick?.(e, node)}
+          onContextMenu={(e) => onNodeContextMenu?.(e, node)}
+          onDoubleClick={(e) => onNodeDoubleClick?.(e, node)}
+        >
+          {NodeComponent ? (
+            <NodeComponent data={node.data ?? {}} />
+          ) : (
+            <>
+              <span>{node.data?.label ?? node.data?.task?.description ?? node.id}</span>
+              <span>{node.id}</span>
+            </>
+          )}
+        </div>
+      );
+    });
+
     return (
       <div data-testid="mock-react-flow" className="react-flow">
         <div
@@ -74,7 +99,9 @@ export function createReactFlowMock() {
           onPointerDown={(e) => emitManualMove(e.nativeEvent)}
           onPointerUp={(e) => emitManualMoveEnd(e.nativeEvent)}
           onWheel={(e) => emitManualMove(e.nativeEvent)}
-        />
+        >
+          {nodeElements}
+        </div>
         {props.edges?.map((edge: any) => (
           <div
             key={edge.id}
@@ -86,30 +113,6 @@ export function createReactFlowMock() {
             aria-label={edge.ariaLabel}
           />
         ))}
-        {nodes.map((node) => {
-          const NodeComponent = nodeTypes[node.type ?? ''];
-          return (
-            <div
-              key={node.id}
-              data-testid={`rf__node-${node.id}`}
-              data-x={(node as { position?: { x?: number } }).position?.x}
-              data-y={(node as { position?: { y?: number } }).position?.y}
-              className="react-flow__node"
-              onClick={(e) => onNodeClick?.(e, node)}
-              onContextMenu={(e) => onNodeContextMenu?.(e, node)}
-              onDoubleClick={(e) => onNodeDoubleClick?.(e, node)}
-            >
-              {NodeComponent ? (
-                <NodeComponent data={node.data ?? {}} />
-              ) : (
-                <>
-                  <span>{node.data?.label ?? node.data?.task?.description ?? node.id}</span>
-                  <span>{node.id}</span>
-                </>
-              )}
-            </div>
-          );
-        })}
         {children}
       </div>
     );

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -533,7 +533,23 @@ describe('WorkflowGraph', () => {
     expect(setViewportMock).toHaveBeenCalledWith({ x: 40, y: 8, zoom: 0.75 }, { duration: 0 });
   });
 
-  it('starts pane drags from workflow node surfaces inside the pane bounds', async () => {
+  it('selects a workflow when clicking its node inside the pane', async () => {
+    const onSelectWorkflow = vi.fn();
+
+    await renderAndSettleInitialFit({
+      workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
+      selectedWorkflowId: null,
+      statusFilters: new Set(),
+      onSelectWorkflow,
+      onWorkflowContextMenu: () => {},
+    });
+
+    fireEvent.click(screen.getByTestId('workflow-node-wf-a'));
+
+    expect(onSelectWorkflow).toHaveBeenCalledWith('wf-a');
+  });
+
+  it('does not start pane drags when pressing on a workflow node surface', async () => {
     getViewportMock.mockReturnValue({ x: 10, y: 20, zoom: 0.75 });
 
     await renderAndSettleInitialFit({
@@ -544,24 +560,11 @@ describe('WorkflowGraph', () => {
       onWorkflowContextMenu: () => {},
     });
 
-    const pane = screen.getByTestId('rf__pane');
-    vi.spyOn(pane, 'getBoundingClientRect').mockReturnValue({
-      x: 0,
-      y: 0,
-      left: 0,
-      top: 0,
-      right: 200,
-      bottom: 200,
-      width: 200,
-      height: 200,
-      toJSON: () => ({}),
-    } as DOMRect);
-
     fireEvent.mouseDown(screen.getByTestId('workflow-node-wf-a'), { clientX: 100, clientY: 100, button: 0 });
     fireEvent.mouseMove(window, { clientX: 130, clientY: 88, buttons: 1 });
     fireEvent.mouseUp(window, { clientX: 130, clientY: 88, button: 0 });
 
-    expect(setViewportMock).toHaveBeenCalledWith({ x: 40, y: 8, zoom: 0.75 }, { duration: 0 });
+    expect(setViewportMock).not.toHaveBeenCalled();
   });
 
   it('centers the selected workflow on a centerSelection command, preserving the current zoom', async () => {

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -44,6 +44,7 @@ interface WorkflowNodeData extends Record<string, unknown> {
   selected: boolean;
   dimmed: boolean;
   coreActivity?: WorkflowCoreActivity;
+  onSelect?: () => void;
 }
 
 interface GraphViewport {
@@ -97,6 +98,7 @@ function shouldStartPanePan(
   if (targetElement) {
     if (!root.contains(targetElement)) return false;
     if (targetElement.closest(PANE_PAN_BLOCK_SELECTOR)) return false;
+    if (targetElement.closest('.react-flow__node, [data-testid^="workflow-node-"]')) return false;
     if (targetElement.closest('.react-flow__pane')) return true;
   }
 
@@ -238,7 +240,7 @@ function WorkflowFlowNode({ data }: NodeProps<Node<WorkflowNodeData>>): JSX.Elem
         selected={data.selected}
         dimmed={data.dimmed}
         coreActivity={data.coreActivity}
-        onClick={() => {}}
+        onClick={() => data.onSelect?.()}
         onContextMenu={() => {}}
       />
       <Handle
@@ -307,12 +309,13 @@ function WorkflowGraphInner({
           selected: selectedWorkflowId === node.id,
           dimmed,
           coreActivity: coreActivityByWorkflow?.get(node.id),
+          onSelect: () => onSelectWorkflow(node.id),
         },
       };
     });
     graphMetricsRef.current.objectsMs = performance.now() - startedAt;
     return nextNodes;
-  }, [coreActivityByWorkflow, graph.nodes, positions, selectedWorkflowId, statusFilters]);
+  }, [coreActivityByWorkflow, graph.nodes, onSelectWorkflow, positions, selectedWorkflowId, statusFilters]);
   const [rfNodes, setRfNodes] = useState<Node<WorkflowNodeData>[]>([]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Workflow graph pane-pan handlers from #4459 swallowed left clicks on workflow nodes.

React Flow never received the click, so the task DAG only opened on right-click.

This slice excludes workflow nodes from pane-pan capture and wires node `onSelect` directly.

## Review Claim

Approve restoring left-click workflow selection so the task graph opens from a normal workflow node click.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Pane panning still works on empty graph background.

Only workflow node hit-testing and selection wiring change.

## Slice Rationale

Deferred startup reconcile slices land first because they unblock owner boot on large databases.

This UI regression is independent and stacks after that work.

## Non-goals

- No workflow graph camera refocus changes
- No task DAG selection changes
- No Run/Stop rail changes

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm exec vitest run src/__tests__/workflow-graph.test.tsx`

</details>

## Visual Proof

Left-click on a workflow node now opens the task graph panel.

![Workflow left-click opens task graph](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260715-d7fc47/workflow-left-click-task-graph.gif)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4552