### PR TITLE
[Runner Capacity](5) Re-top stranded ready work when slots are free

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -1069,6 +1069,56 @@ describe('LaunchDispatcher', () => {
       expect(leases[0]?.resourceKey).toBe('ssh:live');
     });
 
-  });
+    it('re-tops stranded ready work when free scheduler slots remain', () => {
+      const strandedTask = {
+        id: 'wf/ready',
+        status: 'pending',
+        execution: { selectedAttemptId: 'wf/ready-a1', generation: 0 },
+      };
+      const prepare = vi.fn();
+      const startExecution = vi.fn()
+        .mockReturnValueOnce([])
+        .mockReturnValueOnce([strandedTask]);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-topup',
+        orchestrator: {
+          prepareTaskForNewAttempt: prepare,
+          getExecutableReadyTasks: () => [strandedTask as any],
+          getQueueStatus: () => ({ runningCount: 2, maxConcurrency: 13 }),
+          isLaunchParked: () => false,
+          startExecution,
+        },
+        taskRunnerProvider: () => ({ executeTask: vi.fn() }),
+      });
+      dispatcher.poll();
+      expect(prepare).toHaveBeenCalledWith('wf/ready', 'launch-dispatcher-ready-topup');
+      expect(startExecution).toHaveBeenCalledTimes(2);
+    });
 
+    it('does not thrash parked ready tasks when slots are free', () => {
+      const parkedTask = {
+        id: 'wf/parked',
+        status: 'pending',
+        execution: { selectedAttemptId: 'wf/parked-a1', generation: 0 },
+      };
+      const prepare = vi.fn();
+      const startExecution = vi.fn().mockReturnValue([]);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-parked',
+        orchestrator: {
+          prepareTaskForNewAttempt: prepare,
+          getExecutableReadyTasks: () => [parkedTask as any],
+          getQueueStatus: () => ({ runningCount: 0, maxConcurrency: 13 }),
+          isLaunchParked: () => true,
+          startExecution,
+        },
+        taskRunnerProvider: () => ({ executeTask: vi.fn() }),
+      });
+      dispatcher.poll();
+      expect(prepare).not.toHaveBeenCalled();
+      expect(startExecution).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -41,6 +41,13 @@ export interface LaunchDispatcherOrchestrator {
   syncFromDb?(workflowId: string): void;
   getTask?(taskId: string): TaskState | undefined;
   getTaskLaunchReadiness?(taskId: string): TaskLaunchReadiness;
+  /**
+   * Optional: when startExecution leaves free slots idle with ready work that
+   * has no launching phase (lost outbox after cancel/recreate), mint attempts.
+   */
+  getExecutableReadyTasks?(): TaskState[];
+  getQueueStatus?(): { runningCount: number; maxConcurrency: number };
+  isLaunchParked?(taskId: string, now?: number): boolean;
   startExecution?(): TaskState[];
 }
 
@@ -142,7 +149,43 @@ export class LaunchDispatcher {
 
   private topUpReadyLaunches(): void {
     try {
-      const started = this.orchestrator?.startExecution?.() ?? [];
+      let started = this.orchestrator?.startExecution?.() ?? [];
+      // Ready pending roots can lose their outbox row after cancel/recreate while
+      // free scheduler slots remain. Mint a fresh attempt only for non-parked
+      // ready work, then drain again.
+      if (
+        started.length === 0
+        && typeof this.orchestrator?.getExecutableReadyTasks === 'function'
+        && typeof this.orchestrator.prepareTaskForNewAttempt === 'function'
+      ) {
+        const queue = this.orchestrator.getQueueStatus?.();
+        const freeSlots = queue
+          ? Math.max(0, queue.maxConcurrency - queue.runningCount)
+          : 0;
+        if (freeSlots > 0) {
+          const now = Date.now();
+          const stranded = this.orchestrator.getExecutableReadyTasks().filter((task) => {
+            if (task.status !== 'pending' || task.execution.phase === 'launching') return false;
+            if (this.orchestrator?.isLaunchParked?.(task.id, now)) return false;
+            return true;
+          });
+          const toRecover = stranded.slice(0, freeSlots);
+          for (const task of toRecover) {
+            this.orchestrator.prepareTaskForNewAttempt(task.id, 'launch-dispatcher-ready-topup');
+          }
+          if (toRecover.length > 0) {
+            started = this.orchestrator.startExecution?.() ?? [];
+            this.logger?.info?.('[launch-dispatcher] re-topped ready launches after stranded pending', {
+              ownerId: this.ownerId,
+              stranded: toRecover.length,
+              freeSlots,
+              started: started.length,
+              taskIds: toRecover.map((task) => task.id),
+              module: 'launch-dispatcher',
+            });
+          }
+        }
+      }
       if (started.length > 0) {
         this.logger?.info?.('[launch-dispatcher] topped up ready launches', {
           ownerId: this.ownerId,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2472,7 +2472,17 @@ function createEmbeddedTerminalBackendFromConfig(
       );
       launchDispatcher = new LaunchDispatcher({
         persistence,
-        orchestrator,
+        orchestrator: {
+          prepareTaskForNewAttempt: (taskId, reason) =>
+            orchestrator.prepareTaskForNewAttempt(taskId, reason),
+          syncFromDb: (workflowId) => orchestrator.syncFromDb(workflowId),
+          getTask: (taskId) => orchestrator.getTask(taskId),
+          getTaskLaunchReadiness: (taskId) => orchestrator.getTaskLaunchReadiness(taskId),
+          getExecutableReadyTasks: () => orchestrator.getExecutableReadyTasks(),
+          getQueueStatus: () => orchestrator.getQueueStatus({ refresh: false }),
+          isLaunchParked: (taskId, now) => orchestrator.isLaunchParked(taskId, now),
+          startExecution: () => orchestrator.startExecution(),
+        },
         // taskExecutor is re-built by rebuildTaskRunner(); read via
         // a provider so the dispatcher always picks up the current
         // instance instead of capturing a stale reference.

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -3073,7 +3073,7 @@ export class Orchestrator {
    * deferred set (retry / cancel / recreate / completion re-enqueue) releases
    * the park immediately, without a per-transition clear at every call site.
    */
-  private isLaunchParked(taskId: string, now: number): boolean {
+  isLaunchParked(taskId: string, now: number = Date.now()): boolean {
     const deferral = this.launchDeferrals.get(taskId);
     return deferral !== undefined
       && this.deferredTaskIds.has(taskId)


### PR DESCRIPTION
## Summary

Re-tops stranded ready roots when free scheduler slots remain after cancel or recreate.

Ready pending tasks could sit with no launch outbox row while capacity was idle.

Parked resource-limit tasks are skipped so the poll loop does not thrash them.

## Review Claim

Approve stranded ready recovery in LaunchDispatcher top-up when free slots remain.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Recovery runs only with free scheduler slots and skips `isLaunchParked` tasks.

## Slice Rationale

Monkey verdict `ready-no-dispatch` is the outbox/top-up gap after churn, separate from lease and pool orphans.

## Non-goals

Does not redesign the launch outbox schema or change DAG readiness rules.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-ready-no-dispatch-live-scale.sh --gate`
- [ ] `bash scripts/repro/repro-capacity-fill-13-after-recreate-churn.sh`
- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/launch-dispatcher.test.ts -t "capacity recovery"`
- [ ] `bash scripts/repro/runner-capacity-monkey.sh`

</details>

## Visual Proof

![Capacity fill before/after walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260717-e036a5/4800-capacity-fill-walkthrough.gif)

Animated before/after: underfilled occupancy recovers to fillable pool capacity after the fix.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>