### PR TITLE
Reject pnpm vitest plan commands

### DIFF
--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -539,6 +539,18 @@ tasks:
     expect(() => parsePlan(yaml)).toThrow(PlanParseError);
     expect(() => parsePlan(yaml)).toThrow('npx vitest run');
   });
+  it('rejects task commands using pnpm vitest run', () => {
+    const yaml = `
+name: Bad Command Plan
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: test-it
+    description: "Run tests"
+    command: "cd packages/ui && pnpm vitest run src/__tests__/edge.test.tsx"
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow('pnpm vitest run');
+  });
 
   it('parses task with prompt instead of command', () => {
     const yaml = `

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -248,6 +248,10 @@ function assertNoLegacyRoutingKeys(ownerLabel: string, value: object): void {
     }
   }
 }
+function findDisallowedVitestCommand(command: string): string | undefined {
+  const match = command.match(/\bnpx vitest run\b|\bpnpm vitest(?:\s+run)?\b/);
+  return match?.[0];
+}
 
 /**
  * Parse a YAML string into a validated PlanDefinition.
@@ -355,9 +359,12 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
       );
     }
 
-    if (task.command && /\bnpx vitest run\b/.test(task.command)) {
+    const disallowedVitestCommand = task.command
+      ? findDisallowedVitestCommand(task.command)
+      : undefined;
+    if (disallowedVitestCommand) {
       throw new PlanParseError(
-        `Task "${task.id}" uses 'npx vitest run' which may not resolve correctly. ` +
+        `Task "${task.id}" uses '${disallowedVitestCommand}' which may not resolve correctly. ` +
         `Use 'pnpm test' instead.`,
       );
     }

--- a/packages/workflow-core/src/__tests__/plan-parser.test.ts
+++ b/packages/workflow-core/src/__tests__/plan-parser.test.ts
@@ -47,6 +47,19 @@ tasks:
     expect(() => parsePlan(yaml)).toThrow(PlanParseError);
     expect(() => parsePlan(yaml)).toThrow('Task at index 0 must be an object with an "id" field');
   });
+  it('rejects task commands using pnpm vitest run', () => {
+    const yaml = `
+name: Bad Command Plan
+repoUrl: git@github.com:test/repo.git
+baseBranch: main
+tasks:
+  - id: test-it
+    description: Run tests
+    command: "cd packages/ui && pnpm vitest run src/__tests__/edge.test.tsx"
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow('pnpm vitest run');
+  });
 
   it('parses and trims executionModel from task definitions', () => {
     const yaml = `

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -145,6 +145,10 @@ function assertNoLegacyRoutingKeys(ownerLabel: string, value: object): void {
     }
   }
 }
+function findDisallowedVitestCommand(command: string): string | undefined {
+  const match = command.match(/\bnpx vitest run\b|\bpnpm vitest(?:\s+run)?\b/);
+  return match?.[0];
+}
 
 export function parsePlan(yamlContent: string): PlanDefinition {
   let raw: RawPlan;
@@ -213,8 +217,13 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     if (hasOwn(task as object, 'autoFixRetries')) {
       throw new PlanParseError(`Task "${task.id}" uses "autoFixRetries", which is no longer supported in plan YAML. Configure "~/.invoker/config.json" with "autoFixRetries" instead.`);
     }
-    if (task.command && /\bnpx vitest run\b/.test(task.command)) {
-      throw new PlanParseError(`Task "${task.id}" uses 'npx vitest run' which may not resolve correctly. Use 'pnpm test' instead.`);
+    const disallowedVitestCommand = task.command
+      ? findDisallowedVitestCommand(task.command)
+      : undefined;
+    if (disallowedVitestCommand) {
+      throw new PlanParseError(
+        `Task "${task.id}" uses '${disallowedVitestCommand}' which may not resolve correctly. Use 'pnpm test' instead.`,
+      );
     }
 
     if (task.externalDependencies !== undefined) {


### PR DESCRIPTION
## Summary

Plan files could still ask for direct `pnpm vitest` invocations, even though they fail in this repo before any test file runs.

This change teaches both plan parsers to catch those invocations and point authors back to `pnpm test`.

## Review Claim

Both plan parsers now send direct `pnpm vitest` invocations through the same parse error path and `Use 'pnpm test' instead.` guidance already used for `npx vitest run`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new helper only matches direct Vitest spellings and preserves the existing parse flow and error text for everything else.

## Slice Rationale

This is one parser fix. Splitting it would add review overhead without reducing risk.

## Non-goals

- Rewriting persisted task rows.
- Changing how executors run shell text after parsing.
- Broadening parser handling beyond direct Vitest invocations.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/plan-parser.test.ts`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/plan-parser.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8f772647c`
- Post-revert steps: None
- Data migration? No

</details>
