### PR TITLE
[Slack Preset Source of Truth](2) Prefer config preset over owner env

### DIFF
--- a/packages/slack-manager/src/__tests__/runtime-config.test.ts
+++ b/packages/slack-manager/src/__tests__/runtime-config.test.ts
@@ -20,12 +20,10 @@ describe('runtime-config', () => {
   it('falls back to the owner env preset when no config default is present', () => {
     expect(resolveDefaultHarnessPreset('omp+codex', undefined)).toBe('omp+codex');
   });
-
-  // `it.fails`: this asserts the DESIRED behavior, which the current standalone
-  // Slack manager does not satisfy — it documents the stale owner-env override
-  // bug and stays green in CI. The fix slice removes `.fails` once
-  // ~/.invoker/config.json wins over a stale INVOKER_SLACK_DEFAULT_PRESET.
-  it.fails('prefers ~/.invoker/config.json over a stale owner env preset', () => {
+  // The standalone Slack manager should follow ~/.invoker/config.json first so
+  // the documented default preset cannot be shadowed by a stale
+  // INVOKER_SLACK_DEFAULT_PRESET in ~/.invoker/.slack-owner.env.
+  it('prefers ~/.invoker/config.json over a stale owner env preset', () => {
     expect(resolveDefaultHarnessPreset('omp+codex', 'codex')).toBe('codex');
   });
 });

--- a/packages/slack-manager/src/runtime-config.ts
+++ b/packages/slack-manager/src/runtime-config.ts
@@ -19,7 +19,7 @@ export function readDefaultSlackHarnessPreset(configPath = resolveInvokerConfigP
 }
 
 export function resolveDefaultHarnessPreset(envPreset: string | undefined, configPreset: string | undefined): string | undefined {
-  if (envPreset?.trim()) return envPreset.trim();
   if (configPreset?.trim()) return configPreset.trim();
+  if (envPreset?.trim()) return envPreset.trim();
   return undefined;
 }


### PR DESCRIPTION
## Summary

Standalone Slack planning now follows the same default preset setting as the rest of Invoker.

The bug was a hidden second source of truth: `~/.invoker/.slack-owner.env` could keep an old `INVOKER_SLACK_DEFAULT_PRESET`, so Slack mentions on remote hosts still launched the wrong tool.

This flips slack-manager to read `defaultSlackHarnessPreset` from `~/.invoker/config.json` first and keeps the env value only as a fallback when the config leaves the preset unset.

## Review Claim

Makes the standalone Slack manager treat `~/.invoker/config.json` as the source of truth for its default harness preset.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Only standalone Slack preset selection changes, and only when both config and owner-env defaults disagree; credentials, channel routing, and explicit `[preset]` tags are unchanged.

## Slice Rationale

The proof slice already isolates the bug and its regression. This slice only flips the precedence in the shared runtime-config helper.

## Non-goals

- Do not change Slack credential loading.
- Do not remove `INVOKER_SLACK_DEFAULT_PRESET` as an env-only fallback.
- Do not change plan generation, workflow submission, or Slack channel behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/slack-manager test -- runtime-config.test.ts invoker-launcher.test.ts invoker-client.test.ts`
- [x] `pnpm --filter @invoker/slack-manager build`
- [x] End-to-end smoke on DO1 Slack after the same fix: sent `@Invoker hi from e2e-1784333444. Reply with exactly ok.` in the real Slack client and got `ok`; DO1 logs showed `preset=codex` and `cmd="codex exec ..."`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert fb28c2820a727298f9966da37628d4ef11053b61`
- Post-revert steps: If a host depends on config-first behavior, re-set `INVOKER_SLACK_DEFAULT_PRESET` in `~/.invoker/.slack-owner.env`.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected harness preset selection so the configured preset takes precedence over a stale environment preset.
  * Blank configuration values now correctly fall back to the environment-provided preset.

* **Tests**
  * Updated coverage to verify the corrected preset precedence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->