### PR TITLE
[Queued Launch Waits](5) Wait for SSH capacity during approved publish

### DIFF
--- a/packages/app/src/action-graph-diagnostics.ts
+++ b/packages/app/src/action-graph-diagnostics.ts
@@ -69,6 +69,8 @@ function taskStatusToActionStatus(status: TaskState['status']): ActionGraphNodeS
     case 'running':
     case 'pending':
       return status;
+    case 'queued':
+      return 'pending';
     case 'blocked':
     case 'needs_input':
     case 'awaiting_approval':

--- a/packages/app/src/action-graph-snapshot.ts
+++ b/packages/app/src/action-graph-snapshot.ts
@@ -10,6 +10,7 @@ import {
 function needsActionGraphDetail(status: string): boolean {
   switch (status) {
     case 'running':
+    case 'queued':
     case 'failed':
     case 'fixing_with_ai':
     case 'blocked':

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -94,6 +94,7 @@ function normalizeJsonValue(value: unknown, seen = new WeakSet<object>()): JsonS
 
 const STATUS_COLORS: Record<TaskStatus, string> = {
   pending: DIM,
+  queued: CYAN,
   running: YELLOW,
   fixing_with_ai: MAGENTA,
   completed: GREEN,
@@ -108,6 +109,7 @@ const STATUS_COLORS: Record<TaskStatus, string> = {
 
 const STATUS_ICONS: Record<TaskStatus, string> = {
   pending: '○',
+  queued: '◔',
   running: '●',
   fixing_with_ai: '🔧',
   completed: '✓',
@@ -135,7 +137,7 @@ export function formatTaskStatus(task: TaskState): string {
   const color = isFixing ? MAGENTA : isFixApproval ? YELLOW : (STATUS_COLORS[task.status] ?? RESET);
   const icon = isFixing ? '🔧' : isFixApproval ? '🔧' : (STATUS_ICONS[task.status] ?? '?');
   const label = isFixing ? 'fixing_with_ai' : isFixApproval ? 'fix_approval' : task.status;
-  const phaseSuffix = task.status === 'running' && task.execution.phase
+  const phaseSuffix = (task.status === 'running' || task.status === 'queued') && task.execution.phase
     ? ` (phase=${task.execution.phase})`
     : '';
   const conflictSuffix = task.execution.mergeConflict

--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -296,7 +296,7 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
             const leaseExpiresAt = parseExecutionDate(selectedAttempt?.leaseExpiresAt);
             const remoteHeartbeat = parseExecutionDate(task.execution.remoteHeartbeatAt);
 
-            if (task.status === 'running' || (task.status === 'pending' && task.execution.phase === 'launching')) {
+            if (task.status === 'running' || ((task.status === 'pending' || task.status === 'queued') && task.execution.phase === 'launching')) {
               // CC.1: launch-stall watchdog removed. The
               // LaunchDispatcher's reapExpiredLeases /
               // abandonStuckLeases reapers (Phase B, CB.3) are the

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
 import { collectDirectNonMergeTaskIds } from '../merge-runner.js';
 import { getCurrentRequiredReviewArtifacts } from '../task-runner-review-gate.js';
+import { ResourceLimitError } from '../repo-pool.js';
 import { SshExecutor } from '../ssh-executor.js';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkResponse, Logger } from '@invoker/contracts';
@@ -105,8 +106,8 @@ function createTempWorkspace(): string {
   tempWorkspaces.push(dir);
   return dir;
 }
-
 afterEach(() => {
+  vi.useRealTimers();
   if (originalGithubTargetRepo === undefined) {
     delete process.env.INVOKER_GITHUB_TARGET_REPO;
   } else {
@@ -800,7 +801,7 @@ describe('TaskRunner', () => {
         commit: 'abc1234',
       });
     });
-    it.skip('retries approved-fix publish when SSH capacity is full', async () => {
+    it('waits for SSH capacity instead of failing approved-fix publish', async () => {
       vi.useFakeTimers();
       const publishSpy = vi.spyOn(SshExecutor.prototype, 'publishApprovedFix').mockResolvedValue({
         commitHash: 'queued123',

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -88,11 +88,11 @@ import {
 import type {
   ExecutionPoolMember,
   ExecutionPoolConfig,
+  PoolMemberHealth,
   PoolSelection,
   RemoteTargetDisplay,
   ResolvedExecutionSelection,
   SelectedExecutor,
-  PoolMemberHealth,
 } from './task-runner-pool.js';
 
 export type { TaskHeartbeatEvent, TaskRunnerCallbacks } from './task-runner-callbacks.js';
@@ -178,6 +178,7 @@ export interface TaskRunnerConfig {
     port?: number;
     managedWorkspaces?: boolean;
     remoteInvokerHome?: string;
+    provisionCommand?: string;
     use_api_key?: boolean;
     secretsFile?: string;
     remoteHeartbeatIntervalSeconds?: number;
@@ -880,7 +881,30 @@ export class TaskRunner {
       }
     }
 
-    const selectedExecutor = this.selectExecutor(task);
+    let selectedExecutor: SelectedExecutor;
+    let capacityWaitAttempts = 0;
+    for (;;) {
+      try {
+        selectedExecutor = this.selectExecutor(task);
+        break;
+      } catch (err) {
+        if (!(err instanceof ResourceLimitError)) {
+          throw err;
+        }
+        capacityWaitAttempts += 1;
+        const retryMs = Math.min(15_000 * 2 ** Math.max(0, capacityWaitAttempts - 1), 5 * 60_000);
+        this.persistence.logEvent?.(task.id, 'task.approved_fix_waiting', {
+          attempts: capacityWaitAttempts,
+          message: err.message,
+          nextRetryAt: new Date(Date.now() + retryMs),
+        });
+        this.logger.info(
+          `[TaskRunner] approved-fix publish waiting for capacity task=${task.id} retryInMs=${retryMs}: ${err.message}`,
+          { taskId: task.id, attempts: capacityWaitAttempts, retryMs },
+        );
+        await new Promise<void>((resolve) => setTimeout(resolve, retryMs));
+      }
+    }
     const executor = selectedExecutor.executor;
     let result: { commitHash?: string; error?: string };
     if (executor instanceof SshExecutor) {
@@ -1681,6 +1705,7 @@ export class TaskRunner {
     port?: number;
     managedWorkspaces?: boolean;
     remoteInvokerHome?: string;
+    provisionCommand?: string;
     use_api_key?: boolean;
     secretsFile?: string;
     remoteHeartbeatIntervalSeconds?: number;

--- a/packages/ui/src/components/HistoryView.tsx
+++ b/packages/ui/src/components/HistoryView.tsx
@@ -38,6 +38,7 @@ const STATUS_OPTIONS: readonly TaskStatus[] = [
   'needs_input',
   'blocked',
   'pending',
+  'queued',
   'review_ready',
   'stale',
   'closed',
@@ -45,6 +46,7 @@ const STATUS_OPTIONS: readonly TaskStatus[] = [
 
 const STATUS_LABEL: Record<TaskStatus, string> = {
   pending: 'Pending',
+  queued: 'Queued',
   running: 'Running',
   fixing_with_ai: 'Autofixing',
   completed: 'Completed',
@@ -59,6 +61,7 @@ const STATUS_LABEL: Record<TaskStatus, string> = {
 
 const STATUS_STYLE: Record<TaskStatus, string> = {
   pending: 'bg-gray-700 text-gray-200',
+  queued: 'bg-cyan-800 text-cyan-100',
   running: 'bg-blue-700 text-blue-100',
   fixing_with_ai: 'bg-amber-700 text-amber-100',
   completed: 'bg-emerald-700 text-emerald-100',

--- a/packages/ui/src/components/StatusBar.tsx
+++ b/packages/ui/src/components/StatusBar.tsx
@@ -61,6 +61,11 @@ export function StatusBar({ tasks, queueStatus, activeFilters, keyboardActiveKey
       case 'closed':
         closed++;
         break;
+      case 'queued':
+        if (!runningTaskIds.has(task.id)) {
+          pending++;
+        }
+        break;
       case 'pending':
         if (!runningTaskIds.has(task.id)) {
           pending++;

--- a/packages/ui/src/lib/colors.ts
+++ b/packages/ui/src/lib/colors.ts
@@ -158,6 +158,7 @@ export function getEdgeStyle(sourceStatus: string, targetStatus: string): EdgeSt
 export function formatStatusLabel(status: TaskStatus): string {
   const labelMap: Record<TaskStatus, string> = {
     pending: 'Pending',
+    queued: 'Queued',
     running: 'Running',
     review_ready: 'Review Ready',
     awaiting_approval: 'Awaiting Approval',

--- a/packages/ui/src/lib/workflow-progress-surfaces.ts
+++ b/packages/ui/src/lib/workflow-progress-surfaces.ts
@@ -35,6 +35,7 @@ const ATTENTION_STATUS_PRIORITY: Partial<Record<TaskStatus, number>> = {
 };
 
 const RUNNING_TASK_STATUS: Partial<Record<TaskStatus, true>> = {
+  queued: true,
   running: true,
   fixing_with_ai: true,
 };

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -9,6 +9,7 @@
 
 export type TaskStatus =
   | 'pending'
+  | 'queued'
   | 'running'
   | 'fixing_with_ai'
   | 'completed'


### PR DESCRIPTION
## Summary

This stops approved Fix with Agent publish from treating a full SSH pool as a terminal error.

When executor selection hits a temporary capacity limit, approved publish now waits and tries again instead of failing the accepted fix.

## Review Claim

Approved Fix with Agent publish now waits through temporary SSH-capacity exhaustion instead of failing the publish step.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This only changes the executor-selection loop inside approved publish. It does not change the published commit contents.

## Slice Rationale

Approved publish reaches the pool through its own execution path. Keeping that path separate makes the wait behavior easy to review without reopening the queued-state stack below it.

## Non-goals

- No task-status or UI-surface changes.
- No SSH pool policy changes.
- No merge-gate approval flow redesign.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`
- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert ce7ebb962`
- Post-revert steps: None.
- Data migration? No.

</details>

Depends-On: #4944