### PR TITLE
[Bound the cost-attribution attempt read](1) Stop loading full attempt rows

### DIFF
--- a/packages/app/src/__tests__/cost-attribution-attempt-read-cost.test.ts
+++ b/packages/app/src/__tests__/cost-attribution-attempt-read-cost.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { createAttempt, createTaskState, type TaskState } from '@invoker/workflow-core';
+
+import {
+  runReadOnlyHeadlessQueryToString,
+  type HeadlessQueryDeps,
+} from '../headless-query-list.js';
+
+describe('cost attribution attempt read cost', () => {
+  let adapter: SQLiteAdapter | undefined;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    adapter?.close();
+    adapter = undefined;
+  });
+
+  it('attributes costs from projected attempt metadata without loading full attempt rows', async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'Workflow',
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-01T00:00:00.000Z',
+    });
+
+    const task = {
+      ...createTaskState('wf-1/task-a', 'Task A', [], {
+        workflowId: 'wf-1',
+        runnerKind: 'worktree',
+      }),
+      status: 'completed',
+      execution: {
+        generation: 0,
+        agentName: 'codex',
+      },
+    } satisfies TaskState;
+    adapter.saveTask('wf-1', task);
+
+    const largeError = 'x'.repeat(100_000);
+    adapter.saveAttempt({
+      ...createAttempt(task.id, {
+        status: 'failed',
+        agentSessionId: 'sess-old',
+        error: largeError,
+      }),
+      id: 'attempt-old',
+      createdAt: new Date('2026-07-01T00:00:00.000Z'),
+    });
+    adapter.saveAttempt({
+      ...createAttempt(task.id, {
+        status: 'completed',
+        agentSessionId: 'sess-new',
+        error: largeError,
+      }),
+      id: 'attempt-new',
+      createdAt: new Date('2026-07-01T00:01:00.000Z'),
+    });
+
+    const queryAll = vi.spyOn(
+      adapter as unknown as { queryAll: (sql: string, params?: unknown[]) => Record<string, unknown>[] },
+      'queryAll',
+    );
+    const loadAttempts = vi.spyOn(adapter, 'loadAttempts').mockImplementation(() => {
+      throw new Error('cost attribution must not load full attempts');
+    });
+    const driver = {
+      processOutput: vi.fn(),
+      loadSession: vi.fn((sessionId: string) => (sessionId === 'sess-new' ? '{"ok":true}' : null)),
+      parseSession: vi.fn(() => []),
+      inspectSession: vi.fn(() => ({ state: 'finished' as const })),
+      extractUsage: vi.fn(() => [
+        {
+          eventId: 'turn-1',
+          timestamp: '2026-07-01T00:02:00.000Z',
+          model: 'gpt-5.2',
+          inputTokens: 10,
+          outputTokens: 5,
+          cachedTokens: 0,
+          totalTokens: 15,
+          confidence: 'exact' as const,
+        },
+      ]),
+    };
+    const deps: HeadlessQueryDeps = {
+      persistence: adapter,
+      orchestrator: {
+        syncFromDb: vi.fn(),
+        getAllTasks: vi.fn(() => [task]),
+      } as unknown as HeadlessQueryDeps['orchestrator'],
+      executionAgentRegistry: {
+        getSessionDriver: vi.fn(() => driver),
+      } as unknown as HeadlessQueryDeps['executionAgentRegistry'],
+      invokerConfig: {} as unknown as HeadlessQueryDeps['invokerConfig'],
+      getUiPerfStats: () => ({}),
+      resetUiPerfStats: () => {},
+    };
+
+    const output = await runReadOnlyHeadlessQueryToString(
+      ['query', 'cost-events', '--output', 'json'],
+      deps,
+    );
+
+    const parsed = JSON.parse(output) as Array<{ attemptId: string }>;
+    expect(parsed.map((event) => event.attemptId)).toEqual(['attempt-new']);
+    expect(driver.loadSession).toHaveBeenCalledWith('sess-new');
+    expect(loadAttempts).not.toHaveBeenCalled();
+
+    const attemptSqlCalls = queryAll.mock.calls
+      .map(([sql]) => String(sql))
+      .filter((sql) => /\bFROM attempts\b/.test(sql));
+    expect(attemptSqlCalls).toEqual([
+      expect.stringMatching(
+        /SELECT id, node_id, agent_session_id, created_at\s+FROM attempts\s+WHERE node_id = \?\s+ORDER BY created_at ASC/,
+      ),
+    ]);
+    expect(attemptSqlCalls[0]).not.toMatch(/SELECT\s+\*/i);
+    expect(attemptSqlCalls[0]).not.toMatch(/\berror\b/i);
+  });
+});

