### PR TITLE
[Unblock runnable pending tasks](4) Repro the expired-lease slot leak against real SQLite

### DIFF
--- a/packages/workflow-core/src/__tests__/zombie-running-slot-leak.test.ts
+++ b/packages/workflow-core/src/__tests__/zombie-running-slot-leak.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { Orchestrator } from '../orchestrator.js';
+import { InMemoryPersistence, InMemoryBus } from './helpers/cross-workflow-cascade-helpers.js';
+
+function makeOrchestratorWith(persistence: InMemoryPersistence, maxConcurrency: number): Orchestrator {
+  return new Orchestrator({ persistence, messageBus: new InMemoryBus(), maxConcurrency });
+}
+
+/**
+ * Repro for bug #1: a task stuck in `running` whose attempt lease has expired
+ * (its executor stopped heart-beating and no completion ever arrived) keeps
+ * consuming a global concurrency slot forever. With a full slot table, a
+ * genuinely ready pending task can never launch even though nothing is really
+ * executing.
+ */
+describe('zombie running task consumes a concurrency slot', () => {
+  it('does not count a running task with an expired lease against capacity', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestratorWith(persistence, 1);
+
+    // Workflow A takes the single slot and starts running.
+    orchestrator.loadPlan({
+      name: 'zombie-workflow',
+      baseBranch: 'master',
+      featureBranch: 'feature/zombie',
+      tasks: [{ id: 'stuck', description: 'runs then strands' }],
+    });
+    const zombieId = orchestrator.getAllTasks().find((t) => t.id.endsWith('/stuck'))!.id;
+    orchestrator.startExecution();
+    expect(orchestrator.getTask(zombieId)!.status).toBe('running');
+
+    // Its executor dies without a completion: the lease lapses far in the past.
+    const attemptId = orchestrator.getTask(zombieId)!.execution.selectedAttemptId!;
+    const longAgo = new Date(Date.now() - 60 * 60 * 1000);
+    (persistence.updateAttempt as (id: string, changes: Record<string, unknown>) => void)(attemptId, {
+      leaseExpiresAt: longAgo,
+      lastHeartbeatAt: longAgo,
+    });
+
+    // Workflow B is ready and only needs the one slot the zombie is squatting.
+    orchestrator.loadPlan({
+      name: 'blocked-workflow',
+      baseBranch: 'master',
+      featureBranch: 'feature/blocked',
+      tasks: [{ id: 'wants-slot', description: 'ready, waiting for capacity' }],
+    });
+    const waitingId = orchestrator.getAllTasks().find((t) => t.id.endsWith('/wants-slot'))!.id;
+
+    const started = orchestrator.startExecution();
+
+    expect(started.map((t) => t.id)).toContain(waitingId);
+    expect(orchestrator.getTask(waitingId)!.status).toBe('running');
+  });
+});

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -993,6 +993,14 @@ export class Orchestrator {
     return attempt.leaseExpiresAt.getTime() >= now;
   }
 
