### PR TITLE
[Owner Rail Cleanup](2) Update planner messaging for Start ready work

### DIFF
--- a/packages/app/e2e/global-teardown.ts
+++ b/packages/app/e2e/global-teardown.ts
@@ -1,11 +1,11 @@
 import { execFileSync } from 'node:child_process';
-import { rmSync } from 'node:fs';
+import { existsSync, rmSync } from 'node:fs';
 import * as path from 'node:path';
 import { E2E_BROWSER_REGISTRY_ENV } from './fixtures/browser-process-registry.js';
 
 export default async function globalTeardown(): Promise<void> {
   const registryPath = process.env[E2E_BROWSER_REGISTRY_ENV];
-  if (!registryPath) return;
+  if (!registryPath || !existsSync(registryPath)) return;
 
   const repoRoot = path.resolve(__dirname, '..', '..', '..');
   const cleanupScript = path.join(repoRoot, 'scripts', 'cleanup-orphaned-automation-chrome.mjs');

--- a/packages/app/e2e/start-ready-production-click.spec.ts
+++ b/packages/app/e2e/start-ready-production-click.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * Repro: clicking "Start ready work" must not crash Invoker against the
+ * production ~/.invoker database.
+ *
+ * Run only via scripts/repro/repro-start-ready-production-click.sh
+ * (sets INVOKER_REPRO_PRODUCTION_DB=1).
+ */
+import { _electron as electron, expect, test } from '@playwright/test';
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const MAIN_JS = path.resolve(__dirname, '..', 'dist', 'main.js');
+const INVOKER_LOG = path.join(process.env.HOME ?? '', '.invoker', 'invoker.log');
+const USE_PRODUCTION_DB = process.env.INVOKER_REPRO_PRODUCTION_DB === '1';
+
+function logWatermark(): string {
+  return new Date().toISOString();
+}
+
+function uncaughtExceptionsSince(watermark: string): string[] {
+  if (!fs.existsSync(INVOKER_LOG)) return [];
+  try {
+    const out = execSync(
+      `rg "uncaughtException" ${JSON.stringify(INVOKER_LOG)} | tail -100`,
+      { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 },
+    );
+    return out.split('\n').filter((line) => {
+      if (!line.includes('uncaughtException')) return false;
+      const match = line.match(/"time":"([^"]+)"/);
+      return Boolean(match && match[1] >= watermark);
+    });
+  } catch {
+    return [];
+  }
+}
+
+test.describe('Start ready production click survival', () => {
+  if (!USE_PRODUCTION_DB) return;
+
+  test('clicking Start ready work keeps Electron alive', async () => {
+    const watermark = logWatermark();
+    const electronApp = await electron.launch({
+      args: [MAIN_JS],
+      env: {
+        ...process.env,
+        ELECTRON_ENABLE_LOGGING: '1',
+        INVOKER_E2E_ENABLE_COMPOSITOR: '1',
+      },
+    });
+
+    try {
+      const page = await electronApp.firstWindow({ timeout: 90_000 });
+      await page.waitForLoadState('domcontentloaded');
+      await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 60_000 });
+
+      const startButton = page.getByTestId('rail-start-ready');
+      await expect(startButton).toBeVisible({ timeout: 60_000 });
+      await startButton.click();
+
+      await page.waitForFunction(() => {
+        const button = document.querySelector('[data-testid="rail-start-ready"]') as HTMLButtonElement | null;
+        return button !== null && !button.disabled;
+      }, null, { timeout: 120_000 });
+
+      await page.waitForTimeout(5_000);
+      const tasks = await page.evaluate(async () => {
+        const result = await window.invoker.getTasks();
+        return Array.isArray(result) ? result.length : result.tasks.length;
+      });
+      expect(tasks).toBeGreaterThan(0);
+
+      const pid = electronApp.process()?.pid;
+      expect(pid).toBeTruthy();
+      if (pid) {
+        execSync(`kill -0 ${pid}`);
+      }
+
+      const crashes = uncaughtExceptionsSince(watermark);
+      expect(crashes, `uncaught exceptions after click:\n${crashes.join('\n')}`).toEqual([]);
+    } finally {
+      await electronApp.close();
+    }
+  });
+});

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -530,7 +530,7 @@ tasks:
       workflowCount: 2,
     });
     expect(sessions.get(sent.sessionId)?.messages.at(-1)?.text).toBe(
-      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then Run.',
+      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then use Start ready work.',
     );
   });
 

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -622,8 +622,8 @@ export async function submitPlanningChatDraft(
         session,
         'system',
         loaded.workflowCount && loaded.workflowCount > 1
-          ? `Plan "${loaded.planName}" submitted as ${loaded.workflowCount} stacked workflows. Review them, then Run.`
-          : `Plan "${loaded.planName}" submitted to Invoker. Review it, then Run.`,
+          ? `Plan "${loaded.planName}" submitted as ${loaded.workflowCount} stacked workflows. Review them, then use Start ready work.`
+          : `Plan "${loaded.planName}" submitted to Invoker. Review it, then use Start ready work.`,
         'success',
       );
       persistPlanningSession(session, deps.planningSessionStore, false);

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3534,34 +3534,42 @@ function createEmbeddedTerminalBackendFromConfig(
         autoFixRetries: resolveAutoFixRetries(invokerConfig),
         canControl: () => ownerMode,
       });
