### PR TITLE
[Task DAG Double-Click](1) Keep DAG double-click dispatch centralized

### DIFF
--- a/packages/ui/src/__tests__/task-dag-interaction.test.ts
+++ b/packages/ui/src/__tests__/task-dag-interaction.test.ts
@@ -10,17 +10,22 @@ vi.mock('@xyflow/react', async () => {
 });
 
 type TaskDAGProps = Parameters<typeof TaskDAG>[0];
+type TaskOverrides = Parameters<typeof makeUITask>[0];
 
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
 });
 
-function renderOneTaskDag(props: Partial<Omit<TaskDAGProps, 'tasks'>> = {}) {
+function renderOneTaskDag(
+  props: Partial<Omit<TaskDAGProps, 'tasks'>> = {},
+  overrides: TaskOverrides = {},
+) {
   const task = makeUITask({
     id: 'task-1',
     description: 'Test task',
     status: 'running',
+    ...overrides,
   });
   const tasks = new Map([[task.id, task]]);
 
@@ -63,6 +68,22 @@ describe('TaskDAG interactions', () => {
     });
 
     expect(onTaskClick).toHaveBeenCalledTimes(1);
+    expect(onTaskDoubleClick).toHaveBeenCalledTimes(1);
+    expect(onTaskDoubleClick).toHaveBeenCalledWith(task);
+  });
+
+  it('dispatches one double-click callback for a merge-gate event sequence', async () => {
+    const onTaskDoubleClick = vi.fn();
+    const { task } = renderOneTaskDag(
+      { onTaskDoubleClick },
+      { id: '__merge__wf-1', workflowId: 'wf-1', isMergeNode: true },
+    );
+    const taskCard = await findRenderedTaskCard(task.id);
+
+    fireEvent.click(taskCard, { detail: 1 });
+    fireEvent.click(taskCard, { detail: 2 });
+    fireEvent.doubleClick(taskCard, { detail: 2 });
+
     expect(onTaskDoubleClick).toHaveBeenCalledTimes(1);
     expect(onTaskDoubleClick).toHaveBeenCalledWith(task);
   });

--- a/packages/ui/src/components/TaskNode.tsx
+++ b/packages/ui/src/components/TaskNode.tsx
@@ -11,7 +11,6 @@
  */
 
 import { Handle, Position } from '@xyflow/react';
-import type { MouseEvent } from 'react';
 import type { TaskState } from '../types.js';
 import { getStatusColor, getEffectiveVisualStatus } from '../lib/colors.js';
 
@@ -21,7 +20,6 @@ interface TaskNodeData {
   dimmed?: boolean;
   selected?: boolean;
   runningLike?: boolean;
-  onDoubleClick?: (task: TaskState) => void;
   [key: string]: unknown;
 }
 
@@ -65,18 +63,12 @@ export function TaskNode({ data }: TaskNodeProps) {
 
   const isStale = task.status === 'stale';
   const dotClass = `${colors.dot} ${isAnimated ? 'pulse-strong' : ''}`;
-  const handleDoubleClick = (event: MouseEvent<HTMLDivElement>) => {
-    if (!data.onDoubleClick) return;
-    event.stopPropagation();
-    data.onDoubleClick(task);
-  };
 
   return (
     <div
       className={`relative w-[167px] overflow-hidden rounded-xl border px-2 py-2 transition-[opacity,box-shadow,border-color] duration-150 shadow-sm ${colors.bg} ${colors.border} ${selected ? 'ring-1 ring-ring/60 shadow-md' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : isStale ? 'opacity-50' : ''}`}
       title={task.id}
       data-selected={selected ? 'true' : 'false'}
-      onDoubleClick={handleDoubleClick}
     >
       <Handle
         type="target"


### PR DESCRIPTION
## Summary

This supersedes #3627 with the same DAG activation fix on a stack-compatible head.

Current master already handles task graph double-clicks through React Flow. TaskNode still carried a local double-click handler from the older path.

This drops that dormant handler so graph nodes keep one double-click dispatch path. The interaction test now covers merge-gate nodes too.

## Review Claim

Approve keeping DAG double-click activation centralized in React Flow so task nodes cannot open a second terminal request path.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only TaskNode's unused node-local double-click hook is removed. The React Flow double-click handler, single-click selection, and context-menu dispatch stay in TaskDAG.

## Slice Rationale

#3627 included DAG edits that are now on master. This slice carries the remaining activation-surface invariant by itself.

## Non-goals

- No backend terminal session changes.
- No change to single-click selection.
- No change to right-click context menus.
- No visual or styling changes to task or merge-gate nodes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `git diff --check origin/master...HEAD`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/task-dag-interaction.test.ts`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/context-menu-dismiss.test.tsx`

</details>

## Visual Proof

This change is not distinguishable in static media: the backend reuses the terminal session, so the visible terminal tab state is unchanged.

The reviewer-visible proof is the render-test walkthrough: [Walkthrough: click/click/dblclick dispatch count](https://github.com/Neko-Catpital-Labs/Invoker/blob/76dd4f85cb8a46ad7b32df02315c2743e5e5761b/packages/ui/src/__tests__/task-dag-interaction.test.ts#L51-L88). It drives React Flow mock events for task and merge-gate nodes and asserts one double-click callback.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 76dd4f85cb8a46ad7b32df02315c2743e5e5761b`
- Post-revert steps: None
- Data migration? No

</details>
