### PR TITLE
[Planning Chat Persistence Hot Path Fix](1) Keep conversation persistence incremental

### DIFF
--- a/packages/data-store/src/__tests__/conversation-repository.test.ts
+++ b/packages/data-store/src/__tests__/conversation-repository.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
 import { ConversationRepository } from '../conversation-repository.js';
 import type { ConversationMessageEntry } from '../conversation-repository.js';
@@ -97,6 +97,36 @@ describe('ConversationRepository', () => {
 
       const loaded = repo.loadConversation('ts-1');
       expect(loaded!.messages).toHaveLength(3);
+    });
+
+    it('does not load the full transcript to compute the append offset', () => {
+      const existingMessages: ConversationMessageEntry[] = Array.from({ length: 1_000 }, (_, index) => ({
+        role: index % 2 === 0 ? 'user' : 'assistant',
+        content: `message-${index}`,
+      }));
+      repo.saveConversation('ts-large', existingMessages);
+
+      const loadMessages = vi.spyOn(adapter, 'loadMessages').mockImplementation(() => {
+        throw new Error('saveConversation should not read the full transcript');
+      });
+      const appendMessage = vi.spyOn(adapter, 'appendMessage');
+
+      repo.saveConversation('ts-large', [
+        ...existingMessages,
+        { role: 'user', content: 'one more turn' },
+      ]);
+
+      expect(loadMessages).not.toHaveBeenCalled();
+      expect(appendMessage).toHaveBeenCalledTimes(1);
+      expect(adapter.countMessages('ts-large')).toBe(1_001);
+
+      loadMessages.mockRestore();
+      appendMessage.mockRestore();
+      const loaded = repo.loadConversation('ts-large');
+      expect(loaded!.messages.at(-1)).toEqual({
+        role: 'user',
+        content: 'one more turn',
+      });
     });
 
     it('handles complex message content (arrays of blocks)', () => {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1279,6 +1279,21 @@ describe('SQLiteAdapter', () => {
       expect(adapter.loadMessages('ts-1')).toEqual([]);
     });
 
+    it('counts messages for a thread', () => {
+      adapter.saveConversation(makeConversation('ts-1'));
+      adapter.saveConversation(makeConversation('ts-2'));
+
+      expect(adapter.countMessages('ts-1')).toBe(0);
+
+      adapter.appendMessage('ts-1', 'user', '"thread 1 msg"');
+      adapter.appendMessage('ts-2', 'user', '"thread 2 msg"');
+      adapter.appendMessage('ts-1', 'assistant', '"reply to thread 1"');
+
+      expect(adapter.countMessages('ts-1')).toBe(2);
+      expect(adapter.countMessages('ts-2')).toBe(1);
+      expect(adapter.countMessages('missing')).toBe(0);
+    });
+
     it('isolates messages by thread_ts', () => {
       adapter.saveConversation(makeConversation('ts-1'));
       adapter.saveConversation(makeConversation('ts-2'));

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -109,6 +109,7 @@ export interface PersistenceAdapter {
 
   // Conversation messages
   appendMessage(threadTs: string, role: 'user' | 'assistant', content: string): void;
+  countMessages(threadTs: string): number;
   loadMessages(threadTs: string): ConversationMessage[];
 
   // Task output (stdout/stderr persistence)

--- a/packages/data-store/src/conversation-repository.ts
+++ b/packages/data-store/src/conversation-repository.ts
@@ -88,9 +88,9 @@ export class ConversationRepository {
       });
     }
 
-    // Determine how many messages already exist and append new ones
-    const existingMessages = this.adapter.loadMessages(threadTs);
-    const newMessages = messages.slice(existingMessages.length);
+    // Determine how many messages already exist without reading the transcript.
+    const existingMessageCount = this.adapter.countMessages(threadTs);
+    const newMessages = messages.slice(existingMessageCount);
 
     for (const msg of newMessages) {
       const contentJson = typeof msg.content === 'string'

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1664,6 +1664,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
     `, [threadTs, nextSeq, role, content]);
   }
 
+  countMessages(threadTs: string): number {
+    const row = this.queryOne(
+      'SELECT COUNT(*) AS count FROM conversation_messages WHERE thread_ts = ?',
+      [threadTs],
+    ) as { count?: number } | undefined;
+    return Number(row?.count ?? 0);
+  }
+
   loadMessages(threadTs: string): ConversationMessage[] {
     const rows = this.queryAll(
       'SELECT * FROM conversation_messages WHERE thread_ts = ? ORDER BY seq ASC',


### PR DESCRIPTION
## Summary

Planning chat persistence no longer reloads the full transcript just to append new turns.

The repository now asks the adapter for the current message count and appends only the delta.

SQLite implements that count with a thread-scoped aggregate, keeping the send path bounded by new messages instead of existing history.

## Review Claim

Approve the persistence hot-path change that replaces full transcript reads with a thread message count before appending new planning chat messages.

## Review Lane

behavior

## Review Unit

data-store-persistence

## Safety Invariant

Only the append offset calculation changes. Conversation rows, message serialization, ordering, and load behavior stay on the existing storage path.

## Slice Rationale

This slice owns the lower-level persistence contract needed by the hot-path fix. The app-level cost guard and restored-session regression are kept in the next slice.

## Non-goals

- Do not change planning prompt generation or model calls.
- Do not change transcript serialization format.
- Do not change Slack, UI, or workflow execution behavior.

## Architecture

### Before

`ConversationRepository.saveConversation()` loaded every persisted message for the thread, measured that array, then appended messages after that offset.

### After

`ConversationRepository.saveConversation()` asks the adapter for `countMessages(threadTs)`, then slices the in-memory message list from that count and appends only the new entries.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/conversation-repository.test.ts src/__tests__/sqlite-adapter.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/planning-chat-persistence-pr1.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 970798fde3b2f1a63344149382ee08d9c58c80c7`
- Post-revert steps: Rerun the focused data-store tests.
- Data migration? No

</details>
