### PR TITLE
[Planner file plan](1) Read a drafted plan from a file, falling back to inline

### DIFF
--- a/packages/surfaces/src/__tests__/plan-draft-file.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PlanConversation } from '../slack/plan-conversation.js';
+
+// A large plan can truncate when the model emits it inline, because the reply
+// then has to carry the whole YAML. The planner instead writes the plan to a
+// file and replies with a short summary. This suite covers the read side: the
+// conversation prefers the file when it exists, and falls back to inline
+// extraction from the chat history when it does not.
+
+const COMPLETE_PLAN = [
+  'name: "File plan"',
+  'onFinish: none',
+  'tasks:',
+  '  - id: first',
+  '    description: First task',
+  '    command: echo first',
+].join('\n');
+
+const INLINE_REPLY = [
+  'Here is the plan.',
+  '',
+  '```yaml',
+  COMPLETE_PLAN,
+  '```',
+].join('\n');
+
+describe('plan draft file — read side', () => {
+  let workingDir: string;
+
+  beforeEach(() => {
+    workingDir = mkdtempSync(join(tmpdir(), 'plan-draft-'));
+  });
+
+  afterEach(() => {
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  function conversationWith(threadTs: string | undefined): PlanConversation {
+    return new PlanConversation({ workingDir, threadTs, plannerRetryLimit: 0 });
+  }
+
+  it('resolves a plan draft path under .invoker when workingDir and threadTs are set', () => {
+    const conversation = conversationWith('abc-123');
+    expect(conversation.planDraftFilePath()).toBe(
+      join(workingDir, '.invoker', 'plan-drafts', 'abc-123.yaml'),
+    );
+  });
+
+  it('has no plan draft path without a threadTs', () => {
+    expect(conversationWith(undefined).planDraftFilePath()).toBeNull();
+  });
+
+  it('reads the drafted plan from the file when the planner wrote one', () => {
+    const conversation = conversationWith('abc-123');
+    const path = conversation.planDraftFilePath();
+    if (!path) throw new Error('expected a plan draft path');
+    mkdirSync(join(workingDir, '.invoker', 'plan-drafts'), { recursive: true });
+    writeFileSync(path, COMPLETE_PLAN, 'utf8');
+
+    expect(conversation.getDraftedPlan()).toBe(COMPLETE_PLAN);
+  });
+
+  it('falls back to inline extraction when no plan file exists', () => {
+    const conversation = conversationWith('abc-123');
+    // Simulate a turn whose reply carried an inline ```yaml block.
+    (conversation as unknown as { messages: Array<{ role: string; content: string }> })
+      .messages.push({ role: 'assistant', content: INLINE_REPLY });
+
+    const drafted = conversation.getDraftedPlan();
+    expect(drafted).not.toBeNull();
+    expect(drafted).toContain('File plan');
+    expect(drafted).toContain('id: first');
+  });
+});

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -11,6 +11,8 @@
  */
 
 import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import type { ConversationRepository } from '@invoker/data-store';
 import { formatCodexPlannerStdout } from '@invoker/execution-engine';
@@ -443,7 +445,30 @@ export class PlanConversation {
 
   /** Returns the last complete YAML plan drafted in this conversation, or null. */
   getDraftedPlan(): string | null {
-    return this.extractLastPlanFromMessages();
+    return this.readPlanDraftFile() ?? this.extractLastPlanFromMessages();
+  }
+
+  // The planner writes the full YAML plan here so its chat reply can stay a
+  // short summary instead of an inline block that truncates when the model hits
+  // its output limit. Gated on workingDir + threadTs; without both, planning
+  // falls back to inline extraction unchanged. `.invoker/` is gitignored.
+  planDraftFilePath(): string | null {
+    if (!this.workingDir || !this.threadTs) return null;
+    const safeId = this.threadTs.replace(/[^a-zA-Z0-9._-]/g, '_');
+    return join(this.workingDir, '.invoker', 'plan-drafts', `${safeId}.yaml`);
+  }
+
+  private readPlanDraftFile(): string | null {
+    const path = this.planDraftFilePath();
+    if (!path) return null;
+    try {
+      if (!existsSync(path)) return null;
+      const content = readFileSync(path, 'utf8').trim();
+      return content.length > 0 ? content : null;
+    } catch (err) {
+      this.log('plan-conversation', 'error', `Failed to read plan draft file ${path}: ${err}`);
+      return null;
+    }
   }
 
   /** Returns the conversation history. */


### PR DESCRIPTION
## Summary

Planner replies get cut off when a big plan is pasted into one chat message and the model hits its output limit mid-YAML.

The fix is to let the planner write the plan to a file and reply with just a summary. This slice adds the read side of that.

A conversation now discovers a plan file under the working dir's gitignored `.invoker/` folder, keyed by the thread. If it finds one, that is the drafted plan.

Nothing writes that file yet, so today every path falls through to the existing inline-YAML extraction, unchanged. The next slice begins writing it.

## Review Claim

`getDraftedPlan` should prefer a plan file under `.invoker/plan-drafts/` when present, and otherwise behave exactly as before.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

The file read is gated on both a working dir and a thread id, and returns null on any miss or error. With no file present — every case until the next slice — the method returns the same inline extraction it does today, so behavior is unchanged in practice.

## Slice Rationale

Foundation before behavior. This adds the dormant read capability on its own, so the reviewer checks the file-vs-inline fallback in isolation before the prompt change begins using it.

## Non-goals

Does not change the planning prompt, so nothing writes the file yet. Does not touch submit, summary rendering, or the inline extraction logic it falls back to.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm test -- plan-draft-file`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>