### PR TITLE
Repro Planning Thinking Stream After Submit

### DIFF
--- a/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { InAppPlanningChatResponse } from '@invoker/contracts';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  // Dynamic import is required because Vitest hoists mock factories before test imports.
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+// Dynamic import is required so App sees the hoisted @xyflow/react mock.
+const { App } = await import('../App.js');
+
+// Regression repro: after submitting a draft-ready planning session, starting a
+// new planning turn must still show the live raw planner stream while the new
+// planningChatSend request is pending. Buggy code loses the stream surface until
+// the final assistant reply arrives.
+describe('planning draft submit -> new turn live planner stream repro', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  async function openPlanningTerminal() {
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+    });
+  }
+
+  function submitPlanningText(text: string) {
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+  }
+
+  it('keeps live planner output visible during the new pending turn after submit', async () => {
+    let resolveSecondSend: ((value: InAppPlanningChatResponse) => void) | null = null;
+    const draftReply: InAppPlanningChatResponse = {
+      ok: true,
+      sessionId: 'session-1',
+      reply: 'Here is the plan.',
+      draftPlanAvailable: true,
+      draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First', 'Second'] },
+    };
+
+    mock.api.planningChatSend = vi
+      .fn()
+      .mockResolvedValueOnce(draftReply)
+      .mockImplementationOnce(() => new Promise<InAppPlanningChatResponse>((resolve) => {
+        resolveSecondSend = resolve;
+      })) as any;
+    mock.api.planningChatSubmit = vi.fn(async () => ({
+      ok: true,
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft the full plan');
+    await screen.findByTestId('invoker-terminal-ready-bar');
+    fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });
+    });
+    await openPlanningTerminal();
+    expect(await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.')).toBeInTheDocument();
+    expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    expect(screen.getByTestId('invoker-terminal-harness')).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'New' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-input')).not.toBeDisabled();
+    });
+
+    submitPlanningText('draft the next plan');
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledTimes(2);
+      expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
+        message: 'draft the next plan',
+        presetKey: 'codex',
+      });
+    });
+
+    await act(async () => {
+      mock.firePlanningChatStream({ sessionId: 'session-2', chunk: 'live planner thinking after submit' });
+    });
+
+    const stream = await screen.findByTestId('invoker-terminal-planner-stream');
+    expect(stream).toHaveAttribute('data-state', 'streaming');
+    expect(stream).toHaveTextContent('live planner thinking after submit');
+
+    await act(async () => {
+      resolveSecondSend?.({
+        ok: true,
+        sessionId: 'session-2',
+        reply: 'Final assistant reply for the new turn.',
+        draftPlanAvailable: false,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('invoker-terminal-planner-stream')).not.toBeInTheDocument();
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Final assistant reply for the new turn.');
+      expect(screen.getByTestId('invoker-terminal-transcript')).not.toHaveTextContent('live planner thinking after submit');
+    });
+  });
+});

--- a/scripts/repro/repro-planning-thinking-after-submit.sh
+++ b/scripts/repro/repro-planning-thinking-after-submit.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repro: after a draft-ready planning session is submitted, a new planning turn
+# must keep the live planner stream visible while planningChatSend is still
+# pending, then remove it when the final assistant reply arrives.
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/invoker-planning-thinking-after-submit.XXXXXX.log")"
+trap 'rm -f "$LOG_FILE"' EXIT
+
+echo "[repro] Running focused planning stream visibility regression."
+
+if pnpm -C "$REPO_ROOT" --filter @invoker/ui exec vitest run \
+  src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx \
+  >"$LOG_FILE" 2>&1; then
+  echo "[repro] PASS: live planner output stays visible during the pending new turn and clears after the final reply."
+else
+  status=$?
+  echo "[repro] FAIL: planning stream visibility regression failed."
+  cat "$LOG_FILE"
+  exit "$status"
+fi


### PR DESCRIPTION
## Summary

Add proof coverage for the planning chat thinking stream after a draft-ready turn is sent.

Coverage verifies the live planner text remains visible during the next pending turn and disappears once the reply is final.

Only a UI regression test and repro script are included.

## Review Claim

Approve proof coverage for the planning stream visibility regression after draft handoff.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes only proof files:

- `packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx`
- `scripts/repro/repro-planning-thinking-after-submit.sh`

Runtime source is unchanged.

## Slice Rationale

The behavior already exists on `master`. This slice adds focused proof so the visible stream state cannot regress silently.

## Non-goals

- Does not change how planner stream chunks are produced or sent.
- Does not touch draft handoff logic.
- Does not restyle the planning panel.
- Does not add or change saved data.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-planning-thinking-after-submit.sh`
- [x] `cd packages/ui && pnpm test -- src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <squash-merge-sha>`
- Post-revert steps: None; only proof coverage is removed.
- Data migration? No

</details>