### PR TITLE
[Planning Chat Persistence Hot Path Fix](1) Keep conversation persistence incremental

### DIFF
--- a/packages/data-store/src/__tests__/conversation-repository.test.ts
+++ b/packages/data-store/src/__tests__/conversation-repository.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
 import { ConversationRepository } from '../conversation-repository.js';
 import type { ConversationMessageEntry } from '../conversation-repository.js';
@@ -97,6 +97,36 @@ describe('ConversationRepository', () => {
 
       const loaded = repo.loadConversation('ts-1');
       expect(loaded!.messages).toHaveLength(3);
+    });
+
+    it('does not load the full transcript to compute the append offset', () => {
+      const existingMessages: ConversationMessageEntry[] = Array.from({ length: 1_000 }, (_, index) => ({
+        role: index % 2 === 0 ? 'user' : 'assistant',
+        content: `message-${index}`,
+      }));
+      repo.saveConversation('ts-large', existingMessages);
+
+      const loadMessages = vi.spyOn(adapter, 'loadMessages').mockImplementation(() => {
+        throw new Error('saveConversation should not read the full transcript');
+      });
+      const appendMessage = vi.spyOn(adapter, 'appendMessage');
+
+      repo.saveConversation('ts-large', [
+        ...existingMessages,
+        { role: 'user', content: 'one more turn' },
+      ]);
+
+      expect(loadMessages).not.toHaveBeenCalled();
+      expect(appendMessage).toHaveBeenCalledTimes(1);
+      expect(adapter.countMessages('ts-large')).toBe(1_001);
+
+      loadMessages.mockRestore();
+      appendMessage.mockRestore();
+      const loaded = repo.loadConversation('ts-large');
+      expect(loaded!.messages.at(-1)).toEqual({
+        role: 'user',
+        content: 'one more turn',
+      });
     });
 
     it('handles complex message content (arrays of blocks)', () => {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -3714,6 +3714,21 @@ describe('SQLiteAdapter', () => {
       expect(adapter.loadMessages('ts-1')).toEqual([]);
     });
 
+    it('counts messages for a thread', () => {
+      adapter.saveConversation(makeConversation('ts-1'));
+      adapter.saveConversation(makeConversation('ts-2'));
+
+      expect(adapter.countMessages('ts-1')).toBe(0);
+
+      adapter.appendMessage('ts-1', 'user', '"thread 1 msg"');
+      adapter.appendMessage('ts-2', 'user', '"thread 2 msg"');
+      adapter.appendMessage('ts-1', 'assistant', '"reply to thread 1"');
+
+      expect(adapter.countMessages('ts-1')).toBe(2);
+      expect(adapter.countMessages('ts-2')).toBe(1);
+      expect(adapter.countMessages('missing')).toBe(0);
+    });
+
     it('isolates messages by thread_ts', () => {
       adapter.saveConversation(makeConversation('ts-1'));
       adapter.saveConversation(makeConversation('ts-2'));

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -332,6 +332,7 @@ export interface PersistenceAdapter {
 
   // Conversation messages
   appendMessage(threadTs: string, role: 'user' | 'assistant', content: string): void;
+  countMessages(threadTs: string): number;
   loadMessages(threadTs: string): ConversationMessage[];
 
   // Workflow channels (Slack workflow↔channel mapping)

--- a/packages/data-store/src/conversation-repository.ts
+++ b/packages/data-store/src/conversation-repository.ts
@@ -92,9 +92,9 @@ export class ConversationRepository {
       });
     }
 
-    // Determine how many messages already exist and append new ones
-    const existingMessages = this.adapter.loadMessages(threadTs);
-    const newMessages = messages.slice(existingMessages.length);
+    // Determine how many messages already exist without reading the transcript.
+    const existingMessageCount = this.adapter.countMessages(threadTs);
+    const newMessages = messages.slice(existingMessageCount);
 
     for (const msg of newMessages) {
       const contentJson = typeof msg.content === 'string'

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -2079,6 +2079,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
     `, [threadTs, nextSeq, role, content]);
   }
 
+  countMessages(threadTs: string): number {
+    const row = this.queryOne(
+      'SELECT COUNT(*) AS count FROM conversation_messages WHERE thread_ts = ?',
+      [threadTs],
+    ) as { count?: number } | undefined;
+    return Number(row?.count ?? 0);
+  }
+
   loadMessages(threadTs: string): ConversationMessage[] {
     const rows = this.queryAll(
       'SELECT * FROM conversation_messages WHERE thread_ts = ? ORDER BY seq ASC',


### PR DESCRIPTION
## Summary

Sending a planning-chat message used to reload the entire saved transcript from SQLite just to figure out how many messages already existed. On a long conversation, that read grew with every turn.

This slice adds a cheap `countMessages` lookup and switches the save path to use it. The repository now asks the database for a count instead of pulling every stored row.

Behavior is unchanged: the same new messages are appended in the same order. Only the offset lookup stops doing full-transcript work.

## Review Claim

Approve replacing the full-transcript read in `ConversationRepository.saveConversation` with a `countMessages` count so the planning-chat save path stops doing O(n) work per send.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

`countMessages` returns the same row count that `loadMessages(...).length` returned, so the slice index used to pick new messages is identical. The append loop and its inputs are untouched.

## Slice Rationale

This slice is the persistence-layer fix alone: the adapter interface, SQLite implementation, repository call site, and directly affected data-store unit tests. The app-level send-path guard lives in the next slice.

## Non-goals

- No change to message content, ordering, or what gets persisted.
- No change to the app or surfaces send flow.
- No change to test infrastructure or runner scripts.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --dir packages/data-store test -- src/__tests__/conversation-repository.test.ts src/__tests__/sqlite-adapter.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8fff05a75`
- Post-revert steps: None. The save path falls back to reading the full transcript, which is correct but slower.
- Data migration? No. `countMessages` only reads; no schema change.

</details>

