### PR TITLE
[Owner Rail Cleanup](2) Update planner copy for Start ready work

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -699,7 +699,7 @@ test.describe('Visual proof capture', () => {
     await page.getByTestId('sidebar-planning').click();
     await expect(transcript).toContainText('Add README');
     await expect(transcript).toContainText('sleep 2 && echo hello-gamma');
-    await expect(transcript).toContainText('Plan "Terminal Planned Flow" submitted to Invoker. Review it, then Run.');
+    await expect(transcript).toContainText('Plan "Terminal Planned Flow" submitted to Invoker. Review it, then use Start ready work.');
     await captureScreenshot(page, 'terminal-planned-conversation-after-submit');
 
     await page.evaluate(async () => {

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -530,7 +530,7 @@ tasks:
       workflowCount: 2,
     });
     expect(sessions.get(sent.sessionId)?.messages.at(-1)?.text).toBe(
-      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then Run.',
+      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then use Start ready work.',
     );
   });
 

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -622,8 +622,8 @@ export async function submitPlanningChatDraft(
         session,
         'system',
         loaded.workflowCount && loaded.workflowCount > 1
-          ? `Plan "${loaded.planName}" submitted as ${loaded.workflowCount} stacked workflows. Review them, then Run.`
-          : `Plan "${loaded.planName}" submitted to Invoker. Review it, then Run.`,
+          ? `Plan "${loaded.planName}" submitted as ${loaded.workflowCount} stacked workflows. Review them, then use Start ready work.`
+          : `Plan "${loaded.planName}" submitted to Invoker. Review it, then use Start ready work.`,
         'success',
       );
       persistPlanningSession(session, deps.planningSessionStore, false);

--- a/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
@@ -58,7 +58,7 @@ describe('CodeRabbit PR #3050 — draft state cleared after submit', () => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });
     await openPlanningTerminal();
-    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then Run.');
+    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
     // The submit succeeded; the ready bar must be gone so it cannot resubmit the same session.
     await waitFor(() => {
       expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();

--- a/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
@@ -4,18 +4,13 @@ import type { InAppPlanningChatResponse } from '@invoker/contracts';
 import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
 
 vi.mock('@xyflow/react', async () => {
-  // Dynamic import is required because Vitest hoists mock factories before test imports.
   const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
   return createReactFlowMock();
 });
 
-// Dynamic import is required so App sees the hoisted @xyflow/react mock.
 const { App } = await import('../App.js');
 
-// Submitted planning sessions are read-only. Starting work goes through the
-// graph Run button, and once a run starts the button disappears so it cannot
-// call invoker.start() a second time.
-describe('CodeRabbit PR #3050 — "run" respects the already-started guard', () => {
+describe('CodeRabbit PR #3050 — submitted planning stays read-only after start ready', () => {
   let mock: MockInvoker;
 
   beforeEach(() => {
@@ -27,11 +22,6 @@ describe('CodeRabbit PR #3050 — "run" respects the already-started guard', () 
     mock.cleanup();
   });
 
-  function submitPlanningText(text: string) {
-    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
-    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
-  }
-
   async function openPlanningTerminal() {
     fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await waitFor(() => {
@@ -39,7 +29,7 @@ describe('CodeRabbit PR #3050 — "run" respects the already-started guard', () 
     });
   }
 
-  it('does not re-invoke start after a run has already started', async () => {
+  it('keeps the submitted planning session read-only after start ready work fires', async () => {
     const draftReply: InAppPlanningChatResponse = {
       ok: true,
       sessionId: 'session-1',
@@ -52,24 +42,28 @@ describe('CodeRabbit PR #3050 — "run" respects the already-started guard', () 
     render(<App />);
     await openPlanningTerminal();
 
-    submitPlanningText('draft the full plan');
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'draft the full plan' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
     await screen.findByTestId('invoker-terminal-ready-bar');
     fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });
+
     await openPlanningTerminal();
-    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then Run.');
+    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
+
     fireEvent.click(screen.getByTestId('sidebar-home'));
-    fireEvent.click(await screen.findByTestId('rail-start'));
+    fireEvent.click(await screen.findByTestId('rail-start-ready'));
     await waitFor(() => {
-      expect(mock.api.start).toHaveBeenCalledTimes(1);
+      expect(mock.api.startReady).toHaveBeenCalledTimes(1);
     });
     expect(screen.queryByTestId('rail-start')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('rail-stop')).not.toBeInTheDocument();
 
     await openPlanningTerminal();
     expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
     expect(screen.getByTestId('invoker-terminal-harness')).toBeDisabled();
-    expect(mock.api.start).toHaveBeenCalledTimes(1);
+    expect(mock.api.start).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -565,7 +565,7 @@ describe('Invoker terminal (component)', () => {
       expect(screen.getByText('Plan graph')).toBeInTheDocument();
     });
     fireEvent.click(screen.getByTestId('sidebar-planning'));
-    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review it, then Run.');
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
     expect(mock.api.start).not.toHaveBeenCalled();
   });
 
@@ -608,7 +608,7 @@ describe('Invoker terminal (component)', () => {
     });
     fireEvent.click(screen.getByTestId('sidebar-planning'));
     expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(
-      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then Run.',
+      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then use Start ready work.',
     );
   });
 
@@ -649,7 +649,7 @@ describe('Invoker terminal (component)', () => {
       expect(screen.getByText('Plan graph')).toBeInTheDocument();
     });
     fireEvent.click(screen.getByTestId('sidebar-planning'));
-    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. Review it, then Run.');
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. Review it, then use Start ready work.');
     expect(screen.queryByTestId('invoker-terminal-submit-error')).not.toBeInTheDocument();
   });
 
@@ -682,7 +682,8 @@ describe('Invoker terminal (component)', () => {
 
     submitPlanningText('run');
 
-    expect(await screen.findByText('Create or submit a plan before running.')).toBeInTheDocument();
+    expect(await screen.findByText('Create or submit a plan before starting ready work.')).toBeInTheDocument();
+    expect(mock.api.startReady).not.toHaveBeenCalled();
     expect(mock.api.start).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Planner success copy still told users to press Run after submitting a plan.

This slice updates planner messaging and the affected regression tests to say Start ready work instead.

## Review Claim

Approve updating planner copy and regression tests after dropping legacy Run controls.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

No new planner behavior ships here.

Only user-facing strings and test expectations change to match the prior rail slice.

## Slice Rationale

The prior slice drops Run and Stop from the owner rail without mixed proof files.

This slice updates the planner strings and tests that referenced Run.

## Non-goals

- No additional App.tsx rail changes
- No workflow graph changes

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/in-app-planner.test.ts`
- [ ] `cd packages/ui && pnpm exec vitest run src/__tests__/invoker-terminal.test.tsx src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