--- a/packages/app/src/__tests__/headless-query-cost.test.ts
+++ b/packages/app/src/__tests__/headless-query-cost.test.ts
@@ -101,7 +101,7 @@ describe('headless query cost', () => {
         readOnly: false,
         listWorkflows: vi.fn(() => [makeWorkflow('wf-1', 'completed')]),
         loadTasks: vi.fn(() => []),
-        loadAttempts: vi.fn((taskId: string) => attemptsByTaskId.get(taskId) ?? []),
+        loadCostAttributionAttempts: vi.fn((taskId: string) => attemptsByTaskId.get(taskId) ?? []),
       } as unknown as SQLiteAdapter,
       commandService: {} as CommandService,
       executorRegistry: {} as any,
@@ -219,7 +219,7 @@ describe('headless query cost', () => {
         } as any,
       }),
     ] as any);
-    (mockDeps.persistence.loadAttempts as any) = vi.fn(() => [
+    (mockDeps.persistence.loadCostAttributionAttempts as any) = vi.fn(() => [
       { id: 'wf-1/task-a-selected', agentSessionId: 'sess-stale' },
       { id: 'wf-1/task-a-exact', agentSessionId: 'sess-wf-1-task-a' },
     ]);
@@ -243,7 +243,7 @@ describe('headless query cost', () => {
         } as any,
       }),
     ] as any);
-    (mockDeps.persistence.loadAttempts as any) = vi.fn(() => [
+    (mockDeps.persistence.loadCostAttributionAttempts as any) = vi.fn(() => [
       { id: 'wf-1/task-b-older', agentSessionId: 'sess-old-b' },
       { id: 'wf-1/task-b-latest', agentSessionId: 'sess-wf-1-task-b' },
     ]);
@@ -305,7 +305,7 @@ describe('headless query cost-events', () => {
         readOnly: false,
         listWorkflows: vi.fn(() => [makeWorkflow('wf-1', 'completed')]),
         loadTasks: vi.fn(() => []),
-        loadAttempts: vi.fn((taskId: string) => attemptsByTaskId.get(taskId) ?? []),
+        loadCostAttributionAttempts: vi.fn((taskId: string) => attemptsByTaskId.get(taskId) ?? []),
       } as unknown as SQLiteAdapter,
       commandService: {} as CommandService,
       executorRegistry: {} as any,
@@ -426,7 +426,7 @@ describe('headless query cost-events', () => {
         } as any,
       }),
     ] as any);
-    (mockDeps.persistence.loadAttempts as any) = vi.fn(() => [
+    (mockDeps.persistence.loadCostAttributionAttempts as any) = vi.fn(() => [
       { id: 'wf-1/task-a-older', agentSessionId: 'sess-older' },
       { id: 'wf-1/task-a-selected', agentSessionId: 'sess-wf-1-task-a' },
     ]);
@@ -446,7 +446,7 @@ describe('headless query cost-events', () => {
         } as any,
       }),
     ] as any);
-    (mockDeps.persistence.loadAttempts as any) = vi.fn(() => [
+    (mockDeps.persistence.loadCostAttributionAttempts as any) = vi.fn(() => [
       { id: 'wf-1/task-a-selected', agentSessionId: 'sess-stale' },
       { id: 'wf-1/task-a-exact', agentSessionId: 'sess-wf-1-task-a' },
     ]);
@@ -469,7 +469,7 @@ describe('headless query cost-events', () => {
         } as any,
       }),
     ] as any);
-    (mockDeps.persistence.loadAttempts as any) = vi.fn(() => [
+    (mockDeps.persistence.loadCostAttributionAttempts as any) = vi.fn(() => [
       { id: 'wf-1/task-b-older', agentSessionId: 'sess-old-b' },
       { id: 'wf-1/task-b-latest', agentSessionId: 'sess-wf-1-task-b' },
     ]);
@@ -491,7 +491,7 @@ describe('headless query cost-events', () => {
         } as any,
       }),
     ] as any);
