### PR TITLE
fix(execution-engine): isolate CI-failure event processing per event

### DIFF
--- a/packages/execution-engine/src/__tests__/ci-failure-tick-drops-events.test.ts
+++ b/packages/execution-engine/src/__tests__/ci-failure-tick-drops-events.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { WorkerActionRecord, WorkerActionWrite, WorkflowMutationPriority } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+import { createAutoFixAttemptLedger } from '../auto-fix-attempt-ledger.js';
+import type { ReviewGateCiFailedLifecycleEvent } from '../lifecycle-events.js';
+import {
+  CI_FAILURE_WORKER_KIND,
+  createCiFailureTick,
+} from '../workers/ci-failure-worker.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+function makeTask(taskId: string): TaskState {
+  return {
+    id: taskId,
+    description: 'merge',
+    status: 'review_ready',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: 'wf-1', isMergeNode: true },
+    execution: {
+      generation: 2,
+      selectedAttemptId: 'attempt-1',
+      branch: 'feature/ci',
+      reviewGate: {
+        activeGeneration: 2,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [{
+          id: 'pr-123',
+          providerId: '123',
+          provider: 'github',
+          required: true,
+          status: 'open',
+          generation: 2,
+          headSha: 'sha-1',
+        }],
+      },
+    },
+    taskStateVersion: 10,
+  } as TaskState;
+}
+
+function makeEvent(taskId: string): ReviewGateCiFailedLifecycleEvent {
+  return {
+    eventKey: `review_gate.ci_failed|workflow:wf-1|task:${taskId}`,
+    kind: 'review_gate.ci_failed',
+    workflowId: 'wf-1',
+    taskId,
+    status: 'review_ready',
+    taskStateVersion: 10,
+    generation: 2,
+    attemptId: 'attempt-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    recoveryWakeup: {
+      eventKey: `review_gate.ci_failed|workflow:wf-1|task:${taskId}`,
+      eventKind: 'review_gate.ci_failed',
+      workflowId: 'wf-1',
+      taskId,
+      taskStateVersion: 10,
+      generation: 2,
+      attemptId: 'attempt-1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      reason: 'review_gate_failure',
+      authoritative: false,
+    },
+    reviewId: '123',
+    reviewUrl: 'https://github.com/owner/repo/pull/123',
+    headSha: 'sha-1',
+    headRef: 'feature/ci',
+    branch: 'feature/ci',
+    failedChecks: [
+      { name: 'unit', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/1' },
+    ],
+    statusText: 'CI failed',
+  };
+}
+
+function toRecord(write: WorkerActionWrite): WorkerActionRecord {
+  const now = '2026-01-01T00:00:00.000Z';
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? now,
+    updatedAt: write.updatedAt ?? now,
+  };
+}
+
+describe('createCiFailureTick resilience', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('processes remaining drained events when one event throws', async () => {
+    const events = [makeEvent('task-1'), makeEvent('task-2'), makeEvent('task-3')];
+    const tasks = new Map<string, TaskState>(events.map((event) => [event.taskId, makeTask(event.taskId)]));
+    const actions = new Map<string, WorkerActionRecord>();
+    const submit = vi.fn<[string, WorkflowMutationPriority, string, unknown[]], number>(() => 42);
+    const store = {
+      loadTasks: vi.fn((workflowId: string) => workflowId === 'wf-1' ? Array.from(tasks.values()) : []),
+      loadTask: vi.fn((taskId: string) => {
+        if (taskId === 'task-2') {
+          throw new Error('boom loading task-2');
+        }
+        return tasks.get(taskId);
+      }),
+      listWorkflowMutationIntents: vi.fn(() => []),
+      getWorkerAction: vi.fn((workerKind: string, externalKey: string) => actions.get(`${workerKind}:${externalKey}`)),
+      upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+        const existing = actions.get(`${write.workerKind}:${write.externalKey}`);
+        const saved = toRecord({ ...write, id: existing?.id ?? write.id, createdAt: existing?.createdAt });
+        actions.set(`${write.workerKind}:${write.externalKey}`, saved);
+        return saved;
+      }),
+      logEvent: vi.fn(),
+    };
+
+    const tick = createCiFailureTick({
+      store,
+      submitter: { submit },
+      logger,
+      attemptLedger: createAutoFixAttemptLedger(),
+      defaultAutoFixRetries: 2,
+      drainEvents: () => events,
+    });
+
+    await tick({
+      identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' },
+      reason: 'wake',
+      tickNumber: 1,
+      signal: new AbortController().signal,
+    });
+
+    const submittedTaskIds = submit.mock.calls.map((call) => (call[3] as [string, ...unknown[]])[0]);
+    expect(submittedTaskIds).toContain('task-1');
+    expect(submittedTaskIds).toContain('task-3');
+    expect(submit).toHaveBeenCalledTimes(2);
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/packages/execution-engine/src/workers/ci-failure-worker.ts
+++ b/packages/execution-engine/src/workers/ci-failure-worker.ts
@@ -76,7 +76,18 @@ export function createCiFailureTick(options: CiFailureWorkerPolicyOptions): Work
       const externalKey = ciFailureActionKey(event);
       if (seen.has(externalKey)) continue;
       seen.add(externalKey);
-      await queueReviewGateCiRepair(options, event);
+      try {
+        await queueReviewGateCiRepair(options, event);
+      } catch (error) {
+        options.logger.error(`[worker:${CI_FAILURE_WORKER_KIND}] worker-ci-failure-tick-error`, {
+          module: 'ci-failure-worker',
+          externalKey,
+          taskId: event.taskId,
+          workflowId: event.workflowId,
+          reviewId: event.reviewId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   };
 }


### PR DESCRIPTION
## Summary

One bad CI-failure event could silently discard a whole batch of others.

The CI-failure tick pulls every pending event out of the queue at once, then walks them one by one.

The pull empties the queue, so nothing is left to fall back on if the walk aborts partway.

That walk had no guard around each event. If handling one event threw, the whole tick threw, and every remaining already-pulled event was lost — never handled, never put back.

Each event is now handled inside its own try/catch. A failure is logged with context and the walk continues to the rest.

CodeRabbit reported this on #2900 as Critical. It was never fixed.

## Review Claim

One event that throws during a CI-failure tick must not discard the other events already pulled from the queue.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change adds a per-event try/catch inside the existing walk. The success path is byte-for-byte the same; only the throwing case changes, from "abort the whole tick" to "log and continue."

Nothing is swallowed silently: the catch logs the failure with the external key, task, workflow, review, and error message, matching how the surrounding worker already logs.

The existing key-tracking guard and the ordering of the walk are untouched.

## Slice Rationale

One worker, one loop, one guard, one regression test. Nothing else belongs with it.

## Non-goals

Does not change how events are pulled from the queue or how a repair is handled.

Does not add any re-queue or backoff behavior for the failed event beyond logging it.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test src/__tests__/ci-failure-tick-drops-events.test.ts`
- [ ] `cd packages/execution-engine && pnpm test`

Ran locally. The new test `processes remaining drained events when one event throws` seeds three events where the second throws, and asserts the third is still handled. It fails on master, where the third is dropped, and passes with this change.

Two unrelated files fail on this branch (`no-autofix-outside-worker.test.ts`, `fix-prompt-transport.test.ts`). Both fail identically on clean upstream/master with this change stashed out — 11 failures either way — so they are pre-existing and not touched here.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the earlier all-or-nothing tick.
- Data migration? No

</details>
