### PR TITLE
[Retry Safe Failed Invoker Frontier](2) Allow queue snapshots without an owner

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -629,6 +629,18 @@ describe('headless-client', () => {
     expect(runElectronHeadless).toHaveBeenCalledWith(['query', 'action-graph', '--output', 'json']);
   }, 30_000);
 
+  it('falls back to direct Electron headless for query queue when no owner endpoint is reachable', async () => {
+    const runElectronHeadless = vi.fn(async () => 0);
+    const exitCode = await runHeadlessClientCommand(['query', 'queue', '--output', 'json'], {
+      messageBus: new LocalBus(),
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runElectronHeadless).toHaveBeenCalledWith(['query', 'queue', '--output', 'json']);
+  }, 30_000);
+
   it('delegates query queue to a reachable owner endpoint', async () => {
     const bus = new LocalBus();
     bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));

--- a/packages/app/src/__tests__/viewer-detached-db.test.ts
+++ b/packages/app/src/__tests__/viewer-detached-db.test.ts
@@ -30,6 +30,25 @@ const wf: Workflow = {
 };
 
 describe('detached viewer persistence boundary', () => {
+  it('uses empty in-memory persistence for read-only startup when the db file is absent', async () => {
+    const dir = makeDir();
+    const missingDbPath = join(dir, 'invoker.db');
+    const adapter = await openMainProcessDatabase({
+      dbPath: missingDbPath,
+      detachedViewer: false,
+      readOnly: true,
+      exclusiveLocking: false,
+    });
+
+    try {
+      expect(adapter.listWorkflows()).toEqual([]);
+      expect(existsSync(missingDbPath)).toBe(false);
+      expect(readdirSync(dir)).toEqual([]);
+    } finally {
+      adapter.close();
+    }
+  });
+
   it('ignores the real db path and opens no database file (no -shm to truncate)', async () => {
     const dir = makeDir();
     const probeDbPath = join(dir, 'invoker.db');

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -93,6 +93,7 @@ const DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS = 30_000;
 const POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS = 90_000;
 const POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS = 20_000;
 const READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS = 20_000;
+const OPTIONAL_READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS = 2_000;
 const READ_ONLY_QUERY_REQUEST_TIMEOUT_MS = 15_000;
 const GENERIC_READ_OWNER_PING_TIMEOUT_MS = 10_000;
 const POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS = 3;
@@ -261,9 +262,11 @@ async function delegateReadOnlyQuery(
     { messageBus: bus, refreshMessageBus, ensureStandaloneOwner: async () => {} },
     { discoveryTimeoutMs: 2_000 },
   );
-  const ownerResult = await resolver.waitForAny(READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS);
+  const ownerResult = await resolver.waitForAny(
+    isUiPerf ? READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS : OPTIONAL_READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS,
+  );
   if (!ownerResult.resolved) {
-    if (isActionGraph) return false;
+    if (isQueue || isActionGraph) return false;
     throw new Error(isUiPerf
       ? 'query ui-perf requires a running shared owner process'
       : 'query queue requires a running shared owner process');

--- a/packages/app/src/viewer-db-boundary.ts
+++ b/packages/app/src/viewer-db-boundary.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { SQLiteAdapter } from '@invoker/data-store';
 
 export interface MainProcessDatabaseOptions {
@@ -9,6 +10,12 @@ export interface MainProcessDatabaseOptions {
 
 export async function openMainProcessDatabase(options: MainProcessDatabaseOptions): Promise<SQLiteAdapter> {
   if (options.detachedViewer) {
+    return openDetachedViewerDatabase();
+  }
+
+  // Read-only headless snapshots should report an empty store before the first
+  // owner creates invoker.db; opening SQLite read-only cannot create that file.
+  if (options.readOnly && !existsSync(options.dbPath)) {
     return openDetachedViewerDatabase();
   }
 


### PR DESCRIPTION
## Summary

Headless queue snapshots need a running owner to answer the query.

When none responds quickly, the whole query failed instead of reading directly.

Now a queue or action-graph snapshot falls back to direct read-only execution.

A ui-perf query still requires a live owner, because it needs owner-only state.

## Review Claim

Headless queue and action-graph snapshots can use direct read-only execution when no owner answers.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The fallback is limited to queue and action-graph reads, which are answerable from the store alone. A ui-perf query keeps its hard requirement for a live owner, so no owner-only read is weakened.

## Slice Rationale

This is the command-surface fallback built on the detached-store startup from the previous slice, kept separate so the read-path relaxation is reviewed by itself.

## Non-goals

- No scheduler queue policy or ordering changes.
- No mutation or dispatch behavior.
- No UI behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test` (covers `src/__tests__/headless-client.test.ts`)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a0a01c1`
- Post-revert steps: None
- Data migration? No

</details>
