### PR TITLE
[Merge gate generation](2) Stamp make-pr publisher artifacts from the caller generation

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
 import { collectDirectNonMergeTaskIds } from '../merge-runner.js';
+import { getCurrentRequiredReviewArtifacts } from '../task-runner-review-gate.js';
 import { SshExecutor } from '../ssh-executor.js';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkResponse, Logger } from '@invoker/contracts';
@@ -2677,6 +2678,56 @@ describe('TaskRunner', () => {
           }),
         }),
       }), expect.objectContaining({ generation: 0 }));
+    });
+    it('stamps published stack artifacts with the merge task generation so the poller keeps them live', async () => {
+      const contractsTask = makeTask({
+        id: 'contracts',
+        status: 'completed',
+        config: { workflowId: 'wf-pub' },
+        execution: { branch: 'invoker/contracts' },
+        description: 'Contracts',
+      });
+
+      const { executor, mergeTask, orchestrator } = setupPublishAfterFix({
+        mergeMode: 'external_review',
+        featureBranch: 'plan/feature',
+        gateWorkspacePath: '/tmp/gate-clone',
+        taskBranches: [contractsTask],
+        repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+      });
+
+      mergeTask.execution.generation = 26;
+
+      (executor as any).publishReviewStackWithMakePrSkill = vi.fn().mockResolvedValue({
+        artifacts: [
+          {
+            id: 'contracts',
+            title: 'Define contracts',
+            url: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/1',
+            providerId: '1',
+            branch: 'stack/contracts',
+            baseBranch: 'master',
+            required: true,
+            status: 'open',
+            generation: 0,
+          },
+        ],
+        sessionId: 'sess-stack',
+        agentName: 'codex',
+      });
+
+      await executor.publishAfterFix(mergeTask);
+
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledTimes(1);
+      const [, changes] = (orchestrator.setTaskReviewReady as any).mock.calls[0];
+      const gate = changes.execution.reviewGate;
+      expect(gate.activeGeneration).toBe(26);
+      for (const artifact of gate.artifacts) {
+        expect(artifact.generation).toBe(gate.activeGeneration);
+      }
+
+      const publishedTask = { execution: changes.execution } as TaskState;
+      expect(getCurrentRequiredReviewArtifacts(publishedTask)).toHaveLength(1);
     });
     it('external_review mode: detaches HEAD, fetches, consolidates, creates PR', async () => {
       const completedTask = makeTask({

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1321,11 +1321,13 @@ describe('TaskRunner', () => {
           workflowSummary: 'summary',
           cwd: '/tmp',
           mergeNodeTaskId: '__merge__wf-1',
+          expectedGeneration: 26,
         });
 
         expect(attempts).toEqual(['claude', 'codex']);
         expect(result.agentName).toBe('codex');
         expect(result.artifacts[1].dependsOn).toEqual(['contracts']);
+        expect(result.artifacts.map((a: any) => a.generation)).toEqual([26, 26]);
         expect(logEvent).toHaveBeenCalledWith(
           '__merge__wf-1',
           'task.log',

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -124,6 +124,24 @@ function buildSingleArtifactReviewGate(args: {
   };
 }
 
+function assertReviewGateGenerationsAligned(gate: ReviewGateState): void {
+  const mismatched = gate.artifacts.filter(
+    (artifact) =>
+      artifact.status !== 'discarded'
+      && !artifact.discardedAt
+      && artifact.generation !== gate.activeGeneration,
+  );
+  if (mismatched.length === 0) return;
+  const detail = mismatched
+    .map((artifact) => `${artifact.providerId ?? artifact.id ?? 'unknown'}@${artifact.generation}`)
+    .join(', ');
+  throw new Error(
+    `review gate generation mismatch: activeGeneration=${gate.activeGeneration} `
+      + `but live artifacts at [${detail}]; published artifacts must share the gate generation `
+      + 'or the poller treats them as discarded',
+  );
+}
+
 function buildMergeConflictJson(errorText: string, failedBranch: string): string | undefined {
   const hasConflictMarkers =
     errorText.includes('CONFLICT (') ||
@@ -269,6 +287,7 @@ export interface MergeRunnerHost {
     featureBranch: string;
     workflowSummary: string;
     cwd: string;
+    expectedGeneration: number;
     reviewGate?: ReviewGateState;
   }): Promise<{ artifacts: ReviewGateArtifact[]; sessionId: string; agentName: string }>;
   authorPrBodyWithSkill?(args: {
@@ -359,6 +378,7 @@ async function publishReviewArtifactsForMerge(host: MergeRunnerHost, args: {
       featureBranch: args.featureBranch,
       workflowSummary: args.workflowSummary,
       cwd: args.cwd,
+      expectedGeneration: args.expectedGeneration,
       reviewGate: args.reviewGate,
     });
     logTaskProgress(host, args.mergeNodeTaskId, 'info', 'Review stack published', {
@@ -371,13 +391,14 @@ async function publishReviewArtifactsForMerge(host: MergeRunnerHost, args: {
       baseBranch: artifact.baseBranch ?? args.baseBranch,
       required: artifact.required ?? true,
       status: artifact.status ?? 'open' as const,
-      generation: artifact.generation ?? args.expectedGeneration,
+      generation: args.expectedGeneration,
     }));
     const reviewGate = {
       activeGeneration: args.expectedGeneration,
       completion: { required: 'all' as const, status: 'approved' as const },
       artifacts,
     };
+    assertReviewGateGenerationsAligned(reviewGate);
     const firstArtifact = artifacts[0];
     console.log(
       `[merge] Published Invoker review stack via ${published.agentName} skill`,
@@ -428,20 +449,22 @@ async function publishReviewArtifactsForMerge(host: MergeRunnerHost, args: {
   });
   console.log(`[merge] Created GitHub PR: ${result.url}`);
 
+  const reviewGate = buildSingleArtifactReviewGate({
+    expectedGeneration: args.expectedGeneration,
+    title: args.workflowName,
+    url: result.url,
+    providerId: result.identifier,
+    provider: host.mergeGateProvider.name,
+    branch: args.featureBranch,
+    baseBranch: args.baseBranch,
+    nowIso: new Date().toISOString(),
+  });
+  assertReviewGateGenerationsAligned(reviewGate);
   return {
     reviewUrl: result.url,
     reviewId: result.identifier,
     reviewStatus: 'Awaiting review',
-    reviewGate: buildSingleArtifactReviewGate({
-      expectedGeneration: args.expectedGeneration,
-      title: args.workflowName,
-      url: result.url,
-      providerId: result.identifier,
-      provider: host.mergeGateProvider.name,
-      branch: args.featureBranch,
-      baseBranch: args.baseBranch,
-      nowIso: new Date().toISOString(),
-    }),
+    reviewGate,
   };
 }
 

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1458,6 +1458,7 @@ export class TaskRunner {
     featureBranch: string;
     workflowSummary: string;
     cwd: string;
+    expectedGeneration: number;
     reviewGate?: ReviewGateState;
   }): Promise<{ artifacts: ReviewGateArtifact[]; sessionId: string; agentName: string }> {
     if (!this.executionAgentRegistry) {
@@ -1573,7 +1574,7 @@ export class TaskRunner {
         }
 
         const nowIso = new Date().toISOString();
-        const generation = args.reviewGate?.activeGeneration ?? 0;
+        const generation = args.expectedGeneration;
         const artifacts: ReviewGateArtifact[] = parsedArtifacts.map(({ body: _body, ...artifact }) => ({
           ...artifact,
           provider: 'github',


### PR DESCRIPTION
## Summary

The make-pr publisher tagged each pull request with generation 0 on first publish. Slice (1) already overwrites that in the merge runner.

This slice tags it correctly at the source. The publisher no longer emits a number that has to be fixed later.

## Review Claim

The make-pr publisher stamps each artifact's generation from the caller's generation instead of a 0 default.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The value this slice sets is the same one the merge runner already applies on top, so the published output is unchanged. Only the publisher's own emitted number changes from 0 to the passed generation.

## Slice Rationale

Slice (2) of two. A repo rule forbids changing publication and poll/approval runtime in one PR, so this publisher change is kept apart from the merge-runner fix in slice (1).

## Non-goals

Does not change the published review gate output, which slice (1) already stamps. Does not change how generations are bumped.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test task-runner-fix-publish-and-ssh`
- [ ] `cd packages/execution-engine && pnpm build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 389bef88b`
- Post-revert steps: None
- Data migration? No

</details>
