### PR TITLE
[Godfile app step 3: extract gui-mutation-handlers](1) Late-bind renderer task feed owner

### DIFF
--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -65,7 +65,7 @@ export interface RendererTaskFeedDeps {
   logger: Logger;
   persistence: RendererTaskFeedPersistence;
   messageBus: Pick<MessageBus, 'publish' | 'request'>;
-  orchestrator: RendererTaskFeedOrchestrator;
+  getOrchestrator: () => RendererTaskFeedOrchestrator;
   taskHandles: { has(taskId: string): boolean };
   taskGraphEventPublisher: Pick<TaskGraphEventPublisher, 'publishDelta'>;
   getMainWindow: () => BrowserWindow | null;
@@ -166,7 +166,7 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
       deps.logger.info(`[gap-detect] quarantined task="${taskId}" — triggering authoritative reload`, { module: 'delta-merge' });
       const { rendererDelta } = recoverQuarantinedTask(lastKnownTaskStates, taskId, {
         loadTask: (recoveryTaskId) => deps.persistence.loadTask(recoveryTaskId),
-        getMergeNode: (workflowId) => deps.orchestrator.getMergeNode(workflowId),
+        getMergeNode: (workflowId) => deps.getOrchestrator().getMergeNode(workflowId),
       });
       if (rendererDelta) {
         rendererDeltas.push(rendererDelta);
@@ -177,7 +177,7 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
 
   const seedUiSnapshotCache = (): void => {
     lastKnownWorkflowCount = deps.persistence.listWorkflows().length;
-    seedTaskCachesFromSnapshot(deps.orchestrator.getAllTasks(), { lastKnownTaskStates, workflowRollupProjection });
+    seedTaskCachesFromSnapshot(deps.getOrchestrator().getAllTasks(), { lastKnownTaskStates, workflowRollupProjection });
   };
 
   // Detached viewer: the local DB is empty, so seed the delta caches and
@@ -236,7 +236,7 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
     const deltaTaskId = delta.type === 'updated' || delta.type === 'removed' ? delta.taskId : undefined;
     if (delta.type === 'updated' && delta.changes.status === 'failed') {
       const cancellationError = shouldSkipAutoFixForError(delta.changes.execution?.error);
-      const shouldAutoFixFromOrchestrator = deps.orchestrator.shouldAutoFix(delta.taskId);
+      const shouldAutoFixFromOrchestrator = deps.getOrchestrator().shouldAutoFix(delta.taskId);
       deps.logAutoFixDebug(delta.taskId, 'delta-failed', {
         shouldSkipForCancellation: cancellationError,
         shouldAutoFixFromOrchestrator,
@@ -279,7 +279,7 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
           lastKnownWorkflowCount = workflows.length;
           deps.requestWorkflowMetadataPublish('db-poll-count');
 
-          deps.orchestrator.syncAllFromDb();
+          deps.getOrchestrator().syncAllFromDb();
           deps.logger.info(`Synced orchestrator for all ${workflows.length} workflows`, { module: 'db-poll' });
         }
 
@@ -350,7 +350,7 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
                     ? 'Startup Failure Diagnostic'
                     : 'Shutdown Diagnostic',
                 });
-                deps.orchestrator.handleWorkerResponse(failedResponse);
+                deps.getOrchestrator().handleWorkerResponse(failedResponse);
                 continue;
               }
             }
@@ -379,7 +379,7 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
                   `Fix session stalled: task remained in fixing_with_ai for ${Math.floor(fixAgeMs / 1000)}s ` +
                   `without a live fix handle (${staleReason}).`;
                 deps.logger.error(`[fix-session-stall] reclaiming "${task.id}": ${reason}`, { module: 'db-poll' });
