### PR TITLE
[Disk reclaim orphans](2) Reap stale /tmp scratch homes, local + remote

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
@@ -1,4 +1,12 @@
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync, rmSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+  readdirSync,
+  rmSync,
+  utimesSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -10,9 +18,23 @@ import {
   DiskCleanupCooldownTracker,
   isSafeInvokerHome,
   isSafeRemoteInvokerHomePath,
+  reapLocalTmpScratch,
   resolveDiskCleanupCooldownMs,
   resolveDiskCleanupEnabled,
+  resolveTmpScratchDir,
+  TMP_SCRATCH_GLOBS,
+  TMP_SCRATCH_MIN_AGE_MINUTES,
 } from '../workers/disk-headroom-reclaim.js';
+
+/** Create a temp entry with an mtime `ageMinutes` in the past. */
+function makeAgedDir(parent: string, name: string, ageMinutes: number, nowMs: number): string {
+  const full = join(parent, name);
+  mkdirSync(full, { recursive: true });
+  writeFileSync(join(full, 'payload.bin'), 'x');
+  const seconds = (nowMs - ageMinutes * 60_000) / 1000;
+  utimesSync(full, seconds, seconds);
+  return full;
+}
 
 const tempDirs: string[] = [];
 
@@ -56,6 +78,43 @@ describe('disk-headroom cleanup guards', () => {
     expect(script).not.toContain('$HOME/.cache/electron');
     expect(script).not.toContain('$HOME/.local/share/pnpm');
     expect(script).not.toContain('$HOME/.pnpm-store');
+  });
+
+  it('reclaims the pr-cron-work scratch dir', () => {
+    expect(DISK_RECLAIMABLE_DIRS).toContain('pr-cron-work');
+    const script = buildInvokerHomeCleanupScript('~/.invoker');
+    expect(script).toContain('$INVOKER_HOME/pr-cron-work');
+  });
+
+  it('sweeps only Invoker/test scratch from the shared temp dir, never a blanket /tmp wipe', () => {
+    const script = buildInvokerHomeCleanupScript('~/.invoker');
+    // Resolves the temp dir with a safe fallback, and re-anchors unsafe values to /tmp.
+    expect(script).toContain('TMP_CLEAN="${TMPDIR:-/tmp}"');
+    expect(script).toContain('TMP_CLEAN=/tmp');
+    for (const glob of TMP_SCRATCH_GLOBS) {
+      expect(script).toContain(glob);
+    }
+    // Age guard protects in-flight runs; system + lock entries are excluded.
+    expect(script).toContain(`-mmin +${TMP_SCRATCH_MIN_AGE_MINUTES}`);
+    expect(script).toContain("! -name 'systemd-private-*'");
+    expect(script).toContain("! -name 'ssh-*'");
+    expect(script).toContain("! -name '*.lock'");
+    // Must never wipe the whole temp dir.
+    expect(script).not.toMatch(/rm -rf ["']?\/tmp["']?\s/);
+    expect(script).not.toMatch(/rm -rf ["']?\$TMP_CLEAN["']?\s*$/m);
+    expect(script).not.toContain('rm -rf "$TMP_CLEAN"/*');
+  });
+
+  it('age-gates the targeted glob sweep and never deletes the live invoker home', () => {
+    const script = buildInvokerHomeCleanupScript('~/.invoker');
+    // The targeted glob loop must be age-gated (find + -mmin), not an un-aged `rm -rf`.
+    expect(script).not.toContain('rm -rf "$TMP_CLEAN"/$pat');
+    expect(script).toMatch(/find "\$TMP_CLEAN"[^\n]*-name "\$pat"[^\n]*-mmin \+/);
+    // Globbing is disabled around the pattern loop so patterns can't expand against the CWD.
+    expect(script).toContain('set -f');
+    expect(script).toContain('set +f');
+    // Both sweeps refuse to touch the live invoker home.
+    expect(script.match(/! -path "\$INVOKER_HOME"/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
   });
 });
 
@@ -111,6 +170,9 @@ describe('cleanupLocalInvokerHome', () => {
     const result = await cleanupLocalInvokerHome({
       invokerHome: home,
       userHome,
+      // Isolate the scratch reap onto an empty sandbox so the test never
+      // touches the machine's real temp dir.
+      tmpDir: join(root, 'empty-tmp'),
       logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
     });
 
@@ -135,5 +197,96 @@ describe('cleanupLocalInvokerHome', () => {
     });
     expect(result.ok).toBe(false);
     expect(result.reason).toBe('path-guard');
+  });
+
+  it('reaps a stale orphaned scratch home from the shared temp dir', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'invoker-disk-cleanup-tmp-'));
+    tempDirs.push(root);
+    const home = join(root, '.invoker');
+    mkdirSync(home, { recursive: true });
+    const fakeTmp = join(root, 'tmp');
+    mkdirSync(fakeTmp, { recursive: true });
+    const nowMs = 1_000_000_000_000;
+    const stale = makeAgedDir(fakeTmp, 'invoker-e2e-db.OLD', 120, nowMs);
+    const fresh = makeAgedDir(fakeTmp, 'invoker-e2e-db.NEW', 5, nowMs);
+
+    const result = await cleanupLocalInvokerHome({
+      invokerHome: home,
+      userHome: root,
+      tmpDir: fakeTmp,
+      nowMs,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(stale)).toBe(false);
+    expect(existsSync(fresh)).toBe(true);
+  });
+});
+
+describe('resolveTmpScratchDir', () => {
+  it('uses TMPDIR when safe and falls back to /tmp otherwise', () => {
+    expect(resolveTmpScratchDir({ TMPDIR: '/scratch/tmp/' }, '/home/me')).toBe('/scratch/tmp');
+    expect(resolveTmpScratchDir({}, '/home/me')).toBe('/tmp');
+    expect(resolveTmpScratchDir({ TMPDIR: '/' }, '/home/me')).toBe('/tmp');
+    expect(resolveTmpScratchDir({ TMPDIR: '/home/me' }, '/home/me')).toBe('/tmp');
+  });
+});
+
+describe('reapLocalTmpScratch', () => {
+  const nowMs = 1_000_000_000_000;
+
+  function sandbox(): string {
+    const root = mkdtempSync(join(tmpdir(), 'invoker-tmp-reap-'));
+    tempDirs.push(root);
+    return root;
+  }
+
+  it('removes stale Invoker/test scratch but preserves fresh entries', () => {
+    const tmp = sandbox();
+    const staleInvoker = makeAgedDir(tmp, 'invoker-e2e-db.old', 90, nowMs);
+    const staleEsbuild = makeAgedDir(tmp, 'esbuild-abc.map', 90, nowMs);
+    const freshInvoker = makeAgedDir(tmp, 'invoker-e2e-db.fresh', 10, nowMs);
+
+    const errors: string[] = [];
+    reapLocalTmpScratch({ tmpDir: tmp, nowMs }, errors);
+
+    expect(errors).toEqual([]);
+    expect(existsSync(staleInvoker)).toBe(false);
+    expect(existsSync(staleEsbuild)).toBe(false);
+    expect(existsSync(freshInvoker)).toBe(true);
+  });
+
+  it('blanket-sweeps stale non-Invoker entries but never excluded system/lock entries', () => {
+    const tmp = sandbox();
+    const staleJunk = makeAgedDir(tmp, 'random-junk', 90, nowMs);
+    const staleClaude = makeAgedDir(tmp, 'claude-1000', 90, nowMs);
+    const staleSystemd = makeAgedDir(tmp, 'systemd-private-abc', 90, nowMs);
+    const staleLock = makeAgedDir(tmp, 'session.lock', 90, nowMs);
+
+    const errors: string[] = [];
+    reapLocalTmpScratch({ tmpDir: tmp, nowMs }, errors);
+
+    expect(existsSync(staleJunk)).toBe(false);
+    expect(existsSync(staleClaude)).toBe(true);
+    expect(existsSync(staleSystemd)).toBe(true);
+    expect(existsSync(staleLock)).toBe(true);
+  });
+
+  it('never deletes the live invoker home even when it is stale scratch under /tmp', () => {
+    const tmp = sandbox();
+    const selfHome = makeAgedDir(tmp, 'invoker-e2e-db.self', 240, nowMs);
+
+    const errors: string[] = [];
+    reapLocalTmpScratch({ tmpDir: tmp, nowMs, selfHome }, errors);
+
+    expect(existsSync(selfHome)).toBe(true);
+  });
+
+  it('is a no-op for unsafe or missing temp dirs', () => {
+    const errors: string[] = [];
+    reapLocalTmpScratch({ tmpDir: '/', nowMs }, errors);
+    reapLocalTmpScratch({ tmpDir: '', nowMs }, errors);
+    reapLocalTmpScratch({ tmpDir: join(sandbox(), 'does-not-exist'), nowMs }, errors);
+    expect(errors).toEqual([]);
   });
 });

