### PR TITLE
[Durable SSH Pool Capacity](14b) Export start-ready recreate contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -609,7 +609,7 @@ export interface StartReadyPreview {
   failedWorkflowIds: string[];
   pendingWorkflowIds: string[];
   runningWorkflowIds: string[];
-  completedWorkflowIds: string[];
+  completedWorkflowIds?: string[];
   skipped: {
     awaitingApproval: number;
     reviewReady: number;
@@ -617,7 +617,7 @@ export interface StartReadyPreview {
     failedTasks: number;
     pendingTasks: number;
     runningTasks: number;
-    completedTasks: number;
+    completedTasks?: number;
   };
 }
 

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -596,6 +596,10 @@ export interface WorkflowMutationAcceptedResult {
 
 export interface StartReadyRequest {
   recreateFailed?: boolean;
+  recreateFailedAndPending?: boolean;
+  recreateFailedPendingAndRunning?: boolean;
+  /** Recreate failed + pending/queued + running + completed (finished) workflows. */
+  recreateAll?: boolean;
   dryRun?: boolean;
 }
 
@@ -603,11 +607,17 @@ export interface StartReadyPreview {
   readyTaskIds: string[];
   recoverableTaskIds: string[];
   failedWorkflowIds: string[];
+  pendingWorkflowIds: string[];
+  runningWorkflowIds: string[];
+  completedWorkflowIds: string[];
   skipped: {
     awaitingApproval: number;
     reviewReady: number;
     blocked: number;
     failedTasks: number;
+    pendingTasks: number;
+    runningTasks: number;
+    completedTasks: number;
   };
 }
 


### PR DESCRIPTION
## Summary

Start-ready recreate modes need shared request and preview fields before later slices can use them safely.

This slice only adds the extra typed fields for pending, running, and completed workflow recreation.

## Review Claim

Approve the shared `StartReadyRequest` and `StartReadyPreview` field additions for recreate-all support.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This only widens typed payload shapes. No caller behavior changes yet.

## Slice Rationale

Shared fields land first so later slices can consume them without local type drift.

## Non-goals

No recreate selection logic. No CLI or UI copy changes. No repro scripts.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/validate-pr-body.mjs --body-file local://pr-14b-start-ready-contract.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added additional workflow recreation options, including pending, running, failed, all, and dry-run modes.
  * Enhanced start-ready previews with pending and running workflow details.
  * Added task counts for pending and running workflows, with optional completed workflow and task information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->