### PR TITLE
Stabilize Slack watchdog recovery before clearing relaunch state

### DIFF
--- a/packages/slack-manager/src/__tests__/watchdog.test.ts
+++ b/packages/slack-manager/src/__tests__/watchdog.test.ts
@@ -54,23 +54,30 @@ describe('createWatchdog', () => {
     expect(launch).toHaveBeenCalledTimes(3);
   });
 
-  it('resets after a successful relaunch', async () => {
+  it('keeps attempt state after a successful relaunch until health is stable', async () => {
     let nowMs = 0;
-    const launch = vi.fn(async () => true); // relaunch succeeds
+    let healthy = false;
+    const launch = vi.fn(async () => {
+      healthy = true;
+      return true;
+    });
     const wd = createWatchdog({
-      client: { isHealthy: vi.fn(async () => false), launch },
+      client: { isHealthy: vi.fn(async () => healthy), launch },
       log: () => {}, alert: vi.fn(),
       failuresBeforeRelaunch: 1, baseBackoffMs: 60_000,
+      stableHealthyPolls: 3,
       now: () => nowMs,
     });
-    await wd.tick();
+    await wd.tick(); // down → launch succeeds
     expect(launch).toHaveBeenCalledTimes(1);
-    // success reset the window → next failure relaunches again immediately
-    await wd.tick();
+
+    healthy = false; // flap immediately
+    nowMs += 100;
+    await wd.tick(); // still counts as recovery; launches again
     expect(launch).toHaveBeenCalledTimes(2);
   });
 
-  it('resets when Invoker recovers on its own', async () => {
+  it('resets only after enough consecutive healthy polls', async () => {
     let nowMs = 0;
     let healthy = false;
     const launch = vi.fn(async () => false);
@@ -78,12 +85,45 @@ describe('createWatchdog', () => {
       client: { isHealthy: vi.fn(async () => healthy), launch },
       log: () => {}, alert: vi.fn(),
       failuresBeforeRelaunch: 1, baseBackoffMs: 60_000,
+      stableHealthyPolls: 3,
       now: () => nowMs,
     });
     await wd.tick();
     expect(launch).toHaveBeenCalledTimes(1);
-    healthy = true; await wd.tick(); // recovered → reset
-    healthy = false; nowMs += 100; await wd.tick(); // fresh failure relaunches without waiting a window
+
+    healthy = true;
+    await wd.tick(); // 1/3
+    await wd.tick(); // 2/3
+    healthy = false; nowMs += 100; await wd.tick(); // flap before stable → relaunch
     expect(launch).toHaveBeenCalledTimes(2);
+
+    healthy = true;
+    await wd.tick();
+    await wd.tick();
+    await wd.tick(); // 3/3 → reset
+    healthy = false; nowMs += 100; await wd.tick(); // fresh failure after full recovery
+    expect(launch).toHaveBeenCalledTimes(3);
+  });
+
+  it('rate-limits repeated give-up alerts while Invoker stays down', async () => {
+    let nowMs = 0;
+    const launch = vi.fn(async () => false);
+    const alert = vi.fn();
+    const wd = createWatchdog({
+      client: { isHealthy: vi.fn(async () => false), launch },
+      log: () => {}, alert,
+      failuresBeforeRelaunch: 1, maxAttempts: 1, baseBackoffMs: 1_000, maxBackoffMs: 1_000,
+      alertCooldownMs: 60_000,
+      now: () => nowMs,
+    });
+
+    await wd.tick();
+    expect(alert).toHaveBeenCalledTimes(1);
+
+    nowMs += 1_000; await wd.tick(); // still within cooldown
+    expect(alert).toHaveBeenCalledTimes(1);
+
+    nowMs += 60_000; await wd.tick(); // cooldown elapsed → remind once
+    expect(alert).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/slack-manager/src/watchdog.ts
+++ b/packages/slack-manager/src/watchdog.ts
@@ -7,6 +7,11 @@
  * (`baseBackoffMs` → `maxBackoffMs`); after `maxAttempts` it posts an alert and
  * stops auto-restarting until Invoker is healthy again (e.g. via a manual
  * `restart`). This backoff is the load-bearing guard against restart storms.
+ *
+ * A single healthy ping after relaunch does not clear attempt state. Invoker
+ * must stay healthy for `stableHealthyPolls` consecutive ticks before the
+ * watchdog treats recovery as complete. Alerts are rate-limited so a flapping
+ * host does not spam the Slack lobby.
  */
 
 import type { InvokerClient } from './invoker-client.js';
@@ -22,6 +27,10 @@ export interface WatchdogDeps {
   maxAttempts?: number;
   baseBackoffMs?: number;
   maxBackoffMs?: number;
+  /** Consecutive healthy polls required before clearing relaunch/attempt state. */
+  stableHealthyPolls?: number;
+  /** Minimum time between lobby/operator alerts while still down. */
+  alertCooldownMs?: number;
   now?: () => number;
 }
 
@@ -38,23 +47,34 @@ export function createWatchdog(deps: WatchdogDeps): Watchdog {
   const maxAttempts = deps.maxAttempts ?? 5;
   const baseBackoffMs = deps.baseBackoffMs ?? 60_000;
   const maxBackoffMs = deps.maxBackoffMs ?? 300_000;
+  const stableHealthyPolls = deps.stableHealthyPolls ?? 3;
+  const alertCooldownMs = deps.alertCooldownMs ?? 30 * 60_000;
   const now = deps.now ?? (() => Date.now());
 
   let consecutiveFailures = 0;
+  let consecutiveHealthy = 0;
   let attempts = 0;
   let backoffMs = baseBackoffMs;
   let nextAttemptAt = 0;
   let gaveUp = false;
+  let lastAlertAt: number | null = null;
   let busy = false;
   let timer: ReturnType<typeof setInterval> | undefined;
 
   const reset = (): void => {
     consecutiveFailures = 0;
+    consecutiveHealthy = 0;
     attempts = 0;
     backoffMs = baseBackoffMs;
     nextAttemptAt = 0;
     gaveUp = false;
   };
+
+  const inRecovery = (): boolean =>
+    consecutiveFailures > 0 || attempts > 0 || gaveUp;
+
+  const canAlert = (): boolean =>
+    lastAlertAt === null || now() - lastAlertAt >= alertCooldownMs;
 
   const tick = async (): Promise<void> => {
     if (busy) return;
@@ -62,28 +82,62 @@ export function createWatchdog(deps: WatchdogDeps): Watchdog {
     try {
       const healthy = await deps.client.isHealthy();
       if (healthy) {
-        if (consecutiveFailures > 0 || attempts > 0 || gaveUp) deps.log('info', 'Invoker is healthy again');
+        consecutiveFailures = 0;
+        nextAttemptAt = 0;
+        if (!inRecovery()) {
+          consecutiveHealthy = 0;
+          return;
+        }
+        consecutiveHealthy++;
+        if (consecutiveHealthy < stableHealthyPolls) {
+          deps.log(
+            'info',
+            `Invoker appears healthy (${consecutiveHealthy}/${stableHealthyPolls}) — waiting to confirm recovery`,
+          );
+          return;
+        }
+        deps.log('info', 'Invoker is healthy again');
         reset();
         return;
       }
+
+      consecutiveHealthy = 0;
       consecutiveFailures++;
       if (consecutiveFailures < failuresBeforeRelaunch) return;
-      if (gaveUp) return;
+
+      if (gaveUp) {
+        if (canAlert()) {
+          lastAlertAt = now();
+          await deps.alert(
+            `:rotating_light: Invoker is still down after ${maxAttempts} relaunch attempts. Reply \`restart\` to retry.`,
+          );
+        }
+        return;
+      }
+
       if (now() < nextAttemptAt) return;
 
       attempts++;
       deps.log('warn', `Invoker is down — relaunch attempt ${attempts}/${maxAttempts}`);
       const ok = await deps.client.launch();
       if (ok) {
-        deps.log('info', 'watchdog relaunch succeeded');
-        reset();
+        // Launch claimed success, but keep attempt state until health is stable.
+        consecutiveFailures = 0;
+        consecutiveHealthy = 0;
+        nextAttemptAt = 0;
+        deps.log('info', 'watchdog relaunch succeeded — confirming stable health');
         return;
       }
       if (attempts >= maxAttempts) {
         gaveUp = true;
-        await deps.alert(
-          `:rotating_light: Invoker is down and I could not bring it back after ${maxAttempts} attempts. Reply \`restart\` to retry.`,
-        );
+        if (canAlert()) {
+          lastAlertAt = now();
+          await deps.alert(
+            `:rotating_light: Invoker is down and I could not bring it back after ${maxAttempts} attempts. Reply \`restart\` to retry.`,
+          );
+        } else {
+          deps.log('warn', 'Invoker still down after max relaunch attempts — alert suppressed by cooldown');
+        }
         return;
       }
       nextAttemptAt = now() + backoffMs;


### PR DESCRIPTION
## Summary

On DO1 the Slack watchdog briefly saw Invoker as healthy after each relaunch, reset its attempt counter, and kept restarting.

That flap eventually posted repeated "Invoker is down" alerts into the lobby root.

Live lobby root message: https://invokerorchestrator.slack.com/archives/C0BCNM0UTFY/p1784426059306669

This requires a few consecutive healthy polls before recovery counts, and rate-limits give-up alerts.

## Review Claim

Approve requiring stable healthy polls before clearing watchdog relaunch state and cooldown-limiting lobby alerts.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Failed launches still escalate to give-up. Manual `@Invoker restart` remains the recovery path after give-up.

## Slice Rationale

This is the DO1 lobby spam / false-down UX issue. Scope and message sanitizer fixes stay in other PRs.

## Non-goals

Does not fix why the Electron owner dies on DO1, change IPC health probes, or move alerts out of the lobby channel.

## Visual Proof

Live DO1 lobby root alert (not in a thread):

https://invokerorchestrator.slack.com/archives/C0BCNM0UTFY/p1784426059306669

Issue screenshot:

![Lobby Invoker-is-down alert with bad restart copy](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-805c84/5043-5045-watchdog-restart.png)

Walkthrough video:

[do1-slack-ux-issues.mp4](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-805c84/do1-slack-ux-issues.mp4)


## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/slack-manager && pnpm exec vitest run src/__tests__/watchdog.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 32150defc`
- Post-revert steps: None
- Data migration? No

</details>
