### PR TITLE
[Planning Chat Persistence Hot Path Fix](2) Guard planning chat send-path cost

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -57,7 +57,7 @@
     "dist": "electron-builder --publish never",
     "dist:linux": "electron-builder --linux AppImage deb --publish never",
     "dist:mac": "electron-builder --mac dmg --publish never",
-    "test": "vitest run",
+    "test": "node ../../scripts/run-vitest.cjs",
     "start": "unset ELECTRON_RUN_AS_NODE && node ../../scripts/electron.cjs dist/main.js",
     "dev": "tsup src/main.ts src/preload.ts --format cjs --outDir dist --external electron && unset ELECTRON_RUN_AS_NODE && node ../../scripts/electron.cjs dist/main.js",
     "test:e2e": "xvfb-run --auto-servernum playwright test"

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConversationRepository, SQLiteAdapter } from '@invoker/data-store';
+import { PlanConversation } from '@invoker/surfaces';
+
+const silentLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+const VALID_PLAN_RESPONSE = `Here is the plan:
+
+\`\`\`yaml
+name: "In-App Plan"
+onFinish: none
+baseBranch: main
+tasks:
+  - id: implement
+    description: "Implement the feature"
+    prompt: "Make the change"
+    dependencies: []
+\`\`\`
+
+Reply with yes to execute.`;
+
+describe('in-app planner persistence bridge', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('restores a persisted planner conversation and submits the recovered plan', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    const repo = new ConversationRepository(adapter, silentLogger);
+    const spawnCursor = vi
+      .spyOn(PlanConversation.prototype, 'spawnCursor')
+      .mockResolvedValueOnce(VALID_PLAN_RESPONSE);
+
+    try {
+      const firstSession = new PlanConversation({
+        threadTs: 'in-app-thread-1',
+        conversationRepo: repo,
+        log: () => {},
+      });
+      await firstSession.sendMessage('Create a plan for this app');
+
+      const restoredSession = new PlanConversation({
+        threadTs: 'in-app-thread-1',
+        conversationRepo: repo,
+        log: () => {},
+      });
+      await restoredSession.init();
+
+      const reply = await restoredSession.sendMessage('execute');
+
+      expect(spawnCursor).toHaveBeenCalledTimes(1);
+      expect(reply).toContain('In-App Plan');
+      expect(restoredSession.planSubmitted).toBe(true);
+      expect(restoredSession.submittedPlanText).toContain('name: In-App Plan');
+
+      const saved = repo.loadConversation('in-app-thread-1');
+      expect(saved?.planSubmitted).toBe(true);
+      expect(saved?.messages.map((message) => message.role)).toEqual([
+        'user',
+        'assistant',
+        'user',
+        'assistant',
+      ]);
+    } finally {
+      adapter.close();
+    }
+  });
+});

--- a/packages/app/src/__tests__/planning-chat-send-main-process-cost.test.ts
+++ b/packages/app/src/__tests__/planning-chat-send-main-process-cost.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ConversationRepository } from '@invoker/data-store';
+import { PlanConversation } from '@invoker/surfaces';
+
+describe('planning chat send main-process cost guard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not re-load persisted conversation history after the first send initializes state', async () => {
+    const repo = {
+      loadConversation: vi.fn(() => ({
+        threadTs: 'thread-hot-path',
+        channelId: '',
+        userId: '',
+        messages: [
+          { role: 'user', content: 'Initial request' },
+          { role: 'assistant', content: 'Initial response' },
+        ],
+        extractedPlan: null,
+        planSubmitted: false,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      })),
+      saveConversation: vi.fn(),
+      deleteConversation: vi.fn(),
+    } as unknown as ConversationRepository;
+
+    vi.spyOn(PlanConversation.prototype, 'spawnCursor')
+      .mockResolvedValueOnce('First reply')
+      .mockResolvedValueOnce('Second reply');
+
+    const conversation = new PlanConversation({
+      threadTs: 'thread-hot-path',
+      conversationRepo: repo,
+      log: () => {},
+    });
+
+    await conversation.sendMessage('First follow-up');
+    await conversation.sendMessage('Second follow-up');
+
+    expect(repo.loadConversation).toHaveBeenCalledTimes(1);
+    expect(repo.saveConversation).toHaveBeenCalledTimes(2);
+    expect(repo.saveConversation).toHaveBeenNthCalledWith(
+      1,
+      'thread-hot-path',
+      expect.arrayContaining([
+        { role: 'user', content: 'Initial request' },
+        { role: 'assistant', content: 'Initial response' },
+        { role: 'user', content: 'First follow-up' },
+        { role: 'assistant', content: 'First reply' },
+      ]),
+      null,
+      false,
+    );
+    expect(repo.saveConversation).toHaveBeenNthCalledWith(
+      2,
+      'thread-hot-path',
+      expect.arrayContaining([
+        { role: 'user', content: 'Second follow-up' },
+        { role: 'assistant', content: 'Second reply' },
+      ]),
+      null,
+      false,
+    );
+  });
+});

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -1,7 +1,13 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig, mergeConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.ts';
 
 export default mergeConfig(sharedConfig, defineConfig({
+  resolve: {
+    alias: {
+      '@invoker/surfaces': fileURLToPath(new URL('../surfaces/src/index.ts', import.meta.url)),
+    },
+  },
   test: {
     exclude: ['e2e/**', 'node_modules/**', 'dist/**'],
   },

--- a/packages/data-store/package.json
+++ b/packages/data-store/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
-    "test": "vitest run",
+    "test": "node ../../scripts/run-vitest.cjs",
     "test:watch": "vitest",
     "clean": "rm -rf dist"
   },

--- a/scripts/run-vitest.cjs
+++ b/scripts/run-vitest.cjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+const { spawn } = require('node:child_process');
+
+const args = process.argv.slice(2);
+const forwarded = args[0] === '--' ? args.slice(1) : args;
+const child = spawn('vitest', ['run', ...forwarded], {
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});
+
+child.on('error', (error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -5,7 +5,7 @@ const maxWorkers = process.env.INVOKER_VITEST_MAX_WORKERS
 
 export default defineConfig({
   test: {
-    exclude: ['**/dist/**'],
+    exclude: ['**/node_modules/**', '**/dist/**'],
     globals: true,
     // App plan-parser tests call git ls-remote (execSync timeout 10s); Vitest default 5s flakes.
     testTimeout: 20_000,


### PR DESCRIPTION
## Summary

The app test surface now exercises planning chat persistence across restored in-app sessions.

It also guards the hot send path so repeated sends do not keep reloading persisted conversation history.

The Vitest wrapper lets filtered package test commands run consistently from workspace scripts.

## Review Claim

Approve the app-level regression coverage that proves restored planning sessions still submit plans and repeated planning sends avoid extra persisted-history loads.

## Review Lane

proof

## Review Unit

planning-chat-regression

## Safety Invariant

This slice adds focused tests and package test-command plumbing. It does not change production planning chat control flow.

## Slice Rationale

This follows the persistence change so the regression guard can assert the fixed hot-path contract against the app planning surface.

## Non-goals

- Do not change the plan parser or YAML submission behavior.
- Do not change Electron IPC or renderer UI behavior.
- Do not broaden app test coverage outside the planning chat persistence path.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/planning-chat-send-main-process-cost.test.ts src/__tests__/in-app-planner.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/planning-chat-persistence-pr2.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f9288947f2c8f41a972c706bcdf50622bf86cc0c`
- Post-revert steps: Restore package test scripts if this slice is reverted without the previous persistence slice.
- Data migration? No

</details>