--- a/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
@@ -5,9 +5,9 @@
  * Never touches invoker.db / config.json / the home root / paths outside the home.
  */
 
-import { existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 
 import type { Logger } from '@invoker/contracts';
 
@@ -25,9 +25,30 @@ export const DISK_RECLAIMABLE_DIRS = [
   'worktrees',
   'merge-clones',
   'merge-launches',
+  'pr-cron-work',
 ] as const;
 
 export type DiskReclaimableDir = (typeof DISK_RECLAIMABLE_DIRS)[number];
+
+/**
+ * Invoker/test scratch name globs reclaimed from the shared temp dir. The
+ * disk-headroom cleaner never wipes `/tmp` wholesale — only entries matching
+ * these globs, plus stale mktemp leftovers older than the age threshold below.
+ */
+export const TMP_SCRATCH_GLOBS = [
+  'invoker-*',
+  'scoped_dir*',
+  'electron-download-*',
+  'playwright-artifacts-*',
+  'playwright-transform-cache-*',
+  'esbuild-*.map',
+  'node-compile-cache',
+  'runner-test-*',
+  'omp-*',
+] as const;
+
+/** Leave temp entries newer than this alone — an active run may still hold them. */
+export const TMP_SCRATCH_MIN_AGE_MINUTES = 60;
 
 export interface DiskCleanupResult {
   targetKey: string;
@@ -103,6 +124,7 @@ export function buildInvokerHomeCleanupScript(invokerHome: string): string {
   const mkdirArgs = DISK_RECLAIMABLE_DIRS
     .map((name) => `"$INVOKER_HOME/${name}"`)
     .join(' ');
+  const tmpGlobList = TMP_SCRATCH_GLOBS.join(' ');
   return `set +e
 INVOKER_HOME=${homeQ}
 ${bashNormalizeTildePath('INVOKER_HOME')}
@@ -136,6 +158,36 @@ ${removeCalls}
 rm -rf "$INVOKER_HOME"/*.deleting.* >/dev/null 2>&1
 mkdir -p ${mkdirArgs}
 chmod 700 ${mkdirArgs}
+# Shared temp dir: reclaim only Invoker/test scratch, never a blanket /tmp wipe.
+# Age guard leaves entries newer than ${TMP_SCRATCH_MIN_AGE_MINUTES}m alone (an active run may hold them).
+TMP_CLEAN="\${TMPDIR:-/tmp}"
+TMP_CLEAN="\${TMP_CLEAN%/}"
+case "$TMP_CLEAN" in
+  ""|"/"|"$HOME") TMP_CLEAN=/tmp ;;
+esac
+# Never reap a temp entry that holds mineable .jsonl session data (agent transcripts).
+reap_tmp() {
+  [ -e "$1" ] || return 0
+  if find "$1" -type f -name '*.jsonl' -print -quit 2>/dev/null | grep -q .; then
+    return 0
+  fi
+  rm -rf "$1" >/dev/null 2>&1
+}
+set -f
+for pat in ${tmpGlobList}; do
+  find "$TMP_CLEAN" -mindepth 1 -maxdepth 1 -name "$pat" -mmin +${TMP_SCRATCH_MIN_AGE_MINUTES} \\
+    ! -path "$INVOKER_HOME" -print0 2>/dev/null | while IFS= read -r -d '' entry; do
+    reap_tmp "$entry"
+  done
+done
+set +f
+find "$TMP_CLEAN" -mindepth 1 -maxdepth 1 -mmin +${TMP_SCRATCH_MIN_AGE_MINUTES} \\
+  ! -path "$INVOKER_HOME" \\
+  ! -name 'systemd-private-*' ! -name 'snap-*' ! -name '.*-unix' \\
+  ! -name 'ssh-*' ! -name 'claude-*' ! -name '*.lock' \\
+  -print0 2>/dev/null | while IFS= read -r -d '' entry; do
+  reap_tmp "$entry"
+done
 echo "[disk-headroom-cleanup] done"
 df -h / | tail -1
 exit 0
@@ -174,11 +226,114 @@ function sweepLocalDeletingOrphans(home: string, errors: string[]): void {
   }
 }
 
+/**
+ * Blanket-sweep excludes: entries never removed by the age-gated blanket pass,
+ * even when stale. Mirrors the `! -name` guards in the remote cleanup script.
+ */
+export const TMP_SCRATCH_BLANKET_EXCLUDE_GLOBS = [
+  'systemd-private-*',
+  'snap-*',
+  '.*-unix',
+  'ssh-*',
+  'claude-*',
+  '*.lock',
+] as const;
+
+function tmpGlobToRegExp(glob: string): RegExp {
+  const escaped = glob.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+function matchesAnyTmpGlob(name: string, globs: readonly string[]): boolean {
+  return globs.some((glob) => tmpGlobToRegExp(glob).test(name));
+}
+
+/**
+ * True if `path` is, or contains, a mineable `.jsonl` (agent-session transcript).
+ * Never follows symlinks, so a symlinked dir cannot loop or escape the temp tree.
+ */
+export function holdsMineableSessionData(path: string): boolean {
+  let stat;
+  try {
+    stat = lstatSync(path);
+  } catch {
+    return false;
+  }
+  if (stat.isFile()) return path.endsWith('.jsonl');
+  if (!stat.isDirectory()) return false;
+  let names: string[];
+  try {
+    names = readdirSync(path);
+  } catch {
+    return false;
+  }
+  for (const name of names) {
+    if (name.endsWith('.jsonl')) return true;
+    if (holdsMineableSessionData(join(path, name))) return true;
+  }
+  return false;
+}
+
+/** Resolve the shared temp dir, re-anchoring unsafe values (``/``/`$HOME`) to `/tmp`. */
+export function resolveTmpScratchDir(
+  env: NodeJS.ProcessEnv = process.env,
+  userHome: string = homedir(),
+): string {
+  const raw = (env.TMPDIR ?? '/tmp').replace(/\/+$/, '');
+  if (!raw || raw === '/' || raw === userHome) return '/tmp';
+  return raw;
+}
+
+/**
+ * Reap stale Invoker/test scratch from the shared temp dir. Targeted globs plus
+ * an age-gated blanket sweep of everything else, minus system/lock excludes.
+ * Entries newer than {@link TMP_SCRATCH_MIN_AGE_MINUTES} and the live Invoker
+ * home ({@link opts.selfHome}) are always preserved.
+ */
+export function reapLocalTmpScratch(
+  opts: { tmpDir: string; nowMs: number; selfHome?: string },
+  errors: string[],
+): void {
+  const { tmpDir, nowMs } = opts;
+  if (!tmpDir || tmpDir === '/') return;
+  if (!existsSync(tmpDir)) return;
+  const cutoffMs = nowMs - TMP_SCRATCH_MIN_AGE_MINUTES * 60_000;
+  const selfHome = opts.selfHome ? resolve(opts.selfHome) : undefined;
+  let entries: string[];
+  try {
+    entries = readdirSync(tmpDir);
+  } catch (err) {
+    errors.push(`readdir ${tmpDir}: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+  for (const name of entries) {
+    const full = join(tmpDir, name);
+    if (selfHome && resolve(full) === selfHome) continue;
+    let mtimeMs: number;
+    try {
+      mtimeMs = lstatSync(full).mtimeMs;
+    } catch {
+      continue;
+    }
+    if (mtimeMs >= cutoffMs) continue;
+    const isScratch = matchesAnyTmpGlob(name, TMP_SCRATCH_GLOBS);
+    const isExcluded = matchesAnyTmpGlob(name, TMP_SCRATCH_BLANKET_EXCLUDE_GLOBS);
+    if (isScratch || !isExcluded) {
+      if (holdsMineableSessionData(full)) continue;
+      removeLocalDir(full, errors);
+    }
+  }
+}
+
 export async function cleanupLocalInvokerHome(opts: {
   invokerHome: string;
   targetKey?: string;
   logger?: Logger;
   userHome?: string;
+  /** Test seam: override the temp dir reaped for scratch (defaults to $TMPDIR/`/tmp`). */
+  tmpDir?: string;
+  /** Test seam: override the reference time for the scratch age guard. */
+  nowMs?: number;
 }): Promise<DiskCleanupResult> {
   const targetKey = opts.targetKey ?? `local ${opts.invokerHome}`;
   const userHome = opts.userHome ?? homedir();
@@ -200,6 +355,14 @@ export async function cleanupLocalInvokerHome(opts: {
   for (const name of DISK_RECLAIMABLE_DIRS) {
     ensureLocalDir(join(home, name), errors);
   }
+  reapLocalTmpScratch(
+    {
+      tmpDir: opts.tmpDir ?? resolveTmpScratchDir(process.env, userHome),
+      nowMs: opts.nowMs ?? Date.now(),
+      selfHome: home,
+    },
+    errors,
+  );
 
   if (errors.length > 0) {
     opts.logger?.warn?.(`[disk-headroom-cleanup] local partial failures`, {


### PR DESCRIPTION
## Summary

A remote worker box filled its disk to 100 percent. A full disk makes every git clone on that box fail.

Tasks then ended before a workspace folder was ever written, which is what surfaced the confusing state to the operator.

The disk-headroom worker did notice the full disk. It just could not free enough room.

Today it only empties a few fixed folders inside a known Invoker home.

It never reaps the orphaned `/tmp/invoker-*` end-to-end scratch folders, which had grown to roughly 50 GB on that box.

This change teaches the same worker to reclaim that leftover temp scratch on both the local and remote paths.

An age guard keeps any folder touched in the last hour, so a live run is never disturbed.

## Review Claim

The disk-headroom worker now frees leftover Invoker temp scratch on both the local and remote paths, while keeping recent folders, the live Invoker home, and system or lock folders safe.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Removal is bounded three ways: entries younger than 60 minutes are left alone (a live run may still hold them), the live Invoker home is excluded from every sweep, and system and lock names (`systemd-private-*`, `ssh-*`, `claude-*`, `*.lock`, and similar) are always preserved. The existing path guards that refuse `/`, `~`, and `$HOME` are unchanged. Unit tests assert both the deletions and the preservations for the local path, and assert the age gate and home exclusion for the remote script.

## Slice Rationale

This is one focused behavior change to the disk-headroom worker. It finishes an in-tree partial edit that had only touched the remote path, and closes an age-guard hole in that edit, so both belong together as one reviewable idea.

## Non-goals

Does not change disk detection, thresholds, cooldown, or the worker schedule. Does not change the set of reclaimable Invoker-home subfolders. Does not touch the "no saved workspace" message or the fix-with-agent gate that surfaces it.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && npx vitest run src/__tests__/disk-headroom-reclaim.test.ts`
- [ ] `cd packages/execution-engine && pnpm build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7b0d0291f`
- Post-revert steps: None. Reverting restores the prior behavior, where the worker does not reap temp scratch. No data is deleted or migrated by the revert.
- Data migration? No

</details>
