### PR TITLE
[Runner Capacity](1) Add live-scale capacity monkey and fill guarantee

### DIFF
--- a/packages/app/src/__tests__/runner-capacity-fill-guarantee.test.ts
+++ b/packages/app/src/__tests__/runner-capacity-fill-guarantee.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator, type PlanDefinition } from '@invoker/workflow-core';
+import { LaunchDispatcher } from '../launch-dispatcher.js';
+
+/**
+ * Live-shaped scale (snapshot of ~/.invoker/invoker.db):
+ *   ~51 workflows, ~162 tasks, avg ~3.2 tasks/wf, longest ~9.
+ * Scheduler/pool under test: expectedCap=13.
+ */
+const EXPECTED_CAP = 13;
+const WORKFLOW_COUNT = 51;
+const TARGET_TASK_COUNT = 162;
+
+function chainPlan(name: string, depth: number): PlanDefinition {
+  const tasks: PlanDefinition['tasks'] = [];
+  for (let i = 0; i < depth; i += 1) {
+    tasks.push({
+      id: `t${i}`,
+      description: `${name}/t${i}`,
+      command: 'sleep 3600',
+      ...(i > 0 ? { dependencies: [`t${i - 1}`] } : {}),
+    });
+  }
+  return { name, tasks };
+}
+
+/** Distribute ~162 tasks across 51 workflows like the live DB (many 3s, some longer). */
+function liveShapedWorkflowDepths(): number[] {
+  const depths: number[] = [];
+  // One long workflow (~9) like the live top
+  depths.push(9);
+  // Several 5s and 4s
+  for (let i = 0; i < 4; i += 1) depths.push(5);
+  for (let i = 0; i < 6; i += 1) depths.push(4);
+  // Fill remaining with 3-task chains (dominant live pattern)
+  while (depths.length < WORKFLOW_COUNT) depths.push(3);
+  // Trim/pad to hit target task count without exploding workflow count.
+  let total = depths.reduce((a, b) => a + b, 0);
+  let idx = depths.length - 1;
+  while (total > TARGET_TASK_COUNT && idx >= 0) {
+    if (depths[idx]! > 2) {
+      depths[idx]! -= 1;
+      total -= 1;
+    } else {
+      idx -= 1;
+    }
+  }
+  while (total < TARGET_TASK_COUNT) {
+    depths[total % depths.length]! += 1;
+    total += 1;
+  }
+  return depths.slice(0, WORKFLOW_COUNT);
+}
+
+function makeDispatcher(orchestrator: Orchestrator, persistence: SQLiteAdapter) {
+  return new LaunchDispatcher({
+    persistence,
+    orchestrator: {
+      prepareTaskForNewAttempt: (taskId, reason) =>
+        orchestrator.prepareTaskForNewAttempt(taskId, reason),
+      getTask: (taskId) => orchestrator.getTask(taskId),
+      getTaskLaunchReadiness: (taskId) => orchestrator.getTaskLaunchReadiness(taskId),
+      getExecutableReadyTasks: () => orchestrator.getExecutableReadyTasks(),
+      getQueueStatus: () => orchestrator.getQueueStatus({ refresh: false }),
+      isLaunchParked: (taskId, now) => orchestrator.isLaunchParked(taskId, now),
+      startExecution: () => orchestrator.startExecution(),
+    },
+    ownerId: 'capacity-fill-owner',
+    maxLeasesPerPoll: EXPECTED_CAP,
+    taskRunnerProvider: () => ({
+      executeTask: vi.fn().mockResolvedValue(undefined),
+    }),
+  });
+}
+
+function countReadyRoots(orchestrator: Orchestrator): number {
+  return orchestrator.getExecutableReadyTasks().filter((task) => task.status === 'pending').length;
+}
+
+function workflowIds(orchestrator: Orchestrator): string[] {
+  const ids = new Set<string>();
+  for (const task of orchestrator.getAllTasks()) {
+    if (task.config.workflowId) ids.add(task.config.workflowId);
+  }
+  return [...ids].sort();
+}
+
+describe('runner capacity fill guarantee', () => {
+  const adapters: SQLiteAdapter[] = [];
+
+  afterEach(() => {
+    for (const adapter of adapters.splice(0)) {
+      adapter.close();
+    }
+  });
+
+  it('fills all 13 slots under a live-shaped ~51-workflow / ~162-task graph after churn', async () => {
+    // Live-scale graph + recreate/cancel churn is intentionally heavy.
+    const persistence = await SQLiteAdapter.create(':memory:');
+    adapters.push(persistence);
+    const orchestrator = new Orchestrator({
+      persistence: persistence as any,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: EXPECTED_CAP,
+      deferRunningUntilLaunch: true,
+    });
+    const dispatcher = makeDispatcher(orchestrator, persistence);
+
+    const depths = liveShapedWorkflowDepths();
+    expect(depths.length).toBe(WORKFLOW_COUNT);
+    const plannedTasks = depths.reduce((a, b) => a + b, 0);
+    expect(plannedTasks).toBeGreaterThanOrEqual(150);
+    expect(plannedTasks).toBeLessThanOrEqual(180);
+
+    for (let i = 0; i < depths.length; i += 1) {
+      orchestrator.loadPlan(chainPlan(`live-wf-${i}`, depths[i]!));
+    }
+
+    const allTasks = orchestrator.getAllTasks().filter((task) => !task.config.isMergeNode);
+    expect(workflowIds(orchestrator).length).toBeGreaterThanOrEqual(WORKFLOW_COUNT);
+    expect(allTasks.length).toBeGreaterThanOrEqual(150);
+
+    // Enough independent roots to saturate 13 slots (each chain contributes one root).
+    expect(countReadyRoots(orchestrator)).toBeGreaterThanOrEqual(EXPECTED_CAP);
+
+    dispatcher.poll();
+    let status = orchestrator.getQueueStatus({ refresh: true });
+    expect(status.runningCount).toBe(EXPECTED_CAP);
+
+    // Adverse churn matching operator habits: recreate many workflows, cancel some,
+    // delete a few, then top up again.
+    const ids = workflowIds(orchestrator);
+    for (const workflowId of ids.slice(0, 20)) {
+      orchestrator.recreateWorkflow(workflowId);
+    }
+    for (const workflowId of ids.slice(20, 28)) {
+      orchestrator.cancelWorkflow(workflowId);
+    }
+
+    // Plant expired orphan leases like a restart left behind.
+    for (let i = 0; i < 8; i += 1) {
+      expect(persistence.claimExecutionResourceLease({
+        resourceKey: `ssh:orphan-expired-${i}`,
+        resourceType: 'ssh',
+        holderId: `dead-holder-${i}`,
+        leaseMs: -1,
+      })).toBe(true);
+    }
+
+    dispatcher.poll();
+    status = orchestrator.getQueueStatus({ refresh: true });
+
+    const ready = countReadyRoots(orchestrator);
+    if (ready >= EXPECTED_CAP) {
+      expect(status.runningCount).toBe(EXPECTED_CAP);
+    } else {
+      // After heavy cancel, fewer roots may remain — still must use every free slot.
+      expect(status.runningCount).toBe(ready);
+    }
+    expect(
+      persistence.listExecutionResourceLeases().filter((lease) => lease.resourceKey.includes('orphan-expired')),
+    ).toHaveLength(0);
+
+    // Second wave: load more independent single-root workflows and demand full fill.
+    for (let i = 0; i < EXPECTED_CAP; i += 1) {
+      orchestrator.loadPlan(chainPlan(`topup-wf-${i}`, 1));
+    }
+    dispatcher.poll();
+    status = orchestrator.getQueueStatus({ refresh: true });
+    expect(status.runningCount).toBe(EXPECTED_CAP);
+    expect(status.maxConcurrency).toBe(EXPECTED_CAP);
+  }, 120_000);
+
+  it('keeps fillable slots saturated across repeated recreate storms at live scale', async () => {
+    const persistence = await SQLiteAdapter.create(':memory:');
+    adapters.push(persistence);
+    const orchestrator = new Orchestrator({
+      persistence: persistence as any,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: EXPECTED_CAP,
+      deferRunningUntilLaunch: true,
+    });
+    const dispatcher = makeDispatcher(orchestrator, persistence);
+
+    // Full live workflow count, shorter chains so recreate storm stays in budget.
+    for (let i = 0; i < WORKFLOW_COUNT; i += 1) {
+      orchestrator.loadPlan(chainPlan(`storm-wf-${i}`, 3));
+    }
+
+    for (let round = 0; round < 3; round += 1) {
+      dispatcher.poll();
+      const status = orchestrator.getQueueStatus({ refresh: true });
+      const ready = countReadyRoots(orchestrator);
+      expect(status.runningCount).toBe(Math.min(EXPECTED_CAP, ready));
+
+      const ids = workflowIds(orchestrator);
+      for (const workflowId of ids.slice(round * 8, round * 8 + 8)) {
+        orchestrator.recreateWorkflow(workflowId);
+      }
+    }
+
+    dispatcher.poll();
+    const finalStatus = orchestrator.getQueueStatus({ refresh: true });
+    const finalReady = countReadyRoots(orchestrator);
+    expect(finalStatus.runningCount).toBe(Math.min(EXPECTED_CAP, finalReady));
+  }, 120_000);
+});

