### PR TITLE
Delete planning terminals — backend + IPC (1): Add planning delete IPC contracts

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -841,6 +841,18 @@ export interface SearchOptions {
   offset?: number;
 }
 
+export interface InAppPlanningDeleteRequest {
+  sessionId: string;
+}
+
+export type InAppPlanningDeleteResponse =
+  | { ok: true }
+  | { ok: false; error: string };
+
+export type InAppPlanningDeleteSubmittedResponse =
+  | { ok: true; deletedSessionIds: string[] }
+  | { ok: false; error: string };
+
 // ── Invoke Channel Registry ─────────────────────────────────
 // Each key is the channel name string; value is { request, response }.
 // `request` is a tuple of the arguments passed after the channel name.
@@ -870,6 +882,14 @@ export const IpcChannels = {
   'invoker:planning-chat-reset': {} as {
     request: [request: InAppPlanningResetRequest];
     response: InAppPlanningResetResponse;
+  },
+  'invoker:planning-chat-delete': {} as {
+    request: [request: InAppPlanningDeleteRequest];
+    response: InAppPlanningDeleteResponse;
+  },
+  'invoker:planning-chat-delete-submitted': {} as {
+    request: [];
+    response: InAppPlanningDeleteSubmittedResponse;
   },
   'invoker:planning-chat-set-terminal-mode': {} as {
     request: [request: InAppPlanningSetTerminalModeRequest];


### PR DESCRIPTION
## Summary

Delete planning terminals — backend + IPC — 3 tasks completed, 0 failed, 0 closed, 0 skipped

This slice adds typed planning-chat delete and delete-submitted IPC contracts, including the contracts package export ordering needed by downstream TypeScript builds.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784313643116-1/backend-delete-planning-chat | Add planning-chat delete + delete-submitted IPC channels and backend cleanup (session + persisted row + override conversation + tmux terminal) | completed |
| wf-1784313643116-1/verify-backend-contracts | Verify contracts package (new channels + types) compiles/tests clean | completed (passed) |
| wf-1784313643116-1/verify-backend-planner | Verify in-app-planner delete + delete-submitted behavior | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784313643116-1/backend-delete-planning-chat — Add planning-chat delete + delete-submitted IPC channels and backend cleanup (session + persisted row + override conversation + tmux terminal)

### wf-1784313643116-1/verify-backend-contracts — Verify contracts package (new channels + types) compiles/tests clean

### wf-1784313643116-1/verify-backend-planner — Verify in-app-planner delete + delete-submitted behavior

</details>

## Review Claim

Approve the new typed IPC surface for deleting one planning chat or all submitted planning chats.

## Review Lane

behavior

## Review Unit

ipc-contracts

## Safety Invariant

This slice only defines request and response types plus channel registry entries; no backend handler is reachable until the next slice wires it.

## Slice Rationale

The contract lands first so downstream backend code can compile against a stable public IPC shape.

## Non-goals

- Does not register Electron handlers.
- Does not delete sessions, conversations, or terminals.
- Does not add UI controls.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/contracts build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, after reverting dependent PRs #4906 and #4907.
- Revert command: `git revert a1260424056b665a12763c53fac9453667ccf58a`
- Post-revert steps: None.
- Data migration? No.

</details>
