### PR TITLE
[Missing workflow recreate-task](2) Accept task-id missing-workflow races

### DIFF
--- a/packages/app/src/__tests__/workflow-mutation-submit.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-submit.test.ts
@@ -147,7 +147,7 @@ describe('submitWorkflowMutationOrAcknowledgeDeleted', () => {
     expect(result.accepted).toBe(true);
     expect(submit).toHaveBeenCalledTimes(1);
   });
-  it.fails('proof: headless recreate-task for a missing workflow is accepted without queueing', () => {
+  it('headless recreate-task for a missing workflow is accepted without queueing', () => {
     const submit = vi.fn(() => 42);
 
     const result = submitWorkflowMutationOrAcknowledgeDeleted(
@@ -166,7 +166,7 @@ describe('submitWorkflowMutationOrAcknowledgeDeleted', () => {
     expect(submit).not.toHaveBeenCalled();
   });
 
-  it.fails('proof: headless recreate-task foreign-key race is accepted when the workflow is gone', () => {
+  it('headless recreate-task foreign-key race is accepted when the workflow is gone', () => {
     const submit = vi.fn(() => {
       throw makeForeignKeyError();
     });

--- a/packages/app/src/workflow-mutation-submit.ts
+++ b/packages/app/src/workflow-mutation-submit.ts
@@ -33,6 +33,17 @@ function headlessExecCommand(args: unknown[]): string | undefined {
   return typeof command === 'string' ? command : undefined;
 }
 
+function matchesWorkflowTarget(target: unknown, workflowId: string): boolean {
+  if (target === workflowId) {
+    return true;
+  }
+  if (typeof target !== 'string') {
+    return false;
+  }
+  const slashIndex = target.indexOf('/');
+  return slashIndex > 0 && target.slice(0, slashIndex) === workflowId;
+}
+
 function isMissingWorkflowIdempotentMutation(channel: string, workflowId: string, args: unknown[]): boolean {
   if (
     channel === 'invoker:delete-workflow'
@@ -46,10 +57,10 @@ function isMissingWorkflowIdempotentMutation(channel: string, workflowId: string
   }
   const payload = args[0] as { args?: unknown[] } | undefined;
   const command = headlessExecCommand(args);
-  if (!command || !MISSING_WORKFLOW_IDEMPOTENT_COMMANDS.has(command)) {
+  if (!command || !MISSING_WORKFLOW_IDEMPOTENT_COMMANDS.has(command) || !Array.isArray(payload?.args)) {
     return false;
   }
-  return Array.isArray(payload?.args) && payload.args[1] === workflowId;
+  return matchesWorkflowTarget(payload.args[1], workflowId);
 }
 
 function isForeignKeyConstraintError(error: unknown): boolean {


### PR DESCRIPTION
## Summary

This fixes the workflow task-id case behind the `FOREIGN KEY constraint failed` error during `recreate-task` recovery.

The bug came from a guard that only recognized bare workflow IDs. Task IDs like `wf-.../task-id` missed that missing-workflow check.

The fix teaches that guard to treat task-shaped IDs from the same workflow as already gone, so the mutation is not queued again.

## Review Claim

This slice makes workflow mutation routing recognize `wf-.../task-id` recreate targets.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change stays inside one routing helper in `workflow-mutation-submit.ts` and is covered by the focused regression tests from slice 1.

## Slice Rationale

The routing change is easier to review after the proof slice shows the exact task-id case it fixes.

## Non-goals

- No SSH pool scheduling changes.
- No remote disk cleanup.
- No changes to unrelated mutation flows.

## Architecture

### Before

Only the bare workflow ID path reached the missing-workflow result.

### After

Task-shaped IDs from the same workflow reach that same result through the same routing helper.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && ./node_modules/.bin/vitest run src/__tests__/workflow-mutation-submit.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <fix-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
