### PR TITLE
[Preempted Mutations](2b) Label preempted cancellations in the coordinator

### DIFF
--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -1100,7 +1100,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it('reports intents cancelled by a delete fence as task-scoped failures indistinguishable from real errors', async () => {
+  it('reports intents cancelled by a delete fence as preempted, not as real errors', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({ id: 'wf-1',
@@ -1130,16 +1130,36 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await expect(running).rejects.toThrow(/superseded by delete intent/i);
     await expect(queued).rejects.toThrow(/evicted/i);
 
-    // Deleting a workflow deliberately cancels its in-flight work, yet every
-    // cancellation is announced as a task-scoped failure carrying no marker that
-    // separates it from a genuine error. Renderers therefore treat a routine
-    // delete as work the user must attend to.
     expect(failedEvents).toHaveLength(2);
     expect(failedEvents.map((event) => event.taskId)).toEqual(['wf-1/blocker-task', 'wf-1/queued-task']);
     expect(failedEvents.map((event) => event.message)).toEqual([
       expect.stringMatching(/superseded by delete intent/i),
       expect.stringMatching(/evicted/i),
     ]);
+    expect(failedEvents.map((event) => event.cause)).toEqual(['preempted', 'preempted']);
+  });
+
+  it('reports a genuine handler error as an error cause', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
+
+    const failedEvents: WorkflowMutationFailedEvent[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async () => { throw new Error('harness exploded'); },
+      { onIntentFailed: (event) => failedEvents.push(event) },
+    );
+
+    await expect(
+      coordinator.enqueue<void>('wf-1', 'normal', 'invoker:approve', ['wf-1/approve-task']),
+    ).rejects.toThrow(/harness exploded/i);
+
+    expect(failedEvents).toHaveLength(1);
+    expect(failedEvents[0].cause).toBe('error');
   });
 
   it('invalidates an older running workflow intent when delegated headless delete is enqueued', async () => {

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -443,7 +443,11 @@ export class PersistedWorkflowMutationCoordinator {
         });
         const deferred = this.inFlightPromises.get(evictedId);
         if (evictedIntent) {
-          this.notifyIntentFailed(evictedIntent, evictedIntent.error ?? `Evicted by ${intent.channel}#${intent.id}`);
+          this.notifyIntentFailed(
+            evictedIntent,
+            evictedIntent.error ?? `Evicted by ${intent.channel}#${intent.id}`,
+            'preempted',
+          );
         }
         if (!deferred) continue;
         deferred.reject(new Error(`Workflow mutation intent ${evictedId} was evicted by ${intent.channel}#${intent.id}`));
@@ -505,7 +509,7 @@ export class PersistedWorkflowMutationCoordinator {
       }
       const reason = `Superseded by ${fenceKind} intent #${newIntentId}`;
       this.persistence.failWorkflowMutationIntent(activeIntentId, reason);
-      this.notifyIntentFailed(activeIntent, reason);
+      this.notifyIntentFailed(activeIntent, reason, 'preempted');
       this.createTiming(workflowId, activeIntent.channel, activeIntent.id, activeIntent.args)
         .mark('PersistedWorkflowMutationCoordinator.invalidateSupersededRunningIntent', 'invalidated', {
           newIntentId,
@@ -551,7 +555,11 @@ export class PersistedWorkflowMutationCoordinator {
     return null;
   }
 
-  private notifyIntentFailed(intent: WorkflowMutationIntent, message: string): void {
+  private notifyIntentFailed(
+    intent: WorkflowMutationIntent,
+    message: string,
+    cause: 'error' | 'preempted' = 'error',
+  ): void {
     const headlessCommand = intent.channel === 'headless.exec'
       ? resolveHeadlessExecCommand(intent.args ?? [])
       : undefined;
@@ -563,6 +571,7 @@ export class PersistedWorkflowMutationCoordinator {
       failedAt: new Date().toISOString(),
       taskId: this.resolveIntentFailureTaskId(intent),
       headlessCommand,
+      cause,
     });
     try {
       this.options?.onIntentFailed?.(event);


### PR DESCRIPTION
## Summary

A hard-preempt fence cancels a workflow's other mutation intents on purpose. That is intended housekeeping, not a fault.

Both cancellation paths announced themselves exactly like a handler that genuinely threw, so no consumer could tell the two apart.

Those two paths now report a `preempted` cause. A handler that really throws still reports `error`, which stays the default.

Nothing reads the field yet, so behavior is unchanged. This is the producer the renderer fix builds on.

The proof from the first slice flips here to assert the new labeling, and a companion case pins that genuine faults keep reporting `error`.

## Review Claim

The coordinator marks intents cancelled by a hard-preempt fence as `preempted`, and genuine handler faults as `error`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The `cause` argument defaults to `error`, so the one call site that reports a genuine fault is unchanged by construction.

No consumer reads `cause`, so no user-visible behavior can shift in this slice.

The persisted intent record, its `error` text, and the `workflow.mutation.failed` audit event keep their existing shape and message.

## Slice Rationale

The producer lands dormant and separate from the renderer that consumes it, so each stays reviewable alone.

The field it fills shipped in the previous slice, because the shared payload definition and app runtime files cannot ride in one PR.

## Non-goals

Does not change any renderer. The Needs Attention tab jump still happens after this slice.

Does not change which intents a fence cancels, or the order it cancels them in.

Does not change the persisted audit trail or the messages already written to it.

## Architecture

Data flow gains one discriminator. The fence already cancelled these intents; only what consumers are told about them changes.

### Before

```mermaid
graph TD
    A["hard-preempt fence cancels running + queued intents"] --> B["notifyIntentFailed(intent, message)"]
    C["handler throws a genuine fault"] --> B
    B --> D["WorkflowMutationFailedEvent { taskId, message }"]
    D --> E["consumer cannot tell a cancellation from a fault"]
```

### After

```mermaid
graph TD
    A["hard-preempt fence cancels running + queued intents"] --> B["notifyIntentFailed(intent, message, 'preempted')"]
    C["handler throws a genuine fault"] --> F["notifyIntentFailed(intent, message) — cause defaults to 'error'"]
    B --> D["WorkflowMutationFailedEvent { taskId, message, cause: 'preempted' }"]
    F --> G["WorkflowMutationFailedEvent { taskId, message, cause: 'error' }"]
    D --> E["consumer can ignore intended cancellations"]
    G --> E
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Nothing reads the field, so reverting restores the prior payload exactly.
- Data migration? No

</details>
