### PR TITLE
[Durable SSH Pool Capacity](1) Prove memory capacity ignores empty leases

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-lease-capacity-authority.proof.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-lease-capacity-authority.proof.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TaskRunner } from '../task-runner.js';
+import type { TaskState } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '@invoker/data-store';
+
+/**
+ * Proof for durable SSH lease capacity authority.
+ *
+ * Desired end state (slices 2–4): SSH member capacity is decided by unexpired
+ * `execution_resource_leases` rows (host-keyed), not by in-memory
+ * `activeExecutions` / `pendingPoolSelections`.
+ *
+ * These tests use `it.fails` so CI stays green while the current memory-backed
+ * authority still exhibits the buggy contract. Fix slices remove `.fails`.
+ */
+
+const sharedHost = {
+  host: 'shared.example.com',
+  user: 'invoker',
+  sshKeyPath: '/tmp/fake-shared',
+};
+
+function makeSshExecutor() {
+  return {
+    type: 'ssh',
+    start: vi.fn(),
+    onComplete: vi.fn(),
+    onOutput: vi.fn(),
+    onHeartbeat: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    destroyAll: vi.fn(),
+  };
+}
+
+function makeTask(id: string, poolId: string, attempt = `${id}-attempt`): TaskState {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { command: 'echo hi', runnerKind: 'ssh', poolId },
+    execution: { selectedAttemptId: attempt, generation: 0 },
+  } as TaskState;
+}
+
+function makeDualPoolRunner(opts: {
+  persistence?: unknown;
+  orchestrator?: unknown;
+  sshExecutor?: unknown;
+} = {}): TaskRunner {
+  const sshExecutor = opts.sshExecutor ?? makeSshExecutor();
+  return new TaskRunner({
+    orchestrator: opts.orchestrator ?? {
+      getTask: () => null,
+      getAllTasks: () => [],
+      deferTask: vi.fn(),
+    },
+    persistence: opts.persistence ?? { logEvent: vi.fn() },
+    executorRegistry: {
+      getDefault: () => sshExecutor,
+      get: (type: string) => (type === 'ssh' ? sshExecutor : null),
+      getAll: () => [sshExecutor],
+      register: vi.fn(),
+    } as never,
+    cwd: '/tmp',
+    remoteTargetsProvider: () => ({
+      'remote-shared': sharedHost,
+    }),
+    executionPoolsProvider: () => ({
+      'mixed-local-ssh': {
+        selectionStrategy: 'leastLoaded',
+        maxConcurrentTasksPerMember: 1,
+        members: [{ id: 'remote-shared', type: 'ssh', maxConcurrentTasks: 1 }],
+      },
+      'pnpm-ssh': {
+        selectionStrategy: 'leastLoaded',
+        maxConcurrentTasksPerMember: 1,
+        members: [{ id: 'remote-shared', type: 'ssh', maxConcurrentTasks: 1 }],
+      },
+    }),
+  } as never);
+}
+
+describe('SSH lease capacity authority (proof)', () => {
+  // Desired: a live-looking activeExecutions row with no durable lease must not
+  // wedge capacity. Today reclaim leaves matching selectedAttemptId entries in
+  // place, so poolMemberLoad still reports full while leases are empty.
+  it.fails('does not wedge SSH capacity on a lease-less activeExecutions ghost', () => {
+    const liveTask = makeTask('wf-1/task-a', 'pnpm-ssh', 'wf-1/task-a-live');
+    liveTask.status = 'running';
+    const sshExecutor = makeSshExecutor();
+    const runner = makeDualPoolRunner({
+      sshExecutor,
+      orchestrator: {
+        getTask: (id: string) => (id === liveTask.id ? liveTask : null),
+        getAllTasks: () => [liveTask],
+        deferTask: vi.fn(),
+      },
+      persistence: {
+        logEvent: vi.fn(),
+        listExecutionResourceLeases: () => [],
+        claimExecutionResourceLease: () => true,
+        releaseExecutionResourceLease: vi.fn(),
+      },
+    });
+
+    (runner as unknown as { activeExecutions: Map<string, unknown> }).activeExecutions.set(
+      'wf-1/task-a-live',
+      {
+        handle: { attemptId: 'wf-1/task-a-live' },
+        executor: sshExecutor,
+        taskId: liveTask.id,
+        poolId: 'pnpm-ssh',
+        poolMemberKey: 'ssh:remote-shared',
+      },
+    );
+
+    expect((runner as any).persistence.listExecutionResourceLeases()).toEqual([]);
+    expect(() => runner.selectExecutor(makeTask('wf-2/task-b', 'pnpm-ssh'))).not.toThrow();
+  });
+
+  // Desired: host-keyed leases prevent two pools from double-booking one droplet.
+  // Today memory capacity is per (poolId, member), so mixed-local + pnpm both
+  // select the same remote-shared successfully without any host lease.
+  it.fails('blocks a second pool from selecting a host already reserved by another pool', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const first = makeTask('wf-1/task-a', 'mixed-local-ssh');
+      const second = makeTask('wf-2/task-b', 'pnpm-ssh');
+      const runner = makeDualPoolRunner({
+        persistence: {
+          logEvent: vi.fn(),
+          claimExecutionResourceLease: adapter.claimExecutionResourceLease.bind(adapter),
+          renewExecutionResourceLease: adapter.renewExecutionResourceLease.bind(adapter),
+          releaseExecutionResourceLease: adapter.releaseExecutionResourceLease.bind(adapter),
+          listExecutionResourceLeases: adapter.listExecutionResourceLeases.bind(adapter),
+        },
+      });
+
+      expect(() => runner.selectExecutor(first)).not.toThrow();
+      // After claim-at-select, the first selection holds a host lease. The second
+      // pool must see the shared host as full.
+      expect(() => runner.selectExecutor(second)).toThrow(/no member capacity|resource-limit|lease/i);
+      expect(adapter.listExecutionResourceLeases().length).toBeGreaterThanOrEqual(1);
+    } finally {
+      adapter.close();
+    }
+  });
+});

