### PR TITLE
Tell Slack operators to @Invoker restart when down

### DIFF
--- a/packages/slack-manager/src/__tests__/workflow-ops.test.ts
+++ b/packages/slack-manager/src/__tests__/workflow-ops.test.ts
@@ -86,5 +86,7 @@ describe('createRunWorkflowOp', () => {
     const res = await createRunWorkflowOp(client, noop)({ operation: 'recreate', target: { all: true } });
     expect(res.ok).toBe(false);
     expect(res.summary).toContain('Invoker is down');
+    expect(res.summary).toContain('@Invoker restart');
+    expect(res.summary).not.toMatch(/Reply `restart`/);
   });
 });

--- a/packages/slack-manager/src/command-handler.ts
+++ b/packages/slack-manager/src/command-handler.ts
@@ -18,7 +18,7 @@ export interface CommandHandlerDeps {
   log: (level: string, message: string) => void;
 }
 
-const DOWN_MESSAGE = 'Invoker is down and I could not bring it back. Reply `restart` to retry.';
+const DOWN_MESSAGE = 'Invoker is down and I could not bring it back. Reply `@Invoker restart` to retry.';
 
 export function createCommandHandler(deps: CommandHandlerDeps): CommandHandler {
   return async (command: SurfaceCommand): Promise<void> => {

--- a/packages/slack-manager/src/watchdog.ts
+++ b/packages/slack-manager/src/watchdog.ts
@@ -109,7 +109,7 @@ export function createWatchdog(deps: WatchdogDeps): Watchdog {
         if (canAlert()) {
           lastAlertAt = now();
           await deps.alert(
-            `:rotating_light: Invoker is still down after ${maxAttempts} relaunch attempts. Reply \`restart\` to retry.`,
+            `:rotating_light: Invoker is still down after ${maxAttempts} relaunch attempts. Reply \`@Invoker restart\` to retry.`,
           );
         }
         return;
@@ -133,7 +133,7 @@ export function createWatchdog(deps: WatchdogDeps): Watchdog {
         if (canAlert()) {
           lastAlertAt = now();
           await deps.alert(
-            `:rotating_light: Invoker is down and I could not bring it back after ${maxAttempts} attempts. Reply \`restart\` to retry.`,
+            `:rotating_light: Invoker is down and I could not bring it back after ${maxAttempts} attempts. Reply \`@Invoker restart\` to retry.`,
           );
         } else {
           deps.log('warn', 'Invoker still down after max relaunch attempts — alert suppressed by cooldown');

--- a/packages/slack-manager/src/workflow-ops.ts
+++ b/packages/slack-manager/src/workflow-ops.ts
@@ -17,7 +17,7 @@ export type RunWorkflowOp = (
   onProgress?: (p: WorkflowOpProgress) => void,
 ) => Promise<WorkflowOpResult>;
 
-const DOWN_SUMMARY = 'Invoker is down and I could not bring it back. Reply `restart` to retry.';
+const DOWN_SUMMARY = 'Invoker is down and I could not bring it back. Reply `@Invoker restart` to retry.';
 
 /** Workflow-op verb → delegated headless `exec` command (workflow id appended). `cancel` is workflow-scoped. */
 const MUTATION_COMMAND: Partial<Record<WorkflowOpName, string>> = {


### PR DESCRIPTION
## Summary

DO1 lobby alerts told operators to reply `restart` after Invoker stayed down.

Live message: https://invokerorchestrator.slack.com/archives/C0BCNM0UTFY/p1784426059306669

Bare thread replies are ignored, so that instruction could not recover the bot.

This points operators at `@Invoker restart`, which is the real control path.

## Review Claim

Approve changing down/recovery copy to `@Invoker restart` instead of bare `restart`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only user-facing recovery strings change. Restart command handling is unchanged.

## Slice Rationale

This is the live lobby copy bug. Watchdog flap logic and headless launch stay in other PRs.

## Non-goals

Does not accept bare `restart` as a command, and does not change relaunch mechanics.

## Visual Proof

Live DO1 lobby root alert showing the bad instruction:

https://invokerorchestrator.slack.com/archives/C0BCNM0UTFY/p1784426059306669

Issue screenshot — “Reply `restart`” is wrong:

![Bad restart recovery copy on lobby root](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-805c84/5043-5045-watchdog-restart.png)

Walkthrough video of the down/restart failure state:

[do1-slack-ux-issues.mp4](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-805c84/do1-slack-ux-issues.mp4)


## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/slack-manager && pnpm exec vitest run src/__tests__/workflow-ops.test.ts src/__tests__/watchdog.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b8c903329`
- Post-revert steps: None
- Data migration? No

</details>
