### PR TITLE
[Durable SSH Pool Capacity](15) Add start-ready --recreate-all for finished work

### DIFF
--- a/packages/app/src/__tests__/start-ready.test.ts
+++ b/packages/app/src/__tests__/start-ready.test.ts
@@ -64,6 +64,7 @@ describe('start-ready', () => {
       failedWorkflowIds: ['wf-2'],
       pendingWorkflowIds: ['wf-1'],
       runningWorkflowIds: [],
+      completedWorkflowIds: [],
       skipped: {
         awaitingApproval: 1,
         reviewReady: 0,
@@ -71,6 +72,7 @@ describe('start-ready', () => {
         failedTasks: 1,
         pendingTasks: 2,
         runningTasks: 0,
+        completedTasks: 0,
       },
     });
   });
@@ -195,5 +197,40 @@ describe('start-ready', () => {
     });
 
     expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2', 'wf-3']);
+  });
+
+  it('recreates failed, pending/queued, running, and completed workflows when recreateAll is set', () => {
+    const failed = makeTask('wf-1/failed', 'failed');
+    const pendingOnly = makeTask('wf-2/pending', 'pending');
+    const runningOnly = makeTask('wf-3/running', 'running');
+    const completedOnly = makeTask('wf-4/completed', 'completed');
+    const approval = makeTask('wf-5/approval', 'awaiting_approval');
+    const orchestrator = harness(
+      [failed, pendingOnly, runningOnly, completedOnly, approval],
+      [],
+    );
+
+    const result = runStartReady(orchestrator, { recreateAll: true });
+
+    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-2');
+    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-3');
+    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-4');
+    expect(orchestrator.recreateWorkflow).not.toHaveBeenCalledWith('wf-5');
+    expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2', 'wf-3', 'wf-4']);
+    expect(result.preview.completedWorkflowIds).toEqual(['wf-4']);
+  });
+
+  it('prefers recreateAll over narrower recreate flags', () => {
+    const failed = makeTask('wf-1/failed', 'failed');
+    const completedOnly = makeTask('wf-2/completed', 'completed');
+    const orchestrator = harness([failed, completedOnly], []);
+
+    const result = runStartReady(orchestrator, {
+      recreateFailed: true,
+      recreateAll: true,
+    });
+
+    expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2']);
   });
 });

--- a/packages/app/src/start-ready.ts
+++ b/packages/app/src/start-ready.ts
@@ -93,6 +93,14 @@ function workflowIdsToRecreate(
   request: StartReadyRequestExt,
   preview: StartReadyPreviewExt,
 ): string[] {
+  if (request.recreateAll) {
+    return unionWorkflowIds(
+      preview.failedWorkflowIds,
+      preview.pendingWorkflowIds,
+      preview.runningWorkflowIds,
+      preview.completedWorkflowIds,
+    );
+  }
   if (request.recreateFailedPendingAndRunning) {
     return unionWorkflowIds(
       preview.failedWorkflowIds,
@@ -116,6 +124,7 @@ export function collectStartReadyPreview(orchestrator: StartReadyOrchestrator): 
   const failedTasks = tasks.filter((task) => task.status === 'failed');
   const pendingTasks = tasks.filter((task) => isPendingOrQueued(task));
   const runningTasks = tasks.filter((task) => task.status === 'running');
+  const completedTasks = tasks.filter((task) => task.status === 'completed');
 
   const preview: StartReadyPreviewExt = {
     readyTaskIds: readyTasks.map((task) => task.id),
@@ -123,6 +132,7 @@ export function collectStartReadyPreview(orchestrator: StartReadyOrchestrator): 
     failedWorkflowIds: uniqueWorkflowIds(failedTasks),
     pendingWorkflowIds: uniqueWorkflowIds(pendingTasks),
     runningWorkflowIds: uniqueWorkflowIds(runningTasks),
+    completedWorkflowIds: uniqueWorkflowIds(completedTasks),
     skipped: {
       awaitingApproval: tasks.filter((task) => task.status === 'awaiting_approval').length,
       reviewReady: tasks.filter((task) => task.status === 'review_ready').length,
@@ -130,6 +140,7 @@ export function collectStartReadyPreview(orchestrator: StartReadyOrchestrator): 
       failedTasks: failedTasks.length,
       pendingTasks: pendingTasks.length,
       runningTasks: runningTasks.length,
+      completedTasks: completedTasks.length,
     },
   };
   return preview;

--- a/packages/app/src/start-ready.ts
+++ b/packages/app/src/start-ready.ts
@@ -24,9 +24,11 @@ type StartReadyRequestExt = StartReadyRequest & {
 type StartReadyPreviewExt = StartReadyPreview & {
   pendingWorkflowIds: string[];
   runningWorkflowIds: string[];
+  completedWorkflowIds: string[];
   skipped: StartReadyPreview['skipped'] & {
     pendingTasks: number;
     runningTasks: number;
+    completedTasks: number;
   };
 };
 function collectRecoverableTasks(orchestrator: StartReadyOrchestrator): TaskState[] {


### PR DESCRIPTION
## Summary

Capacity babysitting emptied when finished workflows left only completed work behind.

This slice adds start-ready recreate-all so refill can recreate completed workflows too.

## Review Claim

Approve adding recreateAll and the recreate-all flag so finished workflows can be recreated during capacity refill.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Opt-in flag only. Existing recreate modes keep their prior semantics.

## Slice Rationale

Extends the start-ready recreate ladder after failed pending running modes already landed.

## Non-goals

Does not change lease accounting or UI chips.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/start-ready.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

