### PR TITLE
chore: drop CHANGELOG from topological queue behavior slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ All notable changes to Invoker will be documented in this file.
 
 
 - Stop manual Fix with Agent from starting when a failed task has no saved workspace. It now fails fast with a recreate-this-task message instead of entering a broken fix session.
-- Pending launches now re-sort by dependency order whenever runnable work changes, so ready tasks launch before stale dependency-blocked queue entries.
 ## 0.0.7
 
 - Ship Slack as a separate npm-released SEA binary (`@neko-catpital-labs/invoker-slack` / `invoker-slack`), built and archived like the CLI, published from the release workflow, and always included in `scripts/local-macos-release-build.sh` maintainer cuts. The desktop app no longer embeds Slack; GUI relaunch from the manager resolves `INVOKER_GUI_COMMAND`, `invoker-ui`, macOS `open -a Invoker`, then the monorepo xvfb path.


### PR DESCRIPTION
Keep user-facing release notes out of the behavior PR body scope.

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #4633