### PR TITLE
[Planner truncation notice](2) Flag cut-off planner replies to the user

### DIFF
--- a/packages/surfaces/src/__tests__/planner-truncated-output-repro.test.ts
+++ b/packages/surfaces/src/__tests__/planner-truncated-output-repro.test.ts
@@ -9,11 +9,14 @@ import { PlanConversation } from '../slack/plan-conversation.js';
 // itself did not fail. A model that stops early — it reached its own output
 // budget — is indistinguishable from one that finished: stdout is non-empty and
 // the exit code is 0. `spawnPlanner` only rejects on empty stdout, so a partial
-// reply is accepted as a complete turn and recorded in conversation history with
-// nothing anywhere saying the reply was cut off.
+// reply is accepted as a complete turn and recorded in conversation history.
 //
-// This suite pins the CURRENT (buggy) behavior so the proof lands green. The fix
-// slice flips these expectations to the corrected behavior.
+// A missing closing fence cannot be the signal: `extractYamlPlan` deliberately
+// accepts a plan whose closing fence never arrived. The signal only truncation
+// produces is an opened ```yaml block whose content no longer parses as YAML —
+// it ends on an unterminated string or key. A complete plan always parses,
+// closing fence or not, so this suite also pins that a valid unfenced plan is
+// left untouched.
 
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof child_process>();
@@ -49,8 +52,7 @@ function fakePlannerChild({ stdout = '', stderr = '', exitCode = 0 }: FakeChildO
 }
 
 // A reply that stops partway through the YAML plan: the ```yaml fence opens and
