### PR TITLE
[Durable SSH Pool Capacity](12) Prove queue UI lock and chip metric mismatch

### DIFF
--- a/scripts/repro/repro-queue-chip-executing-vs-slots.sh
+++ b/scripts/repro/repro-queue-chip-executing-vs-slots.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Prove UI "Executing" chip historically used runningCount (slots) which includes launching,
+# so Executing != active executions. Gate checks active+launching identity and that
+# chip semantics can separate active vs slots.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+python3 <<'PY'
+import json, re, subprocess, sys
+
+p = subprocess.run(
+    ["node", "./packages/app/dist/headless-client.js", "query", "queue", "--output", "json"],
+    capture_output=True, text=True, timeout=120,
+)
+raw = p.stdout + "\n" + p.stderr
+if "spawning detached standalone" in raw or "[init] Loaded" in raw:
+    print("FAIL local DB / standalone bootstrap", flush=True)
+    sys.exit(2)
+m = re.search(r'\{"maxConcurrency".*', raw, re.S)
+blob = m.group(0)
+depth = 0
+for i, ch in enumerate(blob):
+    if ch == "{":
+        depth += 1
+    elif ch == "}":
+        depth -= 1
+        if depth == 0:
+            q = json.loads(blob[: i + 1])
+            break
+
+rc = q["runningCount"]
+ac = q.get("activeExecutionCount")
+lc = q.get("launchingCount")
+queued = len(q.get("queued") or [])
+print(json.dumps({
+    "runningCount_slots": rc,
+    "activeExecutionCount": ac,
+    "launchingCount": lc,
+    "queued": queued,
+    "legacy_Executing_chip_would_show": f"{rc}/{q['maxConcurrency']}",
+    "correct_Executing_chip_should_show": f"{ac}/{q['maxConcurrency']}",
+    "slots_chip_should_show": f"{rc}/{q['maxConcurrency']}",
+}, indent=2))
+
+if ac is None or lc is None:
+    print("FAIL missing active/launching fields", flush=True)
+    sys.exit(2)
+if ac + lc != rc:
+    print(f"FAIL identity active+launching ({ac}+{lc}) != runningCount ({rc})", flush=True)
+    sys.exit(3)
+if ac < rc:
+    print("REPRO_CONFIRMED Executing_chip_using_runningCount_overstates_executing", flush=True)
+elif ac == rc:
+    print("NOTE all_slots_are_executing launching=0", flush=True)
+print("OK identity holds", flush=True)
+PY

--- a/scripts/repro/repro-queue-status-ui-lock.sh
+++ b/scripts/repro/repro-queue-status-ui-lock.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Prove owner getQueueStatus used by the UI must stay fast.
+# Under load, the old path (topo-sort + uncached attempt SQLite reads + full
+# descriptions) blocked Electron main for ~0.5–2s per 2s UI poll → drag lockup.
+#
+# Gate: with --gate, expect owner-delegated queue query p50 < 0.75s.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+GATE=0
+if [ "${1:-}" = "--gate" ]; then GATE=1; fi
+
+python3 - "$GATE" <<'PY'
+import json, re, statistics, subprocess, sys, time
+
+gate = sys.argv[1] == "1"
+
+def queue_once():
+    t0 = time.time()
+    p = subprocess.run(
+        ["node", "./packages/app/dist/headless-client.js", "query", "queue", "--output", "json"],
+        capture_output=True, text=True, timeout=120,
+    )
+    dt = time.time() - t0
+    raw = p.stdout + "\n" + p.stderr
+    if "spawning detached standalone" in raw or "[init] Loaded" in raw:
+        raise RuntimeError("local DB / standalone bootstrap — not measuring owner UI path")
+    m = re.search(r'\{"maxConcurrency".*', raw, re.S)
+    if not m:
+        raise RuntimeError("no queue json: " + raw[-400:])
+    blob = m.group(0)
+    depth = 0
+    for i, ch in enumerate(blob):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return dt, json.loads(blob[: i + 1]), ("mode=gui" in raw or "ownerId=" in raw)
+    raise RuntimeError("unbalanced")
+
+times = []
+last = None
+mode_gui = False
+for i in range(5):
+    dt, obj, mode_gui = queue_once()
+    times.append(dt)
+    last = obj
+    desc_bytes = sum(len(x.get("description") or "") for x in obj.get("running") or [])
+    print(
+        f"sample[{i}] {dt:.3f}s runningCount={obj['runningCount']} "
+        f"active={obj.get('activeExecutionCount')} launching={obj.get('launchingCount')} "
+        f"queued={len(obj['queued'])} desc_bytes={desc_bytes} mode_gui={mode_gui}",
+        flush=True,
+    )
+
+p50 = statistics.median(times)
+mx = max(times)
+print(f"RESULT p50={p50:.3f}s max={mx:.3f}s", flush=True)
+if last:
+    ac = last.get("activeExecutionCount") or 0
+    lc = last.get("launchingCount") or 0
+    rc = last.get("runningCount") or 0
+    if ac + lc != rc:
+        print(f"FAIL count identity active+launching={ac+lc} runningCount={rc}", flush=True)
+        sys.exit(2)
+    if len(last["running"]) != rc:
+        print(f"FAIL running list len={len(last['running'])} runningCount={rc}", flush=True)
+        sys.exit(3)
+
+THRESHOLD = 0.75
+if gate:
+    if not mode_gui:
+        print("GATE_FAIL not talking to GUI owner", flush=True)
+        sys.exit(1)
+    if p50 > THRESHOLD:
+        print(f"GATE_FAIL p50={p50:.3f}s > {THRESHOLD}s (UI poll will hitch)", flush=True)
+        sys.exit(1)
+    print(f"GATE_PASS p50={p50:.3f}s <= {THRESHOLD}s", flush=True)
+else:
+    if p50 > THRESHOLD:
+        print(f"REPRO_CONFIRMED slow_queue_query p50={p50:.3f}s (expected before fix)", flush=True)
+    else:
+        print(f"ALREADY_FAST p50={p50:.3f}s", flush=True)
+sys.exit(0)
+PY

