### PR TITLE
Reclaim pr-cron-work and stale /tmp scratch on critical disk pressure

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
@@ -12,6 +12,8 @@ import {
   isSafeRemoteInvokerHomePath,
   resolveDiskCleanupCooldownMs,
   resolveDiskCleanupEnabled,
+  TMP_SCRATCH_GLOBS,
+  TMP_SCRATCH_MIN_AGE_MINUTES,
 } from '../workers/disk-headroom-reclaim.js';
 
 const tempDirs: string[] = [];
@@ -56,6 +58,42 @@ describe('disk-headroom cleanup guards', () => {
     expect(script).not.toContain('$HOME/.cache/electron');
     expect(script).not.toContain('$HOME/.local/share/pnpm');
     expect(script).not.toContain('$HOME/.pnpm-store');
+  });
+
+  it('reclaims the pr-cron-work scratch dir', () => {
+    expect(DISK_RECLAIMABLE_DIRS).toContain('pr-cron-work');
+    const script = buildInvokerHomeCleanupScript('~/.invoker');
+    expect(script).toContain('$INVOKER_HOME/pr-cron-work');
+  });
+
+  it('sweeps only Invoker/test scratch from the shared temp dir, never a blanket /tmp wipe', () => {
+    const script = buildInvokerHomeCleanupScript('~/.invoker');
+    // Resolves the temp dir with a safe fallback, and re-anchors unsafe values to /tmp.
+    expect(script).toContain('TMP_CLEAN="${TMPDIR:-/tmp}"');
+    expect(script).toContain('TMP_CLEAN=/tmp');
+    for (const glob of TMP_SCRATCH_GLOBS) {
+      expect(script).toContain(glob);
+    }
+    // Age guard protects in-flight runs; system + lock entries are excluded.
+    expect(script).toContain(`-mmin +${TMP_SCRATCH_MIN_AGE_MINUTES}`);
+    expect(script).toContain("! -name 'systemd-private-*'");
+    expect(script).toContain("! -name 'ssh-*'");
+    expect(script).toContain("! -name '*.lock'");
+    // Must never wipe the whole temp dir.
+    expect(script).not.toMatch(/rm -rf ["']?\/tmp["']?\s/);
+    expect(script).not.toMatch(/rm -rf ["']?\$TMP_CLEAN["']?\s*$/m);
+    expect(script).not.toContain('rm -rf "$TMP_CLEAN"/*');
+  });
+
+  it('never reaps a temp entry that holds mineable .jsonl session data', () => {
+    const script = buildInvokerHomeCleanupScript('~/.invoker');
+    // The reaper skips any entry containing a .jsonl (agent-session transcripts).
+    expect(script).toContain('reap_tmp');
+    expect(script).toContain("-name '*.jsonl'");
+    // Every temp removal routes through the guard, not a raw rm.
+    expect(script).toContain('reap_tmp "$entry"');
+    expect(script).not.toContain('rm -rf "$TMP_CLEAN"/$pat');
+    expect(script).not.toMatch(/-mmin \+\d+[\s\S]*?-exec rm -rf/);
   });
 });
 

--- a/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
@@ -25,9 +25,30 @@ export const DISK_RECLAIMABLE_DIRS = [
   'worktrees',
   'merge-clones',
   'merge-launches',
+  'pr-cron-work',
 ] as const;
 
 export type DiskReclaimableDir = (typeof DISK_RECLAIMABLE_DIRS)[number];
+
+/**
+ * Invoker/test scratch name globs reclaimed from the shared temp dir. The
+ * disk-headroom cleaner never wipes `/tmp` wholesale — only entries matching
+ * these globs, plus stale mktemp leftovers older than the age threshold below.
+ */
+export const TMP_SCRATCH_GLOBS = [
+  'invoker-*',
+  'scoped_dir*',
+  'electron-download-*',
+  'playwright-artifacts-*',
+  'playwright-transform-cache-*',
+  'esbuild-*.map',
+  'node-compile-cache',
+  'runner-test-*',
+  'omp-*',
+] as const;
+
+/** Leave temp entries newer than this alone — an active run may still hold them. */
+export const TMP_SCRATCH_MIN_AGE_MINUTES = 60;
 
 export interface DiskCleanupResult {
   targetKey: string;
@@ -103,6 +124,7 @@ export function buildInvokerHomeCleanupScript(invokerHome: string): string {
   const mkdirArgs = DISK_RECLAIMABLE_DIRS
     .map((name) => `"$INVOKER_HOME/${name}"`)
     .join(' ');
+  const tmpGlobList = TMP_SCRATCH_GLOBS.join(' ');
   return `set +e
 INVOKER_HOME=${homeQ}
 ${bashNormalizeTildePath('INVOKER_HOME')}
@@ -136,6 +158,32 @@ ${removeCalls}
 rm -rf "$INVOKER_HOME"/*.deleting.* >/dev/null 2>&1
 mkdir -p ${mkdirArgs}
 chmod 700 ${mkdirArgs}
+# Shared temp dir: reclaim only Invoker/test scratch, never a blanket /tmp wipe.
+# Age guard leaves entries newer than ${TMP_SCRATCH_MIN_AGE_MINUTES}m alone (an active run may hold them).
+TMP_CLEAN="\${TMPDIR:-/tmp}"
+TMP_CLEAN="\${TMP_CLEAN%/}"
+case "$TMP_CLEAN" in
+  ""|"/"|"$HOME") TMP_CLEAN=/tmp ;;
+esac
+# Never reap a temp entry that holds mineable .jsonl session data (agent transcripts).
+reap_tmp() {
+  [ -e "$1" ] || return 0
+  if find "$1" -type f -name '*.jsonl' -print -quit 2>/dev/null | grep -q .; then
+    return 0
+  fi
+  rm -rf "$1" >/dev/null 2>&1
+}
+for pat in ${tmpGlobList}; do
+  for entry in "$TMP_CLEAN"/$pat; do
+    reap_tmp "$entry"
+  done
+done
+find "$TMP_CLEAN" -mindepth 1 -maxdepth 1 -mmin +${TMP_SCRATCH_MIN_AGE_MINUTES} \\
+  ! -name 'systemd-private-*' ! -name 'snap-*' ! -name '.*-unix' \\
+  ! -name 'ssh-*' ! -name 'claude-*' ! -name '*.lock' \\
+  -print0 2>/dev/null | while IFS= read -r -d '' entry; do
+  reap_tmp "$entry"
+done
 echo "[disk-headroom-cleanup] done"
 df -h / | tail -1
 exit 0


### PR DESCRIPTION
## Summary

A droplet in the SSH pool filled to 100% disk and stayed there. Work pinned to it waited forever while the disk-headroom reclaim reported success on every pass.

The reclaim only freed a fixed set of dirs under `~/.invoker`. It never touched `pr-cron-work` (3.3G of leftover PR clones) or `/tmp`.

But `/tmp` is where the test scratch that overflows the box lives.

This adds `pr-cron-work` to the reclaimable dirs and teaches the remote reclaim script to free Invoker and test scratch from the shared temp dir.

The `/tmp` pass is deliberately narrow. It matches only known scratch name patterns, plus stray `mktemp` leftovers older than 60 minutes.

It excludes system dirs, sockets, and lockfiles, and never wipes the whole temp dir, so an in-flight run keeps files it is still writing.

It also preserves any temp entry holding a mineable `.jsonl` agent-session transcript, so session data we can mine survives.

## Review Claim

The critical-disk reclaim now frees `pr-cron-work` and old `/tmp` scratch, and never wipes `/tmp` wholesale.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The `/tmp` pass matches an explicit allowlist of scratch name patterns and only frees `mktemp` leftovers older than 60 minutes, excluding `systemd-private-*`, `snap-*`, `.*-unix`, `ssh-*`, `claude-*`, and `*.lock`. There is no `rm -rf /tmp` and no wipe of the whole temp dir; the tests assert both are absent. Every removal routes through a guard that preserves any entry holding a `.jsonl`, so mineable agent-session transcripts survive.

## Slice Rationale

One cohesive change to the reclaim target set. Both new targets are regenerable scratch freed under the same critical-pressure trigger and the same guards, so they belong in one slice.

## Non-goals

Does not change the disk-pressure thresholds, the cooldown, or which pool members are probed. Does not change how launches are routed or dispatched. Does not touch the separate 7-day `pr-cron-work` prune in the PR-maintenance cron.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/disk-headroom-reclaim.test.ts`
- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/disk-headroom-monitor.test.ts src/__tests__/disk-headroom.test.ts src/__tests__/disk-headroom-worker.test.ts src/__tests__/worker-registry.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
