### PR TITLE
[Planner file plan](2) Tell the planner to write the plan to a file and summarize

### DIFF
--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as child_process from 'node:child_process';
+import { PlanConversation } from '../slack/plan-conversation.js';
+
+// Activation side: the planner is told to write the full plan to the draft file
+// and reply with a summary, and each turn starts from a cleared file so a prior
+// turn's plan can never be mistaken for the current one.
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof child_process>();
+  return { ...actual, spawn: vi.fn() };
+});
+
+const mockSpawn = vi.mocked(child_process.spawn);
+
+function fakePlannerChild(stdout: string): any {
+  const proc = new EventEmitter() as any;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  setTimeout(() => {
+    if (stdout) proc.stdout.emit('data', Buffer.from(stdout));
+    proc.emit('close', 0);
+  }, 0);
+  return proc;
+}
+
+describe('plan draft file — activation side', () => {
+  let workingDir: string;
+
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    workingDir = mkdtempSync(join(tmpdir(), 'plan-draft-act-'));
+  });
+
+  afterEach(() => {
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  it('instructs the planner to write the plan to the draft file instead of inline', () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', plannerRetryLimit: 0 });
+    const path = conversation.planDraftFilePath();
+    const prompt = conversation.buildCursorPrompt();
+
+    expect(path).not.toBeNull();
+    expect(prompt).toContain(String(path));
+    expect(prompt).toContain('write the COMPLETE YAML plan to the file');
+    expect(prompt).toContain('for each of its tasks');
+    expect(prompt).not.toContain('output the plan inside a ```yaml code block');
+  });
+
+  it('keeps the inline instruction when there is no draft file path', () => {
+    const conversation = new PlanConversation({ plannerRetryLimit: 0 });
+    const prompt = conversation.buildCursorPrompt();
+
+    expect(conversation.planDraftFilePath()).toBeNull();
+    expect(prompt).toContain('output the plan inside a ```yaml code block');
+  });
+
+  it('clears a stale plan file before the turn so getDraftedPlan cannot return it', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', plannerRetryLimit: 0 });
+    const path = conversation.planDraftFilePath();
+    if (!path) throw new Error('expected a plan draft path');
+    mkdirSync(join(workingDir, '.invoker', 'plan-drafts'), { recursive: true });
+    writeFileSync(path, 'name: Stale plan\ntasks: []', 'utf8');
+
+    // The planner replies with only a summary and does NOT write a new file.
+    mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the plan. Summary: one step.'));
+    await conversation.sendMessage('Draft it');
+
+    expect(existsSync(path)).toBe(false);
+    expect(conversation.getDraftedPlan()).toBeNull();
+  });
+});

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -11,8 +11,8 @@
  */
 
 import { spawn } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import type { ConversationRepository } from '@invoker/data-store';
 import { formatCodexPlannerStdout } from '@invoker/execution-engine';
@@ -216,13 +216,21 @@ workflows:
 When submitted, Invoker creates one workflow per child in listed order. Each downstream workflow is based on the previous workflow's feature branch and waits on the previous merge gate.`;
 }
 
