### PR TITLE
Clear leftover Slack Processing acks on early exits

### DIFF
--- a/packages/surfaces/src/__tests__/slack-do1-ux-stuck-ack.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-do1-ux-stuck-ack.e2e.test.ts
@@ -1,0 +1,155 @@
+/**
+ * DO1 e2e: empty `plan:` mentions must not leave a sticky Processing ack.
+ * Bolt mock pattern copied from slack-surface-immediate-response.integration.test.ts.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SlackSurface } from '../slack/slack-surface.js';
+
+const LIVE_FENCED_PLAN_BOT_REPLY =
+  'I’ll treat this as a normal worktree task here, not an Invoker plan\n\nThere are already local edits in the target areas.';
+const LIVE_FENCED_PLAN_USER =
+  '```text\nplan: Prove and fix the adverse UI test issues found in the agent thread for Invoker.\n\nScope:\n1. Fix/prove @invoker/app build behavior when git SHA lookup hits false EPERM.\n```';
+const LIVE_ADVERSE_AGENT_PROSE =
+  'I’ll interpret “averse test” as adverse/edge-case UI testing for an Invoker plan';
+const LIVE_PATH_LEAK =
+  'I inspected [scripts/land-stack.mjs](/home/invoker/.invoker/slack-manager/planning-clones/64a63486912a/scripts/land-stack.mjs:1)';
+
+interface MockHandler {
+  pattern: string | RegExp;
+  handler: Function;
+}
+
+interface ApiCall {
+  method: 'postMessage' | 'update' | 'delete' | 'reactions.add' | 'reactions.remove';
+  timestamp?: string;
+  ts?: string;
+  text?: string;
+  name?: string;
+  channel: string;
+}
+
+const apiCalls: ApiCall[] = [];
+
+vi.mock('@slack/bolt', () => {
+  class MockApp {
+    _commandHandlers: MockHandler[] = [];
+    _actionHandlers: MockHandler[] = [];
+    _eventHandlers: MockHandler[] = [];
+
+    command = vi.fn((name: string, handler: Function) => {
+      this._commandHandlers.push({ pattern: name, handler });
+    });
+
+    action = vi.fn((pattern: string | RegExp, handler: Function) => {
+      this._actionHandlers.push({ pattern, handler });
+    });
+
+    event = vi.fn((name: string, handler: Function) => {
+      this._eventHandlers.push({ pattern: name, handler });
+    });
+
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+
+    client = {
+      chat: {
+        postMessage: vi.fn().mockImplementation(async ({ channel, text }) => {
+          const ts = `${Date.now()}.${Math.random().toString(36).substr(2, 6)}`;
+          apiCalls.push({ method: 'postMessage', channel, text, ts });
+          return { ts, ok: true };
+        }),
+        update: vi.fn().mockImplementation(async ({ channel, ts, text }) => {
+          apiCalls.push({ method: 'update', channel, ts, text });
+          return { ok: true };
+        }),
+        delete: vi.fn().mockImplementation(async ({ channel, ts }) => {
+          apiCalls.push({ method: 'delete', channel, ts });
+          return { ok: true };
+        }),
+      },
+      auth: {
+        test: vi.fn().mockResolvedValue({ user_id: 'UBOT123456' }),
+      },
+      reactions: {
+        add: vi.fn().mockImplementation(async ({ channel, timestamp, name }) => {
+          apiCalls.push({ method: 'reactions.add', channel, timestamp, name });
+          return { ok: true };
+        }),
+        remove: vi.fn().mockImplementation(async ({ channel, timestamp, name }) => {
+          apiCalls.push({ method: 'reactions.remove', channel, timestamp, name });
+          return { ok: true };
+        }),
+      },
+    };
+  }
+
+  return { App: MockApp };
+});
+
+const mockSendMessage = vi.fn();
+let mockDraftedPlan: string | null = null;
+const mockPlanConversation = {
+  sendMessage: mockSendMessage,
+  getDraftedPlan: () => mockDraftedPlan,
+  submittedPlanText: null as any,
+  planSubmitted: false,
+  conversationMode: 'plan' as const,
+  init: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('../slack/plan-conversation.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../slack/plan-conversation.js')>()),
+  PlanConversation: vi.fn(() => mockPlanConversation),
+}));
+
+describe('DO1 e2e: clear leftover Processing ack on empty plan:', () => {
+  let surface: SlackSurface;
+
+  beforeEach(() => {
+    apiCalls.length = 0;
+    mockSendMessage.mockReset();
+    mockDraftedPlan = null;
+  });
+
+  it('keeps LIVE DO1 payload fixtures available for this repro', () => {
+    expect(LIVE_FENCED_PLAN_BOT_REPLY).toContain('Invoker plan');
+    expect(LIVE_FENCED_PLAN_USER).toContain('plan:');
+    expect(LIVE_ADVERSE_AGENT_PROSE).toContain('Invoker plan');
+    expect(LIVE_PATH_LEAK).toContain('/home/invoker');
+  });
+
+  afterEach(async () => {
+    if (surface) await surface.stop();
+  });
+
+  it('posts Processing then deletes that ack for empty plan: mention', async () => {
+    surface = new SlackSurface({
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      signingSecret: 'test-secret',
+      channelId: 'C-test',
+      anthropicApiKey: 'test-anthropic-key',
+    });
+    await surface.start(async () => {});
+
+    const app = surface.getApp() as any;
+    const mentionHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')?.handler;
+    const say = vi.fn().mockImplementation(async ({ text }) => {
+      const ts = `${Date.now()}.${Math.random().toString(36).substr(2, 6)}`;
+      apiCalls.push({ method: 'postMessage', channel: 'C-test', text, ts });
+      return { ts, ok: true };
+    });
+
+    await mentionHandler({
+      event: { text: '<@UBOT123456> plan:', ts: '3333.001', user: 'U123' },
+      say,
+    });
+
+    expect(apiCalls[0]).toEqual(expect.objectContaining({
+      method: 'postMessage',
+      text: 'Processing your request...',
+    }));
+    expect(apiCalls.some((c) => c.method === 'delete' && c.ts === apiCalls[0].ts)).toBe(true);
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
@@ -253,6 +253,67 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
         expect.objectContaining({ type: 'start_plan', planText }),
       ]);
     });
+
+    it('clears a leftover Processing ack when plan: is empty', async () => {
+      surface = new SlackSurface({
+        botToken: 'xoxb-test',
+        appToken: 'xapp-test',
+        signingSecret: 'test-secret',
+        channelId: 'C-test',
+        anthropicApiKey: 'test-anthropic-key',
+      });
+      await surface.start(async () => {});
+
+      const app = surface.getApp() as any;
+      const mentionHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')?.handler;
+      const say = vi.fn().mockImplementation(async ({ text }) => {
+        const ts = `${Date.now()}.${Math.random().toString(36).substr(2, 6)}`;
+        apiCalls.push({ method: 'postMessage', channel: 'C-test', text, ts });
+        return { ts, ok: true };
+      });
+
+      await mentionHandler({
+        event: { text: '<@UBOT123456> plan:', ts: '3333.001', user: 'U123' },
+        say,
+      });
+
+      expect(apiCalls[0]).toEqual(expect.objectContaining({
+        method: 'postMessage',
+        text: 'Processing your request...',
+      }));
+      expect(apiCalls.some((c) => c.method === 'delete' && c.ts === apiCalls[0].ts)).toBe(true);
+      expect(mockSendMessage).not.toHaveBeenCalled();
+    });
+
+    it('clears a leftover Processing ack when the planner throws', async () => {
+      surface = new SlackSurface({
+        botToken: 'xoxb-test',
+        appToken: 'xapp-test',
+        signingSecret: 'test-secret',
+        channelId: 'C-test',
+        anthropicApiKey: 'test-anthropic-key',
+      });
+      mockSendMessage.mockRejectedValue(new Error('planner crashed'));
+      await surface.start(async () => {});
+
+      const app = surface.getApp() as any;
+      const mentionHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')?.handler;
+      const say = vi.fn().mockImplementation(async ({ text }) => {
+        const ts = `${Date.now()}.${Math.random().toString(36).substr(2, 6)}`;
+        apiCalls.push({ method: 'postMessage', channel: 'C-test', text, ts });
+        return { ts, ok: true };
+      });
+
+      await mentionHandler({
+        event: { text: '<@UBOT123456> fix the typo', ts: '4444.001', user: 'U123' },
+        say,
+      });
+
+      const ack = apiCalls.find((c) => c.method === 'postMessage' && c.text === 'Processing your request...');
+      expect(ack).toBeTruthy();
+      expect(apiCalls.some((c) => c.method === 'postMessage' && c.text?.includes('planner crashed'))).toBe(true);
+      expect(apiCalls.some((c) => c.method === 'delete' && c.ts === ack?.ts)).toBe(true);
+    });
   });
 
   describe('Configuration Options', () => {

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -846,59 +846,64 @@ export class SlackSurface implements Surface {
     // Slower paths (LLM classifier, repo checkout, agent) acknowledge receipt up front.
     if (this.enableImmediateAck) await this.sendImmediateAck(threadTs, say);
 
-    // Fallback classifier: only when a non-verb message looks operational.
-    if (!explicitLocalAgent && looksOperational(parsed.text)) {
-      const cls = await this.classifyLobbyIntent(parsed.text, preset);
-      this.log('slack', 'info', `[CLASSIFY] thread_ts=${threadTs} intent=${cls.intent}`);
-      if (cls.intent === 'command') {
-        await this.clearImmediateAck(channel, threadTs);
-        await this.proposeLobbyOp(cls, threadTs, channel, say);
-        return;
+    try {
+      // Fallback classifier: only when a non-verb message looks operational.
+      if (!explicitLocalAgent && looksOperational(parsed.text)) {
+        const cls = await this.classifyLobbyIntent(parsed.text, preset);
+        this.log('slack', 'info', `[CLASSIFY] thread_ts=${threadTs} intent=${cls.intent}`);
+        if (cls.intent === 'command') {
+          await this.clearImmediateAck(channel, threadTs);
+          await this.proposeLobbyOp(cls, threadTs, channel, say);
+          return;
+        }
+        if (cls.intent === 'question') {
+          await this.clearImmediateAck(channel, threadTs);
+          await this.answerLobbyQuestion(parsed.text, preset, threadTs, say);
+          return;
+        }
+        // invalid-command / plan → fall through to a planning conversation.
       }
-      if (cls.intent === 'question') {
-        await this.clearImmediateAck(channel, threadTs);
-        await this.answerLobbyQuestion(parsed.text, preset, threadTs, say);
-        return;
+
+      const threadRequest = parseThreadRequest(parsed.text);
+      if (!threadRequest) return;
+
+      // Default: a normal agent conversation. `plan:` opts into an Invoker YAML draft.
+      let workingDir = this.workingDir;
+      if (repoUrl && this.prepareRepoCheckout) {
+        try {
+          workingDir = await this.prepareRepoCheckout(repoUrl);
+        } catch (err) {
+          this.log('slack', 'error', `Failed to prepare repo checkout for ${repoUrl}: ${err}`);
+          await say({ text: `Failed to check out repo: ${err instanceof Error ? err.message : String(err)}`, thread_ts: threadTs });
+          return;
+        }
       }
-      // invalid-command / plan → fall through to a planning conversation.
-    }
 
-    const threadRequest = parseThreadRequest(parsed.text);
-    if (!threadRequest) return;
-
-    // Default: a normal agent conversation. `plan:` opts into an Invoker YAML draft.
-    let workingDir = this.workingDir;
-    if (repoUrl && this.prepareRepoCheckout) {
-      try {
-        workingDir = await this.prepareRepoCheckout(repoUrl);
-      } catch (err) {
-        this.log('slack', 'error', `Failed to prepare repo checkout for ${repoUrl}: ${err}`);
-        await say({ text: `Failed to check out repo: ${err instanceof Error ? err.message : String(err)}`, thread_ts: threadTs });
-        return;
-      }
-    }
-
-    const conversation = await this.getSession(channel, threadTs, event.user ?? 'unknown', true, {
-      tool: preset.tool,
-      model: preset.model,
-      workingDir,
-      mode: threadRequest.mode,
-    });
-    if (!conversation) {
-      await say({ text: 'Too many active conversations. Please wait.', thread_ts: threadTs });
-      return;
-    }
-
-    if (threadRequest.mode === 'plan') {
-      this.planningContexts.set(threadTs, {
-        repoUrl,
-        presetKey: parsed.presetKey,
-        requestedBy: event.user,
-        lobbyChannel: channel,
+      const conversation = await this.getSession(channel, threadTs, event.user ?? 'unknown', true, {
+        tool: preset.tool,
+        model: preset.model,
+        workingDir,
+        mode: threadRequest.mode,
       });
-    }
+      if (!conversation) {
+        await say({ text: 'Too many active conversations. Please wait.', thread_ts: threadTs });
+        return;
+      }
 
-    await this.handleConversationMessage(conversation, threadRequest.text, threadTs, say, channel);
+      if (threadRequest.mode === 'plan') {
+        this.planningContexts.set(threadTs, {
+          repoUrl,
+          presetKey: parsed.presetKey,
+          requestedBy: event.user,
+          lobbyChannel: channel,
+        });
+      }
+
+      await this.handleConversationMessage(conversation, threadRequest.text, threadTs, say, channel);
+    } finally {
+      // Drop any leftover Processing… ack (success paths already replace/delete it).
+      await this.clearImmediateAck(channel, threadTs);
+    }
   }
 
   /** Post the immediate "received it" acknowledgment and track it for in-place replacement. */


