### PR TITLE
[UI Responsiveness Guardrails Step 3](2) Require UI-stall chaos coverage

### DIFF
--- a/packages/app/e2e/embedded-terminal-pty.spec.ts
+++ b/packages/app/e2e/embedded-terminal-pty.spec.ts
@@ -10,6 +10,7 @@ import {
 } from './fixtures/electron-app.js';
 import {
   activityLogWatermark,
+  maxPayloadNumber,
   numberOrZero,
   uiPerfPayloadsSince,
 } from './fixtures/ui-perf.js';
@@ -417,6 +418,8 @@ test.describe('Embedded terminal PTY', () => {
     const outputPayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_output_write');
     const resizePayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_resize');
     const scrollPayloads = payloads.filter((payload) => payload.metric === 'embedded_terminal_scroll');
+    const eventLoopLagPayloads = payloads.filter((payload) => payload.metric === 'renderer_event_loop_lag');
+    const longTaskPayloads = payloads.filter((payload) => payload.metric === 'renderer_long_task');
     const perf = await page.evaluate(async () => window.invoker.getUiPerfStats());
     const terminalEvidence = {
       fullAlphaTaskId,
@@ -430,6 +433,8 @@ test.describe('Embedded terminal PTY', () => {
       outputPayloads,
       resizePayloads,
       scrollPayloads,
+      eventLoopLagPayloads,
+      longTaskPayloads,
       perf,
       budgets: TERMINAL_PRESSURE_BUDGETS,
     };
@@ -472,5 +477,7 @@ test.describe('Embedded terminal PTY', () => {
     expect(numberOrZero(perf.maxTerminalSessionUpsertMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_SESSION_UPSERT_BUDGET_MS);
     expect(numberOrZero(perf.maxRendererEventLoopLagMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RENDERER_EVENT_LOOP_LAG_BUDGET_MS);
     expect(numberOrZero(perf.maxRendererLongTaskMs), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RENDERER_LONG_TASK_BUDGET_MS);
+    expect(maxPayloadNumber(payloads, 'renderer_event_loop_lag', 'lagMs'), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RENDERER_EVENT_LOOP_LAG_BUDGET_MS);
+    expect(maxPayloadNumber(payloads, 'renderer_long_task', 'durationMs'), terminalEvidenceMessage).toBeLessThanOrEqual(TERMINAL_RENDERER_LONG_TASK_BUDGET_MS);
   });
 });

--- a/packages/app/e2e/fixtures/ui-perf.ts
+++ b/packages/app/e2e/fixtures/ui-perf.ts
@@ -14,6 +14,19 @@ export function numberOrZero(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : 0;
 }
 
+export function maxPayloadNumber(
+  payloads: readonly UiPerfPayload[],
+  metric: string,
+  field: string,
+): number {
+  let max = 0;
+  for (const payload of payloads) {
+    if (payload.metric !== metric) continue;
+    max = Math.max(max, numberOrZero(payload[field]));
+  }
+  return max;
+}
+
 export async function activityLogWatermark(page: Page): Promise<number> {
   const rows = await page.evaluate(async () => window.invoker.getActivityLogs(0, 100000));
   return rows.at(-1)?.id ?? 0;

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -15,6 +15,12 @@ import {
   startPlan,
   test,
 } from './fixtures/electron-app.js';
+import {
+  activityLogWatermark,
+  maxPayloadNumber,
+  numberOrZero,
+  uiPerfPayloadsSince,
+} from './fixtures/ui-perf.js';
 
 test.use({ guiOwnerMode: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'daemon' });
 
@@ -154,6 +160,7 @@ test.describe('Headless thundering herd', () => {
 
     await page.waitForTimeout(500);
 
+    const perfWatermark = await activityLogWatermark(page);
     const retryBurstStartedAt = Date.now();
     const burst = Array.from(workflowIds).map((workflowId) =>
       runHeadlessClient(testDir, ['retry', workflowId, '--no-track']),
@@ -180,6 +187,7 @@ test.describe('Headless thundering herd', () => {
     }
 
     const perf = await page.evaluate(async () => await window.invoker.getUiPerfStats());
+    const perfPayloads = await uiPerfPayloadsSince(page, perfWatermark);
     const delegatedPerf = parseJsonStdout(
       (await runHeadlessClient(testDir, ['query', 'ui-perf', '--output', 'json'])).stdout,
     );
@@ -190,6 +198,7 @@ test.describe('Headless thundering herd', () => {
       firstInteractionMs,
       secondInteractionMs,
       perf,
+      perfPayloads,
       delegatedPerf,
       budgets: HEADLESS_HERD_BUDGETS,
     };
@@ -200,9 +209,11 @@ test.describe('Headless thundering herd', () => {
     expect(retryBurstWallMs, evidenceMessage).toBeLessThanOrEqual(MAX_RETRY_BURST_WALL_MS);
     expect(firstInteractionMs, evidenceMessage).toBeLessThanOrEqual(MAX_INSPECTOR_TOGGLE_MS);
     expect(secondInteractionMs, evidenceMessage).toBeLessThanOrEqual(MAX_INSPECTOR_TOGGLE_MS);
-    expect(Number(perf.maxRendererEventLoopLagMs), evidenceMessage).toBeLessThanOrEqual(MAX_RENDERER_EVENT_LOOP_LAG_MS);
-    expect(Number(perf.maxRendererLongTaskMs), evidenceMessage).toBeLessThanOrEqual(MAX_RENDERER_LONG_TASK_MS);
-    expect(delegatedPerf.ownerMode).toBe('standalone');
+    expect(numberOrZero(perf.maxRendererEventLoopLagMs), evidenceMessage).toBeLessThanOrEqual(MAX_RENDERER_EVENT_LOOP_LAG_MS);
+    expect(numberOrZero(perf.maxRendererLongTaskMs), evidenceMessage).toBeLessThanOrEqual(MAX_RENDERER_LONG_TASK_MS);
+    expect(maxPayloadNumber(perfPayloads, 'renderer_event_loop_lag', 'lagMs'), evidenceMessage).toBeLessThanOrEqual(MAX_RENDERER_EVENT_LOOP_LAG_MS);
+    expect(maxPayloadNumber(perfPayloads, 'renderer_long_task', 'durationMs'), evidenceMessage).toBeLessThanOrEqual(MAX_RENDERER_LONG_TASK_MS);
+    expect(delegatedPerf.ownerMode, evidenceMessage).toBe('standalone');
   });
 
   test('standalone owner serves delegated headless commands from isolated test paths', async ({ testDir }) => {

--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -11,6 +11,7 @@ import { E2E_REPO_URL } from './fixtures/electron-app.js';
 import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
 import {
   activityLogWatermark,
+  maxPayloadNumber,
   numberOrZero,
   parseActivityPayload,
   uiPerfPayloadsSince,
@@ -186,8 +187,11 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
 
       const startupEntries = result.activityLogs
         .filter((entry) => entry.source === 'startup-phase' || entry.source === 'ui-perf')
-        .map((entry) => ({ source: entry.source, payload: parseActivityPayload(entry.message) }))
-        .filter((entry) => entry.payload !== null);
+        .flatMap((entry) => {
+          const payload = parseActivityPayload(entry.message);
+          return payload ? [{ source: entry.source, payload }] : [];
+        });
+      const startupPerfPayloads = startupEntries.map((entry) => entry.payload);
 
       const windowShow = [...startupEntries]
         .reverse()
@@ -226,6 +230,7 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
         taskCount: result.taskCount,
         perf: result.perf,
         startupEntries,
+        startupPerfPayloads,
         budgets: STARTUP_NONEMPTY_BUDGETS,
       };
       console.log(`STARTUP_NONEMPTY_BENCH_RESULT=${JSON.stringify(startupEvidence)}`);
@@ -241,6 +246,8 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
       expect(elapsedMs, startupEvidenceMessage).toBeLessThanOrEqual(STARTUP_BUDGET_MS);
       expect(numberOrZero(result.perf.maxRendererEventLoopLagMs), startupEvidenceMessage).toBeLessThanOrEqual(MAX_STARTUP_RENDERER_EVENT_LOOP_LAG_MS);
       expect(numberOrZero(result.perf.maxRendererLongTaskMs), startupEvidenceMessage).toBeLessThanOrEqual(MAX_STARTUP_RENDERER_LONG_TASK_MS);
+      expect(maxPayloadNumber(startupPerfPayloads, 'renderer_event_loop_lag', 'lagMs'), startupEvidenceMessage).toBeLessThanOrEqual(MAX_STARTUP_RENDERER_EVENT_LOOP_LAG_MS);
+      expect(maxPayloadNumber(startupPerfPayloads, 'renderer_long_task', 'durationMs'), startupEvidenceMessage).toBeLessThanOrEqual(MAX_STARTUP_RENDERER_LONG_TASK_MS);
       expect([...phaseNames], startupEvidenceMessage).toEqual(expect.arrayContaining([
         'listWorkflowsByStartupRecency',
         'orchestrator.restore.full-snapshot',
@@ -345,6 +352,7 @@ test('planning chat typing stays responsive with a large restored transcript', a
       const inputCommit = payloads.find((payload) => payload.metric === 'planning_chat_input_commit' && payload.valueLength === typedText.length);
       const perf = await page.evaluate(async () => window.invoker.getUiPerfStats());
       const transcriptCommitPayloads = payloads.filter((payload) => payload.metric === 'planning_chat_transcript_commit');
+      const eventLoopLagPayloads = payloads.filter((payload) => payload.metric === 'renderer_event_loop_lag');
       const longTaskPayloads = payloads.filter((payload) => payload.metric === 'renderer_long_task');
       const planningEvidence = {
         pressureTurns: PLANNING_PRESSURE_TURNS,
@@ -353,6 +361,7 @@ test('planning chat typing stays responsive with a large restored transcript', a
         inputChange,
         inputCommit,
         transcriptCommitPayloads,
+        eventLoopLagPayloads,
         longTaskPayloads,
         perf,
         budgets: PLANNING_PRESSURE_BUDGETS,
@@ -376,6 +385,8 @@ test('planning chat typing stays responsive with a large restored transcript', a
       expect(Number(perf.maxPlanningChatTranscriptLines), planningEvidenceMessage).toBeGreaterThanOrEqual(PLANNING_PRESSURE_TURNS * 2);
       expect(numberOrZero(perf.maxRendererEventLoopLagMs), planningEvidenceMessage).toBeLessThanOrEqual(MAX_PLANNING_RENDERER_EVENT_LOOP_LAG_MS);
       expect(numberOrZero(perf.maxRendererLongTaskMs), planningEvidenceMessage).toBeLessThanOrEqual(MAX_PLANNING_RENDERER_LONG_TASK_MS);
+      expect(maxPayloadNumber(payloads, 'renderer_event_loop_lag', 'lagMs'), planningEvidenceMessage).toBeLessThanOrEqual(MAX_PLANNING_RENDERER_EVENT_LOOP_LAG_MS);
+      expect(maxPayloadNumber(payloads, 'renderer_long_task', 'durationMs'), planningEvidenceMessage).toBeLessThanOrEqual(MAX_PLANNING_RENDERER_LONG_TASK_MS);
     } finally {
       await app.close();
     }

--- a/packages/app/e2e/ui-graph-drag-performance.spec.ts
+++ b/packages/app/e2e/ui-graph-drag-performance.spec.ts
@@ -1,7 +1,13 @@
 import { expect, test, E2E_REPO_URL } from './fixtures/electron-app.js';
 import { stringify as yamlStringify } from 'yaml';
 import type { Page } from '@playwright/test';
-import { numberOrZero } from './fixtures/ui-perf.js';
+import {
+  activityLogWatermark,
+  maxPayloadNumber,
+  numberOrZero,
+  uiPerfPayloadsSince,
+  type UiPerfPayload,
+} from './fixtures/ui-perf.js';
 
 const WORKFLOW_COUNT = 50;
 const TASKS_PER_WORKFLOW = 8;
@@ -198,8 +204,12 @@ async function streamTaskUpdatesDuringDrag(page: Page): Promise<number> {
   return updateCount;
 }
 
-function expectSmoothDrag(result: DragPerfResult, perf: Record<string, unknown>): void {
-  const evidence = JSON.stringify({ ...result, perf, budgets: DRAG_PERF_BUDGETS });
+function expectSmoothDrag(
+  result: DragPerfResult,
+  perf: Record<string, unknown>,
+  perfPayloads: readonly UiPerfPayload[],
+): void {
+  const evidence = JSON.stringify({ ...result, perf, perfPayloads, budgets: DRAG_PERF_BUDGETS });
   expect(result.frameCount, evidence).toBeGreaterThanOrEqual(MIN_FRAME_COUNT);
   expect(result.p95FrameGapMs, evidence).toBeLessThanOrEqual(MAX_P95_FRAME_GAP_MS);
   expect(result.maxFrameGapMs, evidence).toBeLessThanOrEqual(MAX_FRAME_GAP_MS);
@@ -208,33 +218,39 @@ function expectSmoothDrag(result: DragPerfResult, perf: Record<string, unknown>)
   expect(result.firstTransformMs ?? Number.POSITIVE_INFINITY, evidence).toBeLessThanOrEqual(MAX_FIRST_TRANSFORM_MS);
   expect(numberOrZero(perf.maxRendererEventLoopLagMs), evidence).toBeLessThanOrEqual(MAX_RENDERER_EVENT_LOOP_LAG_MS);
   expect(numberOrZero(perf.maxRendererLongTaskMs), evidence).toBeLessThanOrEqual(MAX_RENDERER_LONG_TASK_MS);
+  expect(maxPayloadNumber(perfPayloads, 'renderer_event_loop_lag', 'lagMs'), evidence).toBeLessThanOrEqual(MAX_RENDERER_EVENT_LOOP_LAG_MS);
+  expect(maxPayloadNumber(perfPayloads, 'renderer_long_task', 'durationMs'), evidence).toBeLessThanOrEqual(MAX_RENDERER_LONG_TASK_MS);
   expect(numberOrZero(perf.maxTaskDeltaBatchSize), evidence).toBeLessThanOrEqual(MAX_TASK_DELTA_BATCH_SIZE);
 }
 
 test('workflow graph pan stays responsive under a large persisted graph', async ({ page }) => {
   await seedLargeWorkflowGraph(page);
 
+  const perfWatermark = await activityLogWatermark(page);
   const result = await recordDragPerformance(
     page,
     '[data-testid="workflow-graph-react-flow"] .react-flow__pane',
     '[data-testid="workflow-graph-react-flow"] .react-flow__viewport',
   );
+  const perfPayloads = await uiPerfPayloadsSince(page, perfWatermark);
   const perf = await page.evaluate(async () => await window.invoker.getUiPerfStats());
 
   console.log(`UI_GRAPH_DRAG_BENCH_RESULT=${JSON.stringify({
     ...result,
     workflowCount: WORKFLOW_COUNT,
     taskCount: WORKFLOW_COUNT * TASKS_PER_WORKFLOW,
+    perfPayloads,
     perf,
     budgets: DRAG_PERF_BUDGETS,
   })}`);
-  expectSmoothDrag(result, perf);
+  expectSmoothDrag(result, perf, perfPayloads);
 });
 
 test('workflow graph pan stays responsive while task updates arrive', async ({ page }) => {
   await seedLargeWorkflowGraph(page);
 
   let updateCount = 0;
+  const perfWatermark = await activityLogWatermark(page);
   const result = await recordDragPerformance(
     page,
     '[data-testid="workflow-graph-react-flow"] .react-flow__pane',
@@ -243,6 +259,7 @@ test('workflow graph pan stays responsive while task updates arrive', async ({ p
       updateCount = await streamTaskUpdatesDuringDrag(page);
     },
   );
+  const perfPayloads = await uiPerfPayloadsSince(page, perfWatermark);
   const perf = await page.evaluate(async () => await window.invoker.getUiPerfStats());
 
   console.log(`UI_GRAPH_DRAG_WITH_UPDATES_BENCH_RESULT=${JSON.stringify({
@@ -252,10 +269,11 @@ test('workflow graph pan stays responsive while task updates arrive', async ({ p
     updateCount,
     updateBursts: UPDATE_BURSTS,
     updatesPerBurst: UPDATES_PER_BURST,
+    perfPayloads,
     perf,
     budgets: DRAG_PERF_BUDGETS,
   })}`);
-  const evidence = JSON.stringify({ ...result, updateCount, perf, budgets: DRAG_PERF_BUDGETS });
+  const evidence = JSON.stringify({ ...result, updateCount, perfPayloads, perf, budgets: DRAG_PERF_BUDGETS });
   expect(updateCount, evidence).toBe(UPDATE_BURSTS * UPDATES_PER_BURST);
-  expectSmoothDrag(result, perf);
+  expectSmoothDrag(result, perf, perfPayloads);
 });

--- a/scripts/e2e-chaos/run-matrix.sh
+++ b/scripts/e2e-chaos/run-matrix.sh
@@ -17,6 +17,7 @@ esac
 RESULT_ROOT="${INVOKER_CHAOS_RESULT_ROOT:-$GIT_DIR/invoker-chaos/$RUN_ID}"
 RESULTS_FILE="${INVOKER_CHAOS_RESULTS_FILE:-$RESULT_ROOT/results.jsonl}"
 UI_STALL_REQUIRED_SCENARIOS="
+cancel-downstream-standalone
 reset-race-coalesced
 timeout-deadlock-guard
 retry-vs-recreate-window
@@ -73,6 +74,7 @@ seed = int(sys.argv[2])
 lines = [line.strip() for line in os.environ["BASE_LINES"].splitlines() if line.strip()]
 
 high_risk = {
+    "cancel-downstream-standalone",
     "reset-race-coalesced",
     "timeout-deadlock-guard",
     "retry-vs-recreate-window",
@@ -254,6 +256,18 @@ if [ -z "$SCENARIO_FILTER" ]; then
   done
   if [ -n "$missing_ui_stall" ]; then
     echo "FAILED: chaos matrix omitted UI-stall-relevant scenario(s):$missing_ui_stall" >&2
+    exit 1
+  fi
+  required_ui_stall_list=" ${UI_STALL_REQUIRED_SCENARIOS//$'\n'/ } "
+  unrequired_ui_stall=""
+  for seen_scenario in $ui_stall_seen; do
+    case "$required_ui_stall_list" in
+      *" $seen_scenario "*) ;;
+      *) unrequired_ui_stall="$unrequired_ui_stall $seen_scenario" ;;
+    esac
+  done
+  if [ -n "$unrequired_ui_stall" ]; then
+    echo "FAILED: chaos matrix has UI-stall-tagged scenario(s) missing from required coverage:$unrequired_ui_stall" >&2
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary

UI Responsiveness Guardrails Step 3 completed the chaos coverage gate for UI-stall scenarios.

The chaos matrix now fails when UI-stall-tagged scenarios drift away from the required coverage list.

## Review Claim

The chaos matrix enforces its UI-stall coverage catalog so required scenarios cannot silently drift.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the existing chaos matrix shell gate changes; individual case scripts and product code stay untouched.

## Slice Rationale

This separate policy slice keeps shell matrix enforcement out of the performance-test proof diff.

## Non-goals

- No new chaos case implementation.
- No product behavior changes.
- No changes to deterministic or nightly execution order.
- No threshold changes inside the Electron specs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Invoker workflow task `wf-1783387742398-18/verify-adverse-load-and-chaos-thresholds` passed `pnpm run test:e2e-chaos`.
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ui-step3-pr2.md --changed-files-file /tmp/ui-step3-pr2-files.txt --diff-file /tmp/ui-step3-pr2.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <this-pr-merge-sha>`.
- Post-revert steps: Re-run `pnpm run test:e2e-chaos` before relying on UI-stall chaos coverage.
- Data migration? No.

</details>
