### PR TITLE
[Headless Server Owner](4) Let invoker-cli use headless owners

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -200,7 +200,7 @@ describe('invoker-cli', () => {
     expect(result.stderr).toContain('Invalid YAML');
   });
 
-  it('--live delegates run to a reachable GUI owner', async () => {
+  it('--live delegates run to a reachable headless owner', async () => {
     const output = captureProcessOutput();
     const bus = new LocalBus();
     const runHandler = vi.fn(async (req: unknown) => {
@@ -210,7 +210,7 @@ describe('invoker-cli', () => {
       }));
       return { workflowId: 'wf-live-1', tasks: [] };
     });
-    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'gui-1', mode: 'gui' }));
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'standalone' }));
     bus.onRequest('headless.run', runHandler);
 
     const code = await main(['run', fixturePlan, '--live'], { createMessageBus: () => bus });
@@ -221,14 +221,14 @@ describe('invoker-cli', () => {
     output.restore();
   });
 
-  it('--live exits non-zero when no GUI owner is reachable', async () => {
+  it('--live exits non-zero when no owner is reachable', async () => {
     const output = captureProcessOutput();
     const bus = new LocalBus();
 
     const code = await main(['run', fixturePlan, '--live'], { createMessageBus: () => bus });
 
     expect(code).toBe(1);
-    expect(output.stderr).toContain('No running Invoker UI owner is reachable');
+    expect(output.stderr).toContain('No running Invoker owner is reachable');
     output.restore();
   });
 
@@ -271,6 +271,20 @@ tasks:
     expect(code).toBe(0);
     expect(runHandler).toHaveBeenCalledTimes(1);
     expect(output.stdout).toContain('wf-auto-live');
+    output.restore();
+  });
+  it('auto mode delegates when a headless owner exists', async () => {
+    const output = captureProcessOutput();
+    const bus = new LocalBus();
+    const runHandler = vi.fn(async () => ({ workflowId: 'wf-auto-headless', tasks: [] }));
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'standalone' }));
+    bus.onRequest('headless.run', runHandler);
+
+    const code = await main(['run', fixturePlan], { createMessageBus: () => bus });
+
+    expect(code).toBe(0);
+    expect(runHandler).toHaveBeenCalledTimes(1);
+    expect(output.stdout).toContain('wf-auto-headless');
     output.restore();
   });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -148,7 +148,7 @@ function usage(): string {
     '  invoker-cli --version',
     '',
     'Commands:',
-    '  run <plan.yaml>  Submit to a live Invoker UI when available, otherwise run standalone.',
+    '  run <plan.yaml>  Submit to a live Invoker owner when available, otherwise run standalone.',
     '  owner serve     Start a headless Invoker owner process.',
     '  doctor          Validate tools, config, and your default planning preset.',
     '  setup [planner|slack]  Run the setup wizard, or directly configure planner MCP or Slack.',
@@ -161,7 +161,7 @@ function usage(): string {
     `  --planner-package <spec>  Planner MCP package spec for \`setup planner\`. Defaults to ${DEFAULT_DRAFTER_MCP_PACKAGE_SPEC}.`,
     '  --target <path>       MCP config path for planner setup. Defaults to ~/.invoker/mcp.json.',
     '  --uninstall           Remove the experimental planner MCP entry and disable its Invoker flag.',
-    '  --live           Require a running Invoker UI owner and submit over IPC.',
+    '  --live           Require a running Invoker owner and submit over IPC.',
     '  --standalone     Skip IPC and run with an isolated CLI database.',
     '  --db-dir <path>  Runtime database directory. Defaults to ~/.invoker-cli',
     '  --config <path>  Optional config path reserved for CLI runtime configuration.',
@@ -243,10 +243,12 @@ async function discoverLiveOwner(bus: MessageBus, timeoutMs = 10_000): Promise<L
     );
     if (!raw || typeof raw !== 'object') return null;
     const response = raw as Record<string, unknown>;
-    if (response.mode !== 'gui') return null;
+    if (typeof response.mode !== 'string' || response.mode.length === 0) {
+      return null;
+    }
     return {
       ownerId: typeof response.ownerId === 'string' ? response.ownerId : '',
-      mode: 'gui',
+      mode: response.mode,
     };
   } catch (err) {
     if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
@@ -668,7 +670,7 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     }
 
     if (parsed.options.mode === 'live' && parsed.options.dbDir) {
-      throw new Error('--db-dir cannot be used with --live because the UI owner database is authoritative');
+      throw new Error('--db-dir cannot be used with --live because the owner database is authoritative');
     }
 
     if (parsed.options.mode !== 'standalone') {
@@ -676,7 +678,7 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
       const owner = await discoverLiveOwner(bus);
       if (owner) {
         if (parsed.options.dbDir) {
-          throw new Error('--db-dir cannot be used when a live UI owner accepts the run; use --standalone to force an isolated database');
+          throw new Error('--db-dir cannot be used when a live owner accepts the run; use --standalone to force an isolated database');
         }
         const submitted = await submitPlanToLiveOwner(parsed.planPath, bus, owner);
         printRunResult({
@@ -689,7 +691,7 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
         return 0;
       }
       if (parsed.options.mode === 'live') {
-        throw new Error('No running Invoker UI owner is reachable; start the UI or omit --live to run standalone');
+        throw new Error('No running Invoker owner is reachable; start the owner or omit --live to run standalone');
       }
     }
 


### PR DESCRIPTION
## Summary

This lets `invoker-cli --live` treat a headless server owner as a valid live owner.

The bug was simple: CLI owner discovery ignored any `headless.owner-ping` reply whose mode was not `gui`. That forced packaged callers back into isolated standalone state.

The fix accepts any non-empty owner mode, keeps the same `headless.run` request, and updates the CLI copy so it talks about a live owner instead of only a UI owner.

## Review Claim

`invoker-cli --live` now accepts a headless server owner as a valid live owner.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice only broadens live-owner acceptance. The delegated `headless.run` payload and standalone fallback behavior stay the same.

## Slice Rationale

This is separate from the owner-serve command because the review question here is narrower: which already-running owners `--live` should accept.

## Non-goals

- Changing how a headless owner gets started.
- Changing Slack manager behavior.
- Changing worker registration.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/cli build && pnpm --filter @invoker/cli exec vitest run src/__tests__/cli.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert a5b3775`
- Post-revert steps: None.
- Data migration? No.

</details>