-// the text ends mid-token on an unterminated quoted string, exactly as it looks
-// when a model hits its output cap.
+// the text ends mid-token, exactly as it looks when a model hits its output cap.
 const TRUNCATED_REPLY = [
   'Here is the plan we discussed.',
   '',
@@ -63,7 +65,20 @@ const TRUNCATED_REPLY = [
   '    description: "Move planning composer text into local component state so keystrokes stop re-rendering App; lock the fix with the fat-graph e2e b',
 ].join('\n');
 
-describe('planner exit=0 with a cut-off reply — current behavior silently accepts truncation', () => {
+const COMPLETE_REPLY = [
+  'Here is the plan we discussed.',
+  '',
+  '```yaml',
+  'name: "Planning composer typing responsiveness"',
+  'onFinish: pull_request',
+  'mergeMode: external_review',
+  'tasks:',
+  '  - id: localize-composer-state',
+  '    description: "Move planning composer text into local component state"',
+  '```',
+].join('\n');
+
+describe('planner exit=0 with a cut-off reply — repro for silently accepted truncation', () => {
   let conversation: PlanConversation;
 
   beforeEach(() => {
@@ -71,24 +86,52 @@ describe('planner exit=0 with a cut-off reply — current behavior silently acce
     conversation = new PlanConversation({ plannerRetryLimit: 0 });
   });
 
-  it('accepts a cut-off reply as a complete turn with no truncation notice', async () => {
+  it('marks the reply as cut off when the planner stops mid-message', async () => {
     mockSpawn.mockReturnValueOnce(fakePlannerChild({ stdout: TRUNCATED_REPLY, exitCode: 0 }));
 
     const reply = await conversation.sendMessage('Draft the plan');
 
-    // BUG: the reply ends mid-word and nothing flags it as cut off.
-    expect(reply).not.toContain('cut off');
-    expect(reply.trimEnd().endsWith('fat-graph e2e b')).toBe(true);
+    // The partial text is still worth showing, but the reply must say it was cut off.
+    expect(reply).toContain('cut off');
   });
 
-  it('stores the partial reply in history verbatim, as if the planner had finished', async () => {
+  it('records the truncation in conversation history rather than storing a partial reply as complete', async () => {
     mockSpawn.mockReturnValueOnce(fakePlannerChild({ stdout: TRUNCATED_REPLY, exitCode: 0 }));
 
     await conversation.sendMessage('Draft the plan').catch(() => undefined);
 
     const assistant = conversation.history.filter((entry) => entry.role === 'assistant');
     expect(assistant.length).toBeGreaterThan(0);
-    // BUG: history keeps the cut-off text with no marker that it was truncated.
-    expect(assistant[assistant.length - 1].content).not.toContain('cut off');
+    expect(assistant[assistant.length - 1].content).toContain('cut off');
+  });
+
+  it('leaves a complete reply untouched', async () => {
+    mockSpawn.mockReturnValueOnce(fakePlannerChild({ stdout: COMPLETE_REPLY, exitCode: 0 }));
+
+    const reply = await conversation.sendMessage('Draft the plan');
+
+    expect(reply).not.toContain('cut off');
+    expect(reply).toContain('localize-composer-state');
+  });
+
+  it('does not flag a complete plan whose closing fence is missing', async () => {
+    // A finished plan that simply lacks its closing ``` still parses as YAML.
+    // The tolerant extractor accepts it, so truncation detection must not fire.
+    const noClosingFence = [
+      'Here is the plan.',
+      '',
+      '```yaml',
+      'name: Mock Plan',
+      'onFinish: none',
+      'tasks:',
+      '  - id: first',
+      '    description: First task',
+      '    command: echo first',
+    ].join('\n');
+    mockSpawn.mockReturnValueOnce(fakePlannerChild({ stdout: noClosingFence, exitCode: 0 }));
+
+    const reply = await conversation.sendMessage('Draft the plan');
+
+    expect(reply).not.toContain('cut off');
   });
 });

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -66,6 +66,36 @@ export function buildEmptyPlannerOutputError(
   return new Error(`${plannerLabel} exited 0 but produced no output${attemptSuffix}${tail}`);
 }
 
+const YAML_FENCE_OPEN = '```yaml\n';
+const YAML_FENCE_CLOSE = /^```\s*$/m;
+
+export const TRUNCATED_PLANNER_REPLY_NOTICE =
+  '\n\n_[invoker] This reply was cut off before it finished — the planner opened a YAML plan block that ends mid-way and does not parse. '
+  + 'The planner model most likely reached its own output limit. Ask it to continue, or ask for a smaller plan._';
+
+// A planner CLI that exits 0 with a partial reply is indistinguishable from one
+// that finished: stdout is non-empty and nothing reports a stop reason. A missing
+// closing fence cannot be the signal — extractYamlPlan deliberately accepts a plan
+// whose closing fence never arrived. The signal that only truncation produces is an
+// opened ```yaml block whose content no longer parses as YAML (it ends on an
+// unterminated string or key). A complete plan always parses, closing fence or not.
+export function plannerReplyWasCutOff(message: string): boolean {
+  const fenceStart = message.lastIndexOf(YAML_FENCE_OPEN);
+  if (fenceStart === -1) return false;
+  const rest = message.slice(fenceStart + YAML_FENCE_OPEN.length);
+  const closeMatch = rest.match(YAML_FENCE_CLOSE);
+  const yamlContent = closeMatch && closeMatch.index !== undefined
+    ? rest.slice(0, closeMatch.index)
+    : rest;
+  if (!yamlContent.trim()) return false;
+  try {
+    parseYaml(yamlContent);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
 // Internal marker for the specific "success with empty stdout" case so the
 // retry wrapper can distinguish transient silent-success from user-actionable
 // failures (non-zero exit, spawn error, timeout) that must not be retried.
@@ -410,7 +440,15 @@ export class PlanConversation {
     const response = await this.spawnPlanner(prompt);
     const tCursor = Date.now();
     const formatted = formatCodexPlannerStdout(response);
-    const message = formatted.message;
+    const cutOff = plannerReplyWasCutOff(formatted.message);
+    if (cutOff) {
+      this.log('plan-conversation', 'error',
+        `[PLANNER_TRUNCATED] Turn ${turn}: planner exited 0 with a cut-off reply `
+        + `(planner=${this.tool ?? 'cursor'}, model=${this.model ?? 'default'}, stdoutLen=${response.length}, `
+        + `messageLen=${formatted.message.length}, promptLen=${prompt.length}, historyMsgs=${this.messages.length - 1}, `
+        + `messageTail="${formatted.message.slice(-200).replace(/\n/g, '\\n')}")`);
+    }
+    const message = cutOff ? `${formatted.message}${TRUNCATED_PLANNER_REPLY_NOTICE}` : formatted.message;
     this._lastTurnReasoning = formatted.reasoning;
     this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: responseLen=${response.length}, messageLen=${message.length}, reasoningParts=${formatted.reasoning.length}, responsePreview="${message.slice(0, 500).replace(/\n/g, '\\n')}"`);
 


### PR DESCRIPTION
## Summary

When a planner reply is cut off, the terminal now appends a visible notice: the planner likely hit its output limit. Ask it to continue, or for a smaller plan.

Before this, a half-finished reply looked identical to a finished one, so the user saw text that stopped mid-word and no explanation.

Detection is a parse check, not a missing closing fence. The extractor already accepts a plan whose closing fence never arrived, so a fence check would wrongly flag valid plans.

Truncation instead leaves an opened YAML block whose content no longer parses — it ends on an unterminated string. A complete plan always parses, fence or not.

## Review Claim

Detect a cut-off planner reply by an unparseable open YAML block and append a truncation notice, without flagging valid replies.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Detection runs after the planner returns and only appends text to the reply; it never drops or rewrites planner output. A valid reply — including a complete plan with no closing fence — parses and is passed through untouched, pinned by test.

## Slice Rationale

The behavior fix lands after its proof. This slice adds the detection helper and wiring and flips the proof slice's expectations to the corrected behavior.

## Non-goals

Does not retry the planner, raise its output budget, or change how the CLI is spawned. Does not touch the empty-output path, which already rejects and retries.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm test -- planner-truncated-output-repro`
- [ ] `cd packages/surfaces && pnpm test -- planner-no-output-repro planner-retry-repro`
- [ ] `cd packages/app && pnpm test -- in-app-planner`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverts to silently accepting cut-off replies.
- Data migration? No

</details>
