### PR TITLE
Fix Slack sanitizer rewriting Invoker prose

### DIFF
--- a/packages/surfaces/src/__tests__/slack-do1-ux-sanitize.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-do1-ux-sanitize.e2e.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeSlashCommands } from '../slack/slack-message-helpers.js';
+
+const LIVE_FENCED_PLAN_BOT_REPLY =
+  'I’ll treat this as a normal worktree task here, not an Invoker plan\n\nThere are already local edits in the target areas.';
+const LIVE_FENCED_PLAN_USER =
+  '```text\nplan: Prove and fix the adverse UI test issues found in the agent thread for Invoker.\n\nScope:\n1. Fix/prove @invoker/app build behavior when git SHA lookup hits false EPERM.\n```';
+const LIVE_ADVERSE_AGENT_PROSE =
+  'I’ll interpret “averse test” as adverse/edge-case UI testing for an Invoker plan';
+const LIVE_PATH_LEAK =
+  'I inspected [scripts/land-stack.mjs](/home/invoker/.invoker/slack-manager/planning-clones/64a63486912a/scripts/land-stack.mjs:1)';
+
+describe('DO1 e2e: sanitizeSlashCommands leaves Invoker plan prose alone', () => {
+  it('does not rewrite LIVE_FENCED_PLAN_BOT_REPLY', () => {
+    expect(sanitizeSlashCommands(LIVE_FENCED_PLAN_BOT_REPLY)).toBe(LIVE_FENCED_PLAN_BOT_REPLY);
+  });
+
+  it('does not rewrite LIVE_FENCED_PLAN_USER', () => {
+    expect(sanitizeSlashCommands(LIVE_FENCED_PLAN_USER)).toBe(LIVE_FENCED_PLAN_USER);
+  });
+
+  it('does not rewrite LIVE_ADVERSE_AGENT_PROSE', () => {
+    expect(sanitizeSlashCommands(LIVE_ADVERSE_AGENT_PROSE)).toBe(LIVE_ADVERSE_AGENT_PROSE);
+  });
+
+  it('does not rewrite LIVE_PATH_LEAK', () => {
+    expect(sanitizeSlashCommands(LIVE_PATH_LEAK)).toBe(LIVE_PATH_LEAK);
+  });
+
+  it('still rewrites /invoker start_plan', () => {
+    expect(sanitizeSlashCommands('run `/invoker start_plan` now')).toBe(
+      'reply with "yes", "go", or "execute" to confirm now',
+    );
+  });
+});

--- a/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SlackSurface } from '../slack/slack-surface.js';
-import { splitForSlack } from '../slack/slack-message-helpers.js';
+import { sanitizeSlashCommands, splitForSlack } from '../slack/slack-message-helpers.js';
 import type { SurfaceCommand } from '../surface.js';
 
 // ── Mock @slack/bolt ────────────────────────────────────────
@@ -659,6 +659,32 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
       expect(updates[0].text).toBe('First response');
       expect(updates[1].text).toBe('Second response');
     });
+  });
+});
+
+describe('sanitizeSlashCommands', () => {
+  it('replaces hallucinated /invoker commands but keeps /invoker conversations', () => {
+    expect(sanitizeSlashCommands('run `/invoker start_plan` now')).toBe(
+      'reply with "yes", "go", or "execute" to confirm now',
+    );
+    expect(sanitizeSlashCommands('Please `/invoker approve task-1`')).toBe(
+      'Please reply with "yes", "go", or "execute" to confirm',
+    );
+    expect(sanitizeSlashCommands('use /invoker conversations list')).toBe(
+      'use /invoker conversations list',
+    );
+  });
+
+  it('does not rewrite ordinary Invoker prose', () => {
+    expect(sanitizeSlashCommands('This thread can’t create or submit an Invoker plan')).toBe(
+      'This thread can’t create or submit an Invoker plan',
+    );
+    expect(sanitizeSlashCommands('I can’t submit or execute an Invoker plan; try submit')).toBe(
+      'I can’t submit or execute an Invoker plan; try submit',
+    );
+    expect(sanitizeSlashCommands('Start a new Invoker workflow channel')).toBe(
+      'Start a new Invoker workflow channel',
+    );
   });
 });
 

--- a/packages/surfaces/src/slack/slack-message-helpers.ts
+++ b/packages/surfaces/src/slack/slack-message-helpers.ts
@@ -156,10 +156,12 @@ export function splitCodeBlockChunk(text: string, limit: number): string[] {
  * The inner Claude sometimes invents non-existent commands like "/invoker start_plan".
  * This replaces any such references (except /invoker conversations, which is real)
  * with the correct user instruction.
+ *
+ * Requires a leading `/` so ordinary prose like "an Invoker plan" is left alone.
  */
 export function sanitizeSlashCommands(text: string): string {
   return text.replace(
-    /(?:use |run |type |try )?`?\/?invoker\s+(?!conversations\b)\w+[^`\n]*`?/gi,
+    /(?:use |run |type |try )?`?\/invoker\s+(?!conversations\b)\w+[^`\n]*`?/gi,
     'reply with "yes", "go", or "execute" to confirm',
   );
 }


### PR DESCRIPTION
## Summary

On DO1 Slack, bot replies corrupted ordinary prose that said "Invoker plan".

The outbound sanitizer treated bare `Invoker <word>` like a `/invoker` command and spliced in the confirm prompt.

Live lobby thread (fenced plan paste):
https://invokerorchestrator.slack.com/archives/C0BCNM0UTFY/p1784353362855019?thread_ts=1784353362.855019&cid=C0BCNM0UTFY

Corrupted bot text:
> I'll treat this as a normal worktree task here, not an reply with "yes", "go", or "execute" to confirm

This requires a real leading `/` before rewriting.

## Review Claim

Approve requiring a leading `/` in `sanitizeSlashCommands` so prose like "an Invoker plan" is no longer rewritten.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the Slack outbound scrubber regex changes. Real `/invoker …` hallucinations are still replaced; `/invoker conversations` is still preserved.

## Slice Rationale

This is the live DO1 corruption users hit first. Other Slack UX fixes stay in separate PRs.

## Non-goals

Does not change plan/agent routing, Slack scopes, watchdog alerts, or path redaction.

## Visual Proof

Live DO1 Slack thread evidence (remote_digital_ocean_1 lobby):

- Fenced-plan thread with corrupted reply: https://invokerorchestrator.slack.com/archives/C0BCNM0UTFY/p1784353362855019?thread_ts=1784353362.855019&cid=C0BCNM0UTFY
- Adverse-UI thread with the same splice: https://invokerorchestrator.slack.com/archives/C0BCNM0UTFY/p1784340626830469?thread_ts=1784340626.830469&cid=C0BCNM0UTFY

Issue screenshot (yellow = corrupted confirm prompt text):

![Sanitizer corruption in fenced plan thread](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-805c84/5040-sanitizer-corruption.png)

Same bug earlier in the adverse-UI thread:

![Sanitizer corruption in adverse UI thread](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-805c84/5040-adverse-sanitizer.png)

Walkthrough video across DO1 Slack UX failures:

[do1-slack-ux-issues.mp4](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-805c84/do1-slack-ux-issues.mp4)


## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm exec vitest run src/__tests__/slack-do1-ux-sanitize.e2e.test.ts`
- [ ] `cd packages/surfaces && pnpm exec vitest run src/__tests__/slack-surface-immediate-response.integration.test.ts -t 'sanitizeSlashCommands'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a63fb54ce`
- Post-revert steps: None
- Data migration? No

</details>
