### PR TITLE
[Queued Launch Waits](5) Wait for SSH capacity during approved publish

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
 import { collectDirectNonMergeTaskIds } from '../merge-runner.js';
 import { getCurrentRequiredReviewArtifacts } from '../task-runner-review-gate.js';
+import { ResourceLimitError } from '../repo-pool.js';
 import { SshExecutor } from '../ssh-executor.js';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkResponse, Logger } from '@invoker/contracts';
@@ -105,8 +106,8 @@ function createTempWorkspace(): string {
   tempWorkspaces.push(dir);
   return dir;
 }
-
 afterEach(() => {
+  vi.useRealTimers();
   if (originalGithubTargetRepo === undefined) {
     delete process.env.INVOKER_GITHUB_TARGET_REPO;
   } else {
@@ -800,7 +801,7 @@ describe('TaskRunner', () => {
         commit: 'abc1234',
       });
     });
-    it.skip('retries approved-fix publish when SSH capacity is full', async () => {
+    it('waits for SSH capacity instead of failing approved-fix publish', async () => {
       vi.useFakeTimers();
       const publishSpy = vi.spyOn(SshExecutor.prototype, 'publishApprovedFix').mockResolvedValue({
         commitHash: 'queued123',

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -88,11 +88,11 @@ import {
 import type {
   ExecutionPoolMember,
   ExecutionPoolConfig,
+  PoolMemberHealth,
   PoolSelection,
   RemoteTargetDisplay,
   ResolvedExecutionSelection,
   SelectedExecutor,
-  PoolMemberHealth,
 } from './task-runner-pool.js';
 
 export type { TaskHeartbeatEvent, TaskRunnerCallbacks } from './task-runner-callbacks.js';
@@ -178,6 +178,7 @@ export interface TaskRunnerConfig {
     port?: number;
     managedWorkspaces?: boolean;
     remoteInvokerHome?: string;
+    provisionCommand?: string;
     use_api_key?: boolean;
     secretsFile?: string;
     remoteHeartbeatIntervalSeconds?: number;
@@ -880,7 +881,30 @@ export class TaskRunner {
       }
     }
 
-    const selectedExecutor = this.selectExecutor(task);
+    let selectedExecutor: SelectedExecutor;
+    let capacityWaitAttempts = 0;
+    for (;;) {
+      try {
+        selectedExecutor = this.selectExecutor(task);
+        break;
+      } catch (err) {
+        if (!(err instanceof ResourceLimitError)) {
+          throw err;
+        }
+        capacityWaitAttempts += 1;
+        const retryMs = Math.min(15_000 * 2 ** Math.max(0, capacityWaitAttempts - 1), 5 * 60_000);
+        this.persistence.logEvent?.(task.id, 'task.approved_fix_waiting', {
+          attempts: capacityWaitAttempts,
+          message: err.message,
+          nextRetryAt: new Date(Date.now() + retryMs),
+        });
+        this.logger.info(
+          `[TaskRunner] approved-fix publish waiting for capacity task=${task.id} retryInMs=${retryMs}: ${err.message}`,
+          { taskId: task.id, attempts: capacityWaitAttempts, retryMs },
+        );
+        await new Promise<void>((resolve) => setTimeout(resolve, retryMs));
+      }
+    }
     const executor = selectedExecutor.executor;
     let result: { commitHash?: string; error?: string };
     if (executor instanceof SshExecutor) {
@@ -1681,6 +1705,7 @@ export class TaskRunner {
     port?: number;
     managedWorkspaces?: boolean;
     remoteInvokerHome?: string;
+    provisionCommand?: string;
     use_api_key?: boolean;
     secretsFile?: string;
     remoteHeartbeatIntervalSeconds?: number;


### PR DESCRIPTION
## Summary

This stops approved Fix with Agent publish from treating a full SSH pool as a terminal error.

When executor selection hits a temporary capacity limit, approved publish now waits and tries again instead of failing the accepted fix.

## Review Claim

Approved Fix with Agent publish now waits through temporary SSH-capacity exhaustion instead of failing the publish step.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This only changes the executor-selection loop inside approved publish. It does not change the published commit contents.

## Slice Rationale

Approved publish reaches the pool through its own execution path. Keeping that path separate makes the wait behavior easy to review without reopening the queued-state stack below it.

## Non-goals

- No task-status or UI-surface changes.
- No SSH pool policy changes.
- No merge-gate approval flow redesign.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`
- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert ce7ebb962`
- Post-revert steps: None.
- Data migration? No.

</details>
