### PR TITLE
[Latest Check Rollup](1) Count only the latest GitHub check run per name

### DIFF
--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -623,6 +623,117 @@ describe('GitHubMergeGateProvider', () => {
       });
     });
 
+    it('uses only the latest check run per name from historical statusCheckRollup', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'OPEN',
+            reviewDecision: 'APPROVED',
+            url: 'https://github.com/owner/repo/pull/4583',
+            headRefOid: 'headsha',
+            headRefName: 'stack/ui-responsiveness',
+            mergeStateStatus: 'CLEAN',
+            statusCheckRollup: [
+              {
+                name: 'PR Body',
+                status: 'COMPLETED',
+                conclusion: 'FAILURE',
+                completedAt: '2026-07-15T04:02:25Z',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/1',
+              },
+              {
+                name: 'PR Body',
+                status: 'COMPLETED',
+                conclusion: 'CANCELLED',
+                completedAt: '2026-07-15T05:00:00Z',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/2',
+              },
+              {
+                name: 'PR Body',
+                status: 'COMPLETED',
+                conclusion: 'FAILURE',
+                completedAt: '2026-07-15T06:00:00Z',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/3',
+              },
+              {
+                name: 'PR Body',
+                status: 'COMPLETED',
+                conclusion: 'SUCCESS',
+                completedAt: '2026-07-15T09:10:14Z',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/4',
+              },
+              {
+                name: 'quality / TypeScript Types',
+                status: 'COMPLETED',
+                conclusion: 'SUCCESS',
+                completedAt: '2026-07-15T09:11:00Z',
+              },
+            ],
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '4583', cwd: '/tmp/repo' });
+
+      expect(result.checks).toEqual({ state: 'success', failed: [] });
+    });
+
+    it('reports failure from the latest check when older runs of the same name succeeded', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'OPEN',
+            reviewDecision: null,
+            url: 'https://github.com/owner/repo/pull/9',
+            headRefOid: 'headsha',
+            headRefName: 'feature/regressed',
+            mergeStateStatus: 'CLEAN',
+            statusCheckRollup: [
+              {
+                name: 'PR Body',
+                status: 'COMPLETED',
+                conclusion: 'SUCCESS',
+                completedAt: '2026-07-15T01:00:00Z',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/old',
+              },
+              {
+                name: 'PR Body',
+                status: 'COMPLETED',
+                conclusion: 'FAILURE',
+                completedAt: '2026-07-15T09:00:00Z',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/new',
+                summary: 'Body invalid',
+              },
+            ],
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '9', cwd: '/tmp/repo' });
+
+      expect(result.checks).toEqual({
+        state: 'failure',
+        failed: [
+          {
+            name: 'PR Body',
+            conclusion: 'FAILURE',
+            detailsUrl: 'https://github.com/owner/repo/actions/runs/new',
+            summary: 'Body invalid',
+          },
+        ],
+      });
+    });
+
     it('marks only DIRTY merge state as a merge conflict signal', async () => {
       process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
       const { spawn } = await import('node:child_process');

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -346,14 +346,37 @@ function stringProp(value: Record<string, unknown>, ...keys: string[]): string |
   return undefined;
 }
 
+function checkRecencyMs(check: Record<string, unknown>): number {
+  const stamp = stringProp(check, 'completedAt', 'startedAt');
+  if (!stamp) return Number.NEGATIVE_INFINITY;
+  const ms = Date.parse(stamp);
+  return Number.isFinite(ms) ? ms : Number.NEGATIVE_INFINITY;
+}
+
+// statusCheckRollup retains historical runs; only the latest per name is current.
+function latestStatusChecksByName(items: unknown[]): Record<string, unknown>[] {
+  const latestByName = new Map<string, { check: Record<string, unknown>; recency: number; index: number }>();
+  items.forEach((item, index) => {
+    if (!item || typeof item !== 'object') return;
+    const check = item as Record<string, unknown>;
+    const name = stringProp(check, 'name', 'workflowName', 'context') ?? 'unknown check';
+    const recency = checkRecencyMs(check);
+    const previous = latestByName.get(name);
+    if (!previous || recency > previous.recency || (recency === previous.recency && index > previous.index)) {
+      latestByName.set(name, { check, recency, index });
+    }
+  });
+  return [...latestByName.values()]
+    .sort((a, b) => a.index - b.index)
+    .map((entry) => entry.check);
+}
+
 function summarizeStatusChecks(items: unknown[] | undefined): MergeGateApprovalStatus['checks'] {
   if (!Array.isArray(items) || items.length === 0) return undefined;
 
   let hasPending = false;
   const failed: MergeGateFailedCheck[] = [];
-  for (const item of items) {
-    if (!item || typeof item !== 'object') continue;
-    const check = item as Record<string, unknown>;
+  for (const check of latestStatusChecksByName(items)) {
     const name = stringProp(check, 'name', 'workflowName', 'context') ?? 'unknown check';
     const status = stringProp(check, 'status')?.toUpperCase();
     const conclusion = stringProp(check, 'conclusion')?.toUpperCase();


### PR DESCRIPTION
## Summary

Review-gate CI status was reading every historical check run on a PR.

GitHub's statusCheckRollup keeps old cancelled and failed PR Body runs after body edits and recreates.

That made fixed PRs still look red, and the inspector repeated PR Body for each old run.

This change keeps only the latest run per check name before classifying success or failure.

## Review Claim

Review-gate check summary uses the latest GitHub check run per name, not the full historical rollup.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the GitHub check summarizer changes. PR creation, merge conflict detection, and UI rendering stay the same.

A later SUCCESS still clears older FAILURE or CANCELLED runs for that same check name.

A later FAILURE still reports that check as failing.

## Slice Rationale

This is one behavior fix plus its regression coverage. A separate proof-only branch would leave the bug unaddressed on the fix branch.

## Non-goals

- No UI component changes.
- No change to which GitHub fields are fetched.
- No Mergify or PR Body workflow changes.
- No head-SHA filtering for checks that re-run on the same commit.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test src/__tests__/github-merge-gate-provider.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c4fa2202a`
- Post-revert steps: None
- Data migration? No

</details>
