### PR TITLE
[Remove Running Browser Rail](1) Drop the running browser surface

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -49,7 +49,6 @@ import { ChevronDownIcon, PlayIcon } from './components/icons/index.js';
 import { CommandPalette } from './components/CommandPalette.js';
 import {
   getAttentionTaskEntries,
-  getRunningTaskEntries,
   getSortedWorkflows,
   formatTaskStatus,
   formatWorkflowStatus,
@@ -1452,7 +1451,6 @@ export function App() {
     () => getAttentionTaskEntries(tasks, workflows, attentionTaskIdsWithFailures),
     [tasks, workflows, attentionTaskIdsWithFailures],
   );
-  const runningEntries = useMemo(() => getRunningTaskEntries(tasks, workflows, queueStatus), [tasks, workflows, queueStatus]);
 
   const searchResults = useMemo<SearchResult[]>(
     () => computeSearchResults(searchQuery, tasks, workflows),
@@ -1993,24 +1991,8 @@ export function App() {
       selectTaskById(attentionEntries[0].task.id);
       return;
     }
-
-    if (sidebarSurface === 'running') {
-      if (!runningEntries.length) {
-        if (selectedTaskId !== null || selectedWorkflowId !== null) {
-          setSelectedTaskId(null);
-          setSelectedWorkflowId(null);
-          setWorkflowSelectionDismissed(false);
-        }
-        return;
-      }
-      if (runningEntries.some((entry) => entry.task.id === selectedTaskId)) {
-        return;
-      }
-      selectTaskById(runningEntries[0].task.id);
-    }
   }, [
     attentionEntries,
-    runningEntries,
     selectTaskById,
     selectWorkflowById,
     selectedTaskId,
@@ -3516,20 +3498,8 @@ export function App() {
   const attentionSubtitle = attentionEntries.length === 0
     ? 'Nothing needs a decision right now.'
     : `${attentionEntries.length} item${attentionEntries.length === 1 ? '' : 's'} need attention.`;
-  const runningSubtitle = runningEntries.length === 0
-    ? 'No active tasks right now.'
-    : `${runningEntries.length} task${runningEntries.length === 1 ? '' : 's'} active now.`;
-
-  const browserSurfaceTitle = sidebarSurface === 'workflows'
-    ? 'Workflows'
-    : sidebarSurface === 'attention'
-      ? 'Needs Attention'
-      : 'Running';
-  const browserSurfaceSubtitle = sidebarSurface === 'workflows'
-    ? workflowsSubtitle
-    : sidebarSurface === 'attention'
-      ? attentionSubtitle
-      : runningSubtitle;
+  const browserSurfaceTitle = sidebarSurface === 'workflows' ? 'Workflows' : 'Needs Attention';
+  const browserSurfaceSubtitle = sidebarSurface === 'workflows' ? workflowsSubtitle : attentionSubtitle;
 
   const browserSelectedTitle = sidebarSurface === 'workflows'
     ? selectedWorkflow?.name ?? 'Select a workflow'
@@ -3546,11 +3516,9 @@ export function App() {
     : selectedTask
       ? formatTaskStatus(selectedTask.status)
       : 'No item selected';
-  const browserStatusToneClass = sidebarSurface === 'running'
-    ? 'bg-secondary text-secondary-foreground'
-    : sidebarSurface === 'attention'
-      ? 'bg-amber-950/70 text-amber-100'
-      : 'bg-secondary text-foreground';
+  const browserStatusToneClass = sidebarSurface === 'attention'
+    ? 'bg-amber-950/70 text-amber-100'
+    : 'bg-secondary text-foreground';
 
   const relatedBrowserTasks = Array.from(miniDagTasks.values()).filter((task) =>
     sidebarSurface === 'workflows' || task.id !== selectedTask?.id,
@@ -3576,9 +3544,9 @@ export function App() {
     )
   );
 
-  const renderTaskList = (entries: typeof attentionEntries, emptyTitle: string, emptyCopy: string, tone: 'attention' | 'running'): JSX.Element => (
+  const renderTaskList = (entries: typeof attentionEntries, emptyTitle: string, emptyCopy: string): JSX.Element => (
     entries.length === 0 ? renderBrowserEmptyState(emptyTitle, emptyCopy) : (
-      <div data-testid={`${tone}-rail-list`} className={`${RAIL_SCROLL_BODY_CLASS} p-3`}>
+      <div data-testid="attention-rail-list" className={`${RAIL_SCROLL_BODY_CLASS} p-3`}>
         <div className="space-y-1">
           {entries.map((entry) => (
             <BrowserTaskRow
@@ -3587,7 +3555,7 @@ export function App() {
               title={entry.task.description || entry.task.id}
               workflowName={entry.workflow?.name}
               statusLabel={formatTaskStatus(entry.task.status)}
-              tone={tone}
+              tone="attention"
               selected={selectedTaskId === entry.task.id}
               onSelect={selectTaskById}
             />
@@ -3716,9 +3684,7 @@ export function App() {
       <div className={RAIL_LIST_FRAME_CLASS}>
         {sidebarSurface === 'workflows'
           ? renderWorkflowsList()
-          : sidebarSurface === 'attention'
-            ? renderTaskList(attentionEntries, 'All clear', 'Nothing needs a decision right now.', 'attention')
-            : renderTaskList(runningEntries, 'No tasks running', 'Start a run to watch live work here.', 'running')}
+          : renderTaskList(attentionEntries, 'All clear', 'Nothing needs a decision right now.')}
       </div>
     </div>
   );
@@ -3909,6 +3875,10 @@ export function App() {
               renderGraphWorkspace('Plan graph', homeSubtitle, true)
             ) : sidebarSurface === 'planning' ? (
               renderPlanningTerminalSurface()
+            ) : sidebarSurface === 'workers' ? (
+              <div className="flex min-h-0 flex-1 overflow-hidden">
+                {renderBrowserDetailWorkspace()}
+              </div>
             ) : (
               <div className="flex min-h-0 flex-1 overflow-hidden">
                 {renderBrowserRail()}

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -184,6 +184,14 @@ describe('App launch (component)', () => {
     expect(sidebar.className).toContain('w-60');
   });
 
+  it('does not show the running browser rail on workers', async () => {
+    render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-workers'));
+    expect(screen.queryByTestId('browser-rail')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('running-rail-list')).not.toBeInTheDocument();
+    expect(screen.getByTestId('workflow-graph-surface')).toBeInTheDocument();
+  });
+
 
   it('shows workflow status chips and terminal drawer controls in home view', () => {
     render(<App />);

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Regression: a browser surface (Needs Attention / Running / Workflows) must not
+ * Regression: a browser surface (Needs Attention / Workflows) must not
  * re-center or re-fit the task graph on every live update.
  *
  * The browser-surface camera effect in App used to depend on

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -928,5 +928,6 @@ describe('Invoker terminal (component)', () => {
     await expectSurfaceRailList('planning', 'planning-session-list');
     await expectSurfaceRailList('workflows', 'workflows-rail-list');
     await expectSurfaceRailList('attention', 'attention-rail-list');
+    expect(screen.queryByTestId('running-rail-list')).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/CommandPalette.tsx
+++ b/packages/ui/src/components/CommandPalette.tsx
@@ -86,11 +86,6 @@ export function CommandPalette({
                 <span>Needs Attention</span>
                 {attentionEntries.length > 0 && <CommandShortcut>{attentionEntries.length}</CommandShortcut>}
               </CommandItem>
-              <CommandItem value="running tasks" onSelect={closeAnd(() => onSelectSurface('running'))}>
-                <Clock strokeWidth={1.75} />
-                <span>Running</span>
-                {runningEntries.length > 0 && <CommandShortcut>{runningEntries.length}</CommandShortcut>}
-              </CommandItem>
               <CommandItem value="workflows browser" onSelect={closeAnd(() => onSelectSurface('workflows'))}>
                 <Layers strokeWidth={1.75} />
                 <span>Workflows</span>

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -2,7 +2,7 @@ import type { QueueStatus } from '@invoker/contracts';
 import type { JSX } from 'react';
 import type { TaskState, WorkflowMeta, WorkerStatusSnapshot } from '../types.js';
 import type { SidebarSurface } from '../lib/workflow-progress-surfaces.js';
-import { getAttentionTaskEntries, getRunningTaskEntries, getSortedWorkflows } from '../lib/workflow-progress-surfaces.js';
+import { getAttentionTaskEntries, getSortedWorkflows } from '../lib/workflow-progress-surfaces.js';
 import { countActiveWorkerActions } from '../lib/worker-display.js';
 import {
   AttentionIcon,
@@ -84,7 +84,6 @@ export function LeftStatusColumn({
 }: LeftStatusColumnProps): JSX.Element {
   const workflowEntries = getSortedWorkflows(workflows, tasks);
   const attentionEntries = getAttentionTaskEntries(tasks, workflows, attentionTaskIdsWithFailures);
-  const runningEntries = getRunningTaskEntries(tasks, workflows, queueStatus);
   const runningWorkers = workerStatus?.workers.filter((worker) => worker.lifecycle === 'running').length ?? 0;
   const registeredWorkers = workerStatus?.workers.length ?? 0;
   const activeWorkerActions = workerStatus ? countActiveWorkerActions(workerStatus.workers) : 0;
@@ -223,11 +222,6 @@ export function LeftStatusColumn({
             attentionEntries.length === 0
               ? 'Nothing needs a decision right now.'
               : `${attentionEntries.length} item${attentionEntries.length === 1 ? ' needs' : 's need'} attention.`
-          )}
-          {selectedSurface === 'running' && (
-            runningEntries.length === 0
-              ? 'No tasks are running right now.'
-              : `${runningEntries.length} task${runningEntries.length === 1 ? '' : 's'} active now.`
           )}
           {selectedSurface === 'workers' && (
             workerStatus === null

--- a/packages/ui/src/lib/workflow-progress-surfaces.ts
+++ b/packages/ui/src/lib/workflow-progress-surfaces.ts
@@ -1,7 +1,7 @@
 import type { QueueStatus } from '@invoker/contracts';
 import type { TaskState, TaskStatus, WorkflowMeta, WorkflowStatus } from '../types.js';
 
-export type SidebarSurface = 'home' | 'planning' | 'workflows' | 'attention' | 'running' | 'workers';
+export type SidebarSurface = 'home' | 'planning' | 'workflows' | 'attention' | 'workers';
 
 export interface WorkflowListEntry {
   workflow: WorkflowMeta;


### PR DESCRIPTION
## Summary

The Running sidebar entry is already gone, but the Running browser rail and surface navigation were still live.

This slice drops that orphaned surface so Workflows and Needs Attention keep their rails while Workers use the full-width queue view.

Command palette no longer opens a dedicated Running tab. Running tasks can still be jumped to from the task list.

## Review Claim

Approve dropping the Running browser rail and `'running'` sidebar surface now that the sidebar entry is gone.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This is presentation-only surface trimming. Task status labels, queue view, workflow chips, and command-palette task jumps are unchanged.

## Slice Rationale

This follows the Owner Rail work and sidebar Running entry drop. It finishes the navigation simplification without mixing graph or startup work.

## Non-goals

- Does not drop running status labels on tasks, workflows, or chips.
- Does not change queue scheduling or worker lifecycle controls.
- Does not drop the command palette Running task jump group.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test`
- [x] Component tests assert `sidebar-running` and `running-rail-list` stay absent
- [x] Workers surface test asserts no `browser-rail`

</details>

## Visual Proof

Library sidebar still shows Needs Attention, Workers, and Workflows with no Running entry (unchanged from #4150).

![Sidebar without Running entry](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-009165/pr-4150-sidebar-no-running.png)

Component tests pin that `running-rail-list` never mounts and Workers opens without a left `browser-rail`.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 886e834a2`
- Post-revert steps: None
- Data migration? No

</details>


Depends-On: #4571
