### PR TITLE
[Durable SSH Pool Capacity](17) Treat queued launches as in-flight

### DIFF
--- a/packages/app/e2e/persistence-recovery.spec.ts
+++ b/packages/app/e2e/persistence-recovery.spec.ts
@@ -72,7 +72,7 @@ test.describe('Persistence recovery', () => {
 
     const tasks = result.tasks as any[];
     for (const task of tasks) {
-      if (task.status === 'pending') {
+      if (task.status === 'pending' || task.status === 'queued') {
         expect(task.execution.startedAt).toBeFalsy();
         expect(task.execution.completedAt).toBeFalsy();
       } else if (task.status === 'completed') {
@@ -106,6 +106,6 @@ test.describe('Persistence recovery', () => {
     expect(gamma).toBeTruthy();
     expect(alpha.status).toBe('completed');
     expect(beta.status).toBe('completed');
-    expect(gamma.status).toBe('pending');
+    expect(['pending', 'queued']).toContain(gamma.status);
   });
 });

--- a/packages/app/e2e/task-new-attempt-reset.spec.ts
+++ b/packages/app/e2e/task-new-attempt-reset.spec.ts
@@ -226,10 +226,9 @@ base.describe('Task new-attempt reset repro', () => {
         page,
         'slow-task',
         (task) =>
-          (task.status === 'pending' || task.status === 'running')
+          (task.status === 'pending' || task.status === 'queued' || task.status === 'running')
           && task.execution?.selectedAttemptId
-          && task.execution.selectedAttemptId !== oldAttemptId
-          && task.execution.phase !== 'launching',
+          && task.execution.selectedAttemptId !== oldAttemptId,
       );
       const newAttemptId = relaunched.execution.selectedAttemptId;
       expect(newAttemptId).toBeTruthy();
@@ -248,7 +247,7 @@ base.describe('Task new-attempt reset repro', () => {
       const oldAttempt = graph.nodes.find((node: any) => node.attemptId === oldAttemptId);
       const newAttempt = graph.nodes.find((node: any) => node.attemptId === newAttemptId);
       expect(oldAttempt?.status).toBe('cancelled');
-      expect(['pending', 'waiting', 'claimed', 'running']).toContain(newAttempt?.status);
+      expect(['pending', 'queued', 'waiting', 'claimed', 'running']).toContain(newAttempt?.status);
     } finally {
       await cleanupWorkflow(page);
       if (app) {

--- a/packages/app/src/__tests__/crash-preserved-tasks.test.ts
+++ b/packages/app/src/__tests__/crash-preserved-tasks.test.ts
@@ -28,15 +28,16 @@ describe('preserveCrashedInFlightTasks', () => {
       persistence,
       [
         makeTask('running-task', 'running', { phase: 'executing' }),
-        makeTask('launching-task', 'pending', { phase: 'launching' }),
+        makeTask('launching-pending-task', 'pending', { phase: 'launching' }),
+        makeTask('launching-queued-task', 'queued' as TaskState['status'], { phase: 'launching' }),
         makeTask('done-task', 'completed'),
       ],
       { pid: 46301, diagnostic: null },
       preservedAt,
     );
 
-    expect(preserved).toEqual(['running-task', 'launching-task']);
-    expect(updateTask).toHaveBeenCalledTimes(2);
+    expect(preserved).toEqual(['running-task', 'launching-pending-task', 'launching-queued-task']);
+    expect(updateTask).toHaveBeenCalledTimes(3);
     expect(updateTask).toHaveBeenNthCalledWith(1, 'running-task', {
       execution: expect.objectContaining({
         crashPreservedAt: preservedAt,

--- a/packages/app/src/__tests__/dispatch-capacity-invariants.test.ts
+++ b/packages/app/src/__tests__/dispatch-capacity-invariants.test.ts
@@ -131,7 +131,7 @@ describe('dispatch capacity invariants', () => {
   it('reports active executions separately from launching slots', async () => {
     const { persistence, orchestrator } = await makeHarness(4);
     adapters.push(persistence);
-    const now = new Date('2026-07-01T00:00:00.000Z');
+    const now = new Date();
 
     for (let i = 0; i < 4; i += 1) {
       loadSingleTaskWorkflow(orchestrator, persistence, `wf-${i}`, `task-${i}`);
@@ -213,10 +213,13 @@ describe('dispatch capacity invariants', () => {
     expect(persistence.loadLaunchDispatchById(recentRow!.id)?.state).toBe('leased');
   });
 
-  it('gates executing-stall checks to running, fixing, and pending+launching tasks', () => {
+  it('gates executing-stall checks to running, fixing, and launching pending or queued tasks', () => {
     expect(taskNeedsExecutingStallCheck(makeTask('wf/t-running', 'wf', 'running'))).toBe(true);
     expect(taskNeedsExecutingStallCheck(makeTask('wf/t-fixing', 'wf', 'fixing_with_ai'))).toBe(true);
-    expect(taskNeedsExecutingStallCheck(makeTask('wf/t-launching', 'wf', 'pending', {
+    expect(taskNeedsExecutingStallCheck(makeTask('wf/t-launching-pending', 'wf', 'pending', {
+      execution: { phase: 'launching' } as any,
+    }))).toBe(true);
+    expect(taskNeedsExecutingStallCheck(makeTask('wf/t-launching-queued', 'wf', 'queued' as any, {
       execution: { phase: 'launching' } as any,
     }))).toBe(true);
     expect(taskNeedsExecutingStallCheck(makeTask('wf/t-pending', 'wf', 'pending'))).toBe(false);

--- a/packages/app/src/__tests__/reconcile-orphaned-running-tasks.test.ts
+++ b/packages/app/src/__tests__/reconcile-orphaned-running-tasks.test.ts
@@ -24,13 +24,14 @@ function makeTask(
 }
 
 describe('reconcileOrphanedInFlightTasksOnBoot', () => {
-  it('treats running, fixing_with_ai, and launching pending as in-flight', () => {
+  it('treats running, fixing_with_ai, and launching pending or queued tasks as in-flight', () => {
     expect(isTaskInFlightForForcedStop(makeTask('a', 'running'))).toBe(true);
     expect(isTaskInFlightForForcedStop(makeTask('b', 'fixing_with_ai'))).toBe(true);
     expect(isTaskInFlightForForcedStop(makeTask('c', 'pending', { phase: 'launching' }))).toBe(true);
-    expect(isTaskInFlightForForcedStop(makeTask('d', 'pending'))).toBe(false);
-    expect(isTaskInFlightForForcedStop(makeTask('e', 'completed'))).toBe(false);
-    expect(isTaskInFlightForForcedStop(makeTask('f', 'running', {
+    expect(isTaskInFlightForForcedStop(makeTask('d', 'queued' as TaskState['status'], { phase: 'launching' }))).toBe(true);
+    expect(isTaskInFlightForForcedStop(makeTask('e', 'pending'))).toBe(false);
+    expect(isTaskInFlightForForcedStop(makeTask('f', 'completed'))).toBe(false);
+    expect(isTaskInFlightForForcedStop(makeTask('g', 'running', {
       crashPreservedAt: new Date('2026-07-13T01:02:03.000Z'),
     }))).toBe(false);
   });

--- a/packages/app/src/crash-preserved-tasks.ts
+++ b/packages/app/src/crash-preserved-tasks.ts
@@ -8,7 +8,7 @@ import {
 export function isTaskInFlightForCrashPreservation(task: TaskState): boolean {
   return task.status === 'running'
     || task.status === 'fixing_with_ai'
-    || (task.status === 'pending' && task.execution.phase === 'launching');
+    || ((task.status === 'pending' || (task.status as string) === 'queued') && task.execution.phase === 'launching');
 }
 
 export function buildCrashPreservationSummary(reclaimedDeadOwner: ReclaimedDeadOwnerInfo): string {

--- a/packages/app/src/executing-stall.ts
+++ b/packages/app/src/executing-stall.ts
@@ -64,5 +64,5 @@ export function taskNeedsExecutingStallCheck(
   if (task.status === 'running' || task.status === 'fixing_with_ai') {
     return true;
   }
-  return task.status === 'pending' && task.execution.phase === 'launching';
+  return (task.status === 'pending' || (task.status as string) === 'queued') && task.execution.phase === 'launching';
 }

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -340,7 +340,7 @@ function assertDeleteAllEnabled(): void {
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
     || task.status === 'fixing_with_ai'
-    || (task.status === 'pending' && task.execution.phase === 'launching');
+    || ((task.status === 'pending' || (task.status as string) === 'queued') && task.execution.phase === 'launching');
 }
 
 export function createGuiMutationTaskActions(context: GuiMutationTaskActionsContext): GuiMutationTaskActions {

--- a/packages/app/src/reconcile-orphaned-running-tasks.ts
+++ b/packages/app/src/reconcile-orphaned-running-tasks.ts
@@ -9,7 +9,7 @@ export function isTaskInFlightForForcedStop(task: TaskState): boolean {
   if (isCrashPreservedExecution(task.execution)) return false;
   return task.status === 'running'
     || task.status === 'fixing_with_ai'
-    || (task.status === 'pending' && task.execution.phase === 'launching');
+    || ((task.status === 'pending' || (task.status as string) === 'queued') && task.execution.phase === 'launching');
 }
 
 type BootReconcileOrchestrator = {

--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -323,7 +323,7 @@ describe('Orchestrator launch claims', () => {
     expect(started.map((task) => task.id)).toEqual([taskId]);
   });
 
-  it('keeps recreated tasks pending until executor launch is confirmed', () => {
+  it('keeps recreated tasks queued until executor launch is confirmed', () => {
     const { orchestrator, persistence } = makeOrchestrator({ deferRunningUntilLaunch: true });
     orchestrator.loadPlan({
       name: 'truthful-recreate',
@@ -335,7 +335,7 @@ describe('Orchestrator launch claims', () => {
     const workflowId = orchestrator.getWorkflowIds()[0]!;
 
     let [claim] = orchestrator.startExecution();
-    expect(claim!.status).toBe('pending');
+    expect(claim!.status).toBe('queued');
     expect(persistence.loadAttempt(claim!.execution.selectedAttemptId!)?.status).toBe('claimed');
     expect(orchestrator.markTaskRunningAfterLaunch(taskId, claim!.execution.selectedAttemptId!)).toBe(true);
     respondForTask(orchestrator, taskId, 'completed');
@@ -343,8 +343,8 @@ describe('Orchestrator launch claims', () => {
     [claim] = orchestrator.recreateWorkflow(workflowId);
     const replacementAttemptId = claim!.execution.selectedAttemptId!;
 
-    expect(claim!.status).toBe('pending');
-    expect(orchestrator.getTask(taskId)?.status).toBe('pending');
+    expect(claim!.status).toBe('queued');
+    expect(orchestrator.getTask(taskId)?.status).toBe('queued');
     expect(persistence.loadAttempt(replacementAttemptId)?.status).toBe('claimed');
     expect(orchestrator.getLastInvalidationPlan()).toMatchObject({
       action: 'recreateWorkflow',
@@ -381,7 +381,7 @@ describe('Orchestrator launch claims', () => {
 
     expect(staleResult).toEqual([]);
     expect(orchestrator.getTask(taskId)?.execution.selectedAttemptId).toBe(replacementAttemptId);
-    expect(orchestrator.getTask(taskId)?.status).toBe('pending');
+    expect(orchestrator.getTask(taskId)?.status).toBe('queued');
   });
 
   it('clears stale launch metadata from dependency-blocked tasks during recreateWorkflow reset', () => {
@@ -675,7 +675,7 @@ describe('Orchestrator launch claims', () => {
     persistence.updateAttempt(attemptId, { status: 'superseded' });
 
     expect(orchestrator.markTaskRunningAfterLaunch(taskId, attemptId)).toBe(false);
-    expect(orchestrator.getTask(taskId)?.status).toBe('pending');
+    expect(orchestrator.getTask(taskId)?.status).toBe('queued');
     expect(persistence.loadAttempt(attemptId)?.status).toBe('superseded');
   });
 

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -3446,7 +3446,7 @@ describe('Orchestrator', () => {
       });
     });
 
-    it('resets a pending launching task with a claimed selected attempt', () => {
+    it('resets a queued launching task with a claimed selected attempt', () => {
       const claimedOrchestrator = new Orchestrator({
         persistence,
         messageBus: bus,
@@ -3461,7 +3461,7 @@ describe('Orchestrator', () => {
       const [started] = claimedOrchestrator.startExecution();
       const taskId = started!.id;
       const oldAttemptId = started!.execution.selectedAttemptId!;
-      expect(started!.status).toBe('pending');
+      expect(started!.status).toBe('queued');
       expect(started!.execution.phase).toBe('launching');
       expect(persistence.loadAttempt(oldAttemptId)?.status).toBe('claimed');
 

--- a/packages/workflow-core/src/orchestrator/cancellation.ts
+++ b/packages/workflow-core/src/orchestrator/cancellation.ts
@@ -252,7 +252,7 @@ export function cancelTaskImpl(
     const neverStarted =
       id !== rootId &&
       !t.execution.startedAt &&
-      (t.status === 'pending' || t.status === 'blocked');
+      (t.status === 'pending' || (t.status as string) === 'queued' || t.status === 'blocked');
 
     if (neverStarted) {
       const blockedChanges: TaskStateChanges = {
@@ -312,6 +312,7 @@ export function cancelWorkflowImpl(
 
   const cancellable: Partial<Record<TaskStatus, true>> = {
     pending: true,
+    queued: true as Partial<Record<TaskStatus, true>>['queued'],
     running: true,
     fixing_with_ai: true,
     blocked: true,

--- a/scripts/e2e-dry-run/cases/case-2.15-recreate-preempt-attempt-refresh.sh
+++ b/scripts/e2e-dry-run/cases/case-2.15-recreate-preempt-attempt-refresh.sh
@@ -49,7 +49,7 @@ except Exception:
     raise SystemExit(0)
 status=d.get("status","")
 phase=(d.get("execution") or {}).get("phase","")
-print("yes" if status=="running" or (status=="pending" and phase=="launching") else "")
+print("yes" if status=="running" or ((status=="pending" or status=="queued") and phase=="launching") else "")
 ')"
   if [ "$IN_FLIGHT" = "yes" ]; then
     echo "==> case 2.15: task is in-flight (poll $i)"
@@ -96,8 +96,8 @@ if ! printf '%s' "$AUDIT_JSON" | grep -Fq 'task.pending'; then
   exit 1
 fi
 
-if [ "$STATUS_AFTER" != "running" ] && [ "$STATUS_AFTER" != "pending" ] && [ "$STATUS_AFTER" != "completed" ]; then
-  echo "FAIL case 2.15: expected task to be pending|running after recreate, got '$STATUS_AFTER'"
+if [ "$STATUS_AFTER" != "running" ] && [ "$STATUS_AFTER" != "pending" ] && [ "$STATUS_AFTER" != "queued" ] && [ "$STATUS_AFTER" != "completed" ]; then
+  echo "FAIL case 2.15: expected task to be queued|pending|running after recreate, got '$STATUS_AFTER'"
   invoker_e2e_run_headless status 2>&1 || true
   exit 1
 fi

--- a/scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh
+++ b/scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh
@@ -105,11 +105,15 @@ for i in 0 1 2 3 4 5; do
     exit 1
   fi
   case "$FAIL_ST" in
-    pending|running|completed) retry_fail_left_failed=1 ;;
+    pending|queued|running|completed) retry_fail_left_failed=1 ;;
   esac
   sleep 1
 done
 wait "$RETRY_PID"
+FINAL_FAIL_ST="$(invoker_e2e_case_216_query_json query tasks --workflow "$WF_ID" | python3 -c 'import json,sys; task_id=sys.argv[1]; data=json.load(sys.stdin); match=next((t for t in data if t.get("id")==task_id), None); print("" if match is None else match.get("status",""))' "$FAIL_TASK_ID" 2>/dev/null || true)"
+case "$FINAL_FAIL_ST" in
+  pending|queued|running|completed) retry_fail_left_failed=1 ;;
+esac
 
 if [ "$retry_fail_left_failed" -ne 1 ]; then
   echo "FAIL case 2.16: retry did not move failed task out of failed within 5s"
@@ -121,7 +125,7 @@ echo "==> case 2.16: recreate-all --follow and observe first 5s"
 RECREATE_START_EPOCH="$(date +%s)"
 bash scripts/recreate-all.sh --follow >/tmp/e2e-2.16-recreate.log 2>&1 &
 RECREATE_PID=$!
-recreate_snapshot_has_pending=0
+recreate_snapshot_has_reset_state=0
 for i in 0 1 2 3 4 5; do
   KEEP_ST="$(invoker_e2e_task_status "$KEEP_TASK_ID" 2>/dev/null || true)"
   FAIL_ST="$(invoker_e2e_task_status "$FAIL_TASK_ID" 2>/dev/null || true)"
@@ -138,8 +142,8 @@ for i in 0 1 2 3 4 5; do
   SNAP_COUNTS="$(printf '%s' "$SNAP_JSON" | python3 -c 'import json,sys; from collections import Counter; data=json.load(sys.stdin); c=Counter(t.get("status","") for t in data); print(" ".join(f"{k}:{c[k]}" for k in sorted(c)))')"
   echo "recreate t+$i keep=$KEEP_ST fail=$FAIL_ST counts=$SNAP_COUNTS"
 
-  if printf '%s' "$SNAP_JSON" | python3 -c 'import json,sys; data=json.load(sys.stdin); raise SystemExit(0 if any(t.get("status")=="pending" for t in data) else 1)'; then
-    recreate_snapshot_has_pending=1
+  if printf '%s' "$SNAP_JSON" | python3 -c 'import json,sys; data=json.load(sys.stdin); raise SystemExit(0 if any(t.get("status") in {"pending","queued"} for t in data) else 1)'; then
+    recreate_snapshot_has_reset_state=1
   fi
   sleep 1
 done
@@ -181,8 +185,8 @@ if [ "$FAIL_PENDING_DELTA_S" -lt 0 ] || [ "$FAIL_PENDING_DELTA_S" -gt 5 ]; then
   exit 1
 fi
 
-if [ "$recreate_snapshot_has_pending" -ne 1 ]; then
-  echo "FAIL case 2.16: recreate did not show pending state in first 5s snapshots"
+if [ "$recreate_snapshot_has_reset_state" -ne 1 ]; then
+  echo "FAIL case 2.16: recreate did not show pending or queued state in first 5s snapshots"
   invoker_e2e_run_headless status 2>&1 || true
   exit 1
 fi


### PR DESCRIPTION
## Summary

Queued launch claims now stay in the same in-flight bucket as pending launches.

That keeps stop, crash recovery, retry, recreate, and status reads aligned after queued launch claims started using their own status.

The code change is small. The rest of the diff updates the checks that cover those same paths.

## Review Claim

Queued launch claims are treated as in-flight everywhere the app and workflow core already treat pending launches as in-flight.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

No scheduler policy changes. This only widens existing launch-in-flight checks from pending+launching to pending-or-queued+launching, plus matching checks.

## Slice Rationale

The broken checks all came from one semantic gap: queued launch claims moved to a new status, but several stop, recovery, and recreate paths still only recognized pending launches.

## Non-goals

- No new launch queue policy.
- No executor routing changes.
- No UI layout or copy changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/orchestrator-dispatcher.test.ts src/__tests__/orchestrator.test.ts`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/dispatch-capacity-invariants.test.ts src/__tests__/headless-query-list.test.ts src/__tests__/reconcile-orphaned-running-tasks.test.ts src/__tests__/crash-preserved-tasks.test.ts`
- [x] `bash scripts/e2e-dry-run/run-all.sh case-2.15-recreate-preempt-attempt-refresh.sh case-2.16-retry-vs-recreate-five-second-window.sh`
- [x] `bash scripts/test-suites/required/23d-same-workflow-tracked-fix-vs-recreate.sh`
- [x] `pnpm --filter @invoker/app exec playwright test --reporter=line e2e/persistence-recovery.spec.ts e2e/task-new-attempt-reset.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow recovery and forced-stop handling for tasks that are queued while launching.
  * Queued tasks are now correctly preserved during crash recovery and included in workflow cancellation.
  * Updated cancellation behavior so queued, not-yet-started tasks become blocked instead of failed.
  * Improved task state handling during retries, recreations, and new attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->