### PR TITLE
[Owner Rail Cleanup](2) Update planner messaging for Start ready work

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -530,7 +530,7 @@ tasks:
       workflowCount: 2,
     });
     expect(sessions.get(sent.sessionId)?.messages.at(-1)?.text).toBe(
-      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then Run.',
+      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then use Start ready work.',
     );
   });
 

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -622,8 +622,8 @@ export async function submitPlanningChatDraft(
         session,
         'system',
         loaded.workflowCount && loaded.workflowCount > 1
-          ? `Plan "${loaded.planName}" submitted as ${loaded.workflowCount} stacked workflows. Review them, then Run.`
-          : `Plan "${loaded.planName}" submitted to Invoker. Review it, then Run.`,
+          ? `Plan "${loaded.planName}" submitted as ${loaded.workflowCount} stacked workflows. Review them, then use Start ready work.`
+          : `Plan "${loaded.planName}" submitted to Invoker. Review it, then use Start ready work.`,
         'success',
       );
       persistPlanningSession(session, deps.planningSessionStore, false);


### PR DESCRIPTION
## Summary

Planner success copy still told users to press Run after a plan finished loading.

This slice updates the planner message to reference Start ready work instead.

## Review Claim

Approve updating planner success messaging to match the new owner rail model.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the planner success string changes.

No planner flow or owner handler changes.

## Slice Rationale

The prior slice drops Run and Stop from the owner rail.

This slice updates the planner text that still referenced Run.

## Non-goals

- No App.tsx rail changes
- No regression test updates in this slice

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/in-app-planner.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4555