### PR TITLE
[Delete planning terminals — UI](1) Add Planning Terminal rail controls

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -49,6 +49,7 @@ import { InvokerTerminal, type InvokerTerminalLine, type PlanningTerminalMode } 
 import { Toaster, toast } from 'sonner';
 import { Button } from './components/primitives/index.js';
 import { ChevronDownIcon, PlayIcon } from './components/icons/index.js';
+import { Trash2 } from 'lucide-react';
 import { CommandPalette, COMMAND_PALETTE_MAX_ROWS } from './components/CommandPalette.js';
 import {
   getAttentionTaskEntries,
@@ -2729,22 +2730,83 @@ export function App() {
     workflows.size,
   ]);
 
-  const handleCreatePlanningSession = useCallback(() => {
+  const makeLocalPlanningSession = useCallback(() => {
     const index = nextPlanningSessionLocalIdRef.current;
     nextPlanningSessionLocalIdRef.current += 1;
     const now = new Date().toISOString();
     const localId = `local-planning-session-${index}`;
-    const session: PlanningSessionView = {
+    return {
       ...makeInitialPlanningSession(now),
       id: localId,
       conversationKey: localId,
       presetKey: selectedPlanningPresetKey,
     };
+  }, [selectedPlanningPresetKey]);
+
+  const handleCreatePlanningSession = useCallback(() => {
+    const session: PlanningSessionView = makeLocalPlanningSession();
     setPlanningSessions((prev) => [session, ...prev]);
     setActivePlanningSessionId(session.id);
     setSidebarSurface('home');
     focusKeyboardRegion('planning');
-  }, [focusKeyboardRegion, selectedPlanningPresetKey]);
+  }, [focusKeyboardRegion, makeLocalPlanningSession]);
+
+  const removePlanningSessionsByIds = useCallback((sessionIds: string[]) => {
+    const idsToRemove = new Set(sessionIds);
+    if (idsToRemove.size === 0) return;
+
+    const currentSessions = planningSessionsRef.current;
+    const nextSessions = currentSessions.filter((session) => !idsToRemove.has(session.id));
+    if (nextSessions.length === currentSessions.length) return;
+
+    let finalSessions = nextSessions;
+    let nextActiveSessionId = activePlanningSessionIdRef.current;
+    const activeSessionWasRemoved = idsToRemove.has(nextActiveSessionId);
+    if (finalSessions.length === 0) {
+      const replacementSession = makeLocalPlanningSession();
+      finalSessions = [replacementSession];
+      nextActiveSessionId = replacementSession.id;
+    } else if (activeSessionWasRemoved || !finalSessions.some((session) => session.id === nextActiveSessionId)) {
+      const previousActiveIndex = currentSessions.findIndex((session) => session.id === activePlanningSessionIdRef.current);
+      const reselectionIndex = previousActiveIndex >= 0
+        ? Math.min(previousActiveIndex, finalSessions.length - 1)
+        : 0;
+      nextActiveSessionId = finalSessions[reselectionIndex]?.id ?? finalSessions[0].id;
+    }
+
+    planningSessionsRef.current = finalSessions;
+    activePlanningSessionIdRef.current = nextActiveSessionId;
+    setPlanningSessions(finalSessions);
+    setActivePlanningSessionId(nextActiveSessionId);
+    setReviewDraftSessionId((currentSessionId) => (
+      currentSessionId && idsToRemove.has(currentSessionId) ? null : currentSessionId
+    ));
+    clearPlanningStreamForSessionIds(sessionIds);
+    forgetPlanningStreamAliasesForSessionIds(sessionIds);
+    for (const sessionId of sessionIds) {
+      pendingPlanningStreamSessionIdsRef.current.delete(sessionId);
+    }
+  }, [clearPlanningStreamForSessionIds, forgetPlanningStreamAliasesForSessionIds, makeLocalPlanningSession]);
+
+  const handleDeletePlanningSession = useCallback((sessionId: string) => {
+    if (activePlanningReadOnly) return;
+    if (!sessionId.startsWith('local-')) {
+      void invoker?.planningChatDelete?.({ sessionId });
+    }
+    removePlanningSessionsByIds([sessionId]);
+  }, [activePlanningReadOnly, invoker, removePlanningSessionsByIds]);
+
+  const handleClearSubmittedPlanningSessions = useCallback(() => {
+    if (activePlanningReadOnly) return;
+    const confirmed = window.confirm('Clear all submitted planning chats?');
+    if (!confirmed) return;
+    const submittedSessionIds = planningSessionsRef.current
+      .filter((session) => session.status === 'submitted')
+      .map((session) => session.id);
+    if (submittedSessionIds.length === 0) return;
+    void invoker?.planningChatDeleteSubmitted?.();
+    removePlanningSessionsByIds(submittedSessionIds);
+  }, [activePlanningReadOnly, invoker, removePlanningSessionsByIds]);
 
   const handlePlanningModeChange = useCallback(async (mode: PlanningTerminalMode) => {
     const sourceSession = activePlanningSession;
@@ -3998,30 +4060,48 @@ export function App() {
           const selected = session.id === activePlanningSession.id;
           const preview = previewPlanningMessage(session);
           return (
-            <button
+            <div
               key={session.id}
-              type="button"
-              onClick={() => setActivePlanningSessionId(session.id)}
-              className={`flex w-full items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              data-testid={`planning-session-row-${session.id}`}
+              className="group flex w-full items-stretch"
             >
-              <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-start justify-between gap-2">
-                  <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
-                    {session.title}
+              <button
+                type="button"
+                onClick={() => setActivePlanningSessionId(session.id)}
+                className={`flex w-full min-w-0 flex-1 items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              >
+                <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
+                      {session.title}
+                    </div>
+                    <span className="shrink-0 text-[11px] text-muted-foreground">
+                      {relativePlanningUpdatedAt(session.updatedAt)}
+                    </span>
                   </div>
-                  <span className="shrink-0 text-[11px] text-muted-foreground">
-                    {relativePlanningUpdatedAt(session.updatedAt)}
-                  </span>
+                  <div
+                    className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
+                    title={preview}
+                  >
+                    {preview}
+                  </div>
                 </div>
-                <div
-                  className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
-                  title={preview}
+              </button>
+              {!activePlanningReadOnly ? (
+                <button
+                  type="button"
+                  aria-label="Delete planning chat"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleDeletePlanningSession(session.id);
+                  }}
+                  className={`flex w-8 shrink-0 items-start justify-center px-2 py-2 text-muted-foreground transition-colors hover:text-destructive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${selected ? 'bg-accent/40' : 'hover:bg-accent/20'}`}
                 >
-                  {preview}
-                </div>
-              </div>
-            </button>
+                  <Trash2 className="mt-0.5 h-4 w-4" aria-hidden="true" strokeWidth={1.75} />
+                </button>
+              ) : null}
+            </div>
           );
         })}
       </div>
