### PR TITLE
[Durable SSH Pool Capacity](8b) Route start-ready recreate modes

### DIFF
--- a/packages/app/src/__tests__/start-ready.test.ts
+++ b/packages/app/src/__tests__/start-ready.test.ts
@@ -36,7 +36,8 @@ function harness(initialTasks: TaskState[], readyTasks: TaskState[], activeTaskI
     }),
     recreateWorkflow: vi.fn((workflowId: string) => {
       const recreated = makeTask(`${workflowId}/recreated`, 'pending');
-      tasks = tasks.filter((task) => task.config.workflowId !== workflowId || task.status !== 'failed');
+      tasks = tasks.filter((task) => task.config.workflowId !== workflowId
+        || (task.status !== 'failed' && task.status !== 'pending' && (task.status as string) !== 'queued'));
       tasks.push(recreated);
       readyTasks.push(recreated);
       return [recreated];
@@ -61,11 +62,15 @@ describe('start-ready', () => {
       readyTaskIds: ['wf-1/ready'],
       recoverableTaskIds: ['wf-1/recoverable'],
       failedWorkflowIds: ['wf-2'],
+      pendingWorkflowIds: ['wf-1'],
+      runningWorkflowIds: [],
       skipped: {
         awaitingApproval: 1,
         reviewReady: 0,
         blocked: 1,
         failedTasks: 1,
+        pendingTasks: 2,
+        runningTasks: 0,
       },
     });
   });
