### PR TITLE
[Planner truncation notice](1) Prove cut-off planner replies are silently accepted

### DIFF
--- a/packages/surfaces/src/__tests__/planner-truncated-output-repro.test.ts
+++ b/packages/surfaces/src/__tests__/planner-truncated-output-repro.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import * as child_process from 'node:child_process';
+import { PlanConversation } from '../slack/plan-conversation.js';
+
+// Repro for planner replies that are cut off mid-message.
+//
+// The planner CLI streams the model's answer to stdout and exits 0 when the CLI
+// itself did not fail. A model that stops early — it reached its own output
+// budget — is indistinguishable from one that finished: stdout is non-empty and
+// the exit code is 0. `spawnPlanner` only rejects on empty stdout, so a partial
+// reply is accepted as a complete turn and recorded in conversation history with
+// nothing anywhere saying the reply was cut off.
+//
+// This suite pins the CURRENT (buggy) behavior so the proof lands green. The fix
+// slice flips these expectations to the corrected behavior.
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof child_process>();
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
+
+const mockSpawn = vi.mocked(child_process.spawn);
+
+interface FakeChildOptions {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+}
+
+function fakePlannerChild({ stdout = '', stderr = '', exitCode = 0 }: FakeChildOptions): any {
+  const proc = new EventEmitter() as any;
+  const stdoutEmitter = new EventEmitter();
+  const stderrEmitter = new EventEmitter();
+  proc.stdout = stdoutEmitter;
+  proc.stderr = stderrEmitter;
+  proc.kill = vi.fn();
+
+  setTimeout(() => {
+    if (stdout) stdoutEmitter.emit('data', Buffer.from(stdout));
+    if (stderr) stderrEmitter.emit('data', Buffer.from(stderr));
+    proc.emit('close', exitCode);
+  }, 0);
+
+  return proc;
+}
+
+// A reply that stops partway through the YAML plan: the ```yaml fence opens and
+// the text ends mid-token on an unterminated quoted string, exactly as it looks
+// when a model hits its output cap.
+const TRUNCATED_REPLY = [
+  'Here is the plan we discussed.',
+  '',
+  '```yaml',
+  'name: "Planning composer typing responsiveness"',
+  'onFinish: pull_request',
+  'mergeMode: external_review',
+  'tasks:',
+  '  - id: localize-composer-state',
+  '    description: "Move planning composer text into local component state so keystrokes stop re-rendering App; lock the fix with the fat-graph e2e b',
+].join('\n');
+
+describe('planner exit=0 with a cut-off reply — current behavior silently accepts truncation', () => {
+  let conversation: PlanConversation;
+
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    conversation = new PlanConversation({ plannerRetryLimit: 0 });
+  });
+
+  it('accepts a cut-off reply as a complete turn with no truncation notice', async () => {
+    mockSpawn.mockReturnValueOnce(fakePlannerChild({ stdout: TRUNCATED_REPLY, exitCode: 0 }));
+
+    const reply = await conversation.sendMessage('Draft the plan');
+
+    // BUG: the reply ends mid-word and nothing flags it as cut off.
+    expect(reply).not.toContain('cut off');
+    expect(reply.trimEnd().endsWith('fat-graph e2e b')).toBe(true);
+  });
+
+  it('stores the partial reply in history verbatim, as if the planner had finished', async () => {
+    mockSpawn.mockReturnValueOnce(fakePlannerChild({ stdout: TRUNCATED_REPLY, exitCode: 0 }));
+
+    await conversation.sendMessage('Draft the plan').catch(() => undefined);
+
+    const assistant = conversation.history.filter((entry) => entry.role === 'assistant');
+    expect(assistant.length).toBeGreaterThan(0);
+    // BUG: history keeps the cut-off text with no marker that it was truncated.
+    expect(assistant[assistant.length - 1].content).not.toContain('cut off');
+  });
+});


### PR DESCRIPTION
## Summary

The planning terminal does not run the model itself. It shells out to a planner CLI and prints that program's output as it streams in.

When the model reaches its own output limit, it stops mid-sentence. The CLI still exits successfully, because the CLI did not fail — the model did.

Invoker only treats a completely empty answer as a failure. So a half-finished reply is accepted as if it were complete, with nothing telling you it was cut off.

This slice is the proof. It adds a test that pins the current behavior: a reply ending mid-word is accepted with no truncation notice and stored in history verbatim.

## Review Claim

A cut-off planner reply is currently accepted as a complete turn with no notice, and this test documents that.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. It adds one spec file and touches no product code, so it cannot alter runtime behavior. It asserts today's behavior, so it is green on this branch.

## Slice Rationale

Evidence lands before the fix. This slice demonstrates the bug on the unfixed tree; the next slice flips these expectations to the corrected behavior.

## Non-goals

No product code changes. No detection logic, no user-facing notice, no change to how the planner CLI is spawned.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm test -- planner-truncated-output-repro`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage documenting how truncated planner output is currently handled.
  * Verifies that incomplete streamed responses are accepted and preserved without adding a truncation notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->