@@ -4029,6 +4109,7 @@ export function App() {
   );
 
   const planningReadyCount = planningSessions.filter((session) => session.status === 'draft_ready').length;
+  const hasSubmittedPlanningSessions = planningSessions.some((session) => session.status === 'submitted');
   const connectedAgentLabels = (systemDiagnostics?.tools ?? [])
     .filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed)
     .map((tool) => tool.name.replace(/\s+CLI$/i, ''));
@@ -4171,6 +4252,14 @@ export function App() {
                 </p>
               </div>
               <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleClearSubmittedPlanningSessions}
+                  disabled={activePlanningReadOnly || !hasSubmittedPlanningSessions}
+                >
+                  Clear submitted
+                </Button>
                 <Button variant="outline" size="sm" onClick={handleCreatePlanningSession}>
                   New chat
                 </Button>

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -220,6 +220,8 @@ export function createMockInvoker(
       workflowId: 'wf-1',
     })),
     planningChatReset: vi.fn(async () => ({ ok: true })),
+    planningChatDelete: vi.fn(async () => ({ ok: true })),
+    planningChatDeleteSubmitted: vi.fn(async () => ({ ok: true, deletedSessionIds: [] })),
     onPlanningChatStream: vi.fn((cb: (event: InAppPlanningStreamEvent) => void) => {
       planningChatStreamCallbacks.add(cb);
       return () => { planningChatStreamCallbacks.delete(cb); };

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -917,6 +917,203 @@ describe('Invoker terminal (component)', () => {
     expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('I can help draft that.');
   });
 
+  it('deletes a saved planning chat from its row trash button', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'delete-saved-chat',
+          title: 'Delete saved chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          messages: [{ id: 1, role: 'user', text: 'Remove this saved chat', createdAt: '2026-07-07T00:00:01.000Z' }],
+        }),
+        makePlanningSessionSummary({
+          id: 'keep-saved-chat',
+          title: 'Keep saved chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          messages: [{ id: 1, role: 'user', text: 'Keep this saved chat', createdAt: '2026-07-07T00:00:01.000Z' }],
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    const rail = screen.getByTestId('planning-session-list');
+    await within(rail).findByText('Delete saved chat');
+    fireEvent.click(within(screen.getByTestId('planning-session-row-delete-saved-chat')).getByRole('button', { name: 'Delete planning chat' }));
+
+    await waitFor(() => {
+      expect(within(rail).queryByText('Delete saved chat')).not.toBeInTheDocument();
+    });
+    expect(within(rail).getByText('Keep saved chat')).toBeInTheDocument();
+    expect(mock.api.planningChatDelete).toHaveBeenCalledWith({ sessionId: 'delete-saved-chat' });
+  });
+
+  it('deletes a local planning chat without calling the delete IPC bridge', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'local-delete-chat',
+          title: 'Local delete chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          messages: [{ id: 1, role: 'user', text: 'Remove this local chat', createdAt: '2026-07-07T00:00:01.000Z' }],
+        }),
+        makePlanningSessionSummary({
+          id: 'keep-after-local-delete',
+          title: 'Keep after local delete',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          messages: [{ id: 1, role: 'user', text: 'Keep after local deletion', createdAt: '2026-07-07T00:00:01.000Z' }],
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    const rail = screen.getByTestId('planning-session-list');
+    await within(rail).findByText('Local delete chat');
+    fireEvent.click(within(screen.getByTestId('planning-session-row-local-delete-chat')).getByRole('button', { name: 'Delete planning chat' }));
+
+    await waitFor(() => {
+      expect(within(rail).queryByText('Local delete chat')).not.toBeInTheDocument();
+    });
+    expect(within(rail).getByText('Keep after local delete')).toBeInTheDocument();
+    expect(mock.api.planningChatDelete).not.toHaveBeenCalled();
+  });
+
+  it('disables clear submitted without submitted chats and clears submitted chats after confirmation', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'no-submitted-chat',
+          title: 'No submitted chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+        }),
+      ],
+    }));
+    const firstRender = render(<App />);
+    await openPlanningTerminal();
+    await within(screen.getByTestId('planning-session-list')).findByText('No submitted chat');
+    expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
+    firstRender.unmount();
+    mock.cleanup();
+
+    mock = createMockInvoker();
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'active-draft-chat',
+          title: 'Active draft chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+        }),
+        makePlanningSessionSummary({
+          id: 'submitted-chat-one',
+          title: 'Submitted chat one',
+          status: 'submitted',
+          draftPlanAvailable: false,
+        }),
+        makePlanningSessionSummary({
+          id: 'submitted-chat-two',
+          title: 'Submitted chat two',
+          status: 'submitted',
+          draftPlanAvailable: false,
+        }),
+      ],
+    }));
+    mock.install();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<App />);
+    await openPlanningTerminal();
+
+    const rail = screen.getByTestId('planning-session-list');
+    await within(rail).findByText('Submitted chat one');
+    const clearSubmitted = screen.getByRole('button', { name: 'Clear submitted' });
+    expect(clearSubmitted).toBeEnabled();
+    fireEvent.click(clearSubmitted);
+
+    await waitFor(() => {
+      expect(within(rail).queryByText('Submitted chat one')).not.toBeInTheDocument();
+      expect(within(rail).queryByText('Submitted chat two')).not.toBeInTheDocument();
+    });
+    expect(within(rail).getByText('Active draft chat')).toBeInTheDocument();
+    expect(confirmSpy).toHaveBeenCalledWith('Clear all submitted planning chats?');
+    expect(mock.api.planningChatDeleteSubmitted).toHaveBeenCalledTimes(1);
+    confirmSpy.mockRestore();
+  });
+
+  it('recreates a fresh empty planning chat after deleting the last remaining chat', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'last-saved-chat',
+          title: 'Last saved chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          messages: [
+            { id: 1, role: 'user', text: 'Only saved transcript', createdAt: '2026-07-07T00:00:01.000Z' },
+            { id: 2, role: 'assistant', text: 'Only saved reply', createdAt: '2026-07-07T00:00:02.000Z' },
+          ],
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Only saved reply');
+    });
+
+    fireEvent.click(within(screen.getByTestId('planning-session-row-last-saved-chat')).getByRole('button', { name: 'Delete planning chat' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Last saved chat')).not.toBeInTheDocument();
+      expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('1 chat');
+      expect(screen.getByTestId('invoker-terminal-empty-hero')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('invoker-terminal-input')).toHaveValue('');
+    expect(screen.getByTestId('invoker-terminal-transcript')).not.toHaveTextContent('Only saved reply');
+    expect(mock.api.planningChatDelete).toHaveBeenCalledWith({ sessionId: 'last-saved-chat' });
+  });
+
+  it('hides planning chat trash buttons and disables clear submitted in read-only mode', async () => {
+    mock.setRuntimeStatus({ ownerMode: false, readOnly: true, mode: 'read-only' });
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'readonly-active-chat',
+          title: 'Readonly active chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+        }),
+        makePlanningSessionSummary({
+          id: 'readonly-submitted-chat',
+          title: 'Readonly submitted chat',
+          status: 'submitted',
+          draftPlanAvailable: false,
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+    await within(screen.getByTestId('planning-session-list')).findByText('Readonly active chat');
+
+    expect(screen.queryByRole('button', { name: 'Delete planning chat' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
+  });
+
   it('wraps long planning session rail titles and previews instead of clipping them to one line', async () => {
     const longPrompt = 'Draft a very long planning session title that needs multiple readable wrapped lines in the fixed planning rail';
     const longReply = [


### PR DESCRIPTION
## Summary

Planning Terminal rail now has per-row trash controls and a guarded bulk rail action.

Selection falls through to a remaining chat, and an empty local chat is recreated when the rail would otherwise have no rows.

The focused renderer coverage exercises saved, local, completed, last-row, read-only, and stream bookkeeping cases.

## Review Claim

Approve the Planning Terminal rail activation surface for individual chat disposal and bulk rail pruning.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The backend IPC contract already exists on master, so this slice only changes the renderer state transition and bridge usage.

Read-only mode hides or disables the mutation controls, and the bulk action only targets sessions marked submitted.

## Slice Rationale

This stays as one activation-surface slice because the rail controls, session reselection, and bridge calls are one renderer interaction path.

The verification coverage stays with the UI behavior because it exercises the same rail boundary and pending-stream bookkeeping.

## Non-goals

- Do not change backend delete semantics, persistence schema, or planner submission behavior.
- Do not change workflow, task, or history deletion behavior.
- Do not clear draft, failed, or active in-progress planning chats through Clear submitted.

## Architecture

### Before

```mermaid
graph TD
    A["Planning session rail row"] --> B["Select session only"]
    C["Submitted planning chats"] --> D["Stay visible until another backend refresh"]
```

### After

```mermaid
graph TD
    A["Planning session rail row"] --> B["Select session"]
    A --> C["Trash action updates renderer state and calls delete IPC when saved"]
    D["Clear submitted button"] --> E["Confirm, call submitted-delete IPC, and reselect or recreate a chat"]
    E --> F["Stream aliases and pending stream ids are cleared"]
```

## Visual Proof

The walkthrough shows the rail with Clear submitted enabled and per-row trash buttons, then the submitted chat gone, then the final row trash action recreating an empty chat.

[Planning delete controls walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-3dbc73/planning-delete-controls-walkthrough.mp4)

![Planning rail controls](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-3dbc73/planning-delete-controls-visible.png)

![Submitted chats cleared](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-3dbc73/planning-clear-submitted-result.png)

![Last row trash recreates empty chat](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-3dbc73/planning-row-delete-recreated-empty.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile --ignore-scripts`
- [x] `node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs`
- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/invoker-terminal.test.tsx`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`
- [x] `node scripts/validate-pr-body.mjs --body-file packages/app/test-results/pr-bodies/delete-planning-terminals-ui.md --require-visual-proof --changed-files-file packages/app/test-results/pr-bodies/delete-planning-terminals-ui.changed-files.txt --diff-file packages/app/test-results/pr-bodies/delete-planning-terminals-ui.diff`
- [x] `node scripts/validate-pr-body-local.mjs --body-file packages/app/test-results/pr-bodies/delete-planning-terminals-ui.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 823c3452f794125f18bd619cd6dad8c638b9ec57`
- Post-revert steps: Re-run the focused Planning Terminal UI test.
- Data migration? No.

</details>
