### PR TITLE
Surface Slack workflow-channel invite failures in the lobby

### DIFF
--- a/packages/surfaces/src/__tests__/slack-do1-ux-invite.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-do1-ux-invite.e2e.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SlackSurface } from '../slack/slack-surface.js';
+import { SQLiteAdapter, WorkflowChannelRepository } from '@invoker/data-store';
+
+const LIVE_FENCED_PLAN_BOT_REPLY =
+  'I’ll treat this as a normal worktree task here, not an Invoker plan\n\nThere are already local edits in the target areas.';
+const LIVE_FENCED_PLAN_USER =
+  '```text\nplan: Prove and fix the adverse UI test issues found in the agent thread for Invoker.\n\nScope:\n1. Fix/prove @invoker/app build behavior when git SHA lookup hits false EPERM.\n```';
+const LIVE_ADVERSE_AGENT_PROSE =
+  'I’ll interpret “averse test” as adverse/edge-case UI testing for an Invoker plan';
+const LIVE_PATH_LEAK =
+  'I inspected [scripts/land-stack.mjs](/home/invoker/.invoker/slack-manager/planning-clones/64a63486912a/scripts/land-stack.mjs:1)';
+
+interface MockHandler {
+  pattern: string | RegExp;
+  handler: Function;
+}
+
+vi.mock('@slack/bolt', () => {
+  class MockApp {
+    _eventHandlers: MockHandler[] = [];
+    _actionHandlers: MockHandler[] = [];
+    _commandHandlers: MockHandler[] = [];
+    command = vi.fn((name: string, handler: Function) => { this._commandHandlers.push({ pattern: name, handler }); });
+    action = vi.fn((pattern: string | RegExp, handler: Function) => { this._actionHandlers.push({ pattern, handler }); });
+    event = vi.fn((name: string, handler: Function) => { this._eventHandlers.push({ pattern: name, handler }); });
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    client = {
+      chat: {
+        postMessage: vi.fn().mockResolvedValue({ ts: '1.1' }),
+        update: vi.fn().mockResolvedValue({}),
+        delete: vi.fn().mockResolvedValue({}),
+      },
+      auth: { test: vi.fn().mockResolvedValue({ user_id: 'U_BOT' }) },
+      reactions: { add: vi.fn().mockResolvedValue({}), remove: vi.fn().mockResolvedValue({}) },
+      conversations: {
+        create: vi.fn().mockResolvedValue({ channel: { id: 'C_NEW' } }),
+        invite: vi.fn().mockResolvedValue({}),
+        list: vi.fn().mockResolvedValue({ channels: [] }),
+      },
+    };
+  }
+  return { App: MockApp };
+});
+
+const silentLog = () => {};
+
+function baseConfig() {
+  return {
+    botToken: 'xoxb', appToken: 'xapp', signingSecret: 's', channelId: 'CLOBBY', log: silentLog,
+  };
+}
+
+describe('DO1 e2e: surface Slack workflow-channel invite failures', () => {
+  let adapter: SQLiteAdapter;
+  let repo: WorkflowChannelRepository;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    repo = new WorkflowChannelRepository(adapter);
+    expect(LIVE_FENCED_PLAN_BOT_REPLY.length).toBeGreaterThan(0);
+    expect(LIVE_FENCED_PLAN_USER.length).toBeGreaterThan(0);
+    expect(LIVE_ADVERSE_AGENT_PROSE.length).toBeGreaterThan(0);
+    expect(LIVE_PATH_LEAK.length).toBeGreaterThan(0);
+  });
+
+  it('workflow_created with invite missing_scope posts lobby text containing could not invite you', async () => {
+    const surface = new SlackSurface({ ...baseConfig(), workflowChannelRepo: repo });
+    const client = (surface.getApp() as any).client;
+    client.conversations.invite.mockRejectedValueOnce({ data: { error: 'missing_scope' } });
+
+    await surface.handleEvent({
+      type: 'workflow_created', workflowId: 'wf-1-2', requestedBy: 'U1',
+      lobbyChannel: 'CLOBBY', lobbyThreadTs: 't1',
+    });
+
+    const lobbyPost = client.chat.postMessage.mock.calls.find((c: any[]) => c[0].channel === 'CLOBBY')?.[0];
+    expect(lobbyPost?.text).toContain('could not invite you');
+    expect(lobbyPost?.text).toContain('missing_scope');
+  });
+});

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -278,6 +278,23 @@ describe('workflow channel creation', () => {
 
     expect(repo.getByWorkflowId('wf-1-2')?.channelId).toBe('C_EXIST');
   });
