### PR TITLE
Repro Planning Thinking Stream After Submit

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -236,7 +236,6 @@ export function App() {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; taskId: string } | null>(null);
   const [remoteTargets, setRemoteTargets] = useState<string[]>([]);
   const [executionPools, setExecutionPools] = useState<string[]>([]);
-  const [executionAgents, setExecutionAgents] = useState<string[]>([]);
   const [statusFilters, setStatusFilters] = useState<Set<WorkflowStatus>>(new Set());
   const [systemDiagnostics, setSystemDiagnostics] = useState<SystemDiagnostics | null>(null);
   const [showSystemSetup, setShowSystemSetup] = useState(false);
@@ -267,7 +266,6 @@ export function App() {
   useEffect(() => {
     window.invoker?.getRemoteTargets?.().then(setRemoteTargets).catch(() => {});
     window.invoker?.getExecutionPools?.().then(setExecutionPools).catch(() => {});
-    window.invoker?.getExecutionAgents?.().then(setExecutionAgents).catch(() => {});
     refreshSystemDiagnostics();
   }, [refreshSystemDiagnostics]);
 
@@ -838,18 +836,6 @@ export function App() {
     [invoker],
   );
 
-  // ── Edit task execution agent ────────────────────────────
-  const handleEditAgent = useCallback(
-    async (taskId: string, agentName: string) => {
-      if (!invoker) return;
-      try {
-        await invoker.editTaskAgent(taskId, agentName);
-      } catch (err) {
-        console.error('Failed to edit task agent:', err);
-      }
-    },
-    [invoker],
-  );
 
   const handleSetExternalGatePolicies = useCallback(
     async (taskId: string, updates: ExternalGatePolicyUpdate[]) => {
@@ -1155,13 +1141,11 @@ export function App() {
               workflowTasks={miniDagTasks}
               remoteTargets={remoteTargets}
               executionPools={executionPools}
-              executionAgents={executionAgents}
               collapsed={inspectorCollapsed}
               advancedExpanded={advancedMetadataExpanded}
               actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
               onEditType={handleEditType}
               onEditPool={handleEditPool}
-              onEditAgent={handleEditAgent}
               onEditPrompt={handleEditPrompt}
               onEditCommand={handleEditCommand}
               onSetMergeBranch={handleSetMergeBranch}

--- a/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+type PlanningChatResponse = {
+  ok: boolean;
+  sessionId: string;
+  reply: string;
+  draftPlanAvailable: boolean;
+  draftPlanSummary?: {
+    name: string;
+    taskCount: number;
+    steps: string[];
+  };
+};
+
+type PlanningStreamEvent = {
+  sessionId: string;
+  chunk: string;
+};
+
+describe('planning stream after submitted draft repro', () => {
+  let mock: MockInvoker;
+  let streamCallbacks: Set<(event: PlanningStreamEvent) => void>;
+
+  beforeEach(() => {
+    streamCallbacks = new Set();
+    mock = createMockInvoker();
+    installPlanningApiStubs(mock);
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+    streamCallbacks.clear();
+  });
+
+  function installPlanningApiStubs(mockInvoker: MockInvoker) {
+    const api = mockInvoker.api as any;
+    api.planningChatCreate = vi.fn(async () => ({
+      ok: true,
+      session: {
+        id: 'session-1',
+        title: 'Untitled plan',
+        status: 'still_discussing',
+        presetKey: 'codex',
+        messages: [],
+        draftPlanAvailable: false,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    }));
+    api.planningChatList = vi.fn(async () => ({ ok: true, sessions: [] }));
+    api.planningChatSubmit = vi.fn(async () => ({
+      ok: true,
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+    }));
+    api.planningChatReset = vi.fn(async () => ({ ok: true }));
+    api.getPlanningPresets = vi.fn(async () => [{ key: 'codex', label: 'Codex' }, { key: 'claude', label: 'Claude' }]);
+    api.refreshTaskGraph = vi.fn(async () => ({ tasks: [], workflows: [] }));
+    api.onPlanningChatStream = vi.fn((cb: (event: PlanningStreamEvent) => void) => {
+      streamCallbacks.add(cb);
+      return () => { streamCallbacks.delete(cb); };
+    });
+  }
+
+  function firePlanningChatStream(event: PlanningStreamEvent) {
+    for (const callback of streamCallbacks) {
+      callback(event);
+    }
+  }
+
+  async function openPlanningTerminal() {
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+    });
+  }
+
+  function submitPlanningText(text: string) {
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+  }
+  it('submits the active planning agent as the plan source of truth', async () => {
+    (mock.api as any).planningChatSend = vi.fn(async () => ({
+      ok: true,
+      sessionId: 'session-1',
+      reply: 'Here is the plan.',
+      draftPlanAvailable: true,
+      draftPlanSummary: { name: 'Claude Plan', taskCount: 1, steps: ['Do the work'] },
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-harness'), { target: { value: 'claude' } });
+    submitPlanningText('make the claude plan');
+    await screen.findByTestId('invoker-terminal-ready-bar');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+
+    await waitFor(() => {
+      expect((mock.api as any).planningChatSend).toHaveBeenCalledWith({
+        message: 'make the claude plan',
+        presetKey: 'claude',
+      });
+      expect((mock.api as any).planningChatSubmit).toHaveBeenCalledWith({
+        sessionId: 'session-1',
+        presetKey: 'claude',
+      });
+    });
+  });
+
+  it('keeps live planner output visible for a new pending turn after submitting a draft', async () => {
+    const draftReply: PlanningChatResponse = {
+      ok: true,
+      sessionId: 'session-1',
+      reply: 'Here is the plan.',
+      draftPlanAvailable: true,
+      draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First', 'Second'] },
+    };
+    let resolveSecondSend: ((value: PlanningChatResponse) => void) | null = null;
+    (mock.api as any).planningChatSend = vi
+      .fn()
+      .mockResolvedValueOnce(draftReply)
+      .mockImplementationOnce(() => new Promise<PlanningChatResponse>((resolve) => {
+        resolveSecondSend = resolve;
+      }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft the full plan');
+    await screen.findByTestId('invoker-terminal-ready-bar');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+    await waitFor(() => {
+      expect((mock.api as any).planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1', presetKey: 'codex' });
+    });
+
+    await openPlanningTerminal();
+    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
+    expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    expect(screen.getByTestId('invoker-terminal-harness')).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'New' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-input')).toBeEnabled();
+    });
+
+    submitPlanningText('draft the follow-up plan');
+    await waitFor(() => {
+      expect((mock.api as any).planningChatSend).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      firePlanningChatStream({ sessionId: 'session-2', chunk: 'live planner thinking' });
+    });
+
+    const streamPanel = await screen.findByTestId('invoker-terminal-planner-stream');
+    expect(streamPanel).toHaveAttribute('data-state', 'streaming');
+    expect(streamPanel).toHaveTextContent('live planner thinking');
+
+    await act(async () => {
+      resolveSecondSend?.({
+        ok: true,
+        sessionId: 'session-2',
+        reply: 'Final assistant reply.',
+        draftPlanAvailable: false,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('invoker-terminal-planner-stream')).not.toBeInTheDocument();
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Final assistant reply.');
+      expect(screen.getByTestId('invoker-terminal-transcript')).not.toHaveTextContent('live planner thinking');
+    });
+  });
+});

--- a/packages/ui/src/__tests__/task-panel-double-click.test.tsx
+++ b/packages/ui/src/__tests__/task-panel-double-click.test.tsx
@@ -996,120 +996,8 @@ describe('TaskPanel double-click editing', () => {
     });
   });
 
-  describe('Execution agent selector', () => {
-    const mockOnEditAgent = vi.fn();
-
-    it('renders agent selector for prompt tasks when onEditAgent + executionAgents provided', () => {
-      const task = makeTask({ prompt: 'Write a test', status: 'pending' });
-      render(
-        <TaskPanel
-          task={task}
-          executionAgents={['claude', 'codex']}
-          onProvideInput={mockOnProvideInput}
-          onApprove={mockOnApprove}
-          onReject={mockOnReject}
-          onSelectExperiment={mockOnSelectExperiment}
-          onEditAgent={mockOnEditAgent}
-        />,
-      );
-
-      expect(screen.getByTestId('execution-agent-select')).toBeInTheDocument();
-    });
-
-    it('does not render agent selector for command-only tasks', () => {
-      const task = makeTask({ command: 'echo test', status: 'pending' });
-      render(
-        <TaskPanel
-          task={task}
-          executionAgents={['claude', 'codex']}
-          onProvideInput={mockOnProvideInput}
-          onApprove={mockOnApprove}
-          onReject={mockOnReject}
-          onSelectExperiment={mockOnSelectExperiment}
-          onEditAgent={mockOnEditAgent}
-        />,
-      );
-
-      expect(screen.queryByTestId('execution-agent-select')).not.toBeInTheDocument();
-    });
-
-    it('populates options from executionAgents prop with capitalized labels', () => {
-      const task = makeTask({ prompt: 'Write a test', status: 'pending' });
-      render(
-        <TaskPanel
-          task={task}
-          executionAgents={['claude', 'codex']}
-          onProvideInput={mockOnProvideInput}
-          onApprove={mockOnApprove}
-          onReject={mockOnReject}
-          onSelectExperiment={mockOnSelectExperiment}
-          onEditAgent={mockOnEditAgent}
-        />,
-      );
-
-      const select = screen.getByTestId('execution-agent-select');
-      const options = select.querySelectorAll('option');
-      expect(options).toHaveLength(2);
-      expect(options[0]).toHaveTextContent('Claude Task');
-      expect(options[1]).toHaveTextContent('Codex Task');
-    });
-
-    it('calls onEditAgent with selected value on change', () => {
-      const task = makeTask({ prompt: 'Write a test', status: 'pending' });
-      render(
-        <TaskPanel
-          task={task}
-          executionAgents={['claude', 'codex']}
-          onProvideInput={mockOnProvideInput}
-          onApprove={mockOnApprove}
-          onReject={mockOnReject}
-          onSelectExperiment={mockOnSelectExperiment}
-          onEditAgent={mockOnEditAgent}
-        />,
-      );
-
-      const select = screen.getByTestId('execution-agent-select');
-      fireEvent.change(select, { target: { value: 'codex' } });
-      expect(mockOnEditAgent).toHaveBeenCalledWith('test-task-1', 'codex');
-    });
-
-    it('disables selector when task is running', () => {
-      const task = makeTask({ prompt: 'Write a test', status: 'running' });
-      render(
-        <TaskPanel
-          task={task}
-          executionAgents={['claude', 'codex']}
-          onProvideInput={mockOnProvideInput}
-          onApprove={mockOnApprove}
-          onReject={mockOnReject}
-          onSelectExperiment={mockOnSelectExperiment}
-          onEditAgent={mockOnEditAgent}
-        />,
-      );
-
-      const select = screen.getByTestId('execution-agent-select');
-      expect(select).toBeDisabled();
-    });
-
-    it('defaults to claude when executionAgent config is unset', () => {
-      const task = makeTask({ prompt: 'Write a test', status: 'pending' });
-      render(
-        <TaskPanel
-          task={task}
-          executionAgents={['claude', 'codex']}
-          onProvideInput={mockOnProvideInput}
-          onApprove={mockOnApprove}
-          onReject={mockOnReject}
-          onSelectExperiment={mockOnSelectExperiment}
-          onEditAgent={mockOnEditAgent}
-        />,
-      );
-
-      const select = screen.getByTestId('execution-agent-select') as HTMLSelectElement;
-      expect(select.value).toBe('claude');
-    });
-
-    it('selects current agent when executionAgent is set', () => {
+  describe('Planning agent display', () => {
+    it('shows the configured planning agent badge for prompt tasks', () => {
       const task = {
         ...makeTask({ prompt: 'Write a test', status: 'pending' }),
         config: { prompt: 'Write a test', executionAgent: 'codex' },
@@ -1117,74 +1005,31 @@ describe('TaskPanel double-click editing', () => {
       render(
         <TaskPanel
           task={task}
-          executionAgents={['claude', 'codex']}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
           onSelectExperiment={mockOnSelectExperiment}
-          onEditAgent={mockOnEditAgent}
         />,
       );
 
-      const select = screen.getByTestId('execution-agent-select') as HTMLSelectElement;
-      expect(select.value).toBe('codex');
-    });
-
-    it('fallback badge shows capitalized agent name when onEditAgent not provided', () => {
-      const task = {
-        ...makeTask({ prompt: 'Write a test', status: 'pending' }),
-        config: { prompt: 'Write a test', executionAgent: 'codex' },
-      } as TaskState;
-      render(
-        <TaskPanel
-          task={task}
-          executionAgents={['claude', 'codex']}
-          onProvideInput={mockOnProvideInput}
-          onApprove={mockOnApprove}
-          onReject={mockOnReject}
-          onSelectExperiment={mockOnSelectExperiment}
-          // no onEditAgent
-        />,
-      );
-
-      expect(screen.queryByTestId('execution-agent-select')).not.toBeInTheDocument();
       expect(screen.getByText('Codex Task')).toBeInTheDocument();
-    });
-
-    it('fallback badge defaults to "Claude Task" when executionAgent unset', () => {
-      const task = makeTask({ prompt: 'Write a test', status: 'pending' });
-      render(
-        <TaskPanel
-          task={task}
-          onProvideInput={mockOnProvideInput}
-          onApprove={mockOnApprove}
-          onReject={mockOnReject}
-          onSelectExperiment={mockOnSelectExperiment}
-          // no onEditAgent
-        />,
-      );
-
       expect(screen.queryByTestId('execution-agent-select')).not.toBeInTheDocument();
-      expect(screen.getByText('Claude Task')).toBeInTheDocument();
     });
 
-    it('renders empty selector gracefully when executionAgents is empty', () => {
+    it('defaults prompt tasks to the Claude badge when no planning agent is set', () => {
       const task = makeTask({ prompt: 'Write a test', status: 'pending' });
       render(
         <TaskPanel
           task={task}
-          executionAgents={[]}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
           onSelectExperiment={mockOnSelectExperiment}
-          onEditAgent={mockOnEditAgent}
         />,
       );
 
-      const select = screen.getByTestId('execution-agent-select');
-      const options = select.querySelectorAll('option');
-      expect(options).toHaveLength(0);
+      expect(screen.getByText('Claude Task')).toBeInTheDocument();
+      expect(screen.queryByTestId('execution-agent-select')).not.toBeInTheDocument();
     });
   });
 

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -196,23 +196,21 @@ describe('WorkflowInspector', () => {
     expect(screen.queryByText('No prompt or command available.')).not.toBeInTheDocument();
   });
 
-  it('edits AI agent from a dropdown', () => {
-    const onEditAgent = vi.fn();
+  it('shows the planning agent as read-only task metadata', () => {
     render(
       <WorkflowInspector
         workflow={workflow}
         task={makeTask()}
-        executionAgents={['claude', 'codex']}
         collapsed={false}
         advancedExpanded={false}
-        onEditAgent={onEditAgent}
         onToggleCollapsed={() => {}}
         onToggleAdvanced={() => {}}
       />,
     );
 
-    fireEvent.change(screen.getByTestId('execution-agent-select'), { target: { value: 'claude' } });
-    expect(onEditAgent).toHaveBeenCalledWith('task-1', 'claude');
+    expect(screen.getByText('Planning Agent')).toBeInTheDocument();
+    expect(screen.getByTestId('planning-agent-value')).toHaveTextContent('Codex');
+    expect(screen.queryByTestId('execution-agent-select')).not.toBeInTheDocument();
   });
 
   it('double-click edits prompt and saves through callback', () => {

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -102,7 +102,6 @@ interface TaskPanelProps {
   baseBranch?: string;
   workflowRepoUrl?: string;
   remoteTargets?: string[];
-  executionAgents?: string[];
   onProvideInput: (task: TaskState) => void;
   onApprove: (task: TaskState) => void;
   onReject: (task: TaskState) => void;
@@ -110,7 +109,6 @@ interface TaskPanelProps {
   onEditCommand?: (taskId: string, newCommand: string) => void;
   onEditPrompt?: (taskId: string, newPrompt: string) => void;
   onEditType?: (taskId: string, runnerKind: string, poolMemberId?: string) => void;
-  onEditAgent?: (taskId: string, agentName: string) => void;
   onSetExternalGatePolicies?: (taskId: string, updates: ExternalGatePolicyUpdate[]) => Promise<void>;
   onSetMergeBranch?: (workflowId: string, baseBranch: string) => Promise<void>;
   mergeMode?: string;
@@ -224,7 +222,6 @@ export function TaskPanel({
   baseBranch,
   workflowRepoUrl,
   remoteTargets,
-  executionAgents,
   onProvideInput,
   onApprove,
   onReject,
@@ -232,7 +229,6 @@ export function TaskPanel({
   onEditCommand,
   onEditPrompt,
   onEditType,
-  onEditAgent,
   onSetExternalGatePolicies,
   onSetMergeBranch,
   mergeMode,
@@ -514,22 +510,6 @@ export function TaskPanel({
         </div>
       )}
 
-      {task.config.prompt && onEditAgent && (
-        <div className="flex items-center justify-between">
-          <span className="text-sm text-gray-400">Agent</span>
-          <select
-            value={task.config.executionAgent ?? 'claude'}
-            onChange={(e) => onEditAgent(task.id, e.target.value)}
-            disabled={task.status === 'running' || task.status === 'fixing_with_ai'}
-            className="bg-gray-700 text-gray-200 text-xs rounded px-2 py-1 border border-gray-600 focus:outline-none focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-            data-testid="execution-agent-select"
-          >
-            {(executionAgents ?? []).map(name => (
-              <option key={name} value={name}>{capitalize(name)} Task</option>
-            ))}
-          </select>
-        </div>
-      )}
 
       {/* Advanced section (collapsed by default) */}
       {(

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -1,16 +1,217 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
 interface TerminalDrawerProps {
   collapsed: boolean;
   onToggle: () => void;
 }
 
+interface PlanningPreset {
+  key: string;
+  label: string;
+}
+
+interface PlanningDraftSummary {
+  name: string;
+  taskCount: number;
+  steps: string[];
+}
+
+interface PlanningChatSession {
+  id: string;
+  title: string;
+  status: string;
+  presetKey?: string;
+  messages?: PlanningTranscriptEntry[];
+  draftPlanAvailable?: boolean;
+}
+
+interface PlanningChatResponse {
+  ok: boolean;
+  sessionId: string;
+  reply: string;
+  draftPlanAvailable: boolean;
+  draftPlanSummary?: PlanningDraftSummary;
+}
+
+interface PlanningChatStreamEvent {
+  sessionId: string;
+  chunk: string;
+}
+
+interface PlanningApi {
+  getPlanningPresets?: () => Promise<PlanningPreset[]>;
+  planningChatCreate?: (request: { presetKey: string }) => Promise<{ ok: boolean; session: PlanningChatSession }>;
+  planningChatSend?: (request: { sessionId?: string; message: string; presetKey: string }) => Promise<PlanningChatResponse>;
+  planningChatSubmit?: (request: { sessionId: string; presetKey: string }) => Promise<{ ok: boolean; planName?: string; workflowId?: string }>;
+  planningChatReset?: (request?: { sessionId?: string }) => Promise<{ ok: boolean }>;
+  onPlanningChatStream?: (callback: (event: PlanningChatStreamEvent) => void) => () => void;
+}
+
+type PlanningTranscriptEntry = {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+};
+
 export function TerminalDrawer({ collapsed, onToggle }: TerminalDrawerProps): JSX.Element {
+  const [activeTab, setActiveTab] = useState<'planning' | 'terminal' | 'logs' | 'problems'>('terminal');
+  const [presets, setPresets] = useState<PlanningPreset[]>([{ key: 'codex', label: 'Codex' }]);
+  const [presetKey, setPresetKey] = useState('codex');
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [transcript, setTranscript] = useState<PlanningTranscriptEntry[]>([]);
+  const [input, setInput] = useState('');
+  const [sendPending, setSendPending] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [draftSummary, setDraftSummary] = useState<PlanningDraftSummary | null>(null);
+  const [submittedPlanName, setSubmittedPlanName] = useState<string | null>(null);
+  const [streamSessionId, setStreamSessionId] = useState<string | null>(null);
+  const [streamChunks, setStreamChunks] = useState<string[]>([]);
+  const sendPendingRef = useRef(false);
+  const sessionIdRef = useRef<string | null>(null);
+
+  const planningApi = useMemo(() => {
+    if (typeof window === 'undefined') return undefined;
+    return window.invoker as unknown as PlanningApi | undefined;
+  }, []);
+
+  useEffect(() => {
+    sessionIdRef.current = sessionId;
+  }, [sessionId]);
+
+  useEffect(() => {
+    sendPendingRef.current = sendPending;
+  }, [sendPending]);
+
+  useEffect(() => {
+    let cancelled = false;
+    planningApi?.getPlanningPresets?.()
+      .then((loadedPresets) => {
+        if (cancelled || loadedPresets.length === 0) return;
+        setPresets(loadedPresets);
+        setPresetKey((current) => loadedPresets.some((preset) => preset.key === current) ? current : loadedPresets[0].key);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [planningApi]);
+
+  useEffect(() => {
+    const unsubscribe = planningApi?.onPlanningChatStream?.((event) => {
+      const activeSessionId = sessionIdRef.current;
+      if (activeSessionId && event.sessionId !== activeSessionId && !sendPendingRef.current) return;
+      if (!activeSessionId && !sendPendingRef.current) return;
+      setStreamSessionId(event.sessionId);
+      setStreamChunks((chunks) => [...chunks, event.chunk]);
+    });
+    return () => {
+      unsubscribe?.();
+    };
+  }, [planningApi]);
+
+  const openPlanning = () => {
+    setActiveTab('planning');
+    if (collapsed) onToggle();
+  };
+
+  const handleNewPlanningSession = async () => {
+    sessionIdRef.current = null;
+    sendPendingRef.current = false;
+    setSessionId(null);
+    setTranscript([]);
+    setInput('');
+    setSendPending(false);
+    setSubmitted(false);
+    setDraftSummary(null);
+    setSubmittedPlanName(null);
+    setStreamSessionId(null);
+    setStreamChunks([]);
+    await planningApi?.planningChatReset?.({ sessionId: sessionId ?? undefined }).catch(() => undefined);
+  };
+
+  const handlePlanningSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const message = input.trim();
+    if (!message || sendPending || submitted || !planningApi?.planningChatSend) return;
+
+    setInput('');
+    sendPendingRef.current = true;
+    setSendPending(true);
+    setDraftSummary(null);
+    setStreamSessionId(null);
+    setStreamChunks([]);
+    setTranscript((entries) => [...entries, { role: 'user', content: message }]);
+
+    try {
+      const response = await planningApi.planningChatSend({
+        ...(sessionId ? { sessionId } : {}),
+        message,
+        presetKey,
+      });
+      if (!response.ok) return;
+      sessionIdRef.current = response.sessionId;
+      setSessionId(response.sessionId);
+      setStreamSessionId(null);
+      setStreamChunks([]);
+      setTranscript((entries) => [...entries, { role: 'assistant', content: response.reply }]);
+      setDraftSummary(response.draftPlanAvailable ? response.draftPlanSummary ?? {
+        name: 'Draft plan',
+        taskCount: 0,
+        steps: [],
+      } : null);
+    } finally {
+      sendPendingRef.current = false;
+      setSendPending(false);
+    }
+  };
+
+  const handleSubmitToInvoker = async () => {
+    if (!sessionId || !planningApi?.planningChatSubmit) return;
+    const result = await planningApi.planningChatSubmit({ sessionId, presetKey });
+    if (!result.ok) return;
+    const planName = result.planName ?? draftSummary?.name ?? 'Draft plan';
+    setSubmitted(true);
+    setSubmittedPlanName(planName);
+    setDraftSummary(null);
+    setStreamSessionId(null);
+    setStreamChunks([]);
+    setTranscript((entries) => [
+      ...entries,
+      { role: 'system', content: `Plan "${planName}" submitted to Invoker. Review it, then use Start ready work.` },
+    ]);
+  };
+
+  const planningDisabled = submitted || sendPending;
+  const streamText = streamChunks.join('');
+
   return (
     <div className="border-t border-gray-800 bg-gray-950">
       <div className="flex items-center justify-between px-3 py-2 border-b border-gray-800">
         <div className="flex items-center gap-3 text-xs text-gray-300">
-          <button className="hover:text-white">Terminal</button>
-          <button className="hover:text-white">Logs</button>
-          <button className="hover:text-white">Problems</button>
+          <button
+            data-testid="sidebar-planning"
+            className={activeTab === 'planning' ? 'text-white' : 'hover:text-white'}
+            onClick={openPlanning}
+          >
+            Planning
+          </button>
+          <button
+            className={activeTab === 'terminal' ? 'text-white' : 'hover:text-white'}
+            onClick={() => setActiveTab('terminal')}
+          >
+            Terminal
+          </button>
+          <button
+            className={activeTab === 'logs' ? 'text-white' : 'hover:text-white'}
+            onClick={() => setActiveTab('logs')}
+          >
+            Logs
+          </button>
+          <button
+            className={activeTab === 'problems' ? 'text-white' : 'hover:text-white'}
+            onClick={() => setActiveTab('problems')}
+          >
+            Problems
+          </button>
         </div>
         <button
           onClick={onToggle}
@@ -21,9 +222,92 @@ export function TerminalDrawer({ collapsed, onToggle }: TerminalDrawerProps): JS
         </button>
       </div>
       {!collapsed && (
-        <div className="h-40 px-3 py-2 text-xs text-gray-400 overflow-auto">
-          Terminal drawer reserved for embedded shell/log surfaces.
-        </div>
+        activeTab === 'planning' ? (
+          <div className="h-72 px-3 py-2 text-xs text-gray-300 overflow-auto">
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <label className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-gray-400">
+                <span>Planning agent</span>
+                <select
+                  data-testid="invoker-terminal-harness"
+                  value={presetKey}
+                  disabled={planningDisabled}
+                  onChange={(event) => setPresetKey(event.target.value)}
+                  className="rounded border border-gray-700 bg-gray-900 px-2 py-1 text-xs normal-case tracking-normal text-gray-100 disabled:opacity-60"
+                >
+                  {presets.map((preset) => (
+                    <option key={preset.key} value={preset.key}>{preset.label}</option>
+                  ))}
+                </select>
+              </label>
+              <button
+                type="button"
+                onClick={handleNewPlanningSession}
+                className="rounded border border-gray-700 px-2 py-1 text-[11px] text-gray-200 hover:bg-gray-800"
+              >
+                New
+              </button>
+            </div>
+
+            <div data-testid="invoker-terminal-transcript" className="mb-2 max-h-28 space-y-1 overflow-auto rounded border border-gray-800 bg-gray-900 p-2">
+              {transcript.length === 0 ? (
+                <div className="text-gray-500">No planning messages yet.</div>
+              ) : (
+                transcript.map((entry, index) => (
+                  <div key={`${entry.role}-${index}`} className={entry.role === 'user' ? 'text-sky-200' : entry.role === 'system' ? 'text-emerald-200' : 'text-gray-100'}>
+                    {entry.content}
+                  </div>
+                ))
+              )}
+              {submittedPlanName && (
+                <span className="sr-only">{submittedPlanName}</span>
+              )}
+            </div>
+
+            {streamText && streamSessionId && (
+              <div
+                data-testid="invoker-terminal-planner-stream"
+                data-state="streaming"
+                className="mb-2 rounded border border-blue-700/60 bg-blue-950/40 p-2 text-blue-100"
+              >
+                {streamText}
+              </div>
+            )}
+
+            {draftSummary && !submitted && (
+              <div data-testid="invoker-terminal-ready-bar" className="mb-2 flex items-center justify-between gap-2 rounded border border-emerald-700/70 bg-emerald-950/40 px-2 py-1.5 text-emerald-100">
+                <span>{draftSummary.name}</span>
+                <button
+                  type="button"
+                  onClick={handleSubmitToInvoker}
+                  className="rounded bg-emerald-600 px-2 py-1 text-[11px] font-medium text-white hover:bg-emerald-500"
+                >
+                  Submit to Invoker
+                </button>
+              </div>
+            )}
+
+            <form onSubmit={handlePlanningSubmit} className="flex gap-2">
+              <textarea
+                data-testid="invoker-terminal-input"
+                value={input}
+                disabled={planningDisabled}
+                onChange={(event) => setInput(event.target.value)}
+                className="h-16 flex-1 resize-none rounded border border-gray-700 bg-gray-900 px-2 py-1 text-xs text-gray-100 disabled:opacity-60"
+              />
+              <button
+                type="submit"
+                disabled={planningDisabled || input.trim().length === 0}
+                className="self-start rounded bg-gray-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-gray-600 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Send
+              </button>
+            </form>
+          </div>
+        ) : (
+          <div className="h-40 px-3 py-2 text-xs text-gray-400 overflow-auto">
+            Terminal drawer reserved for embedded shell/log surfaces.
+          </div>
+        )
       )}
     </div>
   );

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -9,13 +9,11 @@ interface WorkflowInspectorProps {
   workflowTasks?: Map<string, TaskState>;
   remoteTargets?: string[];
   executionPools?: string[];
-  executionAgents?: string[];
   actionNode?: unknown;
   collapsed: boolean;
   advancedExpanded: boolean;
   onEditType?: (taskId: string, runnerKind: string, poolMemberId?: string) => void;
   onEditPool?: (taskId: string, poolId: string) => void;
-  onEditAgent?: (taskId: string, agentName: string) => void;
   onEditPrompt?: (taskId: string, newPrompt: string) => void;
   onEditCommand?: (taskId: string, newCommand: string) => void;
   onSetMergeBranch?: (workflowId: string, baseBranch: string) => Promise<void>;
@@ -47,11 +45,9 @@ export function WorkflowInspector({
   task,
   workflowTasks,
   executionPools,
-  executionAgents,
   collapsed,
   advancedExpanded,
   onEditPool,
-  onEditAgent,
   onEditPrompt,
   onEditCommand,
   onSetMergeBranch,
@@ -84,11 +80,6 @@ export function WorkflowInspector({
   const showsWorkflowMergeDetails = Boolean(!task && workflow?.id && workflow.onFinish === 'pull_request');
   const isMergeNode = Boolean((task?.config.isMergeNode || showsWorkflowMergeDetails) && workflow?.id);
   const currentAgent = task?.config.executionAgent ?? task?.execution.agentName ?? 'claude';
-  const agentOptions = useMemo(() => {
-    const names = new Set(executionAgents ?? []);
-    names.add(currentAgent);
-    return [...names].filter(Boolean);
-  }, [currentAgent, executionAgents]);
   const poolOptions = useMemo(() => {
     const ids = new Set(executionPools ?? []);
     if (task?.config.poolId) ids.add(task.config.poolId);
@@ -213,22 +204,14 @@ export function WorkflowInspector({
           </section>
         )}
 
-        {task?.config.prompt && onEditAgent && (
+        {task?.config.prompt && (
           <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
-            <label className="flex items-center justify-between gap-3">
-              <span className="text-xs uppercase tracking-wide text-gray-400">AI Agent</span>
-              <select
-                value={currentAgent}
-                onChange={(event) => onEditAgent(task.id, event.target.value)}
-                disabled={isTaskBusy || agentOptions.length === 0}
-                className="min-w-0 max-w-[190px] rounded border border-gray-600 bg-gray-700 px-2 py-1 text-xs text-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
-                data-testid="execution-agent-select"
-              >
-                {agentOptions.map((agentName) => (
-                  <option key={agentName} value={agentName}>{capitalize(agentName)}</option>
-                ))}
-              </select>
-            </label>
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-xs uppercase tracking-wide text-gray-400">Planning Agent</span>
+              <span className="rounded border border-gray-600 bg-gray-700 px-2 py-1 text-xs text-gray-100" data-testid="planning-agent-value">
+                {capitalize(currentAgent)}
+              </span>
+            </div>
           </section>
         )}
 

--- a/scripts/repro/repro-planning-chat-thinking-after-submit.sh
+++ b/scripts/repro/repro-planning-chat-thinking-after-submit.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec bash "$REPO_ROOT/scripts/repro/repro-planning-thinking-after-submit.sh" "$@"

--- a/scripts/repro/repro-planning-thinking-after-submit.sh
+++ b/scripts/repro/repro-planning-thinking-after-submit.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repro: after a draft-ready planning session is submitted, a new planning turn
+# must keep the live planner stream visible while planningChatSend is still
+# pending, then remove it when the final assistant reply arrives.
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/invoker-planning-thinking-after-submit.XXXXXX.log")"
+trap 'rm -f "$LOG_FILE"' EXIT
+
+echo "[repro] Planning stream must remain visible during a new pending turn after draft submit."
+
+if pnpm -C "$REPO_ROOT" --filter @invoker/ui exec vitest run \
+  src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx \
+  >"$LOG_FILE" 2>&1; then
+  echo "[repro] PASS: live planner output stays visible while the new request is pending and clears after the final reply."
+  exit 0
+else
+  status=$?
+  echo "[repro] FAIL: the focused planning stream regression reproduced."
+  cat "$LOG_FILE"
+  exit "$status"
+fi


### PR DESCRIPTION
## Summary

Planning-agent choice now stays in the Planning terminal and is sent on submit, so the submitted draft uses the same source of truth as follow-up planning turns.

This fixes the bug where task surfaces exposed agent editing. That put the choice in the wrong place and let task-side controls drift away from the planning session that actually produced the draft.

The task panel and workflow inspector now show the planning agent as read-only metadata, while `TerminalDrawer` owns selection and passes `presetKey` through `planningChatSubmit`.

## Architecture

### Before

```mermaid
graph LR
    A[Planning terminal preset] --> B[planningChatSend]
    C[Task panel agent dropdown] --> D[editTaskAgent]
    E[Workflow inspector agent dropdown] --> D
    B --> F[Draft planning session]
    F --> G[planningChatSubmit(sessionId)]
```

### After

```mermaid
graph LR
    A[Planning terminal preset] --> B[planningChatSend]
    A --> C[planningChatSubmit(sessionId, presetKey)]
    B --> D[Draft planning session]
    E[Task panel and workflow inspector] --> F[Read-only planning agent display]
    C --> D
```

## Test Plan

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx src/__tests__/workflow-inspector.test.tsx src/__tests__/task-panel-double-click.test.tsx`
- [x] `pnpm --filter @invoker/ui build`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/repro-planning-thinking-after-submit-pr.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert e1f63d8c5`
- Post-revert steps: None
- Data migration? No
