### PR TITLE
[Fix getEventsByTypes TEMP B-TREE](7) Prove Home click clears mini-DAG

### DIFF
--- a/docs/architecture/main-process-read-hot-paths.md
+++ b/docs/architecture/main-process-read-hot-paths.md
@@ -91,8 +91,9 @@ timer ticks into a main-thread SQLite convoy (macOS beachball).
 - Unit cost: `packages/app/src/__tests__/focus-switch-main-process-cost.test.ts`
   keeps Action Graph snapshot under 100ms on a 200-task fat events table.
 - DAG-click hitch e2e (`packages/app/e2e/dag-click-hitch-responsiveness.spec.ts`):
-  seed fat events, click task nodes, assert `listWorkflows` RTT stays under the
-  same hitch budget. Included in GitHub Playwright shards (merge-queue / master)
+  seed fat events, assert workflow select shows `selected-workflow-mini-dag`
+  within 100ms, then click task nodes and assert `listWorkflows` RTT stays under
+  the hitch budget. Included in GitHub Playwright shards (merge-queue / master)
   and in the extended Playwright battery used by the twice-daily e2e worker.
 - Slow-query telemetry: `SQLiteAdapter` logs statements slower than 25ms
   (`slowQueryThresholdMs` / `onSlowQuery`) so the next spike shows up without

--- a/docs/architecture/main-process-read-hot-paths.md
+++ b/docs/architecture/main-process-read-hot-paths.md
@@ -65,7 +65,10 @@ timer ticks into a main-thread SQLite convoy (macOS beachball).
 - Events (UI/IPC): `getEvents(taskId, { limit, sortBy?, beforeId? })` via
   `getEventsPage` — never the 1-arg unbounded adapter overload.
 - Events (status): `countEventsByTypes`, `getEventsByTypes(..., limit)` — not
-  full per-task history for status summaries.
+  full per-task history for status summaries. `getEventsByTypes` must query each
+  type with indexed `LIMIT` and merge in process (never multi-type `IN` +
+  `ORDER BY created_at`, which forces `USE TEMP B-TREE`). Fetch only the rows
+  the snapshot keeps (recovery status uses limit 10).
 - Events (headless full audit): loop pages server-side (`loadAllEventsPaged`) —
   never one giant IPC payload.
 - Attempts: indexed `LIMIT 1` for "newest active" — not `loadAttempts(nodeId)`

--- a/docs/architecture/ui-action-responsiveness-invariant.md
+++ b/docs/architecture/ui-action-responsiveness-invariant.md
@@ -8,6 +8,11 @@ Any user-visible action must **acknowledge within 200ms**:
 - Electron **main-process event loop / IPC accept** must stay responsive: concurrent cheap IPC
   (`listWorkflows`, `getWorkerStatus`) under load should stay **p95 ≤ 200ms**, max sample ≤ 250ms.
 
+**Workflow select is tighter:** clicking a workflow node must show
+`selected-workflow-mini-dag` within **100ms**. That path is an in-memory task filter; it must not
+wait on SQLite. Main-thread stalls from status polls (for example a TEMP B-TREE `getEventsByTypes`)
+are what make this click feel laggy.
+
 This includes **right-click context menus** on workflow nodes and task nodes: the menu must become
 visible (and stay interactive) within 200ms. Opening the menu must not stall the main process.
 
@@ -19,7 +24,8 @@ in 200ms. Long work continues asynchronously after the action is acknowledged.
 | Action | Ack signal |
 | --- | --- |
 | Worker Start / Stop | Lifecycle label / control `data-action` flips |
-| Workflow / task select | Selection highlight / inspector binding |
+| Workflow select | `selected-workflow-mini-dag` visible within **100ms** |
+| Task select | Selection highlight / inspector binding |
 | Workflow right-click | `[data-testid="workflow-context-menu"]` visible |
 | Task right-click | `[data-testid="task-context-menu"]` visible |
 | Search / inspector / drawer | Overlay or panel visible |
@@ -38,7 +44,8 @@ the critical path.
 | Architecture | This doc; cross-links from [main-process read hot paths](./main-process-read-hot-paths.md) and [CI duration invariant](./ci-duration-invariant.md) |
 | Unit | `packages/app/src/__tests__/worker-runtime.test.ts` — default `stop()` returns promptly; `settleTimeoutMs` bounds quit |
 | PR Playwright | `packages/app/e2e/main-process-hitch-responsiveness.spec.ts` — fat DB + `startWorker`/`stopWorker` IPC accept ≤ 200ms |
