### PR TITLE
[Slow-query telemetry aggregator](1) Aggregate slow queries by SQL shape

### DIFF
--- a/packages/data-store/src/__tests__/slow-query-aggregator.test.ts
+++ b/packages/data-store/src/__tests__/slow-query-aggregator.test.ts
@@ -32,6 +32,23 @@ describe('normalizeSlowQuerySql', () => {
       normalizeSlowQuerySql('SELECT * FROM attempts WHERE workflow_id IN (1, 2, 3)'),
     );
   });
+
+  it('preserves delimited identifiers instead of normalizing their contents', () => {
+    expect(
+      normalizeSlowQuerySql('SELECT "tenant:alpha" FROM attempts'),
+    ).toBe('SELECT "tenant:alpha" FROM attempts');
+    expect(
+      normalizeSlowQuerySql('SELECT * FROM attempts WHERE "tenant:alpha" = 1'),
+    ).not.toBe(
+      normalizeSlowQuerySql('SELECT * FROM attempts WHERE "tenant:beta" = 1'),
+    );
+    expect(
+      normalizeSlowQuerySql('SELECT `tenant:alpha` FROM attempts'),
+    ).toBe('SELECT `tenant:alpha` FROM attempts');
+    expect(
+      normalizeSlowQuerySql('SELECT [tenant:alpha] FROM attempts'),
+    ).toBe('SELECT [tenant:alpha] FROM attempts');
+  });
 });
 
 describe('SlowQueryAggregator', () => {
@@ -96,5 +113,31 @@ describe('SlowQueryAggregator', () => {
     expect(aggregator.totalCount).toBe(0);
     expect(aggregator.shapeCount).toBe(0);
     expect(aggregator.topN()).toEqual([]);
+  });
+
+  it('bounds per-shape memory instead of retaining every duration sample forever', () => {
+    const aggregator = new SlowQueryAggregator({ now: () => 1_000 });
+
+    for (let i = 0; i < 5_000; i += 1) {
+      aggregator.record({ durationMs: i, sql: 'SELECT * FROM attempts WHERE node_id = ?' });
+    }
+
+    expect(aggregator.totalCount).toBe(5_000);
+    const [stats] = aggregator.topN(1);
+    expect(stats?.maxMs).toBe(4_999);
+    expect(stats?.count).toBe(5_000);
+    expect(stats?.p50Ms).toBeGreaterThanOrEqual(0);
+    expect(stats?.p50Ms).toBeLessThanOrEqual(4_999);
+  });
+
+  it('bounds distinct tracked shapes instead of growing the shape map forever', () => {
+    const aggregator = new SlowQueryAggregator({ now: () => 1_000 });
+
+    for (let i = 0; i < 5_000; i += 1) {
+      aggregator.record({ durationMs: 1, sql: `SELECT * FROM t${i} WHERE id = 'literal-${i}'` });
+    }
+
+    expect(aggregator.totalCount).toBe(5_000);
+    expect(aggregator.shapeCount).toBeLessThanOrEqual(200);
   });
 });

