### PR TITLE
Fix workflow graph left-click selection after pane-pan regression.

### DIFF
--- a/packages/app/e2e/global-teardown.ts
+++ b/packages/app/e2e/global-teardown.ts
@@ -1,11 +1,11 @@
 import { execFileSync } from 'node:child_process';
-import { rmSync } from 'node:fs';
+import { existsSync, rmSync } from 'node:fs';
 import * as path from 'node:path';
 import { E2E_BROWSER_REGISTRY_ENV } from './fixtures/browser-process-registry.js';
 
 export default async function globalTeardown(): Promise<void> {
   const registryPath = process.env[E2E_BROWSER_REGISTRY_ENV];
-  if (!registryPath) return;
+  if (!registryPath || !existsSync(registryPath)) return;
 
   const repoRoot = path.resolve(__dirname, '..', '..', '..');
   const cleanupScript = path.join(repoRoot, 'scripts', 'cleanup-orphaned-automation-chrome.mjs');

--- a/packages/app/e2e/start-ready-production-click.spec.ts
+++ b/packages/app/e2e/start-ready-production-click.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * Repro: clicking "Start ready work" must not crash Invoker against the
+ * production ~/.invoker database.
+ *
+ * Run only via scripts/repro/repro-start-ready-production-click.sh
+ * (sets INVOKER_REPRO_PRODUCTION_DB=1).
+ */
+import { _electron as electron, expect, test } from '@playwright/test';
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const MAIN_JS = path.resolve(__dirname, '..', 'dist', 'main.js');
+const INVOKER_LOG = path.join(process.env.HOME ?? '', '.invoker', 'invoker.log');
+const USE_PRODUCTION_DB = process.env.INVOKER_REPRO_PRODUCTION_DB === '1';
+
+function logWatermark(): string {
+  return new Date().toISOString();
+}
+
+function uncaughtExceptionsSince(watermark: string): string[] {
+  if (!fs.existsSync(INVOKER_LOG)) return [];
+  try {
+    const out = execSync(
+      `rg "uncaughtException" ${JSON.stringify(INVOKER_LOG)} | tail -100`,
+      { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+    );
+    return out.split('\n').filter((line) => {
+      if (!line.includes('uncaughtException')) return false;
+      const match = line.match(/"time":"([^"]+)"/);
+      return Boolean(match && match[1] >= watermark);
+    });
+  } catch {
+    return [];
+  }
+}
+
+test.describe('Start ready production click survival', () => {
+  if (!USE_PRODUCTION_DB) return;
+
+  test('clicking Start ready work keeps Electron alive', async () => {
+    const watermark = logWatermark();
+    const electronApp = await electron.launch({
+      args: [MAIN_JS],
+      env: {
+        ...process.env,
+        ELECTRON_ENABLE_LOGGING: '1',
+        INVOKER_E2E_ENABLE_COMPOSITOR: '1',
+      },
+    });
+
+    try {
+      const page = await electronApp.firstWindow({ timeout: 90_000 });
+      await page.waitForLoadState('domcontentloaded');
+      await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 60_000 });
+
+      const startButton = page.getByTestId('rail-start-ready');
+      await expect(startButton).toBeVisible({ timeout: 60_000 });
+      await startButton.click();
+
+      await page.waitForFunction(() => {
+        const button = document.querySelector('[data-testid="rail-start-ready"]') as HTMLButtonElement | null;
+        return button !== null && !button.disabled;
+      }, null, { timeout: 120_000 });
+
+      await page.waitForTimeout(5_000);
+      const tasks = await page.evaluate(async () => {
+        const result = await window.invoker.getTasks();
+        return Array.isArray(result) ? result.length : result.tasks.length;
+      });
+      expect(tasks).toBeGreaterThan(0);
+
+      const pid = electronApp.process()?.pid;
+      expect(pid).toBeTruthy();
+      if (pid) {
+        execSync(`kill -0 ${pid}`);
+      }
+
+      const crashes = uncaughtExceptionsSince(watermark);
+      expect(crashes, `uncaught exceptions after click:\n${crashes.join('\n')}`).toEqual([]);
+    } finally {
+      await electronApp.close();
+    }
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3534,34 +3534,42 @@ function createEmbeddedTerminalBackendFromConfig(
         autoFixRetries: resolveAutoFixRetries(invokerConfig),
         canControl: () => ownerMode,
       });
-      const reconciledWorkerActions = reconcileTerminalWorkerActionsOnStartup(persistence);
-      if (reconciledWorkerActions > 0) {
-        logger.info(
-          `reconciled ${reconciledWorkerActions} terminal worker action(s) on startup`,
-          { module: 'init' },
-        );
-      }
     }
 
     // Fail orphaned in-flight tasks left by a previous crash, then start ready work.
     if (!ownerMode) {
       logger.info('follower mode startup: auto-run disabled', { module: 'init' });
     } else {
-      const orphaned = reconcileOrphanedInFlightTasksOnBoot({
-        orchestrator,
-        persistence,
-      });
-      if (orphaned.length > 0) {
-        logger.info(
-          `failed ${orphaned.length} orphaned in-flight task(s) left by a previous owner crash`,
-          { module: 'init', taskIds: orphaned.map((task) => task.id) },
-        );
-      }
-      if (invokerConfig.disableAutoRunOnStartup) {
-        logger.info('auto-run on startup disabled by config', { module: 'init' });
-      } else {
-        orchestrator.startExecution();
-      }
+      setTimeout(() => {
+        if (!ownerMode) return;
+        try {
+          const reconciledWorkerActions = reconcileTerminalWorkerActionsOnStartup(persistence);
+          if (reconciledWorkerActions > 0) {
+            logger.info(
+              `reconciled ${reconciledWorkerActions} terminal worker action(s) on startup`,
+              { module: 'init' },
+            );
+          }
+          const orphaned = reconcileOrphanedInFlightTasksOnBoot({
+            orchestrator,
+            persistence,
+          });
+          if (orphaned.length > 0) {
+            logger.info(
+              `failed ${orphaned.length} orphaned in-flight task(s) left by a previous owner crash`,
+              { module: 'init', taskIds: orphaned.map((task) => task.id) },
+            );
+          }
+          if (invokerConfig.disableAutoRunOnStartup) {
+            logger.info('auto-run on startup disabled by config', { module: 'init' });
+          } else {
+            orchestrator.startExecution();
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          logger.error(`deferred owner startup maintenance failed: ${message}`, { module: 'init' });
+        }
+      }, 0);
     }
 
     const dbPath = path.join(resolveInvokerHomeRoot(), 'invoker.db');

--- a/packages/execution-engine/src/__tests__/reconcile-terminal-worker-actions.test.ts
+++ b/packages/execution-engine/src/__tests__/reconcile-terminal-worker-actions.test.ts
@@ -82,4 +82,45 @@ describe('reconcileTerminalWorkerActionsOnStartup', () => {
       summary: 'Worker action reconciled from failed intent on startup: boom',
     });
   });