+  private isAttemptLeaseExpired(attempt: Attempt | undefined, now: number = Date.now()): boolean {
+    if (!attempt) return false;
+    if (isDiscardedAttempt(attempt)) return false;
+    if (attempt.status !== 'claimed' && attempt.status !== 'running') return false;
+    if (!attempt.leaseExpiresAt) return false;
+    return attempt.leaseExpiresAt.getTime() < now;
+  }
+
   private isTaskExecutionActive(
     task: TaskState,
     attempt: Attempt | undefined,
@@ -1001,6 +1009,9 @@ export class Orchestrator {
     if (isCrashPreservedExecution(task.execution)) return false;
     if (attempt && this.isAttemptLeaseActive(attempt, now)) {
       return task.status === 'pending' || task.status === 'running' || task.status === 'fixing_with_ai';
+    }
+    if (attempt && this.isAttemptLeaseExpired(attempt, now)) {
+      return false;
     }
 
     return task.status === 'running' || task.status === 'fixing_with_ai';

--- a/scripts/repro/repro-expired-lease-running-task-wedges-capacity.sh
+++ b/scripts/repro/repro-expired-lease-running-task-wedges-capacity.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/invoker-expired-lease-capacity-repro.XXXXXX")"
+TEST_DIR="$ROOT_DIR/packages/data-store/.tmp/expired-lease-capacity-repro.$$"
+TEST_FILE="$TEST_DIR/expired-lease-capacity-repro.test.ts"
+DB_DIR="$TMP_ROOT/db"
+
+cleanup() {
+  local ec=$?
+  rm -rf "$TEST_DIR"
+  rm -rf "$TMP_ROOT"
+  return "$ec"
+}
+trap cleanup EXIT
+
+mkdir -p "$DB_DIR" "$TEST_DIR"
+
+cat > "$TEST_FILE" <<'TS'
+import { mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { Orchestrator } from '@invoker/workflow-core';
+import type { OrchestratorMessageBus } from '@invoker/workflow-core';
+
+class NoopBus implements OrchestratorMessageBus {
+  publish(): void {}
+}
+
+const adapters: SQLiteAdapter[] = [];
+
+afterEach(() => {
+  while (adapters.length > 0) {
+    adapters.pop()?.close();
+  }
+});
+
+describe('a running task with an expired lease wedges concurrency capacity', () => {
+  it('frees the slot once the executor lease has lapsed so a ready task can launch', async () => {
+    const dbDir = mkdtempSync(join(tmpdir(), 'invoker-expired-lease-capacity-'));
+    process.env.INVOKER_DB_DIR = dbDir;
+    const adapter = await SQLiteAdapter.create(join(dbDir, 'invoker.db'), { ownerCapability: true });
+    adapters.push(adapter);
+
+    const orchestrator = new Orchestrator({
+      persistence: adapter,
+      messageBus: new NoopBus(),
+      maxConcurrency: 1,
+    });
+
+    // Workflow A takes the single slot and starts running.
+    orchestrator.loadPlan({
+      name: 'zombie',
+      tasks: [{ id: 'stuck', description: 'runs then strands' }],
+    });
+    const zombieWfId = orchestrator.getWorkflowIds()[0]!;
+    const zombieId = `${zombieWfId}/stuck`;
+    orchestrator.startExecution();
+    expect(orchestrator.getTask(zombieId)?.status).toBe('running');
+
+    // Its executor dies with no completion: the attempt lease lapses in the past.
+    const attemptId = orchestrator.getTask(zombieId)!.execution.selectedAttemptId!;
+    const longAgo = new Date(Date.now() - 60 * 60 * 1000);
+    adapter.updateAttempt(attemptId, { leaseExpiresAt: longAgo, lastHeartbeatAt: longAgo });
+
+    // Workflow B is ready and only needs the one slot the zombie is squatting.
+    orchestrator.loadPlan({
+      name: 'blocked',
+      tasks: [{ id: 'wants-slot', description: 'ready, waiting for capacity' }],
+    });
+    const waitingWfId = orchestrator.getWorkflowIds()[1]!;
+    const waitingId = `${waitingWfId}/wants-slot`;
+
+    const started = orchestrator.startExecution();
+
+    console.log(JSON.stringify({
+      zombieStatus: orchestrator.getTask(zombieId)?.status,
+      zombieLeaseExpiresAt: adapter.loadAttempt(attemptId)?.leaseExpiresAt?.toISOString(),
+      waitingStatus: orchestrator.getTask(waitingId)?.status,
+      startedIds: started.map((t) => t.id),
+    }));
+
+    expect(orchestrator.getTask(zombieId)?.status).toBe('running');
+    expect(started.map((t) => t.id)).toContain(waitingId);
+    expect(orchestrator.getTask(waitingId)?.status).toBe('running');
+  });
+});
+TS
+
+echo "temporary_root=$TMP_ROOT"
+echo "temporary_db_dir=$DB_DIR"
+echo "repro_test=$TEST_FILE"
+echo "command=INVOKER_DB_DIR=$DB_DIR pnpm --filter @invoker/data-store exec vitest run $TEST_FILE --reporter=dot"
+
+(
+  cd "$ROOT_DIR"
+  INVOKER_DB_DIR="$DB_DIR" pnpm --filter @invoker/data-store exec vitest run "$TEST_FILE" --reporter=dot
+)
+
+echo "PASS: a running task whose executor lease has expired no longer counts against maxConcurrency, so a genuinely ready pending task launches into the freed slot."


### PR DESCRIPTION
## Summary

This adds a runnable shell repro for the concurrency-slot fix in the slice below.

The script strands a running task with a lapsed lease, then checks that a second ready task claims the freed slot against a real SQLite store.

It is a standalone tool under `scripts/repro`. CI never runs it, so it changes no test surface.

## Review Claim

`scripts/repro/repro-expired-lease-running-task-wedges-capacity.sh` reproduces and guards the freed-slot behavior against a real database.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Adds one shell script under `scripts/repro` and nothing else. No product code, no CI wiring, no test-suite registration. It cannot affect runtime behavior.

## Slice Rationale

Repro scripts under `scripts/repro` are a `proof` review unit and cannot ship inside a `behavior` fix slice. This carries the repro on its own, directly above the fix it exercises.

## Non-goals

Changes no product code and registers nothing into CI. It does not fix anything by itself.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-expired-lease-running-task-wedges-capacity.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
