### PR TITLE
[Merge gate generation](2) Stamp make-pr publisher artifacts from the caller generation

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1321,11 +1321,13 @@ describe('TaskRunner', () => {
           workflowSummary: 'summary',
           cwd: '/tmp',
           mergeNodeTaskId: '__merge__wf-1',
+          expectedGeneration: 26,
         });
 
         expect(attempts).toEqual(['claude', 'codex']);
         expect(result.agentName).toBe('codex');
         expect(result.artifacts[1].dependsOn).toEqual(['contracts']);
+        expect(result.artifacts.map((a: any) => a.generation)).toEqual([26, 26]);
         expect(logEvent).toHaveBeenCalledWith(
           '__merge__wf-1',
           'task.log',

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1458,6 +1458,7 @@ export class TaskRunner {
     featureBranch: string;
     workflowSummary: string;
     cwd: string;
+    expectedGeneration: number;
     reviewGate?: ReviewGateState;
   }): Promise<{ artifacts: ReviewGateArtifact[]; sessionId: string; agentName: string }> {
     if (!this.executionAgentRegistry) {
@@ -1573,7 +1574,7 @@ export class TaskRunner {
         }
 
         const nowIso = new Date().toISOString();
-        const generation = args.reviewGate?.activeGeneration ?? 0;
+        const generation = args.expectedGeneration;
         const artifacts: ReviewGateArtifact[] = parsedArtifacts.map(({ body: _body, ...artifact }) => ({
           ...artifact,
           provider: 'github',


### PR DESCRIPTION
## Summary

The make-pr publisher tagged each pull request with generation 0 on first publish. Slice (1) already overwrites that in the merge runner.

This slice tags it correctly at the source. The publisher no longer emits a number that has to be fixed later.

## Review Claim

The make-pr publisher stamps each artifact's generation from the caller's generation instead of a 0 default.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The value this slice sets is the same one the merge runner already applies on top, so the published output is unchanged. Only the publisher's own emitted number changes from 0 to the passed generation.

## Slice Rationale

Slice (2) of two. A repo rule forbids changing publication and poll/approval runtime in one PR, so this publisher change is kept apart from the merge-runner fix in slice (1).

## Non-goals

Does not change the published review gate output, which slice (1) already stamps. Does not change how generations are bumped.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test task-runner-fix-publish-and-ssh`
- [ ] `cd packages/execution-engine && pnpm build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert HEAD`
- Post-revert steps: None
- Data migration? No

</details>
