### PR TITLE
[Planner file plan](2) Summarize every task, grouped by workflow

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -444,11 +444,17 @@ export interface PlanningPresetOption {
   isDefault: boolean;
 }
 
+export interface InAppPlanningPlanSummaryTaskGroup {
+  workflow: string | null;
+  tasks: string[];
+}
+
 export interface InAppPlanningPlanSummary {
   name: string;
   taskCount: number;
   workflowCount?: number;
   steps: string[];
+  taskGroups: InAppPlanningPlanSummaryTaskGroup[];
 }
 export type InAppPlanningSessionStatus =
   | 'still_discussing'

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -98,6 +98,7 @@ describe('SQLiteAdapter', () => {
         taskCount: 1,
         workflowCount: 1,
         steps: ['Update README'],
+        taskGroups: [{ workflow: 'Docs', tasks: ['Update README'] }],
       },
       submittedWorkflowId: 'wf-planning',
       submittedPlanName: 'README plan',

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -551,11 +551,22 @@ function parseInAppPlanningPlanSummary(value: unknown): InAppPlanningPlanSummary
   ) {
     throw new Error('planning summary has invalid shape');
   }
+  const taskGroups = Array.isArray(candidate.taskGroups)
+    ? candidate.taskGroups.filter(
+      (group): group is InAppPlanningPlanSummary['taskGroups'][number] =>
+        !!group
+        && typeof group === 'object'
+        && (group.workflow === null || typeof group.workflow === 'string')
+        && Array.isArray(group.tasks)
+        && group.tasks.every((task) => typeof task === 'string'),
+    )
+    : [];
   return {
     name: candidate.name,
     taskCount: candidate.taskCount,
     ...(candidate.workflowCount === undefined ? {} : { workflowCount: candidate.workflowCount }),
     steps: candidate.steps,
+    taskGroups,
   };
 }
 

