### PR TITLE
[Merge gate generation](1) Stamp published review-stack artifacts with the gate generation

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
 import { collectDirectNonMergeTaskIds } from '../merge-runner.js';
+import { getCurrentRequiredReviewArtifacts } from '../task-runner-review-gate.js';
 import { SshExecutor } from '../ssh-executor.js';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkResponse, Logger } from '@invoker/contracts';
@@ -2677,6 +2678,56 @@ describe('TaskRunner', () => {
           }),
         }),
       }), expect.objectContaining({ generation: 0 }));
+    });
+    it('stamps published stack artifacts with the merge task generation so the poller keeps them live', async () => {
+      const contractsTask = makeTask({
+        id: 'contracts',
+        status: 'completed',
+        config: { workflowId: 'wf-pub' },
+        execution: { branch: 'invoker/contracts' },
+        description: 'Contracts',
+      });
+
+      const { executor, mergeTask, orchestrator } = setupPublishAfterFix({
+        mergeMode: 'external_review',
+        featureBranch: 'plan/feature',
+        gateWorkspacePath: '/tmp/gate-clone',
+        taskBranches: [contractsTask],
+        repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+      });
+
+      mergeTask.execution.generation = 26;
+
+      (executor as any).publishReviewStackWithMakePrSkill = vi.fn().mockResolvedValue({
+        artifacts: [
+          {
+            id: 'contracts',
+            title: 'Define contracts',
+            url: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/1',
+            providerId: '1',
+            branch: 'stack/contracts',
+            baseBranch: 'master',
+            required: true,
+            status: 'open',
+            generation: 0,
+          },
+        ],
+        sessionId: 'sess-stack',
+        agentName: 'codex',
+      });
+
+      await executor.publishAfterFix(mergeTask);
+
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledTimes(1);
+      const [, changes] = (orchestrator.setTaskReviewReady as any).mock.calls[0];
+      const gate = changes.execution.reviewGate;
+      expect(gate.activeGeneration).toBe(26);
+      for (const artifact of gate.artifacts) {
+        expect(artifact.generation).toBe(gate.activeGeneration);
+      }
+
+      const publishedTask = { execution: changes.execution } as TaskState;
+      expect(getCurrentRequiredReviewArtifacts(publishedTask)).toHaveLength(1);
     });
     it('external_review mode: detaches HEAD, fetches, consolidates, creates PR', async () => {
       const completedTask = makeTask({

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -124,6 +124,24 @@ function buildSingleArtifactReviewGate(args: {
   };
 }
 
+function assertReviewGateGenerationsAligned(gate: ReviewGateState): void {
+  const mismatched = gate.artifacts.filter(
+    (artifact) =>
+      artifact.status !== 'discarded'
+      && !artifact.discardedAt
+      && artifact.generation !== gate.activeGeneration,
+  );
+  if (mismatched.length === 0) return;
+  const detail = mismatched
+    .map((artifact) => `${artifact.providerId ?? artifact.id ?? 'unknown'}@${artifact.generation}`)
+    .join(', ');
+  throw new Error(
+    `review gate generation mismatch: activeGeneration=${gate.activeGeneration} `
+      + `but live artifacts at [${detail}]; published artifacts must share the gate generation `
+      + 'or the poller treats them as discarded',
+  );
+}
+
 function buildMergeConflictJson(errorText: string, failedBranch: string): string | undefined {
   const hasConflictMarkers =
     errorText.includes('CONFLICT (') ||
@@ -269,6 +287,7 @@ export interface MergeRunnerHost {
     featureBranch: string;
     workflowSummary: string;
     cwd: string;
+    expectedGeneration: number;
     reviewGate?: ReviewGateState;
   }): Promise<{ artifacts: ReviewGateArtifact[]; sessionId: string; agentName: string }>;
   authorPrBodyWithSkill?(args: {
@@ -359,6 +378,7 @@ async function publishReviewArtifactsForMerge(host: MergeRunnerHost, args: {
       featureBranch: args.featureBranch,
       workflowSummary: args.workflowSummary,
       cwd: args.cwd,
+      expectedGeneration: args.expectedGeneration,
       reviewGate: args.reviewGate,
     });
     logTaskProgress(host, args.mergeNodeTaskId, 'info', 'Review stack published', {
@@ -371,13 +391,14 @@ async function publishReviewArtifactsForMerge(host: MergeRunnerHost, args: {
       baseBranch: artifact.baseBranch ?? args.baseBranch,
       required: artifact.required ?? true,
       status: artifact.status ?? 'open' as const,
-      generation: artifact.generation ?? args.expectedGeneration,
+      generation: args.expectedGeneration,
     }));
     const reviewGate = {
       activeGeneration: args.expectedGeneration,
       completion: { required: 'all' as const, status: 'approved' as const },
       artifacts,
     };
+    assertReviewGateGenerationsAligned(reviewGate);
     const firstArtifact = artifacts[0];
     console.log(
       `[merge] Published Invoker review stack via ${published.agentName} skill`,
@@ -428,20 +449,22 @@ async function publishReviewArtifactsForMerge(host: MergeRunnerHost, args: {
   });
   console.log(`[merge] Created GitHub PR: ${result.url}`);
 
+  const reviewGate = buildSingleArtifactReviewGate({
+    expectedGeneration: args.expectedGeneration,
+    title: args.workflowName,
+    url: result.url,
+    providerId: result.identifier,
+    provider: host.mergeGateProvider.name,
+    branch: args.featureBranch,
+    baseBranch: args.baseBranch,
+    nowIso: new Date().toISOString(),
+  });
+  assertReviewGateGenerationsAligned(reviewGate);
   return {
     reviewUrl: result.url,
     reviewId: result.identifier,
     reviewStatus: 'Awaiting review',
-    reviewGate: buildSingleArtifactReviewGate({
-      expectedGeneration: args.expectedGeneration,
-      title: args.workflowName,
-      url: result.url,
-      providerId: result.identifier,
-      provider: host.mergeGateProvider.name,
-      branch: args.featureBranch,
-      baseBranch: args.baseBranch,
-      nowIso: new Date().toISOString(),
-    }),
+    reviewGate,
   };
 }
 


### PR DESCRIPTION
## Summary

A finished workflow could get stuck at its review step with the pull requests it opened hidden from the gate.

When the gate opens its pull requests, it tags each one with a generation number. That number was read from the wrong place.

So it could disagree with the generation the gate keeps for itself. Each time a gate is rebuilt, its generation goes up.

After a rebuild the pull requests still carried the old number while the gate held the new one.

The gate only counts a pull request as live when the two numbers agree. Out of sync, it saw none live and stayed frozen.

That is why the PRs looked missing.

Now every published pull request is tagged with the gate's own generation, and the gate throws before publishing if any live one disagrees, so this cannot slip through quietly again.

## Review Claim

Published review-gate artifacts carry the merge gate's generation, so the poller keeps them live instead of counting them as gone.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change sets each published artifact's generation to the value the gate already holds for itself, and adds a guard that throws before publishing when they differ. No control flow, ordering, or data shape changes.

## Slice Rationale

Slice (1) of two. This slice carries the whole fix in the merge runner plus its regression test. A repo rule forbids changing publication and poll/approval runtime in one PR, so a follow-up slice (2) tidies the publisher origin.

## Non-goals

Does not repair gates already frozen with the old numbers; those need a manual gate rebuild. Does not change how generations are bumped.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test task-runner-fix-publish-and-ssh`
- [ ] `cd packages/execution-engine && pnpm build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c4127a294`
- Post-revert steps: None
- Data migration? No

</details>
