### PR TITLE
[UI Responsiveness Guardrails Step 2](1) Precompute planning-chat typing telemetry off the keystroke frame

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -889,7 +889,7 @@ export function App() {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchActiveIndex, setSearchActiveIndex] = useState(0);
   const uiPerfThrottleRef = useRef<Record<string, number>>({});
-  const planningTypingStateRef = useRef<PlanningTypingTelemetryState | null>(null);
+  const planningTypingContextRef = useRef<Record<string, unknown> | null>(null);
   const planningTypingSequenceRef = useRef(0);
   const planningTypingFrameIdsRef = useRef<Set<number>>(new Set());
   const systemSetupAutoOpenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1194,7 +1194,7 @@ export function App() {
     };
   }, []);
   useEffect(() => {
-    planningTypingStateRef.current = {
+    planningTypingContextRef.current = createPlanningTypingTelemetryContext({
       tasks,
       workflows,
       viewMode,
@@ -1202,7 +1202,7 @@ export function App() {
       selectedTaskId,
       selectedWorkflowId,
       hasLoadedPlan,
-    };
+    });
   }, [
     tasks,
     workflows,
@@ -1245,9 +1245,9 @@ export function App() {
 
       const frameId = scheduleFrame(() => {
         planningTypingFrameIdsRef.current.delete(frameId);
-        const telemetryState = planningTypingStateRef.current;
+        const telemetryContext = planningTypingContextRef.current;
         void window.invoker?.reportUiPerf?.(PLANNING_TYPING_LAG_METRIC, {
-          ...(telemetryState ? createPlanningTypingTelemetryContext(telemetryState) : {}),
+          ...(telemetryContext ?? {}),
           sequence,
           eventType: event.type,
           lagMs: Math.round(performance.now() - startedAt),


### PR DESCRIPTION
## Summary

Typing in the planning chat stays smooth even when the restored transcript is large.

Each keystroke used to rebuild a telemetry context by walking every task transcript inside the animation frame, adding avoidable work on the hot path.

Now that context is built once when its inputs change and cached, so the keystroke frame only spreads a ready object.

## Review Claim

Precomputing the planning-typing telemetry context keeps keystrokes responsive without changing the emitted `ui-perf` payload.

## Review Lane

refactor

## Review Unit

activation-surface

## Safety Invariant

The change touches only planning-typing telemetry inside `packages/ui/src/App.tsx`. It reuses the existing `createPlanningTypingTelemetryContext` builder and the same effect dependency list, so a reviewer can confirm equivalence by reading one file.

## Slice Rationale

This is one cohesive hot-path change to a single owning component. Keeping it alone lets a reviewer confirm the keystroke frame does less work while the telemetry payload stays identical.

## Non-goals

- Behavior unchanged: the emitted `ui-perf` telemetry payload and its values stay identical.
- Does not touch the terminal, drawer, or workflow-graph surfaces.
- No new metrics, and no change to when the animation frame is scheduled.

## Visual Proof

This change is invisible in a static frame: the planning chat looks pixel-identical, and only the per-keystroke responsiveness improves. A screenshot cannot show responsiveness, so the proof is the focused end-to-end responsiveness scenario that exercises typing under a large restored transcript.

- [Planning-chat typing responsiveness walkthrough — E2E scenario `planning chat typing stays responsive with a large restored transcript`](https://github.com/Neko-Catpital-Labs/Invoker/blob/master/packages/app/e2e/startup-nonempty-responsiveness.spec.ts) — the reviewer should see the test drive typing into the planning chat and assert the input handler and commit stay within the `ui-perf` latency budgets.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test`
- [ ] `cd packages/app && pnpm test:e2e startup-nonempty-responsiveness.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
