### PR TITLE
[Deferred Startup Reconcile](1) Prove unbound-method and per-action query regressions

### DIFF
--- a/packages/execution-engine/src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store';
+
+import { reconcileTerminalWorkerActionsOnStartup } from '../reconcile-terminal-worker-actions.js';
+
+function toRecord(write: WorkerActionWrite): WorkerActionRecord {
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? '2026-01-01T00:00:00.000Z',
+    updatedAt: write.updatedAt ?? '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function buildQueuedAction(id: string, intentId: string): WorkerActionWrite {
+  return {
+    id,
+    workerKind: 'ci-failure',
+    actionType: 'fix-ci-failure',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/t',
+    subjectType: 'review',
+    subjectId: '1',
+    externalKey: id,
+    status: 'queued',
+    intentId,
+  };
+}
+
+describe('repro: deferred startup reconcile method binding', () => {
+  it('fails like production when listWorkflowMutationIntents is extracted without bind', () => {
+    const store = {
+      listWorkflowMutationIntents(workflowId?: string) {
+        if (!workflowId) return [];
+        return this.queryAll(workflowId);
+      },
+      queryAll(workflowId: string) {
+        return workflowId === 'wf-1'
+          ? [{ id: 9, workflowId: 'wf-1', channel: 'x', args: [], priority: 'normal', status: 'completed', createdAt: 't' }]
+          : [];
+      },
+    };
+    const unboundList = store.listWorkflowMutationIntents;
+    expect(() => unboundList('wf-1', ['completed', 'failed'])).toThrow(
+      /Cannot read properties of undefined \(reading 'queryAll'\)/,
+    );
+  });
+
+  it.fails('queries terminal intents once per workflow during startup reconcile', () => {
+    const actions = [
+      toRecord(buildQueuedAction('a', '9')),
+      toRecord(buildQueuedAction('b', '9')),
+    ];
+    const listWorkflowMutationIntents = vi.fn((workflowId?: string) => {
+      expect(workflowId).toBe('wf-1');
+      return [{
+        id: 9,
+        workflowId: 'wf-1',
+        channel: 'invoker:fix-with-agent',
+        args: [],
+        priority: 'normal' as const,
+        status: 'completed' as const,
+        createdAt: '2026-01-01T00:00:00.000Z',
+      }];
+    });
+    const store = {
+      listWorkerActions: () => actions,
+      listWorkflowMutationIntents,
+      upsertWorkerAction: vi.fn((write: WorkerActionWrite) => toRecord(write)),
+    };
+
+    expect(reconcileTerminalWorkerActionsOnStartup(store)).toBe(2);
+    expect(listWorkflowMutationIntents).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Deferred owner startup reconcile can crash when SQLite adapter methods lose their `this` binding.

This slice adds unit repros that document the production failure mode.

One repro proves unbound `listWorkflowMutationIntents` extraction throws the same `queryAll` error seen in `~/.invoker/invoker.log`.

A second repro is marked `it.fails` until slice (2) caches terminal intents per workflow instead of re-querying for every queued worker action.

## Review Claim

Approve the regression proofs that document the deferred-startup reconcile crash and the per-action intent-query inefficiency.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice adds tests only. No runtime startup, reconcile, or GUI behavior changes ship here.

## Slice Rationale

Reviewers should see the demonstrated failure modes before the behavior fix in slice (2).

## Non-goals

- No reconcile implementation changes
- No deferred startup wiring in `main.ts`
- No Playwright click harness yet

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
