### PR TITLE
[Topological Pending Queue](2) Topologically reorder runnable pending launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Invoker will be documented in this file.
 
 
 - Stop manual Fix with Agent from starting when a failed task has no saved workspace. It now fails fast with a recreate-this-task message instead of entering a broken fix session.
+- Pending launches now re-sort by dependency order whenever runnable work changes, so ready tasks launch before stale dependency-blocked queue entries.
 ## 0.0.7
 
 - Ship Slack as a separate npm-released SEA binary (`@neko-catpital-labs/invoker-slack` / `invoker-slack`), built and archived like the CLI, published from the release workflow, and always included in `scripts/local-macos-release-build.sh` maintainer cuts. The desktop app no longer embeds Slack; GUI relaunch from the manager resolves `INVOKER_GUI_COMMAND`, `invoker-ui`, macOS `open -a Invoker`, then the monorepo xvfb path.

--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -598,7 +598,7 @@ describe('Orchestrator launch claims', () => {
     expect(orchestrator.getTask(downstreamId)?.status).toBe('pending');
     expect(persistence.launchDispatchRows.some((row) => row.taskId === downstreamId)).toBe(false);
   });
-  it.fails('rebuilds the pending queue so runnable tasks stay ahead of dependency-blocked stale jobs', () => {
+  it('rebuilds the pending queue so runnable tasks stay ahead of dependency-blocked stale jobs', () => {
     const { orchestrator, persistence } = makeOrchestrator({
       deferRunningUntilLaunch: true,
       enqueueLaunchDispatchEnabled: true,

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -7205,7 +7205,7 @@ describe('Orchestrator', () => {
       expect(queueStatus.queued).toHaveLength(1);
       expect(queueStatus.queued[0]?.taskId).toBe(sid(orchestrator, 0, 't1'));
     });
-    it.fails('getQueueStatus reports queued tasks in the same dependency order used for launch selection', () => {
+    it('getQueueStatus reports queued tasks in the same dependency order used for launch selection', () => {
       const workflowId = 'wf-queue-order';
       persistence.saveWorkflow({
         id: workflowId,
@@ -7238,6 +7238,7 @@ describe('Orchestrator', () => {
         config: { workflowId },
         execution: { completedAt: new Date('2026-01-01T00:00:02.000Z') },
       });
+      orchestrator.syncAllFromDb();
       const queueStatus = orchestrator.getQueueStatus();
       expect(queueStatus.queued.map((task) => task.taskId)).toEqual([
         'aardvark-root',

--- a/packages/workflow-core/src/__tests__/scheduler.test.ts
+++ b/packages/workflow-core/src/__tests__/scheduler.test.ts
@@ -97,6 +97,24 @@ describe('TaskScheduler', () => {
       expect(scheduler.getQueuedJobs()).toHaveLength(2);
     });
   });
+  describe('replaceQueue', () => {
+    it('replaces the queue with the provided ordering verbatim', () => {
+      const scheduler = new TaskScheduler();
+      scheduler.enqueue({ taskId: 'old', priority: 10 });
+
+      scheduler.replaceQueue([
+        { taskId: 'first', attemptId: 'first-a1', priority: 0 },
+        { taskId: 'second', attemptId: 'second-a1', priority: 100, bypassLocalDependencyReadiness: true },
+      ]);
+
+      expect(scheduler.getQueuedJobs()).toEqual([
+        { taskId: 'first', attemptId: 'first-a1', priority: 0 },
+        { taskId: 'second', attemptId: 'second-a1', priority: 100, bypassLocalDependencyReadiness: true },
+      ]);
+      expect(scheduler.takeNext()?.taskId).toBe('first');
+      expect(scheduler.takeNext()?.taskId).toBe('second');
+    });
+  });
 
   describe('removeJob', () => {
     it('removes a queued job and returns true', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -85,6 +85,7 @@ import {
   enqueueIfNotScheduledImpl,
   autoStartExternallyUnblockedReadyTasksImpl,
   autoStartUnblockedTasksImpl,
+  getPendingLaunchQueueSnapshotImpl,
   getTaskLaunchReadinessImpl,
   areLocalDependenciesSatisfiedImpl,
   getLocalDependencyBlockerImpl,
@@ -1386,20 +1387,21 @@ export class Orchestrator {
       maxConcurrency: this.maxConcurrency,
       readyIds: readyTasks.map((task) => task.id),
     });
-    const started: TaskState[] = [];
 
     const launchPollNow = Date.now();
-    for (const task of readyTasks) {
-      // A task deferred for execution-pool capacity waits in line with a
-      // heartbeat instead of being re-dispatched (and re-deferred) every poll.
-      if (this.isLaunchParked(task.id, launchPollNow)) {
-        this.emitLaunchWaitingHeartbeat(task.id, launchPollNow);
-        continue;
-      }
-      this.enqueueIfNotScheduled(task.id);
-    }
+    const readyTaskIds = readyTasks
+      .filter((task) => {
+        // A task deferred for execution-pool capacity waits in line with a
+        // heartbeat instead of being re-dispatched (and re-deferred) every poll.
+        if (this.isLaunchParked(task.id, launchPollNow)) {
+          this.emitLaunchWaitingHeartbeat(task.id, launchPollNow);
+          return false;
+        }
+        return true;
+      })
+      .map((task) => task.id);
 
-    return this.drainScheduler();
+    return this.autoStartReadyTasks(readyTaskIds);
   }
 
   /**
@@ -2958,9 +2960,20 @@ export class Orchestrator {
   }
 
   getExecutableReadyTasks(): TaskState[] {
-    return this.stateMachine
+    const readyTasks = this.stateMachine
       .getReadyTasks()
       .filter((task) => this.getExternalDependencyBlocker(task) === undefined);
+    const readyTasksById = new Map(readyTasks.map((task) => [task.id, task]));
+    return getPendingLaunchQueueSnapshotImpl(
+      this as unknown as SchedulerDomainHost,
+      readyTasks.map((task) => ({
+        taskId: task.id,
+        attemptId: task.execution.selectedAttemptId,
+        priority: this.loadAttemptById(task.execution.selectedAttemptId)?.queuePriority ?? 0,
+      })),
+    )
+      .map((job) => readyTasksById.get(job.taskId))
+      .filter((task): task is TaskState => task !== undefined);
   }
 
   /**
@@ -3125,24 +3138,31 @@ export class Orchestrator {
       }
       return workflowBlockerCache.get(workflowId) !== undefined;
     };
-    const queuedTasks = this.stateMachine
-      .getReadyTasks()
-      .filter((task) => task.status === 'pending')
-      .filter((task) => !activeTaskIds.has(task.id))
-      .filter((task) => !isExternallyBlocked(task))
-      .map((task) => {
-        const attempt = task.execution.selectedAttemptId
-          ? this.loadAttemptById(task.execution.selectedAttemptId)
-          : undefined;
+    const queuedJobs = getPendingLaunchQueueSnapshotImpl(
+      this as unknown as SchedulerDomainHost,
+      this.stateMachine
+        .getReadyTasks()
+        .filter((task) => task.status === 'pending')
+        .filter((task) => !activeTaskIds.has(task.id))
+        .filter((task) => !isExternallyBlocked(task))
+        .map((task) => ({
+          taskId: task.id,
+          attemptId: task.execution.selectedAttemptId,
+          priority: this.loadAttemptById(task.execution.selectedAttemptId)?.queuePriority ?? 0,
+        })),
+    );
+    const queuedTasks = queuedJobs
+      .map((job) => {
+        const task = this.stateGetTask(job.taskId);
+        if (!task || task.status !== 'pending') return undefined;
+        if (activeTaskIds.has(task.id) || isExternallyBlocked(task)) return undefined;
         return {
           taskId: task.id,
-          priority: attempt?.queuePriority ?? 0,
+          priority: job.priority,
           description: task.description,
-          createdAt: attempt?.createdAt?.getTime() ?? task.createdAt.getTime(),
         };
       })
-      .sort((a, b) => (b.priority - a.priority) || (a.createdAt - b.createdAt));
-
+      .filter((task): task is { taskId: string; priority: number; description: string } => task !== undefined);
     const activeExecutionCount = activeAttempts.filter(({ task }) =>
       task.status === 'running' || task.status === 'fixing_with_ai',
     ).length;

--- a/packages/workflow-core/src/orchestrator/scheduler-domain.ts
+++ b/packages/workflow-core/src/orchestrator/scheduler-domain.ts
@@ -13,12 +13,13 @@
  */
 
 import type { TaskState, TaskDelta, TaskStateChanges, Attempt } from '@invoker/workflow-graph';
+import { topologicalSort } from '@invoker/workflow-graph';
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
 import type { Logger } from '@invoker/contracts';
 import { isDiscardedAttempt } from '../attempt-policy.js';
 import { assertResetComplete, buildTaskResetChanges } from '../task-reset-policy.js';
 import type { TaskStateMachine } from '../state-machine.js';
-import type { TaskScheduler } from '../scheduler.js';
+import type { TaskJob, TaskScheduler } from '../scheduler.js';
 import type { TaskRepository } from '../task-repository.js';
 import type {
   OrchestratorPersistence,
@@ -69,6 +70,121 @@ export interface SchedulerDomainHost {
   getExecutionGeneration(task: TaskState | undefined): number;
   getExternalDependencyBlocker(task: TaskState): string | undefined;
 }
+function byCreatedAtThenId(left: TaskState, right: TaskState): number {
+  return (left.createdAt.getTime() - right.createdAt.getTime()) || left.id.localeCompare(right.id);
+}
+
+function getCandidatePriority(host: SchedulerDomainHost, task: TaskState, fallback: number): number {
+  const attempt = task.execution.selectedAttemptId
+    ? host.loadAttemptById(task.execution.selectedAttemptId)
+    : undefined;
+  return Math.max(fallback, attempt?.queuePriority ?? fallback);
+}
+
+function hasActiveLaunchAttempt(
+  host: SchedulerDomainHost,
+  task: TaskState,
+  attemptId: string | undefined,
+): boolean {
+  if (!attemptId) return false;
+  if (task.execution.selectedAttemptId !== attemptId) return false;
+  const attempt = host.loadAttemptById(attemptId);
+  if (!host.isAttemptLeaseActive(attempt)) return false;
+  return task.status === 'running'
+    || task.status === 'fixing_with_ai'
+    || attempt?.status === 'claimed'
+    || attempt?.status === 'running';
+}
+
+function planPendingLaunchQueue(host: SchedulerDomainHost, candidateJobs: TaskJob[]): TaskJob[] {
+  const mergedJobs = new Map<string, TaskJob>();
+  for (const sourceJob of [...host.scheduler.getQueuedJobs(), ...candidateJobs]) {
+    const task = host.stateGetTask(sourceJob.taskId);
+    if (!task || task.status !== 'pending') continue;
+    if (host.getExternalDependencyBlocker(task) !== undefined) continue;
+    const knownAttemptId = sourceJob.attemptId ?? task.execution.selectedAttemptId;
+    if (hasActiveLaunchAttempt(host, task, knownAttemptId)) continue;
+    const existing = mergedJobs.get(task.id);
+    mergedJobs.set(task.id, {
+      taskId: task.id,
+      attemptId: existing?.attemptId ?? knownAttemptId,
+      priority: Math.max(existing?.priority ?? sourceJob.priority, sourceJob.priority),
+      ...(existing?.bypassLocalDependencyReadiness || sourceJob.bypassLocalDependencyReadiness
+        ? { bypassLocalDependencyReadiness: true }
+        : {}),
+    });
+  }
+
+  let topologyIndex: Map<string, number> | undefined;
+  try {
+    topologyIndex = new Map(
+      topologicalSort([...host.stateMachine.getAllTasks()].sort(byCreatedAtThenId))
+        .map((task, index) => [task.id, index]),
+    );
+  } catch (error) {
+    host.logger.warn('[orchestrator] rebuildPendingLaunchQueue: topological sort failed; falling back to deterministic order', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const orderedJobs = [...mergedJobs.values()]
+    .map((job) => {
+      const task = host.stateGetTask(job.taskId);
+      if (!task) return undefined;
+      return {
+        job,
+        task,
+        ready: getTaskLaunchReadinessImpl(host, job.taskId, {
+          bypassLocalDependencyReadiness: job.bypassLocalDependencyReadiness,
+        }).ready,
+      };
+    })
+    .filter((entry): entry is { job: TaskJob; task: TaskState; ready: boolean } => entry !== undefined);
+
+  orderedJobs.sort((left, right) => {
+    const priorityDiff = right.job.priority - left.job.priority;
+    if (priorityDiff !== 0) return priorityDiff;
+    const readinessDiff = Number(right.ready) - Number(left.ready);
+    if (readinessDiff !== 0) return readinessDiff;
+    if (topologyIndex) {
+      const topologyDiff = (topologyIndex.get(left.task.id) ?? Number.MAX_SAFE_INTEGER)
+        - (topologyIndex.get(right.task.id) ?? Number.MAX_SAFE_INTEGER);
+      if (topologyDiff !== 0) return topologyDiff;
+    }
+    return byCreatedAtThenId(left.task, right.task);
+  });
+
+  return orderedJobs.map(({ job }) => job);
+}
+
+export function getPendingLaunchQueueSnapshotImpl(
+  host: SchedulerDomainHost,
+  candidateJobs: TaskJob[],
+): TaskJob[] {
+  return planPendingLaunchQueue(host, candidateJobs);
+}
+
+function rebuildPendingLaunchQueue(host: SchedulerDomainHost, candidateJobs: TaskJob[]): void {
+  const orderedJobs = planPendingLaunchQueue(host, candidateJobs)
+    .map((job) => {
+      const task = host.stateGetTask(job.taskId);
+      if (!task) return undefined;
+      const attemptId = host.ensureCurrentPendingAttempt(task);
+      const currentAttempt = host.loadAttemptById(attemptId);
+      if ((currentAttempt?.queuePriority ?? 0) !== job.priority) {
+        host.taskRepository.updateAttempt(attemptId, { queuePriority: job.priority });
+      }
+      return {
+        taskId: task.id,
+        attemptId,
+        priority: job.priority,
+        ...(job.bypassLocalDependencyReadiness ? { bypassLocalDependencyReadiness: true } : {}),
+      };
+    })
+    .filter((job): job is TaskJob => job !== undefined);
+  host.scheduler.replaceQueue(orderedJobs);
+}
+
 
 // ── Extracted Functions ─────────────────────────────────────
 
@@ -78,6 +194,7 @@ export function autoStartReadyTasksImpl(
   priority: number = 0,
   opts?: LaunchReadinessOptions,
 ): TaskState[] {
+  const candidateJobs: TaskJob[] = [];
   for (const taskId of taskIds) {
     let task = host.stateGetTask(taskId);
     if (!task) continue;
@@ -98,9 +215,15 @@ export function autoStartReadyTasksImpl(
       if (!task) continue;
     }
 
-    enqueueIfNotScheduledImpl(host, taskId, priority, opts);
+    candidateJobs.push({
+      taskId,
+      attemptId: task.execution.selectedAttemptId,
+      priority: getCandidatePriority(host, task, priority),
+      ...(opts?.bypassLocalDependencyReadiness ? { bypassLocalDependencyReadiness: true } : {}),
+    });
   }
 
+  rebuildPendingLaunchQueue(host, candidateJobs);
   return drainSchedulerImpl(host);
 }
 
@@ -113,46 +236,16 @@ export function enqueueIfNotScheduledImpl(
   const task = host.stateGetTask(taskId);
   if (!task) return;
   if (host.getExternalDependencyBlocker(task) !== undefined) return;
+  if (hasActiveLaunchAttempt(host, task, task.execution.selectedAttemptId)) {
+    return;
+  }
 
-  const attemptId = host.ensureCurrentPendingAttempt(task);
-  const currentAttempt = host.loadAttemptById(attemptId);
-  if ((currentAttempt?.queuePriority ?? 0) !== priority) {
-    host.taskRepository.updateAttempt(attemptId, { queuePriority: priority });
-  }
-  // A task can be force-set back to blocked/pending by recovery logic while
-  // still carrying a stale selectedAttemptId from an older run. Only skip
-  // re-enqueue when the task is actually active.
-  if (
-    (task.status === 'running' || task.status === 'fixing_with_ai') &&
-    task.execution.selectedAttemptId === attemptId &&
-    host.isAttemptLeaseActive(currentAttempt)
-  ) {
-    return;
-  }
-  const queuedJob = host.scheduler
-    .getQueuedJobs()
-    .find((job) => job.attemptId === attemptId || job.taskId === taskId);
-  if (queuedJob) {
-    const shouldReplaceQueuedJob =
-      priority > queuedJob.priority ||
-      (opts?.bypassLocalDependencyReadiness === true && !queuedJob.bypassLocalDependencyReadiness);
-    if (shouldReplaceQueuedJob) {
-      host.scheduler.removeJob(queuedJob.attemptId ?? queuedJob.taskId);
-      host.scheduler.enqueue({
-        taskId,
-        attemptId,
-        priority: Math.max(priority, queuedJob.priority),
-        ...(opts?.bypassLocalDependencyReadiness ? { bypassLocalDependencyReadiness: true } : {}),
-      });
-    }
-    return;
-  }
-  host.scheduler.enqueue({
+  rebuildPendingLaunchQueue(host, [{
     taskId,
-    attemptId,
-    priority,
+    attemptId: task.execution.selectedAttemptId,
+    priority: getCandidatePriority(host, task, priority),
     ...(opts?.bypassLocalDependencyReadiness ? { bypassLocalDependencyReadiness: true } : {}),
-  });
+  }]);
 }
 
 export function autoStartExternallyUnblockedReadyTasksImpl(host: SchedulerDomainHost): TaskState[] {
@@ -161,14 +254,17 @@ export function autoStartExternallyUnblockedReadyTasksImpl(host: SchedulerDomain
     .getReadyTasks()
     .filter((task) => host.getExternalDependencyBlocker(task) === undefined);
 
-  for (const task of readyTasks) {
-    enqueueIfNotScheduledImpl(host, task.id);
-  }
+  rebuildPendingLaunchQueue(host, readyTasks.map((task) => ({
+    taskId: task.id,
+    attemptId: task.execution.selectedAttemptId,
+    priority: getCandidatePriority(host, task, 0),
+  })));
   started.push(...drainSchedulerImpl(host));
   return started;
 }
 
 export function autoStartUnblockedTasksImpl(host: SchedulerDomainHost): TaskState[] {
+  const candidateJobs: TaskJob[] = [];
   for (const task of host.stateMachine.getAllTasks()) {
     if (task.status !== 'blocked') continue;
     if (!areLocalDependenciesSatisfiedImpl(host, task)) continue;
@@ -180,8 +276,15 @@ export function autoStartUnblockedTasksImpl(host: SchedulerDomainHost): TaskStat
     const changes = buildTaskResetChanges('externalUnblock');
     const updated = host.writeAndSync(task.id, changes);
     assertResetComplete(resetBefore, updated, 'externalUnblock', { execution: changes.execution });
-    enqueueIfNotScheduledImpl(host, task.id);
+    const pendingTask = host.stateGetTask(task.id);
+    if (!pendingTask) continue;
+    candidateJobs.push({
+      taskId: pendingTask.id,
+      attemptId: pendingTask.execution.selectedAttemptId,
+      priority: getCandidatePriority(host, pendingTask, 0),
+    });
   }
+  rebuildPendingLaunchQueue(host, candidateJobs);
   return drainSchedulerImpl(host);
 }
 

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -19,7 +19,6 @@ import type { ParsedResponse } from '../response-handler.js';
 import { scopePlanTaskId } from '../task-id-scope.js';
 import { parseMergeConflictError } from '../merge-conflict-error.js';
 import type { TaskStateMachine } from '../state-machine.js';
-import type { TaskScheduler } from '../scheduler.js';
 import type { TaskRepository } from '../task-repository.js';
 import {
   OrchestratorError,
@@ -44,7 +43,6 @@ const TASK_DELTA_CHANNEL = 'task.delta';
  */
 export interface TransitionHost {
   readonly stateMachine: TaskStateMachine;
-  readonly scheduler: TaskScheduler;
   readonly persistence: OrchestratorPersistence;
   readonly messageBus: OrchestratorMessageBus;
   readonly logger: Logger;
@@ -173,15 +171,10 @@ export function handleCompletedImpl(
 
   // Re-enqueue deferred tasks now that a slot freed up
   if (host.deferredTaskIds.size > 0) {
-    for (const id of host.deferredTaskIds) {
-      const t = host.stateGetTask(id);
-      if (t && t.status === 'pending') {
-        const attemptId = host.ensureCurrentPendingAttempt(t);
-        host.scheduler.enqueue({ taskId: id, attemptId, priority: 0 });
-      }
-    }
+    const deferredTaskIds = [...host.deferredTaskIds]
+      .filter((id) => host.stateGetTask(id)?.status === 'pending');
     host.deferredTaskIds.clear();
-    started.push(...host.drainScheduler());
+    started.push(...host.autoStartReadyTasks(deferredTaskIds));
   }
 
   checkWorkflowCompletionImpl(host);
@@ -256,15 +249,10 @@ export function finalizeFailedTaskImpl(
 
   // Re-enqueue deferred tasks now that a slot freed up
   if (host.deferredTaskIds.size > 0) {
-    for (const id of host.deferredTaskIds) {
-      const t = host.stateGetTask(id);
-      if (t && t.status === 'pending') {
-        const attemptId = host.ensureCurrentPendingAttempt(t);
-        host.scheduler.enqueue({ taskId: id, attemptId, priority: 0 });
-      }
-    }
+    const deferredTaskIds = [...host.deferredTaskIds]
+      .filter((id) => host.stateGetTask(id)?.status === 'pending');
     host.deferredTaskIds.clear();
-    started.push(...host.drainScheduler());
+    started.push(...host.autoStartReadyTasks(deferredTaskIds));
   }
 
   checkWorkflowCompletionImpl(host);

--- a/packages/workflow-core/src/scheduler.ts
+++ b/packages/workflow-core/src/scheduler.ts
@@ -82,6 +82,10 @@ export class TaskScheduler {
     };
   }
 
+  replaceQueue(jobs: TaskJob[]): void {
+    this.queue = [...jobs];
+  }
+
   /** Return a shallow copy of the internal queue (not-yet-running jobs). */
   getQueuedJobs(): TaskJob[] {
     return [...this.queue];


### PR DESCRIPTION
## Summary

This rebuilds the pending launch queue from the task graph whenever runnable work changes.

The bug was that FIFO appends could leave dependency-blocked jobs ahead of ready work, and the queue view could disagree with launch order.

The fix replans pending jobs by priority, readiness, and DAG order, then makes queue status read the same order.

## Review Claim

Pending launch selection now keeps ready tasks ahead of dependency-blocked rows, and `getQueueStatus()` reports the same order.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Priority still wins first. If the graph is corrupt, the planner warns once and falls back to deterministic created-at ordering instead of blocking launches.

## Slice Rationale

The proof slice already shows the bug. This slice keeps the change local to queue planning, its queue surface, and directly affected tests.

## Non-goals

- No change to expedited priority semantics.
- No new launch-readiness rules.
- No UI behavior change.

## Architecture

### Before

Ready tasks appended into the scheduler in encounter order. The scheduler then picked by priority and FIFO, while `getQueueStatus()` used a separate created-at sort.

### After

`scheduler-domain.ts` replans pending jobs from the current graph, sorts by priority, ready-first, topology, then created-at and id, rewrites the in-memory queue with `replaceQueue()`, and `getQueueStatus()` reads that same plan.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/scheduler.test.ts src/__tests__/orchestrator-dispatcher.test.ts src/__tests__/orchestrator.test.ts`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator-dispatcher.test.ts -t "rebuilds the pending queue so runnable tasks stay ahead of dependency-blocked stale jobs"`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts -t "getQueueStatus reports queued tasks in the same dependency order used for launch selection"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 9093932d5`
- Post-revert steps: None.
- Data migration? No.

</details>

