### PR TITLE
[CI Vitest Workspace](3) Fix fix-prompt-transport model-support and spawn-mock leak

### DIFF
--- a/packages/execution-engine/src/__tests__/fix-prompt-transport.test.ts
+++ b/packages/execution-engine/src/__tests__/fix-prompt-transport.test.ts
@@ -71,12 +71,17 @@ function makeExecutionAgent(buildFixCommand: ExecutionAgent['buildFixCommand']):
     buildCommand: (fullPrompt: string) => ({ cmd: 'codex', args: ['exec', '--json', fullPrompt] }),
     buildResumeArgs: (sessionId: string) => ({ cmd: 'codex', args: ['resume', sessionId] }),
     buildFixCommand,
+    supportsModel: () => true,
   };
 }
 
 describe('fix prompt transport for oversized prompts', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    // Reset the spawn mock's once-queue so a test that rejects before calling
+    // spawn cannot leak its queued child into the next test.
+    const { spawn } = await import('node:child_process');
+    vi.mocked(spawn).mockReset();
   });
 
   it('local fix path replaces oversized prompt arg with file-backed bootstrap prompt', async () => {
@@ -167,6 +172,7 @@ describe('fix prompt transport for oversized prompts', () => {
       buildCommand: (fullPrompt: string) => ({ cmd: 'omp', args: ['-p', fullPrompt] }),
       buildResumeArgs: (sessionId: string) => ({ cmd: 'omp', args: ['resume', sessionId] }),
       buildFixCommand,
+      supportsModel: () => true,
     };
 
     vi.mocked(spawn).mockReturnValueOnce(mockSpawnChild('ok', 0) as any);
@@ -202,8 +208,8 @@ describe('fix prompt transport for oversized prompts', () => {
     vi.mocked(spawn).mockReturnValueOnce(child);
 
     const registry = {
-      get: () => ({ name: 'omp', buildFixCommand }),
-      getOrThrow: () => ({ name: 'omp', buildFixCommand }),
+      get: () => ({ name: 'omp', buildFixCommand, supportsModel: () => true }),
+      getOrThrow: () => ({ name: 'omp', buildFixCommand, supportsModel: () => true }),
       getSessionDriver: () => undefined,
     } as unknown as AgentRegistry;
 
@@ -235,8 +241,12 @@ describe('fix prompt transport for oversized prompts', () => {
  * to recognize argv-size and OOM-kill failures.
  */
 describe('spawn errors during agent fix surface diagnostic info', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    // Reset the spawn mock's once-queue so a test that rejects before calling
+    // spawn cannot leak its queued child into the next test.
+    const { spawn } = await import('node:child_process');
+    vi.mocked(spawn).mockReset();
   });
 
   it('surfaces E2BIG when spawn emits an error event (argv too long)', async () => {


### PR DESCRIPTION
## Summary

Fix the 9 red `fix-prompt-transport` tests so the Vitest Workspace suite goes green, without changing any product behavior.

The Execution Model Guard (#4245) made the fix path validate the executionModel, but these mock agents declared no model support, so validation threw before spawn. The unconsumed spawn mock then cascaded into every later test.

## Review Claim

Declare `supportsModel` on the model-using mock agents and reset the spawn mock in `beforeEach`.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the test file changes: mock agents gain `supportsModel: () => true` and `beforeEach` resets the spawn mock's once-queue. No product code and no assertions change.

## Slice Rationale

Both sub-fixes address one failure mode (a pre-spawn rejection leaking its queued child), so they belong in one test-only change.

## Non-goals

- No change to `assertExecutionModelSupported` or any agent's real model list.
- No change to `spawnAgentFixViaRegistry` or the diagnostics it emits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && node_modules/.bin/vitest run src/__tests__/fix-prompt-transport.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert df772047e`
- Post-revert steps: None
- Data migration? No

</details>
