### PR TITLE
[Headless Server Owner](3) Add invoker-cli owner serve

### DIFF
--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { join, resolve } from 'node:path';
 
-import { resolveRepoRoot, type WorkerStatusSnapshot } from '@invoker/contracts';
+import { buildElectronHeadlessArgs, resolveRepoRoot, type WorkerStatusSnapshot } from '@invoker/contracts';
 import { hasLiveWritableOwner } from '@invoker/data-store';
 import { IpcBus } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
@@ -53,22 +53,7 @@ function delegationClientLog(message: string): void {
 }
 
 export function electronCommandArgs(args: string[], platform: NodeJS.Platform = process.platform): string[] {
-  const mainJs = resolve(__dirname, 'main.js');
-  return [
-    ...(platform === 'linux'
-      ? [
-          '--no-sandbox',
-          '--disable-dev-shm-usage',
-          '--disable-gpu',
-          '--disable-gpu-compositing',
-          '--disable-gpu-sandbox',
-          '--disable-software-rasterizer',
-        ]
-      : []),
-    mainJs,
-    '--headless',
-    ...args,
-  ];
+  return buildElectronHeadlessArgs(resolve(__dirname, 'main.js'), args, platform);
 }
 
 async function runElectronHeadless(args: string[]): Promise<number> {

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -60,6 +61,15 @@ function captureProcessOutput() {
       stderrSpy.mockRestore();
     },
   };
