### PR TITLE
Control the selected worker from the Workers details panel

### DIFF
--- a/packages/app/e2e/workers-surface.spec.ts
+++ b/packages/app/e2e/workers-surface.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, captureScreenshot } from './fixtures/electron-app.js';
 
-test('workers surface shows read-only worker activity', async ({ page }) => {
+test('workers surface shows the worker control in the details panel', async ({ page }) => {
   await page.getByTestId('sidebar-workers').click();
 
   await expect(page.getByTestId('workers-rail')).toBeVisible();
@@ -10,8 +10,45 @@ test('workers surface shows read-only worker activity', async ({ page }) => {
   await expect(page.getByTestId('worker-row-autofix')).toBeVisible();
   await expect(page.getByTestId('worker-row-pr-status')).toBeVisible();
   await expect(page.getByTestId('worker-row-ci-failure')).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Start process' })).toHaveCount(0);
-  await expect(page.getByRole('button', { name: 'Stop process' })).toHaveCount(0);
+
+  await page.getByTestId('worker-row-pr-status').click();
+  await expect(page.getByTestId('worker-detail-start-stop')).toBeVisible();
+  await expect(page.locator('[data-testid^="worker-start-stop-"]')).toHaveCount(0);
 
   await captureScreenshot(page, 'workers-read-only-surface');
+});
+
+test('workers surface details control turns one worker off without touching the others', async ({ page }) => {
+  await page.getByTestId('sidebar-workers').click();
+  await expect(page.getByTestId('worker-process-list')).toBeVisible();
+
+  await page.getByTestId('worker-row-pr-status').click();
+  const control = page.getByTestId('worker-detail-start-stop');
+  await expect(control).toHaveAttribute('data-action', 'stop');
+  await expect(page.getByTestId('worker-lifecycle-pr-status')).toHaveAttribute('data-lifecycle', 'running');
+  await captureScreenshot(page, 'workers-detail-control-step-1-running');
+
+  await control.click();
+
+  await expect(page.getByTestId('worker-lifecycle-pr-status')).toHaveAttribute('data-lifecycle', 'stopped');
+  await expect(control).toHaveAttribute('data-action', 'start');
+  await expect(page.getByTestId('worker-lifecycle-ci-failure')).toHaveAttribute('data-lifecycle', 'running');
+  await captureScreenshot(page, 'workers-detail-control-step-2-one-off');
+
+  await control.click();
+
+  await expect(page.getByTestId('worker-lifecycle-pr-status')).toHaveAttribute('data-lifecycle', 'running');
+  await expect(control).toHaveAttribute('data-action', 'stop');
+  await captureScreenshot(page, 'workers-detail-control-step-3-back-on');
+});
+
+test('workers surface details control follows the selected worker', async ({ page }) => {
+  await page.getByTestId('sidebar-workers').click();
+  await expect(page.getByTestId('worker-process-list')).toBeVisible();
+
+  await page.getByTestId('worker-row-pr-status').click();
+  await expect(page.getByTestId('worker-detail-start-stop')).toHaveAttribute('data-action', 'stop');
+
+  await page.getByTestId('worker-row-autofix').click();
+  await expect(page.getByTestId('worker-detail-start-stop')).toHaveAttribute('data-action', 'start');
 });

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -35,6 +35,7 @@ import { WorkflowGraph } from './components/WorkflowGraph.js';
 import { FloatingGraphPanel } from './components/FloatingGraphPanel.js';
 import { WorkflowInspector } from './components/WorkflowInspector.js';
 import { WorkerDetailsPanel } from './components/WorkerDetailsPanel.js';
+import { WorkerDetailControl } from './components/WorkerDetailControl.js';
 import { WorkerActivityCard } from './components/WorkerActivityCard.js';
 import { groupWorkflowCoreActivity } from './lib/workflow-core-activity.js';
 import { ActionGraphView } from './components/ActionGraphView.js';
@@ -3667,15 +3668,23 @@ export function App() {
                 </span>
               </div>
             </div>
-            <button
-              type="button"
-              aria-label="Return home"
-              data-testid="workers-return-home"
-              onClick={handleDismissBrowserSurface}
-              className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
-            >
-              Home
-            </button>
+            <div className="flex shrink-0 items-center gap-2">
+              <WorkerDetailControl
+                worker={selectedWorker}
+                readOnly={runtimeStatus?.readOnly === true}
+                onStartWorker={handleStartWorker}
+                onStopWorker={handleStopWorker}
+              />
+              <button
+                type="button"
+                aria-label="Return home"
+                data-testid="workers-return-home"
+                onClick={handleDismissBrowserSurface}
+                className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+              >
+                Home
+              </button>
+            </div>
           </div>
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto p-4">

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, act, cleanup, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { WorkflowMeta } from '../types.js';
@@ -68,7 +68,7 @@ describe('App launch (component)', () => {
     Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
   });
 
-  it('opens read-only worker status from the left panel', async () => {
+  it('opens worker status and controls the selected worker from the details panel', async () => {
     Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
     act(() => window.dispatchEvent(new Event('resize')));
     mock.setWorkerStatus({
@@ -143,8 +143,18 @@ describe('App launch (component)', () => {
     expect(screen.getAllByText('Source: Built In').length).toBeGreaterThan(0);
     expect(screen.getByText('Checked PR status')).toBeInTheDocument();
     expect(screen.getByText('PR check finished')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Start process' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Stop process' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('worker-start-stop-pr-status')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('worker-row-pr-status'));
+
+    const control = await screen.findByTestId('worker-detail-start-stop');
+    expect(control).toBeEnabled();
+    expect(control).toHaveTextContent('Disable worker');
+
+    fireEvent.click(control);
+
+    await waitFor(() => expect(mock.api.stopWorker).toHaveBeenCalledWith('pr-status'));
+    expect(mock.api.startWorker).not.toHaveBeenCalled();
   });
   it('renders the Apple-like source list without manual plan loading', async () => {
     Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });

--- a/packages/ui/src/__tests__/worker-detail-control.test.tsx
+++ b/packages/ui/src/__tests__/worker-detail-control.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { WorkerDetailControl } from '../components/WorkerDetailControl.js';
+import type { WorkerStatusEntry } from '../types.js';
+
+function makeWorker(overrides: Partial<WorkerStatusEntry> = {}): WorkerStatusEntry {
+  return {
+    kind: 'pr-status',
+    note: 'Polls review-gate PR status.',
+    lifecycle: 'running',
+    policy: 'enabled',
+    autoStarts: true,
+    desiredEnabled: true,
+    startable: false,
+    stoppable: true,
+    recentActions: [],
+    ...overrides,
+  };
+}
+
+describe('WorkerDetailControl', () => {
+  it('stops the selected worker and names it in the call', async () => {
+    const onStopWorker = vi.fn(async () => {});
+    render(
+      <WorkerDetailControl
+        worker={makeWorker()}
+        onStartWorker={vi.fn()}
+        onStopWorker={onStopWorker}
+      />,
+    );
+
+    const control = screen.getByTestId('worker-detail-start-stop');
+    expect(control).toHaveTextContent('Disable worker');
+    expect(control).toHaveAttribute('data-action', 'stop');
+
+    fireEvent.click(control);
+
+    await waitFor(() => expect(onStopWorker).toHaveBeenCalledWith('pr-status'));
+  });
+
+  it('starts a stopped worker', async () => {
+    const onStartWorker = vi.fn(async () => {});
+    render(
+      <WorkerDetailControl
+        worker={makeWorker({ kind: 'autofix', lifecycle: 'stopped', startable: true, stoppable: false })}
+        onStartWorker={onStartWorker}
+        onStopWorker={vi.fn()}
+      />,
+    );
+
+    const control = screen.getByTestId('worker-detail-start-stop');
+    expect(control).toHaveTextContent('Enable worker');
+
+    fireEvent.click(control);
+
+    await waitFor(() => expect(onStartWorker).toHaveBeenCalledWith('autofix'));
+  });
+
+  it('offers to start an exited worker rather than stop it', () => {
+    render(
+      <WorkerDetailControl
+        worker={makeWorker({ lifecycle: 'exited' })}
+        onStartWorker={vi.fn()}
+        onStopWorker={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('worker-detail-start-stop')).toHaveAttribute('data-action', 'start');
+  });
+
+  it('is disabled in a read-only window', () => {
+    const onStopWorker = vi.fn();
+    render(
+      <WorkerDetailControl
+        worker={makeWorker()}
+        readOnly
+        onStartWorker={vi.fn()}
+        onStopWorker={onStopWorker}
+      />,
+    );
+
+    const control = screen.getByTestId('worker-detail-start-stop');
+    expect(control).toBeDisabled();
+    expect(control).toHaveAttribute('title', 'Read-only window');
+    fireEvent.click(control);
+    expect(onStopWorker).not.toHaveBeenCalled();
+  });
+
+  it('honours a host-supplied reason for disabling the control', () => {
+    render(
+      <WorkerDetailControl
+        worker={makeWorker({ controlDisabledReason: 'Controls unavailable' })}
+        onStartWorker={vi.fn()}
+        onStopWorker={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('worker-detail-start-stop')).toBeDisabled();
+  });
+
+  it('snaps back and logs when the host rejects the change', async () => {
+    const error = new Error('Worker runtime controller is unavailable');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <WorkerDetailControl
+        worker={makeWorker()}
+        onStartWorker={vi.fn()}
+        onStopWorker={vi.fn(async () => { throw error; })}
+      />,
+    );
+
+    const control = screen.getByTestId('worker-detail-start-stop');
+    fireEvent.click(control);
+
+    await waitFor(() => expect(control).toHaveAttribute('data-action', 'stop'));
+    expect(control).toHaveTextContent('Disable worker');
+    expect(consoleError).toHaveBeenCalledWith('Failed to disable worker pr-status', error);
+    consoleError.mockRestore();
+  });
+
+  it('drops optimistic state when the panel switches to another worker', async () => {
+    const { rerender } = render(
+      <WorkerDetailControl
+        worker={makeWorker()}
+        onStartWorker={vi.fn()}
+        onStopWorker={vi.fn(async () => {})}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('worker-detail-start-stop'));
+    await waitFor(() => expect(screen.getByTestId('worker-detail-start-stop')).toHaveAttribute('data-action', 'start'));
+
+    rerender(
+      <WorkerDetailControl
+        worker={makeWorker({ kind: 'ci-failure', lifecycle: 'running' })}
+        onStartWorker={vi.fn()}
+        onStopWorker={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('worker-detail-start-stop')).toHaveAttribute('data-action', 'stop');
+  });
+});

--- a/packages/ui/src/components/WorkerDetailControl.tsx
+++ b/packages/ui/src/components/WorkerDetailControl.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+import type { WorkerStatusEntry } from '../types.js';
+
+interface WorkerDetailControlProps {
+  worker: WorkerStatusEntry;
+  readOnly?: boolean;
+  onStartWorker: (kind: string) => Promise<void> | void;
+  onStopWorker: (kind: string) => Promise<void> | void;
+}
+
+type OptimisticLifecycle = 'running' | 'stopped';
+
+export function WorkerDetailControl({
+  worker,
+  readOnly = false,
+  onStartWorker,
+  onStopWorker,
+}: WorkerDetailControlProps) {
+  const [optimistic, setOptimistic] = useState<OptimisticLifecycle | null>(null);
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    setOptimistic(null);
+    setPending(false);
+  }, [worker.kind]);
+
+  useEffect(() => {
+    if (!optimistic) return;
+    const serverRunning = worker.lifecycle === 'running';
+    if (serverRunning === (optimistic === 'running')) {
+      setOptimistic(null);
+    }
+  }, [worker.lifecycle, optimistic]);
+
+  const lifecycle = optimistic ?? worker.lifecycle;
+  const showStart = lifecycle !== 'running';
+  const disabledReason = readOnly ? 'Read-only window' : worker.controlDisabledReason;
+  const disabled = Boolean(disabledReason) || pending;
+
+  return (
+    <button
+      type="button"
+      data-testid="worker-detail-start-stop"
+      data-action={showStart ? 'start' : 'stop'}
+      title={disabledReason}
+      disabled={disabled}
+      className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-200 disabled:cursor-not-allowed disabled:opacity-50 hover:bg-gray-800"
+      onClick={() => {
+        if (disabled) return;
+        setOptimistic(showStart ? 'running' : 'stopped');
+        setPending(true);
+        void Promise.resolve(showStart ? onStartWorker(worker.kind) : onStopWorker(worker.kind))
+          .catch((error: unknown) => {
+            setOptimistic(null);
+            console.error(`Failed to ${showStart ? 'enable' : 'disable'} worker ${worker.kind}`, error);
+          })
+          .finally(() => setPending(false));
+      }}
+    >
+      {pending ? (showStart ? 'Enabling…' : 'Disabling…') : showStart ? 'Enable worker' : 'Disable worker'}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

The Workers page shows every worker and its state, but gives you no way to turn one off.

The details panel on the right now has an Enable/Disable button at the top, next to Home. It acts on whichever worker you select on the left.

Turning one worker off leaves the others running, and the choice survives a restart.

The button is disabled in a read-only window.

## Review Claim

The Workers details panel can turn its selected worker on and off, and using it affects only that worker.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Reuses the per-kind channels already driving the Queue view buttons, so this adds a caller, not a mutation path.

The worker rows and the shared `WorkerActivityCard` are untouched, so the Queue view cannot regress.

Reverses one earlier decision on purpose: #3149 built this page read-only and hid start/stop here. That invariant is retired, and the guards that named it are rewritten rather than deleted.

## Slice Rationale

One surface, one control. The engine, channels, and handlers already exist; only the Workers details panel was missing the button.

## Non-goals

Does not put a button on each worker row; the list stays read-only.

Does not change the Queue view, whose own per-worker buttons are untouched.

Does not add a global "turn everything off" switch.

## Architecture

The Workers page was the only worker surface with no route to the existing per-kind channels. Its details panel now uses the same handlers the Queue view already uses.

### Before

```mermaid
graph TD
    Q["Queue view rows"] --> H["handleStartWorker / handleStopWorker"]
    H --> C["invoker:start-worker / invoker:stop-worker (per kind)"]
    W["Workers page"] --> R["read-only: no route to controls"]
```

### After

```mermaid
graph TD
    Q["Queue view rows"] --> H["handleStartWorker / handleStopWorker"]
    W["Workers details panel"] --> D["WorkerDetailControl (selected worker)"]
    D --> H
    H --> C["invoker:start-worker / invoker:stop-worker (per kind)"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test` — 772 pass, incl. 7 in `worker-detail-control.test.tsx` covering start, stop, exited, read-only, host rejection, and switching selection
- [ ] `cd packages/app && CAPTURE_MODE=after npx playwright test workers-surface.spec.ts` — 3 pass; drives the real button in Electron, asserts one worker stops while its neighbour keeps running, and that the control follows the selected worker
- [ ] `pnpm build` — clean across all packages
- [ ] `pnpm run check:comments && pnpm run check:types` — clean

The shared `WorkerActivityCard` is not in this diff, so the Queue view is unchanged by construction.

</details>

## Visual Proof

Captured by `workers-surface.spec.ts`, driving the real button in Electron on the Workers page.

**Walkthrough (PR status: running → off → running):**

![Worker control in the details panel](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-0d71b3/workers-detail-control-walkthrough.gif)

**Step 1 — control at the top of the details panel.** With PR status selected, "Disable worker" sits at the top right next to Home. The chip reads `State: Running`, and the rows on the left stay read-only. The sidebar reads "9 processes running".

![Step 1: Disable worker at the top of the details panel](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-0d71b3/workers-detail-control-step-1-running.png)

**Step 2 — one worker off, neighbours untouched.** The button becomes "Enable worker", the chip becomes `State: Stopped`, Registry Runtime becomes "Not running", and the PR status row on the left flips to `Process: Stopped`. PR summary refresh below it still shows `Process: Running`, and the sidebar drops to "8 processes running" — one, not all.

![Step 2: PR status off while others keep running](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-0d71b3/workers-detail-control-step-2-one-off.png)

**Step 3 — back on.** PR status returns to `State: Running` and the sidebar returns to "9 processes running".

![Step 3: PR status back on](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-0d71b3/workers-detail-control-step-3-back-on.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 99dd3af78`
- Post-revert steps: None. The Workers page returns to read-only and the Queue view keeps its buttons.
- Data migration? No. No schema, contract, or persistence change.

</details>