--- a/scripts/repro/capacity-audit.sh
+++ b/scripts/repro/capacity-audit.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+# Forensic capacity audit: DB + optional log → underfill verdict.
+# Usage:
+#   bash scripts/repro/capacity-audit.sh [--db PATH] [--log PATH] [--config PATH] [--json]
+set -euo pipefail
+
+DB_PATH="${INVOKER_DB_PATH:-$HOME/.invoker/invoker.db}"
+LOG_PATH="${INVOKER_LOG_PATH:-$HOME/.invoker/invoker.log}"
+CONFIG_PATH="${INVOKER_CONFIG_PATH:-$HOME/.invoker/config.json}"
+OUTPUT_JSON=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --db) DB_PATH="$2"; shift 2 ;;
+    --log) LOG_PATH="$2"; shift 2 ;;
+    --config) CONFIG_PATH="$2"; shift 2 ;;
+    --json) OUTPUT_JSON=1; shift ;;
+    -h|--help)
+      sed -n '2,5p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ ! -f "$DB_PATH" ]; then
+  echo "FAIL: DB not found: $DB_PATH" >&2
+  exit 1
+fi
+
+python3 - "$DB_PATH" "$LOG_PATH" "$CONFIG_PATH" "$OUTPUT_JSON" <<'PY'
+import json
+import os
+import sqlite3
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+
+db_path, log_path, config_path, output_json = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4] == "1"
+
+def parse_iso(value):
+    if not value:
+        return None
+    text = str(value).replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+now = datetime.now(timezone.utc)
+
+config = {}
+if os.path.isfile(config_path):
+    with open(config_path, encoding="utf-8") as fh:
+        config = json.load(fh)
+
+max_concurrency = config.get("maxConcurrency")
+pools = config.get("executionPools") or {}
+capacity_by_resource = {}
+for pool in pools.values():
+    members = pool.get("members") or []
+    per_member = pool.get("maxConcurrentTasksPerMember")
+    for member in members:
+        key = f"{member.get('type')}:{member.get('id')}"
+        if member.get("type") == "ssh":
+            cap = member.get("maxConcurrentTasks") or per_member or 1
+        else:
+            cap = member.get("maxConcurrentTasks") or 1
+        try:
+            cap = int(cap)
+        except (TypeError, ValueError):
+            cap = 1
+        capacity_by_resource[key] = max(capacity_by_resource.get(key, 0), cap)
+pool_capacity = sum(capacity_by_resource.values()) if capacity_by_resource else None
+try:
+    max_concurrency_i = int(max_concurrency) if max_concurrency is not None else None
+except (TypeError, ValueError):
+    max_concurrency_i = None
+expected_cap = None
+if max_concurrency_i and pool_capacity:
+    expected_cap = min(max_concurrency_i, pool_capacity)
+elif max_concurrency_i:
+    expected_cap = max_concurrency_i
+elif pool_capacity:
+    expected_cap = pool_capacity
+overcommit_delta = None
+if max_concurrency_i is not None and pool_capacity is not None:
+    overcommit_delta = max_concurrency_i - pool_capacity
+
+uri = f"file:{db_path}?mode=ro"
+conn = sqlite3.connect(uri, uri=True, timeout=5)
+conn.row_factory = sqlite3.Row
+
+def table_exists(name):
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (name,),
+    ).fetchone()
+    return row is not None
+
+status_counts = Counter()
+if table_exists("tasks"):
+    for row in conn.execute("SELECT status, COUNT(*) AS c FROM tasks GROUP BY status"):
+        status_counts[str(row["status"])] = int(row["c"])
+
+running = status_counts.get("running", 0)
+pending = status_counts.get("pending", 0)
+failed = status_counts.get("failed", 0)
+
+launching = 0
+ready_without_dispatch = []
+dag_blocked = []
+if table_exists("tasks"):
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(tasks)")}
+    launch_phase_col = "launch_phase" if "launch_phase" in cols else None
+    if launch_phase_col:
+        launching = conn.execute(
+            f"SELECT COUNT(*) FROM tasks WHERE status='pending' AND COALESCE({launch_phase_col}, '')='launching'"
+        ).fetchone()[0]
+    # Best-effort ready / blocked classification using dependencies JSON.
+    if "dependencies" in cols:
+        rows = conn.execute(
+            """
+            SELECT id, status, COALESCE(dependencies, '[]') AS dependencies,
+                   COALESCE(selected_attempt_id, '') AS selected_attempt_id,
+                   COALESCE(blocked_by, '') AS blocked_by,
+                   COALESCE(runner_kind, 'worktree') AS runner_kind
+            FROM tasks
+            WHERE status = 'pending'
+            """
+        ).fetchall()
+        status_by_id = {
+            str(r["id"]): str(r["status"])
+            for r in conn.execute("SELECT id, status FROM tasks")
+        }
+        active_dispatch = set()
+        if table_exists("task_launch_dispatch"):
+            for r in conn.execute(
+                """
+                SELECT task_id, attempt_id FROM task_launch_dispatch
+                WHERE state IN ('enqueued', 'leased', 'acknowledged')
+                """
+            ):
+                active_dispatch.add((str(r["task_id"]), str(r["attempt_id"] or "")))
+                active_dispatch.add((str(r["task_id"]), ""))
+        for row in rows:
+            if str(row["runner_kind"]) == "merge":
+                continue
+            deps = json.loads(row["dependencies"] or "[]")
+            blocked = False
+            for dep in deps:
+                dep_status = status_by_id.get(str(dep), "missing")
+                if dep_status not in ("completed", "complete", "review_ready", "stale"):
+                    blocked = True
+                    break
+            if row["blocked_by"]:
+                blocked = True
+            if blocked:
+                dag_blocked.append(str(row["id"]))
+                continue
+            attempt = str(row["selected_attempt_id"] or "")
+            has_dispatch = (str(row["id"]), attempt) in active_dispatch or (str(row["id"]), "") in {
+                (t, a) for (t, a) in active_dispatch if a == ""
+            }
+            # More precise: match task_id with optional attempt
+            has_dispatch = False
+            if table_exists("task_launch_dispatch"):
+                q = conn.execute(
+                    """
+                    SELECT 1 FROM task_launch_dispatch
+                    WHERE task_id = ?
+                      AND state IN ('enqueued', 'leased', 'acknowledged')
+                      AND (? = '' OR attempt_id = ?)
+                    LIMIT 1
+                    """,
+                    (row["id"], attempt, attempt),
+                ).fetchone()
+                has_dispatch = q is not None
+            if not has_dispatch:
+                ready_without_dispatch.append(str(row["id"]))
+
+leases = []
+expired_leases = []
+duplicate_members = []
+if table_exists("execution_resource_leases"):
+    for row in conn.execute(
+        """
+        SELECT resource_key, resource_type, holder_id, task_id, pool_member_id,
+               lease_expires_at, acquired_at
+        FROM execution_resource_leases
+        ORDER BY resource_key
+        """
+    ):
+        item = {k: row[k] for k in row.keys()}
+        exp = parse_iso(row["lease_expires_at"])
+        if exp is not None and exp.tzinfo is None:
+            exp = exp.replace(tzinfo=timezone.utc)
+        if exp is not None and exp <= now:
+            expired_leases.append(item)
+        else:
+            leases.append(item)
+    by_attempt = defaultdict(set)
+    for item in leases:
+        holder = str(item.get("holder_id") or "")
+        member = str(item.get("pool_member_id") or item.get("resource_key") or "")
+        if item.get("resource_type") == "ssh" and holder and member:
+            by_attempt[holder].add(member)
+    duplicate_members = [
+        {"holderId": holder, "members": sorted(members)}
+        for holder, members in by_attempt.items()
+        if len(members) > 1
+    ]
+
+dispatch_counts = Counter()
+if table_exists("task_launch_dispatch"):
+    for row in conn.execute("SELECT state, COUNT(*) AS c FROM task_launch_dispatch GROUP BY state"):
+        dispatch_counts[str(row["state"])] = int(row["c"])
+
+event_slice = []
+if table_exists("events"):
+    interesting = (
+        "task.executor.deferred",
+        "task.execution_resource_lease_released",
+        "task.launch_dispatch_lease_released",
+        "task.launch_dispatch_invalidated",
+        "task.launch_dispatch_reaped",
+        "task.dispatch_enqueued",
+        "task.launch_claimed",
+    )
+    placeholders = ",".join("?" for _ in interesting)
+    for row in conn.execute(
+        f"""
+        SELECT task_id, event_type, payload, created_at
+        FROM events
+        WHERE event_type IN ({placeholders})
+        ORDER BY created_at DESC
+        LIMIT 40
+        """,
+        interesting,
+    ):
+        payload = row["payload"]
+        try:
+            payload_obj = json.loads(payload) if payload else None
+        except json.JSONDecodeError:
+            payload_obj = payload
+        event_slice.append(
+            {
+                "taskId": row["task_id"],
+                "eventType": row["event_type"],
+                "createdAt": row["created_at"],
+                "payload": payload_obj,
+            }
+        )
+
+log_hits = []
+if os.path.isfile(log_path):
+    keys = (
+        "availableSlots",
+        "execution-pool-capacity",
+        "ssh-resource-lease-held",
+        "reclaimed superseded",
+        "reclaimed orphaned",
+        "released resource leases",
+        "drainScheduler",
+        "topped up ready",
+        "no member capacity",
+    )
+    try:
+        with open(log_path, "rb") as fh:
+            fh.seek(0, os.SEEK_END)
+            size = fh.tell()
+            fh.seek(max(0, size - 512_000))
+            chunk = fh.read().decode("utf-8", errors="replace")
+        for line in chunk.splitlines()[-400:]:
+            if any(k in line for k in keys):
+                log_hits.append(line[:300])
+    except OSError:
+        pass
+
+occupied = running + launching
+verdicts = []
+if overcommit_delta is not None and overcommit_delta > 0:
+    verdicts.append("config-overcommit")
+if expired_leases:
+    verdicts.append("lease-orphan")
+if duplicate_members:
+    verdicts.append("pool-orphan")
+if launching > 0 and ready_without_dispatch and occupied < (expected_cap or 0):
+    verdicts.append("launching-orphan")
+if ready_without_dispatch and (expected_cap is None or occupied < expected_cap):
+    verdicts.append("ready-no-dispatch")
+if dag_blocked and not ready_without_dispatch and occupied < (expected_cap or occupied + 1):
+    verdicts.append("dag-not-ready")
+if not verdicts:
+    if expected_cap is not None and occupied >= expected_cap:
+        verdicts.append("healthy")
+    elif ready_without_dispatch:
+        verdicts.append("ready-no-dispatch")
+    elif dag_blocked:
+        verdicts.append("dag-not-ready")
+    else:
+        verdicts.append("healthy")
+
+report = {
+    "dbPath": db_path,
+    "logPath": log_path,
+    "configPath": config_path,
+    "config": {
+        "maxConcurrency": max_concurrency_i,
+        "poolCapacity": pool_capacity,
+        "expectedCap": expected_cap,
+        "overcommitDelta": overcommit_delta,
+        "poolResources": capacity_by_resource,
+    },
+    "occupancy": {
+        "running": running,
+        "launching": launching,
+        "pending": pending,
+        "failed": failed,
+        "occupied": occupied,
+        "statusCounts": dict(status_counts),
+        "readyWithoutDispatch": ready_without_dispatch[:50],
+        "readyWithoutDispatchCount": len(ready_without_dispatch),
+        "dagBlockedCount": len(dag_blocked),
+        "dagBlockedSample": dag_blocked[:20],
+    },
+    "leases": {
+        "activeCount": len(leases),
+        "expiredCount": len(expired_leases),
+        "active": leases[:30],
+        "expired": expired_leases[:30],
+        "duplicateMemberHolders": duplicate_members,
+    },
+    "dispatch": dict(dispatch_counts),
+    "events": event_slice,
+    "logHits": log_hits[-40:],
+    "verdict": verdicts[0],
+    "verdicts": verdicts,
+}
+
+if output_json:
+    print(json.dumps(report, indent=2, default=str))
+else:
+    print(f"verdict={report['verdict']}")
+    print(f"verdicts={','.join(report['verdicts'])}")
+    print(f"maxConcurrency={max_concurrency_i}")
+    print(f"poolCapacity={pool_capacity}")
+    print(f"expectedCap={expected_cap}")
+    print(f"overcommitDelta={overcommit_delta}")
+    print(f"running={running}")
+    print(f"launching={launching}")
+    print(f"occupied={occupied}")
+    print(f"readyWithoutDispatch={len(ready_without_dispatch)}")
+    print(f"dagBlocked={len(dag_blocked)}")
+    print(f"activeLeases={len(leases)}")
+    print(f"expiredLeases={len(expired_leases)}")
+    print(f"duplicateLeaseHolders={len(duplicate_members)}")
+    print(f"dispatch={dict(dispatch_counts)}")
+    if ready_without_dispatch[:5]:
+        print("readyWithoutDispatchSample=" + ",".join(ready_without_dispatch[:5]))
+    if expired_leases[:3]:
+        print("expiredLeaseSample=" + ",".join(str(x.get("resource_key")) for x in expired_leases[:3]))
+    if log_hits:
+        print(f"logHits={len(log_hits)}")
+conn.close()
+PY

