### PR TITLE
[Durable SSH Pool Capacity](14) Separate Executing, Slots, and workflows running chips

### DIFF
--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -229,7 +229,7 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
       for (const workflow of workflows) {
         deps.orchestrator.syncFromDb(workflow.id);
       }
-      const status = deps.orchestrator.getQueueStatus();
+      const status = deps.orchestrator.getQueueStatus({ refresh: false });
 
       switch (flags.output) {
         case 'label': {

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1738,7 +1738,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   });
 
   ipcMain.handle('invoker:get-queue-status', () => {
-    return orchestrator.getQueueStatus();
+    return orchestrator.getQueueStatus({ refresh: false });
   });
   ipcMain.handle('invoker:get-worker-status', async () => {
     if (!ownerMode) {

--- a/packages/ui/src/__tests__/workflow-status-chips-queue.test.tsx
+++ b/packages/ui/src/__tests__/workflow-status-chips-queue.test.tsx
@@ -11,6 +11,8 @@ describe('WorkflowStatusChips queue capacity', () => {
     const queueStatus: QueueStatus = {
       maxConcurrency: 8,
       runningCount: 3,
+      activeExecutionCount: 1,
+      launchingCount: 2,
       running: [
         { taskId: 'a', description: 'a' },
         { taskId: 'b', description: 'b' },
@@ -33,9 +35,11 @@ describe('WorkflowStatusChips queue capacity', () => {
       />,
     );
 
-    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (3/8)');
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/8)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (3/8)');
+    expect(screen.getByTestId('queue-chip-launching')).toHaveTextContent('Launching (2)');
     expect(screen.getByTestId('queue-chip-queued')).toHaveTextContent('Queued (2)');
-    expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('running (1)');
+    expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('workflows running (1)');
 
     fireEvent.click(screen.getByTestId('queue-chip-queued'));
     expect(onOpenRunningSurface).toHaveBeenCalledTimes(1);

--- a/packages/ui/src/components/QueueView.tsx
+++ b/packages/ui/src/components/QueueView.tsx
@@ -120,7 +120,12 @@ export function QueueView({
         <div className="shrink-0 border-b border-border px-4 py-3">
           <div className="grid gap-3 sm:grid-cols-2">
             <section data-testid="running-queue-section-running" className="rounded-md border border-border bg-card/60 p-3">
-              <div className="text-sm font-medium text-foreground">Running ({queueRunning.length})</div>
+              <div className="text-sm font-medium text-foreground">
+                In flight ({queueRunning.length})
+              </div>
+              <div className="mt-0.5 text-[11px] text-muted-foreground">
+                Concurrency slots (executing + launching)
+              </div>
               <div className="mt-2 space-y-1 text-xs text-muted-foreground">
                 {queueRunning.length > 0 ? (
                   queueRunning.map((entry) => (

--- a/packages/ui/src/components/WorkflowStatusChips.tsx
+++ b/packages/ui/src/components/WorkflowStatusChips.tsx
@@ -39,7 +39,10 @@ export function WorkflowStatusChips({
   }
 
   const hasFilters = activeFilters.size > 0;
-  const queueRunning = queueStatus?.runningCount ?? 0;
+  const queueSlots = queueStatus?.runningCount ?? 0;
+  const queueExecuting = queueStatus?.activeExecutionCount ?? queueSlots;
+  const queueLaunching = queueStatus?.launchingCount
+    ?? Math.max(0, queueSlots - queueExecuting);
   const queueMax = queueStatus?.maxConcurrency ?? 0;
   const queueQueued = queueStatus?.queued.length ?? 0;
 
@@ -53,8 +56,26 @@ export function WorkflowStatusChips({
             onClick={() => onOpenRunningSurface?.()}
             className="px-2 py-0.5 text-xs rounded-full cursor-pointer select-none text-blue-300 hover:brightness-125"
           >
-            Executing ({queueRunning}/{queueMax})
+            Executing ({queueExecuting}/{queueMax})
           </button>
+          <button
+            type="button"
+            data-testid="queue-chip-slots"
+            onClick={() => onOpenRunningSurface?.()}
+            className="px-2 py-0.5 text-xs rounded-full cursor-pointer select-none text-sky-200/90 hover:brightness-125"
+          >
+            Slots ({queueSlots}/{queueMax})
+          </button>
+          {queueLaunching > 0 && (
+            <button
+              type="button"
+              data-testid="queue-chip-launching"
+              onClick={() => onOpenRunningSurface?.()}
+              className="px-2 py-0.5 text-xs rounded-full cursor-pointer select-none text-cyan-300/90 hover:brightness-125"
+            >
+              Launching ({queueLaunching})
+            </button>
+          )}
           <button
             type="button"
             data-testid="queue-chip-queued"
@@ -81,7 +102,7 @@ export function WorkflowStatusChips({
               keyboardActiveKey === status ? 'ring-2 ring-ring/90 ring-offset-1 ring-offset-background' : '',
             ].join(' ')}
           >
-            {status.replaceAll('_', ' ')} ({count})
+            {status === 'running' ? 'workflows running' : status.replaceAll('_', ' ')} ({count})
           </button>
         );
       })}

--- a/packages/ui/src/hooks/useQueueStatus.ts
+++ b/packages/ui/src/hooks/useQueueStatus.ts
@@ -3,7 +3,7 @@ import type { QueueStatus } from '../types.js';
 import { areStructurallyEqual } from './useDedupedState.js';
 import { subscribeVisibilityAwarePoll } from './visibilityAwarePoll.js';
 
-export function useQueueStatus(pollMs = 2000, enabled = true): QueueStatus | null {
+export function useQueueStatus(pollMs = 5000, enabled = true): QueueStatus | null {
   const [queueStatus, setQueueStatus] = useState<QueueStatus | null>(null);
   const inFlightRef = useRef(false);
 


### PR DESCRIPTION
## Summary

The bottom chips mixed workflow status with concurrency slots so running looked like it disagreed with Executing.

This slice labels workflow status as workflows running and shows Executing Slots and Launching as distinct queue chips.

## Review Claim

Approve clarifying queue capacity chips versus the workflows-running status pill so operators can read capacity correctly.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only labels and which queue fields are displayed change. Scheduling and task state are unchanged.

## Slice Rationale

Chip copy is separate from the orchestrator fast-path that feeds the numbers.

## Non-goals

Does not change how workflow status is computed.

## Visual Proof

![queue chips after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260718-cf547c/queue-chips-after.png)

Caption: After change the bottom chrome shows Executing Slots Launching Queued plus workflows running instead of a single Running chip overloading slot meaning.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/workflow-status-chips-queue.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Queue metrics now distinguish executing, launching, and available slots.
  - Queue views display “In flight” status with concurrency slot details.
  - Running workflow labels are clearer and more descriptive.

- **Bug Fixes**
  - Queue status checks no longer force unnecessary refreshes.
  - Queue status updates now use a less frequent polling interval, reducing redundant refresh activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->