### PR TITLE
[Deferred Startup Reconcile](3) Flip startup reconcile regression tests green

### DIFF
--- a/packages/execution-engine/src/__tests__/reconcile-terminal-worker-actions.test.ts
+++ b/packages/execution-engine/src/__tests__/reconcile-terminal-worker-actions.test.ts
@@ -82,4 +82,45 @@ describe('reconcileTerminalWorkerActionsOnStartup', () => {
       summary: 'Worker action reconciled from failed intent on startup: boom',
     });
   });
+
+  it('preserves store method binding when listing terminal intents', () => {
+    const actions = new Map<string, WorkerActionRecord>([
+      ['a', toRecord({
+        id: 'a',
+        workerKind: 'ci-failure',
+        actionType: 'fix-ci-failure',
+        workflowId: 'wf-1',
+        taskId: 'wf-1/t',
+        subjectType: 'review',
+        subjectId: '1',
+        externalKey: 'a',
+        status: 'queued',
+        intentId: '9',
+      })],
+    ]);
+    const store = {
+      listWorkerActions: () => Array.from(actions.values()),
+      listWorkflowMutationIntents(workflowId?: string) {
+        expect(this).toBe(store);
+        expect(workflowId).toBe('wf-1');
+        return [{
+          id: 9,
+          workflowId: 'wf-1',
+          channel: 'invoker:fix-with-agent',
+          args: [],
+          priority: 'normal' as const,
+          status: 'completed' as const,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        }];
+      },
+      upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+        const saved = toRecord(write);
+        actions.set(write.id, saved);
+        return saved;
+      }),
+    };
+
+    expect(reconcileTerminalWorkerActionsOnStartup(store)).toBe(1);
+    expect(actions.get('a')?.status).toBe('completed');
+  });
 });

--- a/packages/execution-engine/src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
@@ -47,7 +47,7 @@ describe('repro: deferred startup reconcile method binding', () => {
     );
   });
 
-  it.fails('queries terminal intents once per workflow during startup reconcile', () => {
+  it('queries terminal intents once per workflow during startup reconcile', () => {
     const actions = [
       toRecord(buildQueuedAction('a', '9')),
       toRecord(buildQueuedAction('b', '9')),


### PR DESCRIPTION
## Summary

This slice flips the deferred startup reconcile regression tests from pending to passing.

The binding regression in `reconcile-terminal-worker-actions.test.ts` now asserts store methods keep their receiver.

The per-workflow intent cache repro now passes against the slice (2) reconcile implementation.

## Review Claim

Approve turning the startup reconcile regression tests green after the behavior fix.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only updates tests. Runtime startup behavior shipped in slice (2).

## Slice Rationale

Slice (1) documents the regressions as pending proof.

Slice (2) lands the behavior fix without mixed proof files.

This slice connects the proof to the fix.

## Non-goals

- No production code changes
- No Playwright harness in this slice

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/reconcile-terminal-worker-actions.test.ts src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


