### PR TITLE
[Worker Timeline](5) Finish worker timeline row styling

### DIFF
--- a/packages/ui/src/components/WorkerActionTimelinePane.tsx
+++ b/packages/ui/src/components/WorkerActionTimelinePane.tsx
@@ -268,6 +268,7 @@ export function WorkerActionTimelinePane({
                   <li
                     key={`${row.action.id}-${row.eventKind}`}
                     data-testid={`worker-timeline-row-${row.action.id}-${row.eventKind}`}
+                    className={`border rounded-md ${selected ? 'bg-indigo-900/60 border-indigo-600' : 'bg-gray-800 border-gray-800 hover:border-gray-600'} transition-colors ${interactive ? '' : 'opacity-90'}`}
                   >
                     <button
                       type="button"
@@ -276,7 +277,7 @@ export function WorkerActionTimelinePane({
                       onClick={() => {
                         if (target.task) onTaskClick(target.task);
                       }}
-                      className={`w-full rounded px-3 py-2 text-left ${selected ? 'bg-secondary/60' : ''} ${interactive ? 'cursor-pointer hover:bg-secondary/40' : 'cursor-default opacity-90'}`}
+                      className={`w-full bg-transparent px-3 py-2 text-left ${interactive ? 'cursor-pointer' : 'cursor-default'}`}
                       title={`${worker.name} · ${formatWorkerValue(row.action.actionType)} · ${taskLabel}`}
                     >
                       <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">


### PR DESCRIPTION
## Summary

This gives each worker event row the same bordered look as the History rows.

The worker rows still looked like pill buttons, which read as a different surface from History.

The fix reuses the History row treatment in the worker pane and keeps the current click and search behavior.

## Review Claim

This slice makes the Timeline worker rows look like the in-app History rows.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This keeps the current worker event source, ordering, task search, and task-mode bars. The only change is the worker row presentation.

## Slice Rationale

The row treatment is presentation-only and touches one component, so it stays apart from the slice that introduced the worker mode and from the proof slice above it.

## Non-goals

- No new production worker timeline source.
- No cross-workflow combined worker history.
- No removal of the existing task Gantt.
- No worker lane cards, duration rails, or percent spans.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/use-worker-timeline-actions.test.tsx src/__tests__/timeline-view.test.ts src/__tests__/timeline-view-e2e.test.tsx`
- [x] `pnpm --filter @invoker/ui build`

</details>

## Visual Proof

Workers mode now shows the bordered worker rows instead of pill buttons:

![Workers mode shows the bordered worker rows in the real app shell](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260715-dc30e4/timeline-worker-events.png)

Clicking a finished worker row still updates the inspector to the linked task:

![Finished worker row selection still updates the inspector](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260715-dc30e4/timeline-worker-events-selected.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert eb6eac410`
- Post-revert steps: None.
- Data migration? No.

</details>
