### PR TITLE
[Headless Server Owner](5) Run Slack manager through headless owners

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -200,7 +200,7 @@ describe('invoker-cli', () => {
     expect(result.stderr).toContain('Invalid YAML');
   });
 
-  it('--live delegates run to a reachable GUI owner', async () => {
+  it('--live delegates run to a reachable headless owner', async () => {
     const output = captureProcessOutput();
     const bus = new LocalBus();
     const runHandler = vi.fn(async (req: unknown) => {
@@ -210,7 +210,7 @@ describe('invoker-cli', () => {
       }));
       return { workflowId: 'wf-live-1', tasks: [] };
     });
-    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'gui-1', mode: 'gui' }));
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'standalone' }));
     bus.onRequest('headless.run', runHandler);
 
     const code = await main(['run', fixturePlan, '--live'], { createMessageBus: () => bus });
@@ -221,14 +221,14 @@ describe('invoker-cli', () => {
     output.restore();
   });
 
-  it('--live exits non-zero when no GUI owner is reachable', async () => {
+  it('--live exits non-zero when no owner is reachable', async () => {
     const output = captureProcessOutput();
     const bus = new LocalBus();
 
     const code = await main(['run', fixturePlan, '--live'], { createMessageBus: () => bus });
 
     expect(code).toBe(1);
-    expect(output.stderr).toContain('No running Invoker UI owner is reachable');
+    expect(output.stderr).toContain('No running Invoker owner is reachable');
     output.restore();
   });
 
@@ -271,6 +271,20 @@ tasks:
     expect(code).toBe(0);
     expect(runHandler).toHaveBeenCalledTimes(1);
     expect(output.stdout).toContain('wf-auto-live');
+    output.restore();
+  });
+  it('auto mode delegates when a headless owner exists', async () => {
+    const output = captureProcessOutput();
+    const bus = new LocalBus();
+    const runHandler = vi.fn(async () => ({ workflowId: 'wf-auto-headless', tasks: [] }));
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'standalone' }));
+    bus.onRequest('headless.run', runHandler);
+
+    const code = await main(['run', fixturePlan], { createMessageBus: () => bus });
+
+    expect(code).toBe(0);
+    expect(runHandler).toHaveBeenCalledTimes(1);
+    expect(output.stdout).toContain('wf-auto-headless');
     output.restore();
   });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -148,7 +148,7 @@ function usage(): string {
     '  invoker-cli --version',
     '',
     'Commands:',
-    '  run <plan.yaml>  Submit to a live Invoker UI when available, otherwise run standalone.',
+    '  run <plan.yaml>  Submit to a live Invoker owner when available, otherwise run standalone.',
     '  owner serve     Start a headless Invoker owner process.',
     '  doctor          Validate tools, config, and your default planning preset.',
     '  setup [planner|slack]  Run the setup wizard, or directly configure planner MCP or Slack.',
@@ -161,7 +161,7 @@ function usage(): string {
     `  --planner-package <spec>  Planner MCP package spec for \`setup planner\`. Defaults to ${DEFAULT_DRAFTER_MCP_PACKAGE_SPEC}.`,
     '  --target <path>       MCP config path for planner setup. Defaults to ~/.invoker/mcp.json.',
     '  --uninstall           Remove the experimental planner MCP entry and disable its Invoker flag.',
-    '  --live           Require a running Invoker UI owner and submit over IPC.',
+    '  --live           Require a running Invoker owner and submit over IPC.',
     '  --standalone     Skip IPC and run with an isolated CLI database.',
     '  --db-dir <path>  Runtime database directory. Defaults to ~/.invoker-cli',
     '  --config <path>  Optional config path reserved for CLI runtime configuration.',
@@ -243,10 +243,12 @@ async function discoverLiveOwner(bus: MessageBus, timeoutMs = 10_000): Promise<L
     );
     if (!raw || typeof raw !== 'object') return null;
     const response = raw as Record<string, unknown>;
-    if (response.mode !== 'gui') return null;
+    if (typeof response.mode !== 'string' || response.mode.length === 0) {
+      return null;
+    }
     return {
       ownerId: typeof response.ownerId === 'string' ? response.ownerId : '',
-      mode: 'gui',
+      mode: response.mode,
     };
   } catch (err) {
     if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
@@ -668,7 +670,7 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     }
 
     if (parsed.options.mode === 'live' && parsed.options.dbDir) {
-      throw new Error('--db-dir cannot be used with --live because the UI owner database is authoritative');
+      throw new Error('--db-dir cannot be used with --live because the owner database is authoritative');
     }
 
     if (parsed.options.mode !== 'standalone') {
@@ -676,7 +678,7 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
       const owner = await discoverLiveOwner(bus);
       if (owner) {
         if (parsed.options.dbDir) {
-          throw new Error('--db-dir cannot be used when a live UI owner accepts the run; use --standalone to force an isolated database');
+          throw new Error('--db-dir cannot be used when a live owner accepts the run; use --standalone to force an isolated database');
         }
         const submitted = await submitPlanToLiveOwner(parsed.planPath, bus, owner);
         printRunResult({
@@ -689,7 +691,7 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
         return 0;
       }
       if (parsed.options.mode === 'live') {
-        throw new Error('No running Invoker UI owner is reachable; start the UI or omit --live to run standalone');
+        throw new Error('No running Invoker owner is reachable; start the owner or omit --live to run standalone');
       }
     }
 

--- a/packages/slack-manager/src/__tests__/invoker-launcher.test.ts
+++ b/packages/slack-manager/src/__tests__/invoker-launcher.test.ts
@@ -1,45 +1,40 @@
 import { describe, it, expect } from 'vitest';
-import { resolveGuiLaunch } from '../invoker-launcher.js';
 
-describe('resolveGuiLaunch', () => {
+import { LINUX_HEADLESS_ELECTRON_FLAGS } from '@invoker/contracts';
+
+import { resolveOwnerLaunch } from '../invoker-launcher.js';
+
+describe('resolveOwnerLaunch', () => {
   it('prefers INVOKER_GUI_COMMAND when set', () => {
-    const spec = resolveGuiLaunch({
+    const spec = resolveOwnerLaunch({
       repoRoot: '/repo',
       platform: 'darwin',
-      env: { INVOKER_GUI_COMMAND: '/opt/Invoker.app/Contents/MacOS/Invoker --flag' },
+      env: { INVOKER_GUI_COMMAND: '/opt/invoker-owner --flag' },
       which: () => undefined,
       existsSync: () => false,
     });
     expect(spec).toEqual({
-      command: '/opt/Invoker.app/Contents/MacOS/Invoker',
+      command: '/opt/invoker-owner',
       args: ['--flag'],
     });
   });
 
-  it('uses invoker-ui on PATH before macOS open', () => {
-    const spec = resolveGuiLaunch({
+  it('uses invoker-ui in headless owner mode when it is on PATH', () => {
+    const spec = resolveOwnerLaunch({
       repoRoot: '/repo',
       platform: 'darwin',
       env: {},
-      which: (cmd) => (cmd === 'invoker-ui' ? '/usr/local/bin/invoker-ui' : undefined),
+      which: (command) => (command === 'invoker-ui' ? '/usr/local/bin/invoker-ui' : undefined),
       existsSync: () => false,
     });
-    expect(spec).toEqual({ command: '/usr/local/bin/invoker-ui', args: [] });
-  });
-
-  it('falls back to open -a Invoker on macOS', () => {
-    const spec = resolveGuiLaunch({
-      repoRoot: '/repo',
-      platform: 'darwin',
-      env: {},
-      which: () => undefined,
-      existsSync: () => false,
+    expect(spec).toEqual({
+      command: '/usr/local/bin/invoker-ui',
+      args: ['--headless', 'owner-serve'],
     });
-    expect(spec).toEqual({ command: 'open', args: ['-a', 'Invoker'] });
   });
 
-  it('uses monorepo xvfb-run path on Linux when checkout artifacts exist', () => {
-    const spec = resolveGuiLaunch({
+  it('uses the repo headless owner path on Linux when checkout artifacts exist', () => {
+    const spec = resolveOwnerLaunch({
       repoRoot: '/repo',
       platform: 'linux',
       env: {},
@@ -49,20 +44,27 @@ describe('resolveGuiLaunch', () => {
     });
     expect(spec).toEqual({
       command: 'xvfb-run',
-      args: ['--auto-servernum', './scripts/electron.cjs', 'packages/app/dist/main.js', '--no-sandbox'],
+      args: [
+        '--auto-servernum',
+        './scripts/electron.cjs',
+        ...LINUX_HEADLESS_ELECTRON_FLAGS,
+        'packages/app/dist/main.js',
+        '--headless',
+        'owner-serve',
+      ],
       cwd: '/repo',
     });
   });
 
-  it('throws on Linux when no GUI launch path is available', () => {
+  it('throws when no headless owner launch path is available', () => {
     expect(() =>
-      resolveGuiLaunch({
+      resolveOwnerLaunch({
         repoRoot: '/repo',
         platform: 'linux',
         env: {},
         which: () => undefined,
         existsSync: () => false,
       }),
-    ).toThrow(/Cannot launch Invoker GUI/);
+    ).toThrow(/Cannot launch Invoker headless owner/);
   });
 });

--- a/packages/slack-manager/src/invoker-client.ts
+++ b/packages/slack-manager/src/invoker-client.ts
@@ -77,7 +77,7 @@ export interface InvokerClient {
 }
 
 export interface InvokerClientOptions {
-  /** Starts a fresh detached Invoker GUI process. Owns kill-and-respawn for force restarts. */
+  /** Starts a fresh detached Invoker owner process. Owns kill-and-respawn for force restarts. */
   spawnInvoker: () => void;
   log: (level: string, message: string) => void;
   socketPath?: string;

--- a/packages/slack-manager/src/invoker-launcher.ts
+++ b/packages/slack-manager/src/invoker-launcher.ts
@@ -1,21 +1,24 @@
 /**
- * Invoker GUI launcher — spawns the Slack-free Invoker GUI as a detached process
- * group. Tracks the spawned child so a forced restart can tear down a
+ * Invoker owner launcher — spawns the Slack-free headless owner as a detached
+ * process group. Tracks the spawned child so a forced restart can tear down a
  * manager-managed instance before respawning.
  *
  * Resolution order:
- *   1. INVOKER_GUI_COMMAND (shell-split argv[0] + args)
- *   2. `invoker-ui` on PATH
- *   3. macOS: `open -a Invoker`
- *   4. monorepo checkout: xvfb-run + ./scripts/electron.cjs (Linux headless)
+ *   1. INVOKER_GUI_COMMAND (explicit override command)
+ *   2. `invoker-ui --headless owner-serve`
+ *   3. monorepo checkout: repo Electron `--headless owner-serve`
  *
  * Slack credentials are stripped from the child env: post-cutover Invoker has no
  * Slack surface, and the manager owns the only Slack connection.
  */
 
-import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
-import { existsSync, openSync } from 'node:fs';
-import { join } from 'node:path';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { openSync } from 'node:fs';
+
+import {
+  resolveHeadlessOwnerLaunchSpec,
+  type HeadlessOwnerLaunchSpec,
+} from '@invoker/contracts';
 
 const SLACK_ENV_VARS = [
   'SLACK_BOT_TOKEN',
@@ -23,11 +26,11 @@ const SLACK_ENV_VARS = [
   'SLACK_SIGNING_SECRET',
   'SLACK_CHANNEL_ID',
   'SLACK_LOBBY_CHANNEL_ID',
-];
+] as const;
 
 export interface InvokerLauncherOptions {
   repoRoot: string;
-  /** Path the GUI's stdout/stderr is appended to. */
+  /** Path the owner stdout/stderr is appended to. */
   logPath: string;
   log: (level: string, message: string) => void;
 }
@@ -36,82 +39,30 @@ export interface InvokerLauncher {
   spawnInvoker: () => void;
 }
 
-export interface GuiLaunchSpec {
-  command: string;
-  args: string[];
-  cwd?: string;
-}
-
-function defaultWhich(command: string): string | undefined {
-  try {
-    return execFileSync('which', [command], { encoding: 'utf8' }).trim() || undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-/** Exported for unit tests — pure resolution, no spawn. */
-export function resolveGuiLaunch(options: {
-  repoRoot: string;
-  platform?: NodeJS.Platform;
-  env?: NodeJS.ProcessEnv;
-  which?: (command: string) => string | undefined;
-  existsSync?: (path: string) => boolean;
-}): GuiLaunchSpec {
-  const env = options.env ?? process.env;
-  const platform = options.platform ?? process.platform;
-  const which = options.which ?? defaultWhich;
-  const fileExists = options.existsSync ?? existsSync;
-
-  const guiCommand = env.INVOKER_GUI_COMMAND?.trim();
-  if (guiCommand) {
-    const parts = guiCommand.split(/\s+/).filter(Boolean);
-    return { command: parts[0]!, args: parts.slice(1) };
-  }
-
-  const invokerUi = which('invoker-ui');
-  if (invokerUi) {
-    return { command: invokerUi, args: [] };
-  }
-
-  if (platform === 'darwin') {
-    return { command: 'open', args: ['-a', 'Invoker'] };
-  }
-
-  const electronCjs = join(options.repoRoot, 'scripts', 'electron.cjs');
-  const mainJs = join(options.repoRoot, 'packages', 'app', 'dist', 'main.js');
-  if (fileExists(electronCjs) && fileExists(mainJs)) {
-    return {
-      command: 'xvfb-run',
-      args: ['--auto-servernum', './scripts/electron.cjs', 'packages/app/dist/main.js', '--no-sandbox'],
-      cwd: options.repoRoot,
-    };
-  }
-
-  throw new Error(
-    'Cannot launch Invoker GUI: set INVOKER_GUI_COMMAND, install invoker-ui, or run from a built monorepo checkout',
-  );
-}
+export type OwnerLaunchSpec = HeadlessOwnerLaunchSpec;
+export { resolveHeadlessOwnerLaunchSpec as resolveOwnerLaunch };
 
 export function createInvokerLauncher(options: InvokerLauncherOptions): InvokerLauncher {
   let child: ChildProcess | undefined;
 
   return {
     spawnInvoker: () => {
-      // Tear down a previously manager-spawned GUI (force-restart of a managed instance).
       if (child?.pid && child.exitCode === null) {
         try {
           process.kill(-child.pid, 'SIGTERM');
-          options.log('info', `sent SIGTERM to previous Invoker GUI group (pid=${child.pid})`);
+          options.log('info', `sent SIGTERM to previous Invoker owner group (pid=${child.pid})`);
         } catch {
           /* already gone */
         }
       }
 
-      const env: NodeJS.ProcessEnv = { ...process.env, LIBGL_ALWAYS_SOFTWARE: '1' };
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        LIBGL_ALWAYS_SOFTWARE: process.platform === 'linux' ? '1' : process.env.LIBGL_ALWAYS_SOFTWARE,
+      };
       for (const key of SLACK_ENV_VARS) delete env[key];
 
-      const spec = resolveGuiLaunch({ repoRoot: options.repoRoot });
+      const spec = resolveHeadlessOwnerLaunchSpec({ repoRoot: options.repoRoot });
       const out = openSync(options.logPath, 'a');
       child = spawn(spec.command, spec.args, {
         cwd: spec.cwd,
@@ -120,7 +71,7 @@ export function createInvokerLauncher(options: InvokerLauncherOptions): InvokerL
         stdio: ['ignore', out, out],
       });
       child.unref();
-      options.log('info', `spawned Invoker GUI via ${spec.command} (pid=${child.pid})`);
+      options.log('info', `spawned Invoker owner via ${spec.command} (pid=${child.pid})`);
     },
   };
 }


### PR DESCRIPTION
## Summary

This makes Slack manager start the headless owner process instead of a GUI-oriented owner process.

The bug was that the Slack watchdog chose the wrong owner process. On a server, Slack could not cleanly own the same headless process that CLI and web should use.

The fix changes only the owner process that the watchdog starts, keeps the same detached supervision model, and leaves the existing Slack request handling alone.

## Review Claim

Slack manager now starts a headless owner process.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Slack thread parsing, heartbeats, progress cards, and workflow operations do not change in this slice. Only the owner process started by the watchdog changes.

## Slice Rationale

This lands last because it depends on the earlier slices making the server owner valid for packaged callers. Reviewing the owner-process switch separately keeps the Slack behavior question local.

## Non-goals

- Changing Slack thread UX or workflow-channel behavior.
- Changing `invoker-cli` live-owner discovery again.
- Adding new Slack controls.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/contracts exec vitest run src/__tests__/headless-owner-launch.test.ts`
- [x] `pnpm --filter @invoker/slack-manager exec vitest run src/__tests__/invoker-launcher.test.ts src/__tests__/invoker-client.test.ts`
- [x] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/slack-surface-heartbeat.integration.test.ts src/__tests__/slack-surface-immediate-response.integration.test.ts src/__tests__/slack-surface-workflows.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 16a7b6f`
- Post-revert steps: None.
- Data migration? No.

</details>

Depends-On: #4924