### PR TITLE
[Focus Steal](1) Capture where focus lands when a mutation fails

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -700,6 +700,28 @@ test.describe('Visual proof capture', () => {
     await captureScreenshot(page, 'workflow-delete-after-3s');
   });
 
+  test('mutation failure does not steal focus', async ({ page }) => {
+    const workflowId = await loadPlanAndSelectWorkflow(page, TEST_PLAN);
+    await expect(workflowNode(page, workflowId)).toBeVisible();
+    await expect(page.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
+    await captureScreenshot(page, 'mutation-failure-focus-1-before');
+
+    // Asking for a fix with a harness that is not installed fails inside the
+    // mutation coordinator, which is the real path that emits a task-scoped
+    // failure event.
+    const tasks = await getTasks(page);
+    const targetTaskId = String(tasks[0].id);
+    await page.evaluate(
+      (id) => { void (window.invoker.fixWithAgent(id, 'not-a-real-harness') as Promise<unknown>).catch(() => {}); },
+      targetTaskId,
+    );
+
+    // The badge proves the failure actually landed. Without this the capture
+    // would look identical whether or not any event was ever emitted.
+    await expect(page.getByTestId('sidebar-attention')).toContainText('1', { timeout: 15000 });
+    await captureScreenshot(page, 'mutation-failure-focus-2-after');
+  });
+
   test('terminal planning loads graph', async ({ page }) => {
     const plannedYaml = yamlStringify(TERMINAL_PLANNED_PLAN);
     // Mirror the real planner reply shape: prose followed by the full fenced


### PR DESCRIPTION
## Summary

A mutation failure currently throws you across the app.

This slice only adds the capture that records where focus lands, so the fix can be judged against a picture rather than a claim.

The capture asks for a fix with a harness that is not installed. That fails inside the mutation coordinator, which is the real path that emits a task-scoped failure.

It asserts the Needs Attention badge before capturing. Without that assertion the screenshots look identical whether or not any failure was ever emitted.

An earlier attempt at this proof did exactly that: two frames of nothing happening, because the driver never actually failed.

Green on master today, where it records the sidebar switching to Needs Attention on its own.

## Review Claim

The visual-proof run drives a genuine task-scoped mutation failure and captures the sidebar state on either side of it.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Capture-only. It touches no product code, so no runtime behavior can shift.

The badge assertion holds on master and after the fix, so the case stays green across the pair.

## Slice Rationale

Evidence lands before the change it justifies. The repo also classifies anything named visual-proof as its own review unit, so it cannot ride with the renderer fix.

## Non-goals

Does not change any product behavior. The jump still happens after this slice.

Does not change existing capture cases or their baselines.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec playwright test e2e/visual-proof.spec.ts -g "mutation failure does not steal focus"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
