### PR TITLE
fix(app): stop start-ready from superseding live execution leases

### DIFF
--- a/packages/app/src/__tests__/start-ready.test.ts
+++ b/packages/app/src/__tests__/start-ready.test.ts
@@ -21,11 +21,12 @@ function makeTask(
   } as TaskState;
 }
 
-function harness(initialTasks: TaskState[], readyTasks: TaskState[]) {
+function harness(initialTasks: TaskState[], readyTasks: TaskState[], activeTaskIds: string[] = []) {
   let tasks = [...initialTasks];
   const orchestrator = {
     syncAllFromDb: vi.fn(() => undefined),
     getAllTasks: vi.fn(() => tasks),
+    getPersistedActiveTaskIds: vi.fn(() => new Set(activeTaskIds)),
     getExecutableReadyTasks: vi.fn(() => readyTasks),
     prepareTaskForNewAttempt: vi.fn((taskId: string) => {
       tasks = tasks.map((task) => task.id === taskId
@@ -93,6 +94,21 @@ describe('start-ready', () => {
     expect(orchestrator.prepareTaskForNewAttempt).toHaveBeenCalledWith('wf-1/recoverable', 'start_ready_recovery');
     expect(orchestrator.startExecution).toHaveBeenCalledTimes(1);
     expect(result.started.map((task) => task.id)).toEqual(['wf-1/ready']);
+  });
+
+  it('leaves actively executing tasks alone instead of superseding their attempts', () => {
+    const ready = makeTask('wf-1/ready', 'pending');
+    const live = makeTask('wf-1/live', 'running', {
+      execution: { selectedAttemptId: 'attempt-live' },
+    });
+    const orphaned = makeTask('wf-1/orphaned', 'running');
+    const orchestrator = harness([ready, live, orphaned], [ready], ['wf-1/live']);
+
+    const result = runStartReady(orchestrator);
+
+    expect(orchestrator.prepareTaskForNewAttempt).not.toHaveBeenCalledWith('wf-1/live', 'start_ready_recovery');
+    expect(orchestrator.prepareTaskForNewAttempt).toHaveBeenCalledWith('wf-1/orphaned', 'start_ready_recovery');
+    expect(result.preview.recoverableTaskIds).toEqual(['wf-1/orphaned']);
   });
 
   it('recreates failed workflows only when requested', () => {

--- a/packages/app/src/start-ready.ts
+++ b/packages/app/src/start-ready.ts
@@ -9,11 +9,19 @@ type StartReadyOrchestrator = Pick<
   Orchestrator,
   | 'syncAllFromDb'
   | 'getAllTasks'
+  | 'getPersistedActiveTaskIds'
   | 'getExecutableReadyTasks'
   | 'prepareTaskForNewAttempt'
   | 'recreateWorkflow'
   | 'startExecution'
 >;
+
+function collectRecoverableTasks(orchestrator: StartReadyOrchestrator): TaskState[] {
+  const activeTaskIds = orchestrator.getPersistedActiveTaskIds();
+  return orchestrator
+    .getAllTasks()
+    .filter((task) => !activeTaskIds.has(task.id) && isTaskRecoverableOnExplicitResume(task));
+}
 
 export function isTaskRecoverableOnExplicitResume(task: TaskState): boolean {
   if (task.status === 'running') return true;
@@ -59,7 +67,7 @@ function uniqueTasks(tasks: readonly TaskState[]): TaskState[] {
 export function collectStartReadyPreview(orchestrator: StartReadyOrchestrator): StartReadyPreview {
   const tasks = orchestrator.getAllTasks();
   const readyTasks = orchestrator.getExecutableReadyTasks();
-  const recoverableTasks = tasks.filter(isTaskRecoverableOnExplicitResume);
+  const recoverableTasks = collectRecoverableTasks(orchestrator);
   const failedTasks = tasks.filter((task) => task.status === 'failed');
 
   return {
@@ -99,7 +107,7 @@ export function runStartReady(
     }
   }
 
-  const recoverableTasks = orchestrator.getAllTasks().filter(isTaskRecoverableOnExplicitResume);
+  const recoverableTasks = collectRecoverableTasks(orchestrator);
   for (const task of recoverableTasks) {
     orchestrator.prepareTaskForNewAttempt(task.id, 'start_ready_recovery');
   }


### PR DESCRIPTION
## Summary

`start-ready` could kill work that was still running.

It treated every task whose status was `running` as something to recover, so it superseded that task's live attempt and relaunched it from scratch.

Nothing had to go wrong for this to fire. The background `workflow-resume-worker` sends `invoker:start-ready` on a timer, so live work could die with no user action.

The recovery sweep now leaves any task holding an active execution lease alone.

Tasks orphaned by a crash are still recovered. On boot they get stamped as crash-preserved, and a crash-preserved task never counts as active, so recovery still reaches it.

CodeRabbit reported this on #4348 as Critical. It was never fixed.

## Review Claim

`runStartReady` must leave the attempt of a lease-active task untouched, while still recovering orphaned ones.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Recovery candidates are narrowed, never widened, so this cannot supersede more work than before.

The exclusion source is `orchestrator.getPersistedActiveTaskIds()`, which already existed and is the same lease predicate execution itself relies on. No new liveness rule is introduced here.

Crash orphans are provably unaffected. `preserveCrashedInFlightTasks` stamps `crashPreservedAt` on boot, and `isTaskExecutionActive` reports a crash-preserved execution as inactive, so orphans stay outside the active set and recovery still reaches them.

## Slice Rationale

The fix and its focused regression proof are one claim and ship together.

The standalone repro under `scripts/repro/**` is held back because it belongs to the proof review unit, which cannot ride along with product files in one PR.

## Non-goals

Does not change `isTaskRecoverableOnExplicitResume`, so which statuses count as recoverable is untouched.

Does not change lease semantics, crash preservation, or `getPersistedActiveTaskIds`.

Does not change the `workflow-resume-worker` timer that drives `start-ready`.

## Architecture

### Before

```mermaid
graph TD
    A["runStartReady()"] --> B["getAllTasks()"]
    B --> C["isTaskRecoverableOnExplicitResume"]
    C --> D["status === 'running' counts as recoverable"]
    D --> E["prepareTaskForNewAttempt(task.id)"]
    E --> F["live attempt superseded, running work dies"]
```

### After

```mermaid
graph TD
    A["runStartReady()"] --> B["collectRecoverableTasks()"]
    B --> C["getPersistedActiveTaskIds()"]
    B --> D["getAllTasks()"]
    C --> E["not lease-active AND isTaskRecoverableOnExplicitResume"]
    D --> E
    E --> F["lease-active task: left running"]
    E --> G["orphaned task: prepareTaskForNewAttempt(task.id)"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test src/__tests__/start-ready.test.ts`
- [ ] `cd packages/app && pnpm test`
- [ ] `node scripts/lint-pr-diff-atomicity.mjs --base origin/master`

Ran locally. The new case `leaves actively executing tasks alone instead of superseding their attempts` fails on master, where `prepareTaskForNewAttempt` fires twice and catches the lease-active task, and passes with this change.

Full `packages/app` run: 1559 passed. The one failure, `focus-switch-main-process-cost.test.ts`, is a timing-sensitive perf assertion that fails identically on clean master and is unrelated to this change.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the earlier behavior, where `start-ready` supersedes live attempts.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented start-ready recovery from superseding tasks that are already actively running.
  * Improved recovery previews and processing by excluding active tasks while continuing to recover eligible orphaned tasks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->