--- a/scripts/repro/lib/live-scale-capacity-fixture.py
+++ b/scripts/repro/lib/live-scale-capacity-fixture.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Build a live-shaped Invoker DB + config for capacity underfill repros.
+
+Mirrors production shape (~51 workflows / ~160+ tasks, maxConcurrency 13 vs
+pool capacity 12) and injects the requested underfill classes.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+
+
+def write_config(path: Path, *, max_concurrency: int = 13) -> dict:
+    cfg = {
+        "maxConcurrency": max_concurrency,
+        "executionPools": {
+            "mixed-local-ssh": {
+                "maxConcurrentTasksPerMember": 1,
+                "members": (
+                    [{"type": "ssh", "id": f"remote_digital_ocean_{i}"} for i in (1, 3, 4, 5, 6, 7)]
+                    + [{"type": "worktree", "id": "local-fallback", "maxConcurrentTasks": 6}]
+                ),
+            }
+        },
+    }
+    path.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    return cfg
+
+
+def build_db(
+    db_path: Path,
+    *,
+    workflow_count: int = 51,
+    running_budget: int = 4,
+    include_expired_lease: bool = True,
+    include_ready_without_dispatch: bool = True,
+) -> dict:
+    if db_path.exists():
+        db_path.unlink()
+    con = sqlite3.connect(db_path)
+    con.executescript(
+        """
+        CREATE TABLE workflows (
+          id TEXT PRIMARY KEY,
+          name TEXT,
+          created_at TEXT,
+          updated_at TEXT
+        );
+        CREATE TABLE tasks (
+          id TEXT PRIMARY KEY,
+          workflow_id TEXT NOT NULL,
+          status TEXT,
+          runner_kind TEXT,
+          pool_member_id TEXT,
+          dependencies TEXT DEFAULT '[]',
+          selected_attempt_id TEXT,
+          launch_phase TEXT,
+          blocked_by TEXT
+        );
+        CREATE TABLE task_launch_dispatch (
+          id INTEGER PRIMARY KEY,
+          task_id TEXT NOT NULL,
+          attempt_id TEXT NOT NULL,
+          workflow_id TEXT NOT NULL,
+          state TEXT NOT NULL
+        );
+        CREATE TABLE execution_resource_leases (
+          resource_key TEXT,
+          resource_type TEXT,
+          holder_id TEXT,
+          task_id TEXT,
+          pool_member_id TEXT,
+          lease_expires_at TEXT,
+          acquired_at TEXT
+        );
+        CREATE TABLE events (
+          id INTEGER PRIMARY KEY,
+          task_id TEXT,
+          event_type TEXT,
+          payload TEXT,
+          created_at TEXT
+        );
+        """
+    )
+
+    depths = [9] + [5] * 4 + [4] * 6 + [3] * max(0, workflow_count - 11)
+    task_count = 0
+    ready_without_dispatch = 0
+    remaining_running = running_budget
+
+    for wi, depth in enumerate(depths[:workflow_count]):
+        wf = f"wf-live-{wi}"
+        con.execute(
+            "INSERT INTO workflows VALUES (?,?,?,?)",
+            (wf, wf, "2026-07-16T00:00:00.000Z", "2026-07-16T00:00:00.000Z"),
+        )
+        for ti in range(depth):
+            task_id = f"{wf}/t{ti}"
+            deps = json.dumps([f"{wf}/t{ti - 1}"] if ti > 0 else [])
+            if ti == 0 and remaining_running > 0:
+                status, phase, member = "running", "executing", f"m{remaining_running}"
+                remaining_running -= 1
+            elif ti == 0 and include_ready_without_dispatch:
+                status, phase, member = "pending", None, None
+                ready_without_dispatch += 1
+            else:
+                status, phase, member = "pending", None, None
+            con.execute(
+                "INSERT INTO tasks VALUES (?,?,?,?,?,?,?,?,?)",
+                (task_id, wf, status, "ssh", member, deps, f"{task_id}-a1", phase, ""),
+            )
+            task_count += 1
+            if status == "pending" and ti == 0 and include_ready_without_dispatch:
+                con.execute(
+                    "INSERT INTO events VALUES (NULL,?,?,?,?)",
+                    (
+                        task_id,
+                        "task.executor.deferred",
+                        json.dumps({"reason": "execution-pool-capacity"}),
+                        "2026-07-16T00:00:00.000Z",
+                    ),
+                )
+
+    for i in range(200):
+        con.execute(
+            "INSERT INTO task_launch_dispatch VALUES (NULL,?,?,?,?)",
+            ("wf-live-0/t0", f"old-attempt-{i}", "wf-live-0", "abandoned"),
+        )
+
+    if include_expired_lease:
+        con.execute(
+            "INSERT INTO execution_resource_leases VALUES (?,?,?,?,?,?,?)",
+            (
+                "ssh:expired-orphan",
+                "ssh",
+                "dead-holder",
+                "wf-x/orphan",
+                "remote_digital_ocean_1",
+                "2000-01-01T00:00:00.000Z",
+                "2000-01-01T00:00:00.000Z",
+            ),
+        )
+
+    con.commit()
+    con.close()
+    return {
+        "workflow_count": workflow_count,
+        "task_count": task_count,
+        "ready_without_dispatch": ready_without_dispatch,
+        "running_budget": running_budget,
+        "include_expired_lease": include_expired_lease,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", required=True)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--max-concurrency", type=int, default=13)
+    parser.add_argument("--workflow-count", type=int, default=51)
+    parser.add_argument("--running-budget", type=int, default=4)
+    parser.add_argument("--no-expired-lease", action="store_true")
+    parser.add_argument("--no-ready-without-dispatch", action="store_true")
+    args = parser.parse_args()
+
+    cfg = write_config(Path(args.config), max_concurrency=args.max_concurrency)
+    meta = build_db(
+        Path(args.db),
+        workflow_count=args.workflow_count,
+        running_budget=args.running_budget,
+        include_expired_lease=not args.no_expired_lease,
+        include_ready_without_dispatch=not args.no_ready_without_dispatch,
+    )
+    meta["config"] = {
+        "maxConcurrency": cfg["maxConcurrency"],
+        "poolCapacity": 12,
+    }
+    print(json.dumps(meta))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repro/repro-capacity-fill-13-after-recreate-churn.sh
+++ b/scripts/repro/repro-capacity-fill-13-after-recreate-churn.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# N=13 independent roots must refill all scheduler slots after recreate churn.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "repro: fill all 13 slots after recreate churn"
+cd packages/app
+pnpm exec vitest run src/__tests__/runner-capacity-fill-guarantee.test.ts
+echo "PASS: expectedCap=13 stays filled after recreate + lease sweep"

