### PR TITLE
[Master E2E Green](1) Gate read-only WAL guard on a live owner

### DIFF
--- a/packages/data-store/src/__tests__/exclusive-locking.test.ts
+++ b/packages/data-store/src/__tests__/exclusive-locking.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
@@ -64,12 +64,14 @@ describe('SQLiteAdapter exclusiveLocking', () => {
     try {
       owner.saveWorkflow(wf);
       expect(existsSync(`${dbPath}-shm`)).toBe(true);
+      expect(existsSync(`${dbPath}.owner`)).toBe(true);
       await expect(
         SQLiteAdapter.create(dbPath, { readOnly: true }),
-      ).rejects.toThrow(/WAL sidecars exist/i);
+      ).rejects.toThrow(/writable owner PID \d+ holds live WAL sidecars/i);
     } finally {
       owner.close();
     }
+    expect(existsSync(`${dbPath}.owner`)).toBe(false);
   });
 
   it('read-only opens are still allowed after a clean close', async () => {
@@ -87,6 +89,47 @@ describe('SQLiteAdapter exclusiveLocking', () => {
       expect(reader.listWorkflows().map((w) => w.id)).toEqual(['wf-1']);
     } finally {
       reader.close();
+    }
+  });
+
+  it('allows a second read-only open after an earlier reader left sidecars behind', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    owner.saveWorkflow(wf);
+    owner.close();
+
+    // A read-only connection creates -wal/-shm and cannot checkpoint them away
+    // on close, so the sidecars outlive it with no owner behind them.
+    const first = await SQLiteAdapter.create(dbPath, { readOnly: true });
+    first.close();
+    expect(existsSync(`${dbPath}-wal`) || existsSync(`${dbPath}-shm`)).toBe(true);
+
+    const second = await SQLiteAdapter.create(dbPath, { readOnly: true });
+    try {
+      expect(second.listWorkflows().map((w) => w.id)).toEqual(['wf-1']);
+    } finally {
+      second.close();
+    }
+  });
+
+  it('ignores an owner marker left by a dead process', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    owner.saveWorkflow(wf);
+    owner.close();
+
+    const reader = await SQLiteAdapter.create(dbPath, { readOnly: true });
+    reader.close();
+    // PID 2^22 is above every configured pid_max, so it can never be alive.
+    writeFileSync(`${dbPath}.owner`, '4194304', 'utf-8');
+
+    const survivor = await SQLiteAdapter.create(dbPath, { readOnly: true });
+    try {
+      expect(survivor.listWorkflows().map((w) => w.id)).toEqual(['wf-1']);
+    } finally {
+      survivor.close();
     }
   });
 

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -18,6 +18,7 @@ import {
   renameSync,
   rmSync,
   statSync,
+  writeFileSync,
 } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
@@ -100,6 +101,57 @@ export interface OutputChunk {
 }
 
 const SQLITE_EPHEMERAL_DATABASE = ':memory:';
+
+function ownerMarkerPath(dbPath: string): string {
+  return `${dbPath}.owner`;
+}
+
+/**
+ * PID of the writable owner currently holding `dbPath`, or null when none is
+ * live. A marker left behind by a crashed owner reports null so a dead process
+ * can never lock readers out permanently.
+ */
+function readLiveOwnerPid(dbPath: string): number | null {
+  const marker = ownerMarkerPath(dbPath);
+  if (!existsSync(marker)) return null;
+  let pid: number;
+  try {
+    pid = Number.parseInt(readFileSync(marker, 'utf-8').trim(), 10);
+  } catch {
+    return null;
+  }
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  if (pid === process.pid) return pid;
+  try {
+    process.kill(pid, 0);
+    return pid;
+  } catch {
+    return null;
+  }
+}
+
+function writeOwnerMarker(dbPath: string): void {
+  try {
+    writeFileSync(ownerMarkerPath(dbPath), String(process.pid), 'utf-8');
+  } catch (err) {
+    console.warn(
+      `[SQLiteAdapter] Could not write owner marker for ${dbPath}: ${err instanceof Error ? err.message : String(err)}. ` +
+      'Read-only opens cannot detect this owner and will be allowed alongside it.',
+    );
+  }
+}
+
+function clearOwnerMarker(dbPath: string): void {
+  const marker = ownerMarkerPath(dbPath);
+  try {
+    if (existsSync(marker) && readLiveOwnerPid(dbPath) === process.pid) rmSync(marker, { force: true });
+  } catch (err) {
+    console.warn(
+      `[SQLiteAdapter] Could not clear owner marker for ${dbPath}: ${err instanceof Error ? err.message : String(err)}. ` +
+      'A stale marker is ignored once this PID exits.',
+    );
+  }
+}
 
 interface SQLiteAdapterOptions {
   readOnly?: boolean;
@@ -615,11 +667,19 @@ export class SQLiteAdapter implements PersistenceAdapter {
       );
     }
 
