### PR TITLE
Planning Summary Live Update Proof Step 1 (2) Regression coverage for draft-file activation and latest-plan selection

### DIFF
--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+import * as child_process from 'node:child_process';
+import { PlanConversation } from '../slack/plan-conversation.js';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof child_process>();
+  return { ...actual, spawn: vi.fn() };
+});
+
+const mockSpawn = vi.mocked(child_process.spawn);
+
+function fakePlannerChild(stdout: string): any {
+  const proc = new EventEmitter() as any;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+
+  setTimeout(() => {
+    if (stdout) proc.stdout.emit('data', Buffer.from(stdout));
+    proc.emit('close', 0);
+  }, 0);
+
+  return proc;
+}
+
+const FIRST_PLAN = [
+  'name: "First file plan"',
+  'onFinish: none',
+  'tasks:',
+  '  - id: first',
+  '    description: First task',
+  '    command: echo first',
+].join('\n');
+
+const SECOND_INLINE_REPLY = [
+  'Here is the revised plan.',
+  '',
+  '```yaml',
+  'name: "Second inline plan"',
+  'onFinish: none',
+  'tasks:',
+  '  - id: second',
+  '    description: Second task',
+  '    command: echo second',
+  '```',
+].join('\n');
+
+describe('plan draft file - activation side', () => {
+  let workingDir: string;
+
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    workingDir = mkdtempSync(join(tmpdir(), 'plan-draft-act-'));
+  });
+
+  afterEach(() => {
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  it('instructs the planner to write the plan to the draft file instead of inline', () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123' });
+    const path = conversation.planDraftFilePath();
+    const prompt = conversation.buildCursorPrompt();
+
+    expect(path).not.toBeNull();
+    expect(prompt).toContain(String(path));
+    const deliveryIndex = prompt.indexOf('HOW TO DELIVER THE PLAN');
+    const firstSchemaIndex = prompt.indexOf('```yaml');
+    expect(deliveryIndex).toBeGreaterThanOrEqual(0);
+    expect(deliveryIndex).toBeLessThan(firstSchemaIndex);
+    expect(prompt).toContain('NEVER paste the YAML plan into your chat reply');
+    expect(prompt).not.toContain('output the plan inside a ```yaml code block');
+  });
+
+  it('keeps the inline instruction when there is no draft file path', () => {
+    const conversation = new PlanConversation({});
+    const prompt = conversation.buildCursorPrompt();
+
+    expect(conversation.planDraftFilePath()).toBeNull();
+    expect(prompt).toContain('output the plan inside a ```yaml code block');
+  });
+
+  it('clears a stale plan file before the turn so getDraftedPlan cannot return it', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123' });
+    const path = conversation.planDraftFilePath();
+    if (!path) throw new Error('expected a plan draft path');
+    mkdirSync(join(workingDir, '.invoker', 'plan-drafts'), { recursive: true });
+    writeFileSync(path, FIRST_PLAN, 'utf8');
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the plan. Summary: one step.'));
+    await conversation.sendMessage('Draft it');
+
+    expect(existsSync(path)).toBe(false);
+    expect(conversation.getDraftedPlan()).toBeNull();
+  });
+
+  it('can submit a summary-only turn from the draft file while clearing that file', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123' });
+    const path = conversation.planDraftFilePath();
+    if (!path) throw new Error('expected a plan draft path');
+    mkdirSync(join(workingDir, '.invoker', 'plan-drafts'), { recursive: true });
+    writeFileSync(path, FIRST_PLAN, 'utf8');
+    (conversation as unknown as { messages: Array<{ role: string; content: string }> })
+      .messages.push({ role: 'assistant', content: 'Drafted the plan. Summary: one step.' });
+
+    const reply = await conversation.sendMessage('yes');
+
+    expect(reply).toBe('Plan "First file plan" submitted for execution.');
+    expect(conversation.submittedPlanText).toBe(FIRST_PLAN);
+    expect(conversation.planSubmitted).toBe(true);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it('clears stale draft-file content so the next inline assistant plan wins', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123' });
+    const path = conversation.planDraftFilePath();
+    if (!path) throw new Error('expected a plan draft path');
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild([
+      '```yaml',
+      FIRST_PLAN,
+      '```',
+    ].join('\n')));
+    await conversation.sendMessage('Draft the first plan');
+
+    mkdirSync(join(workingDir, '.invoker', 'plan-drafts'), { recursive: true });
+    writeFileSync(path, FIRST_PLAN, 'utf8');
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(SECOND_INLINE_REPLY));
+    await conversation.sendMessage('Revise the plan');
+
+    expect(existsSync(path)).toBe(false);
+    const drafted = conversation.getDraftedPlan();
+    expect(drafted).not.toBeNull();
+    const plan = parseYaml(drafted!) as Record<string, any>;
+    expect(plan.name).toBe('Second inline plan');
+    expect(plan.tasks[0].description).toBe('Second task');
+    expect(drafted).not.toContain('First file plan');
+  });
+});

