### PR TITLE
[Slack Preset Source of Truth](3) Document standalone preset source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to Invoker will be documented in this file.
 
 
 - Stop manual Fix with Agent from starting when a failed task has no saved workspace. It now fails fast with a recreate-this-task message instead of entering a broken fix session.
+- Make the standalone Slack manager follow `~/.invoker/config.json` for its default harness preset before it falls back to `INVOKER_SLACK_DEFAULT_PRESET`. A stale owner-env preset could silently shadow the documented `defaultSlackHarnessPreset`, so `@Invoker` threads on remote hosts could still launch OMP after the UI and CLI had been switched to Codex. The manager now treats `config.json` as the source of truth, keeping `.slack-owner.env` for credentials and env-only fallback. Guarded by a dedicated slack-manager runtime-config regression test.
+
 ## 0.0.7
 
 - Ship Slack as a separate npm-released SEA binary (`@neko-catpital-labs/invoker-slack` / `invoker-slack`), built and archived like the CLI, published from the release workflow, and always included in `scripts/local-macos-release-build.sh` maintainer cuts. The desktop app no longer embeds Slack; GUI relaunch from the manager resolves `INVOKER_GUI_COMMAND`, `invoker-ui`, macOS `open -a Invoker`, then the monorepo xvfb path.

--- a/docs/slack-native-workflows.md
+++ b/docs/slack-native-workflows.md
@@ -81,8 +81,13 @@ invoker-cli setup slack
 ```
 
 For the Slack manager daemon, also put owner credentials in `~/.invoker/.slack-owner.env`
-(or set `INVOKER_SLACK_OWNER_ENV`). To configure by hand, put these in `~/.invoker/.env` (canonical, loaded on startup before the Slack
-check) or `<repoRoot>/.env` (fallback), then run `invoker-slack` (or `./run.sh` for the desktop app only):
+(or set `INVOKER_SLACK_OWNER_ENV`). Keep the default harness preset in
+`~/.invoker/config.json`, where `defaultSlackHarnessPreset` is already
+documented. The standalone manager reads that config first, then falls back to
+`INVOKER_SLACK_DEFAULT_PRESET` only when the config leaves the preset unset.
+To configure by hand, put these credential values in `~/.invoker/.env`
+(canonical, loaded on startup before the Slack check) or `<repoRoot>/.env`
+(fallback), then run `invoker-slack` (or `./run.sh` for the desktop app only):
 
 ```
 SLACK_BOT_TOKEN=xoxb-...


### PR DESCRIPTION
## Summary

The Slack workflow docs now say the standalone manager reads `defaultSlackHarnessPreset` from `~/.invoker/config.json` first.

The old wording only talked about owner env files, which made the standalone setup harder to understand on remote hosts.

This also adds a changelog note so the release notes carry the same explanation.

## Review Claim

Documents where standalone Slack default presets are configured.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Docs and changelog only. No runtime files change in this slice.

## Slice Rationale

Keep the written setup guidance in one follow-up slice so the behavior PR stays focused on runtime code.

## Non-goals

- Do not change runtime preset resolution.
- Do not change Slack credential loading.
- Do not change deployment scripts.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/validate-pr-body.mjs --body-file /var/folders/rq/1lflpr1n1jzgkvdc4f6cqfw80000gn/T/omp-agent-iso/75944-1784314497-1797/sessions/-Documents-GitHub-Invoker/2026-07-17T18-54-58-101Z_019f716e-8c35-7000-9826-8fae9dd5587c/local/slack-preset-docs-pr.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 6f44eab01d663a31a19a40e8db3036c0ecb7e0c5`
- Post-revert steps: None.
- Data migration? No.

</details>
