### PR TITLE
[Fix Task Context Menu Layering](1) Raise task context menus above graph panels

### DIFF
--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -46,6 +46,8 @@ const workflows: WorkflowMeta[] = [
   { id: 'wf-1', name: 'Test Workflow', status: 'running', baseBranch: 'master' },
 ];
 
+const FLOATING_GRAPH_PANEL_Z_INDEX = 1000;
+
 describe('Context menu (component)', () => {
   let mock: MockInvoker;
 
@@ -100,6 +102,22 @@ describe('Context menu (component)', () => {
     expect(screen.queryByText('Retry Workflow')).not.toBeInTheDocument();
     expect(screen.queryByText('Cancel Workflow')).not.toBeInTheDocument();
     expect(screen.queryByText('Delete Workflow')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Open Terminal'));
+    await waitFor(() => expect(mock.api.openTerminal).toHaveBeenCalledWith('task-alpha'));
+  });
+
+  it('task context menu opened from the selected workflow mini DAG layers above the floating graph panel', async () => {
+    await setup();
+    fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
+    const panel = await screen.findByTestId('selected-workflow-mini-dag');
+
+    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+
+    const menu = await screen.findByRole('menu');
+    expect(panel).toBeInTheDocument();
+    expect(menu).toHaveStyle({ zIndex: String(FLOATING_GRAPH_PANEL_Z_INDEX + 100) });
+    expect(Number(menu.style.zIndex)).toBeGreaterThan(FLOATING_GRAPH_PANEL_Z_INDEX);
   });
 
   it('workflow context menu retries workflow', async () => {

--- a/packages/ui/src/components/ContextMenu.tsx
+++ b/packages/ui/src/components/ContextMenu.tsx
@@ -28,6 +28,8 @@ interface ContextMenuProps {
   onClose: () => void;
 }
 
+const TASK_CONTEXT_MENU_Z_INDEX = 1100;
+
 export function ContextMenu({
   x,
   y,
@@ -216,8 +218,8 @@ export function ContextMenu({
     <div
       ref={menuRef}
       role="menu"
-      className="fixed z-50 bg-gray-800 border border-gray-600 rounded-lg shadow-xl py-1 min-w-[160px]"
-      style={{ left: position.left, top: position.top }}
+      className="fixed bg-gray-800 border border-gray-600 rounded-lg shadow-xl py-1 min-w-[160px]"
+      style={{ left: position.left, top: position.top, zIndex: TASK_CONTEXT_MENU_Z_INDEX }}
       onKeyDown={handleKeyDown}
       onClick={(event) => event.stopPropagation()}
       tabIndex={-1}


### PR DESCRIPTION
## Summary

Fix Task Context Menu Layering — 3 tasks completed, 0 failed, 0 closed, 0 skipped

Task context menus now use an explicit top-level z-index so they render above the selected-workflow mini DAG.

The focused regression keeps the mini DAG interaction intact and proves the task menu still exposes task actions.

## Review Claim

Task context menus render above task graph surfaces, including the floating selected-workflow mini DAG.

## Review Lane

behavior

## Review Unit

ui-overlay

## Safety Invariant

Only task context-menu overlay ordering and direct regression coverage change; TaskDAG click/context-menu dispatch stays intact.

## Slice Rationale

This is one local UI layering bug: `ContextMenu` used `z-50` while `FloatingGraphPanel` renders at `z-[1000]`.

## Non-goals

This does not redesign context-menu actions, graph layout, task selection, or workflow mutation behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/context-menu-e2e.test.tsx`
- [x] `pnpm --filter @invoker/ui build`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/fix-task-context-menu-layering-pr-body.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit for this PR>`
- Post-revert steps: rerun the focused context-menu test if the context menu changes again.
- Data migration? No

</details>
