### PR TITLE
[Planning Home UX](1) Make Planning the default home surface

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -74,23 +74,6 @@ import {
 } from './lib/graph-camera.js';
 import type { SystemDiagnostics } from '@invoker/contracts';
 
-type StartReadyRequestExt = StartReadyRequest & {
-  recreateFailedAndPending?: boolean;
-  recreateFailedPendingAndRunning?: boolean;
-};
-
-type StartReadyPreviewExt = StartReadyResult['preview'] & {
-  pendingWorkflowIds: string[];
-  runningWorkflowIds: string[];
-  skipped: StartReadyResult['preview']['skipped'] & {
-    pendingTasks: number;
-    runningTasks: number;
-  };
-};
-
-type StartReadyResultExt = StartReadyResult & {
-  preview: StartReadyPreviewExt;
-};
 type ModalState =
   | { type: 'none' }
   | { type: 'input'; task: TaskState }
@@ -98,12 +81,13 @@ type ModalState =
   | { type: 'experiment'; task: TaskState }
   | { type: 'replace'; task: TaskState };
 
-type KeyboardRegion = 'workflowGraph' | 'taskGraph' | 'inspector' | 'bottomBar';
+type KeyboardRegion = 'workflowGraph' | 'taskGraph' | 'inspector' | 'bottomBar' | 'planning';
 type GraphKeyboardRegion = Extract<KeyboardRegion, 'workflowGraph' | 'taskGraph'>;
 type ContextMenuCloseOptions = { restoreFocus?: boolean };
 type ContextMenuState = { x: number; y: number; taskId: string; returnFocusRegion?: GraphKeyboardRegion };
 type WorkflowContextMenuState = { x: number; y: number; workflowId: string; returnFocusRegion?: GraphKeyboardRegion };
