### PR TITLE
[Runner Capacity](6) Wire headless dispatcher to full orchestrator

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -1069,6 +1069,56 @@ describe('LaunchDispatcher', () => {
       expect(leases[0]?.resourceKey).toBe('ssh:live');
     });
 
-  });
+    it('re-tops stranded ready work when free scheduler slots remain', () => {
+      const strandedTask = {
+        id: 'wf/ready',
+        status: 'pending',
+        execution: { selectedAttemptId: 'wf/ready-a1', generation: 0 },
+      };
+      const prepare = vi.fn();
+      const startExecution = vi.fn()
+        .mockReturnValueOnce([])
+        .mockReturnValueOnce([strandedTask]);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-topup',
+        orchestrator: {
+          prepareTaskForNewAttempt: prepare,
+          getExecutableReadyTasks: () => [strandedTask as any],
+          getQueueStatus: () => ({ runningCount: 2, maxConcurrency: 13 }),
+          isLaunchParked: () => false,
+          startExecution,
+        },
+        taskRunnerProvider: () => ({ executeTask: vi.fn() }),
+      });
+      dispatcher.poll();
+      expect(prepare).toHaveBeenCalledWith('wf/ready', 'launch-dispatcher-ready-topup');
+      expect(startExecution).toHaveBeenCalledTimes(2);
+    });
 
