### PR TITLE
[Durable SSH Pool Capacity](13) Keep queue status UI polls off the DB hot path

### DIFF
--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -230,7 +230,7 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     onActivity: deps.onActivity,
     getUiPerfStats: deps.getUiPerfStats,
     resetUiPerfStats: deps.resetUiPerfStats,
-    getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
+    getQueueStatus: () => orchestrator.getQueueStatus({ refresh: false }) as unknown as Record<string, unknown>,
     getWorkerStatus: deps.getWorkerStatus,
     getWorkers: deps.getWorkers,
     listWorkerActionHistory: (request: WorkerActionHistoryRequest) => listWorkerActionHistory(persistence, request),

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -108,7 +108,7 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       case 'invoker:get-status':
         return orchestrator.getWorkflowStatus();
       case 'invoker:get-queue-status':
-        return orchestrator.getQueueStatus();
+        return orchestrator.getQueueStatus({ refresh: false });
       case 'invoker:get-worker-status':
       case 'invoker:get-workers':
         return deps.getWorkers?.() ?? { generatedAt: new Date().toISOString(), workers: [] };

--- a/packages/workflow-core/src/__tests__/queue-status-ui-poll-fast-path.test.ts
+++ b/packages/workflow-core/src/__tests__/queue-status-ui-poll-fast-path.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Orchestrator } from '../orchestrator.js';
+import { InMemoryPersistence, InMemoryBus } from './helpers/cross-workflow-cascade-helpers.js';
+
+describe('getQueueStatus UI poll fast path', () => {
+  it('refresh:false skips launch-order snapshot work and caches briefly', () => {
+    const persistence = new InMemoryPersistence();
+    const loadAttempt = vi.spyOn(persistence, 'loadAttempt');
+    const orchestrator = new Orchestrator({
+      persistence,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 2,
+    });
+
+    orchestrator.loadPlan({
+      name: 'ui-poll-fast',
+      baseBranch: 'master',
+      featureBranch: 'feature/ui-poll',
+      tasks: [
+        { id: 'a', description: 'A'.repeat(400) },
+        { id: 'b', description: 'B', dependencies: ['a'] },
+        { id: 'c', description: 'C' },
+      ],
+    });
+    orchestrator.startExecution();
+
+    loadAttempt.mockClear();
+    const first = orchestrator.getQueueStatus({ refresh: false });
+    expect(first.runningCount).toBeGreaterThan(0);
+    expect(first.running[0]?.description.length).toBeLessThanOrEqual(160);
+    // UI poll must not hit SQLite/attempt storage — that is what froze the GUI.
+    expect(loadAttempt).not.toHaveBeenCalled();
+
+    const second = orchestrator.getQueueStatus({ refresh: false });
+    expect(second).toBe(first);
+    expect(loadAttempt).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -666,6 +666,11 @@ export class Orchestrator {
 
   private activeWorkflowIds = new Set<string>();
   private deferredTaskIds = new Set<string>();
+  /** Coalesces UI polls (`refresh: false`) so IPC does not recompute every 2s. */
+  private queueStatusUiCache:
+    | { at: number; value: ReturnType<Orchestrator['getQueueStatus']> }
+    | null = null;
+  private static readonly QUEUE_STATUS_UI_CACHE_MS = 2500;
   /**
    * Owner-local backoff for tasks deferred due to execution-pool capacity.
    * Keyed to `deferredTaskIds` membership: the periodic scheduler skips
@@ -764,6 +769,7 @@ export class Orchestrator {
     }
     const id = existing.id;
     this.taskRepository.updateTask(id, changes);
+    this.queueStatusUiCache = null;
     const updated: TaskState = {
       ...existing,
       ...(changes.status !== undefined ? { status: changes.status } : {}),
@@ -985,9 +991,10 @@ export class Orchestrator {
     return loadAttempt.call(this.persistence, attemptId);
   }
 
-    private attemptLeaseAnchor(attempt: Attempt): Date | undefined {
+  private attemptLeaseAnchor(attempt: Attempt): Date | undefined {
     return attempt.lastHeartbeatAt ?? attempt.claimedAt ?? attempt.startedAt;
   }
+
   private isAttemptLeaseActive(attempt: Attempt | undefined, now: number = Date.now()): boolean {
     if (!attempt) return false;
     if (isDiscardedAttempt(attempt)) return false;
@@ -3148,23 +3155,79 @@ export class Orchestrator {
     running: Array<{ taskId: string; attemptId?: string; description: string }>;
     queued: Array<{ taskId: string; priority: number; description: string }>;
   } {
-    if (options?.refresh !== false) {
+    const refresh = options?.refresh !== false;
+    const uiPoll = !refresh;
+    if (uiPoll && this.queueStatusUiCache) {
+      const age = Date.now() - this.queueStatusUiCache.at;
+      if (age >= 0 && age < Orchestrator.QUEUE_STATUS_UI_CACHE_MS) {
+        return this.queueStatusUiCache.value;
+      }
+    }
+    if (refresh) {
       this.refreshFromDb();
     }
+    // UI polls must stay cheap on the Electron main thread: no per-attempt
+    // SQLite reads, no launch-order topo sort. Full path keeps exact semantics.
+    const attemptCache = new Map<string, Attempt | undefined>();
+    const loadAttemptCached = (attemptId: string | undefined): Attempt | undefined => {
+      if (!attemptId) return undefined;
+      if (attemptCache.has(attemptId)) return attemptCache.get(attemptId);
+      const attempt = this.loadAttemptById(attemptId);
+      attemptCache.set(attemptId, attempt);
+      return attempt;
+    };
+    const summarizeDescription = (description: string): string => {
+      if (!uiPoll || description.length <= 160) return description;
+      return `${description.slice(0, 157)}...`;
+    };
+    const taskLivenessActive = (task: TaskState, nowMs: number): boolean => {
+      if (isCrashPreservedExecution(task.execution)) return false;
+      const raw = task.execution.lastHeartbeatAt
+        ?? task.execution.startedAt
+        ?? task.execution.launchStartedAt;
+      if (!raw) return true;
+      const ts = raw instanceof Date
+        ? raw.getTime()
+        : typeof raw === 'string'
+          ? Date.parse(raw)
+          : Number.NaN;
+      if (!Number.isFinite(ts)) return true;
+      return ts + ATTEMPT_LEASE_MS >= nowMs;
+    };
     const tasks = this.stateMachine.getAllTasks();
     const now = Date.now();
-    const activeAttempts = tasks
-      .filter((task) =>
-        task.status === 'running'
-        || task.status === 'fixing_with_ai'
-        || ((task.status === 'pending' || (task.status as string) === 'queued') && !!task.execution.selectedAttemptId),
-      )
-      .map((task) => {
-        const attemptId = task.execution.selectedAttemptId;
-        const attempt = this.loadAttemptById(attemptId);
-        return { task, attemptId, attempt };
-      })
-      .filter(({ task, attempt }) => this.isTaskExecutionActive(task, attempt, now));
+    const activeAttempts = uiPoll
+      ? tasks
+        .filter((task) => {
+          if (task.status === 'running' || task.status === 'fixing_with_ai') {
+            return taskLivenessActive(task, now);
+          }
+          if (
+            (task.status === 'pending' || (task.status as string) === 'queued')
+            && task.execution.phase === 'launching'
+            && !!task.execution.selectedAttemptId
+          ) {
+            return taskLivenessActive(task, now);
+          }
+          return false;
+        })
+        .map((task) => ({
+          task,
+          attemptId: task.execution.selectedAttemptId,
+          attempt: undefined as Attempt | undefined,
+        }))
+      : tasks
+        .filter((task) =>
+          task.status === 'running'
+          || task.status === 'fixing_with_ai'
+          || ((task.status === 'pending' || (task.status as string) === 'queued') && !!task.execution.selectedAttemptId),
+        )
+        .map((task) => {
+          const attemptId = task.execution.selectedAttemptId;
+          const attempt = loadAttemptCached(attemptId);
+          return { task, attemptId, attempt };
+        })
+        .filter(({ task, attempt }) => this.isTaskExecutionActive(task, attempt, now));
     const activeTaskIds = new Set(activeAttempts.map(({ task }) => task.id));
     const workflowBlockerCache = new Map<string, string | undefined>();
     const isExternallyBlocked = (task: TaskState): boolean => {
@@ -3175,35 +3238,46 @@ export class Orchestrator {
       }
       return workflowBlockerCache.get(workflowId) !== undefined;
     };
-    const queuedJobs = getPendingLaunchQueueSnapshotImpl(
-      this as unknown as SchedulerDomainHost,
-      this.stateMachine
-        .getReadyTasks()
-        .filter((task) => task.status === 'pending' || (task.status as string) === 'queued')
-        .filter((task) => !activeTaskIds.has(task.id))
-        .filter((task) => !isExternallyBlocked(task))
+    const readyCandidates = this.stateMachine
+      .getReadyTasks()
+      .filter((task) => task.status === 'pending' || (task.status as string) === 'queued')
+      .filter((task) => !activeTaskIds.has(task.id))
+      .filter((task) => !isExternallyBlocked(task));
+    let queuedTasks: Array<{ taskId: string; priority: number; description: string }>;
+    if (uiPoll) {
+      queuedTasks = readyCandidates
         .map((task) => ({
           taskId: task.id,
-          attemptId: task.execution.selectedAttemptId,
-          priority: this.loadAttemptById(task.execution.selectedAttemptId)?.queuePriority ?? 0,
-        })),
-    );
-    const queuedTasks = queuedJobs
-      .map((job) => {
-        const task = this.stateGetTask(job.taskId);
-        if (!task || (task.status !== 'pending' && (task.status as string) !== 'queued')) return undefined;
-        if (activeTaskIds.has(task.id) || isExternallyBlocked(task)) return undefined;
-        return {
+          priority: 0,
+          description: summarizeDescription(task.description),
+        }))
+        .sort((left, right) => left.taskId.localeCompare(right.taskId));
+    } else {
+      const queuedJobs = getPendingLaunchQueueSnapshotImpl(
+        this as unknown as SchedulerDomainHost,
+        readyCandidates.map((task) => ({
           taskId: task.id,
-          priority: job.priority,
-          description: task.description,
-        };
-      })
-      .filter((task): task is { taskId: string; priority: number; description: string } => task !== undefined);
+          attemptId: task.execution.selectedAttemptId,
+          priority: loadAttemptCached(task.execution.selectedAttemptId)?.queuePriority ?? 0,
+        })),
+      );
+      queuedTasks = queuedJobs
+        .map((job) => {
+          const task = this.stateGetTask(job.taskId);
+          if (!task || (task.status !== 'pending' && (task.status as string) !== 'queued')) return undefined;
+          if (activeTaskIds.has(task.id) || isExternallyBlocked(task)) return undefined;
+          return {
+            taskId: task.id,
+            priority: job.priority,
+            description: task.description,
+          };
+        })
+        .filter((task): task is { taskId: string; priority: number; description: string } => task !== undefined);
+    }
     const activeExecutionCount = activeAttempts.filter(({ task }) =>
       task.status === 'running' || task.status === 'fixing_with_ai',
     ).length;
-    return {
+    const value = {
       maxConcurrency: this.maxConcurrency,
       runningCount: activeAttempts.length,
       activeExecutionCount,
@@ -3211,14 +3285,20 @@ export class Orchestrator {
       running: activeAttempts.map(({ task, attemptId }) => ({
         taskId: task.id,
         attemptId,
-        description: task.description,
+        description: summarizeDescription(task.description),
       })),
       queued: queuedTasks.map((task) => ({
         taskId: task.taskId,
         priority: task.priority,
-        description: task.description,
+        description: summarizeDescription(task.description),
       })),
     };
+    if (uiPoll) {
+      this.queueStatusUiCache = { at: Date.now(), value };
+    } else {
+      this.queueStatusUiCache = null;
+    }
+    return value;
   }
 
   // ── Private: Response Handling ─────────────────────────────
@@ -3600,7 +3680,7 @@ export class Orchestrator {
     // append the same provenance entry twice.
     const existingProvenance = targetWorkflow?.detachedExternalDependencies ?? [];
     const provenanceKey = (dep: { workflowId: string; taskId?: string; requiredStatus: 'completed'; gatePolicy?: 'completed' | 'review_ready' }) =>
-      `${dep.workflowId} ${dep.taskId?.trim() ?? ''} ${dep.requiredStatus} ${dep.gatePolicy ?? ''}`;
+      `${dep.workflowId}/${dep.taskId?.trim() ?? ''}/${dep.requiredStatus}/${dep.gatePolicy ?? ''}`;
     const seenProvenance = new Set(existingProvenance.map(provenanceKey));
     const detachedProvenance: DetachedExternalDependency[] = [...existingProvenance];
     for (const dep of removedDeps) {

--- a/scripts/repro/repro-queue-chip-executing-vs-slots.sh
+++ b/scripts/repro/repro-queue-chip-executing-vs-slots.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Prove UI "Executing" chip historically used runningCount (slots) which includes launching,
+# so Executing != active executions. Gate checks active+launching identity and that
+# chip semantics can separate active vs slots.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+python3 <<'PY'
+import json, re, subprocess, sys
+
+p = subprocess.run(
+    ["node", "./packages/app/dist/headless-client.js", "query", "queue", "--output", "json"],
+    capture_output=True, text=True, timeout=120,
+)
+raw = p.stdout + "\n" + p.stderr
+if "spawning detached standalone" in raw or "[init] Loaded" in raw:
+    print("FAIL local DB / standalone bootstrap", flush=True)
+    sys.exit(2)
+m = re.search(r'\{"maxConcurrency".*', raw, re.S)
+blob = m.group(0)
+depth = 0
+for i, ch in enumerate(blob):
+    if ch == "{":
+        depth += 1
+    elif ch == "}":
+        depth -= 1
+        if depth == 0:
+            q = json.loads(blob[: i + 1])
+            break
+
+rc = q["runningCount"]
+ac = q.get("activeExecutionCount")
+lc = q.get("launchingCount")
+queued = len(q.get("queued") or [])
+print(json.dumps({
+    "runningCount_slots": rc,
+    "activeExecutionCount": ac,
+    "launchingCount": lc,
+    "queued": queued,
+    "legacy_Executing_chip_would_show": f"{rc}/{q['maxConcurrency']}",
+    "correct_Executing_chip_should_show": f"{ac}/{q['maxConcurrency']}",
+    "slots_chip_should_show": f"{rc}/{q['maxConcurrency']}",
+}, indent=2))
+
+if ac is None or lc is None:
+    print("FAIL missing active/launching fields", flush=True)
+    sys.exit(2)
+if ac + lc != rc:
+    print(f"FAIL identity active+launching ({ac}+{lc}) != runningCount ({rc})", flush=True)
+    sys.exit(3)
+if ac < rc:
+    print("REPRO_CONFIRMED Executing_chip_using_runningCount_overstates_executing", flush=True)
+elif ac == rc:
+    print("NOTE all_slots_are_executing launching=0", flush=True)
+print("OK identity holds", flush=True)
+PY

--- a/scripts/repro/repro-queue-status-ui-lock.sh
+++ b/scripts/repro/repro-queue-status-ui-lock.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Prove owner getQueueStatus used by the UI must stay fast.
+# Under load, the old path (topo-sort + uncached attempt SQLite reads + full
+# descriptions) blocked Electron main for ~0.5–2s per 2s UI poll → drag lockup.
+#
+# Gate: with --gate, expect owner-delegated queue query p50 < 0.75s.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+GATE=0
+if [ "${1:-}" = "--gate" ]; then GATE=1; fi
+
+python3 - "$GATE" <<'PY'
+import json, re, statistics, subprocess, sys, time
+
+gate = sys.argv[1] == "1"
+
+def queue_once():
+    t0 = time.time()
+    p = subprocess.run(
+        ["node", "./packages/app/dist/headless-client.js", "query", "queue", "--output", "json"],
+        capture_output=True, text=True, timeout=120,
+    )
+    dt = time.time() - t0
+    raw = p.stdout + "\n" + p.stderr
+    if "spawning detached standalone" in raw or "[init] Loaded" in raw:
+        raise RuntimeError("local DB / standalone bootstrap — not measuring owner UI path")
+    m = re.search(r'\{"maxConcurrency".*', raw, re.S)
+    if not m:
+        raise RuntimeError("no queue json: " + raw[-400:])
+    blob = m.group(0)
+    depth = 0
+    for i, ch in enumerate(blob):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return dt, json.loads(blob[: i + 1]), ("mode=gui" in raw or "ownerId=" in raw)
+    raise RuntimeError("unbalanced")
+
+times = []
+last = None
+mode_gui = False
+for i in range(5):
+    dt, obj, mode_gui = queue_once()
+    times.append(dt)
+    last = obj
+    desc_bytes = sum(len(x.get("description") or "") for x in obj.get("running") or [])
+    print(
+        f"sample[{i}] {dt:.3f}s runningCount={obj['runningCount']} "
+        f"active={obj.get('activeExecutionCount')} launching={obj.get('launchingCount')} "
+        f"queued={len(obj['queued'])} desc_bytes={desc_bytes} mode_gui={mode_gui}",
+        flush=True,
+    )
+
+p50 = statistics.median(times)
+mx = max(times)
+print(f"RESULT p50={p50:.3f}s max={mx:.3f}s", flush=True)
+if last:
+    ac = last.get("activeExecutionCount") or 0
+    lc = last.get("launchingCount") or 0
+    rc = last.get("runningCount") or 0
+    if ac + lc != rc:
+        print(f"FAIL count identity active+launching={ac+lc} runningCount={rc}", flush=True)
+        sys.exit(2)
+    if len(last["running"]) != rc:
+        print(f"FAIL running list len={len(last['running'])} runningCount={rc}", flush=True)
+        sys.exit(3)
+
+THRESHOLD = 0.75
+if gate:
+    if not mode_gui:
+        print("GATE_FAIL not talking to GUI owner", flush=True)
+        sys.exit(1)
+    if p50 > THRESHOLD:
+        print(f"GATE_FAIL p50={p50:.3f}s > {THRESHOLD}s (UI poll will hitch)", flush=True)
+        sys.exit(1)
+    print(f"GATE_PASS p50={p50:.3f}s <= {THRESHOLD}s", flush=True)
+else:
+    if p50 > THRESHOLD:
+        print(f"REPRO_CONFIRMED slow_queue_query p50={p50:.3f}s (expected before fix)", flush=True)
+    else:
+        print(f"ALREADY_FAST p50={p50:.3f}s", flush=True)
+sys.exit(0)
+PY

--- a/scripts/repro/repro-running-pill-vs-queue-slots.sh
+++ b/scripts/repro/repro-running-pill-vs-queue-slots.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Prove UI "workflows running (N)" is a workflow-status count, not queue slots.
+# Historical confusion: chip said "Running (14)" next to "Executing 13/13" + "Queued (4)".
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+python3 <<'PY'
+import json, re, subprocess, sys
+
+def run(args):
+    p = subprocess.run(
+        ["node", "./packages/app/dist/headless-client.js", *args],
+        capture_output=True, text=True, timeout=120,
+    )
+    raw = p.stdout + "\n" + p.stderr
+    if "mode=gui" not in raw and "ownerId=" not in raw:
+        # Still OK if stdout is pure JSON from delegated path with quiet logs
+        pass
+    if "spawning detached standalone" in raw or "[init] Loaded" in raw:
+        print("FAIL opened local DB / bootstrapped standalone instead of GUI owner", flush=True)
+        sys.exit(2)
+    return raw, p.returncode
+
+raw_q, code = run(["query", "queue", "--output", "json"])
+if code != 0:
+    print(raw_q[-500:])
+    sys.exit(code)
+m = re.search(r'\{"maxConcurrency".*', raw_q, re.S)
+blob = m.group(0)
+depth = 0
+q = None
+for i, ch in enumerate(blob):
+    if ch == "{":
+        depth += 1
+    elif ch == "}":
+        depth -= 1
+        if depth == 0:
+            q = json.loads(blob[: i + 1])
+            break
+assert q is not None
+
+raw_w, code = run(["query", "workflows", "--output", "json"])
+if code != 0:
+    print(raw_w[-500:])
+    sys.exit(code)
+arr_i = raw_w.find("[")
+workflows = json.loads(raw_w[arr_i:])
+wf_running = sum(1 for w in workflows if w.get("status") == "running")
+
+slots = q["runningCount"]
+active = q.get("activeExecutionCount")
+launching = q.get("launchingCount")
+queued = len(q.get("queued") or [])
+
+print(json.dumps({
+    "workflow_pill_running": wf_running,
+    "queue_slots_runningCount": slots,
+    "queue_activeExecutionCount": active,
+    "queue_launchingCount": launching,
+    "queue_queued": queued,
+    "mismatch_workflow_vs_slots": wf_running != slots,
+    "mismatch_slots_vs_active": slots != active,
+}, indent=2), flush=True)
+
+if active is None or launching is None:
+    print("FAIL missing active/launching fields", flush=True)
+    sys.exit(3)
+if active + launching != slots:
+    print(f"FAIL identity {active}+{launching} != {slots}", flush=True)
+    sys.exit(4)
+
+if wf_running != slots or slots != active:
+    print(
+        "REPRO_CONFIRMED distinct_metrics: "
+        "workflows running pill counts workflows; "
+        "Executing/Slots chips count task attempts; "
+        "Queued is ready-but-not-slotted tasks",
+        flush=True,
+    )
+else:
+    print("NOTE all three metrics currently equal (no mismatch visible)", flush=True)
+print("OK", flush=True)
+PY


### PR DESCRIPTION
## Summary

UI queue polls were blocking Electron main with topo-sort and per-attempt SQLite reads which froze navigation under load.

This slice serves refresh false polls from a cached light snapshot that omits attempt DB reads and launch-order sorting.

## Review Claim

Approve making getQueueStatus with refresh false cheap and cached so UI polling no longer hitchs the main process.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Full refresh true path still uses launch-order semantics. Only UI owner poll path is made cheaper and cached briefly.

## Slice Rationale

Comes after the repro scripts that proved the hitch and before chip-label follow-up that depends on accurate active launching fields staying cheap to read.

## Non-goals

Does not redesign scheduling or change maxConcurrency.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/queue-status-ui-poll-fast-path.test.ts`
- [x] `bash scripts/repro/repro-queue-status-ui-lock.sh --gate`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
