### PR TITLE
Stop Slack sanitizer from rewriting Invoker prose

### DIFF
--- a/packages/surfaces/src/__tests__/slack-do1-ux-sanitize.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-do1-ux-sanitize.e2e.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeSlashCommands } from '../slack/slack-message-helpers.js';
+
+const LIVE_FENCED_PLAN_BOT_REPLY =
+  'I’ll treat this as a normal worktree task here, not an Invoker plan\n\nThere are already local edits in the target areas.';
+const LIVE_FENCED_PLAN_USER =
+  '```text\nplan: Prove and fix the adverse UI test issues found in the agent thread for Invoker.\n\nScope:\n1. Fix/prove @invoker/app build behavior when git SHA lookup hits false EPERM.\n```';
+const LIVE_ADVERSE_AGENT_PROSE =
+  'I’ll interpret “averse test” as adverse/edge-case UI testing for an Invoker plan';
+const LIVE_PATH_LEAK =
+  'I inspected [scripts/land-stack.mjs](/home/invoker/.invoker/slack-manager/planning-clones/64a63486912a/scripts/land-stack.mjs:1)';
+
+describe('DO1 e2e: sanitizeSlashCommands leaves Invoker plan prose alone', () => {
+  it('does not rewrite LIVE_FENCED_PLAN_BOT_REPLY', () => {
+    expect(sanitizeSlashCommands(LIVE_FENCED_PLAN_BOT_REPLY)).toBe(LIVE_FENCED_PLAN_BOT_REPLY);
+  });
+
+  it('does not rewrite LIVE_FENCED_PLAN_USER', () => {
+    expect(sanitizeSlashCommands(LIVE_FENCED_PLAN_USER)).toBe(LIVE_FENCED_PLAN_USER);
+  });
+
+  it('does not rewrite LIVE_ADVERSE_AGENT_PROSE', () => {
+    expect(sanitizeSlashCommands(LIVE_ADVERSE_AGENT_PROSE)).toBe(LIVE_ADVERSE_AGENT_PROSE);
+  });
+
+  it('does not rewrite LIVE_PATH_LEAK', () => {
+    expect(sanitizeSlashCommands(LIVE_PATH_LEAK)).toBe(LIVE_PATH_LEAK);
+  });
+
+  it('still rewrites /invoker start_plan', () => {
+    expect(sanitizeSlashCommands('run `/invoker start_plan` now')).toBe(
+      'reply with "yes", "go", or "execute" to confirm now',
+    );
+  });
+});

--- a/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SlackSurface } from '../slack/slack-surface.js';
-import { splitForSlack } from '../slack/slack-message-helpers.js';
+import { sanitizeSlashCommands, splitForSlack } from '../slack/slack-message-helpers.js';
 import type { SurfaceCommand } from '../surface.js';
 
 // ── Mock @slack/bolt ────────────────────────────────────────
@@ -659,6 +659,32 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
       expect(updates[0].text).toBe('First response');
       expect(updates[1].text).toBe('Second response');
     });
+  });
+});
+
+describe('sanitizeSlashCommands', () => {
+  it('replaces hallucinated /invoker commands but keeps /invoker conversations', () => {
+    expect(sanitizeSlashCommands('run `/invoker start_plan` now')).toBe(
+      'reply with "yes", "go", or "execute" to confirm now',
+    );
+    expect(sanitizeSlashCommands('Please `/invoker approve task-1`')).toBe(
+      'Please reply with "yes", "go", or "execute" to confirm',
+    );
+    expect(sanitizeSlashCommands('use /invoker conversations list')).toBe(
+      'use /invoker conversations list',
+    );
+  });
+
+  it('does not rewrite ordinary Invoker prose', () => {
+    expect(sanitizeSlashCommands('This thread can’t create or submit an Invoker plan')).toBe(
+      'This thread can’t create or submit an Invoker plan',
+    );
+    expect(sanitizeSlashCommands('I can’t submit or execute an Invoker plan; try submit')).toBe(
+      'I can’t submit or execute an Invoker plan; try submit',
+    );
+    expect(sanitizeSlashCommands('Start a new Invoker workflow channel')).toBe(
+      'Start a new Invoker workflow channel',
+    );
   });
 });
 

--- a/packages/surfaces/src/slack/slack-message-helpers.ts
+++ b/packages/surfaces/src/slack/slack-message-helpers.ts
@@ -156,10 +156,12 @@ export function splitCodeBlockChunk(text: string, limit: number): string[] {
  * The inner Claude sometimes invents non-existent commands like "/invoker start_plan".
  * This replaces any such references (except /invoker conversations, which is real)
  * with the correct user instruction.
+ *
+ * Requires a leading `/` so ordinary prose like "an Invoker plan" is left alone.
  */
 export function sanitizeSlashCommands(text: string): string {
   return text.replace(
-    /(?:use |run |type |try )?`?\/?invoker\s+(?!conversations\b)\w+[^`\n]*`?/gi,
+    /(?:use |run |type |try )?`?\/invoker\s+(?!conversations\b)\w+[^`\n]*`?/gi,
     'reply with "yes", "go", or "execute" to confirm',
   );
 }


### PR DESCRIPTION
Bare "Invoker plan" was matching the optional-slash /invoker scrubber and
corrupting agent refusals with the confirm prompt on DO1.

Co-authored-by: Cursor <cursoragent@cursor.com>