### PR TITLE
[Review Gate Worker Migration](4) Add merge-conflict repair command

### DIFF
--- a/packages/app/src/__tests__/headless-repair-review-gate-merge-conflict.test.ts
+++ b/packages/app/src/__tests__/headless-repair-review-gate-merge-conflict.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CommandService, Orchestrator } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { MessageBus } from '@invoker/transport';
+import { LocalBus } from '@invoker/transport';
+
+import type { HeadlessDeps } from '../headless.js';
+import { runHeadless } from '../headless.js';
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn(function () { return noopLogger; }),
+};
+
+describe('headless repair-review-gate-merge-conflict', () => {
+  let mockDeps: HeadlessDeps;
+  let stdoutWrites: string[];
+  let repairReviewGateMergeConflictMock = vi.fn(async () => ({
+    status: 'queued' as const,
+    reason: 'queued',
+    message: 'Queued merge-conflict repair for PR 123 on wf-1/merge.',
+    prNumber: '123',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/merge',
+  }));
+
+  beforeEach(() => {
+    stdoutWrites = [];
+    repairReviewGateMergeConflictMock = vi.fn(async () => ({
+      status: 'queued' as const,
+      reason: 'queued',
+      message: 'Queued merge-conflict repair for PR 123 on wf-1/merge.',
+      prNumber: '123',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+    }));
+    mockDeps = {
+      logger: noopLogger,
+      orchestrator: {} as unknown as Orchestrator,
+      persistence: {} as unknown as SQLiteAdapter,
+      commandService: {} as unknown as CommandService,
+      executorRegistry: {} as unknown as HeadlessDeps['executorRegistry'],
+      messageBus: new LocalBus() as MessageBus,
+      repoRoot: '/fake/repo',
+      invokerConfig: {} as HeadlessDeps['invokerConfig'],
+      initServices: vi.fn(async () => {}),
+      repairReviewGateMergeConflict: repairReviewGateMergeConflictMock,
+    } as HeadlessDeps;
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      stdoutWrites.push(String(chunk));
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('delegates to the repair callback and prints its message', async () => {
+    await runHeadless(['repair-review-gate-merge-conflict', '123'], mockDeps);
+
+    expect(repairReviewGateMergeConflictMock).toHaveBeenCalledWith('123');
+    expect(stdoutWrites[0]).toBe('Queued merge-conflict repair for PR 123 on wf-1/merge.\n');
+  });
+
+  it('requires a PR argument', async () => {
+    await expect(runHeadless(['repair-review-gate-merge-conflict'], mockDeps)).rejects.toThrow(/repair-review-gate-merge-conflict/);
+  });
+});

--- a/packages/app/src/__tests__/review-gate-merge-conflict-command.test.ts
+++ b/packages/app/src/__tests__/review-gate-merge-conflict-command.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ReviewGateLookup } from '@invoker/data-store';
+import type { MergeGateApprovalStatus } from '@invoker/execution-engine';
+import type { TaskState } from '@invoker/workflow-core';
+
+import { repairReviewGateMergeConflictByPr } from '../review-gate-merge-conflict-command.js';
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+function makeLookup(overrides: Partial<ReviewGateLookup> = {}): ReviewGateLookup {
+  return {
+    workflowId: 'wf-1',
+    mergeTaskId: 'wf-1/merge',
+    reviewId: '123',
+    reviewUrl: 'https://github.com/owner/repo/pull/123',
+    branch: 'feature/conflict',
+    baseBranch: 'master',
+    workflowStatus: 'running',
+    workflowGeneration: 2,
+    mergeTaskStatus: 'review_ready',
+    selectedAttemptId: 'attempt-1',
+    ...overrides,
+  };
+}
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id: 'wf-1/merge',
+    description: 'merge',
+    status: 'review_ready',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: 'wf-1', isMergeNode: true, ...(config ?? {}) },
+    execution: {
+      generation: 2,
+      selectedAttemptId: 'attempt-1',
+      branch: 'feature/conflict',
+      reviewGate: {
+        activeGeneration: 2,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [{
+          id: 'pr-123',
+          providerId: '123',
+          provider: 'github',
+          required: true,
+          status: 'open',
+          generation: 2,
+          headSha: 'sha-1',
+        }],
+      },
+      ...(execution ?? {}),
+    },
+    taskStateVersion: 10,
+    ...rest,
+  } as TaskState;
+}
+
+function makeCheckStatus(overrides: Partial<MergeGateApprovalStatus> = {}): MergeGateApprovalStatus {
+  return {
+    lifecycle: 'open',
+    rejected: false,
+    statusText: 'Merge conflict',
+    url: 'https://github.com/owner/repo/pull/123',
+    headSha: 'sha-1',
+    headRef: 'feature/conflict',
+    mergeState: 'dirty',
+    hasMergeConflict: true,
+    ...overrides,
+  };
+}
+
+describe('repairReviewGateMergeConflictByPr', () => {
+  it('returns unmapped when the PR has no local workflow', async () => {
+    const checkApproval = vi.fn();
+    const result = await repairReviewGateMergeConflictByPr('123', {
+      persistence: {
+        findReviewGateByPr: () => undefined,
+        loadTask: () => undefined,
+      },
+      repoRoot: '/repo',
+      policy: {
+        store: { loadTasks: () => [] },
+        submitter: { submit: vi.fn(() => 42) },
+        logger,
+      },
+      mergeGateProvider: { checkApproval },
+    });
+
+    expect(result).toMatchObject({ status: 'unmapped', reason: 'no-local-workflow', prNumber: '123' });
+    expect(checkApproval).not.toHaveBeenCalled();
+  });
+
+  it('returns unmapped when the merge task is missing', async () => {
+    const checkApproval = vi.fn();
+    const result = await repairReviewGateMergeConflictByPr('123', {
+      persistence: {
+        findReviewGateByPr: () => makeLookup(),
+        loadTask: () => undefined,
+      },
+      repoRoot: '/repo',
+      policy: {
+        store: { loadTasks: () => [] },
+        submitter: { submit: vi.fn(() => 42) },
+        logger,
+      },
+      mergeGateProvider: { checkApproval },
+    });
+
+    expect(result).toMatchObject({ status: 'unmapped', reason: 'merge-task-missing', prNumber: '123' });
+    expect(checkApproval).not.toHaveBeenCalled();
+  });
+
+  it('queues a merge-conflict repair when the mapped PR is conflicted', async () => {
+    const submit = vi.fn(() => 42);
+    const checkApproval = vi.fn(async () => makeCheckStatus());
+    const result = await repairReviewGateMergeConflictByPr('123', {
+      persistence: {
+        findReviewGateByPr: () => makeLookup(),
+        loadTask: () => makeTask(),
+      },
+      repoRoot: '/repo',
+      policy: {
+        store: {
+          loadTasks: () => [makeTask()],
+          loadTask: () => makeTask(),
+          listWorkflowMutationIntents: () => [],
+          getWorkerAction: () => undefined,
+        },
+        submitter: { submit },
+        logger,
+      },
+      mergeGateProvider: { checkApproval },
+      now: () => '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(checkApproval).toHaveBeenCalledWith({ identifier: '123', cwd: '/repo' });
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      status: 'queued',
+      reason: 'queued',
+      prNumber: '123',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+    });
+  });
+
+  it('skips mapped PRs whose status is not an actionable merge conflict', async () => {
+    const submit = vi.fn(() => 42);
+    const result = await repairReviewGateMergeConflictByPr('123', {
+      persistence: {
+        findReviewGateByPr: () => makeLookup(),
+        loadTask: () => makeTask(),
+      },
+      repoRoot: '/repo',
+      policy: {
+        store: {
+          loadTasks: () => [makeTask()],
+          loadTask: () => makeTask(),
+          listWorkflowMutationIntents: () => [],
+          getWorkerAction: () => undefined,
+        },
+        submitter: { submit },
+        logger,
+      },
+      mergeGateProvider: {
+        checkApproval: async () => makeCheckStatus({
+          hasMergeConflict: false,
+          statusText: 'Branch is behind base',
+        }),
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: 'skipped',
+      reason: 'review status is Branch is behind base',
+      prNumber: '123',
+    });
+    expect(result.message).toContain('Branch is behind base');
+    expect(submit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -45,6 +45,7 @@ export const HEADLESS_COMMANDS = [
   { name: 'rebase-retry', kind: 'write' },
   { name: 'rebase-recreate', kind: 'write' },
   { name: 'repair-review-gate-ci', kind: 'write' },
+  { name: 'repair-review-gate-merge-conflict', kind: 'write' },
   { name: 'fix', kind: 'write' },
   { name: 'resolve-conflict', kind: 'write' },
   { name: 'approve', kind: 'write' },

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -365,6 +365,21 @@ export async function headlessRepairReviewGateCi(prArg: string | undefined, deps
   const result = await deps.repairReviewGateCi(prArg);
   process.stdout.write(`${result.message}\n`);
 }
+export async function headlessRepairReviewGateMergeConflict(
+  prArg: string | undefined,
+  deps: HeadlessDeps,
+): Promise<void> {
+  if (!prArg) {
+    throw new Error(
+      'Missing PR argument. Usage: --headless repair-review-gate-merge-conflict <prNumber|prUrl>',
+    );
+  }
+  if (!deps.repairReviewGateMergeConflict) {
+    throw new Error('Review-gate merge-conflict repair is unavailable in this process.');
+  }
+  const result = await deps.repairReviewGateMergeConflict(prArg);
+  process.stdout.write(`${result.message}\n`);
+}
 
 export async function headlessFix(rawArgs: string[], deps: HeadlessDeps): Promise<void> {
   const parsed = parseHeadlessFixArgs(rawArgs);

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -35,6 +35,7 @@ import type { WorkflowCancelResult } from './workflow-preemption.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import type { RuntimeServices } from '@invoker/runtime-service';
 import type { ReviewGateCiRepairCommandResult } from './review-gate-ci-repair-command.js';
+import type { ReviewGateMergeConflictRepairCommandResult } from './review-gate-merge-conflict-command.js';
 
 
 export interface HeadlessDeps {
@@ -61,6 +62,7 @@ export interface HeadlessDeps {
   getBundledSkillsStatus?: () => BundledSkillsStatus;
   installBundledSkills?: (mode?: BundledSkillsInstallMode) => BundledSkillsStatus;
   repairReviewGateCi?: (prArg: string) => Promise<ReviewGateCiRepairCommandResult>;
+  repairReviewGateMergeConflict?: (prArg: string) => Promise<ReviewGateMergeConflictRepairCommandResult>;
   /** Abort signal from the workflow mutation coordinator, if running inside a coordinated mutation. */
   signal?: AbortSignal;
   mutationTiming?: WorkflowMutationTiming;

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -88,6 +88,7 @@ import {
   headlessRebaseRetry,
   headlessRebaseRecreate,
   headlessRepairReviewGateCi,
+  headlessRepairReviewGateMergeConflict,
   headlessFix,
   headlessResolveConflict,
 } from './headless-run-resume.js';
@@ -310,6 +311,9 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       break;
     case 'repair-review-gate-ci':
       await headlessRepairReviewGateCi(args[1], deps);
+      break;
+    case 'repair-review-gate-merge-conflict':
+      await headlessRepairReviewGateMergeConflict(args[1], deps);
       break;
     case 'fix':
       await headlessFix(args, deps);
@@ -550,6 +554,7 @@ ${BOLD}Execute:${RESET}
   rebase-retry <workflowId|mergeTaskId|taskId>        Refresh pool base, then retry incomplete work
   rebase-recreate <workflowId|mergeTaskId|taskId>     Refresh pool base, then recreate workflow
   repair-review-gate-ci <prNumber|prUrl>              Queue CI repair for one mapped review-gate PR
+  repair-review-gate-merge-conflict <prNumber|prUrl>  Queue merge-conflict repair for one mapped review-gate PR
   fix <taskId> [claude|codex]                         Fix a failed task (default: claude)
 
 ${BOLD}Respond:${RESET}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -145,6 +145,7 @@ import {
   type HeadlessDeps,
 } from './headless.js';
 import { parseReviewGatePrNumber, repairReviewGateCiByPr } from './review-gate-ci-repair-command.js';
+import { repairReviewGateMergeConflictByPr } from './review-gate-merge-conflict-command.js';
 import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
 import {
   startStandaloneLaunchDispatcher,
@@ -1049,6 +1050,15 @@ function startHeadlessMode(): void {
             attemptLedger: autoFixAttemptLedger,
           },
         }),
+        repairReviewGateMergeConflict: (prArg: string) => repairReviewGateMergeConflictByPr(prArg, {
+          persistence,
+          repoRoot,
+          policy: {
+            store: persistence,
+            submitter: { submit: submitRegisteredOwnerWorkerMutation },
+            logger,
+          },
+        }),
         runtimeServices,
         appRootDir: __dirname,
       } as HeadlessDeps;
@@ -1449,6 +1459,7 @@ function startHeadlessMode(): void {
             case 'resolve-conflict':
               return { workflowId: standaloneWorkflowIdForTaskArg(arg0), priority: 'normal' };
             case 'repair-review-gate-ci':
+            case 'repair-review-gate-merge-conflict':
               return { workflowId: standaloneWorkflowIdForReviewGatePrArg(arg0), priority: 'normal' };
             default:
               return { priority: 'normal' };

--- a/packages/app/src/review-gate-merge-conflict-command.ts
+++ b/packages/app/src/review-gate-merge-conflict-command.ts
@@ -1,0 +1,122 @@
+import type { SQLiteAdapter } from '@invoker/data-store';
+import {
+  GitHubMergeGateProvider,
+  queueReviewGateMergeConflictRepair,
+  type ReviewGateMergeConflictWorkerPolicyOptions,
+} from '@invoker/execution-engine';
+
+import { parseReviewGatePrNumber } from './review-gate-ci-repair-command.js';
+
+export interface ReviewGateMergeConflictRepairCommandResult {
+  status: 'queued' | 'skipped' | 'unmapped';
+  reason: string;
+  message: string;
+  prNumber: string;
+  workflowId?: string;
+  taskId?: string;
+}
+
+export interface ReviewGateMergeConflictRepairCommandDeps {
+  persistence: Pick<SQLiteAdapter, 'findReviewGateByPr' | 'loadTask'>;
+  repoRoot: string;
+  policy: ReviewGateMergeConflictWorkerPolicyOptions;
+  mergeGateProvider?: Pick<GitHubMergeGateProvider, 'checkApproval'>;
+  now?: () => string;
+}
+
+export async function repairReviewGateMergeConflictByPr(
+  prArg: string,
+  deps: ReviewGateMergeConflictRepairCommandDeps,
+): Promise<ReviewGateMergeConflictRepairCommandResult> {
+  const prNumber = parseReviewGatePrNumber(prArg);
+  if (!prNumber) {
+    throw new Error(`Could not parse a PR number from "${prArg}".`);
+  }
+
+  const lookup = deps.persistence.findReviewGateByPr(prNumber);
+  if (!lookup) {
+    return {
+      status: 'unmapped',
+      reason: 'no-local-workflow',
+      message: `No Invoker workflow found for PR ${prNumber}.`,
+      prNumber,
+    };
+  }
+
+  const mergeTask = deps.persistence.loadTask(lookup.mergeTaskId);
+  if (!mergeTask) {
+    return {
+      status: 'unmapped',
+      reason: 'merge-task-missing',
+      message: `PR ${prNumber} maps to workflow ${lookup.workflowId}, but merge task ${lookup.mergeTaskId} is missing.`,
+      prNumber,
+      workflowId: lookup.workflowId,
+      taskId: lookup.mergeTaskId,
+    };
+  }
+
+  const provider = deps.mergeGateProvider ?? new GitHubMergeGateProvider();
+  const reviewId = lookup.reviewId?.trim() || prNumber;
+  const status = await provider.checkApproval({ identifier: reviewId, cwd: deps.repoRoot });
+  if (status.lifecycle !== 'open') {
+    const reason = `review is ${status.lifecycle} (${status.statusText})`;
+    return {
+      status: 'skipped',
+      reason,
+      message: `PR ${prNumber} ${reason}; no merge-conflict repair queued.`,
+      prNumber,
+      workflowId: lookup.workflowId,
+      taskId: mergeTask.id,
+    };
+  }
+  if (status.hasMergeConflict !== true) {
+    const reason = `review status is ${status.statusText}`;
+    return {
+      status: 'skipped',
+      reason,
+      message: `PR ${prNumber} has no actionable merge conflict (${status.statusText}).`,
+      prNumber,
+      workflowId: lookup.workflowId,
+      taskId: mergeTask.id,
+    };
+  }
+
+  const createdAt = deps.now?.() ?? new Date().toISOString();
+  const generation = mergeTask.execution.generation ?? lookup.workflowGeneration ?? 0;
+  const attemptId = mergeTask.execution.selectedAttemptId ?? lookup.selectedAttemptId;
+  const result = await queueReviewGateMergeConflictRepair(deps.policy, {
+    eventKey: `review_gate.merge_conflict|workflow:${lookup.workflowId}|task:${mergeTask.id}|scan:${prNumber}`,
+    kind: 'review_gate.merge_conflict',
+    workflowId: lookup.workflowId,
+    taskId: mergeTask.id,
+    status: mergeTask.status,
+    taskStateVersion: mergeTask.taskStateVersion,
+    generation,
+    attemptId,
+    createdAt,
+    reviewId,
+    reviewUrl: status.url,
+    headSha: status.headSha,
+    headRef: status.headRef,
+    branch: mergeTask.execution.branch ?? lookup.branch,
+    statusText: status.statusText,
+  });
+
+  return result.decision === 'queued'
+    ? {
+      status: 'queued',
+      reason: result.reason,
+      message: `Queued merge-conflict repair for PR ${prNumber} on ${mergeTask.id}.`,
+      prNumber,
+      workflowId: lookup.workflowId,
+      taskId: mergeTask.id,
+    }
+    : {
+      status: 'skipped',
+      reason: result.reason,
+      message: `Skipped PR ${prNumber}: ${result.reason}.`,
+      prNumber,
+      workflowId: lookup.workflowId,
+      taskId: mergeTask.id,
+    };
+}


### PR DESCRIPTION
## Summary

This slice wires the manual headless command into the mapped merge-conflict repair path.

Operators can now run `repair-review-gate-merge-conflict <prNumber|prUrl>` and the headless stack resolves the mapped workflow, checks the live review state, and queues the existing repair path.

That gives the live owner repair flow a matching manual route for backfills and one-off retries.

## Review Claim

The headless command stack now routes mapped merge-conflict repair requests into the existing repair path.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The command still requires a mapped workflow, an open review, and `hasMergeConflict === true` before it queues anything.

## Slice Rationale

This keeps the manual command routing separate from the owner wakeup slice and from the later cleanup deletion.

## Non-goals

- No shell worker removal yet.
- No new repair algorithm.
- No change to CodeRabbit maintenance.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/review-gate-merge-conflict-command.test.ts src/__tests__/headless-repair-review-gate-merge-conflict.test.ts`

</details>

## Visual Proof

The headless help surface now lists `repair-review-gate-merge-conflict`, and the command prints the queued repair message for a mapped PR.

![Headless help and queued repair output for merge-conflict repair](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-7a26e8/review-gate-merge-conflict-after.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <command-slice-sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
