### PR TITLE
[Worker Timeline](2) Add worker history mode to Timeline

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3477,7 +3477,13 @@ export function App() {
       ) : viewMode === 'history' ? (
         <HistoryView onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
       ) : viewMode === 'timeline' ? (
-        <TimelineView tasks={tasks} onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
+        <TimelineView
+          tasks={tasks}
+          workflows={workflows}
+          selectedWorkflowId={selectedWorkflowId}
+          onTaskClick={handleTaskClick}
+          selectedTaskId={selectedTaskId}
+        />
       ) : viewMode === 'actionGraph' ? (
         <ActionGraphView
           graph={actionGraph}

--- a/packages/ui/src/__tests__/timeline-view-e2e.test.tsx
+++ b/packages/ui/src/__tests__/timeline-view-e2e.test.tsx
@@ -2,39 +2,72 @@
  * Component test: Timeline view rendering and interaction.
  *
  * Demoted from packages/app/e2e/timeline-view.spec.ts.
- * Tests switching to timeline view, bar rendering, elapsed time, and task selection.
+ * Tests worker timeline behavior plus the preserved task Gantt mode.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, act, waitFor, fireEvent, within } from '@testing-library/react';
 import { vi } from 'vitest';
+import { App } from '../App.js';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
-import type { WorkflowMeta } from '../types.js';
+import type { WorkerActionSummary, WorkflowMeta } from '../types.js';
 
 vi.mock('@xyflow/react', async () => {
   const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
   return createReactFlowMock();
 });
 
-const { App } = await import('../App.js');
+const workflowAlpha: WorkflowMeta = { id: 'wf-alpha', name: 'Alpha Flow', status: 'running' };
+const workflowBeta: WorkflowMeta = { id: 'wf-beta', name: 'Beta Flow', status: 'running' };
 
 const alpha = makeUITask({
-  id: 'task-alpha',
+  id: 'wf-alpha/task-alpha',
   description: 'First test task',
   status: 'pending',
-  workflowId: 'wf-timeline',
+  workflowId: workflowAlpha.id,
   command: 'echo hello-alpha',
 });
 
 const beta = makeUITask({
-  id: 'task-beta',
+  id: 'wf-alpha/task-beta',
   description: 'Second test task',
   status: 'pending',
-  workflowId: 'wf-timeline',
-  dependencies: ['task-alpha'],
+  workflowId: workflowAlpha.id,
+  dependencies: [alpha.id],
   command: 'echo hello-beta',
 });
