### PR TITLE
[Graph Jump](2) Reuse workflow graph layout when topology is unchanged

### DIFF
--- a/packages/ui/src/__tests__/workflow-graph-layout-jump-repro.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph-layout-jump-repro.test.tsx
@@ -1,15 +1,14 @@
 /**
- * Characterization repro: the workflow graph re-packs every node whenever
- * workflow data refreshes, because positions are rank-based (newest-createdAt
- * first, cumulative Y offset) and recomputed from scratch each render.
+ * Regression: the workflow graph must not re-pack existing nodes on a refresh.
  *
- * A workflow first seen through a rollup-delta patch has no createdAt and
- * name = its id, so it sorts LAST. A frame later refreshWorkflowMetadata lands
- * the real createdAt (newest) and it jumps to FIRST — shifting every other node
- * down a row, though the user did nothing.
+ * Positions are rank-based (newest-createdAt first, cumulative Y offset). A
+ * workflow first seen through a rollup-delta patch has no createdAt and name =
+ * its id, so it sorts LAST; a frame later refreshWorkflowMetadata lands the real
+ * createdAt (newest) and it used to jump to FIRST, shifting every other node.
  *
- * This slice pins that behavior: the assertions below describe the current jump
- * so the fix has a baseline. The fix slice flips them to assert stability.
+ * The fix keys layout reuse on topology (node ids + edges) alone, so a refresh
+ * that changes neither the node set nor the edges reuses the prior positions. A
+ * genuine node add/remove still relays out. Fails on the pre-fix code.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -22,16 +21,17 @@ vi.mock('@xyflow/react', async () => {
   return createReactFlowMock();
 });
 
-function wf(id: string, name: string, createdAt?: string): WorkflowMeta {
-  return { id, name, status: 'running' as WorkflowStatus, createdAt, updatedAt: createdAt } as WorkflowMeta;
+function wf(id: string, name: string, createdAt?: string, status: WorkflowStatus = 'running'): WorkflowMeta {
+  return { id, name, status, createdAt, updatedAt: createdAt } as WorkflowMeta;
 }
 
 function wfMap(...list: WorkflowMeta[]): Map<string, WorkflowMeta> {
   return new Map(list.map((w) => [w.id, w]));
 }
 
-function nodeY(id: string): string | null {
-  return document.querySelector(`[data-testid="rf__node-${id}"]`)?.getAttribute('data-y') ?? null;
+function nodePos(id: string): { x: string | null; y: string | null } {
+  const el = document.querySelector(`[data-testid="rf__node-${id}"]`);
+  return { x: el?.getAttribute('data-x') ?? null, y: el?.getAttribute('data-y') ?? null };
 }
 
 const baseProps = {
@@ -41,12 +41,12 @@ const baseProps = {
   onWorkflowContextMenu: () => {},
 };
 
-describe('workflow graph re-packs on a metadata refresh', () => {
+describe('workflow graph does not re-pack existing nodes on refresh', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
   });
 
-  it('shifts existing nodes when a patched workflow later gains its metadata', () => {
+  it('keeps positions stable when a patched workflow later gains its metadata', () => {
     const oldA = wf('wf-old-a', 'Alpha plan', '2026-07-01T00:00:00Z');
     const oldB = wf('wf-old-b', 'Beta plan', '2026-07-02T00:00:00Z');
 
@@ -54,17 +54,50 @@ describe('workflow graph re-packs on a metadata refresh', () => {
     const { rerender } = render(
       <WorkflowGraph {...baseProps} workflows={wfMap(oldA, oldB, wf('wf-new', 'wf-new'))} />,
     );
-    const beforeA = nodeY('wf-old-a');
-    const beforeB = nodeY('wf-old-b');
+    const before = { a: nodePos('wf-old-a'), b: nodePos('wf-old-b'), n: nodePos('wf-new') };
 
     // Frame 2: refreshWorkflowMetadata lands the real name + newest createdAt.
     rerender(
       <WorkflowGraph {...baseProps} workflows={wfMap(oldA, oldB, wf('wf-new', 'Fix login bug', '2026-07-15T00:00:00Z'))} />,
     );
 
-    // Current behavior: the metadata refresh re-packs the canvas, so the two
-    // untouched workflows are no longer where they were.
-    expect(nodeY('wf-old-a')).not.toBe(beforeA);
-    expect(nodeY('wf-old-b')).not.toBe(beforeB);
+    expect(nodePos('wf-old-a')).toEqual(before.a);
+    expect(nodePos('wf-old-b')).toEqual(before.b);
+    expect(nodePos('wf-new')).toEqual(before.n);
+  });
+
+  it('keeps positions stable across a status-only refresh', () => {
+    const a = wf('wf-a', 'Alpha', '2026-07-01T00:00:00Z', 'running');
+    const b = wf('wf-b', 'Beta', '2026-07-02T00:00:00Z', 'running');
+
+    const { rerender } = render(<WorkflowGraph {...baseProps} workflows={wfMap(a, b)} />);
+    const before = { a: nodePos('wf-a'), b: nodePos('wf-b') };
+
+    // Same set, a status flips, brand-new Map (as the delta pipeline produces).
+    rerender(
+      <WorkflowGraph
+        {...baseProps}
+        workflows={wfMap(wf('wf-a', 'Alpha', '2026-07-01T00:00:00Z', 'completed'), b)}
+      />,
+    );
+
+    expect(nodePos('wf-a')).toEqual(before.a);
+    expect(nodePos('wf-b')).toEqual(before.b);
+  });
+
+  it('still relays out when the node set genuinely changes', () => {
+    const a = wf('wf-a', 'Alpha', '2026-07-01T00:00:00Z');
+    const b = wf('wf-b', 'Beta', '2026-07-02T00:00:00Z');
+
+    const { rerender } = render(<WorkflowGraph {...baseProps} workflows={wfMap(a, b)} />);
+    rerender(
+      <WorkflowGraph
+        {...baseProps}
+        workflows={wfMap(a, b, wf('wf-c', 'Gamma', '2026-07-15T00:00:00Z'))}
+      />,
+    );
+
+    // The genuinely-new node must have a real position (layout actually ran).
+    expect(nodePos('wf-c').y).not.toBeNull();
   });
 });

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -3,7 +3,7 @@ import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent }
 import type { WorkflowMeta, WorkflowStatus } from '../types.js';
 import type { GraphCameraCommand } from '../lib/graph-camera.js';
 import type { WorkflowCoreActivity } from '../lib/workflow-core-activity.js';
-import { deriveWorkflowGraph, layoutWorkflowGraph, type WorkflowGraphEdge } from '../lib/workflow-graph.js';
+import { deriveWorkflowGraph, layoutWorkflowGraph, workflowGraphLayoutKey, type WorkflowGraphEdge, type WorkflowPosition } from '../lib/workflow-graph.js';
 import { WorkflowNode } from './WorkflowNode.js';
 import {
   Background,
@@ -313,12 +313,19 @@ function WorkflowGraphInner({
     graphMetricsRef.current.deriveMs = performance.now() - startedAt;
     return nextGraph;
   }, [workflows]);
+  const layoutKey = useMemo(() => workflowGraphLayoutKey(graph), [graph]);
+  const layoutRef = useRef<{ key: string; positions: Map<string, WorkflowPosition> } | null>(null);
   const positions = useMemo(() => {
+    const cached = layoutRef.current;
+    if (cached && cached.key === layoutKey) {
+      return cached.positions;
+    }
     const startedAt = performance.now();
     const nextPositions = layoutWorkflowGraph(graph);
     graphMetricsRef.current.layoutMs = performance.now() - startedAt;
+    layoutRef.current = { key: layoutKey, positions: nextPositions };
     return nextPositions;
-  }, [graph]);
+  }, [graph, layoutKey]);
 
   const nodes = useMemo<Node<WorkflowNodeData>[]>(() => {
     const startedAt = performance.now();

--- a/packages/ui/src/lib/workflow-graph.ts
+++ b/packages/ui/src/lib/workflow-graph.ts
@@ -74,10 +74,19 @@ export function deriveWorkflowGraph(
   }
 
   return {
-    nodes: nodes.sort((a, b) => a.name.localeCompare(b.name)),
+    nodes: nodes.sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id)),
     edges,
     missingDependencies: [...missingDependencies].sort(),
   };
+}
+
+export function workflowGraphLayoutKey(graph: WorkflowGraph): string {
+  return JSON.stringify({
+    nodes: graph.nodes.map((node) => node.id).sort(),
+    edges: graph.edges
+      .map((edge) => `${edge.kind}:${edge.source}->${edge.target}`)
+      .sort(),
+  });
 }
 
 function hasWorkflowEdge(


### PR DESCRIPTION
## Summary

A background metadata refresh used to shove every node in the workflow graph down a row. Nobody touched anything; the canvas just re-packed.

The graph places nodes by rank — newest workflow first, stacked down a running vertical offset — and recomputed that from scratch on every refresh.

A workflow first seen through a rollup-delta patch has no timestamp and sorts last. A frame later its real timestamp arrives, it sorts first, and everything below slides down.

Layout reuse now keys on topology alone — the set of node ids plus edges. A refresh that changes neither reuses the prior positions exactly.

So a late metadata arrival or a status change no longer re-packs the graph. A genuine change to the node set still lays out fresh.

## Review Claim

The workflow graph reuses its prior node positions whenever the node set and edges are unchanged, so a data refresh no longer moves existing nodes.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Every node still renders and every status still updates: node data is rebuilt each render from the live workflow map, and only the x/y positions are reused. A genuine change to the node set or edges recomputes the layout, so nothing goes stale on screen.

The task DAG (topology-keyed with position carry-forward) and the action graph (ordered by workflow id and label, independent of status) never had this behavior, so they are untouched.

## Slice Rationale

One claim in one graph component, with the proof it satisfies. The characterization from the previous slice flips here to assert stability.

## Non-goals

Does not change how a genuine node addition lays out — a real change to the set still re-flows, as it should.

Does not change the rollup-patch path that first shows a workflow without its metadata; the fix simply stops that from moving the canvas.

Does not touch the task DAG or the action graph.

## Architecture

The layout gains a topology gate. The event still arrives and node data is still rebuilt; only the positions are held when the node set and edges are unchanged.

### Before

```mermaid
graph TD
    A["workflow data refresh (status or late metadata)"] --> B["deriveWorkflowGraph + layoutWorkflowGraph, from scratch"]
    B --> C["positions reflect the new sort rank"]
    C --> D["every node re-packs down the canvas"]
```

### After

```mermaid
graph TD
    A["workflow data refresh (status or late metadata)"] --> B["topology key = node ids + edges"]
    B --> E{"key unchanged?"}
    E -->|yes| F["reuse prior positions exactly — no movement"]
    E -->|no| G["lay out fresh for the new node/edge set"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Visual Proof

Driven live in a browser against the real `WorkflowGraph` component and real React Flow. Both runs start from the same frame: two dated workflows plus a newcomer that arrived through a rollup patch (no timestamp, name shows its id), sitting at the bottom.

Then the newcomer's real metadata is applied — the exact frame a background refresh produces.

Shared starting frame (newcomer "wf-new" at the bottom):

![Workflow graph: Beta plan top, Alpha plan middle, wf-new at the bottom](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-bcb81d/graph-jump-start.png)

Before — the metadata lands and the whole canvas re-packs: the newcomer ("Fix login bug") jumps to the top and Beta and Alpha are shoved down.

![Before fix: Fix login bug jumped to the top, Beta and Alpha pushed down a row](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-bcb81d/graph-jump-before.png)

After — the same metadata lands, the newcomer's name updates in place, and not one node moves.

![After fix: Beta and Alpha unchanged, Fix login bug still at the bottom with its new name](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-bcb81d/graph-jump-after.png)

The transition is a one-frame reflow, so the walkthrough videos are the primary proof; the stills are the endpoints.

[Walkthrough video, before: applying the metadata refresh re-packs every node](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-bcb81d/graph-jump-before.webm)

[Walkthrough video, after: applying the metadata refresh moves nothing](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-bcb81d/graph-jump-after.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
