### PR TITLE
[Durable SSH Pool Capacity](2) Allow counted execution resource leases

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1003,6 +1003,50 @@ describe('SQLiteAdapter', () => {
       expect(leases).toHaveLength(1);
       expect(leases[0]?.resourceKey).toBe('ssh:live-b');
     });
+
+    it('allows up to maxHolders live holders on one resource key', () => {
+      expect(adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:invoker@counted.example.com:22',
+        resourceType: 'ssh',
+        holderId: 'holder-1',
+        maxHolders: 2,
+      })).toBe(true);
+      expect(adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:invoker@counted.example.com:22',
+        resourceType: 'ssh',
+        holderId: 'holder-2',
+        maxHolders: 2,
+      })).toBe(true);
+      expect(adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:invoker@counted.example.com:22',
+        resourceType: 'ssh',
+        holderId: 'holder-3',
+        maxHolders: 2,
+      })).toBe(false);
+
+      expect(adapter.countExecutionResourceLeases('ssh:invoker@counted.example.com:22')).toBe(2);
+      expect(adapter.listExecutionResourceLeasesByKey('ssh:invoker@counted.example.com:22')).toHaveLength(2);
+    });
+
+    it('renews an existing holder without consuming an extra maxHolders slot', () => {
+      expect(adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:invoker@renew.example.com:22',
+        resourceType: 'ssh',
+        holderId: 'holder-1',
+        maxHolders: 1,
+      })).toBe(true);
+      expect(adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:invoker@renew.example.com:22',
+        resourceType: 'ssh',
+        holderId: 'holder-1',
+        maxHolders: 1,
+        taskId: 'task-renewed',
+      })).toBe(true);
+
+      const leases = adapter.listExecutionResourceLeasesByKey('ssh:invoker@renew.example.com:22');
+      expect(leases).toHaveLength(1);
+      expect(leases[0]?.taskId).toBe('task-renewed');
+    });
   });
 
   describe('task_launch_dispatch outbox', () => {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -969,6 +969,9 @@ describe('SQLiteAdapter', () => {
       const leases = adapter.listExecutionResourceLeases();
       expect(leases).toHaveLength(1);
       expect(leases[0].holderId).toBe('holder-2');
+      expect(adapter.listExecutionResourceLeasesByKey('ssh:invoker@example.com:22')).toEqual([
+        expect.objectContaining({ holderId: 'holder-2' }),
+      ]);
     });
 
     it('renews and releases resource leases by holder', () => {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -2819,24 +2819,37 @@ export class SQLiteAdapter implements PersistenceAdapter {
     poolMemberId?: string;
     metadata?: unknown;
     leaseMs?: number;
+    /** Max live holders for this resource key. Default 1 preserves exclusive semantics. */
+    maxHolders?: number;
   }): boolean {
     const now = new Date();
     const nowIso = now.toISOString();
     const leaseExpiresAt = new Date(now.getTime() + (options.leaseMs ?? EXECUTION_RESOURCE_LEASE_MS)).toISOString();
+    const maxHolders = Math.max(1, Math.floor(options.maxHolders ?? 1));
     return this.runTransaction(() => {
       this.execRun(
         'DELETE FROM execution_resource_leases WHERE resource_key = ? AND lease_expires_at <= ?',
         [options.resourceKey, nowIso],
       );
-      const active = this.queryOne(
+      const existingForHolder = this.queryOne(
         `SELECT holder_id FROM execution_resource_leases
          WHERE resource_key = ?
-           AND holder_id != ?
+           AND holder_id = ?
            AND lease_expires_at > ?
          LIMIT 1`,
         [options.resourceKey, options.holderId, nowIso],
       );
-      if (active) return false;
+      if (!existingForHolder) {
+        const otherHolders = this.queryOne(
+          `SELECT COUNT(*) AS cnt FROM execution_resource_leases
+           WHERE resource_key = ?
+             AND holder_id != ?
+             AND lease_expires_at > ?`,
+          [options.resourceKey, options.holderId, nowIso],
+        );
+        const otherCount = Number(otherHolders?.cnt ?? 0);
+        if (otherCount >= maxHolders) return false;
+      }
 
       this.execRun(
         `INSERT OR REPLACE INTO execution_resource_leases (
@@ -2858,6 +2871,37 @@ export class SQLiteAdapter implements PersistenceAdapter {
       );
       return true;
     });
+  }
+
+  countExecutionResourceLeases(resourceKey: string, nowIso?: string): number {
+    const cutoff = nowIso ?? new Date().toISOString();
+    const row = this.queryOne(
+      `SELECT COUNT(*) AS cnt FROM execution_resource_leases
+       WHERE resource_key = ?
+         AND lease_expires_at > ?`,
+      [resourceKey, cutoff],
+    );
+    return Number(row?.cnt ?? 0);
+  }
+
+  listExecutionResourceLeasesByKey(resourceKey: string): ExecutionResourceLease[] {
+    return this.queryAll(
+      `SELECT * FROM execution_resource_leases
+       WHERE resource_key = ?
+       ORDER BY acquired_at ASC`,
+      [resourceKey],
+    ).map((row) => ({
+      resourceKey: String(row.resource_key),
+      resourceType: String(row.resource_type),
+      holderId: String(row.holder_id),
+      taskId: row.task_id ? String(row.task_id) : undefined,
+      poolId: row.pool_id ? String(row.pool_id) : undefined,
+      poolMemberId: row.pool_member_id ? String(row.pool_member_id) : undefined,
+      acquiredAt: String(row.acquired_at),
+      lastHeartbeatAt: String(row.last_heartbeat_at),
+      leaseExpiresAt: String(row.lease_expires_at),
+      metadata: row.metadata_json ? JSON.parse(String(row.metadata_json)) : undefined,
+    }));
   }
 
   renewExecutionResourceLease(

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -2884,12 +2884,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return Number(row?.cnt ?? 0);
   }
 
-  listExecutionResourceLeasesByKey(resourceKey: string): ExecutionResourceLease[] {
+  listExecutionResourceLeasesByKey(resourceKey: string, nowIso?: string): ExecutionResourceLease[] {
+    const cutoff = nowIso ?? new Date().toISOString();
     return this.queryAll(
       `SELECT * FROM execution_resource_leases
        WHERE resource_key = ?
+         AND lease_expires_at > ?
        ORDER BY acquired_at ASC`,
-      [resourceKey],
+      [resourceKey, cutoff],
     ).map((row) => ({
       resourceKey: String(row.resource_key),
       resourceType: String(row.resource_type),


### PR DESCRIPTION
## Summary

SSH hosts may need more than one concurrent holder when `maxConcurrentTasksPerMember` is greater than one.

This slice extends durable lease claims with `maxHolders` and adds count helpers. Default `maxHolders=1` keeps today's exclusive semantics.

## Review Claim

Approve counted `claimExecutionResourceLease` writes with `maxHolders`, plus count and by-key helpers, without changing TaskRunner selection yet.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

Default maxHolders remains 1, so existing exclusive SSH claims behave as before. New helpers are additive.

## Slice Rationale

Persistence must support counted host leases before selection can claim them as capacity truth.

## Non-goals

No TaskRunner claim-at-select, poolMemberLoad changes, battery, query surface, or docs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/data-store && pnpm exec vitest run src/__tests__/sqlite-adapter.test.ts -t "execution resource leases"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 45c1524df`
- Post-revert steps: None
- Data migration? No

</details>