-const KEYBOARD_REGION_ORDER: readonly KeyboardRegion[] = ['workflowGraph', 'taskGraph', 'inspector', 'bottomBar'];
+const KEYBOARD_REGION_ORDER: readonly KeyboardRegion[] = ['planning', 'workflowGraph', 'taskGraph', 'inspector', 'bottomBar'];
+const GRAPH_KEYBOARD_REGION_ORDER: readonly KeyboardRegion[] = ['workflowGraph', 'taskGraph', 'inspector', 'bottomBar'];
 const SIDEBAR_NAV_ITEM_SELECTOR = '[data-sidebar-nav-item]';
 export const SELECTED_WORKFLOW_VANISH_GRACE_MS = 1000;
 const STATUS_KEY_ORDER: readonly WorkflowStatus[] = [
@@ -681,15 +665,18 @@ function WorkflowContextMenu({
   );
 }
 
-function EmptyGraphTutorial(): JSX.Element {
+function EmptyPlanGraphCta({ onGoHome }: { onGoHome: () => void }): JSX.Element {
   return (
-    <aside className="h-full w-full border-l border-border bg-background/90 p-4">
+    <aside className="h-full w-full border-l border-border bg-background/90 p-4" data-testid="empty-plan-graph-cta">
       <div className="rounded-xl border border-border bg-card/70 p-4">
-        <h2 className="text-sm font-semibold text-foreground">What to expect</h2>
+        <h2 className="text-sm font-semibold text-foreground">No plan yet</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Draft a plan from Home, then review the graph and start ready work.
+        </p>
         <ol className="mt-3 space-y-3 text-sm text-muted-foreground">
           <li>
             <div className="font-medium text-foreground">1. Type a goal</div>
-            <div className="mt-1 text-xs text-muted-foreground">Describe the change in the terminal to generate a plan.</div>
+            <div className="mt-1 text-xs text-muted-foreground">Describe the change in the planning chat.</div>
           </li>
           <li>
             <div className="font-medium text-foreground">2. Review the plan</div>
@@ -700,6 +687,14 @@ function EmptyGraphTutorial(): JSX.Element {
             <div className="mt-1 text-xs text-muted-foreground">Use Start ready work when the plan looks right.</div>
           </li>
         </ol>
+        <button
+          type="button"
+          data-testid="empty-plan-graph-go-home"
+          onClick={onGoHome}
+          className="mt-4 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Go to Home to draft
+        </button>
       </div>
     </aside>
   );
@@ -876,14 +871,15 @@ export function App() {
   const [graphActionsMenuOpen, setGraphActionsMenuOpen] = useState(false);
   const [startReadyMenuOpen, setStartReadyMenuOpen] = useState(false);
   const [startReadyBusy, setStartReadyBusy] = useState(false);
-  const [startReadyPreview, setStartReadyPreview] = useState<StartReadyResultExt | null>(null);
+  const [startReadyPreview, setStartReadyPreview] = useState<StartReadyResult | null>(null);
   const [startReadyPreviewMode, setStartReadyPreviewMode] = useState<
     'failed' | 'failedAndPending' | 'failedPendingAndRunning'
   >('failed');
   // Transient, user-visible outcome line for a confirmed workflow detach.
   const [detachNotice, setDetachNotice] = useState<string | null>(null);
-  const [keyboardRegion, setKeyboardRegion] = useState<KeyboardRegion>('workflowGraph');
+  const [keyboardRegion, setKeyboardRegion] = useState<KeyboardRegion>('planning');
   const [previousGraphRegion, setPreviousGraphRegion] = useState<KeyboardRegion>('workflowGraph');
+  const [planningContextCollapsed, setPlanningContextCollapsed] = useState(false);
   // Typed graph camera state. The graph viewport is user-owned after the
   // initial render: only explicit navigation commands (issued through the
   // central factory) move it. No per-handler event++/requestId++ counters.
@@ -909,7 +905,7 @@ export function App() {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchActiveIndex, setSearchActiveIndex] = useState(0);
   const uiPerfThrottleRef = useRef<Record<string, number>>({});
-  const planningTypingContextRef = useRef<Record<string, unknown> | null>(null);
+  const planningTypingStateRef = useRef<PlanningTypingTelemetryState | null>(null);
   const planningTypingSequenceRef = useRef(0);
   const planningTypingFrameIdsRef = useRef<Set<number>>(new Set());
   const systemSetupAutoOpenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1214,7 +1210,7 @@ export function App() {
     };
   }, []);
   useEffect(() => {
-    planningTypingContextRef.current = createPlanningTypingTelemetryContext({
+    planningTypingStateRef.current = {
       tasks,
       workflows,
       viewMode,
@@ -1222,7 +1218,7 @@ export function App() {
       selectedTaskId,
       selectedWorkflowId,
       hasLoadedPlan,
-    });
+    };
   }, [
     tasks,
     workflows,
@@ -1265,9 +1261,9 @@ export function App() {
 
       const frameId = scheduleFrame(() => {
         planningTypingFrameIdsRef.current.delete(frameId);
-        const telemetryContext = planningTypingContextRef.current;
+        const telemetryState = planningTypingStateRef.current;
         void window.invoker?.reportUiPerf?.(PLANNING_TYPING_LAG_METRIC, {
-          ...(telemetryContext ?? {}),
+          ...(telemetryState ? createPlanningTypingTelemetryContext(telemetryState) : {}),
           sequence,
           eventType: event.type,
           lagMs: Math.round(performance.now() - startedAt),
@@ -1780,11 +1776,12 @@ export function App() {
 
       if (event.key === 'Tab') {
         event.preventDefault();
-        const currentIndex = KEYBOARD_REGION_ORDER.indexOf(keyboardRegion);
+        const regionOrder = sidebarSurface === 'home' ? (['planning'] as const) : GRAPH_KEYBOARD_REGION_ORDER;
+        const currentIndex = Math.max(0, regionOrder.indexOf(keyboardRegion as typeof regionOrder[number]));
         const nextIndex = event.shiftKey
-          ? (currentIndex - 1 + KEYBOARD_REGION_ORDER.length) % KEYBOARD_REGION_ORDER.length
-          : (currentIndex + 1) % KEYBOARD_REGION_ORDER.length;
-        focusKeyboardRegion(KEYBOARD_REGION_ORDER[nextIndex]);
+          ? (currentIndex - 1 + regionOrder.length) % regionOrder.length
+          : (currentIndex + 1) % regionOrder.length;
+        focusKeyboardRegion(regionOrder[nextIndex]);
         return;
       }
 
@@ -1903,6 +1900,7 @@ export function App() {
     modal.type,
     openSelectedContextMenu,
     previousGraphRegion,
+    sidebarSurface,
     searchActiveIndex,
     searchOpen,
     searchResults,
@@ -2058,7 +2056,8 @@ export function App() {
     setSelectedWorkerKind(workerStatus?.workers[0]?.kind ?? null);
   }, [selectedWorkerKind, sidebarSurface, workerStatus]);
   useEffect(() => {
-    if (viewMode !== 'dag' || sidebarSurface === 'home' || !selectedWorkflowGraphAvailable) {
+    // Camera resnap for browser surfaces only; plan graph handles its own fit on enter.
+    if (viewMode !== 'dag' || (sidebarSurface !== 'workflows' && sidebarSurface !== 'attention') || !selectedWorkflowGraphAvailable) {
       return;
     }
 
@@ -2090,11 +2089,30 @@ export function App() {
   ]);
 
 
-  const handleDagSurfaceClick = useCallback(() => {
+  const handleDagSurfaceClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     if (contextMenu || workflowContextMenu) {
       setContextMenu(null);
       setWorkflowContextMenu(null);
+      return;
     }
+
+    if (suppressDagSurfaceDismissRef.current) {
+      return;
+    }
+
+    const target = event.target as HTMLElement;
+    if (
+      target.closest('[data-testid^="workflow-node-"]') ||
+      target.closest('[data-testid="selected-workflow-mini-dag"]') ||
+      target.closest('.react-flow__node') ||
+      target.closest('[role="menu"]')
+    ) {
+      return;
+    }
+
+    setSelectedTaskId(null);
+    setSelectedWorkflowId(null);
+    setWorkflowSelectionDismissed(true);
   }, [contextMenu, workflowContextMenu]);
 
   const handleRestartTask = useCallback(async (taskId: string) => {
@@ -2437,13 +2455,13 @@ export function App() {
   }, [updateActivePlanningSession]);
 
   const handleStartReadyAction = useCallback(async (
-    request: StartReadyRequestExt = {},
-  ): Promise<StartReadyResultExt | null> => {
+    request: StartReadyRequest = {},
+  ): Promise<StartReadyResult | null> => {
     if (!invoker?.startReady) return null;
     setStartReadyBusy(true);
     setStartReadyMenuOpen(false);
     try {
-      const result = await invoker.startReady(request as StartReadyRequest) as StartReadyResultExt;
+      const result = await invoker.startReady(request);
       if (!result.dryRun) {
         await refreshTaskGraph();
         void refreshActionGraph();
@@ -2482,12 +2500,12 @@ export function App() {
     setStartReadyPreviewMode(mode);
     try {
       const result = await invoker.startReady(
-        (mode === 'failedPendingAndRunning'
+        mode === 'failedPendingAndRunning'
           ? { dryRun: true, recreateFailedPendingAndRunning: true }
           : mode === 'failedAndPending'
             ? { dryRun: true, recreateFailedAndPending: true }
-            : { dryRun: true, recreateFailed: true }) as StartReadyRequest,
-      ) as StartReadyResultExt;
+            : { dryRun: true, recreateFailed: true },
+      );
       setStartReadyPreview(result);
     } catch (err) {
       notifyMutationError('Failed to preview ready work:', err);
@@ -2531,6 +2549,7 @@ export function App() {
         setGraphActionsMenuOpen(false);
         setPlanName(result.planName);
         setSelectedWorkflowId(result.workflowId);
+        issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason: 'planning-submit' });
         updatePlanningSessionById(planningSessionId, (session) => ({
           ...session,
           busy: false,
@@ -2560,7 +2579,7 @@ export function App() {
       setPlanningSubmitError({ title: 'Plan could not be submitted', message });
       appendTerminalLine(`Plan could not be submitted:\n${message}`, 'system', 'error');
     }
-  }, [activePlanningReadOnly, appendTerminalLine, invoker, planningSessionId, refreshTaskGraph, updatePlanningSessionById]);
+  }, [activePlanningReadOnly, appendTerminalLine, invoker, issueCameraCommand, planningSessionId, refreshTaskGraph, updatePlanningSessionById]);
 
   const handlePlanningSubmit = useCallback(async () => {
     const input = planningInput.trim();
@@ -2700,8 +2719,9 @@ export function App() {
     };
     setPlanningSessions((prev) => [session, ...prev]);
     setActivePlanningSessionId(session.id);
-    setSidebarSurface('planning');
-  }, [selectedPlanningPresetKey]);
+    setSidebarSurface('home');
+    focusKeyboardRegion('planning');
+  }, [focusKeyboardRegion, selectedPlanningPresetKey]);
 
   const handlePlanningModeChange = useCallback(async (mode: PlanningTerminalMode) => {
     const sourceSession = activePlanningSession;
@@ -2887,14 +2907,18 @@ export function App() {
     }
   }, [clearTasks, invoker]);
   const showStartReadyControl = hasLoadedPlan || tasks.size > 0 || workflows.size > 0;
-  const showEmptyGraphTutorial = sidebarSurface === 'home' && !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
-  const autoCollapseInspector = sidebarSurface !== 'home' && viewportWidth < 1440;
+  const showEmptyPlanGraphCta = sidebarSurface === 'planning' && !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
+  const setupIncomplete = Boolean(
+    systemDiagnostics
+    && (missingRequiredTool || needsBundledSkillsPrompt || installedAgentCount === 0),
+  );
+  const autoCollapseInspector = sidebarSurface !== 'planning' && viewportWidth < 1440;
   const effectiveInspectorCollapsed = inspectorCollapsed || (autoCollapseInspector && !inspectorManualOpen);
   const showWorkerDetailsPanel = viewMode === 'queue' && sidebarSurface === 'workers';
-  const showInspectorPlaceholder = !showEmptyGraphTutorial && !showWorkerDetailsPanel && !selectedTask && !selectedWorkflow && !(viewMode === 'actionGraph' && selectedActionNode);
+  const showInspectorPlaceholder = !showEmptyPlanGraphCta && !showWorkerDetailsPanel && !selectedTask && !selectedWorkflow && !(viewMode === 'actionGraph' && selectedActionNode);
 
   useEffect(() => {
-    if (sidebarSurface === 'home' || !autoCollapseInspector) {
+    if (sidebarSurface === 'planning' || !autoCollapseInspector) {
       setInspectorManualOpen(false);
     }
   }, [autoCollapseInspector, sidebarSurface]);
@@ -2932,7 +2956,7 @@ export function App() {
       setSelectedActionNodeId(null);
     }
     if (nextView === 'actionGraph') {
-      setSidebarSurface('home');
+      setSidebarSurface('planning');
       setViewMode('actionGraph');
       setWorkflowSelectionDismissed(true);
       setSelectedTaskId(null);
@@ -2943,11 +2967,12 @@ export function App() {
       return;
     }
     if (nextView === 'queue') {
-      setSidebarSurface('home');
+      setSidebarSurface('workers');
       setInspectorCollapsed(true);
       setInspectorManualOpen(false);
     } else {
-      setSidebarSurface('home');
+      // Timeline / history live on the plan-graph surface.
+      setSidebarSurface('planning');
     }
     setViewMode(nextView);
   }, [selectedActionNodeId, sidebarSurface, viewMode]);
@@ -2962,13 +2987,21 @@ export function App() {
     setInspectorCollapsed((prev) => !prev);
   }, [autoCollapseInspector]);
 
-  const navigateHomeAndFitWorkflowGraph = useCallback((reason: string) => {
-    cameraSuppressedRef.current = false;
+  const navigatePlanningHome = useCallback((_reason: string) => {
     setSidebarSurface('home');
     setInspectorManualOpen(false);
     setViewMode('dag');
+    focusKeyboardRegion('planning');
+  }, [focusKeyboardRegion]);
+
+  const navigatePlanGraphAndFit = useCallback((reason: string) => {
+    cameraSuppressedRef.current = false;
+    setSidebarSurface('planning');
+    setInspectorManualOpen(false);
+    setViewMode('dag');
+    focusKeyboardRegion('workflowGraph');
     issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason });
-  }, [issueCameraCommand]);
+  }, [focusKeyboardRegion, issueCameraCommand]);
 
   const handleSelectSidebarSurface = useCallback((nextSurface: SidebarSurface) => {
     setGraphActionsMenuOpen(false);
@@ -2987,14 +3020,18 @@ export function App() {
       return;
     }
     if (nextSurface === 'home') {
-      navigateHomeAndFitWorkflowGraph('sidebar-home');
+      navigatePlanningHome('sidebar-home');
+      return;
+    }
+    if (nextSurface === 'planning') {
+      navigatePlanGraphAndFit('sidebar-planning');
       return;
     }
     setViewMode('dag');
     setSidebarSurface(nextSurface);
     setInspectorManualOpen(false);
     setStatusFilters(new Set<WorkflowStatus>());
-  }, [navigateHomeAndFitWorkflowGraph, sidebarSurface, viewMode]);
+  }, [navigatePlanGraphAndFit, navigatePlanningHome, sidebarSurface, viewMode]);
 
   const handleDismissBrowserSurface = useCallback(() => {
     setGraphActionsMenuOpen(false);
@@ -3005,8 +3042,8 @@ export function App() {
       viewMode,
       dismiss: true,
     });
-    navigateHomeAndFitWorkflowGraph('browser-return-home');
-  }, [navigateHomeAndFitWorkflowGraph, sidebarSurface, viewMode]);
+    navigatePlanningHome('browser-return-home');
+  }, [navigatePlanningHome, sidebarSurface, viewMode]);
 
   // ── Task actions ──────────────────────────────────────────
   const handleProvideInput = useCallback(
@@ -3336,12 +3373,22 @@ export function App() {
                 type="button"
                 data-testid="rail-home"
                 onClick={() => {
-                  handleSelectSidebarSurface('home');
+                  handleSelectSidebarSurface('planning');
                   selectViewMode('dag');
                 }}
                 className="block w-full rounded px-3 py-2 text-left text-xs text-foreground hover:bg-secondary"
               >
-                Home
+                Plan graph
+              </button>
+              <button
+                type="button"
+                data-testid="rail-planning-home"
+                onClick={() => {
+                  handleSelectSidebarSurface('home');
+                }}
+                className="block w-full rounded px-3 py-2 text-left text-xs text-foreground hover:bg-secondary"
+              >
+                Planning home
               </button>
               <button
                 type="button"
@@ -3516,7 +3563,7 @@ export function App() {
         />
       ) : (
         <>
-          {sidebarSurface === 'home' && (
+          {sidebarSurface === 'planning' && (
             <WorkflowGraph
               workflows={workflows}
               selectedWorkflowId={selectedWorkflow?.id ?? null}
@@ -3528,7 +3575,7 @@ export function App() {
               onManualViewport={handleManualViewport}
             />
           )}
-          {renderSelectedWorkflowTaskGraph(sidebarSurface === 'home')}
+          {renderSelectedWorkflowTaskGraph(sidebarSurface === 'planning')}
         </>
       )}
     </div>
@@ -3587,7 +3634,7 @@ export function App() {
   );
 
   const renderWorkflowsList = (): JSX.Element => (
-    workflowEntries.length === 0 ? renderBrowserEmptyState('No workflows yet', 'Use the terminal to plan your first run.') : (
+    workflowEntries.length === 0 ? renderBrowserEmptyState('No workflows yet', 'Go to Home to draft your first plan.') : (
       <div data-testid="workflows-rail-list" className={`${RAIL_SCROLL_BODY_CLASS} p-3`}>
         <div className="space-y-1">
           {workflowEntries.map((entry) => (
@@ -3841,13 +3888,104 @@ export function App() {
   );
 
   const planningReadyCount = planningSessions.filter((session) => session.status === 'draft_ready').length;
+  const connectedAgentLabels = (systemDiagnostics?.tools ?? [])
+    .filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed)
+    .map((tool) => tool.name.replace(/\s+CLI$/i, ''));
+  const planningPhase = activePlanningSession.status === 'submitted'
+    ? 'review'
+    : draftPlanAvailable
+      ? 'draft'
+      : terminalLines.some((line) => line.role === 'user')
+        ? 'discuss'
+        : 'discuss';
+
+  const renderPlanningContextPanel = (): JSX.Element => (
+    <aside
+      data-testid="planning-context-panel"
+      className={`${planningContextCollapsed ? 'w-16' : 'w-72'} shrink-0 border-l border-border bg-card/60 transition-all duration-150`}
+    >
+      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2.5">
+        {!planningContextCollapsed && (
+          <h2 className="text-sm font-semibold text-foreground">Current plan</h2>
+        )}
+        <button
+          type="button"
+          data-testid="planning-context-toggle"
+          aria-label={planningContextCollapsed ? 'Expand current plan' : 'Collapse current plan'}
+          onClick={() => setPlanningContextCollapsed((value) => !value)}
+          className="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-secondary"
+        >
+          {planningContextCollapsed ? '›' : '‹'}
+        </button>
+      </div>
+      {!planningContextCollapsed && (
+        <div className="space-y-4 p-4 text-sm">
+          <div>
+            <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Goal</div>
+            <p className="mt-1 text-foreground">
+              {activePlanningSession.title === 'Untitled plan'
+                ? 'Describe a goal in the chat to begin drafting.'
+                : activePlanningSession.title}
+            </p>
+          </div>
+          {draftPlanSummary && (
+            <div>
+              <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Draft</div>
+              <p className="mt-1 text-foreground">
+                {draftPlanSummary.name} · {draftPlanSummary.taskCount} task{draftPlanSummary.taskCount === 1 ? '' : 's'}
+              </p>
+            </div>
+          )}
+          {activePlanningSession.submittedPlanName && (
+            <div>
+              <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Submitted</div>
+              <p className="mt-1 text-foreground">{activePlanningSession.submittedPlanName}</p>
+            </div>
+          )}
+          <div>
+            <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Agents</div>
+            <p className="mt-1 text-foreground">
+              {connectedAgentLabels.length > 0 ? connectedAgentLabels.join(', ') : 'None detected yet'}
+            </p>
+          </div>
+          <div>
+            <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Phase</div>
+            <ol className="mt-2 space-y-1.5 text-xs text-muted-foreground">
+              {(['discuss', 'draft', 'review', 'run'] as const).map((phase) => {
+                const order = { discuss: 0, draft: 1, review: 2, run: 3 } as const;
+                const current = order[planningPhase];
+                const done = order[phase] < current || (phase === 'discuss' && terminalLines.some((line) => line.role === 'user'));
+                const active = phase === planningPhase;
+                return (
+                  <li key={phase} className={active ? 'font-medium text-foreground' : done ? 'text-emerald-400' : ''}>
+                    {(done && !active) ? '✓ ' : active ? '● ' : '○ '}
+                    {phase.charAt(0).toUpperCase() + phase.slice(1)}
+                  </li>
+                );
+              })}
+            </ol>
+          </div>
+          {(draftPlanAvailable || activePlanningSession.status === 'submitted') && (
+            <button
+              type="button"
+              data-testid="planning-context-open-graph"
+              onClick={() => navigatePlanGraphAndFit('planning-context')}
+              className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
+            >
+              Open graph
+            </button>
+          )}
+        </div>
+      )}
+    </aside>
+  );
 
   const renderPlanningTerminalSurface = (): JSX.Element => (
     <div className="flex min-h-0 flex-1 overflow-hidden">
       <div data-testid="planning-session-rail" className="flex h-full w-64 shrink-0 flex-col border-r border-border bg-card">
         <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2.5">
           <div className="min-w-0">
-            <h2 className="text-sm font-medium text-foreground">Planning Terminal</h2>
+            <h2 className="text-sm font-medium text-foreground">Planning</h2>
             <p className="mt-0.5 font-mono text-[11px] text-muted-foreground">
               {planningSessions.length} chat{planningSessions.length === 1 ? '' : 's'}
               {planningReadyCount > 0 ? ` · ${planningReadyCount} ready` : ''}
@@ -3858,15 +3996,46 @@ export function App() {
             size="sm"
             onClick={handleCreatePlanningSession}
           >
-            New
+            New chat
           </Button>
         </div>
         <div className={RAIL_LIST_FRAME_CLASS}>{renderPlanningSessionList()}</div>
       </div>
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div
+        className="flex min-h-0 flex-1 flex-col overflow-hidden"
+        data-keyboard-region="planning"
+        tabIndex={0}
+        data-keyboard-active={keyboardRegion === 'planning' ? 'true' : 'false'}
+      >
+        {(setupIncomplete || connectedAgentLabels.length > 0) && (
+          <div
+            data-testid="planning-setup-strip"
+            className="flex flex-wrap items-center justify-between gap-2 border-b border-border bg-card/50 px-4 py-2 text-xs"
+          >
+            <div className="flex flex-wrap items-center gap-3 text-muted-foreground">
+              <span className={setupIncomplete ? 'text-amber-300' : 'text-emerald-400'}>
+                {setupIncomplete ? 'Setup needed' : 'Invoker is ready'}
+              </span>
+              {connectedAgentLabels.length > 0 && (
+                <span>Agents connected: {connectedAgentLabels.join(', ')}</span>
+              )}
+            </div>
+            <button
+              type="button"
+              data-testid="planning-finish-setup"
+              onClick={() => {
+                cancelPendingSystemSetupAutoOpen();
+                setShowSystemSetup(true);
+              }}
+              className="rounded-md border border-border px-2.5 py-1 text-xs text-foreground hover:bg-secondary"
+            >
+              {setupIncomplete ? 'Finish setup' : 'Manage setup'}
+            </button>
+          </div>
+        )}
         <div className="flex items-center justify-between gap-3 border-b border-border bg-card px-4 py-2.5">
           <div className="min-w-0">
-            <h2 className="truncate text-sm font-medium text-foreground">Planning chat window</h2>
+            <h2 className="truncate text-sm font-medium text-foreground">Planning chat</h2>
             <p className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">{activePlanningSession.title}</p>
           </div>
           <span className="shrink-0 rounded-full border border-border bg-background px-2.5 py-1 font-mono text-[11px] text-muted-foreground">
@@ -3890,15 +4059,23 @@ export function App() {
             terminalSession={activePlanningTerminalSession}
             terminalBusy={activePlanningTerminalBusy}
             terminalError={activePlanningTerminalError}
+            setupIncomplete={setupIncomplete}
+            submittedPlanName={activePlanningSession.submittedPlanName}
             onValueChange={setPlanningInput}
             onSubmit={() => void handlePlanningSubmit()}
             onSubmitDraft={() => void handlePlanningSubmitDraft()}
             onPresetChange={setSelectedPlanningPresetKey}
             onModeChange={(mode) => void handlePlanningModeChange(mode)}
             onExpand={() => setPlanningTerminalExpanded(true)}
+            onOpenGraph={() => navigatePlanGraphAndFit('planning-open-graph')}
+            onFinishSetup={() => {
+              cancelPendingSystemSetupAutoOpen();
+              setShowSystemSetup(true);
+            }}
           />
         </div>
       </div>
+      {renderPlanningContextPanel()}
     </div>
   );
   const renderBrowserRail = (): JSX.Element => (
@@ -3933,7 +4110,7 @@ export function App() {
       data-keyboard-active={keyboardRegion === 'bottomBar' ? 'true' : 'false'}
       className={`outline-none ${keyboardRegion === 'bottomBar' ? 'ring-2 ring-inset ring-ring/50' : ''}`}
     >
-      {sidebarSurface === 'home' && (
+      {sidebarSurface === 'planning' && (
         <WorkflowStatusChips
           workflows={workflows}
           activeFilters={statusFilters}
@@ -3998,7 +4175,7 @@ export function App() {
   );
 
   const homeSubtitle = workflows.size === 0
-    ? 'Your plan will appear here.'
+    ? 'No plan yet — draft one from Home.'
     : selectedWorkflow
       ? `${selectedWorkflow.name} · ${formatWorkflowStatus(selectedWorkflow.status)}`
       : `${workflowEntries.length} workflow${workflowEntries.length === 1 ? '' : 's'} ready`;
@@ -4117,9 +4294,9 @@ export function App() {
         <div className="flex min-h-0 flex-1 overflow-hidden">
           <main className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
             {sidebarSurface === 'home' ? (
-              renderGraphWorkspace('Plan graph', homeSubtitle, true)
-            ) : sidebarSurface === 'planning' ? (
               renderPlanningTerminalSurface()
+            ) : sidebarSurface === 'planning' ? (
+              renderGraphWorkspace('Plan graph', homeSubtitle, true)
             ) : sidebarSurface === 'workers' ? (
               renderWorkersSurface()
             ) : (
@@ -4129,19 +4306,19 @@ export function App() {
               </div>
             )}
 
-            {sidebarSurface === 'home' && viewMode === 'dag' && renderGraphTerminalChrome()}
+            {sidebarSurface === 'planning' && viewMode === 'dag' && renderGraphTerminalChrome()}
           </main>
 
-          {sidebarSurface !== 'planning' && sidebarSurface !== 'workers' && (
+          {sidebarSurface !== 'home' && sidebarSurface !== 'workers' && (
             <div
               data-testid="workflow-inspector-shell"
               data-keyboard-region="inspector"
               tabIndex={0}
               data-keyboard-active={keyboardRegion === 'inspector' ? 'true' : 'false'}
-              className={`${showEmptyGraphTutorial || showInspectorPlaceholder ? 'w-96' : effectiveInspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-ring/50' : ''}`}
+              className={`${showEmptyPlanGraphCta || showInspectorPlaceholder ? 'w-96' : effectiveInspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-ring/50' : ''}`}
             >
-              {showEmptyGraphTutorial ? (
-                <EmptyGraphTutorial />
+              {showEmptyPlanGraphCta ? (
+                <EmptyPlanGraphCta onGoHome={() => navigatePlanningHome('empty-graph-cta')} />
               ) : showInspectorPlaceholder ? (
                 <EmptyInspectorPlaceholder />
               ) : showWorkerDetailsPanel ? (
@@ -4211,6 +4388,8 @@ export function App() {
             terminalSession={activePlanningTerminalSession}
             terminalBusy={activePlanningTerminalBusy}
             terminalError={activePlanningTerminalError}
+            setupIncomplete={setupIncomplete}
+            submittedPlanName={activePlanningSession.submittedPlanName}
             onValueChange={setPlanningInput}
             readOnly={activePlanningReadOnly}
             onSubmit={() => void handlePlanningSubmit()}
@@ -4219,6 +4398,14 @@ export function App() {
             onModeChange={(mode) => void handlePlanningModeChange(mode)}
             onExpand={() => setPlanningTerminalExpanded(true)}
             onCloseExpanded={() => setPlanningTerminalExpanded(false)}
+            onOpenGraph={() => {
+              setPlanningTerminalExpanded(false);
+              navigatePlanGraphAndFit('planning-expanded-open-graph');
+            }}
+            onFinishSetup={() => {
+              cancelPendingSystemSetupAutoOpen();
+              setShowSystemSetup(true);
+            }}
           />
         </div>
       )}

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -40,19 +40,23 @@ describe('App launch (component)', () => {
     Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
     render(<App />);
     act(() => window.dispatchEvent(new Event('resize')));
-    expect(await screen.findByText('Plan graph')).toBeInTheDocument();
-    expect(screen.queryByText('What do you want to build?')).not.toBeInTheDocument();
-    expect(screen.getByText('What to expect')).toBeInTheDocument();
-    expect(screen.getAllByText('Your plan will appear here.').length).toBeGreaterThan(0);
+    expect(await screen.findByText('What do you want to build?')).toBeInTheDocument();
+    expect(screen.getByTestId('planning-session-rail')).toBeInTheDocument();
     expect(screen.getByTestId('sidebar-home')).toBeInTheDocument();
-    expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Planning Terminal');
+    expect(screen.getByTestId('sidebar-home')).toHaveTextContent('Planning chats');
+    expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Plan graph');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
     expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
+
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+    expect(await screen.findByRole('heading', { name: 'Plan graph' })).toBeInTheDocument();
+    expect(screen.getByTestId('empty-plan-graph-cta')).toBeInTheDocument();
+    expect(screen.getByText('No plan yet')).toBeInTheDocument();
   });
 
-  it('hides the collapsed Planning Terminal badge for the idle initial chat', async () => {
+  it('hides the collapsed Plan graph badge for the idle initial chat', async () => {
     Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
 
     render(<App />);
@@ -163,7 +167,7 @@ describe('App launch (component)', () => {
     expect(await screen.findByTestId('sidebar-home')).toHaveTextContent('Invoker');
     expect(screen.queryByTestId('rail-open-file')).not.toBeInTheDocument();
     expect(screen.getByTestId('rail-settings')).toBeInTheDocument();
-    expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Planning Terminal');
+    expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Plan graph');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
     expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
@@ -184,7 +188,11 @@ describe('App launch (component)', () => {
     expect(await screen.findByText('1 workflow')).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('sidebar-home'));
-    expect(await screen.findByText('Plan graph')).toBeInTheDocument();
+    expect(await screen.findByTestId('planning-session-rail')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+    expect(await screen.findByRole('heading', { name: 'Plan graph' })).toBeInTheDocument();
     expect(screen.getByText('Alpha · running')).toBeInTheDocument();
   });
   it('keeps sidebar width under explicit toggle control while surfaces change', async () => {
@@ -199,15 +207,14 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('app-sidebar').className).toContain('w-60');
 
     fireEvent.click(screen.getByTestId('browser-rail-dismiss'));
-    expect(await screen.findByText('Plan graph')).toBeInTheDocument();
+    expect(await screen.findByTestId('planning-session-rail')).toBeInTheDocument();
     expect(screen.getByTestId('app-sidebar').className).toContain('w-60');
 
     fireEvent.click(screen.getByTestId('sidebar-collapse-toggle'));
     expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
 
     fireEvent.click(screen.getByTestId('sidebar-planning'));
-    expect(await screen.findByTestId('planning-session-rail')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Planning Terminal' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Plan graph' })).toBeInTheDocument();
     expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
 
     fireEvent.click(screen.getByTestId('sidebar-attention'));
@@ -220,7 +227,7 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
 
     fireEvent.click(screen.getByTestId('sidebar-home'));
-    expect(await screen.findByText('Plan graph')).toBeInTheDocument();
+    expect(await screen.findByTestId('planning-session-rail')).toBeInTheDocument();
     expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
 
     fireEvent.click(screen.getByTestId('sidebar-collapse-toggle'));
@@ -270,9 +277,10 @@ describe('App launch (component)', () => {
   });
 
 
-  it('shows workflow status chips and terminal drawer controls in home view', () => {
+  it('shows workflow status chips and terminal drawer controls in plan graph view', async () => {
     render(<App />);
-    expect(screen.getByTestId('workflow-status-pill-running')).toBeInTheDocument();
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    expect(await screen.findByTestId('workflow-status-pill-running')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Partial terminal drawer' })).toBeInTheDocument();
   });
 

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -176,14 +176,14 @@ describe('Browser-surface camera (component)', () => {
     setCenterMock.mockClear();
     workflowGraphSpy.reset();
 
-    fireEvent.click(screen.getByTestId('sidebar-home'));
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
 
     await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
     await waitFor(() => {
       const matchingCommands = workflowGraphSpy.commands.filter((command): command is GraphCameraCommand => (
         command?.kind === 'fitInitial'
         && command.scope === 'workflow'
-        && command.reason === 'sidebar-home'
+        && command.reason === 'sidebar-planning'
       ));
       expect(matchingCommands.length).toBeGreaterThan(0);
     });

--- a/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
@@ -30,7 +30,7 @@ describe('CodeRabbit PR #3050 — draft state cleared after submit', () => {
   });
 
   async function openPlanningTerminal() {
-    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
     });

--- a/packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx
@@ -29,7 +29,7 @@ describe('CodeRabbit PR #3050 — Enter-to-submit ignores IME composition', () =
   });
 
   async function openPlanningTerminal() {
-    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
     });

--- a/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
@@ -23,7 +23,7 @@ describe('CodeRabbit PR #3050 — submitted planning stays read-only after start
   });
 
   async function openPlanningTerminal() {
-    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
     });
@@ -53,7 +53,7 @@ describe('CodeRabbit PR #3050 — submitted planning stays read-only after start
     await openPlanningTerminal();
     await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
 
-    fireEvent.click(screen.getByTestId('sidebar-home'));
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
     fireEvent.click(await screen.findByTestId('rail-start-ready'));
     await waitFor(() => {
       expect(mock.api.startReady).toHaveBeenCalledTimes(1);

--- a/packages/ui/src/__tests__/context-menu-dismiss.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-dismiss.test.tsx
@@ -51,6 +51,7 @@ describe('Context menu dismissal (node-right-click regression)', () => {
 
   async function openContextMenu() {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([task], workflows));
 
     await waitFor(() => {

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -72,6 +72,7 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
     workflowList = workflows,
   ) {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks(tasks, workflowList));
     expect(await screen.findByTestId('workflow-node-wf-1')).toBeInTheDocument();
   }
@@ -364,6 +365,7 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
 
     async function setupStack() {
       render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
       act(() => mock.setTasks([upTask, downTask], stackWorkflows));
       await waitFor(() => {
         expect(screen.getByTestId('workflow-node-wf-down')).toBeInTheDocument();

--- a/packages/ui/src/__tests__/history-view-e2e.test.tsx
+++ b/packages/ui/src/__tests__/history-view-e2e.test.tsx
@@ -65,6 +65,7 @@ describe('History view (component)', () => {
     act(() => mock.setTasks([completed, failed], workflows));
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await chooseGraphMenuItem('rail-history');
 
     await waitFor(() => {
@@ -104,6 +105,7 @@ describe('History view (component)', () => {
     act(() => mock.setTasks([failed], workflows));
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await chooseGraphMenuItem('rail-history');
 
     await waitFor(() => {
@@ -143,6 +145,7 @@ describe('History view (component)', () => {
     act(() => mock.setTasks([newer, older], workflows));
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await chooseGraphMenuItem('rail-history');
 
     await waitFor(() => {
@@ -183,6 +186,7 @@ describe('History view (component)', () => {
     act(() => mock.setTasks([completed, closed], workflows));
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await chooseGraphMenuItem('rail-history');
 
     await waitFor(() => {
@@ -205,6 +209,7 @@ describe('History view (component)', () => {
     act(() => mock.setTasks([], workflows));
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await chooseGraphMenuItem('rail-history');
 
     await waitFor(() => {

--- a/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
+++ b/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
@@ -6,6 +6,7 @@
  * so workflow-graph-surface's dismiss handler clears the selection in the same
  * turn. Unit tests that only fireEvent.click(node) never hit that path.
  */
+
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
 import { vi } from 'vitest';
@@ -20,7 +21,6 @@ vi.mock('@xyflow/react', async () => {
 const { App } = await import('../App.js');
 
 const workflows: WorkflowMeta[] = [{ id: 'wf-a', name: 'Workflow A', status: 'running' }];
-
 const alpha = makeUITask({
   id: 'task-alpha',
   description: 'First test task',
@@ -28,7 +28,6 @@ const alpha = makeUITask({
   workflowId: 'wf-a',
   command: 'echo hello-alpha',
 });
-
 const beta = makeUITask({
   id: 'task-beta',
   description: 'Second test task',
@@ -38,7 +37,7 @@ const beta = makeUITask({
   command: 'echo hello-beta',
 });
 
-describe('Home workflow graph mini DAG click dismissal repro', () => {
+describe('Home workflow click mini-DAG dismiss race', () => {
   let mock: MockInvoker;
 
   beforeEach(() => {
@@ -50,44 +49,58 @@ describe('Home workflow graph mini DAG click dismissal repro', () => {
     mock.cleanup();
   });
 
-  async function selectWorkflowA() {
+  it('keeps the mini-DAG when select is followed by a retargeted surface click in the same turn', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
       expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByTestId('rf__node-wf-a'));
+    const node = screen.getByTestId('workflow-node-wf-a');
+    const captureRoot = screen.getByTestId('workflow-graph-react-flow');
 
-    await waitFor(() => {
-      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
-      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
+    act(() => {
+      fireEvent.click(node);
+      // Same-turn click retargeted to the pointer-capture root (not inside the node).
+      fireEvent.click(captureRoot);
     });
-  }
-
-  it('keeps the selected mini DAG after a blank graph surface click', async () => {
-    await selectWorkflowA();
-
-    fireEvent.click(screen.getByTestId('workflow-graph-surface'));
 
     await waitFor(() => {
       expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
-      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
+    });
+    expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
+  });
+
+  it('restores the mini-DAG after leave-Home reselect when selection was dismissed', async () => {
+    render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    act(() => mock.setTasks([alpha, beta], workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('workflow-node-wf-a'));
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('workflow-graph-react-flow'));
+    await waitFor(() => {
+      expect(screen.queryByTestId('selected-workflow-mini-dag')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('sidebar-workflows'));
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
+    });
+
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
     });
   });
 
-  it('keeps the selected mini DAG after a retargeted React Flow pane click', async () => {
-    await selectWorkflowA();
-
-    fireEvent.click(screen.getByTestId('workflow-graph-react-flow'), {
-      clientX: 24,
-      clientY: 24,
-    });
-
-    await waitFor(() => {
-      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
-      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
-    });
-  });
 });

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -30,7 +30,7 @@ describe('Invoker terminal (component)', () => {
   });
 
   async function openPlanningTerminal() {
-    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
     });
@@ -46,25 +46,23 @@ describe('Invoker terminal (component)', () => {
     expect(list.parentElement).toHaveClass('flex', 'min-h-0', 'flex-1', 'flex-col');
   }
 
-  async function expectSurfaceRailList(surface: 'planning' | 'workflows' | 'attention', listTestId: string) {
-    fireEvent.click(await screen.findByTestId(`sidebar-${surface}`));
+  async function expectSurfaceRailList(surface: 'home' | 'workflows' | 'attention', listTestId: string) {
+    fireEvent.click(screen.getByTestId(`sidebar-${surface}`));
     await waitFor(() => {
       expect(screen.getByTestId(`sidebar-${surface}`)).toHaveAttribute('aria-current', 'page');
     });
-    expectRailListScrollContract(await screen.findByTestId(listTestId));
+    expectRailListScrollContract(screen.getByTestId(listTestId));
   }
 
   it('renders an empty flush planning pane before the first message', async () => {
     render(<App />);
     await openPlanningTerminal();
 
-    expect(screen.getByRole('heading', { name: 'Planning chat window' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
     expect(screen.getByText('Still discussing')).toBeInTheDocument();
-    expect(screen.queryByText('What do you want to build?')).not.toBeInTheDocument();
-    expect(screen.queryByText('Talk it through, then submit the plan to Invoker.')).not.toBeInTheDocument();
-    expect(screen.queryByText('Ask Invoker what you want to build.')).not.toBeInTheDocument();
+    expect(screen.getByText('What do you want to build?')).toBeInTheDocument();
+    expect(screen.getByTestId('invoker-terminal-empty-hero')).toBeInTheDocument();
     const transcript = screen.getByTestId('invoker-terminal-transcript');
-    expect(transcript).toBeEmptyDOMElement();
     const terminalShell = transcript.closest('section');
     expect(terminalShell).not.toBeNull();
     expect(terminalShell?.className).not.toContain('border border-border');
@@ -259,7 +257,7 @@ describe('Invoker terminal (component)', () => {
     });
     expect(await screen.findByTestId('invoker-terminal-planner-stream')).toHaveTextContent('first raw stream');
 
-    fireEvent.click(screen.getByRole('button', { name: 'New' }));
+    fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
     expect(screen.queryByTestId('invoker-terminal-planner-stream')).not.toBeInTheDocument();
 
     submitPlanningText('second session request');
@@ -478,6 +476,7 @@ describe('Invoker terminal (component)', () => {
   it('reports a many-workflow planning typing lag baseline from the task prompt editor', async () => {
     const { tasks, workflows } = makeManyWorkflowTypingBaseline();
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
 
     act(() => mock.setTasks(tasks, workflows));
 
@@ -622,12 +621,12 @@ describe('Invoker terminal (component)', () => {
 
     render(<App />);
 
-    const planningButton = await screen.findByTestId('sidebar-planning');
+    const homeButton = await screen.findByTestId('sidebar-home');
     await waitFor(() => {
-      expect(within(planningButton).getByText('2')).toBeInTheDocument();
+      expect(within(homeButton).getByText('2')).toBeInTheDocument();
     });
 
-    fireEvent.click(planningButton);
+    fireEvent.click(homeButton);
 
     expect(await screen.findByText('4 planning chats.')).toBeInTheDocument();
     expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('4 chats');
@@ -637,20 +636,18 @@ describe('Invoker terminal (component)', () => {
     Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
     render(<App />);
 
-    const planningButton = await screen.findByTestId('sidebar-planning');
-    await waitFor(() => {
-      expect(within(planningButton).getByText('0')).toBeInTheDocument();
-    });
+    const homeButton = await screen.findByTestId('sidebar-home');
+    expect(within(homeButton).queryByText('0')).not.toBeInTheDocument();
 
-    fireEvent.click(planningButton);
+    fireEvent.click(homeButton);
 
     expect(await screen.findByText('1 planning chat.')).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'New' }));
+    fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
 
     await waitFor(() => {
       expect(screen.getByText('2 planning chats.')).toBeInTheDocument();
     });
-    expect(within(screen.getByTestId('sidebar-planning')).getByText('0')).toBeInTheDocument();
+    expect(within(screen.getByTestId('sidebar-home')).queryByText('0')).not.toBeInTheDocument();
     expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('2 chats');
   });
 
@@ -708,8 +705,8 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });
       expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
-      expect(screen.getByTestId('sidebar-planning')).toHaveAttribute('aria-current', 'page');
-      expect(screen.getByRole('heading', { name: 'Planning chat window' })).toBeInTheDocument();
+      expect(screen.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
+      expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
       expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
     });
     expect(screen.queryByRole('heading', { name: 'Plan graph' })).not.toBeInTheDocument();
@@ -764,8 +761,8 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });
       expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
-      expect(screen.getByTestId('sidebar-planning')).toHaveAttribute('aria-current', 'page');
-      expect(screen.getByRole('heading', { name: 'Planning chat window' })).toBeInTheDocument();
+      expect(screen.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
+      expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
       expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(
         'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then use Start ready work.',
       );
@@ -809,8 +806,8 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(2);
       expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
-      expect(screen.getByTestId('sidebar-planning')).toHaveAttribute('aria-current', 'page');
-      expect(screen.getByRole('heading', { name: 'Planning chat window' })).toBeInTheDocument();
+      expect(screen.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
+      expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
       expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. Review it, then use Start ready work.');
     });
     expect(screen.queryByRole('heading', { name: 'Plan graph' })).not.toBeInTheDocument();
@@ -869,7 +866,7 @@ describe('Invoker terminal (component)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
     await waitFor(() => expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' }));
 
-    fireEvent.click(screen.getByTestId('sidebar-planning'));
+    fireEvent.click(screen.getByTestId('sidebar-home'));
 
     const input = screen.getByTestId('invoker-terminal-input');
     expect(input).toBeDisabled();
@@ -903,7 +900,7 @@ describe('Invoker terminal (component)', () => {
     submitPlanningText('hello');
     await waitFor(() => expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('I can help draft that.'));
 
-    fireEvent.click(screen.getByRole('button', { name: 'New' }));
+    fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
 
     expect(screen.getByTestId('invoker-terminal-input')).toHaveValue('');
     expect(screen.getByTestId('invoker-terminal-transcript')).not.toHaveTextContent('I can help draft that.');
@@ -970,7 +967,7 @@ describe('Invoker terminal (component)', () => {
     submitPlanningText('first session request');
     await waitFor(() => expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1));
 
-    fireEvent.click(screen.getByRole('button', { name: 'New' }));
+    fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
 
     const secondInput = screen.getByTestId('invoker-terminal-input');
     expect(secondInput).not.toBeDisabled();
@@ -1080,12 +1077,13 @@ describe('Invoker terminal (component)', () => {
     mock = createMockInvoker(tasks, workflows);
     mock.install();
     render(<App />);
+    await screen.findByTestId('planning-session-list');
 
-    await expectSurfaceRailList('planning', 'planning-session-list');
+    await expectSurfaceRailList('home', 'planning-session-list');
     await expectSurfaceRailList('workflows', 'workflows-rail-list');
     await expectSurfaceRailList('attention', 'attention-rail-list');
     expect(screen.queryByTestId('running-rail-list')).not.toBeInTheDocument();
-  });
+  }, 15_000);
 
   it('keeps the submit button accessible as Send while rendering an icon-only affordance', () => {
     render(<InvokerTerminal {...terminalProps({ value: 'draft a plan' })} />);

--- a/packages/ui/src/__tests__/keyboard-controls.test.tsx
+++ b/packages/ui/src/__tests__/keyboard-controls.test.tsx
@@ -54,6 +54,7 @@ const tasks = [
 async function renderKeyboardFixture(mock: MockInvoker) {
   mock.setTasks(tasks, workflows);
   render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
   await screen.findByTestId('workflow-node-wf-a');
   await screen.findByTestId('selected-workflow-mini-dag');
 }
@@ -80,6 +81,7 @@ describe('Side rail controls (component)', () => {
 
   it('Refresh button calls refreshTaskGraph', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     fireEvent.click(screen.getByTestId('rail-refresh'));
 
     await waitFor(() => {
@@ -108,6 +110,7 @@ describe('Side rail controls (component)', () => {
 
   it('Clear button calls clear', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     fireEvent.click(screen.getByTestId('graph-more-button'));
     fireEvent.click(screen.getByTestId('rail-clear'));
     await waitFor(() => {
@@ -198,6 +201,7 @@ describe('Side rail controls (component)', () => {
     try {
       mock.setTasks(reviewTasks, reviewWorkflows);
       render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
       await screen.findByTestId('workflow-node-wf-pr');
       await screen.findByTestId('selected-workflow-mini-dag');
 
@@ -400,6 +404,7 @@ describe('Sidebar keyboard navigation (component)', () => {
   async function renderReviewFixture() {
     mock.setTasks(reviewTasks, reviewWorkflows);
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await screen.findByTestId('workflow-node-wf-r');
     await screen.findByTestId('selected-workflow-mini-dag');
     await screen.findByTestId('inspector-pr-link');
@@ -547,9 +552,14 @@ describe('Camera lock controls (component)', () => {
   ) {
     mock.setTasks(tks, wfs);
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await screen.findByTestId(`workflow-node-${wfs[0].id}`);
     await screen.findByTestId('selected-workflow-mini-dag');
     await waitFor(() => expect(fitViewMock.mock.calls.length).toBeGreaterThanOrEqual(2));
+    // Opening Plan graph issues a fit; drain any trailing center/fit from that
+    // transition before tests assert on post-mount camera moves.
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
     fitViewMock.mockClear();
     setCenterMock.mockClear();
   }

--- a/packages/ui/src/__tests__/merge-branch.test.tsx
+++ b/packages/ui/src/__tests__/merge-branch.test.tsx
@@ -52,6 +52,7 @@ describe('workflow advanced metadata (component)', () => {
 
   it('shows base branch inside advanced metadata section', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([taskA, mergeNode], workflows));
 
     await waitFor(() => {

--- a/packages/ui/src/__tests__/merge-gate-approval-flow.test.tsx
+++ b/packages/ui/src/__tests__/merge-gate-approval-flow.test.tsx
@@ -57,6 +57,7 @@ describe('Merge gate approval flow (integration)', () => {
 
   it('workflow context menu retries workflow', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([taskA, gateA], [wfA]));
 
     await waitFor(() => {
@@ -82,6 +83,7 @@ describe('Merge gate approval flow (integration)', () => {
     });
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([fixedTask], [wfA]));
 
     await waitFor(() => {
@@ -133,6 +135,7 @@ describe('Merge gate approval flow (integration)', () => {
     };
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([completedTask, reviewGate], [reviewWorkflow]));
 
     await waitFor(() => {

--- a/packages/ui/src/__tests__/plan-loading.test.tsx
+++ b/packages/ui/src/__tests__/plan-loading.test.tsx
@@ -77,6 +77,7 @@ describe('Plan loading (component)', () => {
 
   it('renders workflow graph nodes after setTasks', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
@@ -91,17 +92,19 @@ describe('Plan loading (component)', () => {
 
   it('empty state disappears after tasks are loaded', async () => {
     render(<App />);
-    expect(screen.getByTestId('workflow-graph-surface')).toHaveTextContent('Your plan will appear here.');
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    expect(screen.getByTestId('workflow-graph-surface')).toHaveTextContent('No plan yet — draft one from Home.');
 
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
-      expect(screen.getByTestId('workflow-graph-surface')).not.toHaveTextContent('Your plan will appear here.');
+      expect(screen.getByTestId('workflow-graph-surface')).not.toHaveTextContent('No plan yet — draft one from Home.');
     });
   });
 
   it('selecting workflow renders mini DAG for its tasks', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
@@ -115,6 +118,7 @@ describe('Plan loading (component)', () => {
     const messagesPerSession = 16;
     const scenario = makeTypingLagScenario(sessionCount, messagesPerSession);
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks(scenario.tasks, scenario.workflows));
 
     await waitFor(() => {

--- a/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
@@ -29,7 +29,7 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
   });
 
   async function openPlanningTerminal() {
-    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
     });
@@ -77,7 +77,7 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
     expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
     expect(screen.getByTestId('invoker-terminal-harness')).toBeDisabled();
 
-    fireEvent.click(screen.getByRole('button', { name: 'New' }));
+    fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-input')).not.toBeDisabled();
     });

--- a/packages/ui/src/__tests__/selected-workflow-graph-disappears-repro.test.tsx
+++ b/packages/ui/src/__tests__/selected-workflow-graph-disappears-repro.test.tsx
@@ -47,6 +47,7 @@ describe('selected workflow graph metadata-gap regression', () => {
 
   it('keeps the selected mini-DAG visible when workflow metadata briefly omits the selected workflow', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([taskAlpha, taskBeta], [workflowA, workflowB]));
 
     await waitFor(() => {
@@ -110,6 +111,7 @@ describe('selected workflow graph metadata-gap regression', () => {
     });
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha, beta, merge, gamma], [workflowA, workflowB]));
 
     await waitFor(() => {

--- a/packages/ui/src/__tests__/selected-workflow-selection-steal-repro.test.tsx
+++ b/packages/ui/src/__tests__/selected-workflow-selection-steal-repro.test.tsx
@@ -51,6 +51,7 @@ describe('selected workflow selection-steal regression', () => {
 
   it('keeps focus on the selected workflow when it briefly drops out of the graph (home surface)', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     const { alpha, gamma } = buildTasks();
     act(() => mock.setTasks([alpha, gamma], [workflowA, workflowB]));
     await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
@@ -73,6 +74,7 @@ describe('selected workflow selection-steal regression', () => {
 
   it('keeps focus on the selected workflow during churn (workflows browser surface)', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     const { alpha, gamma } = buildTasks();
     act(() => mock.setTasks([alpha, gamma], [workflowA, workflowB]));
     await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
@@ -94,6 +96,7 @@ describe('selected workflow selection-steal regression', () => {
 
   it('keeps an open task context menu usable through recreate churn', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     const { alpha, beta, gamma } = buildTasks();
     act(() => mock.setTasks([alpha, beta, gamma], [workflowA, workflowB]));
     await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
@@ -121,6 +124,7 @@ describe('selected workflow selection-steal regression', () => {
 
   it('still moves off the selected workflow once it is genuinely gone (after the grace window)', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     const { alpha, gamma } = buildTasks();
     act(() => mock.setTasks([alpha, gamma], [workflowA, workflowB]));
     await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());

--- a/packages/ui/src/__tests__/start-ready-recreate-failed-and-pending.test.tsx
+++ b/packages/ui/src/__tests__/start-ready-recreate-failed-and-pending.test.tsx
@@ -60,7 +60,7 @@ describe('Start and recreate failed and pending', () => {
 
     render(<App />);
     act(() => mock.setTasks([pending, failed], workflows));
-    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
 
     await waitFor(() => {
       expect(screen.getByTestId('rail-start-ready-menu')).toBeInTheDocument();

--- a/packages/ui/src/__tests__/start-ready-recreate-failed-pending-and-running.test.tsx
+++ b/packages/ui/src/__tests__/start-ready-recreate-failed-pending-and-running.test.tsx
@@ -66,7 +66,7 @@ describe('Start and recreate failed, pending, and running', () => {
 
     render(<App />);
     act(() => mock.setTasks([pending, failed, running], workflows));
-    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
 
     await waitFor(() => {
       expect(screen.getByTestId('rail-start-ready-menu')).toBeInTheDocument();

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -37,6 +37,7 @@ describe('Task interaction (component)', () => {
 
   it('selecting a workflow shows mini DAG and inspector content', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
@@ -53,6 +54,7 @@ describe('Task interaction (component)', () => {
 
   it('clicking a mini DAG task updates prompt details', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
@@ -81,6 +83,7 @@ describe('Task interaction (component)', () => {
     });
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([failedTask], failedWorkflows));
 
     await waitFor(() => {
@@ -117,6 +120,7 @@ describe('Task interaction (component)', () => {
     }]);
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([task], workflows));
 
     fireEvent.click(await screen.findByTestId('rf__node-task-worker-action'));
@@ -148,6 +152,7 @@ describe('Task interaction (component)', () => {
     });
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([promptTask], workflows));
 
     await waitFor(() => {
@@ -173,6 +178,7 @@ describe('Task interaction (component)', () => {
 
   it('clicking a task expands a minimized inspector', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
@@ -196,15 +202,16 @@ describe('Task interaction (component)', () => {
     expect(screen.queryByLabelText('Maximize inspector')).not.toBeInTheDocument();
   });
 
-  it('clicking workflow graph background keeps the selected mini DAG', async () => {
+  it('clicking workflow graph background dismisses the selected mini DAG', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
       expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByTestId('rf__node-wf-a'));
+    fireEvent.click(screen.getByTestId('workflow-node-wf-a'));
     await waitFor(() => {
       expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
     });
@@ -212,13 +219,13 @@ describe('Task interaction (component)', () => {
     fireEvent.click(screen.getByTestId('workflow-graph-react-flow'));
 
     await waitFor(() => {
-      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
-      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
+      expect(screen.queryByTestId('selected-workflow-mini-dag')).not.toBeInTheDocument();
     });
   });
 
   it('clicking inside the mini DAG panel keeps the workflow selected', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
@@ -235,6 +242,7 @@ describe('Task interaction (component)', () => {
 
   it('drags the selected workflow mini DAG by its header', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
@@ -282,6 +290,7 @@ describe('Task interaction (component)', () => {
 
   it('clamps the selected workflow mini DAG inside the graph surface while dragging', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
@@ -329,6 +338,7 @@ describe('Task interaction (component)', () => {
 
   it('opens and closes the maximized graph without clearing selection', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -160,6 +160,7 @@ describe('Terminal drawer (component)', () => {
 
   it('starts minimized: header is shown but no terminal body', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await waitFor(() => {
       // From minimized, the single button's next action is "Partial".
       expect(screen.getByRole('button', { name: 'Partial terminal drawer' })).toBeInTheDocument();
@@ -175,6 +176,7 @@ describe('Terminal drawer (component)', () => {
     vi.mocked(mock.api.terminalList).mockResolvedValue([restored]);
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
 
     await waitFor(() => {
       expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
@@ -262,6 +264,7 @@ describe('Terminal drawer (component)', () => {
 
   it('opens the drawer in the partial state (not maximized) when opening a terminal via double-click', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([taskAlpha, taskBeta], workflows));
     await selectWorkflow();
 
@@ -281,6 +284,7 @@ describe('Terminal drawer (component)', () => {
 
   it('cycles minimized → partial → maximized → minimized via the single button', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([taskAlpha], workflows));
     await selectWorkflow();
 
@@ -328,6 +332,7 @@ describe('Terminal drawer (component)', () => {
 
   it('focuses an existing running tab when double-clicking the same task again', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([taskAlpha, taskBeta], workflows));
     await selectWorkflow();
 
@@ -366,6 +371,7 @@ describe('Terminal drawer (component)', () => {
 
   it('renders distinct tabs for different tasks side by side', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([taskAlpha, taskBeta], workflows));
     await selectWorkflow();
 
@@ -384,6 +390,7 @@ describe('Terminal drawer (component)', () => {
 
   it('keeps the minimize control reachable when many tabs are open', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([taskAlpha, taskBeta], workflows));
     await selectWorkflow();
 
@@ -408,6 +415,7 @@ describe('Terminal drawer (component)', () => {
     });
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([taskAlpha], workflows));
     await selectWorkflow();
 
@@ -421,6 +429,7 @@ describe('Terminal drawer (component)', () => {
 
   it('opens the drawer when the context-menu Open Terminal action is used', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([taskAlpha], workflows));
     await selectWorkflow();
 
@@ -438,6 +447,7 @@ describe('Terminal drawer (component)', () => {
 
   it('keeps the context-menu Open Terminal action routed through open-terminal IPC', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([taskAlpha], workflows));
     await selectWorkflow();
 
@@ -469,6 +479,7 @@ describe('Terminal drawer (component)', () => {
     });
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([taskAlpha], workflows));
     await selectWorkflow();
 
@@ -736,6 +747,7 @@ describe('Terminal drawer (component)', () => {
     }));
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([taskAlpha, taskBeta], workflows));
     await selectWorkflow();
 

--- a/packages/ui/src/__tests__/timeline-view-e2e.test.tsx
+++ b/packages/ui/src/__tests__/timeline-view-e2e.test.tsx
@@ -103,6 +103,7 @@ describe('Timeline view (component)', () => {
 
   it('opening Timeline shows Workers mode by default', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => {
       mock.setTasks([alpha, beta], [workflowAlpha]);
       mock.setWorkerDecisions({ actions: [], limit: 100, offset: 0, hasMore: false, workflowId: workflowAlpha.id });
@@ -132,6 +133,7 @@ describe('Timeline view (component)', () => {
     });
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => {
       mock.setTasks([], [workflowAlpha, workflowBeta]);
       mock.setWorkerDecisions((request) => {
@@ -167,6 +169,7 @@ describe('Timeline view (component)', () => {
 
   it('labels timeline mode and worker search controls for assistive technology', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => {
       mock.setTasks([alpha, gamma], [workflowAlpha, workflowBeta]);
       mock.setWorkerDecisions({ actions: [], limit: 100, offset: 0, hasMore: false, workflowId: workflowAlpha.id });
@@ -192,6 +195,7 @@ describe('Timeline view (component)', () => {
     });
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => {
       mock.setTasks([], [workflowAlpha]);
       mock.setWorkerDecisions({ actions: [invalidAction], limit: 100, offset: 0, hasMore: false, workflowId: workflowAlpha.id });
@@ -208,6 +212,7 @@ describe('Timeline view (component)', () => {
 
   it('switching to Tasks mode still shows the existing task bars', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => {
       mock.setTasks([alpha, beta], [workflowAlpha]);
     });
@@ -236,6 +241,7 @@ describe('Timeline view (component)', () => {
     } as never);
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => {
       mock.setTasks([completedAlpha, beta], [workflowAlpha]);
     });
@@ -264,6 +270,7 @@ describe('Timeline view (component)', () => {
     } as never);
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => {
       mock.setTasks([startedAlpha, beta], [workflowAlpha]);
     });
@@ -284,6 +291,7 @@ describe('Timeline view (component)', () => {
 
   it('task timeline row text keeps selectable text styling', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => {
       mock.setTasks([alpha, beta], [workflowAlpha]);
     });
@@ -315,6 +323,7 @@ describe('Timeline view (component)', () => {
     });
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => {
       mock.setTasks([alpha, beta, gamma], [workflowAlpha, workflowBeta]);
       mock.setWorkerDecisions((request) => {
@@ -388,6 +397,7 @@ describe('Timeline view (component)', () => {
     });
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => {
       mock.setTasks([alpha, beta, gamma], [workflowAlpha, workflowBeta]);
       mock.setWorkerDecisions((request) => {
@@ -499,8 +509,9 @@ describe('Timeline view (component)', () => {
     });
   });
 
-  it('switching back to Home workflow graph works', async () => {
+  it('switching back to Plan graph works', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => {
       mock.setTasks([alpha, beta], [workflowAlpha]);
     });

--- a/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
+++ b/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
@@ -33,13 +33,14 @@ describe('Visual proof snapshots', () => {
 
   it('empty-state', () => {
     render(<App />);
-    expect(screen.getByText('What to expect')).toBeInTheDocument();
-    expect(screen.getAllByText('Your plan will appear here.').length).toBeGreaterThan(0);
+    expect(screen.getByText('What do you want to build?')).toBeInTheDocument();
+    expect(screen.getByTestId('planning-session-rail')).toBeInTheDocument();
     expect(screen.getByTestId('sidebar-home')).toHaveTextContent('Invoker');
+    expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Plan graph');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
     expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
-    expect(screen.getByText('Describe the change in the terminal to generate a plan.')).toBeInTheDocument();
+    expect(screen.getByText('Describe a change, investigate a bug, or ask Invoker to draft a full plan. Review the graph before starting work.')).toBeInTheDocument();
     expect(screen.getByTestId('rail-settings')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();
     expect(screen.queryByText('System Setup')).not.toBeInTheDocument();
@@ -63,6 +64,7 @@ describe('Visual proof snapshots', () => {
     });
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
@@ -110,6 +112,7 @@ describe('Visual proof snapshots', () => {
     const detached = makeUITask({ id: 'task-detached', description: 'Detached downstream task', status: 'running', workflowId: 'wf-detached' });
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([upstream, active, detached], workflows));
 
     await waitFor(() => {
@@ -141,6 +144,7 @@ describe('Visual proof snapshots', () => {
     const alpha = makeUITask({ id: 'task-alpha', description: 'First test task', status: 'running', workflowId: 'wf-alpha' });
 
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha], workflows));
 
     await waitFor(() => {

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -391,12 +391,12 @@ describe('WorkflowGraph', () => {
     );
     expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
     expect(screen.getByTestId('workflow-node-wf-b')).toBeInTheDocument();
-    expect(screen.queryByText('Your plan will appear here.')).not.toBeInTheDocument();
+    expect(screen.queryByText('No plan yet — draft one from Home.')).not.toBeInTheDocument();
     expect(fitViewMock).not.toHaveBeenCalled();
     expect(setCenterMock).not.toHaveBeenCalled();
 
     fireEvent.pointerUp(screen.getByTestId('rf__pane'));
-    await waitFor(() => expect(screen.getByText('Your plan will appear here.')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('No plan yet — draft one from Home.')).toBeInTheDocument());
 
     rerender(
       <WorkflowGraph

--- a/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
+++ b/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
@@ -68,6 +68,7 @@ describe('Workflow mutation failed handling', () => {
 
   it('does not show the top banner for task-scoped approve failures', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await settleTasks();
 
     act(() => {
@@ -81,8 +82,9 @@ describe('Workflow mutation failed handling', () => {
 
   it('leaves the sidebar surface alone when a task-scoped failure arrives', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await settleTasks();
-    expect(screen.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByTestId('sidebar-planning')).toHaveAttribute('aria-current', 'page');
 
     act(() => {
       mock.fireWorkflowMutationFailed(approveFailure);
@@ -91,14 +93,15 @@ describe('Workflow mutation failed handling', () => {
     await waitFor(() => {
       expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('1');
     });
-    expect(screen.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByTestId('sidebar-planning')).toHaveAttribute('aria-current', 'page');
     expect(screen.getByTestId('sidebar-attention')).not.toHaveAttribute('aria-current', 'page');
   });
 
   it('leaves the sidebar surface alone when a workflow-scoped failure arrives', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await settleTasks();
-    expect(screen.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByTestId('sidebar-planning')).toHaveAttribute('aria-current', 'page');
 
     act(() => {
       mock.fireWorkflowMutationFailed({
@@ -113,12 +116,13 @@ describe('Workflow mutation failed handling', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
     });
-    expect(screen.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByTestId('sidebar-planning')).toHaveAttribute('aria-current', 'page');
     expect(screen.getByTestId('sidebar-workflows')).not.toHaveAttribute('aria-current', 'page');
   });
 
   it('does not steal the selection while the operator is working elsewhere', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await settleTasks();
     fireEvent.click(screen.getByTestId('sidebar-workflows'));
     await waitFor(() => {
@@ -138,6 +142,7 @@ describe('Workflow mutation failed handling', () => {
 
   it('surfaces failure details in the inspector once the operator opens Needs Attention', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await settleTasks();
 
     act(() => {
@@ -169,6 +174,7 @@ describe('Workflow mutation failed handling', () => {
 
   it('keeps mutation failure details visible when reselecting the task from Needs Attention', async () => {
     render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await settleTasks();
 
     act(() => {

--- a/packages/ui/src/__tests__/workflow-task-graph-status-divergence-repro.test.tsx
+++ b/packages/ui/src/__tests__/workflow-task-graph-status-divergence-repro.test.tsx
@@ -57,6 +57,7 @@ async function renderWorkflow(
   workflows: WorkflowMeta[],
 ): Promise<HTMLElement> {
   render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
   act(() => mock.setTasks(tasks, workflows));
 
   await waitFor(() => {

--- a/packages/ui/src/components/CommandPalette.tsx
+++ b/packages/ui/src/components/CommandPalette.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useRef, useState, type JSX, type RefObject } from 'react';
-import { AlertTriangle, Clock, GitBranch, Home, Layers, Settings, Terminal } from 'lucide-react';
+import { AlertTriangle, Clock, GitBranch, Home, Layers, Settings } from 'lucide-react';
 import type { SidebarSurface, WorkflowListEntry, WorkflowTaskEntry } from '../lib/workflow-progress-surfaces.js';
 import {
   Command,
@@ -92,14 +92,15 @@ const CommandPaletteBody = memo(function CommandPaletteBody({
           <CommandEmpty>No matches.</CommandEmpty>
 
           <CommandGroup heading="Navigate">
-            <CommandItem value="home go home" onSelect={closeAnd(() => onSelectSurface('home'))}>
+            <CommandItem value="home go home planning" onSelect={closeAnd(() => onSelectSurface('home'))}>
               <Home strokeWidth={1.75} />
               <span>Go home</span>
-            </CommandItem>
-            <CommandItem value="planning terminal" onSelect={closeAnd(() => onSelectSurface('planning'))}>
-              <Terminal strokeWidth={1.75} />
-              <span>Planning Terminal</span>
               {planningSessionCount > 0 && <CommandShortcut>{planningSessionCount}</CommandShortcut>}
+            </CommandItem>
+            <CommandItem value="plan graph" onSelect={closeAnd(() => onSelectSurface('planning'))}>
+              <Layers strokeWidth={1.75} />
+              <span>Plan graph</span>
+              {workflowCount > 0 && <CommandShortcut>{workflowCount}</CommandShortcut>}
             </CommandItem>
             <CommandItem value="needs attention" onSelect={closeAnd(() => onSelectSurface('attention'))}>
               <AlertTriangle strokeWidth={1.75} />

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -71,6 +71,10 @@ interface InvokerTerminalProps {
   onExpand: () => void;
   onCloseExpanded?: () => void;
   onCollapse?: () => void;
+  onOpenGraph?: () => void;
+  onFinishSetup?: () => void;
+  setupIncomplete?: boolean;
+  submittedPlanName?: string;
   activeConversationKey: string;
 }
 
@@ -297,6 +301,10 @@ export function InvokerTerminal({
   onExpand,
   onCloseExpanded,
   onCollapse,
+  onOpenGraph,
+  onFinishSetup,
+  setupIncomplete = false,
+  submittedPlanName,
   activeConversationKey,
 }: InvokerTerminalProps): JSX.Element {
   const renderStartedAt = nowMs();
@@ -596,7 +604,47 @@ export function InvokerTerminal({
             onScroll={handleTranscriptScroll}
             className="min-h-0 flex-1 space-y-3 overflow-y-auto bg-background px-4 py-4 font-mono text-[13px] leading-6"
           >
-            {transcriptContent}
+            {lines.length === 0 && !planningStream?.text ? (
+              <div data-testid="invoker-terminal-empty-hero" className="flex h-full min-h-[220px] flex-col justify-center gap-4">
+                <div>
+                  <h3 className="text-base font-semibold text-foreground">What do you want to build?</h3>
+                  <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+                    Describe a change, investigate a bug, or ask Invoker to draft a full plan. Review the graph before starting work.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {['Plan a feature', 'Investigate a bug', 'Compare approaches'].map((chip) => (
+                    <button
+                      key={chip}
+                      type="button"
+                      disabled={busy || readOnly}
+                      onClick={() => {
+                        onValueChange(chip);
+                        focusComposer();
+                      }}
+                      className="rounded-full border border-border px-3 py-1 text-xs text-muted-foreground hover:border-border-strong hover:text-foreground disabled:opacity-50"
+                    >
+                      {chip}
+                    </button>
+                  ))}
+                </div>
+                {setupIncomplete && onFinishSetup && (
+                  <div className="rounded-md border border-amber-700/50 bg-amber-950/30 px-3 py-2 text-xs text-amber-100">
+                    <div className="font-medium">Finish setup once, then plan from here.</div>
+                    <button
+                      type="button"
+                      data-testid="invoker-terminal-finish-setup"
+                      onClick={onFinishSetup}
+                      className="mt-2 rounded-md bg-amber-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-amber-500"
+                    >
+                      Finish setup
+                    </button>
+                  </div>
+                )}
+              </div>
+            ) : (
+              transcriptContent
+            )}
           </div>
 
           {submitError && !readOnly && (
@@ -640,6 +688,7 @@ export function InvokerTerminal({
               data-testid="invoker-terminal-ready-bar"
               className="sticky bottom-0 z-10 border-t border-border bg-background px-4 py-3 text-sm text-foreground"
             >
+              <div className="mb-2 text-sm font-medium text-foreground">Plan draft ready</div>
               {draftPlanSummary?.taskGroups && draftPlanSummary.taskGroups.length > 0 && (
                 <div
                   data-testid="invoker-terminal-plan-tasks"
@@ -677,6 +726,16 @@ export function InvokerTerminal({
                   >
                     Submit to Invoker
                   </button>
+                  {onOpenGraph && (
+                    <button
+                      type="button"
+                      data-testid="invoker-terminal-open-graph"
+                      onClick={onOpenGraph}
+                      className="rounded-sm border border-border px-3 py-1.5 text-xs text-muted-foreground hover:border-border-strong hover:text-foreground"
+                    >
+                      Open graph
+                    </button>
+                  )}
                   <button
                     type="button"
                     onClick={focusComposer}
@@ -685,6 +744,27 @@ export function InvokerTerminal({
                     Keep chatting
                   </button>
                 </div>
+              </div>
+            </div>
+          )}
+
+          {readOnly && submittedPlanName && onOpenGraph && (
+            <div
+              data-testid="invoker-terminal-submitted-bar"
+              className="sticky bottom-0 z-10 border-t border-border bg-background px-4 py-3 text-sm text-foreground"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <span className="font-mono text-xs text-muted-foreground">
+                  Plan ready · &quot;{submittedPlanName}&quot; · review the graph, then Start ready work
+                </span>
+                <button
+                  type="button"
+                  data-testid="invoker-terminal-open-graph"
+                  onClick={onOpenGraph}
+                  className="rounded-sm bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                >
+                  Open graph
+                </button>
               </div>
             </div>
           )}

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -8,7 +8,6 @@ import {
   ChevronRightIcon,
   InvokerIcon,
   MoonIcon,
-  PlanningTerminalIcon,
   SettingsIcon,
   SunIcon,
   WorkerIcon,
@@ -105,28 +104,41 @@ export function LeftStatusColumn({
         className={[
           'rounded-md text-left transition-colors duration-100 hover:bg-sidebar-accent/60',
           collapsed ? 'px-2 py-2.5 text-center' : 'px-2.5 py-2',
+          selectedSurface === 'home' ? 'bg-sidebar-accent text-sidebar-accent-foreground' : '',
         ].join(' ')}
       >
         {collapsed ? (
-          <div className="inline-flex text-sidebar-foreground">
+          <div className="relative inline-flex h-9 w-9 items-center justify-center text-sidebar-foreground">
             <InvokerIcon className={ICON_CLASS} />
+            {planningAttentionCount > 0 && (
+              <span className={`absolute -right-1 -top-1 rounded-full px-1.5 py-0.5 text-[10px] leading-none bg-background ${countClass('neutral')}`}>
+                {planningAttentionCount}
+              </span>
+            )}
           </div>
         ) : (
-          <div className="flex items-center gap-3">
-            <span className="inline-flex rounded-md border border-border bg-sidebar-accent/60 p-1.5 text-sidebar-foreground">
-              <InvokerIcon className={ICON_CLASS} />
-            </span>
-            <div>
-              <div className="text-sm font-semibold text-sidebar-foreground">Invoker</div>
-              <div className="mt-0.5 text-[11px] text-muted-foreground">Home</div>
+          <div className="flex w-full items-center justify-between gap-3">
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="inline-flex rounded-md border border-border bg-sidebar-accent/60 p-1.5 text-sidebar-foreground">
+                <InvokerIcon className={ICON_CLASS} />
+              </span>
+              <div className="min-w-0">
+                <div className="text-sm font-semibold text-sidebar-foreground">Invoker</div>
+                <div className="mt-0.5 text-[11px] text-muted-foreground">Planning chats</div>
+              </div>
             </div>
+            {planningAttentionCount > 0 && (
+              <span className={`rounded-full px-2 py-0.5 text-[11px] ${countClass('neutral')}`}>
+                {planningAttentionCount}
+              </span>
+            )}
           </div>
         )}
       </button>
 
       <button
         type="button"
-        aria-label="Planning Terminal"
+        aria-label="Plan graph"
         data-testid="sidebar-planning"
         data-sidebar-nav-item
         data-sidebar-nav-order="2"
@@ -139,24 +151,21 @@ export function LeftStatusColumn({
       >
         {collapsed ? (
           <div className="relative inline-flex h-9 w-9 items-center justify-center">
-            <span><PlanningTerminalIcon className={ICON_CLASS} /></span>
-            {planningAttentionCount > 0 && (
-              <span className={`absolute -right-1 -top-1 rounded-full px-1.5 py-0.5 text-[10px] leading-none bg-background ${countClass('neutral')}`}>
-                {planningAttentionCount}
-              </span>
-            )}
+            <span><WorkflowsIcon className={ICON_CLASS} /></span>
           </div>
         ) : (
           <>
             <span className="flex min-w-0 items-center gap-3">
               <span className="inline-flex rounded-md border border-border bg-sidebar-accent/40 p-1.5 text-muted-foreground">
-                <PlanningTerminalIcon className={ICON_CLASS} />
+                <WorkflowsIcon className={ICON_CLASS} />
               </span>
-              <span className="truncate">Planning Terminal</span>
+              <span className="truncate">Plan graph</span>
             </span>
-            <span className={`rounded-full px-2 py-0.5 text-[11px] ${countClass('neutral')}`}>
-              {planningAttentionCount}
-            </span>
+            {workflowCount > 0 && (
+              <span className={`rounded-full px-2 py-0.5 text-[11px] ${countClass('neutral')}`}>
+                {workflowCount}
+              </span>
+            )}
           </>
         )}
       </button>
@@ -221,8 +230,8 @@ export function LeftStatusColumn({
               ? 'Worker status is not available yet.'
               : `${runningWorkers} process${runningWorkers === 1 ? '' : 'es'} running · ${activeWorkerActions} active action${activeWorkerActions === 1 ? '' : 's'}`
           )}
-          {selectedSurface === 'home' && 'Plan graph details live here.'}
-          {selectedSurface === 'planning' && `${planningSessionCount} planning chat${planningSessionCount === 1 ? '' : 's'}.`}
+          {selectedSurface === 'home' && `${planningSessionCount} planning chat${planningSessionCount === 1 ? '' : 's'}.`}
+          {selectedSurface === 'planning' && 'Workflow graph and task terminals.'}
         </div>
       )}
 

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -658,7 +658,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
     return (
       <div className="h-full w-full flex items-center justify-center text-muted-foreground">
         <div className="text-center">
-          <p>Your plan will appear here.</p>
+          <p>No plan yet — draft one from Home.</p>
         </div>
       </div>
     );

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -841,7 +841,7 @@ function WorkflowGraphInner({
   if (flowNodes.length === 0) {
     return (
       <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
-        Your plan will appear here.
+        No plan yet — draft one from Home.
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Invoker now opens on the planning chat by default instead of the workflow graph.

The workflow graph moves to a "Plan graph" sidebar tab. It shows an empty-state CTA that sends you back to Home when there is no plan yet.

This makes the planning conversation the first thing a user sees and works from, with the graph available as a supporting view.

## Review Claim

Opening the app, or clicking Home, lands on the planning chat; the graph is reachable as a demoted "Plan graph" tab and points back to Home when empty.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the default sidebar surface and graph empty-state copy change. Planner requests, draft validation, and workflow execution are unchanged.

## Slice Rationale

This isolates the home-surface swap from later composer and rail refinements later in the stack, so the default-surface change can be reviewed on its own.

## Non-goals

- Does not change planner request or draft-review behavior.
- Does not change workflow execution or the graph's non-empty rendering.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --dir packages/ui test`
- [x] `pnpm --dir packages/app run test:e2e -- planning-chat-typography-demo.spec.ts`

</details>

## Visual Proof

Home now opens on the planning chat instead of the workflow graph.

![Home before: workflow graph](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260720-ecca0a/empty-home-before.png)
![Home after: planning chat](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260720-ecca0a/empty-home-after.png)

Plan graph is demoted to a sidebar tab with an empty-state CTA back to Home.

![Plan graph before: labeled Workflow graph, no CTA back to a chat](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260720-ecca0a/empty-graph-before.png)
![Plan graph after: "No plan yet" with a "Go to Home to draft" CTA](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260720-ecca0a/empty-graph-after.png)

Walkthrough of opening the app on planning chat and navigating to the empty Plan graph tab.

[Planning home walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260720-ecca0a/planning-home-submit-walkthrough.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a431082`
- Post-revert steps: None
- Data migration? No

</details>