@@ -113,12 +118,82 @@ describe('start-ready', () => {
 
   it('recreates failed workflows only when requested', () => {
     const failed = makeTask('wf-1/failed', 'failed');
-    const orchestrator = harness([failed], []);
+    const pendingOnly = makeTask('wf-2/pending', 'pending');
+    const orchestrator = harness([failed, pendingOnly], []);
 
     const result = runStartReady(orchestrator, { recreateFailed: true });
 
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(orchestrator.recreateWorkflow).not.toHaveBeenCalledWith('wf-2');
     expect(result.recreatedWorkflowIds).toEqual(['wf-1']);
     expect(result.started.map((task) => task.id)).toEqual(['wf-1/recreated']);
+  });
+
+  it('recreates failed and pending/queued workflows when requested', () => {
+    const failed = makeTask('wf-1/failed', 'failed');
+    const pendingOnly = makeTask('wf-2/pending', 'pending');
+    const queuedOnly = makeTask('wf-3/queued', 'queued' as TaskState['status']);
+    const orchestrator = harness([failed, pendingOnly, queuedOnly], []);
+
+    const result = runStartReady(orchestrator, { recreateFailedAndPending: true });
+
+    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-2');
+    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-3');
+    expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2', 'wf-3']);
+  });
+
+  it('prefers failed-and-pending union when both recreate flags are set', () => {
+    const failed = makeTask('wf-1/failed', 'failed');
+    const pendingOnly = makeTask('wf-2/pending', 'pending');
+    const orchestrator = harness([failed, pendingOnly], []);
+
+    const result = runStartReady(orchestrator, {
+      recreateFailed: true,
+      recreateFailedAndPending: true,
+    });
+
+    expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2']);
+  });
+
+  it('recreates failed, pending/queued, and running workflows when requested', () => {
+    const failed = makeTask('wf-1/failed', 'failed');
+    const pendingOnly = makeTask('wf-2/pending', 'pending');
+    const runningOnly = makeTask('wf-3/running', 'running');
+    const approval = makeTask('wf-4/approval', 'awaiting_approval');
+    const orchestrator = harness([failed, pendingOnly, runningOnly, approval], []);
+
+    const result = runStartReady(orchestrator, { recreateFailedPendingAndRunning: true });
+
+    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-2');
+    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-3');
+    expect(orchestrator.recreateWorkflow).not.toHaveBeenCalledWith('wf-4');
+    expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2', 'wf-3']);
+  });
+
+  it('failed-and-pending does not recreate running-only workflows', () => {
+    const runningOnly = makeTask('wf-1/running', 'running');
+    const orchestrator = harness([runningOnly], []);
+
+    const result = runStartReady(orchestrator, { recreateFailedAndPending: true });
+
+    expect(orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+    expect(result.recreatedWorkflowIds).toEqual([]);
+  });
+
+  it('prefers failed-pending-and-running union when all recreate flags are set', () => {
+    const failed = makeTask('wf-1/failed', 'failed');
+    const pendingOnly = makeTask('wf-2/pending', 'pending');
+    const runningOnly = makeTask('wf-3/running', 'running');
+    const orchestrator = harness([failed, pendingOnly, runningOnly], []);
+
+    const result = runStartReady(orchestrator, {
+      recreateFailed: true,
+      recreateFailedAndPending: true,
+      recreateFailedPendingAndRunning: true,
+    });
+
+    expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2', 'wf-3']);
   });
 });

--- a/packages/app/src/start-ready.ts
+++ b/packages/app/src/start-ready.ts
@@ -64,21 +64,59 @@ function uniqueTasks(tasks: readonly TaskState[]): TaskState[] {
   return result;
 }
 
+function isPendingOrQueued(task: TaskState): boolean {
+  return task.status === 'pending' || (task.status as string) === 'queued';
+}
+
+function unionWorkflowIds(...groups: readonly (readonly string[])[]): string[] {
+  const ids = new Set<string>();
+  for (const group of groups) {
+    for (const id of group) ids.add(id);
+  }
+  return Array.from(ids);
+}
+
+function workflowIdsToRecreate(
+  request: StartReadyRequest,
+  preview: StartReadyPreview,
+): string[] {
+  if (request.recreateFailedPendingAndRunning) {
+    return unionWorkflowIds(
+      preview.failedWorkflowIds,
+      preview.pendingWorkflowIds,
+      preview.runningWorkflowIds,
+    );
+  }
+  if (request.recreateFailedAndPending) {
+    return unionWorkflowIds(preview.failedWorkflowIds, preview.pendingWorkflowIds);
+  }
+  if (request.recreateFailed) {
+    return [...preview.failedWorkflowIds];
+  }
+  return [];
+}
+
 export function collectStartReadyPreview(orchestrator: StartReadyOrchestrator): StartReadyPreview {
   const tasks = orchestrator.getAllTasks();
   const readyTasks = orchestrator.getExecutableReadyTasks();
   const recoverableTasks = collectRecoverableTasks(orchestrator);
   const failedTasks = tasks.filter((task) => task.status === 'failed');
+  const pendingTasks = tasks.filter((task) => isPendingOrQueued(task));
+  const runningTasks = tasks.filter((task) => task.status === 'running');
 
   return {
     readyTaskIds: readyTasks.map((task) => task.id),
     recoverableTaskIds: recoverableTasks.map((task) => task.id),
     failedWorkflowIds: uniqueWorkflowIds(failedTasks),
+    pendingWorkflowIds: uniqueWorkflowIds(pendingTasks),
+    runningWorkflowIds: uniqueWorkflowIds(runningTasks),
     skipped: {
       awaitingApproval: tasks.filter((task) => task.status === 'awaiting_approval').length,
       reviewReady: tasks.filter((task) => task.status === 'review_ready').length,
       blocked: tasks.filter((task) => task.status === 'blocked' || task.status === 'needs_input').length,
       failedTasks: failedTasks.length,
+      pendingTasks: pendingTasks.length,
+      runningTasks: runningTasks.length,
     },
   };
 }
@@ -100,11 +138,9 @@ export function runStartReady(
 
   const started: TaskState[] = [];
   const recreatedWorkflowIds: string[] = [];
-  if (request.recreateFailed) {
-    for (const workflowId of preview.failedWorkflowIds) {
-      started.push(...orchestrator.recreateWorkflow(workflowId));
-      recreatedWorkflowIds.push(workflowId);
-    }
+  for (const workflowId of workflowIdsToRecreate(request, preview)) {
+    started.push(...orchestrator.recreateWorkflow(workflowId));
+    recreatedWorkflowIds.push(workflowId);
   }
 
   const recoverableTasks = collectRecoverableTasks(orchestrator);

--- a/packages/app/src/start-ready.ts
+++ b/packages/app/src/start-ready.ts
@@ -16,6 +16,19 @@ type StartReadyOrchestrator = Pick<
   | 'startExecution'
 >;
 
+type StartReadyRequestExt = StartReadyRequest & {
+  recreateFailedAndPending?: boolean;
+  recreateFailedPendingAndRunning?: boolean;
+};
+
+type StartReadyPreviewExt = StartReadyPreview & {
+  pendingWorkflowIds: string[];
+  runningWorkflowIds: string[];
+  skipped: StartReadyPreview['skipped'] & {
+    pendingTasks: number;
+    runningTasks: number;
+  };
+};
 function collectRecoverableTasks(orchestrator: StartReadyOrchestrator): TaskState[] {
   const activeTaskIds = orchestrator.getPersistedActiveTaskIds();
   return orchestrator
@@ -77,8 +90,8 @@ function unionWorkflowIds(...groups: readonly (readonly string[])[]): string[] {
 }
 
 function workflowIdsToRecreate(
-  request: StartReadyRequest,
-  preview: StartReadyPreview,
+  request: StartReadyRequestExt,
+  preview: StartReadyPreviewExt,
 ): string[] {
   if (request.recreateFailedPendingAndRunning) {
     return unionWorkflowIds(
@@ -104,7 +117,7 @@ export function collectStartReadyPreview(orchestrator: StartReadyOrchestrator): 
   const pendingTasks = tasks.filter((task) => isPendingOrQueued(task));
   const runningTasks = tasks.filter((task) => task.status === 'running');
 
-  return {
+  const preview: StartReadyPreviewExt = {
     readyTaskIds: readyTasks.map((task) => task.id),
     recoverableTaskIds: recoverableTasks.map((task) => task.id),
     failedWorkflowIds: uniqueWorkflowIds(failedTasks),
@@ -119,14 +132,16 @@ export function collectStartReadyPreview(orchestrator: StartReadyOrchestrator): 
       runningTasks: runningTasks.length,
     },
   };
+  return preview;
 }
 
 export function runStartReady(
   orchestrator: StartReadyOrchestrator,
   request: StartReadyRequest = {},
 ): StartReadyResult {
+  const extendedRequest = request as StartReadyRequestExt;
   orchestrator.syncAllFromDb();
-  const preview = collectStartReadyPreview(orchestrator);
+  const preview = collectStartReadyPreview(orchestrator) as StartReadyPreviewExt;
   if (request.dryRun) {
     return {
       preview,
@@ -138,7 +153,7 @@ export function runStartReady(
 
   const started: TaskState[] = [];
   const recreatedWorkflowIds: string[] = [];
-  for (const workflowId of workflowIdsToRecreate(request, preview)) {
+  for (const workflowId of workflowIdsToRecreate(extendedRequest, preview)) {
     started.push(...orchestrator.recreateWorkflow(workflowId));
     recreatedWorkflowIds.push(workflowId);
   }


### PR DESCRIPTION
## Summary

Start-ready recreate modes need backend support for pending/queued and running workflows.

This slice extends `runStartReady()` preview and workflow selection inside app code, while keeping the extra request and preview fields local for now.

## Review Claim

Approve app-side support for `recreateFailedAndPending` and `recreateFailedPendingAndRunning`, including preview counts and workflow recreation selection.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Default start-ready behavior is unchanged. Only explicit recreate modes widen which workflow ids are recreated before recovery and dispatch.

## Slice Rationale

The app has to understand the broader recreate sets before later slices can use them.

## Non-goals

No contract export changes. No extra operator affordances. No visual-proof updates.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/start-ready.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c3345b950`
- Post-revert steps: None
- Data migration? No

</details>

<!-- refresh-2026-07-18T23:57Z -->
