### PR TITLE
Redact absolute checkout paths from Slack replies

### DIFF
--- a/packages/surfaces/src/__tests__/slack-do1-ux-paths.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-do1-ux-paths.e2e.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { redactAbsolutePaths, sanitizeSlackOutbound } from '../slack/slack-message-helpers.js';
+
+const LIVE_FENCED_PLAN_BOT_REPLY =
+  'I’ll treat this as a normal worktree task here, not an Invoker plan\n\nThere are already local edits in the target areas.';
+const LIVE_FENCED_PLAN_USER =
+  '```text\nplan: Prove and fix the adverse UI test issues found in the agent thread for Invoker.\n\nScope:\n1. Fix/prove @invoker/app build behavior when git SHA lookup hits false EPERM.\n```';
+const LIVE_ADVERSE_AGENT_PROSE =
+  'I’ll interpret “averse test” as adverse/edge-case UI testing for an Invoker plan';
+const LIVE_PATH_LEAK =
+  'I inspected [scripts/land-stack.mjs](/home/invoker/.invoker/slack-manager/planning-clones/64a63486912a/scripts/land-stack.mjs:1)';
+
+describe('DO1 e2e: redact absolute checkout paths from Slack replies', () => {
+  it('redactAbsolutePaths removes /home/invoker from LIVE_PATH_LEAK', () => {
+    const redacted = redactAbsolutePaths(LIVE_PATH_LEAK);
+    expect(redacted).not.toContain('/home/invoker');
+    expect(redacted).toContain('scripts/land-stack.mjs');
+  });
+
+  it('sanitizeSlackOutbound removes /home/invoker from LIVE_PATH_LEAK', () => {
+    const scrubbed = sanitizeSlackOutbound(LIVE_PATH_LEAK);
+    expect(scrubbed).not.toContain('/home/invoker');
+    expect(scrubbed).toContain('…/');
+  });
+
+  it('does not alter LIVE_* prose without absolute paths', () => {
+    expect(redactAbsolutePaths(LIVE_FENCED_PLAN_BOT_REPLY)).toBe(LIVE_FENCED_PLAN_BOT_REPLY);
+    expect(redactAbsolutePaths(LIVE_FENCED_PLAN_USER)).toBe(LIVE_FENCED_PLAN_USER);
+    expect(redactAbsolutePaths(LIVE_ADVERSE_AGENT_PROSE)).toBe(LIVE_ADVERSE_AGENT_PROSE);
+  });
+});

--- a/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SlackSurface } from '../slack/slack-surface.js';
-import { sanitizeSlashCommands, splitForSlack } from '../slack/slack-message-helpers.js';
+import { redactAbsolutePaths, sanitizeSlashCommands, sanitizeSlackOutbound, splitForSlack } from '../slack/slack-message-helpers.js';
 import type { SurfaceCommand } from '../surface.js';
 
 // ── Mock @slack/bolt ────────────────────────────────────────
@@ -684,6 +684,21 @@ describe('sanitizeSlashCommands', () => {
     );
     expect(sanitizeSlashCommands('Start a new Invoker workflow channel')).toBe(
       'Start a new Invoker workflow channel',
+    );
+  });
+});
+
+describe('redactAbsolutePaths', () => {
+  it('collapses host absolute paths to a short tail', () => {
+    const input = 'Changed: [tsup.config.ts](/home/invoker/.invoker/slack-manager/planning-clones/64a63486912a/packages/app/tsup.config.ts:5)';
+    expect(redactAbsolutePaths(input)).toBe(
+      'Changed: [tsup.config.ts](…/packages/app/tsup.config.ts:5)',
+    );
+  });
+
+  it('is applied by sanitizeSlackOutbound', () => {
+    expect(sanitizeSlackOutbound('see /Users/edbert/Documents/GitHub/Invoker/packages/app/foo.ts')).toBe(
+      'see …/packages/app/foo.ts',
     );
   });
 });

--- a/packages/surfaces/src/slack/slack-message-helpers.ts
+++ b/packages/surfaces/src/slack/slack-message-helpers.ts
@@ -165,3 +165,23 @@ export function sanitizeSlashCommands(text: string): string {
     'reply with "yes", "go", or "execute" to confirm',
   );
 }
