### PR TITLE
[Vitest Task Commands](1) Prove plans still accept pnpm vitest

### DIFF
--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -539,6 +539,17 @@ tasks:
     expect(() => parsePlan(yaml)).toThrow(PlanParseError);
     expect(() => parsePlan(yaml)).toThrow('npx vitest run');
   });
+  it('currently accepts pnpm vitest task commands', () => {
+    const yaml = `
+name: Bad Command Plan
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: test-it
+    description: "Run tests"
+    command: "cd packages/ui && pnpm vitest run src/__tests__/edge.test.tsx"
+`;
+    expect(() => parsePlan(yaml)).not.toThrow();
+  });
 
   it('parses task with prompt instead of command', () => {
     const yaml = `

--- a/packages/workflow-core/src/__tests__/plan-parser.test.ts
+++ b/packages/workflow-core/src/__tests__/plan-parser.test.ts
@@ -47,6 +47,18 @@ tasks:
     expect(() => parsePlan(yaml)).toThrow(PlanParseError);
     expect(() => parsePlan(yaml)).toThrow('Task at index 0 must be an object with an "id" field');
   });
+  it('currently accepts pnpm vitest task commands', () => {
+    const yaml = `
+name: Bad Command Plan
+repoUrl: git@github.com:test/repo.git
+baseBranch: main
+tasks:
+  - id: test-it
+    description: Run tests
+    command: "cd packages/ui && pnpm vitest run src/__tests__/edge.test.tsx"
+`;
+    expect(() => parsePlan(yaml)).not.toThrow();
+  });
 
   it('parses and trims executionModel from task definitions', () => {
     const yaml = `


### PR DESCRIPTION
## Summary

Plan files still accept direct `pnpm vitest` invocations today, even though those commands fail in this repo before any package test script runs.

This slice adds parser proof in both packages so the bad acceptance is visible before the behavior change lands.

## Review Claim

The parser test suites now prove that direct `pnpm vitest` plan invocations are still accepted today.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes tests only. Runtime behavior stays exactly the same.

## Slice Rationale

Evidence comes first. This isolates the current bad behavior before the next slice changes parser behavior.

## Non-goals

- Changing parser behavior.
- Rewriting saved tasks.
- Changing executor behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/plan-parser.test.ts`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/plan-parser.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert eb442a62e`
- Post-revert steps: None
- Data migration? No

</details>