--- a/packages/surfaces/src/__tests__/plan-draft-file.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PlanConversation } from '../slack/plan-conversation.js';
+
+const FILE_PLAN = [
+  'name: "File plan"',
+  'onFinish: none',
+  'tasks:',
+  '  - id: file-task',
+  '    description: File task',
+  '    command: echo file',
+].join('\n');
+
+const INLINE_REPLY = [
+  'Here is the plan.',
+  '',
+  '```yaml',
+  'name: "Inline plan"',
+  'onFinish: none',
+  'tasks:',
+  '  - id: inline-task',
+  '    description: Inline task',
+  '    command: echo inline',
+  '```',
+].join('\n');
+
+describe('plan draft file - read side', () => {
+  let workingDir: string;
+
+  beforeEach(() => {
+    workingDir = mkdtempSync(join(tmpdir(), 'plan-draft-'));
+  });
+
+  afterEach(() => {
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  function conversationWith(threadTs: string | undefined): PlanConversation {
+    return new PlanConversation({ workingDir, threadTs });
+  }
+
+  it('resolves a plan draft path under .invoker when workingDir and threadTs are set', () => {
+    const conversation = conversationWith('abc-123');
+    expect(conversation.planDraftFilePath()).toBe(
+      join(workingDir, '.invoker', 'plan-drafts', 'abc-123.yaml'),
+    );
+  });
+
+  it('sanitizes threadTs in the plan draft file path', () => {
+    const conversation = conversationWith('abc:123/456');
+    expect(conversation.planDraftFilePath()).toBe(
+      join(workingDir, '.invoker', 'plan-drafts', 'abc_123_456.yaml'),
+    );
+  });
+
+  it('has no plan draft path without a threadTs', () => {
+    expect(conversationWith(undefined).planDraftFilePath()).toBeNull();
+  });
+
+  it('reads the drafted plan from the file when the planner wrote one', () => {
+    const conversation = conversationWith('abc-123');
+    const path = conversation.planDraftFilePath();
+    if (!path) throw new Error('expected a plan draft path');
+    mkdirSync(join(workingDir, '.invoker', 'plan-drafts'), { recursive: true });
+    writeFileSync(path, FILE_PLAN, 'utf8');
+
+    expect(conversation.getDraftedPlan()).toBe(FILE_PLAN);
+  });
+
+  it('prefers the plan draft file over inline YAML in history', () => {
+    const conversation = conversationWith('abc-123');
+    const path = conversation.planDraftFilePath();
+    if (!path) throw new Error('expected a plan draft path');
+    mkdirSync(join(workingDir, '.invoker', 'plan-drafts'), { recursive: true });
+    writeFileSync(path, FILE_PLAN, 'utf8');
+    (conversation as unknown as { messages: Array<{ role: string; content: string }> })
+      .messages.push({ role: 'assistant', content: INLINE_REPLY });
+
+    expect(conversation.getDraftedPlan()).toBe(FILE_PLAN);
+  });
+
+  it('falls back to inline extraction when no plan file exists', () => {
+    const conversation = conversationWith('abc-123');
+    (conversation as unknown as { messages: Array<{ role: string; content: string }> })
+      .messages.push({ role: 'assistant', content: INLINE_REPLY });
+
+    const drafted = conversation.getDraftedPlan();
+    expect(drafted).not.toBeNull();
+    expect(drafted).toContain('Inline plan');
+    expect(drafted).toContain('id: inline-task');
+  });
+});


### PR DESCRIPTION
## Summary

This slice adds the regression tests that prove the fix in slice (1) works.

The tests cover two things: reading a plan back from the per-thread draft file, and the full flow where a user drafts several plans and confirms the newest one.

They lock in the behavior so a future change cannot quietly bring back the stale-draft bug.

The tests depend on the draft-file methods added in slice (1), so this slice stacks on top of it.

## Review Claim

Approve the focused surfaces planner regression suite that proves draft-file activation and latest-plan selection across consecutive assistant turns.

## Review Lane

`proof`

## Review Unit

`slack-planner`

## Safety Invariant

This slice adds only two new test files under `packages/surfaces/src/__tests__/`. It changes no production code and no runtime behavior, so it cannot regress the app; it can only pass or fail against the behavior introduced in slice (1).

## Slice Rationale

The proof is split from the behavior change so a reviewer can approve the guarantee (slice 1) and its dedicated regression evidence (this slice) as separate, single-claim units. These files are the exact focused tests the verify task ran.

## Non-goals

- Does not change any production code.
- Does not change the Electron, web, or Slack runtime behavior.
- Does not add CI wiring beyond the existing `pnpm test` surface.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm test -- plan-draft-file`
- [ ] `cd packages/surfaces && pnpm test -- plan-draft-file-activation`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #4988
