### PR TITLE
Remove legacy Run/Stop controls in favor of Start ready work.

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -699,7 +699,7 @@ test.describe('Visual proof capture', () => {
     await page.getByTestId('sidebar-planning').click();
     await expect(transcript).toContainText('Add README');
     await expect(transcript).toContainText('sleep 2 && echo hello-gamma');
-    await expect(transcript).toContainText('Plan "Terminal Planned Flow" submitted to Invoker. Review it, then Run.');
+    await expect(transcript).toContainText('Plan "Terminal Planned Flow" submitted to Invoker. Review it, then use Start ready work.');
     await captureScreenshot(page, 'terminal-planned-conversation-after-submit');
 
     await page.evaluate(async () => {

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -530,7 +530,7 @@ tasks:
       workflowCount: 2,
     });
     expect(sessions.get(sent.sessionId)?.messages.at(-1)?.text).toBe(
-      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then Run.',
+      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then use Start ready work.',
     );
   });
 

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -622,8 +622,8 @@ export async function submitPlanningChatDraft(
         session,
         'system',
         loaded.workflowCount && loaded.workflowCount > 1
-          ? `Plan "${loaded.planName}" submitted as ${loaded.workflowCount} stacked workflows. Review them, then Run.`
-          : `Plan "${loaded.planName}" submitted to Invoker. Review it, then Run.`,
+          ? `Plan "${loaded.planName}" submitted as ${loaded.workflowCount} stacked workflows. Review them, then use Start ready work.`
+          : `Plan "${loaded.planName}" submitted to Invoker. Review it, then use Start ready work.`,
         'success',
       );
       persistPlanningSession(session, deps.planningSessionStore, false);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -253,7 +253,6 @@ interface PlanningTypingTelemetryState {
   selectedTaskId: string | null;
   selectedWorkflowId: string | null;
   hasLoadedPlan: boolean;
-  hasStarted: boolean;
 }
 
 function utf8Size(value: string): number {
@@ -304,7 +303,6 @@ function createPlanningTypingTelemetryContext({
   selectedTaskId,
   selectedWorkflowId,
   hasLoadedPlan,
-  hasStarted,
 }: PlanningTypingTelemetryState): Record<string, unknown> {
   const sessions = new Set<string>();
   const taskStatusCounts: Record<string, number> = {};
@@ -340,7 +338,6 @@ function createPlanningTypingTelemetryContext({
     selectedTaskId,
     selectedWorkflowId,
     hasLoadedPlan,
-    hasStarted,
   };
 }
 
@@ -653,8 +650,8 @@ function EmptyGraphTutorial(): JSX.Element {
             <div className="mt-1 text-xs text-muted-foreground">Check the graph before starting work.</div>
           </li>
           <li>
-            <div className="font-medium text-foreground">3. Run it</div>
-            <div className="mt-1 text-xs text-muted-foreground">Start the workflow when the plan looks right.</div>
+            <div className="font-medium text-foreground">3. Start ready work</div>
+            <div className="mt-1 text-xs text-muted-foreground">Use Start ready work when the plan looks right.</div>
           </li>
         </ol>
       </div>
@@ -751,7 +748,6 @@ export function App() {
   const [selectedWorkflowVanished, setSelectedWorkflowVanished] = useState(false);
   const [modal, setModal] = useState<ModalState>({ type: 'none' });
   const [hasLoadedPlan, setHasLoadedPlan] = useState(false);
-  const [hasStarted, setHasStarted] = useState(false);
   const [planName, setPlanName] = useState<string | null>(null);
   const [planningSessions, setPlanningSessions] = useState<PlanningSessionView[]>(() => [makeInitialPlanningSession()]);
   const planningSessionsRef = useRef<PlanningSessionView[]>(planningSessions);
@@ -1173,7 +1169,6 @@ export function App() {
       selectedTaskId,
       selectedWorkflowId,
       hasLoadedPlan,
-      hasStarted,
     };
   }, [
     tasks,
@@ -1183,7 +1178,6 @@ export function App() {
     selectedTaskId,
     selectedWorkflowId,
     hasLoadedPlan,
-    hasStarted,
   ]);
 
   useEffect(() => {
@@ -2432,18 +2426,6 @@ export function App() {
     }));
   }, [updateActivePlanningSession]);
 
-  const handleStart = useCallback(async (): Promise<boolean> => {
-    if (!invoker) return false;
-    try {
-      await invoker.start();
-      setHasStarted(true);
-      return true;
-    } catch (err) {
-      notifyMutationError('Failed to start:', err);
-      return false;
-    }
-  }, [invoker]);
-
   const handleStartReadyAction = useCallback(async (
     request: StartReadyRequest = {},
   ): Promise<StartReadyResult | null> => {
@@ -2455,7 +2437,6 @@ export function App() {
       if (!result.dryRun) {
         await refreshTaskGraph();
         void refreshActionGraph();
-        if (result.started.length > 0) setHasStarted(true);
         if (result.started.length > 0 || result.recreatedWorkflowIds.length > 0) {
           const descriptionParts = [
             result.recreatedWorkflowIds.length > 0
@@ -2521,7 +2502,6 @@ export function App() {
       if (result.ok) {
         setPlanningSubmitError(null);
         setHasLoadedPlan(true);
-        setHasStarted(false);
         setSidebarSurface('home');
         setWorkflowSelectionDismissed(false);
         setViewMode('dag');
@@ -2541,8 +2521,8 @@ export function App() {
         await refreshTaskGraph();
         appendTerminalLine(
           result.workflowCount && result.workflowCount > 1
-            ? `Plan "${result.planName}" submitted as ${result.workflowCount} stacked workflows. Review them, then Run.`
-            : `Plan "${result.planName}" submitted to Invoker. Review it, then Run.`,
+            ? `Plan "${result.planName}" submitted as ${result.workflowCount} stacked workflows. Review them, then use Start ready work.`
+            : `Plan "${result.planName}" submitted to Invoker. Review it, then use Start ready work.`,
           'system',
           'success',
         );
@@ -2567,9 +2547,9 @@ export function App() {
     setPlanningSubmitError(null);
 
     if (input.toLowerCase() === 'run') {
-      if (!hasLoadedPlan || hasStarted) {
+      if (!hasLoadedPlan && tasks.size === 0 && workflows.size === 0) {
         appendTerminalLine(
-          hasStarted ? 'Run already started.' : 'Create or submit a plan before running.',
+          'Create or submit a plan before starting ready work.',
           'system',
           'error',
         );
@@ -2577,8 +2557,17 @@ export function App() {
       }
       updatePlanningSessionById(activePlanningSessionId, (session) => ({ ...session, busy: true }));
       try {
-        const started = await handleStart();
-        appendTerminalLine(started ? 'Run started.' : 'Run failed to start.', 'system', started ? 'success' : 'error');
+        const result = await handleStartReadyAction();
+        if (result && !result.dryRun) {
+          const startedCount = result.started.length;
+          appendTerminalLine(
+            startedCount > 0
+              ? `Started ${startedCount} ready task${startedCount === 1 ? '' : 's'}.`
+              : 'No ready work to start.',
+            'system',
+            startedCount > 0 ? 'success' : undefined,
+          );
+        }
       } finally {
         updatePlanningSessionById(activePlanningSessionId, (session) => ({ ...session, busy: false }));
       }
@@ -2662,16 +2651,17 @@ export function App() {
     clearPlanningStreamForSessionIds,
     forgetPlanningStreamAliasesForSessionIds,
     handlePlanningSubmitDraft,
-    handleStart,
+    handleStartReadyAction,
     hasLoadedPlan,
-    hasStarted,
     keepPlanningStreamFailureForSessionIds,
     invoker,
     planningInput,
     planningSessionId,
     selectedPlanningPresetKey,
     setPlanningInput,
+    tasks.size,
     updatePlanningSessionById,
+    workflows.size,
   ]);
 
   const handleCreatePlanningSession = useCallback(() => {
@@ -2830,22 +2820,12 @@ export function App() {
   ]);
 
 
-  const handleStop = useCallback(async () => {
-    if (!invoker) return;
-    try {
-      await invoker.stop();
-    } catch (err) {
-      notifyMutationError('Failed to stop:', err);
-    }
-  }, [invoker]);
-
   const handleClear = useCallback(async () => {
     if (!invoker) return;
     try {
       await invoker.clear();
       clearTasks();
       setHasLoadedPlan(false);
-      setHasStarted(false);
       setPlanName(null);
       setSidebarSurface('home');
       setSidebarCollapsed(null);
@@ -2870,7 +2850,6 @@ export function App() {
       await invoker.deleteAllWorkflowsBulk();
       clearTasks();
       setHasLoadedPlan(false);
-      setHasStarted(false);
       setPlanName(null);
       setSidebarSurface('home');
       setSidebarCollapsed(null);
@@ -2884,18 +2863,6 @@ export function App() {
       notifyMutationError('Failed to delete workflows:', err);
     }
   }, [clearTasks, invoker]);
-  const allSettled = useMemo(() => {
-    if (tasks.size === 0) return false;
-    for (const task of tasks.values()) {
-      if (task.status !== 'completed' && task.status !== 'failed' && task.status !== 'closed' && task.status !== 'blocked') {
-        return false;
-      }
-    }
-    return true;
-  }, [tasks]);
-
-  const showStart = hasLoadedPlan && !hasStarted;
-  const showStop = hasStarted && !allSettled;
   const showStartReadyControl = hasLoadedPlan || tasks.size > 0 || workflows.size > 0;
   const showEmptyGraphTutorial = sidebarSurface === 'home' && !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
   const autoCollapseSidebar = viewportWidth < 1440;
@@ -3258,26 +3225,6 @@ export function App() {
 
   const renderGraphActions = (showMoreMenu: boolean): JSX.Element => (
     <div className="flex items-center gap-2">
-      {showStart && (
-        <button
-          type="button"
-          data-testid="rail-start"
-          onClick={handleStart}
-          className="rounded bg-green-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-600"
-        >
-          Run
-        </button>
-      )}
-      {showStop && (
-        <button
-          type="button"
-          data-testid="rail-stop"
-          onClick={handleStop}
-          className="rounded bg-red-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-600"
-        >
-          Stop
-        </button>
-      )}
       {showStartReadyControl && (
         <div ref={startReadyMenuRef} className="relative inline-flex">
           <button

--- a/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
@@ -58,7 +58,7 @@ describe('CodeRabbit PR #3050 — draft state cleared after submit', () => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });
     await openPlanningTerminal();
-    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then Run.');
+    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
     // The submit succeeded; the ready bar must be gone so it cannot resubmit the same session.
     await waitFor(() => {
       expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();

--- a/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
@@ -4,18 +4,13 @@ import type { InAppPlanningChatResponse } from '@invoker/contracts';
 import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
 
 vi.mock('@xyflow/react', async () => {
-  // Dynamic import is required because Vitest hoists mock factories before test imports.
   const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
   return createReactFlowMock();
 });
 
-// Dynamic import is required so App sees the hoisted @xyflow/react mock.
 const { App } = await import('../App.js');
 
-// Submitted planning sessions are read-only. Starting work goes through the
-// graph Run button, and once a run starts the button disappears so it cannot
-// call invoker.start() a second time.
-describe('CodeRabbit PR #3050 — "run" respects the already-started guard', () => {
+describe('CodeRabbit PR #3050 — submitted planning stays read-only after start ready', () => {
   let mock: MockInvoker;
 
   beforeEach(() => {
@@ -27,11 +22,6 @@ describe('CodeRabbit PR #3050 — "run" respects the already-started guard', () 
     mock.cleanup();
   });
 
-  function submitPlanningText(text: string) {
-    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
-    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
-  }
-
   async function openPlanningTerminal() {
     fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await waitFor(() => {
@@ -39,7 +29,7 @@ describe('CodeRabbit PR #3050 — "run" respects the already-started guard', () 
     });
   }
 
-  it('does not re-invoke start after a run has already started', async () => {
+  it('keeps the submitted planning session read-only after start ready work fires', async () => {
     const draftReply: InAppPlanningChatResponse = {
       ok: true,
       sessionId: 'session-1',
@@ -52,24 +42,28 @@ describe('CodeRabbit PR #3050 — "run" respects the already-started guard', () 
     render(<App />);
     await openPlanningTerminal();
 
-    submitPlanningText('draft the full plan');
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'draft the full plan' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
     await screen.findByTestId('invoker-terminal-ready-bar');
     fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });
+
     await openPlanningTerminal();
-    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then Run.');
+    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
+
     fireEvent.click(screen.getByTestId('sidebar-home'));
-    fireEvent.click(await screen.findByTestId('rail-start'));
+    fireEvent.click(await screen.findByTestId('rail-start-ready'));
     await waitFor(() => {
-      expect(mock.api.start).toHaveBeenCalledTimes(1);
+      expect(mock.api.startReady).toHaveBeenCalledTimes(1);
     });
     expect(screen.queryByTestId('rail-start')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('rail-stop')).not.toBeInTheDocument();
 
     await openPlanningTerminal();
     expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
     expect(screen.getByTestId('invoker-terminal-harness')).toBeDisabled();
-    expect(mock.api.start).toHaveBeenCalledTimes(1);
+    expect(mock.api.start).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -565,7 +565,7 @@ describe('Invoker terminal (component)', () => {
       expect(screen.getByText('Plan graph')).toBeInTheDocument();
     });
     fireEvent.click(screen.getByTestId('sidebar-planning'));
-    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review it, then Run.');
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
     expect(mock.api.start).not.toHaveBeenCalled();
   });
 
@@ -608,7 +608,7 @@ describe('Invoker terminal (component)', () => {
     });
     fireEvent.click(screen.getByTestId('sidebar-planning'));
     expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(
-      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then Run.',
+      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then use Start ready work.',
     );
   });
 
@@ -649,7 +649,7 @@ describe('Invoker terminal (component)', () => {
       expect(screen.getByText('Plan graph')).toBeInTheDocument();
     });
     fireEvent.click(screen.getByTestId('sidebar-planning'));
-    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. Review it, then Run.');
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. Review it, then use Start ready work.');
     expect(screen.queryByTestId('invoker-terminal-submit-error')).not.toBeInTheDocument();
   });
 
@@ -682,7 +682,8 @@ describe('Invoker terminal (component)', () => {
 
     submitPlanningText('run');
 
-    expect(await screen.findByText('Create or submit a plan before running.')).toBeInTheDocument();
+    expect(await screen.findByText('Create or submit a plan before starting ready work.')).toBeInTheDocument();
+    expect(mock.api.startReady).not.toHaveBeenCalled();
     expect(mock.api.start).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Start ready is fire-and-forget, so the old start/stop lifecycle buttons and planning run command no longer fit the activation model.

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #4553