+
+/** Collapse host absolute paths so Slack replies do not leak checkout layout. */
+export function redactAbsolutePaths(text: string): string {
+  return text.replace(
+    /(?:\/(?:home|Users|var|tmp|private\/tmp|opt|usr\/local)\/[^\s)\]`'"<>]+)/g,
+    (path) => {
+      const lineMatch = path.match(/:\d+(?:-\d+)?$/);
+      const lineSuffix = lineMatch?.[0] ?? '';
+      const cleaned = lineSuffix ? path.slice(0, -lineSuffix.length) : path;
+      const parts = cleaned.split('/').filter(Boolean);
+      const tail = parts.slice(-3).join('/');
+      return `…/${tail}${lineSuffix}`;
+    },
+  );
+}
+
+/** Outbound Slack text scrub: drop hallucinated slash-commands and absolute paths. */
+export function sanitizeSlackOutbound(text: string): string {
+  return redactAbsolutePaths(sanitizeSlashCommands(text));
+}

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -11,7 +11,7 @@ import type { Surface, CommandHandler, SurfaceCommand, SurfaceEvent, LogFn, Work
 import { parseSlackCommand } from './slack-commands.js';
 import type { ConversationCommand } from './slack-commands.js';
 import { formatSurfaceEvent, formatWorkflowStatus } from './slack-formatter.js';
-import { splitForSlack, sanitizeSlashCommands } from './slack-message-helpers.js';
+import { splitForSlack, sanitizeSlackOutbound } from './slack-message-helpers.js';
 import type { SlackMessage } from './slack-formatter.js';
 import {
   DEFAULT_PLANNER_RETRY_BASE_DELAY_MS,
@@ -1231,7 +1231,7 @@ export class SlackSurface implements Surface {
   ): Promise<void> {
     try {
       const reply = await this.runOneShotPlanner(harness, buildLobbyQuestionPrompt(text));
-      const chunks = splitForSlack(sanitizeSlashCommands(reply));
+      const chunks = splitForSlack(sanitizeSlackOutbound(reply));
       for (let i = 0; i < chunks.length; i++) {
         if (i > 0) await this.sleep(this.messagePacingMs);
         await this.sayWithRateLimitRetry(say, { text: chunks[i], thread_ts: threadTs });
@@ -1265,7 +1265,7 @@ export class SlackSurface implements Surface {
       try {
         const result = await this.runLocalCommand(request.text, dir.workingDir);
         const reply = this.formatLocalCommandResult(result);
-        const chunks = splitForSlack(sanitizeSlashCommands(reply));
+        const chunks = splitForSlack(sanitizeSlackOutbound(reply));
         for (let i = 0; i < chunks.length; i++) {
           if (i > 0) await this.sleep(this.messagePacingMs);
           await this.sayWithRateLimitRetry(say, { text: chunks[i], thread_ts: threadTs });
@@ -1284,7 +1284,7 @@ export class SlackSurface implements Surface {
     await say({ text: 'Making that local change on DO1. I will not create or submit an Invoker plan.', thread_ts: threadTs });
     try {
       const reply = await this.runOneShotPlanner(harness, this.buildLocalChangePrompt(request.text, dir.workingDir));
-      const chunks = splitForSlack(sanitizeSlashCommands(reply));
+      const chunks = splitForSlack(sanitizeSlackOutbound(reply));
       for (let i = 0; i < chunks.length; i++) {
         if (i > 0) await this.sleep(this.messagePacingMs);
         await this.sayWithRateLimitRetry(say, { text: chunks[i], thread_ts: threadTs });
@@ -1375,7 +1375,7 @@ ${text}`;
   private formatLocalCommandResult(result: { code: number | null; stdout: string; stderr: string; timedOut: boolean }): string {
     const status = result.timedOut ? 'timed out' : `exit ${result.code ?? 'unknown'}`;
     const output = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n\n');
-    const safeOutput = output.replace(/```/g, '`\u200b``');
+    const safeOutput = sanitizeSlackOutbound(output.replace(/```/g, '`\u200b``'));
     const maxChars = 12_000;
     const body = safeOutput.length > maxChars
       ? `[showing last ${maxChars} chars]\n${safeOutput.slice(-maxChars)}`
@@ -1435,7 +1435,7 @@ ${text}`;
       const ctx = await this.gatherWorkflowContext(mapping.workflowId);
       const harness = this.resolveHarnessPreset(mapping.harnessPreset ?? this.defaultHarnessPreset);
       const reply = await this.runOneShotPlanner(harness, buildAssistantPrompt(text, ctx));
-      const chunks = splitForSlack(sanitizeSlashCommands(reply));
+      const chunks = splitForSlack(sanitizeSlackOutbound(reply));
       for (let i = 0; i < chunks.length; i++) {
         if (i > 0) await this.sleep(this.messagePacingMs);
         await this.sayWithRateLimitRetry(say, { text: chunks[i], thread_ts: threadTs });
@@ -1732,7 +1732,7 @@ ${text}`;
         await this.stopTypingIndicator(channel, threadTs);
       }
 
-      const chunks = splitForSlack(sanitizeSlashCommands(reply));
+      const chunks = splitForSlack(sanitizeSlackOutbound(reply));
 
       const ackTs = this.ackMessages.get(threadTs);
       if (ackTs) {


### PR DESCRIPTION
## Summary

DO1 Slack agent replies included absolute `/home/invoker/.invoker/.../planning-clones/...` paths.

Live thread: https://invokerorchestrator.slack.com/archives/C0BCNM0UTFY/p1784393420447429?thread_ts=1784393420.447429&cid=C0BCNM0UTFY

Those host paths leak checkout layout and make markdown links useless outside the droplet.

This redacts absolute paths in outbound Slack text down to a short `…/tail` form.

## Review Claim

Approve redacting host absolute paths from Slack outbound replies before they are posted.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only presentation of outbound Slack text changes. Command execution and worktree paths on disk are unchanged.

## Slice Rationale

This is a separate DO1 readability leak from the sanitizer, plan parsing, scope, and watchdog fixes.

## Non-goals

Does not stop the planner from seeing absolute cwd internally, and does not change Slack block formatting beyond path text.

## Visual Proof

Live DO1 Slack thread with leaked host paths:

https://invokerorchestrator.slack.com/archives/C0BCNM0UTFY/p1784393420447429?thread_ts=1784393420.447429&cid=C0BCNM0UTFY

Issue screenshot (yellow = absolute `/home/invoker/...` paths):

![Absolute planning-clones paths in Slack reply](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-805c84/5044-absolute-paths.png)

Walkthrough video:

[do1-slack-ux-issues.mp4](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-805c84/do1-slack-ux-issues.mp4)


## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm exec vitest run src/__tests__/slack-do1-ux-paths.e2e.test.ts`
- [ ] `cd packages/surfaces && pnpm exec vitest run src/__tests__/slack-surface-immediate-response.integration.test.ts -t 'redactAbsolutePaths'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 73b379b24`
- Post-revert steps: None
- Data migration? No

</details>
