### PR TITLE
Constrain mini task DAG layering to workflow graph surface

### DIFF
--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -65,10 +65,14 @@ function buildPlan(index: number) {
 
 async function waitForWorkflowGraphVisible(page: Page, timeoutMs: number): Promise<number> {
   const startedAt = Date.now();
-  await page.locator('[data-testid^="workflow-node-"]').first().waitFor({
-    state: 'visible',
-    timeout: timeoutMs,
-  });
+  await page
+    .getByTestId('workflow-graph-content')
+    .locator('[data-testid^="workflow-node-"]:visible')
+    .first()
+    .waitFor({
+      state: 'visible',
+      timeout: timeoutMs,
+    });
   return Date.now() - startedAt;
 }
 
@@ -81,8 +85,9 @@ function parseActivityPayload(message: string): Record<string, unknown> | null {
 }
 
 async function dragGraphAndAssertViewportMoves(page: Page): Promise<void> {
-  const viewport = page.locator('.react-flow__viewport').first();
-  const pane = page.locator('.react-flow__pane').first();
+  const workflowGraph = page.getByTestId('workflow-graph-content');
+  const viewport = workflowGraph.locator('.react-flow__viewport').first();
+  const pane = workflowGraph.locator('.react-flow__pane').first();
   const before = await viewport.evaluate((el) => getComputedStyle(el).transform);
   const box = await pane.boundingBox();
   if (!box) {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1076,7 +1076,7 @@ export function App() {
             <div
               ref={graphSurfaceRef}
               data-testid="workflow-graph-surface"
-              className="flex-1 relative overflow-hidden border-r border-gray-800 bg-gray-900"
+              className="flex-1 relative isolate z-0 overflow-hidden border-r border-gray-800 bg-gray-900"
               onClick={viewMode === 'dag' ? handleDagSurfaceClick : undefined}
             >
               {viewMode === 'queue' ? (
@@ -1101,14 +1101,16 @@ export function App() {
                 />
               ) : (
                 <>
-                  <WorkflowGraph
-                    tasks={tasks}
-                    workflows={workflows}
-                    selectedWorkflowId={selectedWorkflow?.id ?? null}
-                    statusFilters={statusFilters}
-                    onSelectWorkflow={handleWorkflowClick}
-                    onWorkflowContextMenu={handleWorkflowContextMenu}
-                  />
+                  <div data-testid="workflow-graph-content" className="relative z-0 h-full w-full">
+                    <WorkflowGraph
+                      tasks={tasks}
+                      workflows={workflows}
+                      selectedWorkflowId={selectedWorkflow?.id ?? null}
+                      statusFilters={statusFilters}
+                      onSelectWorkflow={handleWorkflowClick}
+                      onWorkflowContextMenu={handleWorkflowContextMenu}
+                    />
+                  </div>
                   {selectedWorkflow && miniDagTasks.size > 0 && (
                     <FloatingGraphPanel
                       key={selectedWorkflow.id}

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -46,7 +46,7 @@ const workflows: WorkflowMeta[] = [
   { id: 'wf-1', name: 'Test Workflow', status: 'running', baseBranch: 'master' },
 ];
 
-const FLOATING_GRAPH_PANEL_Z_INDEX = 1000;
+const FLOATING_GRAPH_PANEL_LOCAL_Z_INDEX = 10;
 
 describe('Context menu (component)', () => {
   let mock: MockInvoker;
@@ -116,8 +116,9 @@ describe('Context menu (component)', () => {
 
     const menu = await screen.findByRole('menu');
     expect(panel).toBeInTheDocument();
-    expect(menu).toHaveStyle({ zIndex: String(FLOATING_GRAPH_PANEL_Z_INDEX + 100) });
-    expect(Number(menu.style.zIndex)).toBeGreaterThan(FLOATING_GRAPH_PANEL_Z_INDEX);
+    expect(panel).toHaveClass(`z-${FLOATING_GRAPH_PANEL_LOCAL_Z_INDEX}`);
+    expect(panel.style.zIndex).toBe('');
+    expect(Number(menu.style.zIndex)).toBeGreaterThan(FLOATING_GRAPH_PANEL_LOCAL_Z_INDEX);
   });
 
   it('workflow context menu retries workflow', async () => {

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -51,6 +51,35 @@ describe('Task interaction (component)', () => {
     });
   });
 
+  it('scopes mini DAG layering to the workflow graph surface', async () => {
+    render(<App />);
+    act(() => mock.setTasks([alpha, beta], workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('rf__node-wf-a'));
+
+    const surface = screen.getByTestId('workflow-graph-surface');
+    const graphContent = screen.getByTestId('workflow-graph-content');
+    const panel = await screen.findByTestId('selected-workflow-mini-dag');
+
+    expect(surface).toHaveClass('relative', 'isolate', 'z-0');
+    expect(graphContent).toHaveClass('relative', 'z-0');
+    expect(panel).toHaveClass('absolute', 'z-10');
+    expect(panel).not.toHaveClass('z-[1000]');
+    expect(panel.style.zIndex).toBe('');
+    expect(surface).toContainElement(graphContent);
+    expect(surface).toContainElement(panel);
+
+    fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-a'));
+    const globalMenu = await screen.findByRole('menu');
+
+    expect(globalMenu).toHaveClass('fixed', 'z-50');
+    expect(surface).not.toContainElement(globalMenu);
+  });
+
   it('clicking a mini DAG task updates prompt details', async () => {
     render(<App />);
     act(() => mock.setTasks([alpha, beta], workflows));

--- a/packages/ui/src/components/FloatingGraphPanel.tsx
+++ b/packages/ui/src/components/FloatingGraphPanel.tsx
@@ -95,7 +95,7 @@ export function FloatingGraphPanel({
     <div
       ref={panelRef}
       data-testid={testId}
-      className={`absolute h-[280px] w-[420px] rounded border border-gray-700 bg-gray-900/95 overflow-hidden shadow-lg ${className}`}
+      className={`absolute z-10 h-[280px] w-[420px] rounded border border-gray-700 bg-gray-900/95 overflow-hidden shadow-lg ${className}`}
       style={position ? { left: position.left, top: position.top } : { top: PANEL_MARGIN, right: PANEL_MARGIN }}
       onClick={(event) => event.stopPropagation()}
       onPointerDown={(event) => event.stopPropagation()}


### PR DESCRIPTION
## Summary

Selecting a workflow shows a small floating DAG panel over the graph. That panel was stacking above global overlays, so it could cover the task context menu.

This change gives the workflow graph area its own private stacking context. The floating mini-DAG now rises above the graph only, and stays below app-wide overlays.

The fix also scopes the startup Playwright graph locators to the workflow graph content layer added here. That keeps the focused UI and affected e2e coverage aligned with the new surface structure.

## Review Claim

Approve scoping the selected-workflow mini-DAG panel's stacking to the workflow graph surface, including the directly affected tests.

## Review Lane

`behavior`

## Review Unit

`workflow-graph-ui`

## Safety Invariant

The product change only adds an isolated stacking context to the graph surface, wraps the workflow graph in a local content layer, and lowers the mini-DAG panel to a local z-index. The panel's position, contents, event handlers, and render conditions are unchanged.

## Slice Rationale

This is one review claim: the mini-DAG should float over the workflow graph but not over global overlays. The startup locator adjustment is folded into this slice because it is a directly affected test fix for the new graph content wrapper.

## Non-goals

- No change to when the mini-DAG appears or which workflow it shows.
- No change to context-menu behavior, contents, or actions.
- No change to queue mode behavior.
- No restyling beyond the stacking-context adjustment.

## Visual Proof

A static screenshot is weak proof for this change because the failure is the DOM stacking relationship between overlapping surfaces.

The focused component tests inspect the rendered layers directly: the graph surface owns the isolated `z-0` context, the mini-DAG panel uses local `z-10`, and the global context menu remains fixed at `z-50` outside that isolated surface. The startup Playwright spec also verifies graph interaction through the new `workflow-graph-content` layer.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/task-interaction.test.tsx src/__tests__/context-menu-e2e.test.tsx` - 17 tests passed.
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && cd packages/app && pnpm exec playwright test e2e/startup-nonempty-responsiveness.spec.ts` - 1 Playwright test passed.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
