### PR TITLE
[PR maintenance workers Step 8: Finalize worker-only operator docs](1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ Spread work across SSH targets and remote machines you already manage — same a
 
 ## Workers
 
-Invoker recovery is driven by a worker registry, not a single hard-coded auto-fix loop. Built-in worker definitions are registered by stable kind; `autofix` remains the built-in default worker for failed-task recovery and submits normal `fix-with-agent` intents after reconciling persisted state.
+Invoker background work is owned by the built-in worker registry. `autofix` is the default failed-task recovery worker; it reconciles persisted state and submits normal `fix-with-agent` intents instead of running recovery from task-state producers.
 
-Manual headless worker runs use the registered kind (`./run.sh --headless worker autofix`) and take a single-instance lock named for that kind, so a second `autofix` scan is refused without blocking other worker kinds. The same registry powers desktop worker status and start/stop controls.
+Run workers on the Invoker owner host. Operators can start and stop them from the desktop Workers tab, inspect them with `./run.sh --headless worker status --output text|json|jsonl`, or trigger one explicit scan with `./run.sh --headless worker <kind>`. Each kind takes its own single-instance lock, so a second scan of the same worker is refused without blocking other worker kinds.
 
-External worker support is configured with `externalWorkers`, where each entry declares a registry `kind` and a `launch` command (`executable`, optional `args`, optional `cwd`). The loader registers each external worker kind and supervises its process boundary: start/wake launches the process, stop terminates it, and producers still only publish lifecycle wakeups rather than launching scripts directly.
+PR maintenance uses the same owner-host worker path. Enable the built-in `coderabbit-address`, `pr-conflict-rebase`, and `pr-ci-failure-scan` workers with the `prMaintenance` config block; do not install separate cron jobs or external worker launchers for the supported setup.
 
 ## Install
 

--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -97,6 +97,18 @@
   "autoApproveAIFixes": true,
   "autoFixCi": false,
 
+  "prMaintenance": {
+    "comment": "Built-in owner-host PR maintenance workers. Enable on the host that owns the Invoker database; start/stop from Workers or run one scan with ./run.sh --headless worker <kind>.",
+    "enabled": true,
+    "repoRoot": "/srv/invoker",
+    "intervalMs": 300000,
+    "lockPath": "/tmp/invoker-pr-maintenance.lock",
+    "env": {
+      "INVOKER_GITHUB_TARGET_REPO": "acme/web",
+      "INVOKER_CODERABBIT_LOGIN": "coderabbitai[bot]"
+    }
+  },
+
   "webToken": "change-me-to-a-long-random-secret",
   "webHost": "127.0.0.1",
   "webPort": 4200,

--- a/docs/remote-ssh-targets.md
+++ b/docs/remote-ssh-targets.md
@@ -39,6 +39,21 @@ If you want to use a repo-specific config file, launch Invoker with `INVOKER_REP
 ```
 Invoker does not run repo bootstrap automatically on managed SSH checkouts. If a repo needs setup such as `pnpm install` or `flutter pub get`, make the task command run that repo-owned step explicitly.
 
+## Owner-host workers
+
+Remote SSH targets execute workflow tasks only. Long-lived operator automation belongs on the Invoker owner host, where the process owns the workflow database and worker registry.
+
+For the supported PR-maintenance setup, enable `prMaintenance` in `~/.invoker/config.json` on the owner host and run the built-in worker kinds from the Workers tab or headless CLI:
+
+```bash
+./run.sh --headless worker status --output text
+./run.sh --headless worker coderabbit-address
+./run.sh --headless worker pr-conflict-rebase
+./run.sh --headless worker pr-ci-failure-scan
+```
+
+Do not install separate cron jobs on SSH targets for these maintenance paths. The workers share the owner process, owner database, and per-kind worker locks; SSH targets stay disposable execution capacity.
+
 ### Fields
 
 | Field | Type | Required | Description |


### PR DESCRIPTION
## Summary

Finalize the worker-only operator docs after native parity and proof migration are complete.

Older guidance still showed mixed local fallback pools and separate PR-maintenance launchers. That left the supported path unclear after the worker-based path became the supported one.

This slice updates the sample config, README, and SSH guide so built-in `prMaintenance` workers are the only documented PR-maintenance setup.

## Review Claim

The remaining operator docs point only at the worker-based owner-host path.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice edits documentation and one sample config file only. No runtime code, worker behavior, tooling, or file deletion changes are included.

## Slice Rationale

Finishing the docs before the final cron-file removal keeps this review on one question: whether the supported operator path is now described consistently everywhere.

## Non-goals

- Do not delete retired cron files in this slice.
- Do not change worker or runtime behavior.
- Do not add new proof or automation.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node -e "JSON.parse(require('node:fs').readFileSync('docs/invoker-config-example.json', 'utf8'))"`
- [x] `git diff --stat origin/plan/pr-maintenance-workers-step-7-repro-migration...HEAD`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-step8-pr-body.md --changed-files-file /tmp/invoker-step8-changed.txt --diff-file /tmp/invoker-step8.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4afbb5fbe`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how built-in background and maintenance workers operate on the Invoker owner host.
  * Documented worker controls through the desktop Workers tab and headless CLI commands.
  * Added configuration guidance for pull request maintenance workers, including scheduling, locking, and environment settings.
  * Clarified that remote SSH targets are intended for workflow tasks, not long-running maintenance workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->