### PR TITLE
[Keep Planning Terminal On Submit](1) Preserve planning terminal after submit

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2527,10 +2527,10 @@ export function App() {
       if (result.ok) {
         setPlanningSubmitError(null);
         setHasLoadedPlan(true);
-        setWorkflowSelectionDismissed(false);
-        setGraphActionsMenuOpen(false);
+        if (!selectedTaskId && !selectedWorkflowId) {
+          setWorkflowSelectionDismissed(true);
+        }
         setPlanName(result.planName);
-        setSelectedWorkflowId(result.workflowId);
         updatePlanningSessionById(planningSessionId, (session) => ({
           ...session,
           busy: false,
@@ -2560,7 +2560,7 @@ export function App() {
       setPlanningSubmitError({ title: 'Plan could not be submitted', message });
       appendTerminalLine(`Plan could not be submitted:\n${message}`, 'system', 'error');
     }
-  }, [activePlanningReadOnly, appendTerminalLine, invoker, planningSessionId, refreshTaskGraph, updatePlanningSessionById]);
+  }, [activePlanningReadOnly, appendTerminalLine, invoker, planningSessionId, refreshTaskGraph, selectedTaskId, selectedWorkflowId, updatePlanningSessionById]);
 
   const handlePlanningSubmit = useCallback(async () => {
     const input = planningInput.trim();

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, type Mock } from 'vitest';
 import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { vi } from 'vitest';
 import { useState } from 'react';
+import * as ReactFlowModule from '@xyflow/react';
 import { createMockInvoker, makePlanningSessionSummary, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { TaskState, WorkflowMeta } from '../types.js';
 
@@ -14,6 +15,8 @@ vi.mock('@xyflow/react', async () => {
 // Dynamic imports are required so modules see the hoisted @xyflow/react mock.
 const { App } = await import('../App.js');
 const { InvokerTerminal } = await import('../components/InvokerTerminal.js');
+
+const setCenterMock = (ReactFlowModule as unknown as { __setCenterMock: Mock }).__setCenterMock;
 
 const COMPONENT_INPUT_HANDLER_BUDGET_MS = 16;
 
@@ -716,6 +719,55 @@ describe('Invoker terminal (component)', () => {
     expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Submit to Invoker' })).not.toBeInTheDocument();
     expect(mock.api.start).not.toHaveBeenCalled();
+  });
+
+  it('does not select the submitted workflow when the graph had no selection', async () => {
+    const submittedWorkflow: WorkflowMeta = { id: 'wf-submitted', name: 'Submitted Workflow', status: 'pending' };
+    const submittedTask = makeUITask({
+      id: 'wf-submitted/task-1',
+      workflowId: 'wf-submitted',
+      description: 'Submitted task',
+    });
+    mock.api.planningChatSend = vi.fn(async () => ({
+      ok: true,
+      sessionId: 'session-1',
+      reply: 'Here is the plan.',
+      draftPlanAvailable: true,
+      draftPlanSummary: { name: 'Mock Plan', taskCount: 1, steps: ['First'] },
+    })) as any;
+    mock.api.refreshTaskGraph = vi.fn(async () => {
+      mock.fireGraphEvent({
+        type: 'snapshot',
+        tasks: [submittedTask],
+        workflows: [submittedWorkflow],
+        reason: 'mock-refresh',
+        streamSequence: 0,
+      });
+    }) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft the full plan');
+    await screen.findByTestId('invoker-terminal-ready-bar');
+
+    setCenterMock.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });
+      expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
+      expect(screen.getByTestId('sidebar-planning')).toHaveAttribute('aria-current', 'page');
+    });
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
+    expect(setCenterMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-submitted')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('workflow-node-wf-submitted')).not.toHaveClass('ring-2');
+    expect(screen.getByText('No task selected')).toBeInTheDocument();
   });
 
   it('shows stacked workflow counts and submit messaging', async () => {


### PR DESCRIPTION
## Summary

Planning Terminal stays selected after draft acceptance. Graph refresh and read-only session state remain unchanged.

## Review Claim

Planning Terminal remains the active UI surface after draft acceptance.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The planner acceptance path still calls `planningChatSubmit`, refreshes graph data, marks the planning session submitted, clears draft readiness, and writes the same success transcript message.

## Slice Rationale

This is one UI activation change in the Planning Terminal success path, covered in the existing terminal component spec.

## Non-goals

Do not change explicit workflow clicks, command palette navigation, Start ready work, workflow graph initial fit behavior, planning chat read-only behavior, or backend planningChatSubmit contracts.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/invoker-terminal.test.tsx`
- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/app build`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr4890-body-updated.md --changed-files-file /tmp/pr4890-changed-files.txt --diff-file /tmp/pr4890.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit for this PR>`
- Post-revert steps: rerun the focused planning terminal component spec if this path changes again.
- Data migration? No

</details>