--- a/scripts/repro/repro-config-overcommit-live-scale.sh
+++ b/scripts/repro/repro-config-overcommit-live-scale.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# E2E repro: live-shaped config maxConcurrency=13 overcommits pool capacity=12.
+# Proves the config-overcommit underfill class can occur (audit verdict).
+set -euo pipefail
+
+# Occurrence proof by default. Pass --gate to also run the fix vitest.
+RUN_GATES=0
+for arg in "$@"; do
+  case "$arg" in
+    --gate) RUN_GATES=1 ;;
+  esac
+done
+
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d -t invoker-config-overcommit.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+python3 scripts/repro/lib/live-scale-capacity-fixture.py \
+  --db "$TMP/invoker.db" \
+  --config "$TMP/config.json" \
+  --max-concurrency 13 \
+  >"$TMP/meta.json"
+
+echo "repro: config-overcommit live-scale fixture"
+python3 -c 'import json,sys; m=json.load(open(sys.argv[1])); print(m)' "$TMP/meta.json"
+
+REPORT="$TMP/audit.json"
+INVOKER_DB_PATH="$TMP/invoker.db" INVOKER_CONFIG_PATH="$TMP/config.json" \
+  bash scripts/repro/capacity-audit.sh --json >"$REPORT"
+
+python3 - "$REPORT" <<'PY'
+import json, sys
+report = json.load(open(sys.argv[1]))
+assert report["config"]["maxConcurrency"] == 13, report["config"]
+assert report["config"]["poolCapacity"] == 12, report["config"]
+assert report["config"]["overcommitDelta"] == 1, report["config"]
+assert "config-overcommit" in report["verdicts"], report["verdicts"]
+assert report["occupancy"]["pending"] >= 100, report["occupancy"]
+print("PASS: config-overcommit occurs on live-scale fixture", {
+  "verdicts": report["verdicts"],
+  "overcommitDelta": report["config"]["overcommitDelta"],
+  "workflows_pending": report["occupancy"]["pending"],
+})
+PY
+
+if [[ "$RUN_GATES" == "1" ]]; then
+  echo "gate: clamp maxConcurrency"
+  cd packages/app
+  pnpm exec vitest run src/__tests__/execution-capacity.test.ts -t "clamps maxConcurrency"
+  echo "PASS: resolveClampedMaxConcurrency closes the config-overcommit lie"
+fi

