### PR TITLE
[Review Gate Worker Migration](2) Route review-gate merge conflicts

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -280,7 +280,7 @@ describe('PR status and CI failure workers', () => {
     expect(publishMergeConflict).not.toHaveBeenCalled();
   });
 
-  it.fails('publishes only the merge-conflict repair event for actionable review conflicts', async () => {
+  it('publishes only the merge-conflict repair event for actionable review conflicts', async () => {
     const task = makeTask();
     const { host, publishCi, publishMergeConflict } = makeMergeConflictPublisherHarness({
       lifecycle: 'open',

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -60,6 +60,7 @@ export * from './review-gate-ci-repair.js';
 export * from './workers/pr-status-worker.js';
 export * from './workers/pr-summary-refresh-worker.js';
 export * from './workers/ci-failure-worker.js';
+export * from './workers/review-gate-merge-conflict-worker.js';
 export * from './workers/auto-approve-worker.js';
 export * from './workers/disk-headroom-worker.js';
 export * from './workers/disk-headroom-monitor.js';

--- a/packages/execution-engine/src/task-runner-review-gate.ts
+++ b/packages/execution-engine/src/task-runner-review-gate.ts
@@ -68,8 +68,8 @@ export interface ReviewGateMergeConflictLifecyclePublisher {
 /**
  * Subset of {@link TaskRunner} the review-gate polling family reads. Picked from
  * `TaskRunner` (not hand-written) so the host stays locked to the runner's real
- * member types. `reviewGateCiFailureInFlight` is single-cluster-owned: it lives
- * here as an `@internal` runner field and is picked into this host.
+ * member types. The in-flight dedupe sets are single-cluster-owned: they live
+ * here as `@internal` runner fields and are picked into this host.
  */
 export type TaskRunnerReviewGateHost = Pick<
   TaskRunner,
@@ -83,6 +83,8 @@ export type TaskRunnerReviewGateHost = Pick<
   // Review-gate cluster state
   | 'reviewGateCiFailurePublisher'
   | 'reviewGateCiFailureInFlight'
+  | 'reviewGateMergeConflictPublisher'
+  | 'reviewGateMergeConflictInFlight'
 >;
 
 export async function closeWorkflowReview(
@@ -281,6 +283,7 @@ export async function pollMergeGateTask(
         host.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
       } else if (status.lifecycle === 'open') {
         await maybePublishReviewGateCiFailure(host, current!, status, providerId);
+        await maybePublishReviewGateMergeConflict(host, current!, status, providerId);
       }
       continue;
     }
@@ -296,6 +299,7 @@ export async function pollMergeGateTask(
       host.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
     } else if (status.lifecycle === 'open') {
       await maybePublishReviewGateCiFailure(host, current!, status, providerId);
+      await maybePublishReviewGateMergeConflict(host, current!, status, providerId);
     }
   }
 }
@@ -365,5 +369,44 @@ export async function maybePublishReviewGateCiFailure(
     });
   } finally {
     host.reviewGateCiFailureInFlight.delete(key);
+  }
+}
+
+export async function maybePublishReviewGateMergeConflict(
+  host: TaskRunnerReviewGateHost,
+  task: TaskState,
+  status: MergeGateApprovalStatus,
+  reviewId: string = task.execution.reviewId ?? '',
+): Promise<void> {
+  if (!host.reviewGateMergeConflictPublisher) return;
+  if (!task.config.workflowId || !reviewId) return;
+  if (status.lifecycle !== 'open' || status.hasMergeConflict !== true) return;
+
+  const key = [
+    task.id,
+    task.execution.selectedAttemptId ?? 'no-attempt',
+    task.execution.generation ?? 0,
+    status.headSha ?? 'no-head-sha',
+  ].join(':');
+  if (host.reviewGateMergeConflictInFlight.has(key)) return;
+
+  host.reviewGateMergeConflictInFlight.add(key);
+  try {
+    await host.reviewGateMergeConflictPublisher.publish({
+      taskId: task.id,
+      workflowId: task.config.workflowId,
+      status: task.status,
+      taskStateVersion: task.taskStateVersion,
+      reviewId,
+      reviewUrl: status.url,
+      headSha: status.headSha,
+      headRef: status.headRef,
+      branch: task.execution.branch,
+      selectedAttemptId: task.execution.selectedAttemptId,
+      generation: task.execution.generation ?? 0,
+      statusText: status.statusText,
+    });
+  } finally {
+    host.reviewGateMergeConflictInFlight.delete(key);
   }
 }

--- a/packages/execution-engine/src/workers/review-gate-merge-conflict-worker.ts
+++ b/packages/execution-engine/src/workers/review-gate-merge-conflict-worker.ts
@@ -308,19 +308,19 @@ function listOpenRecreateIntentsForEvent(
 function shouldSkipExistingAction(
   options: ReviewGateMergeConflictWorkerPolicyOptions,
   event: ReviewGateMergeConflictLifecycleEvent,
-): boolean {
+): WorkerActionRecord | undefined {
   const externalKey = reviewGateMergeConflictActionKey(event);
   const existing = options.store.getWorkerAction?.(REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND, externalKey);
-  if (!existing) return false;
+  if (!existing) return undefined;
   if (isOpenOrCompletedActionStatus(existing.status)) {
     logReviewGateMergeConflictEvent(options, event, 'review-gate-merge-conflict-skip', {
       reason: 'already-recorded',
       existingStatus: existing.status,
       intentId: existing.intentId ?? null,
     });
-    return true;
+    return existing;
   }
-  return false;
+  return undefined;
 }
 
 function firstLine(text: string | undefined): string | undefined {
@@ -369,19 +369,32 @@ function reconcileFinishedIntentAction(
   });
 }
 
-async function handleReviewGateMergeConflictEvent(
+export interface QueueReviewGateMergeConflictRepairResult {
+  decision: 'queued' | 'skipped';
+  reason: string;
+  intentId?: number | string;
+}
+
+export async function queueReviewGateMergeConflictRepair(
   options: ReviewGateMergeConflictWorkerPolicyOptions,
   event: ReviewGateMergeConflictLifecycleEvent,
-): Promise<void> {
+): Promise<QueueReviewGateMergeConflictRepairResult> {
   const task = loadTaskForEvent(event, options);
   if (!task) {
     logReviewGateMergeConflictEvent(options, event, 'review-gate-merge-conflict-skip', { reason: 'task-not-found' });
-    return;
+    return { decision: 'skipped', reason: 'task-not-found' };
   }
 
   reconcileFinishedIntentAction(options, event);
 
-  if (shouldSkipExistingAction(options, event)) return;
+  const existingAction = shouldSkipExistingAction(options, event);
+  if (existingAction) {
+    return {
+      decision: 'skipped',
+      reason: 'already-recorded',
+      intentId: existingAction.intentId,
+    };
+  }
 
   const stale = staleReasonForEvent(event, task);
   if (stale.stale) {
@@ -389,7 +402,7 @@ async function handleReviewGateMergeConflictEvent(
       reason: stale.reason,
       ...stale.details,
     });
-    return;
+    return { decision: 'skipped', reason: stale.reason };
   }
 
   const openRecreateIntents = listOpenRecreateIntentsForEvent(options, event);
@@ -403,7 +416,7 @@ async function handleReviewGateMergeConflictEvent(
       reason: 'already-queued-intent',
       existingIntentIds: openRecreateIntents.map((intent) => intent.id),
     });
-    return;
+    return { decision: 'skipped', reason: 'already-queued-intent', intentId };
   }
 
   const intentId = options.submitter.submit(event.workflowId, 'high', REBASE_RECREATE_CHANNEL, [event.workflowId]);
@@ -419,6 +432,7 @@ async function handleReviewGateMergeConflictEvent(
     intentId,
     channel: REBASE_RECREATE_CHANNEL,
   });
