### PR TITLE
fix(app): run no-track headless work as a microtask, not an unref'd timer

### DIFF
--- a/packages/app/src/__tests__/headless-no-track-microtask.test.ts
+++ b/packages/app/src/__tests__/headless-no-track-microtask.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { headlessStartReady, headlessRetryTask } from '../headless-run-resume.js';
+import type { HeadlessDeps } from '../headless-shared.js';
+
+function makeRunningTask(id: string, workflowId: string): any {
+  return {
+    id,
+    status: 'running',
+    config: { workflowId },
+    execution: {},
+  };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+describe('--no-track microtask dispatch (no deferRunnableTasks)', () => {
+  let executeTasks: ReturnType<typeof vi.fn>;
+  let deps: HeadlessDeps;
+  let stdout: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    executeTasks = vi.fn().mockResolvedValue(undefined);
+    const noopLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(() => noopLogger),
+    };
+    deps = {
+      logger: noopLogger as any,
+      orchestrator: {} as any,
+      persistence: {} as any,
+      commandService: {} as any,
+      executorRegistry: {} as any,
+      messageBus: {} as any,
+      repoRoot: '/fake/repo',
+      invokerConfig: {} as any,
+      noTrack: true,
+      ownerTaskRunnerProvider: () => ({ executeTasks } as any),
+    } as HeadlessDeps;
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    stdout.mockRestore();
+  });
+
+  it('headlessStartReady dispatches runnable tasks as a microtask', async () => {
+    const task = makeRunningTask('wf-1/task-1', 'wf-1');
+    deps.orchestrator.syncAllFromDb = vi.fn();
+    deps.orchestrator.getAllTasks = vi.fn(() => []);
+    deps.orchestrator.getExecutableReadyTasks = vi.fn(() => []);
+    deps.orchestrator.getPersistedActiveTaskIds = vi.fn(() => new Set<string>());
+    deps.orchestrator.startExecution = vi.fn(() => [task]);
+
+    await headlessStartReady(['--no-track'], deps);
+    await flushMicrotasks();
+
+    expect(executeTasks).toHaveBeenCalledTimes(1);
+    expect(executeTasks).toHaveBeenCalledWith([task]);
+  });
+
+  it('headlessRetryTask dispatches runnable tasks as a microtask', async () => {
+    const task = makeRunningTask('wf-1/task-1', 'wf-1');
+    deps.preemptTaskSubgraph = vi.fn(async () => {});
+    deps.orchestrator.syncFromDb = vi.fn();
+    deps.orchestrator.startExecution = vi.fn(() => []);
+    deps.persistence.listWorkflows = vi.fn(() => [{
+      id: 'wf-1',
+      name: 'wf-1',
+      generation: 0,
+      status: 'running' as const,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }]);
+    deps.persistence.loadTasks = vi.fn(() => [{
+      id: 'wf-1/task-1',
+      status: 'failed',
+      config: { workflowId: 'wf-1' },
+      execution: {},
+    } as any]);
+    deps.commandService.retryTask = vi.fn(async () => ({ ok: true as const, data: [task] }));
+
+    await headlessRetryTask('wf-1/task-1', deps);
+    await flushMicrotasks();
+
+    expect(executeTasks).toHaveBeenCalledTimes(1);
+    expect(executeTasks).toHaveBeenCalledWith([task]);
+  });
+});

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -260,15 +260,14 @@ export async function headlessStartReady(args: string[], deps: HeadlessDeps): Pr
       deps.deferRunnableTasks(runnable);
     } else {
       const taskExecutor = createHeadlessExecutor(deps);
-      const launch = setTimeout(() => {
-        void taskExecutor.executeTasks(runnable).catch((err) => {
+      void Promise.resolve()
+        .then(() => taskExecutor.executeTasks(runnable))
+        .catch((err) => {
           deps.logger.error(
             `background no-track start-ready failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
             { module: 'headless' },
           );
         });
-      }, 25);
-      launch.unref?.();
     }
     process.stdout.write('[headless] --no-track enabled: start-ready accepted; exiting without tracking.\n');
     return;
@@ -321,15 +320,14 @@ export async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Pro
           deps.deferRunnableTasks(dispatchable, restored.workflowId);
         } else {
           const taskExecutor = createHeadlessExecutor(deps);
-          const launch = setTimeout(() => {
-            void taskExecutor.executeTasks(dispatchable).catch((err) => {
+          void Promise.resolve()
+            .then(() => taskExecutor.executeTasks(dispatchable))
+            .catch((err) => {
               deps.logger.error(
                 `background no-track task retry failed for ${taskId}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
                 { module: 'headless' },
               );
             });
-          }, 25);
-          launch.unref?.();
         }
       }
       process.stdout.write('[headless] --no-track enabled: retry-task accepted; exiting without tracking.\n');
@@ -850,15 +848,14 @@ export async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDe
       deps.deferRunnableTasks(dispatchable, workflowId);
     } else {
       const te = createHeadlessExecutor(deps);
-      const launch = setTimeout(() => {
-        void te.executeTasks(dispatchable).catch((err) => {
+      void Promise.resolve()
+        .then(() => te.executeTasks(dispatchable))
+        .catch((err) => {
           deps.logger.error(
             `background no-track workflow retry failed for ${workflowId}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
             { module: 'headless' },
           );
         });
-      }, 25);
-      launch.unref?.();
     }
     process.stdout.write('[headless] --no-track enabled: retry accepted; exiting without tracking.\n');
     return;


### PR DESCRIPTION
## Summary

Headless `--no-track` commands could report success while doing nothing.

When a command runs with `--no-track`, it kicks off the real work in the background and then returns so the process can exit.

Three of these paths scheduled that work on an unref'd 25ms timer. An unref'd timer does not hold the process open, so Node could exit before the work ever started.

The command printed "accepted; exiting" and left. The tasks it promised to run never ran.

The work now runs as a microtask, the same way the sibling run and resume paths already do, so it happens before the process exits.

CodeRabbit reported this on #4348 as Critical. It was never fixed.

## Review Claim

No-track headless work in this file must run before the process exits, not sit behind a timer that never fires.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change swaps one scheduling mechanism for another in the same spot: an unref'd `setTimeout(fn, 25)` becomes `void Promise.resolve().then(fn)`. The work, the error handler, and the log text are unchanged.

This is the exact form the `headlessRun` and `headlessResume` paths in the same file already use, so all no-track paths now behave alike.

The `deferRunnableTasks` branch, taken when a caller supplies its own scheduler, is untouched.

## Slice Rationale

All three fixes are the same defect in the same file under one claim, so they belong together. Separating them would scatter one behavior across three PRs.

## Non-goals

Does not change the `deferRunnableTasks` path or the tracked (non-no-track) path.

Does not change what work is scheduled, only when it runs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test src/__tests__/headless-no-track-microtask.test.ts`
- [ ] `cd packages/app && pnpm test`

Ran locally. The two new tests, covering `headlessStartReady` and `headlessRetryTask`, fail on master: under fake timers the unref'd timer never fires, so `executeTasks` is never called. They pass with this change.

Full `packages/app` run: the only committed-code failure is `focus-switch-main-process-cost.test.ts`, a timing-sensitive perf assertion that fails identically on clean master and is unrelated to this change.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the earlier unref'd-timer scheduling.
- Data migration? No

</details>