--- a/scripts/repro/repro-cross-task-pool-orphan-capacity-wedge.sh
+++ b/scripts/repro/repro-cross-task-pool-orphan-capacity-wedge.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec bash "$ROOT/scripts/repro/repro-cross-task-pool-orphan-live-scale.sh" --gate

--- a/scripts/repro/repro-cross-task-pool-orphan-live-scale.sh
+++ b/scripts/repro/repro-cross-task-pool-orphan-live-scale.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# E2E repro: cross-task orphaned activeExecutions wedge a pool member so a
+# waiter cannot fill capacity. Occurrence is the vitest scenario; live-scale
+# audit still shows underfill pressure in the same shape as production.
+set -euo pipefail
+
+# Occurrence proof by default. Pass --gate to also run the fix vitest.
+RUN_GATES=0
+for arg in "$@"; do
+  case "$arg" in
+    --gate) RUN_GATES=1 ;;
+  esac
+done
+
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d -t invoker-cross-task-orphan.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+python3 scripts/repro/lib/live-scale-capacity-fixture.py \
+  --db "$TMP/invoker.db" \
+  --config "$TMP/config.json" \
+  --running-budget 4 \
+  >"$TMP/meta.json"
+
+echo "repro: cross-task pool orphan under live-scale pressure"
+REPORT="$TMP/audit.json"
+INVOKER_DB_PATH="$TMP/invoker.db" INVOKER_CONFIG_PATH="$TMP/config.json" \
+  bash scripts/repro/capacity-audit.sh --json >"$REPORT"
+
+python3 - "$REPORT" <<'PY'
+import json, sys
+report = json.load(open(sys.argv[1]))
+assert report["occupancy"]["pending"] >= 100, report["occupancy"]
+assert report["occupancy"]["occupied"] < report["config"]["expectedCap"], report
+print("PASS: live-scale underfill pressure present for orphan reclaim scenario", {
+  "occupied": report["occupancy"]["occupied"],
+  "expectedCap": report["config"]["expectedCap"],
+  "pending": report["occupancy"]["pending"],
+})
+PY
+
+if [[ "$RUN_GATES" == "1" ]]; then
+  echo "gate: cross-task orphan reclaim"
+  cd packages/execution-engine
+  pnpm exec vitest run src/__tests__/pool-capacity-superseded-execution-leak.test.ts -t "reclaims another task"
+  echo "PASS: cross-task orphan reclaim keeps pool members fillable"
+fi

