### PR TITLE
Constrain mini task DAG layering to workflow graph surface (1) — isolate mini-DAG stacking context

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3594,7 +3594,7 @@ export function App() {
       data-keyboard-region="workflowGraph"
       tabIndex={0}
       data-keyboard-active={keyboardRegion === 'workflowGraph' ? 'true' : 'false'}
-      className={`relative min-h-0 flex-1 overflow-hidden border-r border-border bg-background outline-none ${keyboardRegion === 'workflowGraph' ? 'ring-2 ring-inset ring-ring/50' : ''}`}
+      className={`relative isolate z-0 min-h-0 flex-1 overflow-hidden border-r border-border bg-background outline-none ${keyboardRegion === 'workflowGraph' ? 'ring-2 ring-inset ring-ring/50' : ''}`}
       onClick={viewMode === 'dag' ? handleDagSurfaceClick : undefined}
     >
       {viewMode === 'queue' ? (
@@ -3635,18 +3635,20 @@ export function App() {
       ) : (
         <>
           {sidebarSurface === 'planning' && (
-            <WorkflowGraph
-              workflows={workflows}
-              selectedWorkflowId={selectedWorkflow?.id ?? null}
-              cameraCommand={cameraCommand}
-              initialViewport={workflowGraphViewportRef.current}
-              statusFilters={statusFilters}
-              coreActivityByWorkflow={coreActivityByWorkflow}
-              onSelectWorkflow={handleWorkflowClick}
-              onWorkflowContextMenu={handleWorkflowContextMenu}
-              onViewportSnapshot={handleWorkflowGraphViewportSnapshot}
-              onManualViewport={handleManualViewport}
-            />
+            <div data-testid="workflow-graph-content" className="relative z-0 h-full w-full">
+              <WorkflowGraph
+                workflows={workflows}
+                selectedWorkflowId={selectedWorkflow?.id ?? null}
+                cameraCommand={cameraCommand}
+                initialViewport={workflowGraphViewportRef.current}
+                statusFilters={statusFilters}
+                coreActivityByWorkflow={coreActivityByWorkflow}
+                onSelectWorkflow={handleWorkflowClick}
+                onWorkflowContextMenu={handleWorkflowContextMenu}
+                onViewportSnapshot={handleWorkflowGraphViewportSnapshot}
+                onManualViewport={handleManualViewport}
+              />
+            </div>
           )}
           {renderSelectedWorkflowTaskGraph(sidebarSurface === 'planning')}
         </>

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -46,7 +46,7 @@ const workflows: WorkflowMeta[] = [
   { id: 'wf-1', name: 'Test Workflow', status: 'running', baseBranch: 'master' },
 ];
 
-const FLOATING_GRAPH_PANEL_Z_INDEX = 1000;
+const FLOATING_GRAPH_PANEL_LOCAL_Z_INDEX = 10;
 const APP_CONTEXT_MENU_TEST_TIMEOUT_MS = 20_000;
 
 describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS }, () => {
@@ -252,8 +252,9 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
 
     const menu = await screen.findByRole('menu');
     expect(panel).toBeInTheDocument();
-    expect(menu).toHaveStyle({ zIndex: String(FLOATING_GRAPH_PANEL_Z_INDEX + 100) });
-    expect(Number(menu.style.zIndex)).toBeGreaterThan(FLOATING_GRAPH_PANEL_Z_INDEX);
+    expect(panel).toHaveClass(`z-${FLOATING_GRAPH_PANEL_LOCAL_Z_INDEX}`);
+    expect(panel.style.zIndex).toBe('');
+    expect(Number(menu.style.zIndex)).toBeGreaterThan(FLOATING_GRAPH_PANEL_LOCAL_Z_INDEX);
   });
 
   it('workflow context menu retries workflow', async () => {

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -52,6 +52,36 @@ describe('Task interaction (component)', () => {
     });
   });
 
+  it('scopes mini DAG layering to the workflow graph surface', async () => {
+    render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    act(() => mock.setTasks([alpha, beta], workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('rf__node-wf-a'));
+
+    const surface = screen.getByTestId('workflow-graph-surface');
+    const graphContent = screen.getByTestId('workflow-graph-content');
+    const panel = await screen.findByTestId('selected-workflow-mini-dag');
+
+    expect(surface).toHaveClass('relative', 'isolate', 'z-0');
+    expect(graphContent).toHaveClass('relative', 'z-0');
+    expect(panel).toHaveClass('absolute', 'z-10');
+    expect(panel).not.toHaveClass('z-[1000]');
+    expect(panel.style.zIndex).toBe('');
+    expect(surface).toContainElement(graphContent);
+    expect(surface).toContainElement(panel);
+
+    fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-a'));
+    const globalMenu = await screen.findByRole('menu');
+
+    expect(globalMenu).toHaveClass('fixed', 'z-50');
+    expect(surface).not.toContainElement(globalMenu);
+  });
+
   it('clicking a mini DAG task updates prompt details', async () => {
     render(<App />);
     fireEvent.click(await screen.findByTestId('sidebar-planning'));

--- a/packages/ui/src/components/FloatingGraphPanel.tsx
+++ b/packages/ui/src/components/FloatingGraphPanel.tsx
@@ -95,12 +95,10 @@ export function FloatingGraphPanel({
     <div
       ref={panelRef}
       data-testid={testId}
-      className={`absolute top-3 right-3 z-[1000] h-[210px] w-[315px] rounded border border-border bg-background/95 overflow-hidden shadow-lg ${className}`}
+      className={`absolute top-3 right-3 z-10 h-[210px] w-[315px] rounded border border-border bg-background/95 overflow-hidden shadow-lg ${className}`}
       style={{
         ...(position ? { left: position.left, top: position.top, right: 'auto' } : {}),
-        isolation: 'isolate',
         pointerEvents: 'auto',
-        zIndex: 1000,
       }}
       onClick={(event) => event.stopPropagation()}
       onPointerDown={(event) => event.stopPropagation()}


### PR DESCRIPTION
## Summary

When you picked a workflow, its floating mini task DAG could cover the task context menu and other app-wide pop-ups.

The panel used a very high stacking value to sit above the graph. That value also let it climb above overlays it should never cover.

This change gives the workflow graph area its own private stacking layer. The mini DAG now floats above the graph only.

Global overlays like the task context menu live outside that layer, so they always render on top of the mini DAG again.

## Review Claim

Approve that the selected-workflow mini DAG floats above the workflow graph surface only, and no longer stacks above global overlays such as the task context menu.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change only adds Tailwind stacking classes: `isolate z-0` on the graph surface, a `relative z-0` content wrapper, and `z-10` (replacing a global-scale z-index) on the mini DAG panel. No data, state, or control flow changes, so it is safe to review by reading the class changes and the added component test.

## Slice Rationale

This slice is the behavior fix plus the regression tests that lock it in. Both must land together to stay green, because the tests assert the fixed stacking classes. The separate focused-test-runner tooling is split into the next slice so this diff contains only the user-visible fix.

## Non-goals

- Does not change the mini DAG contents, position, size, or open/close behavior.
- Does not change the context menu itself or any other overlay.
- Does not touch the test runner script or `package.json` (that is the next slice).

## Visual Proof

This is a stacking-order fix. A single static screenshot cannot prove which element is on top when two elements overlap, so the honest proof is the focused component test that inspects the rendered layers.

The added test `scopes mini DAG layering to the workflow graph surface` in `packages/ui/src/__tests__/task-interaction.test.tsx` asserts the surface has `relative isolate z-0`, the mini DAG panel has `absolute z-10` with no inline z-index, and the global context menu (`fixed z-50`) renders outside the isolated surface. `packages/ui/src/__tests__/context-menu-e2e.test.tsx` additionally checks the menu stacks above the panel's local z-index.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test src/__tests__/task-interaction.test.tsx src/__tests__/context-menu-e2e.test.tsx`
- [ ] `cd packages/ui && pnpm test` — currently fails in `src/__tests__/context-menu-dismiss.test.tsx` because `[data-testid="rf__node-task-node-1"]` is not found.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <squash-merge-sha>`
- Post-revert steps: None
- Data migration? No

</details>