-function buildPlanSystemPrompt(defaultBranch: string, repoUrl?: string, preferStackedWorkflows = false): string {
+function buildPlanSystemPrompt(
+  defaultBranch: string,
+  repoUrl?: string,
+  preferStackedWorkflows = false,
+  planFilePath?: string,
+): string {
   const repoUrlLine = repoUrl
     ? `repoUrl: "${repoUrl}"          # git clone URL for the repository`
     : `repoUrl: "git@github.com:user/repo.git"  # git clone URL for the repository`;
   const stackedWorkflowSection = preferStackedWorkflows
     ? `\n${buildStackedWorkflowPrompt(repoUrlLine, defaultBranch)}\n`
     : '';
+  const outputInstruction = planFilePath
+    ? `When ready, write the COMPLETE YAML plan to the file at \`${planFilePath}\` using your file-writing tool. Do NOT paste the full YAML into your chat reply — a large plan pasted inline gets cut off at your output limit. Instead reply with a compact summary that still covers every task: the plan name, then each workflow's name with a one-line bullet under it for each of its tasks (the task's intent only — no commands, prompts, or YAML). For a flat plan with no workflows, list one short bullet per task. Keep every line short so the reply stays small.`
+    : 'When ready, output the plan inside a \`\`\`yaml code block.';
   return `You are an assistant for the Invoker orchestrator. The user explicitly requested an Invoker plan.
 
 Generate a YAML task plan as described below. Answer simple follow-up questions directly only when they are about the plan being drafted.
@@ -269,7 +277,7 @@ Rules:
    - If Invoker config auto-routes heavyweight commands, keep discovered test/build commands as normal command tasks unless the task must name a specific remote target
    - NEVER invent test file names. Verify the test file exists before referencing it in a command.
 7. Use meaningful task IDs (kebab-case).
-8. When ready, output the plan inside a \`\`\`yaml code block.
+8. ${outputInstruction}
 9. Always include \`dependencies\` (even if empty array).
 10. After generating a plan, tell the user they can submit it by replying with \`submit\`.
 11. NEVER generate bash commands or shell scripts to execute plans. The orchestrator handles plan execution automatically after explicit Slack approval.
@@ -403,6 +411,7 @@ export class PlanConversation {
     if (!this._initialized) await this.init();
     const tInit = Date.now();
 
+    this.resetPlanDraftFile();
     this.messages.push({ role: 'user', content: userMessage });
 
     const prompt = this.buildCursorPrompt();
@@ -471,6 +480,20 @@ export class PlanConversation {
     }
   }
 
+  // Remove any prior turn's plan file and ensure the directory exists, so a fresh
+  // write is required each turn (getDraftedPlan must never return a stale plan)
+  // and the planner's write into it succeeds.
+  private resetPlanDraftFile(): void {
+    const path = this.planDraftFilePath();
+    if (!path) return;
+    try {
+      rmSync(path, { force: true });
+      mkdirSync(dirname(path), { recursive: true });
+    } catch (err) {
+      this.log('plan-conversation', 'error', `Failed to reset plan draft file ${path}: ${err}`);
+    }
+  }
+
   /** Returns the conversation history. */
   get history(): readonly ConversationMessage[] {
     return this.messages.filter((m) => m.content.length > 0);
@@ -494,7 +517,7 @@ export class PlanConversation {
    */
   buildCursorPrompt(): string {
     const systemPrompt = this.mode === 'plan'
-      ? buildPlanSystemPrompt(this.defaultBranch ?? 'main', this.repoUrl, this.preferStackedWorkflows)
+      ? buildPlanSystemPrompt(this.defaultBranch ?? 'main', this.repoUrl, this.preferStackedWorkflows, this.planDraftFilePath() ?? undefined)
       : buildAgentSystemPrompt();
     const parts: string[] = [systemPrompt];
 


### PR DESCRIPTION
## Summary

This turns on the fix for cut-off planner replies. The planner is now told to write the full YAML plan to a file and reply with only a short summary.

Because the plan no longer has to fit in one chat message, the reply stays small and does not get cut off at the model's output limit.

In chat the user sees the plan name and, under each workflow, one short line per task. The full plan lives in the file, which `getDraftedPlan` already loads.

Each turn first clears any old plan file, so an earlier turn's plan can never be read as the current one. Slack and in-app planning share this path.

## Review Claim

When a draft-file path is available, the planner prompt should ask for a file write plus a summary, and each turn should start from a cleared file.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The prompt only changes when a working dir and thread id are both present; otherwise it keeps the inline-YAML instruction and nothing changes. The per-turn reset is wrapped so a filesystem error logs and the turn continues. A model that ignores the instruction and still pastes inline YAML is read by the same fallback from slice 1.

## Slice Rationale

Behavior after foundation. Slice 1 landed the dormant read path; this slice activates it by changing the prompt and adding the per-turn file reset, so the prompt flip is reviewed on its own.

## Non-goals

Does not add a token budget or a second attempt. Does not change how the plan is summarized or read. Does not force the file path when working dir or thread id is missing.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm test -- plan-draft-file-activation`
- [ ] `cd packages/surfaces && pnpm test`
- [ ] `cd packages/app && pnpm test -- in-app-planner`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverts to the inline-YAML prompt.
- Data migration? No

</details>
