### PR TITLE
Add headless query task-output and container-id read commands

### DIFF
--- a/packages/app/src/__tests__/headless-query-list.test.ts
+++ b/packages/app/src/__tests__/headless-query-list.test.ts
@@ -177,3 +177,61 @@ describe('headless query worker-decisions', () => {
     ).rejects.toThrow('Invalid --decision');
   });
 });
+
+function makeTaskQueryDeps(overrides: {
+  taskOutput?: string;
+  containerId?: string | null;
+}): HeadlessQueryDeps {
+  return {
+    persistence: {
+      listWorkflows: () => [{ id: 'wf-1' }],
+      loadTasks: (workflowId: string) =>
+        workflowId === 'wf-1' ? [{ id: 'wf-1/task-1' }] : [],
+      getTaskOutput: () => overrides.taskOutput ?? '',
+      getContainerId: () => overrides.containerId ?? null,
+    } as unknown as HeadlessQueryDeps['persistence'],
+    orchestrator: {
+      syncFromDb: () => {},
+    } as unknown as HeadlessQueryDeps['orchestrator'],
+    executionAgentRegistry: undefined,
+    invokerConfig: {} as unknown as HeadlessQueryDeps['invokerConfig'],
+    getUiPerfStats: () => ({}),
+    resetUiPerfStats: () => {},
+  };
+}
+
+describe('headless query task-output', () => {
+  it('prints the task output for a short task id', async () => {
+    const output = await runReadOnlyHeadlessQueryToString(
+      ['query', 'task-output', 'task-1'],
+      makeTaskQueryDeps({ taskOutput: 'build ok\n' }),
+    );
+    expect(output).toBe('build ok\n');
+  });
+
+  it('emits the resolved id and output as JSON', async () => {
+    const output = await runReadOnlyHeadlessQueryToString(
+      ['query', 'task-output', 'task-1', '--output', 'json'],
+      makeTaskQueryDeps({ taskOutput: 'log line' }),
+    );
+    expect(JSON.parse(output)).toEqual({ id: 'wf-1/task-1', output: 'log line' });
+  });
+});
+
+describe('headless query container-id', () => {
+  it('prints the container id for a short task id', async () => {
+    const output = await runReadOnlyHeadlessQueryToString(
+      ['query', 'container-id', 'task-1'],
+      makeTaskQueryDeps({ containerId: 'container-abc' }),
+    );
+    expect(output).toBe('container-abc\n');
+  });
+
+  it('prints an empty line when there is no container', async () => {
+    const output = await runReadOnlyHeadlessQueryToString(
+      ['query', 'container-id', 'task-1'],
+      makeTaskQueryDeps({ containerId: null }),
+    );
+    expect(output).toBe('\n');
+  });
+});

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -66,7 +66,7 @@ export type HeadlessQueryDeps = Pick<
 export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Promise<void> {
   const subCommand = args[0];
   if (!subCommand) {
-    throw new Error('Missing query sub-command. Usage: --headless query <workflows|workflow|tasks|task|queue|review-gate|action-graph|audit|session|workers|worker-actions|worker-decisions|cost|cost-events|costs|ui-perf|stats>');
+    throw new Error('Missing query sub-command. Usage: --headless query <workflows|workflow|tasks|task|task-output|container-id|queue|review-gate|action-graph|audit|session|workers|worker-actions|worker-decisions|cost|cost-events|costs|ui-perf|stats>');
   }
   const flags = parseQueryFlags(args.slice(1));
 
@@ -167,6 +167,33 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
         case 'json':  writeOut(formatAsJson(serializeTask(task)) + '\n'); break;
         case 'jsonl': writeOut(formatAsJsonl([serializeTask(task)]) + '\n'); break;
         default:      writeOut(task.status + '\n'); break;
+      }
+      break;
+    }
+    case 'task-output': {
+      const taskId = flags.positional[0];
+      if (!taskId) throw new Error('Usage: --headless query task-output <taskId>');
+      const resolved = restoreWorkflowForTask(taskId, deps).resolvedTaskId;
+      const output = deps.persistence.getTaskOutput(resolved);
+
+      switch (flags.output) {
+        case 'label': writeOut(output + '\n'); break;
+        case 'json':  writeOut(formatAsJson({ id: resolved, output }) + '\n'); break;
+        case 'jsonl': writeOut(formatAsJsonl([{ id: resolved, output }]) + '\n'); break;
+        default:      writeOut(output); break;
+      }
+      break;
+    }
+    case 'container-id': {
+      const taskId = flags.positional[0];
+      if (!taskId) throw new Error('Usage: --headless query container-id <taskId>');
+      const resolved = restoreWorkflowForTask(taskId, deps).resolvedTaskId;
+      const containerId = deps.persistence.getContainerId(resolved);
+
+      switch (flags.output) {
+        case 'json':  writeOut(formatAsJson({ id: resolved, containerId }) + '\n'); break;
+        case 'jsonl': writeOut(formatAsJsonl([{ id: resolved, containerId }]) + '\n'); break;
+        default:      writeOut((containerId ?? '') + '\n'); break;
       }
       break;
     }
@@ -401,7 +428,7 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
       break;
     }
     default:
-      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, workflow, tasks, task, queue, review-gate, action-graph, audit, session, workers, worker-actions, worker-decisions, cost, cost-events, costs, ui-perf, stats`);
+      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, workflow, tasks, task, task-output, container-id, queue, review-gate, action-graph, audit, session, workers, worker-actions, worker-decisions, cost, cost-events, costs, ui-perf, stats`);
   }
 }
 


### PR DESCRIPTION
## Summary

The docker CI proof reads task output and container ids straight from SQLite with the `sqlite3` CLI, which the runner cannot install.

This adds the two headless read commands those reads need, so the proof can use the app instead of a raw database client.

`query task-output <id>` returns a task's captured output, and `query container-id <id>` returns its container id, both resolving short task ids like the existing `query task`.

## Review Claim

Expose task output and container id as headless read commands so callers never need the `sqlite3` CLI.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Both are read-only commands that reuse the existing `restoreWorkflowForTask` id resolution and existing persistence readers; they add no writes and change no existing command.

## Slice Rationale

This adds only the command surface. The CI proof is switched over to it, and the `sqlite3` dependency dropped, in the follow-up slice.

## Non-goals

- No change to existing query subcommands.
- No change to persistence.
- No CI or script change (follow-up slice).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test src/__tests__/headless-query-list.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
