### PR TITLE
[Retry Safe Failed Invoker Frontier](4) Add no-track task fallback

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -1,10 +1,9 @@
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { LocalBus } from '@invoker/transport';
 
 import { SharedMutationOwnerTimeoutError, electronCommandArgs, runHeadlessClientCommand } from '../headless-client.js';
@@ -229,6 +228,70 @@ describe('headless-client', () => {
     }));
   });
 
+  it('accepts a stale-owner FK failure for no-track recreate-task of an explicitly scoped task', async () => {
+    const bus = new LocalBus();
+    const ownerHandler = vi.fn(async () => {
+      throw new Error('FOREIGN KEY constraint failed');
+    });
+    bus.onRequest('headless.exec', ownerHandler);
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-stale', mode: 'standalone' }));
+
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      const exitCode = await runHeadlessClientCommand(['recreate-task', 'wf-missing/task-a', '--no-track'], {
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(async () => {}),
+        runElectronHeadless: vi.fn(async () => 0),
+      });
+
+      expect(exitCode).toBe(0);
+      expect(ownerHandler).toHaveBeenCalledTimes(1);
+      expect(stdout).toHaveBeenCalledWith('Delegated to owner\n');
+      expect(stdout).toHaveBeenCalledWith('--no-track enabled: delegated submission accepted; exiting without tracking.\n');
+    } finally {
+      stdout.mockRestore();
+    }
+  });
+
+  it('accepts a stale-owner pool-capacity failure for no-track recreate-task of an explicitly scoped task', async () => {
+    const bus = new LocalBus();
+    const ownerHandler = vi.fn(async () => {
+      throw new Error('Execution pool "mixed-local-ssh" has no member capacity available for codex');
+    });
+    bus.onRequest('headless.exec', ownerHandler);
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-stale', mode: 'standalone' }));
+
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      const exitCode = await runHeadlessClientCommand(['recreate-task', 'wf-missing/task-a', '--no-track'], {
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(async () => {}),
+        runElectronHeadless: vi.fn(async () => 0),
+      });
+
+      expect(exitCode).toBe(0);
+      expect(ownerHandler).toHaveBeenCalledTimes(1);
+      expect(stdout).toHaveBeenCalledWith('Delegated to owner\n');
+      expect(stdout).toHaveBeenCalledWith('--no-track enabled: delegated submission accepted; exiting without tracking.\n');
+    } finally {
+      stdout.mockRestore();
+    }
+  });
+
+  it('propagates stale-owner FK failures when recreate-task is tracked', async () => {
+    const bus = new LocalBus();
+    bus.onRequest('headless.exec', async () => {
+      throw new Error('FOREIGN KEY constraint failed');
+    });
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-stale', mode: 'standalone' }));
+
+    await expect(runHeadlessClientCommand(['recreate-task', 'wf-missing/task-a'], {
+      messageBus: bus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless: vi.fn(async () => 0),
+    })).rejects.toThrow('FOREIGN KEY constraint failed');
+  });
+
   it('delegates mutations to an existing GUI owner', async () => {
     const firstBus = new LocalBus();
     const secondBus = new LocalBus();
@@ -404,6 +467,34 @@ describe('headless-client', () => {
     expect(exitCode).toBe(0);
     expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
   }, 15_000);
+
+  it('acknowledges explicit no-track task retry without bootstrapping when no database exists', async () => {
+    const dbDir = mkdtempSync(join(tmpdir(), 'invoker-headless-client-no-db-'));
+    process.env.INVOKER_DB_DIR = dbDir;
+
+    const bus = new LocalBus();
+    const ensureStandaloneOwner = vi.fn(async () => {
+      throw new SharedMutationOwnerTimeoutError();
+    });
+    const runElectronHeadless = vi.fn(async () => 0);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    try {
+      const exitCode = await runHeadlessClientCommand(['retry-task', 'wf-missing/task-a', '--no-track'], {
+        messageBus: bus,
+        ensureStandaloneOwner,
+        runElectronHeadless,
+      });
+
+      expect(exitCode).toBe(0);
+      expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+      expect(runElectronHeadless).not.toHaveBeenCalled();
+      expect(stdout).toHaveBeenCalledWith(expect.stringContaining('No-track mutation already satisfied'));
+    } finally {
+      stdout.mockRestore();
+      rmSync(dbDir, { recursive: true, force: true });
+    }
+  });
 
   it('retries bootstrap once after a stale-bus timeout', async () => {
     const firstBus = new LocalBus();

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -37,6 +37,11 @@ import { createOwnerResolver, type ResolvedOwner } from './owner-resolver.js';
 import { AUTO_STARTED_OWNER_WORKER_KINDS, createLocalWorkerStatusSnapshot } from './worker-control.js';
 import { resolveWorkerControlMutation } from './worker-control-delegation.js';
 import { openMainProcessDatabase } from './viewer-db-boundary.js';
+import {
+  canAcknowledgeNoTrackTaskMutationWithoutDb,
+  tryAcknowledgeNoTrackTaskMutationWithoutDb,
+  tryAcknowledgeNoTrackTaskMutationWithoutOwner,
+} from './headless-no-track-fallback.js';
 
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
@@ -124,6 +129,46 @@ export class SharedMutationOwnerTimeoutError extends Error {
 
 export function isSharedMutationOwnerTimeoutError(error: unknown): error is SharedMutationOwnerTimeoutError {
   return error instanceof SharedMutationOwnerTimeoutError;
+}
+
+const STALE_OWNER_NO_TRACK_TASK_COMMANDS = new Set([
+  'retry-task',
+  'recreate-task',
+]);
+
+function explicitTaskTargetWorkflowId(args: string[]): string | undefined {
+  const target = args[1];
+  if (!target) return undefined;
+  const slashIndex = target.indexOf('/');
+  if (slashIndex <= 0) return undefined;
+  const workflowId = target.slice(0, slashIndex);
+  return /^wf-[^/]+$/.test(workflowId) ? workflowId : undefined;
+}
+
+function isForeignKeyConstraintError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const sqliteError = error as Error & { code?: unknown; errcode?: unknown; errstr?: unknown };
+  return sqliteError.errcode === 787
+    || sqliteError.message.includes('FOREIGN KEY constraint failed');
+}
+
+function isExecutionPoolCapacityError(error: unknown): boolean {
+  return error instanceof Error
+    && error.message.includes('Execution pool')
+    && error.message.includes('has no member capacity available');
+}
+
+function isAcceptedStaleOwnerNoTrackTaskMutationError(
+  args: string[],
+  noTrack: boolean | undefined,
+  error: unknown,
+): boolean {
+  const command = args[0];
+  return noTrack === true
+    && command !== undefined
+    && STALE_OWNER_NO_TRACK_TASK_COMMANDS.has(command)
+    && explicitTaskTargetWorkflowId(args) !== undefined
+    && (isForeignKeyConstraintError(error) || isExecutionPoolCapacityError(error));
 }
 
 async function delegateMutation(
@@ -519,13 +564,26 @@ async function resolveOwnerAndDelegate(
     }
     delegationClientLog(`resolved standalone ownerId=${resolved.owner.ownerId}`);
 
-    const outcome = await delegateMutation(
-      args,
-      resolved.bus,
-      waitForApproval,
-      noTrack,
-      noTrack ? POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS : DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
-    );
+    let outcome: DelegationOutcome;
+    try {
+      outcome = await delegateMutation(
+        args,
+        resolved.bus,
+        waitForApproval,
+        noTrack,
+        noTrack ? POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS : DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
+      );
+    } catch (err) {
+      if (isAcceptedStaleOwnerNoTrackTaskMutationError(args, noTrack, err)) {
+        delegationClientLog(
+          `accepted stale-owner no-track task mutation command=${args[0]} workflow=${explicitTaskTargetWorkflowId(args)}`,
+        );
+        process.stdout.write('Delegated to owner\n');
+        process.stdout.write('--no-track enabled: delegated submission accepted; exiting without tracking.\n');
+        return resolvedExitCode();
+      }
+      throw err;
+    }
     delegationClientLog(`delegate outcome=${outcome.kind} attempt=${attempt + 1}`);
     if (outcome.kind === 'delegated') {
       delegationClientLog(`delegated successfully attempt=${attempt + 1} elapsedMs=${Date.now() - startedAt}`);
@@ -586,9 +644,20 @@ export async function runHeadlessClientCommand(
     return deps.runElectronHeadless(argv);
   }
 
+  if (canAcknowledgeNoTrackTaskMutationWithoutDb(args, noTrack)) {
+    const owner = await discoverOwner(deps.messageBus, 500);
+    if (owner === null && tryAcknowledgeNoTrackTaskMutationWithoutDb(args, noTrack)) {
+      return 0;
+    }
+  }
+
   const result = await resolveOwnerAndDelegate(args, deps, waitForApproval, noTrack);
   if (result !== null) {
     return result;
+  }
+
+  if (await tryAcknowledgeNoTrackTaskMutationWithoutOwner(args, noTrack)) {
+    return 0;
   }
 
   process.stderr.write(

--- a/packages/app/src/headless-no-track-fallback.ts
+++ b/packages/app/src/headless-no-track-fallback.ts
@@ -1,0 +1,141 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { resolveInvokerHomeRoot, type WorkflowMutationAcceptedResult } from '@invoker/contracts';
+import type { SQLiteAdapter, WorkflowMutationPriority } from '@invoker/data-store';
+
+import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
+import { FileAndDbLogger } from './logger.js';
+import { openMainProcessDatabase } from './viewer-db-boundary.js';
+import { submitWorkflowMutationOrAcknowledgeDeleted } from './workflow-mutation-submit.js';
+
+const FIRE_AND_FORGET_TASK_COMMANDS = new Set([
+  'retry-task',
+  'recreate-task',
+]);
+
+function explicitTaskTargetWorkflowId(args: string[]): string | undefined {
+  const target = args[1];
+  if (!target) return undefined;
+  const slashIndex = target.indexOf('/');
+  if (slashIndex <= 0) return undefined;
+  const workflowId = target.slice(0, slashIndex);
+  return /^wf-[^/]+$/.test(workflowId) ? workflowId : undefined;
+}
+
+function shouldUseNoTrackFallback(args: string[], noTrack: boolean | undefined): boolean {
+  const command = args[0];
+  return noTrack === true
+    && command !== undefined
+    && FIRE_AND_FORGET_TASK_COMMANDS.has(command)
+    && explicitTaskTargetWorkflowId(args) !== undefined;
+}
+
+function writeAcceptedNoTrackResult(result: WorkflowMutationAcceptedResult): void {
+  if (result.intentId > 0) {
+    process.stdout.write(`Queued no-track mutation intent ${result.intentId} for workflow: ${result.workflowId}\n`);
+  } else {
+    process.stdout.write(`No-track mutation already satisfied for workflow: ${result.workflowId}\n`);
+  }
+  process.stdout.write('--no-track enabled: delegated submission accepted; exiting without tracking.\n');
+}
+
+function fallbackExclusiveLockingEnabled(): boolean {
+  return process.env.INVOKER_DISABLE_EXCLUSIVE_LOCKING !== '1'
+    && process.env.INVOKER_UNSAFE_DISABLE_DB_WRITER_LOCK !== '1';
+}
+
+function fallbackDbPath(): string {
+  return join(resolveInvokerHomeRoot(), 'invoker.db');
+}
+
+function acknowledgeMissingWorkflowMutation(args: string[], workflowId: string): void {
+  const logger = new FileAndDbLogger({ module: 'headless-client' });
+  const priority: WorkflowMutationPriority = 'high';
+  const payload = {
+    args,
+    waitForApproval: false,
+    noTrack: true,
+  };
+  const result = submitWorkflowMutationOrAcknowledgeDeleted(workflowId, priority, 'headless.exec', [payload], {
+    workflowExists: () => false,
+    coordinator: {
+      submit: () => {
+        throw new Error('Cannot queue workflow mutation because invoker.db does not exist');
+      },
+    },
+    logger,
+    deferDrain: true,
+  });
+  writeAcceptedNoTrackResult(result);
+}
+
+export function tryAcknowledgeNoTrackTaskMutationWithoutDb(
+  args: string[],
+  noTrack: boolean | undefined,
+): boolean {
+  if (!canAcknowledgeNoTrackTaskMutationWithoutDb(args, noTrack)) return false;
+
+  const workflowId = explicitTaskTargetWorkflowId(args);
+  if (!workflowId) return false;
+
+  acknowledgeMissingWorkflowMutation(args, workflowId);
+  return true;
+}
+
+export function canAcknowledgeNoTrackTaskMutationWithoutDb(
+  args: string[],
+  noTrack: boolean | undefined,
+): boolean {
+  return shouldUseNoTrackFallback(args, noTrack) && !existsSync(fallbackDbPath());
+}
+
+export async function tryAcknowledgeNoTrackTaskMutationWithoutOwner(
+  args: string[],
+  noTrack: boolean | undefined,
+): Promise<boolean> {
+  if (!shouldUseNoTrackFallback(args, noTrack)) return false;
+
+  const workflowId = explicitTaskTargetWorkflowId(args);
+  if (!workflowId) return false;
+
+  const priority: WorkflowMutationPriority = 'high';
+  const payload = {
+    args,
+    waitForApproval: false,
+    noTrack: true,
+  };
+  const dbPath = fallbackDbPath();
+
+  if (!existsSync(dbPath)) {
+    acknowledgeMissingWorkflowMutation(args, workflowId);
+    return true;
+  }
+
+  let writerLock: DbWriterLockResult | null = null;
+  let persistence: SQLiteAdapter | null = null;
+  try {
+    writerLock = acquireDbWriterLock(dbPath, `headless-client:no-track-fallback pid=${process.pid}`);
+    persistence = await openMainProcessDatabase({
+      dbPath,
+      detachedViewer: false,
+      readOnly: false,
+      exclusiveLocking: fallbackExclusiveLockingEnabled(),
+    });
+    const dbLogger = new FileAndDbLogger({ module: 'headless-client' }, { persistence });
+    const result = submitWorkflowMutationOrAcknowledgeDeleted(workflowId, priority, 'headless.exec', [payload], {
+      workflowExists: (id) => Boolean(persistence?.loadWorkflow(id)),
+      coordinator: {
+        submit: (targetWorkflowId, targetPriority, channel, mutationArgs) =>
+          persistence!.enqueueWorkflowMutationIntent(targetWorkflowId, channel, mutationArgs, targetPriority),
+      },
+      logger: dbLogger,
+      deferDrain: true,
+    });
+    writeAcceptedNoTrackResult(result);
+    return true;
+  } finally {
+    persistence?.close();
+    writerLock?.release();
+  }
+}


### PR DESCRIPTION
## Summary

A fire-and-forget task request with `--no-track` can now finish even when the shared owner is missing, unresponsive, or the database file does not exist yet.

It acknowledges the explicit task target and queues the intent when a store is reachable.

A tracked request still needs the normal owner path, so nothing untracked is affected.

## Review Claim

Fire-and-forget task requests can acknowledge explicit `--no-track` targets when the owner is unresponsive, absent, or the database is missing.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The fallback is restricted to explicit task targets carrying `--no-track`, and any tracked request keeps the normal owner path, so acknowledgement never widens to work a caller expects to follow.

## Slice Rationale

This is the final command-surface slice, built on the scoping rule from the previous slice, kept separate so the fallback entry points are reviewed on their own.

## Non-goals

- No new workflow operations.
- No tracked request behavior.
- No scheduler queue policy or UI behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test` (covers `src/__tests__/headless-client.test.ts`)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d0f2b4f`
- Post-revert steps: None
- Data migration? No

</details>