--- a/scripts/repro/repro-ssh-lease-capacity-authority.sh
+++ b/scripts/repro/repro-ssh-lease-capacity-authority.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Proof / gate for durable SSH lease capacity authority.
+#
+# Default: run the proof suite (it.fails documents today's memory-backed bugs).
+# Pass --gate after slices 2–4 land to require the fixed (non-.fails) suite.
+set -euo pipefail
+
+RUN_GATES=0
+for arg in "$@"; do
+  case "$arg" in
+    --gate) RUN_GATES=1 ;;
+  esac
+done
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "repro: SSH lease capacity authority proof"
+cd packages/execution-engine
+pnpm exec vitest run src/__tests__/ssh-lease-capacity-authority.proof.test.ts
+
+if [[ "$RUN_GATES" == "1" ]]; then
+  echo "gate: lease capacity battery"
+  bash "$ROOT/scripts/repro/repro-ssh-lease-capacity-battery.sh" --gate
+fi
+
+echo "PASS: SSH lease capacity authority repro finished"


### PR DESCRIPTION
## Summary

SSH pool capacity today trusts in-memory maps. A lease-less ghost can still report a member as full.

This proof locks that contract with focused regressions and a repro harness. Later slices flip the expectations once leases own capacity.

## Review Claim

Approve the proof regressions for lease-less activeExecutions wedges and cross-pool host double-booking, plus the repro harness.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

No product runtime change in this slice. The suite documents the authority contract for later fix slices.

## Slice Rationale

Proof comes first so reviewers see the ghost-slot and cross-pool bugs before the lease authority change.

## Non-goals

No counted lease API, claim-at-select, load math changes, battery gate, headless query, or docs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/ssh-lease-capacity-authority.proof.test.ts`
- [ ] `bash scripts/repro/repro-ssh-lease-capacity-authority.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d3cc1e470`
- Post-revert steps: None
- Data migration? No

</details>