### PR TITLE
[Worker Timeline](4) Add test-only worker seeding handler

### DIFF
--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -17,7 +17,7 @@ import type {
   WorkflowMutationAcceptedResult,
 } from '@invoker/contracts';
 import { ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
-import type { SQLiteAdapter } from '@invoker/data-store';
+import type { SQLiteAdapter, WorkerActionWrite } from '@invoker/data-store';
 import { Channels } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
 import {
@@ -1267,6 +1267,12 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       const seeded = seedMainProcessHitchFixture(persistence);
       orchestrator.syncAllFromDb();
       return seeded;
+    });
+    registerGuiMutationHandler('invoker:ingest-worker-actions', async (actionsArg: unknown) => {
+      const actions = actionsArg as WorkerActionWrite[];
+      for (const action of actions) {
+        persistence.upsertWorkerAction(action);
+      }
     });
     registerGuiMutationHandler('invoker:seed-stress-fixture', async (optionsArg: unknown) => {
       const options = optionsArg as StressFixtureOptions | undefined;


### PR DESCRIPTION
## Summary

This adds the test-only app hook that seeds worker timeline actions after the Electron app starts.

The app process owns the persistence writer, so nothing outside it can insert worker actions mid-run.

The fix adds one handler, active only under `NODE_ENV === 'test'`, that writes seeded worker actions through the normal owner.

## Review Claim

This slice exposes one test-only IPC handler that lets a test harness hand worker actions to the running app process.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This handler only registers when `NODE_ENV === 'test'`. It does not change production worker behavior, runtime wiring, or persisted app state outside a test run.

## Slice Rationale

The handler is the app-side half of the test-only channel named in the slice below it. Keeping the two apart leaves each one small enough to review on its own.

## Non-goals

- No production IPC surface.
- No worker timeline UI changes.
- No task graph or worker ordering changes.
- No proof captures or screenshot baselines.

## Architecture

### Before

```mermaid
graph TD
    A["Test harness"] -.->|"blocked by writer lock"| B["invoker.db"]
    C["App process"] --> B
```

### After

```mermaid
graph TD
    A["Test harness"] -->|"test-only IPC call"| C["App process"]
    C --> B["invoker.db"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert HEAD`
- Post-revert steps: None.
- Data migration? No.

</details>
