### PR TITLE
[Fix Workflow Graph Camera Refocus](2) Keep node drags under viewport ownership

### DIFF
--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -69,9 +69,11 @@ export const test = base.extend<ElectronFixtures>({
     const configPath = path.join(testDir, 'e2e-config.json');
     const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
     const electronUserDataDir = path.join(testDir, 'electron-user-data');
+    const homeDir = path.join(testDir, 'home');
     await fs.mkdir(stubDir, { recursive: true });
     await fs.mkdir(markerRoot, { recursive: true });
     await fs.mkdir(electronUserDataDir, { recursive: true });
+    await fs.mkdir(homeDir, { recursive: true });
     registerTrackedBrowserUserDataDir(electronUserDataDir);
     writeFileSync(configPath, JSON.stringify(repoConfig), 'utf8');
     try {
@@ -175,6 +177,7 @@ exit 64
         INVOKER_TEST_FIXED_NOW: '2025-01-01T00:00:00.000Z',
         INVOKER_CLAUDE_COMMAND: claudeMarker,
         INVOKER_CLAUDE_FIX_COMMAND: claudeMarker,
+        HOME: homeDir,
         ...(process.env.INVOKER_E2E_CODEX_DEMO
           ? { INVOKER_E2E_CODEX_DEMO: process.env.INVOKER_E2E_CODEX_DEMO }
           : {}),

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -620,7 +620,41 @@ describe('WorkflowGraph', () => {
     expect(onSelectWorkflow).toHaveBeenCalledWith('wf-a');
   });
 
-  it('does not start pane drags when pressing on a workflow node surface', async () => {
+  it('keeps workflow node clicks selectable without starting a pane drag', async () => {
+    const onSelectWorkflow = vi.fn();
+    getViewportMock.mockReturnValue({ x: 10, y: 20, zoom: 0.75 });
+
+    await renderAndSettleInitialFit({
+      workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
+      selectedWorkflowId: 'wf-a',
+      statusFilters: new Set(),
+      onSelectWorkflow,
+      onWorkflowContextMenu: () => {},
+    });
+
+    const pane = screen.getByTestId('rf__pane');
+    vi.spyOn(pane, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    const node = screen.getByTestId('workflow-node-wf-a');
+    fireEvent.mouseDown(node, { clientX: 100, clientY: 100, button: 0 });
+    fireEvent.mouseUp(window, { clientX: 100, clientY: 100, button: 0 });
+    fireEvent.click(node);
+
+    expect(onSelectWorkflow).toHaveBeenCalledWith('wf-a');
+    expect(setViewportMock).not.toHaveBeenCalled();
+  });
+
+  it('starts pane drags from workflow node surfaces after pointer movement', async () => {
     getViewportMock.mockReturnValue({ x: 10, y: 20, zoom: 0.75 });
 
     await renderAndSettleInitialFit({
@@ -631,11 +665,26 @@ describe('WorkflowGraph', () => {
       onWorkflowContextMenu: () => {},
     });
 
+    const pane = screen.getByTestId('rf__pane');
+    vi.spyOn(pane, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      toJSON: () => ({}),
+    } as DOMRect);
+
     fireEvent.mouseDown(screen.getByTestId('workflow-node-wf-a'), { clientX: 100, clientY: 100, button: 0 });
+    fireEvent.mouseMove(window, { clientX: 102, clientY: 101, buttons: 1 });
+    expect(setViewportMock).not.toHaveBeenCalled();
     fireEvent.mouseMove(window, { clientX: 130, clientY: 88, buttons: 1 });
     fireEvent.mouseUp(window, { clientX: 130, clientY: 88, button: 0 });
 
-    expect(setViewportMock).not.toHaveBeenCalled();
+    expect(setViewportMock).toHaveBeenCalledWith({ x: 40, y: 8, zoom: 0.75 }, { duration: 0 });
   });
 
   it('clears pane-pan inline transforms after drag and restores fit from controls', async () => {

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -57,6 +57,8 @@ const nodeTypes = {
   workflowNode: WorkflowFlowNode,
 };
 const WATCHDOG_RECOVERY_MISS_COUNT = 3;
+const PANE_PAN_DRAG_THRESHOLD_PX = 6;
+const PANE_PAN_IMMEDIATE_STEP = 0.65;
 
 interface PanePan {
   startClientX: number;
@@ -106,6 +108,26 @@ function shouldStartPanePan(
   return clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom;
 }
 
+function shouldDeferPanePanFromNode(
+  root: HTMLElement | null,
+  target: EventTarget | null,
+  clientX: number,
+  clientY: number,
+): boolean {
+  if (!root) return false;
+  const pane = root.querySelector<HTMLElement>('.react-flow__pane');
+  if (!pane) return false;
+
+  const targetElement = target instanceof Element ? target : null;
+  if (!targetElement) return false;
+  if (!root.contains(targetElement)) return false;
+  if (targetElement.closest(PANE_PAN_BLOCK_SELECTOR)) return false;
+  if (!targetElement.closest('.react-flow__node, [data-testid^="workflow-node-"]')) return false;
+
+  const rect = pane.getBoundingClientRect();
+  return clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom;
+}
+
 function createPanePan(
   startClientX: number,
   startClientY: number,
@@ -132,6 +154,12 @@ function getPanePanViewport(pan: PanePan, clientX: number, clientY: number): Gra
     y: pan.startViewport.y + clientY - pan.startClientY,
     zoom: pan.startViewport.zoom,
   };
+}
+
+function movedBeyondPanePanThreshold(pan: PanePan, clientX: number, clientY: number): boolean {
+  const dx = clientX - pan.startClientX;
+  const dy = clientY - pan.startClientY;
+  return dx * dx + dy * dy >= PANE_PAN_DRAG_THRESHOLD_PX * PANE_PAN_DRAG_THRESHOLD_PX;
 }
 
 function applyViewportTransform(viewportElement: HTMLElement | null, viewport: GraphViewport): void {
@@ -174,7 +202,7 @@ function schedulePanePanAnimation(pan: PanePan): void {
         };
     applyViewportTransform(pan.viewportElement, pan.visualViewport);
 
-    if (!settled) {
+    if (pan.active || !settled) {
       pan.animationFrame = requestAnimationFrame(step);
     }
   };
@@ -280,7 +308,9 @@ function WorkflowGraphInner({
   const pendingGestureNodesRef = useRef<Node<WorkflowNodeData>[] | null>(null);
   const pendingGestureEdgesRef = useRef<Edge[] | null>(null);
   const panePointerPanRef = useRef<PanePointerPan | null>(null);
+  const pendingPanePointerPanRef = useRef<PanePointerPan | null>(null);
   const paneMousePanRef = useRef<PanePan | null>(null);
+  const pendingPaneMousePanRef = useRef<PanePan | null>(null);
 
   const getViewportElement = useCallback(
     () => graphRootRef.current?.querySelector<HTMLElement>('.react-flow__viewport') ?? null,
@@ -298,6 +328,8 @@ function WorkflowGraphInner({
       }
       ref.current = null;
     }
+    pendingPanePointerPanRef.current = null;
+    pendingPaneMousePanRef.current = null;
   }, []);
 
   const performFitView = useCallback(() => {
@@ -495,9 +527,7 @@ function WorkflowGraphInner({
 
   const onPanePointerDownCapture = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0 || event.isPrimary === false) return;
-    if (!shouldStartPanePan(event.currentTarget, event.target, event.clientX, event.clientY)) return;
-
-    panePointerPanRef.current = {
+    const pan = {
       ...createPanePan(
         event.clientX,
         event.clientY,
@@ -506,6 +536,16 @@ function WorkflowGraphInner({
       ),
       pointerId: event.pointerId,
     };
+
+    if (shouldDeferPanePanFromNode(event.currentTarget, event.target, event.clientX, event.clientY)) {
+      pendingPanePointerPanRef.current = pan;
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+      return;
+    }
+
+    if (!shouldStartPanePan(event.currentTarget, event.target, event.clientX, event.clientY)) return;
+
+    panePointerPanRef.current = pan;
     schedulePanePanAnimation(panePointerPanRef.current);
     viewportGestureActiveRef.current = true;
     onManualViewport?.();
@@ -516,9 +556,18 @@ function WorkflowGraphInner({
 
   const updatePanePanViewport = useCallback((pan: PanePan, clientX: number, clientY: number) => {
     pan.hasMoved = true;
-    pan.targetViewport = getPanePanViewport(pan, clientX, clientY);
+    pan.warmupFrame = 0;
+    pan.viewportElement = getViewportElement() ?? pan.viewportElement;
+    const nextViewport = getPanePanViewport(pan, clientX, clientY);
+    pan.targetViewport = nextViewport;
+    pan.visualViewport = {
+      x: pan.visualViewport.x + (nextViewport.x - pan.visualViewport.x) * PANE_PAN_IMMEDIATE_STEP,
+      y: pan.visualViewport.y + (nextViewport.y - pan.visualViewport.y) * PANE_PAN_IMMEDIATE_STEP,
+      zoom: nextViewport.zoom,
+    };
+    applyViewportTransform(pan.viewportElement, pan.visualViewport);
     schedulePanePanAnimation(pan);
-  }, []);
+  }, [getViewportElement]);
 
   const finishPanePan = useCallback((pan: PanePan) => {
     pan.active = false;
@@ -532,7 +581,22 @@ function WorkflowGraphInner({
   }, [setViewport]);
 
   const onPanePointerMoveCapture = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    const pan = panePointerPanRef.current;
+    let pan = panePointerPanRef.current;
+    if (!pan) {
+      const pendingPan = pendingPanePointerPanRef.current;
+      if (!pendingPan || pendingPan.pointerId !== event.pointerId) return;
+      if ((event.buttons & 1) !== 1) {
+        pendingPanePointerPanRef.current = null;
+        return;
+      }
+      if (!movedBeyondPanePanThreshold(pendingPan, event.clientX, event.clientY)) return;
+
+      pendingPanePointerPanRef.current = null;
+      panePointerPanRef.current = pendingPan;
+      pan = pendingPan;
+      viewportGestureActiveRef.current = true;
+      onManualViewport?.();
+    }
     if (!pan || pan.pointerId !== event.pointerId) return;
 
     updatePanePanViewport(pan, event.clientX, event.clientY);
@@ -541,6 +605,13 @@ function WorkflowGraphInner({
   }, [updatePanePanViewport]);
 
   const onPanePointerEndCapture = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const pendingPan = pendingPanePointerPanRef.current;
+    if (pendingPan?.pointerId === event.pointerId) {
+      pendingPanePointerPanRef.current = null;
+      event.currentTarget.releasePointerCapture?.(event.pointerId);
+      return;
+    }
+
     const pan = panePointerPanRef.current;
     if (!pan || pan.pointerId !== event.pointerId) return;
 
@@ -553,7 +624,7 @@ function WorkflowGraphInner({
   }, [endViewportGesture, finishPanePan]);
 
   const onPaneMouseDownCapture = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
-    if (event.button !== 0 || panePointerPanRef.current) return;
+    if (event.button !== 0 || panePointerPanRef.current || pendingPanePointerPanRef.current) return;
     if (!shouldStartPanePan(event.currentTarget, event.target, event.clientX, event.clientY)) return;
 
     paneMousePanRef.current = createPanePan(
@@ -594,15 +665,28 @@ function WorkflowGraphInner({
     if (!root) return;
 
     const beginPaneMousePan = (event: MouseEvent): void => {
-      if (event.button !== 0 || panePointerPanRef.current) return;
-      if (!shouldStartPanePan(root, event.target, event.clientX, event.clientY)) return;
+      if (
+        event.button !== 0 ||
+        panePointerPanRef.current ||
+        pendingPanePointerPanRef.current ||
+        paneMousePanRef.current
+      ) return;
 
-      paneMousePanRef.current = createPanePan(
+      const pan = createPanePan(
         event.clientX,
         event.clientY,
         getViewport(),
         root.querySelector('.react-flow__viewport'),
       );
+
+      if (shouldDeferPanePanFromNode(root, event.target, event.clientX, event.clientY)) {
+        pendingPaneMousePanRef.current = pan;
+        return;
+      }
+
+      if (!shouldStartPanePan(root, event.target, event.clientX, event.clientY)) return;
+
+      paneMousePanRef.current = pan;
       schedulePanePanAnimation(paneMousePanRef.current);
       viewportGestureActiveRef.current = true;
       onManualViewport?.();
@@ -611,7 +695,22 @@ function WorkflowGraphInner({
     };
 
     const updatePaneMousePan = (event: MouseEvent): void => {
-      const pan = paneMousePanRef.current;
+      let pan = paneMousePanRef.current;
+      if (!pan) {
+        const pendingPan = pendingPaneMousePanRef.current;
+        if (!pendingPan) return;
+        if ((event.buttons & 1) !== 1) {
+          pendingPaneMousePanRef.current = null;
+          return;
+        }
+        if (!movedBeyondPanePanThreshold(pendingPan, event.clientX, event.clientY)) return;
+
+        pendingPaneMousePanRef.current = null;
+        paneMousePanRef.current = pendingPan;
+        pan = pendingPan;
+        viewportGestureActiveRef.current = true;
+        onManualViewport?.();
+      }
       if (!pan) return;
 
       updatePanePanViewport(pan, event.clientX, event.clientY);
@@ -620,6 +719,11 @@ function WorkflowGraphInner({
     };
 
     const endPaneMousePan = (event: MouseEvent): void => {
+      if (pendingPaneMousePanRef.current) {
+        pendingPaneMousePanRef.current = null;
+        return;
+      }
+
       const pan = paneMousePanRef.current;
       if (!pan) return;
 


### PR DESCRIPTION
## Summary

Workflow graph node-origin drags now become pane pans after a small movement threshold.

Click-size movement still falls through to normal workflow selection.

The e2e fixture isolates `HOME` so graph drag proof does not read user runtime config.

## Review Claim

Dragging from workflow node surfaces preserves user-owned viewport movement while ordinary node clicks remain selectable.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The pan path only activates after the drag threshold; click selection, context menus, explicit camera commands, and fit controls keep their existing behavior.

## Slice Rationale

This slice follows the watchdog fix because it changes user interaction handling rather than the recovery caller that caused implicit refits.

## Non-goals

No graph layout rewrite, node dragging enablement, selection model change, scheduler change, persistence change, or visual redesign.

## Architecture

### Before

Workflow node surfaces were excluded from pane pan starts, so drag input from a node could be swallowed while nodes stayed non-draggable.

### After

Node-origin input starts as a pending pane pan; crossing the movement threshold activates viewport ownership while click-sized movement remains selection.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/workflow-graph.test.tsx src/__tests__/browser-surface-camera-resnap.test.tsx src/__tests__/selected-workflow-selection-steal-repro.test.tsx src/__tests__/selected-workflow-graph-disappears-repro.test.tsx src/__tests__/task-dag-stability.test.ts`
- [x] `bash scripts/ui-visual-proof.sh validate`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && pnpm --filter @invoker/app test:e2e -- ui-graph-drag-performance.spec.ts`

</details>

## Visual Proof

The fast visual snapshot still renders the workflow graph after the node-drag viewport change.

![Workflow graph visual proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260716-af947b/neutral-chrome-home-graph.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9f6a2cffa`
- Post-revert steps: Re-run the focused UI camera and graph drag regression tests.
- Data migration? No

</details>