+
+  it('preserves store method binding when listing terminal intents', () => {
+    const actions = new Map<string, WorkerActionRecord>([
+      ['a', toRecord({
+        id: 'a',
+        workerKind: 'ci-failure',
+        actionType: 'fix-ci-failure',
+        workflowId: 'wf-1',
+        taskId: 'wf-1/t',
+        subjectType: 'review',
+        subjectId: '1',
+        externalKey: 'a',
+        status: 'queued',
+        intentId: '9',
+      })],
+    ]);
+    const store = {
+      listWorkerActions: () => Array.from(actions.values()),
+      listWorkflowMutationIntents(workflowId?: string) {
+        expect(this).toBe(store);
+        expect(workflowId).toBe('wf-1');
+        return [{
+          id: 9,
+          workflowId: 'wf-1',
+          channel: 'invoker:fix-with-agent',
+          args: [],
+          priority: 'normal' as const,
+          status: 'completed' as const,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        }];
+      },
+      upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+        const saved = toRecord(write);
+        actions.set(write.id, saved);
+        return saved;
+      }),
+    };
+
+    expect(reconcileTerminalWorkerActionsOnStartup(store)).toBe(1);
+    expect(actions.get('a')?.status).toBe('completed');
+  });
 });

--- a/packages/execution-engine/src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
@@ -47,7 +47,7 @@ describe('repro: deferred startup reconcile method binding', () => {
     );
   });
 
