### PR TITLE
Disable Needs Attention Auto Open

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -45,6 +45,63 @@ type ModalState =
   | { type: 'experiment'; task: TaskState }
   | { type: 'replace'; task: TaskState };
 
+type AppViewMode = 'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph' | 'attention';
+
+interface WorkflowMutationFailedEvent {
+  readonly workflowId?: unknown;
+  readonly failedTaskId?: unknown;
+  readonly message?: unknown;
+  readonly error?: unknown;
+  readonly reason?: unknown;
+  readonly mutationKind?: unknown;
+  readonly functionName?: unknown;
+  readonly channel?: unknown;
+  readonly intentId?: unknown;
+}
+
+interface TaskMutationFailureDetail {
+  readonly taskId: string;
+  readonly workflowId?: string;
+  readonly message: string;
+  readonly mutationKind?: string;
+  readonly intentId?: string | number;
+}
+
+interface WorkflowMutationFailureEventApi {
+  onWorkflowMutationFailed?: (cb: (event: WorkflowMutationFailedEvent) => void) => () => void;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function getTaskScopedFailureId(event: WorkflowMutationFailedEvent): string | undefined {
+  return stringField(event.failedTaskId);
+}
+
+function normalizeTaskMutationFailure(
+  event: WorkflowMutationFailedEvent,
+  taskId: string,
+): TaskMutationFailureDetail {
+  return {
+    taskId,
+    workflowId: stringField(event.workflowId),
+    message:
+      stringField(event.message) ??
+      stringField(event.error) ??
+      stringField(event.reason) ??
+      'Workflow mutation failed.',
+    mutationKind:
+      stringField(event.mutationKind) ??
+      stringField(event.functionName) ??
+      stringField(event.channel),
+    intentId:
+      typeof event.intentId === 'number' || typeof event.intentId === 'string'
+        ? event.intentId
+        : undefined,
+  };
+}
+
 interface WorkflowContextMenuProps {
   x: number;
   y: number;
@@ -231,7 +288,7 @@ export function App() {
   const [hasStarted, setHasStarted] = useState(false);
   const [planName, setPlanName] = useState<string | null>(null);
   const [onFinish, setOnFinish] = useState<'none' | 'merge' | 'pull_request'>('merge');
-  const [viewMode, setViewMode] = useState<'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph'>('dag');
+  const [viewMode, setViewMode] = useState<AppViewMode>('dag');
   const [selectedActionNode, setSelectedActionNode] = useState<ActionGraphNode | null>(null);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; taskId: string } | null>(null);
   const [remoteTargets, setRemoteTargets] = useState<string[]>([]);
@@ -247,6 +304,9 @@ export function App() {
   const [advancedMetadataExpanded, setAdvancedMetadataExpanded] = useState(false);
   const [terminalCollapsed, setTerminalCollapsed] = useState(true);
   const [workflowContextMenu, setWorkflowContextMenu] = useState<{ x: number; y: number; workflowId: string } | null>(null);
+  const [mutationFailuresByTaskId, setMutationFailuresByTaskId] = useState<Map<string, TaskMutationFailureDetail>>(
+    new Map(),
+  );
   const uiPerfThrottleRef = useRef<Record<string, number>>({});
 
   const refreshSystemDiagnostics = useCallback(() => {
@@ -270,6 +330,32 @@ export function App() {
     window.invoker?.getExecutionAgents?.().then(setExecutionAgents).catch(() => {});
     refreshSystemDiagnostics();
   }, [refreshSystemDiagnostics]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.invoker) return;
+    const eventApi = window.invoker as typeof window.invoker & WorkflowMutationFailureEventApi;
+    if (typeof eventApi.onWorkflowMutationFailed !== 'function') return;
+
+    return eventApi.onWorkflowMutationFailed((event) => {
+      const failedTaskId = getTaskScopedFailureId(event);
+      if (failedTaskId) {
+        setMutationFailuresByTaskId((prev) => {
+          const next = new Map(prev);
+          next.set(failedTaskId, normalizeTaskMutationFailure(event, failedTaskId));
+          return next;
+        });
+        return;
+      }
+
+      const workflowId = stringField(event.workflowId);
+      if (workflowId) {
+        setViewMode('dag');
+        setWorkflowSelectionDismissed(false);
+        setSelectedTaskId(null);
+        setSelectedWorkflowId(workflowId);
+      }
+    });
+  }, []);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !window.invoker) return;
@@ -359,6 +445,18 @@ export function App() {
     }
     return next;
   }, [selectedWorkflow, selectedWorkflowId, tasks]);
