### PR TITLE
[Graph Jump](1) Pin the workflow graph re-packing on a metadata refresh

### DIFF
--- a/packages/ui/src/__tests__/workflow-graph-layout-jump-repro.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph-layout-jump-repro.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Characterization repro: the workflow graph re-packs every node whenever
+ * workflow data refreshes, because positions are rank-based (newest-createdAt
+ * first, cumulative Y offset) and recomputed from scratch each render.
+ *
+ * A workflow first seen through a rollup-delta patch has no createdAt and
+ * name = its id, so it sorts LAST. A frame later refreshWorkflowMetadata lands
+ * the real createdAt (newest) and it jumps to FIRST — shifting every other node
+ * down a row, though the user did nothing.
+ *
+ * This slice pins that behavior: the assertions below describe the current jump
+ * so the fix has a baseline. The fix slice flips them to assert stability.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { WorkflowGraph } from '../components/WorkflowGraph.js';
+import type { WorkflowMeta, WorkflowStatus } from '../types.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+function wf(id: string, name: string, createdAt?: string): WorkflowMeta {
+  return { id, name, status: 'running' as WorkflowStatus, createdAt, updatedAt: createdAt } as WorkflowMeta;
+}
+
+function wfMap(...list: WorkflowMeta[]): Map<string, WorkflowMeta> {
+  return new Map(list.map((w) => [w.id, w]));
+}
+
+function nodeY(id: string): string | null {
+  return document.querySelector(`[data-testid="rf__node-${id}"]`)?.getAttribute('data-y') ?? null;
+}
+
+const baseProps = {
+  selectedWorkflowId: null,
+  statusFilters: new Set<WorkflowStatus>(),
+  onSelectWorkflow: () => {},
+  onWorkflowContextMenu: () => {},
+};
+
+describe('workflow graph re-packs on a metadata refresh', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('shifts existing nodes when a patched workflow later gains its metadata', () => {
+    const oldA = wf('wf-old-a', 'Alpha plan', '2026-07-01T00:00:00Z');
+    const oldB = wf('wf-old-b', 'Beta plan', '2026-07-02T00:00:00Z');
+
+    // Frame 1: the newcomer arrived via a rollup patch — no createdAt, name = id.
+    const { rerender } = render(
+      <WorkflowGraph {...baseProps} workflows={wfMap(oldA, oldB, wf('wf-new', 'wf-new'))} />,
+    );
+    const beforeA = nodeY('wf-old-a');
+    const beforeB = nodeY('wf-old-b');
+
+    // Frame 2: refreshWorkflowMetadata lands the real name + newest createdAt.
+    rerender(
+      <WorkflowGraph {...baseProps} workflows={wfMap(oldA, oldB, wf('wf-new', 'Fix login bug', '2026-07-15T00:00:00Z'))} />,
+    );
+
+    // Current behavior: the metadata refresh re-packs the canvas, so the two
+    // untouched workflows are no longer where they were.
+    expect(nodeY('wf-old-a')).not.toBe(beforeA);
+    expect(nodeY('wf-old-b')).not.toBe(beforeB);
+  });
+});


### PR DESCRIPTION
## Summary

The workflow graph shifts every node whenever workflow data refreshes. This slice pins that behavior down before any fix.

Node positions are rank-based: newest workflow first, stacked down a running vertical offset, recomputed from scratch on each render.

A workflow first seen through a rollup-delta patch has no timestamp and shows its id as a name, so it sorts last.

A frame later the real metadata arrives, the workflow sorts first, and every other node slides down a row — though nobody touched anything.

The test renders the real graph through that two-frame sequence and asserts the current shifting. It is green on master.

## Review Claim

The workflow graph moves its existing nodes when a late metadata arrival changes a workflow's sort order.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only. No product code changes, so nothing about the running graph can change. The assertion describes today's behavior and passes on master.

## Slice Rationale

Evidence lands before the change it justifies, so the shifting is demonstrated first and the fix slice can flip the assertion.

## Non-goals

Does not change the graph, its layout, or any product code.

Does not touch the task DAG or the action graph.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test`

</details>

## Visual Proof

The jump this test characterizes, driven live in a browser against the real `WorkflowGraph` component and real React Flow. The newcomer "wf-new" arrived through a rollup patch (no timestamp, name shows its id) and sits at the bottom.

Starting frame:

![Workflow graph: Beta plan top, Alpha plan middle, wf-new at the bottom](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-bf89b7/graph-jump-start.png)

Then its real metadata is applied — the frame a background refresh produces. The whole canvas re-packs: the newcomer ("Fix login bug") jumps to the top, Beta and Alpha shoved down.

![Metadata lands: Fix login bug jumped to the top, Beta and Alpha pushed down a row](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-bf89b7/graph-jump-before.png)

The reflow is a single frame, so the walkthrough video is the primary proof.

[Walkthrough video: applying the metadata refresh re-packs every node](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-bf89b7/graph-jump-before.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