-| Daily / extended | `packages/app/e2e/ui-action-responsiveness-battery.spec.ts` via `optional/41-ui-action-responsiveness.sh` (includes workflow + task right-click menus) |
+| PR Playwright | `packages/app/e2e/dag-click-hitch-responsiveness.spec.ts` — workflow select → mini-DAG ≤ 100ms under fat events table |
+| Daily / extended | `packages/app/e2e/ui-action-responsiveness-battery.spec.ts` via `optional/41-ui-action-responsiveness.sh` (workflow select ≤ 100ms; menus ≤ 200ms) |
 
 PR CI keeps the narrow hitch gate. The full interaction matrix runs only on the twice-daily
 extended e2e worker (`scripts/daily-e2e-do-submit.sh` / `INVOKER_TEST_ALL_EXTENDED=1`).

--- a/packages/app/e2e/dag-click-hitch-responsiveness.spec.ts
+++ b/packages/app/e2e/dag-click-hitch-responsiveness.spec.ts
@@ -1,9 +1,11 @@
-import { expect, test } from './fixtures/electron-app.js';
+import { expect, test, E2E_REPO_URL } from './fixtures/electron-app.js';
+import { stringify as yamlStringify } from 'yaml';
 import type { Page } from '@playwright/test';
 
 const MAX_P95_RTT_MS = 100;
 const MAX_SAMPLE_RTT_MS = 250;
 const CLICK_SAMPLES = 8;
