### PR TITLE
Reply Slack command failures in-thread instead of false success

### DIFF
--- a/packages/slack-manager/src/__tests__/command-handler.test.ts
+++ b/packages/slack-manager/src/__tests__/command-handler.test.ts
@@ -97,9 +97,11 @@ describe('createCommandHandler', () => {
     });
   });
 
-  it('posts an error event when Invoker stays down', async () => {
+  it('rethrows a SlackCommandError when Invoker stays down so the surface can reply in-thread', async () => {
     const client = makeClient({ withRecovery: vi.fn(async () => { throw new InvokerDownError('down'); }) as InvokerClient['withRecovery'] });
-    await createCommandHandler({ client, slack, plansDir, log: noop })({ type: 'approve', taskId: 't1' });
-    expect(slack.handleEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    await expect(
+      createCommandHandler({ client, slack, plansDir, log: noop })({ type: 'approve', taskId: 't1' }),
+    ).rejects.toThrow(/Invoker is down/);
+    expect(slack.handleEvent).not.toHaveBeenCalled();
   });
 });

--- a/packages/slack-manager/src/command-handler.ts
+++ b/packages/slack-manager/src/command-handler.ts
@@ -36,8 +36,6 @@ export function createCommandHandler(deps: CommandHandlerDeps): CommandHandler {
         ? DOWN_MESSAGE
         : `Command \`${command.type}\` failed: ${errMessage(err)}`;
       deps.log('error', message);
-      // Rethrow so SlackSurface can reply in the active thread instead of
-      // posting a false success line while an unscoped lobby error appears.
       throw err instanceof SlackCommandError ? err : new SlackCommandError(message);
     }
   };