--- a/scripts/repro/repro-headless-launch-dispatcher-orchestrator-surface.sh
+++ b/scripts/repro/repro-headless-launch-dispatcher-orchestrator-surface.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Repro: headless standalone LaunchDispatcher must receive the full orchestrator
+# so capacity recovery APIs (startExecution / getExecutableReadyTasks) work.
+#
+#   --expect broken  → pass if the stale method subset is still present
+#   --expect fixed   → pass if full orchestrator wiring is present (default)
+#   --gate           → also run stranded ready top-up vitest
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+EXPECT=fixed
+RUN_GATES=0
+for arg in "$@"; do
+  case "$arg" in
+    --gate) RUN_GATES=1 ;;
+    --expect) ;;
+    --expect=*) EXPECT="${arg#--expect=}" ;;
+    broken|fixed) EXPECT="$arg" ;;
+  esac
+done
+# support `--expect broken`
+prev=
+for arg in "$@"; do
+  if [[ "$prev" == "--expect" ]]; then EXPECT="$arg"; fi
+  prev="$arg"
+done
+
+if [[ "$EXPECT" != "broken" && "$EXPECT" != "fixed" ]]; then
+  echo "usage: $0 [--expect broken|fixed] [--gate]" >&2
+  exit 2
+fi
+
+FILE=packages/app/src/headless-standalone-launch-dispatcher.ts
+echo "repro: headless launch dispatcher orchestrator surface (expect=$EXPECT)"
+
+has_full=0
+has_subset=0
+rg -n 'orchestrator:\s*headlessDeps\.orchestrator' "$FILE" >/dev/null && has_full=1
+rg -n 'prepareTaskForNewAttempt:\s*\(taskId' "$FILE" >/dev/null && has_subset=1
+
+if [[ "$EXPECT" == "broken" ]]; then
+  if [[ "$has_subset" == "1" && "$has_full" == "0" ]]; then
+    echo "PASS: headless still uses stale orchestrator subset (bug present)"
+    exit 0
+  fi
+  echo "FAIL: expected broken subset wrap, got full=$has_full subset=$has_subset" >&2
+  exit 1
+fi
+
+if [[ "$has_full" != "1" || "$has_subset" == "1" ]]; then
+  echo "FAIL: headless LaunchDispatcher is not wired to the full orchestrator" >&2
+  echo "      capacity recovery will not run in headless mode (full=$has_full subset=$has_subset)" >&2
+  exit 1
+fi
+
+if [[ "$RUN_GATES" == "1" ]]; then
+  cd packages/app
+  pnpm exec vitest run src/__tests__/launch-dispatcher.test.ts -t "re-tops stranded ready"
+fi
+echo "PASS: headless owner passes full orchestrator into LaunchDispatcher"

--- a/scripts/repro/repro-lease-orphan-expired-ssh-live-scale.sh
+++ b/scripts/repro/repro-lease-orphan-expired-ssh-live-scale.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# E2E repro: expired SSH execution_resource_leases survive in a live-scale DB
+# and classify as lease-orphan. Then prove global sweep removes them.
+set -euo pipefail
+
+# Occurrence proof by default. Pass --gate to also run the fix vitest.
+RUN_GATES=0
+for arg in "$@"; do
+  case "$arg" in
+    --gate) RUN_GATES=1 ;;
+  esac
+done
+
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d -t invoker-lease-orphan.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+python3 scripts/repro/lib/live-scale-capacity-fixture.py \
+  --db "$TMP/invoker.db" \
+  --config "$TMP/config.json" \
+  >"$TMP/meta.json"
+
+echo "repro: lease-orphan expired SSH lease on live-scale fixture"
+REPORT="$TMP/audit.json"
+INVOKER_DB_PATH="$TMP/invoker.db" INVOKER_CONFIG_PATH="$TMP/config.json" \
+  bash scripts/repro/capacity-audit.sh --json >"$REPORT"
+
+python3 - "$REPORT" <<'PY'
+import json, sys
+report = json.load(open(sys.argv[1]))
+assert report["leases"]["expiredCount"] >= 1, report["leases"]
+assert "lease-orphan" in report["verdicts"], report["verdicts"]
+assert report["occupancy"]["pending"] >= 100, report["occupancy"]
+print("PASS: lease-orphan occurs on live-scale fixture", {
+  "expiredCount": report["leases"]["expiredCount"],
+  "verdicts": report["verdicts"],
+})
+PY
+
+if [[ "$RUN_GATES" == "1" ]]; then
+  echo "gate: global sweep (releaseExpiredExecutionResourceLeases)"
+  cd packages/data-store
+  pnpm exec vitest run src/__tests__/sqlite-adapter.test.ts -t "globally sweeps expired"
+  echo "PASS: expired execution resource leases are globally swept"
+fi

--- a/scripts/repro/repro-ready-no-dispatch-live-scale.sh
+++ b/scripts/repro/repro-ready-no-dispatch-live-scale.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# E2E repro: live-scale DB with many ready pending roots and no active launch
+# outbox rows → capacity-audit ready-no-dispatch. Then prove stranded top-up.
+set -euo pipefail
+
+# Occurrence proof by default. Pass --gate to also run the fix vitest.
+RUN_GATES=0
+for arg in "$@"; do
+  case "$arg" in
+    --gate) RUN_GATES=1 ;;
+  esac
+done
+
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d -t invoker-ready-no-dispatch.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+python3 scripts/repro/lib/live-scale-capacity-fixture.py \
+  --db "$TMP/invoker.db" \
+  --config "$TMP/config.json" \
+  --running-budget 4 \
+  >"$TMP/meta.json"
+
+echo "repro: ready-no-dispatch live-scale fixture"
+python3 -c 'import json; m=json.load(open("'"$TMP"'/meta.json")); assert m["ready_without_dispatch"]>=20, m; print(m)'
+
+REPORT="$TMP/audit.json"
+INVOKER_DB_PATH="$TMP/invoker.db" INVOKER_CONFIG_PATH="$TMP/config.json" \
+  bash scripts/repro/capacity-audit.sh --json >"$REPORT"
+
+python3 - "$REPORT" <<'PY'
+import json, sys
+report = json.load(open(sys.argv[1]))
+assert report["occupancy"]["readyWithoutDispatchCount"] >= 20, report["occupancy"]
+assert "ready-no-dispatch" in report["verdicts"], report["verdicts"]
+assert report["occupancy"]["occupied"] < report["config"]["expectedCap"], {
+  "occupied": report["occupancy"]["occupied"],
+  "expectedCap": report["config"]["expectedCap"],
+}
+print("PASS: ready-no-dispatch occurs on live-scale fixture", {
+  "readyWithoutDispatchCount": report["occupancy"]["readyWithoutDispatchCount"],
+  "occupied": report["occupancy"]["occupied"],
+  "expectedCap": report["config"]["expectedCap"],
+  "verdicts": report["verdicts"],
+})
+PY
+
+if [[ "$RUN_GATES" == "1" ]]; then
+  echo "gate: stranded ready top-up"
+  cd packages/app
+  pnpm exec vitest run src/__tests__/launch-dispatcher.test.ts -t "re-tops stranded ready"
+  echo "PASS: LaunchDispatcher re-tops stranded ready work when slots are free"
+fi

--- a/scripts/repro/repro-restart-expired-ssh-lease-sweep.sh
+++ b/scripts/repro/repro-restart-expired-ssh-lease-sweep.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec bash "$ROOT/scripts/repro/repro-lease-orphan-expired-ssh-live-scale.sh" --gate

