### PR TITLE
Tell users when @mentions are outside lobby or workflow channels

### DIFF
--- a/packages/surfaces/src/__tests__/slack-do1-ux-non-lobby-mention.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-do1-ux-non-lobby-mention.e2e.test.ts
@@ -1,0 +1,95 @@
+/**
+ * DO1 Slack UX e2e: @mentions outside lobby/workflow must not fail silently.
+ * Pre-fix: registerMentionHandler logged and returned with no user-visible reply.
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { SlackSurface } from '../slack/slack-surface.js';
+import { SQLiteAdapter, WorkflowChannelRepository } from '@invoker/data-store';
+
+interface MockHandler {
+  pattern: string | RegExp;
+  handler: Function;
+}
+
+vi.mock('@slack/bolt', () => {
+  class MockApp {
+    _eventHandlers: MockHandler[] = [];
+    _commandHandlers: MockHandler[] = [];
+    _actionHandlers: MockHandler[] = [];
+    command = vi.fn((name: string, handler: Function) => {
+      this._commandHandlers.push({ pattern: name, handler });
+    });
+    action = vi.fn((pattern: string | RegExp, handler: Function) => {
+      this._actionHandlers.push({ pattern, handler });
+    });
+    event = vi.fn((name: string, handler: Function) => {
+      this._eventHandlers.push({ pattern: name, handler });
+    });
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    client = {
+      chat: {
+        postMessage: vi.fn().mockResolvedValue({ ts: '1.1', ok: true }),
+        update: vi.fn().mockResolvedValue({ ok: true }),
+        delete: vi.fn().mockResolvedValue({ ok: true }),
+      },
+      auth: { test: vi.fn().mockResolvedValue({ user_id: 'UBOT' }) },
+      reactions: {
+        add: vi.fn().mockResolvedValue({ ok: true }),
+        remove: vi.fn().mockResolvedValue({ ok: true }),
+      },
+      conversations: {
+        create: vi.fn(),
+        invite: vi.fn(),
+        list: vi.fn(),
+      },
+    };
+  }
+  return { App: MockApp };
+});
+
+describe('DO1 Slack UX e2e — non-lobby mention feedback', () => {
+  let surface: SlackSurface;
+
+  afterEach(async () => {
+    if (surface) await surface.stop();
+  });
+
+  it('replies in-thread when @mentioned outside lobby and workflow channels', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    const repo = new WorkflowChannelRepository(adapter);
+    repo.save({
+      workflowId: 'wf-1',
+      channelId: 'CWF',
+      createdAt: new Date().toISOString(),
+    });
+    surface = new SlackSurface({
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      signingSecret: 'secret',
+      channelId: 'CLOBBY',
+      workflowChannelRepo: repo,
+      enableImmediateAck: false,
+    });
+    await surface.start(async () => {});
+
+    const app = surface.getApp() as any;
+    const mention = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')?.handler;
+    const say = vi.fn().mockResolvedValue({ ts: 's1' });
+    await mention({
+      event: {
+        text: '<@UBOT> can you help?',
+        ts: 't1',
+        thread_ts: 't1',
+        user: 'U1',
+        channel: 'COTHER',
+      },
+      say,
+    });
+
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringMatching(/lobby channel/i),
+      thread_ts: 't1',
+    }));
+  });
+});

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -766,6 +766,10 @@ export class SlackSurface implements Surface {
       const isLobbyOrDm = !channel || channel === this.lobbyChannelId || channel.startsWith('D');
       if (!isLobbyOrDm) {
         this.log('slack', 'info', `Ignoring @mention in non-lobby channel ${channel}`);
+        await say({
+          text: 'I only plan in the lobby channel (or DMs), and only run workflow controls in a mapped workflow channel. Mention me there instead.',
+          thread_ts: event.thread_ts ?? event.ts,
+        });
         return;
       }
 


### PR DESCRIPTION
## Summary

@mentions outside the lobby and workflow channels looked like the bot was dead.

The handler logged the ignore and returned with no Slack reply.

This replies in-thread with where planning and workflow controls work.

## Review Claim

Approve telling users in-thread when an @mention is outside the lobby or a mapped workflow channel.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Lobby, DM, and mapped workflow channel mentions keep their existing handlers unchanged.

## Slice Rationale

This is the silent non-lobby mention UX. False-success approve/status stays in another PR.

## Non-goals

Does not expand planning into arbitrary channels or change workflow channel mapping.

## Visual Proof

Issue card for the silent-ignore path vs the new in-thread guidance:

![Silent non-lobby mention ignore](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-95966e/5056-non-lobby-mention.png)

Live lobby where planning works:

https://invokerorchestrator.slack.com/archives/C0BCNM0UTFY

Live mapped workflow channel where controls work:

https://invokerorchestrator.slack.com/archives/C0BHK2LB4N9/p1784158514098019

Short walkthrough:

[5056-non-lobby-mention.mp4](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-95966e/5056-non-lobby-mention.mp4)

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm exec vitest run src/__tests__/slack-do1-ux-non-lobby-mention.e2e.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 35fad6c87`
- Post-revert steps: None
- Data migration? No

</details>