--- a/packages/surfaces/src/__tests__/plan-summary.test.ts
+++ b/packages/surfaces/src/__tests__/plan-summary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { summarizePlanText } from '../slack/plan-summary.js';
+import { summarizePlanText, formatPlanSummaryLines } from '../slack/plan-summary.js';
 
 describe('summarizePlanText', () => {
   it('returns name, one step per task, and taskCount for a valid 2-task plan', () => {
@@ -59,6 +59,63 @@ workflows:
     expect(summary!.workflowCount).toBe(2);
     expect(summary!.taskCount).toBe(4);
     expect(summary!.steps).toEqual(['Workers Surface Contracts', 'Workers Surface UI']);
+    expect(summary!.taskGroups).toEqual([
+      { workflow: 'Workers Surface Contracts', tasks: ['Define contracts', 'Verify contracts'] },
+      { workflow: 'Workers Surface UI', tasks: ['Build UI', 'Verify UI'] },
+    ]);
+  });
+
+  it('groups a flat plan under a single null-workflow group in execution order', () => {
+    const summary = summarizePlanText(`
+name: Flat plan
+tasks:
+  - id: b
+    description: Second task
+    dependencies: [a]
+  - id: a
+    description: First task
+`);
+    expect(summary!.taskGroups).toEqual([
+      { workflow: null, tasks: ['First task', 'Second task'] },
+    ]);
+  });
+});
+
+describe('formatPlanSummaryLines', () => {
+  it('lists every task under its workflow name for a stacked plan', () => {
+    const summary = summarizePlanText(`
+name: Dark mode
+workflows:
+  - name: Add theme tokens
+    tasks:
+      - id: t1
+        description: Add CSS variables
+      - id: t2
+        description: Test the tokens
+  - name: Wire the toggle
+    tasks:
+      - id: t3
+        description: Add the toggle control
+`)!;
+    expect(formatPlanSummaryLines(summary)).toEqual([
+      'Add theme tokens',
+      '   • Add CSS variables',
+      '   • Test the tokens',
+      'Wire the toggle',
+      '   • Add the toggle control',
+    ]);
+  });
+
+  it('lists one bullet per task with no workflow heading for a flat plan', () => {
+    const summary = summarizePlanText(`
+name: Flat plan
+tasks:
+  - id: a
+    description: First task
+  - id: b
+    description: Second task
+`)!;
+    expect(formatPlanSummaryLines(summary)).toEqual(['• First task', '• Second task']);
   });
 
   it('keeps long descriptions intact after normalizing whitespace', () => {

--- a/packages/surfaces/src/slack/plan-summary.ts
+++ b/packages/surfaces/src/slack/plan-summary.ts
@@ -10,11 +10,17 @@ import { parse as parseYaml } from 'yaml';
 
 // ── Types ───────────────────────────────────────────────────
 
+export interface PlanSummaryTaskGroup {
+  workflow: string | null;
+  tasks: string[];
+}
+
 export interface PlanSummary {
   name: string;
   steps: string[];
   taskCount: number;
   workflowCount?: number;
+  taskGroups: PlanSummaryTaskGroup[];
 }
 
 interface PlanTask {
@@ -42,6 +48,7 @@ export function summarizePlanText(planText: string): PlanSummary | null {
   if (Array.isArray(rawWorkflows)) {
     if (rawWorkflows.length === 0) return null;
     const workflowNames: string[] = [];
+    const taskGroups: PlanSummaryTaskGroup[] = [];
     let taskCount = 0;
     for (const rawWorkflow of rawWorkflows) {
       if (!isRecord(rawWorkflow)) return null;
@@ -49,10 +56,15 @@ export function summarizePlanText(planText: string): PlanSummary | null {
       if (typeof workflowName !== 'string' || workflowName.trim().length === 0) return null;
       const workflowTasks = parseTasks(rawWorkflow.tasks);
       if (!workflowTasks) return null;
-      workflowNames.push(summarizeDescription(workflowName));
+      const label = summarizeDescription(workflowName);
+      workflowNames.push(label);
+      taskGroups.push({
+        workflow: label,
+        tasks: topoSort(workflowTasks).map((t) => summarizeDescription(t.description)),
+      });
       taskCount += workflowTasks.length;
     }
-    return { name, steps: workflowNames, taskCount, workflowCount: rawWorkflows.length };
+    return { name, steps: workflowNames, taskCount, workflowCount: rawWorkflows.length, taskGroups };
   }
 
   const tasks = parseTasks(parsed.tasks);
@@ -61,7 +73,24 @@ export function summarizePlanText(planText: string): PlanSummary | null {
   const ordered = topoSort(tasks);
   const steps = ordered.map((t) => summarizeDescription(t.description));
 
-  return { name, steps, taskCount: tasks.length };
+  return { name, steps, taskCount: tasks.length, taskGroups: [{ workflow: null, tasks: steps }] };
+}
+
+/**
+ * Deterministic per-task summary lines, grouped by workflow. This is the single
+ * source of truth for the plan summary the user reads on every surface, so a
+ * cut-off or verbose planner reply can never change what tasks are shown.
+ */
+export function formatPlanSummaryLines(summary: PlanSummary): string[] {
+  const lines: string[] = [];
+  const flat = summary.taskGroups.length === 1 && summary.taskGroups[0].workflow === null;
+  for (const group of summary.taskGroups) {
+    if (group.workflow && !flat) lines.push(group.workflow);
+    for (const task of group.tasks) {
+      lines.push(flat ? `• ${task}` : `   • ${task}`);
+    }
+  }
+  return lines;
 }
 
 // ── Internals ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The plan summary the user reads only named each workflow. The individual tasks under a workflow were counted but never shown.

This changes the summary contract so it carries every task, grouped under its workflow. A flat plan becomes a single group with no workflow name.

A shared formatter turns that structure into deterministic per-task lines. This is the one place those lines are produced, for every surface.

Because Invoker builds the list from the parsed plan, a cut-off or wordy planner reply can no longer change which tasks the user sees on any surface.

## Review Claim

The plan summary type carries each task grouped by workflow, and a shared formatter renders those tasks deterministically.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Additive change to the summary type: existing fields keep their meaning, and existing consumers that read only name and counts are unaffected. No surface renders the new grouping yet, so behavior is unchanged until a later slice.

## Slice Rationale

Foundation before behavior. The type and formatter land alone so the reviewer checks the parsing and grouping in isolation, before Slack and the terminal render it.

## Non-goals

Does not change any surface. Does not touch the planner prompt, the file read path, or how the plan is submitted.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm test -- plan-summary`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>