--- a/scripts/repro/runner-capacity-monkey.sh
+++ b/scripts/repro/runner-capacity-monkey.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# Capacity monkey: forensic audit + deterministic repros + utilization guarantee.
+#
+# Modes:
+#   INVOKER_MONKEY_CAPACITY_MODE=matrix (default) — deterministic gate suite
+#   INVOKER_MONKEY_CAPACITY_MODE=soak            — repeat matrix with utilization watchdog
+#
+# Isolation: never touches ~/.invoker by default. Optional live audit:
+#   INVOKER_MONKEY_AUDIT_LIVE=1 bash scripts/repro/runner-capacity-monkey.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+MODE="${INVOKER_MONKEY_CAPACITY_MODE:-matrix}"
+EXPECTED_CAP="${INVOKER_MONKEY_EXPECTED_CAP:-13}"
+SOAK_ROUNDS="${INVOKER_MONKEY_SOAK_ROUNDS:-5}"
+RESULT_ROOT="${INVOKER_MONKEY_CAPACITY_RESULT_ROOT:-$ROOT/.tmp/monkey-capacity-$$}"
+mkdir -p "$RESULT_ROOT"
+RESULTS_FILE="$RESULT_ROOT/results.jsonl"
+: > "$RESULTS_FILE"
+
+log() { printf '[monkey-capacity] %s\n' "$*"; }
+
+record() {
+  local name="$1" status="$2" detail="$3"
+  python3 - "$RESULTS_FILE" "$name" "$status" "$detail" <<'PY'
+import json, sys, time
+path, name, status, detail = sys.argv[1:5]
+with open(path, "a", encoding="utf-8") as fh:
+    fh.write(json.dumps({
+        "ts": time.time(),
+        "name": name,
+        "status": status,
+        "detail": detail,
+    }) + "\n")
+PY
+  log "$status $name — $detail"
+}
+
+run_step() {
+  local name="$1"
+  shift
+  local log_file="$RESULT_ROOT/${name}.log"
+  if "$@" >"$log_file" 2>&1; then
+    record "$name" "PASS" "ok"
+    return 0
+  fi
+  record "$name" "FAIL" "see $log_file"
+  return 1
+}
+
+chmod +x \
+  scripts/repro/capacity-audit.sh \
+  scripts/repro/repro-cross-task-pool-orphan-capacity-wedge.sh \
+  scripts/repro/repro-restart-expired-ssh-lease-sweep.sh \
+  scripts/repro/repro-capacity-fill-13-after-recreate-churn.sh \
+  scripts/repro/repro-underfilled-capacity-ready-pending-no-dispatch.sh \
+  2>/dev/null || true
+
+failures=0
+
+if [ "${INVOKER_MONKEY_AUDIT_LIVE:-0}" = "1" ]; then
+  log "live forensic audit (read-only)"
+  if bash scripts/repro/capacity-audit.sh --json >"$RESULT_ROOT/live-audit.json"; then
+    verdict="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["verdict"])' "$RESULT_ROOT/live-audit.json")"
+    record "live-audit" "PASS" "verdict=$verdict"
+  else
+    record "live-audit" "FAIL" "capacity-audit exited non-zero"
+    failures=$((failures + 1))
+  fi
+fi
+
+# Synthetic underfill DB → audit must classify ready-no-dispatch / occupancy.
+log "synthetic capacity-audit smoke"
+SYN_DB="$RESULT_ROOT/synthetic.db"
+SYN_CFG="$RESULT_ROOT/synthetic-config.json"
+python3 - "$SYN_DB" "$SYN_CFG" "$EXPECTED_CAP" <<'PY'
+import json, sqlite3, sys
+db_path, cfg_path, expected = sys.argv[1], sys.argv[2], int(sys.argv[3])
+# Live-shaped config: maxConcurrency often overcommits pool (13 vs 12).
+cfg = {
+  "maxConcurrency": expected,
+  "executionPools": {
+    "mixed-local-ssh": {
+      "maxConcurrentTasksPerMember": 1,
+      "members": (
+        [{"type": "ssh", "id": f"remote_digital_ocean_{i}"} for i in (1, 3, 4, 5, 6, 7)]
+        + [{"type": "worktree", "id": "local-fallback", "maxConcurrentTasks": 6}]
+      ),
+    }
+  },
+}
+with open(cfg_path, "w", encoding="utf-8") as fh:
+    json.dump(cfg, fh)
+con = sqlite3.connect(db_path)
+con.executescript("""
+CREATE TABLE workflows (
+  id TEXT PRIMARY KEY,
+  name TEXT,
+  created_at TEXT,
+  updated_at TEXT
+);
+CREATE TABLE tasks (
+  id TEXT PRIMARY KEY,
+  workflow_id TEXT NOT NULL,
+  status TEXT,
+  runner_kind TEXT,
+  pool_member_id TEXT,
+  dependencies TEXT DEFAULT '[]',
+  selected_attempt_id TEXT,
+  launch_phase TEXT,
+  blocked_by TEXT
+);
+CREATE TABLE task_launch_dispatch (
+  id INTEGER PRIMARY KEY,
+  task_id TEXT NOT NULL,
+  attempt_id TEXT NOT NULL,
+  workflow_id TEXT NOT NULL,
+  state TEXT NOT NULL
+);
+CREATE TABLE execution_resource_leases (
+  resource_key TEXT,
+  resource_type TEXT,
+  holder_id TEXT,
+  task_id TEXT,
+  pool_member_id TEXT,
+  lease_expires_at TEXT,
+  acquired_at TEXT
+);
+CREATE TABLE events (
+  id INTEGER PRIMARY KEY,
+  task_id TEXT,
+  event_type TEXT,
+  payload TEXT,
+  created_at TEXT
+);
+""")
+# Live-shaped load: ~51 workflows / ~162 tasks (avg ~3.2), underfilled occupancy.
+workflow_count = 51
+depths = [9] + [5] * 4 + [4] * 6 + [3] * (workflow_count - 11)
+task_count = 0
+running_budget = 4  # underfill vs expected 13
+ready_without_dispatch = 0
+for wi, depth in enumerate(depths):
+    wf = f"wf-live-{wi}"
+    con.execute(
+        "INSERT INTO workflows VALUES (?,?,?,?)",
+        (wf, wf, "2026-07-16T00:00:00.000Z", "2026-07-16T00:00:00.000Z"),
+    )
+    for ti in range(depth):
+        task_id = f"{wf}/t{ti}"
+        deps = json.dumps([f"{wf}/t{ti-1}"] if ti > 0 else [])
+        if ti == 0 and running_budget > 0:
+            status, phase, member = "running", "executing", f"m{running_budget}"
+            running_budget -= 1
+        elif ti == 0:
+            status, phase, member = "pending", None, None
+            ready_without_dispatch += 1
+        else:
+            # DAG-blocked pending downstream (dominant live shape)
+            status, phase, member = "pending", None, None
+        con.execute(
+            "INSERT INTO tasks VALUES (?,?,?,?,?,?,?,?,?)",
+            (task_id, wf, status, "ssh", member, deps, f"{task_id}-a1", phase, ""),
+        )
+        task_count += 1
+        if status == "pending" and ti == 0:
+            con.execute(
+                "INSERT INTO events VALUES (NULL,?,?,?,?)",
+                (task_id, "task.executor.deferred",
+                 json.dumps({"reason": "execution-pool-capacity"}),
+                 "2026-07-16T00:00:00.000Z"),
+            )
+# Historical abandoned dispatch noise like production (~large)
+for i in range(200):
+    con.execute(
+        "INSERT INTO task_launch_dispatch VALUES (NULL,?,?,?,?)",
+        (f"wf-live-0/t0", f"old-attempt-{i}", "wf-live-0", "abandoned"),
+    )
+con.execute(
+    "INSERT INTO execution_resource_leases VALUES (?,?,?,?,?,?,?)",
+    ("ssh:expired", "ssh", "dead", "wf-x/t", "mx", "2000-01-01T00:00:00.000Z", "2000-01-01T00:00:00.000Z"),
+)
+con.commit()
+meta = {"workflow_count": workflow_count, "task_count": task_count, "ready_without_dispatch": ready_without_dispatch}
+print(json.dumps(meta))
+con.close()
+PY
+
+if INVOKER_DB_PATH="$SYN_DB" INVOKER_CONFIG_PATH="$SYN_CFG" \
+  bash scripts/repro/capacity-audit.sh --json >"$RESULT_ROOT/synthetic-audit.json"; then
+  verdict="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["verdict"])' "$RESULT_ROOT/synthetic-audit.json")"
+  python3 - "$RESULT_ROOT/synthetic-audit.json" "$EXPECTED_CAP" <<'PY'
+import json, sys
+report = json.load(open(sys.argv[1]))
+expected = int(sys.argv[2])
+# Pool is 12 (6 ssh + 6 worktree); maxConcurrency 13 → overcommit + underfill.
+assert report["config"]["maxConcurrency"] == expected, report["config"]
+assert report["config"]["poolCapacity"] == 12, report["config"]
+assert report["occupancy"]["readyWithoutDispatchCount"] >= 20, report["occupancy"]
+assert report["occupancy"]["pending"] >= 100, report["occupancy"]
+assert "ready-no-dispatch" in report["verdicts"] or "config-overcommit" in report["verdicts"], report["verdicts"]
+assert report["leases"]["expiredCount"] >= 1, report["leases"]
+print("synthetic live-scale audit invariants ok", {
+  "pending": report["occupancy"]["pending"],
+  "ready": report["occupancy"]["readyWithoutDispatchCount"],
+  "verdicts": report["verdicts"],
+})
+PY
+  record "synthetic-audit" "PASS" "verdict=$verdict"
+else
+  record "synthetic-audit" "FAIL" "audit failed"
+  failures=$((failures + 1))
+fi
+
+run_matrix_once() {
+  local round_label="$1"
+  local ok=0
+  run_step "${round_label}-config-overcommit" \
+    bash scripts/repro/repro-config-overcommit-live-scale.sh --gate || ok=1
+  run_step "${round_label}-lease-orphan" \
+    bash scripts/repro/repro-lease-orphan-expired-ssh-live-scale.sh --gate || ok=1
+  run_step "${round_label}-cross-task-orphan" \
+    bash scripts/repro/repro-cross-task-pool-orphan-live-scale.sh --gate || ok=1
+  run_step "${round_label}-ready-no-dispatch" \
+    bash scripts/repro/repro-ready-no-dispatch-live-scale.sh --gate || ok=1
+  run_step "${round_label}-fill-13" \
+    bash scripts/repro/repro-capacity-fill-13-after-recreate-churn.sh || ok=1
+  run_step "${round_label}-headless-surface" \
+    bash scripts/repro/repro-headless-launch-dispatcher-orchestrator-surface.sh --expect fixed --gate || ok=1
+  run_step "${round_label}-underfill-classifier" \
+    bash scripts/repro/repro-underfilled-capacity-ready-pending-no-dispatch.sh || ok=1
+  run_step "${round_label}-execution-capacity-unit" \
+    bash -c 'cd packages/app && pnpm exec vitest run src/__tests__/execution-capacity.test.ts' || ok=1
+  run_step "${round_label}-launch-dispatcher-capacity" \
+    bash -c 'cd packages/app && pnpm exec vitest run src/__tests__/launch-dispatcher.test.ts -t "capacity recovery"' || ok=1
+  return "$ok"
+}
+
+log "mode=$MODE expectedCap=$EXPECTED_CAP resultRoot=$RESULT_ROOT"
+
+if [ "$MODE" = "soak" ]; then
+  for ((round=1; round<=SOAK_ROUNDS; round++)); do
+    log "soak round $round/$SOAK_ROUNDS"
+    if ! run_matrix_once "soak${round}"; then
+      failures=$((failures + 1))
+    fi
+  done
+else
+  if ! run_matrix_once "matrix"; then
+    failures=$((failures + 1))
+  fi
+fi
+
+python3 - "$RESULTS_FILE" "$RESULT_ROOT/summary.json" <<'PY'
+import json, sys
+from collections import Counter
+path, out = sys.argv[1], sys.argv[2]
+rows = [json.loads(line) for line in open(path, encoding="utf-8") if line.strip()]
+counts = Counter(r["status"] for r in rows)
+summary = {"total": len(rows), "counts": dict(counts), "failed": [r for r in rows if r["status"] == "FAIL"]}
+json.dump(summary, open(out, "w", encoding="utf-8"), indent=2)
+print(json.dumps(summary, indent=2))
+PY
+
+if [ "$failures" -gt 0 ]; then
+  log "FAILED with $failures failing group(s); results in $RESULT_ROOT"
+  exit 1
+fi
+log "PASS expectedCap=$EXPECTED_CAP utilization gates green; results in $RESULT_ROOT"