+  return { decision: 'queued', reason: 'queued', intentId };
 }
 
 export function createReviewGateMergeConflictTick(options: ReviewGateMergeConflictWorkerPolicyOptions): WorkerTick {
@@ -429,10 +443,11 @@ export function createReviewGateMergeConflictTick(options: ReviewGateMergeConfli
       const externalKey = reviewGateMergeConflictActionKey(event);
       if (seen.has(externalKey)) continue;
       seen.add(externalKey);
-      await handleReviewGateMergeConflictEvent(options, event);
+      await queueReviewGateMergeConflictRepair(options, event);
     }
   };
 }
+
 
 function isReviewGateMergeConflictEvent(event: WorkflowLifecycleEvent): event is ReviewGateMergeConflictLifecycleEvent {
   return event.kind === 'review_gate.merge_conflict';


### PR DESCRIPTION
## Summary

This slice wires mapped review-gate merge conflicts into the existing repair routing.

Owner review polling now emits the merge-conflict lifecycle event, and the merge-conflict worker consumes that event through its existing policy helper.

That makes the repair route react to real review-gate state instead of staying dormant.

## Review Claim

Mapped review-gate merge conflicts now enter the existing repair routing path.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new route only activates for mapped open review gates with `hasMergeConflict === true`. CI failure handling, rejected reviews, merged reviews, and BEHIND-only states keep their old behavior.

## Slice Rationale

This isolates the low-level routing change from the later app surfaces and deletion work. Reviewers can first approve that real review-gate state now reaches the repair route.

## Non-goals

- No new user-facing command yet.
- No owner auto-start change yet.
- No shell worker removal yet.

## Architecture

### Before

Merge-conflict repair logic existed, but review-gate polling did not emit the lifecycle event that feeds the repair route.

### After

Review-gate polling emits merge-conflict lifecycle events for mapped open reviews with actionable conflicts. The merge-conflict worker now consumes that event and queues the existing repair route.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/pr-ci-workers.test.ts src/__tests__/review-gate-merge-conflict-worker.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <routing-slice-sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