+
+  it('tells the lobby when the requester invite fails', async () => {
+    const surface = new SlackSurface({ ...baseConfig(), workflowChannelRepo: repo });
+    const client = (surface.getApp() as any).client;
+    client.conversations.invite.mockRejectedValueOnce({ data: { error: 'missing_scope' } });
+
+    await surface.handleEvent({
+      type: 'workflow_created', workflowId: 'wf-1-2', requestedBy: 'U1',
+      lobbyChannel: 'CLOBBY', lobbyThreadTs: 't1',
+    });
+
+    expect(repo.getByWorkflowId('wf-1-2')?.channelId).toBe('C_NEW');
+    const lobbyPost = client.chat.postMessage.mock.calls.find((c: any[]) => c[0].channel === 'CLOBBY')?.[0];
+    expect(lobbyPost?.text).toContain('could not invite you');
+    expect(lobbyPost?.text).toContain('missing_scope');
+    expect(lobbyPost?.text).not.toBe('Created <#C_NEW> for workflow `wf-1-2`.');
+  });
 });
 
 // ── Outbound routing ─────────────────────────────────────────

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -1593,12 +1593,16 @@ ${text}`;
       return;
     }
 
+    let inviteFailed: string | undefined;
     if (event.requestedBy) {
       try {
         await client.conversations.invite({ channel: channelId, users: event.requestedBy });
       } catch (err) {
         const code = this.slackErrorCode(err);
-        if (code !== 'already_in_channel' && code !== 'cant_invite_self') {
+        if (code === 'already_in_channel' || code === 'cant_invite_self') {
+          // Requester is already present — treat as success.
+        } else {
+          inviteFailed = code ?? (err instanceof Error ? err.message : String(err));
           this.log('slack', 'warn', `Failed to invite ${event.requestedBy} to ${channelId}: ${err}`);
         }
       }
@@ -1624,7 +1628,15 @@ ${text}`;
     );
 
     if (event.lobbyChannel) {
-      await this.postToThread(event.lobbyChannel, event.lobbyThreadTs, `Created <#${channelId}> for workflow \`${event.workflowId}\`.`);
+      if (inviteFailed) {
+        await this.postToThread(
+          event.lobbyChannel,
+          event.lobbyThreadTs,
+          `Created private <#${channelId}> for workflow \`${event.workflowId}\`, but I could not invite you (${inviteFailed}). Ask a workspace admin to invite you, or check the bot has \`groups:write\` and was reinstalled after adding scopes.`,
+        );
+      } else {
+        await this.postToThread(event.lobbyChannel, event.lobbyThreadTs, `Created <#${channelId}> for workflow \`${event.workflowId}\`.`);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Workflow channel creation told the lobby the private channel was ready even when the requester invite failed.

That left users locked out of a private `workflow-*` channel with no signal in Slack.

This reports the invite error in the lobby thread instead of claiming success.

## Review Claim

Approve surfacing workflow-channel invite failures in the lobby thread.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Channel creation and persistence still happen. Only the lobby success copy changes when invite fails.

## Slice Rationale

This is a distinct private-channel UX failure from ack handling and restart copy.

## Non-goals

Does not change Slack scopes, channel naming, or auto-retry invites.

## Visual Proof

Issue card for the silent invite-failure path:

![Invite failure hidden behind Created channel copy](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-666f68/5047-invite-failure.png)

Live private workflow channel from DO1 battle-test (invite path left users in a private channel the bot joined):

https://invokerorchestrator.slack.com/archives/C0BHK2LB4N9/p1784158514098019

Parent lobby thread that created that workflow:

https://invokerorchestrator.slack.com/archives/C0BCNM0UTFY/p1784158004604289?thread_ts=1784158004.604289&cid=C0BCNM0UTFY


## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm exec vitest run src/__tests__/slack-do1-ux-invite.e2e.test.ts`
- [ ] `cd packages/surfaces && pnpm exec vitest run src/__tests__/slack-surface-workflows.test.ts -t 'workflow channel creation'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f3d39eafa`
- Post-revert steps: None
- Data migration? No

</details>