-    (mockDeps.persistence.loadAttempts as any) = vi.fn(() => [
+    (mockDeps.persistence.loadCostAttributionAttempts as any) = vi.fn(() => [
       { id: 'wf-1/task-a-older', agentSessionId: 'sess-older' },
       { id: 'wf-1/task-a-selected', agentSessionId: 'sess-wf-1-task-a' },
     ]);

--- a/packages/app/src/__tests__/headless-query-costs.test.ts
+++ b/packages/app/src/__tests__/headless-query-costs.test.ts
@@ -102,7 +102,7 @@ describe('headless query costs', () => {
         readOnly: false,
         listWorkflows: vi.fn(() => [makeWorkflow('wf-1', 'completed')]),
         loadTasks: vi.fn(() => []),
-        loadAttempts: vi.fn((taskId: string) => attemptsByTaskId.get(taskId) ?? []),
+        loadCostAttributionAttempts: vi.fn((taskId: string) => attemptsByTaskId.get(taskId) ?? []),
       } as unknown as SQLiteAdapter,
       commandService: {} as CommandService,
       executorRegistry: {} as any,
@@ -201,7 +201,7 @@ describe('headless query costs', () => {
         } as any,
       }),
     ] as any);
-    (mockDeps.persistence.loadAttempts as any) = vi.fn(() => [
+    (mockDeps.persistence.loadCostAttributionAttempts as any) = vi.fn(() => [
       { id: 'wf-1/task-a-selected', agentSessionId: 'sess-stale' },
       { id: 'wf-1/task-a-exact', agentSessionId: 'sess-wf-1-task-a' },
     ]);
@@ -225,7 +225,7 @@ describe('headless query costs', () => {
         } as any,
       }),
     ] as any);
