### PR TITLE
[Planner file plan](4) Show every task in the planning terminal

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -444,11 +444,17 @@ export interface PlanningPresetOption {
   isDefault: boolean;
 }
 
+export interface InAppPlanningPlanSummaryTaskGroup {
+  workflow: string | null;
+  tasks: string[];
+}
+
 export interface InAppPlanningPlanSummary {
   name: string;
   taskCount: number;
   workflowCount?: number;
   steps: string[];
+  taskGroups: InAppPlanningPlanSummaryTaskGroup[];
 }
 export type InAppPlanningSessionStatus =
   | 'still_discussing'

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -98,6 +98,7 @@ describe('SQLiteAdapter', () => {
         taskCount: 1,
         workflowCount: 1,
         steps: ['Update README'],
+        taskGroups: [{ workflow: 'Docs', tasks: ['Update README'] }],
       },
       submittedWorkflowId: 'wf-planning',
       submittedPlanName: 'README plan',

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -551,11 +551,22 @@ function parseInAppPlanningPlanSummary(value: unknown): InAppPlanningPlanSummary
   ) {
     throw new Error('planning summary has invalid shape');
   }
+  const taskGroups = Array.isArray(candidate.taskGroups)
+    ? candidate.taskGroups.filter(
+      (group): group is InAppPlanningPlanSummary['taskGroups'][number] =>
+        !!group
+        && typeof group === 'object'
+        && (group.workflow === null || typeof group.workflow === 'string')
+        && Array.isArray(group.tasks)
+        && group.tasks.every((task) => typeof task === 'string'),
+    )
+    : [];
   return {
     name: candidate.name,
     taskCount: candidate.taskCount,
     ...(candidate.workflowCount === undefined ? {} : { workflowCount: candidate.workflowCount }),
     steps: candidate.steps,
+    taskGroups,
   };
 }
 

