### PR TITLE
[Focus Steal](2) Stop mutation failures from stealing the operator's focus

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -700,6 +700,28 @@ test.describe('Visual proof capture', () => {
     await captureScreenshot(page, 'workflow-delete-after-3s');
   });
 
+  test('mutation failure does not steal focus', async ({ page }) => {
+    const workflowId = await loadPlanAndSelectWorkflow(page, TEST_PLAN);
+    await expect(workflowNode(page, workflowId)).toBeVisible();
+    await expect(page.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
+    await captureScreenshot(page, 'mutation-failure-focus-1-before');
+
+    // Asking for a fix with a harness that is not installed fails inside the
+    // mutation coordinator, which is the real path that emits a task-scoped
+    // failure event.
+    const tasks = await getTasks(page);
+    const targetTaskId = String(tasks[0].id);
+    await page.evaluate(
+      (id) => { void (window.invoker.fixWithAgent(id, 'not-a-real-harness') as Promise<unknown>).catch(() => {}); },
+      targetTaskId,
+    );
+
+    // The badge proves the failure actually landed. Without this the capture
+    // would look identical whether or not any event was ever emitted.
+    await expect(page.getByTestId('sidebar-attention')).toContainText('1', { timeout: 15000 });
+    await captureScreenshot(page, 'mutation-failure-focus-2-after');
+  });
+
   test('terminal planning loads graph', async ({ page }) => {
     const plannedYaml = yamlStringify(TERMINAL_PLANNED_PLAN);
     // Mirror the real planner reply shape: prose followed by the full fenced

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1594,38 +1594,12 @@ export function App() {
       const failedTaskId = event.taskId;
       if (failedTaskId) {
         setMutationFailuresByTaskId((prev) => new Map(prev).set(failedTaskId, event));
-        const task = tasksRef.current.get(failedTaskId);
-        if (task) {
-          selectTaskById(task.id);
-        } else {
-          // Set selection from the event ids directly so the inspector opens even
-          // if the task map has not hydrated this id yet.
-          setSelectedTaskId(failedTaskId);
-          setWorkflowSelectionDismissed(false);
-          if (event.workflowId) {
-            setSelectedWorkflowId(event.workflowId);
-          }
-          setInspectorCollapsed(false);
-          setInspectorManualOpen(true);
-          setContextMenu(null);
-          setWorkflowContextMenu(null);
-          focusKeyboardRegion('taskGraph');
-        }
-        setSidebarSurface('attention');
-      } else if (event.workflowId) {
-        setSelectedWorkflowId(event.workflowId);
-        setSelectedTaskId(null);
-        setWorkflowSelectionDismissed(false);
-        setContextMenu(null);
-        setWorkflowContextMenu(null);
-        setSidebarSurface('workflows');
-        focusKeyboardRegion('workflowGraph');
-      } else {
-        notifyMutationError('Mutation failed', event.message);
+        return;
       }
+      notifyMutationError('Mutation failed', event.message);
     });
     return () => { unsubscribe?.(); };
-  }, [focusKeyboardRegion, selectTaskById]);
+  }, []);
 
   const selectRelativeNode = useCallback((direction: 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight') => {
     const inTaskGraph = keyboardRegion === 'taskGraph';

--- a/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
+++ b/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
@@ -1,11 +1,11 @@
 /**
  * Integration test: workflow-mutation-failed handling in <App />.
  *
- * Task-scoped mutation failures are surfaced through the Needs Attention
- * workflow/task browser: the relevant task is selected, the attention surface is
- * opened/focused, and the inspector shows a persistent mutation-failure detail
- * panel. Workflow-scoped failures open the Workflows browser. Routine failures
- * no longer render a global top banner.
+ * A mutation failure never moves the operator. It does not change the sidebar
+ * surface, the selection, or the camera. Task-scoped failures are recorded so
+ * Needs Attention counts them and the inspector shows the failure detail once
+ * the operator navigates there themselves. Failures with no task context are
+ * transient toast errors. No global top banner is rendered.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -33,7 +33,16 @@ const workflow: WorkflowMeta = {
   status: 'running',
 };
 
-describe('Workflow mutation failed banner', () => {
+const approveFailure = {
+  intentId: 42,
+  workflowId: 'wf-1',
+  channel: 'invoker:approve',
+  taskId: 'wf-1/verify-worker-summary-surface',
+  message: 'Error: SSH target "remote_digital_ocean_3" cannot run codex: missing execution harness "codex"',
+  failedAt: '2026-07-08T10:00:00.000Z',
+};
+
+describe('Workflow mutation failed handling', () => {
   let mock: MockInvoker;
 
   beforeEach(() => {
@@ -62,14 +71,7 @@ describe('Workflow mutation failed banner', () => {
     await settleTasks();
 
     act(() => {
-      mock.fireWorkflowMutationFailed({
-        intentId: 42,
-        workflowId: 'wf-1',
-        channel: 'invoker:approve',
-        taskId: 'wf-1/verify-worker-summary-surface',
-        message: 'Error: SSH target "remote_digital_ocean_3" cannot run codex: missing execution harness "codex"',
-        failedAt: '2026-07-08T10:00:00.000Z',
-      });
+      mock.fireWorkflowMutationFailed(approveFailure);
     });
 
     await waitFor(() => {
@@ -77,21 +79,76 @@ describe('Workflow mutation failed banner', () => {
     });
   });
 
-  it('selects the task, opens Needs Attention, and surfaces failure details in the inspector', async () => {
+  it('leaves the sidebar surface alone when a task-scoped failure arrives', async () => {
     render(<App />);
     await settleTasks();
+    expect(screen.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
+
+    act(() => {
+      mock.fireWorkflowMutationFailed(approveFailure);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('1');
+    });
+    expect(screen.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByTestId('sidebar-attention')).not.toHaveAttribute('aria-current', 'page');
+  });
+
+  it('leaves the sidebar surface alone when a workflow-scoped failure arrives', async () => {
+    render(<App />);
+    await settleTasks();
+    expect(screen.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
 
     act(() => {
       mock.fireWorkflowMutationFailed({
-        intentId: 42,
+        intentId: 47,
         workflowId: 'wf-1',
-        channel: 'invoker:approve',
-        taskId: 'wf-1/verify-worker-summary-surface',
-        message: 'Error: SSH target "remote_digital_ocean_3" cannot run codex: missing execution harness "codex"',
+        channel: 'invoker:recreate',
+        message: 'recreate failed',
         failedAt: '2026-07-08T10:00:00.000Z',
       });
     });
 
+    await waitFor(() => {
+      expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByTestId('sidebar-workflows')).not.toHaveAttribute('aria-current', 'page');
+  });
+
+  it('does not steal the selection while the operator is working elsewhere', async () => {
+    render(<App />);
+    await settleTasks();
+    fireEvent.click(screen.getByTestId('sidebar-workflows'));
+    await waitFor(() => {
+      expect(screen.getByTestId('sidebar-workflows')).toHaveAttribute('aria-current', 'page');
+    });
+
+    act(() => {
+      mock.fireWorkflowMutationFailed(approveFailure);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('1');
+    });
+    expect(screen.getByTestId('sidebar-workflows')).toHaveAttribute('aria-current', 'page');
+    expect(screen.queryByTestId('task-mutation-failure-detail')).not.toBeInTheDocument();
+  });
+
+  it('surfaces failure details in the inspector once the operator opens Needs Attention', async () => {
+    render(<App />);
+    await settleTasks();
+
+    act(() => {
+      mock.fireWorkflowMutationFailed(approveFailure);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('1');
+    });
+
+    fireEvent.click(screen.getByTestId('sidebar-attention'));
     await waitFor(() => {
       expect(screen.getByTestId('sidebar-attention')).toHaveAttribute('aria-current', 'page');
     });
@@ -126,6 +183,7 @@ describe('Workflow mutation failed banner', () => {
       });
     });
 
+    fireEvent.click(screen.getByTestId('sidebar-attention'));
     await waitFor(() => {
       expect(screen.getByTestId('task-mutation-failure-detail')).toBeInTheDocument();
     });
@@ -146,31 +204,6 @@ describe('Workflow mutation failed banner', () => {
       expect(detail).toBeInTheDocument();
       expect(detail).toHaveTextContent('Fix failed');
       expect(detail).toHaveTextContent('Command: fix');
-    });
-  });
-
-  it('opens the Workflows browser for workflow-scoped failures', async () => {
-    render(<App />);
-    await settleTasks();
-
-    act(() => {
-      mock.fireWorkflowMutationFailed({
-        intentId: 47,
-        workflowId: 'wf-1',
-        channel: 'invoker:recreate',
-        message: 'recreate failed',
-        failedAt: '2026-07-08T10:00:00.000Z',
-      });
-    });
-
-    await waitFor(() => {
-      expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
-    });
-    await waitFor(() => {
-      expect(screen.getByTestId('sidebar-workflows')).toHaveAttribute('aria-current', 'page');
-    });
-    await waitFor(() => {
-      expect(screen.getByTestId('browser-rail')).toHaveTextContent('Workflows');
     });
   });
 });


### PR DESCRIPTION
## Summary

A mutation failure used to hijack the app. It switched the sidebar to Needs Attention, grabbed the graph selection, forced the inspector open, and recentered the camera.

Tearing down a workflow tripped this constantly, because a teardown cancels that workflow's in-flight mutations and every cancellation is announced as a failure.

The handler now records the failure and does nothing else.

Needs Attention already counts it in the sidebar badge. The inspector still shows the detail once you navigate there yourself.

Failures with no task context stay a transient toast. That now also covers workflow-scoped failures, which used to open the Workflows surface instead of telling you anything.

This undoes the navigation half of #4146. That PR retired a dismissible banner and put an involuntary jump in its place; the badge is the passive channel it needed.

## Review Claim

A mutation failure never changes the sidebar surface, the selection, or the camera.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Every failure stays visible. Task-scoped failures are still recorded, so the Needs Attention badge still counts them and the inspector detail panel is unchanged once you open it. Failures with no task id now reach the toast that already existed for the no-context case.

The handler only ever wrote renderer state. It adds no IPC, persistence, or mutation semantics, and the events it consumes are untouched.

## Slice Rationale

One claim, one file of product code. The capture that produced the proof below landed in the previous slice, because the repo classifies anything named visual-proof as its own review unit.

## Non-goals

Does not change when mutation-failure events are emitted, or what they contain.

Does not change the Needs Attention badge count, its ordering, or the inspector detail panel.

Does not change any navigation you trigger yourself, including the command palette entry for Needs Attention.

## Architecture

Control flow loses its involuntary branch. The event still arrives and is still recorded; it just stops driving the sidebar.

### Before

```mermaid
graph TD
    A["onWorkflowMutationFailed event"] --> B["Has task id?"]
    B -->|yes| C["record failure"]
    C --> D["force sidebar to Needs Attention"]
    D --> E["steal selection, open inspector, recenter camera"]
    B -->|workflow only| F["force sidebar to Workflows, steal selection"]
    B -->|no context| G["toast"]
```

### After

```mermaid
graph TD
    A["onWorkflowMutationFailed event"] --> B["Has task id?"]
    B -->|yes| C["record failure — operator stays put"]
    C --> D["Needs Attention badge count goes up"]
    D --> E["operator opens Needs Attention when ready; inspector detail is there"]
    B -->|no task id| G["toast"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Visual Proof

Driven live in the Electron app. The capture asks for a fix with a harness that is not installed, which fails inside the mutation coordinator — the real path that emits a task-scoped failure.

Baseline for both runs: sidebar on Home, Needs Attention badge reads 0.

![Home selected, Needs Attention badge reads 0, before any failure](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-fa55fc/focus-steal-baseline.png)

Before — the failure arrives and the app throws you across the room: sidebar switched to Needs Attention, the browser rail opened itself, and the inspector is showing the amber "FIX FAILED" panel for a task you never selected.

![Sidebar jumped to Needs Attention with the rail open and an amber FIX FAILED inspector panel](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-fa55fc/focus-steal-before.png)

After — same failure, same moment. The sidebar is still on Home and the graph is untouched. The only change is the Needs Attention badge ticking to 1.

![Sidebar still on Home, graph untouched, Needs Attention badge reads 1](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-fa55fc/focus-steal-after.png)

The badge going 0 to 1 is what proves the failure actually landed. Without it these frames would look identical whether or not any event was ever emitted, which is exactly how an earlier attempt produced two screenshots of nothing happening.

[Walkthrough video, before: the failure fires and the sidebar jumps to Needs Attention on its own](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-fa55fc/focus-steal-before.webm)

[Walkthrough video, after: the same failure fires, the badge ticks up, and the sidebar stays on Home](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-fa55fc/focus-steal-after.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the previous navigation behavior.
- Data migration? No

</details>
