### PR TITLE
[PR maintenance workers Step 6: Add local headless query workers support](2) Serve query workers without an invoker.db

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -75,6 +78,33 @@ describe('headless-client', () => {
     expect(ensureStandaloneOwner).not.toHaveBeenCalled();
     expect(refreshMessageBus).toHaveBeenCalled();
     expect(runElectronHeadless).not.toHaveBeenCalled();
+  });
+
+  it('serves query workers locally without booting Electron or delegating to an owner', async () => {
+    const previousDbDir = process.env.INVOKER_DB_DIR;
+    const homeRoot = mkdtempSync(join(tmpdir(), 'invoker-query-workers-'));
+    process.env.INVOKER_DB_DIR = homeRoot;
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const runElectronHeadless = vi.fn(async () => 23);
+    try {
+      const exitCode = await runHeadlessClientCommand(['query', 'workers', '--output', 'json'], {
+        messageBus: new LocalBus(),
+        ensureStandaloneOwner: vi.fn(async () => {}),
+        refreshMessageBus: vi.fn(async () => new LocalBus()),
+        runElectronHeadless,
+      });
+
+      const output = stdout.mock.calls.map(([chunk]) => String(chunk)).join('');
+      const parsed = JSON.parse(output) as { workers?: Array<{ kind?: string }> };
+      expect(exitCode).toBe(0);
+      expect(runElectronHeadless).not.toHaveBeenCalled();
+      expect(parsed.workers?.some((worker) => worker.kind === 'autofix')).toBe(true);
+    } finally {
+      stdout.mockRestore();
+      if (previousDbDir === undefined) delete process.env.INVOKER_DB_DIR;
+      else process.env.INVOKER_DB_DIR = previousDbDir;
+      rmSync(homeRoot, { recursive: true, force: true });
+    }
   });
 
   it('falls back to direct execution for generic standalone reads when no owner exists', async () => {

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -1,10 +1,15 @@
 import { spawn } from 'node:child_process';
-import { resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 
-import { resolveRepoRoot } from '@invoker/contracts';
+import { resolveRepoRoot, type WorkerStatusSnapshot } from '@invoker/contracts';
 import { hasLiveWritableOwner } from '@invoker/data-store';
 import { IpcBus } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
+import {
+  createWorkerRegistry,
+  registerBuiltinWorkers,
+  type WorkerRuntimeDependencies,
+} from '@invoker/execution-engine';
 
 import { resolveInvokerHomeRoot } from './delete-all-snapshot.js';
 import { isHeadlessMutatingCommand } from './headless-command-classification.js';
@@ -22,13 +27,16 @@ import {
   spawnDetachedStandaloneOwner,
   tryAcquireOwnerBootstrapLock,
 } from './headless-owner-bootstrap.js';
-import { loadConfig } from './config.js';
+import { loadConfig, type InvokerConfig } from './config.js';
+import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 import {
   discoverOwner,
   isStandaloneCapable,
 } from './owner-endpoint.js';
 import { createOwnerResolver, type ResolvedOwner } from './owner-resolver.js';
+import { AUTO_STARTED_OWNER_WORKER_KINDS, createLocalWorkerStatusSnapshot } from './worker-control.js';
 import { resolveWorkerControlMutation } from './worker-control-delegation.js';
+import { openMainProcessDatabase } from './viewer-db-boundary.js';
 
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
@@ -160,7 +168,7 @@ function isGenericDelegatableReadCommand(args: string[]): boolean {
   const command = args[0];
   if (command === 'query') {
     const sub = args[1];
-    return sub !== undefined && sub !== 'queue' && sub !== 'ui-perf' && sub !== 'action-graph';
+    return sub !== undefined && sub !== 'workers' && sub !== 'queue' && sub !== 'ui-perf' && sub !== 'action-graph';
   }
   return command !== undefined && GENERIC_DELEGATABLE_READ_COMMANDS.has(command);
 }
@@ -340,6 +348,65 @@ async function delegateReadOnlyQuery(
   return true;
 }
 
+function isLocalWorkersQuery(args: string[]): boolean {
+  return args[0] === 'query' && args[1] === 'workers';
+}
+
+function readOutputFormat(args: string[]): string | undefined {
+  const outputIndex = args.indexOf('--output');
+  if (outputIndex < 0) return undefined;
+  return args[outputIndex + 1];
+}
+
+function writeWorkerSnapshot(snapshot: WorkerStatusSnapshot, args: string[]): void {
+  const output = readOutputFormat(args);
+  if (output === 'label') {
+    process.stdout.write(`${snapshot.workers.map((worker) => worker.kind).join('\n')}\n`);
+    return;
+  }
+  if (output === 'jsonl') {
+    process.stdout.write(`${JSON.stringify(snapshot)}\n`);
+    return;
+  }
+  if (output === 'json') {
+    process.stdout.write(`${JSON.stringify(snapshot)}\n`);
+    return;
+  }
+
+  process.stdout.write(`Workers\n`);
+  process.stdout.write(`  generatedAt: ${snapshot.generatedAt}\n`);
+  process.stdout.write(`  count: ${snapshot.workers.length}\n`);
+  for (const worker of snapshot.workers) {
+    const source = worker.source ? ` · ${worker.source}` : '';
+    process.stdout.write(`  - ${worker.kind}: ${worker.lifecycle} · ${worker.policy}${source}\n`);
+  }
+}
+
+async function runLocalWorkersQuery(args: string[], invokerConfig: InvokerConfig): Promise<number> {
+  const dbPath = join(resolveInvokerHomeRoot(), 'invoker.db');
+  const persistence = await openMainProcessDatabase({
+    dbPath,
+    detachedViewer: false,
+    readOnly: true,
+    exclusiveLocking: false,
+  });
+  try {
+    const registry = registerExternalWorkersFromConfig(
+      invokerConfig.externalWorkers,
+      registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
+    );
+    const snapshot = createLocalWorkerStatusSnapshot({
+      registry,
+      persistence,
+      autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+    });
+    writeWorkerSnapshot(snapshot, args);
+    return 0;
+  } finally {
+    persistence.close();
+  }
+}
+
 export interface HeadlessClientDeps {
   messageBus: MessageBus;
   ensureStandaloneOwner: (bus?: MessageBus) => Promise<void>;
@@ -483,7 +550,7 @@ export async function runHeadlessClientCommand(
 ): Promise<number> {
   // Validate config before any delegation path so malformed JSON fails fast
   // even for commands that do not boot the full Electron owner process.
-  loadConfig();
+  const invokerConfig = loadConfig();
 
   const { args, waitForApproval, noTrack } = parseArgs(argv);
   const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1';
@@ -509,6 +576,10 @@ export async function runHeadlessClientCommand(
       const exitCode = process.exitCode;
       return typeof exitCode === 'number' ? exitCode : 0;
     }
+  }
+
+  if (!internalOwnerServe && isLocalWorkersQuery(args)) {
+    return runLocalWorkersQuery(args, invokerConfig);
   }
 
   if (!shouldUseSharedMutationOwner(args, standaloneMode, internalOwnerServe)) {


### PR DESCRIPTION
## Summary

Serve `query workers` locally when no `invoker.db` exists.

The headless client now answers that one read without booting Electron or waiting for an owner.

This keeps worker inspection usable on fresh or ownerless machines.

All other query delegation stays as it was.

## Review Claim

Route `query workers` through the local headless client so it works without Electron or `invoker.db`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This only special-cases `query workers`. All other read routing and worker snapshot contents stay unchanged.

## Slice Rationale

The ownerless local-read fallback is easier to review after the command surface already exists.

## Non-goals

- No new delegated-owner query behavior.
- No worker startup or policy changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && node_modules/.bin/vitest run src/__tests__/headless-client.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a062a63b5b5a5bc75fc1552b0f9461a27fc5a65f`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local execution for the `query workers` command.
  * Worker status can now be displayed in label, JSON, JSONL, or human-readable formats.
  * Local worker queries include built-in and configured external workers.

* **Bug Fixes**
  * Prevented worker queries from being routed through remote or shared execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->