### PR TITLE
Stop PR tooling dying on large diffs

### DIFF
--- a/scripts/check-added-comments.mjs
+++ b/scripts/check-added-comments.mjs
@@ -51,10 +51,14 @@ function parseArgs(argv) {
   };
 }
 
+/** Diff output scales with the change, so a large PR outgrows Node's 1MB default. */
+const GIT_MAX_BUFFER_BYTES = 256 * 1024 * 1024;
+
 function runGit(root, args) {
   return execFileSync('git', args, {
     cwd: root,
     encoding: 'utf8',
+    maxBuffer: GIT_MAX_BUFFER_BYTES,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 }

--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -348,9 +348,13 @@ export function buildGitHubRawMediaUrl(nwo, branch, filePath) {
 
 // ── Git + GitHub helpers ────────────────────────────────────────────────────
 
+/** Full-context diffs scale with whole-file size, so they outgrow Node's 1MB default. */
+const GIT_MAX_BUFFER_BYTES = 256 * 1024 * 1024;
+
 function runGit(args, options = {}) {
   return execFileSync('git', args, {
     encoding: 'utf-8',
+    maxBuffer: GIT_MAX_BUFFER_BYTES,
     ...options,
   });
 }

--- a/scripts/lint-pr-diff-atomicity.mjs
+++ b/scripts/lint-pr-diff-atomicity.mjs
@@ -314,10 +314,14 @@ export function formatDiffAtomicityFindings(findings) {
   });
 }
 
+/** Full-context diffs scale with whole-file size, so they outgrow Node's 1MB default. */
+const GIT_MAX_BUFFER_BYTES = 256 * 1024 * 1024;
+
 function runGit(root, args) {
   return execFileSync('git', args, {
     cwd: root,
     encoding: 'utf8',
+    maxBuffer: GIT_MAX_BUFFER_BYTES,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 }

--- a/scripts/test-check-added-comments.mjs
+++ b/scripts/test-check-added-comments.mjs
@@ -96,4 +96,34 @@ const scriptPath = fileURLToPath(new URL('./check-added-comments.mjs', import.me
   }
 }
 
+// Temp git case: a diff larger than Node's 1MB execFileSync default still runs.
+// `git diff` streams every changed file back before any path filtering, so a
+// large lockfile update used to kill the checker with ENOBUFS.
+{
+  const root = mkdtempSync(path.join(tmpdir(), 'invoker-added-comments-big-'));
+  try {
+    execFileSync('git', ['init', '-q', '-b', 'master'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: root, stdio: 'ignore' });
+    writeFileSync(path.join(root, 'seed.txt'), 'seed\n');
+    execFileSync('git', ['add', '-A'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['commit', '-q', '-m', 'seed'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['checkout', '-q', '-b', 'feature'], { cwd: root, stdio: 'ignore' });
+
+    let lockfile = '';
+    for (let index = 0; index < 60000; index += 1) {
+      lockfile += `  '/some-package-${index}@1.0.0': {}\n`;
+    }
+    writeFileSync(path.join(root, 'pnpm-lock.yaml'), lockfile);
+    writeFileSync(path.join(root, 'package.json'), '{\n  "name": "probe"\n}\n');
+    execFileSync('git', ['add', '-A'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['commit', '-q', '-m', 'big dependency update'], { cwd: root, stdio: 'ignore' });
+
+    const output = execFileSync(process.execPath, [scriptPath, '--root', root, '--base', 'master'], { encoding: 'utf8' });
+    assert.match(output, /Checked added source lines; no disallowed comments found\./);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
 console.log('ok added comment checker');

--- a/scripts/test-pr-diff-atomicity.mjs
+++ b/scripts/test-pr-diff-atomicity.mjs
@@ -9,6 +9,7 @@ import {
   parseUnifiedDiff,
   collectDiffAtomicityFindings,
   formatDiffAtomicityFindings,
+  lintDiffAtomicityForGit,
 } from './lint-pr-diff-atomicity.mjs';
 
 const scriptPath = fileURLToPath(new URL('./lint-pr-diff-atomicity.mjs', import.meta.url));
@@ -220,6 +221,38 @@ function kinds(findings) {
 
     writeFileSync(path.join(root, 'packages/core/src/thing.ts'), 'export function run() {\n  return 2;\n}\n');
     execFileSync('git', ['commit', '-aqm', 'clean'], { cwd: root, stdio: 'ignore' });
+    const passOutput = execFileSync(process.execPath, [scriptPath, '--root', root, '--base', 'HEAD~1'], { encoding: 'utf8' });
+    assert.match(passOutput, /Diff atomicity validation passed\./);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+// Temp git case: a full-context diff larger than Node's 1MB execFileSync
+// default still lints. `--unified=200000` scales output with whole-file size,
+// so a small edit to a large file can exceed the default and used to throw
+// ENOBUFS before the diff was ever parsed.
+{
+  const root = mkdtempSync(path.join(tmpdir(), 'invoker-diff-atomicity-big-'));
+  try {
+    execFileSync('git', ['init', '-q'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: root, stdio: 'ignore' });
+    mkdirSync(path.join(root, 'packages/core/src'), { recursive: true });
+
+    const filler = 'export const padding = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";\n';
+    const fillerLines = Math.ceil((1024 * 1024 * 1.2) / filler.length);
+    const bigFile = path.join(root, 'packages/core/src/big.ts');
+    writeFileSync(bigFile, filler.repeat(fillerLines));
+    execFileSync('git', ['add', '.'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['commit', '-q', '-m', 'base'], { cwd: root, stdio: 'ignore' });
+
+    writeFileSync(bigFile, `export const added = 1;\n${filler.repeat(fillerLines)}`);
+    execFileSync('git', ['commit', '-aqm', 'small edit to a large file'], { cwd: root, stdio: 'ignore' });
+
+    const findings = lintDiffAtomicityForGit({ root, baseRef: 'HEAD~1' });
+    assert.ok(Array.isArray(findings), 'expected findings for an over-1MB full-context diff');
+
     const passOutput = execFileSync(process.execPath, [scriptPath, '--root', root, '--base', 'HEAD~1'], { encoding: 'utf8' });
     assert.match(passOutput, /Diff atomicity validation passed\./);
   } finally {


### PR DESCRIPTION
## Summary

Three PR/CI scripts die on large diffs. `create-pr` refuses to publish, and the `check:comments` gate crashes in CI.

Each shells out to git without a buffer size, so Node's 1MB default applies and git is killed mid-output.

`create-pr` and the atomicity linter ask git for full context, so output grows with the whole file, not the change.

A one-line edit to a couple of large files is enough to go over.

The comment gate diffs every changed file with no filter, so one big lockfile update is enough — even though it never reads that file.

All three git helpers now set the buffer explicitly. The `gh` helpers already set 20MB, which is why `gh` calls never hit this.

## Review Claim

The three git-shelling PR/CI scripts set an explicit buffer, so a large diff is processed instead of killing the tool.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

`maxBuffer` caps how much output a call may return; it reserves nothing up front, so raising it costs nothing on ordinary calls and only changes behaviour where the tool used to die.

No detection rule, severity, or message changes. Each script reaches the same verdict it always would have, on diffs it previously could not read at all.

## Slice Rationale

One cause, one fix. All three scripts carry the same missing option on the same kind of call, and two regressions cover the three entry points (the comment gate makes three diff calls through one helper).

I audited every other `execFileSync`/`spawnSync` in the repo. The rest are safe: build scripts inherit stdio, `gh` helpers already cap at 20MB, `gh pr list` is bounded by `--limit`, and the `ps` snapshot is ~0.24MB against 895 live processes.

## Non-goals

Does not retune any atomicity or comment rule, severity, or message.

Does not touch the `gh` helpers, which already set their own buffer.

## Test Plan

<details>
<summary>Test Plan</summary>

Reproductions, each on a sandbox repo:

- [ ] atomicity linter, 1.22MB full-context diff: before the fix `node scripts/test-pr-diff-atomicity.mjs` exits 1 with `spawnSync git ENOBUFS`; after, `ok pr diff atomicity`
- [ ] comment gate, 2MB lockfile diff: before the fix `node scripts/test-check-added-comments.mjs` exits 1 with ENOBUFS; after, `ok added comment checker`
- [ ] each regression re-fails when only its `maxBuffer` line is removed, confirming it guards the fix rather than passing vacuously

End-to-end through the real tool, throwaway branch, 1.22MB diff:

- [ ] `node scripts/create-pr.mjs --title "probe" --base master --body-file <f> --dry-run` — before: `Unable to compute diff atomicity context… / spawnSync git ENOBUFS`; after: computes the diff and proceeds to publication

Suites covering all three changed scripts:

- [ ] `node scripts/test-pr-diff-atomicity.mjs` — pass
- [ ] `node scripts/test-check-added-comments.mjs` — pass
- [ ] `node scripts/test-pr-body-validator.mjs` — pass
- [ ] `node scripts/test-review-unit-classification.mjs` — pass
- [ ] `node scripts/test-create-pr-visual-proof.mjs` — pass
- [ ] `node scripts/test-create-pr-stack-workflow.mjs` — pass
- [ ] `node scripts/test-pr-body-rollout.mjs` — pass
- [ ] `node scripts/test-land-stack.mjs` — pass

Found while publishing #4724, whose diff was 1.01MB — just over the limit.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f0e2d5269`
- Post-revert steps: None. The scripts return to failing on large diffs.
- Data migration? No.

</details>