+    it('does not thrash parked ready tasks when slots are free', () => {
+      const parkedTask = {
+        id: 'wf/parked',
+        status: 'pending',
+        execution: { selectedAttemptId: 'wf/parked-a1', generation: 0 },
+      };
+      const prepare = vi.fn();
+      const startExecution = vi.fn().mockReturnValue([]);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-parked',
+        orchestrator: {
+          prepareTaskForNewAttempt: prepare,
+          getExecutableReadyTasks: () => [parkedTask as any],
+          getQueueStatus: () => ({ runningCount: 0, maxConcurrency: 13 }),
+          isLaunchParked: () => true,
+          startExecution,
+        },
+        taskRunnerProvider: () => ({ executeTask: vi.fn() }),
+      });
+      dispatcher.poll();
+      expect(prepare).not.toHaveBeenCalled();
+      expect(startExecution).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/app/src/headless-standalone-launch-dispatcher.ts
+++ b/packages/app/src/headless-standalone-launch-dispatcher.ts
@@ -32,13 +32,7 @@ export function startStandaloneLaunchDispatcher(
 
   const dispatcher = new LaunchDispatcher({
     persistence: headlessDeps.persistence,
-    orchestrator: {
-      prepareTaskForNewAttempt: (taskId, reason) =>
-        headlessDeps.orchestrator.prepareTaskForNewAttempt(taskId, reason),
-      syncFromDb: (workflowId) => headlessDeps.orchestrator.syncFromDb(workflowId),
-      getTask: (taskId) => headlessDeps.orchestrator.getTask(taskId),
-      getTaskLaunchReadiness: (taskId) => headlessDeps.orchestrator.getTaskLaunchReadiness(taskId),
-    },
+    orchestrator: headlessDeps.orchestrator,
     taskRunnerProvider: () => executor,
     ownerId,
     logger: headlessDeps.logger,

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -41,6 +41,13 @@ export interface LaunchDispatcherOrchestrator {
   syncFromDb?(workflowId: string): void;
   getTask?(taskId: string): TaskState | undefined;
   getTaskLaunchReadiness?(taskId: string): TaskLaunchReadiness;
+  /**
+   * Optional: when startExecution leaves free slots idle with ready work that
+   * has no launching phase (lost outbox after cancel/recreate), mint attempts.
+   */
+  getExecutableReadyTasks?(): TaskState[];
+  getQueueStatus?(): { runningCount: number; maxConcurrency: number };
+  isLaunchParked?(taskId: string, now?: number): boolean;
   startExecution?(): TaskState[];
 }
 
@@ -142,7 +149,43 @@ export class LaunchDispatcher {
 
   private topUpReadyLaunches(): void {
     try {
-      const started = this.orchestrator?.startExecution?.() ?? [];
+      let started = this.orchestrator?.startExecution?.() ?? [];
+      // Ready pending roots can lose their outbox row after cancel/recreate while
+      // free scheduler slots remain. Mint a fresh attempt only for non-parked
+      // ready work, then drain again.
+      if (
+        started.length === 0
+        && typeof this.orchestrator?.getExecutableReadyTasks === 'function'
+        && typeof this.orchestrator.prepareTaskForNewAttempt === 'function'
+      ) {
+        const queue = this.orchestrator.getQueueStatus?.();
+        const freeSlots = queue
+          ? Math.max(0, queue.maxConcurrency - queue.runningCount)
+          : 0;
+        if (freeSlots > 0) {
+          const now = Date.now();
+          const stranded = this.orchestrator.getExecutableReadyTasks().filter((task) => {
+            if (task.status !== 'pending' || task.execution.phase === 'launching') return false;
+            if (this.orchestrator?.isLaunchParked?.(task.id, now)) return false;
+            return true;
+          });
+          const toRecover = stranded.slice(0, freeSlots);
+          for (const task of toRecover) {
+            this.orchestrator.prepareTaskForNewAttempt(task.id, 'launch-dispatcher-ready-topup');
+          }
+          if (toRecover.length > 0) {
+            started = this.orchestrator.startExecution?.() ?? [];
+            this.logger?.info?.('[launch-dispatcher] re-topped ready launches after stranded pending', {
+              ownerId: this.ownerId,
+              stranded: toRecover.length,
+              freeSlots,
+              started: started.length,
+              taskIds: toRecover.map((task) => task.id),
+              module: 'launch-dispatcher',
+            });
+          }
+        }
+      }
       if (started.length > 0) {
         this.logger?.info?.('[launch-dispatcher] topped up ready launches', {
           ownerId: this.ownerId,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2472,7 +2472,17 @@ function createEmbeddedTerminalBackendFromConfig(
       );
       launchDispatcher = new LaunchDispatcher({
         persistence,
-        orchestrator,
+        orchestrator: {
+          prepareTaskForNewAttempt: (taskId, reason) =>
+            orchestrator.prepareTaskForNewAttempt(taskId, reason),
+          syncFromDb: (workflowId) => orchestrator.syncFromDb(workflowId),
+          getTask: (taskId) => orchestrator.getTask(taskId),
+          getTaskLaunchReadiness: (taskId) => orchestrator.getTaskLaunchReadiness(taskId),
+          getExecutableReadyTasks: () => orchestrator.getExecutableReadyTasks(),
+          getQueueStatus: () => orchestrator.getQueueStatus({ refresh: false }),
+          isLaunchParked: (taskId, now) => orchestrator.isLaunchParked(taskId, now),
+          startExecution: () => orchestrator.startExecution(),
+        },
         // taskExecutor is re-built by rebuildTaskRunner(); read via
         // a provider so the dispatcher always picks up the current
         // instance instead of capturing a stale reference.

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -3073,7 +3073,7 @@ export class Orchestrator {
    * deferred set (retry / cancel / recreate / completion re-enqueue) releases
    * the park immediately, without a per-transition clear at every call site.
    */
-  private isLaunchParked(taskId: string, now: number): boolean {
+  isLaunchParked(taskId: string, now: number = Date.now()): boolean {
     const deferral = this.launchDeferrals.get(taskId);
     return deferral !== undefined
       && this.deferredTaskIds.has(taskId)


### PR DESCRIPTION
## Summary

Passes the full orchestrator into the headless LaunchDispatcher owner.

A hand-maintained method subset omitted startExecution and ready-task helpers.

Headless mode now shares the same capacity recovery APIs as the GUI owner.

## Review Claim

Approve wiring the headless launch dispatcher to the full orchestrator surface for capacity recovery.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

No new headless control plane methods. It only stops wrapping a stale subset of existing orchestrator APIs.

## Slice Rationale

Headless owner wiring is isolated so activation-surface stays a single review unit after the GUI recovery path.

## Non-goals

Does not change headless CLI flags, planning submit, or dispatcher algorithm itself.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-headless-launch-dispatcher-orchestrator-surface.sh --expect fixed --gate`
- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/launch-dispatcher.test.ts -t "capacity recovery"`
- [ ] `bash scripts/repro/runner-capacity-monkey.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4800

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined standalone launch dispatching by using the orchestrator directly, preserving existing launch behavior while simplifying internal integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->