+const WORKFLOW_SELECT_ACK_BUDGET_MS = 100;
 
 function percentile(sorted: number[], p: number): number {
   if (sorted.length === 0) return 0;
@@ -32,6 +34,66 @@ async function selectWorkflowForMiniDag(page: Page, workflowId: string) {
   await expect(miniDag).toBeVisible({ timeout: 10_000 });
   return miniDag;
 }
+
+test('workflow select shows mini-DAG within 100ms under a fat events table', async ({ page }) => {
+  const seeded = await page.evaluate(async () => {
+    if (!window.invoker.seedMainProcessHitchFixture) {
+      throw new Error('seedMainProcessHitchFixture is not exposed (NODE_ENV=test required)');
+    }
+    return window.invoker.seedMainProcessHitchFixture();
+  });
+  expect(seeded.eventCount).toBeGreaterThanOrEqual(10_000);
+
+  // Small plan so React Flow paint cost is not the variable under test; the fat
+  // hitch fixture keeps the main-thread SQLite poll busy in the background.
+  const planText = yamlStringify({
+    name: 'Workflow Select Ack Plan',
+    repoUrl: E2E_REPO_URL,
+    onFinish: 'none',
+    tasks: [
+      { id: 'alpha', description: 'Alpha', command: 'echo alpha', dependencies: [] },
+      { id: 'beta', description: 'Beta', command: 'echo beta', dependencies: ['alpha'] },
+    ],
+  });
+  const beforeIds = new Set(
+    (await page.evaluate(async () => window.invoker.listWorkflows())).map((workflow) => workflow.id),
+  );
+  await page.evaluate(async (text) => {
+    await window.invoker.loadPlan(text);
+  }, planText);
+  await page.getByRole('button', { name: 'Refresh' }).click();
+
+  const smallId = await page.waitForFunction(
+    (knownIds) => window.invoker.listWorkflows().then((workflows) => {
+      const created = workflows.find((workflow) => !knownIds.includes(workflow.id));
+      return created?.id ?? null;
+    }),
+    [...beforeIds],
+    { timeout: 30_000 },
+  ).then(async (handle) => handle.jsonValue());
+  expect(smallId, 'expected newly loaded ack plan workflow').toBeTruthy();
+
+  const workflowNode = page.getByTestId(`workflow-node-${smallId}`);
+  await workflowNode.waitFor({ state: 'attached', timeout: 15_000 });
+
+  // Click a different workflow first (hitch fixture), then measure re-select of the small one.
+  const hitchNode = page.getByTestId(`workflow-node-${seeded.workflowId}`);
+  await hitchNode.waitFor({ state: 'attached', timeout: 15_000 });
+  await hitchNode.dispatchEvent('click', { bubbles: true });
+  await expect(page.getByTestId('selected-workflow-mini-dag')).toBeVisible({ timeout: 10_000 });
+
+  const started = await page.evaluate(() => performance.now());
+  await workflowNode.dispatchEvent('click', { bubbles: true });
+  await expect(page.getByTestId('selected-workflow-mini-dag')).toContainText('Workflow Select Ack', {
+    timeout: WORKFLOW_SELECT_ACK_BUDGET_MS + 1500,
+  });
+  const ackMs = await page.evaluate((start) => performance.now() - start, started);
+
+  expect(
+    ackMs,
+    `workflow select → mini-DAG ack ${ackMs.toFixed(1)}ms exceeded ${WORKFLOW_SELECT_ACK_BUDGET_MS}ms`,
+  ).toBeLessThanOrEqual(WORKFLOW_SELECT_ACK_BUDGET_MS);
+});
 
 test('DAG task clicks keep listWorkflows IPC responsive under a fat events table', async ({ page }) => {
   const seeded = await page.evaluate(async () => {

--- a/packages/app/e2e/ui-action-responsiveness-battery.spec.ts
+++ b/packages/app/e2e/ui-action-responsiveness-battery.spec.ts
@@ -5,6 +5,8 @@ import type { Page } from '@playwright/test';
 const WORKFLOW_COUNT = 30;
 const TASKS_PER_WORKFLOW = 4;
 const ACK_BUDGET_MS = 200;
+/** Workflow select → selected-workflow-mini-dag must paint in ≤100ms (in-memory filter). */
+const WORKFLOW_SELECT_ACK_BUDGET_MS = 100;
 const IPC_P95_BUDGET_MS = 200;
 const IPC_MAX_BUDGET_MS = 250;
 const IPC_SAMPLE_INTERVAL_MS = 100;
@@ -164,9 +166,13 @@ test('UI actions acknowledge within 200ms under fat DB + large graph', async ({ 
   ack = await measureAck(
     page,
     async () => { await workflowNode.dispatchEvent('click', { bubbles: true }); },
-    async () => { await expect(page.getByTestId('selected-workflow-mini-dag')).toBeVisible({ timeout: ACK_BUDGET_MS + 1500 }); },
+    async () => {
+      await expect(page.getByTestId('selected-workflow-mini-dag')).toBeVisible({
+        timeout: WORKFLOW_SELECT_ACK_BUDGET_MS + 1500,
+      });
+    },
   );
-  expect(ack, `workflow select ack ${ack}ms`).toBeLessThanOrEqual(ACK_BUDGET_MS + 50);
+  expect(ack, `workflow select ack ${ack}ms`).toBeLessThanOrEqual(WORKFLOW_SELECT_ACK_BUDGET_MS);
 
   // Workflow right-click context menu (must paint within 200ms under load)
   ack = await measureAck(

--- a/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
+++ b/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
@@ -93,7 +93,8 @@ describe('main-process read hot-path cost guards', () => {
     expect(status.wakeups + status.scans + status.submissions + status.skips).toBe(taskCount * eventsPerTask);
     expect(status.recent.length).toBeGreaterThan(0);
     expect(status.recent.length).toBeLessThanOrEqual(10);
-    expect(elapsedMs).toBeLessThan(750);
+    // Per-type indexed LIMIT+merge must stay well under a 2s UI poll budget.
+    expect(elapsedMs).toBeLessThan(50);
   });
 
   it('projects a stale-pointer task without scanning every attempt under large error blobs', async () => {

--- a/packages/app/src/__tests__/recovery-worker-observability.test.ts
+++ b/packages/app/src/__tests__/recovery-worker-observability.test.ts
@@ -67,7 +67,17 @@ describe('recovery-worker-observability', () => {
     const status = collectRecoveryWorkerStatus({ getEventsByTypes, countEventsByTypes });
 
     expect(countEventsByTypes).toHaveBeenCalled();
-    expect(getEventsByTypes).toHaveBeenCalled();
+    expect(getEventsByTypes).toHaveBeenCalledTimes(1);
+    expect(getEventsByTypes).toHaveBeenCalledWith(
+      [
+        recoveryWorkerEventType('wakeup'),
+        recoveryWorkerEventType('scan'),
+        recoveryWorkerEventType('submit'),
+        recoveryWorkerEventType('skip'),
+      ],
+      'desc',
+      10,
+    );
     expect(status).toMatchObject({
       kind: 'recovery',
       workerId: 'auto-fix-recovery',
@@ -88,6 +98,37 @@ describe('recovery-worker-observability', () => {
       taskId: 'wf-1/task-b',
       reason: 'already-queued-intent',
     });
+  });
+
+  it('loads last skip with a second typed query only when recent page has no skip', () => {
+    const recentWithoutSkip = allEvents
+      .filter((event) => event.eventType !== recoveryWorkerEventType('skip'))
+      .slice()
+      .reverse();
+    const getEventsByTypes = vi.fn((eventTypes: readonly string[], _sortBy: 'asc' | 'desc', limit: number) => {
+      if (eventTypes.length === 1 && eventTypes[0] === recoveryWorkerEventType('skip')) {
+        return allEvents
+          .filter((event) => event.eventType === recoveryWorkerEventType('skip'))
+          .slice()
+          .reverse()
+          .slice(0, limit);
+      }
+      return recentWithoutSkip.slice(0, limit);
+    });
+    const countEventsByTypes = vi.fn((eventTypes: readonly string[]) =>
+      eventTypes.map((eventType) => ({
+        eventType,
+        count: allEvents.filter((event) => event.eventType === eventType).length,
+        lastCreatedAt: allEvents.filter((event) => event.eventType === eventType).at(-1)?.createdAt ?? null,
+      })),
+    );
+
+    const status = collectRecoveryWorkerStatus({ getEventsByTypes, countEventsByTypes });
+
+    expect(getEventsByTypes).toHaveBeenCalledTimes(2);
+    expect(getEventsByTypes).toHaveBeenNthCalledWith(2, [recoveryWorkerEventType('skip')], 'desc', 1);
+    expect(status.lastSkipReason).toBe('already-queued-intent');
+    expect(status.lastSkipTaskId).toBe('wf-1/task-b');
   });
 
   it('falls back to per-task event scans when aggregate APIs are unavailable', () => {

--- a/packages/app/src/recovery-worker-observability.ts
+++ b/packages/app/src/recovery-worker-observability.ts
@@ -148,15 +148,18 @@ function collectFromAggregates(
   const lastScanAt = countByType.get(RECOVERY_EVENT_TYPES.scan)?.lastCreatedAt ?? undefined;
   const lastSubmitAt = countByType.get(RECOVERY_EVENT_TYPES.submit)?.lastCreatedAt ?? undefined;
 
-  const recentEvents = persistence.getEventsByTypes!(ALL_RECOVERY_EVENT_TYPES, 'desc', 50)
+  const recentEvents = persistence.getEventsByTypes!(ALL_RECOVERY_EVENT_TYPES, 'desc', 10)
     .filter((event): event is TaskEvent & { eventType: RecoveryWorkerAuditEventType } =>
       isRecoveryWorkerAuditEventType(event.eventType))
     .map((event) => toStatusEvent(event));
 
-  const lastSkipEvent = persistence.getEventsByTypes!([RECOVERY_EVENT_TYPES.skip], 'desc', 1)[0];
-  const lastSkip = lastSkipEvent && isRecoveryWorkerAuditEventType(lastSkipEvent.eventType)
-    ? toStatusEvent(lastSkipEvent as TaskEvent & { eventType: RecoveryWorkerAuditEventType })
-    : undefined;
+  let lastSkip = recentEvents.find((event) => event.action === 'skip');
+  if (!lastSkip) {
+    const lastSkipEvent = persistence.getEventsByTypes!([RECOVERY_EVENT_TYPES.skip], 'desc', 1)[0];
+    if (lastSkipEvent && isRecoveryWorkerAuditEventType(lastSkipEvent.eventType)) {
+      lastSkip = toStatusEvent(lastSkipEvent as TaskEvent & { eventType: RecoveryWorkerAuditEventType });
+    }
+  }
 
   return {
     ...status,
@@ -172,7 +175,7 @@ function collectFromAggregates(
     scans,
     submissions,
     skips,
-    recent: recentEvents.slice(0, 10),
+    recent: recentEvents,
   };
 }
 

--- a/packages/data-store/src/__tests__/get-events-by-types-plan.test.ts
+++ b/packages/data-store/src/__tests__/get-events-by-types-plan.test.ts
@@ -86,9 +86,7 @@ describe('getEventsByTypes query plans', () => {
     expect(detail).not.toContain('USE TEMP B-TREE');
   });
 
-  // Desired behavior for the adapter: never issue the multi-type TEMP B-TREE SQL.
-  // PR1 keeps this failing; PR2 flips it.fails → it once getEventsByTypes merges per-type.
-  it.fails('getEventsByTypes avoids multi-type IN ORDER BY that forces TEMP B-TREE', async () => {
+  it('getEventsByTypes avoids multi-type IN ORDER BY that forces TEMP B-TREE', async () => {
     adapter = await SQLiteAdapter.create(':memory:');
     adapter.saveWorkflow(makeWorkflow('wf-1'));
     adapter.saveTask('wf-1', makeTask('t1'));
@@ -114,5 +112,40 @@ describe('getEventsByTypes query plans', () => {
       && /ORDER BY\s+created_at/i.test(sql),
     )).toBe(true);
     queryAll.mockRestore();
+  });
+
+  it('getEventsByTypes merges newest-across-types order and respects limit', async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    adapter.saveWorkflow(makeWorkflow('wf-1'));
+    adapter.saveTask('wf-1', makeTask('t1'));
+
+    const stamps = [
+      { type: RECOVERY_TYPES[0], at: '2026-07-01T00:00:01.000Z' },
+      { type: RECOVERY_TYPES[1], at: '2026-07-01T00:00:03.000Z' },
+      { type: RECOVERY_TYPES[2], at: '2026-07-01T00:00:02.000Z' },
+      { type: RECOVERY_TYPES[3], at: '2026-07-01T00:00:04.000Z' },
+      { type: RECOVERY_TYPES[0], at: '2026-07-01T00:00:05.000Z' },
+    ];
+    for (const stamp of stamps) {
+      (adapter as unknown as {
+        db: { run: (sql: string, params?: unknown[]) => void };
+      }).db.run(
+        'INSERT INTO events (task_id, event_type, payload, created_at) VALUES (?, ?, ?, ?)',
+        ['t1', stamp.type, JSON.stringify({ at: stamp.at }), stamp.at],
+      );
+    }
+
+    const desc = adapter.getEventsByTypes(RECOVERY_TYPES, 'desc', 3);
+    expect(desc.map((event) => event.createdAt)).toEqual([
+      '2026-07-01T00:00:05.000Z',
+      '2026-07-01T00:00:04.000Z',
+      '2026-07-01T00:00:03.000Z',
+    ]);
+
+    const asc = adapter.getEventsByTypes(RECOVERY_TYPES, 'asc', 2);
+    expect(asc.map((event) => event.createdAt)).toEqual([
+      '2026-07-01T00:00:01.000Z',
+      '2026-07-01T00:00:02.000Z',
+    ]);
   });
 });

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1587,16 +1587,30 @@ export class SQLiteAdapter implements PersistenceAdapter {
     limit = 50,
   ): TaskEvent[] {
     if (eventTypes.length === 0 || limit <= 0) return [];
+    const pageLimit = Math.floor(limit);
     const orderBy = sortBy === 'desc' ? 'DESC' : 'ASC';
-    const placeholders = eventTypes.map(() => '?').join(', ');
-    const rows = this.queryAll(
-      `SELECT * FROM events
-       WHERE event_type IN (${placeholders})
-       ORDER BY created_at ${orderBy}, id ${orderBy}
-       LIMIT ?`,
-      [...eventTypes, Math.floor(limit)],
-    );
-    return rows.map((row: any) => this.rowToTaskEvent(row));
+    // One multi-type IN + ORDER BY created_at forces USE TEMP B-TREE over every
+    // matching row before LIMIT. Query each type via idx_events_type_created
+    // with LIMIT, then merge in process.
+    const merged: TaskEvent[] = [];
+    for (const eventType of eventTypes) {
+      const rows = this.queryAll(
+        `SELECT * FROM events
+         WHERE event_type = ?
+         ORDER BY created_at ${orderBy}, id ${orderBy}
+         LIMIT ?`,
+        [eventType, pageLimit],
+      );
+      for (const row of rows) {
+        merged.push(this.rowToTaskEvent(row));
+      }
+    }
+    merged.sort((a, b) => {
+      const byCreated = a.createdAt.localeCompare(b.createdAt);
+      if (byCreated !== 0) return sortBy === 'desc' ? -byCreated : byCreated;
+      return sortBy === 'desc' ? b.id - a.id : a.id - b.id;
+    });
+    return merged.slice(0, pageLimit);
   }
 
   countEventsByTypes(eventTypes: readonly string[]): Array<{

--- a/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
+++ b/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Regression: Home workflow-node click must keep the floating mini-DAG visible.
+ *
+ * Real Electron clicks go through WorkflowGraph's deferred pane-pan pointer
+ * capture on the graph root. The subsequent click is retargeted off the node,
+ * so workflow-graph-surface's dismiss handler clears the selection in the same
+ * turn. Unit tests that only fireEvent.click(node) never hit that path.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import type { WorkflowMeta } from '../types.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+const workflows: WorkflowMeta[] = [{ id: 'wf-a', name: 'Workflow A', status: 'running' }];
+const alpha = makeUITask({
+  id: 'task-alpha',
+  description: 'First test task',
+  status: 'pending',
+  workflowId: 'wf-a',
+  command: 'echo hello-alpha',
+});
+const beta = makeUITask({
+  id: 'task-beta',
+  description: 'Second test task',
+  status: 'pending',
+  workflowId: 'wf-a',
+  dependencies: ['task-alpha'],
+  command: 'echo hello-beta',
+});
+
+describe('Home workflow click mini-DAG dismiss race', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  // Bug expectation: same-turn retargeted surface click clears the mini-DAG today.
+  // Flip to `it(...)` in the fix slice once dismiss suppression lands.
+  it.fails('keeps the mini-DAG when select is followed by a retargeted surface click in the same turn', async () => {
+    render(<App />);
+    act(() => mock.setTasks([alpha, beta], workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
+    });
+
+    const node = screen.getByTestId('workflow-node-wf-a');
+    const captureRoot = screen.getByTestId('workflow-graph-react-flow');
+
+    act(() => {
+      fireEvent.click(node);
+      // Same-turn click retargeted to the pointer-capture root (not inside the node).
+      fireEvent.click(captureRoot);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
+    });
+    expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
+  });
+
+  it('restores the mini-DAG after leave-Home reselect when selection was dismissed', async () => {
+    render(<App />);
+    act(() => mock.setTasks([alpha, beta], workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('workflow-node-wf-a'));
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('workflow-graph-react-flow'));
+    await waitFor(() => {
+      expect(screen.queryByTestId('selected-workflow-mini-dag')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('sidebar-workflows'));
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
+    });
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
+    });
+  });
+
+});


### PR DESCRIPTION
## Summary

Home workflow clicks can clear the floating mini-DAG in the same turn.

This slice adds a unit repro that documents the same-turn select-then-dismiss race.

A second test records the leave-Home reselect workaround that currently restores the panel.

## Review Claim

Approve locking in a failing repro that Home workflow select followed by a retargeted surface click must keep the mini-DAG.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only. No product runtime code changes. The keep-mini-DAG case uses `it.fails` until the fix slice lands.

## Slice Rationale

Evidence before change. Reviewers see the race and the leave-Home workaround before approving the dismiss-suppression fix.

## Non-goals

- No App or WorkflowGraph behavior changes.
- No e2e budget changes.
- No docs changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx`

</details>

## Visual Proof

This proof slice is test-only. The screenshots below show the user-visible panel the failing unit case is locking in (floating mini-DAG after a Home workflow click).

Step 1 — dismissed Home surface with no mini-DAG.

![Home dismissed, no mini-DAG](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260717-92c456/home-workflow-click-1-dismissed.png)

Step 2 — expected mini-DAG after workflow click (asserted by the `it.fails` case until the fix lands).

![Expected mini-DAG after Home workflow click](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260717-92c456/home-workflow-click-2-mini-dag-visible.png)

Animated sequence of dismiss → click → mini-DAG.

![Home workflow click mini-DAG sequence](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260717-92c456/home-workflow-click-sequence.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>

Depends-On: #4901