### PR TITLE
[UI Responsiveness Guardrails Step 2](1) Track terminal scroll perf counters

### DIFF
--- a/packages/app/src/__tests__/renderer-ui-perf.test.ts
+++ b/packages/app/src/__tests__/renderer-ui-perf.test.ts
@@ -36,9 +36,10 @@ describe('renderer ui perf counters', () => {
     recordRendererUiPerfMetric(counters, 'embedded_terminal_input', { durationMs: 3, bytes: 5 });
     recordRendererUiPerfMetric(counters, 'embedded_terminal_output_write', { durationMs: 80, bytes: 4096 });
     recordRendererUiPerfMetric(counters, 'embedded_terminal_resize', { durationMs: 18 });
+    recordRendererUiPerfMetric(counters, 'embedded_terminal_scroll', { durationMs: 6 });
     recordRendererUiPerfMetric(counters, 'embedded_terminal_snapshot_write', { durationMs: 90, bytes: 8192 });
 
-    expect(counters.rendererReports).toBe(14);
+    expect(counters.rendererReports).toBe(15);
     expect(counters.maxRendererEventLoopLagMs).toBe(300);
     expect(counters.maxRendererHiddenEventLoopLagMs).toBe(900);
     expect(counters.maxRendererCumulativeLagMs).toBe(450);
@@ -67,6 +68,8 @@ describe('renderer ui perf counters', () => {
     expect(counters.maxEmbeddedTerminalOutputWriteBytes).toBe(4096);
     expect(counters.embeddedTerminalResizeReports).toBe(1);
     expect(counters.maxEmbeddedTerminalResizeMs).toBe(18);
+    expect(counters.embeddedTerminalScrollReports).toBe(1);
+    expect(counters.maxEmbeddedTerminalScrollMs).toBe(6);
     expect(counters.embeddedTerminalSnapshotWriteReports).toBe(1);
     expect(counters.maxEmbeddedTerminalSnapshotWriteMs).toBe(90);
     expect(counters.maxEmbeddedTerminalSnapshotBytes).toBe(8192);
@@ -76,6 +79,7 @@ describe('renderer ui perf counters', () => {
     expect(counters.rendererReports).toBe(0);
     expect(counters.maxPlanningTypingLagMs).toBe(0);
     expect(counters.maxPlanningChatInputCommitMs).toBe(0);
+    expect(counters.maxEmbeddedTerminalScrollMs).toBe(0);
     expect(counters.maxEmbeddedTerminalOutputWriteBytes).toBe(0);
   });
 });

--- a/packages/app/src/renderer-ui-perf.ts
+++ b/packages/app/src/renderer-ui-perf.ts
@@ -35,6 +35,8 @@ export type RendererUiPerfCounters = {
   maxEmbeddedTerminalOutputWriteBytes: number;
   embeddedTerminalResizeReports: number;
   maxEmbeddedTerminalResizeMs: number;
+  embeddedTerminalScrollReports: number;
+  maxEmbeddedTerminalScrollMs: number;
   embeddedTerminalSnapshotWriteReports: number;
   maxEmbeddedTerminalSnapshotWriteMs: number;
   maxEmbeddedTerminalSnapshotBytes: number;
@@ -71,6 +73,8 @@ export function createRendererUiPerfCounters(): RendererUiPerfCounters {
     maxEmbeddedTerminalOutputWriteBytes: 0,
     embeddedTerminalResizeReports: 0,
     maxEmbeddedTerminalResizeMs: 0,
+    embeddedTerminalScrollReports: 0,
+    maxEmbeddedTerminalScrollMs: 0,
     embeddedTerminalSnapshotWriteReports: 0,
     maxEmbeddedTerminalSnapshotWriteMs: 0,
     maxEmbeddedTerminalSnapshotBytes: 0,
@@ -185,6 +189,12 @@ export function recordRendererUiPerfMetric(
   if (metric === 'embedded_terminal_resize') {
     counters.embeddedTerminalResizeReports += 1;
     updateMax(counters, 'maxEmbeddedTerminalResizeMs', numberField(data, 'durationMs'));
+    return;
+  }
+
+  if (metric === 'embedded_terminal_scroll') {
+    counters.embeddedTerminalScrollReports += 1;
+    updateMax(counters, 'maxEmbeddedTerminalScrollMs', numberField(data, 'durationMs'));
     return;
   }
 


### PR DESCRIPTION
## Summary

Renderer UI perf stats now route embedded terminal scroll reports into the existing counter table.

This gives the terminal responsiveness work scroll budget data without changing the terminal UI.

## Review Claim

Renderer UI perf stats route embedded terminal scroll reports into existing counters for terminal responsiveness evidence.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change only extends the existing renderer UI perf counter table and its focused unit coverage.

## Slice Rationale

This counter route lands before terminal drawer reporting so the lower-level evidence path stays reviewable on its own.

## Non-goals

No terminal UI behavior, drawer interaction, IPC shape, persistence ownership, or Electron E2E behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile --ignore-scripts`
- [x] `pnpm --filter @invoker/app test -- renderer-ui-perf`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-4583-repaired-body.md --changed-files-file /tmp/pr-4583-changed-files.txt --diff-file /tmp/pr-4583.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 480b5cfdec751c5754de198957b4b2d503e91576`
- Post-revert steps: None
- Data migration? No

</details>
