### PR TITLE
[Workflow Graph Controls Fit](1) Restore fit-to-frame after pane pan

### DIFF
--- a/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
+++ b/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
@@ -93,6 +93,7 @@ export function createReactFlowMock() {
 
     return (
       <div data-testid="mock-react-flow" className="react-flow">
+        <div className="react-flow__viewport" />
         <div
           data-testid="rf__pane"
           className="react-flow__pane"
@@ -150,7 +151,11 @@ export function createReactFlowMock() {
       return next;
     }),
     Background: () => null,
-    Controls: () => null,
+    Controls: ({ onFitView }: { onFitView?: () => void }) => (
+      <button type="button" data-testid="rf__fit-view" onClick={() => onFitView?.()}>
+        Fit
+      </button>
+    ),
     MarkerType: { ArrowClosed: 'arrowclosed' },
     Handle: () => null,
     Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -567,6 +567,34 @@ describe('WorkflowGraph', () => {
     expect(setViewportMock).not.toHaveBeenCalled();
   });
 
+  it('clears pane-pan inline transforms after drag and restores fit from controls', async () => {
+    getViewportMock.mockReturnValue({ x: 10, y: 20, zoom: 0.75 });
+
+    await renderAndSettleInitialFit({
+      workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
+      selectedWorkflowId: 'wf-a',
+      statusFilters: new Set(),
+      onSelectWorkflow: () => {},
+      onWorkflowContextMenu: () => {},
+    });
+
+    const viewport = screen.getByTestId('workflow-graph-react-flow').querySelector('.react-flow__viewport');
+    expect(viewport).not.toBeNull();
+
+    const pane = screen.getByTestId('rf__pane');
+    fireEvent.mouseDown(pane, { clientX: 100, clientY: 100, button: 0 });
+    fireEvent.mouseMove(window, { clientX: 130, clientY: 88, buttons: 1 });
+    await waitFor(() => expect((viewport as HTMLElement).style.transform).not.toBe(''));
+    fireEvent.mouseUp(window, { clientX: 130, clientY: 88, button: 0 });
+    await waitFor(() => expect((viewport as HTMLElement).style.transform).toBe(''));
+
+    fitViewMock.mockClear();
+    fireEvent.click(screen.getByTestId('rf__fit-view'));
+    expect(fitViewMock).toHaveBeenCalledTimes(1);
+    expect(fitViewMock).toHaveBeenCalledWith({ padding: 0.2 });
+    expect((viewport as HTMLElement).style.transform).toBe('');
+  });
+
   it('centers the selected workflow on a centerSelection command, preserving the current zoom', async () => {
     const issuer = createGraphCameraCommandIssuer();
     getZoomMock.mockReturnValue(1.75);

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -141,6 +141,10 @@ function applyViewportTransform(viewportElement: HTMLElement | null, viewport: G
   );
 }
 
+function clearViewportInlineTransform(viewportElement: HTMLElement | null): void {
+  viewportElement?.style.removeProperty('transform');
+}
+
 function schedulePanePanAnimation(pan: PanePan): void {
   if (pan.animationFrame !== 0) return;
 
@@ -277,6 +281,30 @@ function WorkflowGraphInner({
   const pendingGestureEdgesRef = useRef<Edge[] | null>(null);
   const panePointerPanRef = useRef<PanePointerPan | null>(null);
   const paneMousePanRef = useRef<PanePan | null>(null);
+
+  const getViewportElement = useCallback(
+    () => graphRootRef.current?.querySelector<HTMLElement>('.react-flow__viewport') ?? null,
+    [],
+  );
+
+  const cancelActivePanePans = useCallback(() => {
+    for (const ref of [panePointerPanRef, paneMousePanRef] as const) {
+      const pan = ref.current;
+      if (!pan) continue;
+      pan.active = false;
+      if (pan.animationFrame !== 0) {
+        cancelAnimationFrame(pan.animationFrame);
+        pan.animationFrame = 0;
+      }
+      ref.current = null;
+    }
+  }, []);
+
+  const performFitView = useCallback(() => {
+    cancelActivePanePans();
+    clearViewportInlineTransform(getViewportElement());
+    fitView({ padding: 0.2 });
+  }, [cancelActivePanePans, fitView, getViewportElement]);
   const [flowInstanceKey, setFlowInstanceKey] = useState(0);
   const graphMetricsRef = useRef({ deriveMs: 0, layoutMs: 0, objectsMs: 0 });
   const graph = useMemo(() => {
@@ -401,9 +429,9 @@ function WorkflowGraphInner({
     initFitFrameRef.current = requestAnimationFrame(() => {
       if (initialFitCompletedRef.current) return;
       initialFitCompletedRef.current = true;
-      fitView({ padding: 0.2 });
+      performFitView();
     });
-  }, [fitView]);
+  }, [performFitView]);
 
   // Cancel a pending first-fit frame on unmount so it never fires against a
   // torn-down graph after the component has gone away.
@@ -492,8 +520,8 @@ function WorkflowGraphInner({
       pan.animationFrame = 0;
     }
     pan.visualViewport = { ...pan.targetViewport };
-    applyViewportTransform(pan.viewportElement, pan.targetViewport);
     void setViewport(pan.targetViewport, { duration: 0 });
+    clearViewportInlineTransform(pan.viewportElement);
   }, [setViewport]);
 
   const onPanePointerMoveCapture = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
@@ -648,7 +676,7 @@ function WorkflowGraphInner({
     if (nodes.length === 0) return;
 
     if (command.kind === 'fitInitial') {
-      const frame = requestAnimationFrame(() => fitView({ padding: 0.2 }));
+      const frame = requestAnimationFrame(() => performFitView());
       return () => cancelAnimationFrame(frame);
     }
 
@@ -661,11 +689,11 @@ function WorkflowGraphInner({
         const zoom = typeof getZoom === 'function' ? getZoom() : 1;
         setCenter(node.position.x + 110, node.position.y + 45, { zoom, duration: 180 });
       } else {
-        fitView({ padding: 0.2 });
+        performFitView();
       }
     });
     return () => cancelAnimationFrame(frame);
-  }, [cameraCommand, fitView, getZoom, nodes, setCenter]);
+  }, [cameraCommand, getZoom, nodes, performFitView, setCenter]);
 
   useEffect(() => {
     if (nodes.length === 0) return;
@@ -684,7 +712,7 @@ function WorkflowGraphInner({
         const shouldRecover =
           watchdogMissCountRef.current >= WATCHDOG_RECOVERY_MISS_COUNT &&
           !watchdogRecoveryAttemptedRef.current;
-        fitView({ padding: 0.2 });
+        performFitView();
         if (shouldRecover) {
           watchdogRecoveryAttemptedRef.current = true;
           setFlowInstanceKey((key) => key + 1);
@@ -694,7 +722,7 @@ function WorkflowGraphInner({
       }
     }, 2000);
     return () => clearInterval(interval);
-  }, [fitView, nodes.length]);
+  }, [nodes.length, performFitView]);
 
   const flowNodes = rfNodes.length > 0 ? rfNodes : nodes;
   const flowEdges = rfEdges.length > 0 || edges.length === 0 ? rfEdges : edges;
@@ -745,6 +773,8 @@ function WorkflowGraphInner({
         >
           <Background color="var(--graph-grid)" gap={20} />
           <Controls
+            fitViewOptions={{ padding: 0.2 }}
+            onFitView={performFitView}
             style={{
               background: 'var(--graph-controls)',
               borderRadius: '8px',


### PR DESCRIPTION
## Summary

Merged #4459 pane-pan writes inline transforms on the React Flow viewport element.

Those transforms stay after drag ends and override fitView from the bottom-left Controls button.

The graph then jumps to a wrong frame instead of fitting all workflows.

This slice clears inline transforms when pan ends and funnels every fit call through one helper.

## Review Claim

Approve restoring the bottom-left Fit View control so it reliably frames the full workflow graph after manual panning.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Pane-pan drag behavior is unchanged during the gesture.

Only pan teardown and programmatic fit paths clear the temporary inline transform.

## Slice Rationale

#4459 landed on master without a fit-control regression test.

This stacks after the deferred-startup and left-click slices because it fixes a separate camera bug from the same pane-pan work.

## Non-goals

- No left-click selection changes
- No home-button camera command changes
- No Run/Stop rail changes

## Architecture

### Before

```mermaid
graph TD
    A["Pane pan ends"] --> B["inline style.transform kept"]
    B --> C["Controls fitView updates RF state"]
    C --> D["DOM inline transform wins; viewport jumps"]
```

### After

```mermaid
graph TD
    A["Pane pan ends"] --> B["setViewport then clear inline transform"]
    C["Controls onFitView"] --> D["cancel pans + clear transform + fitView"]
    D --> E["React Flow owns viewport; graph fits frame"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm exec vitest run src/__tests__/workflow-graph.test.tsx -t "clears pane-pan"`
- [ ] `cd packages/ui && pnpm test`

</details>

## Visual Proof

Plan graph with workflow nodes and the bottom-left React Flow controls (zoom + Fit View).

![Plan graph with bottom-left Fit View controls visible](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260715-6837a6/workflow-graph-fit-controls-visible.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4570