-const workflows: WorkflowMeta[] = [{ id: 'wf-timeline', name: 'Timeline WF', status: 'running' }];
+
+const gamma = makeUITask({
+  id: 'wf-beta/task-gamma',
+  description: 'Third test task',
+  status: 'pending',
+  workflowId: workflowBeta.id,
+  command: 'echo hello-gamma',
+});
+
+function makeWorkerAction(overrides: Partial<WorkerActionSummary> & {
+  id: string;
+  workerKind: string;
+  workflowId: string;
+  createdAt: string;
+}): WorkerActionSummary {
+  return {
+    id: overrides.id,
+    workerKind: overrides.workerKind,
+    actionType: 'repair',
+    workflowId: overrides.workflowId,
+    taskId: alpha.id,
+    subjectType: 'task',
+    subjectId: alpha.id,
+    externalKey: `action:${overrides.id}`,
+    status: 'completed',
+    attemptCount: 1,
+    createdAt: overrides.createdAt,
+    updatedAt: overrides.createdAt,
+    ...overrides,
+  };
+}
+
 async function chooseGraphMenuItem(testId: string): Promise<void> {
   fireEvent.click(screen.getByTestId('graph-more-button'));
   await waitFor(() => {
@@ -43,6 +76,18 @@ async function chooseGraphMenuItem(testId: string): Promise<void> {
   fireEvent.click(screen.getByTestId(testId));
 }
 
+async function chooseTimelineMode(mode: 'workers' | 'tasks'): Promise<void> {
+  fireEvent.click(screen.getByTestId(`timeline-mode-${mode}`));
+  await waitFor(() => {
+    expect(screen.getByTestId(`timeline-mode-${mode}`)).toHaveAttribute('aria-pressed', 'true');
+  });
+}
+
+function getWorkerActionOrder(): Array<string | null> {
+  return within(screen.getByTestId('worker-timeline-list'))
+    .getAllByRole('button')
+    .map((element) => element.getAttribute('data-testid'));
+}
 
 describe('Timeline view (component)', () => {
   let mock: MockInvoker;
@@ -56,95 +101,201 @@ describe('Timeline view (component)', () => {
     mock.cleanup();
   });
 
-  it('clicking Timeline button shows the timeline view', async () => {
+  it('opening Timeline shows Workers mode by default', async () => {
     render(<App />);
-    act(() => mock.setTasks([alpha, beta], workflows));
+    act(() => {
+      mock.setTasks([alpha, beta], [workflowAlpha]);
+      mock.setWorkerDecisions({ actions: [], limit: 100, offset: 0, hasMore: false, workflowId: workflowAlpha.id });
+    });
 
     await chooseGraphMenuItem('rail-timeline');
 
     await waitFor(() => {
       expect(screen.getByTestId('timeline-view')).toBeInTheDocument();
+      expect(screen.getByTestId('timeline-mode-workers')).toHaveAttribute('aria-pressed', 'true');
+      expect(screen.getByTestId('worker-timeline-view')).toBeInTheDocument();
     });
   });
 
-  it('timeline shows task bars after loading tasks', async () => {
+  it('keeps Workers scoped to the selected workflow during workflow metadata grace', async () => {
+    const alphaAction = makeWorkerAction({
+      id: 'alpha-gap',
+      workerKind: 'autofix',
+      workflowId: workflowAlpha.id,
+      createdAt: '2024-01-01T00:00:10Z',
+    });
+    const betaAction = makeWorkerAction({
+      id: 'beta-gap',
+      workerKind: 'autofix',
+      workflowId: workflowBeta.id,
+      createdAt: '2024-01-01T00:00:20Z',
+    });
+
     render(<App />);
-    act(() => mock.setTasks([alpha, beta], workflows));
+    act(() => {
+      mock.setTasks([], [workflowAlpha, workflowBeta]);
+      mock.setWorkerDecisions((request) => {
+        if (request.workflowId === workflowBeta.id) {
+          return { actions: [betaAction], limit: 100, offset: request.offset ?? 0, hasMore: false, workflowId: workflowBeta.id };
+        }
+        return { actions: [alphaAction], limit: 100, offset: request.offset ?? 0, hasMore: false, workflowId: workflowAlpha.id };
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-alpha')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-beta')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('rf__node-wf-alpha'));
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Alpha Flow');
+    });
+
+    await chooseGraphMenuItem('rail-timeline');
+    await waitFor(() => {
+      expect(screen.getByTestId('worker-timeline-action-alpha-gap-launched')).toBeInTheDocument();
+    });
+
+    act(() => mock.fireWorkflowsChanged([workflowBeta]));
+    await new Promise((resolve) => { setTimeout(resolve, 250); });
+
+    expect(mock.api.getWorkerDecisions).not.toHaveBeenCalledWith({ workflowId: workflowBeta.id, limit: 100, offset: 0 });
+    expect(screen.getByTestId('worker-timeline-action-alpha-gap-launched')).toBeInTheDocument();
+    expect(screen.queryByTestId('worker-timeline-action-beta-gap-launched')).not.toBeInTheDocument();
+  });
+
+  it('labels timeline mode and worker search controls for assistive technology', async () => {
+    render(<App />);
+    act(() => {
+      mock.setTasks([alpha, gamma], [workflowAlpha, workflowBeta]);
+      mock.setWorkerDecisions({ actions: [], limit: 100, offset: 0, hasMore: false, workflowId: workflowAlpha.id });
+    });
 
     await chooseGraphMenuItem('rail-timeline');
 
     await waitFor(() => {
-      expect(screen.getByTestId('timeline-bar-task-alpha')).toBeInTheDocument();
-      expect(screen.getByTestId('timeline-bar-task-beta')).toBeInTheDocument();
+      const modeGroup = screen.getByRole('group', { name: 'Timeline mode' });
+      expect(modeGroup).toBeInTheDocument();
+      expect(within(modeGroup).getByRole('button', { name: 'Workers' })).toHaveAttribute('aria-pressed', 'true');
+      expect(screen.getByLabelText('Workflow')).toHaveValue(workflowAlpha.id);
+      expect(screen.getByLabelText('Search tasks')).toBeInTheDocument();
     });
   });
 
-  it('completed task shows elapsed time', async () => {
+  it('shows invalid timestamp empty state from validated worker rows', async () => {
+    const invalidAction = makeWorkerAction({
+      id: 'invalid-time',
+      workerKind: 'autofix',
+      workflowId: workflowAlpha.id,
+      createdAt: 'not-a-date',
+    });
+
+    render(<App />);
+    act(() => {
+      mock.setTasks([], [workflowAlpha]);
+      mock.setWorkerDecisions({ actions: [invalidAction], limit: 100, offset: 0, hasMore: false, workflowId: workflowAlpha.id });
+    });
+
+    await chooseGraphMenuItem('rail-timeline');
+
+    await waitFor(() => {
+      expect(screen.getByText('No matching worker actions have valid timestamps.')).toBeInTheDocument();
+      expect(screen.getByText('0 / 0')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('No worker actions match the current filters.')).not.toBeInTheDocument();
+  });
+
+  it('switching to Tasks mode still shows the existing task bars', async () => {
+    render(<App />);
+    act(() => {
+      mock.setTasks([alpha, beta], [workflowAlpha]);
+    });
+
+    await chooseGraphMenuItem('rail-timeline');
+    await chooseTimelineMode('tasks');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('timeline-bar-wf-alpha/task-alpha')).toBeInTheDocument();
+      expect(screen.getByTestId('timeline-bar-wf-alpha/task-beta')).toBeInTheDocument();
+    });
+  });
+
+  it('completed task shows elapsed time in Tasks mode', async () => {
     const now = Date.now();
     const completedAlpha = makeUITask({
-      id: 'task-alpha',
-      description: 'First test task',
+      id: alpha.id,
+      description: alpha.description,
       status: 'completed',
-      workflowId: 'wf-timeline',
+      workflowId: workflowAlpha.id,
       command: 'echo hello-alpha',
       execution: {
         startedAt: new Date(now - 5000),
         completedAt: new Date(now),
       },
-    } as any);
+    } as never);
 
     render(<App />);
-    act(() => mock.setTasks([completedAlpha, beta], workflows));
+    act(() => {
+      mock.setTasks([completedAlpha, beta], [workflowAlpha]);
+    });
 
     await chooseGraphMenuItem('rail-timeline');
+    await chooseTimelineMode('tasks');
 
     await waitFor(() => {
-      const bar = screen.getByTestId('timeline-bar-task-alpha');
+      const bar = screen.getByTestId('timeline-bar-wf-alpha/task-alpha');
       expect(bar).toHaveTextContent(/\d+s/);
     });
   });
 
-  it('clicking a timeline row updates the inspector to the selected task', async () => {
+  it('clicking a task timeline row updates the inspector', async () => {
     const now = Date.now();
     const startedAlpha = makeUITask({
-      id: 'task-alpha',
-      description: 'First test task',
+      id: alpha.id,
+      description: alpha.description,
       status: 'completed',
-      workflowId: 'wf-timeline',
+      workflowId: workflowAlpha.id,
       command: 'echo hello-alpha',
       execution: {
         startedAt: new Date(now - 5000),
         completedAt: new Date(now),
       },
-    } as any);
+    } as never);
 
     render(<App />);
-    act(() => mock.setTasks([startedAlpha, beta], workflows));
-
-    await chooseGraphMenuItem('rail-timeline');
-
-    await waitFor(() => {
-      expect(screen.getByTestId('timeline-bar-task-alpha')).toBeInTheDocument();
+    act(() => {
+      mock.setTasks([startedAlpha, beta], [workflowAlpha]);
     });
 
-    fireEvent.click(screen.getByTestId('timeline-bar-task-alpha'));
+    await chooseGraphMenuItem('rail-timeline');
+    await chooseTimelineMode('tasks');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('timeline-bar-wf-alpha/task-alpha')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('timeline-bar-wf-alpha/task-alpha'));
 
     await waitFor(() => {
       expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('First test task');
     });
   });
 
-  it('timeline row text has selectable text styling', async () => {
+  it('task timeline row text keeps selectable text styling', async () => {
     render(<App />);
-    act(() => mock.setTasks([alpha, beta], workflows));
-
-    await chooseGraphMenuItem('rail-timeline');
-
-    await waitFor(() => {
-      expect(screen.getByTestId('timeline-bar-task-alpha')).toBeInTheDocument();
+    act(() => {
+      mock.setTasks([alpha, beta], [workflowAlpha]);
     });
 
-    const row = screen.getByTestId('timeline-bar-task-alpha');
+    await chooseGraphMenuItem('rail-timeline');
+    await chooseTimelineMode('tasks');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('timeline-bar-wf-alpha/task-alpha')).toBeInTheDocument();
+    });
+
+    const row = screen.getByTestId('timeline-bar-wf-alpha/task-alpha');
     expect(row.getAttribute('role')).toBe('button');
 
     const taskLabel = row.querySelector('.select-text');
@@ -152,21 +303,220 @@ describe('Timeline view (component)', () => {
     expect(taskLabel!.classList.contains('cursor-text')).toBe(true);
   });
 
-  it('switching back to Home workflow graph works', async () => {
+  it('workflow select changes the worker decision request scope', async () => {
+    const betaAction = makeWorkerAction({
+      id: 'beta-action',
+      workerKind: 'autofix',
+      workflowId: workflowBeta.id,
+      createdAt: '2024-01-01T00:03:00Z',
+      taskId: gamma.id,
+      subjectId: gamma.id,
+      completedAt: '2024-01-01T00:03:10Z',
+    });
+
     render(<App />);
-    act(() => mock.setTasks([alpha, beta], workflows));
+    act(() => {
+      mock.setTasks([alpha, beta, gamma], [workflowAlpha, workflowBeta]);
+      mock.setWorkerDecisions((request) => {
+        if (request.workflowId === workflowBeta.id) {
+          return { actions: [betaAction], limit: 100, offset: request.offset ?? 0, hasMore: false, workflowId: workflowBeta.id };
+        }
+        return { actions: [], limit: 100, offset: request.offset ?? 0, hasMore: false, workflowId: workflowAlpha.id };
+      });
+    });
 
     await chooseGraphMenuItem('rail-timeline');
 
     await waitFor(() => {
-      expect(screen.getByTestId('timeline-bar-task-alpha')).toBeInTheDocument();
+      expect(mock.api.getWorkerDecisions).toHaveBeenCalledWith({ workflowId: workflowAlpha.id, limit: 100, offset: 0 });
+    });
+
+    fireEvent.change(screen.getByTestId('worker-timeline-workflow-select'), { target: { value: workflowBeta.id } });
+
+    await waitFor(() => {
+      expect(mock.api.getWorkerDecisions).toHaveBeenCalledWith({ workflowId: workflowBeta.id, limit: 100, offset: 0 });
+      expect(screen.getByTestId('worker-timeline-action-beta-action-launched')).toBeInTheDocument();
+    });
+  });
+
+  it('renders worker events as one chronological list and preserves task mode behavior', async () => {
+    const alphaOlder = makeWorkerAction({
+      id: 'alpha-older',
+      workerKind: 'autofix',
+      workflowId: workflowAlpha.id,
+      createdAt: '2024-01-01T00:00:05Z',
+      taskId: alpha.id,
+      subjectId: alpha.id,
+      completedAt: '2024-01-01T00:00:08Z',
+      reason: 'Retry budget opened a repair path.',
+      summary: 'Repair finished cleanly.',
+    });
+    const alphaRepair = makeWorkerAction({
+      id: 'alpha-repair',
+      workerKind: 'autofix',
+      workflowId: workflowAlpha.id,
+      createdAt: '2024-01-01T00:00:10Z',
+      taskId: alpha.id,
+      subjectId: alpha.id,
+      completedAt: '2024-01-01T00:00:20Z',
+      reason: 'Autofix picked the failing task.',
+      summary: 'Repair finished cleanly.',
+    });
+    const alphaReview = makeWorkerAction({
+      id: 'alpha-review',
+      workerKind: 'pr-summary-refresh',
+      workflowId: workflowAlpha.id,
+      createdAt: '2024-01-01T00:00:30Z',
+      taskId: beta.id,
+      subjectId: beta.id,
+      actionType: 'refresh-review',
+      completedAt: '2024-01-01T00:00:40Z',
+      summary: 'Updated review metadata.',
+    });
+    const alphaInspect = makeWorkerAction({
+      id: 'alpha-inspect',
+      workerKind: 'autofix',
+      workflowId: workflowAlpha.id,
+      createdAt: '2024-01-01T00:00:50Z',
+      taskId: alpha.id,
+      subjectId: alpha.id,
+      actionType: 'inspect',
+      status: 'running',
+      updatedAt: '2024-01-01T00:00:55Z',
+      completedAt: undefined,
+      reason: 'Selected task still has open execution output.',
+    });
+
+    render(<App />);
+    act(() => {
+      mock.setTasks([alpha, beta, gamma], [workflowAlpha, workflowBeta]);
+      mock.setWorkerDecisions((request) => {
+        if (request.workflowId !== workflowAlpha.id) {
+          return { actions: [], limit: 100, offset: request.offset ?? 0, hasMore: false, workflowId: request.workflowId };
+        }
+        if ((request.offset ?? 0) === 0) {
+          return {
+            actions: [alphaRepair, alphaReview, alphaInspect],
+            limit: 100,
+            offset: 0,
+            hasMore: true,
+            workflowId: workflowAlpha.id,
+          };
+        }
+        return {
+          actions: [alphaOlder],
+          limit: 100,
+          offset: request.offset ?? 0,
+          hasMore: false,
+          workflowId: workflowAlpha.id,
+        };
+      });
+    });
+
+    await chooseGraphMenuItem('rail-timeline');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('timeline-mode-workers')).toHaveAttribute('aria-pressed', 'true');
+      expect(getWorkerActionOrder()).toEqual([
+        'worker-timeline-action-alpha-repair-launched',
+        'worker-timeline-action-alpha-repair-finished',
+        'worker-timeline-action-alpha-review-launched',
+        'worker-timeline-action-alpha-review-finished',
+        'worker-timeline-action-alpha-inspect-launched',
+      ]);
+    });
+
+    expect(screen.getByTestId('worker-timeline-row-alpha-repair-launched')).toHaveTextContent('Autofix');
+    expect(screen.getByTestId('worker-timeline-row-alpha-repair-launched')).toHaveTextContent('Repair');
+    expect(screen.getByTestId('worker-timeline-row-alpha-repair-launched')).toHaveTextContent('Launched');
+    expect(screen.getByTestId('worker-timeline-row-alpha-repair-finished')).toHaveTextContent('Finished executing');
+    expect(screen.getByTestId('worker-timeline-row-alpha-review-launched')).toHaveTextContent('PR summary refresh');
+    expect(screen.getByTestId('worker-timeline-row-alpha-review-launched')).toHaveTextContent('Refresh Review');
+    expect(screen.getByTestId('worker-timeline-row-alpha-inspect-launched')).toHaveTextContent('Inspect');
+
+    fireEvent.click(screen.getByTestId('worker-timeline-action-alpha-repair-finished'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('First test task');
+    });
+
+    fireEvent.click(screen.getByTestId('worker-timeline-filter-autofix'));
+
+    await waitFor(() => {
+      expect(getWorkerActionOrder()).toEqual([
+        'worker-timeline-action-alpha-repair-launched',
+        'worker-timeline-action-alpha-repair-finished',
+        'worker-timeline-action-alpha-inspect-launched',
+      ]);
+      expect(screen.queryByTestId('worker-timeline-action-alpha-review-launched')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('worker-timeline-filter-autofix'));
+
+    await waitFor(() => {
+      expect(getWorkerActionOrder()).toEqual([
+        'worker-timeline-action-alpha-repair-launched',
+        'worker-timeline-action-alpha-repair-finished',
+        'worker-timeline-action-alpha-review-launched',
+        'worker-timeline-action-alpha-review-finished',
+        'worker-timeline-action-alpha-inspect-launched',
+      ]);
+    });
+
+    fireEvent.change(screen.getByTestId('worker-timeline-task-search'), { target: { value: 'first' } });
+
+    await waitFor(() => {
+      expect(getWorkerActionOrder()).toEqual([
+        'worker-timeline-action-alpha-repair-launched',
+        'worker-timeline-action-alpha-repair-finished',
+        'worker-timeline-action-alpha-inspect-launched',
+      ]);
+      expect(screen.queryByTestId('worker-timeline-action-alpha-review-launched')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('worker-timeline-load-more'));
+
+    await waitFor(() => {
+      expect(mock.api.getWorkerDecisions).toHaveBeenCalledWith({ workflowId: workflowAlpha.id, limit: 100, offset: 3 });
+      expect(getWorkerActionOrder()).toEqual([
+        'worker-timeline-action-alpha-older-launched',
+        'worker-timeline-action-alpha-older-finished',
+        'worker-timeline-action-alpha-repair-launched',
+        'worker-timeline-action-alpha-repair-finished',
+        'worker-timeline-action-alpha-inspect-launched',
+      ]);
+    });
+
+    expect(within(screen.getByTestId('worker-timeline-list')).getAllByText('Retry budget opened a repair path.')).toHaveLength(2);
+    expect(within(screen.getByTestId('worker-timeline-list')).getAllByText('Repair finished cleanly.')).toHaveLength(4);
+    expect(within(screen.getByTestId('worker-timeline-list')).getByText('Selected task still has open execution output.')).toBeInTheDocument();
+
+    await chooseTimelineMode('tasks');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('timeline-bar-wf-alpha/task-alpha')).toBeInTheDocument();
+      expect(screen.getByTestId('timeline-bar-wf-alpha/task-beta')).toBeInTheDocument();
+    });
+  });
+
+  it('switching back to Home workflow graph works', async () => {
+    render(<App />);
+    act(() => {
+      mock.setTasks([alpha, beta], [workflowAlpha]);
+    });
+
+    await chooseGraphMenuItem('rail-timeline');
+    await chooseTimelineMode('tasks');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('timeline-bar-wf-alpha/task-alpha')).toBeInTheDocument();
     });
 
     await chooseGraphMenuItem('rail-home');
 
     await waitFor(() => {
       expect(screen.queryByTestId('timeline-view')).not.toBeInTheDocument();
-      expect(screen.getByTestId('workflow-node-wf-timeline')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-alpha')).toBeInTheDocument();
     });
   });
 });

--- a/packages/ui/src/components/TimelineView.tsx
+++ b/packages/ui/src/components/TimelineView.tsx
@@ -1,18 +1,19 @@
 /**
- * TimelineView — Gantt-style horizontal timeline of task execution.
+ * TimelineView — worker-history timeline plus task execution Gantt.
  *
- * Shows each task as a horizontal bar on a time axis, with live elapsed
- * timers for running tasks. Useful for spotting which tasks are taking
- * long and understanding execution parallelism.
+ * Workers mode is the default surface. Tasks mode keeps the existing
+ * task-duration view intact for execution debugging.
  */
 
-import type { TaskState } from '../types.js';
+import { useState } from 'react';
+import type { TaskState, WorkflowMeta } from '../types.js';
 import { useNow } from '../hooks/useNow.js';
 import {
   getStatusInlineColors,
   getEffectiveVisualStatus,
   getRunningPhaseLabel,
 } from '../lib/colors.js';
+import { WorkerActionTimelinePane } from './WorkerActionTimelinePane.js';
 
 // ── Exported helpers (tested independently) ─────────────────
 
@@ -103,30 +104,37 @@ export function computeBarWidths(tasks: TaskState[], now: number): BarInfo[] {
 
 // ── Component ───────────────────────────────────────────────
 
+type TimelineMode = 'workers' | 'tasks';
+
 interface TimelineViewProps {
   tasks: Map<string, TaskState>;
+  workflows: Map<string, WorkflowMeta>;
+  selectedWorkflowId: string | null;
   onTaskClick: (task: TaskState) => void;
   selectedTaskId: string | null;
 }
 
-export function TimelineView({ tasks, onTaskClick, selectedTaskId }: TimelineViewProps) {
-  const hasRunning = Array.from(tasks.values()).some((t) => t.status === 'running');
+function TaskTimelinePane({
+  tasks,
+  onTaskClick,
+  selectedTaskId,
+}: Pick<TimelineViewProps, 'tasks' | 'onTaskClick' | 'selectedTaskId'>) {
+  const hasRunning = Array.from(tasks.values()).some((task) => task.status === 'running');
   const now = useNow(1000, hasRunning);
-
   const taskList = sortTasksForTimeline(Array.from(tasks.values()));
   const bars = computeBarWidths(taskList, now);
-  const barMap = new Map(bars.map((b) => [b.taskId, b]));
+  const barMap = new Map(bars.map((bar) => [bar.taskId, bar]));
 
   if (taskList.length === 0) {
     return (
-      <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
         No tasks to display
       </div>
     );
   }
 
   return (
-    <div className="h-full overflow-y-auto p-4" data-testid="timeline-view">
+    <div className="h-full overflow-y-auto p-4" data-testid="task-timeline-view">
       <div className="space-y-1">
         {taskList.map((task) => {
           const bar = barMap.get(task.id)!;
@@ -150,35 +158,30 @@ export function TimelineView({ tasks, onTaskClick, selectedTaskId }: TimelineVie
               tabIndex={0}
               data-testid={`timeline-bar-${task.id}`}
               onClick={() => onTaskClick(task)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  if (e.key === ' ') e.preventDefault();
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  if (event.key === ' ') event.preventDefault();
                   onTaskClick(task);
                 }
               }}
-              className={`w-full text-left rounded transition-all ${
+              className={`w-full rounded text-left transition-all ${
                 isSelected ? 'ring-2 ring-indigo-400 ring-offset-1 ring-offset-gray-900' : ''
               }`}
               style={{ background: 'transparent' }}
             >
               <div className="flex items-center gap-3 px-2 py-1.5">
-                {/* Task label */}
                 <div className="w-40 shrink-0 truncate text-xs text-muted-foreground select-text cursor-text" title={task.description}>
                   {task.id}
                 </div>
-                {phaseLabel && (
-                  <div className="w-20 shrink-0 text-xs text-amber-300 uppercase select-text cursor-text">
+                {phaseLabel ? (
+                  <div className="w-20 shrink-0 text-xs uppercase text-amber-300 select-text cursor-text">
                     {phaseLabel}
                   </div>
-                )}
-
-                {/* Bar area */}
-                <div className="flex-1 h-6 relative bg-secondary rounded overflow-hidden">
-                  {bar.widthPercent > 0 && (
+                ) : null}
+                <div className="relative h-6 flex-1 overflow-hidden rounded bg-secondary">
+                  {bar.widthPercent > 0 ? (
                     <div
-                      className={`absolute top-0 bottom-0 rounded ${
-                        task.status === 'running' ? 'animate-pulse' : ''
-                      }`}
+                      className={`absolute bottom-0 top-0 rounded ${task.status === 'running' ? 'animate-pulse' : ''}`}
                       style={{
                         left: `${bar.offsetPercent}%`,
                         width: `${bar.widthPercent}%`,
@@ -186,10 +189,8 @@ export function TimelineView({ tasks, onTaskClick, selectedTaskId }: TimelineVie
                         minWidth: '4px',
                       }}
                     />
-                  )}
+                  ) : null}
                 </div>
-
-                {/* Duration label */}
                 <div className="w-16 shrink-0 text-right text-xs tabular-nums select-text cursor-text" style={{ color: colors.bg }}>
                   {elapsed ?? '—'}
                 </div>
@@ -197,6 +198,61 @@ export function TimelineView({ tasks, onTaskClick, selectedTaskId }: TimelineVie
             </div>
           );
         })}
+      </div>
+    </div>
+  );
+}
+
+export function TimelineView({
+  tasks,
+  workflows,
+  selectedWorkflowId,
+  onTaskClick,
+  selectedTaskId,
+}: TimelineViewProps) {
+  const [mode, setMode] = useState<TimelineMode>('workers');
+
+  return (
+    <div className="flex h-full min-h-0 flex-col" data-testid="timeline-view">
+      <div className="border-b border-gray-800 bg-gray-900/40 px-4 py-3">
+        <div className="inline-flex overflow-hidden rounded-sm border border-border" role="group" aria-label="Timeline mode">
+          <button
+            type="button"
+            data-testid="timeline-mode-workers"
+            aria-pressed={mode === 'workers'}
+            onClick={() => setMode('workers')}
+            className={`px-3 py-1.5 text-sm ${mode === 'workers' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-secondary'}`}
+          >
+            Workers
+          </button>
+          <button
+            type="button"
+            data-testid="timeline-mode-tasks"
+            aria-pressed={mode === 'tasks'}
+            onClick={() => setMode('tasks')}
+            className={`px-3 py-1.5 text-sm ${mode === 'tasks' ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-secondary'}`}
+          >
+            Tasks
+          </button>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1">
+        {mode === 'workers' ? (
+          <WorkerActionTimelinePane
+            tasks={tasks}
+            workflows={workflows}
+            selectedTaskId={selectedTaskId}
+            selectedWorkflowId={selectedWorkflowId}
+            onTaskClick={onTaskClick}
+          />
+        ) : (
+          <TaskTimelinePane
+            tasks={tasks}
+            onTaskClick={onTaskClick}
+            selectedTaskId={selectedTaskId}
+          />
+        )}
       </div>
     </div>
   );

--- a/packages/ui/src/components/WorkerActionTimelinePane.tsx
+++ b/packages/ui/src/components/WorkerActionTimelinePane.tsx
@@ -1,0 +1,329 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { TaskState, WorkerActionSummary, WorkflowMeta } from '../types.js';
+import { useNow } from '../hooks/useNow.js';
+import { useWorkerTimelineActions } from '../hooks/useWorkerTimelineActions.js';
+import {
+  displayWorkerTaskId,
+  formatWorkerValue,
+  getWorkerDisplayCopy,
+  resolveWorkerActionTarget,
+  ACTIVE_WORKER_ACTION_STATUSES,
+} from '../lib/worker-display.js';
+import {
+  buildWorkerTimelineEventRows,
+  sortWorkerTimelineActions,
+  sortWorkerTimelineEventRows,
+  type WorkerTimelineEventKind,
+  type WorkerTimelineEventRow,
+} from '../lib/worker-timeline.js';
+
+interface WorkerActionTimelinePaneProps {
+  tasks: Map<string, TaskState>;
+  workflows: Map<string, WorkflowMeta>;
+  selectedTaskId: string | null;
+  selectedWorkflowId: string | null;
+  onTaskClick: (task: TaskState) => void;
+}
+
+const ACTION_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  hour: 'numeric',
+  minute: '2-digit',
+  second: '2-digit',
+});
+
+function resolveDefaultWorkflowId(
+  workflows: Map<string, WorkflowMeta>,
+  selectedWorkflowId: string | null,
+  selectedTaskId: string | null,
+  tasks: Map<string, TaskState>,
+): string | null {
+  if (selectedWorkflowId) return selectedWorkflowId;
+  const selectedTaskWorkflowId = selectedTaskId ? tasks.get(selectedTaskId)?.config.workflowId : undefined;
+  if (selectedTaskWorkflowId && workflows.has(selectedTaskWorkflowId)) return selectedTaskWorkflowId;
+  return [...workflows.values()]
+    .sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id))[0]?.id ?? null;
+}
+
+function resolveWorkerActionTaskId(action: WorkerActionSummary): string | null {
+  return action.taskId ?? (action.subjectType === 'task' ? action.subjectId : null);
+}
+
+function resolveWorkerActionTaskLabel(
+  action: WorkerActionSummary,
+  tasks: Map<string, TaskState>,
+  workflows: Map<string, WorkflowMeta>,
+): string {
+  const target = resolveWorkerActionTarget(action, tasks, workflows);
+  if (target.task?.description) return target.task.description;
+  const taskId = resolveWorkerActionTaskId(action);
+  return taskId ? displayWorkerTaskId(taskId) : target.taskTitle;
+}
+
+function matchesWorkerTimelineTaskSearch(
+  action: WorkerActionSummary,
+  taskSearch: string,
+  tasks: Map<string, TaskState>,
+  workflows: Map<string, WorkflowMeta>,
+): boolean {
+  const query = taskSearch.trim().toLocaleLowerCase();
+  if (query === '') return true;
+  return resolveWorkerActionTaskLabel(action, tasks, workflows).toLocaleLowerCase().includes(query);
+}
+
+function formatActionTimestamp(timestampMs: number): string {
+  return ACTION_TIME_FORMATTER.format(new Date(timestampMs));
+}
+
+function formatWorkerEventLabel(eventKind: WorkerTimelineEventKind): string {
+  return eventKind === 'launched' ? 'Launched' : 'Finished executing';
+}
+
+function describeWhy(action: WorkerActionSummary): { why: string | null; result: string | null } {
+  return {
+    why: action.reason ?? null,
+    result: action.summary ?? null,
+  };
+}
+
+export function WorkerActionTimelinePane({
+  tasks,
+  workflows,
+  selectedTaskId,
+  selectedWorkflowId,
+  onTaskClick,
+}: WorkerActionTimelinePaneProps) {
+  const defaultWorkflowId = useMemo(
+    () => resolveDefaultWorkflowId(workflows, selectedWorkflowId, selectedTaskId, tasks),
+    [selectedTaskId, selectedWorkflowId, tasks, workflows],
+  );
+  const [workflowOverrideId, setWorkflowOverrideId] = useState<string | null>(null);
+  const [workerFilter, setWorkerFilter] = useState<Set<string>>(() => new Set());
+  const [taskFilter, setTaskFilter] = useState('');
+
+  useEffect(() => {
+    if (workflowOverrideId && !workflows.has(workflowOverrideId)) {
+      setWorkflowOverrideId(null);
+    }
+  }, [workflowOverrideId, workflows]);
+
+  const workflowId = workflowOverrideId && workflows.has(workflowOverrideId)
+    ? workflowOverrideId
+    : defaultWorkflowId;
+
+  const { actions, loading, loadingMore, hasMore, loadMore } = useWorkerTimelineActions(workflowId);
+
+  useEffect(() => {
+    setWorkerFilter(new Set());
+    setTaskFilter('');
+  }, [workflowId]);
+
+  const sortedActions = useMemo(() => sortWorkerTimelineActions(actions), [actions]);
+  const workerKinds = useMemo(() => {
+    const seen = new Set<string>();
+    const values: string[] = [];
+    for (const action of sortedActions) {
+      if (seen.has(action.workerKind)) continue;
+      seen.add(action.workerKind);
+      values.push(action.workerKind);
+    }
+    return values.sort((a, b) => getWorkerDisplayCopy(a).name.localeCompare(getWorkerDisplayCopy(b).name));
+  }, [sortedActions]);
+
+  const filteredActions = useMemo(() => sortedActions.filter((action) => {
+    if (workerFilter.size > 0 && !workerFilter.has(action.workerKind)) return false;
+    return matchesWorkerTimelineTaskSearch(action, taskFilter, tasks, workflows);
+  }), [sortedActions, taskFilter, tasks, workflows, workerFilter]);
+
+  const now = useNow(
+    1000,
+    filteredActions.some((action) => ACTIVE_WORKER_ACTION_STATUSES.has(action.status)),
+  );
+
+  const timelineRows = useMemo(() => {
+    const rows: WorkerTimelineEventRow[] = [];
+    for (const action of filteredActions) {
+      const actionRows = buildWorkerTimelineEventRows(action, now);
+      if (!actionRows) {
+        console.warn('[worker-timeline] skipped action with invalid timestamp', {
+          id: action.id,
+          workerKind: action.workerKind,
+        });
+        continue;
+      }
+      rows.push(...actionRows);
+      if (action.completedAt && actionRows.length === 1) {
+        console.warn('[worker-timeline] skipped action with invalid timestamp', {
+          id: action.id,
+          workerKind: action.workerKind,
+        });
+      }
+    }
+    return sortWorkerTimelineEventRows(rows);
+  }, [filteredActions, now]);
+
+  const totalRowCount = useMemo(
+    () => sortedActions.reduce((count, action) => count + (buildWorkerTimelineEventRows(action, now)?.length ?? 0), 0),
+    [sortedActions, now],
+  );
+  const hasTaskFilter = taskFilter.trim() !== '';
+  const anyFilterActive = workflowOverrideId !== null || workerFilter.size > 0 || hasTaskFilter;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col" data-testid="worker-timeline-view">
+      <div className="space-y-3 border-b border-gray-800 bg-gray-900/40 p-3">
+        <div className="flex flex-wrap items-center gap-2">
+          {workflows.size > 1 ? (
+            <select
+              data-testid="worker-timeline-workflow-select"
+              aria-label="Workflow"
+              value={workflowId ?? ''}
+              onChange={(event) => setWorkflowOverrideId(event.target.value || null)}
+              className="min-w-0 rounded border border-border-strong bg-muted px-2 py-1 text-xs text-foreground focus:border-border-strong focus:outline-none"
+            >
+              {[...workflows.values()]
+                .sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id))
+                .map((workflow) => (
+                  <option key={workflow.id} value={workflow.id}>{workflow.name}</option>
+                ))}
+            </select>
+          ) : null}
+          <input
+            type="search"
+            data-testid="worker-timeline-task-search"
+            value={taskFilter}
+            onChange={(event) => setTaskFilter(event.target.value)}
+            placeholder="Search tasks"
+            className="flex-1 bg-gray-900 border border-gray-700 rounded px-2 py-1 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"
+            aria-label="Search tasks"
+          />
+          <span className="shrink-0 text-xs text-gray-500">{timelineRows.length} / {totalRowCount}</span>
+          {anyFilterActive ? (
+            <button
+              type="button"
+              onClick={() => {
+                setWorkflowOverrideId(null);
+                setWorkerFilter(new Set());
+                setTaskFilter('');
+              }}
+              className="shrink-0 text-xs text-gray-400 hover:text-gray-100"
+            >
+              Clear
+            </button>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap gap-1.5" aria-label="Filter by worker">
+          {workerKinds.map((workerKind) => {
+            const active = workerFilter.has(workerKind);
+            return (
+              <button
+                key={workerKind}
+                type="button"
+                data-testid={`worker-timeline-filter-${workerKind}`}
+                aria-pressed={active}
+                onClick={() => {
+                  setWorkerFilter((current) => {
+                    const next = new Set(current);
+                    if (next.has(workerKind)) next.delete(workerKind);
+                    else next.add(workerKind);
+                    return next;
+                  });
+                }}
+                className={`rounded px-2 py-1 text-xs ${active ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-secondary'}`}
+              >
+                {getWorkerDisplayCopy(workerKind).name}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {loading && sortedActions.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">Loading worker actions…</div>
+        ) : sortedActions.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            No worker actions recorded for this workflow yet.
+          </div>
+        ) : filteredActions.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            No worker actions match the current filters.
+          </div>
+        ) : timelineRows.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            No matching worker actions have valid timestamps.
+          </div>
+        ) : (
+          <>
+            <ol className="space-y-1.5 p-3" data-testid="worker-timeline-list">
+              {timelineRows.map((row) => {
+                const target = resolveWorkerActionTarget(row.action, tasks, workflows);
+                const taskId = resolveWorkerActionTaskId(row.action);
+                const taskLabel = resolveWorkerActionTaskLabel(row.action, tasks, workflows);
+                const taskWarning = !target.task && Boolean(taskId);
+                const interactive = Boolean(target.task);
+                const detail = describeWhy(row.action);
+                const worker = getWorkerDisplayCopy(row.action.workerKind);
+                const selected = target.task?.id === selectedTaskId;
+                return (
+                  <li
+                    key={`${row.action.id}-${row.eventKind}`}
+                    data-testid={`worker-timeline-row-${row.action.id}-${row.eventKind}`}
+                  >
+                    <button
+                      type="button"
+                      data-testid={`worker-timeline-action-${row.action.id}-${row.eventKind}`}
+                      disabled={!interactive}
+                      onClick={() => {
+                        if (target.task) onTaskClick(target.task);
+                      }}
+                      className={`w-full rounded px-3 py-2 text-left ${selected ? 'bg-secondary/60' : ''} ${interactive ? 'cursor-pointer hover:bg-secondary/40' : 'cursor-default opacity-90'}`}
+                      title={`${worker.name} · ${formatWorkerValue(row.action.actionType)} · ${taskLabel}`}
+                    >
+                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+                        <span className="font-medium text-foreground">{worker.name}</span>
+                        <span className="text-muted-foreground">{formatWorkerValue(row.action.actionType)}</span>
+                        <span className="text-muted-foreground">{formatWorkerEventLabel(row.eventKind)}</span>
+                        <span className="text-foreground">{taskLabel}</span>
+                        <span className="ml-auto text-xs text-muted-foreground">
+                          {formatActionTimestamp(row.timestampMs)}
+                        </span>
+                      </div>
+                      {detail.why ? (
+                        <div className="mt-1 text-xs text-muted-foreground">
+                          <span className="font-medium text-foreground/80">Why:</span>{' '}
+                          {detail.why}
+                        </div>
+                      ) : null}
+                      {detail.result ? (
+                        <div className="mt-1 text-xs text-muted-foreground">
+                          <span className="font-medium text-foreground/80">Result:</span>{' '}
+                          {detail.result}
+                        </div>
+                      ) : null}
+                      {taskWarning ? (
+                        <div className="mt-1 text-xs text-amber-300">Target task is not loaded.</div>
+                      ) : null}
+                    </button>
+                  </li>
+                );
+              })}
+            </ol>
+            {hasMore ? (
+              <div className="flex justify-center px-3 pb-3">
+                <button
+                  type="button"
+                  data-testid="worker-timeline-load-more"
+                  onClick={() => void loadMore()}
+                  disabled={loadingMore}
+                  className="rounded border border-border-strong bg-muted px-3 py-1.5 text-sm text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {loadingMore ? 'Loading…' : 'Load older worker actions'}
+                </button>
+              </div>
+            ) : null}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

This makes Timeline open on worker history as one plain chronological sequence.

The old worker view looked like grouped cards with timing rails.

Task filtering also depended on a picker instead of typing part of a task name.

The fix replaces grouped worker cards with per-event rows, swaps the picker for search, and keeps the old task bars under `Tasks`.

## Review Claim

This activation exposes worker history as a plain chronological launched-and-finished event sequence, with task search and inspector linking, while preserving the old task timeline in `Tasks`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice only changes the `Workers` presentation. It keeps the existing `Tasks` helpers unchanged, reuses the existing worker data source, and covers the new event-row ordering with targeted unit coverage.

## Slice Rationale

This activation turns on one user-facing worker history surface: chronological rows, launched-versus-finished events, task search, and click-through. The repro scripts and the real-app proof move to a separate proof slice so this diff reads as pure surface behavior.

## Non-goals

- No new backend API.
- No cross-workflow combined worker history.
- No removal of the existing task Gantt.
- No right-side timing bars in the worker surface.
- No repro scripts or Electron proof captures in this slice.

## Architecture

### Before

```mermaid
graph TD
    A["TimelineView Workers mode"] --> B["Grouped worker cards with timing rails"]
    A --> C["Task picker dropdown"]
```

### After

```mermaid
graph TD
    A["TimelineView Workers mode"] --> B["Chronological worker event rows"]
    A --> C["Task search input"]
    A --> D["Tasks mode keeps existing task bars"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/use-worker-timeline-actions.test.tsx src/__tests__/timeline-view.test.ts src/__tests__/timeline-view-e2e.test.tsx`

</details>

## Visual Proof

Workers mode now shows one plain chronological sequence with separate launch and finish rows for each completed action:

![Workers mode renders plain launched-and-finished worker rows](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260715-dc30e4/timeline-worker-events.png)

Clicking a finished worker row still selects the linked task in the inspector:

![Finished worker rows still drive the inspector selection](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260715-dc30e4/timeline-worker-events-selected.png)

Typing part of the task title narrows the worker rows immediately:

![Task search filters the worker rows by substring](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260715-dc30e4/timeline-worker-events-search.png)

Switching to `Tasks` still shows the existing task bars:

![Tasks mode still renders the preserved task timeline bars](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260715-dc30e4/timeline-worker-tasks-mode.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 57c84f21d`
- Post-revert steps: None.
- Data migration? No.

</details>
