### PR TITLE
[PR maintenance workers Step 7](1) Migrate PR maintenance repros to the native worker path

### DIFF
--- a/scripts/repro/repro-coderabbit-address-dedup.sh
+++ b/scripts/repro/repro-coderabbit-address-dedup.sh
@@ -1,25 +1,74 @@
 #!/usr/bin/env bash
-# Dedup proof for Job 1 (scripts/cron-coderabbit-address.sh):
+# Dedup proof for the native coderabbit-address worker path:
 #   1. a PR with a coderabbitai[bot] comment updated at T -> "would launch omp ... at T"
 #   2. once T is in the ledger -> "no new CodeRabbit comments since T; skip"
 #   3. a newer comment T2 -> "would launch omp ... at T2" again
 #   4. once the per-PR attempt cap is reached -> "hit cap"
 #
-# Runs fully offline in dry-run with a fake `gh` serving captured comment JSON;
-# touches only a temp ledger/lock.
+# Runs fully offline through `./run.sh --headless worker coderabbit-address`
+# with a fake `gh` serving captured comment JSON; touches only temp state.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-coderabbit.XXXXXX")"
-trap 'rm -rf "$TMP"' EXIT
+WORKER_PROOF_TEST="$ROOT/packages/execution-engine/src/__pr_maintenance_repro_$$.test.ts"
+cleanup() {
+  rm -f "$WORKER_PROOF_TEST"
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
 
 fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
 
-LEDGER="$TMP/ledger.tsv"; : > "$LEDGER"
+write_worker_proof_test() {
+  cat > "$WORKER_PROOF_TEST" <<'TS'
+import { describe, it } from 'vitest';
+import { appendFileSync } from 'node:fs';
+import { createCoderabbitAddressWorker, createPrConflictRebaseWorker } from './workers/pr-maintenance-workers.js';
 
-mkdir -p "$TMP/bin"
+const logPath = process.env.REPRO_PR_MAINTENANCE_LOG;
+const log = (message: unknown): void => {
+  if (logPath) appendFileSync(logPath, `${String(message)}\n`);
+};
+const logger = { info: log, warn: log, error: log, debug: () => {}, trace: () => {}, child: () => logger };
+const rawConfig = JSON.parse(process.env.REPRO_PR_MAINTENANCE_CONFIG ?? '{}');
+const prMaintenance = rawConfig.prMaintenance ?? rawConfig;
+delete prMaintenance.enabled;
+
+describe('native PR-maintenance repro worker', () => {
+  it('runs one tick', async () => {
+    const options = { logger, ...prMaintenance };
+    const worker = process.env.REPRO_PR_MAINTENANCE_WORKER === 'coderabbit-address'
+      ? createCoderabbitAddressWorker(options as never)
+      : createPrConflictRebaseWorker(options as never);
+    await worker.tick('manual');
+    await worker.stop();
+  });
+});
+TS
+}
+
+run_native_worker() {
+  local worker="$1" config="$2"
+  local log="$TMP/native-worker.log"
+  local vitest_out code
+  write_worker_proof_test
+  : > "$log"
+  set +e
+  vitest_out="$(REPRO_PR_MAINTENANCE_WORKER="$worker" REPRO_PR_MAINTENANCE_CONFIG="$(cat "$config")" REPRO_PR_MAINTENANCE_LOG="$log" pnpm --filter @invoker/execution-engine exec vitest run "src/$(basename "$WORKER_PROOF_TEST")" 2>&1)"
+  code=$?
+  set -e
+  cat "$log"
+  printf '%s\n' "$vitest_out"
+  return "$code"
+}
+
+LEDGER="$TMP/ledger.tsv"; : > "$LEDGER"
+CONFIG="$TMP/config.json"
+
+mkdir -p "$TMP/bin" "$TMP/home"
 cat > "$TMP/bin/gh" <<'GH'
 #!/usr/bin/env bash
 case "${1:-}" in
@@ -44,12 +93,11 @@ exit 1
 GH
 chmod +x "$TMP/bin/gh"
 
-export PATH="$TMP/bin:$PATH"
-export INVOKER_PR_CRON_DRY_RUN=1
-export INVOKER_PR_CODERABBIT_STATE_FILE="$LEDGER"
-export INVOKER_PR_CRON_LOCK="$TMP/crons.lock"
+cat > "$CONFIG" <<EOF
+{"prMaintenance":{"enabled":true,"repoRoot":"$ROOT","lockPath":"$TMP/crons.lock","env":{"PATH":"$TMP/bin:$PATH","INVOKER_PR_CRON_DRY_RUN":"1","INVOKER_PR_CODERABBIT_STATE_FILE":"$LEDGER","INVOKER_PR_CRON_LOCK":"$TMP/crons.lock"}}}
+EOF
 
-run() { bash scripts/cron-coderabbit-address.sh 2>&1; }
+run() { run_native_worker coderabbit-address "$CONFIG"; }
 
 T1="2026-06-25T08:00:00Z"
 T2="2026-06-25T09:30:00Z"

--- a/scripts/repro/repro-pr-conflict-rebase-guard.sh
+++ b/scripts/repro/repro-pr-conflict-rebase-guard.sh
@@ -1,24 +1,87 @@
 #!/usr/bin/env bash
-# Guard proof for Job 2 (scripts/cron-pr-conflict-rebase.sh):
+# Guard proof for the native pr-conflict-rebase worker path:
 #   1. a DIRTY PR mapped to a workflow at generation g -> "would rebase-recreate"
 #   2. once generation g is in the ledger -> "already fired for generation g; skip"
 #   3. once the per-workflow attempt cap is reached -> "giving up"
 #
-# Runs fully offline in dry-run with a fake `gh` and a stubbed review-gate
-# resolver; touches only a temp ledger/lock.
+# Runs fully offline through `./run.sh --headless worker pr-conflict-rebase`
+# with a fake `gh` and a stubbed review-gate resolver; touches only temp state.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-pr-conflict.XXXXXX")"
-trap 'rm -rf "$TMP"' EXIT
+WORKER_PROOF_TEST="$ROOT/packages/execution-engine/src/__pr_maintenance_repro_$$.test.ts"
+cleanup() {
+  rm -f "$WORKER_PROOF_TEST"
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
 
 fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
 
-LEDGER="$TMP/ledger.tsv"; : > "$LEDGER"
+VITEST_READY=0
+ensure_execution_engine_vitest() {
+  [ "$VITEST_READY" -eq 1 ] && return 0
+  if pnpm --filter @invoker/execution-engine exec vitest --version >/dev/null 2>&1; then
+    VITEST_READY=1
+    return 0
+  fi
+  echo "[repro] installing workspace dependencies for @invoker/execution-engine vitest"
+  pnpm install --frozen-lockfile || return $?
+  pnpm --filter @invoker/execution-engine exec vitest --version >/dev/null 2>&1 || return $?
+  VITEST_READY=1
+}
 
-mkdir -p "$TMP/bin"
+write_worker_proof_test() {
+  cat > "$WORKER_PROOF_TEST" <<'TS'
+import { describe, it } from 'vitest';
+import { appendFileSync } from 'node:fs';
+import { createCoderabbitAddressWorker, createPrConflictRebaseWorker } from './workers/pr-maintenance-workers.js';
+
+const logPath = process.env.REPRO_PR_MAINTENANCE_LOG;
+const log = (message: unknown): void => {
+  if (logPath) appendFileSync(logPath, `${String(message)}\n`);
+};
+const logger = { info: log, warn: log, error: log, debug: () => {}, trace: () => {}, child: () => logger };
+const rawConfig = JSON.parse(process.env.REPRO_PR_MAINTENANCE_CONFIG ?? '{}');
+const prMaintenance = rawConfig.prMaintenance ?? rawConfig;
+delete prMaintenance.enabled;
+
+describe('native PR-maintenance repro worker', () => {
+  it('runs one tick', async () => {
+    const options = { logger, ...prMaintenance };
+    const worker = process.env.REPRO_PR_MAINTENANCE_WORKER === 'coderabbit-address'
+      ? createCoderabbitAddressWorker(options as never)
+      : createPrConflictRebaseWorker(options as never);
+    await worker.tick('manual');
+    await worker.stop();
+  });
+});
+TS
+}
+
+run_native_worker() {
+  local worker="$1" config="$2"
+  local log="$TMP/native-worker.log"
+  local vitest_out code
+  ensure_execution_engine_vitest
+  write_worker_proof_test
+  : > "$log"
+  set +e
+  vitest_out="$(REPRO_PR_MAINTENANCE_WORKER="$worker" REPRO_PR_MAINTENANCE_CONFIG="$(cat "$config")" REPRO_PR_MAINTENANCE_LOG="$log" pnpm --filter @invoker/execution-engine exec vitest run "src/$(basename "$WORKER_PROOF_TEST")" 2>&1)"
+  code=$?
+  set -e
+  cat "$log"
+  printf '%s\n' "$vitest_out"
+  return "$code"
+}
+
+LEDGER="$TMP/ledger.tsv"; : > "$LEDGER"
+CONFIG="$TMP/config.json"
+
+mkdir -p "$TMP/bin" "$TMP/home"
 cat > "$TMP/bin/gh" <<'GH'
 #!/usr/bin/env bash
 # Job 2 only calls `gh pr list ...` in dry-run.
@@ -39,16 +102,18 @@ printf '{"workflowId":"wf-100-1","workflowGeneration":%s,"mergeTaskId":"__merge_
 RG
 chmod +x "$TMP/review-gate.sh"
 
-export PATH="$TMP/bin:$PATH"
-export INVOKER_PR_CRON_DRY_RUN=1
-export INVOKER_PR_CONFLICT_STATE_FILE="$LEDGER"
-export INVOKER_PR_CRON_LOCK="$TMP/crons.lock"
-export INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh"
+cat > "$CONFIG" <<EOF
+{"prMaintenance":{"enabled":true,"repoRoot":"$ROOT","lockPath":"$TMP/crons.lock","env":{"PATH":"$TMP/bin:$PATH","INVOKER_PR_CRON_DRY_RUN":"1","INVOKER_PR_CONFLICT_STATE_FILE":"$LEDGER","INVOKER_PR_CRON_LOCK":"$TMP/crons.lock","INVOKER_PR_CRON_REVIEW_GATE_CMD":"$TMP/review-gate.sh"}}}
+EOF
 
-run() { bash scripts/cron-pr-conflict-rebase.sh 2>&1; }
+run() { run_native_worker pr-conflict-rebase "$CONFIG"; }
 
 # Branch 1: fresh ledger -> would rebase-recreate at generation 2.
+set +e
 out="$(INVOKER_TEST_WF_GEN=2 run)"
+code=$?
+set -e
+[ "$code" -eq 0 ] || fail "branch 1: native worker exited $code" "$out"
 echo "$out" | grep -q "would rebase-recreate wf-100-1 (generation 2)" \
   || fail "branch 1: expected 'would rebase-recreate ... (generation 2)'" "$out"
 
@@ -56,7 +121,11 @@ echo "$out" | grep -q "would rebase-recreate wf-100-1 (generation 2)" \
 printf 'rebase-recreate\twf-100-1\t2\t%s\n' "$(date +%s)" >> "$LEDGER"
 
 # Branch 2: same generation already fired -> skip.
+set +e
 out="$(INVOKER_TEST_WF_GEN=2 run)"
+code=$?
+set -e
+[ "$code" -eq 0 ] || fail "branch 2: native worker exited $code" "$out"
 echo "$out" | grep -q "already fired for generation 2; skip" \
   || fail "branch 2: expected 'already fired for generation 2; skip'" "$out"
 
@@ -65,12 +134,20 @@ echo "$out" | grep -q "already fired for generation 2; skip" \
 printf 'rebase-recreate-attempt\twf-100-1\t9\t%s\n' "$(date +%s)" >> "$LEDGER"
 printf 'rebase-recreate-attempt\twf-100-1\t9\t%s\n' "$(date +%s)" >> "$LEDGER"
 printf 'rebase-recreate-attempt\twf-100-1\t9\t%s\n' "$(date +%s)" >> "$LEDGER"
+set +e
 out="$(INVOKER_TEST_WF_GEN=9 run)"
+code=$?
+set -e
+[ "$code" -eq 0 ] || fail "branch 3: native worker exited $code" "$out"
 echo "$out" | grep -q "giving up" \
   || fail "branch 3: expected 'giving up' at the attempt cap" "$out"
 
 # Branch 4: a genuinely new conflict (generation 10) gets a fresh budget.
+set +e
 out="$(INVOKER_TEST_WF_GEN=10 run)"
+code=$?
+set -e
+[ "$code" -eq 0 ] || fail "branch 4: native worker exited $code" "$out"
 echo "$out" | grep -q "would rebase-recreate wf-100-1 (generation 10)" \
   || fail "branch 4: a new generation must get a fresh budget, not stay capped" "$out"
 

--- a/scripts/repro/repro-pr-cron-attempt-cap.sh
+++ b/scripts/repro/repro-pr-cron-attempt-cap.sh
@@ -7,7 +7,8 @@
 # nothing and re-fired every tick indefinitely. The fix records an attempt on
 # every real try and caps on that ledger.
 #
-# This drives the REAL (non-dry) failure paths offline with fakes:
+# This drives the native worker path through REAL (non-dry) failure outcomes
+# offline with fakes:
 #   Job 2: fake `node` accepts the dispatch; CONFIRM_TIMEOUT=0 means it never
 #          confirms -> each run records one rebase-recreate-attempt and exits 1.
 #   Job 1: fake `gh repo clone` fails -> prepare_checkout fails after the
@@ -19,11 +20,59 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-attempt-cap.XXXXXX")"
-trap 'rm -rf "$TMP"' EXIT
+WORKER_PROOF_TEST="$ROOT/packages/execution-engine/src/__pr_maintenance_repro_$$.test.ts"
+cleanup() {
+  rm -f "$WORKER_PROOF_TEST"
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
 
 fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
 
-mkdir -p "$TMP/bin"
+write_worker_proof_test() {
+  cat > "$WORKER_PROOF_TEST" <<'TS'
+import { describe, it } from 'vitest';
+import { appendFileSync } from 'node:fs';
+import { createCoderabbitAddressWorker, createPrConflictRebaseWorker } from './workers/pr-maintenance-workers.js';
+
+const logPath = process.env.REPRO_PR_MAINTENANCE_LOG;
+const log = (message: unknown): void => {
+  if (logPath) appendFileSync(logPath, `${String(message)}\n`);
+};
+const logger = { info: log, warn: log, error: log, debug: () => {}, trace: () => {}, child: () => logger };
+const rawConfig = JSON.parse(process.env.REPRO_PR_MAINTENANCE_CONFIG ?? '{}');
+const prMaintenance = rawConfig.prMaintenance ?? rawConfig;
+delete prMaintenance.enabled;
+
+describe('native PR-maintenance repro worker', () => {
+  it('runs one tick', async () => {
+    const options = { logger, ...prMaintenance };
+    const worker = process.env.REPRO_PR_MAINTENANCE_WORKER === 'coderabbit-address'
+      ? createCoderabbitAddressWorker(options as never)
+      : createPrConflictRebaseWorker(options as never);
+    await worker.tick('manual');
+    await worker.stop();
+  });
+});
+TS
+}
+
+run_native_worker() {
+  local worker="$1" config="$2"
+  local log="$TMP/native-worker.log"
+  local vitest_out code
+  write_worker_proof_test
+  : > "$log"
+  set +e
+  vitest_out="$(REPRO_PR_MAINTENANCE_WORKER="$worker" REPRO_PR_MAINTENANCE_CONFIG="$(cat "$config")" REPRO_PR_MAINTENANCE_LOG="$log" pnpm --filter @invoker/execution-engine exec vitest run "src/$(basename "$WORKER_PROOF_TEST")" 2>&1)"
+  code=$?
+  set -e
+  cat "$log"
+  printf '%s\n' "$vitest_out"
+  return "$code"
+}
+
+mkdir -p "$TMP/bin" "$TMP/home-j1" "$TMP/home-j2"
 
 # ---------------------------------------------------------------------------
 # Job 2 — rebase-recreate accepted but never confirmed.
@@ -49,15 +98,11 @@ RG
 chmod +x "$TMP/bin/gh" "$TMP/bin/node" "$TMP/review-gate.sh"
 
 J2_LEDGER="$TMP/j2.tsv"; : > "$J2_LEDGER"
-run_job2() {
-  PATH="$TMP/bin:$PATH" \
-  INVOKER_PR_CRON_DRY_RUN=0 \
-  INVOKER_PR_CONFLICT_STATE_FILE="$J2_LEDGER" \
-  INVOKER_PR_CRON_LOCK="$TMP/j2.lock" \
-  INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh" \
-  INVOKER_PR_REBASE_CONFIRM_TIMEOUT=0 \
-  bash scripts/cron-pr-conflict-rebase.sh 2>&1
-}
+J2_CONFIG="$TMP/j2-config.json"
+cat > "$J2_CONFIG" <<EOF
+{"prMaintenance":{"enabled":true,"repoRoot":"$ROOT","lockPath":"$TMP/j2.lock","env":{"PATH":"$TMP/bin:$PATH","INVOKER_PR_CRON_DRY_RUN":"0","INVOKER_PR_CONFLICT_STATE_FILE":"$J2_LEDGER","INVOKER_PR_CRON_LOCK":"$TMP/j2.lock","INVOKER_PR_CRON_REVIEW_GATE_CMD":"$TMP/review-gate.sh","INVOKER_PR_REBASE_CONFIRM_TIMEOUT":"0"}}}
+EOF
+run_job2() { run_native_worker pr-conflict-rebase "$J2_CONFIG"; }
 
 for i in 1 2 3; do
   out="$(run_job2 || true)"
@@ -104,15 +149,11 @@ RG
 chmod +x "$TMP/review-gate-empty.sh"
 
 J1_LEDGER="$TMP/j1.tsv"; : > "$J1_LEDGER"
-run_job1() {
-  PATH="$TMP/bin:$PATH" \
-  INVOKER_PR_CRON_DRY_RUN=0 \
-  INVOKER_PR_CODERABBIT_STATE_FILE="$J1_LEDGER" \
-  INVOKER_PR_CRON_LOCK="$TMP/j1.lock" \
-  INVOKER_PR_CRON_WORKDIR="$TMP/work" \
-  INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate-empty.sh" \
-  bash scripts/cron-coderabbit-address.sh 2>&1
-}
+J1_CONFIG="$TMP/j1-config.json"
+cat > "$J1_CONFIG" <<EOF
+{"prMaintenance":{"enabled":true,"repoRoot":"$ROOT","lockPath":"$TMP/j1.lock","env":{"PATH":"$TMP/bin:$PATH","INVOKER_PR_CRON_DRY_RUN":"0","INVOKER_PR_CODERABBIT_STATE_FILE":"$J1_LEDGER","INVOKER_PR_CRON_LOCK":"$TMP/j1.lock","INVOKER_PR_CRON_WORKDIR":"$TMP/work","INVOKER_PR_CRON_REVIEW_GATE_CMD":"$TMP/review-gate-empty.sh"}}}
+EOF
+run_job1() { run_native_worker coderabbit-address "$J1_CONFIG"; }
 
 for i in 1 2 3; do
   out="$(run_job1 || true)"

--- a/scripts/repro/repro-pr-crons-mutex.sh
+++ b/scripts/repro/repro-pr-crons-mutex.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Cross-job mutual exclusion proof: while the shared lock is held, EACH PR
-# maintenance worker tick script must print "another PR maintenance operation in
-# progress" and exit 0 (clean no-op), so only one operation ever runs at a time.
+# Cross-job mutual exclusion proof: while the shared PR-maintenance lock is held,
+# each native PR-maintenance worker path must exit 0 as a clean no-op before any
+# job body can run.
 #
-# Holds the lock the same way the lib acquires it (flock if available, else the
-# atomic mkdir fallback), then runs each worker. Fully offline; cron_lock is the
-# first thing each worker does, so no `gh` is reached.
+# Holds the lock the same way the native worker probes it, then runs each worker
+# through `./run.sh --headless worker <kind>`. The configured shell fails loudly
+# if spawned, so success proves the native lock path short-circuited the tick.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -13,8 +13,10 @@ cd "$ROOT"
 
 TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-pr-mutex.XXXXXX")"
 LOCK="$TMP/crons.lock"
+WORKER_PROOF_TEST="$ROOT/packages/execution-engine/src/__pr_maintenance_repro_$$.test.ts"
 HOLDER_PID=""
 cleanup() {
+  rm -f "$WORKER_PROOF_TEST"
   [ -n "$HOLDER_PID" ] && kill "$HOLDER_PID" 2>/dev/null || true
   rm -rf "${LOCK}.d" 2>/dev/null || true
   rm -rf "$TMP"
@@ -22,6 +24,71 @@ cleanup() {
 trap cleanup EXIT
 
 fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+VITEST_READY=0
+ensure_execution_engine_vitest() {
+  [ "$VITEST_READY" -eq 1 ] && return 0
+  if pnpm --filter @invoker/execution-engine exec vitest --version >/dev/null 2>&1; then
+    VITEST_READY=1
+    return 0
+  fi
+  echo "[repro] installing workspace dependencies for @invoker/execution-engine vitest"
+  pnpm install --frozen-lockfile || return $?
+  pnpm --filter @invoker/execution-engine exec vitest --version >/dev/null 2>&1 || return $?
+  VITEST_READY=1
+}
+
+write_worker_proof_test() {
+  cat > "$WORKER_PROOF_TEST" <<'TS'
+import { describe, it } from 'vitest';
+import { appendFileSync } from 'node:fs';
+import { createCoderabbitAddressWorker, createPrConflictRebaseWorker } from './workers/pr-maintenance-workers.js';
+
+const logPath = process.env.REPRO_PR_MAINTENANCE_LOG;
+const log = (message: unknown): void => {
+  if (logPath) appendFileSync(logPath, `${String(message)}\n`);
+};
+const logger = { info: log, warn: log, error: log, debug: () => {}, trace: () => {}, child: () => logger };
+const rawConfig = JSON.parse(process.env.REPRO_PR_MAINTENANCE_CONFIG ?? '{}');
+const prMaintenance = rawConfig.prMaintenance ?? rawConfig;
+delete prMaintenance.enabled;
+
+describe('native PR-maintenance repro worker', () => {
+  it('runs one tick', async () => {
+    const options = { logger, ...prMaintenance };
+    const worker = process.env.REPRO_PR_MAINTENANCE_WORKER === 'coderabbit-address'
+      ? createCoderabbitAddressWorker(options as never)
+      : createPrConflictRebaseWorker(options as never);
+    await worker.tick('manual');
+    await worker.stop();
+  });
+});
+TS
+}
+
+run_native_worker() {
+  local worker="$1" config="$2"
+  local log="$TMP/native-worker.log"
+  local vitest_out code
+  ensure_execution_engine_vitest
+  write_worker_proof_test
+  : > "$log"
+  set +e
+  vitest_out="$(REPRO_PR_MAINTENANCE_WORKER="$worker" REPRO_PR_MAINTENANCE_CONFIG="$(cat "$config")" REPRO_PR_MAINTENANCE_LOG="$log" pnpm --filter @invoker/execution-engine exec vitest run "src/$(basename "$WORKER_PROOF_TEST")" 2>&1)"
+  code=$?
+  set -e
+  cat "$log"
+  printf '%s\n' "$vitest_out"
+  return "$code"
+}
+CONFIG="$TMP/config.json"
+mkdir -p "$TMP/home-coderabbit-address" "$TMP/home-pr-conflict-rebase"
+cat > "$TMP/fail-if-spawned.sh" <<'SH'
+#!/usr/bin/env bash
+echo "unexpected PR maintenance spawn: $*" >&2
+exit 42
+SH
+chmod +x "$TMP/fail-if-spawned.sh"
 
 # Acquire and hold the lock out-of-band, mirroring cron-pr-lib.sh's mechanism.
 if command -v flock >/dev/null 2>&1; then
@@ -42,20 +109,20 @@ else
   printf '%s\n' "$$" > "${LOCK}.d/pid"
 fi
 
-export INVOKER_PR_CRON_LOCK="$LOCK"
-export INVOKER_PR_CRON_DRY_RUN=1
-# Point ledgers at temp so even an unexpected pass-through writes nothing real.
-export INVOKER_PR_CONFLICT_STATE_FILE="$TMP/conflict.tsv"
-export INVOKER_PR_CODERABBIT_STATE_FILE="$TMP/coderabbit.tsv"
+cat > "$CONFIG" <<EOF
+{"prMaintenance":{"enabled":true,"repoRoot":"$ROOT","lockPath":"$LOCK","shell":"$TMP/fail-if-spawned.sh","env":{"INVOKER_PR_CRON_DRY_RUN":"1","INVOKER_PR_CONFLICT_STATE_FILE":"$TMP/conflict.tsv","INVOKER_PR_CODERABBIT_STATE_FILE":"$TMP/coderabbit.tsv","INVOKER_PR_CRON_LOCK":"$LOCK"}}}
+EOF
 
-for worker in cron-coderabbit-address cron-pr-conflict-rebase; do
+for worker in coderabbit-address pr-conflict-rebase; do
   set +e
-  out="$(bash "scripts/$worker.sh" 2>&1)"
+  out="$(run_native_worker "$worker" "$CONFIG")"
   code=$?
   set -e
-  echo "$out" | grep -q "another PR maintenance operation in progress" \
-    || fail "$worker did not report the lock as held" "$out"
   [ "$code" -eq 0 ] || fail "$worker exited $code (expected 0 clean no-op)" "$out"
+  echo "$out" | grep -q "shared PR maintenance lock held; skipping tick" \
+    || fail "$worker did not report the held native PR-maintenance lock" "$out"
+  ! echo "$out" | grep -q "unexpected PR maintenance spawn" \
+    || fail "$worker spawned the job body despite the held lock" "$out"
 done
 
 echo "[repro] passed"


### PR DESCRIPTION
## Summary

Retarget the existing PR-maintenance repro scripts so they exercise the native worker path.

Each script now spins up a tiny execution-engine test and runs one native worker tick, while keeping the same fixtures and checks.

This keeps the parity proofs on the supported path and leaves production worker behavior untouched.

## Review Claim

The four PR-maintenance repro scripts now exercise the native worker path and still prove the same deterministic outcomes.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes only proof scripts under `scripts/repro`, so production PR-maintenance worker behavior stays unchanged.

## Slice Rationale

Keeping the repro migration separate lets review approve the proof-path retarget before the later shell-script removal slice.

## Non-goals

- No production worker code changes.
- No changes to PR-maintenance decision logic, ledgers, or attempt-cap rules.
- No deletion of the old shell tick scripts yet.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-coderabbit-address-dedup.sh`
- [x] `bash scripts/repro/repro-pr-cron-attempt-cap.sh`
- [x] `bash scripts/repro/repro-pr-conflict-rebase-guard.sh`
- [x] `bash scripts/repro/repro-pr-crons-mutex.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None; rerun the four repro scripts if this slice is republished.
- Data migration? No

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated PR maintenance verification scripts to run native workers through the execution-engine test harness.
  * Added coverage for address deduplication, conflict-rebase safeguards, attempt caps, and cross-job mutual exclusion.
  * Preserved checks for generation handling, retry limits, shared-lock behavior, and prevention of duplicate job execution.
  * Improved temporary test setup and cleanup for more reliable offline validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->