-                const outcome = deps.orchestrator.reclaimStalledFixSession(task.id, {
+                const outcome = deps.getOrchestrator().reclaimStalledFixSession(task.id, {
                   reason,
                   expectedLineage: {
                     taskId: task.id,


### PR DESCRIPTION
## Summary

Godfile app step 3, slice 1: late-bind the renderer task feed orchestrator dependency.

`RendererTaskFeedDeps` now takes `getOrchestrator()` instead of a concrete orchestrator instance.

Every call site resolves the orchestrator at use time. Runtime behavior is intentionally identical.

```mermaid
flowchart LR
  M[main.ts ~2800 ln] --> RH[ipc-read-handlers.ts]
  M -->|new| MH[ipc/gui-mutation-handlers.ts]
  MH --> A[execution/workflow-task-actions.ts]
```

Invoker-on-Invoker dogfood: keep onFinish pull_request + external_review; publish the
resulting commit stack with mergify stack push once the chain branches are ready.

## Review Claim

Late-bind the renderer task feed orchestrator dependency so gui-mutation wiring can resolve the owner after construction.

## Review Lane

refactor

## Review Unit

activation-surface

## Safety Invariant

Mechanical deps-interface change only; every former `deps.orchestrator` call site now invokes `deps.getOrchestrator()` with the same methods and arguments.

## Slice Rationale

Isolates the task-feed late-bind seam as step 1 before the larger gui-mutation-handler extraction in dependent PRs.

## Non-goals

- No gui-mutation-handler extraction in this slice.
- No IPC registration or translation changes.
- Behavior unchanged: task-feed, delta-merge, and auto-fix paths pass unchanged.
## Pipeline

| Time | Worker | Action | Status | Target | Summary |
| --- | --- | --- | --- | --- | --- |
| 2026-07-08T23:50:53.055Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-08T23:50:53.114Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-08T23:50:53.421Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-08T23:50:53.438Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-08T23:50:53.439Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-08T23:50:53.544Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:01:00.770Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:01:00.811Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:01:00.811Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:24:46.501Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:24:46.539Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:24:46.540Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:45:15.174Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:45:15.214Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T00:45:15.215Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:13:06.051Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:13:06.093Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:13:06.093Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:35:53.026Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:35:53.065Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:35:53.066Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:48:03.411Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:48:03.449Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T01:48:03.449Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:16:07.127Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:16:07.175Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:16:07.176Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:42:49.375Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:42:49.423Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:42:49.424Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:59:46.755Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:59:46.803Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T02:59:46.804Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:07:28.205Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:07:28.271Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:07:28.277Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:16:52.838Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:16:52.890Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:16:52.890Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:37:45.433Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:37:45.489Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:37:45.490Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:48:38.989Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:48:39.048Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T03:48:39.049Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:00:13.151Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:00:13.213Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:00:13.214Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:08:44.495Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:08:44.555Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:08:44.556Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:15:21.783Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:15:21.856Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:15:21.858Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:25:27.326Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:25:27.383Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:25:27.383Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:32:01.513Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:32:01.569Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:32:01.569Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:41:38.189Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:41:38.253Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:41:38.254Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:48:51.572Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:48:51.643Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:48:51.645Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:55:20.388Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:55:20.444Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T04:55:20.445Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:01:28.939Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:01:29.008Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:01:29.012Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:10:58.029Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:10:58.087Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:10:58.087Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:16:36.971Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:16:37.022Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:16:37.023Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:51:11.201Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:51:11.252Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:51:11.252Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:59:15.268Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:59:15.329Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T05:59:15.330Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:06:48.786Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:06:48.949Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:06:48.950Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:23:16.887Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:23:16.964Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:23:16.964Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:30:42.625Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:30:42.676Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:30:42.677Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:40:06.891Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:40:06.940Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:40:06.941Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:46:22.995Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:46:23.047Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:46:23.047Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:56:52.403Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:56:52.481Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T06:56:52.484Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:05:27.478Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:05:27.534Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:05:27.534Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:12:09.671Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:12:09.722Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:12:09.727Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:21:31.162Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:21:31.254Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T07:21:31.255Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: retry-budget-disabled (retry-budget-disabled) |
| 2026-07-09T08:13:32.786Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:13:32.843Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:13:32.843Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:21:24.334Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:21:24.391Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:21:24.395Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:39:32.989Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:39:33.046Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:39:33.062Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:59:06.465Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:59:06.544Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T08:59:06.544Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T17:55:09.811Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T17:55:09.812Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T17:55:09.813Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T17:56:33.789Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T17:56:33.789Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T17:56:33.790Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:23:14.310Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:23:14.311Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:23:14.311Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:24:15.575Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:24:15.575Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:24:15.576Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:25:29.670Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:25:29.671Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:25:29.672Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:26:42.157Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:26:42.158Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:26:42.159Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:27:45.531Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:27:45.532Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:27:45.532Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:28:55.619Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:28:55.619Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:28:55.620Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:30:13.757Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:30:13.758Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:30:13.758Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:31:17.939Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:31:17.940Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:31:17.940Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:32:25.379Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:32:25.380Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:32:25.381Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:33:26.039Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:33:26.040Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:33:26.040Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:34:30.700Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:34:30.701Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:34:30.701Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:35:33.818Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:35:33.819Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:35:33.819Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:36:41.797Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:36:41.797Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:36:41.798Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:37:45.967Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:37:45.968Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:37:45.968Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:39:04.736Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:39:04.736Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:39:04.737Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:40:09.057Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:40:09.058Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:40:09.059Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:41:23.992Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:41:23.992Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:41:23.993Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:42:25.552Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:42:25.553Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:42:25.553Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:43:28.208Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:43:28.209Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:43:28.209Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:44:40.084Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:44:40.085Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:44:40.085Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:45:50.577Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:45:50.577Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:45:50.578Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:46:52.165Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:46:52.165Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:46:52.166Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:47:58.914Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:47:58.915Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:47:58.916Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:49:17.587Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:49:17.588Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:49:17.588Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:50:36.756Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:50:36.756Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:50:36.757Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:51:52.109Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:51:52.110Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:51:52.111Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:52:57.880Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:52:57.881Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:52:57.881Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:54:12.716Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:54:12.716Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:54:12.717Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:55:13.336Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:55:13.336Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:55:13.337Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:56:13.780Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:56:13.780Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:56:13.781Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:57:25.812Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:57:25.812Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:57:25.816Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:58:41.435Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:58:41.436Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:58:41.436Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:59:47.777Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:59:47.777Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T18:59:47.778Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:00:52.269Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:00:52.270Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:00:52.271Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:02:06.480Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:02:06.480Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:02:06.481Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:03:07.473Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:03:07.473Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:03:07.474Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:04:18.318Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:04:18.318Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:04:18.319Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:05:27.127Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:05:27.132Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:05:27.132Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:06:47.196Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:06:47.197Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:06:47.198Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:07:57.282Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:07:57.282Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:07:57.283Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:09:01.973Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:09:01.973Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:09:01.974Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:10:13.799Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:10:13.800Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:10:13.800Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:11:43.508Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:11:43.508Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:11:43.509Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:12:49.112Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:12:49.113Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:12:49.113Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:13:49.524Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:13:49.525Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:13:49.526Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:14:54.782Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:14:54.782Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:14:54.783Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:16:10.578Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:16:10.580Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:16:10.581Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:17:11.517Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:17:11.517Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:17:11.518Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:18:12.526Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:18:12.526Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:18:12.532Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:19:20.992Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:19:20.993Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:19:20.993Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:20:34.062Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:20:34.063Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:20:34.064Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:21:52.412Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:21:52.412Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:21:52.413Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:22:54.491Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:22:54.491Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:22:54.492Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:23:59.295Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:23:59.296Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:23:59.297Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:25:03.624Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:25:03.625Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:25:03.625Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:26:05.875Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:26:05.875Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:26:05.876Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:27:13.017Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:27:13.018Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:27:13.019Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:28:15.260Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:28:15.260Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:28:15.261Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:29:17.462Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:29:17.463Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:29:17.464Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:30:25.618Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:30:25.619Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:30:25.619Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:31:27.972Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:31:27.973Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:31:27.976Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:32:41.649Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:32:41.650Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:32:41.651Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:34:06.702Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:34:06.702Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:34:06.703Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:35:14.376Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:35:14.377Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:35:14.378Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:36:16.392Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:36:16.392Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:36:16.393Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:37:16.446Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:37:16.447Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:37:16.448Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:38:22.508Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:38:22.509Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:38:22.509Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:39:37.358Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:39:37.358Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:39:37.359Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:40:42.376Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:40:42.378Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:40:42.379Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:41:52.528Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:41:52.529Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:41:52.530Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:42:57.916Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:42:57.917Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:42:57.917Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:43:58.382Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:43:58.383Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:43:58.386Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:45:16.117Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:45:16.118Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:45:16.118Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:46:34.648Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:46:34.648Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-09T19:46:34.649Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:12:09.923Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:12:09.925Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:12:09.925Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:13:24.562Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:13:24.562Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:13:24.563Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:14:54.750Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:14:54.754Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:14:54.755Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:15:54.716Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:15:54.717Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:15:54.718Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:16:54.986Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:16:54.987Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:16:54.992Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:17:56.312Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:17:56.313Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:17:56.314Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:19:55.789Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:19:55.790Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:19:55.791Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:20:55.967Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:20:55.968Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:20:55.969Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:21:56.851Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:21:56.852Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:21:56.854Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:22:56.948Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:22:56.949Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:22:56.950Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:23:57.738Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:23:57.740Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:23:57.741Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:25:17.824Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:25:17.824Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:25:17.825Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:26:18.494Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:26:18.495Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:26:18.497Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:27:53.485Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:27:53.486Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:27:53.499Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:29:02.095Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:29:02.096Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:29:02.098Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:31:07.224Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:31:07.225Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:31:07.226Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:32:16.909Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:32:16.910Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:32:16.911Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:33:17.185Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:33:17.186Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:33:17.188Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:34:18.001Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:34:18.002Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:34:18.003Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:35:36.913Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:35:36.914Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:35:36.915Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:36:36.861Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:36:36.862Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:36:36.864Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:37:37.103Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:37:37.105Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:37:37.106Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:38:37.127Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:38:37.132Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:38:37.133Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:39:37.181Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:39:37.184Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:39:37.185Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:40:45.542Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:40:45.544Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:40:45.545Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:41:46.326Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:41:46.327Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:41:46.329Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:42:49.659Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:42:49.665Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:42:49.667Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:43:57.638Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:43:57.639Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:43:57.641Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:44:58.068Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:44:58.069Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:44:58.070Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:47:08.096Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:47:08.097Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:47:08.098Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:48:08.291Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:48:08.292Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:48:08.295Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:49:08.282Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:49:08.283Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:49:08.285Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:50:09.190Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:50:09.190Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:50:09.192Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:51:26.145Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:51:26.146Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:51:26.148Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:52:41.606Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:52:41.610Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:52:41.611Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:53:45.455Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:53:45.456Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:53:45.460Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:54:49.396Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:54:49.397Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:54:49.399Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:55:49.577Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:55:49.580Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:55:49.584Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:56:50.212Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:56:50.215Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:56:50.226Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:57:50.574Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:57:50.575Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:57:50.577Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:59:11.318Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:59:11.320Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T04:59:11.330Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:00:13.640Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:00:13.640Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:00:13.641Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:01:32.223Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:01:32.226Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:01:32.227Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:02:32.488Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:02:32.489Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:02:32.490Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:03:37.869Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:03:37.870Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:03:37.871Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:04:39.165Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:04:39.174Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:04:39.175Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:05:39.787Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:05:39.788Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:05:39.789Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:07:58.299Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:07:58.301Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:07:58.302Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:08:59.383Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:08:59.385Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:08:59.386Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:10:00.776Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:10:00.777Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:10:00.786Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:11:03.146Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:11:03.291Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:11:03.309Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:13:32.499Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:13:32.500Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:13:32.501Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:15:13.005Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:15:13.006Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:15:13.007Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:16:22.754Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:16:22.755Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:16:22.756Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:17:23.624Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:17:23.625Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:17:23.626Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:18:23.718Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:18:23.719Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:18:23.720Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:19:23.816Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:19:23.817Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:19:23.818Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:20:24.268Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:20:24.270Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:20:24.270Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:21:24.377Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:21:24.379Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:21:24.380Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:22:35.940Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:22:35.941Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:22:35.942Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:23:38.280Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:23:38.281Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:23:38.281Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:25:38.775Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:25:38.776Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:25:38.777Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:26:39.583Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:26:39.584Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:26:39.584Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:27:53.052Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:27:53.053Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:27:53.054Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:28:53.464Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:28:53.465Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:28:53.466Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:29:53.433Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:29:53.434Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:29:53.435Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:30:58.800Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:30:58.801Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:30:58.802Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:31:58.783Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:31:58.784Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:31:58.786Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:32:58.941Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:32:58.943Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:32:58.944Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:34:05.383Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:34:05.384Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:34:05.385Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:35:14.651Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:35:14.653Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:35:14.654Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:36:15.918Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:36:15.919Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:36:15.920Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:37:16.197Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:37:16.198Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:37:16.200Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:38:17.120Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:38:17.126Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:38:17.129Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:39:24.223Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:39:24.224Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:39:24.225Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:41:06.445Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:41:06.446Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:41:06.447Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:42:24.713Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:42:24.719Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:42:24.722Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:43:26.786Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:43:26.787Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:43:26.788Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:45:32.820Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:45:32.821Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:45:32.821Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:46:56.330Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:46:56.331Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:46:56.332Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:47:57.692Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:47:57.694Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:47:57.694Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:48:57.858Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:48:57.859Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:48:57.861Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:49:57.860Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:49:57.861Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:49:57.861Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:50:58.429Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:50:58.430Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:50:58.431Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:52:53.606Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:52:53.607Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:52:53.610Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:54:07.347Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:54:07.348Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:54:07.349Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:55:07.597Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:55:07.598Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:55:07.600Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:56:08.091Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:56:08.094Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:56:08.096Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:57:33.789Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:57:33.791Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:57:33.792Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:58:33.945Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:58:33.946Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:58:33.947Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:59:34.001Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:59:34.002Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T05:59:34.003Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:00:37.514Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:00:37.515Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:00:37.517Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:02:00.339Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:02:00.340Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:02:00.341Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:03:00.546Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:03:00.547Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:03:00.548Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:04:00.964Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:04:00.965Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:04:00.966Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:05:10.319Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:05:10.319Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:05:10.320Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:06:14.819Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:06:14.820Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:06:14.820Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:07:28.008Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:07:28.010Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:07:28.011Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:08:28.370Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:08:28.371Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:08:28.371Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:09:29.155Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:09:29.157Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:09:29.159Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:12:04.117Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:12:04.118Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:12:04.119Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:13:20.182Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:13:20.184Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:13:20.184Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:14:21.500Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:14:21.523Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:14:21.524Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:15:21.007Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:15:21.008Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:15:21.008Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:16:21.616Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:16:21.617Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:16:21.618Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:17:40.330Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:17:40.331Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:17:40.332Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:18:56.258Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:18:56.259Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:18:56.260Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:20:22.967Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:20:22.969Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:20:22.971Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:21:23.328Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:21:23.329Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:21:23.330Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:22:53.096Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:22:53.097Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:22:53.098Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:24:18.195Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:24:18.196Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:24:18.200Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:25:19.639Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:25:19.640Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:25:19.641Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:26:19.670Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:26:19.671Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:26:19.672Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:27:21.948Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:27:21.949Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:27:21.956Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:28:22.852Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:28:22.853Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:28:22.854Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:30:24.397Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:30:24.398Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:30:24.400Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:31:26.004Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:31:26.009Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:31:26.010Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:32:41.874Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:32:41.875Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:32:41.876Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:34:41.888Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:34:41.896Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:34:41.896Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:35:46.302Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:35:46.304Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:35:46.305Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:37:31.904Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:37:31.905Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:37:31.906Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:38:32.652Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:38:32.653Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:38:32.653Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:39:49.310Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:39:49.311Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:39:49.312Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:41:29.950Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:41:29.951Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:41:29.952Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:42:30.443Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:42:30.444Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:42:30.445Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:43:30.709Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:43:30.709Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:43:30.710Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:44:40.353Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:44:40.354Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:44:40.355Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:45:40.842Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:45:40.843Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:45:40.844Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:46:41.040Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:46:41.041Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:46:41.042Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:47:41.279Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:47:41.280Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:47:41.281Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:48:41.416Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:48:41.417Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:48:41.418Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:49:46.902Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:49:46.903Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:49:46.918Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:51:07.118Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:51:07.129Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:51:07.130Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:52:24.322Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:52:24.323Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:52:24.324Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:53:24.901Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:53:24.905Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:53:24.906Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:55:27.500Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:55:27.501Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:55:27.502Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:56:54.476Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:56:54.477Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:56:54.478Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:58:13.656Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:58:13.657Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:58:13.658Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:59:21.475Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:59:21.476Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T06:59:21.477Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:00:21.668Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:00:21.668Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:00:21.669Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:01:21.732Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:01:21.733Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:01:21.734Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:02:25.130Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:02:25.132Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:02:25.133Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:04:20.810Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:04:20.811Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:04:20.812Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:05:35.627Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:05:35.628Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:05:35.629Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:06:36.043Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:06:36.044Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:06:36.045Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:08:38.655Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:08:38.656Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:08:38.657Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:09:47.590Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:09:47.591Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:09:47.592Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:10:48.480Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:10:48.481Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:10:48.482Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:13:07.667Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:13:07.669Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:13:07.669Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:14:37.772Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:14:37.773Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:14:37.773Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:15:38.232Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:15:38.233Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:15:38.234Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:16:38.295Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:16:38.296Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:16:38.298Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:19:01.450Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:19:01.451Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:19:01.453Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:21:18.086Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:21:18.088Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:21:18.089Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:22:18.340Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:22:18.341Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:22:18.342Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:23:33.585Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:23:33.585Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:23:33.586Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:24:35.950Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:24:35.952Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:24:35.954Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:25:56.975Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:25:56.976Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:25:56.977Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:26:58.476Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:26:58.477Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:26:58.478Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:28:01.762Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:28:01.763Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:28:01.764Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:29:28.298Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:29:28.299Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:29:28.300Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:30:28.551Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:30:28.552Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:30:28.553Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:31:29.173Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:31:29.174Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:31:29.175Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:32:29.402Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:32:29.403Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:32:29.404Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:33:47.453Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:33:47.454Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:33:47.455Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:36:03.931Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:36:03.932Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:36:03.933Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:38:05.058Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:38:05.059Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:38:05.059Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:39:21.527Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:39:21.528Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:39:21.529Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:41:21.479Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:41:21.489Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-10T07:41:21.489Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:16:25.200Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:16:25.201Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:16:25.201Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:16:28.711Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:16:28.712Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:16:28.713Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:17:50.075Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:17:50.076Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:17:50.076Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:19:06.842Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:19:06.842Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:19:06.843Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:20:00.925Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:20:00.943Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:20:00.944Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:20:56.745Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:20:56.746Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:20:56.746Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:22:12.076Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:22:12.077Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:22:12.078Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:23:22.455Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:23:22.456Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:23:22.457Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:24:32.312Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:24:32.313Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:24:32.314Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:25:41.845Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:25:41.846Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:25:41.847Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:47:33.887Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:47:33.887Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:47:33.888Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:48:38.230Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:48:38.231Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:48:38.233Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:49:50.747Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:49:50.748Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:49:50.749Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:51:17.511Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:51:17.512Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:51:17.513Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:52:24.524Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:52:24.525Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:52:24.525Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:53:44.531Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:53:44.533Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:53:44.533Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:55:01.188Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:55:01.189Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:55:01.191Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:56:23.282Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:56:23.283Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:56:23.284Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:57:25.304Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:57:25.306Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:57:25.306Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:58:35.787Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:58:35.788Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:58:35.789Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:59:45.688Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:59:45.689Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T08:59:45.689Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:00:54.406Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:00:54.407Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:00:54.408Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:02:04.862Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:02:04.863Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:02:04.864Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:03:22.938Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:03:22.939Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:03:22.940Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:04:30.529Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:04:30.530Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:04:30.531Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:06:06.192Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:06:06.192Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:06:06.194Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:07:25.481Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:07:25.482Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:07:25.483Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:08:48.917Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:08:48.918Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:08:48.919Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:10:26.851Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:10:26.852Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:10:26.852Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:12:34.845Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:12:34.846Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:12:34.847Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:13:36.412Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:13:36.417Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:13:36.418Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:15:53.277Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:15:53.278Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:15:53.279Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:19:07.624Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:19:07.628Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:19:07.629Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:21:53.028Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:21:53.029Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:21:53.030Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:26:29.440Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:26:29.441Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:26:29.442Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:27:50.901Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:27:50.902Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:27:50.903Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:30:54.350Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:30:54.351Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:30:54.351Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:32:23.200Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:32:23.201Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:32:23.202Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:35:50.909Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:35:50.910Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:35:50.911Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:38:09.224Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:38:09.225Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:38:09.226Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:41:38.070Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:41:38.071Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:41:38.072Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:43:08.380Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:43:08.381Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:43:08.382Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:46:06.135Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:46:06.136Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:46:06.137Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:47:21.375Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:47:21.376Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:47:21.377Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:48:58.997Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:48:58.999Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:48:59.000Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:51:43.475Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:51:43.476Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:51:43.477Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:53:53.469Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:53:53.470Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:53:53.471Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:55:24.377Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:55:24.378Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:55:24.379Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:56:41.600Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:56:41.601Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:56:41.601Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:57:50.954Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:57:50.955Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:57:50.956Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:59:52.878Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:59:52.879Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T09:59:52.880Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:01:06.239Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:01:06.240Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:01:06.241Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:03:03.349Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:03:03.350Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:03:03.351Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:04:06.824Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:04:06.825Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:04:06.826Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:06:13.465Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:06:13.466Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:06:13.467Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:08:45.795Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:08:45.796Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:08:45.797Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:10:18.958Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:10:18.959Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:10:18.960Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:11:34.810Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:11:34.811Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T10:11:34.811Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T11:09:24.730Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T11:09:24.730Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T11:09:24.731Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T11:11:11.614Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T11:11:11.763Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T11:11:11.763Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-11T17:11:58.582Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-13T08:41:15.968Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-13T09:00:41.431Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-13T09:01:43.604Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-13T17:06:27.868Z | ci-failure | fix-ci-failure | completed | __merge__wf-1783449128163-12 | CI repair intent completed |
| 2026-07-13T17:06:27.869Z | autofix | auto-retry-cap | queued | __merge__wf-1783449128163-12 | Durable per-task auto-fix retry counter |
| 2026-07-13T17:06:28.673Z | ci-failure | fix-ci-failure | completed | __merge__wf-1783449128163-12 | CI repair intent completed |
| 2026-07-14T03:14:20.231Z | autofix | auto-retry | completed | wf-1783449128163-12/extract-gui-mutation-handlers | Worker action reconciled from completed intent on startup |
| 2026-07-14T03:14:20.231Z | autofix | auto-retry-cap | queued | wf-1783449128163-12/extract-gui-mutation-handlers | Durable per-task auto-fix retry counter |
| 2026-07-14T03:14:20.586Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:14:20.587Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:14:20.587Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:14:21.431Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:14:40.003Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:14:47.667Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:15:08.078Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:15:16.230Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:15:26.047Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:31:02.874Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:31:18.910Z | autofix | auto-retry | completed | wf-1783449128163-12/verify-gui-mutation-handlers | Worker action reconciled from completed intent on startup |
| 2026-07-14T03:31:18.910Z | autofix | auto-retry-cap | queued | wf-1783449128163-12/verify-gui-mutation-handlers | Durable per-task auto-fix retry counter |
| 2026-07-14T03:31:19.039Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:31:19.140Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:31:31.968Z | autofix | auto-retry | completed | wf-1783449128163-12/verify-gui-mutation-handlers | Worker action reconciled from completed intent on startup |
| 2026-07-14T03:31:32.081Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:31:32.193Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:31:46.583Z | autofix | auto-retry | completed | wf-1783449128163-12/verify-gui-mutation-handlers | Worker action reconciled from completed intent on startup |
| 2026-07-14T03:31:46.697Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:31:46.816Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: worker-retry-budget-exhausted (worker-retry-budget-exhausted) |
| 2026-07-14T03:32:01.529Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:32:05.833Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:44:40.183Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T03:45:32.693Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T07:13:32.281Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T07:13:46.633Z | autofix | auto-retry | completed | wf-1783449128163-12/extract-gui-mutation-handlers | Worker action reconciled from completed intent on startup |
| 2026-07-14T07:13:46.742Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T07:13:46.742Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T07:13:46.847Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T07:14:00.127Z | autofix | auto-retry | completed | wf-1783449128163-12/extract-gui-mutation-handlers | Worker action reconciled from completed intent on startup |
| 2026-07-14T07:14:00.244Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T07:14:00.245Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T07:14:00.331Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T07:32:12.277Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: worker-retry-budget-exhausted (worker-retry-budget-exhausted) |
| 2026-07-14T07:32:25.077Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: worker-retry-budget-exhausted (worker-retry-budget-exhausted) |
| 2026-07-14T07:46:40.800Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T07:46:40.974Z | autofix | auto-fix | skipped | wf-1783449128163-12/extract-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T08:10:18.724Z | autofix | auto-fix | skipped | wf-1783449128163-12/verify-gui-mutation-handlers | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T08:11:34.771Z | autofix | auto-fix | skipped | __merge__wf-1783449128163-12 | Skipped auto-fix: not-eligible (not-eligible) |
| 2026-07-14T23:57:11.073Z | ci-failure | fix-ci-failure | completed | __merge__wf-1783449128163-12 | Worker action reconciled from completed intent on startup |
| 2026-07-14T23:58:09.237Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-14T23:59:08.546Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T00:00:08.987Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T00:01:08.754Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T00:02:08.938Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T00:03:08.702Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T00:05:08.590Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T00:36:35.537Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T00:37:35.621Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T00:38:35.770Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T00:39:35.511Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T00:40:35.576Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T00:41:35.508Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T00:44:35.516Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T00:46:35.463Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T00:49:35.713Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T00:56:35.724Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T01:00:35.817Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T01:27:22.579Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T01:31:22.661Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T01:33:22.748Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T01:48:39.334Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T01:49:39.365Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T01:51:59.187Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T01:52:59.407Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T01:53:59.413Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T01:54:59.534Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:45:48.306Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:45:49.077Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:46:48.264Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:47:48.257Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:47:48.911Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:48:48.468Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:48:49.126Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:49:48.544Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:49:49.281Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:50:48.398Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:50:49.876Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:51:48.372Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:51:49.046Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:52:48.320Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:52:48.995Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:53:48.389Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:53:49.105Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:54:48.303Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:54:49.041Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:55:48.538Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:55:49.370Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:56:48.560Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:56:49.311Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:57:48.485Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:57:49.176Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:58:48.472Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:59:48.530Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T04:59:49.245Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:00:48.441Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:01:49.331Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:02:48.553Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:02:49.284Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:03:48.547Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:03:49.277Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:04:48.643Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:04:49.516Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:05:48.798Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:05:49.675Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:06:48.544Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:06:49.386Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:07:48.565Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:07:49.234Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:08:48.556Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:08:49.470Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:09:48.593Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:09:49.337Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:10:48.692Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:10:49.514Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:11:48.942Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:11:49.669Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:12:48.609Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:12:49.287Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:13:48.757Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:13:49.646Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:14:48.643Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:14:49.457Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:15:48.834Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:15:49.792Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:16:48.730Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:16:49.451Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:17:48.837Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:17:49.702Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:18:48.763Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:18:49.542Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:19:48.635Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:19:49.423Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:20:48.692Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:20:49.505Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:21:48.675Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:21:49.634Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:22:48.656Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |
| 2026-07-15T05:22:49.377Z | ci-failure | fix-ci-failure | skipped | __merge__wf-1783449128163-12 | Skipped CI repair because retry budget is exhausted (worker-retry-budget-exhausted) |

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `echo hello` — Terminal focused proof for this slice.
Review claim: The pinned regression suites still pass after this slice lands.
Review lane: proof
Safety invariant: Read-only test execution; runs the exact suites that pin the affected behavior.
Slice rationale: Focused proof tied to the changed files; no blanket full-suite gate.
Architectural effect: None; verification only.
Goal:
Prove behavior preservation for slice 3 of the app chain.
Motivation:
These suites pin the affected symbols and fail on drift in write order, delta publication, or public surface.
Alternative considerations:
- Run the whole package suite (slower, without additional signal for this slice).
- Rely on the compiler alone, without executing behavior (weaker evidence).
Implementation details:
- Run the pinned vitest files from the package directory via pnpm filter.
- A non-zero exit fails the workflow and blocks the merge gate.
Non-goals:
- No code changes; no test edits in this task.
Layer: app_regression
Feature state: active
Files:
- packages/app/src/__tests__/gui-mutation-translation.test.ts
- packages/app/src/__tests__/ipc-registration.test.ts
- packages/app/src/__tests__/no-manual-dispatch.test.ts
- packages/app/src/__tests__/workflow-mutation-submit.test.ts
Change types:
- none
Acceptance criteria:
- Exits 0 with all pinned suites passing.


</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
