### PR TITLE
[Fix Workflow Graph Camera Refocus](1) Bound watchdog camera recovery

### DIFF
--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { WorkflowGraph } from '../components/WorkflowGraph.js';
@@ -67,6 +67,7 @@ async function renderAndSettleInitialFit(props: Parameters<typeof WorkflowGraph>
 
 describe('WorkflowGraph', () => {
   beforeEach(() => {
+    vi.useRealTimers();
     fitViewMock.mockClear();
     setCenterMock.mockClear();
     setViewportMock.mockClear();
@@ -74,6 +75,9 @@ describe('WorkflowGraph', () => {
     getZoomMock.mockReturnValue(1);
     getViewportMock.mockReset();
     getViewportMock.mockReturnValue({ x: 0, y: 0, zoom: 1 });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('calls selection and context menu handlers', () => {
@@ -415,6 +419,73 @@ describe('WorkflowGraph', () => {
     // selected, mock nodes are visible, and the watchdog timer is not advanced.
     // A failure here isolates the source to WorkflowGraph's React Flow remount.
     expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+  });
+
+  it('does not let pre-recovery watchdog misses refit after a manual pan and graph data change', async () => {
+    const onManualViewport = vi.fn();
+
+    const { rerender } = await renderAndSettleInitialFit({
+      workflows: new Map([
+        ['wf-a', wf('wf-a', 'running')],
+        ['wf-b', wf('wf-b', 'pending')],
+      ]),
+      selectedWorkflowId: 'wf-a',
+      statusFilters: new Set(),
+      onSelectWorkflow: () => {},
+      onWorkflowContextMenu: () => {},
+      onManualViewport,
+    });
+
+    const pane = screen.getByTestId('rf__pane');
+    fireEvent.pointerDown(pane);
+    fireEvent.pointerUp(pane);
+    expect(onManualViewport).toHaveBeenCalled();
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    setViewportMock.mockClear();
+
+    vi.useFakeTimers();
+    rerender(
+      <WorkflowGraph
+        workflows={new Map([
+          ['wf-a', wf('wf-a', 'completed')],
+          ['wf-b', wf('wf-b', 'pending')],
+          ['wf-c', wf('wf-c', 'running')],
+        ])}
+        selectedWorkflowId="wf-a"
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+        onManualViewport={onManualViewport}
+      />,
+    );
+
+    expect(screen.getByTestId('workflow-node-wf-c')).toBeInTheDocument();
+    for (const element of document.querySelectorAll<HTMLElement>('.react-flow__node')) {
+      element.style.visibility = 'hidden';
+    }
+
+    // No App is mounted and no cameraCommand is supplied, so App command
+    // reissue, WorkflowGraph command consumption, and selection fallback are
+    // ruled out. Advancing the watchdog isolates the source to blank-render
+    // recovery; only the bounded recovery threshold may move the camera.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(fitViewMock).toHaveBeenCalledTimes(1);
     expect(setCenterMock).not.toHaveBeenCalled();
   });
 

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -719,9 +719,9 @@ function WorkflowGraphInner({
         const shouldRecover =
           watchdogMissCountRef.current >= WATCHDOG_RECOVERY_MISS_COUNT &&
           !watchdogRecoveryAttemptedRef.current;
-        performFitView();
         if (shouldRecover) {
           watchdogRecoveryAttemptedRef.current = true;
+          performFitView();
           setFlowInstanceKey((key) => key + 1);
         }
       } else {


### PR DESCRIPTION
## Summary

Workflow graph watchdog misses no longer refit on every poll.

The camera changes position only after the bounded blank-render recovery threshold.

A regression isolates the watchdog path after manual pan and graph churn.

## Review Claim

Workflow graph data changes no longer trigger pre-recovery `fitView` calls after the user has manually panned or zoomed.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Initial graph fit, explicit fit commands, explicit selection centering, and the bounded blank-render recovery path still reposition the camera intentionally.

## Slice Rationale

This slice fixes the proven refocus source first, keeping the watchdog behavior review separate from node-drag interaction changes.

## Non-goals

No graph layout rewrite, selection fallback change, React Flow upgrade, scheduler change, persistence change, or UI redesign.

## Architecture

### Before

The watchdog called `performFitView` on every hidden-node miss, before checking whether the bounded recovery threshold had been reached.

### After

The watchdog only calls `performFitView` when the recovery threshold is reached and the graph remount recovery is attempted.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/workflow-graph.test.tsx src/__tests__/browser-surface-camera-resnap.test.tsx src/__tests__/selected-workflow-selection-steal-repro.test.tsx src/__tests__/selected-workflow-graph-disappears-repro.test.tsx src/__tests__/task-dag-stability.test.ts`
- [x] `bash scripts/ui-visual-proof.sh validate`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && pnpm --filter @invoker/app test:e2e -- ui-graph-drag-performance.spec.ts`

</details>

## Visual Proof

The fast visual snapshot still renders the workflow graph after the camera recovery change.

![Workflow graph visual proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-ebbd68/neutral-chrome-home-graph.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ced6ecfc7`
- Post-revert steps: Re-run the focused UI camera regression test.
- Data migration? No

</details>