--- a/packages/slack-manager/src/command-handler.ts
+++ b/packages/slack-manager/src/command-handler.ts
@@ -20,6 +20,13 @@ export interface CommandHandlerDeps {
 
 const DOWN_MESSAGE = 'Invoker is down and I could not bring it back. Reply `@Invoker restart` to retry.';
 
+export class SlackCommandError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SlackCommandError';
+  }
+}
+
 export function createCommandHandler(deps: CommandHandlerDeps): CommandHandler {
   return async (command: SurfaceCommand): Promise<void> => {
     try {
@@ -29,7 +36,9 @@ export function createCommandHandler(deps: CommandHandlerDeps): CommandHandler {
         ? DOWN_MESSAGE
         : `Command \`${command.type}\` failed: ${errMessage(err)}`;
       deps.log('error', message);
-      await deps.slack.handleEvent({ type: 'error', message }).catch(() => {});
+      // Rethrow so SlackSurface can reply in the active thread instead of
+      // posting a false success line while an unscoped lobby error appears.
+      throw err instanceof SlackCommandError ? err : new SlackCommandError(message);
     }
   };
 }

--- a/packages/surfaces/src/__tests__/slack-do1-ux-command-error.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-do1-ux-command-error.e2e.test.ts
@@ -1,0 +1,102 @@
+/**
+ * DO1 Slack UX e2e: workflow control must not claim success when onCommand fails.
+ * Live symptom: thread said "Approving…" while lobby root said Invoker is down.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { SlackSurface } from '../slack/slack-surface.js';
+import { SQLiteAdapter, WorkflowChannelRepository } from '@invoker/data-store';
+
+interface MockHandler {
+  pattern: string | RegExp;
+  handler: Function;
+}
+
+vi.mock('@slack/bolt', () => {
+  class MockApp {
+    _eventHandlers: MockHandler[] = [];
+    _commandHandlers: MockHandler[] = [];
+    _actionHandlers: MockHandler[] = [];
+    command = vi.fn((name: string, handler: Function) => {
+      this._commandHandlers.push({ pattern: name, handler });
+    });
+    action = vi.fn((pattern: string | RegExp, handler: Function) => {
+      this._actionHandlers.push({ pattern, handler });
+    });
+    event = vi.fn((name: string, handler: Function) => {
+      this._eventHandlers.push({ pattern: name, handler });
+    });
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    client = {
+      chat: {
+        postMessage: vi.fn().mockResolvedValue({ ts: '1.1', ok: true }),
+        update: vi.fn().mockResolvedValue({ ok: true }),
+        delete: vi.fn().mockResolvedValue({ ok: true }),
+      },
+      auth: { test: vi.fn().mockResolvedValue({ user_id: 'UBOT' }) },
+      reactions: {
+        add: vi.fn().mockResolvedValue({ ok: true }),
+        remove: vi.fn().mockResolvedValue({ ok: true }),
+      },
+      conversations: {
+        create: vi.fn(),
+        invite: vi.fn(),
+        list: vi.fn(),
+      },
+    };
+  }
+  return { App: MockApp };
+});
+
+describe('DO1 Slack UX e2e — command error in thread', () => {
+  let surface: SlackSurface;
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(async () => {
+    if (surface) await surface.stop();
+  });
+
+  it('says the failure in-thread instead of Approving when onCommand throws', async () => {
+    const repo = new WorkflowChannelRepository(adapter);
+    repo.save({
+      workflowId: 'wf-1',
+      channelId: 'CWF',
+      createdAt: new Date().toISOString(),
+    });
+    surface = new SlackSurface({
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      signingSecret: 'secret',
+      channelId: 'CLOBBY',
+      workflowChannelRepo: repo,
+      enableImmediateAck: false,
+    });
+    await surface.start(async () => {
+      throw new Error('Invoker is down and I could not bring it back. Reply `@Invoker restart` to retry.');
+    });
+
+    const app = surface.getApp() as any;
+    const mention = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')?.handler;
+    const say = vi.fn().mockResolvedValue({ ts: 's1' });
+    await mention({
+      event: {
+        text: '<@UBOT> approve hello',
+        ts: 't1',
+        thread_ts: 't1',
+        user: 'U1',
+        channel: 'CWF',
+      },
+      say,
+      context: {},
+      body: { event: { channel: 'CWF' } },
+    });
+
+    const texts = say.mock.calls.map((c) => c[0].text).join('\n');
+    expect(texts).toContain('Invoker is down');
+    expect(texts).not.toMatch(/^Approving /m);
+  });
+});

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -1121,19 +1121,24 @@ export class SlackSurface implements Surface {
       await this.runConfirmedRestart(threadTs, say);
       return;
     }
-    await say({ text: 'Starting plan execution…', thread_ts: threadTs });
     const ctx = pending.ctx;
-    await this.onCommand?.({
-      type: 'start_plan',
-      planText: pending.planText,
-      repoUrl: ctx?.repoUrl,
-      harnessPreset: ctx?.presetKey,
-      requestedBy: ctx?.requestedBy,
-      lobbyChannel: ctx?.lobbyChannel ?? pending.channel,
-      lobbyThreadTs: pending.lobbyThreadTs,
-    });
-    this.planningContexts.delete(pending.lobbyThreadTs);
-    this.cleanupSession(pending.lobbyThreadTs, 'plan_submitted');
+    try {
+      await this.onCommand?.({
+        type: 'start_plan',
+        planText: pending.planText,
+        repoUrl: ctx?.repoUrl,
+        harnessPreset: ctx?.presetKey,
+        requestedBy: ctx?.requestedBy,
+        lobbyChannel: ctx?.lobbyChannel ?? pending.channel,
+        lobbyThreadTs: pending.lobbyThreadTs,
+      });
+      await say({ text: 'Starting plan execution…', thread_ts: threadTs });
+      this.planningContexts.delete(pending.lobbyThreadTs);
+      this.cleanupSession(pending.lobbyThreadTs, 'plan_submitted');
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      await say({ text: detail, thread_ts: threadTs });
+    }
   }
 
   /** Restart Invoker on request — always confirm first (it interrupts the running app). */
@@ -1465,26 +1470,45 @@ ${text}`;
     threadTs: string,
   ): Promise<void> {
     const scoped = (task: string): string => `${mapping.workflowId}/${task}`;
+    const run = async (command: Parameters<NonNullable<typeof this.onCommand>>[0], okText: string): Promise<void> => {
+      try {
+        await this.onCommand?.(command);
+        await say({ text: okText, thread_ts: threadTs });
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        await say({ text: detail, thread_ts: threadTs });
+      }
+    };
     switch (ctrl.kind) {
       case 'status':
-        await this.onCommand?.({ type: 'get_status', workflowId: mapping.workflowId });
-        await say({ text: `Fetching status for \`${mapping.workflowId}\`...`, thread_ts: threadTs });
+        await run(
+          { type: 'get_status', workflowId: mapping.workflowId },
+          `Fetching status for \`${mapping.workflowId}\`...`,
+        );
         return;
       case 'approve':
