### PR TITLE
Add a master switch to turn all workers on and off

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -2139,6 +2139,31 @@ test.describe('Visual proof capture', () => {
 
 
 
+  test('global worker switch turns all workers off and back on', async ({ page }) => {
+    await loadPlan(page, TEST_PLAN);
+    await selectGraphMenuItem(page, 'rail-queue');
+    await expectQueueViewVisible(page);
+
+    const toggle = page.getByTestId('worker-global-switch');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+    await expect(toggle).toHaveText('Turn workers off');
+    await expect(page.getByTestId('worker-process-list')).toContainText('Running');
+    await captureScreenshot(page, 'worker-global-switch-step-1-on');
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+    await expect(toggle).toHaveText('Turn workers on');
+    await expect(page.getByTestId('worker-process-list')).not.toContainText('Running');
+    await expect(page.getByTestId('worker-start-stop-pr-status')).toBeDisabled();
+    await captureScreenshot(page, 'worker-global-switch-step-2-off');
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+    await expect(page.getByTestId('worker-process-list')).toContainText('Running');
+    await captureScreenshot(page, 'worker-global-switch-step-3-back-on');
+  });
+
   test('queue view concurrency display', async ({ page }) => {
     await loadPlan(page, TEST_PLAN);
     const now = new Date();

--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -2139,6 +2139,28 @@ test.describe('Visual proof capture', () => {
 
 
 
+  test('global worker switch turns all workers off and back on from the Workers surface', async ({ page }) => {
+    await loadPlan(page, TEST_PLAN);
+    await page.getByTestId('sidebar-workers').click();
+    await expect(page.getByTestId('worker-processes-section')).toBeVisible();
+
+    const toggle = page.getByTestId('worker-global-switch');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+    await expect(page.getByTestId('worker-process-list')).toContainText('Running');
+    await captureScreenshot(page, 'workers-surface-switch-step-1-on');
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+    await expect(page.getByTestId('worker-process-list')).not.toContainText('Running');
+    await captureScreenshot(page, 'workers-surface-switch-step-2-off');
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+    await expect(page.getByTestId('worker-process-list')).toContainText('Running');
+    await captureScreenshot(page, 'workers-surface-switch-step-3-back-on');
+  });
+
   test('global worker switch turns all workers off and back on', async ({ page }) => {
     await loadPlan(page, TEST_PLAN);
     await selectGraphMenuItem(page, 'rail-queue');

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -53,9 +53,15 @@ function runtime(kind: string): TestWorkerRuntime {
   };
 }
 
-function persistence(initialDesired: Record<string, boolean> = {}) {
+function persistence(initialDesired: Record<string, boolean> = {}, initialGlobalEnabled = true) {
   const desired = new Map(Object.entries(initialDesired));
+  let globalEnabled = initialGlobalEnabled;
   return {
+    getWorkersGloballyEnabled: vi.fn(() => globalEnabled),
+    setWorkersGloballyEnabled: vi.fn((enabled: boolean) => {
+      globalEnabled = enabled;
+      return { enabled, updatedAt: '2026-01-01T00:00:00.000Z' };
+    }),
     listWorkerActions: vi.fn(() => []),
     listWorkflows: vi.fn(() => []),
     loadTasks: vi.fn(() => []),
@@ -95,10 +101,11 @@ function deps(): WorkerRuntimeDependencies {
 function controller(
   autoStartKinds: readonly string[] = AUTO_STARTED_OWNER_WORKER_KINDS,
   desiredState: Record<string, boolean> = {},
+  globalEnabled = true,
 ) {
   const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
   const runtimes = new Map<string, TestWorkerRuntime[]>();
-  const store = persistence(desiredState);
+  const store = persistence(desiredState, globalEnabled);
   const register = (kind: string, note: string, runtimeKind = kind) => {
     registry.register({
       kind,
@@ -444,5 +451,65 @@ describe('listWorkerDecisions', () => {
     ]);
     const res = listWorkerDecisions({ listWorkerActions } as never, { reason: 'BUDGET' });
     expect(res.actions.map((action) => action.id)).toEqual(['a2']);
+  });
+});
+
+describe('global worker switch', () => {
+  it('defaults to on so existing installs keep auto-starting workers', () => {
+    const harness = controller();
+    harness.controller.startAutoStartedWorkers();
+    expect(harness.controller.snapshot().globalEnabled).toBe(true);
+    expect(harness.runtimes.get(PR_STATUS_WORKER_KIND)?.[0]?.starts).toBe(1);
+  });
+
+  it('starts no workers on boot while the switch is off', () => {
+    const harness = controller(AUTO_STARTED_OWNER_WORKER_KINDS, {}, false);
+    harness.controller.startAutoStartedWorkers();
+    expect(harness.runtimes.size).toBe(0);
+    expect(harness.controller.snapshot().globalEnabled).toBe(false);
+  });
+
+  it('stops every running worker when switched off', async () => {
+    const harness = controller();
+    harness.controller.startAutoStartedWorkers();
+    const prStatus = harness.runtimes.get(PR_STATUS_WORKER_KIND)?.[0];
+    expect(prStatus?.isRunning()).toBe(true);
+
+    const snapshot = await harness.controller.setGlobalEnabled(false);
+
+    expect(snapshot.globalEnabled).toBe(false);
+    expect(prStatus?.isRunning()).toBe(false);
+    expect(snapshot.workers.every((worker) => worker.lifecycle !== 'running')).toBe(true);
+  });
+
+  it('keeps each per-worker setting intact across an off/on cycle', async () => {
+    const harness = controller(AUTO_STARTED_OWNER_WORKER_KINDS, { [CI_FAILURE_WORKER_KIND]: false });
+    harness.controller.startAutoStartedWorkers();
+    expect(harness.runtimes.get(CI_FAILURE_WORKER_KIND)).toBeUndefined();
+
+    await harness.controller.setGlobalEnabled(false);
+    await harness.controller.setGlobalEnabled(true);
+
+    const snapshot = harness.controller.snapshot();
+    expect(snapshot.globalEnabled).toBe(true);
+    const ciFailure = snapshot.workers.find((worker) => worker.kind === CI_FAILURE_WORKER_KIND);
+    expect(ciFailure?.desiredEnabled).toBe(false);
+    expect(ciFailure?.lifecycle).not.toBe('running');
+    expect(harness.runtimes.get(PR_STATUS_WORKER_KIND)?.at(-1)?.isRunning()).toBe(true);
+  });
+
+  it('records intent but spawns nothing when a worker is enabled while the switch is off', () => {
+    const harness = controller(AUTO_STARTED_OWNER_WORKER_KINDS, {}, false);
+    const row = harness.controller.start(CI_FAILURE_WORKER_KIND);
+    expect(row.desiredEnabled).toBe(true);
+    expect(row.lifecycle).not.toBe('running');
+    expect(harness.runtimes.get(CI_FAILURE_WORKER_KIND)).toBeUndefined();
+  });
+
+  it('reports the switch as the reason per-worker controls are unavailable', () => {
+    const harness = controller(AUTO_STARTED_OWNER_WORKER_KINDS, {}, false);
+    const worker = harness.controller.snapshot().workers[0];
+    expect(worker?.startable).toBe(false);
+    expect(worker?.controlDisabledReason).toBe('Workers are turned off');
   });
 });

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -779,6 +779,8 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:stop-worker':
         return { channel: 'headless.gui-mutation', request: payload };
+      case 'invoker:set-workers-enabled':
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resume-workflow': {
         const workflows = rendererTaskFeed.getDetachedViewerWorkflows() ?? persistence.listWorkflows();
         const firstWorkflow = workflows[0] as { id?: unknown } | undefined;
@@ -1649,6 +1651,13 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       throw new Error('Worker runtime controller is unavailable');
     }
     return workerRuntimeController.stop(String(kindArg));
+  });
+
+  registerGuiMutationHandler('invoker:set-workers-enabled', async (enabledArg: unknown) => {
+    if (!workerRuntimeController) {
+      throw new Error('Worker runtime controller is unavailable');
+    }
+    return workerRuntimeController.setGlobalEnabled(Boolean(enabledArg));
   });
 
   ipcMain.handle('invoker:get-queue-status', () => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1266,6 +1266,12 @@ function startHeadlessMode(): void {
             }
             return workerRuntimeController.stop(String(payload.args[0]));
           }
+          case 'invoker:set-workers-enabled': {
+            if (!workerRuntimeController) {
+              throw new Error('Worker runtime controller is unavailable');
+            }
+            return workerRuntimeController.setGlobalEnabled(Boolean(payload.args[0]));
+          }
           case 'invoker:inject-task-states': {
             if (process.env.NODE_ENV !== 'test') {
               throw new Error('inject-task-states is only available in tests');

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -48,6 +48,7 @@ export interface WorkerRuntimeController {
   start(kind: string, options?: { persistDesiredState?: boolean }): WorkerStatusEntry;
   stop(kind: string): Promise<WorkerStatusEntry>;
   stopAll(): Promise<void>;
+  setGlobalEnabled(enabled: boolean): Promise<WorkerStatusSnapshot>;
   snapshot(): WorkerStatusSnapshot;
 }
 
@@ -60,7 +61,14 @@ type WorkerStatusPersistence = Pick<
   | 'getEvents'
   | 'getEventsByTypes'
   | 'countEventsByTypes'
-> & Partial<Pick<SQLiteAdapter, 'getWorkerDesiredState' | 'setWorkerDesiredState' | 'listWorkerDesiredStates'>>;
+> & Partial<Pick<
+  SQLiteAdapter,
+  | 'getWorkerDesiredState'
+  | 'setWorkerDesiredState'
+  | 'listWorkerDesiredStates'
+  | 'getWorkersGloballyEnabled'
+  | 'setWorkersGloballyEnabled'
+>>;
 
 const DEFAULT_WORKER_ACTION_HISTORY_LIMIT = 20;
 const MAX_WORKER_ACTION_HISTORY_LIMIT = 100;
@@ -206,6 +214,8 @@ export function createWorkerRuntimeController(options: {
     return saved?.desiredEnabled ?? options.autoStartKinds.includes(kind);
   };
 
+  const globalEnabled = (): boolean => options.persistence.getWorkersGloballyEnabled?.() ?? true;
+
   const rowForKind = (kind: string): WorkerStatusEntry => {
     const definition = options.registry.get(kind);
     if (!definition) {
@@ -223,6 +233,7 @@ export function createWorkerRuntimeController(options: {
       policy: policyForKind(kind),
       persistence: options.persistence,
       canControl: options.canControl(),
+      globalEnabled: globalEnabled(),
       recovery: definition.kind === AUTO_FIX_WORKER_KIND
         ? toWorkerRecoverySummary(options.persistence)
         : undefined,
@@ -241,18 +252,30 @@ export function createWorkerRuntimeController(options: {
     handles.delete(kind);
   };
 
-  return {
+  const startDesiredWorkers = (): void => {
+    if (!globalEnabled()) return;
+    for (const definition of options.registry.list()) {
+      if (!desiredEnabledForKind(definition.kind)) continue;
+      controller.start(definition.kind, { persistDesiredState: false });
+    }
+  };
+
+  const stopRuntimesKeepingDesiredState = async (): Promise<void> => {
+    await controller.stopAll();
+  };
+
+  const controller: WorkerRuntimeController = {
     startAutoStartedWorkers(): void {
-      for (const definition of options.registry.list()) {
-        if (!desiredEnabledForKind(definition.kind)) continue;
-        this.start(definition.kind, { persistDesiredState: false });
-      }
+      startDesiredWorkers();
     },
 
     start(kind: string, optionsArg?: { persistDesiredState?: boolean }): WorkerStatusEntry {
       const definition = requireDefinition(kind);
       if (optionsArg?.persistDesiredState !== false) {
         options.persistence.setWorkerDesiredState?.(kind, true);
+      }
+      if (!globalEnabled()) {
+        return rowForKind(kind);
       }
 
       const existing = handles.get(kind);
@@ -291,13 +314,26 @@ export function createWorkerRuntimeController(options: {
       await Promise.all(stopping);
     },
 
+    async setGlobalEnabled(enabled: boolean): Promise<WorkerStatusSnapshot> {
+      options.persistence.setWorkersGloballyEnabled?.(enabled);
+      if (enabled) {
+        startDesiredWorkers();
+      } else {
+        await stopRuntimesKeepingDesiredState();
+      }
+      return this.snapshot();
+    },
+
     snapshot(): WorkerStatusSnapshot {
       return {
         generatedAt: new Date().toISOString(),
+        globalEnabled: globalEnabled(),
         workers: options.registry.list().map((definition) => rowForKind(definition.kind)),
       };
     },
   };
+
+  return controller;
 }
 export function createLocalWorkerStatusSnapshot(options: {
   registry: WorkerRegistry<WorkerRuntimeDependencies>;
@@ -307,8 +343,10 @@ export function createLocalWorkerStatusSnapshot(options: {
   const recovery = options.registry.list().some((definition) => definition.kind === AUTO_FIX_WORKER_KIND)
     ? toWorkerRecoverySummary(options.persistence)
     : undefined;
+  const globalEnabled = options.persistence.getWorkersGloballyEnabled?.() ?? true;
   return {
     generatedAt: new Date().toISOString(),
+    globalEnabled,
     workers: options.registry.list().map((definition) => {
       const desiredEnabled = options.persistence.getWorkerDesiredState?.(definition.kind)?.desiredEnabled
         ?? options.autoStartKinds.includes(definition.kind);
@@ -321,6 +359,7 @@ export function createLocalWorkerStatusSnapshot(options: {
         policy: 'unknown',
         persistence: options.persistence,
         canControl: false,
+        globalEnabled,
         recovery: definition.kind === AUTO_FIX_WORKER_KIND ? recovery : undefined,
         runningKnown: false,
       });
@@ -340,13 +379,14 @@ function buildWorkerStatusEntry(args: {
   policy: WorkerPolicyStatus;
   persistence: WorkerStatusPersistence;
   canControl: boolean;
+  globalEnabled: boolean;
   recovery?: WorkerRecoverySummary;
   runningKnown: boolean;
 }): WorkerStatusEntry {
   const lifecycle = args.handle
     ? args.handle.runtime.isRunning() ? 'running' : 'exited'
     : 'stopped';
-  const controlDisabledReason = getControlDisabledReason(args.canControl);
+  const controlDisabledReason = getControlDisabledReason(args.canControl, args.globalEnabled);
   const runtime = args.handle?.runtime;
   const rawActions = args.persistence.listWorkerActions({ workerKind: args.definitionKind, limit: 5 }).slice(0, 5);
   const recentActions = rawActions.map(toWorkerActionSummary);
@@ -361,7 +401,7 @@ function buildWorkerStatusEntry(args: {
     policy: args.policy,
     autoStarts: args.autoStarts,
     desiredEnabled: args.desiredEnabled,
-    startable: lifecycle !== 'running' && args.policy !== 'disabled' && args.canControl,
+    startable: lifecycle !== 'running' && args.policy !== 'disabled' && args.canControl && args.globalEnabled,
     stoppable: lifecycle === 'running' && args.canControl,
     ...(controlDisabledReason ? { controlDisabledReason } : {}),
     ...(args.handle?.startedAt ? { startedAt: args.handle.startedAt } : {}),
@@ -381,8 +421,9 @@ function policyForKind(kind: string): WorkerPolicyStatus {
   return 'unknown';
 }
 
-function getControlDisabledReason(canControl: boolean): string | undefined {
+function getControlDisabledReason(canControl: boolean, globalEnabled: boolean): string | undefined {
   if (!canControl) return 'Controls unavailable';
+  if (!globalEnabled) return 'Workers are turned off';
   return undefined;
 }
 

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -303,6 +303,7 @@ export interface WorkerStatusEntry {
 export interface WorkerStatusSnapshot {
   generatedAt: string;
   workers: WorkerStatusEntry[];
+  globalEnabled?: boolean;
 }
 
 export interface WorkerActionHistoryRequest {
@@ -1146,6 +1147,10 @@ export const IpcChannels = {
   'invoker:stop-worker': {} as {
     request: [kind: string];
     response: WorkerStatusEntry;
+  },
+  'invoker:set-workers-enabled': {} as {
+    request: [enabled: boolean];
+    response: WorkerStatusSnapshot;
   },
   'invoker:get-action-graph': {} as {
     request: [];

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -925,6 +925,26 @@ describe('SQLiteAdapter', () => {
         expect.objectContaining({ workerKind: 'workflow-resume', desiredEnabled: false }),
       ]);
     });
+
+    it('reports workers globally enabled until the switch is used', () => {
+      expect(adapter.getWorkersGloballyEnabled()).toBe(true);
+    });
+
+    it('persists the global worker switch across both directions', () => {
+      expect(adapter.setWorkersGloballyEnabled(false)).toMatchObject({ enabled: false });
+      expect(adapter.getWorkersGloballyEnabled()).toBe(false);
+
+      adapter.setWorkersGloballyEnabled(true);
+      expect(adapter.getWorkersGloballyEnabled()).toBe(true);
+    });
+
+    it('keeps per-worker desired states untouched when the global switch flips', () => {
+      adapter.setWorkerDesiredState('pr-status', false);
+      adapter.setWorkersGloballyEnabled(false);
+      adapter.setWorkersGloballyEnabled(true);
+
+      expect(adapter.getWorkerDesiredState('pr-status')).toMatchObject({ desiredEnabled: false });
+    });
   });
 
   describe('execution resource leases', () => {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -177,6 +177,11 @@ export interface WorkerDesiredStateRecord {
   updatedAt: string;
 }
 
+export interface WorkerGlobalStateRecord {
+  enabled: boolean;
+  updatedAt: string;
+}
+
 export interface WorkerActionWrite {
   /** Insert-only row id. Updates are keyed by workerKind/externalKey and reject a different id. */
   id: string;
@@ -318,6 +323,8 @@ export interface PersistenceAdapter {
   getWorkerDesiredState(workerKind: string): WorkerDesiredStateRecord | undefined;
   setWorkerDesiredState(workerKind: string, desiredEnabled: boolean): WorkerDesiredStateRecord;
   listWorkerDesiredStates(): WorkerDesiredStateRecord[];
+  getWorkersGloballyEnabled(): boolean;
+  setWorkersGloballyEnabled(enabled: boolean): WorkerGlobalStateRecord;
 
   // Conversations (Slack thread-based)
   saveConversation(conversation: Conversation): void;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -50,6 +50,7 @@ import type {
   WorkerActionRecord,
   WorkerActionWrite,
   WorkerDesiredStateRecord,
+  WorkerGlobalStateRecord,
   TerminalSessionPatch,
   TerminalSessionRecord,
   InAppPlanningSessionPatch,
@@ -1852,6 +1853,24 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'SELECT worker_kind, desired_enabled, updated_at FROM worker_desired_states ORDER BY worker_kind ASC',
     );
     return rows.map((row) => this.rowToWorkerDesiredState(row));
+  }
+
+  getWorkersGloballyEnabled(): boolean {
+    const row = this.queryOne('SELECT enabled FROM worker_global_state WHERE id = 1');
+    return row ? Number(row.enabled) !== 0 : true;
+  }
+
+  setWorkersGloballyEnabled(enabled: boolean): WorkerGlobalStateRecord {
+    const updatedAt = new Date().toISOString();
+    this.execRun(
+      `INSERT INTO worker_global_state (id, enabled, updated_at)
+       VALUES (1, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         enabled = excluded.enabled,
+         updated_at = excluded.updated_at`,
+      [enabled ? 1 : 0, updatedAt],
+    );
+    return { enabled, updatedAt };
   }
 
   // ── Queries ─────────────────────────────────────────

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -400,6 +400,12 @@ export const SCHEMA_DDL = `
         updated_at TEXT DEFAULT (datetime('now'))
       );
 
+      CREATE TABLE IF NOT EXISTS worker_global_state (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        enabled INTEGER NOT NULL,
+        updated_at TEXT DEFAULT (datetime('now'))
+      );
+
       CREATE TABLE IF NOT EXISTS execution_resource_leases (
         resource_key TEXT NOT NULL,
         resource_type TEXT NOT NULL,
@@ -564,6 +570,11 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  `CREATE TABLE IF NOT EXISTS worker_global_state (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    enabled INTEGER NOT NULL,
+    updated_at TEXT DEFAULT (datetime('now'))
+  )`,
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -759,6 +759,10 @@ export function App() {
     await invoker.stopWorker(kind);
     void refreshWorkerStatus();
   }, [invoker, refreshWorkerStatus]);
+  const handleSetWorkersEnabled = useCallback(async (enabled: boolean) => {
+    await invoker.setWorkersEnabled(enabled);
+    void refreshWorkerStatus();
+  }, [invoker, refreshWorkerStatus]);
   const runningTaskIds = useMemo(
     () => new Set((queueStatus?.running ?? []).map((entry) => entry.taskId)),
     [queueStatus],
@@ -3469,6 +3473,7 @@ export function App() {
           readOnly={runtimeStatus?.readOnly === true}
           onStartWorker={handleStartWorker}
           onStopWorker={handleStopWorker}
+          onSetWorkersEnabled={handleSetWorkersEnabled}
           onTaskClick={handleTaskClick}
           selectedTaskId={selectedTaskId}
           selectedWorkerKind={selectedWorkerKind}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3769,6 +3769,8 @@ export function App() {
               snapshot={workerStatus}
               selectedWorkerKind={selectedWorkerKind}
               onSelectWorker={setSelectedWorkerKind}
+              onSetWorkersEnabled={handleSetWorkersEnabled}
+              readOnly={runtimeStatus?.readOnly === true}
               showControls={false}
             />
           </div>

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -437,6 +437,10 @@ export function createMockInvoker(
       const row = workerStatus.workers.find((worker) => worker.kind === kind) ?? makeMockWorkerStatusEntry(kind);
       return row;
     }),
+    setWorkersEnabled: vi.fn(async (enabled: boolean) => {
+      workerStatus = { ...workerStatus, globalEnabled: enabled };
+      return workerStatus;
+    }),
     getActionGraph: vi.fn(async () => actionGraphSnapshot),
     getClaudeSession: vi.fn(async () => null),
     getAgentSession: vi.fn(async () => null),

--- a/packages/ui/src/__tests__/worker-global-switch.test.tsx
+++ b/packages/ui/src/__tests__/worker-global-switch.test.tsx
@@ -100,6 +100,27 @@ describe('worker global switch', () => {
     expect(screen.getByTestId('worker-global-switch')).toHaveAttribute('aria-checked', 'true');
   });
 
+  it('snaps back and logs when the host rejects the change', async () => {
+    const error = new Error('Worker runtime controller is unavailable');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <WorkerActivityCard
+        snapshot={makeSnapshot()}
+        selectedWorkerKind={null}
+        onSelectWorker={vi.fn()}
+        onSetWorkersEnabled={vi.fn(async () => { throw error; })}
+      />,
+    );
+
+    const toggle = screen.getByTestId('worker-global-switch');
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(toggle).toHaveAttribute('aria-checked', 'true'));
+    expect(toggle).toHaveTextContent('Turn workers off');
+    expect(consoleError).toHaveBeenCalledWith('Failed to turn workers off', error);
+    consoleError.mockRestore();
+  });
+
   it('hides the switch on read-only surfaces that render without controls', () => {
     render(
       <WorkerActivityCard

--- a/packages/ui/src/__tests__/worker-global-switch.test.tsx
+++ b/packages/ui/src/__tests__/worker-global-switch.test.tsx
@@ -121,16 +121,48 @@ describe('worker global switch', () => {
     consoleError.mockRestore();
   });
 
-  it('hides the switch on read-only surfaces that render without controls', () => {
+  it('shows the switch on the Workers surface, which renders no per-worker buttons', () => {
     render(
       <WorkerActivityCard
         snapshot={makeSnapshot()}
         selectedWorkerKind={null}
         onSelectWorker={vi.fn()}
+        onSetWorkersEnabled={vi.fn()}
         showControls={false}
       />,
     );
 
+    expect(screen.getByTestId('worker-global-switch')).toBeVisible();
+    expect(screen.queryByTestId('worker-start-stop-ci-failure')).toBeNull();
+  });
+
+  it('hides the switch when the host offers no way to set it', () => {
+    render(
+      <WorkerActivityCard
+        snapshot={makeSnapshot()}
+        selectedWorkerKind={null}
+        onSelectWorker={vi.fn()}
+      />,
+    );
+
     expect(screen.queryByTestId('worker-global-switch')).toBeNull();
+  });
+
+  it('disables the switch in a read-only window', () => {
+    const onSetWorkersEnabled = vi.fn();
+    render(
+      <WorkerActivityCard
+        snapshot={makeSnapshot()}
+        selectedWorkerKind={null}
+        onSelectWorker={vi.fn()}
+        onSetWorkersEnabled={onSetWorkersEnabled}
+        readOnly
+      />,
+    );
+
+    const toggle = screen.getByTestId('worker-global-switch');
+    expect(toggle).toBeDisabled();
+    fireEvent.click(toggle);
+    expect(onSetWorkersEnabled).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/__tests__/worker-global-switch.test.tsx
+++ b/packages/ui/src/__tests__/worker-global-switch.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { WorkerActivityCard } from '../components/WorkerActivityCard.js';
+import type { WorkerStatusEntry, WorkerStatusSnapshot } from '../types.js';
+
+function makeWorker(overrides: Partial<WorkerStatusEntry> = {}): WorkerStatusEntry {
+  return {
+    kind: 'ci-failure',
+    note: 'Repairs failed CI.',
+    lifecycle: 'running',
+    policy: 'enabled',
+    autoStarts: true,
+    desiredEnabled: true,
+    startable: false,
+    stoppable: true,
+    recentActions: [],
+    ...overrides,
+  };
+}
+
+function makeSnapshot(overrides: Partial<WorkerStatusSnapshot> = {}): WorkerStatusSnapshot {
+  return {
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    globalEnabled: true,
+    workers: [makeWorker()],
+    ...overrides,
+  };
+}
+
+describe('worker global switch', () => {
+  it('turns workers off and reports the new state to the caller', async () => {
+    const onSetWorkersEnabled = vi.fn(async () => {});
+    render(
+      <WorkerActivityCard
+        snapshot={makeSnapshot()}
+        selectedWorkerKind={null}
+        onSelectWorker={vi.fn()}
+        onSetWorkersEnabled={onSetWorkersEnabled}
+      />,
+    );
+
+    const toggle = screen.getByTestId('worker-global-switch');
+    expect(toggle).toHaveTextContent('Turn workers off');
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(onSetWorkersEnabled).toHaveBeenCalledWith(false));
+  });
+
+  it('turns workers back on when the switch is off', async () => {
+    const onSetWorkersEnabled = vi.fn(async () => {});
+    render(
+      <WorkerActivityCard
+        snapshot={makeSnapshot({ globalEnabled: false, workers: [makeWorker({ lifecycle: 'stopped' })] })}
+        selectedWorkerKind={null}
+        onSelectWorker={vi.fn()}
+        onSetWorkersEnabled={onSetWorkersEnabled}
+      />,
+    );
+
+    const toggle = screen.getByTestId('worker-global-switch');
+    expect(toggle).toHaveTextContent('Turn workers on');
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(onSetWorkersEnabled).toHaveBeenCalledWith(true));
+  });
+
+  it('disables the per-worker control while the switch is off', () => {
+    render(
+      <WorkerActivityCard
+        snapshot={makeSnapshot({ globalEnabled: false, workers: [makeWorker({ lifecycle: 'stopped' })] })}
+        selectedWorkerKind={null}
+        onSelectWorker={vi.fn()}
+        onStartWorker={vi.fn()}
+        onStopWorker={vi.fn()}
+        onSetWorkersEnabled={vi.fn()}
+      />,
+    );
+
+    const control = screen.getByTestId('worker-start-stop-ci-failure');
+    expect(control).toBeDisabled();
+    expect(control).toHaveAttribute('title', 'Workers are turned off');
+  });
+
+  it('treats a snapshot with no global flag as on, so older hosts keep working', () => {
+    const snapshot = makeSnapshot();
+    delete snapshot.globalEnabled;
+    render(
+      <WorkerActivityCard
+        snapshot={snapshot}
+        selectedWorkerKind={null}
+        onSelectWorker={vi.fn()}
+        onSetWorkersEnabled={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('worker-global-switch')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('hides the switch on read-only surfaces that render without controls', () => {
+    render(
+      <WorkerActivityCard
+        snapshot={makeSnapshot()}
+        selectedWorkerKind={null}
+        onSelectWorker={vi.fn()}
+        showControls={false}
+      />,
+    );
+
+    expect(screen.queryByTestId('worker-global-switch')).toBeNull();
+  });
+});

--- a/packages/ui/src/components/QueueView.tsx
+++ b/packages/ui/src/components/QueueView.tsx
@@ -18,6 +18,7 @@ interface QueueViewProps {
   readOnly: boolean;
   onStartWorker: (kind: string) => Promise<void> | void;
   onStopWorker: (kind: string) => Promise<void> | void;
+  onSetWorkersEnabled?: (enabled: boolean) => Promise<void> | void;
   onTaskClick: (task: TaskState) => void;
   selectedTaskId: string | null;
   selectedWorkerKind: string | null;
@@ -45,6 +46,7 @@ export function QueueView({
   readOnly,
   onStartWorker,
   onStopWorker,
+  onSetWorkersEnabled,
   onTaskClick,
   selectedTaskId,
   selectedWorkerKind,
@@ -275,6 +277,7 @@ export function QueueView({
             readOnly={readOnly}
             onStartWorker={onStartWorker}
             onStopWorker={onStopWorker}
+            onSetWorkersEnabled={onSetWorkersEnabled}
             onSelectWorker={onSelectWorker}
           />
         </div>

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -8,6 +8,7 @@ interface WorkerActivityCardProps {
   readOnly?: boolean;
   onStartWorker?: (kind: string) => Promise<void> | void;
   onStopWorker?: (kind: string) => Promise<void> | void;
+  onSetWorkersEnabled?: (enabled: boolean) => Promise<void> | void;
   onSelectWorker: (kind: string) => void;
   showControls?: boolean;
 }
@@ -53,11 +54,24 @@ export function WorkerActivityCard({
   readOnly = false,
   onStartWorker,
   onStopWorker,
+  onSetWorkersEnabled,
   onSelectWorker,
   showControls = true,
 }: WorkerActivityCardProps) {
   const [optimisticByKind, setOptimisticByKind] = useState<Record<string, OptimisticLifecycle>>({});
   const [pendingByKind, setPendingByKind] = useState<Record<string, boolean>>({});
+  const [optimisticGlobalEnabled, setOptimisticGlobalEnabled] = useState<boolean | null>(null);
+  const [globalPending, setGlobalPending] = useState(false);
+
+  const serverGlobalEnabled = snapshot?.globalEnabled ?? true;
+  const globalEnabled = optimisticGlobalEnabled ?? serverGlobalEnabled;
+
+  useEffect(() => {
+    if (optimisticGlobalEnabled === null) return;
+    if (serverGlobalEnabled === optimisticGlobalEnabled) {
+      setOptimisticGlobalEnabled(null);
+    }
+  }, [serverGlobalEnabled, optimisticGlobalEnabled]);
 
   useEffect(() => {
     if (!snapshot) return;
@@ -99,13 +113,54 @@ export function WorkerActivityCard({
 
   return (
     <div data-testid="worker-activity-card" className="flex min-h-0 flex-col">
+      {snapshot && showControls ? (
+        <div
+          data-testid="worker-global-switch-row"
+          className="mb-3 flex shrink-0 items-center justify-between gap-3 rounded border border-border bg-card/60 px-3 py-2"
+        >
+          <div className="min-w-0">
+            <div className="text-sm text-foreground">All workers</div>
+            <div className="text-xs text-muted-foreground">
+              {globalEnabled
+                ? 'Workers run as configured below.'
+                : 'Master switch is off. No worker runs, and each worker keeps its own setting for when you turn this back on.'}
+            </div>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={globalEnabled}
+            aria-label="Turn all workers on or off"
+            className="shrink-0 rounded border border-border-strong px-2 py-1 text-xs text-foreground disabled:cursor-not-allowed disabled:opacity-50 hover:bg-muted"
+            title={readOnly ? 'Read-only window' : undefined}
+            disabled={readOnly || globalPending || !onSetWorkersEnabled}
+            data-testid="worker-global-switch"
+            data-action={globalEnabled ? 'disable-all' : 'enable-all'}
+            onClick={() => {
+              if (globalPending || readOnly || !onSetWorkersEnabled) return;
+              const next = !globalEnabled;
+              setOptimisticGlobalEnabled(next);
+              setGlobalPending(true);
+              void Promise.resolve(onSetWorkersEnabled(next)).finally(() => setGlobalPending(false));
+            }}
+          >
+            {globalPending
+              ? (globalEnabled ? 'Turning off…' : 'Turning on…')
+              : globalEnabled ? 'Turn workers off' : 'Turn workers on'}
+          </button>
+        </div>
+      ) : null}
       {!snapshot ? (
         <div className="rounded border border-border bg-card/60 px-3 py-2 text-sm text-muted-foreground">Worker status unavailable</div>
       ) : (
         <div data-testid="worker-process-list" className="min-h-0 space-y-3">
           {snapshot.workers.map((worker) => {
             const copy = getWorkerDisplayCopy(worker.kind);
-            const disabledTitle = readOnly ? 'Read-only window' : worker.controlDisabledReason;
+            const disabledTitle = readOnly
+              ? 'Read-only window'
+              : !globalEnabled
+                ? 'Workers are turned off'
+                : worker.controlDisabledReason;
             const lifecycle = optimisticByKind[worker.kind] ?? worker.lifecycle;
             const showStart = lifecycle !== 'running';
             const pending = Boolean(pendingByKind[worker.kind]);

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -141,7 +141,12 @@ export function WorkerActivityCard({
               const next = !globalEnabled;
               setOptimisticGlobalEnabled(next);
               setGlobalPending(true);
-              void Promise.resolve(onSetWorkersEnabled(next)).finally(() => setGlobalPending(false));
+              void Promise.resolve(onSetWorkersEnabled(next))
+                .catch((error: unknown) => {
+                  setOptimisticGlobalEnabled(null);
+                  console.error(`Failed to turn workers ${next ? 'on' : 'off'}`, error);
+                })
+                .finally(() => setGlobalPending(false));
             }}
           >
             {globalPending

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -113,7 +113,7 @@ export function WorkerActivityCard({
 
   return (
     <div data-testid="worker-activity-card" className="flex min-h-0 flex-col">
-      {snapshot && showControls ? (
+      {snapshot && onSetWorkersEnabled ? (
         <div
           data-testid="worker-global-switch-row"
           className="mb-3 flex shrink-0 items-center justify-between gap-3 rounded border border-border bg-card/60 px-3 py-2"
@@ -122,8 +122,8 @@ export function WorkerActivityCard({
             <div className="text-sm text-foreground">All workers</div>
             <div className="text-xs text-muted-foreground">
               {globalEnabled
-                ? 'Workers run as configured below.'
-                : 'Master switch is off. No worker runs, and each worker keeps its own setting for when you turn this back on.'}
+                ? 'Each worker follows its own setting.'
+                : 'Nothing runs. Each worker keeps its setting.'}
             </div>
           </div>
           <button


### PR DESCRIPTION
## Summary

The Workers panel only had an Enable/Disable button on each worker row. To stop everything you had to click every worker one at a time.

This adds one master switch above the worker rows: **Turn workers off** / **Turn workers on**. It appears on the Workers page and in the Queue view.

Turning it off stops every running worker and keeps them off across restarts. Turning it on brings back exactly the workers that were on before.

The switch is stored separately from each worker's own setting. A worker you deliberately disabled stays disabled after an off/on cycle.

It defaults to on, so existing installs behave exactly as they do today.

## Review Claim

One master switch turns all workers off and back on, without overwriting any individual worker's own enabled setting.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The global flag lives in its own `worker_global_state` row and is read-only to the per-kind path. `setGlobalEnabled` never calls `setWorkerDesiredState`, so per-worker intent survives the cycle.

Absent rows read as enabled, so existing databases keep their current auto-start behavior with no migration step.

## Slice Rationale

The switch is one user-facing control. Its persistence, IPC channel, engine gating, and UI are the minimum that makes it work; a smaller slice would ship a switch wired to nothing.

## Non-goals

Does not change what any individual worker does, or its polling interval.

Does not restore the rail Run/Stop task-execution controls removed in #4618. Those drive `invoker:start` / `invoker:stop`, not workers.

Does not add the switch to the read-only web surface, which renders worker controls disabled already.

## Architecture

Worker start-up now passes through two gates instead of one. The master switch gates the per-worker setting; it does not overwrite it.

### Before

```mermaid
graph TD
    A["startAutoStartedWorkers()"] --> B["desiredEnabledForKind(kind)"]
    B -->|true| C["runtime.start()"]
    B -->|false| D["stays stopped"]
```

### After

```mermaid
graph TD
    A["startAutoStartedWorkers()"] --> G{"globalEnabled?"}
    G -->|false| H["no worker starts"]
    G -->|true| B["desiredEnabledForKind(kind)"]
    B -->|true| C["runtime.start()"]
    B -->|false| D["stays stopped"]
    S["setGlobalEnabled(false)"] --> T["stopAll() — desired state untouched"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test` — 22 pass in `worker-control.test.ts`, incl. off/on cycle preserving per-worker state
- [ ] `cd packages/ui && pnpm test` — 773 pass, incl. 8 in `worker-global-switch.test.tsx`
- [ ] `cd packages/data-store && pnpm test` — 398 pass, incl. global-switch round-trip and default-on
- [ ] `cd packages/contracts && pnpm test` — 87 pass
- [ ] `cd packages/app && CAPTURE_MODE=after npx playwright test visual-proof.spec.ts -g "global worker switch"` — 2 pass; drives the real switch in Electron from both the Workers surface and the Queue view
- [ ] `pnpm build` — clean across all packages
- [ ] `pnpm run check:comments && pnpm run check:types` — clean

Not fixed here, fails identically on unmodified `master`: `focus-switch-main-process-cost.test.ts` perf budget (~4.8s vs 100ms) on this machine.

</details>

## Visual Proof

Captured by `visual-proof.spec.ts`, driving the real switch in Electron on both surfaces that show workers.

### Workers surface (sidebar → Workers)

**Walkthrough (on → off → on):**

![Master switch on the Workers surface](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-ae6805/workers-surface-switch-walkthrough.gif)

**Step 1 — on.** Header reads "Turn workers off". Requeue shows a green `Process: Running`; the sidebar reads "9 processes running".

![Step 1: workers on](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-ae6805/workers-surface-switch-step-1-on.png)

**Step 2 — off.** Header reads "Turn workers on". Requeue flipped to `Process: Stopped` and the sidebar reads "0 processes running". Requeue keeps its `Starts on launch` chip — that is the preserved per-worker setting.

![Step 2: workers off](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-ae6805/workers-surface-switch-step-2-off.png)

**Step 3 — back on.** Requeue returns to `Process: Running` and the sidebar returns to "9 processes running". Autofix was off before the cycle and is still `Process: Stopped` — the switch did not turn it on.

![Step 3: back on, previously-off workers still off](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-ae6805/workers-surface-switch-step-3-back-on.png)

### Queue view

Same switch, above the per-worker rows. Here the per-worker "Enable worker" buttons grey out while the switch is off.

![Master switch in the Queue view](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-ae6805/queue-view-switch-walkthrough.gif)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert cbf01f18b 7a6a6cf35 d8ef2a7ff`
- Post-revert steps: None. Workers return to auto-starting from per-kind desired state.
- Data migration? No. The `worker_global_state` table is additive and simply goes unread; a stale `enabled = 0` row is ignored after revert, so workers resume.

</details>
