### PR TITLE
Planning Summary Live Update Proof Step 1

### DIFF
--- a/packages/surfaces/src/__tests__/plan-draft-file.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file.test.ts
@@ -27,6 +27,19 @@ const INLINE_REPLY = [
   '```',
 ].join('\n');
 
+const DIFFERENT_INLINE_REPLY = [
+  'Here is another plan.',
+  '',
+  '```yaml',
+  'name: "Inline plan"',
+  'onFinish: none',
+  'tasks:',
+  '  - id: inline',
+  '    description: Inline task',
+  '    command: echo inline',
+  '```',
+].join('\n');
+
 describe('plan draft file — read side', () => {
   let workingDir: string;
 
@@ -49,6 +62,13 @@ describe('plan draft file — read side', () => {
     );
   });
 
+  it('sanitizes threadTs in the plan draft file path', () => {
+    const conversation = conversationWith('abc:123/456');
+    expect(conversation.planDraftFilePath()).toBe(
+      join(workingDir, '.invoker', 'plan-drafts', 'abc_123_456.yaml'),
+    );
+  });
+
   it('has no plan draft path without a threadTs', () => {
     expect(conversationWith(undefined).planDraftFilePath()).toBeNull();
   });
@@ -59,6 +79,18 @@ describe('plan draft file — read side', () => {
     if (!path) throw new Error('expected a plan draft path');
     mkdirSync(join(workingDir, '.invoker', 'plan-drafts'), { recursive: true });
     writeFileSync(path, COMPLETE_PLAN, 'utf8');
+
+    expect(conversation.getDraftedPlan()).toBe(COMPLETE_PLAN);
+  });
+
+  it('prefers the plan draft file over inline YAML in history', () => {
+    const conversation = conversationWith('abc-123');
+    const path = conversation.planDraftFilePath();
+    if (!path) throw new Error('expected a plan draft path');
+    mkdirSync(join(workingDir, '.invoker', 'plan-drafts'), { recursive: true });
+    writeFileSync(path, COMPLETE_PLAN, 'utf8');
+    (conversation as unknown as { messages: Array<{ role: string; content: string }> })
+      .messages.push({ role: 'assistant', content: DIFFERENT_INLINE_REPLY });
 
     expect(conversation.getDraftedPlan()).toBe(COMPLETE_PLAN);
   });


### PR DESCRIPTION
## Summary

Adds read-side regression coverage for Slack plan draft files after rebasing the proof slice onto current master.

## Review Claim

PlanConversation draft lookup prefers the per-thread draft file over inline assistant YAML and safely maps Slack thread timestamps to draft-file paths.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes only `packages/surfaces/src/__tests__/plan-draft-file.test.ts`. It does not change runtime planning or Slack submission behavior; it pins the existing `PlanConversation` draft-file contract after the branch was rebased onto current `master`.

## Slice Rationale

The previous branch carried implementation code that already exists on `master`. Keeping this as a one-file proof slice preserves the useful regression coverage while avoiding stale implementation conflicts.

## Non-goals

- No runtime changes to `PlanConversation`.
- No Slack surface submission flow changes.
- No plan schema or merge-gate behavior changes.

## Visual Proof

This is a non-visual unit-test proof. The changed behavior is draft-plan selection precedence, so deterministic Vitest coverage is the proof surface.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test src/__tests__/plan-draft-file.test.ts src/__tests__/plan-draft-file-activation.test.ts src/__tests__/plan-conversation.test.ts`
- [x] `git merge-tree --write-tree origin/master HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <this PR's merge commit>`.
- Post-revert steps: None.
- Data migration? No.

</details>