--- a/packages/data-store/src/__tests__/slow-query-aggregator.test.ts
+++ b/packages/data-store/src/__tests__/slow-query-aggregator.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { SlowQueryAggregator, normalizeSlowQuerySql } from '../slow-query-aggregator.js';
+
+describe('normalizeSlowQuerySql', () => {
+  it('collapses literals, bound params, IN-list arity, and whitespace into a stable shape', () => {
+    const literalShape = normalizeSlowQuerySql(`
+      SELECT * FROM attempts
+      WHERE node_id IN ('node-1', 'node-2', 'node-3')
+        AND run_number = 42
+        AND status = 'done'
+    `);
+    const parameterShape = normalizeSlowQuerySql(
+      'SELECT * FROM attempts WHERE node_id IN (?, ?, ?, ?) AND run_number = ? AND status = :status',
+    );
+
+    expect(literalShape).toBe(
+      'SELECT * FROM attempts WHERE node_id IN (?) AND run_number = ? AND status = ?',
+    );
+    expect(parameterShape).toBe(literalShape);
+    expect(
+      normalizeSlowQuerySql(
+        "SELECT * FROM attempts WHERE id = @id AND retry_count = -12 AND payload = 'it''s fine'",
+      ),
+    ).toBe('SELECT * FROM attempts WHERE id = ? AND retry_count = ? AND payload = ?');
+  });
+
+  it('keeps genuinely different SQL shapes separate', () => {
+    expect(
+      normalizeSlowQuerySql('SELECT * FROM attempts WHERE node_id IN (1, 2, 3)'),
+    ).not.toBe(
+      normalizeSlowQuerySql('SELECT * FROM attempts WHERE workflow_id IN (1, 2, 3)'),
+    );
+  });
+});
+
+describe('SlowQueryAggregator', () => {
+  it('aggregates equivalent shapes and tracks percentile, max, rows, and timestamps', () => {
+    const observedAtMs = [1_000, 2_000, 3_000, 4_000, 5_000];
+    const aggregator = new SlowQueryAggregator({ now: () => observedAtMs.shift() ?? 0 });
+
+    aggregator.record({
+      durationMs: 10,
+      sql: 'SELECT * FROM attempts WHERE node_id = 1',
+      rowCount: 1,
+    });
+    aggregator.record({ durationMs: 30, sql: 'SELECT * FROM attempts WHERE node_id = 2' });
+    aggregator.record({
+      durationMs: 20,
+      sql: 'SELECT * FROM attempts WHERE node_id = 3',
+      rowCount: 9,
+    });
+    aggregator.record({
+      durationMs: 50,
+      sql: 'SELECT * FROM attempts WHERE node_id = ?',
+      rowCount: 3,
+    });
+    aggregator.record({
+      durationMs: 40,
+      sql: 'SELECT * FROM attempts WHERE node_id = :nodeId',
+      rowCount: 0,
+    });
+
+    expect(aggregator.totalCount).toBe(5);
+    expect(aggregator.shapeCount).toBe(1);
+    expect(aggregator.topN()).toEqual([
+      {
+        shape: 'SELECT * FROM attempts WHERE node_id = ?',
+        count: 5,
+        p50Ms: 30,
+        p95Ms: 50,
+        maxMs: 50,
+        maxRows: 9,
+        firstSeenAtMs: 1_000,
+        lastSeenAtMs: 5_000,
+      },
+    ]);
+  });
+
+  it('ranks top-N by max duration, then count', () => {
+    const aggregator = new SlowQueryAggregator({ now: () => 1_000 });
+
+    aggregator.record({ durationMs: 100, sql: "SELECT * FROM attempts WHERE node_id = 'a'" });
+    aggregator.record({ durationMs: 90, sql: "SELECT * FROM attempts WHERE node_id = 'b'" });
+    aggregator.record({ durationMs: 200, sql: 'SELECT * FROM workflows WHERE id = ?' });
+    aggregator.record({ durationMs: 100, sql: 'SELECT * FROM task_events WHERE task_id = ?' });
+    aggregator.record({ durationMs: 95, sql: 'SELECT * FROM task_events WHERE task_id = ?' });
+    aggregator.record({ durationMs: 80, sql: 'SELECT * FROM task_events WHERE task_id = ?' });
+
+    expect(aggregator.topN(2).map((stats) => stats.shape)).toEqual([
+      'SELECT * FROM workflows WHERE id = ?',
+      'SELECT * FROM task_events WHERE task_id = ?',
+    ]);
+
+    aggregator.reset();
+    expect(aggregator.totalCount).toBe(0);
+    expect(aggregator.shapeCount).toBe(0);
+    expect(aggregator.topN()).toEqual([]);
+  });
+});

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -1,5 +1,6 @@
 export * from './adapter.js';
 export * from './sqlite-adapter.js';
+export * from './slow-query-aggregator.js';
 export * from './conversation-repository.js';
 export * from './sqlite-task-repository.js';
 export * from './workflow-channel-repository.js';

