### PR TITLE
[Fix getEventsByTypes TEMP B-TREE](4) Document status poll contract

### DIFF
--- a/docs/architecture/main-process-read-hot-paths.md
+++ b/docs/architecture/main-process-read-hot-paths.md
@@ -65,7 +65,10 @@ timer ticks into a main-thread SQLite convoy (macOS beachball).
 - Events (UI/IPC): `getEvents(taskId, { limit, sortBy?, beforeId? })` via
   `getEventsPage` — never the 1-arg unbounded adapter overload.
 - Events (status): `countEventsByTypes`, `getEventsByTypes(..., limit)` — not
-  full per-task history for status summaries.
+  full per-task history for status summaries. `getEventsByTypes` must query each
+  type with indexed `LIMIT` and merge in process (never multi-type `IN` +
+  `ORDER BY created_at`, which forces `USE TEMP B-TREE`). Fetch only the rows
+  the snapshot keeps (recovery status uses limit 10).
 - Events (headless full audit): loop pages server-side (`loadAllEventsPaged`) —
   never one giant IPC payload.
 - Attempts: indexed `LIMIT 1` for "newest active" — not `loadAttempts(nodeId)`

--- a/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
+++ b/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
@@ -93,7 +93,8 @@ describe('main-process read hot-path cost guards', () => {
     expect(status.wakeups + status.scans + status.submissions + status.skips).toBe(taskCount * eventsPerTask);
     expect(status.recent.length).toBeGreaterThan(0);
     expect(status.recent.length).toBeLessThanOrEqual(10);
-    expect(elapsedMs).toBeLessThan(750);
+    // Per-type indexed LIMIT+merge must stay well under a 2s UI poll budget.
+    expect(elapsedMs).toBeLessThan(50);
   });
 
   it('projects a stale-pointer task without scanning every attempt under large error blobs', async () => {

--- a/packages/app/src/__tests__/recovery-worker-observability.test.ts
+++ b/packages/app/src/__tests__/recovery-worker-observability.test.ts
@@ -67,7 +67,17 @@ describe('recovery-worker-observability', () => {
     const status = collectRecoveryWorkerStatus({ getEventsByTypes, countEventsByTypes });
 
     expect(countEventsByTypes).toHaveBeenCalled();
-    expect(getEventsByTypes).toHaveBeenCalled();
+    expect(getEventsByTypes).toHaveBeenCalledTimes(1);
+    expect(getEventsByTypes).toHaveBeenCalledWith(
+      [
+        recoveryWorkerEventType('wakeup'),
+        recoveryWorkerEventType('scan'),
+        recoveryWorkerEventType('submit'),
+        recoveryWorkerEventType('skip'),
+      ],
+      'desc',
+      10,
+    );
     expect(status).toMatchObject({
       kind: 'recovery',
       workerId: 'auto-fix-recovery',
@@ -88,6 +98,37 @@ describe('recovery-worker-observability', () => {
       taskId: 'wf-1/task-b',
       reason: 'already-queued-intent',
     });
+  });
+
+  it('loads last skip with a second typed query only when recent page has no skip', () => {
+    const recentWithoutSkip = allEvents
+      .filter((event) => event.eventType !== recoveryWorkerEventType('skip'))
+      .slice()
+      .reverse();
+    const getEventsByTypes = vi.fn((eventTypes: readonly string[], _sortBy: 'asc' | 'desc', limit: number) => {
+      if (eventTypes.length === 1 && eventTypes[0] === recoveryWorkerEventType('skip')) {
+        return allEvents
+          .filter((event) => event.eventType === recoveryWorkerEventType('skip'))
+          .slice()
+          .reverse()
+          .slice(0, limit);
+      }
+      return recentWithoutSkip.slice(0, limit);
+    });
+    const countEventsByTypes = vi.fn((eventTypes: readonly string[]) =>
+      eventTypes.map((eventType) => ({
+        eventType,
+        count: allEvents.filter((event) => event.eventType === eventType).length,
+        lastCreatedAt: allEvents.filter((event) => event.eventType === eventType).at(-1)?.createdAt ?? null,
+      })),
+    );
+
+    const status = collectRecoveryWorkerStatus({ getEventsByTypes, countEventsByTypes });
+
+    expect(getEventsByTypes).toHaveBeenCalledTimes(2);
+    expect(getEventsByTypes).toHaveBeenNthCalledWith(2, [recoveryWorkerEventType('skip')], 'desc', 1);
+    expect(status.lastSkipReason).toBe('already-queued-intent');
+    expect(status.lastSkipTaskId).toBe('wf-1/task-b');
   });
 
   it('falls back to per-task event scans when aggregate APIs are unavailable', () => {

--- a/packages/app/src/recovery-worker-observability.ts
+++ b/packages/app/src/recovery-worker-observability.ts
@@ -148,15 +148,18 @@ function collectFromAggregates(
   const lastScanAt = countByType.get(RECOVERY_EVENT_TYPES.scan)?.lastCreatedAt ?? undefined;
   const lastSubmitAt = countByType.get(RECOVERY_EVENT_TYPES.submit)?.lastCreatedAt ?? undefined;
 
-  const recentEvents = persistence.getEventsByTypes!(ALL_RECOVERY_EVENT_TYPES, 'desc', 50)
+  const recentEvents = persistence.getEventsByTypes!(ALL_RECOVERY_EVENT_TYPES, 'desc', 10)
     .filter((event): event is TaskEvent & { eventType: RecoveryWorkerAuditEventType } =>
       isRecoveryWorkerAuditEventType(event.eventType))
     .map((event) => toStatusEvent(event));
 
-  const lastSkipEvent = persistence.getEventsByTypes!([RECOVERY_EVENT_TYPES.skip], 'desc', 1)[0];
-  const lastSkip = lastSkipEvent && isRecoveryWorkerAuditEventType(lastSkipEvent.eventType)
-    ? toStatusEvent(lastSkipEvent as TaskEvent & { eventType: RecoveryWorkerAuditEventType })
-    : undefined;
+  let lastSkip = recentEvents.find((event) => event.action === 'skip');
+  if (!lastSkip) {
+    const lastSkipEvent = persistence.getEventsByTypes!([RECOVERY_EVENT_TYPES.skip], 'desc', 1)[0];
+    if (lastSkipEvent && isRecoveryWorkerAuditEventType(lastSkipEvent.eventType)) {
+      lastSkip = toStatusEvent(lastSkipEvent as TaskEvent & { eventType: RecoveryWorkerAuditEventType });
+    }
+  }
 
   return {
     ...status,
@@ -172,7 +175,7 @@ function collectFromAggregates(
     scans,
     submissions,
     skips,
-    recent: recentEvents.slice(0, 10),
+    recent: recentEvents,
   };
 }
 

--- a/packages/data-store/src/__tests__/get-events-by-types-plan.test.ts
+++ b/packages/data-store/src/__tests__/get-events-by-types-plan.test.ts
@@ -86,9 +86,7 @@ describe('getEventsByTypes query plans', () => {
     expect(detail).not.toContain('USE TEMP B-TREE');
   });
 
-  // Desired behavior for the adapter: never issue the multi-type TEMP B-TREE SQL.
-  // PR1 keeps this failing; PR2 flips it.fails → it once getEventsByTypes merges per-type.
-  it.fails('getEventsByTypes avoids multi-type IN ORDER BY that forces TEMP B-TREE', async () => {
+  it('getEventsByTypes avoids multi-type IN ORDER BY that forces TEMP B-TREE', async () => {
     adapter = await SQLiteAdapter.create(':memory:');
     adapter.saveWorkflow(makeWorkflow('wf-1'));
     adapter.saveTask('wf-1', makeTask('t1'));
@@ -114,5 +112,40 @@ describe('getEventsByTypes query plans', () => {
       && /ORDER BY\s+created_at/i.test(sql),
     )).toBe(true);
     queryAll.mockRestore();
+  });
+
+  it('getEventsByTypes merges newest-across-types order and respects limit', async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    adapter.saveWorkflow(makeWorkflow('wf-1'));
+    adapter.saveTask('wf-1', makeTask('t1'));
+
+    const stamps = [
+      { type: RECOVERY_TYPES[0], at: '2026-07-01T00:00:01.000Z' },
+      { type: RECOVERY_TYPES[1], at: '2026-07-01T00:00:03.000Z' },
+      { type: RECOVERY_TYPES[2], at: '2026-07-01T00:00:02.000Z' },
+      { type: RECOVERY_TYPES[3], at: '2026-07-01T00:00:04.000Z' },
+      { type: RECOVERY_TYPES[0], at: '2026-07-01T00:00:05.000Z' },
+    ];
+    for (const stamp of stamps) {
+      (adapter as unknown as {
+        db: { run: (sql: string, params?: unknown[]) => void };
+      }).db.run(
+        'INSERT INTO events (task_id, event_type, payload, created_at) VALUES (?, ?, ?, ?)',
+        ['t1', stamp.type, JSON.stringify({ at: stamp.at }), stamp.at],
+      );
+    }
+
+    const desc = adapter.getEventsByTypes(RECOVERY_TYPES, 'desc', 3);
+    expect(desc.map((event) => event.createdAt)).toEqual([
+      '2026-07-01T00:00:05.000Z',
+      '2026-07-01T00:00:04.000Z',
+      '2026-07-01T00:00:03.000Z',
+    ]);
+
+    const asc = adapter.getEventsByTypes(RECOVERY_TYPES, 'asc', 2);
+    expect(asc.map((event) => event.createdAt)).toEqual([
+      '2026-07-01T00:00:01.000Z',
+      '2026-07-01T00:00:02.000Z',
+    ]);
   });
 });

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1587,16 +1587,30 @@ export class SQLiteAdapter implements PersistenceAdapter {
     limit = 50,
   ): TaskEvent[] {
     if (eventTypes.length === 0 || limit <= 0) return [];
+    const pageLimit = Math.floor(limit);
     const orderBy = sortBy === 'desc' ? 'DESC' : 'ASC';
-    const placeholders = eventTypes.map(() => '?').join(', ');
-    const rows = this.queryAll(
-      `SELECT * FROM events
-       WHERE event_type IN (${placeholders})
-       ORDER BY created_at ${orderBy}, id ${orderBy}
-       LIMIT ?`,
-      [...eventTypes, Math.floor(limit)],
-    );
-    return rows.map((row: any) => this.rowToTaskEvent(row));
+    // One multi-type IN + ORDER BY created_at forces USE TEMP B-TREE over every
+    // matching row before LIMIT. Query each type via idx_events_type_created
+    // with LIMIT, then merge in process.
+    const merged: TaskEvent[] = [];
+    for (const eventType of eventTypes) {
+      const rows = this.queryAll(
+        `SELECT * FROM events
+         WHERE event_type = ?
+         ORDER BY created_at ${orderBy}, id ${orderBy}
+         LIMIT ?`,
+        [eventType, pageLimit],
+      );
+      for (const row of rows) {
+        merged.push(this.rowToTaskEvent(row));
+      }
+    }
+    merged.sort((a, b) => {
+      const byCreated = a.createdAt.localeCompare(b.createdAt);
+      if (byCreated !== 0) return sortBy === 'desc' ? -byCreated : byCreated;
+      return sortBy === 'desc' ? b.id - a.id : a.id - b.id;
+    });
+    return merged.slice(0, pageLimit);
   }
 
   countEventsByTypes(eventTypes: readonly string[]): Array<{


### PR DESCRIPTION
## Summary

This updates the main-process read hot-path guide.

It records that status polls must use per-type indexed LIMIT merge.

It also notes recovery status should fetch only the ten recent rows it keeps.

## Review Claim

Approve documenting the getEventsByTypes TEMP B-TREE trap and limit-10 status contract.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Docs only. No runtime code changes.

## Slice Rationale

Keep architecture guidance out of the behavior slices so review lanes stay pure.

## Non-goals

- No code or test changes.
- No poll cadence policy changes beyond the documented contract.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `rg -n "TEMP B-TREE|limit 10" docs/architecture/main-process-read-hot-paths.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>

Depends-On: #4898