### PR TITLE
Prove launch-dispatch churn: resource-limit defer double-terminates the dispatch row

### DIFF
--- a/packages/app/src/__tests__/launch-dispatch-resource-defer-churn-repro.test.ts
+++ b/packages/app/src/__tests__/launch-dispatch-resource-defer-churn-repro.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import type { Logger } from '@invoker/contracts';
+import { LaunchDispatcher } from '../launch-dispatcher.js';
+
+/**
+ * Repro for the launch-dispatch churn behind stuck-pending tasks.
+ *
+ * Observed in production (invoker.log): a queued task loops forever —
+ * `[launch-dispatcher] complete accepted:false` every cycle, no executor
+ * spawns, the task stays `pending`, generations climb into the thousands.
+ *
+ * Root cause: on the resource-limit path, `executeTask` calls
+ * `orchestrator.deferTask()`, which invalidates launch artifacts and
+ * `abandonLaunchDispatchesForTasks()` flips the leased dispatch row to
+ * `abandoned`. `executeTask` then calls `completeDispatch()` on the same
+ * row, which is now terminal — so it returns false. The dispatch is
+ * double-terminated (abandoned by defer, never completed) and the task
+ * re-drains into a fresh row that hits the same wall.
+ *
+ * This test models that exact ordering with the real adapter + dispatcher
+ * and a fake TaskRunner. It fails on current code (accepted:false, row
+ * abandoned); the fix should let the launch complete cleanly.
+ */
+function makeLogger(): Logger & {
+  records: { level: string; msg: string; fields?: Record<string, unknown> }[];
+} {
+  const records: { level: string; msg: string; fields?: Record<string, unknown> }[] = [];
+  const push = (level: string) => (msg: string, fields?: Record<string, unknown>) => {
+    records.push({ level, msg, fields });
+  };
+  const logger: Logger = {
+    debug: push('debug'),
+    info: push('info'),
+    warn: push('warn'),
+    error: push('error'),
+    child: () => logger,
+  };
+  return Object.assign(logger, { records });
+}
+
+describe('launch-dispatch resource-limit defer churn (repro)', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  // `it.fails`: this asserts the DESIRED behavior, which the current code does
+  // not satisfy — it documents the bug and stays green in CI. The fix slice
+  // removes `.fails` once the launch completes cleanly instead of churning.
+  it.fails('does not double-terminate the dispatch row when a launch defers on resource limit', () => {
+    const attemptId = 'attempt-resource-limit';
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    adapter.saveTask('wf-1', {
+      id: 'wf-1/t1',
+      description: 'one',
+      status: 'pending',
+      dependencies: [],
+      createdAt: new Date(),
+      config: { workflowId: 'wf-1' },
+      execution: {},
+      taskStateVersion: 1,
+    });
+    adapter.updateTask('wf-1/t1', {
+      execution: { selectedAttemptId: attemptId, generation: 0 },
+    });
+    const enqueued = adapter.enqueueLaunchDispatch({
+      taskId: 'wf-1/t1',
+      attemptId,
+      workflowId: 'wf-1',
+      generation: 0,
+    });
+
+    const logger = makeLogger();
+    const task = { id: 'wf-1/t1', execution: { selectedAttemptId: attemptId, generation: 0 } };
+
+    const dispatcher = new LaunchDispatcher({
+      persistence: adapter,
+      ownerId: 'owner-test',
+      logger,
+      orchestrator: {
+        prepareTaskForNewAttempt: vi.fn(),
+        startExecution: () => [],
+        getTask: () => task as never,
+      },
+      // A launch that hits a saturated pool: defer (invalidates + abandons
+      // the leased dispatch row), then complete the same row. This is the
+      // executeTask resource-limit branch, faithfully ordered.
+      taskRunnerProvider: () => ({
+        executeTask: (t, opts) => {
+          adapter.abandonLaunchDispatchesForTasks([t.id], 'task deferred');
+          opts?.launchOutbox.completeDispatch(opts.dispatchId);
+          return Promise.resolve();
+        },
+      }),
+    });
+
+    dispatcher.poll();
+
+    const completeLog = logger.records.find(
+      (r) => r.msg.includes('[launch-dispatcher] complete'),
+    );
+    const row = adapter.loadLaunchDispatchById(enqueued.id);
+
+    // Bug signature: the dispatch is abandoned by the defer, so completeDispatch
+    // is rejected — the exact `accepted:false` churn seen in production.
+    expect(completeLog?.fields?.accepted).toBe(true);
+    expect(row?.state).toBe('completed');
+  });
+});


### PR DESCRIPTION
## Summary

Queued tasks can sit pending forever while the pool has room. The log shows `[launch-dispatcher] complete accepted:false` on every cycle and no executor ever spawns.

On the resource-limit path, `executeTask` defers the task, and the defer abandons the leased dispatch row. `executeTask` then completes the same row, which is already terminal, so `completeDispatch` returns false.

The row is finished twice — abandoned by the defer, never completed. The task then drains back into a fresh row that hits the same wall.

The loop never ends; generations climb into the thousands.

This slice only proves the defect. The behavior fix is a separate, later slice.

## Review Claim

An `it.fails` test reproduces the launch-dispatch churn where a resource-limit defer abandons the dispatch row before `completeDispatch`, so the launch never finishes cleanly.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only. It is marked `it.fails`, so it passes CI while documenting the desired behavior. It adds no product behavior and drives no runtime path — it exercises the real adapter and dispatcher with a fake task runner that models the defer-then-complete ordering.

## Slice Rationale

Proof lands before the fix so the defect is demonstrated before the change is approved. This slice adds only the failing test; the behavior fix comes in its own slice that removes `it.fails`.

## Non-goals

Does not change the dispatcher, the defer path, or capacity accounting. Does not fix the churn. Does not remove `it.fails`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/launch-dispatch-resource-defer-churn-repro.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