--- a/packages/data-store/src/slow-query-aggregator.ts
+++ b/packages/data-store/src/slow-query-aggregator.ts
@@ -18,11 +18,32 @@ export interface SlowQueryShapeStats {
 interface MutableShapeStats {
   shape: string;
   count: number;
+  /** Bounded reservoir sample of durations, used only to estimate percentiles. */
   durationsMs: number[];
   maxMs: number;
   maxRows?: number;
   firstSeenAtMs: number;
   lastSeenAtMs: number;
+}
+
+/** Caps per-shape duration samples so memory stays bounded for a long-lived process. */
+const MAX_DURATION_SAMPLES_PER_SHAPE = 500;
+/** Caps distinct tracked shapes; least-severe shape is evicted to make room for a new one. */
+const MAX_TRACKED_SHAPES = 200;
+
+/**
+ * Reservoir sampling (Algorithm R): keeps a fixed-size, statistically
+ * representative sample of an unbounded stream without retaining every value.
+ */
+function addReservoirSample(samples: number[], value: number, seenCount: number): void {
+  if (samples.length < MAX_DURATION_SAMPLES_PER_SHAPE) {
+    samples.push(value);
+    return;
+  }
+  const replaceIndex = Math.floor(Math.random() * seenCount);
+  if (replaceIndex < MAX_DURATION_SAMPLES_PER_SHAPE) {
+    samples[replaceIndex] = value;
+  }
 }
 
 const PARAMETER_PREFIXES = new Set([':', '@', '$']);
@@ -93,6 +114,36 @@ function skipSqlStringLiteral(sql: string, quoteIndex: number): number {
   return sql.length;
 }
 
+/**
+ * Skips a quoted identifier (e.g. "col", `col`) so its contents are copied
+ * verbatim instead of being mistaken for parameter/literal syntax. The quote
+ * character escapes itself by doubling, matching SQL identifier-quoting rules.
+ */
+function skipDelimitedIdentifier(sql: string, quoteIndex: number, quoteChar: string): number {
+  let index = quoteIndex + 1;
+  while (index < sql.length) {
+    if (sql[index] === quoteChar) {
+      if (sql[index + 1] === quoteChar) {
+        index += 2;
+        continue;
+      }
+      return index + 1;
+    }
+    index += 1;
+  }
+  return sql.length;
+}
+
+/** Skips a bracket-delimited identifier (e.g. [col]), MSSQL/Access style. */
+function skipBracketDelimitedIdentifier(sql: string, bracketIndex: number): number {
+  let index = bracketIndex + 1;
+  while (index < sql.length) {
+    if (sql[index] === ']') return index + 1;
+    index += 1;
+  }
+  return sql.length;
+}
+
 function skipNumberLiteral(sql: string, startIndex: number): number {
   let index = startIndex;
   if (sql[index] === '0' && (sql[index + 1] === 'x' || sql[index + 1] === 'X')) {
@@ -142,6 +193,20 @@ export function normalizeSlowQuerySql(sql: string): string {
     if (ch === "'") {
       normalized.push('?');
       index = skipSqlStringLiteral(sql, index);
+      continue;
+    }
+
+    if (ch === '"' || ch === '`') {
+      const end = skipDelimitedIdentifier(sql, index, ch);
+      normalized.push(sql.slice(index, end));
+      index = end;
+      continue;
+    }
+
+    if (ch === '[') {
+      const end = skipBracketDelimitedIdentifier(sql, index);
+      normalized.push(sql.slice(index, end));
+      index = end;
       continue;
     }
 
@@ -229,6 +294,7 @@ export class SlowQueryAggregator {
     this.recordedCount += 1;
 
     if (!existing) {
+      this.evictLeastSevereShapeIfAtCapacity();
       this.shapes.set(shape, {
         shape,
         count: 1,
@@ -242,7 +308,7 @@ export class SlowQueryAggregator {
     }
 
     existing.count += 1;
-    existing.durationsMs.push(info.durationMs);
+    addReservoirSample(existing.durationsMs, info.durationMs, existing.count);
     existing.maxMs = Math.max(existing.maxMs, info.durationMs);
     if (info.rowCount !== undefined) {
       existing.maxRows = existing.maxRows === undefined
@@ -250,6 +316,20 @@ export class SlowQueryAggregator {
         : Math.max(existing.maxRows, info.rowCount);
     }
     existing.lastSeenAtMs = observedAtMs;
+  }
+
+  /** Bounds distinct shapes tracked by dropping the currently least-severe one. */
+  private evictLeastSevereShapeIfAtCapacity(): void {
+    if (this.shapes.size < MAX_TRACKED_SHAPES) return;
+    let leastSevereKey: string | undefined;
+    let leastSevereMaxMs = Infinity;
+    for (const [key, stats] of this.shapes) {
+      if (stats.maxMs < leastSevereMaxMs) {
+        leastSevereMaxMs = stats.maxMs;
+        leastSevereKey = key;
+      }
+    }
+    if (leastSevereKey !== undefined) this.shapes.delete(leastSevereKey);
   }
 
   topN(n = 10): SlowQueryShapeStats[] {

--- a/packages/data-store/src/slow-query-aggregator.ts
+++ b/packages/data-store/src/slow-query-aggregator.ts
@@ -1,0 +1,270 @@
+import type { SlowQueryInfo } from './sqlite-adapter.js';
+
+export interface SlowQueryAggregatorOptions {
+  now?: () => number;
+}
+
+export interface SlowQueryShapeStats {
+  shape: string;
+  count: number;
+  p50Ms: number;
+  p95Ms: number;
+  maxMs: number;
+  maxRows?: number;
+  firstSeenAtMs: number;
+  lastSeenAtMs: number;
+}
+
+interface MutableShapeStats {
+  shape: string;
+  count: number;
+  durationsMs: number[];
+  maxMs: number;
+  maxRows?: number;
+  firstSeenAtMs: number;
+  lastSeenAtMs: number;
+}
+
+const PARAMETER_PREFIXES = new Set([':', '@', '$']);
+const SIGNED_NUMBER_PREFIXES = new Set([
+  '(',
+  '[',
+  '{',
+  ',',
+  '=',
+  '<',
+  '>',
+  '!',
+  '+',
+  '-',
+  '*',
+  '/',
+  '%',
+  '|',
+  '&',
+  '~',
+]);
+
+function isDigit(value: string | undefined): boolean {
+  return value !== undefined && value >= '0' && value <= '9';
+}
+
+function isHexDigit(value: string | undefined): boolean {
+  return value !== undefined && /^[0-9a-fA-F]$/.test(value);
+}
+
+function isIdentifierStart(value: string | undefined): boolean {
+  return value !== undefined && /^[A-Za-z_]$/.test(value);
+}
+
+function isIdentifierChar(value: string | undefined): boolean {
+  return value !== undefined && /^[A-Za-z0-9_]$/.test(value);
+}
+
+function previousNonWhitespace(sql: string, index: number): string | undefined {
+  for (let i = index - 1; i >= 0; i -= 1) {
+    const ch = sql[i];
+    if (ch !== undefined && !/\s/.test(ch)) return ch;
+  }
+  return undefined;
+}
+
+function canStartSignedNumber(sql: string, index: number): boolean {
+  const previous = previousNonWhitespace(sql, index);
+  return previous === undefined || SIGNED_NUMBER_PREFIXES.has(previous);
+}
+
+function startsNumberAt(sql: string, index: number): boolean {
+  return isDigit(sql[index]) || (sql[index] === '.' && isDigit(sql[index + 1]));
+}
+
+function skipSqlStringLiteral(sql: string, quoteIndex: number): number {
+  let index = quoteIndex + 1;
+  while (index < sql.length) {
+    if (sql[index] === "'") {
+      if (sql[index + 1] === "'") {
+        index += 2;
+        continue;
+      }
+      return index + 1;
+    }
+    index += 1;
+  }
+  return sql.length;
+}
+
+function skipNumberLiteral(sql: string, startIndex: number): number {
+  let index = startIndex;
+  if (sql[index] === '0' && (sql[index + 1] === 'x' || sql[index + 1] === 'X')) {
+    index += 2;
+    while (isHexDigit(sql[index])) index += 1;
+    return index;
+  }
+
+  while (isDigit(sql[index])) index += 1;
+  if (sql[index] === '.' && isDigit(sql[index + 1])) {
+    index += 1;
+    while (isDigit(sql[index])) index += 1;
+  }
+  if (
+    (sql[index] === 'e' || sql[index] === 'E')
+    && (
+      isDigit(sql[index + 1])
+      || ((sql[index + 1] === '+' || sql[index + 1] === '-') && isDigit(sql[index + 2]))
+    )
+  ) {
+    index += 1;
+    if (sql[index] === '+' || sql[index] === '-') index += 1;
+    while (isDigit(sql[index])) index += 1;
+  }
+
+  return index;
+}
+
+function collapseInLists(sql: string): string {
+  return sql.replace(/\bIN\s*\(\s*\?(?:\s*,\s*\?)+\s*\)/gi, 'IN (?)');
+}
+
+export function normalizeSlowQuerySql(sql: string): string {
+  const normalized: string[] = [];
+
+  for (let index = 0; index < sql.length;) {
+    const ch = sql[index];
+    const next = sql[index + 1];
+    const previous = sql[index - 1];
+
+    if ((ch === 'x' || ch === 'X') && next === "'" && !isIdentifierChar(previous)) {
+      normalized.push('?');
+      index = skipSqlStringLiteral(sql, index + 1);
+      continue;
+    }
+
+    if (ch === "'") {
+      normalized.push('?');
+      index = skipSqlStringLiteral(sql, index);
+      continue;
+    }
+
+    if (ch === '?') {
+      normalized.push('?');
+      index += 1;
+      while (isDigit(sql[index])) index += 1;
+      continue;
+    }
+
+    if (ch !== undefined && PARAMETER_PREFIXES.has(ch) && isIdentifierStart(next)) {
+      normalized.push('?');
+      index += 2;
+      while (isIdentifierChar(sql[index])) index += 1;
+      continue;
+    }
+
+    if (
+      (ch === '-' || ch === '+')
+      && startsNumberAt(sql, index + 1)
+      && canStartSignedNumber(sql, index)
+    ) {
+      normalized.push('?');
+      index = skipNumberLiteral(sql, index + 1);
+      continue;
+    }
+
+    if (startsNumberAt(sql, index) && !isIdentifierChar(previous)) {
+      normalized.push('?');
+      index = skipNumberLiteral(sql, index);
+      continue;
+    }
+
+    if (ch !== undefined) normalized.push(ch);
+    index += 1;
+  }
+
+  return collapseInLists(normalized.join('')).replace(/\s+/g, ' ').trim();
+}
+
+function percentile(sortedValues: readonly number[], percentileValue: number): number {
+  if (sortedValues.length === 0) return 0;
+  const index = Math.min(
+    sortedValues.length - 1,
+    Math.max(0, Math.ceil((percentileValue / 100) * sortedValues.length) - 1),
+  );
+  return sortedValues[index] ?? 0;
+}
+
+function snapshotStats(stats: MutableShapeStats): SlowQueryShapeStats {
+  const sortedDurations = [...stats.durationsMs].sort((a, b) => a - b);
+  return {
+    shape: stats.shape,
+    count: stats.count,
+    p50Ms: percentile(sortedDurations, 50),
+    p95Ms: percentile(sortedDurations, 95),
+    maxMs: stats.maxMs,
+    ...(stats.maxRows === undefined ? {} : { maxRows: stats.maxRows }),
+    firstSeenAtMs: stats.firstSeenAtMs,
+    lastSeenAtMs: stats.lastSeenAtMs,
+  };
+}
+
+export class SlowQueryAggregator {
+  private readonly shapes = new Map<string, MutableShapeStats>();
+  private readonly now: () => number;
+  private recordedCount = 0;
+
+  constructor(options: SlowQueryAggregatorOptions = {}) {
+    this.now = options.now ?? Date.now;
+  }
+
+  get totalCount(): number {
+    return this.recordedCount;
+  }
+
+  get shapeCount(): number {
+    return this.shapes.size;
+  }
+
+  record(info: SlowQueryInfo): void {
+    const shape = normalizeSlowQuerySql(info.sql);
+    const observedAtMs = this.now();
+    const existing = this.shapes.get(shape);
+    this.recordedCount += 1;
+
+    if (!existing) {
+      this.shapes.set(shape, {
+        shape,
+        count: 1,
+        durationsMs: [info.durationMs],
+        maxMs: info.durationMs,
+        ...(info.rowCount === undefined ? {} : { maxRows: info.rowCount }),
+        firstSeenAtMs: observedAtMs,
+        lastSeenAtMs: observedAtMs,
+      });
+      return;
+    }
+
+    existing.count += 1;
+    existing.durationsMs.push(info.durationMs);
+    existing.maxMs = Math.max(existing.maxMs, info.durationMs);
+    if (info.rowCount !== undefined) {
+      existing.maxRows = existing.maxRows === undefined
+        ? info.rowCount
+        : Math.max(existing.maxRows, info.rowCount);
+    }
+    existing.lastSeenAtMs = observedAtMs;
+  }
+
+  topN(n = 10): SlowQueryShapeStats[] {
+    return [...this.shapes.values()]
+      .map((stats) => snapshotStats(stats))
+      .sort((left, right) =>
+        right.maxMs - left.maxMs
+        || right.count - left.count
+        || left.shape.localeCompare(right.shape),
+      )
+      .slice(0, n);
+  }
+
+  reset(): void {
+    this.shapes.clear();
+    this.recordedCount = 0;
+  }
+}

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -69,6 +69,7 @@ import {
   readSpoolLinesFromFile,
   readLastSpoolLinesFromFile,
 } from './sqlite-output-spool.js';
+import { SlowQueryAggregator, type SlowQueryShapeStats } from './slow-query-aggregator.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
 import * as migrations from './sqlite-migrations.js';
 import { SqliteTaskAttemptRepository } from './sqlite-task-attempt-repository.js';
@@ -186,6 +187,58 @@ export type EphemeralSQLiteAdapterOptions = Pick<
   SQLiteAdapterOptions,
   'outputTailLimit' | 'outputDir' | 'activityLogMaxRows'
 >;
+
+const DEFAULT_SLOW_QUERY_SUMMARY_TOP_N = 10;
+const DEFAULT_SLOW_QUERY_SUMMARY_INTERVAL_MS = 30_000;
+const DEFAULT_SLOW_QUERY_SUMMARY_RECORD_COUNT = 1_000;
+const SLOW_QUERY_SUMMARY_SQL_PREVIEW_LENGTH = 240;
+
+function formatSlowQuerySummaryLine(index: number, stats: SlowQueryShapeStats): string {
+  const maxRows = stats.maxRows === undefined ? '' : ` maxRows=${stats.maxRows}`;
+  const firstSeen = new Date(stats.firstSeenAtMs).toISOString();
+  const lastSeen = new Date(stats.lastSeenAtMs).toISOString();
+  const sql = stats.shape.slice(0, SLOW_QUERY_SUMMARY_SQL_PREVIEW_LENGTH);
+
+  return `${index + 1}. max=${stats.maxMs.toFixed(1)}ms p95=${stats.p95Ms.toFixed(1)}ms ` +
+    `p50=${stats.p50Ms.toFixed(1)}ms count=${stats.count}${maxRows} ` +
+    `seen=${firstSeen}..${lastSeen} sql=${sql}`;
+}
+
+function formatSlowQuerySummary(
+  thresholdMs: number,
+  aggregator: SlowQueryAggregator,
+): string {
+  const topQueries = aggregator.topN(DEFAULT_SLOW_QUERY_SUMMARY_TOP_N);
+  const lines = topQueries.map((stats, index) => formatSlowQuerySummaryLine(index, stats));
+  return [
+    `[SQLiteAdapter] slow query summary threshold=${thresholdMs.toFixed(1)}ms ` +
+      `events=${aggregator.totalCount} shapes=${aggregator.shapeCount} top=${topQueries.length}`,
+    ...lines,
+  ].join('\n');
+}
+
+function createDefaultSlowQuerySink(thresholdMs: number): (info: SlowQueryInfo) => void {
+  const aggregator = new SlowQueryAggregator();
+  let lastSummaryAtMs = 0;
+  let recordsSinceLastSummary = 0;
+
+  return (info) => {
+    aggregator.record(info);
+    recordsSinceLastSummary += 1;
+
+    const now = Date.now();
+    const shouldSummarizeByTime =
+      lastSummaryAtMs === 0 || now - lastSummaryAtMs >= DEFAULT_SLOW_QUERY_SUMMARY_INTERVAL_MS;
+    const shouldSummarizeByCount =
+      recordsSinceLastSummary >= DEFAULT_SLOW_QUERY_SUMMARY_RECORD_COUNT;
+
+    if (!shouldSummarizeByTime && !shouldSummarizeByCount) return;
+
+    console.warn(formatSlowQuerySummary(thresholdMs, aggregator));
+    lastSummaryAtMs = now;
+    recordsSinceLastSummary = 0;
+  };
+}
 
 export type WorkflowMutationPriority = 'high' | 'normal';
 export type WorkflowMutationIntentStatus = 'queued' | 'running' | 'completed' | 'failed';
@@ -621,13 +674,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.slowQueryThresholdMs = options?.slowQueryThresholdMs ?? 25;
     this.onSlowQuery = options?.onSlowQuery
       ?? (this.slowQueryThresholdMs > 0
-        ? (info) => {
-            console.warn(
-              `[SQLiteAdapter] slow query ${info.durationMs.toFixed(1)}ms` +
-                (info.rowCount === undefined ? '' : ` rows=${info.rowCount}`) +
-                `: ${info.sql.slice(0, 200)}`,
-            );
-          }
+        ? createDefaultSlowQuerySink(this.slowQueryThresholdMs)
         : null);
     this.corruptionRecovery = corruptionRecovery;
     this.taskAttemptRepo = new SqliteTaskAttemptRepository(this.executor, {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -190,7 +190,6 @@ export type EphemeralSQLiteAdapterOptions = Pick<
 
 const DEFAULT_SLOW_QUERY_SUMMARY_TOP_N = 10;
 const DEFAULT_SLOW_QUERY_SUMMARY_INTERVAL_MS = 30_000;
-const DEFAULT_SLOW_QUERY_SUMMARY_RECORD_COUNT = 1_000;
 const SLOW_QUERY_SUMMARY_SQL_PREVIEW_LENGTH = 240;
 
 function formatSlowQuerySummaryLine(index: number, stats: SlowQueryShapeStats): string {
@@ -220,23 +219,17 @@ function formatSlowQuerySummary(
 function createDefaultSlowQuerySink(thresholdMs: number): (info: SlowQueryInfo) => void {
   const aggregator = new SlowQueryAggregator();
   let lastSummaryAtMs = 0;
-  let recordsSinceLastSummary = 0;
 
   return (info) => {
     aggregator.record(info);
-    recordsSinceLastSummary += 1;
 
     const now = Date.now();
-    const shouldSummarizeByTime =
+    const shouldSummarize =
       lastSummaryAtMs === 0 || now - lastSummaryAtMs >= DEFAULT_SLOW_QUERY_SUMMARY_INTERVAL_MS;
-    const shouldSummarizeByCount =
-      recordsSinceLastSummary >= DEFAULT_SLOW_QUERY_SUMMARY_RECORD_COUNT;
-
-    if (!shouldSummarizeByTime && !shouldSummarizeByCount) return;
+    if (!shouldSummarize) return;
 
     console.warn(formatSlowQuerySummary(thresholdMs, aggregator));
     lastSummaryAtMs = now;
-    recordsSinceLastSummary = 0;
   };
 }
 


### PR DESCRIPTION
## Summary

SQLite slow-query logging now groups repeated statements by SQL shape and prints a throttled ranked summary.

The summary highlights top offenders by max, p95, p50, count, row count, and first/last observation time.

The workflow completed both implementation and verification tasks for this slice.

## Review Claim

Approve replacing per-event SQLite slow-query warnings with an in-memory shape aggregator that emits a throttled ranked summary.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

This only changes slow-query telemetry reporting after a SQLite operation finishes. SQL text, parameters, query results, thresholds, and caller-provided slow-query handlers stay unchanged.

The aggregator is in memory only and writes no database rows or files.

## Slice Rationale

The SQL shape helper, aggregate statistics, default warning sink, and adapter hook are one reporting change.

Keeping them together lets the reviewer inspect the telemetry behavior without bundling unrelated persistence changes.

## Non-goals

- Does not change any SQLite statement, result mapping, transaction behavior, or timing threshold.
- Does not persist telemetry or add a database migration.
- Does not change callers that provide their own `onSlowQuery` handler.
- Does not touch any UI surface.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/data-store test -- slow-query-aggregator`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit>`
- Post-revert steps: None; reverting restores the previous one-warning-per-slow-query behavior.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SQL shape normalization to group equivalent queries for performance analysis.
  * Added aggregated slow-query statistics, including counts, percentiles, maximum duration, row counts, and timestamps.
  * Added ranked top-query summaries with reset and total-count tracking.
  * Slow-query warnings now emit throttled, aggregated top-query summaries instead of logging every event individually.

* **Tests**
  * Added coverage for SQL normalization, aggregation, ranking, and reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->