### PR TITLE
[Durable SSH Pool Capacity](11) Age out zombie leases without leaseExpiresAt

### DIFF
--- a/packages/workflow-core/src/__tests__/zombie-running-slot-leak.test.ts
+++ b/packages/workflow-core/src/__tests__/zombie-running-slot-leak.test.ts
@@ -51,4 +51,39 @@ describe('zombie running task consumes a concurrency slot', () => {
     expect(started.map((t) => t.id)).toContain(waitingId);
     expect(orchestrator.getTask(waitingId)!.status).toBe('running');
   });
+
+  it('does not count a running task with a missing leaseExpiresAt and stale heartbeat', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestratorWith(persistence, 1);
+
+    orchestrator.loadPlan({
+      name: 'zombie-no-lease-expiry',
+      baseBranch: 'master',
+      featureBranch: 'feature/zombie-no-lease',
+      tasks: [{ id: 'stuck', description: 'runs then strands without lease expiry' }],
+    });
+    const zombieId = orchestrator.getAllTasks().find((t) => t.id.endsWith('/stuck'))!.id;
+    orchestrator.startExecution();
+    expect(orchestrator.getTask(zombieId)!.status).toBe('running');
+
+    const attemptId = orchestrator.getTask(zombieId)!.execution.selectedAttemptId!;
+    const longAgo = new Date(Date.now() - 60 * 60 * 1000);
+    (persistence.updateAttempt as (id: string, changes: Record<string, unknown>) => void)(attemptId, {
+      leaseExpiresAt: undefined,
+      lastHeartbeatAt: longAgo,
+      claimedAt: longAgo,
+    });
+
+    orchestrator.loadPlan({
+      name: 'blocked-by-stale-heartbeat',
+      baseBranch: 'master',
+      featureBranch: 'feature/blocked-stale',
+      tasks: [{ id: 'wants-slot', description: 'ready, waiting for capacity' }],
+    });
+    const waitingId = orchestrator.getAllTasks().find((t) => t.id.endsWith('/wants-slot'))!.id;
+
+    const started = orchestrator.startExecution();
+    expect(started.map((t) => t.id)).toContain(waitingId);
+    expect(orchestrator.getQueueStatus({ refresh: true }).runningCount).toBeLessThanOrEqual(1);
+  });
 });

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -985,20 +985,31 @@ export class Orchestrator {
     return loadAttempt.call(this.persistence, attemptId);
   }
 
+    private attemptLeaseAnchor(attempt: Attempt): Date | undefined {
+    return attempt.lastHeartbeatAt ?? attempt.claimedAt ?? attempt.startedAt;
+  }
   private isAttemptLeaseActive(attempt: Attempt | undefined, now: number = Date.now()): boolean {
     if (!attempt) return false;
     if (isDiscardedAttempt(attempt)) return false;
     if (attempt.status !== 'claimed' && attempt.status !== 'running') return false;
-    if (!attempt.leaseExpiresAt) return true;
-    return attempt.leaseExpiresAt.getTime() >= now;
+    if (attempt.leaseExpiresAt) {
+      return attempt.leaseExpiresAt.getTime() >= now;
+    }
+    const anchor = this.attemptLeaseAnchor(attempt);
+    if (!anchor) return true;
+    return anchor.getTime() + ATTEMPT_LEASE_MS >= now;
   }
 
   private isAttemptLeaseExpired(attempt: Attempt | undefined, now: number = Date.now()): boolean {
     if (!attempt) return false;
     if (isDiscardedAttempt(attempt)) return false;
     if (attempt.status !== 'claimed' && attempt.status !== 'running') return false;
-    if (!attempt.leaseExpiresAt) return false;
-    return attempt.leaseExpiresAt.getTime() < now;
+    if (attempt.leaseExpiresAt) {
+      return attempt.leaseExpiresAt.getTime() < now;
+    }
+    const anchor = this.attemptLeaseAnchor(attempt);
+    if (!anchor) return false;
+    return anchor.getTime() + ATTEMPT_LEASE_MS < now;
   }
 
   private isTaskExecutionActive(
@@ -1014,7 +1025,20 @@ export class Orchestrator {
       return false;
     }
 
-    return task.status === 'running' || task.status === 'fixing_with_ai';
+    if (task.status !== 'running' && task.status !== 'fixing_with_ai') {
+      return false;
+    }
+    const raw = task.execution.lastHeartbeatAt
+      ?? task.execution.startedAt
+      ?? task.execution.launchStartedAt;
+    if (!raw) return true;
+    const ts = raw instanceof Date
+      ? raw.getTime()
+      : typeof raw === 'string'
+        ? Date.parse(raw)
+        : Number.NaN;
+    if (!Number.isFinite(ts)) return true;
+    return ts + ATTEMPT_LEASE_MS >= now;
   }
 
   private isExecutableResponseTask(task: TaskState): boolean {


### PR DESCRIPTION
## Summary

Running tasks could keep a concurrency slot forever when their attempt lost heartbeats but never set leaseExpiresAt.

This slice ages those attempts out using the same lease window as heartbeats, so ready work can claim the slot again.

## Review Claim

Approve aging out running attempts that lack leaseExpiresAt once their heartbeat claim or start anchor is older than ATTEMPT_LEASE_MS.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only lease liveness accounting changes. Launch completion and persistence schemas are unchanged.

## Slice Rationale

Slot leaks blocked capacity refill. Fix lease truth before UI and refill tooling.

## Non-goals

Does not change SSH host leases UI chips or start-ready recreate modes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/zombie-running-slot-leak.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
