### PR TITLE
[CI Vitest Workspace](1) Sanction recovery helpers imported by registered workers

### DIFF
--- a/packages/execution-engine/src/__tests__/no-autofix-outside-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/no-autofix-outside-worker.test.ts
@@ -85,6 +85,24 @@ function extractExportedWorkerKinds(source: string): Set<string> {
   return workerKinds;
 }
 
+function localValueImportSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  const pattern = /(?:^|\n)\s*(?:import|export)\s+(?!type\s)[^;]*?\sfrom\s+'(\.[^']+)'/g;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(source)) !== null) specifiers.push(match[1]);
+  return specifiers;
+}
+
+function resolveLocalImport(fromFile: string, specifier: string): string {
+  const parts = fromFile.includes('/') ? fromFile.slice(0, fromFile.lastIndexOf('/')).split('/') : [];
+  for (const segment of specifier.replace(/\.js$/, '.ts').split('/')) {
+    if (segment === '.' || segment === '') continue;
+    if (segment === '..') parts.pop();
+    else parts.push(segment);
+  }
+  return parts.join('/');
+}
+
 function registeredBuiltInWorkerSourceFiles(sourceFiles: SourceFiles): Set<string> {
   const builtinWorkers = sourceFiles.get(BUILTIN_WORKERS_SOURCE);
   expect(builtinWorkers).toBeDefined();
@@ -106,6 +124,24 @@ function registeredBuiltInWorkerSourceFiles(sourceFiles: SourceFiles): Set<strin
     const moduleWorkerKinds = extractExportedWorkerKinds(source ?? '');
     if ([...moduleWorkerKinds].some((kind) => registeredKinds.has(kind))) {
       allowedFiles.add(sourcePath);
+    }
+  }
+
+  // Recovery helpers factored out of a registered worker (and imported by it)
+  // are part of that worker's implementation, so follow value imports to keep
+  // their submitter.submit() calls sanctioned. Files no worker reaches stay
+  // unsanctioned and are still caught as violations.
+  const queue = [...allowedFiles];
+  while (queue.length > 0) {
+    const file = queue.pop() as string;
+    const source = sourceFiles.get(file);
+    if (!source) continue;
+    for (const specifier of localValueImportSpecifiers(source)) {
+      const importedPath = resolveLocalImport(file, specifier);
+      if (sourceFiles.has(importedPath) && !allowedFiles.has(importedPath)) {
+        allowedFiles.add(importedPath);
+        queue.push(importedPath);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Teach the recovery-action worker guard to sanction helper modules that a registered worker imports, so the Vitest Workspace suite passes on master again.

The CI-repair recovery submit was factored into `review-gate-ci-repair.ts`, a helper imported and called by the registered `ci-failure-worker`. The guard only sanctioned direct registration modules, so it flagged the helper as an out-of-worker recovery trigger.

## Review Claim

Follow value imports transitively from registered worker modules when deriving the guard's sanctioned-file set.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The sanctioned set only grows to include files reachable from a registered worker via value imports; a recovery submit in a file no worker imports stays unsanctioned and still fails the guard (the negative test is unchanged and still passes).

## Slice Rationale

Guard-only change; touches a single test file and no product code.

## Non-goals

- No change to any worker, recovery path, or product code.
- No change to what counts as a recovery-action trigger.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && node_modules/.bin/vitest run src/__tests__/no-autofix-outside-worker.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9b823d462`
- Post-revert steps: None
- Data migration? No

</details>
