### PR TITLE
[Worker Timeline](1) Add worker timeline data helpers

### DIFF
--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -17,8 +17,21 @@ import type {
   TaskStatus,
   TaskConfig,
   TaskExecution,
+  WorkerDecisionsRequest,
+  WorkerDecisionsResponse,
 } from '../../types.js';
-import type { ActionGraphResponse, InAppPlanningSessionSummary, InAppPlanningStreamEvent, RuntimeStatus, StartReadyResult, TerminalOutputEvent, WorkerStatusEntry, WorkerStatusSnapshot, WorkflowMutationAcceptedResult, WorkflowMutationFailedEvent } from '@invoker/contracts';
+import type {
+  ActionGraphResponse,
+  InAppPlanningSessionSummary,
+  InAppPlanningStreamEvent,
+  RuntimeStatus,
+  StartReadyResult,
+  TerminalOutputEvent,
+  WorkerStatusEntry,
+  WorkerStatusSnapshot,
+  WorkflowMutationAcceptedResult,
+  WorkflowMutationFailedEvent,
+} from '@invoker/contracts';
 
 export interface MockInvoker {
   /** The mock InvokerAPI object installed on window.invoker. */
@@ -49,6 +62,10 @@ export interface MockInvoker {
   setRuntimeStatus: (status: RuntimeStatus) => void;
   /** Replace the worker status snapshot returned by getWorkerStatus. */
   setWorkerStatus: (status: WorkerStatusSnapshot) => void;
+  /** Replace the worker decision responses returned by getWorkerDecisions. */
+  setWorkerDecisions: (
+    resolver: WorkerDecisionsResponse | ((request: WorkerDecisionsRequest) => WorkerDecisionsResponse | Promise<WorkerDecisionsResponse>),
+  ) => void;
   /** Install the mock on window.invoker. */
   install: () => void;
   /** Remove window.invoker. */
@@ -114,6 +131,14 @@ export function createMockInvoker(
     generatedAt: '2026-01-01T00:00:00.000Z',
     workers: [],
   };
+  let workerDecisionsResolver:
+    | WorkerDecisionsResponse
+    | ((request: WorkerDecisionsRequest) => WorkerDecisionsResponse | Promise<WorkerDecisionsResponse>) = {
+      actions: [],
+      limit: 25,
+      offset: 0,
+      hasMore: false,
+    };
 
   const accepted = (channel: string, workflowId = 'wf-1'): WorkflowMutationAcceptedResult => ({
     ok: true,
@@ -397,7 +422,12 @@ export function createMockInvoker(
       queued: [],
     })),
     getWorkerStatus: vi.fn(async () => workerStatus),
-    getWorkerDecisions: vi.fn(async () => ({ actions: [], limit: 25, offset: 0, hasMore: false })),
+    getWorkerDecisions: vi.fn(async (request: WorkerDecisionsRequest) => {
+      if (typeof workerDecisionsResolver === 'function') {
+        return await workerDecisionsResolver(request);
+      }
+      return workerDecisionsResolver;
+    }),
     getWorkers: vi.fn(async () => workerStatus),
     startWorker: vi.fn(async (kind: string) => {
       const row = workerStatus.workers.find((worker) => worker.kind === kind) ?? makeMockWorkerStatusEntry(kind);
@@ -446,6 +476,11 @@ export function createMockInvoker(
   }
   function setWorkerStatus(status: WorkerStatusSnapshot) {
     workerStatus = status;
+  }
+  function setWorkerDecisions(
+    resolver: WorkerDecisionsResponse | ((request: WorkerDecisionsRequest) => WorkerDecisionsResponse | Promise<WorkerDecisionsResponse>),
+  ) {
+    workerDecisionsResolver = resolver;
   }
 
 
@@ -515,6 +550,7 @@ export function createMockInvoker(
     setActionGraph,
     setRuntimeStatus,
     setWorkerStatus,
+    setWorkerDecisions,
     fireDelta,
     fireGraphEvent,
     fireWorkflowsChanged,

--- a/packages/ui/src/__tests__/timeline-view.test.ts
+++ b/packages/ui/src/__tests__/timeline-view.test.ts
@@ -4,7 +4,12 @@ import {
   sortTasksForTimeline,
   computeBarWidths,
 } from '../components/TimelineView.js';
-import type { TaskState } from '../types.js';
+import {
+  buildWorkerTimelineEventRows,
+  sortWorkerTimelineActions,
+  sortWorkerTimelineEventRows,
+} from '../lib/worker-timeline.js';
+import type { TaskState, WorkerActionSummary } from '../types.js';
 
 function makeTask(overrides: Partial<TaskState> & { id: string } & { startedAt?: Date; completedAt?: Date }): TaskState {
   const { startedAt, completedAt, ...rest } = overrides;
@@ -17,6 +22,24 @@ function makeTask(overrides: Partial<TaskState> & { id: string } & { startedAt?:
     execution: { startedAt, completedAt },
     ...rest,
   } as TaskState;
+}
+
+function makeWorkerAction(overrides: Partial<WorkerActionSummary> & { id: string; workerKind: string; createdAt: string }): WorkerActionSummary {
+  return {
+    id: overrides.id,
+    workerKind: overrides.workerKind,
+    actionType: 'repair',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/task-a',
+    subjectType: 'task',
+    subjectId: 'wf-1/task-a',
+    externalKey: `external:${overrides.id}`,
+    status: 'completed',
+    attemptCount: 1,
+    createdAt: overrides.createdAt,
+    updatedAt: overrides.createdAt,
+    ...overrides,
+  };
 }
 
 describe('formatElapsed', () => {
@@ -90,8 +113,8 @@ describe('sortTasksForTimeline', () => {
 
 describe('computeBarWidths', () => {
   const T0 = new Date('2024-01-01T00:00:00Z').getTime();
-  const T1 = new Date('2024-01-01T00:01:00Z').getTime(); // +60s
-  const T2 = new Date('2024-01-01T00:02:00Z').getTime(); // +120s
+  const T1 = new Date('2024-01-01T00:01:00Z').getTime();
+  const T2 = new Date('2024-01-01T00:02:00Z').getTime();
 
   it('returns zero-width bars for tasks with no startedAt', () => {
     const tasks = [makeTask({ id: 'a', status: 'pending' })];
@@ -106,7 +129,7 @@ describe('computeBarWidths', () => {
       makeTask({ id: 'b', status: 'blocked' }),
     ];
     const bars = computeBarWidths(tasks, T2);
-    expect(bars.every((b) => b.widthPercent === 0)).toBe(true);
+    expect(bars.every((bar) => bar.widthPercent === 0)).toBe(true);
   });
 
   it('computes correct offset and width for a single completed task', () => {
@@ -140,8 +163,8 @@ describe('computeBarWidths', () => {
       }),
     ];
     const bars = computeBarWidths(tasks, T2);
-    const first = bars.find((b) => b.taskId === 'first')!;
-    const second = bars.find((b) => b.taskId === 'second')!;
+    const first = bars.find((bar) => bar.taskId === 'first')!;
+    const second = bars.find((bar) => bar.taskId === 'second')!;
 
     expect(first.offsetPercent).toBe(0);
     expect(first.widthPercent).toBe(50);
@@ -171,5 +194,115 @@ describe('computeBarWidths', () => {
     const bars = computeBarWidths(tasks, T2);
     expect(bars[0].taskId).toBe('x');
     expect(bars[1].taskId).toBe('y');
+  });
+});
+
+describe('worker timeline helpers', () => {
+  it('expands completed actions into launched and finished rows', () => {
+    const rows = buildWorkerTimelineEventRows(
+      makeWorkerAction({
+        id: 'repair',
+        workerKind: 'autofix',
+        createdAt: '2024-01-01T00:00:10Z',
+        completedAt: '2024-01-01T00:00:20Z',
+      }),
+      Date.parse('2024-01-01T00:01:00Z'),
+    );
+
+    expect(rows).toEqual([
+      expect.objectContaining({ eventKind: 'launched', timestampMs: Date.parse('2024-01-01T00:00:10Z') }),
+      expect.objectContaining({ eventKind: 'finished', timestampMs: Date.parse('2024-01-01T00:00:20Z') }),
+    ]);
+  });
+
+  it('drops the finished row when completedAt is invalid but keeps the launched row', () => {
+    const rows = buildWorkerTimelineEventRows(
+      makeWorkerAction({
+        id: 'repair',
+        workerKind: 'autofix',
+        createdAt: '2024-01-01T00:00:10Z',
+        completedAt: 'not-a-timestamp',
+        updatedAt: '2024-01-01T00:00:40Z',
+      }),
+      Date.parse('2024-01-01T00:01:00Z'),
+    );
+
+    expect(rows).toEqual([
+      expect.objectContaining({ eventKind: 'launched', timestampMs: Date.parse('2024-01-01T00:00:10Z') }),
+    ]);
+  });
+
+  it('sorts event rows by timestamp, then action id, with launched before finished for one action', () => {
+    const earlierRows = buildWorkerTimelineEventRows(
+      makeWorkerAction({
+        id: 'earlier',
+        workerKind: 'autofix',
+        createdAt: '2024-01-01T00:00:10Z',
+      }),
+      Date.parse('2024-01-01T00:01:00Z'),
+    ) ?? [];
+    const sameActionRows = buildWorkerTimelineEventRows(
+      makeWorkerAction({
+        id: 'same',
+        workerKind: 'autofix',
+        createdAt: '2024-01-01T00:00:20Z',
+        completedAt: '2024-01-01T00:00:20Z',
+      }),
+      Date.parse('2024-01-01T00:01:00Z'),
+    ) ?? [];
+    const laterRows = buildWorkerTimelineEventRows(
+      makeWorkerAction({
+        id: 'later',
+        workerKind: 'autofix',
+        createdAt: '2024-01-01T00:00:20Z',
+      }),
+      Date.parse('2024-01-01T00:01:00Z'),
+    ) ?? [];
+
+    const sorted = sortWorkerTimelineEventRows([
+      laterRows[0]!,
+      sameActionRows[1]!,
+      sameActionRows[0]!,
+      earlierRows[0]!,
+    ]);
+
+    expect(sorted.map((row) => `${row.action.id}-${row.eventKind}`)).toEqual([
+      'earlier-launched',
+      'later-launched',
+      'same-launched',
+      'same-finished',
+    ]);
+  });
+
+  it('re-sorts combined pages into ascending createdAt order', () => {
+    const combined = sortWorkerTimelineActions([
+      makeWorkerAction({
+        id: 'newer-page',
+        workerKind: 'autofix',
+        createdAt: '2024-01-01T00:00:20Z',
+      }),
+      makeWorkerAction({
+        id: 'older-page',
+        workerKind: 'autofix',
+        createdAt: '2024-01-01T00:00:10Z',
+      }),
+      makeWorkerAction({
+        id: 'same-time-b',
+        workerKind: 'autofix',
+        createdAt: '2024-01-01T00:00:20Z',
+      }),
+      makeWorkerAction({
+        id: 'same-time-a',
+        workerKind: 'autofix',
+        createdAt: '2024-01-01T00:00:20Z',
+      }),
+    ]);
+
+    expect(combined.map((action) => action.id)).toEqual([
+      'older-page',
+      'newer-page',
+      'same-time-a',
+      'same-time-b',
+    ]);
   });
 });

--- a/packages/ui/src/__tests__/use-worker-timeline-actions.test.tsx
+++ b/packages/ui/src/__tests__/use-worker-timeline-actions.test.tsx
@@ -1,0 +1,52 @@
+import React, { StrictMode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useWorkerTimelineActions } from '../hooks/useWorkerTimelineActions.js';
+
+describe('useWorkerTimelineActions', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getWorkerDecisions: vi.fn().mockResolvedValue({
+        actions: [
+          {
+            id: 'wa-1',
+            workerKind: 'autofix',
+            actionType: 'repair',
+            workflowId: 'wf-1',
+            taskId: 'wf-1/task-1',
+            subjectType: 'task',
+            subjectId: 'wf-1/task-1',
+            externalKey: 'wa-1',
+            status: 'completed',
+            attemptCount: 1,
+            createdAt: '2026-07-15T10:00:00.000Z',
+            updatedAt: '2026-07-15T10:00:10.000Z',
+            completedAt: '2026-07-15T10:00:10.000Z',
+          },
+        ],
+        limit: 100,
+        offset: 0,
+        hasMore: false,
+        workflowId: 'wf-1',
+      }),
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as unknown as { invoker?: unknown }).invoker;
+  });
+
+  it('hydrates worker actions under StrictMode', async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => <StrictMode>{children}</StrictMode>;
+    const { result } = renderHook(() => useWorkerTimelineActions('wf-1', 10_000), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.actions).toHaveLength(1);
+    });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.actions[0]?.id).toBe('wa-1');
+    expect(window.invoker.getWorkerDecisions).toHaveBeenCalledWith({ workflowId: 'wf-1', limit: 100, offset: 0 });
+  });
+});

--- a/packages/ui/src/hooks/useWorkerTimelineActions.ts
+++ b/packages/ui/src/hooks/useWorkerTimelineActions.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { WorkerActionSummary, WorkerDecisionsRequest, WorkerDecisionsResponse } from '../types.js';
+import { subscribeVisibilityAwarePoll } from './visibilityAwarePoll.js';
+
+interface WorkerTimelinePageState {
+  readonly head: WorkerDecisionsResponse | null;
+  readonly older: readonly WorkerDecisionsResponse[];
+}
+
+export interface WorkerTimelineActionsState {
+  readonly actions: readonly WorkerActionSummary[];
+  readonly loading: boolean;
+  readonly loadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly refresh: () => Promise<void>;
+  readonly loadMore: () => Promise<void>;
+}
+
+export function useWorkerTimelineActions(
+  workflowId: string | null,
+  pollMs = 4000,
+): WorkerTimelineActionsState {
+  const mountedRef = useRef(true);
+  const [pages, setPages] = useState<WorkerTimelinePageState>({ head: null, older: [] });
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    setPages({ head: null, older: [] });
+  }, [workflowId]);
+
+  const actions = useMemo(() => {
+    const seen = new Set<string>();
+    const merged: WorkerActionSummary[] = [];
+    const allPages = [pages.head, ...pages.older].filter((page): page is WorkerDecisionsResponse => page !== null);
+    for (const page of allPages) {
+      for (const action of page.actions) {
+        if (seen.has(action.id)) continue;
+        seen.add(action.id);
+        merged.push(action);
+      }
+    }
+    return merged;
+  }, [pages]);
+
+  const hasMore = useMemo(() => {
+    const tail = pages.older[pages.older.length - 1] ?? pages.head;
+    return tail?.hasMore ?? false;
+  }, [pages]);
+
+  const nextOffset = useMemo(() => {
+    const tail = pages.older[pages.older.length - 1] ?? pages.head;
+    if (!tail) return 0;
+    return tail.offset + tail.actions.length;
+  }, [pages]);
+
+  const fetchPage = useCallback(async (
+    request: WorkerDecisionsRequest,
+    mode: 'refresh' | 'append',
+  ) => {
+    const response = await window.invoker?.getWorkerDecisions?.(request);
+    if (!mountedRef.current || !response) return;
+    setPages((current) => {
+      if (mode === 'append') {
+        return { head: current.head, older: [...current.older, response] };
+      }
+      return { head: response, older: current.older };
+    });
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!workflowId) {
+      setPages({ head: null, older: [] });
+      return;
+    }
+    setLoading(true);
+    try {
+      await fetchPage({ workflowId, limit: 100, offset: 0 }, 'refresh');
+    } catch (err) {
+      console.warn('[useWorkerTimelineActions] refresh failed', err);
+    } finally {
+      if (mountedRef.current) setLoading(false);
+    }
+  }, [fetchPage, workflowId]);
+
+  const loadMore = useCallback(async () => {
+    if (!workflowId || loadingMore || !hasMore) return;
+    setLoadingMore(true);
+    try {
+      await fetchPage({ workflowId, limit: 100, offset: nextOffset }, 'append');
+    } catch (err) {
+      console.warn('[useWorkerTimelineActions] load more failed', err);
+    } finally {
+      if (mountedRef.current) setLoadingMore(false);
+    }
+  }, [fetchPage, hasMore, loadingMore, nextOffset, workflowId]);
+
+  useEffect(() => {
+    if (!workflowId) {
+      void refresh();
+      return undefined;
+    }
+    return subscribeVisibilityAwarePoll(() => {
+      void refresh();
+    }, pollMs, { restoreDelayMs: 300, initialDelayMs: 150 });
+  }, [pollMs, refresh, workflowId]);
+
+  return {
+    actions,
+    loading,
+    loadingMore,
+    hasMore,
+    refresh,
+    loadMore,
+  };
+}

--- a/packages/ui/src/lib/worker-timeline.ts
+++ b/packages/ui/src/lib/worker-timeline.ts
@@ -1,0 +1,93 @@
+import type { WorkerActionSummary } from '../types.js';
+import { ACTIVE_WORKER_ACTION_STATUSES } from './worker-display.js';
+
+export type WorkerTimelineEventKind = 'launched' | 'finished';
+
+export interface WorkerTimelineActionBounds {
+  readonly startMs: number;
+  readonly endMs: number;
+  readonly isActive: boolean;
+}
+
+export interface WorkerTimelineEventRow {
+  readonly action: WorkerActionSummary;
+  readonly eventKind: WorkerTimelineEventKind;
+  readonly timestampMs: number;
+}
+
+function parseMs(value: string | undefined): number | null {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+export function compareWorkerTimelineActions(a: WorkerActionSummary, b: WorkerActionSummary): number {
+  const createdA = Date.parse(a.createdAt);
+  const createdB = Date.parse(b.createdAt);
+  if (Number.isFinite(createdA) && Number.isFinite(createdB) && createdA !== createdB) {
+    return createdA - createdB;
+  }
+  if (Number.isFinite(createdA) !== Number.isFinite(createdB)) {
+    return Number.isFinite(createdA) ? -1 : 1;
+  }
+  return a.id.localeCompare(b.id);
+}
+
+export function sortWorkerTimelineActions(actions: readonly WorkerActionSummary[]): WorkerActionSummary[] {
+  return [...actions].sort(compareWorkerTimelineActions);
+}
+
+export function compareWorkerTimelineEventRows(
+  a: WorkerTimelineEventRow,
+  b: WorkerTimelineEventRow,
+): number {
+  if (a.timestampMs !== b.timestampMs) return a.timestampMs - b.timestampMs;
+  const idOrder = a.action.id.localeCompare(b.action.id);
+  if (idOrder !== 0) return idOrder;
+  if (a.eventKind === b.eventKind) return 0;
+  return a.eventKind === 'launched' ? -1 : 1;
+}
+
+export function sortWorkerTimelineEventRows(
+  rows: readonly WorkerTimelineEventRow[],
+): WorkerTimelineEventRow[] {
+  return [...rows].sort(compareWorkerTimelineEventRows);
+}
+
+export function getWorkerTimelineActionBounds(
+  action: WorkerActionSummary,
+  nowMs: number,
+): WorkerTimelineActionBounds | null {
+  const startMs = parseMs(action.createdAt);
+  if (startMs === null) return null;
+  const isActive = ACTIVE_WORKER_ACTION_STATUSES.has(action.status);
+  if (isActive) {
+    return { startMs, endMs: nowMs, isActive: true };
+  }
+  const endMs = parseMs(action.completedAt) ?? parseMs(action.updatedAt) ?? startMs;
+  return { startMs, endMs, isActive: false };
+}
+
+export function buildWorkerTimelineEventRows(
+  action: WorkerActionSummary,
+  nowMs: number,
+): WorkerTimelineEventRow[] | null {
+  const bounds = getWorkerTimelineActionBounds(action, nowMs);
+  if (!bounds) return null;
+  const rows: WorkerTimelineEventRow[] = [
+    {
+      action,
+      eventKind: 'launched',
+      timestampMs: bounds.startMs,
+    },
+  ];
+  const finishedMs = parseMs(action.completedAt);
+  if (finishedMs !== null) {
+    rows.push({
+      action,
+      eventKind: 'finished',
+      timestampMs: finishedMs,
+    });
+  }
+  return rows;
+}


### PR DESCRIPTION
## Summary

This adds the worker timeline data layer under the existing Timeline tab code.

The risk sat in paging, merge order, and the new launched-versus-finished event expansion, not in the final UI styling.

The hook now keeps worker-action fetch state stable, merges older pages by action id, and exposes pure ordering helpers for launched and finished rows.

## Review Claim

The worker timeline foundation can fetch, merge, and sort worker-action pages, including launched and finished event expansion, without changing visible Timeline behavior yet.

## Review Lane

refactor

## Review Unit

activation-surface

## Safety Invariant

This slice only adds the hook, pure worker timeline helpers, the shared paged mock, and focused tests. Timeline still renders the current task-only surface in this branch.

## Slice Rationale

The paging and event-ordering rules are reviewable on their own. The later UI slice can assume the fetch, merge, StrictMode, and launched-versus-finished ordering behavior already works.

## Non-goals

- Behavior unchanged.
- No visible Timeline behavior change yet.
- No worker row UI yet.
- No App callsite change yet.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/timeline-view.test.ts src/__tests__/use-worker-timeline-actions.test.tsx`

</details>

## Visual Proof

Timeline still stays on the existing task-only view in this foundation slice:

![Timeline remains task-only before the worker UI activation slice](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260715-7d590a/worker-timeline-foundation-proof.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert ab3d2a28e`
- Post-revert steps: None.
- Data migration? No.

</details>