-      const reconciledWorkerActions = reconcileTerminalWorkerActionsOnStartup(persistence);
-      if (reconciledWorkerActions > 0) {
-        logger.info(
-          `reconciled ${reconciledWorkerActions} terminal worker action(s) on startup`,
-          { module: 'init' },
-        );
-      }
     }
 
     // Fail orphaned in-flight tasks left by a previous crash, then start ready work.
     if (!ownerMode) {
       logger.info('follower mode startup: auto-run disabled', { module: 'init' });
     } else {
-      const orphaned = reconcileOrphanedInFlightTasksOnBoot({
-        orchestrator,
-        persistence,
-      });
-      if (orphaned.length > 0) {
-        logger.info(
-          `failed ${orphaned.length} orphaned in-flight task(s) left by a previous owner crash`,
-          { module: 'init', taskIds: orphaned.map((task) => task.id) },
-        );
-      }
-      if (invokerConfig.disableAutoRunOnStartup) {
-        logger.info('auto-run on startup disabled by config', { module: 'init' });
-      } else {
-        orchestrator.startExecution();
-      }
+      setTimeout(() => {
+        if (!ownerMode) return;
+        try {
+          const reconciledWorkerActions = reconcileTerminalWorkerActionsOnStartup(persistence);
+          if (reconciledWorkerActions > 0) {
+            logger.info(
+              `reconciled ${reconciledWorkerActions} terminal worker action(s) on startup`,
+              { module: 'init' },
+            );
+          }
+          const orphaned = reconcileOrphanedInFlightTasksOnBoot({
+            orchestrator,
+            persistence,
+          });
+          if (orphaned.length > 0) {
+            logger.info(
+              `failed ${orphaned.length} orphaned in-flight task(s) left by a previous owner crash`,
+              { module: 'init', taskIds: orphaned.map((task) => task.id) },
+            );
+          }
+          if (invokerConfig.disableAutoRunOnStartup) {
+            logger.info('auto-run on startup disabled by config', { module: 'init' });
+          } else {
+            orchestrator.startExecution();
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          logger.error(`deferred owner startup maintenance failed: ${message}`, { module: 'init' });
+        }
+      }, 0);
     }
 
     const dbPath = path.join(resolveInvokerHomeRoot(), 'invoker.db');

--- a/packages/execution-engine/src/__tests__/reconcile-terminal-worker-actions.test.ts
+++ b/packages/execution-engine/src/__tests__/reconcile-terminal-worker-actions.test.ts
@@ -82,4 +82,45 @@ describe('reconcileTerminalWorkerActionsOnStartup', () => {
       summary: 'Worker action reconciled from failed intent on startup: boom',
     });
   });
+
+  it('preserves store method binding when listing terminal intents', () => {
+    const actions = new Map<string, WorkerActionRecord>([
+      ['a', toRecord({
+        id: 'a',
+        workerKind: 'ci-failure',
+        actionType: 'fix-ci-failure',
+        workflowId: 'wf-1',
+        taskId: 'wf-1/t',
+        subjectType: 'review',
+        subjectId: '1',
+        externalKey: 'a',
+        status: 'queued',
+        intentId: '9',
+      })],
+    ]);
+    const store = {
+      listWorkerActions: () => Array.from(actions.values()),
+      listWorkflowMutationIntents(workflowId?: string) {
+        expect(this).toBe(store);
+        expect(workflowId).toBe('wf-1');
+        return [{
+          id: 9,
+          workflowId: 'wf-1',
+          channel: 'invoker:fix-with-agent',
+          args: [],
+          priority: 'normal' as const,
+          status: 'completed' as const,
+          createdAt: '2026-01-01T00:00:00.000Z',
+        }];
+      },
+      upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+        const saved = toRecord(write);
+        actions.set(write.id, saved);
+        return saved;
+      }),
+    };
+
+    expect(reconcileTerminalWorkerActionsOnStartup(store)).toBe(1);
+    expect(actions.get('a')?.status).toBe('completed');
+  });
 });

