### PR TITLE
[Review Gate Worker Migration](1) Add review-gate repair proofs

### DIFF
--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -407,13 +407,25 @@ describe('auto-fix recovery candidate validation', () => {
 });
 
 describe('auto-fix recovery scan submission', () => {
-  it('submits a bare restart first, then escalates to fix-with-agent', async () => {
-    const harness = makeRecoveryPolicyHarness();
+  it('retries a failed task wakeup once before escalating to fix-with-agent', async () => {
+    const wakeup = {
+      eventKey: 'event-1',
+      eventKind: 'task.failed' as const,
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-1',
+      taskStateVersion: 4,
+      generation: 1,
+      attemptId: 'attempt-1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      reason: 'task_failure' as const,
+      authoritative: false as const,
+    };
+    const harness = makeRecoveryPolicyHarness(makeTask(), [], () => [wakeup]);
     const tick = createAutoFixRecoveryTick(harness.options);
 
     await tick({
       identity: { kind: 'recovery', instanceId: 'test' },
-      reason: 'startup',
+      reason: 'wake',
       tickNumber: 1,
     });
 
@@ -436,7 +448,7 @@ describe('auto-fix recovery scan submission', () => {
     harness.submit.mockClear();
     await tick({
       identity: { kind: 'recovery', instanceId: 'test' },
-      reason: 'startup',
+      reason: 'wake',
       tickNumber: 2,
     });
 

--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -14,7 +14,10 @@ import {
   ciFailureActionKey,
   createCiFailureTick,
 } from '../workers/ci-failure-worker.js';
-import { maybePublishReviewGateCiFailure } from '../task-runner-review-gate.js';
+import {
+  maybePublishReviewGateCiFailure,
+  pollMergeGateTask,
+} from '../task-runner-review-gate.js';
 import {
   DEFAULT_PR_STATUS_WORKER_INTERVAL_MS,
   createPrStatusWorker,
@@ -136,6 +139,43 @@ function makeHarness(task = makeTask()) {
   const attemptLedger = createAutoFixAttemptLedger();
   return { actions, store, submit, attemptLedger };
 }
+function makeMergeConflictPublisherHarness(
+  status: {
+    lifecycle: 'open' | 'closed' | 'merged';
+    rejected: boolean;
+    statusText: string;
+    url: string;
+    headSha?: string;
+    headRef?: string;
+    mergeState?: 'clean' | 'dirty' | 'unknown';
+    hasMergeConflict?: boolean;
+    checks?: { state: 'pending' | 'success' | 'failure'; failed: Array<{ name: string; conclusion: string; detailsUrl?: string }> };
+  },
+  task = makeTask(),
+) {
+  const publishCi = vi.fn();
+  const publishMergeConflict = vi.fn();
+  const host = {
+    cwd: '/repo',
+    logger,
+    executeTasks: vi.fn(),
+    persistence: {
+      updateTask: vi.fn(),
+    },
+    orchestrator: {
+      getTask: vi.fn(() => task),
+      recordTaskHeartbeat: vi.fn(),
+    },
+    mergeGateProvider: {
+      checkApproval: vi.fn(async () => status),
+    },
+    reviewGateCiFailurePublisher: { publish: publishCi },
+    reviewGateCiFailureInFlight: new Set<string>(),
+    reviewGateMergeConflictPublisher: { publish: publishMergeConflict },
+    reviewGateMergeConflictInFlight: new Set<string>(),
+  } as any;
+  return { host, publishCi, publishMergeConflict };
+}
 
 describe('PR status and CI failure workers', () => {
   afterEach(() => {
@@ -209,6 +249,81 @@ describe('PR status and CI failure workers', () => {
       intentId: '42',
       externalKey: ciFailureActionKey(event),
     });
+  });
+
+  it('publishes only the CI repair event for open reviews with failing checks', async () => {
+    const task = makeTask();
+    const { host, publishCi, publishMergeConflict } = makeMergeConflictPublisherHarness({
+      lifecycle: 'open',
+      rejected: false,
+      statusText: 'CI failed',
+      url: 'https://github.com/owner/repo/pull/123',
+      headSha: 'sha-1',
+      headRef: 'feature/ci',
+      checks: {
+        state: 'failure',
+        failed: [{ name: 'unit', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/1' }],
+      },
+      hasMergeConflict: false,
+      mergeState: 'clean',
+    }, task);
+
+    await pollMergeGateTask(host, task, 'refresh');
+
+    expect(publishCi).toHaveBeenCalledTimes(1);
+    expect(publishCi).toHaveBeenCalledWith(expect.objectContaining({
+      taskId: 'wf-1/merge',
+      workflowId: 'wf-1',
+      reviewId: '123',
+      failedChecks: [{ name: 'unit', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/1' }],
+    }));
+    expect(publishMergeConflict).not.toHaveBeenCalled();
+  });
+
+  it.fails('publishes only the merge-conflict repair event for actionable review conflicts', async () => {
+    const task = makeTask();
+    const { host, publishCi, publishMergeConflict } = makeMergeConflictPublisherHarness({
+      lifecycle: 'open',
+      rejected: false,
+      statusText: 'Merge conflict',
+      url: 'https://github.com/owner/repo/pull/123',
+      headSha: 'sha-1',
+      headRef: 'feature/ci',
+      mergeState: 'dirty',
+      hasMergeConflict: true,
+    }, task);
+
+    await pollMergeGateTask(host, task, 'refresh');
+
+    expect(publishCi).not.toHaveBeenCalled();
+    expect(publishMergeConflict).toHaveBeenCalledTimes(1);
+    expect(publishMergeConflict).toHaveBeenCalledWith(expect.objectContaining({
+      taskId: 'wf-1/merge',
+      workflowId: 'wf-1',
+      reviewId: '123',
+      status: 'review_ready',
+      taskStateVersion: 10,
+      statusText: 'Merge conflict',
+    }));
+  });
+
+  it('does not publish a merge-conflict repair for BEHIND review status', async () => {
+    const task = makeTask();
+    const { host, publishCi, publishMergeConflict } = makeMergeConflictPublisherHarness({
+      lifecycle: 'open',
+      rejected: false,
+      statusText: 'Branch is behind base',
+      url: 'https://github.com/owner/repo/pull/123',
+      headSha: 'sha-1',
+      headRef: 'feature/ci',
+      mergeState: 'dirty',
+      hasMergeConflict: false,
+    }, task);
+
+    await pollMergeGateTask(host, task, 'refresh');
+
+    expect(publishCi).not.toHaveBeenCalled();
+    expect(publishMergeConflict).not.toHaveBeenCalled();
   });
 
   it('queues CI repair while the in-memory retry budget allows it', async () => {

--- a/packages/execution-engine/src/__tests__/review-gate-merge-conflict-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/review-gate-merge-conflict-worker.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { WorkerActionRecord, WorkerActionWrite, WorkflowMutationIntent, WorkflowMutationPriority } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+import type { ReviewGateMergeConflictLifecycleEvent } from '../lifecycle-events.js';
+import {
+  REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
+  createReviewGateMergeConflictTick,
+  reviewGateMergeConflictActionKey,
+} from '../workers/review-gate-merge-conflict-worker.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id: 'wf-1/merge',
+    description: 'merge',
+    status: 'review_ready',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: 'wf-1', isMergeNode: true, ...(config ?? {}) },
+    execution: {
+      generation: 2,
+      selectedAttemptId: 'attempt-1',
+      branch: 'feature/conflict',
+      reviewGate: {
+        activeGeneration: 2,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [{
+          id: 'pr-123',
+          providerId: '123',
+          provider: 'github',
+          required: true,
+          status: 'open',
+          generation: 2,
+          headSha: 'sha-1',
+        }],
+      },
+      ...(execution ?? {}),
+    },
+    taskStateVersion: 10,
+    ...rest,
+  } as TaskState;
+}
+
+function makeEvent(overrides: Partial<ReviewGateMergeConflictLifecycleEvent> = {}): ReviewGateMergeConflictLifecycleEvent {
+  return {
+    eventKey: 'review_gate.merge_conflict|workflow:wf-1|task:wf-1/merge',
+    kind: 'review_gate.merge_conflict',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/merge',
+    status: 'review_ready',
+    taskStateVersion: 10,
+    generation: 2,
+    attemptId: 'attempt-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    reviewId: '123',
+    reviewUrl: 'https://github.com/owner/repo/pull/123',
+    headSha: 'sha-1',
+    headRef: 'feature/conflict',
+    branch: 'feature/conflict',
+    statusText: 'Merge conflict',
+    ...overrides,
+  };
+}
+
+function toRecord(write: WorkerActionWrite): WorkerActionRecord {
+  const now = '2026-01-01T00:00:00.000Z';
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? now,
+    updatedAt: write.updatedAt ?? now,
+  };
+}
+
+function makeHarness(task = makeTask(), existingIntents: WorkflowMutationIntent[] = []) {
+  const tasks = new Map<string, TaskState>([[task.id, task]]);
+  const actions = new Map<string, WorkerActionRecord>();
+  const intents = [...existingIntents];
+  const submit = vi.fn((workflowId: string, priority: WorkflowMutationPriority, channel: string, args: unknown[]) => {
+    expect(workflowId).toBe('wf-1');
+    expect(priority).toBe('high');
+    expect(channel).toBe('invoker:rebase-recreate');
+    expect(args).toEqual(['wf-1']);
+    return 42;
+  });
+  const store = {
+    loadTasks: vi.fn((workflowId: string) => workflowId === 'wf-1' ? Array.from(tasks.values()) : []),
+    loadTask: vi.fn((taskId: string) => tasks.get(taskId)),
+    listWorkflowMutationIntents: vi.fn((workflowId?: string, statuses?: string[]) => intents.filter((intent) => (
+      (!workflowId || intent.workflowId === workflowId)
+      && (!statuses || statuses.includes(intent.status))
+    ))),
+    getWorkerAction: vi.fn((workerKind: string, externalKey: string) => actions.get(`${workerKind}:${externalKey}`)),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+      const existing = actions.get(`${write.workerKind}:${write.externalKey}`);
+      const saved = toRecord({ ...write, id: existing?.id ?? write.id, createdAt: existing?.createdAt });
+      actions.set(`${write.workerKind}:${write.externalKey}`, saved);
+      return saved;
+    }),
+    logEvent: vi.fn(),
+  };
+  return { actions, store, submit };
+}
+
+describe('review-gate merge-conflict worker', () => {
+  it('queues one high-priority rebase-recreate intent for a valid event', async () => {
+    const event = makeEvent();
+    const harness = makeHarness();
+    const tick = createReviewGateMergeConflictTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      drainEvents: () => [event],
+    });
+
+    await tick({ identity: { kind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    expect(harness.actions.get(`${REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND}:${reviewGateMergeConflictActionKey(event)}`)).toMatchObject({
+      workerKind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
+      actionType: 'rebase-recreate-review-gate-conflict',
+      status: 'queued',
+      intentId: '42',
+      externalKey: reviewGateMergeConflictActionKey(event),
+    });
+  });
+
+  it('deduplicates duplicate event keys inside one drain', async () => {
+    const event = makeEvent();
+    const harness = makeHarness();
+    const tick = createReviewGateMergeConflictTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      drainEvents: () => [event, event],
+    });
+
+    await tick({ identity: { kind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('records an already-queued-intent skip when a recreate intent is already open', async () => {
+    const event = makeEvent();
+    const harness = makeHarness(makeTask(), [{
+      id: 73,
+      workflowId: 'wf-1',
+      priority: 'high',
+      channel: 'invoker:rebase-recreate',
+      args: ['wf-1'],
+      status: 'queued',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    }]);
+    const tick = createReviewGateMergeConflictTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      drainEvents: () => [event],
+    });
+
+    await tick({ identity: { kind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
+
+    expect(harness.submit).not.toHaveBeenCalled();
+    expect(harness.actions.get(`${REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND}:${reviewGateMergeConflictActionKey(event)}`)).toMatchObject({
+      status: 'queued',
+      intentId: '73',
+      payload: expect.objectContaining({
+        reason: 'already-queued-intent',
+        existingIntentIds: [73],
+      }),
+    });
+  });
+
+  it.each([
+    {
+      name: 'workflowId changed',
+      task: makeTask({ config: { workflowId: 'wf-2', isMergeNode: true } }),
+    },
+    {
+      name: 'reviewId changed',
+      task: makeTask({
+        execution: {
+          reviewGate: {
+            activeGeneration: 2,
+            completion: { required: 'all', status: 'approved' },
+            artifacts: [{
+              id: 'pr-456',
+              providerId: '456',
+              provider: 'github',
+              required: true,
+              status: 'open',
+              generation: 2,
+              headSha: 'sha-1',
+            }],
+          },
+        },
+      }),
+    },
+    {
+      name: 'generation changed',
+      task: makeTask({ execution: { generation: 3 } }),
+    },
+    {
+      name: 'selectedAttemptId changed',
+      task: makeTask({ execution: { selectedAttemptId: 'attempt-2' } }),
+    },
+    {
+      name: 'headSha changed',
+      task: makeTask({
+        execution: {
+          reviewGate: {
+            activeGeneration: 2,
+            completion: { required: 'all', status: 'approved' },
+            artifacts: [{
+              id: 'pr-123',
+              providerId: '123',
+              provider: 'github',
+              required: true,
+              status: 'open',
+              generation: 2,
+              headSha: 'sha-2',
+            }],
+          },
+        },
+      }),
+    },
+  ])('skips stale lineage when $name', async ({ task }) => {
+    const event = makeEvent();
+    const harness = makeHarness(task);
+    const tick = createReviewGateMergeConflictTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      drainEvents: () => [event],
+    });
+
+    await tick({ identity: { kind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
+
+    expect(harness.submit).not.toHaveBeenCalled();
+    expect(harness.store.upsertWorkerAction).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

This slice adds direct proof for the worker migration.

The new tests lock the expected repair flow in place before the plumbing changes land.

That gives the next slice a fixed target instead of a moving bug report.

## Review Claim

The worker migration now has focused proof coverage for its expected repair flow.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes only tests. Production code and runtime wiring stay untouched.

## Slice Rationale

Evidence comes first. The next slice can change worker plumbing against a fixed proof surface instead of bundling test design with behavior.

## Non-goals

- No owner worker wiring changes.
- No new CLI command.
- No shell worker removal.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/auto-fix-recovery.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/pr-ci-workers.test.ts src/__tests__/review-gate-merge-conflict-worker.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <proof-slice-sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
