### PR TITLE
[Preempted Mutations](2a) Add a cause discriminator to mutation failure events

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -621,6 +621,7 @@ export interface WorkflowMutationFailedEvent {
   headlessCommand?: string;
   message: string;
   failedAt: string;
+  cause?: 'error' | 'preempted';
 }
 
 export interface CancelResult {


### PR DESCRIPTION
## Summary

Tearing down a workflow fires a hard-preempt fence, which cancels that workflow's other mutation intents on purpose. That is intended housekeeping, not a fault.

Those cancellations are announced exactly like a handler that genuinely threw, so no consumer can tell the two apart.

This adds the optional `cause` field to `WorkflowMutationFailedEvent` that makes them separable.

Nothing writes or reads the field yet, so the payload on the wire is unchanged. The producer follows in the next slice.

## Review Claim

`WorkflowMutationFailedEvent` gains an optional `cause` discriminator with the values `error` and `preempted`.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The field is optional and additive, so every existing producer and consumer compiles and behaves identically.

Nothing writes or reads `cause` in this slice, making it dormant by construction.

## Slice Rationale

Foundation lands before behavior, so the producer and the consumer that follow each stay reviewable on their own.

This is also a hard boundary the repo enforces mechanically: a shared contract cannot ship alongside app runtime files in one PR.

## Non-goals

Does not set `cause` anywhere. Every event still goes out without it.

Does not change any renderer. The Needs Attention tab jump still happens after this slice.

Does not change the persisted audit trail.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/contracts && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. The field is additive and unused, so reverting restores the prior shape exactly.
- Data migration? No

</details>
