### PR TITLE
Age-gate the /tmp scratch glob reap so it can't delete a running task's scratch

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
@@ -95,6 +95,18 @@ describe('disk-headroom cleanup guards', () => {
     expect(script).not.toContain('rm -rf "$TMP_CLEAN"/$pat');
     expect(script).not.toMatch(/-mmin \+\d+[\s\S]*?-exec rm -rf/);
   });
+
+  it('age-gates the targeted glob sweep and never touches the live invoker home', () => {
+    const script = buildInvokerHomeCleanupScript('~/.invoker');
+    // The glob loop must be age-gated via find + -mmin, not an un-aged sweep that
+    // could delete a running task's fresh scratch dir.
+    expect(script).toMatch(/find "\$TMP_CLEAN"[^\n]*-name "\$pat"[^\n]*-mmin \+/);
+    // Globbing is disabled around the pattern loop so patterns can't expand against the CWD.
+    expect(script).toContain('set -f');
+    expect(script).toContain('set +f');
+    // Both /tmp sweeps refuse to touch the live invoker home.
+    expect(script.match(/! -path "\$INVOKER_HOME"/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
 });
 
 describe('disk-headroom cleanup env', () => {

--- a/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
@@ -173,12 +173,16 @@ reap_tmp() {
   fi
   rm -rf "$1" >/dev/null 2>&1
 }
+set -f
 for pat in ${tmpGlobList}; do
-  for entry in "$TMP_CLEAN"/$pat; do
+  find "$TMP_CLEAN" -mindepth 1 -maxdepth 1 -name "$pat" -mmin +${TMP_SCRATCH_MIN_AGE_MINUTES} \\
+    ! -path "$INVOKER_HOME" -print0 2>/dev/null | while IFS= read -r -d '' entry; do
     reap_tmp "$entry"
   done
 done
+set +f
 find "$TMP_CLEAN" -mindepth 1 -maxdepth 1 -mmin +${TMP_SCRATCH_MIN_AGE_MINUTES} \\
+  ! -path "$INVOKER_HOME" \\
   ! -name 'systemd-private-*' ! -name 'snap-*' ! -name '.*-unix' \\
   ! -name 'ssh-*' ! -name 'claude-*' ! -name '*.lock' \\
   -print0 2>/dev/null | while IFS= read -r -d '' entry; do


### PR DESCRIPTION
## Summary

The disk-headroom reclaim reaps old scratch directories from the shared temp dir when disk gets tight.

Its targeted glob loop reaped every entry matching a scratch pattern no matter how old it was — even though the code comment promised an age guard.

So a scratch directory a running task had just created could be reaped out from under it, mid-run.

This puts that loop behind the same age filter the general sweep already uses, and adds a guard so neither sweep can touch the live invoker home.

## Review Claim

The targeted glob reap is age-gated like the general sweep, and both sweeps refuse to touch `$INVOKER_HOME`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the reap-selection logic in the generated reclaim script changes: the glob loop now requires `-mmin +${TMP_SCRATCH_MIN_AGE_MINUTES}` before reaping an entry, and `! -path "$INVOKER_HOME"` protects the live home. The `.jsonl` transcript guard and the general sweep are unchanged. A test asserts the generated script is age-gated and home-safe.

## Slice Rationale

Standalone one-file fix. It salvages the single real safety improvement from #4750, which otherwise duplicated the /tmp reaping that #4749 already landed. #4750 is closed in favor of this.

## Non-goals

Does not change the general age-based sweep, the `.jsonl` guard, or the set of scratch globs. Does not add the behavioral-reaper refactor #4750 also carried.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test -- disk-headroom-reclaim`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverts to the un-aged glob reap.
- Data migration? No

</details>
