### PR TITLE
Read docker proof task state via headless commands, drop sqlite3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -909,9 +909,6 @@ jobs:
           git update-ref refs/heads/main refs/remotes/origin/master || true
           git update-ref refs/remotes/origin/main refs/remotes/origin/master || true
 
-      - name: Install sqlite3
-        run: sudo apt-get install -y sqlite3
-
       - name: Build invoker agent base image
         run: bash scripts/build-agent-base-image.sh
 

--- a/scripts/test-docker-comprehensive.sh
+++ b/scripts/test-docker-comprehensive.sh
@@ -155,12 +155,6 @@ else
   exit 2
 fi
 
-if [ ! -f "$DB_PATH" ] && ! command -v sqlite3 >/dev/null 2>&1; then
-  echo -e "  ${RED}ERROR:${NC} sqlite3 is required but not installed"
-  exit 2
-fi
-pass "sqlite3 available"
-
 echo "==> Building Docker fixture image"
 build_fixture_image
 pass "Fixture image $FIXTURE_IMAGE_TAG built with seeded /app git repo"
@@ -191,32 +185,15 @@ fi
 # ── Helper: query task output from DB ────────────────────────
 
 task_output() {
-  local query_id="$1"
-  local task_id
-  task_id="$(sqlite3 "$DB_PATH" "SELECT id FROM tasks WHERE id = '$query_id' OR id LIKE '%/' || '$query_id' ORDER BY id DESC LIMIT 1;" 2>/dev/null || true)"
-  if [[ -z "$task_id" ]]; then
-    task_id="$query_id"
-  fi
-
-  sqlite3 "$DB_PATH" "SELECT data FROM task_output WHERE task_id = '$task_id' ORDER BY id ASC;" 2>/dev/null || true
-
-  local output_file=""
-  if command -v shasum >/dev/null 2>&1; then
-    output_file="$INVOKER_DB_DIR/task-output/full/$(printf '%s' "$task_id" | shasum -a 256 | awk '{print $1}').log"
-  elif command -v sha256sum >/dev/null 2>&1; then
-    output_file="$INVOKER_DB_DIR/task-output/full/$(printf '%s' "$task_id" | sha256sum | awk '{print $1}').log"
-  fi
-  if [[ -n "$output_file" && -f "$output_file" ]]; then
-    cat "$output_file"
-  fi
+  ./run.sh --headless query task-output "$1" 2>/dev/null || true
 }
 
 task_status() {
-  sqlite3 "$DB_PATH" "SELECT status FROM tasks WHERE id = '$1' OR id LIKE '%/' || '$1' ORDER BY id DESC LIMIT 1;" 2>/dev/null || echo "unknown"
+  ./run.sh --headless query task "$1" 2>/dev/null || echo "unknown"
 }
 
 task_container_id() {
-  sqlite3 "$DB_PATH" "SELECT container_id FROM tasks WHERE id = '$1' OR id LIKE '%/' || '$1' ORDER BY id DESC LIMIT 1;" 2>/dev/null || echo ""
+  ./run.sh --headless query container-id "$1" 2>/dev/null || echo ""
 }
 
 wait_for_task_terminal() {


### PR DESCRIPTION
## Summary

The docker comprehensive proof fails on CI because it reads task state with the `sqlite3` CLI, which the self-hosted runner cannot install without passwordless sudo.

The proof now reads the same values through the app's headless query path, which is also safer than touching the database file while the owner holds it.

The `sqlite3` gate and the `Install sqlite3` CI step are no longer needed.

## Review Claim

Read docker proof task state through the app's headless query path so the `sqlite3` CLI is no longer required.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the docker proof script and its CI setup change; the three helpers return the same values as before, and no product code is touched.

## Slice Rationale

This is the CI and script half of the change, kept separate from the headless query commands it depends on (#4866).

## Non-goals

- No product code change.
- No change to what the proof asserts.
- No change to other CI jobs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash -n scripts/test-docker-comprehensive.sh`
- [ ] CI `docker / comprehensive` passes without the `Install sqlite3` step.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
