### PR TITLE
Realign e2e-dry-run cancel/recreate proof cases with current terminal states

### DIFF
--- a/scripts/e2e-dry-run/cases/case-2.10-cancel-downstream.sh
+++ b/scripts/e2e-dry-run/cases/case-2.10-cancel-downstream.sh
@@ -43,9 +43,10 @@ if ! invoker_e2e_wait_task_status e2e-g2210-taskA failed 180; then
 fi
 
 STB=$(invoker_e2e_task_status e2e-g2210-taskB)
-# B may be 'failed' (cascade cancel) or 'pending' (not yet cascaded) — both valid.
-if [ "$STB" != "failed" ] && [ "$STB" != "pending" ]; then
-  echo "FAIL case 2.10: expected B=failed|pending, got B='$STB'"
+# B is a never-started dependent of the cancelled root, so the cascade marks it
+# 'blocked' (#3473). 'pending' is valid if the cascade hasn't reached it yet.
+if [ "$STB" != "blocked" ] && [ "$STB" != "pending" ]; then
+  echo "FAIL case 2.10: expected B=blocked|pending, got B='$STB'"
   invoker_e2e_run_headless status 2>&1 || true
   exit 1
 fi

--- a/scripts/e2e-dry-run/cases/case-2.15-recreate-preempt-attempt-refresh.sh
+++ b/scripts/e2e-dry-run/cases/case-2.15-recreate-preempt-attempt-refresh.sh
@@ -74,15 +74,18 @@ for i in $(seq 1 60); do
   STATUS_AFTER="$(printf '%s' "$TASK_JSON_AFTER" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("status",""))')"
   AUDIT_JSON="$(invoker_e2e_run_headless query audit "$TASK_ID" --output json 2>/dev/null || true)"
 
-  if printf '%s' "$AUDIT_JSON" | grep -Fq 'task.cancelled' && printf '%s' "$AUDIT_JSON" | grep -Fq 'task.pending'; then
-    echo "==> case 2.15: observed cancel + reset audit events (poll $i)"
+  if printf '%s' "$AUDIT_JSON" | grep -Eq 'task\.(cancelled|failed)' && printf '%s' "$AUDIT_JSON" | grep -Fq 'task.pending'; then
+    echo "==> case 2.15: observed preempt + reset audit events (poll $i)"
     break
   fi
   sleep 1
 done
 
-if ! printf '%s' "$AUDIT_JSON" | grep -Fq 'task.cancelled'; then
-  echo "FAIL case 2.15: expected task.cancelled audit event after recreate preempt"
+# Standalone-headless recreate boots a fresh owner that reaps the orphaned
+# in-flight attempt as task.failed before the cancel-first path runs (#4411);
+# the long-lived GUI owner still emits task.cancelled. Accept either preempt event.
+if ! printf '%s' "$AUDIT_JSON" | grep -Eq 'task\.(cancelled|failed)'; then
+  echo "FAIL case 2.15: expected task.cancelled or task.failed audit event after recreate preempt"
   printf '%s\n' "$AUDIT_JSON"
   exit 1
 fi

--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -457,7 +457,7 @@ invoker_e2e_task_status() {
   local task_id="$1"
   invoker_e2e_run_headless task-status "$task_id" 2>/dev/null \
     | sed 's/\x1b\[[0-9;]*m//g' \
-    | grep -E '^(pending|running|completed|failed|awaiting_approval|review_ready|fixing_with_ai|closed|skipped)$' \
+    | grep -E '^(pending|running|completed|failed|blocked|awaiting_approval|review_ready|fixing_with_ai|closed|skipped)$' \
     | tail -1
 }
 


### PR DESCRIPTION
## Summary

Two e2e-dry-run proof cases assert task states that intentional behavior changes have since replaced, so they fail on master even though the product is correct.

Case 2.10 expected a cancelled downstream task to become `failed`, but the cascade now marks never-started dependents `blocked`.

Case 2.15 expected a `task.cancelled` event when recreate preempts an in-flight attempt, but standalone-headless recreate reaps the orphaned attempt as `task.failed`.

This realigns both assertions and teaches the status helper about `blocked`.

## Review Claim

Realign the two e2e-dry-run cancel/recreate proof cases with the current intentional terminal states.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only proof assertions and the test status-helper whitelist change. No product code is touched, so runtime behavior is unchanged.

## Slice Rationale

Both changes are stale-assertion corrections in the same e2e-dry-run proof harness, kept together and separate from any behavior change.

## Non-goals

- No change to cancel, recreate, or orphan-reaper behavior.
- No change to any product code.
- No new proof cases.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/e2e-dry-run/run-all.sh case-2.10-cancel-downstream.sh`
- [ ] `bash scripts/e2e-dry-run/run-all.sh case-2.15-recreate-preempt-attempt-refresh.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>