+}
+function makeSpawnProcessStub() {
+  return vi.fn(() => {
+    const child = new EventEmitter() as ReturnType<typeof spawn>;
+    process.nextTick(() => {
+      child.emit('exit', 0, null);
+    });
+    return child;
+  });
 }
 
 describe('invoker-cli', () => {
@@ -135,6 +145,33 @@ describe('invoker-cli', () => {
 
     expect(code).toBe(0);
     expect(runMcpServer).toHaveBeenCalledTimes(1);
+  });
+  it('--help lists the headless owner command', async () => {
+    const result = await runCli(['--help']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('invoker-cli owner serve');
+    expect(result.stdout).toContain('Start a headless Invoker owner process.');
+  });
+
+  it('owner serve launches the resolved headless owner command', async () => {
+    const spawnProcess = makeSpawnProcessStub();
+
+    const code = await main(['owner', 'serve'], {
+      resolveOwnerLaunchSpec: () => ({
+        command: '/usr/local/bin/invoker-ui',
+        args: ['--headless', 'owner-serve'],
+      }),
+      spawnProcess,
+    });
+
+    expect(code).toBe(0);
+    expect(spawnProcess).toHaveBeenCalledWith(
+      '/usr/local/bin/invoker-ui',
+      ['--headless', 'owner-serve'],
+      expect.objectContaining({
+        stdio: 'inherit',
+      }),
+    );
   });
 
   it('runs the hello-world fixture with an isolated db dir', async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,8 +1,16 @@
+import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve, join } from 'node:path';
 import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
-import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, resolveInvokerHomeRoot, type Logger } from '@invoker/contracts';
+import {
+  DEFAULT_DRAFTER_MCP_PACKAGE_SPEC,
+  resolveHeadlessOwnerLaunchSpec,
+  resolveInvokerHomeRoot,
+  resolveRepoRoot,
+  type HeadlessOwnerLaunchSpec,
+  type Logger,
+} from '@invoker/contracts';
 import { SQLiteAdapter, SqliteTaskRepository } from '@invoker/data-store';
 import {
   AUTO_FIX_WORKER_KIND,
@@ -71,6 +79,8 @@ type LiveSubmissionResult = {
 type CliDeps = {
   createMessageBus?: () => Promise<MessageBus> | MessageBus;
   runMcpServer?: () => Promise<void>;
+  resolveOwnerLaunchSpec?: (repoRoot: string) => HeadlessOwnerLaunchSpec;
+  spawnProcess?: typeof spawn;
 };
 
 type CliRuntimeConfig = {
@@ -129,6 +139,7 @@ function usage(): string {
   return [
     'Usage:',
     '  invoker-cli run <plan.yaml> [--live|--standalone] [--db-dir <path>] [--config <path>] [--json]',
+    '  invoker-cli owner serve',
     '  invoker-cli doctor [--fix] [--json]',
     '  invoker-cli setup [planner|slack] [--check|--from-env] [--yes] [--json]',
     '  invoker-cli mcp',
@@ -138,6 +149,7 @@ function usage(): string {
     '',
     'Commands:',
     '  run <plan.yaml>  Submit to a live Invoker UI when available, otherwise run standalone.',
+    '  owner serve     Start a headless Invoker owner process.',
     '  doctor          Validate tools, config, and your default planning preset.',
     '  setup [planner|slack]  Run the setup wizard, or directly configure planner MCP or Slack.',
     '  mcp             Start the Invoker MCP stdio server.',
@@ -579,6 +591,28 @@ async function runWorker(definition: WorkerDefinition<WorkerRuntimeDependencies>
   process.stdout.write(`${workerDisplayName(definition.kind)} worker stopped.\n`);
   return 0;
 }
+async function runHeadlessOwnerServe(deps: CliDeps): Promise<number> {
+  const repoRoot = resolveRepoRoot(__dirname, { fallback: resolve(__dirname, '../../../..') });
+  const launchSpec = (deps.resolveOwnerLaunchSpec ?? resolveHeadlessOwnerLaunchSpec)(repoRoot);
+  const child = (deps.spawnProcess ?? spawn)(launchSpec.command, launchSpec.args, {
+    cwd: launchSpec.cwd,
+    env: {
+      ...process.env,
+      LIBGL_ALWAYS_SOFTWARE: process.platform === 'linux' ? '1' : process.env.LIBGL_ALWAYS_SOFTWARE,
+    },
+    stdio: 'inherit',
+  });
+  return await new Promise<number>((resolveExit, reject) => {
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (signal) {
+        reject(new Error(`headless owner exited with signal ${signal}`));
+        return;
+      }
+      resolveExit(code ?? 0);
+    });
+  });
+}
 
 export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps = {}): Promise<number> {
   let bus: MessageBus | undefined;
@@ -592,6 +626,12 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     if (argv[0] === 'mcp') {
       await (deps.runMcpServer ?? runMcpServer)();
       return 0;
+    }
+    if (argv[0] === 'owner') {
+      if (argv[1] !== 'serve') {
+        throw new Error('Unknown owner command. Usage: invoker-cli owner serve');
+      }
+      return await runHeadlessOwnerServe(deps);
     }
     if (argv[0] === 'worker') {
       const subcommand = argv[1] ?? 'list';

--- a/packages/contracts/src/__tests__/headless-owner-launch.test.ts
+++ b/packages/contracts/src/__tests__/headless-owner-launch.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildElectronHeadlessArgs,
+  LINUX_HEADLESS_ELECTRON_FLAGS,
+  resolveHeadlessOwnerLaunchSpec,
+} from '../headless-owner-launch.js';
+
+describe('buildElectronHeadlessArgs', () => {
+  it('prepends the Linux stability flags before the app entry point', () => {
+    expect(buildElectronHeadlessArgs('/repo/packages/app/dist/main.js', ['owner-serve'], 'linux')).toEqual([
+      ...LINUX_HEADLESS_ELECTRON_FLAGS,
+      '/repo/packages/app/dist/main.js',
+      '--headless',
+      'owner-serve',
+    ]);
+  });
+
+  it('keeps non-Linux launches free of Linux-only switches', () => {
+    expect(buildElectronHeadlessArgs('/repo/packages/app/dist/main.js', ['owner-serve'], 'darwin')).toEqual([
+      '/repo/packages/app/dist/main.js',
+      '--headless',
+      'owner-serve',
+    ]);
+  });
+});
+
+describe('resolveHeadlessOwnerLaunchSpec', () => {
+  it('prefers INVOKER_GUI_COMMAND when set', () => {
+    expect(resolveHeadlessOwnerLaunchSpec({
+      repoRoot: '/repo',
+      platform: 'linux',
+      env: { INVOKER_GUI_COMMAND: '/usr/local/bin/custom-owner --flag' },
+      which: () => undefined,
+      existsSync: () => false,
+    })).toEqual({
+      command: '/usr/local/bin/custom-owner',
+      args: ['--flag'],
+    });
+  });
+
+  it('uses the packaged invoker-ui wrapper when present', () => {
+    expect(resolveHeadlessOwnerLaunchSpec({
+      repoRoot: '/repo',
+      platform: 'linux',
+      env: {},
+      which: (command) => (command === 'invoker-ui' ? '/usr/local/bin/invoker-ui' : undefined),
+      existsSync: () => false,
+    })).toEqual({
+      command: '/usr/local/bin/invoker-ui',
+      args: ['--headless', 'owner-serve'],
+    });
+  });
+
+  it('falls back to the repo Electron owner-serve path on Linux', () => {
+    expect(resolveHeadlessOwnerLaunchSpec({
+      repoRoot: '/repo',
+      platform: 'linux',
+      env: {},
+      which: () => undefined,
+      existsSync: (path) => path === '/repo/scripts/electron.cjs' || path === '/repo/packages/app/dist/main.js',
+    })).toEqual({
+      command: 'xvfb-run',
+      args: [
+        '--auto-servernum',
+        './scripts/electron.cjs',
+        ...LINUX_HEADLESS_ELECTRON_FLAGS,
+        'packages/app/dist/main.js',
+        '--headless',
+        'owner-serve',
+      ],
+      cwd: '/repo',
+    });
+  });
+
+  it('falls back to the repo Electron owner-serve path on macOS', () => {
+    expect(resolveHeadlessOwnerLaunchSpec({
+      repoRoot: '/repo',
+      platform: 'darwin',
+      env: {},
+      which: () => undefined,
+      existsSync: (path) => path === '/repo/scripts/electron.cjs' || path === '/repo/packages/app/dist/main.js',
+    })).toEqual({
+      command: './scripts/electron.cjs',
+      args: ['packages/app/dist/main.js', '--headless', 'owner-serve'],
+      cwd: '/repo',
+    });
+  });
+
+  it('throws when no packaged or repo owner path exists', () => {
+    expect(() => resolveHeadlessOwnerLaunchSpec({
+      repoRoot: '/repo',
+      platform: 'linux',
+      env: {},
+      which: () => undefined,
+      existsSync: () => false,
+    })).toThrow(/Cannot launch Invoker headless owner/);
+  });
+});

--- a/packages/contracts/src/headless-owner-launch.ts
+++ b/packages/contracts/src/headless-owner-launch.ts
@@ -1,0 +1,115 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const LINUX_HEADLESS_ELECTRON_FLAGS = [
+  '--no-sandbox',
+  '--disable-dev-shm-usage',
+  '--disable-gpu',
+  '--disable-gpu-compositing',
+  '--disable-gpu-sandbox',
+  '--disable-software-rasterizer',
+] as const;
+
+export interface HeadlessOwnerLaunchSpec {
+  command: string;
+  args: string[];
+  cwd?: string;
+}
+
+export interface ResolveHeadlessOwnerLaunchOptions {
+  repoRoot: string;
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  which?: (command: string) => string | undefined;
+  existsSync?: (path: string) => boolean;
+}
+
+function defaultWhich(command: string): string | undefined {
+  try {
+    return execFileSync('which', [command], { encoding: 'utf8' }).trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function splitCommand(commandText: string): HeadlessOwnerLaunchSpec {
+  const parts = commandText.split(/\s+/).filter(Boolean);
+  if (parts.length === 0) {
+    throw new Error('INVOKER_GUI_COMMAND is set but empty');
+  }
+  return { command: parts[0]!, args: parts.slice(1) };
+}
+
+function ensureHeadlessOwnerArgs(spec: HeadlessOwnerLaunchSpec): HeadlessOwnerLaunchSpec {
+  const argsWithoutOwnerServe = spec.args.filter((arg) => arg !== 'owner-serve');
+  const headlessIndex = argsWithoutOwnerServe.indexOf('--headless');
+  if (headlessIndex === -1) {
+    return {
+      command: spec.command,
+      args: [...argsWithoutOwnerServe, '--headless', 'owner-serve'],
+    };
+  }
+  return {
+    command: spec.command,
+    args: [
+      ...argsWithoutOwnerServe.slice(0, headlessIndex + 1),
+      'owner-serve',
+      ...argsWithoutOwnerServe.slice(headlessIndex + 1),
+    ],
+  };
+}
+
+export function buildElectronHeadlessArgs(
+  mainJsPath: string,
+  headlessArgs: readonly string[],
+  platform: NodeJS.Platform = process.platform,
+): string[] {
+  return [
+    ...(platform === 'linux' ? LINUX_HEADLESS_ELECTRON_FLAGS : []),
+    mainJsPath,
+    '--headless',
+    ...headlessArgs,
+  ];
+}
+
+export function resolveHeadlessOwnerLaunchSpec(
+  options: ResolveHeadlessOwnerLaunchOptions,
+): HeadlessOwnerLaunchSpec {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const which = options.which ?? defaultWhich;
+  const fileExists = options.existsSync ?? existsSync;
+
+  const overrideCommand = env.INVOKER_GUI_COMMAND?.trim();
+  if (overrideCommand) {
+    return ensureHeadlessOwnerArgs(splitCommand(overrideCommand));
+  }
+
+  const invokerUi = which('invoker-ui');
+  if (invokerUi) {
+    return { command: invokerUi, args: ['--headless', 'owner-serve'] };
+  }
+
+  const electronCjs = join(options.repoRoot, 'scripts', 'electron.cjs');
+  const mainJs = join(options.repoRoot, 'packages', 'app', 'dist', 'main.js');
+  if (fileExists(electronCjs) && fileExists(mainJs)) {
+    const launchArgs = buildElectronHeadlessArgs('packages/app/dist/main.js', ['owner-serve'], platform);
+    if (platform === 'linux') {
+      return {
+        command: 'xvfb-run',
+        args: ['--auto-servernum', './scripts/electron.cjs', ...launchArgs],
+        cwd: options.repoRoot,
+      };
+    }
+    return {
+      command: './scripts/electron.cjs',
+      args: launchArgs,
+      cwd: options.repoRoot,
+    };
+  }
+
+  throw new Error(
+    'Cannot launch Invoker headless owner: set INVOKER_GUI_COMMAND, install invoker-ui, or run from a built monorepo checkout',
+  );
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -12,4 +12,5 @@ export * from './invoker-home.ts';
 export * from './invoker-config-io.ts';
 export * from './config-diagnostics.ts';
 export * from './prerequisites.ts';
+export * from './headless-owner-launch.ts';
 export { EXTERNAL_DEPENDENCIES, DEFAULT_DRAFTER_MCP_PACKAGE_SPEC } from './external-dependencies.ts';


### PR DESCRIPTION
## Summary

This adds one explicit packaged command to start a headless owner process.

The bug was that packaged installs had no direct owner-serve command. Starting a server owner depended on ad hoc call sites.

The fix adds `invoker-cli owner serve` and covers that new command with focused CLI tests.

## Review Claim

Packaged installs now expose `invoker-cli owner serve` as a headless owner activation surface.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice adds one new command but does not change live-owner discovery or Slack manager behavior. Existing CLI run modes keep their previous behavior.

## Slice Rationale

This lands before the later caller changes because they need one supported packaged command for starting the server owner.

## Non-goals

- Changing which live owners `invoker-cli --live` accepts.
- Changing Slack manager restart behavior.
- Changing standalone CLI execution.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/cli build && pnpm --filter @invoker/cli exec vitest run src/__tests__/cli.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 3ae48a3`
- Post-revert steps: None.
- Data migration? No.

</details>

Depends-On: #4927