+  const attentionEntries = useMemo(
+    () =>
+      [...mutationFailuresByTaskId.entries()].map(([taskId, failure]) => ({
+        taskId,
+        task: tasks.get(taskId) ?? null,
+        failure,
+      })),
+    [mutationFailuresByTaskId, tasks],
+  );
+  const selectedTaskMutationFailure = selectedTaskId
+    ? mutationFailuresByTaskId.get(selectedTaskId) ?? null
+    : null;
 
   useEffect(() => {
     if (selectedTask?.config.workflowId) {
@@ -399,6 +497,35 @@ export function App() {
   const missingRequiredTool = systemDiagnostics?.tools.find((tool) => tool.required && !tool.installed) ?? null;
   const installedAgentCount = systemDiagnostics?.tools.filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed).length ?? 0;
   const needsBundledSkillsPrompt = Boolean(systemDiagnostics?.isPackaged && systemDiagnostics?.bundledSkills?.promptRecommended);
+
+  const handleOpenAttention = useCallback(() => {
+    setViewMode('attention');
+    const selectedHasAttention = selectedTaskId ? mutationFailuresByTaskId.has(selectedTaskId) : false;
+    if (selectedHasAttention) return;
+
+    const firstEntry = attentionEntries[0];
+    if (!firstEntry) return;
+    setSelectedTaskId(firstEntry.taskId);
+    setWorkflowSelectionDismissed(false);
+    const workflowId = firstEntry.task?.config.workflowId ?? firstEntry.failure.workflowId;
+    if (workflowId) {
+      setSelectedWorkflowId(workflowId);
+    }
+  }, [attentionEntries, mutationFailuresByTaskId, selectedTaskId]);
+
+  const handleAttentionEntryClick = useCallback(
+    (taskId: string) => {
+      const task = tasks.get(taskId);
+      const failure = mutationFailuresByTaskId.get(taskId);
+      setSelectedTaskId(taskId);
+      setWorkflowSelectionDismissed(false);
+      const workflowId = task?.config.workflowId ?? failure?.workflowId;
+      if (workflowId) {
+        setSelectedWorkflowId(workflowId);
+      }
+    },
+    [mutationFailuresByTaskId, tasks],
+  );
 
   // ── DAG interaction ───────────────────────────────────────
   const handleTaskClick = useCallback((task: TaskState) => {
@@ -715,6 +842,7 @@ export function App() {
       setSelectedWorkflowId(null);
       setModal({ type: 'none' });
       setStatusFilters(new Set<WorkflowStatus>());
+      setMutationFailuresByTaskId(new Map());
     } catch (err) {
       console.error('Failed to clear:', err);
     }
@@ -735,6 +863,7 @@ export function App() {
       setSelectedTaskId(null);
       setSelectedWorkflowId(null);
       setModal({ type: 'none' });
+      setMutationFailuresByTaskId(new Map());
     } catch (err) {
       console.error('Failed to delete workflows:', err);
     }
@@ -1032,6 +1161,18 @@ export function App() {
             >
               Queue
             </button>
+            {attentionEntries.length > 0 && (
+              <button
+                data-testid="rail-attention"
+                onClick={handleOpenAttention}
+                className={`w-full rounded px-2 py-1.5 text-left text-xs ${viewMode === 'attention' ? 'bg-gray-800 text-white' : 'text-gray-300 hover:bg-gray-800/70'}`}
+              >
+                <span>Needs Attention</span>
+                <span data-testid="rail-attention-count" className="ml-1 text-[10px] text-amber-300">
+                  {attentionEntries.length}
+                </span>
+              </button>
+            )}
             </div>
 
             <div className="space-y-1 border-t border-gray-800 pt-3">
@@ -1086,6 +1227,37 @@ export function App() {
                   onCancel={handleCancelTask}
                   selectedTaskId={selectedTaskId}
                 />
+              ) : viewMode === 'attention' ? (
+                <div data-testid="needs-attention-surface" className="h-full overflow-y-auto bg-gray-900 p-4">
+                  <div className="mb-3 flex items-center justify-between">
+                    <h2 className="text-sm font-semibold text-amber-200">Needs Attention</h2>
+                    <span className="text-xs text-gray-400">{attentionEntries.length}</span>
+                  </div>
+                  <div className="space-y-2">
+                    {attentionEntries.map((entry) => (
+                      <button
+                        key={entry.taskId}
+                        data-testid={`attention-entry-${entry.taskId}`}
+                        onClick={() => handleAttentionEntryClick(entry.taskId)}
+                        className={`w-full rounded border px-3 py-2 text-left ${
+                          selectedTaskId === entry.taskId
+                            ? 'border-amber-400 bg-amber-950/40'
+                            : 'border-gray-700 bg-gray-800/70 hover:bg-gray-800'
+                        }`}
+                      >
+                        <div className="truncate text-sm text-gray-100">
+                          {entry.task?.description ?? entry.taskId}
+                        </div>
+                        <div className="mt-1 truncate text-xs text-amber-200">
+                          {entry.failure.message}
+                        </div>
+                        <div className="mt-1 text-[11px] text-gray-500">
+                          {entry.failure.workflowId ?? entry.task?.config.workflowId ?? 'workflow unknown'}
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                </div>
               ) : viewMode === 'history' ? (
                 <HistoryView onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
               ) : viewMode === 'timeline' ? (
@@ -1156,6 +1328,7 @@ export function App() {
               remoteTargets={remoteTargets}
               executionPools={executionPools}
               executionAgents={executionAgents}
+              mutationFailure={selectedTaskMutationFailure}
               collapsed={inspectorCollapsed}
               advancedExpanded={advancedMetadataExpanded}
               actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -158,7 +158,10 @@ export function createMockInvoker(
 
   function setTasks(tasks: TaskState[], workflows?: WorkflowMeta[]) {
     taskSnapshot = tasks;
-    if (workflows) workflowSnapshot = workflows;
+    if (workflows) {
+      workflowSnapshot = workflows;
+      workflowsCallback?.(workflows);
+    }
 
     // Fire created deltas for each task
     for (const task of tasks) {

--- a/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
+++ b/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
@@ -60,8 +60,8 @@ describe('Visual proof snapshots', () => {
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
-      expect(screen.getByText('Alpha')).toBeInTheDocument();
-      expect(screen.getByText('Beta')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-alpha')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-beta')).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByTestId('workflow-node-wf-alpha'));

--- a/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
+++ b/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
@@ -1,0 +1,137 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import type { WorkflowMeta } from '../types.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+type WorkflowMutationFailedEvent = {
+  workflowId?: string;
+  failedTaskId?: string;
+  message?: string;
+  mutationKind?: string;
+  intentId?: number;
+};
+
+function attachWorkflowMutationFailedEvent(mock: MockInvoker) {
+  let callback: ((event: WorkflowMutationFailedEvent) => void) | undefined;
+  const onWorkflowMutationFailed = vi.fn((cb: (event: WorkflowMutationFailedEvent) => void) => {
+    callback = cb;
+    return () => {
+      callback = undefined;
+    };
+  });
+
+  (mock.api as typeof mock.api & {
+    onWorkflowMutationFailed: typeof onWorkflowMutationFailed;
+  }).onWorkflowMutationFailed = onWorkflowMutationFailed;
+
+  return {
+    onWorkflowMutationFailed,
+    fire(event: WorkflowMutationFailedEvent) {
+      if (!callback) throw new Error('workflow mutation failure listener was not registered');
+      act(() => {
+        callback?.(event);
+      });
+    },
+  };
+}
+
+const workflow: WorkflowMeta = {
+  id: 'wf-a',
+  name: 'Workflow A',
+  status: 'running',
+};
+
+const task = makeUITask({
+  id: 'task-failed',
+  description: 'Regenerate docs',
+  status: 'running',
+  workflowId: 'wf-a',
+  command: 'pnpm docs',
+});
+
+describe('workflow mutation failure UI activation', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  it('records task-scoped mutation failures without opening Needs Attention or selecting the task', async () => {
+    const mutationFailures = attachWorkflowMutationFailedEvent(mock);
+    render(<App />);
+    act(() => mock.setTasks([task], [workflow]));
+
+    await waitFor(() => expect(mutationFailures.onWorkflowMutationFailed).toHaveBeenCalled());
+
+    await screen.findByTestId('workflow-node-wf-a');
+
+    fireEvent.click(screen.getByTestId('workflow-graph-react-flow'));
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('No node selected');
+    });
+
+    fireEvent.click(screen.getByTestId('rail-queue'));
+    await screen.findByText(/Action Queue/);
+
+    mutationFailures.fire({
+      workflowId: 'wf-a',
+      failedTaskId: 'task-failed',
+      message: 'Queued mutation failed',
+      mutationKind: 'recreate-task',
+      intentId: 44,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('rail-attention-count')).toHaveTextContent('1');
+    });
+    expect(screen.queryByTestId('needs-attention-surface')).not.toBeInTheDocument();
+    expect(screen.getByText(/Action Queue/)).toBeInTheDocument();
+    expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('No node selected');
+
+    fireEvent.click(screen.getByTestId('rail-attention'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('needs-attention-surface')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Regenerate docs');
+      expect(screen.getByTestId('task-mutation-failure-detail')).toHaveTextContent('Queued mutation failed');
+    });
+    expect(screen.getByTestId('task-mutation-failure-detail')).toHaveTextContent('recreate-task');
+    expect(screen.getByTestId('task-mutation-failure-detail')).toHaveTextContent('44');
+  });
+
+  it('keeps workflow-scoped mutation failures opening the workflow graph', async () => {
+    const mutationFailures = attachWorkflowMutationFailedEvent(mock);
+    render(<App />);
+    act(() => mock.setTasks([task], [workflow]));
+
+    await waitFor(() => expect(mutationFailures.onWorkflowMutationFailed).toHaveBeenCalled());
+
+    await screen.findByTestId('workflow-node-wf-a');
+
+    fireEvent.click(screen.getByTestId('rail-queue'));
+    await screen.findByText(/Action Queue/);
+
+    mutationFailures.fire({
+      workflowId: 'wf-a',
+      message: 'Workflow mutation failed',
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
+    });
+    expect(screen.queryByTestId('rail-attention')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -10,6 +10,13 @@ interface WorkflowInspectorProps {
   remoteTargets?: string[];
   executionPools?: string[];
   executionAgents?: string[];
+  mutationFailure?: {
+    taskId: string;
+    workflowId?: string;
+    message: string;
+    mutationKind?: string;
+    intentId?: string | number;
+  } | null;
   actionNode?: unknown;
   collapsed: boolean;
   advancedExpanded: boolean;
@@ -48,6 +55,7 @@ export function WorkflowInspector({
   workflowTasks,
   executionPools,
   executionAgents,
+  mutationFailure,
   collapsed,
   advancedExpanded,
   onEditPool,
@@ -190,6 +198,25 @@ export function WorkflowInspector({
             <p className="mt-2 text-xs text-red-300">Exit code: {task.execution.exitCode}</p>
           )}
         </section>
+
+        {task && mutationFailure && (
+          <section
+            data-testid="task-mutation-failure-detail"
+            className="rounded border border-amber-500/50 bg-amber-950/30 p-3"
+          >
+            <h3 className="text-[11px] uppercase tracking-wide text-amber-200">Mutation failure</h3>
+            <p className="mt-1 text-xs text-amber-100 break-words">{mutationFailure.message}</p>
+            <div className="mt-2 space-y-1 text-[11px] text-amber-100/80">
+              {mutationFailure.mutationKind && (
+                <div>mutation: {mutationFailure.mutationKind}</div>
+              )}
+              {mutationFailure.intentId !== undefined && (
+                <div>intent: {mutationFailure.intentId}</div>
+              )}
+              <div>task: {mutationFailure.taskId}</div>
+            </div>
+          </section>
+        )}
 
         {task && !task.config.isMergeNode && onEditPool && (
           <section className="rounded border border-gray-700 bg-gray-800/70 p-3">

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -25,5 +25,6 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test-setup.ts'],
+    testTimeout: 20_000,
   },
 });


### PR DESCRIPTION
## Summary

Task-scoped workflow mutation failures now stay in the current operator surface instead of opening Needs Attention automatically.

The failure is still recorded, listed under Needs Attention, and shown in the Workflow inspector after the operator opens that surface manually.

Workflow-scoped failures still open Workflows, preserving the existing recovery path for workflow-level failures.

The focused test harness now hydrates workflow snapshots before assertions, and visual-proof DOM validation covers the updated graph selectors.

## Review Claim

Task-scoped workflow mutation failures no longer auto-open Needs Attention or steal UI focus.

## Review Lane

behavior

## Review Unit

ui_activation

## Safety Invariant

Mutation failure events are still stored in `mutationFailuresByTaskId`, still feed the Needs Attention entries, and still show the selected task's failure detail. Workflow-scoped failures keep their DAG activation path.

## Slice Rationale

This is one UI activation path plus the directly affected regression and DOM snapshot coverage. Keeping them together avoids publishing a navigation change without its proof and test harness fixes.

## Non-goals

- Do not change main-process failure classification.
- Do not hide mutation failures from Needs Attention.
- Do not change workflow-scoped failures opening Workflows.
- Do not change approval, rejection, fix, recreate, or retry mutation semantics.

## Architecture

### Before

Task-scoped workflow mutation failures activated the failure surface immediately, which could move an operator away from Queue, Timeline, or another active surface.

### After

Task-scoped failures are stored as attention entries without changing the active surface. Opening Needs Attention manually selects the failed task and shows the mutation detail.

Workflow-scoped failures still route to Workflows because they are not tied to a specific task row.

## Visual Proof

The changed behavior is the absence of an automatic navigation event. Static screenshots do not prove that absence reliably, so the proof is the focused regression test `packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx`: it fires a task-scoped failure while Queue is active, verifies Queue remains active and no task is selected, then opens Needs Attention manually and verifies the failure detail is visible.

`bash scripts/ui-visual-proof.sh validate` also passed for the DOM snapshot suite, including the updated visual proof selectors.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-mutation-failed-banner.test.tsx src/__tests__/visual-proof-snapshots.test.tsx`
- [x] `bash scripts/ui-visual-proof.sh validate`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/disable-needs-attention-auto-open-pr-body.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 998b98cc7`
- Post-revert steps: Run the focused UI test if the branch is still under review.
- Data migration? No

</details>
