### PR TITLE
[Fix getEventsByTypes TEMP B-TREE](2) Per-type indexed LIMIT merge

### DIFF
--- a/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
+++ b/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
@@ -93,7 +93,8 @@ describe('main-process read hot-path cost guards', () => {
     expect(status.wakeups + status.scans + status.submissions + status.skips).toBe(taskCount * eventsPerTask);
     expect(status.recent.length).toBeGreaterThan(0);
     expect(status.recent.length).toBeLessThanOrEqual(10);
-    expect(elapsedMs).toBeLessThan(750);
+    // Per-type indexed LIMIT+merge must stay well under a 2s UI poll budget.
+    expect(elapsedMs).toBeLessThan(50);
   });
 
   it('projects a stale-pointer task without scanning every attempt under large error blobs', async () => {

--- a/packages/data-store/src/__tests__/get-events-by-types-plan.test.ts
+++ b/packages/data-store/src/__tests__/get-events-by-types-plan.test.ts
@@ -86,9 +86,7 @@ describe('getEventsByTypes query plans', () => {
     expect(detail).not.toContain('USE TEMP B-TREE');
   });
 
-  // Desired behavior for the adapter: never issue the multi-type TEMP B-TREE SQL.
-  // PR1 keeps this failing; PR2 flips it.fails → it once getEventsByTypes merges per-type.
-  it.fails('getEventsByTypes avoids multi-type IN ORDER BY that forces TEMP B-TREE', async () => {
+  it('getEventsByTypes avoids multi-type IN ORDER BY that forces TEMP B-TREE', async () => {
     adapter = await SQLiteAdapter.create(':memory:');
     adapter.saveWorkflow(makeWorkflow('wf-1'));
     adapter.saveTask('wf-1', makeTask('t1'));
@@ -114,5 +112,40 @@ describe('getEventsByTypes query plans', () => {
       && /ORDER BY\s+created_at/i.test(sql),
     )).toBe(true);
     queryAll.mockRestore();
+  });
+
+  it('getEventsByTypes merges newest-across-types order and respects limit', async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    adapter.saveWorkflow(makeWorkflow('wf-1'));
+    adapter.saveTask('wf-1', makeTask('t1'));
+
+    const stamps = [
+      { type: RECOVERY_TYPES[0], at: '2026-07-01T00:00:01.000Z' },
+      { type: RECOVERY_TYPES[1], at: '2026-07-01T00:00:03.000Z' },
+      { type: RECOVERY_TYPES[2], at: '2026-07-01T00:00:02.000Z' },
+      { type: RECOVERY_TYPES[3], at: '2026-07-01T00:00:04.000Z' },
+      { type: RECOVERY_TYPES[0], at: '2026-07-01T00:00:05.000Z' },
+    ];
+    for (const stamp of stamps) {
+      (adapter as unknown as {
+        db: { run: (sql: string, params?: unknown[]) => void };
+      }).db.run(
+        'INSERT INTO events (task_id, event_type, payload, created_at) VALUES (?, ?, ?, ?)',
+        ['t1', stamp.type, JSON.stringify({ at: stamp.at }), stamp.at],
+      );
+    }
+
+    const desc = adapter.getEventsByTypes(RECOVERY_TYPES, 'desc', 3);
+    expect(desc.map((event) => event.createdAt)).toEqual([
+      '2026-07-01T00:00:05.000Z',
+      '2026-07-01T00:00:04.000Z',
+      '2026-07-01T00:00:03.000Z',
+    ]);
+
+    const asc = adapter.getEventsByTypes(RECOVERY_TYPES, 'asc', 2);
+    expect(asc.map((event) => event.createdAt)).toEqual([
+      '2026-07-01T00:00:01.000Z',
+      '2026-07-01T00:00:02.000Z',
+    ]);
   });
 });

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1587,16 +1587,30 @@ export class SQLiteAdapter implements PersistenceAdapter {
     limit = 50,
   ): TaskEvent[] {
     if (eventTypes.length === 0 || limit <= 0) return [];
+    const pageLimit = Math.floor(limit);
     const orderBy = sortBy === 'desc' ? 'DESC' : 'ASC';
-    const placeholders = eventTypes.map(() => '?').join(', ');
-    const rows = this.queryAll(
-      `SELECT * FROM events
-       WHERE event_type IN (${placeholders})
-       ORDER BY created_at ${orderBy}, id ${orderBy}
-       LIMIT ?`,
-      [...eventTypes, Math.floor(limit)],
-    );
-    return rows.map((row: any) => this.rowToTaskEvent(row));
+    // One multi-type IN + ORDER BY created_at forces USE TEMP B-TREE over every
+    // matching row before LIMIT. Query each type via idx_events_type_created
+    // with LIMIT, then merge in process.
+    const merged: TaskEvent[] = [];
+    for (const eventType of eventTypes) {
+      const rows = this.queryAll(
+        `SELECT * FROM events
+         WHERE event_type = ?
+         ORDER BY created_at ${orderBy}, id ${orderBy}
+         LIMIT ?`,
+        [eventType, pageLimit],
+      );
+      for (const row of rows) {
+        merged.push(this.rowToTaskEvent(row));
+      }
+    }
+    merged.sort((a, b) => {
+      const byCreated = a.createdAt.localeCompare(b.createdAt);
+      if (byCreated !== 0) return sortBy === 'desc' ? -byCreated : byCreated;
+      return sortBy === 'desc' ? b.id - a.id : a.id - b.id;
+    });
+    return merged.slice(0, pageLimit);
   }
 
   countEventsByTypes(eventTypes: readonly string[]): Array<{


### PR DESCRIPTION
## Summary

`getEventsByTypes` stops using one multi-kind `IN` + `ORDER BY created_at` query.

It loads each recovery kind with indexed `LIMIT`, then merges the newest rows in process.

That avoids the TEMP B-TREE sort that blocked the Electron main thread on every worker-status poll.

## Review Claim

Approve rewriting getEventsByTypes to per-kind indexed LIMIT merge with the same cross-kind order.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

Caller surface stays the same. Ordering remains `(created_at, id)`. Focused plan and hotpath cost checks cover the rewrite.

## Slice Rationale

This is the behavior fix that the proof slice justified. Call-site over-fetch stays in the next slice.

## Non-goals

- No recovery status limit or call-count changes.
- No UI poll interval or TTL cache.
- No database migration.

## Architecture

### Before

```mermaid
graph TD
  A["getEventsByTypes"] --> B["one IN query ORDER BY created_at"]
  B --> C["TEMP B-TREE then LIMIT"]
```

### After

```mermaid
graph TD
  A["getEventsByTypes"] --> B["per-kind SELECT LIMIT via idx_events_type_created"]
  B --> C["merge by created_at id"]
  C --> D["return top limit rows"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm test -- get-events-by-types-plan`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/main-process-read-hotpath-cost.test.ts`
- [x] `bash scripts/repro/repro-get-events-by-types-temp-btree.sh --seed-synthetic 80000 --expectation fixed`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>