-    (mockDeps.persistence.loadAttempts as any) = vi.fn((taskId: string) => {
+    (mockDeps.persistence.loadCostAttributionAttempts as any) = vi.fn((taskId: string) => {
       if (taskId === 'wf-1/task-a') {
         return [
           { id: 'wf-1/task-a-older', agentSessionId: 'sess-old' },

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -93,6 +93,16 @@ class InMemoryPersistence implements OrchestratorPersistence {
   loadAttempts(nodeId: string): Attempt[] {
     return Array.from(this.attempts.values()).filter((attempt) => attempt.nodeId === nodeId);
   }
+  loadCostAttributionAttempts(nodeId: string): Array<{ id: string; nodeId: string; agentSessionId?: string; createdAt: Date }> {
+    return this.loadAttempts(nodeId)
+      .map((attempt) => ({
+        id: attempt.id,
+        nodeId: attempt.nodeId,
+        agentSessionId: attempt.agentSessionId,
+        createdAt: attempt.createdAt,
+      }))
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  }
   loadAttempt(attemptId: string): Attempt | undefined {
     const attempt = this.attempts.get(attemptId);
     return attempt ? { ...attempt } : undefined;

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -14,6 +14,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Attempt, TaskState } from '@invoker/workflow-core';
 import type { AgentSessionData, NormalizedCostEvent, WorkerActionSummary, WorkerStatusSnapshot } from '@invoker/contracts';
 import { AUTO_FIX_WORKER_KIND, createWorkerRegistry, registerBuiltinWorkers, type AgentRegistry, type WorkerRuntimeDependencies } from '@invoker/execution-engine';
+import type { CostAttributionAttempt } from '@invoker/data-store';
 import type { CostGroupDimension } from './cost-rollup.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
@@ -550,8 +551,8 @@ type CostQueryDeps = Pick<HeadlessDeps, 'orchestrator' | 'persistence' | 'execut
 
 function resolveCostAttributionAttempt(
   task: TaskState,
-  attempts: readonly Attempt[],
-): Attempt | undefined {
+  attempts: readonly CostAttributionAttempt[],
+): CostAttributionAttempt | undefined {
   const sessionId = task.execution.agentSessionId?.trim();
   if (sessionId) {
     const exactSessionAttempt = attempts.find((attempt) => attempt.agentSessionId?.trim() === sessionId);
@@ -594,7 +595,7 @@ async function collectCostEvents(
     );
 
     for (const task of tasks) {
-      const attempts = deps.persistence.loadAttempts(task.id);
+      const attempts = deps.persistence.loadCostAttributionAttempts(task.id);
       const attributedAttempt = resolveCostAttributionAttempt(task, attempts);
       const ctx = buildAttributionContext({
         id: task.id,

--- a/packages/data-store/src/__tests__/attempt-persistence.test.ts
+++ b/packages/data-store/src/__tests__/attempt-persistence.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
 import { createAttempt, createTaskState } from '@invoker/workflow-core';
 
@@ -60,6 +60,76 @@ describe('Attempt persistence', () => {
     expect(attempts[0].id).toBe(a1.id);
     expect(attempts[1].id).toBe(a2.id);
     expect(attempts[2].id).toBe(a3.id);
+  });
+
+  it('loadCostAttributionAttempts projects only attribution columns in created_at order', () => {
+    const older = {
+      ...createAttempt('taskA', {
+        status: 'failed',
+        agentSessionId: 'sess-old',
+        error: 'x'.repeat(100_000),
+      }),
+      id: 'attempt-old',
+      createdAt: new Date('2026-07-01T00:00:00.000Z'),
+    };
+    const newer = {
+      ...createAttempt('taskA', {
+        status: 'completed',
+        agentSessionId: 'sess-new',
+        error: 'y'.repeat(100_000),
+      }),
+      id: 'attempt-new',
+      createdAt: new Date('2026-07-01T00:01:00.000Z'),
+    };
+    adapter.saveAttempt(newer);
+    adapter.saveAttempt(older);
+
+    const queryAll = vi.spyOn(
+      adapter as unknown as { queryAll: (sql: string, params?: unknown[]) => Record<string, unknown>[] },
+      'queryAll',
+    );
+    let sql = '';
+    try {
+      expect(adapter.loadCostAttributionAttempts('taskA')).toEqual([
+        {
+          id: 'attempt-old',
+          nodeId: 'taskA',
+          agentSessionId: 'sess-old',
+          createdAt: new Date('2026-07-01T00:00:00.000Z'),
+        },
+        {
+          id: 'attempt-new',
+          nodeId: 'taskA',
+          agentSessionId: 'sess-new',
+          createdAt: new Date('2026-07-01T00:01:00.000Z'),
+        },
+      ]);
+      sql = String(queryAll.mock.calls[0]?.[0] ?? '');
+    } finally {
+      queryAll.mockRestore();
+    }
+
+    expect(sql).toMatch(/SELECT id, node_id, agent_session_id, created_at\s+FROM attempts\s+WHERE node_id = \?\s+ORDER BY created_at ASC/);
+    expect(sql).not.toMatch(/SELECT\s+\*/i);
+    expect(sql).not.toMatch(/\berror\b/i);
+  });
+
+  it('uses the node_id, created_at index for cost attribution attempt reads', () => {
+    const planRows = (adapter as any).db
+      .prepare(`
+        EXPLAIN QUERY PLAN
+        SELECT id, node_id, agent_session_id, created_at
+        FROM attempts
+        WHERE node_id = ?
+        ORDER BY created_at ASC
+      `)
+      .all('taskA') as Array<{ detail: string }>;
+    const detail = planRows.map((row) => row.detail).join('\n');
+
+    expect(detail).toContain('SEARCH attempts');
+    expect(detail).toContain('idx_attempts_node_created');
+    expect(detail).not.toContain('SCAN attempts');
+    expect(detail).not.toContain('USE TEMP B-TREE');
   });
 
   it('loadAttempt returns undefined for missing ID', () => {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -7,6 +7,7 @@
 
 import type { TaskState, TaskStateChanges, PlanDefinition, Attempt, WorkflowDerivedStatus, WorkflowRollup, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency } from '@invoker/workflow-core';
 import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
+import type { CostAttributionAttempt } from './attempt-read-models.js';
 
 
 export type ConversationMode = 'agent' | 'plan';
@@ -347,6 +348,7 @@ export interface PersistenceAdapter {
   // Attempts
   saveAttempt(attempt: Attempt): void;
   loadAttempts(nodeId: string): Attempt[];
+  loadCostAttributionAttempts(nodeId: string): CostAttributionAttempt[];
   loadAttempt(attemptId: string): Attempt | undefined;
   updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void;
 

--- a/packages/data-store/src/attempt-read-models.ts
+++ b/packages/data-store/src/attempt-read-models.ts
@@ -1,0 +1,6 @@
+export interface CostAttributionAttempt {
+  id: string;
+  nodeId: string;
+  agentSessionId?: string;
+  createdAt: Date;
+}

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -1,4 +1,5 @@
 export * from './adapter.js';
+export * from './attempt-read-models.js';
 export * from './sqlite-adapter.js';
 export * from './slow-query-aggregator.js';
 export * from './conversation-repository.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -55,6 +55,7 @@ import type {
   InAppPlanningSessionPatch,
   InAppPlanningSessionRecord,
 } from './adapter.js';
+import type { CostAttributionAttempt } from './attempt-read-models.js';
 import { SCHEMA_DDL } from './sqlite-schema.js';
 import {
   mapRowToTaskLaunchDispatch,
@@ -2343,6 +2344,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   loadAttempts(nodeId: string): Attempt[] {
     return this.taskAttemptRepo.loadAttempts(nodeId);
+  }
+
+  loadCostAttributionAttempts(nodeId: string): CostAttributionAttempt[] {
+    return this.taskAttemptRepo.loadCostAttributionAttempts(nodeId);
   }
 
   loadActionGraphAttempts(

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -16,6 +16,7 @@ import {
 } from '@invoker/workflow-core';
 import { mapRowToTask, mapRowToAttempt } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
+import type { CostAttributionAttempt } from './attempt-read-models.js';
 
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
@@ -635,6 +636,22 @@ export class SqliteTaskAttemptRepository {
       [nodeId],
     );
     return rows.map((row) => mapRowToAttempt(row));
+  }
+
+  loadCostAttributionAttempts(nodeId: string): CostAttributionAttempt[] {
+    const rows = this.exec.queryAll(
+      `SELECT id, node_id, agent_session_id, created_at
+       FROM attempts
+       WHERE node_id = ?
+       ORDER BY created_at ASC`,
+      [nodeId],
+    );
+    return rows.map((row) => ({
+      id: String(row.id),
+      nodeId: String(row.node_id),
+      agentSessionId: row.agent_session_id ? String(row.agent_session_id) : undefined,
+      createdAt: new Date(String(row.created_at)),
+    }));
   }
 
   loadActionGraphAttempts(


### PR DESCRIPTION
## Summary

Bound the cost-attribution attempt read — 1 tasks completed, 0 failed, 0 closed, 0 omitted

Cost attribution now reads only attempt id, node, session, and creation time before loading the selected session.

The query output shape and cost math stay unchanged.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784187838297-7/implement-bounded-cost-attempt-read | Stop loading thousands of fat attempt rows during cost attribution | completed |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784187838297-7/implement-bounded-cost-attempt-read — Stop loading thousands of fat attempt rows during cost attribution

</details>

## Review Claim

Cost attribution can use a projected attempt read for session selection without hydrating full attempt rows.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The new projection keeps the existing attempt ordering and session selection rules. Tests cover exact-session, selected-attempt, and latest-attempt attribution.

## Slice Rationale

This slice keeps the data-store projection with the headless cost query consumer because the query path needs both ends to avoid full rows.

## Non-goals

- No change to cost math, pricing, grouping, or output formats.
- No migration or attempts schema change.
- No change to action graph attempt loading.

## Architecture

### Before

```mermaid
graph TD
    A["query cost / cost-events"] --> B["PersistenceAdapter.loadAttempts(taskId)"]
    B --> C["SELECT * FROM attempts"]
    C --> D["Full Attempt rows, including large error payloads"]
```

### After

```mermaid
graph TD
    A["query cost / cost-events"] --> B["PersistenceAdapter.loadCostAttributionAttempts(taskId)"]
    B --> C["SELECT id, node_id, agent_session_id, created_at FROM attempts"]
    C --> D["Selected session attribution without hydrating full Attempt rows"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/attempt-persistence.test.ts`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/cost-attribution-attempt-read-cost.test.ts src/__tests__/headless-query-cost.test.ts src/__tests__/headless-query-costs.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/bound-cost-attempt-read-pr.md --changed-files-file /tmp/bound-cost-attempt-read-files.txt --diff-file /tmp/bound-cost-attempt-read.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 783d689dd5ce446ec7063258d0ddfcc0135af0dd`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cost attribution attempt selection by using the dedicated cost-attribution attempt set, ensuring only the correct (e.g., completed/newer) attempts are considered.
  * Avoided pulling oversized error details into cost-event generation.
* **Performance**
  * Reduced cost-attribution data reads by fetching a smaller, column-specific attempt list and relying on indexed ordering.
* **Tests**
  * Added and updated tests to validate correct attempt selection behavior, output serialization, and query/index efficiency for cost attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->