### PR TITLE
Reclaim a task's superseded execution slot so a stranded attempt can't wedge pool capacity

### DIFF
--- a/packages/execution-engine/src/__tests__/pool-capacity-superseded-execution-leak.test.ts
+++ b/packages/execution-engine/src/__tests__/pool-capacity-superseded-execution-leak.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TaskRunner } from '../task-runner.js';
+import type { TaskState } from '@invoker/workflow-core';
+
+/**
+ * Repro + fix for the execution-pool capacity wedge behind stuck-pending tasks.
+ *
+ * Pool capacity (`task-runner-pool.ts` `poolMemberLoad`) counts a member as
+ * loaded for every `activeExecutions` entry on it. That map is only cleared by
+ * `onComplete` or `killActiveExecution`; when a running attempt is superseded
+ * (recreate/invalidate) and neither fires — an orphaned remote executor, or a
+ * kill hook that no-oped — its entry lingers and occupies the member forever.
+ * Over a long-lived process this wedges every member at capacity while nothing
+ * runs, so all launches fail with "no member capacity".
+ *
+ * `selectExecutor` now reclaims a task's own superseded slot before selecting,
+ * so its next launch frees its member instead of deferring forever.
+ */
+function makeRunner() {
+  const kill = vi.fn().mockResolvedValue(undefined);
+  const sshExecutor = {
+    type: 'ssh',
+    start: vi.fn(),
+    onComplete: vi.fn(),
+    onOutput: vi.fn(),
+    onHeartbeat: vi.fn(),
+    kill,
+    destroyAll: vi.fn(),
+  };
+  const runner = new TaskRunner({
+    orchestrator: { getTask: () => null, getAllTasks: () => [], deferTask: vi.fn() } as never,
+    persistence: { logEvent: vi.fn(), releaseExecutionResourceLease: vi.fn() } as never,
+    executorRegistry: {
+      getDefault: () => sshExecutor,
+      get: (type: string) => (type === 'ssh' ? sshExecutor : null),
+      getAll: () => [sshExecutor],
+      register: vi.fn(),
+    } as never,
+    cwd: '/tmp',
+    remoteTargetsProvider: () => ({ 'remote-a': { host: 'a', user: 'invoker', sshKeyPath: '/tmp/k' } }),
+    executionPoolsProvider: () => ({
+      'ssh-pool': {
+        selectionStrategy: 'leastLoaded',
+        maxConcurrentTasksPerMember: 1,
+        members: [{ id: 'remote-a', type: 'ssh', maxConcurrentTasks: 1 }],
+      },
+    }),
+  } as never);
+  return { runner, sshExecutor, kill };
+}
+
+function makeTask(id: string, attempt: string): TaskState {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { command: 'echo hi', runnerKind: 'ssh', poolId: 'ssh-pool' },
+    execution: { selectedAttemptId: attempt, generation: 0 },
+  } as TaskState;
+}
+
+function strandActiveExecution(runner: TaskRunner, sshExecutor: unknown, taskId: string, attemptId: string): void {
+  (runner as unknown as { activeExecutions: Map<string, unknown> }).activeExecutions.set(attemptId, {
+    handle: { attemptId },
+    executor: sshExecutor,
+    taskId,
+    poolId: 'ssh-pool',
+    poolMemberKey: 'ssh:remote-a',
+  });
+}
+
+describe('pool capacity: superseded execution slot leak', () => {
+  it("reclaims a task's stranded prior-attempt slot so its next launch is not wedged", () => {
+    const { runner, sshExecutor, kill } = makeRunner();
+    // A prior attempt of task-a launched on remote-a and was never reaped.
+    strandActiveExecution(runner, sshExecutor, 'wf-1/task-a', 'wf-1/task-a-old');
+
+    // remote-a (capacity 1) reads full from the stale entry, but task-a's next
+    // attempt must still launch on its own member.
+    const task = makeTask('wf-1/task-a', 'wf-1/task-a-new');
+    expect(() => runner.selectExecutor(task)).not.toThrow();
+
+    expect((runner as unknown as { activeExecutions: Map<string, unknown> }).activeExecutions.has('wf-1/task-a-old')).toBe(false);
+    expect(runner.pendingPoolSelections.get('wf-1/task-a')?.member.id).toBe('remote-a');
+    expect(kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reclaim another task's live execution slot (no over-subscription)", () => {
+    const { runner, sshExecutor, kill } = makeRunner();
+    // task-a is genuinely running on remote-a.
+    strandActiveExecution(runner, sshExecutor, 'wf-1/task-a', 'wf-1/task-a-live');
+
+    // A different task selecting the pool must still see remote-a as full.
+    expect(() => runner.selectExecutor(makeTask('wf-2/task-b', 'wf-2/task-b-attempt'))).toThrow(/no member capacity/);
+    expect((runner as unknown as { activeExecutions: Map<string, unknown> }).activeExecutions.has('wf-1/task-a-live')).toBe(true);
+    expect(kill).not.toHaveBeenCalled();
+  });
+});

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -451,6 +451,43 @@ export function takeResolvedExecutionSelection(host: TaskRunnerPoolHost, taskId:
   return resolvedExecution;
 }
 
+/**
+ * Reclaim any in-memory execution slot this task still holds from a prior
+ * attempt whose executor was never reaped — a superseded/recreated launch
+ * whose kill hook no-oped or whose orphaned executor never fired `onComplete`.
+ * Left in `activeExecutions`, that stale entry counts against member capacity
+ * forever ({@link poolMemberLoad}), so every member can read full while nothing
+ * runs. Mirrors the `pendingPoolSelections` self-heal in `selectExecutor`; the
+ * current attempt is never touched. Best-effort kills the orphan so freeing the
+ * slot cannot over-subscribe the member.
+ */
+function reclaimSupersededExecutionSlots(host: TaskRunnerPoolHost, task: TaskState): void {
+  const liveAttemptId = task.execution.selectedAttemptId;
+  if (liveAttemptId === undefined) return;
+  for (const [attemptId, entry] of host.activeExecutions) {
+    if (entry.taskId !== task.id || attemptId === liveAttemptId) continue;
+    host.activeExecutions.delete(attemptId);
+    host.logger?.warn?.(
+      `[TaskRunner] reclaimed superseded execution slot task=${task.id} staleAttempt=${attemptId} ` +
+        `member=${entry.poolMemberKey ?? 'n/a'}; a prior attempt's executor was never reaped`,
+      { taskId: task.id, staleAttempt: attemptId, member: entry.poolMemberKey, module: 'task-runner' },
+    );
+    if (entry.leaseResourceKey && entry.leaseHolderId) {
+      host.persistence.releaseExecutionResourceLease?.(entry.leaseResourceKey, entry.leaseHolderId);
+    }
+    const onKillError = (err: unknown) =>
+      host.logger?.warn?.(
+        `[TaskRunner] best-effort kill of superseded execution failed task=${task.id} attempt=${attemptId}`,
+        { err, module: 'task-runner' },
+      );
+    try {
+      void Promise.resolve(entry.executor.kill(entry.handle)).catch(onKillError);
+    } catch (err) {
+      onKillError(err);
+    }
+  }
+}
+
 export function selectExecutor(
   host: TaskRunnerPoolHost & MergeRunnerHost,
   task: TaskState,
@@ -466,6 +503,7 @@ export function selectExecutor(
     executionModel: host.resolveExecutionModel(task),
   };
   host.pendingPoolSelections.delete(task.id);
+  reclaimSupersededExecutionSlots(host, task);
 
   if (task.config.poolId && explicitPoolMemberId) {
     const pool = host.getExecutionPools()[task.config.poolId];


### PR DESCRIPTION
## Summary

Queued tasks could sit pending forever while the pool reported every member full, so every launch failed with "no member capacity" — even with nothing actually running.

Capacity counts one load per active execution recorded on a member. That record is only dropped when the execution finishes or is killed.

When a running attempt is superseded — recreated or invalidated — and neither happens (an orphaned remote executor, or a kill hook that no-oped), its record lingers forever.

Over a long-lived owner process this wedges every member, and pinned tasks never launch again.

`selectExecutor` now reclaims a task's own superseded record before it selects, mirroring the pending-selection self-heal already there.

It drops the leftover record, releases its lease, and best-effort kills the orphan so freeing the slot can't over-subscribe the member. The current attempt is never touched.

## Review Claim

`selectExecutor` reclaims a task's superseded active-execution record before selecting, so a stranded prior attempt can no longer wedge member capacity.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The reclaim only touches records for the same task whose attempt differs from the task's current `selectedAttemptId`, and best-effort kills the orphan before freeing the slot — so it never drops a live execution or lets two attempts share a one-capacity member. Two focused tests cover it: the stranded slot is reclaimed and the member frees; another task's live slot is left untouched.

## Slice Rationale

One behavior change in the launch selection path plus its focused tests. The related `pendingPoolSelections` leak and the launch-dispatch double-termination are separate slices.

## Non-goals

Does not change pool selection strategy, capacity limits, or the kill/recreate lifecycle itself. Does not add cross-task orphan reaping — a member held by another task's orphan still frees only when that task next launches. Does not touch the dispatch-row double-termination.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/pool-capacity-superseded-execution-leak.test.ts`
- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/ssh-pool-member-capacity.test.ts src/__tests__/task-runner-launch-dispatch.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
