### PR TITLE
[Missing workflow recreate-task](1) Prove task-id race

### DIFF
--- a/packages/app/src/__tests__/workflow-mutation-submit.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-submit.test.ts
@@ -147,6 +147,50 @@ describe('submitWorkflowMutationOrAcknowledgeDeleted', () => {
     expect(result.accepted).toBe(true);
     expect(submit).toHaveBeenCalledTimes(1);
   });
+  it.fails('proof: headless recreate-task for a missing workflow is accepted without queueing', () => {
+    const submit = vi.fn(() => 42);
+
+    const result = submitWorkflowMutationOrAcknowledgeDeleted(
+      'wf-missing',
+      'high',
+      'headless.exec',
+      [{ args: ['recreate-task', 'wf-missing/task-a'] }],
+      {
+        coordinator: { submit },
+        workflowExists: () => false,
+      },
+    );
+
+    expect(result.intentId).toBe(0);
+    expect(result.accepted).toBe(true);
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it.fails('proof: headless recreate-task foreign-key race is accepted when the workflow is gone', () => {
+    const submit = vi.fn(() => {
+      throw makeForeignKeyError();
+    });
+    let exists = true;
+
+    const result = submitWorkflowMutationOrAcknowledgeDeleted(
+      'wf-missing',
+      'high',
+      'headless.exec',
+      [{ args: ['recreate-task', 'wf-missing/task-a'] }],
+      {
+        coordinator: { submit },
+        workflowExists: () => {
+          const current = exists;
+          exists = false;
+          return current;
+        },
+      },
+    );
+
+    expect(result.intentId).toBe(0);
+    expect(result.accepted).toBe(true);
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
 
   it('fixed: invoker retry-workflow for a missing workflow is accepted without queueing', () => {
     const submit = vi.fn(() => 42);


### PR DESCRIPTION
## Summary

This adds a small regression proof for the missing-workflow task-id case.

The bug shows up when `recreate-task` is given a `wf-.../task-id` target after that workflow is already gone.

These tests use `it.fails` so the broken case is visible without changing runtime behavior yet.

## Review Claim

This slice proves the missing-workflow `recreate-task` task-id case without changing runtime behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only one test file changes, and the new checks are explicitly pending with `it.fails`.

## Slice Rationale

The reviewer should see the failing case before the guard change that fixes it.

## Non-goals

- No runtime behavior change.
- No SSH pool or disk cleanup.
- No broader workflow recovery refactor.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && ./node_modules/.bin/vitest run src/__tests__/workflow-mutation-submit.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <proof-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