### PR DESCRIPTION
## Summary

Slack threads could keep “Processing your request…” forever after empty `plan:` or planner failures.

The immediate ack was posted, then early exits and error paths forgot to drop it.

This drops any leftover ack after the mention handler finishes.

## Review Claim

Approve dropping leftover immediate acks on early exits and planner errors.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Success paths already replace the ack before the final drop runs, so that drop is a no-op there.

## Slice Rationale

This is the stuck Processing UX. Restart copy and invite failures stay in other PRs.

## Non-goals

Does not change ack wording, typing indicators, or heartbeat messages.

## Visual Proof

Issue card from the DO1 empty-`plan:` / planner-error path:

![Stuck Processing ack reproduction](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-666f68/5046-stuck-ack.png)

Related live fenced-plan thread: https://invokerorchestrator.slack.com/archives/C0BCNM0UTFY/p1784353362855019?thread_ts=1784353362.855019&cid=C0BCNM0UTFY

Walkthrough video:

[do1-slack-ux-issues.mp4](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-805c84/do1-slack-ux-issues.mp4)

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm exec vitest run src/__tests__/slack-do1-ux-stuck-ack.e2e.test.ts`
- [ ] `cd packages/surfaces && pnpm exec vitest run src/__tests__/slack-surface-immediate-response.integration.test.ts -t 'clears a leftover'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d2225764e`
- Post-revert steps: None
- Data migration? No

</details>
