### PR TITLE
fix(app): honor delayMs in yieldToPendingRendererInput

### DIFF
--- a/packages/app/src/__tests__/preload-yield-delay.test.ts
+++ b/packages/app/src/__tests__/preload-yield-delay.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+vi.mock('electron', () => ({
+  contextBridge: {
+    exposeInMainWorld: vi.fn(),
+  },
+  ipcRenderer: {
+    sendSync: vi.fn(() => undefined),
+    invoke: vi.fn(() => Promise.resolve()),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  },
+}));
+
+import { yieldToPendingRendererInput } from '../preload.js';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('yieldToPendingRendererInput', () => {
+  it('waits for the requested delay before resolving', async () => {
+    vi.useFakeTimers();
+
+    let resolved = false;
+    const pending = yieldToPendingRendererInput(50).then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(49);
+    expect(resolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await pending;
+    expect(resolved).toBe(true);
+  });
+});

--- a/packages/app/src/preload.ts
+++ b/packages/app/src/preload.ts
@@ -22,7 +22,7 @@ const bootstrapState = ipcRenderer.sendSync('invoker:get-bootstrap-state-sync') 
   | undefined;
 const bootstrapDurationMs = Date.now() - bootstrapStartedAt;
 
-function yieldToPendingRendererInput(delayMs = 0): Promise<void> {
+export function yieldToPendingRendererInput(delayMs = 0): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(() => {
       const requestAnimationFrame = (globalThis as { requestAnimationFrame?: (callback: () => void) => number })
@@ -32,7 +32,7 @@ function yieldToPendingRendererInput(delayMs = 0): Promise<void> {
       } else {
         resolve();
       }
-    }, 0);
+    }, delayMs);
   });
 }
 


### PR DESCRIPTION
## Summary

A helper meant to pause briefly before returning control never actually paused.

`yieldToPendingRendererInput` took a `delayMs` argument but always passed `0` to its timer, so the argument did nothing.

One caller asks for a 50ms pause on the test path for `invoker:get-tasks`. It was getting no pause at all.

The timer now uses `delayMs`. The helper is exported so the pause is testable.

CodeRabbit reported this on #4458 as Critical. It was never fixed.

## Review Claim

`yieldToPendingRendererInput(n)` must wait `n` milliseconds before resolving, not zero.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change is one argument: the timer's second parameter goes from the literal `0` to the already-declared `delayMs`, whose default stays `0`.

Every existing call with no argument keeps its old zero-delay behavior. Only the one call that passes `50` changes, and it changes to what it always asked for.

The added `export` widens no runtime behavior; it only makes the helper reachable from a test.

## Slice Rationale

One helper, one argument, one regression test. Nothing else belongs with it.

## Non-goals

Does not change the caller conditions or which channel triggers the pause.

Does not change the requestAnimationFrame path the timer hands off to.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test src/__tests__/preload-yield-delay.test.ts`
- [ ] `cd packages/app && pnpm test`

Ran locally. The new test `waits for the requested delay before resolving` fails on master, where the promise resolves before the 49ms mark, and passes with this change.

Full `packages/app` run: 1562 passed. The one failure, `focus-switch-main-process-cost.test.ts`, is a timing-sensitive perf assertion that fails identically on clean master and is unrelated to this change.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the earlier zero-delay behavior.
- Data migration? No

</details>
