### PR TITLE
[Queued Launch Waits](4) Render queued launch waits

### DIFF
--- a/packages/app/src/action-graph-diagnostics.ts
+++ b/packages/app/src/action-graph-diagnostics.ts
@@ -69,6 +69,8 @@ function taskStatusToActionStatus(status: TaskState['status']): ActionGraphNodeS
     case 'running':
     case 'pending':
       return status;
+    case 'queued':
+      return 'pending';
     case 'blocked':
     case 'needs_input':
     case 'awaiting_approval':

--- a/packages/app/src/action-graph-snapshot.ts
+++ b/packages/app/src/action-graph-snapshot.ts
@@ -10,6 +10,7 @@ import {
 function needsActionGraphDetail(status: string): boolean {
   switch (status) {
     case 'running':
+    case 'queued':
     case 'failed':
     case 'fixing_with_ai':
     case 'blocked':

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -94,6 +94,7 @@ function normalizeJsonValue(value: unknown, seen = new WeakSet<object>()): JsonS
 
 const STATUS_COLORS: Record<TaskStatus, string> = {
   pending: DIM,
+  queued: CYAN,
   running: YELLOW,
   fixing_with_ai: MAGENTA,
   completed: GREEN,
@@ -108,6 +109,7 @@ const STATUS_COLORS: Record<TaskStatus, string> = {
 
 const STATUS_ICONS: Record<TaskStatus, string> = {
   pending: '○',
+  queued: '◔',
   running: '●',
   fixing_with_ai: '🔧',
   completed: '✓',
@@ -135,7 +137,7 @@ export function formatTaskStatus(task: TaskState): string {
   const color = isFixing ? MAGENTA : isFixApproval ? YELLOW : (STATUS_COLORS[task.status] ?? RESET);
   const icon = isFixing ? '🔧' : isFixApproval ? '🔧' : (STATUS_ICONS[task.status] ?? '?');
   const label = isFixing ? 'fixing_with_ai' : isFixApproval ? 'fix_approval' : task.status;
-  const phaseSuffix = task.status === 'running' && task.execution.phase
+  const phaseSuffix = (task.status === 'running' || task.status === 'queued') && task.execution.phase
     ? ` (phase=${task.execution.phase})`
     : '';
   const conflictSuffix = task.execution.mergeConflict

--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -296,7 +296,7 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
             const leaseExpiresAt = parseExecutionDate(selectedAttempt?.leaseExpiresAt);
             const remoteHeartbeat = parseExecutionDate(task.execution.remoteHeartbeatAt);
 
-            if (task.status === 'running' || (task.status === 'pending' && task.execution.phase === 'launching')) {
+            if (task.status === 'running' || ((task.status === 'pending' || task.status === 'queued') && task.execution.phase === 'launching')) {
               // CC.1: launch-stall watchdog removed. The
               // LaunchDispatcher's reapExpiredLeases /
               // abandonStuckLeases reapers (Phase B, CB.3) are the

--- a/packages/ui/src/components/HistoryView.tsx
+++ b/packages/ui/src/components/HistoryView.tsx
@@ -38,6 +38,7 @@ const STATUS_OPTIONS: readonly TaskStatus[] = [
   'needs_input',
   'blocked',
   'pending',
+  'queued',
   'review_ready',
   'stale',
   'closed',
@@ -45,6 +46,7 @@ const STATUS_OPTIONS: readonly TaskStatus[] = [
 
 const STATUS_LABEL: Record<TaskStatus, string> = {
   pending: 'Pending',
+  queued: 'Queued',
   running: 'Running',
   fixing_with_ai: 'Autofixing',
   completed: 'Completed',
@@ -59,6 +61,7 @@ const STATUS_LABEL: Record<TaskStatus, string> = {
 
 const STATUS_STYLE: Record<TaskStatus, string> = {
   pending: 'bg-gray-700 text-gray-200',
+  queued: 'bg-cyan-800 text-cyan-100',
   running: 'bg-blue-700 text-blue-100',
   fixing_with_ai: 'bg-amber-700 text-amber-100',
   completed: 'bg-emerald-700 text-emerald-100',

--- a/packages/ui/src/components/StatusBar.tsx
+++ b/packages/ui/src/components/StatusBar.tsx
@@ -61,6 +61,11 @@ export function StatusBar({ tasks, queueStatus, activeFilters, keyboardActiveKey
       case 'closed':
         closed++;
         break;
+      case 'queued':
+        if (!runningTaskIds.has(task.id)) {
+          pending++;
+        }
+        break;
       case 'pending':
         if (!runningTaskIds.has(task.id)) {
           pending++;

--- a/packages/ui/src/lib/colors.ts
+++ b/packages/ui/src/lib/colors.ts
@@ -158,6 +158,7 @@ export function getEdgeStyle(sourceStatus: string, targetStatus: string): EdgeSt
 export function formatStatusLabel(status: TaskStatus): string {
   const labelMap: Record<TaskStatus, string> = {
     pending: 'Pending',
+    queued: 'Queued',
     running: 'Running',
     review_ready: 'Review Ready',
     awaiting_approval: 'Awaiting Approval',

--- a/packages/ui/src/lib/workflow-progress-surfaces.ts
+++ b/packages/ui/src/lib/workflow-progress-surfaces.ts
@@ -35,6 +35,7 @@ const ATTENTION_STATUS_PRIORITY: Partial<Record<TaskStatus, number>> = {
 };
 
 const RUNNING_TASK_STATUS: Partial<Record<TaskStatus, true>> = {
+  queued: true,
   running: true,
   fixing_with_ai: true,
 };

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -9,6 +9,7 @@
 
 export type TaskStatus =
   | 'pending'
+  | 'queued'
   | 'running'
   | 'fixing_with_ai'
   | 'completed'


### PR DESCRIPTION
## Summary

This makes the remaining queue and history surfaces show a queued badge for launch-claimed capacity waits.

Those surfaces were still painting the first wait state as pending after the lower layers started storing a separate queued value.

Now the visible badge matches the real wait state.

## Review Claim

Visible task surfaces now show launch-claimed capacity waits as `queued` instead of `pending`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This only changes rendering. It does not change scheduler behavior or executor selection.

## Slice Rationale

The lower-layer work is already below this slice. This branch is only the final user-visible paint step.

## Non-goals

- No launch scheduling or defer logic changes.
- No approved-publish retry logic yet.
- No execution-pool sizing or backoff policy changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`
- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/colors.test.ts src/__tests__/workflow-progress-surfaces.test.ts`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/formatter.test.ts`
- [x] `pnpm --filter @invoker/ui build`

</details>

## Visual Proof

Animated proof — the first task badge flips from **Pending** to **Queued** once the visible surfaces render the queued wait honestly.

![Animated proof: History view switches the first task badge from Pending to Queued](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260718-a2a590/queue-status-chip-proof-transition.gif)

Before — the History view shows the launch-claimed task as **Pending**.

![Before: History view shows the first task as Pending while it is already launch-claimed](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260718-a2a590/queue-status-chip-proof-before.png)

After — the same History view shows the launch-claimed task as **Queued**.

![After: History view shows the first task as Queued while it is waiting for SSH capacity](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260718-a2a590/queue-status-chip-proof-after.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert d11d7c98a`
- Post-revert steps: None.
- Data migration? No.

</details>

Depends-On: #4943