### PR TITLE
Document channels:read in Slack setup guides

### DIFF
--- a/docs/slack-native-workflows.md
+++ b/docs/slack-native-workflows.md
@@ -110,6 +110,7 @@ The bot runs in Socket Mode. Add these bot scopes to the app manifest (reinstall
 - `app_mentions:read` — receive `@Invoker` mentions.
 - `chat:write` — post messages.
 - `channels:history` — read lobby thread replies (public lobby channel).
+- `channels:read` — resolve the lobby channel via `conversations.info` during setup checks.
 - `groups:write` — **create** private `workflow-<id>` channels and invite users.
 - `groups:history` — receive mentions/replies **inside** the private workflow channels.
 - `users:read` — resolve users for invites.

--- a/skills/invoker-setup/SKILL.md
+++ b/skills/invoker-setup/SKILL.md
@@ -54,7 +54,7 @@ invoker-cli setup slack
 If you are doing it on the user's behalf (you cannot click api.slack.com), drive it manually:
 
 1. Generate the manifest (the wizard writes it, or you can): it requests bot scopes
-   `app_mentions:read, chat:write, channels:history, groups:write, groups:history, users:read`,
+   `app_mentions:read, chat:write, channels:history, channels:read, groups:write, groups:history, users:read`,
    enables Socket Mode, and subscribes to the `app_mention` event.
 2. Tell the user: open https://api.slack.com/apps → **Create New App → From a manifest**, pick the
    workspace, paste the manifest JSON, create the app.


### PR DESCRIPTION
## Summary

Slack setup guides omitted `channels:read` from the required bot scopes.

Lobby setup uses `conversations.info`, which needs that scope after reinstall.

This updates the Slack native workflow doc and the invoker-setup skill text.

## Review Claim

Approve documenting `channels:read` in Slack setup guides.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

No runtime code changes in this slice.

## Slice Rationale

Docs and skill prose stay separate from the CLI setup check behavior change.

## Non-goals

Does not change CLI validation behavior or reinstall the Slack app.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `git diff --name-only origin/master...HEAD | rg 'docs/slack-native-workflows.md|skills/invoker-setup/SKILL.md'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert HEAD`
- Post-revert steps: None
- Data migration? No

</details>