+    // Sidecar files alone cannot prove a writable owner is live: opening a
+    // WAL-mode database read-only creates -wal/-shm itself, and a read-only
+    // connection has no write access to checkpoint them away on close. Gating
+    // on mere existence therefore lets the first reader wedge every reader
+    // after it. Only a live owner may turn a reader away.
     if (isFile && options?.readOnly === true && (existsSync(`${dbPath}-wal`) || existsSync(`${dbPath}-shm`))) {
-      throw new Error(
-        `Cannot open SQLite database read-only while WAL sidecars exist for ${dbPath}. ` +
-        'Close the writable owner cleanly before opening a file-backed read-only adapter.',
-      );
+      const ownerPid = readLiveOwnerPid(dbPath);
+      if (ownerPid !== null) {
+        throw new Error(
+          `Cannot open SQLite database read-only while writable owner PID ${ownerPid} holds live WAL sidecars for ${dbPath}. ` +
+          'Close the writable owner cleanly before opening a file-backed read-only adapter.',
+        );
+      }
     }
 
     // Enforce owner-only writable initialization for file-backed databases
@@ -639,6 +699,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     try {
       const { DatabaseSync } = await loadNativeSqlite();
       const db = new DatabaseSync(dbPath, { readOnly: options?.readOnly === true });
+      if (isFile && requestWritable && options?.ownerCapability) writeOwnerMarker(dbPath);
       return new SQLiteAdapter(db, isFile ? dbPath : null, options);
     } catch (err) {
       if (!isFile || options?.readOnly === true || !existsSync(dbPath) || !isDatabaseCorruptionError(err)) {
@@ -2303,6 +2364,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
       this.checkpointWal('PASSIVE');
     }
     this.db.close();
+    if (this.dbPath && !this.readOnly) {
+      clearOwnerMarker(this.dbPath);
+    }
   }
 
   // ── Helpers ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Reading a task's status twice in a row used to fail the second time.

The first read succeeded. Every read after it returned nothing, for the life of that database file.

That broke all eight cases behind `e2e-proof` shard 0 on master, because every case reads status repeatedly.

The guard assumed the SQLite `-wal` and `-shm` files only exist while a writable owner is running. That assumption is wrong.

Opening a database read-only creates those files by itself. A read-only connection cannot clean them up when it closes.

So the first reader left files behind that locked out every later reader. The writable owner was never at fault; it already closes cleanly.

Now the writable owner records its process id in a `<db>.owner` file, and clears it on close. A reader is turned away only while that process is actually alive.

If the owner crashes, the leftover file names a dead process and is ignored. A crash can no longer wedge readers forever.

## Review Claim

Approve gating the read-only WAL guard on a live writable owner instead of on the mere existence of sidecar files.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

The guard still rejects a read-only open whenever a writable owner is live, which is the case it was written to protect. Only the unowned case is now allowed, and that case was already safe: SQLite WAL supports concurrent readers, and no owner exists to contend with. Liveness is proven by `process.kill(pid, 0)`, the same signal the existing `db-writer-lock` already trusts. A dead or unreadable marker fails closed to "no owner", which restores the pre-guard behavior rather than inventing a new one.

## Slice Rationale

This slice is the only one of the three that changes runtime behavior, and it is confined to `packages/data-store`. The Playwright and README slices touch CI config and docs, are independently landable, and share no code with this change. Bundling them would mix three review lanes and trip the diff-atomicity gate.

## Non-goals

- Does not change the writable owner's checkpoint or close path; that was already correct.
- Does not touch `packages/app`'s `db-writer-lock`, which keeps its own separate `<db>.lock` directory.
- Does not fix `case-2.15-recreate-preempt-attempt-refresh.sh`, a separate pre-existing failure this wedge was masking.
- Does not address the two runner-infrastructure failures on master (`sudo` password, missing `xvfb`).

## Architecture

The read-only open decision changes from a file-existence test to a liveness test.

### Before

```mermaid
graph TD
    A["read-only open requested"] --> B{"-wal or -shm exists?"}
    B -- "no" --> C["open succeeds"]
    B -- "yes" --> D["throw: WAL sidecars exist"]
    E["earlier reader created sidecars<br/>and could not discard them"] --> B
```

### After

```mermaid
graph TD
    A["read-only open requested"] --> B{"-wal or -shm exists?"}
    B -- "no" --> C["open succeeds"]
    B -- "yes" --> F{"live owner PID in db.owner?"}
    F -- "no live owner" --> C
    F -- "owner alive" --> D["throw: writable owner PID n holds live WAL"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/data-store && pnpm exec vitest run src/__tests__/exclusive-locking.test.ts` — 8 passed, including the new second-reader and dead-marker cases
- [ ] `cd packages/data-store && pnpm test` — 395 passed (19 files)
- [ ] `pnpm run check:types` — clean
- [ ] `bash scripts/e2e-dry-run/cases/case-2.11-edit-restart-downstream.sh` — exits 0, was exit 1
- [ ] `bash scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh` — 7 of 8 pass, was 0 of 8

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the stricter guard and re-wedges repeated read-only queries. A stray `<db>.owner` file is inert, because the old code never reads it.
- Data migration? No. The marker is an advisory sidecar next to the database and holds no schema or user data.

</details>
