### PR TITLE
[Queued Launch Waits](3) Carry queued status through app readers

### DIFF
--- a/packages/app/src/action-graph-diagnostics.ts
+++ b/packages/app/src/action-graph-diagnostics.ts
@@ -69,6 +69,8 @@ function taskStatusToActionStatus(status: TaskState['status']): ActionGraphNodeS
     case 'running':
     case 'pending':
       return status;
+    case 'queued':
+      return 'pending';
     case 'blocked':
     case 'needs_input':
     case 'awaiting_approval':

--- a/packages/app/src/action-graph-snapshot.ts
+++ b/packages/app/src/action-graph-snapshot.ts
@@ -10,6 +10,7 @@ import {
 function needsActionGraphDetail(status: string): boolean {
   switch (status) {
     case 'running':
+    case 'queued':
     case 'failed':
     case 'fixing_with_ai':
     case 'blocked':

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -94,6 +94,7 @@ function normalizeJsonValue(value: unknown, seen = new WeakSet<object>()): JsonS
 
 const STATUS_COLORS: Record<TaskStatus, string> = {
   pending: DIM,
+  queued: CYAN,
   running: YELLOW,
   fixing_with_ai: MAGENTA,
   completed: GREEN,
@@ -108,6 +109,7 @@ const STATUS_COLORS: Record<TaskStatus, string> = {
 
 const STATUS_ICONS: Record<TaskStatus, string> = {
   pending: '○',
+  queued: '◔',
   running: '●',
   fixing_with_ai: '🔧',
   completed: '✓',
@@ -135,7 +137,7 @@ export function formatTaskStatus(task: TaskState): string {
   const color = isFixing ? MAGENTA : isFixApproval ? YELLOW : (STATUS_COLORS[task.status] ?? RESET);
   const icon = isFixing ? '🔧' : isFixApproval ? '🔧' : (STATUS_ICONS[task.status] ?? '?');
   const label = isFixing ? 'fixing_with_ai' : isFixApproval ? 'fix_approval' : task.status;
-  const phaseSuffix = task.status === 'running' && task.execution.phase
+  const phaseSuffix = (task.status === 'running' || task.status === 'queued') && task.execution.phase
     ? ` (phase=${task.execution.phase})`
     : '';
   const conflictSuffix = task.execution.mergeConflict

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -9,6 +9,7 @@
 
 export type TaskStatus =
   | 'pending'
+  | 'queued'
   | 'running'
   | 'fixing_with_ai'
   | 'completed'


### PR DESCRIPTION
## Summary

This teaches the app-side status readers about the queued launch wait state.

After the launch path keeps queued waits internally, the direct app readers need to carry that state through their labels and diagnostics instead of flattening it back into pending-only output.

## Review Claim

App-side status readers now carry the queued launch wait state through shared typing, labels, and diagnostics.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This only changes the app-side readers for the stored queued state. It does not change scheduler behavior or executor selection.

## Slice Rationale

The launch path is already fixed below this slice. This branch only updates the direct app readers before the larger UI components render the new state.

## Non-goals

- No queue card or history row component changes yet.
- No approved-publish retry logic yet.
- No execution-pool sizing or backoff policy changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/formatter.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 8eb4087cb`
- Post-revert steps: None.
- Data migration? No.

</details>
