### PR TITLE
[Planning tmux output survives Home/Planning switches](2) Preserve hidden planning tmux output

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -113,6 +113,7 @@ const EDITABLE_SELECTOR = [
 const SYSTEM_SETUP_AUTO_OPEN_DELAY_MS = 1200;
 const RAIL_LIST_FRAME_CLASS = 'flex min-h-0 flex-1 flex-col';
 const RAIL_SCROLL_BODY_CLASS = 'min-h-0 flex-1 overflow-y-auto';
+const TERMINAL_OUTPUT_SNAPSHOT_CAP_CHARS = 64 * 1024;
 
 function notifyMutationError(rawTitle: string, err: unknown): void {
   console.error(rawTitle, err);
@@ -124,6 +125,14 @@ function notifyMutationError(rawTitle: string, err: unknown): void {
 function formatCount(count: number, singular: string, plural = `${singular}s`): string {
   return `${count} ${count === 1 ? singular : plural}`;
 }
+
+function appendTerminalOutputSnapshot(snapshot: string | undefined, chunk: string): string {
+  const next = `${snapshot ?? ''}${chunk}`;
+  return next.length > TERMINAL_OUTPUT_SNAPSHOT_CAP_CHARS
+    ? next.slice(next.length - TERMINAL_OUTPUT_SNAPSHOT_CAP_CHARS)
+    : next;
+}
+
 type PlanningSessionView = Omit<InAppPlanningSessionSummary, 'messages'> & {
   messages: InvokerTerminalLine[];
   input: string;
@@ -1049,6 +1058,34 @@ export function App() {
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [graphMaximized, planningTerminalExpanded]);
 
+
+  useEffect(() => {
+    const unsubscribe = window.invoker?.onTerminalOutput?.((event) => {
+      if (event.kind !== 'planning' || !event.data) return;
+
+      setPlanningSessions((prev) => {
+        let changed = false;
+        const next = prev.map((session) => {
+          const terminalSession = session.terminalSession;
+          if (!terminalSession) return session;
+          const matches = event.planningSessionId
+            ? session.id === event.planningSessionId
+            : terminalSession.sessionId === event.sessionId;
+          if (!matches) return session;
+          changed = true;
+          return {
+            ...session,
+            terminalSession: {
+              ...terminalSession,
+              outputSnapshot: appendTerminalOutputSnapshot(terminalSession.outputSnapshot, event.data),
+            },
+          };
+        });
+        return changed ? next : prev;
+      });
+    });
+    return () => { unsubscribe?.(); };
+  }, []);
 
   useEffect(() => {
     const unsubscribe = window.invoker?.onTerminalExit?.((event) => {

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1,9 +1,37 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react';
-import { vi } from 'vitest';
 import { useState } from 'react';
 import { createMockInvoker, makePlanningSessionSummary, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { TaskState, WorkflowMeta } from '../types.js';
+
+const xtermMocks = vi.hoisted(() => ({
+  write: vi.fn(),
+  open: vi.fn(),
+  loadAddon: vi.fn(),
+  onData: vi.fn(() => ({ dispose: vi.fn() })),
+  dispose: vi.fn(),
+  focus: vi.fn(),
+  fit: vi.fn(),
+}));
+
+vi.mock('xterm', () => ({
+  Terminal: vi.fn(() => ({
+    cols: 80,
+    rows: 24,
+    loadAddon: xtermMocks.loadAddon,
+    open: xtermMocks.open,
+    write: xtermMocks.write,
+    onData: xtermMocks.onData,
+    focus: xtermMocks.focus,
+    dispose: xtermMocks.dispose,
+  })),
+}));
+
+vi.mock('xterm-addon-fit', () => ({
+  FitAddon: vi.fn(() => ({
+    fit: xtermMocks.fit,
+  })),
+}));
 
 vi.mock('@xyflow/react', async () => {
   // Dynamic import is required because Vitest hoists mock factories before test imports.
@@ -21,6 +49,13 @@ describe('Invoker terminal (component)', () => {
   let mock: MockInvoker;
 
   beforeEach(() => {
+    xtermMocks.write.mockClear();
+    xtermMocks.open.mockClear();
+    xtermMocks.loadAddon.mockClear();
+    xtermMocks.onData.mockClear();
+    xtermMocks.dispose.mockClear();
+    xtermMocks.focus.mockClear();
+    xtermMocks.fit.mockClear();
     mock = createMockInvoker();
     mock.install();
   });
@@ -867,6 +902,52 @@ describe('Invoker terminal (component)', () => {
     expect(input).toHaveClass('disabled:cursor-not-allowed');
     expect(input).not.toHaveClass('disabled:cursor-wait');
     expect(screen.getAllByText(/submitted/i).length).toBeGreaterThan(0);
+  });
+
+  it('restores planning tmux output received while the planning surface is hidden', async () => {
+    render(<App />);
+    await openPlanningTerminal();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'tmux' }));
+
+    await waitFor(() => {
+      expect(mock.api.planningTerminalOpen).toHaveBeenCalledTimes(1);
+    });
+    expect(await screen.findByTestId('invoker-terminal-tmux-pane')).toHaveAttribute(
+      'data-session-id',
+      'mock-planning-terminal-session-1',
+    );
+
+    xtermMocks.write.mockClear();
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('invoker-terminal-tmux-pane')).not.toBeInTheDocument();
+    });
+
+    await act(async () => {
+      mock.fireTerminalOutput({
+        sessionId: 'mock-planning-terminal-session-1',
+        taskId: 'planning:session-1',
+        kind: 'planning',
+        planningSessionId: 'session-1',
+        data: 'hidden tmux output\n',
+      });
+    });
+    expect(xtermMocks.write).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-tmux-pane')).toHaveAttribute(
+        'data-session-id',
+        'mock-planning-terminal-session-1',
+      );
+    });
+    await waitFor(() => {
+      expect(xtermMocks.write).toHaveBeenCalledWith(expect.stringContaining('hidden tmux output'));
+    });
+    expect(mock.api.planningTerminalOpen).toHaveBeenCalledTimes(1);
   });
 
   it('opens the expanded planning chat and Escape closes it without clearing transcript', async () => {

--- a/packages/ui/src/__tests__/planning-terminal-tmux.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-tmux.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+const xtermMocks = vi.hoisted(() => ({
+  write: vi.fn(),
+  open: vi.fn(),
+  loadAddon: vi.fn(),
+  onData: vi.fn(() => ({ dispose: vi.fn() })),
+  dispose: vi.fn(),
+  focus: vi.fn(),
+  fit: vi.fn(),
+}));
+
+vi.mock('xterm', () => ({
+  Terminal: vi.fn(() => ({
+    cols: 80,
+    rows: 24,
+    loadAddon: xtermMocks.loadAddon,
+    open: xtermMocks.open,
+    write: xtermMocks.write,
+    onData: xtermMocks.onData,
+    focus: xtermMocks.focus,
+    dispose: xtermMocks.dispose,
+  })),
+}));
+
+vi.mock('xterm-addon-fit', () => ({
+  FitAddon: vi.fn(() => ({
+    fit: xtermMocks.fit,
+  })),
+}));
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+describe('Planning terminal tmux history', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    xtermMocks.write.mockClear();
+    xtermMocks.open.mockClear();
+    xtermMocks.loadAddon.mockClear();
+    xtermMocks.onData.mockClear();
+    xtermMocks.dispose.mockClear();
+    xtermMocks.focus.mockClear();
+    xtermMocks.fit.mockClear();
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  async function openPlanningTerminal() {
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+    });
+  }
+
+  it('restores planning tmux output received while the planning surface is hidden', async () => {
+    render(<App />);
+    await openPlanningTerminal();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'tmux' }));
+
+    await waitFor(() => {
+      expect(mock.api.planningTerminalOpen).toHaveBeenCalledTimes(1);
+    });
+    expect(await screen.findByTestId('invoker-terminal-tmux-pane')).toHaveAttribute(
+      'data-session-id',
+      'mock-planning-terminal-session-1',
+    );
+
+    xtermMocks.write.mockClear();
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('invoker-terminal-tmux-pane')).not.toBeInTheDocument();
+    });
+
+    await act(async () => {
+      mock.fireTerminalOutput({
+        sessionId: 'mock-planning-terminal-session-1',
+        taskId: 'planning:session-1',
+        kind: 'planning',
+        planningSessionId: 'session-1',
+        data: 'hidden tmux output\n',
+      });
+    });
+    expect(xtermMocks.write).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-tmux-pane')).toHaveAttribute(
+        'data-session-id',
+        'mock-planning-terminal-session-1',
+      );
+    });
+    await waitFor(() => {
+      expect(xtermMocks.write).toHaveBeenCalledWith(expect.stringContaining('hidden tmux output'));
+    });
+    expect(mock.api.planningTerminalOpen).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -96,30 +96,36 @@ function seedTerminalOutputSnapshot(
   session: TerminalSessionDescriptor,
   seededSnapshotRef: { current: SeededOutputSnapshot | null },
 ): void {
-  const outputSnapshot = session.outputSnapshot;
+  const outputSnapshot = session.outputSnapshot ?? '';
   const seededSnapshot = seededSnapshotRef.current;
-  if (
-    outputSnapshot &&
-    (
-      !seededSnapshot ||
-      seededSnapshot.sessionId !== session.sessionId ||
-      seededSnapshot.snapshot !== outputSnapshot ||
-      seededSnapshot.term !== term
-    )
-  ) {
-    try {
-      term.write(outputSnapshot);
-      seededSnapshotRef.current = {
-        sessionId: session.sessionId,
-        snapshot: outputSnapshot,
-        term,
-      };
-    } catch (err) {
-      console.warn(
-        `Failed to seed output snapshot for planning terminal session ${session.sessionId}:`,
-        err,
-      );
-    }
+  if (seededSnapshot?.sessionId === session.sessionId && seededSnapshot.term === term) {
+    seededSnapshotRef.current = {
+      sessionId: session.sessionId,
+      snapshot: outputSnapshot,
+      term,
+    };
+    return;
+  }
+  if (!outputSnapshot) {
+    seededSnapshotRef.current = {
+      sessionId: session.sessionId,
+      snapshot: outputSnapshot,
+      term,
+    };
+    return;
+  }
+  try {
+    term.write(outputSnapshot);
+    seededSnapshotRef.current = {
+      sessionId: session.sessionId,
+      snapshot: outputSnapshot,
+      term,
+    };
+  } catch (err) {
+    console.warn(
+      `Failed to seed output snapshot for planning terminal session ${session.sessionId}:`,
+      err,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Planning tmux output now keeps a bounded renderer snapshot while the Planning surface is hidden.

When the operator switches Home and back to Planning, the remounted tmux pane replays hidden output without opening another session.

The focused UI regression now covers hidden output arriving while the Planning surface is unmounted.

## Review Claim

Approve preserving planning tmux scrollback across Home and Planning surface switches without reopening the underlying tmux session.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only planning terminal output events update a bounded 64 KiB snapshot, and the existing tmux session ID is reused on remount.

## Slice Rationale

The foundation slice carries the requested target branch state; this slice contains only the user-visible tmux restoration behavior and its focused regression coverage.

## Non-goals

- Do not change task terminal behavior.
- Do not alter backend tmux session lifecycle or IPC contracts.
- Do not change Planning chat persistence.

## Architecture

### Before

```mermaid
graph TD
    A["Planning tmux pane unmounts"] --> B["hidden output reaches no terminal"]
    B --> C["remount starts from the old snapshot"]
```

### After

```mermaid
graph TD
    A["Planning tmux pane unmounts"] --> B["renderer stores hidden output in the session snapshot"]
    B --> C["remount seeds InvokerTerminal from the updated snapshot"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx src/__tests__/planning-terminal-tmux.test.tsx`
- [x] `node scripts/validate-pr-body.mjs --body-file .invoker-pr-bodies/planning-tmux-output-restore-pr.md --require-visual-proof`

</details>

Depends-On: #5013

## Visual Proof

The animated Planning Terminal remount proof shows output restored after the surface is rebuilt:

![Planning Terminal output restoration](https://github.com/Neko-Catpital-Labs/Invoker/blob/stack/EdbertChan/plan/planning-tmux-history-surface-switch-main-stack/planning-tmux-output-survives-home-planning--3c87a5f6/packages/app/e2e/visual-proof/after/planning-terminal-restart.gif?raw=1)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d250d514b65f33955ac4de314fe932e39831dbab`
- Post-revert steps: Re-run `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx src/__tests__/planning-terminal-tmux.test.tsx`.
- Data migration? No

</details>