--- a/packages/surfaces/src/__tests__/plan-summary.test.ts
+++ b/packages/surfaces/src/__tests__/plan-summary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { summarizePlanText } from '../slack/plan-summary.js';
+import { summarizePlanText, formatPlanSummaryLines } from '../slack/plan-summary.js';
 
 describe('summarizePlanText', () => {
   it('returns name, one step per task, and taskCount for a valid 2-task plan', () => {
@@ -59,6 +59,63 @@ workflows:
     expect(summary!.workflowCount).toBe(2);
     expect(summary!.taskCount).toBe(4);
     expect(summary!.steps).toEqual(['Workers Surface Contracts', 'Workers Surface UI']);
+    expect(summary!.taskGroups).toEqual([
+      { workflow: 'Workers Surface Contracts', tasks: ['Define contracts', 'Verify contracts'] },
+      { workflow: 'Workers Surface UI', tasks: ['Build UI', 'Verify UI'] },
+    ]);
+  });
+
+  it('groups a flat plan under a single null-workflow group in execution order', () => {
+    const summary = summarizePlanText(`
+name: Flat plan
+tasks:
+  - id: b
+    description: Second task
+    dependencies: [a]
+  - id: a
+    description: First task
+`);
+    expect(summary!.taskGroups).toEqual([
+      { workflow: null, tasks: ['First task', 'Second task'] },
+    ]);
+  });
+});
+
+describe('formatPlanSummaryLines', () => {
+  it('lists every task under its workflow name for a stacked plan', () => {
+    const summary = summarizePlanText(`
+name: Dark mode
+workflows:
+  - name: Add theme tokens
+    tasks:
+      - id: t1
+        description: Add CSS variables
+      - id: t2
+        description: Test the tokens
+  - name: Wire the toggle
+    tasks:
+      - id: t3
+        description: Add the toggle control
+`)!;
+    expect(formatPlanSummaryLines(summary)).toEqual([
+      'Add theme tokens',
+      '   • Add CSS variables',
+      '   • Test the tokens',
+      'Wire the toggle',
+      '   • Add the toggle control',
+    ]);
+  });
+
+  it('lists one bullet per task with no workflow heading for a flat plan', () => {
+    const summary = summarizePlanText(`
+name: Flat plan
+tasks:
+  - id: a
+    description: First task
+  - id: b
+    description: Second task
+`)!;
+    expect(formatPlanSummaryLines(summary)).toEqual(['• First task', '• Second task']);
   });
 
   it('keeps long descriptions intact after normalizing whitespace', () => {

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -88,10 +88,6 @@ function baseConfig() {
   };
 }
 
-function wordCount(text: string): number {
-  return text.replace(/[`*_"]/g, '').trim().split(/\s+/).filter(Boolean).length;
-}
-
 function mentionHandler(surface: SlackSurface): Function {
   const app = surface.getApp() as any;
   return app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')!.handler;
@@ -805,7 +801,7 @@ describe('lobby verb routing', () => {
     expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('No Invoker plan draft') }));
   });
 
-  it('submit shows a short plain-English plan summary and emits start_plan on confirmation', async () => {
+  it('submit shows every task in the plan summary and emits start_plan on confirmation', async () => {
     const surface = lobbySurface();
     await surface.start(async (cmd) => { received.push(cmd); });
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
@@ -830,14 +826,13 @@ tasks:
 
     const say2 = vi.fn().mockResolvedValue({ ts: 'b' });
     await mentionHandler(surface)({ event: { text: '<@BOT> submit', thread_ts: 't1', ts: 't2', user: 'U1' }, say: say2 });
-    // Shows the ELI5 step summary, does not submit yet.
+    // Shows a deterministic per-task summary in execution order, does not submit yet.
     const confirmationText = say2.mock.calls[0][0].text as string;
-    expect(confirmationText).toContain('steps in order');
-    expect(confirmationText).toContain('First: Add a simple /health endpoint for ...');
-    expect(confirmationText).toContain('Then: Wire the new /health route through ...');
-    expect(confirmationText).toContain('Then 2 more.');
-    expect(confirmationText).not.toContain('without changing unrelated endpoints');
-    expect(wordCount(confirmationText)).toBeLessThanOrEqual(40);
+    expect(confirmationText).toContain('4 tasks');
+    expect(confirmationText).toContain('Add a simple /health endpoint for uptime checks');
+    expect(confirmationText).toContain('Wire the new /health route through the HTTP server');
+    expect(confirmationText).toContain('Add regression coverage for healthy and unhealthy responses');
+    expect(confirmationText).toContain('Run the focused surface test suite and record the result');
     expect(received.some((c) => c.type === 'start_plan')).toBe(false);
 
     const say3 = vi.fn().mockResolvedValue({ ts: 'c' });

--- a/packages/surfaces/src/slack/plan-summary.ts
+++ b/packages/surfaces/src/slack/plan-summary.ts
@@ -10,11 +10,17 @@ import { parse as parseYaml } from 'yaml';
 
 // ── Types ───────────────────────────────────────────────────
 
+export interface PlanSummaryTaskGroup {
+  workflow: string | null;
+  tasks: string[];
+}
+
 export interface PlanSummary {
   name: string;
   steps: string[];
   taskCount: number;
   workflowCount?: number;
+  taskGroups: PlanSummaryTaskGroup[];
 }
 
 interface PlanTask {
@@ -42,6 +48,7 @@ export function summarizePlanText(planText: string): PlanSummary | null {
   if (Array.isArray(rawWorkflows)) {
     if (rawWorkflows.length === 0) return null;
     const workflowNames: string[] = [];
+    const taskGroups: PlanSummaryTaskGroup[] = [];
     let taskCount = 0;
     for (const rawWorkflow of rawWorkflows) {
       if (!isRecord(rawWorkflow)) return null;
@@ -49,10 +56,15 @@ export function summarizePlanText(planText: string): PlanSummary | null {
       if (typeof workflowName !== 'string' || workflowName.trim().length === 0) return null;
       const workflowTasks = parseTasks(rawWorkflow.tasks);
       if (!workflowTasks) return null;
-      workflowNames.push(summarizeDescription(workflowName));
+      const label = summarizeDescription(workflowName);
+      workflowNames.push(label);
+      taskGroups.push({
+        workflow: label,
+        tasks: topoSort(workflowTasks).map((t) => summarizeDescription(t.description)),
+      });
       taskCount += workflowTasks.length;
     }
-    return { name, steps: workflowNames, taskCount, workflowCount: rawWorkflows.length };
+    return { name, steps: workflowNames, taskCount, workflowCount: rawWorkflows.length, taskGroups };
   }
 
   const tasks = parseTasks(parsed.tasks);
@@ -61,7 +73,24 @@ export function summarizePlanText(planText: string): PlanSummary | null {
   const ordered = topoSort(tasks);
   const steps = ordered.map((t) => summarizeDescription(t.description));
 
-  return { name, steps, taskCount: tasks.length };
+  return { name, steps, taskCount: tasks.length, taskGroups: [{ workflow: null, tasks: steps }] };
+}
+
+/**
+ * Deterministic per-task summary lines, grouped by workflow. This is the single
+ * source of truth for the plan summary the user reads on every surface, so a
+ * cut-off or verbose planner reply can never change what tasks are shown.
+ */
+export function formatPlanSummaryLines(summary: PlanSummary): string[] {
+  const lines: string[] = [];
+  const flat = summary.taskGroups.length === 1 && summary.taskGroups[0].workflow === null;
+  for (const group of summary.taskGroups) {
+    if (group.workflow && !flat) lines.push(group.workflow);
+    for (const task of group.tasks) {
+      lines.push(flat ? `• ${task}` : `   • ${task}`);
+    }
+  }
+  return lines;
 }
 
 // ── Internals ───────────────────────────────────────────────

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -25,7 +25,7 @@ import {
 import type { ConversationMode, PlanningCommandBuilder } from './plan-conversation.js';
 import { parseLobbyControl } from './lobby-control.js';
 import type { LobbyControl } from './lobby-control.js';
-import { summarizePlanText } from './plan-summary.js';
+import { summarizePlanText, formatPlanSummaryLines, type PlanSummary } from './plan-summary.js';
 import { SessionManager, SessionIdentifier } from './thread-session-manager.js';
 import { buildAssistantPrompt, parseWorkflowControl, SLACK_DIRECT_ANSWER_GUIDANCE } from './workflow-assistant.js';
 import type { WorkflowContext, WorkflowControl } from './workflow-assistant.js';
@@ -35,10 +35,6 @@ function truncateWords(text: string, maxWords: number): string {
   const words = text.replace(/\s+/g, ' ').trim().split(' ').filter(Boolean);
   if (words.length <= maxWords) return words.join(' ');
   return `${words.slice(0, maxWords).join(' ')} ...`;
-}
-
-function asSentence(text: string): string {
-  return text.endsWith('...') || text.endsWith('…') ? text : `${text}.`;
 }
 
 // ── Config ──────────────────────────────────────────────────
@@ -1037,23 +1033,14 @@ export class SlackSurface implements Surface {
     await this.stageConfirm(threadTs, channel, { kind: 'submit', planText, ctx, channel, lobbyThreadTs: threadTs }, this.renderPlanSummary(summary), say);
   }
 
-  /** Short plain-English plan view: the user approves this, not YAML. */
-  private renderPlanSummary(summary: { name: string; steps: string[]; taskCount: number }): string {
-    const title = truncateWords(summary.name, 5);
-    const first = truncateWords(summary.steps[0] ?? 'Run the plan', 6);
-    const parts = [
-      `I'll start "${title}": ${summary.taskCount} step${summary.taskCount === 1 ? '' : 's'} in order.`,
-      `First: ${asSentence(first)}`,
-    ];
-
-    if (summary.steps.length > 1) {
-      parts.push(`Then: ${asSentence(truncateWords(summary.steps[1], 6))}`);
-    }
-    if (summary.steps.length > 2) {
-      parts.push(`Then ${summary.steps.length - 2} more.`);
-    }
-
-    return parts.join(' ');
+  /** Per-task plan view: the user approves this, not YAML. */
+  private renderPlanSummary(summary: PlanSummary): string {
+    const title = truncateWords(summary.name, 8);
+    const workflowNote = summary.workflowCount && summary.workflowCount > 1
+      ? `${summary.workflowCount} workflows, `
+      : '';
+    const header = `*${title}* — ${workflowNote}${summary.taskCount} task${summary.taskCount === 1 ? '' : 's'}:`;
+    return [header, ...formatPlanSummaryLines(summary)].join('\n');
   }
 
   private buildConfirmBlocks(prompt: string, confirmKey: string): unknown[] {

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -700,7 +700,7 @@ describe('Invoker terminal (component)', () => {
     submitPlanningText('draft the full plan');
 
     await waitFor(() => {
-      expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('draft ready · "Mock Plan" · 2 steps');
+      expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('draft ready · "Mock Plan" · 2 tasks');
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
@@ -726,6 +726,10 @@ describe('Invoker terminal (component)', () => {
         taskCount: 4,
         workflowCount: 2,
         steps: ['Workers Surface Contracts', 'Workers Surface UI'],
+        taskGroups: [
+          { workflow: 'Workers Surface Contracts', tasks: ['Define contracts', 'Verify contracts'] },
+          { workflow: 'Workers Surface UI', tasks: ['Build UI', 'Verify UI'] },
+        ],
       },
     })) as any;
     mock.api.planningChatSubmit = vi.fn(async () => ({
@@ -742,8 +746,15 @@ describe('Invoker terminal (component)', () => {
     submitPlanningText('draft the Workers Surface plan');
 
     await waitFor(() => {
-      expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('draft ready · "Workers Surface" · 2 workflows');
+      expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('draft ready · "Workers Surface" · 2 workflows · 4 tasks');
     });
+
+    const tasks = screen.getByTestId('invoker-terminal-plan-tasks');
+    expect(tasks).toHaveTextContent('Workers Surface Contracts');
+    expect(tasks).toHaveTextContent('Define contracts');
+    expect(tasks).toHaveTextContent('Verify contracts');
+    expect(tasks).toHaveTextContent('Build UI');
+    expect(tasks).toHaveTextContent('Verify UI');
 
     fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
 
@@ -784,7 +795,7 @@ describe('Invoker terminal (component)', () => {
     expect(errorPanel).toHaveTextContent('Plan could not be submitted');
     expect(errorPanel).toHaveTextContent(submitError);
     expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(`Plan could not be submitted: ${submitError}`);
-    expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('draft ready · "Selected lists scroll" · 4 steps');
+    expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('draft ready · "Selected lists scroll" · 4 tasks');
     expect(mock.api.refreshTaskGraph).not.toHaveBeenCalled();
 
     fireEvent.click(within(errorPanel).getByRole('button', { name: 'Retry submit' }));

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -49,7 +49,12 @@ interface InvokerTerminalProps {
   selectedPresetKey: string;
   presetOptions: PlanningPresetOptionView[];
   draftPlanAvailable: boolean;
-  draftPlanSummary?: { name: string; taskCount: number; workflowCount?: number };
+  draftPlanSummary?: {
+    name: string;
+    taskCount: number;
+    workflowCount?: number;
+    taskGroups?: { workflow: string | null; tasks: string[] }[];
+  };
   planningStream?: InvokerTerminalPlanningStream | null;
   submitError?: SubmitErrorView | null;
   readOnly?: boolean;
@@ -633,10 +638,32 @@ export function InvokerTerminal({
               data-testid="invoker-terminal-ready-bar"
               className="sticky bottom-0 z-10 border-t border-border bg-background px-4 py-3 text-sm text-foreground"
             >
+              {draftPlanSummary?.taskGroups && draftPlanSummary.taskGroups.length > 0 && (
+                <div
+                  data-testid="invoker-terminal-plan-tasks"
+                  className="mb-3 max-h-52 overflow-y-auto pr-1"
+                >
+                  {draftPlanSummary.taskGroups.map((group, groupIndex) => (
+                    <div key={group.workflow ?? `group-${groupIndex}`} className="mb-2 last:mb-0">
+                      {group.workflow ? (
+                        <div className="text-xs font-semibold text-foreground">{group.workflow}</div>
+                      ) : null}
+                      <ul className={group.workflow ? 'mt-0.5 border-l border-border-strong pl-3' : ''}>
+                        {group.tasks.map((task, taskIndex) => (
+                          <li key={taskIndex} className="flex gap-2 text-xs text-muted-foreground">
+                            <span aria-hidden="true">–</span>
+                            <span>{task}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+              )}
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <span className="font-mono text-xs text-muted-foreground">
                   {draftPlanSummary
-                    ? `draft ready · "${draftPlanSummary.name}" · ${draftPlanSummary.workflowCount && draftPlanSummary.workflowCount > 1 ? `${draftPlanSummary.workflowCount} workflows` : `${draftPlanSummary.taskCount} step${draftPlanSummary.taskCount === 1 ? '' : 's'}`}`
+                    ? `draft ready · "${draftPlanSummary.name}" · ${draftPlanSummary.workflowCount && draftPlanSummary.workflowCount > 1 ? `${draftPlanSummary.workflowCount} workflows · ${draftPlanSummary.taskCount} task${draftPlanSummary.taskCount === 1 ? '' : 's'}` : `${draftPlanSummary.taskCount} task${draftPlanSummary.taskCount === 1 ? '' : 's'}`}`
                     : 'draft ready'}
                 </span>
                 <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

The planning terminal's draft-ready bar showed only the plan name and a count. To see the tasks, the user had to read the raw plan.

It now exposes every task, grouped under its workflow, right above the action buttons. The count line reads "N workflows · M tasks", or "M tasks" for a flat plan.

Reviewers read exactly what they are about to run.

## Review Claim

The planning terminal exposes each task grouped by workflow in the draft-ready bar, from the summary's grouped tasks.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Rendering only: the grouped tasks come from the draft summary the terminal already receives, and show when present. When absent, the bar falls back to the old count line. No planner, approval, or data behavior changes.

## Slice Rationale

One surface per diff. The terminal rendering lands apart from the Slack rendering, since each surface presents the same grouped tasks in its own way.

## Non-goals

Does not change Slack, the planner prompt, or the plan data. Does not change what submitting does.

## Visual Proof

[Walkthrough of the ready-bar states](https://github.com/Neko-Catpital-Labs/Invoker/pull/4753#issuecomment-4997042704)

Count-only ready bar state:

![Count-only ready bar state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-364ac0/planning-terminal-tasks-before.png)

Grouped-task ready bar state:

![Grouped-task ready bar state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-364ac0/planning-terminal-tasks-after.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- invoker-terminal.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4752
