### PR TITLE
[Preempted Mutations](1) Prove delete-fence cancellations look like real failures

### DIFF
--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -1100,6 +1100,48 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
+  it('reports intents cancelled by a delete fence as task-scoped failures indistinguishable from real errors', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
+
+    const gate = deferred();
+    const failedEvents: WorkflowMutationFailedEvent[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel) => {
+        if (channel === 'invoker:fix-with-agent') {
+          await gate.promise;
+        }
+      },
+      { onIntentFailed: (event) => failedEvents.push(event) },
+    );
+
+    const running = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:fix-with-agent', ['wf-1/blocker-task', null]);
+    void running.catch(() => {});
+    await waitFor(() => adapter.listWorkflowMutationIntents('wf-1', ['running']).length === 1);
+    const queued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['wf-1/queued-task']);
+    void queued.catch(() => {});
+
+    await coordinator.enqueue<void>('wf-1', 'high', 'invoker:delete-workflow', ['wf-1']);
+    await expect(running).rejects.toThrow(/superseded by delete intent/i);
+    await expect(queued).rejects.toThrow(/evicted/i);
+
+    // Deleting a workflow deliberately cancels its in-flight work, yet every
+    // cancellation is announced as a task-scoped failure carrying no marker that
+    // separates it from a genuine error. Renderers therefore treat a routine
+    // delete as work the user must attend to.
+    expect(failedEvents).toHaveLength(2);
+    expect(failedEvents.map((event) => event.taskId)).toEqual(['wf-1/blocker-task', 'wf-1/queued-task']);
+    expect(failedEvents.map((event) => event.message)).toEqual([
+      expect.stringMatching(/superseded by delete intent/i),
+      expect.stringMatching(/evicted/i),
+    ]);
+  });
+
   it('invalidates an older running workflow intent when delegated headless delete is enqueued', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);


### PR DESCRIPTION
## Summary

Deleting a workflow makes the app jump to the Needs Attention tab. This slice pins down why, without fixing anything yet.

A delete is a fence: it deliberately cancels the workflow's running and queued mutation intents.

Both cancellation paths announce themselves through `onIntentFailed`, carrying a `taskId` and nothing else.

So a routine delete is reported exactly like a genuine handler error, and consumers cannot tell the two apart.

The new test asserts today's behavior, so it passes on master and turns into the regression test once the fix lands.

## Review Claim

The coordinator reports delete-fence cancellations as task-scoped failures that carry no marker separating them from genuine errors.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only. No product code changes, so no runtime behavior can shift. The test asserts the current behavior and passes on master.

## Slice Rationale

Evidence lands before the change it justifies, so the bug is demonstrated before any fix is approved. Bundling the repro with the fix would hide which behavior was real and which was introduced.

## Non-goals

Does not change the coordinator, the event payload, or any renderer.

Does not fix the tab jump. That is the follow-up slice.

Does not touch the persisted intent record or its audit trail.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
