### PR TITLE
Parse sole fenced plan: blocks as Slack plan mode

### DIFF
--- a/packages/surfaces/src/__tests__/slack-do1-ux-fenced-plan.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-do1-ux-fenced-plan.e2e.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { parseThreadRequest } from '../slack/slack-surface.js';
+
+const LIVE_FENCED_PLAN_BOT_REPLY =
+  'I’ll treat this as a normal worktree task here, not an Invoker plan\n\nThere are already local edits in the target areas.';
+const LIVE_FENCED_PLAN_USER =
+  '```text\nplan: Prove and fix the adverse UI test issues found in the agent thread for Invoker.\n\nScope:\n1. Fix/prove @invoker/app build behavior when git SHA lookup hits false EPERM.\n```';
+const LIVE_ADVERSE_AGENT_PROSE =
+  'I’ll interpret “averse test” as adverse/edge-case UI testing for an Invoker plan';
+const LIVE_PATH_LEAK =
+  'I inspected [scripts/land-stack.mjs](/home/invoker/.invoker/slack-manager/planning-clones/64a63486912a/scripts/land-stack.mjs:1)';
+
+describe('DO1 e2e: parse sole fenced plan: blocks as plan mode', () => {
+  it('parseThreadRequest(LIVE_FENCED_PLAN_USER) returns mode plan', () => {
+    const result = parseThreadRequest(LIVE_FENCED_PLAN_USER);
+    expect(result).not.toBeNull();
+    expect(result!.mode).toBe('plan');
+    expect(result!.text).toContain('Prove and fix the adverse UI test issues');
+  });
+
+  it('keeps LIVE_* agent prose as agent mode (not plan)', () => {
+    expect(parseThreadRequest(LIVE_FENCED_PLAN_BOT_REPLY)?.mode).toBe('agent');
+    expect(parseThreadRequest(LIVE_ADVERSE_AGENT_PROSE)?.mode).toBe('agent');
+    expect(parseThreadRequest(LIVE_PATH_LEAK)?.mode).toBe('agent');
+  });
+});

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -186,6 +186,19 @@ describe('parseThreadRequest', () => {
     expect(parseThreadRequest('plan: fix the Slack routing bug')).toEqual({ mode: 'plan', text: 'fix the Slack routing bug' });
     expect(parseThreadRequest('draft an Invoker plan: fix the Slack routing bug')).toEqual({ mode: 'plan', text: 'fix the Slack routing bug' });
   });
+
+  it('treats a sole fenced plan: block as plan mode', () => {
+    const fenced = '```text\nplan: Prove and fix the adverse UI test issues\n```';
+    expect(parseThreadRequest(fenced)).toEqual({
+      mode: 'plan',
+      text: 'Prove and fix the adverse UI test issues',
+    });
+  });
+
+  it('does not treat a fence nested after prose as a plan opt-in', () => {
+    const mixed = 'please help\n\n```text\nplan: do not treat this as plan mode\n```';
+    expect(parseThreadRequest(mixed)).toEqual({ mode: 'agent', text: mixed });
+  });
 });
 
 // ── Built-in harness presets ─────────────────────────────────

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -343,8 +343,14 @@ export function parseLocalRequest(text: string): LocalRequest | null {
   return null;
 }
 
+/** If the whole message is one fenced block, return its body; otherwise the original text. */
+export function unwrapSoleFencedBlock(text: string): string {
+  const match = /^```(?:[\w+-]*)?\r?\n([\s\S]*?)\r?\n```\s*$/.exec(text.trim());
+  return match ? match[1].trim() : text.trim();
+}
+
 export function parseThreadRequest(text: string): ThreadRequest | null {
-  const trimmed = text.trim();
+  const trimmed = unwrapSoleFencedBlock(text);
   const planPatterns = [
     /^(?:invoker\s+)?plan\s*:\s*/i,
     /^draft\s+(?:an?\s+)?invoker\s+plan\s*:\s*/i,


### PR DESCRIPTION
## Summary

On DO1, a lobby mention whose whole body was a fenced `plan:` block stayed in agent mode.

Live thread: https://invokerorchestrator.slack.com/archives/C0BCNM0UTFY/p1784353362855019?thread_ts=1784353362.855019&cid=C0BCNM0UTFY

User pasted ` ```text / plan: … ``` `. Bot replied “I'll treat this as a normal worktree task…”, so no Invoker YAML draft/submit path opened.

This unwraps a sole fenced block before plan-prefix detection.

## Review Claim

Approve treating a message that is only a fenced `plan:` block as plan mode.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only sole whole-message fences are unwrapped. Prose plus a nested fence still stays in agent mode.

## Slice Rationale

This is a distinct DO1 paste UX failure from the sanitizer and scope fixes.

## Non-goals

Does not change agent-to-plan promotion, submit confirmation, or Slack scopes.

## Visual Proof

Live DO1 Slack thread:

https://invokerorchestrator.slack.com/archives/C0BCNM0UTFY/p1784353362855019?thread_ts=1784353362.855019&cid=C0BCNM0UTFY

Issue screenshot — user sent fenced `plan:`, bot stayed in agent/worktree mode:

![Fenced plan treated as agent worktree task](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-805c84/5041-fenced-plan-agent.png)

Walkthrough video:

[do1-slack-ux-issues.mp4](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-805c84/do1-slack-ux-issues.mp4)


## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm exec vitest run src/__tests__/slack-do1-ux-fenced-plan.e2e.test.ts`
- [ ] `cd packages/surfaces && pnpm exec vitest run src/__tests__/slack-surface-workflows.test.ts -t 'parseThreadRequest'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 04d8cdb01`
- Post-revert steps: None
- Data migration? No

</details>