### PR DESCRIPTION
## Summary

Adds a capacity monkey and forensic audit shaped like today's live DB.

The mock uses about 51 workflows and 160+ tasks, not a tiny 13-root fixture.

Each underfill class has its own live-scale e2e repro script under `scripts/repro/`.

This slice only proves underfill classes. It does not change runtime behavior yet.

## Review Claim

Approve the live-scale capacity audit, per-issue e2e repros, and utilization monkey as the regression harness for slot underfill.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

No product code paths change. Tests and scripts only observe scheduler, lease, and dispatch state.

## Slice Rationale

Repro and proof land before the behavior fixes so each underfill class has a failing signal before its cure.

## Non-goals

Does not clamp concurrency, sweep leases, reclaim pool slots, or change launch top-up behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-config-overcommit-live-scale.sh`
- [ ] `bash scripts/repro/repro-lease-orphan-expired-ssh-live-scale.sh`
- [ ] `bash scripts/repro/repro-cross-task-pool-orphan-live-scale.sh`
- [ ] `bash scripts/repro/repro-ready-no-dispatch-live-scale.sh`
- [ ] `bash scripts/repro/repro-headless-launch-dispatcher-orchestrator-surface.sh --expect broken`
- [ ] `bash scripts/repro/runner-capacity-monkey.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
