### PR TITLE
[Remove Task Graph Edge Workflow Names](1) Hide workflow names in task graph edge labels

### DIFF
--- a/packages/ui/src/__tests__/bundled-edge.test.tsx
+++ b/packages/ui/src/__tests__/bundled-edge.test.tsx
@@ -4,13 +4,17 @@ import { describe, expect, it } from 'vitest';
 
 import { BundledEdge, type BundledEdgeData } from '../components/BundledEdge.js';
 
-function renderEdge(data?: Partial<BundledEdgeData>, selected = false) {
+function renderEdge(
+  data?: Partial<BundledEdgeData>,
+  selected = false,
+  endpoints: { source?: string; target?: string } = {},
+) {
   return render(
     <svg>
       <BundledEdge
         id="edge-a-b"
-        source="a"
-        target="b"
+        source={endpoints.source ?? 'a'}
+        target={endpoints.target ?? 'b'}
         sourceX={10}
         sourceY={20}
         targetX={110}
@@ -79,5 +83,18 @@ describe('BundledEdge', () => {
     const { container } = renderEdge({ external: true, selectionActive: true });
 
     expect(visibleEdgePath(container).getAttribute('style')).toContain('opacity: 0.86');
+  });
+
+  it('renders the supplied scoped-task edge label without falling back to workflow-prefixed ids', () => {
+    const { container, getByText } = renderEdge(
+      { label: 'setup-task → render-task' },
+      false,
+      { source: 'wf-alpha/setup-task', target: 'wf-alpha/render-task' },
+    );
+
+    fireEvent.mouseEnter(container.querySelector('.bundled-edge-group')!);
+
+    expect(getByText('setup-task → render-task')).toBeInTheDocument();
+    expect(container.textContent).not.toContain('wf-alpha');
   });
 });

--- a/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
+++ b/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
@@ -110,6 +110,7 @@ export function createReactFlowMock() {
             data-source={edge.source}
             data-target={edge.target}
             data-kind={edge.data?.kind}
+            data-label={edge.data?.label ?? ''}
             data-stroke-dasharray={edge.style?.strokeDasharray ?? ''}
             aria-label={edge.ariaLabel}
           />

--- a/packages/ui/src/__tests__/task-dag.test.tsx
+++ b/packages/ui/src/__tests__/task-dag.test.tsx
@@ -68,4 +68,36 @@ describe('TaskDAG status filters', () => {
     expect(assigningNode.className).not.toContain('opacity-20');
     expect(pendingNode.className).toContain('opacity-20');
   });
+
+  it('omits workflow prefixes from generated edge labels for scoped task ids', async () => {
+    const setupTask = makeUITask({
+      id: 'wf-alpha/setup-task',
+      workflowId: 'wf-alpha',
+      status: 'completed',
+      description: 'Setup task',
+    });
+    const renderTask = makeUITask({
+      id: 'wf-alpha/render-task',
+      workflowId: 'wf-alpha',
+      status: 'pending',
+      description: 'Render task',
+      dependencies: ['wf-alpha/setup-task'],
+    });
+    const tasks = new Map<string, TaskState>([
+      [setupTask.id, setupTask],
+      [renderTask.id, renderTask],
+    ]);
+    const workflows = new Map<string, WorkflowMeta>([
+      ['wf-alpha', { id: 'wf-alpha', name: 'Alpha workflow', status: 'running' }],
+    ]);
+
+    render(<TaskDAG tasks={tasks} workflows={workflows} />);
+
+    const edge = await screen.findByTestId(`rf__edge-local:${setupTask.id}->${renderTask.id}`);
+
+    await waitFor(() => {
+      expect(edge).toHaveAttribute('data-label', 'setup-task → render-task');
+    });
+    expect(edge.getAttribute('data-label')).not.toContain('wf-alpha');
+  });
 });

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -71,11 +71,31 @@ type LayoutState = {
   result: TaskGraphLayout;
 };
 
+function truncateEdgeEndpoint(label: string): string {
+  return label.length > 12 ? label.slice(0, 12) + '..' : label;
+}
+
+function unscopedTaskId(task: TaskState): string {
+  const workflowId = task.config.workflowId;
+  if (workflowId && task.id.startsWith(`${workflowId}/`)) {
+    return task.id.slice(workflowId.length + 1);
+  }
+  return task.id;
+}
+
 /** Short label for edge hover tooltip showing the dependency relationship. */
-function buildEdgeLabel(source: TaskState, target: TaskState): string {
-  const srcId = source.id.length > 12 ? source.id.slice(0, 12) + '..' : source.id;
-  const tgtId = target.id.length > 12 ? target.id.slice(0, 12) + '..' : target.id;
-  return `${srcId} → ${tgtId}`;
+function buildEdgeEndpointLabel(taskId: string, task?: TaskState): string {
+  if (task?.config.isMergeNode || isMergeGateId(taskId)) return 'Merge';
+  return truncateEdgeEndpoint(task ? unscopedTaskId(task) : taskId);
+}
+
+function buildEdgeLabel(
+  sourceId: string,
+  targetId: string,
+  sourceTask?: TaskState,
+  targetTask?: TaskState,
+): string {
+  return `${buildEdgeEndpointLabel(sourceId, sourceTask)} → ${buildEdgeEndpointLabel(targetId, targetTask)}`;
 }
 
 function resolveExternalDependencyTaskId(
@@ -384,13 +404,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
       const targetStatus = targetTask?.status ?? rawGraph.gateStatuses.get(e.target) ?? 'pending';
       const edgeStyle = getEdgeStyle(sourceStatus, targetStatus);
 
-      const srcIsMerge = tasks.get(e.source)?.config.isMergeNode || isMergeGateId(e.source);
-      const tgtIsMerge = tasks.get(e.target)?.config.isMergeNode || isMergeGateId(e.target);
-      const srcLabel = srcIsMerge ? 'Merge' : e.source;
-      const tgtLabel = tgtIsMerge ? 'Merge' : e.target;
-      const truncSrc = srcLabel.length > 12 ? srcLabel.slice(0, 12) + '..' : srcLabel;
-      const truncTgt = tgtLabel.length > 12 ? tgtLabel.slice(0, 12) + '..' : tgtLabel;
-      const label = `${truncSrc} → ${truncTgt}`;
+      const label = buildEdgeLabel(e.source, e.target, sourceTask, targetTask);
 
       const edgeDimmed = rawGraph.dimmedNodeIds.has(e.source) || rawGraph.dimmedNodeIds.has(e.target);
       const selectionActive = selectedTaskId === e.source || selectedTaskId === e.target;


### PR DESCRIPTION
## Summary

Standalone workflow waiver: this is one reviewable UI behavior claim.

Task graph edge hover labels now show dependency endpoint names without repeating workflow-scoped prefixes.

The selected workflow already gives the workflow context, so labels stay short while external edges still keep the external cue.

## Review Claim

Task graph edge hover labels omit workflow-scoped task prefixes while preserving graph structure and the external-edge cue.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only display text in task graph edge label data changes. Edge ids, source and target endpoints, layout inputs, statuses, markers, selection state, and graph snapshots stay unchanged.

## Slice Rationale

This is one localized UI presentation claim. The focused regression coverage stays with the renderer change because it proves the visible label behavior.

## Non-goals

Does not change task ids, node titles, workflow graph labels, action graph labels, layout, routing, or external dependency resolution.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/task-dag.test.tsx src/__tests__/bundled-edge.test.tsx`
- [x] `pnpm --filter @invoker/ui build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
