### PR TITLE
[Durable SSH Pool Capacity](17) Add capacity babysit refill tooling

### DIFF
--- a/scripts/repro/babysit-capacity-loop.sh
+++ b/scripts/repro/babysit-capacity-loop.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Continuous capacity babysit: hold runningCount>=TARGET, refill with --recreate-all on drop.
+# Exit 0 only after STABLE_WINDOWS consecutive full DURATION_S windows at target.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+TARGET="${1:-12}"
+DURATION_S="${2:-300}"
+INTERVAL_S="${3:-30}"
+STABLE_WINDOWS="${4:-1}"
+OUT="${5:-/tmp/invoker-capacity-loop.jsonl}"
+: >"$OUT"
+
+python3 - "$TARGET" "$DURATION_S" "$INTERVAL_S" "$STABLE_WINDOWS" "$OUT" <<'PY'
+import json, re, subprocess, sys, time, datetime
+from pathlib import Path
+
+target = int(sys.argv[1])
+duration_s = int(sys.argv[2])
+interval_s = int(sys.argv[3])
+stable_windows = int(sys.argv[4])
+out = Path(sys.argv[5])
+
+def run(cmd, timeout=360):
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+def extract_json_obj(raw, prefix='{"maxConcurrency"'):
+    m = re.search(re.escape(prefix) + r'.*', raw, re.S)
+    if not m:
+        # also try stats-like
+        idx = raw.rfind('\n{')
+        if idx < 0:
+            return None
+        blob = raw[idx+1:]
+    else:
+        blob = m.group(0)
+    depth = 0
+    for i, ch in enumerate(blob):
+        if ch == '{':
+            depth += 1
+        elif ch == '}':
+            depth -= 1
+            if depth == 0:
+                return json.loads(blob[: i + 1])
+    return None
+
+def owner_mode():
+    """Prefer stats owner-ping; fall back to live GUI Electron process."""
+    p = run(['./run.sh', '--headless', 'query', 'stats', '--output', 'json'], timeout=90)
+    raw = p.stdout + '\n' + p.stderr
+    if 'spawning detached standalone' in raw:
+        return 'bootstrap-standalone', raw
+    if 'mode=gui' in raw:
+        return 'gui', raw
+    if 'mode=standalone' in raw and 'mode=gui' not in raw:
+        return 'standalone', raw
+    ps = subprocess.run(['ps', '-axo', 'pid=,command='], capture_output=True, text=True)
+    gui = [
+        l for l in ps.stdout.splitlines()
+        if 'packages/app/dist/main.js' in l and 'headless' not in l
+    ]
+    if gui:
+        return 'gui', raw
+    return None, raw
+
+def query_queue():
+    mode, mode_raw = owner_mode()
+    p = run(['./run.sh', '--headless', 'query', 'queue', '--output', 'json'], timeout=90)
+    raw = p.stdout + '\n' + p.stderr
+    if 'spawning detached standalone' in raw:
+        mode = 'bootstrap-standalone'
+    q = extract_json_obj(raw)
+    if q is None:
+        raise RuntimeError('no queue json: ' + raw[-500:])
+    return mode, q, mode_raw + '\n' + raw
+
+def refill():
+    print('REFILL start-ready --recreate-all --no-track', flush=True)
+    p = run(['./run.sh', '--headless', 'start-ready', '--recreate-all', '--no-track'], timeout=360)
+    raw = p.stdout + '\n' + p.stderr
+    interesting = [
+        l for l in raw.splitlines()
+        if any(k in l for k in [
+            'Start and recreate', 'recreated workflows', 'started:', 'timeoutMs=',
+            'spawning detached', 'Error', 'Delegated', 'fallthrough', 'timeout',
+        ])
+    ]
+    for l in interesting[-30:]:
+        print('  ' + l[:220], flush=True)
+    return p.returncode, raw
+
+stable = 0
+window = 0
+print(
+    f'capacity-loop: target>={target} window={duration_s}s interval={interval_s}s '
+    f'need_stable_windows={stable_windows} -> {out}',
+    flush=True,
+)
+
+while stable < stable_windows:
+    window += 1
+    start = time.time()
+    below = False
+    print(f'=== WINDOW {window} begin ===', flush=True)
+    while True:
+        elapsed = time.time() - start
+        ts = datetime.datetime.utcnow().isoformat() + 'Z'
+        try:
+            mode, q, _ = query_queue()
+            running = q.get('runningCount') or 0
+            sample = {
+                'ts': ts,
+                'window': window,
+                'elapsed_s': round(elapsed, 1),
+                'mode': mode,
+                'runningCount': running,
+                'activeExecutionCount': q.get('activeExecutionCount'),
+                'launchingCount': q.get('launchingCount'),
+                'queuedCount': len(q.get('queued') or []),
+                'maxConcurrency': q.get('maxConcurrency'),
+                'ok': running >= target and mode == 'gui',
+            }
+            if mode != 'gui':
+                sample['ok'] = False
+                sample['error'] = f'owner_mode={mode}'
+                below = True
+                out.open('a').write(json.dumps(sample) + '\n')
+                print(f'[{ts}] OWNER_BAD mode={mode} — abort window for restart', flush=True)
+                sys.exit(2)
+        except Exception as e:
+            sample = {
+                'ts': ts, 'window': window, 'elapsed_s': round(elapsed, 1),
+                'error': str(e), 'ok': False,
+            }
+            below = True
+            out.open('a').write(json.dumps(sample) + '\n')
+            print(f'[{ts}] QUERY_FAIL {e}', flush=True)
+            # attempt refill only if gui might still be up
+            try:
+                refill()
+            except Exception as re:
+                print(f'REFILL_FAIL {re}', flush=True)
+                sys.exit(3)
+            time.sleep(interval_s)
+            continue
+
+        if running < target:
+            below = True
+            sample['refill'] = True
+            out.open('a').write(json.dumps(sample) + '\n')
+            print(
+                f"[{ts}] t+{elapsed:5.0f}s BELOW running={running} "
+                f"active={sample['activeExecutionCount']} launching={sample['launchingCount']} "
+                f"queued={sample['queuedCount']} -> REFILL",
+                flush=True,
+            )
+            try:
+                code, _ = refill()
+                print(f'  refill_exit={code}', flush=True)
+            except Exception as re:
+                print(f'REFILL_FAIL {re}', flush=True)
+                sys.exit(3)
+        else:
+            out.open('a').write(json.dumps(sample) + '\n')
+            print(
+                f"[{ts}] t+{elapsed:5.0f}s OK running={running} "
+                f"active={sample['activeExecutionCount']} launching={sample['launchingCount']} "
+                f"queued={sample['queuedCount']}",
+                flush=True,
+            )
+
+        if elapsed >= duration_s:
+            break
+        time.sleep(interval_s)
+
+    if below:
+        stable = 0
+        print(f'=== WINDOW {window} FAILED (had below-target samples) stable={stable} ===', flush=True)
+    else:
+        stable += 1
+        print(f'=== WINDOW {window} STABLE stable={stable}/{stable_windows} ===', flush=True)
+
+print('RESULT=CAPACITY_HELD', flush=True)
+sys.exit(0)
+PY

