### PR TITLE
Remove Workflow Graph Background Refit Interaction (1) Keep selection on background click

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -449,26 +449,11 @@ export function App() {
     setWorkflowContextMenu({ x: event.clientX, y: event.clientY, workflowId });
   }, []);
 
-  const handleDagSurfaceClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+  const handleDagSurfaceClick = useCallback(() => {
     if (contextMenu || workflowContextMenu) {
       setContextMenu(null);
       setWorkflowContextMenu(null);
-      return;
     }
-
-    const target = event.target as HTMLElement;
-    if (
-      target.closest('[data-testid^="workflow-node-"]') ||
-      target.closest('[data-testid="selected-workflow-mini-dag"]') ||
-      target.closest('.react-flow__node') ||
-      target.closest('[role="menu"]')
-    ) {
-      return;
-    }
-
-    setSelectedTaskId(null);
-    setSelectedWorkflowId(null);
-    setWorkflowSelectionDismissed(true);
   }, [contextMenu, workflowContextMenu]);
 
   const handleRestartTask = useCallback(async (taskId: string) => {

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -94,7 +94,7 @@ describe('Task interaction (component)', () => {
     });
   });
 
-  it('clicking workflow graph background dismisses the selected mini DAG', async () => {
+  it('clicking workflow graph background keeps the selected mini DAG', async () => {
     render(<App />);
     act(() => mock.setTasks([alpha, beta], workflows));
 
@@ -110,7 +110,8 @@ describe('Task interaction (component)', () => {
     fireEvent.click(screen.getByTestId('workflow-graph-react-flow'));
 
     await waitFor(() => {
-      expect(screen.queryByTestId('selected-workflow-mini-dag')).not.toBeInTheDocument();
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
     });
   });
 


### PR DESCRIPTION
## Summary

Clicking empty black space on the Home workflow graph used to wipe out your selection. The selected workflow cleared, its mini-DAG vanished, and the camera jumped to refit.

That made the graph feel twitchy. A stray click near a node lost your place.

This change makes a background click do nothing to selection. The chosen workflow, its mini-DAG, and the inspector all stay put.

Context menus still close on a background click, exactly as before. Only the selection-clearing and camera-refit behavior is removed.

## Review Claim

Approve that a click on empty workflow-graph background no longer clears the selected workflow, dismisses its mini-DAG, or triggers a camera refit — while background clicks still dismiss open context menus.

## Review Lane

`behavior`

## Review Unit

`workflow-graph-interaction`

## Safety Invariant

The change only shrinks `handleDagSurfaceClick` on the Home graph surface. It keeps the context-menu dismissal branch and deletes the selection-clearing and refit branch. No other handler, state setter, or component is touched, so a reviewer can confirm safety by reading one callback plus its updated component test.

## Slice Rationale

This slice carries the one behavior change plus the existing task-interaction test that asserts the new stable-selection outcome. Broader dedicated regression coverage lands in the next slice so the behavior edit and its focused reproduction tests stay independently reviewable.

## Non-goals

- Does not change context-menu open/close behavior.
- Does not change node-click selection or inspector wiring.
- Does not change camera or refit behavior triggered by anything other than the removed background click.
- Adds no new test files (see the follow-up slice).

## Visual Proof

This is an interaction-state change: the selection must persist through a click action. A single static screenshot cannot show the click happening or that state survived it, so the proof is an inspectable state assertion in the component test.

`packages/ui/src/__tests__/task-interaction.test.tsx` now drives a background click on `workflow-graph-react-flow` and asserts the mini-DAG and inspector still read `Workflow A` afterward — the reviewer sees the exact preserved state the UI now keeps.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test src/__tests__/task-interaction.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c2506230d`
- Post-revert steps: None
- Data migration? No

</details>
