### PR TITLE
Keep delegating headless reads to a live owner when the ping times out

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -1,12 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { LocalBus } from '@invoker/transport';
 
 import { SharedMutationOwnerTimeoutError, electronCommandArgs, runHeadlessClientCommand } from '../headless-client.js';
 
 describe('headless-client', () => {
   const savedStandalone = process.env.INVOKER_HEADLESS_STANDALONE;
+  const savedDbDir = process.env.INVOKER_DB_DIR;
+  let dbDir: string;
   beforeEach(() => {
     delete process.env.INVOKER_HEADLESS_STANDALONE;
+    // Isolate the resolved DB path so the owner-marker liveness check in
+    // delegateGenericReadQuery cannot see a real ~/.invoker owner on the dev box.
+    dbDir = mkdtempSync(join(tmpdir(), 'headless-client-'));
+    process.env.INVOKER_DB_DIR = dbDir;
   });
   afterEach(() => {
     if (savedStandalone === undefined) {
@@ -14,6 +23,12 @@ describe('headless-client', () => {
     } else {
       process.env.INVOKER_HEADLESS_STANDALONE = savedStandalone;
     }
+    if (savedDbDir === undefined) {
+      delete process.env.INVOKER_DB_DIR;
+    } else {
+      process.env.INVOKER_DB_DIR = savedDbDir;
+    }
+    rmSync(dbDir, { recursive: true, force: true });
   });
 
   it('passes Linux headless stability flags before the app entry point', () => {
@@ -83,6 +98,39 @@ describe('headless-client', () => {
     expect(refreshMessageBus).toHaveBeenCalledTimes(1);
     expect(ensureStandaloneOwner).not.toHaveBeenCalled();
     expect(runElectronHeadless).toHaveBeenCalledWith(argv);
+  });
+
+  it('keeps delegating a read when the ping misses but a live owner marker exists', async () => {
+    process.env.INVOKER_HEADLESS_STANDALONE = '1';
+    // A live owner holds the DB (marker names this process, sidecars present),
+    // so a direct read-only open would be rejected by the WAL guard. The owner
+    // is too busy to answer the discovery ping, but still serves cli-query.
+    const dbPath = join(dbDir, 'invoker.db');
+    writeFileSync(dbPath, '');
+    writeFileSync(`${dbPath}-wal`, '');
+    writeFileSync(`${dbPath}.owner`, String(process.pid), 'utf-8');
+
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    // No owner-ping handler → discovery misses; cli-query still succeeds.
+    secondBus.onRequest('headless.query', async (request: { kind: string; args: string[] }) => {
+      expect(request).toEqual({ kind: 'cli-query', args: ['query', 'tasks', '--output', 'json'] });
+      return { output: '[]\n' };
+    });
+
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const refreshMessageBus = vi.fn().mockResolvedValue(secondBus);
+    const runElectronHeadless = vi.fn(async () => 23);
+
+    const exitCode = await runHeadlessClientCommand(['query', 'tasks', '--output', 'json'], {
+      messageBus: firstBus,
+      ensureStandaloneOwner,
+      refreshMessageBus,
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runElectronHeadless).not.toHaveBeenCalled();
   });
 
   it('delegates mutating commands to a standalone-capable owner endpoint', async () => {

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import { resolve } from 'node:path';
 
 import { resolveRepoRoot } from '@invoker/contracts';
+import { hasLiveWritableOwner } from '@invoker/data-store';
 import { IpcBus } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
 
@@ -183,7 +184,7 @@ async function delegateGenericReadQuery(
     messageBus = await refreshMessageBus();
     owner = await discoverOwner(messageBus, GENERIC_READ_OWNER_PING_TIMEOUT_MS);
   }
-  if (!owner) return false;
+  if (!owner && !hasLiveWritableOwner(resolve(resolveInvokerHomeRoot(), 'invoker.db'))) return false;
 
   const deadline = Date.now() + READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS;
   while (Date.now() < deadline) {

--- a/packages/data-store/src/__tests__/exclusive-locking.test.ts
+++ b/packages/data-store/src/__tests__/exclusive-locking.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { SQLiteAdapter } from '../sqlite-adapter.js';
+import { SQLiteAdapter, hasLiveWritableOwner } from '../sqlite-adapter.js';
 import type { Workflow } from '../adapter.js';
 
 /**
@@ -150,5 +150,47 @@ describe('SQLiteAdapter exclusiveLocking', () => {
     await expect(
       SQLiteAdapter.create(dbPath, { exclusiveLocking: true }),
     ).rejects.toThrow(/sole opener/);
+  });
+});
+
+describe('hasLiveWritableOwner', () => {
+  it('is true while a live owner holds the db with WAL sidecars', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      owner.saveWorkflow(wf);
+      expect(existsSync(`${dbPath}-shm`)).toBe(true);
+      expect(existsSync(`${dbPath}.owner`)).toBe(true);
+      expect(hasLiveWritableOwner(dbPath)).toBe(true);
+    } finally {
+      owner.close();
+    }
+  });
+
+  it('is false after a clean close leaves no sidecars', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    owner.saveWorkflow(wf);
+    owner.close();
+    expect(hasLiveWritableOwner(dbPath)).toBe(false);
+  });
+
+  it('is false when sidecars exist but the owner marker names a dead process', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    owner.saveWorkflow(wf);
+    owner.close();
+
+    // A read-only reader leaves -wal/-shm behind with no live owner.
+    const reader = await SQLiteAdapter.create(dbPath, { readOnly: true });
+    reader.close();
+    expect(existsSync(`${dbPath}-wal`) || existsSync(`${dbPath}-shm`)).toBe(true);
+    // PID 2^22 is above every configured pid_max, so it can never be alive.
+    writeFileSync(`${dbPath}.owner`, '4194304', 'utf-8');
+
+    expect(hasLiveWritableOwner(dbPath)).toBe(false);
   });
 });

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -130,6 +130,11 @@ function readLiveOwnerPid(dbPath: string): number | null {
   }
 }
 
+export function hasLiveWritableOwner(dbPath: string): boolean {
+  const sidecarsExist = existsSync(`${dbPath}-wal`) || existsSync(`${dbPath}-shm`);
+  return sidecarsExist && readLiveOwnerPid(dbPath) !== null;
+}
+
 function writeOwnerMarker(dbPath: string): void {
   try {
     writeFileSync(ownerMarkerPath(dbPath), String(process.pid), 'utf-8');


### PR DESCRIPTION
## Summary

A headless read command can crash under load with `Cannot open SQLite database read-only while writable owner PID N holds live WAL sidecars`.

When the owner process is alive but too busy to answer the discovery ping within its timeout, the client assumed no owner and opened the database file directly. The owner-marker guard then correctly rejected that direct open and aborted the command.

The ping missing is not proof the owner is gone. Now the client consults the same `.owner` marker the guard uses, and keeps delegating to the live owner instead of opening the file.

## Review Claim

A headless read whose owner ping times out must keep delegating to a live owner rather than open the database file directly.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The new path only changes what happens when the ping misses AND a live owner marker with WAL sidecars exists — the exact case the read-only guard already rejects. When no live owner exists, the original direct-open fallback is preserved, so the genuine sole-opener case is unchanged.

## Slice Rationale

One behavior fix to the headless read delegation, with the shared liveness check added to the data-store module that owns the marker.

## Non-goals

- No change to the read-only WAL guard itself.
- No change to mutation delegation.
- The chaos harness allow-list is deliberately untouched, so the regression stays caught.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/data-store && pnpm test src/__tests__/exclusive-locking.test.ts`
- [ ] `cd packages/app && pnpm test src/__tests__/headless-client.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
