### PR TITLE
[Unblock runnable pending tasks](3) Reclaim a concurrency slot from a running task with an expired lease

### DIFF
--- a/packages/workflow-core/src/__tests__/zombie-running-slot-leak.test.ts
+++ b/packages/workflow-core/src/__tests__/zombie-running-slot-leak.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { Orchestrator } from '../orchestrator.js';
+import { InMemoryPersistence, InMemoryBus } from './helpers/cross-workflow-cascade-helpers.js';
+
+function makeOrchestratorWith(persistence: InMemoryPersistence, maxConcurrency: number): Orchestrator {
+  return new Orchestrator({ persistence, messageBus: new InMemoryBus(), maxConcurrency });
+}
+
+/**
+ * Repro for bug #1: a task stuck in `running` whose attempt lease has expired
+ * (its executor stopped heart-beating and no completion ever arrived) keeps
+ * consuming a global concurrency slot forever. With a full slot table, a
+ * genuinely ready pending task can never launch even though nothing is really
+ * executing.
+ */
+describe('zombie running task consumes a concurrency slot', () => {
+  it('does not count a running task with an expired lease against capacity', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestratorWith(persistence, 1);
+
+    // Workflow A takes the single slot and starts running.
+    orchestrator.loadPlan({
+      name: 'zombie-workflow',
+      baseBranch: 'master',
+      featureBranch: 'feature/zombie',
+      tasks: [{ id: 'stuck', description: 'runs then strands' }],
+    });
+    const zombieId = orchestrator.getAllTasks().find((t) => t.id.endsWith('/stuck'))!.id;
+    orchestrator.startExecution();
+    expect(orchestrator.getTask(zombieId)!.status).toBe('running');
+
+    // Its executor dies without a completion: the lease lapses far in the past.
+    const attemptId = orchestrator.getTask(zombieId)!.execution.selectedAttemptId!;
+    const longAgo = new Date(Date.now() - 60 * 60 * 1000);
+    (persistence.updateAttempt as (id: string, changes: Record<string, unknown>) => void)(attemptId, {
+      leaseExpiresAt: longAgo,
+      lastHeartbeatAt: longAgo,
+    });
+
+    // Workflow B is ready and only needs the one slot the zombie is squatting.
+    orchestrator.loadPlan({
+      name: 'blocked-workflow',
+      baseBranch: 'master',
+      featureBranch: 'feature/blocked',
+      tasks: [{ id: 'wants-slot', description: 'ready, waiting for capacity' }],
+    });
+    const waitingId = orchestrator.getAllTasks().find((t) => t.id.endsWith('/wants-slot'))!.id;
+
+    const started = orchestrator.startExecution();
+
+    expect(started.map((t) => t.id)).toContain(waitingId);
+    expect(orchestrator.getTask(waitingId)!.status).toBe('running');
+  });
+});

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -993,6 +993,14 @@ export class Orchestrator {
     return attempt.leaseExpiresAt.getTime() >= now;
   }
 
+  private isAttemptLeaseExpired(attempt: Attempt | undefined, now: number = Date.now()): boolean {
+    if (!attempt) return false;
+    if (isDiscardedAttempt(attempt)) return false;
+    if (attempt.status !== 'claimed' && attempt.status !== 'running') return false;
+    if (!attempt.leaseExpiresAt) return false;
+    return attempt.leaseExpiresAt.getTime() < now;
+  }
+
   private isTaskExecutionActive(
     task: TaskState,
     attempt: Attempt | undefined,
@@ -1001,6 +1009,9 @@ export class Orchestrator {
     if (isCrashPreservedExecution(task.execution)) return false;
     if (attempt && this.isAttemptLeaseActive(attempt, now)) {
       return task.status === 'pending' || task.status === 'running' || task.status === 'fixing_with_ai';
+    }
+    if (attempt && this.isAttemptLeaseExpired(attempt, now)) {
+      return false;
     }
 
     return task.status === 'running' || task.status === 'fixing_with_ai';


### PR DESCRIPTION
## Summary

Ready tasks could sit pending while the scheduler reported no free capacity, even when nothing was really running.

Capacity counts one slot per active execution. A task stuck in `running` kept its slot even after its executor had died and stopped sending heartbeats.

Nothing reclaimed that slot, so it stayed lost until the owner restarted.

Now a `running` task whose attempt lease has lapsed no longer counts against capacity. The freed slot lets a genuinely ready task launch.

The lease renews every 30 seconds against a 20-minute limit, so only a truly dead execution is reclaimed. A slow-but-alive task keeps its slot.

## Review Claim

`isTaskExecutionActive` stops counting a `running` task once its attempt lease has expired, so an orphaned execution no longer wedges a concurrency slot.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The reclaim only triggers on an attempt that held a lease and let it expire (claimed/running, past `leaseExpiresAt`). A live task renews well inside the 20-minute window, so it is never dropped. Tasks with an active lease are counted exactly as before.

## Slice Rationale

This is the concurrency-slot fix on its own, sitting above the independent gate-evaluation fix in the stack. Each slice carries one claim.

## Non-goals

Does not change lease duration or heartbeat cadence, does not kill or reap the orphaned execution, and does not touch external-dependency gate evaluation.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/zombie-running-slot-leak.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
