### PR TITLE
[Durable SSH Pool Capacity](5) Add SSH lease capacity e2e battery gate

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-lease-capacity-authority.proof.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-lease-capacity-authority.proof.test.ts
@@ -83,10 +83,8 @@ function makeDualPoolRunner(opts: {
 }
 
 describe('SSH lease capacity authority (proof)', () => {
-  // Desired: a live-looking activeExecutions row with no durable lease must not
-  // wedge capacity. Today reclaim leaves matching selectedAttemptId entries in
-  // place, so poolMemberLoad still reports full while leases are empty.
-  it.fails('does not wedge SSH capacity on a lease-less activeExecutions ghost', () => {
+  // Lease-backed SSH load ignores lease-less activeExecutions ghosts.
+  it('does not wedge SSH capacity on a lease-less activeExecutions ghost', () => {
     const liveTask = makeTask('wf-1/task-a', 'pnpm-ssh', 'wf-1/task-a-live');
     liveTask.status = 'running';
     const sshExecutor = makeSshExecutor();

--- a/packages/execution-engine/src/__tests__/ssh-lease-capacity-battery.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-lease-capacity-battery.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+import { TaskRunner } from '../task-runner.js';
+
+/**
+ * Required gate for durable SSH lease capacity (stack slice 5).
+ * Run via: bash scripts/repro/repro-ssh-lease-capacity-battery.sh --gate
+ */
+
+const SHARED_HOST = {
+  host: 'shared.example.com',
+  user: 'invoker',
+  sshKeyPath: '/tmp/fake-shared',
+};
+
+const HOST_A = { host: 'a.example.com', user: 'invoker', sshKeyPath: '/tmp/fake-a' };
+const HOST_B = { host: 'b.example.com', user: 'invoker', sshKeyPath: '/tmp/fake-b' };
+const HOST_C = { host: 'c.example.com', user: 'invoker', sshKeyPath: '/tmp/fake-c' };
+
+function makeTask(id: string, poolId: string, attempt = `${id}-attempt`): TaskState {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { command: 'echo hi', runnerKind: 'ssh', poolId },
+    execution: { selectedAttemptId: attempt, generation: 0 },
+  } as TaskState;
+}
+
+function makeSshExecutor() {
+  const completeByTaskId = new Map<string, (response: unknown) => void>();
+  const executor = {
+    type: 'ssh' as const,
+    start: vi.fn(async (request: { actionId: string }) => ({
+      executionId: `exec-${request.actionId}`,
+      taskId: request.actionId,
+      workspacePath: `/remote/${request.actionId}`,
+    })),
+    onComplete: vi.fn((handle: { taskId: string }, cb: (response: unknown) => void) => {
+      completeByTaskId.set(handle.taskId, cb);
+    }),
+    onOutput: vi.fn(),
+    onHeartbeat: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    destroyAll: vi.fn(),
+    completeByTaskId,
+  };
+  return executor;
+}
+
+function bindLeasePersistence(adapter: SQLiteAdapter) {
+  return {
+    logEvent: vi.fn(),
+    updateTask: vi.fn(),
+    updateAttempt: vi.fn(),
+    appendTaskOutput: vi.fn(),
+    claimExecutionResourceLease: adapter.claimExecutionResourceLease.bind(adapter),
+    renewExecutionResourceLease: adapter.renewExecutionResourceLease.bind(adapter),
+    releaseExecutionResourceLease: adapter.releaseExecutionResourceLease.bind(adapter),
+    countExecutionResourceLeases: adapter.countExecutionResourceLeases.bind(adapter),
+    listExecutionResourceLeases: adapter.listExecutionResourceLeases.bind(adapter),
+    listExecutionResourceLeasesByKey: adapter.listExecutionResourceLeasesByKey.bind(adapter),
+  };
+}
+
+function makePoolRunner(opts: {
+  persistence: ReturnType<typeof bindLeasePersistence>;
+  sshExecutor?: ReturnType<typeof makeSshExecutor>;
+  orchestrator?: unknown;
+  pools?: 'dual-shared' | 'triple-hosts';
+}): TaskRunner {
+  const sshExecutor = opts.sshExecutor ?? makeSshExecutor();
+  const dualShared = opts.pools !== 'triple-hosts';
+  return new TaskRunner({
+    orchestrator: opts.orchestrator ?? {
+      getTask: () => null,
+      getAllTasks: () => [],
+      deferTask: vi.fn(),
+      markTaskRunningAfterLaunch: () => true,
+      handleWorkerResponse: () => [],
+    },
+    persistence: opts.persistence,
+    executorRegistry: {
+      getDefault: () => sshExecutor,
+      get: (type: string) => (type === 'ssh' ? sshExecutor : null),
+      getAll: () => [sshExecutor],
+      register: vi.fn(),
+    } as never,
+    cwd: '/tmp',
+    remoteTargetsProvider: () => (
+      dualShared
+        ? { 'remote-shared': SHARED_HOST }
+        : {
+            'remote-a': HOST_A,
+            'remote-b': HOST_B,
+            'remote-c': HOST_C,
+          }
+    ),
+    executionPoolsProvider: () => (
+      dualShared
+        ? {
+            'mixed-local-ssh': {
+              selectionStrategy: 'leastLoaded',
+              maxConcurrentTasksPerMember: 1,
+              members: [{ id: 'remote-shared', type: 'ssh', maxConcurrentTasks: 1 }],
+            },
+            'pnpm-ssh': {
+              selectionStrategy: 'leastLoaded',
+              maxConcurrentTasksPerMember: 1,
+              members: [{ id: 'remote-shared', type: 'ssh', maxConcurrentTasks: 1 }],
+            },
+          }
+        : {
+            'pnpm-ssh': {
+              selectionStrategy: 'leastLoaded',
+              maxConcurrentTasksPerMember: 1,
+              members: [
+                { id: 'remote-a', type: 'ssh', maxConcurrentTasks: 1 },
+                { id: 'remote-b', type: 'ssh', maxConcurrentTasks: 1 },
+                { id: 'remote-c', type: 'ssh', maxConcurrentTasks: 1 },
+              ],
+            },
+          }
+    ),
+  } as never);
+}
+
+function liveLeases(adapter: SQLiteAdapter) {
+  const now = new Date().toISOString();
+  return adapter.listExecutionResourceLeases().filter((lease) => lease.leaseExpiresAt > now);
+}
+
+describe('SSH lease capacity battery', () => {
+  const adapters: SQLiteAdapter[] = [];
+
+  afterEach(() => {
+    for (const adapter of adapters.splice(0)) {
+      adapter.close();
+    }
+  });
+
+  it('orphan memory does not wedge while leases are empty', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    const ghost = makeTask('wf-ghost/task', 'pnpm-ssh', 'wf-ghost/task-live');
+    ghost.status = 'running';
+    const waiter = makeTask('wf-waiter/task', 'pnpm-ssh');
+    const sshExecutor = makeSshExecutor();
+    const runner = makePoolRunner({
+      pools: 'dual-shared',
+      sshExecutor,
+      persistence: bindLeasePersistence(adapter),
+      orchestrator: {
+        getTask: (id: string) => (id === ghost.id ? ghost : id === waiter.id ? waiter : null),
+        getAllTasks: () => [ghost, waiter],
+        deferTask: vi.fn(),
+        markTaskRunningAfterLaunch: () => true,
+        handleWorkerResponse: () => [],
+      },
+    });
+
+    (runner as unknown as { activeExecutions: Map<string, unknown> }).activeExecutions.set(
+      'wf-ghost/task-live',
+      {
+        handle: { attemptId: 'wf-ghost/task-live', taskId: ghost.id },
+        executor: sshExecutor,
+        taskId: ghost.id,
+        poolId: 'pnpm-ssh',
+        poolMemberKey: 'ssh:remote-shared',
+      },
+    );
+
+    expect(liveLeases(adapter)).toHaveLength(0);
+    expect(() => runner.selectExecutor(waiter)).not.toThrow();
+    expect(liveLeases(adapter).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('enforces cross-pool host exclusivity at maxConcurrentTasksPerMember=1', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    const runner = makePoolRunner({
+      pools: 'dual-shared',
+      persistence: bindLeasePersistence(adapter),
+    });
+
+    expect(() => runner.selectExecutor(makeTask('wf-1/a', 'mixed-local-ssh'))).not.toThrow();
+    expect(() => runner.selectExecutor(makeTask('wf-2/b', 'pnpm-ssh'))).toThrow(/no member capacity/);
+    expect(liveLeases(adapter)).toHaveLength(1);
+    expect(liveLeases(adapter)[0]?.resourceKey).toBe('ssh:invoker@shared.example.com:22');
+  });
+
+  it('fills expectedCap after recreate/preempt-style churn with ready work remaining', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    const expectedCap = 3;
+    const tasks = Array.from({ length: 12 }, (_, i) => makeTask(`wf-${i}/t0`, 'pnpm-ssh'));
+    const taskMap = new Map(tasks.map((task) => [task.id, task]));
+    const sshExecutor = makeSshExecutor();
+    const deferTask = vi.fn();
+    const runner = makePoolRunner({
+      pools: 'triple-hosts',
+      sshExecutor,
+      persistence: bindLeasePersistence(adapter),
+      orchestrator: {
+        getTask: (id: string) => taskMap.get(id) ?? null,
+        getAllTasks: () => [...taskMap.values()],
+        deferTask,
+        markTaskRunningAfterLaunch: () => true,
+        handleWorkerResponse: () => [],
+      },
+    });
+
+    const runs: Promise<void>[] = [];
+    for (let i = 0; i < expectedCap; i += 1) {
+      runs.push(runner.executeTask(tasks[i]!));
+    }
+    await vi.waitFor(() => expect(sshExecutor.start).toHaveBeenCalledTimes(expectedCap));
+    expect(liveLeases(adapter)).toHaveLength(expectedCap);
+
+    // Overwhelm remaining ready work so at least one waiter defers while full.
+    for (let i = expectedCap; i < expectedCap + 3; i += 1) {
+      void runner.executeTask(tasks[i]!);
+    }
+    await vi.waitFor(() => expect(deferTask).toHaveBeenCalled());
+
+    // Supersede first slot: new attempt id, kill old execution, inject a lease-less
+    // ghost, then confirm a deferred waiter can still refill to expectedCap.
+    const victim = tasks[0]!;
+    const oldAttempt = victim.execution.selectedAttemptId!;
+    victim.execution = { ...victim.execution, selectedAttemptId: `${victim.id}-retry` };
+    expect(await runner.killActiveExecution(victim.id)).toBe(true);
+    sshExecutor.completeByTaskId.get(victim.id)?.({
+      requestId: 'kill',
+      actionId: victim.id,
+      attemptId: oldAttempt,
+      status: 'failed',
+      outputs: { exitCode: 130 },
+    });
+    await runs[0];
+    expect(liveLeases(adapter)).toHaveLength(expectedCap - 1);
+
+    (runner as unknown as { activeExecutions: Map<string, unknown> }).activeExecutions.set(
+      'ghost-attempt',
+      {
+        handle: { attemptId: 'ghost-attempt', taskId: 'ghost/task' },
+        executor: sshExecutor,
+        taskId: 'ghost/task',
+        poolId: 'pnpm-ssh',
+        poolMemberKey: 'ssh:remote-a',
+      },
+    );
+
+    const startsBeforeRefill = sshExecutor.start.mock.calls.length;
+    const refillTask = tasks[expectedCap + 3]!;
+    const refillRun = runner.executeTask(refillTask);
+    await vi.waitFor(() => expect(sshExecutor.start.mock.calls.length).toBe(startsBeforeRefill + 1));
+    expect(liveLeases(adapter)).toHaveLength(expectedCap);
+
+    for (const task of [tasks[1], tasks[2], refillTask]) {
+      sshExecutor.completeByTaskId.get(task!.id)?.({
+        requestId: `done-${task!.id}`,
+        actionId: task!.id,
+        attemptId: task!.execution.selectedAttemptId,
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      });
+    }
+    await Promise.all([runs[1], runs[2], refillRun]);
+    expect(liveLeases(adapter)).toHaveLength(0);
+  }, 60_000);
+
+  it('keeps lease/occupancy parity for executing SSH tasks', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    const tasks = [
+      makeTask('wf-1/a', 'pnpm-ssh'),
+      makeTask('wf-2/b', 'pnpm-ssh'),
+      makeTask('wf-3/c', 'pnpm-ssh'),
+    ];
+    const taskMap = new Map(tasks.map((task) => [task.id, task]));
+    const sshExecutor = makeSshExecutor();
+    const runner = makePoolRunner({
+      pools: 'triple-hosts',
+      sshExecutor,
+      persistence: bindLeasePersistence(adapter),
+      orchestrator: {
+        getTask: (id: string) => taskMap.get(id) ?? null,
+        getAllTasks: () => [...taskMap.values()],
+        deferTask: vi.fn(),
+        markTaskRunningAfterLaunch: () => true,
+        handleWorkerResponse: () => [],
+      },
+    });
+
+    const runs = tasks.map((task) => runner.executeTask(task));
+    await vi.waitFor(() => expect(sshExecutor.start).toHaveBeenCalledTimes(3));
+
+    const leases = liveLeases(adapter);
+    expect(leases).toHaveLength(3);
+    const leasedTaskIds = new Set(leases.map((lease) => lease.taskId));
+    for (const task of tasks) {
+      expect(leasedTaskIds.has(task.id)).toBe(true);
+    }
+
+    for (const task of tasks) {
+      sshExecutor.completeByTaskId.get(task.id)?.({
+        requestId: `done-${task.id}`,
+        actionId: task.id,
+        attemptId: task.execution.selectedAttemptId,
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      });
+    }
+    await Promise.all(runs);
+    expect(liveLeases(adapter)).toHaveLength(0);
+  });
+});

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -112,7 +112,7 @@ export function poolMemberKey(member: ExecutionPoolMember): string {
   return `${member.type}:${member.id}`;
 }
 
-function poolMemberLoad(host: TaskRunnerPoolHost, poolId: string, memberKey: string): number {
+function memoryPoolMemberLoad(host: TaskRunnerPoolHost, poolId: string, memberKey: string): number {
   let load = 0;
   for (const selection of host.pendingPoolSelections.values()) {
     if (selection.poolId === poolId && selection.memberKey === memberKey) load += 1;
@@ -123,13 +123,36 @@ function poolMemberLoad(host: TaskRunnerPoolHost, poolId: string, memberKey: str
   return load;
 }
 
+function sshHostLeaseLoad(host: TaskRunnerPoolHost, member: Extract<ExecutionPoolMember, { type: 'ssh' }>): number | undefined {
+  const target = host.getRemoteTargets()[member.id];
+  if (!target) return undefined;
+  const resourceKey = sshResourceKey(target);
+  const countFn = host.persistence.countExecutionResourceLeases?.bind(host.persistence);
+  if (countFn) return countFn(resourceKey);
+  const listFn = host.persistence.listExecutionResourceLeases?.bind(host.persistence);
+  if (!listFn) return undefined;
+  const nowIso = new Date().toISOString();
+  return listFn().filter((lease) => (
+    lease.resourceKey === resourceKey
+    && (!lease.leaseExpiresAt || lease.leaseExpiresAt > nowIso)
+  )).length;
+}
+
+function poolMemberLoad(host: TaskRunnerPoolHost, poolId: string, member: ExecutionPoolMember): number {
+  if (member.type === 'ssh') {
+    const leaseLoad = sshHostLeaseLoad(host, member);
+    if (leaseLoad !== undefined) return leaseLoad;
+  }
+  return memoryPoolMemberLoad(host, poolId, poolMemberKey(member));
+}
+
 function poolMemberLimit(pool: ExecutionPoolConfig, member: ExecutionPoolMember): number | undefined {
   return member.maxConcurrentTasks ?? pool.maxConcurrentTasksPerMember;
 }
 
 function poolMemberHasCapacity(host: TaskRunnerPoolHost, poolId: string, pool: ExecutionPoolConfig, member: ExecutionPoolMember): boolean {
   const limit = poolMemberLimit(pool, member);
-  return limit === undefined || poolMemberLoad(host, poolId, poolMemberKey(member)) < limit;
+  return limit === undefined || poolMemberLoad(host, poolId, member) < limit;
 }
 
 function isPoolMemberDown(host: TaskRunnerPoolHost, memberKey: string, now: number = Date.now()): boolean {
@@ -218,8 +241,7 @@ export function selectPoolMember(
     .filter((member) => !excludedMemberKeys.has(poolMemberKey(member)))
     .filter((member) => !isPoolMemberDown(host, poolMemberKey(member)))
     .map((member, index) => {
-      const memberKey = poolMemberKey(member);
-      const load = poolMemberLoad(host, poolId, memberKey);
+      const load = poolMemberLoad(host, poolId, member);
       const limit = poolMemberLimit(pool, member);
       return {
         member,
@@ -255,7 +277,7 @@ function poolCapacitySnapshot(
     return {
       memberId: member.id,
       memberType: member.type,
-      load: poolMemberLoad(host, poolId, memberKey),
+      load: poolMemberLoad(host, poolId, member),
       limit: poolMemberLimit(pool, member),
       excluded: excludedMemberKeys.has(memberKey),
       down,

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -888,53 +888,61 @@ export class TaskRunner {
         selectedExecutor = this.selectExecutor(task);
         break;
       } catch (err) {
-        if (!(err instanceof ResourceLimitError)) {
+        const cause = err instanceof Error ? err.cause : undefined;
+        if (!(err instanceof ResourceLimitError) && !(cause instanceof ResourceLimitError)) {
           throw err;
         }
         capacityWaitAttempts += 1;
         const retryMs = Math.min(15_000 * 2 ** Math.max(0, capacityWaitAttempts - 1), 5 * 60_000);
+        const message = err instanceof Error ? err.message : String(err);
         this.persistence.logEvent?.(task.id, 'task.approved_fix_waiting', {
           attempts: capacityWaitAttempts,
-          message: err.message,
+          message,
           nextRetryAt: new Date(Date.now() + retryMs),
         });
         this.logger.info(
-          `[TaskRunner] approved-fix publish waiting for capacity task=${task.id} retryInMs=${retryMs}: ${err.message}`,
+          `[TaskRunner] approved-fix publish waiting for capacity task=${task.id} retryInMs=${retryMs}: ${message}`,
           { taskId: task.id, attempts: capacityWaitAttempts, retryMs },
         );
         await new Promise<void>((resolve) => setTimeout(resolve, retryMs));
       }
     }
-    const executor = selectedExecutor.executor;
-    let result: { commitHash?: string; error?: string };
-    if (executor instanceof SshExecutor) {
-      result = await executor.publishApprovedFix(publishWorkspacePath, request, branch);
-    } else if (executor instanceof BaseExecutor) {
-      result = await executor.publishApprovedFix(publishWorkspacePath, request, branch);
-    } else {
-      throw new Error(
-        `Executor ${executor.type} does not support approved-fix publish for task ${task.id}`,
-      );
-    }
+    const poolSelection = this.pendingPoolSelections.get(task.id);
+    try {
+      const executor = selectedExecutor.executor;
+      let result: { commitHash?: string; error?: string };
+      if (executor instanceof SshExecutor) {
+        result = await executor.publishApprovedFix(publishWorkspacePath, request, branch);
+      } else if (executor instanceof BaseExecutor) {
+        result = await executor.publishApprovedFix(publishWorkspacePath, request, branch);
+      } else {
+        throw new Error(
+          `Executor ${executor.type} does not support approved-fix publish for task ${task.id}`,
+        );
+      }
 
-    if (result.error) {
-      throw new Error(result.error);
-    }
-    if (!result.commitHash) {
-      throw new Error(`Approved-fix publish produced no commit hash for task ${task.id}`);
-    }
+      if (result.error) {
+        throw new Error(result.error);
+      }
+      if (!result.commitHash) {
+        throw new Error(`Approved-fix publish produced no commit hash for task ${task.id}`);
+      }
 
-    this.persistence.updateTask(task.id, {
-      execution: {
-        commit: result.commitHash,
-      },
-    });
-    const attemptId = task.execution.selectedAttemptId;
-    if (attemptId) {
-      this.persistence.updateAttempt(attemptId, {
-        branch,
-        commit: result.commitHash,
+      this.persistence.updateTask(task.id, {
+        execution: {
+          commit: result.commitHash,
+        },
       });
+      const attemptId = task.execution.selectedAttemptId;
+      if (attemptId) {
+        this.persistence.updateAttempt(attemptId, {
+          branch,
+          commit: result.commitHash,
+        });
+      }
+    } finally {
+      this.releasePoolSelectionLease(poolSelection);
+      this.pendingPoolSelections.delete(task.id);
     }
   }
 

--- a/scripts/repro/repro-ssh-lease-capacity-authority.sh
+++ b/scripts/repro/repro-ssh-lease-capacity-authority.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Proof / gate for durable SSH lease capacity authority.
 #
-# Default: run the proof suite (it.fails documents today's memory-backed bugs).
-# Pass --gate after slices 2–4 land to require the fixed (non-.fails) suite.
+# Default: run the authority proof suite.
+# Pass --gate to also require the lease-capacity battery.
 set -euo pipefail
 
 RUN_GATES=0

--- a/scripts/repro/repro-ssh-lease-capacity-battery.sh
+++ b/scripts/repro/repro-ssh-lease-capacity-battery.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Required gate: durable SSH lease capacity under orphan/churn/parity scenarios.
+#
+# Usage:
+#   bash scripts/repro/repro-ssh-lease-capacity-battery.sh
+#   bash scripts/repro/repro-ssh-lease-capacity-battery.sh --gate
+set -euo pipefail
+
+for arg in "$@"; do
+  case "$arg" in
+    --gate) ;; # accepted; battery is always the gate suite
+  esac
+done
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "gate: SSH lease capacity battery"
+cd packages/execution-engine
+pnpm exec vitest run src/__tests__/ssh-lease-capacity-battery.test.ts
+echo "PASS: SSH lease capacity battery"


### PR DESCRIPTION
## Summary

Ghost-slot wedges returned because nothing forced lease/occupancy invariants under churn.

This battery covers orphan ghosts, cross-pool exclusivity, refill after preempt-style churn, and lease/occupancy parity. Run it with `--gate`.

## Review Claim

Approve the required SSH lease capacity e2e battery as the regression proof gate after the lease authority fix.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

In-process fixture executors only. No real DigitalOcean SSH and no Playwright UI.

## Slice Rationale

The activating gate lands after the behavior fix so CI requires the fixed contract, not the old memory bugs.

## Non-goals

No launch-outbox stall coverage, UI queued-state work, or docs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-ssh-lease-capacity-battery.sh --gate`
- [ ] `bash scripts/repro/repro-ssh-lease-capacity-authority.sh --gate`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d6d6018de`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4959