### PR TITLE
[Fix getEventsByTypes TEMP B-TREE](8) Keep mini-DAG after Home click

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -769,6 +769,7 @@ export function App() {
   const graphActionsMenuRef = useRef<HTMLDivElement>(null);
   const startReadyMenuRef = useRef<HTMLDivElement>(null);
   const lastGoodSelectedWorkflowGraphRef = useRef<SelectedWorkflowGraphSnapshot | null>(null);
+  const suppressDagSurfaceDismissRef = useRef(false);
   const contextMenuTaskRef = useRef<TaskState | null>(null);
   const [sidebarSurface, setSidebarSurface] = useState<SidebarSurface>('home');
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -1563,7 +1564,15 @@ export function App() {
     cameraSuppressedRef.current = true;
   }, []);
 
+  const armSuppressDagSurfaceDismiss = useCallback(() => {
+    suppressDagSurfaceDismissRef.current = true;
+    queueMicrotask(() => {
+      suppressDagSurfaceDismissRef.current = false;
+    });
+  }, []);
+
   const selectWorkflowById = useCallback((workflowId: string) => {
+    armSuppressDagSurfaceDismiss();
     setWorkflowSelectionDismissed(false);
     setSelectedWorkflowId(workflowId);
     setSelectedTaskId(null);
@@ -1571,7 +1580,7 @@ export function App() {
     setWorkflowContextMenu(null);
     recenterForSelection('workflow', workflowId);
     focusKeyboardRegion('workflowGraph');
-  }, [focusKeyboardRegion, recenterForSelection]);
+  }, [armSuppressDagSurfaceDismiss, focusKeyboardRegion, recenterForSelection]);
 
   const selectTaskById = useCallback((taskId: string) => {
     const task = tasksRef.current.get(taskId);
@@ -1951,13 +1960,14 @@ export function App() {
   }, []);
 
   const handleWorkflowClick = useCallback((workflowId: string) => {
+    armSuppressDagSurfaceDismiss();
     setWorkflowSelectionDismissed(false);
     setSelectedWorkflowId(workflowId);
     setSelectedTaskId(null);
     setContextMenu(null);
     setWorkflowContextMenu(null);
     recenterForSelection('workflow', workflowId);
-  }, [recenterForSelection]);
+  }, [armSuppressDagSurfaceDismiss, recenterForSelection]);
 
   const handleWorkflowContextMenu = useCallback((event: React.MouseEvent<Element>, workflowId: string) => {
     event.preventDefault();
@@ -2064,6 +2074,10 @@ export function App() {
     if (contextMenu || workflowContextMenu) {
       setContextMenu(null);
       setWorkflowContextMenu(null);
+      return;
+    }
+
+    if (suppressDagSurfaceDismissRef.current) {
       return;
     }
 

--- a/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
+++ b/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
@@ -49,9 +49,7 @@ describe('Home workflow click mini-DAG dismiss race', () => {
     mock.cleanup();
   });
 
-  // Bug expectation: same-turn retargeted surface click clears the mini-DAG today.
-  // Flip to `it(...)` in the fix slice once dismiss suppression lands.
-  it.fails('keeps the mini-DAG when select is followed by a retargeted surface click in the same turn', async () => {
+  it('keeps the mini-DAG when select is followed by a retargeted surface click in the same turn', async () => {
     render(<App />);
     act(() => mock.setTasks([alpha, beta], workflows));
 

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -539,7 +539,6 @@ function WorkflowGraphInner({
 
     if (shouldDeferPanePanFromNode(event.currentTarget, event.target, event.clientX, event.clientY)) {
       pendingPanePointerPanRef.current = pan;
-      event.currentTarget.setPointerCapture?.(event.pointerId);
       return;
     }
 
@@ -596,19 +595,19 @@ function WorkflowGraphInner({
       pan = pendingPan;
       viewportGestureActiveRef.current = true;
       onManualViewport?.();
+      event.currentTarget.setPointerCapture?.(event.pointerId);
     }
     if (!pan || pan.pointerId !== event.pointerId) return;
 
     updatePanePanViewport(pan, event.clientX, event.clientY);
     event.preventDefault();
     event.stopPropagation();
-  }, [updatePanePanViewport]);
+  }, [onManualViewport, updatePanePanViewport]);
 
   const onPanePointerEndCapture = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     const pendingPan = pendingPanePointerPanRef.current;
     if (pendingPan?.pointerId === event.pointerId) {
       pendingPanePointerPanRef.current = null;
-      event.currentTarget.releasePointerCapture?.(event.pointerId);
       return;
     }
 
@@ -744,7 +743,8 @@ function WorkflowGraphInner({
     };
   }, [endViewportGesture, finishPanePan, getViewport, onManualViewport, updatePanePanViewport]);
 
-  const onNodeClick = useCallback((_event: ReactMouseEvent, node: Node) => {
+  const onNodeClick = useCallback((event: ReactMouseEvent, node: Node) => {
+    event.stopPropagation();
     onSelectWorkflow(node.id);
   }, [onSelectWorkflow]);
 

--- a/packages/ui/src/components/WorkflowNode.tsx
+++ b/packages/ui/src/components/WorkflowNode.tsx
@@ -38,7 +38,10 @@ export function WorkflowNode({
       data-testid={`workflow-node-${workflow.id}`}
       role="button"
       tabIndex={0}
-      onClick={onClick}
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
       onContextMenu={onContextMenu}
       onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
         if (event.key === 'Enter' || event.key === ' ') {


### PR DESCRIPTION
## Summary

Home workflow clicks were selecting a workflow and then clearing it in the same gesture.

Pointer capture on the graph root retargeted the click, so the surface handler treated it as a background dismiss.

This change defers capture until a real pan starts and ignores same-turn surface dismiss after workflow select.

## Review Claim

Approve keeping the floating mini-DAG after a Home workflow-node click without requiring a sidebar tab switch.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Empty-pane background clicks still dismiss selection. Only same-turn select-linked surface clicks are ignored, and pointer capture still arms once the pan threshold is crossed.

## Slice Rationale

The prior proof slice documents the race with `it.fails`. This slice flips that expectation and lands the product fix.

## Non-goals

- No recovery-status or SQLite read-path changes.
- No change to intentional background dismiss.
- No docs changes.

## Architecture

### Before

```mermaid
sequenceDiagram
  participant User
  participant WFG as WorkflowGraph
  participant App as handleWorkflowClick
  participant Surf as handleDagSurfaceClick

  User->>WFG: pointerdown on workflow node
  WFG->>WFG: setPointerCapture on graph root
  User->>WFG: click retargeted to capture root
  WFG->>App: select workflow
  WFG->>Surf: dismiss selection
```

### After

```mermaid
sequenceDiagram
  participant User
  participant WFG as WorkflowGraph
  participant App as handleWorkflowClick
  participant Surf as handleDagSurfaceClick

  User->>WFG: pointerdown on workflow node
  WFG->>WFG: defer capture until pan threshold
  User->>WFG: click stays on node
  WFG->>App: select and arm dismiss guard
  WFG->>Surf: same-turn dismiss ignored
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx`
- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/task-interaction.test.tsx`

</details>

## Visual Proof

Step 1 — Home after background dismiss: no floating mini-DAG.

![Home with workflow selected dismissed, no mini-DAG](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260717-85354b/home-workflow-click-1-dismissed.png)

Step 2 — After a real workflow-node click: floating "task DAG" panel is visible.

![Home after workflow click shows mini-DAG](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260717-85354b/home-workflow-click-2-mini-dag-visible.png)

Step 3 — Dismiss then re-click: mini-DAG returns without leaving Home.

![Home reselect keeps mini-DAG](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260717-85354b/home-workflow-click-3-reselect-keeps-mini-dag.png)

Animated sequence of the three steps above.

![Home workflow click mini-DAG sequence](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260717-85354b/home-workflow-click-sequence.webm)

Playwright walkthrough of the same click path.

![Home workflow click walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260717-85354b/home-workflow-click-walkthrough.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>

Depends-On: #4902