-        await this.onCommand?.({ type: 'approve', taskId: scoped(ctrl.task) });
-        await say({ text: `Approving \`${scoped(ctrl.task)}\`.`, thread_ts: threadTs });
+        await run(
+          { type: 'approve', taskId: scoped(ctrl.task) },
+          `Approving \`${scoped(ctrl.task)}\`.`,
+        );
         return;
       case 'reject':
-        await this.onCommand?.({ type: 'reject', taskId: scoped(ctrl.task) });
-        await say({ text: `Rejecting \`${scoped(ctrl.task)}\`.`, thread_ts: threadTs });
+        await run(
+          { type: 'reject', taskId: scoped(ctrl.task) },
+          `Rejecting \`${scoped(ctrl.task)}\`.`,
+        );
         return;
       case 'retry':
-        await this.onCommand?.({ type: 'retry', taskId: scoped(ctrl.task) });
-        await say({ text: `Retrying \`${scoped(ctrl.task)}\`.`, thread_ts: threadTs });
+        await run(
+          { type: 'retry', taskId: scoped(ctrl.task) },
+          `Retrying \`${scoped(ctrl.task)}\`.`,
+        );
         return;
       case 'input':
-        await this.onCommand?.({ type: 'provide_input', taskId: scoped(ctrl.task), input: ctrl.text });
-        await say({ text: `Sent input to \`${scoped(ctrl.task)}\`.`, thread_ts: threadTs });
+        await run(
+          { type: 'provide_input', taskId: scoped(ctrl.task), input: ctrl.text },
+          `Sent input to \`${scoped(ctrl.task)}\`.`,
+        );
         return;
     }
   }


### PR DESCRIPTION
## Summary

When Invoker is down, workflow controls still looked successful in Slack.

The thread said Approving while an unscoped lobby error said Invoker is down.

This replies with the failure in the active thread and only posts success text after the command works.

## Review Claim

Approve surfacing Slack command failures in the active thread instead of claiming success while lobby shows Invoker is down.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Successful approve/status/start_plan paths still post their success lines after the command completes.

## Slice Rationale

This is the false-success control UX on DO1 outages. Watchdog spam and restart copy stay in other PRs.

## Non-goals

Does not revive the owner process, change watchdog relaunch policy, or change approval semantics when Invoker is healthy.

## Visual Proof

Issue card from the DO1 outage path (workflow success text vs live lobby down alert):

![False success Approving while Invoker is down](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-e7d687/5049-command-error.png)

Live lobby root alert while owner health was down:

https://invokerorchestrator.slack.com/archives/C0BCNM0UTFY/p1784426059306669

Live workflow channel used for the approve attempt during that outage:

https://invokerorchestrator.slack.com/archives/C0BHK2LB4N9/p1784435974515079

Short walkthrough:

[5049-command-error.mp4](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-e7d687/5049-command-error.mp4)

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm exec vitest run src/__tests__/slack-do1-ux-command-error.e2e.test.ts`
- [ ] `cd packages/slack-manager && pnpm exec vitest run src/__tests__/command-handler.test.ts -t 'rethrows a SlackCommandError'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a5af1b693`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Slack command failures now post the relevant error message directly in the active thread.
  * Prevented misleading success messages when command execution fails.
  * Improved error handling across workflow controls, including approve, reject, retry, status, and input actions.
  * Ensured failed commands do not emit unnecessary Slack events or leave workflow state partially updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->