### PR TITLE
[Fix Task Context Menu Layering](1) Stabilize context-menu layering regression test

### DIFF
--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -46,11 +46,14 @@ const workflows: WorkflowMeta[] = [
   { id: 'wf-1', name: 'Test Workflow', status: 'running', baseBranch: 'master' },
 ];
 
-describe('Context menu (component)', () => {
+const FLOATING_GRAPH_PANEL_Z_INDEX = 1000;
+const APP_CONTEXT_MENU_TEST_TIMEOUT_MS = 20_000;
+
+describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS }, () => {
   let mock: MockInvoker;
 
   beforeEach(() => {
-    mock = createMockInvoker();
+    mock = createMockInvoker([alpha, beta, merge], workflows);
     mock.install();
     vi.spyOn(window, 'confirm').mockReturnValue(true);
     Object.defineProperty(navigator, 'clipboard', {
@@ -70,10 +73,7 @@ describe('Context menu (component)', () => {
   ) {
     render(<App />);
     act(() => mock.setTasks(tasks, workflowList));
-
-    await waitFor(() => {
-      expect(screen.getByTestId('workflow-node-wf-1')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('workflow-node-wf-1')).toBeInTheDocument();
   }
 
   async function openWorkflowContextMenu() {


### PR DESCRIPTION
## Summary

This slice hardens the automated test that guards a fix already shipped in `main`: task right-click menus must render above the floating selected-workflow mini DAG.

The regression test was flaky. It rendered the app, pushed tasks in a second `act()` pass, then polled for the workflow node, which could race under load and intermittently fail before the layering assertion ran.

The change seeds the mock invoker with tasks and workflows at construction, renders once, and awaits the node with `findByTestId`. It also raises the suite timeout so the layering check stays reliable.

No product code changes. The user-facing behavior is unchanged; this only stabilizes the proof that the behavior holds.

## Review Claim

The context-menu layering regression test reliably proves the task menu (zIndex 1100) renders above the floating graph panel (zIndex 1000), without flaking.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice touches only `packages/ui/src/__tests__/context-menu-e2e.test.tsx`. No product code, no shared helper, and no other suite changes, so it cannot alter runtime behavior — only the reliability of the existing assertion.

## Slice Rationale

The behavior fix and the layering assertion already live in `main`. What remained was test flakiness. This is isolated as its own proof slice so a reviewer approves test reliability alone, with no product diff to weigh, and no unrelated changes bundled in.

## Non-goals

- Does not change `ContextMenu.tsx`, `FloatingGraphPanel.tsx`, or any product code.
- Does not redesign context-menu actions, graph layout, task selection, or workflow mutation.
- Does not add new test cases or change the layering assertion itself.
- Does not touch unrelated packages (e.g. the execution-engine SSH executor).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm exec vitest run src/__tests__/context-menu-e2e.test.tsx`

Note: dependencies are not installed in this merge-clone gate directory, so the command was not re-run locally here. The same suite was executed green by the workflow's `verify-task-context-menu-tests` proof gate.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting only restores the earlier, flakier test setup; product behavior is unaffected.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved context-menu end-to-end test reliability by adding explicit timing controls.
  * Updated test setup with representative tasks and workflows.
  * Strengthened workflow readiness checks to reduce flaky test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
