### PR TITLE
Remove Workflow Graph Background Refit Interaction (2) Add background-click stability regressions

### DIFF
--- a/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
+++ b/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import type { WorkflowMeta } from '../types.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+const workflows: WorkflowMeta[] = [
+  { id: 'wf-a', name: 'Workflow A', status: 'running' },
+  { id: 'wf-b', name: 'Workflow B', status: 'running' },
+];
+
+const alpha = makeUITask({
+  id: 'task-alpha',
+  description: 'Alpha task',
+  status: 'pending',
+  workflowId: 'wf-a',
+  command: 'echo alpha',
+});
+
+const beta = makeUITask({
+  id: 'task-beta',
+  description: 'Beta task',
+  status: 'pending',
+  workflowId: 'wf-b',
+  command: 'echo beta',
+});
+
+describe('Home workflow graph mini DAG click dismissal repro', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  async function selectWorkflowB() {
+    render(<App />);
+    act(() => mock.setTasks([alpha, beta], workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-b')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('rf__node-wf-b'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow B');
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow B');
+    });
+  }
+
+  it('keeps the selected mini DAG after a blank graph surface click', async () => {
+    await selectWorkflowB();
+
+    fireEvent.click(screen.getByTestId('workflow-graph-surface'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow B');
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow B');
+    });
+  });
+
+  it('keeps the selected mini DAG after a retargeted React Flow pane click', async () => {
+    await selectWorkflowB();
+
+    fireEvent.click(screen.getByTestId('workflow-graph-react-flow'), {
+      clientX: 24,
+      clientY: 24,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow B');
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow B');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This adds focused regression tests that lock in the stable-selection behavior from the previous slice.

The tests select a workflow, then click the graph two ways: on blank surface space, and with a click retargeted onto the React Flow pane. Both keep the mini-DAG and inspector showing the selected workflow.

The goal is to catch any future change that lets a background click clear selection again.

## Review Claim

Approve two component tests asserting that blank-surface clicks and retargeted React Flow pane clicks on the Home workflow graph keep the selected workflow's mini-DAG and inspector intact.

## Review Lane

`proof`

## Review Unit

`workflow-graph-interaction`

## Safety Invariant

This slice adds one new test file and touches no product code. It cannot change runtime behavior, so a reviewer only needs to confirm the assertions match the intended stable-selection outcome.

## Slice Rationale

Kept separate from the behavior edit so the reproduction coverage is reviewable on its own. The prior slice carried the minimal test that proves the fix; this slice adds the broader, dedicated regression scenarios without mixing new test files into the behavior diff.

## Non-goals

- Changes no product code.
- Does not modify the existing task-interaction test from the prior slice.
- Adds no new UI, state, or handlers.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 6b72a9489`
- Post-revert steps: None
- Data migration? No

</details>
