### PR TITLE
[Queued Launch Waits](1) Prove SSH-capacity queue gaps

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -800,6 +800,79 @@ describe('TaskRunner', () => {
         commit: 'abc1234',
       });
     });
+    it.skip('retries approved-fix publish when SSH capacity is full', async () => {
+      vi.useFakeTimers();
+      const publishSpy = vi.spyOn(SshExecutor.prototype, 'publishApprovedFix').mockResolvedValue({
+        commitHash: 'queued123',
+      });
+      const updateTask = vi.fn();
+      const updateAttempt = vi.fn();
+      const logEvent = vi.fn();
+      const task = makeTask({
+        id: 'ssh-fix-task-capacity',
+        description: 'Apply approved fix after SSH capacity frees up',
+        config: {
+          runnerKind: 'ssh',
+          poolMemberId: 'remote-1',
+          command: 'bash -lc false',
+        },
+        execution: {
+          workspacePath: '/remote/worktree',
+          branch: 'experiment/ssh-fix-gap',
+          selectedAttemptId: 'attempt-ssh-capacity-1',
+        },
+      });
+      const tasks = new Map<string, TaskState>([[task.id, task]]);
+      const executorRegistry = {
+        getDefault: () => ({ type: 'worktree' }),
+        get: () => null,
+        register: () => {},
+        getAll: () => [],
+      };
+      const runner = new TaskRunner({
+        orchestrator: { getTask: (id: string) => tasks.get(id) } as any,
+        persistence: { updateTask, updateAttempt, logEvent } as any,
+        executorRegistry: executorRegistry as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({
+          'remote-1': {
+            host: 'example.com',
+            user: 'invoker',
+            sshKeyPath: '/tmp/test-key',
+          },
+        }),
+      });
+      const selectExecutorSpy = vi.spyOn(runner, 'selectExecutor');
+      const originalSelectExecutor = TaskRunner.prototype.selectExecutor.bind(runner);
+      selectExecutorSpy.mockImplementationOnce(() => {
+        throw new ResourceLimitError('Execution pool "pnpm-ssh" has no member capacity available');
+      });
+      selectExecutorSpy.mockImplementation((selectedTask, excludedPoolMemberKeys = new Set()) =>
+        originalSelectExecutor(selectedTask, excludedPoolMemberKeys)
+      );
+
+      const publishPromise = runner.publishApprovedFix(task);
+      await vi.advanceTimersByTimeAsync(15_000);
+      await publishPromise;
+
+      expect(logEvent).toHaveBeenCalledWith(task.id, 'task.approved_fix_waiting', expect.objectContaining({
+        attempts: 1,
+        message: 'Execution pool "pnpm-ssh" has no member capacity available',
+      }));
+      expect(publishSpy).toHaveBeenCalledWith(
+        '/remote/worktree',
+        expect.objectContaining({ actionId: task.id }),
+        'experiment/ssh-fix-gap',
+      );
+      expect(updateTask).toHaveBeenCalledWith(task.id, {
+        execution: { commit: 'queued123' },
+      });
+      expect(updateAttempt).toHaveBeenCalledWith('attempt-ssh-capacity-1', {
+        branch: 'experiment/ssh-fix-gap',
+        commit: 'queued123',
+      });
+      vi.useRealTimers();
+    });
 
     it('pins SSH approved-fix publish to the recorded pool member in mixed pools', async () => {
       const publishSpy = vi.spyOn(SshExecutor.prototype, 'publishApprovedFix').mockResolvedValue({

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -2201,6 +2201,22 @@ describe('Orchestrator', () => {
       expect(task.execution.startedAt).toBeUndefined();
       expect(task.execution.lastHeartbeatAt).toBeUndefined();
     });
+    it.skip('surfaces deferred tasks as queued instead of pending', () => {
+      orchestrator.loadPlan({
+        name: 'defer-queued-proof',
+        tasks: [{ id: 'task-a', description: 'Task A' }],
+      });
+      const started = orchestrator.startExecution();
+      expect(started.length).toBe(1);
+      expect(orchestrator.getTask('task-a')!.status).toBe('running');
+
+      orchestrator.deferTask('task-a');
+
+      const task = orchestrator.getTask('task-a')!;
+      expect(task.status).toBe('queued');
+      expect(task.execution.startedAt).toBeUndefined();
+      expect(task.execution.lastHeartbeatAt).toBeUndefined();
+    });
 
     it('clears launch claim metadata when deferring a launch-claimed task', () => {
       const launchingOrchestrator = new Orchestrator({
@@ -2380,6 +2396,35 @@ describe('Orchestrator', () => {
       expect(waiting.length).toBeGreaterThan(0);
       expect(waiting.at(-1)?.payload).toMatchObject({ attempts: 1 });
     });
+    it.skip('keeps a parked resource-limit task queued between scheduler polls', () => {
+      const parkOrchestrator = new Orchestrator({
+        persistence,
+        messageBus: bus,
+        logger: consoleLogger,
+        maxConcurrency: 3,
+        deferRunningUntilLaunch: true,
+        launchDeferralBackoffMs: 60_000,
+      });
+      parkOrchestrator.loadPlan({
+        name: 'defer-queued-park-proof',
+        tasks: [{ id: 'task-a', description: 'Task A' }],
+      });
+      const firstStarted = parkOrchestrator.startExecution();
+      expect(firstStarted).toHaveLength(1);
+      const taskId = firstStarted[0].id;
+
+      parkOrchestrator.deferTask(taskId, {
+        reason: 'resource-limit',
+        message: 'Execution pool "pnpm-ssh" has no member capacity available',
+        attemptId: parkOrchestrator.getTask(taskId)!.execution.selectedAttemptId,
+        phase: 'launching',
+      });
+      expect(parkOrchestrator.getTask(taskId)!.status).toBe('queued');
+
+      const restarted = parkOrchestrator.startExecution();
+      expect(restarted.map((t) => t.id)).not.toContain(taskId);
+      expect(parkOrchestrator.getTask(taskId)!.status).toBe('queued');
+    });
 
     it('re-dispatches a resource-limit parked task when a slot frees, ignoring the backoff', () => {
       const parkOrchestrator = new Orchestrator({
@@ -2410,6 +2455,38 @@ describe('Orchestrator', () => {
       expect(parkOrchestrator.startExecution().map((t) => t.id)).not.toContain(taskAId);
 
       // A real slot-free (task-b completes) re-dispatches it despite the backoff.
+      parkOrchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 'task-b', status: 'completed', outputs: { exitCode: 0 } }),
+      );
+      expect(parkOrchestrator.getTask(taskAId)!.status).toBe('running');
+    });
+    it.skip('re-dispatches a queued resource-limit task when a slot frees', () => {
+      const parkOrchestrator = new Orchestrator({
+        persistence,
+        messageBus: bus,
+        logger: consoleLogger,
+        maxConcurrency: 3,
+        launchDeferralBackoffMs: 600_000,
+      });
+      parkOrchestrator.loadPlan({
+        name: 'defer-queued-slotfree-proof',
+        tasks: [
+          { id: 'task-a', description: 'Task A' },
+          { id: 'task-b', description: 'Task B' },
+        ],
+      });
+      const started = parkOrchestrator.startExecution();
+      expect(started).toHaveLength(2);
+      const taskAId = started.find((t) => t.id.endsWith('/task-a'))!.id;
+
+      parkOrchestrator.deferTask(taskAId, {
+        reason: 'resource-limit',
+        message: 'Execution pool "pnpm-ssh" has no member capacity available',
+        attemptId: parkOrchestrator.getTask(taskAId)!.execution.selectedAttemptId,
+      });
+      expect(parkOrchestrator.getTask(taskAId)!.status).toBe('queued');
+      expect(parkOrchestrator.startExecution().map((t) => t.id)).not.toContain(taskAId);
+
       parkOrchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'task-b', status: 'completed', outputs: { exitCode: 0 } }),
       );


### PR DESCRIPTION
## Summary

This adds proof for the SSH-capacity queue bug.

The new tests describe the queued behavior and approved-publish retry path that are missing today.

They stay skipped in this slice, so the repo stays green while the current bug is still present.

## Review Claim

This slice captures the missing SSH-capacity queue behavior in focused regression tests before the fix changes runtime behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Tests only. No product code, no scheduler logic, and no UI behavior change.

## Slice Rationale

Evidence comes first. This gives the later behavior slices exact failing targets without mixing proof and implementation.

## Non-goals

- No runtime queue-state changes.
- No Fix with Agent behavior changes.
- No UI copy or badge changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts`
- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 89faa790c`
- Post-revert steps: None.
- Data migration? No.

</details>