--- a/scripts/repro/repro-running-pill-vs-queue-slots.sh
+++ b/scripts/repro/repro-running-pill-vs-queue-slots.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Prove UI "workflows running (N)" is a workflow-status count, not queue slots.
+# Historical confusion: chip said "Running (14)" next to "Executing 13/13" + "Queued (4)".
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+python3 <<'PY'
+import json, re, subprocess, sys
+
+def run(args):
+    p = subprocess.run(
+        ["node", "./packages/app/dist/headless-client.js", *args],
+        capture_output=True, text=True, timeout=120,
+    )
+    raw = p.stdout + "\n" + p.stderr
+    if "mode=gui" not in raw and "ownerId=" not in raw:
+        # Still OK if stdout is pure JSON from delegated path with quiet logs
+        pass
+    if "spawning detached standalone" in raw or "[init] Loaded" in raw:
+        print("FAIL opened local DB / bootstrapped standalone instead of GUI owner", flush=True)
+        sys.exit(2)
+    return raw, p.returncode
+
+raw_q, code = run(["query", "queue", "--output", "json"])
+if code != 0:
+    print(raw_q[-500:])
+    sys.exit(code)
+m = re.search(r'\{"maxConcurrency".*', raw_q, re.S)
+blob = m.group(0)
+depth = 0
+q = None
+for i, ch in enumerate(blob):
+    if ch == "{":
+        depth += 1
+    elif ch == "}":
+        depth -= 1
+        if depth == 0:
+            q = json.loads(blob[: i + 1])
+            break
+assert q is not None
+
+raw_w, code = run(["query", "workflows", "--output", "json"])
+if code != 0:
+    print(raw_w[-500:])
+    sys.exit(code)
+arr_i = raw_w.find("[")
+workflows = json.loads(raw_w[arr_i:])
+wf_running = sum(1 for w in workflows if w.get("status") == "running")
+
+slots = q["runningCount"]
+active = q.get("activeExecutionCount")
+launching = q.get("launchingCount")
+queued = len(q.get("queued") or [])
+
+print(json.dumps({
+    "workflow_pill_running": wf_running,
+    "queue_slots_runningCount": slots,
+    "queue_activeExecutionCount": active,
+    "queue_launchingCount": launching,
+    "queue_queued": queued,
+    "mismatch_workflow_vs_slots": wf_running != slots,
+    "mismatch_slots_vs_active": slots != active,
+}, indent=2), flush=True)
+
+if active is None or launching is None:
+    print("FAIL missing active/launching fields", flush=True)
+    sys.exit(3)
+if active + launching != slots:
+    print(f"FAIL identity {active}+{launching} != {slots}", flush=True)
+    sys.exit(4)
+
+if wf_running != slots or slots != active:
+    print(
+        "REPRO_CONFIRMED distinct_metrics: "
+        "workflows running pill counts workflows; "
+        "Executing/Slots chips count task attempts; "
+        "Queued is ready-but-not-slotted tasks",
+        flush=True,
+    )
+else:
+    print("NOTE all three metrics currently equal (no mismatch visible)", flush=True)
+print("OK", flush=True)
+PY


### PR DESCRIPTION
## Summary

Operators could not tell whether a frozen UI came from slow queue polls or from confusing chip metrics.

This slice adds repro scripts that measure owner queue latency and show workflows-running versus Executing Slots and Queued.

## Review Claim

Approve adding repro scripts that prove slow queue polls and distinct capacity metrics before the fixes land.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Scripts are read-only against a live GUI owner and do not change product runtime behavior.

## Slice Rationale

Evidence before change: demonstrate the hitch and metric mismatch before the fast-path and chip label slices.

## Non-goals

Does not change orchestrator or UI behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-queue-status-ui-lock.sh`
- [x] `bash scripts/repro/repro-running-pill-vs-queue-slots.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
