### PR TITLE
Fix pr-ci-failure-scan worker: load shared lib from repo root, not sibling dir

### DIFF
--- a/packages/execution-engine/scripts/cron-pr-ci-failure.sh
+++ b/packages/execution-engine/scripts/cron-pr-ci-failure.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=scripts/cron-pr-lib.sh
-source "$(dirname "$0")/cron-pr-lib.sh"
+# shellcheck source=../../../scripts/cron-pr-lib.sh
+source "$(cd "$(dirname "$0")/../../.." && pwd)/scripts/cron-pr-lib.sh"
 
 cron_lock
 

--- a/packages/execution-engine/src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts
@@ -1,0 +1,65 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { resolveRepoRoot } from '@invoker/contracts';
+
+const repoRoot = resolveRepoRoot(process.cwd());
+
+// Every registered PR-maintenance cron entrypoint. Add a new worker's script
+// here so this guard proves the script can source its shared library.
+const PR_MAINTENANCE_ENTRYPOINTS = [
+  { kind: 'coderabbit-address', scriptRelativePath: 'scripts/cron-coderabbit-address.sh' },
+  { kind: 'pr-conflict-rebase', scriptRelativePath: 'scripts/cron-pr-conflict-rebase.sh' },
+  { kind: 'pr-ci-failure-scan', scriptRelativePath: 'packages/execution-engine/scripts/cron-pr-ci-failure.sh' },
+] as const;
+
+describe('PR maintenance entrypoints bootstrap', () => {
+  let stubBin: string;
+  let lockPath: string;
+
+  beforeEach(() => {
+    stubBin = mkdtempSync(join(tmpdir(), 'pr-maintenance-stub-bin-'));
+    // Force every entrypoint down its lock-held early-exit: a `flock` stub that
+    // always reports the lock busy makes cron_lock return exit 0 right after the
+    // script sources cron-pr-lib.sh — so the run only proves the source resolved,
+    // never touching gh/git/the network.
+    const flockStub = join(stubBin, 'flock');
+    writeFileSync(flockStub, '#!/usr/bin/env bash\nexit 1\n', { mode: 0o755 });
+    chmodSync(flockStub, 0o755);
+    lockPath = join(stubBin, 'pr-crons.lock');
+  });
+
+  afterEach(() => {
+    rmSync(stubBin, { recursive: true, force: true });
+  });
+
+  it('registers at least one entrypoint to guard', () => {
+    expect(PR_MAINTENANCE_ENTRYPOINTS.length).toBeGreaterThan(0);
+  });
+
+  for (const entrypoint of PR_MAINTENANCE_ENTRYPOINTS) {
+    it(`${entrypoint.kind} script exists and can source its shared library`, () => {
+      const scriptPath = resolve(repoRoot, entrypoint.scriptRelativePath);
+      expect(existsSync(scriptPath)).toBe(true);
+
+      const result = spawnSync('bash', [scriptPath], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: {
+          ...process.env,
+          PATH: `${stubBin}:${process.env.PATH ?? ''}`,
+          INVOKER_PR_CRON_LOCK: lockPath,
+        },
+      });
+
+      const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+      expect(output).not.toContain('No such file or directory');
+      expect(result.status).toBe(0);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

One execution-engine maintenance worker failed on every scheduled tick and never got past its own startup. This restores it.

The worker runtime routes each scheduled tick to a shell entrypoint. That entrypoint could not load the shared library it depends on, so it aborted before doing any work.

The entrypoint lives in a package subfolder but loaded the shared library from its own directory, where the library is absent. The library lives in the repo-root scripts directory.

The fix resolves the shared library from the repo root, so where the entrypoint lives no longer matters. Two sibling entrypoints in the same routing layer already load it correctly.

This does not change what the pr-ci-failure-scan worker does once it runs, and it does not touch the shared library itself.

A startup guard now drives every routed maintenance entrypoint with its lock held, so each one must load its shared library or the guard fails.

## Review Claim

The routed maintenance entrypoint now loads its shared library and can start, and a startup guard keeps every entrypoint in the worker routing layer from regressing the same way.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change only alters where the entrypoint resolves `cron-pr-lib.sh` (repo root instead of a non-existent sibling path). The new guard spawns each real entrypoint with a `flock` stub that forces the lock-held early exit, so it proves the source line resolves without touching gh, git, or the network.

## Slice Rationale

The path fix and the guard that proves it are one routing change: the fix restores how the worker runtime reaches this entrypoint, and the guard fails without it. They are one claim, not two.

## Non-goals

Does not relocate the entrypoint into `scripts/` alongside its siblings, does not change the scan's actual PR logic, and does not touch the shared `cron-pr-lib.sh` library.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && npx vitest run src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts`
- [ ] With a `flock` stub that exits 1 on `PATH`: `INVOKER_PR_CRON_LOCK=/tmp/stub/lock bash packages/execution-engine/scripts/cron-pr-ci-failure.sh` — expect exit 0 and no "No such file or directory"

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the prior broken load line; the worker returns to exiting 1 each tick.
- Data migration? No

</details>
