### PR TITLE
[Planning Home UX](4) Update planning chat visual-proof fence assertion

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -768,8 +768,10 @@ test.describe('Visual proof capture', () => {
       return el.scrollHeight - el.scrollTop - el.clientHeight;
     });
     expect(scrollGap).toBeLessThanOrEqual(1);
+    const codePanel = expandedTranscript.locator('pre code').last();
+    await expect(codePanel).toBeVisible();
+    await expect(codePanel).toContainText('command: echo B');
     const tailText = await expandedTranscript.evaluate((el) => el.textContent ?? '');
-    expect(tailText.trimEnd().endsWith('```')).toBe(true);
     expect(tailText).toContain('command: echo B');
     await captureScreenshot(page, 'terminal-planned-conversation-end');
     await page.keyboard.press('Escape');


### PR DESCRIPTION
## Summary

Visual-proof no longer expects raw triple-backtick fences in planning chat text.

It asserts the drafted YAML through the mono code panel content instead.

## Review Claim

Approve updating the planning chat visual-proof assertion for fenced YAML rendered as a code panel.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

No product runtime paths change. Only the Playwright assertion for planning transcript fences moves with the chat layout from slice (3).

## Slice Rationale

Harness assertion updates stay separate from the activation-surface typography change so each slice keeps one review unit.

## Non-goals

- Additional product UX
- Regenerating unrelated visual-proof baselines

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && CAPTURE_MODE=after npx playwright test e2e/visual-proof.spec.ts -g "terminal planning loads graph" --update-snapshots`

</details>

## Visual Proof

After — planning chat renders YAML in a mono code panel (assertion target):

![Planning chat code panel after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-9b776e/planning-chat-after.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert HEAD` on the published slice branch
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #5053