### PR TITLE
[Retry Safe Failed Invoker Frontier](1) Use detached store for absent read-only DB

### DIFF
--- a/packages/app/src/__tests__/viewer-detached-db.test.ts
+++ b/packages/app/src/__tests__/viewer-detached-db.test.ts
@@ -30,6 +30,25 @@ const wf: Workflow = {
 };
 
 describe('detached viewer persistence boundary', () => {
+  it('uses empty in-memory persistence for read-only startup when the db file is absent', async () => {
+    const dir = makeDir();
+    const missingDbPath = join(dir, 'invoker.db');
+    const adapter = await openMainProcessDatabase({
+      dbPath: missingDbPath,
+      detachedViewer: false,
+      readOnly: true,
+      exclusiveLocking: false,
+    });
+
+    try {
+      expect(adapter.listWorkflows()).toEqual([]);
+      expect(existsSync(missingDbPath)).toBe(false);
+      expect(readdirSync(dir)).toEqual([]);
+    } finally {
+      adapter.close();
+    }
+  });
+
   it('ignores the real db path and opens no database file (no -shm to truncate)', async () => {
     const dir = makeDir();
     const probeDbPath = join(dir, 'invoker.db');

--- a/packages/app/src/viewer-db-boundary.ts
+++ b/packages/app/src/viewer-db-boundary.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { SQLiteAdapter } from '@invoker/data-store';
 
 export interface MainProcessDatabaseOptions {
@@ -9,6 +10,12 @@ export interface MainProcessDatabaseOptions {
 
 export async function openMainProcessDatabase(options: MainProcessDatabaseOptions): Promise<SQLiteAdapter> {
   if (options.detachedViewer) {
+    return openDetachedViewerDatabase();
+  }
+
+  // Read-only headless snapshots should report an empty store before the first
+  // owner creates invoker.db; opening SQLite read-only cannot create that file.
+  if (options.readOnly && !existsSync(options.dbPath)) {
     return openDetachedViewerDatabase();
   }
 


### PR DESCRIPTION
## Summary

A read-only startup can begin before any owner has created the database file.

Opening SQLite read-only cannot create that file, so startup failed outright.

Now an absent read-only database opens as an empty detached view instead.

Writable owner startup and existing databases still open through SQLite as before.

## Review Claim

Read-only startup for an absent database returns an empty detached store instead of failing to open SQLite.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only read-only, absent-database startup changes. A present database, and every writable owner startup, still opens through the normal SQLite path, so no existing caller sees new behavior.

## Slice Rationale

This prepares the queue snapshot fallback that a later slice builds, kept apart from that later change so the startup boundary is reviewed on its own.

## Non-goals

- No command-surface delegation or fallback wiring.
- No scheduler, dispatch, or mutation behavior.
- No UI behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test` (covers `src/__tests__/viewer-detached-db.test.ts`)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c9b3a01`
- Post-revert steps: None
- Data migration? No

</details>
