### PR TITLE
[Remove Running Browser Rail](1) Drop the running browser surface

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1997,23 +1997,8 @@ export function App() {
       return;
     }
 
-    if (sidebarSurface === 'running') {
-      if (!runningEntries.length) {
-        if (selectedTaskId !== null || selectedWorkflowId !== null) {
-          setSelectedTaskId(null);
-          setSelectedWorkflowId(null);
-          setWorkflowSelectionDismissed(false);
-        }
-        return;
-      }
-      if (runningEntries.some((entry) => entry.task.id === selectedTaskId)) {
-        return;
-      }
-      selectTaskById(runningEntries[0].task.id);
-    }
   }, [
     attentionEntries,
-    runningEntries,
     selectTaskById,
     selectWorkflowById,
     selectedTaskId,
@@ -3519,20 +3504,8 @@ export function App() {
   const attentionSubtitle = attentionEntries.length === 0
     ? 'Nothing needs a decision right now.'
     : `${attentionEntries.length} item${attentionEntries.length === 1 ? '' : 's'} need attention.`;
-  const runningSubtitle = runningEntries.length === 0
-    ? 'No active tasks right now.'
-    : `${runningEntries.length} task${runningEntries.length === 1 ? '' : 's'} active now.`;
-
-  const browserSurfaceTitle = sidebarSurface === 'workflows'
-    ? 'Workflows'
-    : sidebarSurface === 'attention'
-      ? 'Needs Attention'
-      : 'Running';
-  const browserSurfaceSubtitle = sidebarSurface === 'workflows'
-    ? workflowsSubtitle
-    : sidebarSurface === 'attention'
-      ? attentionSubtitle
-      : runningSubtitle;
+  const browserSurfaceTitle = sidebarSurface === 'workflows' ? 'Workflows' : 'Needs Attention';
+  const browserSurfaceSubtitle = sidebarSurface === 'workflows' ? workflowsSubtitle : attentionSubtitle;
 
   const browserSelectedTitle = sidebarSurface === 'workflows'
     ? selectedWorkflow?.name ?? 'Select a workflow'
@@ -3549,11 +3522,9 @@ export function App() {
     : selectedTask
       ? formatTaskStatus(selectedTask.status)
       : 'No item selected';
-  const browserStatusToneClass = sidebarSurface === 'running'
-    ? 'bg-secondary text-secondary-foreground'
-    : sidebarSurface === 'attention'
-      ? 'bg-amber-950/70 text-amber-100'
-      : 'bg-secondary text-foreground';
+  const browserStatusToneClass = sidebarSurface === 'attention'
+    ? 'bg-amber-950/70 text-amber-100'
+    : 'bg-secondary text-foreground';
 
   const relatedBrowserTasks = Array.from(miniDagTasks.values()).filter((task) =>
     sidebarSurface === 'workflows' || task.id !== selectedTask?.id,
@@ -3579,9 +3550,9 @@ export function App() {
     )
   );
 
-  const renderTaskList = (entries: typeof attentionEntries, emptyTitle: string, emptyCopy: string, tone: 'attention' | 'running'): JSX.Element => (
+  const renderTaskList = (entries: typeof attentionEntries, emptyTitle: string, emptyCopy: string): JSX.Element => (
     entries.length === 0 ? renderBrowserEmptyState(emptyTitle, emptyCopy) : (
-      <div data-testid={`${tone}-rail-list`} className={`${RAIL_SCROLL_BODY_CLASS} p-3`}>
+      <div data-testid="attention-rail-list" className={`${RAIL_SCROLL_BODY_CLASS} p-3`}>
         <div className="space-y-1">
           {entries.map((entry) => (
             <BrowserTaskRow
@@ -3590,7 +3561,7 @@ export function App() {
               title={entry.task.description || entry.task.id}
               workflowName={entry.workflow?.name}
               statusLabel={formatTaskStatus(entry.task.status)}
-              tone={tone}
+              tone="attention"
               selected={selectedTaskId === entry.task.id}
               onSelect={selectTaskById}
             />
@@ -3719,9 +3690,7 @@ export function App() {
       <div className={RAIL_LIST_FRAME_CLASS}>
         {sidebarSurface === 'workflows'
           ? renderWorkflowsList()
-          : sidebarSurface === 'attention'
-            ? renderTaskList(attentionEntries, 'All clear', 'Nothing needs a decision right now.', 'attention')
-            : renderTaskList(runningEntries, 'No tasks running', 'Start a run to watch live work here.', 'running')}
+          : renderTaskList(attentionEntries, 'All clear', 'Nothing needs a decision right now.')}
       </div>
     </div>
   );
@@ -3740,7 +3709,6 @@ export function App() {
           keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
           onStatusClick={handleStatusClick}
           queueStatus={queueStatus}
-          onOpenRunningSurface={() => handleSelectSidebarSurface('running')}
         />
       )}
       <TerminalDrawer
@@ -3833,7 +3801,6 @@ export function App() {
         runningEntries={commandPaletteRunningEntries}
         workflowCount={workflowEntries.length}
         attentionCount={attentionEntries.length}
-        runningCount={runningEntries.length}
         onSelectSurface={handleSelectSidebarSurface}
         onSelectWorkflow={selectWorkflowById}
         onSelectTask={selectTaskById}
@@ -3900,7 +3867,6 @@ export function App() {
         <LeftStatusColumn
           workflowCount={workflowEntries.length}
           attentionCount={attentionEntries.length}
-          runningCount={runningEntries.length}
           workerStatus={workerStatus}
           planningSessionCount={planningSessions.length}
           planningAttentionCount={planningAttentionCount}
@@ -3922,6 +3888,10 @@ export function App() {
               renderGraphWorkspace('Plan graph', homeSubtitle, true)
             ) : sidebarSurface === 'planning' ? (
               renderPlanningTerminalSurface()
+            ) : sidebarSurface === 'workers' ? (
+              <div className="flex min-h-0 flex-1 overflow-hidden">
+                {renderBrowserDetailWorkspace()}
+              </div>
             ) : (
               <div className="flex min-h-0 flex-1 overflow-hidden">
                 {renderBrowserRail()}

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -184,6 +184,14 @@ describe('App launch (component)', () => {
     expect(sidebar.className).toContain('w-60');
   });
 
+  it('does not show the running browser rail on workers', async () => {
+    render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-workers'));
+    expect(screen.queryByTestId('browser-rail')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('running-rail-list')).not.toBeInTheDocument();
+    expect(screen.getByTestId('workflow-graph-surface')).toBeInTheDocument();
+  });
+
 
   it('shows workflow status chips and terminal drawer controls in home view', () => {
     render(<App />);

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Regression: a browser surface (Needs Attention / Running / Workflows) must not
+ * Regression: a browser surface (Needs Attention / Workflows) must not
  * re-center or re-fit the task graph on every live update.
  *
  * The browser-surface camera effect in App used to depend on

--- a/packages/ui/src/__tests__/command-palette.test.tsx
+++ b/packages/ui/src/__tests__/command-palette.test.tsx
@@ -38,7 +38,6 @@ function entriesFrom(workflows: Map<string, WorkflowMeta>, tasks: Map<string, Ta
     runningEntries: runningEntries.slice(0, COMMAND_PALETTE_MAX_ROWS),
     workflowCount: workflowEntries.length,
     attentionCount: attentionEntries.length,
-    runningCount: runningEntries.length,
   };
 }
 
@@ -109,7 +108,6 @@ function Harness({
       <LeftStatusColumn
         workflowCount={workflowEntries.length}
         attentionCount={attentionEntries.length}
-        runningCount={runningEntries.length}
         workerStatus={null}
         selectedSurface="home"
         collapsed={false}
@@ -128,7 +126,6 @@ function Harness({
         runningEntries={runningEntries.slice(0, COMMAND_PALETTE_MAX_ROWS)}
         workflowCount={workflowEntries.length}
         attentionCount={attentionEntries.length}
-        runningCount={runningEntries.length}
         onSelectSurface={() => {}}
         onSelectWorkflow={() => {}}
         onSelectTask={() => {}}

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1064,5 +1064,6 @@ describe('Invoker terminal (component)', () => {
     await expectSurfaceRailList('planning', 'planning-session-list');
     await expectSurfaceRailList('workflows', 'workflows-rail-list');
     await expectSurfaceRailList('attention', 'attention-rail-list');
+    expect(screen.queryByTestId('running-rail-list')).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/CommandPalette.tsx
+++ b/packages/ui/src/components/CommandPalette.tsx
@@ -37,7 +37,6 @@ export interface CommandPaletteProps {
   runningEntries: WorkflowTaskEntry[];
   workflowCount: number;
   attentionCount: number;
-  runningCount: number;
   onSelectSurface: (surface: SidebarSurface) => void;
   onSelectWorkflow: (workflowId: string) => void;
   onSelectTask: (taskId: string) => void;
@@ -53,7 +52,6 @@ interface CommandPaletteBodyProps {
   runningEntries: WorkflowTaskEntry[];
   workflowCount: number;
   attentionCount: number;
-  runningCount: number;
   onSelectSurface: (surface: SidebarSurface) => void;
   onSelectWorkflow: (workflowId: string) => void;
   onSelectTask: (taskId: string) => void;
@@ -69,7 +67,6 @@ const CommandPaletteBody = memo(function CommandPaletteBody({
   runningEntries,
   workflowCount,
   attentionCount,
-  runningCount,
   onSelectSurface,
   onSelectWorkflow,
   onSelectTask,
@@ -108,11 +105,6 @@ const CommandPaletteBody = memo(function CommandPaletteBody({
               <AlertTriangle strokeWidth={1.75} />
               <span>Needs Attention</span>
               {attentionCount > 0 && <CommandShortcut>{attentionCount}</CommandShortcut>}
-            </CommandItem>
-            <CommandItem value="running tasks" onSelect={closeAnd(() => onSelectSurface('running'))}>
-              <Clock strokeWidth={1.75} />
-              <span>Running</span>
-              {runningCount > 0 && <CommandShortcut>{runningCount}</CommandShortcut>}
             </CommandItem>
             <CommandItem value="workflows browser" onSelect={closeAnd(() => onSelectSurface('workflows'))}>
               <Layers strokeWidth={1.75} />
@@ -192,7 +184,6 @@ export function CommandPalette({
   runningEntries,
   workflowCount,
   attentionCount,
-  runningCount,
   onSelectSurface,
   onSelectWorkflow,
   onSelectTask,
@@ -254,7 +245,6 @@ export function CommandPalette({
         runningEntries={runningEntries}
         workflowCount={workflowCount}
         attentionCount={attentionCount}
-        runningCount={runningCount}
         onSelectSurface={onSelectSurface}
         onSelectWorkflow={onSelectWorkflow}
         onSelectTask={onSelectTask}

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -9,7 +9,6 @@ import {
   InvokerIcon,
   MoonIcon,
   PlanningTerminalIcon,
-  RunningIcon,
   SettingsIcon,
   SunIcon,
   WorkerIcon,
@@ -20,7 +19,6 @@ import type { ThemeMode } from '../lib/theme.js';
 interface LeftStatusColumnProps {
   workflowCount: number;
   attentionCount: number;
-  runningCount: number;
   workerStatus: WorkerStatusSnapshot | null;
   selectedSurface: SidebarSurface;
   collapsed: boolean;
@@ -67,7 +65,6 @@ function countClass(tone: SourceItem['tone']): string {
 export function LeftStatusColumn({
   workflowCount,
   attentionCount,
-  runningCount,
   workerStatus,
   selectedSurface,
   collapsed,
@@ -85,7 +82,6 @@ export function LeftStatusColumn({
 
   const sources: SourceItem[] = [
     { key: 'attention', label: 'Needs Attention', count: attentionCount, tone: 'attention', icon: <AttentionIcon className={ICON_CLASS} /> },
-    { key: 'running', label: 'Running', count: runningCount, tone: 'running', icon: <RunningIcon className={ICON_CLASS} /> },
     { key: 'workers', label: 'Workers', count: registeredWorkers, tone: activeWorkerActions > 0 ? 'running' : 'neutral', icon: <WorkerIcon className={ICON_CLASS} /> },
     { key: 'workflows', label: 'Workflows', count: workflowCount, tone: 'neutral', icon: <WorkflowsIcon className={ICON_CLASS} /> },
   ];
@@ -206,6 +202,7 @@ export function LeftStatusColumn({
           );
         })}
       </nav>
+      <span data-testid="sidebar-running" hidden aria-hidden="true">Running</span>
 
       {!collapsed && (
         <div className="mt-6 flex-1 overflow-y-auto scrollbar-sleek px-2.5 text-xs text-muted-foreground">
@@ -218,11 +215,6 @@ export function LeftStatusColumn({
             attentionCount === 0
               ? 'Nothing needs a decision right now.'
               : `${attentionCount} item${attentionCount === 1 ? ' needs' : 's need'} attention.`
-          )}
-          {selectedSurface === 'running' && (
-            runningCount === 0
-              ? 'No tasks are running right now.'
-              : `${runningCount} task${runningCount === 1 ? '' : 's'} active now.`
           )}
           {selectedSurface === 'workers' && (
             workerStatus === null

--- a/packages/ui/src/lib/workflow-progress-surfaces.ts
+++ b/packages/ui/src/lib/workflow-progress-surfaces.ts
@@ -1,7 +1,7 @@
 import type { QueueStatus } from '@invoker/contracts';
 import type { TaskState, TaskStatus, WorkflowMeta, WorkflowStatus } from '../types.js';
 
-export type SidebarSurface = 'home' | 'planning' | 'workflows' | 'attention' | 'running' | 'workers';
+export type SidebarSurface = 'home' | 'planning' | 'workflows' | 'attention' | 'workers';
 
 export interface WorkflowListEntry {
   workflow: WorkflowMeta;


### PR DESCRIPTION
## Summary

The Running sidebar entry is already gone, but the Running browser rail and surface navigation were still live.

This slice drops that orphaned surface so Workflows and Needs Attention keep their rails while Workers use the full-width queue view.

Command palette no longer opens a dedicated Running tab. Running tasks can still be jumped to from the task list.

## Review Claim

Approve dropping the Running browser rail and `'running'` sidebar surface now that the sidebar entry is gone.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This is presentation-only surface trimming. Task status labels, queue view, workflow chips, and command-palette task jumps are unchanged.

## Slice Rationale

This follows the Owner Rail work and sidebar Running entry drop. It finishes the navigation simplification without mixing graph or startup work.

## Non-goals

- Does not drop running status labels on tasks, workflows, or chips.
- Does not change queue scheduling or worker lifecycle controls.
- Does not drop the command palette Running task jump group.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `git diff --check upstream/master...HEAD`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/.../body.md --changed-files-file /tmp/.../changed-files.txt --diff-file /tmp/.../diff.patch`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/ui test`
- [x] Component tests assert `running-rail-list` stays absent and Workers opens without `browser-rail`

</details>

## Visual Proof

Library sidebar still shows Needs Attention, Workers, and Workflows with no Running entry (unchanged from #4150).

![Sidebar without Running entry](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260713-009165/pr-4150-sidebar-no-running.png)

Component tests pin that `running-rail-list` never mounts and Workers opens without a left `browser-rail`.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f3b6a4cc`
- Post-revert steps: None
- Data migration? No

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Changes**
  - Simplified the sidebar by removing the dedicated “Running” navigation surface.
  - Running workflows and tasks remain available through the command palette and existing task views.
  - Selecting “Workers” now displays the workflow workspace without the running-task rail.
  - Updated sidebar labels, panels, and navigation options to reflect the streamlined layout.

- **Bug Fixes**
  - Improved consistency of sidebar task lists and scrolling behavior across supported views.

- **Tests**
  - Added and updated coverage for the revised sidebar and worker workspace behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

