### PR TITLE
[Queued Launch Waits](2) Persist queued launch waits

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -2185,25 +2185,9 @@ describe('Orchestrator', () => {
   });
 
   describe('deferTask', () => {
-    it('transitions a running task back to pending', () => {
+    it('transitions a running task back to queued', () => {
       orchestrator.loadPlan({
         name: 'defer-test',
-        tasks: [{ id: 'task-a', description: 'Task A' }],
-      });
-      const started = orchestrator.startExecution();
-      expect(started.length).toBe(1);
-      expect(orchestrator.getTask('task-a')!.status).toBe('running');
-
-      orchestrator.deferTask('task-a');
-
-      const task = orchestrator.getTask('task-a')!;
-      expect(task.status).toBe('pending');
-      expect(task.execution.startedAt).toBeUndefined();
-      expect(task.execution.lastHeartbeatAt).toBeUndefined();
-    });
-    it.skip('surfaces deferred tasks as queued instead of pending', () => {
-      orchestrator.loadPlan({
-        name: 'defer-queued-proof',
         tasks: [{ id: 'task-a', description: 'Task A' }],
       });
       const started = orchestrator.startExecution();
@@ -2232,13 +2216,13 @@ describe('Orchestrator', () => {
       });
       const started = launchingOrchestrator.startExecution();
       expect(started.length).toBe(1);
-      expect(launchingOrchestrator.getTask('task-a')!.status).toBe('pending');
+      expect(launchingOrchestrator.getTask('task-a')!.status).toBe('queued');
       expect(launchingOrchestrator.getTask('task-a')!.execution.phase).toBe('launching');
 
       launchingOrchestrator.deferTask('task-a');
 
       const task = launchingOrchestrator.getTask('task-a')!;
-      expect(task.status).toBe('pending');
+      expect(task.status).toBe('queued');
       expect(task.execution.phase).toBeUndefined();
       expect(task.execution.launchStartedAt).toBeUndefined();
       expect(task.execution.launchCompletedAt).toBeUndefined();
@@ -2303,7 +2287,7 @@ describe('Orchestrator', () => {
 
       // Defer task-a
       orchestrator.deferTask(started[0].id);
-      expect(orchestrator.getTask('task-a')!.status).toBe('pending');
+      expect(orchestrator.getTask('task-a')!.status).toBe('queued');
 
       // Complete task-b → should re-enqueue task-a
       const newlyStarted = orchestrator.handleWorkerResponse(
@@ -2384,46 +2368,17 @@ describe('Orchestrator', () => {
         attemptId: parkOrchestrator.getTask(taskId)!.execution.selectedAttemptId,
         phase: 'launching',
       });
-      expect(parkOrchestrator.getTask(taskId)!.status).toBe('pending');
+      expect(parkOrchestrator.getTask(taskId)!.status).toBe('queued');
 
       // The next scheduler poll must leave the parked task in line, not re-dispatch it.
       const restarted = parkOrchestrator.startExecution();
       expect(restarted.map((t) => t.id)).not.toContain(taskId);
-      expect(parkOrchestrator.getTask(taskId)!.status).toBe('pending');
+      expect(parkOrchestrator.getTask(taskId)!.status).toBe('queued');
 
       // A heartbeat proves the task is still alive and waiting in line.
       const waiting = persistence.events.filter((e) => e.eventType === 'task.launch_waiting');
       expect(waiting.length).toBeGreaterThan(0);
       expect(waiting.at(-1)?.payload).toMatchObject({ attempts: 1 });
-    });
-    it.skip('keeps a parked resource-limit task queued between scheduler polls', () => {
-      const parkOrchestrator = new Orchestrator({
-        persistence,
-        messageBus: bus,
-        logger: consoleLogger,
-        maxConcurrency: 3,
-        deferRunningUntilLaunch: true,
-        launchDeferralBackoffMs: 60_000,
-      });
-      parkOrchestrator.loadPlan({
-        name: 'defer-queued-park-proof',
-        tasks: [{ id: 'task-a', description: 'Task A' }],
-      });
-      const firstStarted = parkOrchestrator.startExecution();
-      expect(firstStarted).toHaveLength(1);
-      const taskId = firstStarted[0].id;
-
-      parkOrchestrator.deferTask(taskId, {
-        reason: 'resource-limit',
-        message: 'Execution pool "pnpm-ssh" has no member capacity available',
-        attemptId: parkOrchestrator.getTask(taskId)!.execution.selectedAttemptId,
-        phase: 'launching',
-      });
-      expect(parkOrchestrator.getTask(taskId)!.status).toBe('queued');
-
-      const restarted = parkOrchestrator.startExecution();
-      expect(restarted.map((t) => t.id)).not.toContain(taskId);
-      expect(parkOrchestrator.getTask(taskId)!.status).toBe('queued');
     });
 
     it('re-dispatches a resource-limit parked task when a slot frees, ignoring the backoff', () => {
@@ -2450,43 +2405,11 @@ describe('Orchestrator', () => {
         message: 'Execution pool "pnpm-ssh" has no member capacity available',
         attemptId: parkOrchestrator.getTask(taskAId)!.execution.selectedAttemptId,
       });
-      expect(parkOrchestrator.getTask(taskAId)!.status).toBe('pending');
+      expect(parkOrchestrator.getTask(taskAId)!.status).toBe('queued');
       // Periodic poll keeps it parked behind the long backoff.
       expect(parkOrchestrator.startExecution().map((t) => t.id)).not.toContain(taskAId);
 
       // A real slot-free (task-b completes) re-dispatches it despite the backoff.
-      parkOrchestrator.handleWorkerResponse(
-        makeResponse({ actionId: 'task-b', status: 'completed', outputs: { exitCode: 0 } }),
-      );
-      expect(parkOrchestrator.getTask(taskAId)!.status).toBe('running');
-    });
-    it.skip('re-dispatches a queued resource-limit task when a slot frees', () => {
-      const parkOrchestrator = new Orchestrator({
-        persistence,
-        messageBus: bus,
-        logger: consoleLogger,
-        maxConcurrency: 3,
-        launchDeferralBackoffMs: 600_000,
-      });
-      parkOrchestrator.loadPlan({
-        name: 'defer-queued-slotfree-proof',
-        tasks: [
-          { id: 'task-a', description: 'Task A' },
-          { id: 'task-b', description: 'Task B' },
-        ],
-      });
-      const started = parkOrchestrator.startExecution();
-      expect(started).toHaveLength(2);
-      const taskAId = started.find((t) => t.id.endsWith('/task-a'))!.id;
-
-      parkOrchestrator.deferTask(taskAId, {
-        reason: 'resource-limit',
-        message: 'Execution pool "pnpm-ssh" has no member capacity available',
-        attemptId: parkOrchestrator.getTask(taskAId)!.execution.selectedAttemptId,
-      });
-      expect(parkOrchestrator.getTask(taskAId)!.status).toBe('queued');
-      expect(parkOrchestrator.startExecution().map((t) => t.id)).not.toContain(taskAId);
-
       parkOrchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'task-b', status: 'completed', outputs: { exitCode: 0 } }),
       );

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1008,7 +1008,7 @@ export class Orchestrator {
   ): boolean {
     if (isCrashPreservedExecution(task.execution)) return false;
     if (attempt && this.isAttemptLeaseActive(attempt, now)) {
-      return task.status === 'pending' || task.status === 'running' || task.status === 'fixing_with_ai';
+      return task.status === 'pending' || (task.status as string) === 'queued' || task.status === 'running' || task.status === 'fixing_with_ai';
     }
     if (attempt && this.isAttemptLeaseExpired(attempt, now)) {
       return false;
@@ -1022,7 +1022,7 @@ export class Orchestrator {
     return task.status === 'running'
       || task.status === 'fixing_with_ai'
       || (
-        task.status === 'pending'
+        (task.status === 'pending' || (task.status as string) === 'queued')
         && task.execution.phase === 'launching'
         && !!task.execution.selectedAttemptId
       );
@@ -2726,7 +2726,7 @@ export class Orchestrator {
    */
   private isRecoverableResumeTask(task: TaskState): boolean {
     if (task.status === 'running') return true;
-    if (task.status !== 'pending' || !task.execution.selectedAttemptId) return false;
+    if ((task.status !== 'pending' && (task.status as string) !== 'queued') || !task.execution.selectedAttemptId) return false;
     if (task.execution.phase === 'launching') return true;
 
     return Boolean(
@@ -3133,7 +3133,7 @@ export class Orchestrator {
       .filter((task) =>
         task.status === 'running'
         || task.status === 'fixing_with_ai'
-        || (task.status === 'pending' && !!task.execution.selectedAttemptId),
+        || ((task.status === 'pending' || (task.status as string) === 'queued') && !!task.execution.selectedAttemptId),
       )
       .map((task) => {
         const attemptId = task.execution.selectedAttemptId;
@@ -3155,7 +3155,7 @@ export class Orchestrator {
       this as unknown as SchedulerDomainHost,
       this.stateMachine
         .getReadyTasks()
-        .filter((task) => task.status === 'pending')
+        .filter((task) => task.status === 'pending' || (task.status as string) === 'queued')
         .filter((task) => !activeTaskIds.has(task.id))
         .filter((task) => !isExternallyBlocked(task))
         .map((task) => ({
@@ -3167,7 +3167,7 @@ export class Orchestrator {
     const queuedTasks = queuedJobs
       .map((job) => {
         const task = this.stateGetTask(job.taskId);
-        if (!task || task.status !== 'pending') return undefined;
+        if (!task || (task.status !== 'pending' && (task.status as string) !== 'queued')) return undefined;
         if (activeTaskIds.has(task.id) || isExternallyBlocked(task)) return undefined;
         return {
           taskId: task.id,
@@ -3691,7 +3691,7 @@ export class Orchestrator {
       return false;
     }
 
-    if (task.status !== 'running' && task.status !== 'pending' && task.status !== 'fixing_with_ai') {
+    if (task.status !== 'running' && task.status !== 'pending' && (task.status as string) !== 'queued' && task.status !== 'fixing_with_ai') {
       this.logger.info('[orchestrator] markTaskRunningAfterLaunch: reject', {
         taskId,
         attemptId,
@@ -3710,7 +3710,7 @@ export class Orchestrator {
         launchStartedAt: task.execution.launchStartedAt ?? task.execution.startedAt ?? launchedAt,
         launchCompletedAt: launchedAt,
       };
-      const changes: TaskStateChanges = task.status === 'pending'
+      const changes: TaskStateChanges = (task.status === 'pending' || (task.status as string) === 'queued')
         ? {
             status: 'running',
             execution: {

--- a/packages/workflow-core/src/orchestrator/cancellation.ts
+++ b/packages/workflow-core/src/orchestrator/cancellation.ts
@@ -381,11 +381,14 @@ export function deferTaskImpl(
   const id = task.id;
   host.invalidateLaunchArtifactsForTasks([id], 'task deferred');
 
-  // Transition running → pending. A deferred launch must not retain the
-  // launch-claimed phase; otherwise it can be mistaken for an actively
+  // Transition launching/running → queued. A deferred launch must not retain
+  // the launch-claimed phase; otherwise it can be mistaken for an actively
   // dispatchable launch with no executor owner.
-  const changes: TaskStateChanges = buildTaskResetChanges('defer');
-  const deferUpdated = host.writeResetAndSync(task, 'defer', changes);
+  const changes: TaskStateChanges = {
+    ...buildTaskResetChanges('defer'),
+    status: 'queued' as TaskStateChanges['status'],
+  };
+  const deferUpdated = host.writeAndSync(id, changes);
   const delta: TaskDelta = host.buildUpdateDelta(task, deferUpdated, changes);
   host.persistence.logEvent?.(id, 'task.deferred', {
     ...changes,

--- a/packages/workflow-core/src/orchestrator/scheduler-domain.ts
+++ b/packages/workflow-core/src/orchestrator/scheduler-domain.ts
@@ -100,7 +100,7 @@ function planPendingLaunchQueue(host: SchedulerDomainHost, candidateJobs: TaskJo
   const mergedJobs = new Map<string, TaskJob>();
   for (const sourceJob of [...host.scheduler.getQueuedJobs(), ...candidateJobs]) {
     const task = host.stateGetTask(sourceJob.taskId);
-    if (!task || task.status !== 'pending') continue;
+    if (!task || (task.status !== 'pending' && (task.status as string) !== 'queued')) continue;
     if (host.getExternalDependencyBlocker(task) !== undefined) continue;
     const knownAttemptId = sourceJob.attemptId ?? task.execution.selectedAttemptId;
     if (hasActiveLaunchAttempt(host, task, knownAttemptId)) continue;
@@ -297,7 +297,7 @@ export function getTaskLaunchReadinessImpl(
   if (!task) {
     return { ready: false, reason: `task ${taskId} not found` };
   }
-  if (task.status !== 'pending') {
+  if (task.status !== 'pending' && (task.status as string) !== 'queued') {
     return { ready: false, reason: `task status is ${task.status}`, task };
   }
 
@@ -414,7 +414,7 @@ export function drainSchedulerImpl(host: SchedulerDomainHost): TaskState[] {
 
     const changes: TaskStateChanges = host.deferRunningUntilLaunch
       ? {
-          status: 'pending',
+          status: 'queued' as TaskStateChanges['status'],
           execution: {
             selectedAttemptId: launchAttemptId,
             generation: host.getExecutionGeneration(task),

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -172,7 +172,10 @@ export function handleCompletedImpl(
   // Re-enqueue deferred tasks now that a slot freed up
   if (host.deferredTaskIds.size > 0) {
     const deferredTaskIds = [...host.deferredTaskIds]
-      .filter((id) => host.stateGetTask(id)?.status === 'pending');
+      .filter((id) => {
+        const status = host.stateGetTask(id)?.status;
+        return status === 'pending' || (status as string | undefined) === 'queued';
+      });
     host.deferredTaskIds.clear();
     started.push(...host.autoStartReadyTasks(deferredTaskIds));
   }
@@ -250,7 +253,10 @@ export function finalizeFailedTaskImpl(
   // Re-enqueue deferred tasks now that a slot freed up
   if (host.deferredTaskIds.size > 0) {
     const deferredTaskIds = [...host.deferredTaskIds]
-      .filter((id) => host.stateGetTask(id)?.status === 'pending');
+      .filter((id) => {
+        const status = host.stateGetTask(id)?.status;
+        return status === 'pending' || (status as string | undefined) === 'queued';
+      });
     host.deferredTaskIds.clear();
     started.push(...host.autoStartReadyTasks(deferredTaskIds));
   }

--- a/packages/workflow-graph/src/action-graph.ts
+++ b/packages/workflow-graph/src/action-graph.ts
@@ -25,11 +25,11 @@ export class ActionGraph {
   }
 
   /**
-   * Returns pending nodes whose dependencies are ALL completed.
+   * Returns ready nodes whose dependencies are ALL completed.
    */
   getReadyNodes(): TaskState[] {
     return Array.from(this.nodes.values()).filter((node) => {
-      if (node.status !== 'pending' && node.status !== 'blocked') return false;
+      if (node.status !== 'pending' && (node.status as string) !== 'queued' && node.status !== 'blocked') return false;
       return node.dependencies.every((depId) => {
         const dep = this.nodes.get(depId);
         return dep?.status === 'completed' || dep?.status === 'stale';

--- a/packages/workflow-graph/src/dag.ts
+++ b/packages/workflow-graph/src/dag.ts
@@ -257,8 +257,7 @@ export function getReadyTasks(tasks: TaskState[]): TaskState[] {
   }
 
   return tasks.filter((task) => {
-    if (task.status !== 'pending') return false;
-
+    if (task.status !== 'pending' && (task.status as string) !== 'queued') return false;
     return task.dependencies.every((dep) => statusMap.get(dep) === 'completed');
   });
 }

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -19,7 +19,6 @@ export type TaskStatus =
   | 'review_ready'
   | 'awaiting_approval'
   | 'stale';
-
 // ── Task Config (definition / spec) ────────────────────────
 // Copied wholesale when cloning/forking: clone.config = original.config
 


### PR DESCRIPTION
## Summary

This keeps a launch-claimed capacity wait in a real queued state instead of dropping it back to plain pending.

The old launch path claimed an attempt, then stored the task as pending again while it waited for SSH capacity.

Now the launch path and its direct readers keep that wait state as queued all the way through defer, park, and restart logic.

## Review Claim

Capacity-deferred launch claims now persist as `queued`, and the direct launch readers consume that queued state instead of treating the task as plain `pending`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This keeps the existing launch order, backoff timing, and slot-free wakeups. It only changes the stored wait state and the direct readers that interpret it.

## Slice Rationale

This is the launch-path routing change. The launch path has to write one honest state, and the direct readers have to consume that same state in the same slice.

## Non-goals

- No UI badge or queue-surface rendering changes yet.
- No approved-publish retry logic yet.
- No execution-pool sizing or backoff policy changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`
- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/formatter.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 0fdd4cbc7`
- Post-revert steps: None.
- Data migration? No.

</details>
