### PR TITLE
[Godfile app step 3: extract gui-mutation-handlers](5) Route exec acknowledgement through helpers

### DIFF
--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -115,14 +115,100 @@ import {
   recoveryWorkerEventType,
 } from '../recovery-worker-observability.js';
 
-interface HeadlessRunMutationPayload {
+export interface HeadlessRunMutationPayload {
   planPath: string;
   traceId?: string;
 }
 
-interface HeadlessResumeMutationPayload {
+export interface HeadlessResumeMutationPayload {
   workflowId: string;
   traceId?: string;
+}
+
+export type HeadlessOwnerMode = 'standalone' | 'gui';
+
+interface HeadlessExecMutationCoordinator {
+  submit: (
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: string,
+    args: unknown[],
+    options?: { deferDrain?: boolean },
+  ) => number;
+}
+
+export interface HeadlessExecMutationContext {
+  logger: Logger;
+  ownerId: string;
+  getWorkflowMutationCoordinator: () => HeadlessExecMutationCoordinator | null;
+  workflowExists: (workflowId: string) => boolean;
+}
+
+function headlessExecLogFields(
+  payload: HeadlessExecMutationPayload,
+  mode: HeadlessOwnerMode,
+  coordinatorAvailable: boolean,
+  extra: Record<string, string | number | undefined> = {},
+): string {
+  const fields: Record<string, string | number | undefined> = {
+    trace: payload.traceId ?? '<none>',
+    args: `"${payload.args.join(' ')}"`,
+    noTrack: payload.noTrack ? 'true' : 'false',
+    ...extra,
+    coordinator: coordinatorAvailable ? 'true' : 'false',
+    mode,
+  };
+  return Object.entries(fields)
+    .map(([key, value]) => `${key}=${value ?? '<none>'}`)
+    .join(' ');
+}
+
+export function logHeadlessExecReceived(
+  payload: HeadlessExecMutationPayload,
+  mode: HeadlessOwnerMode,
+  context: HeadlessExecMutationContext,
+): void {
+  context.logger.info(
+    `headless.exec received ${headlessExecLogFields(payload, mode, Boolean(context.getWorkflowMutationCoordinator()), { ownerId: context.ownerId })}`,
+    { module: 'ipc-delegate' },
+  );
+}
+
+export function acknowledgeNoTrackHeadlessExec(
+  payload: HeadlessExecMutationPayload,
+  workflowId: string | undefined,
+  priority: WorkflowMutationPriority,
+  mode: HeadlessOwnerMode,
+  context: HeadlessExecMutationContext,
+): WorkflowMutationAcceptedResult | undefined {
+  const workflowMutationCoordinator = context.getWorkflowMutationCoordinator();
+  context.logger.info(
+    `headless.exec decision ${headlessExecLogFields(payload, mode, Boolean(workflowMutationCoordinator), { workflow: `"${workflowId ?? '<none>'}"`, priority })}`,
+    { module: 'ipc-delegate' },
+  );
+
+  if (!payload.noTrack) return undefined;
+
+  if (workflowId && workflowMutationCoordinator) {
+    const result = submitWorkflowMutationOrAcknowledgeDeleted(workflowId, priority, 'headless.exec', [payload], {
+      coordinator: workflowMutationCoordinator,
+      workflowExists: context.workflowExists,
+      logger: context.logger,
+      deferDrain: true,
+    });
+    context.logger.info(
+      `headless.exec accepted ${headlessExecLogFields(payload, mode, Boolean(workflowMutationCoordinator), { workflow: `"${workflowId}"`, intent: result.intentId, priority })}`,
+      { module: 'ipc-delegate' },
+    );
+    return result;
+  }
+
+  const reason = !workflowId ? 'workflow-not-resolved' : 'coordinator-unavailable';
+  context.logger.error(
+    `headless.exec rejected ${headlessExecLogFields(payload, mode, Boolean(workflowMutationCoordinator), { reason, workflow: `"${workflowId ?? '<none>'}"` })}`,
+    { module: 'ipc-delegate' },
+  );
+  throw new Error(`Fire-and-forget headless.exec could not be queued: ${reason}`);
 }
 
 type RendererTaskFeed = ReturnType<typeof createRendererTaskFeed>;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -64,7 +64,6 @@ import type {
   Logger,
   StartReadyRequest,
   StartReadyResult,
-  WorkflowMutationAcceptedResult,
 } from '@invoker/contracts';
 import { ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
 import type { SQLiteAdapter } from '@invoker/data-store';
@@ -177,7 +176,6 @@ import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.j
 import { CoalescedWorkflowMetadataPublisher } from './workflow-metadata-invalidation.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
-import { submitWorkflowMutationOrAcknowledgeDeleted } from './workflow-mutation-submit.js';
 import type { WorkflowMutationContext } from './persisted-workflow-mutation-coordinator.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
 import {
@@ -218,11 +216,8 @@ import {
   type GuiMutationRegistrationContext,
   type WorkflowScopedGuiMutationRegistrationContext,
 } from './ipc/ipc-registration.js';
-import {
-  createGuiMutationTaskActions,
-  registerGuiMutationIpcHandlers,
-  type GuiMutationTaskActions,
-} from './ipc/gui-mutation-handlers.js';
+import { acknowledgeNoTrackHeadlessExec, createGuiMutationTaskActions, logHeadlessExecReceived, registerGuiMutationIpcHandlers } from './ipc/gui-mutation-handlers.js';
+import type { GuiMutationTaskActions, HeadlessExecMutationContext, HeadlessRunMutationPayload, HeadlessResumeMutationPayload } from './ipc/gui-mutation-handlers.js';
 import { createTaskDeltaStreamSequence } from './task-delta-stream-sequence.js';
 import {
   createTerminalUiPerfCounters,
@@ -449,82 +444,16 @@ let writerLock: DbWriterLockResult | null = null;
 const workflowMutationOwnerId = `owner-${process.pid}-${Date.now()}`;
 const appProcessStartedAt = Date.now();
 
-interface HeadlessRunMutationPayload {
-  planPath: string;
-  traceId?: string;
-}
-
-interface HeadlessResumeMutationPayload {
-  workflowId: string;
-  traceId?: string;
-}
-
-type HeadlessOwnerMode = 'standalone' | 'gui';
-function headlessExecLogFields(
-  payload: HeadlessExecMutationPayload,
-  mode: HeadlessOwnerMode,
-  extra: Record<string, string | number | undefined> = {},
-): string {
-  const fields: Record<string, string | number | undefined> = {
-    trace: payload.traceId ?? '<none>',
-    args: `"${payload.args.join(' ')}"`,
-    noTrack: payload.noTrack ? 'true' : 'false',
-    ...extra,
-    coordinator: workflowMutationCoordinator ? 'true' : 'false',
-    mode,
-  };
-  return Object.entries(fields)
-    .map(([key, value]) => `${key}=${value ?? '<none>'}`)
-    .join(' ');
-}
-
-function logHeadlessExecReceived(payload: HeadlessExecMutationPayload, mode: HeadlessOwnerMode): void {
-  logger.info(
-    `headless.exec received ${headlessExecLogFields(payload, mode, { ownerId: workflowMutationOwnerId })}`,
-    { module: 'ipc-delegate' },
-  );
-}
-
-function acknowledgeNoTrackHeadlessExec(
-  payload: HeadlessExecMutationPayload,
-  workflowId: string | undefined,
-  priority: WorkflowMutationPriority,
-  mode: HeadlessOwnerMode,
-): WorkflowMutationAcceptedResult | undefined {
-  logger.info(
-    `headless.exec decision ${headlessExecLogFields(payload, mode, { workflow: `"${workflowId ?? '<none>'}"`, priority })}`,
-    { module: 'ipc-delegate' },
-  );
-
-  if (!payload.noTrack) return undefined;
-
-  if (workflowId && workflowMutationCoordinator) {
-    const result = submitWorkflowMutationOrAcknowledgeDeleted(workflowId, priority, 'headless.exec', [payload], {
-      coordinator: workflowMutationCoordinator,
-      workflowExists: (id) => Boolean(persistence.loadWorkflow(id)),
-      logger,
-      deferDrain: true,
-    });
-    logger.info(
-      `headless.exec accepted ${headlessExecLogFields(payload, mode, { workflow: `"${workflowId}"`, intent: result.intentId, priority })}`,
-      { module: 'ipc-delegate' },
-    );
-    return result;
-  }
-
-  const reason = !workflowId ? 'workflow-not-resolved' : 'coordinator-unavailable';
-  logger.error(
-    `headless.exec rejected ${headlessExecLogFields(payload, mode, { reason, workflow: `"${workflowId ?? '<none>'}"` })}`,
-    { module: 'ipc-delegate' },
-  );
-  throw new Error(`Fire-and-forget headless.exec could not be queued: ${reason}`);
-}
-
 let logger: Logger = new FileAndDbLogger({ module: 'main' });
 let guiInstanceLock: GuiInstanceLock | null = null;
 const buildSha = typeof __BUILD_SHA__ !== 'undefined' ? __BUILD_SHA__ : 'dev';
 const buildVersion = typeof __BUILD_VERSION__ !== 'undefined' ? __BUILD_VERSION__ : 'dev';
 logger.info(`Invoker ${buildVersion} (${buildSha})`, { module: 'startup' });
+
+const headlessExecMutationContext: HeadlessExecMutationContext = {
+  get logger() { return logger; }, ownerId: workflowMutationOwnerId,
+  getWorkflowMutationCoordinator: () => workflowMutationCoordinator, workflowExists: (id) => Boolean(persistence.loadWorkflow(id)),
+};
 
 process.on('uncaughtException', (err) => {
   logProcessError('uncaughtException', err, { logger, fallbackConsole: console });
@@ -1660,9 +1589,9 @@ function startHeadlessMode(): void {
             noTrack: delegatedNoTrack,
             traceId,
           };
-          logHeadlessExecReceived(payload, 'standalone');
+          logHeadlessExecReceived(payload, 'standalone', headlessExecMutationContext);
           const { workflowId, priority } = classifyStandaloneHeadlessExecMutation(payload);
-          const acknowledgement = acknowledgeNoTrackHeadlessExec(payload, workflowId, priority, 'standalone');
+          const acknowledgement = acknowledgeNoTrackHeadlessExec(payload, workflowId, priority, 'standalone', headlessExecMutationContext);
           if (acknowledgement) return acknowledgement;
           await runStandaloneWorkflowMutation(workflowId, priority, 'headless.exec', [payload], async () => {
             await runHeadless(args, {
@@ -2644,9 +2573,9 @@ function createEmbeddedTerminalBackendFromConfig(
           noTrack: delegatedNoTrack,
           traceId,
         };
-        logHeadlessExecReceived(payload, 'gui');
+        logHeadlessExecReceived(payload, 'gui', headlessExecMutationContext);
         const { workflowId, priority } = mutationActions.classifyHeadlessExecMutation(payload);
-        const acknowledgement = acknowledgeNoTrackHeadlessExec(payload, workflowId, priority, 'gui');
+        const acknowledgement = acknowledgeNoTrackHeadlessExec(payload, workflowId, priority, 'gui', headlessExecMutationContext);
         if (acknowledgement) return acknowledgement;
         return mutationActions.runWorkflowMutation(
           workflowId,


### PR DESCRIPTION
## Summary

`main.ts` now calls the shared exec logging and no-track acknowledgement helpers from the handler module.

The owner request path keeps the same workflow id, priority, and mutation submission behavior.

`main.ts` delegates to the helper module for those helper bodies.

## Review Claim

Route owner exec acknowledgement through the exported helper functions, behavior unchanged.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

Only call sites change. The same payload, mode, workflow id, and priority flow into the same acknowledgement logic from the parent slice.

## Slice Rationale

This is the call-site slice after the helper export slice. Keeping `main.ts` replacement separate keeps the owner request path reviewable.

## Non-goals

- No behavior changes.
- No IPC channel changes.
- No changes to the helper module introduced by the parent slice.
- Behavior unchanged.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/gui-mutation-translation.test.ts src/__tests__/ipc-registration.test.ts src/__tests__/no-manual-dispatch.test.ts src/__tests__/workflow-mutation-submit.test.ts`

</details>

## Visual Proof

![App shell renders after the main-process request-path refactor](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-9fddd3/neutral-chrome-home-graph.png)

The after-state capture shows the app shell, workflow graph, and task inspector rendering after the main-process request-path refactor.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0d3fc1264`
- Post-revert steps: None
- Data migration? No

</details>