--- a/scripts/repro/babysit-capacity-supervisor.sh
+++ b/scripts/repro/babysit-capacity-supervisor.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Supervise GUI owner + keep runningCount near maxConcurrency via start-ready --recreate-all.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+TARGET="${1:-12}"
+DURATION_S="${2:-600}"
+INTERVAL_S="${3:-30}"
+OUT="${4:-/tmp/invoker-capacity-supervisor.jsonl}"
+: >"$OUT"
+: > /tmp/invoker-gui.log
+
+python3 - "$TARGET" "$DURATION_S" "$INTERVAL_S" "$OUT" <<'PY'
+import json, re, subprocess, sys, time, datetime
+from pathlib import Path
+
+target = int(sys.argv[1])
+duration_s = int(sys.argv[2])
+interval_s = int(sys.argv[3])
+out = Path(sys.argv[4])
+root = Path.cwd()
+
+def run(cmd, timeout=420, cwd=None):
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, cwd=cwd or root)
+
+def gui_procs():
+    p = subprocess.run(['ps', '-axo', 'pid=,command='], capture_output=True, text=True)
+    return [
+        l for l in p.stdout.splitlines()
+        if 'packages/app/dist/main.js' in l and 'headless' not in l
+    ]
+
+def standalone_procs():
+    p = subprocess.run(['ps', '-axo', 'pid=,command='], capture_output=True, text=True)
+    return [l for l in p.stdout.splitlines() if 'owner-serve' in l]
+
+def extract_obj(raw, prefix='{"maxConcurrency"'):
+    m = re.search(re.escape(prefix) + r'.*', raw, re.S)
+    if not m:
+        return None
+    blob = m.group(0)
+    depth = 0
+    for i, ch in enumerate(blob):
+        if ch == '{':
+            depth += 1
+        elif ch == '}':
+            depth -= 1
+            if depth == 0:
+                return json.loads(blob[: i + 1])
+    return None
+
+def ensure_gui():
+    if gui_procs() and not standalone_procs():
+        # confirm ping
+        p = run(['./run.sh', '--headless', 'query', 'stats', '--output', 'json'], timeout=90)
+        raw = p.stdout + '\n' + p.stderr
+        if 'mode=gui' in raw and 'spawning detached standalone' not in raw:
+            return True
+    print('RESTART_GUI', flush=True)
+    run(['./scripts/kill-all-electron.sh'], timeout=60)
+    time.sleep(1)
+    Path('/tmp/invoker-gui.log').write_text('')
+    subprocess.Popen(
+        ['./run.sh'],
+        cwd=str(root),
+        stdout=open('/tmp/invoker-gui.log', 'a'),
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    deadline = time.time() + 480
+    while time.time() < deadline:
+        if gui_procs():
+            p = run(['./run.sh', '--headless', 'query', 'stats', '--output', 'json'], timeout=90)
+            raw = p.stdout + '\n' + p.stderr
+            if 'spawning detached standalone' in raw:
+                print('ABORT_STANDALONE_DURING_START', flush=True)
+                run(['./scripts/kill-all-electron.sh'], timeout=60)
+                time.sleep(2)
+                continue
+            if 'mode=gui' in raw:
+                print('GUI_READY', flush=True)
+                return True
+        time.sleep(6)
+    print('GUI_START_TIMEOUT', flush=True)
+    return False
+
+def query_queue():
+    p = run(['./run.sh', '--headless', 'query', 'queue', '--output', 'json'], timeout=90)
+    raw = p.stdout + '\n' + p.stderr
+    mode = 'gui' if 'mode=gui' in raw else ('standalone' if 'mode=standalone' in raw else None)
+    if gui_procs() and mode is None:
+        mode = 'gui'
+    q = extract_obj(raw)
+    if q is None:
+        raise RuntimeError(raw[-400:])
+    return mode, q
+
+def refill():
+    if not gui_procs():
+        raise RuntimeError('refill refused: no gui process')
+    print('REFILL --recreate-all', flush=True)
+    try:
+        p = run(['./run.sh', '--headless', 'start-ready', '--recreate-all', '--no-track'], timeout=600)
+    except subprocess.TimeoutExpired:
+        print('REFILL_TIMEOUT', flush=True)
+        return 124
+    raw = p.stdout + '\n' + p.stderr
+    if 'spawning detached standalone' in raw:
+        print('REFILL_SPAWNED_STANDALONE', flush=True)
+    print('refill_exit', p.returncode, flush=True)
+    return p.returncode
+
+start = time.time()
+below_samples = 0
+ok_samples = 0
+print(f'supervisor: target>={target} for {duration_s}s every {interval_s}s -> {out}', flush=True)
+
+while time.time() - start < duration_s:
+    ts = datetime.datetime.utcnow().isoformat() + 'Z'
+    elapsed = round(time.time() - start, 1)
+    if not gui_procs() or standalone_procs():
+        if standalone_procs():
+            print('KILL_STANDALONE', flush=True)
+        if not ensure_gui():
+            sample = {'ts': ts, 'elapsed_s': elapsed, 'ok': False, 'error': 'gui-start-failed'}
+            out.open('a').write(json.dumps(sample) + '\n')
+            time.sleep(interval_s)
+            continue
+        try:
+            refill()
+        except Exception as e:
+            print('REFILL_FAIL', e, flush=True)
+
+    try:
+        mode, q = query_queue()
+        running = q.get('runningCount') or 0
+        active = q.get('activeExecutionCount') or 0
+        launching = q.get('launchingCount') or 0
+        queued = len(q.get('queued') or [])
+        ok = mode == 'gui' and running >= target
+        sample = {
+            'ts': ts, 'elapsed_s': elapsed, 'mode': mode,
+            'runningCount': running, 'activeExecutionCount': active,
+            'launchingCount': launching, 'queuedCount': queued,
+            'maxConcurrency': q.get('maxConcurrency'), 'ok': ok,
+            'guiProcs': len(gui_procs()),
+        }
+        if running < target and mode == 'gui':
+            sample['refill'] = True
+            try:
+                sample['refill_exit'] = refill()
+            except Exception as e:
+                sample['refill_error'] = str(e)
+                ok = False
+        out.open('a').write(json.dumps(sample) + '\n')
+        status = 'OK' if ok else 'BELOW'
+        print(
+            f'[{ts}] t+{elapsed:5.0f}s {status} mode={mode} running={running} '
+            f'active={active} launching={launching} queued={queued} gui={sample["guiProcs"]}',
+            flush=True,
+        )
+        if ok:
+            ok_samples += 1
+        else:
+            below_samples += 1
+    except Exception as e:
+        out.open('a').write(json.dumps({'ts': ts, 'elapsed_s': elapsed, 'ok': False, 'error': str(e)}) + '\n')
+        print(f'[{ts}] ERR {e}', flush=True)
+        below_samples += 1
+        ensure_gui()
+    time.sleep(interval_s)
+
+print(f'RESULT ok_samples={ok_samples} below_samples={below_samples}', flush=True)
+sys.exit(0 if below_samples == 0 and ok_samples > 0 else 1)
+PY

--- a/scripts/repro/babysit-running-count.sh
+++ b/scripts/repro/babysit-running-count.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Sample Invoker queue runningCount for TARGET over DURATION_S seconds.
+# Exit 0 if every sample is >= TARGET; exit 1 otherwise (prints BELOW samples).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+TARGET="${1:-12}"
+DURATION_S="${2:-300}"
+INTERVAL_S="${3:-30}"
+OUT="${4:-/tmp/invoker-babysit-samples.jsonl}"
+: >"$OUT"
+
+python3 - "$TARGET" "$DURATION_S" "$INTERVAL_S" "$OUT" <<'PY'
+import json, re, subprocess, sys, time, datetime
+from pathlib import Path
+
+target = int(sys.argv[1])
+duration_s = int(sys.argv[2])
+interval_s = int(sys.argv[3])
+out = Path(sys.argv[4])
+
+def query_queue():
+    p = subprocess.run(
+        ['./run.sh', '--headless', 'query', 'queue', '--output', 'json'],
+        capture_output=True, text=True, timeout=60,
+    )
+    raw = p.stdout + '\n' + p.stderr
+    m = re.search(r'\{"maxConcurrency".*', raw, re.S)
+    if not m:
+        raise RuntimeError('no queue json: ' + raw[-400:])
+    blob = m.group(0)
+    depth = 0
+    for i, ch in enumerate(blob):
+        if ch == '{':
+            depth += 1
+        elif ch == '}':
+            depth -= 1
+            if depth == 0:
+                return json.loads(blob[: i + 1])
+    raise RuntimeError('unbalanced json')
+
+start = time.time()
+below = False
+print(f'babysit: target>={target} for {duration_s}s every {interval_s}s -> {out}', flush=True)
+while True:
+    elapsed = time.time() - start
+    ts = datetime.datetime.utcnow().isoformat() + 'Z'
+    try:
+        q = query_queue()
+        sample = {
+            'ts': ts,
+            'elapsed_s': round(elapsed, 1),
+            'runningCount': q.get('runningCount'),
+            'activeExecutionCount': q.get('activeExecutionCount'),
+            'launchingCount': q.get('launchingCount'),
+            'queuedCount': len(q.get('queued') or []),
+            'ok': (q.get('runningCount') or 0) >= target,
+            'runningIds': [r['taskId'] for r in q.get('running') or []],
+            'queuedIds': [r['taskId'] for r in q.get('queued') or []],
+        }
+    except Exception as e:
+        sample = {'ts': ts, 'elapsed_s': round(elapsed, 1), 'error': str(e), 'ok': False}
+        below = True
+    out.open('a').write(json.dumps(sample) + '\n')
+    status = 'OK' if sample.get('ok') else 'BELOW'
+    print(
+        f"[{ts}] t+{elapsed:5.0f}s {status} running={sample.get('runningCount')} "
+        f"active={sample.get('activeExecutionCount')} launching={sample.get('launchingCount')} "
+        f"queued={sample.get('queuedCount')} err={sample.get('error', '')}",
+        flush=True,
+    )
+    if not sample.get('ok'):
+        below = True
+    if elapsed >= duration_s:
+        break
+    time.sleep(interval_s)
+
+print('RESULT=' + ('STABLE' if not below else 'FAILED'), flush=True)
+sys.exit(0 if not below else 1)
+PY

--- a/scripts/repro/babysit_capacity_daemon.py
+++ b/scripts/repro/babysit_capacity_daemon.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Detached capacity babysit + refill daemon. Logs to OUT jsonl + stdout."""
+from __future__ import annotations
+
+import datetime
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+TARGET = int(sys.argv[1]) if len(sys.argv) > 1 else 12
+DURATION_S = int(sys.argv[2]) if len(sys.argv) > 2 else 300
+# Default 60s — queue queries must not compete with the UI's 2s poll.
+INTERVAL_S = int(sys.argv[3]) if len(sys.argv) > 3 else 60
+OUT = Path(sys.argv[4] if len(sys.argv) > 4 else "/tmp/invoker-capacity-daemon.jsonl")
+
+
+def run(cmd: list[str], timeout: int = 120) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True, timeout=timeout)
+
+
+def gui_procs() -> list[str]:
+    p = subprocess.run(["ps", "-axo", "pid=,command="], capture_output=True, text=True)
+    return [
+        line
+        for line in p.stdout.splitlines()
+        if "packages/app/dist/main.js" in line and "headless" not in line
+    ]
+
+
+def extract_queue(raw: str) -> dict:
+    m = re.search(r'\{"maxConcurrency".*', raw, re.S)
+    if not m:
+        raise RuntimeError("no queue json: " + raw[-400:])
+    blob = m.group(0)
+    depth = 0
+    for i, ch in enumerate(blob):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return json.loads(blob[: i + 1])
+    raise RuntimeError("unbalanced queue json")
+
+
+def query_queue() -> tuple[str | None, dict]:
+    # Prefer headless-client so we never rebuild and never open the DB locally.
+    p = run(
+        ["node", "./packages/app/dist/headless-client.js", "query", "queue", "--output", "json"],
+        timeout=90,
+    )
+    raw = p.stdout + "\n" + p.stderr
+    mode = None
+    if "spawning detached standalone" in raw or "[init] Loaded" in raw:
+        mode = "bootstrap-standalone"
+    elif "mode=gui" in raw or "ownerId=" in raw:
+        mode = "gui"
+    elif "mode=standalone" in raw:
+        mode = "standalone"
+    elif gui_procs():
+        mode = "gui"
+    return mode, extract_queue(raw)
+
+
+def refill() -> int:
+    print("REFILL --recreate-all", flush=True)
+    try:
+        p = run(
+            [
+                "node",
+                "./packages/app/dist/headless-client.js",
+                "start-ready",
+                "--recreate-all",
+                "--no-track",
+            ],
+            timeout=600,
+        )
+    except subprocess.TimeoutExpired:
+        print("REFILL_TIMEOUT", flush=True)
+        return 124
+    raw = p.stdout + "\n" + p.stderr
+    if "spawning detached standalone" in raw or "[init] Loaded" in raw:
+        print("REFILL_SPAWNED_STANDALONE", flush=True)
+        return 125
+    print(f"refill_exit={p.returncode}", flush=True)
+    return p.returncode
+
+
+def restart_gui() -> bool:
+    print("RESTART_GUI", flush=True)
+    run(["./scripts/kill-all-electron.sh"], timeout=60)
+    time.sleep(1)
+    Path("/tmp/invoker-gui.log").write_text("")
+    subprocess.Popen(
+        ["./run.sh"],
+        cwd=str(ROOT),
+        stdout=open("/tmp/invoker-gui.log", "a"),
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    deadline = time.time() + 480
+    while time.time() < deadline:
+        if gui_procs():
+            p = run(
+                ["node", "./packages/app/dist/headless-client.js", "query", "stats", "--output", "json"],
+                timeout=90,
+            )
+            raw = p.stdout + "\n" + p.stderr
+            if (
+                ("mode=gui" in raw or "ownerId=" in raw)
+                and "spawning detached standalone" not in raw
+                and "[init] Loaded" not in raw
+            ):
+                print("GUI_READY", flush=True)
+                return True
+        time.sleep(6)
+    print("GUI_START_TIMEOUT", flush=True)
+    return False
+
+
+def main() -> int:
+    OUT.write_text("")
+    start = time.time()
+    below = False
+    print(
+        f"daemon: target>={TARGET} for {DURATION_S}s every {INTERVAL_S}s -> {OUT}",
+        flush=True,
+    )
+    while True:
+        elapsed = time.time() - start
+        ts = datetime.datetime.utcnow().isoformat() + "Z"
+        try:
+            if not gui_procs():
+                below = True
+                if not restart_gui():
+                    sample = {"ts": ts, "elapsed_s": round(elapsed, 1), "ok": False, "error": "gui-start-failed"}
+                    OUT.open("a").write(json.dumps(sample) + "\n")
+                    print(f"[{ts}] GUI_FAIL", flush=True)
+                    time.sleep(INTERVAL_S)
+                    continue
+                refill()
+
+            mode, q = query_queue()
+            running = q.get("runningCount") or 0
+            active = q.get("activeExecutionCount") or 0
+            launching = q.get("launchingCount") or 0
+            queued = len(q.get("queued") or [])
+            ok = mode == "gui" and running >= TARGET
+            sample = {
+                "ts": ts,
+                "elapsed_s": round(elapsed, 1),
+                "mode": mode,
+                "runningCount": running,
+                "activeExecutionCount": active,
+                "launchingCount": launching,
+                "queuedCount": queued,
+                "maxConcurrency": q.get("maxConcurrency"),
+                "ok": ok,
+                "guiProcs": len(gui_procs()),
+            }
+            if running < TARGET and mode == "gui":
+                below = True
+                sample["refill"] = True
+                sample["refill_exit"] = refill()
+            if mode != "gui":
+                below = True
+                sample["ok"] = False
+            OUT.open("a").write(json.dumps(sample) + "\n")
+            status = "OK" if sample["ok"] else "BELOW"
+            print(
+                f"[{ts}] t+{elapsed:5.0f}s {status} mode={mode} running={running} "
+                f"active={active} launching={launching} queued={queued}",
+                flush=True,
+            )
+        except Exception as exc:
+            below = True
+            OUT.open("a").write(
+                json.dumps({"ts": ts, "elapsed_s": round(elapsed, 1), "ok": False, "error": str(exc)}) + "\n"
+            )
+            print(f"[{ts}] ERR {exc}", flush=True)
+
+        if elapsed >= DURATION_S:
+            break
+        time.sleep(INTERVAL_S)
+
+    result = "STABLE" if not below else "FAILED"
+    print(f"RESULT={result}", flush=True)
+    return 0 if not below else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Manual capacity babysitting was easy to get wrong by opening the DB locally or hammering queue polls.

This slice adds a detached daemon and helpers that refill through the GUI owner on a slow interval.

## Review Claim

Approve adding capacity babysit scripts that refill via recreate-all against mode gui without local DB bootstrap.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Scripts refuse standalone local DB bootstrap paths and only delegate to a live GUI owner.

## Slice Rationale

Operational tooling on top of recreate-all and the queue-status fixes.

## Non-goals

Does not change in-app scheduling.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Scripts present under scripts/repro/babysit_* and default to sixty second polling

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
