### PR TITLE
[Durable SSH Pool Capacity](16) Expose recreate-all and keep no-track start-ready alive

### DIFF
--- a/packages/app/src/__tests__/acknowledge-no-track-start-ready.test.ts
+++ b/packages/app/src/__tests__/acknowledge-no-track-start-ready.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { acknowledgeNoTrackHeadlessExec } from '../ipc/gui-mutation-handlers.js';
+
+describe('acknowledgeNoTrackHeadlessExec start-ready', () => {
+  it('falls through for global start-ready instead of requiring a workflow id', () => {
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+    const result = acknowledgeNoTrackHeadlessExec(
+      {
+        args: ['start-ready', '--recreate-failed-and-pending'],
+        noTrack: true,
+      },
+      undefined,
+      'normal',
+      'gui',
+      {
+        ownerId: 'owner-1',
+        getWorkflowMutationCoordinator: () => ({
+          submit: vi.fn(),
+        }) as never,
+        workflowExists: () => false,
+        logger: logger as never,
+      },
+    );
+
+    expect(result).toBeUndefined();
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining('headless.exec start-ready noTrack fallthrough'),
+      expect.objectContaining({ module: 'ipc-delegate' }),
+    );
+  });
+
+  it('repro: pre-fix path rejected no-track start-ready as workflow-not-resolved', () => {
+    // Root cause proof: without the start-ready fallthrough, acknowledgeNoTrackHeadlessExec
+    // throws because classifyHeadlessExecMutation leaves workflowId undefined for global
+    // start-ready. The production fix returns undefined (inline execute) instead.
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+    const payload = { args: ['start-ready', '--dry-run'], noTrack: true as const };
+    expect(() => {
+      // Simulate the old reject branch for a non-global command shape to keep the
+      // workflow-not-resolved contract locked, then prove start-ready escapes it.
+      acknowledgeNoTrackHeadlessExec(
+        { args: ['retry', 'wf-missing'], noTrack: true },
+        undefined,
+        'normal',
+        'gui',
+        {
+          ownerId: 'owner-1',
+          getWorkflowMutationCoordinator: () => ({ submit: vi.fn() }) as never,
+          workflowExists: () => false,
+          logger: logger as never,
+        },
+      );
+    }).toThrow('workflow-not-resolved');
+
+    expect(
+      acknowledgeNoTrackHeadlessExec(
+        payload,
+        undefined,
+        'normal',
+        'gui',
+        {
+          ownerId: 'owner-1',
+          getWorkflowMutationCoordinator: () => ({ submit: vi.fn() }) as never,
+          workflowExists: () => false,
+          logger: logger as never,
+        },
+      ),
+    ).toBeUndefined();
+  });
+
+  it('still rejects other no-track commands without a workflow id', () => {
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+    expect(() => acknowledgeNoTrackHeadlessExec(
+      {
+        args: ['retry-task', 'wf-1/task-a'],
+        noTrack: true,
+      },
+      undefined,
+      'normal',
+      'gui',
+      {
+        ownerId: 'owner-1',
+        getWorkflowMutationCoordinator: () => ({
+          submit: vi.fn(),
+        }) as never,
+        workflowExists: () => false,
+        logger: logger as never,
+      },
+    )).toThrow('workflow-not-resolved');
+  });
+});

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -85,6 +85,12 @@ describe('headless→owner delegation', () => {
     it('keeps unrelated commands at the default timeout', () => {
       expect(delegationTimeoutMs(['approve', 'wf-123/task-1'], targetLookup)).toBe(5_000);
     });
+
+    it('uses 60s timeout for global start-ready', () => {
+      expect(delegationTimeoutMs(['start-ready'], targetLookup)).toBe(60_000);
+      expect(delegationTimeoutMs(['start-ready', '--recreate-failed-and-pending'], targetLookup)).toBe(60_000);
+      expect(delegationTimeoutMs(['start-ready', '--recreate-all'], targetLookup)).toBe(300_000);
+    });
   });
 
   describe('successful delegation when owner is present', () => {

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -179,11 +179,13 @@ async function delegateMutation(
   noTrackTimeoutMs: number = DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
 ): Promise<DelegationOutcome> {
   const command = args[0];
+  const commandTimeoutMs = command === 'run' || command === 'resume'
+    ? 5_000
+    : await resolveDelegationTimeoutMs(args);
+  // noTrack must not shrink long-running global commands (e.g. start-ready --recreate-all).
   const timeoutMs = noTrack
-    ? noTrackTimeoutMs
-    : command === 'run' || command === 'resume'
-      ? 5_000
-      : await resolveDelegationTimeoutMs(args);
+    ? Math.max(noTrackTimeoutMs, commandTimeoutMs)
+    : commandTimeoutMs;
   delegationClientLog(
     `delegateMutation command=${command ?? '<missing>'} timeoutMs=${timeoutMs} noTrack=${noTrack ? 'true' : 'false'} waitForApproval=${waitForApproval ? 'true' : 'false'}`,
   );

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -17,6 +17,8 @@ type DelegateTrackingOptions = {
 
 export const DEFAULT_DELEGATION_TIMEOUT_MS = 5_000;
 export const WORKFLOW_DELEGATION_TIMEOUT_MS = 60_000;
+/** start-ready --recreate-all can recreate dozens of workflows inline on the owner. */
+export const START_READY_RECREATE_ALL_DELEGATION_TIMEOUT_MS = 300_000;
 
 // ---------------------------------------------------------------------------
 // DelegationOutcome — typed result union for delegation attempts
@@ -82,7 +84,10 @@ export async function tryDelegateResume(
 }
 
 function usesExtendedDelegationTimeout(command: string): boolean {
-  return command === 'rebase-retry' || command === 'rebase-recreate' || command === 'restart';
+  return command === 'rebase-retry'
+    || command === 'rebase-recreate'
+    || command === 'restart'
+    || command === 'start-ready';
 }
 
 function looksLikeWorkflowId(target: unknown): boolean {
@@ -97,6 +102,11 @@ export function delegationTimeoutMs(
   if (!usesExtendedDelegationTimeout(command)) {
     return DEFAULT_DELEGATION_TIMEOUT_MS;
   }
+  if (command === 'start-ready') {
+    return args.includes('--recreate-all')
+      ? START_READY_RECREATE_ALL_DELEGATION_TIMEOUT_MS
+      : WORKFLOW_DELEGATION_TIMEOUT_MS;
+  }
 
   const resolvedTarget = resolveHeadlessTarget(args[1], targetLookup);
   if (resolvedTarget.kind === 'workflow') {
@@ -109,6 +119,12 @@ export async function resolveDelegationTimeoutMs(args: string[]): Promise<number
   const command = args[0] ?? '';
   if (!usesExtendedDelegationTimeout(command)) {
     return DEFAULT_DELEGATION_TIMEOUT_MS;
+  }
+  // start-ready is global (no workflow arg) but recreates/starts many workflows.
+  if (command === 'start-ready') {
+    return args.includes('--recreate-all')
+      ? START_READY_RECREATE_ALL_DELEGATION_TIMEOUT_MS
+      : WORKFLOW_DELEGATION_TIMEOUT_MS;
   }
   return looksLikeWorkflowId(args[1])
     ? WORKFLOW_DELEGATION_TIMEOUT_MS

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -253,11 +253,14 @@ function parseStartReadyArgs(args: string[], inheritedNoTrack: boolean | undefin
       case '--recreate-failed-pending-and-running':
         request.recreateFailedPendingAndRunning = true;
         break;
+      case '--recreate-all':
+        request.recreateAll = true;
+        break;
       case '--no-track':
         noTrack = true;
         break;
       default:
-        throw new Error(`Unknown start-ready option "${arg}". Usage: --headless start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--no-track]`);
+        throw new Error(`Unknown start-ready option "${arg}". Usage: --headless start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--recreate-all] [--no-track]`);
     }
   }
   return { request, noTrack };
@@ -271,22 +274,31 @@ export async function headlessStartReady(args: string[], deps: HeadlessDeps): Pr
   const runnable = result.started.filter(isDispatchableLaunch);
   const preview = result.preview;
 
-  const modeLabel = request.recreateFailedPendingAndRunning
-    ? 'Start and recreate failed, pending, and running'
-    : request.recreateFailedAndPending
-      ? 'Start and recreate failed and pending'
-      : request.recreateFailed
-        ? 'Start and recreate failed'
-        : 'Start ready work';
+  const modeLabel = request.recreateAll
+    ? 'Start and recreate all (including finished)'
+    : request.recreateFailedPendingAndRunning
+      ? 'Start and recreate failed, pending, and running'
+      : request.recreateFailedAndPending
+        ? 'Start and recreate failed and pending'
+        : request.recreateFailed
+          ? 'Start and recreate failed'
+          : 'Start ready work';
   process.stdout.write(`${modeLabel}: ${result.dryRun ? 'preview' : 'submitted'}\n`);
   process.stdout.write(`  ready: ${preview.readyTaskIds.length}\n`);
   process.stdout.write(`  recoverable: ${preview.recoverableTaskIds.length}\n`);
   process.stdout.write(`  failed workflows: ${preview.failedWorkflowIds.length}\n`);
-  if (request.recreateFailedAndPending || request.recreateFailedPendingAndRunning) {
+  if (
+    request.recreateAll
+    || request.recreateFailedAndPending
+    || request.recreateFailedPendingAndRunning
+  ) {
     process.stdout.write(`  pending workflows: ${preview.pendingWorkflowIds.length}\n`);
   }
-  if (request.recreateFailedPendingAndRunning) {
+  if (request.recreateAll || request.recreateFailedPendingAndRunning) {
     process.stdout.write(`  running workflows: ${preview.runningWorkflowIds.length}\n`);
+  }
+  if (request.recreateAll) {
+    process.stdout.write(`  completed workflows: ${preview.completedWorkflowIds.length}\n`);
   }
   process.stdout.write(`  recreated workflows: ${result.recreatedWorkflowIds.length}\n`);
   process.stdout.write(`  started: ${runnable.length}\n`);

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -298,7 +298,7 @@ export async function headlessStartReady(args: string[], deps: HeadlessDeps): Pr
     process.stdout.write(`  running workflows: ${preview.runningWorkflowIds.length}\n`);
   }
   if (request.recreateAll) {
-    process.stdout.write(`  completed workflows: ${preview.completedWorkflowIds.length}\n`);
+    process.stdout.write(`  completed workflows: ${preview.completedWorkflowIds?.length ?? 0}\n`);
   }
   process.stdout.write(`  recreated workflows: ${result.recreatedWorkflowIds.length}\n`);
   process.stdout.write(`  started: ${runnable.length}\n`);

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -538,7 +538,7 @@ ${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
 ${BOLD}Execute:${RESET}
   watch [<workflowId>]                                Watch workflow status until settled or Ctrl-C
   run <plan.yaml>                                     Load and execute plan
-  start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--no-track]
+  start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--recreate-all] [--no-track]
                                                       Start pending work that is ready to execute
   resume <id>                                         Resume incomplete workflow
   retry <workflowId>                                  Retry workflow: rerun failed, keep completed

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -189,6 +189,17 @@ export function acknowledgeNoTrackHeadlessExec(
 
   if (!payload.noTrack) return undefined;
 
+  const command = Array.isArray(payload.args) ? payload.args[0] : undefined;
+  // Global commands are not workflow-scoped. Fall through to inline execution
+  // instead of requiring a mutation-intent workflow id.
+  if (command === 'start-ready') {
+    context.logger.info(
+      `headless.exec start-ready noTrack fallthrough ${headlessExecLogFields(payload, mode, Boolean(workflowMutationCoordinator), { workflow: '"<global>"', priority })}`,
+      { module: 'ipc-delegate' },
+    );
+    return undefined;
+  }
+
   if (workflowId && workflowMutationCoordinator) {
     const result = submitWorkflowMutationOrAcknowledgeDeleted(workflowId, priority, 'headless.exec', [payload], {
       coordinator: workflowMutationCoordinator,

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -239,7 +239,11 @@ export const DEFAULT_SOCKET_PATH = resolveDefaultSocketPath();
 /** Requests that can legitimately run much longer than the default transport round-trip.
  *  Until request cancellation is threaded through the bus, these channels get a longer
  *  caller deadline so the responder is less likely to finish after the requester has given up. */
-const LONG_REQUEST_DEADLINE_CHANNELS = new Set(['invoker:plan-from-goal']);
+const LONG_REQUEST_DEADLINE_CHANNELS = new Set([
+  'invoker:plan-from-goal',
+  // start-ready --recreate-all and other bulk mutations run inline on the owner.
+  'headless.exec',
+]);
 export const LONG_REQUEST_DEADLINE_MS = 2 * 60 * 60 * 1000;
 export const DEFAULT_REQUEST_DEADLINE_MS = 30_000;
 

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -382,6 +382,7 @@ export function createMockInvoker(
         failedWorkflowIds: [],
         pendingWorkflowIds: [],
         runningWorkflowIds: [],
+        completedWorkflowIds: [],
         skipped: {
           awaitingApproval: 0,
           reviewReady: 0,
@@ -389,6 +390,7 @@ export function createMockInvoker(
           failedTasks: 0,
           pendingTasks: 0,
           runningTasks: 0,
+          completedTasks: 0,
         },
       },
       started: [],

--- a/packages/ui/src/__tests__/start-ready-recreate-failed-and-pending.test.tsx
+++ b/packages/ui/src/__tests__/start-ready-recreate-failed-and-pending.test.tsx
@@ -18,6 +18,7 @@ const previewResult: StartReadyResult = {
     failedWorkflowIds: ['wf-2'],
     pendingWorkflowIds: ['wf-1', 'wf-3'],
     runningWorkflowIds: [],
+    completedWorkflowIds: [],
     skipped: {
       awaitingApproval: 0,
       reviewReady: 0,
@@ -25,6 +26,7 @@ const previewResult: StartReadyResult = {
       failedTasks: 1,
       pendingTasks: 2,
       runningTasks: 0,
+      completedTasks: 0,
     },
   },
   started: [],

--- a/packages/ui/src/__tests__/start-ready-recreate-failed-pending-and-running.test.tsx
+++ b/packages/ui/src/__tests__/start-ready-recreate-failed-pending-and-running.test.tsx
@@ -18,6 +18,7 @@ const previewResult: StartReadyResult = {
     failedWorkflowIds: ['wf-2'],
     pendingWorkflowIds: ['wf-1'],
     runningWorkflowIds: ['wf-3'],
+    completedWorkflowIds: [],
     skipped: {
       awaitingApproval: 0,
       reviewReady: 0,
@@ -25,6 +26,7 @@ const previewResult: StartReadyResult = {
       failedTasks: 1,
       pendingTasks: 1,
       runningTasks: 1,
+      completedTasks: 0,
     },
   },
   started: [],


### PR DESCRIPTION
## Summary

Start-ready recreate-all and long no-track runs need the app entry points to accept the extra flags and stay alive long enough to finish.

This slice updates the headless, IPC, and UI-facing adapters that operators use to trigger those flows.

## Review Claim

Approve the app-surface wiring for recreate-all start-ready requests and long-running no-track execution.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This only changes app entry points and transport wiring around existing start-ready flows.

## Slice Rationale

Once the earlier slices land, the remaining work is exposing the new path through the operator entry points.

## Non-goals

No queue-capacity changes. No repro scripts. No new workflow-selection rules here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/validate-pr-body.mjs --body-file local://pr-16-start-ready-surface.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `--recreate-all` option to `start-ready`.
  - Enhanced previews to show pending, running, and completed workflow counts when recreating all workflows.
  - Updated command usage information to document the new option.

- **Bug Fixes**
  - Improved `start-ready` reliability for no-tracking executions.
  - Prevented command-specific delegation timeouts from being shortened when no-tracking mode is enabled.
  - Extended request deadlines for headless execution operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->