### PR TITLE
Add crashPreserved* fields to reset-policy completeness guard list

### DIFF
--- a/packages/workflow-core/src/__tests__/task-reset-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/task-reset-policy.test.ts
@@ -51,6 +51,10 @@ const expectedExecutionFields = [
   'launchStartedAt',
   'launchCompletedAt',
   'mergeConflict',
+  'crashPreservedAt',
+  'crashPreservedOwnerPid',
+  'crashPreservedReportPath',
+  'crashPreservedDiagnosticSummary',
   'selectedAttemptId',
 ].sort();
 


### PR DESCRIPTION
## Summary

The `workflow-core` test suite is red on master, which blocks the whole merge queue.

A completeness guard checks that every `TaskExecution` field has a reset rule. It compares the rulebook against a hand-written list of field names.

Crash-orphan preservation added four `crashPreserved*` fields with correct reset rules, but that hand-written list was never updated.

This change adds the four field names to the list so the guard passes.

## Review Claim

The reset-policy completeness guard should list the four `crashPreserved*` fields that already have reset rules.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the test's expected-field list changes. The rulebook and `TaskExecution` type are untouched, so no runtime reset behavior changes.

## Slice Rationale

This is a test-only correction that unblocks master CI. It is kept separate from any behavior change so it can be reviewed and landed on its own.

## Non-goals

- No change to `TASK_EXECUTION_RESET_RULES` values.
- No change to the `TaskExecution` type.
- No change to reset runtime behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/workflow-core && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
