### PR TITLE
(1) Add proof for topological pending queue ordering

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -598,6 +598,45 @@ describe('Orchestrator launch claims', () => {
     expect(orchestrator.getTask(downstreamId)?.status).toBe('pending');
     expect(persistence.launchDispatchRows.some((row) => row.taskId === downstreamId)).toBe(false);
   });
+  it.fails('rebuilds the pending queue so runnable tasks stay ahead of dependency-blocked stale jobs', () => {
+    const { orchestrator, persistence } = makeOrchestrator({
+      deferRunningUntilLaunch: true,
+      enqueueLaunchDispatchEnabled: true,
+      maxConcurrency: 1,
+    });
+    orchestrator.loadPlan({
+      name: 'pending-queue-rebuild',
+      onFinish: 'none',
+      tasks: [
+        { id: 'ready-root', description: 'ready root', command: 'echo ready' },
+        { id: 'stale-upstream', description: 'stale upstream', command: 'echo stale' },
+        { id: 'stale-blocked', description: 'stale blocked', command: 'echo blocked', dependencies: ['stale-upstream'] },
+      ],
+    });
+    const readyRootId = taskIdBySuffix(orchestrator, 'ready-root');
+    const staleUpstreamId = taskIdBySuffix(orchestrator, 'stale-upstream');
+    const staleBlockedId = taskIdBySuffix(orchestrator, 'stale-blocked');
+    persistence.updateTask(staleUpstreamId, {
+      status: 'failed',
+      execution: {
+        exitCode: 1,
+        error: 'boom',
+        completedAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    });
+    orchestrator.syncAllFromDb();
+    (orchestrator as any).scheduler.enqueue({ taskId: staleBlockedId, priority: 0 });
+    (orchestrator as any).enqueueIfNotScheduled(readyRootId);
+    expect((orchestrator as any).scheduler.getQueuedJobs().map((job: { taskId: string }) => job.taskId)).toEqual([
+      readyRootId,
+      staleBlockedId,
+    ]);
+    const started = (orchestrator as any).drainScheduler() as TaskState[];
+    expect(started).toHaveLength(1);
+    expect(started[0]?.id).toBe(readyRootId);
+    expect(orchestrator.getTask(staleBlockedId)?.status).toBe('pending');
+    expect(persistence.launchDispatchRows.map((row) => row.taskId)).toEqual([readyRootId]);
+  });
 
   it('ignores responses for a selected attempt row that has been superseded', () => {
     const { orchestrator, persistence } = makeOrchestrator();

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -7205,6 +7205,45 @@ describe('Orchestrator', () => {
       expect(queueStatus.queued).toHaveLength(1);
       expect(queueStatus.queued[0]?.taskId).toBe(sid(orchestrator, 0, 't1'));
     });
+    it.fails('getQueueStatus reports queued tasks in the same dependency order used for launch selection', () => {
+      const workflowId = 'wf-queue-order';
+      persistence.saveWorkflow({
+        id: workflowId,
+        name: 'queue-order',
+      });
+      persistence.saveTask(workflowId, {
+        id: 'beta-ready',
+        description: 'Beta ready',
+        status: 'pending',
+        dependencies: ['alpha-root'],
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        config: { workflowId },
+        execution: {},
+      });
+      persistence.saveTask(workflowId, {
+        id: 'aardvark-root',
+        description: 'Aardvark root',
+        status: 'pending',
+        dependencies: [],
+        createdAt: new Date('2026-01-01T00:00:01.000Z'),
+        config: { workflowId },
+        execution: {},
+      });
+      persistence.saveTask(workflowId, {
+        id: 'alpha-root',
+        description: 'Alpha root',
+        status: 'completed',
+        dependencies: [],
+        createdAt: new Date('2026-01-01T00:00:02.000Z'),
+        config: { workflowId },
+        execution: { completedAt: new Date('2026-01-01T00:00:02.000Z') },
+      });
+      const queueStatus = orchestrator.getQueueStatus();
+      expect(queueStatus.queued.map((task) => task.taskId)).toEqual([
+        'aardvark-root',
+        'beta-ready',
+      ]);
+    });
 
     it('getQueueStatus counts claimed selected attempts as active before launch completes', () => {
       orchestrator.loadPlan({


### PR DESCRIPTION
## Summary

This adds two focused regression tests around the pending launch queue.

The bug is that stale queued rows can sit ahead of runnable work, and the queue view can sort by age instead of dependency order.

The tests pin both cases without changing runtime behavior yet, so the next slice can flip proof into the real fix.

## Review Claim

The new proof shows the pending queue and queue-status surface are not dependency-first today.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only tests change. Runtime scheduling and queue code stay byte-for-byte the same in this slice.

## Slice Rationale

Reviewers need the failing proof first, so the later behavior slice can stay narrow and only answer the queue-ordering bug.

## Non-goals

- No runtime scheduler behavior change.
- No queue-surface implementation change.
- No changelog or docs update.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/scheduler.test.ts src/__tests__/orchestrator-dispatcher.test.ts src/__tests__/orchestrator.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert c1d363ea1`
- Post-revert steps: None.
- Data migration? No.

</details>

