### PR TITLE
[UI Responsiveness Guardrails Step 2](2) Gate terminal drawer responsiveness

### DIFF
--- a/packages/app/e2e/embedded-terminal-pty.spec.ts
+++ b/packages/app/e2e/embedded-terminal-pty.spec.ts
@@ -17,7 +17,10 @@ import {
 const TERMINAL_INPUT_BUDGET_MS = 100;
 const TERMINAL_OUTPUT_WRITE_BUDGET_MS = 250;
 const TERMINAL_RESIZE_BUDGET_MS = 250;
+const TERMINAL_SCROLL_BUDGET_MS = 50;
+const TERMINAL_OPEN_WALL_BUDGET_MS = 2000;
 const TERMINAL_TAB_SWITCH_WALL_BUDGET_MS = 1000;
+const TERMINAL_SCROLL_WALL_BUDGET_MS = 2000;
 const TERMINAL_SESSION_UPSERT_BUDGET_MS = 250;
 const TERMINAL_RENDERER_EVENT_LOOP_LAG_BUDGET_MS = 1000;
 const TERMINAL_RENDERER_LONG_TASK_BUDGET_MS = 1500;
@@ -26,7 +29,10 @@ const TERMINAL_PRESSURE_BUDGETS = {
   maxInputMs: TERMINAL_INPUT_BUDGET_MS,
   maxOutputWriteMs: TERMINAL_OUTPUT_WRITE_BUDGET_MS,
   maxResizeMs: TERMINAL_RESIZE_BUDGET_MS,
+  maxScrollMs: TERMINAL_SCROLL_BUDGET_MS,
+  maxOpenWallMs: TERMINAL_OPEN_WALL_BUDGET_MS,
   maxTabSwitchWallMs: TERMINAL_TAB_SWITCH_WALL_BUDGET_MS,
+  maxScrollWallMs: TERMINAL_SCROLL_WALL_BUDGET_MS,
   maxTerminalSessionUpsertMs: TERMINAL_SESSION_UPSERT_BUDGET_MS,
   maxRendererEventLoopLagMs: TERMINAL_RENDERER_EVENT_LOOP_LAG_BUDGET_MS,
   maxRendererLongTaskMs: TERMINAL_RENDERER_LONG_TASK_BUDGET_MS,
@@ -362,18 +368,22 @@ test.describe('Embedded terminal PTY', () => {
     const fullBetaTaskId = await resolveTaskId(page, 'terminal-pressure-beta');
     const watermark = await activityLogWatermark(page);
 
+    const alphaOpenStartedAt = Date.now();
     await openTaskTerminalFromMiniDag(page, 'terminal-pressure-alpha');
     await expect(page.getByTestId('terminal-drawer-body')).toBeVisible({ timeout: 10000 });
     const alphaPane = page.getByTestId(`terminal-pane-${fullAlphaTaskId}`);
     await expect(alphaPane).toBeVisible();
+    const alphaOpenWallMs = Date.now() - alphaOpenStartedAt;
     await alphaPane.click();
 
     await page.keyboard.type('for i in $(seq 1 140); do printf "term-live-%03d\\n" "$i"; done');
     await page.keyboard.press('Enter');
     await expect(alphaPane.getByText('term-live-140')).toBeVisible({ timeout: 10000 });
 
+    const betaOpenStartedAt = Date.now();
     await openTaskTerminalFromMiniDag(page, 'terminal-pressure-beta');
     await expect(page.getByTestId(`terminal-tab-${fullBetaTaskId}`)).toHaveAttribute('data-active', 'true', { timeout: 10000 });
+    const betaOpenWallMs = Date.now() - betaOpenStartedAt;
 
     const switchStartedAt = Date.now();
     await page.getByRole('tab', { name: /Terminal pressure alpha/i }).click();
@@ -384,34 +394,42 @@ test.describe('Embedded terminal PTY', () => {
     await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'maximized');
     const firstLine = alphaPane.getByText('term-live-001');
     await expect(firstLine).not.toBeVisible();
+    const scrollStartedAt = Date.now();
     await alphaPane.hover();
     for (let index = 0; index < 12; index += 1) {
       await page.mouse.wheel(0, -800);
       if (await firstLine.isVisible()) break;
     }
     await expect(firstLine).toBeVisible({ timeout: 10000 });
+    const scrollWallMs = Date.now() - scrollStartedAt;
 
     await expect
       .poll(async () => {
         const payloads = await uiPerfPayloadsSince(page, watermark);
-        return payloads.filter((payload) => payload.metric === 'embedded_terminal_output_write').length;
+        return payloads.some((payload) => payload.metric === 'embedded_terminal_output_write')
+          && payloads.some((payload) => payload.metric === 'embedded_terminal_scroll');
       }, { timeout: 5000 })
-      .toBeGreaterThan(0);
+      .toBe(true);
 
     const payloads = await uiPerfPayloadsSince(page, watermark);
     const attachPayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_attach');
     const inputPayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_input');
     const outputPayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_output_write');
     const resizePayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_resize');
+    const scrollPayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_scroll');
     const perf = await page.evaluate(async () => window.invoker.getUiPerfStats());
     const terminalEvidence = {
       fullAlphaTaskId,
       fullBetaTaskId,
+      alphaOpenWallMs,
+      betaOpenWallMs,
       switchWallMs,
+      scrollWallMs,
       attachPayloads,
       inputPayloads,
       outputPayloads,
       resizePayloads,
+      scrollPayloads,
       perf,
       budgets: TERMINAL_PRESSURE_BUDGETS,
     };
@@ -421,21 +439,36 @@ test.describe('Embedded terminal PTY', () => {
     expect(attachPayloads.length, terminalEvidenceMessage).toBeGreaterThanOrEqual(2);
     expect(inputPayloads.length, terminalEvidenceMessage).toBeGreaterThan(0);
     expect(outputPayloads.length, terminalEvidenceMessage).toBeGreaterThan(0);
+    expect(scrollPayloads.length, terminalEvidenceMessage).toBeGreaterThan(0);
+    expect(
+      scrollPayloads.some((payload) =>
+        payload.taskId === fullAlphaTaskId
+        && payload.active === true
+        && payload.drawerState === 'maximized',
+      ),
+      terminalEvidenceMessage,
+    ).toBe(true);
     expect(
       resizePayloads.some((payload) => payload.source === 'active_session' && payload.taskId === fullAlphaTaskId),
       terminalEvidenceMessage,
     ).toBe(true);
+    expect(alphaOpenWallMs, terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_OPEN_WALL_BUDGET_MS);
+    expect(betaOpenWallMs, terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_OPEN_WALL_BUDGET_MS);
     expect(switchWallMs, terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_TAB_SWITCH_WALL_BUDGET_MS);
+    expect(scrollWallMs, terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_SCROLL_WALL_BUDGET_MS);
     expect(Math.max(...inputPayloads.map((payload) => Number(payload.durationMs))), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_INPUT_BUDGET_MS);
     expect(Math.max(...outputPayloads.map((payload) => Number(payload.durationMs))), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_OUTPUT_WRITE_BUDGET_MS);
     expect(Math.max(...resizePayloads.map((payload) => Number(payload.durationMs))), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RESIZE_BUDGET_MS);
+    expect(Math.max(...scrollPayloads.map((payload) => Number(payload.durationMs))), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_SCROLL_BUDGET_MS);
 
     expect(Number(perf.embeddedTerminalAttachReports), terminalEvidenceMessage).toBeGreaterThanOrEqual(2);
     expect(Number(perf.embeddedTerminalInputReports), terminalEvidenceMessage).toBeGreaterThan(0);
     expect(Number(perf.embeddedTerminalOutputWriteReports), terminalEvidenceMessage).toBeGreaterThan(0);
+    expect(Number(perf.embeddedTerminalScrollReports), terminalEvidenceMessage).toBeGreaterThan(0);
     expect(Number(perf.maxEmbeddedTerminalInputMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_INPUT_BUDGET_MS);
     expect(Number(perf.maxEmbeddedTerminalOutputWriteMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_OUTPUT_WRITE_BUDGET_MS);
     expect(Number(perf.maxEmbeddedTerminalResizeMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RESIZE_BUDGET_MS);
+    expect(Number(perf.maxEmbeddedTerminalScrollMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_SCROLL_BUDGET_MS);
     expect(numberOrZero(perf.maxTerminalSessionUpsertMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_SESSION_UPSERT_BUDGET_MS);
     expect(numberOrZero(perf.maxRendererEventLoopLagMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RENDERER_EVENT_LOOP_LAG_BUDGET_MS);
     expect(numberOrZero(perf.maxRendererLongTaskMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RENDERER_LONG_TASK_BUDGET_MS);

--- a/packages/app/src/__tests__/renderer-ui-perf.test.ts
+++ b/packages/app/src/__tests__/renderer-ui-perf.test.ts
@@ -36,9 +36,10 @@ describe('renderer ui perf counters', () => {
     recordRendererUiPerfMetric(counters, 'embedded_terminal_input', { durationMs: 3, bytes: 5 });
     recordRendererUiPerfMetric(counters, 'embedded_terminal_output_write', { durationMs: 80, bytes: 4096 });
     recordRendererUiPerfMetric(counters, 'embedded_terminal_resize', { durationMs: 18 });
+    recordRendererUiPerfMetric(counters, 'embedded_terminal_scroll', { durationMs: 6 });
     recordRendererUiPerfMetric(counters, 'embedded_terminal_snapshot_write', { durationMs: 90, bytes: 8192 });
 
-    expect(counters.rendererReports).toBe(14);
+    expect(counters.rendererReports).toBe(15);
     expect(counters.maxRendererEventLoopLagMs).toBe(300);
     expect(counters.maxRendererHiddenEventLoopLagMs).toBe(900);
     expect(counters.maxRendererCumulativeLagMs).toBe(450);
@@ -67,6 +68,8 @@ describe('renderer ui perf counters', () => {
     expect(counters.maxEmbeddedTerminalOutputWriteBytes).toBe(4096);
     expect(counters.embeddedTerminalResizeReports).toBe(1);
     expect(counters.maxEmbeddedTerminalResizeMs).toBe(18);
+    expect(counters.embeddedTerminalScrollReports).toBe(1);
+    expect(counters.maxEmbeddedTerminalScrollMs).toBe(6);
     expect(counters.embeddedTerminalSnapshotWriteReports).toBe(1);
     expect(counters.maxEmbeddedTerminalSnapshotWriteMs).toBe(90);
     expect(counters.maxEmbeddedTerminalSnapshotBytes).toBe(8192);
@@ -76,6 +79,7 @@ describe('renderer ui perf counters', () => {
     expect(counters.rendererReports).toBe(0);
     expect(counters.maxPlanningTypingLagMs).toBe(0);
     expect(counters.maxPlanningChatInputCommitMs).toBe(0);
+    expect(counters.maxEmbeddedTerminalScrollMs).toBe(0);
     expect(counters.maxEmbeddedTerminalOutputWriteBytes).toBe(0);
   });
 });

--- a/packages/app/src/renderer-ui-perf.ts
+++ b/packages/app/src/renderer-ui-perf.ts
@@ -35,6 +35,8 @@ export type RendererUiPerfCounters = {
   maxEmbeddedTerminalOutputWriteBytes: number;
   embeddedTerminalResizeReports: number;
   maxEmbeddedTerminalResizeMs: number;
+  embeddedTerminalScrollReports: number;
+  maxEmbeddedTerminalScrollMs: number;
   embeddedTerminalSnapshotWriteReports: number;
   maxEmbeddedTerminalSnapshotWriteMs: number;
   maxEmbeddedTerminalSnapshotBytes: number;
@@ -71,6 +73,8 @@ export function createRendererUiPerfCounters(): RendererUiPerfCounters {
     maxEmbeddedTerminalOutputWriteBytes: 0,
     embeddedTerminalResizeReports: 0,
     maxEmbeddedTerminalResizeMs: 0,
+    embeddedTerminalScrollReports: 0,
+    maxEmbeddedTerminalScrollMs: 0,
     embeddedTerminalSnapshotWriteReports: 0,
     maxEmbeddedTerminalSnapshotWriteMs: 0,
     maxEmbeddedTerminalSnapshotBytes: 0,
@@ -185,6 +189,12 @@ export function recordRendererUiPerfMetric(
   if (metric === 'embedded_terminal_resize') {
     counters.embeddedTerminalResizeReports += 1;
     updateMax(counters, 'maxEmbeddedTerminalResizeMs', numberField(data, 'durationMs'));
+    return;
+  }
+
+  if (metric === 'embedded_terminal_scroll') {
+    counters.embeddedTerminalScrollReports += 1;
+    updateMax(counters, 'maxEmbeddedTerminalScrollMs', numberField(data, 'durationMs'));
     return;
   }
 

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -562,6 +562,18 @@ describe('Terminal drawer (component)', () => {
         }),
       );
     });
+
+    vi.mocked(mock.api.reportUiPerf).mockClear();
+    fireEvent.wheel(screen.getByTestId(`terminal-pane-${session.taskId}`), { deltaY: -800 });
+    expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+      'embedded_terminal_scroll',
+      expect.objectContaining({
+        sessionId: session.sessionId,
+        taskId: session.taskId,
+        deltaY: -800,
+        active: true,
+      }),
+    );
   });
 
   it('keeps live output, input, and tab switching responsive under terminal pressure', async () => {

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -14,6 +14,7 @@ import { FitAddon } from 'xterm-addon-fit';
 import type { TerminalSessionDescriptor } from '@invoker/contracts';
 
 const DRAWER_BODY_HEIGHT_PX = 280;
+const TERMINAL_SCROLL_PERF_SAMPLE_INTERVAL_MS = 100;
 
 /**
  * The drawer has one explicit state model:
@@ -129,11 +130,14 @@ function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: Term
   const fitRef = useRef<FitAddon | null>(null);
   const seededSnapshotRef = useRef<SeededOutputSnapshot | null>(null);
   const isActiveRef = useRef(isActive);
+  const drawerStateRef = useRef(drawerState);
   const sessionRef = useRef(session);
+  const lastScrollPerfAtRef = useRef(Number.NEGATIVE_INFINITY);
   const fitFrameRef = useRef<number | null>(null);
   const secondFitFrameRef = useRef<number | null>(null);
 
   isActiveRef.current = isActive;
+  drawerStateRef.current = drawerState;
   sessionRef.current = session;
 
   const clearScheduledFit = useCallback(() => {
@@ -263,6 +267,26 @@ function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: Term
         /* terminal disposed */
       }
     });
+    const handleWheel = (event: WheelEvent): void => {
+      const startedAt = nowMs();
+      if (startedAt - lastScrollPerfAtRef.current < TERMINAL_SCROLL_PERF_SAMPLE_INTERVAL_MS) return;
+      lastScrollPerfAtRef.current = startedAt;
+      const rawEventAgeMs = startedAt - event.timeStamp;
+      reportTerminalPerf('embedded_terminal_scroll', {
+        durationMs: roundMs(nowMs() - startedAt),
+        eventAgeMs: Number.isFinite(rawEventAgeMs) && Math.abs(rawEventAgeMs) < 60_000
+          ? roundMs(rawEventAgeMs)
+          : undefined,
+        deltaX: Math.round(event.deltaX),
+        deltaY: Math.round(event.deltaY),
+        deltaMode: event.deltaMode,
+        sessionId: session.sessionId,
+        taskId: session.taskId,
+        active: isActiveRef.current,
+        drawerState: drawerStateRef.current,
+      });
+    };
+    host.addEventListener('wheel', handleWheel, { passive: true, capture: true });
 
     let resizeObserver: ResizeObserver | null = null;
     if (typeof ResizeObserver !== 'undefined') {
@@ -285,6 +309,7 @@ function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: Term
     return () => {
       clearScheduledFit();
       resizeObserver?.disconnect();
+      host.removeEventListener('wheel', handleWheel, true);
       inputDisposable.dispose();
       unsubscribeOutput?.();
       try {


### PR DESCRIPTION
## Summary

This adds sampled scroll telemetry for active terminal panes.

The terminal pressure E2E now proves drawer open, tab switch, and scrollback stay inside responsiveness budgets.

## Review Claim

Terminal drawer scrolling now reports bounded UI perf evidence, and the pressure E2E gates scroll responsiveness alongside open and tab switching.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The runtime change is limited to a passive wheel listener on each terminal pane. Existing component and Electron tests exercise the drawer behavior without changing PTY command execution.

## Slice Rationale

This is stacked after the embedded terminal perf counters from #4583 so this slice can gate the user-visible drawer scroll path using that instrumentation.

## Non-goals

- Does not change terminal PTY command execution.
- Does not change terminal session creation or ownership.
- Does not change drawer layout or chat responsiveness behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- terminal-drawer`
- [x] `pnpm --filter @invoker/app test:e2e -- embedded-terminal-pty`

</details>

## Visual Proof

The changed behavior is scroll telemetry and timing, which a static screenshot cannot show. `packages/app/e2e/embedded-terminal-pty.spec.ts` drives the drawer scroll path, verifies the first scrollback line becomes visible, and asserts `embedded_terminal_scroll` perf payloads stay within budget.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 95231dca79f5ae0c263e71afffc527f12721b0cd`
- Post-revert steps: None
- Data migration? No

</details>