-  it.fails('queries terminal intents once per workflow during startup reconcile', () => {
+  it('queries terminal intents once per workflow during startup reconcile', () => {
     const actions = [
       toRecord(buildQueuedAction('a', '9')),
       toRecord(buildQueuedAction('b', '9')),

--- a/packages/execution-engine/src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store';
+
+import { reconcileTerminalWorkerActionsOnStartup } from '../reconcile-terminal-worker-actions.js';
+
+function toRecord(write: WorkerActionWrite): WorkerActionRecord {
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? '2026-01-01T00:00:00.000Z',
+    updatedAt: write.updatedAt ?? '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function buildQueuedAction(id: string, intentId: string): WorkerActionWrite {
+  return {
+    id,
+    workerKind: 'ci-failure',
+    actionType: 'fix-ci-failure',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/t',
+    subjectType: 'review',
+    subjectId: '1',
+    externalKey: id,
+    status: 'queued',
+    intentId,
+  };
+}
+
+describe('repro: deferred startup reconcile method binding', () => {
+  it('fails like production when listWorkflowMutationIntents is extracted without bind', () => {
+    const store = {
+      listWorkflowMutationIntents(workflowId?: string) {
+        if (!workflowId) return [];
+        return this.queryAll(workflowId);
+      },
+      queryAll(workflowId: string) {
+        return workflowId === 'wf-1'
+          ? [{ id: 9, workflowId: 'wf-1', channel: 'x', args: [], priority: 'normal', status: 'completed', createdAt: 't' }]
+          : [];
+      },
+    };
+    const unboundList = store.listWorkflowMutationIntents;
+    expect(() => unboundList('wf-1', ['completed', 'failed'])).toThrow(
+      /Cannot read properties of undefined \(reading 'queryAll'\)/,
+    );
+  });
+
+  it.fails('queries terminal intents once per workflow during startup reconcile', () => {
+    const actions = [
+      toRecord(buildQueuedAction('a', '9')),
+      toRecord(buildQueuedAction('b', '9')),
+    ];
+    const listWorkflowMutationIntents = vi.fn((workflowId?: string) => {
+      expect(workflowId).toBe('wf-1');
+      return [{
+        id: 9,
+        workflowId: 'wf-1',
+        channel: 'invoker:fix-with-agent',
+        args: [],
+        priority: 'normal' as const,
+        status: 'completed' as const,
+        createdAt: '2026-01-01T00:00:00.000Z',
+      }];
+    });
+    const store = {
+      listWorkerActions: () => actions,
+      listWorkflowMutationIntents,
+      upsertWorkerAction: vi.fn((write: WorkerActionWrite) => toRecord(write)),
+    };
+
+    expect(reconcileTerminalWorkerActionsOnStartup(store)).toBe(2);
+    expect(listWorkflowMutationIntents).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/execution-engine/src/reconcile-terminal-worker-actions.ts
+++ b/packages/execution-engine/src/reconcile-terminal-worker-actions.ts
@@ -38,6 +38,8 @@ export function reconcileTerminalWorkerActionsOnStartup(
   if (!store.upsertWorkerAction || !store.listWorkflowMutationIntents) {
     return 0;
   }
+  const upsertWorkerAction = store.upsertWorkerAction.bind(store);
+  const listTerminalIntents = store.listWorkflowMutationIntents.bind(store);
 
   const seen = new Set<string>();
   const open: WorkerActionRecord[] = [];
@@ -51,10 +53,23 @@ export function reconcileTerminalWorkerActionsOnStartup(
 
   let reconciled = 0;
   const nowIso = now.toISOString();
+  const terminalIntentsByWorkflow = new Map<string, Map<string, WorkflowMutationIntent>>();
+  const resolveTerminalIntent = (
+    workflowId: string,
+    intentId: string,
+  ): WorkflowMutationIntent | undefined => {
+    let intentsById = terminalIntentsByWorkflow.get(workflowId);
+    if (!intentsById) {
+      const terminalIntents = listTerminalIntents(workflowId, ['completed', 'failed']);
+      intentsById = new Map(terminalIntents.map((candidate) => [String(candidate.id), candidate]));
+      terminalIntentsByWorkflow.set(workflowId, intentsById);
+    }
+    return intentsById.get(intentId);
+  };
+
   for (const action of open) {
-    if (!action.intentId) continue;
-    const terminalIntents = store.listWorkflowMutationIntents(action.workflowId, ['completed', 'failed']);
-    const intent = terminalIntents.find((candidate) => String(candidate.id) === action.intentId);
+    if (!action.intentId || !action.workflowId) continue;
+    const intent = resolveTerminalIntent(action.workflowId, action.intentId);
     if (!intent) continue;
 
     const status: WorkerActionStatus = intent.status === 'completed' ? 'completed' : 'failed';
@@ -65,7 +80,7 @@ export function reconcileTerminalWorkerActionsOnStartup(
       ? { ...(action.payload as Record<string, unknown>) }
       : {};
 
-    store.upsertWorkerAction({
+    upsertWorkerAction({
       ...action,
       status,
       summary,

--- a/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
+++ b/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
@@ -66,6 +66,31 @@ export function createReactFlowMock() {
     const emitManualMoveEnd = (event: unknown) =>
       onMoveEnd?.(event, { x: 0, y: 0, zoom: getZoom() });
 
+    const nodeElements = nodes.map((node) => {
+      const NodeComponent = nodeTypes[node.type ?? ''];
+      return (
+        <div
+          key={node.id}
+          data-testid={`rf__node-${node.id}`}
+          data-x={(node as { position?: { x?: number } }).position?.x}
+          data-y={(node as { position?: { y?: number } }).position?.y}
+          className="react-flow__node"
+          onClick={(e) => onNodeClick?.(e, node)}
+          onContextMenu={(e) => onNodeContextMenu?.(e, node)}
+          onDoubleClick={(e) => onNodeDoubleClick?.(e, node)}
+        >
+          {NodeComponent ? (
+            <NodeComponent data={node.data ?? {}} />
+          ) : (
+            <>
+              <span>{node.data?.label ?? node.data?.task?.description ?? node.id}</span>
+              <span>{node.id}</span>
+            </>
+          )}
+        </div>
+      );
+    });
+
     return (
       <div data-testid="mock-react-flow" className="react-flow">
         <div
@@ -74,7 +99,9 @@ export function createReactFlowMock() {
           onPointerDown={(e) => emitManualMove(e.nativeEvent)}
           onPointerUp={(e) => emitManualMoveEnd(e.nativeEvent)}
           onWheel={(e) => emitManualMove(e.nativeEvent)}
-        />
+        >
+          {nodeElements}
+        </div>
         {props.edges?.map((edge: any) => (
           <div
             key={edge.id}
@@ -86,30 +113,6 @@ export function createReactFlowMock() {
             aria-label={edge.ariaLabel}
           />
         ))}
-        {nodes.map((node) => {
-          const NodeComponent = nodeTypes[node.type ?? ''];
-          return (
-            <div
-              key={node.id}
-              data-testid={`rf__node-${node.id}`}
-              data-x={(node as { position?: { x?: number } }).position?.x}
-              data-y={(node as { position?: { y?: number } }).position?.y}
-              className="react-flow__node"
-              onClick={(e) => onNodeClick?.(e, node)}
-              onContextMenu={(e) => onNodeContextMenu?.(e, node)}
-              onDoubleClick={(e) => onNodeDoubleClick?.(e, node)}
-            >
-              {NodeComponent ? (
-                <NodeComponent data={node.data ?? {}} />
-              ) : (
-                <>
-                  <span>{node.data?.label ?? node.data?.task?.description ?? node.id}</span>
-                  <span>{node.id}</span>
-                </>
-              )}
-            </div>
-          );
-        })}
         {children}
       </div>
     );

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -533,7 +533,23 @@ describe('WorkflowGraph', () => {
     expect(setViewportMock).toHaveBeenCalledWith({ x: 40, y: 8, zoom: 0.75 }, { duration: 0 });
   });
 
-  it('starts pane drags from workflow node surfaces inside the pane bounds', async () => {
+  it('selects a workflow when clicking its node inside the pane', async () => {
+    const onSelectWorkflow = vi.fn();
+
+    await renderAndSettleInitialFit({
+      workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
+      selectedWorkflowId: null,
+      statusFilters: new Set(),
+      onSelectWorkflow,
+      onWorkflowContextMenu: () => {},
+    });
+
+    fireEvent.click(screen.getByTestId('workflow-node-wf-a'));
+
+    expect(onSelectWorkflow).toHaveBeenCalledWith('wf-a');
+  });
+
+  it('does not start pane drags when pressing on a workflow node surface', async () => {
     getViewportMock.mockReturnValue({ x: 10, y: 20, zoom: 0.75 });
 
     await renderAndSettleInitialFit({
@@ -544,24 +560,11 @@ describe('WorkflowGraph', () => {
       onWorkflowContextMenu: () => {},
     });
 
-    const pane = screen.getByTestId('rf__pane');
-    vi.spyOn(pane, 'getBoundingClientRect').mockReturnValue({
-      x: 0,
-      y: 0,
-      left: 0,
-      top: 0,
-      right: 200,
-      bottom: 200,
-      width: 200,
-      height: 200,
-      toJSON: () => ({}),
-    } as DOMRect);
-
     fireEvent.mouseDown(screen.getByTestId('workflow-node-wf-a'), { clientX: 100, clientY: 100, button: 0 });
     fireEvent.mouseMove(window, { clientX: 130, clientY: 88, buttons: 1 });
     fireEvent.mouseUp(window, { clientX: 130, clientY: 88, button: 0 });
 
-    expect(setViewportMock).toHaveBeenCalledWith({ x: 40, y: 8, zoom: 0.75 }, { duration: 0 });
+    expect(setViewportMock).not.toHaveBeenCalled();
   });
 
   it('centers the selected workflow on a centerSelection command, preserving the current zoom', async () => {

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -44,6 +44,7 @@ interface WorkflowNodeData extends Record<string, unknown> {
   selected: boolean;
   dimmed: boolean;
   coreActivity?: WorkflowCoreActivity;
+  onSelect?: () => void;
 }
 
 interface GraphViewport {
@@ -97,6 +98,7 @@ function shouldStartPanePan(
   if (targetElement) {
     if (!root.contains(targetElement)) return false;
     if (targetElement.closest(PANE_PAN_BLOCK_SELECTOR)) return false;
+    if (targetElement.closest('.react-flow__node, [data-testid^="workflow-node-"]')) return false;
     if (targetElement.closest('.react-flow__pane')) return true;
   }
 
@@ -238,7 +240,7 @@ function WorkflowFlowNode({ data }: NodeProps<Node<WorkflowNodeData>>): JSX.Elem
         selected={data.selected}
         dimmed={data.dimmed}
         coreActivity={data.coreActivity}
-        onClick={() => {}}
+        onClick={() => data.onSelect?.()}
         onContextMenu={() => {}}
       />
       <Handle
@@ -307,12 +309,13 @@ function WorkflowGraphInner({
           selected: selectedWorkflowId === node.id,
           dimmed,
           coreActivity: coreActivityByWorkflow?.get(node.id),
+          onSelect: () => onSelectWorkflow(node.id),
         },
       };
     });
     graphMetricsRef.current.objectsMs = performance.now() - startedAt;
     return nextNodes;
-  }, [coreActivityByWorkflow, graph.nodes, positions, selectedWorkflowId, statusFilters]);
+  }, [coreActivityByWorkflow, graph.nodes, onSelectWorkflow, positions, selectedWorkflowId, statusFilters]);
   const [rfNodes, setRfNodes] = useState<Node<WorkflowNodeData>[]>([]);
 
   useEffect(() => {

--- a/scripts/repro/repro-start-ready-production-click.sh
+++ b/scripts/repro/repro-start-ready-production-click.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Repro: clicking "Start ready work" crashed Invoker after deferred startup
+# reconcile began calling SQLite adapter methods without `this` binding.
+#
+# Observed in ~/.invoker/invoker.log:
+#   uncaughtException: TypeError: Cannot read properties of undefined (reading 'queryAll')
+#     at listWorkflowMutationIntents
+#     at reconcileTerminalWorkerActionsOnStartup
+#     at Timeout._onTimeout (deferred owner startup maintenance)
+#
+# Fixed behavior:
+#   reconcileTerminalWorkerActionsOnStartup binds store methods before calling
+#   them, and deferred startup maintenance is wrapped in try/catch so a reconcile
+#   failure cannot take down the GUI owner.
+#
+# This script:
+#   1. Runs the unit repro proving the unbound-method failure mode
+#   2. Builds the app
+#   3. Launches the real Electron UI against ~/.invoker
+#   4. Playwright clicks [data-testid="rail-start-ready"]
+#   5. Asserts the process stays alive with no new uncaughtException log lines
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] 1/3 unit repro: unbound listWorkflowMutationIntents crashes without bind"
+pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
+
+echo "[repro] 2/3 build app + ui"
+pnpm --filter @invoker/ui build >/dev/null
+pnpm --filter @invoker/app build >/dev/null
+
+echo "[repro] 3/3 production GUI click: Start ready work"
+bash "$ROOT/scripts/kill-all-electron.sh" >/dev/null 2>&1 || true
+sleep 1
+
+INVOKER_REPRO_PRODUCTION_DB=1 pnpm --filter @invoker/app exec playwright test \
+  e2e/start-ready-production-click.spec.ts
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

Workflow graph pane-pan handlers from #4459 swallowed left clicks on workflow nodes.

React Flow never received the click, so the task DAG only opened on right-click.

This slice excludes workflow nodes from pane-pan capture and wires node `onSelect` directly.

## Review Claim

Approve restoring left-click workflow selection so the task graph opens from a normal workflow node click.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Pane panning still works on empty graph background.

Only workflow node hit-testing and selection wiring change.

## Slice Rationale

Deferred startup reconcile slices land first because they unblock owner boot on large databases.

This UI regression is independent and stacks after that work.

## Non-goals

- No workflow graph camera refocus changes
- No task DAG selection changes
- No Run/Stop rail changes

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm exec vitest run src/__tests__/workflow-graph.test.tsx`

</details>

## Visual Proof

Left-click on a workflow node now opens the task graph panel.

![Workflow left-click opens task graph](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260715-d7fc47/workflow-left-click-task-graph.gif)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4566
