### PR TITLE
[Queued Launch Claim](1) Accept queued status in launch dispatch claim

### DIFF
--- a/packages/app/src/global-topup.ts
+++ b/packages/app/src/global-topup.ts
@@ -132,7 +132,7 @@ function executeRunnableTasks({
 export function isDispatchableLaunch(task: TaskState): boolean {
   return task.status === 'running'
     || (
-      task.status === 'pending'
+      (task.status === 'pending' || (task.status as string) === 'queued')
       && task.execution.phase === 'launching'
       && !!task.execution.selectedAttemptId
     );

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1517,6 +1517,28 @@ describe('SQLiteAdapter', () => {
         expect(after?.lastError).toMatch(/status is failed/);
       });
 
+      it('claims queued launch-wait tasks written by deferRunningUntilLaunch', () => {
+        setupWorkflowAndTask('wf-launch', 'wf-launch/t1', {
+          selectedAttemptId: 'attempt-queued-task',
+          status: 'queued',
+        });
+        const row = adapter.enqueueLaunchDispatch({
+          taskId: 'wf-launch/t1',
+          attemptId: 'attempt-queued-task',
+          workflowId: 'wf-launch',
+          generation: 0,
+        });
+
+        const claimed = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-queued',
+          nowIso: '2026-06-03T00:02:30.000Z',
+        });
+
+        expect(claimed?.id).toBe(row.id);
+        expect(claimed?.state).toBe('leased');
+        expect(adapter.loadLaunchDispatchById(row.id)?.state).toBe('leased');
+      });
+
       it('abandons missing-task candidates', () => {
         adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
         (adapter as any).db.run('PRAGMA foreign_keys = OFF');

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3100,12 +3100,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
         const candidateId = Number(candidate.id);
 
         let staleReason: string | undefined;
+        const taskStatus = String(candidate.current_task_status ?? '');
+        const launchClaimable = taskStatus === 'pending' || taskStatus === 'queued';
         if (!candidate.current_task_id) {
           staleReason = `Launch dispatch ${candidateId} is stale: task ${String(candidate.task_id)} no longer exists`;
-        } else if (String(candidate.current_task_status) !== 'pending') {
+        } else if (!launchClaimable) {
           staleReason =
             `Launch dispatch ${candidateId} is stale: task ${String(candidate.task_id)} ` +
-            `status is ${String(candidate.current_task_status)}`;
+            `status is ${taskStatus}`;
         } else if (String(candidate.current_selected_attempt_id ?? '') !== String(candidate.attempt_id)) {
           staleReason =
             `Launch dispatch ${candidateId} is stale: attempt ${String(candidate.attempt_id)} ` +


### PR DESCRIPTION
## Summary

After recreate or capacity wait, tasks sit in `queued` with an enqueued launch row. The dispatcher then silently abandons that row because claim only accepted `pending`.

Restart cleared in-memory capacity parks, so capacity defers stopped, but the outbox still never emitted `launch_dispatch_claimed`. Tasks looked stuck forever.

This change treats `queued` like `pending` for launch claim and for dispatchable-launch filtering.

## Review Claim

Approve claiming launch-dispatch rows when the task is in durable `queued` launch-wait status, matching `deferRunningUntilLaunch`.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

Failed, running, and other non-launch statuses still abandon stale outbox rows. Only `pending` and `queued` are claimable.

## Slice Rationale

This is the minimal fence fix for the recreate/restart stall. Broader stranded-launch recovery can follow separately.

## Non-goals

No SSH lease capacity changes. No UI queued-state work. No launch-outbox topology redesign.

## Architecture

### Before

```mermaid
flowchart LR
  drain["drainScheduler writes queued"] --> enqueue["outbox enqueued"]
  enqueue --> claim["claim requires pending"]
  claim --> abandon["abandon silently"]
```

### After

```mermaid
flowchart LR
  drain["drainScheduler writes queued"] --> enqueue["outbox enqueued"]
  enqueue --> claim["claim accepts pending or queued"]
  claim --> start["launch_dispatch_claimed then TaskRunner"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/data-store && pnpm exec vitest run src/__tests__/sqlite-adapter.test.ts -t "claimLaunchDispatchAtomic"`
- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/launch-claim-orphan-regression.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 494d430e3`
- Post-revert steps: None
- Data migration? No

</details>
