### PR TITLE
Remove Workflow Graph Background Refit Interaction (1) Keep selection on background click

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2070,11 +2070,10 @@ export function App() {
   ]);
 
 
-  const handleDagSurfaceClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+  const handleDagSurfaceClick = useCallback(() => {
     if (contextMenu || workflowContextMenu) {
       setContextMenu(null);
       setWorkflowContextMenu(null);
-      return;
     }
 
     if (suppressDagSurfaceDismissRef.current) {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2075,24 +2075,6 @@ export function App() {
       setContextMenu(null);
       setWorkflowContextMenu(null);
     }
-
-    if (suppressDagSurfaceDismissRef.current) {
-      return;
-    }
-
-    const target = event.target as HTMLElement;
-    if (
-      target.closest('[data-testid^="workflow-node-"]') ||
-      target.closest('[data-testid="selected-workflow-mini-dag"]') ||
-      target.closest('.react-flow__node') ||
-      target.closest('[role="menu"]')
-    ) {
-      return;
-    }
-
-    setSelectedTaskId(null);
-    setSelectedWorkflowId(null);
-    setWorkflowSelectionDismissed(true);
   }, [contextMenu, workflowContextMenu]);
 
   const handleRestartTask = useCallback(async (taskId: string) => {

--- a/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
+++ b/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
@@ -6,7 +6,6 @@
  * so workflow-graph-surface's dismiss handler clears the selection in the same
  * turn. Unit tests that only fireEvent.click(node) never hit that path.
  */
-
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
@@ -20,24 +19,28 @@ vi.mock('@xyflow/react', async () => {
 
 const { App } = await import('../App.js');
 
-const workflows: WorkflowMeta[] = [{ id: 'wf-a', name: 'Workflow A', status: 'running' }];
+const workflows: WorkflowMeta[] = [
+  { id: 'wf-a', name: 'Workflow A', status: 'running' },
+  { id: 'wf-b', name: 'Workflow B', status: 'running' },
+];
+
 const alpha = makeUITask({
   id: 'task-alpha',
-  description: 'First test task',
+  description: 'Alpha task',
   status: 'pending',
   workflowId: 'wf-a',
-  command: 'echo hello-alpha',
-});
-const beta = makeUITask({
-  id: 'task-beta',
-  description: 'Second test task',
-  status: 'pending',
-  workflowId: 'wf-a',
-  dependencies: ['task-alpha'],
-  command: 'echo hello-beta',
+  command: 'echo alpha',
 });
 
-describe('Home workflow click mini-DAG dismiss race', () => {
+const beta = makeUITask({
+  id: 'task-beta',
+  description: 'Beta task',
+  status: 'pending',
+  workflowId: 'wf-b',
+  command: 'echo beta',
+});
+
+describe('Home workflow graph mini DAG click dismissal repro', () => {
   let mock: MockInvoker;
 
   beforeEach(() => {
@@ -49,56 +52,44 @@ describe('Home workflow click mini-DAG dismiss race', () => {
     mock.cleanup();
   });
 
-  it('keeps the mini-DAG when select is followed by a retargeted surface click in the same turn', async () => {
+  async function selectWorkflowB() {
     render(<App />);
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
-      expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-b')).toBeInTheDocument();
     });
 
-    const node = screen.getByTestId('workflow-node-wf-a');
-    const captureRoot = screen.getByTestId('workflow-graph-react-flow');
-
-    act(() => {
-      fireEvent.click(node);
-      // Same-turn click retargeted to the pointer-capture root (not inside the node).
-      fireEvent.click(captureRoot);
-    });
+    fireEvent.click(screen.getByTestId('rf__node-wf-b'));
 
     await waitFor(() => {
-      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow B');
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow B');
     });
-    expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
-  });
+  }
 
-  it('restores the mini-DAG after leave-Home reselect when selection was dismissed', async () => {
-    render(<App />);
-    act(() => mock.setTasks([alpha, beta], workflows));
+  it('keeps the selected mini DAG after a blank graph surface click', async () => {
+    await selectWorkflowB();
+
+    fireEvent.click(screen.getByTestId('workflow-graph-surface'));
 
     await waitFor(() => {
-      expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByTestId('workflow-node-wf-a'));
-    await waitFor(() => {
-      expect(screen.getByTestId('selected-workflow-mini-dag')).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByTestId('workflow-graph-react-flow'));
-    await waitFor(() => {
-      expect(screen.queryByTestId('selected-workflow-mini-dag')).not.toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByTestId('sidebar-workflows'));
-    await waitFor(() => {
-      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
-    });
-
-    fireEvent.click(screen.getByTestId('sidebar-home'));
-    await waitFor(() => {
-      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow B');
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow B');
     });
   });
 
+  it('keeps the selected mini DAG after a retargeted React Flow pane click', async () => {
+    await selectWorkflowB();
+
+    fireEvent.click(screen.getByTestId('workflow-graph-react-flow'), {
+      clientX: 24,
+      clientY: 24,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow B');
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow B');
+    });
+  });
 });

--- a/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
+++ b/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
@@ -19,25 +19,23 @@ vi.mock('@xyflow/react', async () => {
 
 const { App } = await import('../App.js');
 
-const workflows: WorkflowMeta[] = [
-  { id: 'wf-a', name: 'Workflow A', status: 'running' },
-  { id: 'wf-b', name: 'Workflow B', status: 'running' },
-];
+const workflows: WorkflowMeta[] = [{ id: 'wf-a', name: 'Workflow A', status: 'running' }];
 
 const alpha = makeUITask({
   id: 'task-alpha',
-  description: 'Alpha task',
+  description: 'First test task',
   status: 'pending',
   workflowId: 'wf-a',
-  command: 'echo alpha',
+  command: 'echo hello-alpha',
 });
 
 const beta = makeUITask({
   id: 'task-beta',
-  description: 'Beta task',
+  description: 'Second test task',
   status: 'pending',
-  workflowId: 'wf-b',
-  command: 'echo beta',
+  workflowId: 'wf-a',
+  dependencies: ['task-alpha'],
+  command: 'echo hello-beta',
 });
 
 describe('Home workflow graph mini DAG click dismissal repro', () => {
@@ -52,35 +50,35 @@ describe('Home workflow graph mini DAG click dismissal repro', () => {
     mock.cleanup();
   });
 
-  async function selectWorkflowB() {
+  async function selectWorkflowA() {
     render(<App />);
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
-      expect(screen.getByTestId('workflow-node-wf-b')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByTestId('rf__node-wf-b'));
+    fireEvent.click(screen.getByTestId('rf__node-wf-a'));
 
     await waitFor(() => {
-      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow B');
-      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow B');
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
     });
   }
 
   it('keeps the selected mini DAG after a blank graph surface click', async () => {
-    await selectWorkflowB();
+    await selectWorkflowA();
 
     fireEvent.click(screen.getByTestId('workflow-graph-surface'));
 
     await waitFor(() => {
-      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow B');
-      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow B');
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
     });
   });
 
   it('keeps the selected mini DAG after a retargeted React Flow pane click', async () => {
-    await selectWorkflowB();
+    await selectWorkflowA();
 
     fireEvent.click(screen.getByTestId('workflow-graph-react-flow'), {
       clientX: 24,
@@ -88,8 +86,8 @@ describe('Home workflow graph mini DAG click dismissal repro', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow B');
-      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow B');
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
     });
   });
 });

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -196,7 +196,7 @@ describe('Task interaction (component)', () => {
     expect(screen.queryByLabelText('Maximize inspector')).not.toBeInTheDocument();
   });
 
-  it('clicking workflow graph background dismisses the selected mini DAG', async () => {
+  it('clicking workflow graph background keeps the selected mini DAG', async () => {
     render(<App />);
     act(() => mock.setTasks([alpha, beta], workflows));
 
@@ -212,7 +212,8 @@ describe('Task interaction (component)', () => {
     fireEvent.click(screen.getByTestId('workflow-graph-react-flow'));
 
     await waitFor(() => {
-      expect(screen.queryByTestId('selected-workflow-mini-dag')).not.toBeInTheDocument();
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
     });
   });
 

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -204,7 +204,7 @@ describe('Task interaction (component)', () => {
       expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByTestId('workflow-node-wf-a'));
+    fireEvent.click(screen.getByTestId('rf__node-wf-a'));
     await waitFor(() => {
       expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
     });


### PR DESCRIPTION
## Summary

Clicking empty black space on the Home workflow graph used to clear the current selection, hide the mini-DAG, and refit the camera.

This change stops that. A background click now leaves the selected workflow, its mini-DAG, and the inspector alone.

Background clicks still close an open context menu.

## Review Claim

Approve that Home workflow graph background clicks no longer clear selection or dismiss the mini-DAG; they only close an open context menu.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the empty-background click path changes. Node clicks, edge clicks, selection state, and context-menu close behavior stay intact.

## Slice Rationale

This keeps the graph interaction fix and its focused UI regression coverage together in one user-visible slice.

## Non-goals

- Does not change any test runner or package script wiring.
- Does not change mini-DAG rendering outside the background-click path.
- Does not change any other graph interaction.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx src/__tests__/task-interaction.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
