### PR TITLE
Run the Reset Rulebook proof in the Playwright container to get an X display

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,9 +381,6 @@ jobs:
           - name: Launch Dispatch Queue Repro
             command: bash scripts/test-suites/required/25-launch-dispatch-queue-handoff-repro.sh
             runner_label: Runner_2_4_core
-          - name: Reset Rulebook Repro
-            command: bash scripts/test-suites/required/26-reset-rulebook-proof.sh
-            runner_label: Runner_1
 
     name: required-fast / ${{ matrix.name }}
 
@@ -436,6 +433,66 @@ jobs:
       - name: Run suite group
         if: matrix.name != 'Vitest Workspace'
         run: ${{ matrix.command }}
+
+  reset-rulebook-repro:
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
+    needs: build-artifacts
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+    timeout-minutes: 45
+    name: required-fast / Reset Rulebook Repro
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .node-version
+
+      - name: Install test system packages
+        run: apt-get update && apt-get install -y unzip xvfb jq make g++ python3
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: app-build-dist
+          path: /tmp/invoker-build-artifacts
+
+      - name: Extract build artifacts
+        run: tar -xzf /tmp/invoker-build-artifacts/app-build-dist.tgz -C .
+
+      - name: Configure git identity and HTTPS auth
+        run: |
+          git config --global user.name "CI Bot"
+          git config --global user.email "ci@invoker.dev"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "git@github.com:"
+          git config --global --add url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
+          git update-ref refs/heads/main refs/remotes/origin/master || true
+          git update-ref refs/remotes/origin/main refs/remotes/origin/master || true
+
+      - name: Run Reset Rulebook proof
+        env:
+          TMPDIR: /tmp/invoker-tmp
+        run: |
+          mkdir -p "$TMPDIR"
+          chmod 1777 "$TMPDIR"
+          bash scripts/test-suites/required/26-reset-rulebook-proof.sh
 
   scheduled-repros:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary

The `Reset Rulebook Repro` job fails on master with `spawn xvfb-run ENOENT`.

It ran on a self-hosted runner that has no X display and no `xvfb`, and its headless-Electron proof needs one. That runner cannot `sudo apt-get install` without a password, so the dependency cannot be added in-job there.

This moves the job into the same Playwright container the `e2e-proof` job already uses, which installs `xvfb` without sudo, so the proof gets a real display.

## Review Claim

Run the Reset Rulebook proof in the Playwright container so its headless-Electron display dependency is satisfied.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only CI job placement changes. The proof command and its check name (`required-fast / Reset Rulebook Repro`) are unchanged, and no product code is touched.

## Slice Rationale

This is a single CI-runner change kept separate from any product or proof-content change.

## Non-goals

- No change to the reset-rulebook proof itself.
- No change to other self-hosted matrix entries.
- No product code changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
- [ ] CI runs `required-fast / Reset Rulebook Repro` in the Playwright container and it passes.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>