### PR TITLE
[Planning Surface Tmux Step 1 Backend Session Routing](2) Route planning terminal sessions through backend IPC

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -5035,6 +5035,59 @@ function createEmbeddedTerminalBackendFromConfig(
     // (or selecting) an embedded session managed in the main process.
     // Headless `open-terminal` still routes to `openExternalTerminalForTask`
     // in `headless.ts` so existing CLI behaviour is preserved.
+    const planningTerminalOnly = (sessionId: string): { ok: true } | { ok: false; reason: string } => {
+      const session = embeddedTerminalManager.get(sessionId);
+      if (!session) return { ok: false, reason: `Unknown session "${sessionId}".` };
+      if (session.kind !== 'planning') {
+        return { ok: false, reason: `Session "${sessionId}" is not a planning terminal session.` };
+      }
+      return { ok: true };
+    };
+
+    ipcMain.handle('invoker:planning-terminal-open', async (_event, planningSessionIdArg: string) => {
+      const planningSessionId = String(planningSessionIdArg ?? '').trim();
+      if (!planningSessionId) {
+        return { opened: false, reason: 'Planning session id is required.' };
+      }
+      logger.info(`invoked for planningSession="${planningSessionId}"`, { module: 'planning-terminal' });
+      try {
+        const session = embeddedTerminalManager.openOrReuse({
+          kind: 'planning',
+          taskId: `planning:${planningSessionId}`,
+          planningSessionId,
+          spec: { cwd: repoRoot },
+          cwd: repoRoot,
+        });
+        return { opened: true, session };
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        logger.warn(`planning terminal spawn failed for session="${planningSessionId}": ${reason}`, { module: 'planning-terminal' });
+        return { opened: false, reason: `Failed to start planning terminal session: ${reason}` };
+      }
+    });
+
+    ipcMain.handle('invoker:planning-terminal-list', async () => {
+      return embeddedTerminalManager.list().filter((session) => session.kind === 'planning');
+    });
+
+    ipcMain.handle('invoker:planning-terminal-write', async (_event, sessionId: string, data: string) => {
+      const allowed = planningTerminalOnly(sessionId);
+      if (!allowed.ok) return allowed;
+      return embeddedTerminalManager.write(sessionId, data);
+    });
+
+    ipcMain.handle('invoker:planning-terminal-resize', async (_event, sessionId: string, cols: number, rows: number) => {
+      const allowed = planningTerminalOnly(sessionId);
+      if (!allowed.ok) return allowed;
+      return embeddedTerminalManager.resize(sessionId, cols, rows);
+    });
+
+    ipcMain.handle('invoker:planning-terminal-close', async (_event, sessionId: string) => {
+      const allowed = planningTerminalOnly(sessionId);
+      if (!allowed.ok) return allowed;
+      return embeddedTerminalManager.close(sessionId);
+    });
+
     ipcMain.handle('invoker:open-terminal', async (_event, taskId: string) => {
       logger.info(`invoked for task="${taskId}"`, { module: 'open-terminal' });
       const liveHandle = taskHandles.get(taskId);


### PR DESCRIPTION
## Summary

Planning sessions can now open their own shell through the main process, kept separate from task terminals.

The main process routes planning terminal open, write, resize, and close over dedicated IPC channels.

Task terminal channels ignore planning sessions, and planning channels ignore task sessions, so the two never cross.

Planning shells are not saved to the terminal persistence store; only task sessions persist across restarts.

## Review Claim

Approve routing planning-owned embedded terminal sessions through main-process IPC handlers.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The guards added to the task channels only reject sessions tagged planning. Task sessions keep their prior behavior, and the new planning handlers are not consumed by any renderer yet.

## Slice Rationale

The shared IPC shapes already landed on master, so this slice only adds the backend routing and its manager support. Renderer and UI wiring come in a later step.

## Non-goals

- Task terminal open, write, resize, close, and listing behavior stays unchanged.
- No renderer or UI wiring for planning shells.
- No IPC shape changes; those landed in the earlier slice.
- Planning shells are intentionally not persisted.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test src/__tests__/embedded-terminal-manager.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