--- a/packages/execution-engine/src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
@@ -47,7 +47,7 @@ describe('repro: deferred startup reconcile method binding', () => {
     );
   });
 
-  it.fails('queries terminal intents once per workflow during startup reconcile', () => {
+  it('queries terminal intents once per workflow during startup reconcile', () => {
     const actions = [
       toRecord(buildQueuedAction('a', '9')),
       toRecord(buildQueuedAction('b', '9')),

--- a/packages/execution-engine/src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store';
+
+import { reconcileTerminalWorkerActionsOnStartup } from '../reconcile-terminal-worker-actions.js';
+
+function toRecord(write: WorkerActionWrite): WorkerActionRecord {
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? '2026-01-01T00:00:00.000Z',
+    updatedAt: write.updatedAt ?? '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function buildQueuedAction(id: string, intentId: string): WorkerActionWrite {
+  return {
+    id,
+    workerKind: 'ci-failure',
+    actionType: 'fix-ci-failure',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/t',
+    subjectType: 'review',
+    subjectId: '1',
+    externalKey: id,
+    status: 'queued',
+    intentId,
+  };
+}
+
+describe('repro: deferred startup reconcile method binding', () => {
+  it('fails like production when listWorkflowMutationIntents is extracted without bind', () => {
+    const store = {
+      listWorkflowMutationIntents(workflowId?: string) {
+        if (!workflowId) return [];
+        return this.queryAll(workflowId);
+      },
+      queryAll(workflowId: string) {
+        return workflowId === 'wf-1'
+          ? [{ id: 9, workflowId: 'wf-1', channel: 'x', args: [], priority: 'normal', status: 'completed', createdAt: 't' }]
+          : [];
+      },
+    };
+    const unboundList = store.listWorkflowMutationIntents;
+    expect(() => unboundList('wf-1', ['completed', 'failed'])).toThrow(
+      /Cannot read properties of undefined \(reading 'queryAll'\)/,
+    );
+  });
+
+  it.fails('queries terminal intents once per workflow during startup reconcile', () => {
+    const actions = [
+      toRecord(buildQueuedAction('a', '9')),
+      toRecord(buildQueuedAction('b', '9')),
+    ];
+    const listWorkflowMutationIntents = vi.fn((workflowId?: string) => {
+      expect(workflowId).toBe('wf-1');
+      return [{
+        id: 9,
+        workflowId: 'wf-1',
+        channel: 'invoker:fix-with-agent',
+        args: [],
+        priority: 'normal' as const,
+        status: 'completed' as const,
+        createdAt: '2026-01-01T00:00:00.000Z',
+      }];
+    });
+    const store = {
+      listWorkerActions: () => actions,
+      listWorkflowMutationIntents,
+      upsertWorkerAction: vi.fn((write: WorkerActionWrite) => toRecord(write)),
+    };
+
+    expect(reconcileTerminalWorkerActionsOnStartup(store)).toBe(2);
+    expect(listWorkflowMutationIntents).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/execution-engine/src/reconcile-terminal-worker-actions.ts
+++ b/packages/execution-engine/src/reconcile-terminal-worker-actions.ts
@@ -38,6 +38,8 @@ export function reconcileTerminalWorkerActionsOnStartup(
   if (!store.upsertWorkerAction || !store.listWorkflowMutationIntents) {
     return 0;
   }
+  const upsertWorkerAction = store.upsertWorkerAction.bind(store);
+  const listTerminalIntents = store.listWorkflowMutationIntents.bind(store);
 
   const seen = new Set<string>();
   const open: WorkerActionRecord[] = [];
@@ -51,10 +53,23 @@ export function reconcileTerminalWorkerActionsOnStartup(
 
   let reconciled = 0;
   const nowIso = now.toISOString();
+  const terminalIntentsByWorkflow = new Map<string, Map<string, WorkflowMutationIntent>>();
+  const resolveTerminalIntent = (
+    workflowId: string,
+    intentId: string,
+  ): WorkflowMutationIntent | undefined => {
+    let intentsById = terminalIntentsByWorkflow.get(workflowId);
+    if (!intentsById) {
+      const terminalIntents = listTerminalIntents(workflowId, ['completed', 'failed']);
+      intentsById = new Map(terminalIntents.map((candidate) => [String(candidate.id), candidate]));
+      terminalIntentsByWorkflow.set(workflowId, intentsById);
+    }
+    return intentsById.get(intentId);
+  };
+
   for (const action of open) {
-    if (!action.intentId) continue;
-    const terminalIntents = store.listWorkflowMutationIntents(action.workflowId, ['completed', 'failed']);
-    const intent = terminalIntents.find((candidate) => String(candidate.id) === action.intentId);
+    if (!action.intentId || !action.workflowId) continue;
+    const intent = resolveTerminalIntent(action.workflowId, action.intentId);
     if (!intent) continue;
 
     const status: WorkerActionStatus = intent.status === 'completed' ? 'completed' : 'failed';
@@ -65,7 +80,7 @@ export function reconcileTerminalWorkerActionsOnStartup(
       ? { ...(action.payload as Record<string, unknown>) }
       : {};
 
-    store.upsertWorkerAction({
+    upsertWorkerAction({
       ...action,
       status,
       summary,

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -253,7 +253,6 @@ interface PlanningTypingTelemetryState {
   selectedTaskId: string | null;
   selectedWorkflowId: string | null;
   hasLoadedPlan: boolean;
-  hasStarted: boolean;
 }
 
 function utf8Size(value: string): number {
@@ -304,7 +303,6 @@ function createPlanningTypingTelemetryContext({
   selectedTaskId,
   selectedWorkflowId,
   hasLoadedPlan,
-  hasStarted,
 }: PlanningTypingTelemetryState): Record<string, unknown> {
   const sessions = new Set<string>();
   const taskStatusCounts: Record<string, number> = {};
@@ -340,7 +338,6 @@ function createPlanningTypingTelemetryContext({
     selectedTaskId,
     selectedWorkflowId,
     hasLoadedPlan,
-    hasStarted,
   };
 }
 
@@ -653,8 +650,8 @@ function EmptyGraphTutorial(): JSX.Element {
             <div className="mt-1 text-xs text-muted-foreground">Check the graph before starting work.</div>
           </li>
           <li>
-            <div className="font-medium text-foreground">3. Run it</div>
-            <div className="mt-1 text-xs text-muted-foreground">Start the workflow when the plan looks right.</div>
+            <div className="font-medium text-foreground">3. Start ready work</div>
+            <div className="mt-1 text-xs text-muted-foreground">Use Start ready work when the plan looks right.</div>
           </li>
         </ol>
       </div>
@@ -751,7 +748,6 @@ export function App() {
   const [selectedWorkflowVanished, setSelectedWorkflowVanished] = useState(false);
   const [modal, setModal] = useState<ModalState>({ type: 'none' });
   const [hasLoadedPlan, setHasLoadedPlan] = useState(false);
-  const [hasStarted, setHasStarted] = useState(false);
   const [planName, setPlanName] = useState<string | null>(null);
   const [planningSessions, setPlanningSessions] = useState<PlanningSessionView[]>(() => [makeInitialPlanningSession()]);
   const planningSessionsRef = useRef<PlanningSessionView[]>(planningSessions);
@@ -1173,7 +1169,6 @@ export function App() {
       selectedTaskId,
       selectedWorkflowId,
       hasLoadedPlan,
-      hasStarted,
     };
   }, [
     tasks,
@@ -1183,7 +1178,6 @@ export function App() {
     selectedTaskId,
     selectedWorkflowId,
     hasLoadedPlan,
-    hasStarted,
   ]);
 
   useEffect(() => {
@@ -2432,18 +2426,6 @@ export function App() {
     }));
   }, [updateActivePlanningSession]);
 
-  const handleStart = useCallback(async (): Promise<boolean> => {
-    if (!invoker) return false;
-    try {
-      await invoker.start();
-      setHasStarted(true);
-      return true;
-    } catch (err) {
-      notifyMutationError('Failed to start:', err);
-      return false;
-    }
-  }, [invoker]);
-
   const handleStartReadyAction = useCallback(async (
     request: StartReadyRequest = {},
   ): Promise<StartReadyResult | null> => {
@@ -2455,7 +2437,6 @@ export function App() {
       if (!result.dryRun) {
         await refreshTaskGraph();
         void refreshActionGraph();
-        if (result.started.length > 0) setHasStarted(true);
         if (result.started.length > 0 || result.recreatedWorkflowIds.length > 0) {
           const descriptionParts = [
             result.recreatedWorkflowIds.length > 0
@@ -2521,7 +2502,6 @@ export function App() {
       if (result.ok) {
         setPlanningSubmitError(null);
         setHasLoadedPlan(true);
-        setHasStarted(false);
         setSidebarSurface('home');
         setWorkflowSelectionDismissed(false);
         setViewMode('dag');
@@ -2541,8 +2521,8 @@ export function App() {
         await refreshTaskGraph();
         appendTerminalLine(
           result.workflowCount && result.workflowCount > 1
-            ? `Plan "${result.planName}" submitted as ${result.workflowCount} stacked workflows. Review them, then Run.`
-            : `Plan "${result.planName}" submitted to Invoker. Review it, then Run.`,
+            ? `Plan "${result.planName}" submitted as ${result.workflowCount} stacked workflows. Review them, then use Start ready work.`
+            : `Plan "${result.planName}" submitted to Invoker. Review it, then use Start ready work.`,
           'system',
           'success',
         );
@@ -2567,9 +2547,9 @@ export function App() {
     setPlanningSubmitError(null);
 
     if (input.toLowerCase() === 'run') {
-      if (!hasLoadedPlan || hasStarted) {
+      if (!hasLoadedPlan && tasks.size === 0 && workflows.size === 0) {
         appendTerminalLine(
-          hasStarted ? 'Run already started.' : 'Create or submit a plan before running.',
+          'Create or submit a plan before starting ready work.',
           'system',
           'error',
         );
@@ -2577,8 +2557,17 @@ export function App() {
       }
       updatePlanningSessionById(activePlanningSessionId, (session) => ({ ...session, busy: true }));
       try {
-        const started = await handleStart();
-        appendTerminalLine(started ? 'Run started.' : 'Run failed to start.', 'system', started ? 'success' : 'error');
+        const result = await handleStartReadyAction();
+        if (result && !result.dryRun) {
+          const startedCount = result.started.length;
+          appendTerminalLine(
+            startedCount > 0
+              ? `Started ${startedCount} ready task${startedCount === 1 ? '' : 's'}.`
+              : 'No ready work to start.',
+            'system',
+            startedCount > 0 ? 'success' : undefined,
+          );
+        }
       } finally {
         updatePlanningSessionById(activePlanningSessionId, (session) => ({ ...session, busy: false }));
       }
@@ -2662,16 +2651,17 @@ export function App() {
     clearPlanningStreamForSessionIds,
     forgetPlanningStreamAliasesForSessionIds,
     handlePlanningSubmitDraft,
-    handleStart,
+    handleStartReadyAction,
     hasLoadedPlan,
-    hasStarted,
     keepPlanningStreamFailureForSessionIds,
     invoker,
     planningInput,
     planningSessionId,
     selectedPlanningPresetKey,
     setPlanningInput,
+    tasks.size,
     updatePlanningSessionById,
+    workflows.size,
   ]);
 
   const handleCreatePlanningSession = useCallback(() => {
@@ -2830,22 +2820,12 @@ export function App() {
   ]);
 
 
-  const handleStop = useCallback(async () => {
-    if (!invoker) return;
-    try {
-      await invoker.stop();
-    } catch (err) {
-      notifyMutationError('Failed to stop:', err);
-    }
-  }, [invoker]);
-
   const handleClear = useCallback(async () => {
     if (!invoker) return;
     try {
       await invoker.clear();
       clearTasks();
       setHasLoadedPlan(false);
-      setHasStarted(false);
       setPlanName(null);
       setSidebarSurface('home');
       setSidebarCollapsed(null);
@@ -2870,7 +2850,6 @@ export function App() {
       await invoker.deleteAllWorkflowsBulk();
       clearTasks();
       setHasLoadedPlan(false);
-      setHasStarted(false);
       setPlanName(null);
       setSidebarSurface('home');
       setSidebarCollapsed(null);
@@ -2884,18 +2863,6 @@ export function App() {
       notifyMutationError('Failed to delete workflows:', err);
     }
   }, [clearTasks, invoker]);
-  const allSettled = useMemo(() => {
-    if (tasks.size === 0) return false;
-    for (const task of tasks.values()) {
-      if (task.status !== 'completed' && task.status !== 'failed' && task.status !== 'closed' && task.status !== 'blocked') {
-        return false;
-      }
-    }
-    return true;
-  }, [tasks]);
-
-  const showStart = hasLoadedPlan && !hasStarted;
-  const showStop = hasStarted && !allSettled;
   const showStartReadyControl = hasLoadedPlan || tasks.size > 0 || workflows.size > 0;
   const showEmptyGraphTutorial = sidebarSurface === 'home' && !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
   const autoCollapseSidebar = viewportWidth < 1440;
@@ -3258,26 +3225,6 @@ export function App() {
 
   const renderGraphActions = (showMoreMenu: boolean): JSX.Element => (
     <div className="flex items-center gap-2">
-      {showStart && (
-        <button
-          type="button"
-          data-testid="rail-start"
-          onClick={handleStart}
-          className="rounded bg-green-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-600"
-        >
-          Run
-        </button>
-      )}
-      {showStop && (
-        <button
-          type="button"
-          data-testid="rail-stop"
-          onClick={handleStop}
-          className="rounded bg-red-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-600"
-        >
-          Stop
-        </button>
-      )}
       {showStartReadyControl && (
         <div ref={startReadyMenuRef} className="relative inline-flex">
           <button

--- a/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
@@ -58,7 +58,7 @@ describe('CodeRabbit PR #3050 — draft state cleared after submit', () => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });
     await openPlanningTerminal();
-    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then Run.');
+    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
     // The submit succeeded; the ready bar must be gone so it cannot resubmit the same session.
     await waitFor(() => {
       expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();

--- a/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
@@ -4,18 +4,13 @@ import type { InAppPlanningChatResponse } from '@invoker/contracts';
 import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
 
 vi.mock('@xyflow/react', async () => {
-  // Dynamic import is required because Vitest hoists mock factories before test imports.
   const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
   return createReactFlowMock();
 });
 
-// Dynamic import is required so App sees the hoisted @xyflow/react mock.
 const { App } = await import('../App.js');
 
-// Submitted planning sessions are read-only. Starting work goes through the
-// graph Run button, and once a run starts the button disappears so it cannot
-// call invoker.start() a second time.
-describe('CodeRabbit PR #3050 — "run" respects the already-started guard', () => {
+describe('CodeRabbit PR #3050 — submitted planning stays read-only after start ready', () => {
   let mock: MockInvoker;
 
   beforeEach(() => {
@@ -27,11 +22,6 @@ describe('CodeRabbit PR #3050 — "run" respects the already-started guard', () 
     mock.cleanup();
   });
 
-  function submitPlanningText(text: string) {
-    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
-    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
-  }
-
   async function openPlanningTerminal() {
     fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await waitFor(() => {
@@ -39,7 +29,7 @@ describe('CodeRabbit PR #3050 — "run" respects the already-started guard', () 
     });
   }
 
-  it('does not re-invoke start after a run has already started', async () => {
+  it('keeps the submitted planning session read-only after start ready work fires', async () => {
     const draftReply: InAppPlanningChatResponse = {
       ok: true,
       sessionId: 'session-1',
@@ -52,24 +42,28 @@ describe('CodeRabbit PR #3050 — "run" respects the already-started guard', () 
     render(<App />);
     await openPlanningTerminal();
 
-    submitPlanningText('draft the full plan');
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'draft the full plan' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
     await screen.findByTestId('invoker-terminal-ready-bar');
     fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });
+
     await openPlanningTerminal();
-    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then Run.');
+    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
+
     fireEvent.click(screen.getByTestId('sidebar-home'));
-    fireEvent.click(await screen.findByTestId('rail-start'));
+    fireEvent.click(await screen.findByTestId('rail-start-ready'));
     await waitFor(() => {
-      expect(mock.api.start).toHaveBeenCalledTimes(1);
+      expect(mock.api.startReady).toHaveBeenCalledTimes(1);
     });
     expect(screen.queryByTestId('rail-start')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('rail-stop')).not.toBeInTheDocument();
 
     await openPlanningTerminal();
     expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
     expect(screen.getByTestId('invoker-terminal-harness')).toBeDisabled();
-    expect(mock.api.start).toHaveBeenCalledTimes(1);
+    expect(mock.api.start).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
+++ b/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
@@ -66,6 +66,31 @@ export function createReactFlowMock() {
     const emitManualMoveEnd = (event: unknown) =>
       onMoveEnd?.(event, { x: 0, y: 0, zoom: getZoom() });
 
+    const nodeElements = nodes.map((node) => {
+      const NodeComponent = nodeTypes[node.type ?? ''];
+      return (
+        <div
+          key={node.id}
+          data-testid={`rf__node-${node.id}`}
+          data-x={(node as { position?: { x?: number } }).position?.x}
+          data-y={(node as { position?: { y?: number } }).position?.y}
+          className="react-flow__node"
+          onClick={(e) => onNodeClick?.(e, node)}
+          onContextMenu={(e) => onNodeContextMenu?.(e, node)}
+          onDoubleClick={(e) => onNodeDoubleClick?.(e, node)}
+        >
+          {NodeComponent ? (
+            <NodeComponent data={node.data ?? {}} />
+          ) : (
+            <>
+              <span>{node.data?.label ?? node.data?.task?.description ?? node.id}</span>
+              <span>{node.id}</span>
+            </>
+          )}
+        </div>
+      );
+    });
+
     return (
       <div data-testid="mock-react-flow" className="react-flow">
         <div
@@ -74,7 +99,9 @@ export function createReactFlowMock() {
           onPointerDown={(e) => emitManualMove(e.nativeEvent)}
           onPointerUp={(e) => emitManualMoveEnd(e.nativeEvent)}
           onWheel={(e) => emitManualMove(e.nativeEvent)}
-        />
+        >
+          {nodeElements}
+        </div>
         {props.edges?.map((edge: any) => (
           <div
             key={edge.id}
@@ -86,30 +113,6 @@ export function createReactFlowMock() {
             aria-label={edge.ariaLabel}
           />
         ))}
-        {nodes.map((node) => {
-          const NodeComponent = nodeTypes[node.type ?? ''];
-          return (
-            <div
-              key={node.id}
-              data-testid={`rf__node-${node.id}`}
-              data-x={(node as { position?: { x?: number } }).position?.x}
-              data-y={(node as { position?: { y?: number } }).position?.y}
-              className="react-flow__node"
-              onClick={(e) => onNodeClick?.(e, node)}
-              onContextMenu={(e) => onNodeContextMenu?.(e, node)}
-              onDoubleClick={(e) => onNodeDoubleClick?.(e, node)}
-            >
-              {NodeComponent ? (
-                <NodeComponent data={node.data ?? {}} />
-              ) : (
-                <>
-                  <span>{node.data?.label ?? node.data?.task?.description ?? node.id}</span>
-                  <span>{node.id}</span>
-                </>
-              )}
-            </div>
-          );
-        })}
         {children}
       </div>
     );

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -565,7 +565,7 @@ describe('Invoker terminal (component)', () => {
       expect(screen.getByText('Plan graph')).toBeInTheDocument();
     });
     fireEvent.click(screen.getByTestId('sidebar-planning'));
-    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review it, then Run.');
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
     expect(mock.api.start).not.toHaveBeenCalled();
   });
 
@@ -608,7 +608,7 @@ describe('Invoker terminal (component)', () => {
     });
     fireEvent.click(screen.getByTestId('sidebar-planning'));
     expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(
-      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then Run.',
+      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then use Start ready work.',
     );
   });
 
@@ -649,7 +649,7 @@ describe('Invoker terminal (component)', () => {
       expect(screen.getByText('Plan graph')).toBeInTheDocument();
     });
     fireEvent.click(screen.getByTestId('sidebar-planning'));
-    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. Review it, then Run.');
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. Review it, then use Start ready work.');
     expect(screen.queryByTestId('invoker-terminal-submit-error')).not.toBeInTheDocument();
   });
 
@@ -682,7 +682,8 @@ describe('Invoker terminal (component)', () => {
 
     submitPlanningText('run');
 
-    expect(await screen.findByText('Create or submit a plan before running.')).toBeInTheDocument();
+    expect(await screen.findByText('Create or submit a plan before starting ready work.')).toBeInTheDocument();
+    expect(mock.api.startReady).not.toHaveBeenCalled();
     expect(mock.api.start).not.toHaveBeenCalled();
   });
 

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -533,7 +533,23 @@ describe('WorkflowGraph', () => {
     expect(setViewportMock).toHaveBeenCalledWith({ x: 40, y: 8, zoom: 0.75 }, { duration: 0 });
   });
 
-  it('starts pane drags from workflow node surfaces inside the pane bounds', async () => {
+  it('selects a workflow when clicking its node inside the pane', async () => {
+    const onSelectWorkflow = vi.fn();
+
+    await renderAndSettleInitialFit({
+      workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
+      selectedWorkflowId: null,
+      statusFilters: new Set(),
+      onSelectWorkflow,
+      onWorkflowContextMenu: () => {},
+    });
+
+    fireEvent.click(screen.getByTestId('workflow-node-wf-a'));
+
+    expect(onSelectWorkflow).toHaveBeenCalledWith('wf-a');
+  });
+
+  it('does not start pane drags when pressing on a workflow node surface', async () => {
     getViewportMock.mockReturnValue({ x: 10, y: 20, zoom: 0.75 });
 
     await renderAndSettleInitialFit({
@@ -544,24 +560,11 @@ describe('WorkflowGraph', () => {
       onWorkflowContextMenu: () => {},
     });
 
-    const pane = screen.getByTestId('rf__pane');
-    vi.spyOn(pane, 'getBoundingClientRect').mockReturnValue({
-      x: 0,
-      y: 0,
-      left: 0,
-      top: 0,
-      right: 200,
-      bottom: 200,
-      width: 200,
-      height: 200,
-      toJSON: () => ({}),
-    } as DOMRect);
-
     fireEvent.mouseDown(screen.getByTestId('workflow-node-wf-a'), { clientX: 100, clientY: 100, button: 0 });
     fireEvent.mouseMove(window, { clientX: 130, clientY: 88, buttons: 1 });
     fireEvent.mouseUp(window, { clientX: 130, clientY: 88, button: 0 });
 
-    expect(setViewportMock).toHaveBeenCalledWith({ x: 40, y: 8, zoom: 0.75 }, { duration: 0 });
+    expect(setViewportMock).not.toHaveBeenCalled();
   });
 
   it('centers the selected workflow on a centerSelection command, preserving the current zoom', async () => {

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -44,6 +44,7 @@ interface WorkflowNodeData extends Record<string, unknown> {
   selected: boolean;
   dimmed: boolean;
   coreActivity?: WorkflowCoreActivity;
+  onSelect?: () => void;
 }
 
 interface GraphViewport {
@@ -97,6 +98,7 @@ function shouldStartPanePan(
   if (targetElement) {
     if (!root.contains(targetElement)) return false;
     if (targetElement.closest(PANE_PAN_BLOCK_SELECTOR)) return false;
+    if (targetElement.closest('.react-flow__node, [data-testid^="workflow-node-"]')) return false;
     if (targetElement.closest('.react-flow__pane')) return true;
   }
 
@@ -238,7 +240,7 @@ function WorkflowFlowNode({ data }: NodeProps<Node<WorkflowNodeData>>): JSX.Elem
         selected={data.selected}
         dimmed={data.dimmed}
         coreActivity={data.coreActivity}
-        onClick={() => {}}
+        onClick={() => data.onSelect?.()}
         onContextMenu={() => {}}
       />
       <Handle
@@ -307,12 +309,13 @@ function WorkflowGraphInner({
           selected: selectedWorkflowId === node.id,
           dimmed,
           coreActivity: coreActivityByWorkflow?.get(node.id),
+          onSelect: () => onSelectWorkflow(node.id),
         },
       };
     });
     graphMetricsRef.current.objectsMs = performance.now() - startedAt;
     return nextNodes;
-  }, [coreActivityByWorkflow, graph.nodes, positions, selectedWorkflowId, statusFilters]);
+  }, [coreActivityByWorkflow, graph.nodes, onSelectWorkflow, positions, selectedWorkflowId, statusFilters]);
   const [rfNodes, setRfNodes] = useState<Node<WorkflowNodeData>[]>([]);
 
   useEffect(() => {

--- a/scripts/repro/repro-start-ready-production-click.sh
+++ b/scripts/repro/repro-start-ready-production-click.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Repro: clicking "Start ready work" crashed Invoker after deferred startup
+# reconcile began calling SQLite adapter methods without `this` binding.
+#
+# Observed in ~/.invoker/invoker.log:
+#   uncaughtException: TypeError: Cannot read properties of undefined (reading 'queryAll')
+#     at listWorkflowMutationIntents
+#     at reconcileTerminalWorkerActionsOnStartup
+#     at Timeout._onTimeout (deferred owner startup maintenance)
+#
+# Fixed behavior:
+#   reconcileTerminalWorkerActionsOnStartup binds store methods before calling
+#   them, and deferred startup maintenance is wrapped in try/catch so a reconcile
+#   failure cannot take down the GUI owner.
+#
+# This script:
+#   1. Runs the unit repro proving the unbound-method failure mode
+#   2. Builds the app
+#   3. Launches the real Electron UI against ~/.invoker
+#   4. Playwright clicks [data-testid="rail-start-ready"]
+#   5. Asserts the process stays alive with no new uncaughtException log lines
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] 1/3 unit repro: unbound listWorkflowMutationIntents crashes without bind"
+pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/repro-start-ready-deferred-reconcile-bind.test.ts
+
+echo "[repro] 2/3 build app + ui"
+pnpm --filter @invoker/ui build >/dev/null
+pnpm --filter @invoker/app build >/dev/null
+
+echo "[repro] 3/3 production GUI click: Start ready work"
+bash "$ROOT/scripts/kill-all-electron.sh" >/dev/null 2>&1 || true
+sleep 1
+
+INVOKER_REPRO_PRODUCTION_DB=1 pnpm --filter @invoker/app exec playwright test \
+  e2e/start-ready-production-click.spec.ts
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

Planner success copy still told users to press Run after a plan finished loading.

This slice updates the planner message to reference Start ready work instead.

## Review Claim

Approve updating planner success messaging to match the new owner rail model.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the planner success string changes.

No planner flow or owner handler changes.

## Slice Rationale

The prior slice drops Run and Stop from the owner rail.

This slice updates the planner text that still referenced Run.

## Non-goals

- No App.tsx rail changes
- No regression test updates in this slice

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/in-app-planner.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4568
