### PR TITLE
[CI Duration Invariant](1) Exempt reset-rulebook-repro from the 5m budget

### DIFF
--- a/scripts/test-ci-duration-invariant.mjs
+++ b/scripts/test-ci-duration-invariant.mjs
@@ -22,6 +22,7 @@ const EXEMPT_JOBS = new Set([
   'docker',
   'scheduled-repros',
   'playwright-nightly-perf',
+  'reset-rulebook-repro',
 ]);
 
 const workflow = YAML.parse(readFileSync('.github/workflows/ci.yml', 'utf8'));


### PR DESCRIPTION
## Summary

Exempt the `reset-rulebook-repro` CI job from the 5-minute PR-facing duration invariant so the Vitest Workspace suite passes on master again.

The job is a heavy proof (45m timeout, Playwright container) like the other exempt repro jobs, but it was missing from `EXEMPT_JOBS`.

`pnpm test` runs that checker in its chain, so its failure turned the whole Vitest Workspace suite red.

## Review Claim

Add `reset-rulebook-repro` to the duration-invariant `EXEMPT_JOBS` allowlist.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only widens the exempt-job allowlist by one long-running proof job; the 5-minute cap on PR-facing budgeted jobs (quality-required, ui-vitest, quality-extra, playwright) is unchanged.

## Slice Rationale

One-line policy allowlist change with no product-code impact.

## Non-goals

- No change to any job's actual timeout or runtime.
- No change to the budgeted-job set or the 5-minute cap.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-ci-duration-invariant.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 615675c4e`
- Post-revert steps: None
- Data migration? No

</details>
