### PR TITLE
[Planning Home UX](5) Refine planning composer and rails

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -768,8 +768,10 @@ test.describe('Visual proof capture', () => {
       return el.scrollHeight - el.scrollTop - el.clientHeight;
     });
     expect(scrollGap).toBeLessThanOrEqual(1);
+    const codePanel = expandedTranscript.locator('pre code').last();
+    await expect(codePanel).toBeVisible();
+    await expect(codePanel).toContainText('command: echo B');
     const tailText = await expandedTranscript.evaluate((el) => el.textContent ?? '');
-    expect(tailText.trimEnd().endsWith('```')).toBe(true);
     expect(tailText).toContain('command: echo B');
     await captureScreenshot(page, 'terminal-planned-conversation-end');
     await page.keyboard.press('Escape');

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -665,7 +665,41 @@ function WorkflowContextMenu({
   );
 }
 
-function EmptyPlanGraphCta({ onGoHome }: { onGoHome: () => void }): JSX.Element {
+function EmptyPlanGraphCta({
+  creationError,
+  draftPlan,
+  onCreateWorkflow,
+  onGoHome,
+}: {
+  creationError?: string;
+  draftPlan?: { name: string; taskCount: number };
+  onCreateWorkflow?: () => void;
+  onGoHome: () => void;
+}): JSX.Element {
+  if (draftPlan && onCreateWorkflow) {
+    return (
+      <aside className="h-full w-full border-l border-border bg-background/90 p-4" data-testid="empty-plan-graph-cta">
+        <div className="rounded-xl border border-border bg-card/70 p-4">
+          <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Draft review</div>
+          <h2 className="mt-1 text-sm font-semibold text-foreground">{draftPlan.name}</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {draftPlan.taskCount} task{draftPlan.taskCount === 1 ? '' : 's'} ready to create as a workflow.
+          </p>
+          {creationError && (
+            <p className="mt-3 text-xs text-destructive">{creationError}</p>
+          )}
+          <button
+            type="button"
+            data-testid="planning-create-workflow"
+            onClick={onCreateWorkflow}
+            className="mt-4 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Create workflow
+          </button>
+        </div>
+      </aside>
+    );
+  }
   return (
     <aside className="h-full w-full border-l border-border bg-background/90 p-4" data-testid="empty-plan-graph-cta">
       <div className="rounded-xl border border-border bg-card/70 p-4">
@@ -784,7 +818,7 @@ export function App() {
   const suppressDagSurfaceDismissRef = useRef(false);
   const contextMenuTaskRef = useRef<TaskState | null>(null);
   const [sidebarSurface, setSidebarSurface] = useState<SidebarSurface>('home');
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [selectedWorkerKind, setSelectedWorkerKind] = useState<string | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
@@ -879,7 +913,8 @@ export function App() {
   const [detachNotice, setDetachNotice] = useState<string | null>(null);
   const [keyboardRegion, setKeyboardRegion] = useState<KeyboardRegion>('planning');
   const [previousGraphRegion, setPreviousGraphRegion] = useState<KeyboardRegion>('workflowGraph');
-  const [planningContextCollapsed, setPlanningContextCollapsed] = useState(false);
+  const [planningContextCollapsed, setPlanningContextCollapsed] = useState(true);
+  const [planningSessionRailCollapsed, setPlanningSessionRailCollapsed] = useState(false);
   // Typed graph camera state. The graph viewport is user-owned after the
   // initial render: only explicit navigation commands (issued through the
   // central factory) move it. No per-handler event++/requestId++ counters.
@@ -3891,13 +3926,6 @@ export function App() {
   const connectedAgentLabels = (systemDiagnostics?.tools ?? [])
     .filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed)
     .map((tool) => tool.name.replace(/\s+CLI$/i, ''));
-  const planningPhase = activePlanningSession.status === 'submitted'
-    ? 'review'
-    : draftPlanAvailable
-      ? 'draft'
-      : terminalLines.some((line) => line.role === 'user')
-        ? 'discuss'
-        : 'discuss';
 
   const renderPlanningContextPanel = (): JSX.Element => (
     <aside
@@ -3942,29 +3970,6 @@ export function App() {
               <p className="mt-1 text-foreground">{activePlanningSession.submittedPlanName}</p>
             </div>
           )}
-          <div>
-            <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Agents</div>
-            <p className="mt-1 text-foreground">
-              {connectedAgentLabels.length > 0 ? connectedAgentLabels.join(', ') : 'None detected yet'}
-            </p>
-          </div>
-          <div>
-            <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Phase</div>
-            <ol className="mt-2 space-y-1.5 text-xs text-muted-foreground">
-              {(['discuss', 'draft', 'review', 'run'] as const).map((phase) => {
-                const order = { discuss: 0, draft: 1, review: 2, run: 3 } as const;
-                const current = order[planningPhase];
-                const done = order[phase] < current || (phase === 'discuss' && terminalLines.some((line) => line.role === 'user'));
-                const active = phase === planningPhase;
-                return (
-                  <li key={phase} className={active ? 'font-medium text-foreground' : done ? 'text-emerald-400' : ''}>
-                    {(done && !active) ? '✓ ' : active ? '● ' : '○ '}
-                    {phase.charAt(0).toUpperCase() + phase.slice(1)}
-                  </li>
-                );
-              })}
-            </ol>
-          </div>
           {(draftPlanAvailable || activePlanningSession.status === 'submitted') && (
             <button
               type="button"
@@ -3982,24 +3987,58 @@ export function App() {
 
   const renderPlanningTerminalSurface = (): JSX.Element => (
     <div className="flex min-h-0 flex-1 overflow-hidden">
-      <div data-testid="planning-session-rail" className="flex h-full w-64 shrink-0 flex-col border-r border-border bg-card">
-        <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2.5">
-          <div className="min-w-0">
-            <h2 className="text-sm font-medium text-foreground">Planning</h2>
-            <p className="mt-0.5 text-[11px] text-muted-foreground">
-              {planningSessions.length} chat{planningSessions.length === 1 ? '' : 's'}
-              {planningReadyCount > 0 ? ` · ${planningReadyCount} ready` : ''}
-            </p>
+      <div
+        data-testid="planning-session-rail"
+        className={`flex h-full shrink-0 flex-col border-r border-border bg-card transition-all duration-150 ${planningSessionRailCollapsed ? 'w-16' : 'w-64'}`}
+      >
+        {planningSessionRailCollapsed ? (
+          <div className="flex flex-col items-center gap-2 px-2 py-2.5">
+            <button
+              type="button"
+              aria-label="New chat"
+              onClick={handleCreatePlanningSession}
+              className="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-secondary"
+            >
+              +
+            </button>
+            <button
+              type="button"
+              data-testid="planning-session-rail-toggle"
+              aria-label="Expand planning chats"
+              onClick={() => setPlanningSessionRailCollapsed(false)}
+              className="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-secondary"
+            >
+              ›
+            </button>
           </div>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleCreatePlanningSession}
-          >
-            New chat
-          </Button>
-        </div>
-        <div className={RAIL_LIST_FRAME_CLASS}>{renderPlanningSessionList()}</div>
+        ) : (
+          <>
+            <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2.5">
+              <div className="min-w-0">
+                <h2 className="text-sm font-medium text-foreground">Planning</h2>
+                <p className="mt-0.5 text-[11px] text-muted-foreground">
+                  {planningSessions.length} chat{planningSessions.length === 1 ? '' : 's'}
+                  {planningReadyCount > 0 ? ` · ${planningReadyCount} ready` : ''}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" onClick={handleCreatePlanningSession}>
+                  New chat
+                </Button>
+                <button
+                  type="button"
+                  data-testid="planning-session-rail-toggle"
+                  aria-label="Collapse planning chats"
+                  onClick={() => setPlanningSessionRailCollapsed(true)}
+                  className="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-secondary"
+                >
+                  ‹
+                </button>
+              </div>
+            </div>
+            <div className={RAIL_LIST_FRAME_CLASS}>{renderPlanningSessionList()}</div>
+          </>
+        )}
       </div>
       <div
         className="flex min-h-0 flex-1 flex-col overflow-hidden"
@@ -4007,40 +4046,29 @@ export function App() {
         tabIndex={0}
         data-keyboard-active={keyboardRegion === 'planning' ? 'true' : 'false'}
       >
-        {(setupIncomplete || connectedAgentLabels.length > 0) && (
-          <div
-            data-testid="planning-setup-strip"
-            className="flex flex-wrap items-center justify-between gap-2 border-b border-border bg-card/50 px-4 py-2 text-xs"
-          >
-            <div className="flex flex-wrap items-center gap-3 text-muted-foreground">
-              <span className={setupIncomplete ? 'text-amber-300' : 'text-emerald-400'}>
-                {setupIncomplete ? 'Setup needed' : 'Invoker is ready'}
-              </span>
-              {connectedAgentLabels.length > 0 && (
-                <span>Agents connected: {connectedAgentLabels.join(', ')}</span>
-              )}
-            </div>
-            <button
-              type="button"
-              data-testid="planning-finish-setup"
-              onClick={() => {
-                cancelPendingSystemSetupAutoOpen();
-                setShowSystemSetup(true);
-              }}
-              className="rounded-md border border-border px-2.5 py-1 text-xs text-foreground hover:bg-secondary"
-            >
-              {setupIncomplete ? 'Finish setup' : 'Manage setup'}
-            </button>
-          </div>
-        )}
         <div className="flex items-center justify-between gap-3 border-b border-border bg-card px-4 py-2.5">
           <div className="min-w-0">
             <h2 className="truncate text-sm font-medium text-foreground">Planning chat</h2>
             <p className="mt-0.5 truncate text-[11px] text-muted-foreground">{activePlanningSession.title}</p>
           </div>
-          <span className="shrink-0 rounded-full border border-border bg-background px-2.5 py-1 text-[11px] text-muted-foreground">
-            {planningSessionStatusLabel(activePlanningSession)}
-          </span>
+          <div className="flex shrink-0 items-center gap-2">
+            <span className="rounded-full border border-border bg-background px-2.5 py-1 text-[11px] text-muted-foreground">
+              {planningSessionStatusLabel(activePlanningSession)}
+            </span>
+            {setupIncomplete && (
+              <button
+                type="button"
+                data-testid="planning-finish-setup"
+                onClick={() => {
+                  cancelPendingSystemSetupAutoOpen();
+                  setShowSystemSetup(true);
+                }}
+                className="rounded-md border border-border px-2.5 py-1 text-xs text-foreground hover:bg-secondary"
+              >
+                Finish setup
+              </button>
+            )}
+          </div>
         </div>
         <div className="min-h-0 flex-1 overflow-hidden bg-background">
           <InvokerTerminal
@@ -4053,25 +4081,18 @@ export function App() {
             draftPlanAvailable={draftPlanAvailable}
             draftPlanSummary={draftPlanSummary}
             planningStream={activePlanningStream}
-            submitError={planningSubmitError}
             readOnly={activePlanningReadOnly}
             mode={activePlanningMode}
             terminalSession={activePlanningTerminalSession}
             terminalBusy={activePlanningTerminalBusy}
             terminalError={activePlanningTerminalError}
-            setupIncomplete={setupIncomplete}
             submittedPlanName={activePlanningSession.submittedPlanName}
             onValueChange={setPlanningInput}
             onSubmit={() => void handlePlanningSubmit()}
-            onSubmitDraft={() => void handlePlanningSubmitDraft()}
             onPresetChange={setSelectedPlanningPresetKey}
             onModeChange={(mode) => void handlePlanningModeChange(mode)}
             onExpand={() => setPlanningTerminalExpanded(true)}
             onOpenGraph={() => navigatePlanGraphAndFit('planning-open-graph')}
-            onFinishSetup={() => {
-              cancelPendingSystemSetupAutoOpen();
-              setShowSystemSetup(true);
-            }}
           />
         </div>
       </div>
@@ -4318,7 +4339,12 @@ export function App() {
               className={`${showEmptyPlanGraphCta || showInspectorPlaceholder ? 'w-96' : effectiveInspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-ring/50' : ''}`}
             >
               {showEmptyPlanGraphCta ? (
-                <EmptyPlanGraphCta onGoHome={() => navigatePlanningHome('empty-graph-cta')} />
+                <EmptyPlanGraphCta
+                  creationError={planningSubmitError?.message}
+                  draftPlan={draftPlanAvailable && draftPlanSummary ? draftPlanSummary : undefined}
+                  onCreateWorkflow={draftPlanAvailable ? () => void handlePlanningSubmitDraft() : undefined}
+                  onGoHome={() => navigatePlanningHome('empty-graph-cta')}
+                />
               ) : showInspectorPlaceholder ? (
                 <EmptyInspectorPlaceholder />
               ) : showWorkerDetailsPanel ? (
@@ -4382,18 +4408,15 @@ export function App() {
             draftPlanAvailable={draftPlanAvailable}
             draftPlanSummary={draftPlanSummary}
             planningStream={activePlanningStream}
-            submitError={planningSubmitError}
             expanded
             mode={activePlanningMode}
             terminalSession={activePlanningTerminalSession}
             terminalBusy={activePlanningTerminalBusy}
             terminalError={activePlanningTerminalError}
-            setupIncomplete={setupIncomplete}
             submittedPlanName={activePlanningSession.submittedPlanName}
             onValueChange={setPlanningInput}
             readOnly={activePlanningReadOnly}
             onSubmit={() => void handlePlanningSubmit()}
-            onSubmitDraft={() => void handlePlanningSubmitDraft()}
             onPresetChange={setSelectedPlanningPresetKey}
             onModeChange={(mode) => void handlePlanningModeChange(mode)}
             onExpand={() => setPlanningTerminalExpanded(true)}
@@ -4401,10 +4424,6 @@ export function App() {
             onOpenGraph={() => {
               setPlanningTerminalExpanded(false);
               navigatePlanGraphAndFit('planning-expanded-open-graph');
-            }}
-            onFinishSetup={() => {
-              cancelPendingSystemSetupAutoOpen();
-              setShowSystemSetup(true);
             }}
           />
         </div>

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -42,13 +42,11 @@ describe('App launch (component)', () => {
     act(() => window.dispatchEvent(new Event('resize')));
     expect(await screen.findByText('What do you want to build?')).toBeInTheDocument();
     expect(screen.getByTestId('planning-session-rail')).toBeInTheDocument();
+    expect(screen.getByTestId('planning-session-rail')).toHaveClass('w-64');
+    expect(screen.getByTestId('planning-context-panel')).toHaveClass('w-16');
+    expect(screen.getByTestId('app-sidebar')).toHaveClass('w-16');
     expect(screen.getByTestId('sidebar-home')).toBeInTheDocument();
-    expect(screen.getByTestId('sidebar-home')).toHaveTextContent('Planning chats');
-    expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Plan graph');
-    expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
-    expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
-    expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
+    expect(screen.getByTestId('sidebar-home')).toHaveTextContent('');
 
     fireEvent.click(screen.getByTestId('sidebar-planning'));
     expect(await screen.findByRole('heading', { name: 'Plan graph' })).toBeInTheDocument();
@@ -62,8 +60,6 @@ describe('App launch (component)', () => {
     render(<App />);
     act(() => window.dispatchEvent(new Event('resize')));
     await screen.findByTestId('sidebar-planning');
-
-    fireEvent.click(screen.getByTestId('sidebar-collapse-toggle'));
 
     const sidebar = screen.getByTestId('app-sidebar');
     expect(sidebar.className).toContain('w-16');
@@ -138,7 +134,6 @@ describe('App launch (component)', () => {
     render(<App />);
 
     const workersButton = await screen.findByTestId('sidebar-workers');
-    expect(workersButton).toHaveTextContent('Workers');
     fireEvent.click(workersButton);
 
     expect(await screen.findByTestId('worker-activity-card')).toBeInTheDocument();
@@ -164,7 +159,9 @@ describe('App launch (component)', () => {
     Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
     render(<App />);
     act(() => window.dispatchEvent(new Event('resize')));
-    expect(await screen.findByTestId('sidebar-home')).toHaveTextContent('Invoker');
+    expect(await screen.findByTestId('sidebar-home')).toHaveTextContent('');
+    fireEvent.click(screen.getByTestId('sidebar-collapse-toggle'));
+    expect(screen.getByTestId('sidebar-home')).toHaveTextContent('Invoker');
     expect(screen.queryByTestId('rail-open-file')).not.toBeInTheDocument();
     expect(screen.getByTestId('rail-settings')).toBeInTheDocument();
     expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Plan graph');
@@ -199,6 +196,8 @@ describe('App launch (component)', () => {
     render(<App />);
     await screen.findByTestId('sidebar-workflows');
 
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
+    fireEvent.click(screen.getByTestId('sidebar-collapse-toggle'));
     expect(screen.getByTestId('app-sidebar').className).toContain('w-60');
 
     fireEvent.click(screen.getByTestId('sidebar-workflows'));
@@ -242,7 +241,6 @@ describe('App launch (component)', () => {
     const sidebar = screen.getByTestId('app-sidebar');
     const toggle = screen.getByTestId('sidebar-collapse-toggle');
 
-    fireEvent.click(toggle);
     expect(sidebar.className).toContain('w-16');
     expect(screen.getByTestId('sidebar-running')).toBeInTheDocument();
 

--- a/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
@@ -31,6 +31,7 @@ describe('CodeRabbit PR #3050 — draft state cleared after submit', () => {
 
   async function openPlanningTerminal() {
     fireEvent.click(await screen.findByTestId('sidebar-home'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
     });
@@ -53,7 +54,8 @@ describe('CodeRabbit PR #3050 — draft state cleared after submit', () => {
     fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
 
     await screen.findByTestId('invoker-terminal-ready-bar');
-    fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
+    fireEvent.click(await screen.findByTestId('planning-create-workflow'));
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });

--- a/packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx
@@ -30,6 +30,7 @@ describe('CodeRabbit PR #3050 — Enter-to-submit ignores IME composition', () =
 
   async function openPlanningTerminal() {
     fireEvent.click(await screen.findByTestId('sidebar-home'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
     });

--- a/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
@@ -24,6 +24,7 @@ describe('CodeRabbit PR #3050 — submitted planning stays read-only after start
 
   async function openPlanningTerminal() {
     fireEvent.click(await screen.findByTestId('sidebar-home'));
+    fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
     });
@@ -45,7 +46,8 @@ describe('CodeRabbit PR #3050 — submitted planning stays read-only after start
     fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'draft the full plan' } });
     fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
     await screen.findByTestId('invoker-terminal-ready-bar');
-    fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
+    fireEvent.click(await screen.findByTestId('planning-create-workflow'));
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });

--- a/packages/ui/src/__tests__/home-visual-snapshots.test.tsx
+++ b/packages/ui/src/__tests__/home-visual-snapshots.test.tsx
@@ -35,10 +35,11 @@ describe('Visual proof snapshots', () => {
     render(<App />);
     expect(screen.getByText('What do you want to build?')).toBeInTheDocument();
     expect(screen.getByTestId('planning-session-rail')).toBeInTheDocument();
-    expect(screen.getByTestId('sidebar-home')).toHaveTextContent('Invoker');
-    expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Plan graph');
-    expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
-    expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
+    expect(screen.getByTestId('app-sidebar')).toHaveClass('w-16');
+    expect(screen.getByTestId('sidebar-home')).toHaveAccessibleName('Go home');
+    expect(screen.getByTestId('sidebar-planning')).toHaveAccessibleName('Plan graph');
+    expect(screen.getByTestId('sidebar-workflows')).toHaveAccessibleName('Workflows');
+    expect(screen.getByTestId('sidebar-attention')).toHaveAccessibleName('Needs Attention');
     expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
     expect(screen.getByText('Describe a change, investigate a bug, or ask Invoker to draft a full plan. Review the graph before starting work.')).toBeInTheDocument();
     expect(screen.getByTestId('rail-settings')).toBeInTheDocument();

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -31,6 +31,9 @@ describe('Invoker terminal (component)', () => {
 
   async function openPlanningTerminal() {
     fireEvent.click(await screen.findByTestId('sidebar-home'));
+    const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+    if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+    fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
     });
@@ -155,7 +158,7 @@ describe('Invoker terminal (component)', () => {
     expect(screen.queryByText(/Unknown command/)).not.toBeInTheDocument();
   });
 
-  it('shows live raw planner output while busy and removes it when the final reply arrives', async () => {
+  it('shows concise planning activity while busy and removes it when the final reply arrives', async () => {
     let resolveSend: ((value: any) => void) | null = null;
     mock.api.planningChatSend = vi.fn(() => new Promise((resolve) => {
       resolveSend = resolve;
@@ -174,7 +177,7 @@ describe('Invoker terminal (component)', () => {
 
     const panel = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(panel).toHaveAttribute('data-state', 'streaming');
-    expect(panel).toHaveTextContent('raw planner text');
+    expect(panel).toHaveTextContent('Drafting your plan…');
 
     await act(async () => {
       resolveSend?.({
@@ -192,7 +195,7 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
-  it('keeps failed raw planner output visible until the next send starts', async () => {
+  it('keeps concise failed planning activity visible until the next send starts', async () => {
     const plannerError = 'planner exited with code 1';
     let resolveFirstSend: ((value: any) => void) | null = null;
     let resolveSecondSend: ((value: any) => void) | null = null;
@@ -213,7 +216,7 @@ describe('Invoker terminal (component)', () => {
     await act(async () => {
       mock.firePlanningChatStream({ sessionId: 'session-1', chunk: 'partial raw output' });
     });
-    expect(await screen.findByTestId('invoker-terminal-planner-stream')).toHaveTextContent('partial raw output');
+    expect(await screen.findByTestId('invoker-terminal-planner-stream')).toHaveTextContent('Drafting your plan…');
 
     await act(async () => {
       resolveFirstSend?.({ ok: false, sessionId: 'session-1', error: plannerError });
@@ -222,8 +225,7 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       const panel = screen.getByTestId('invoker-terminal-planner-stream');
       expect(panel).toHaveAttribute('data-state', 'failed');
-      expect(panel).toHaveTextContent('partial raw output');
-      expect(panel).toHaveTextContent(plannerError);
+      expect(panel).toHaveTextContent('Planning stopped. Try again when ready.');
     });
 
     submitPlanningText('try again');
@@ -244,7 +246,7 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Recovered.'));
   });
 
-  it('keeps live planner output isolated when switching planning sessions', async () => {
+  it('keeps live planning activity isolated when switching planning sessions', async () => {
     mock.api.planningChatSend = vi.fn(() => new Promise(() => {}) as any) as any;
 
     render(<App />);
@@ -255,7 +257,7 @@ describe('Invoker terminal (component)', () => {
     await act(async () => {
       mock.firePlanningChatStream({ sessionId: 'session-1', chunk: 'first raw stream' });
     });
-    expect(await screen.findByTestId('invoker-terminal-planner-stream')).toHaveTextContent('first raw stream');
+    expect(await screen.findByTestId('invoker-terminal-planner-stream')).toHaveTextContent('Drafting your plan…');
 
     fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
     expect(screen.queryByTestId('invoker-terminal-planner-stream')).not.toBeInTheDocument();
@@ -267,15 +269,13 @@ describe('Invoker terminal (component)', () => {
     });
 
     const secondPanel = await screen.findByTestId('invoker-terminal-planner-stream');
-    expect(secondPanel).toHaveTextContent('second raw stream');
-    expect(secondPanel).not.toHaveTextContent('first raw stream');
+    expect(secondPanel).toHaveTextContent('Drafting your plan…');
 
     const sessionButtons = within(screen.getByTestId('planning-session-list')).getAllByRole('button');
     fireEvent.click(sessionButtons[1]);
 
     const firstPanel = await screen.findByTestId('invoker-terminal-planner-stream');
-    expect(firstPanel).toHaveTextContent('first raw stream');
-    expect(firstPanel).not.toHaveTextContent('second raw stream');
+    expect(firstPanel).toHaveTextContent('Drafting your plan…');
   });
 
   it('renders chat role labels and fenced YAML in a mono code panel', async () => {
@@ -304,7 +304,7 @@ describe('Invoker terminal (component)', () => {
     expect(screen.queryByText('invoker ›')).not.toBeInTheDocument();
   });
 
-  it('shows collapsed Thinking disclosure when reasoning is present', async () => {
+  it('does not render reasoning details when a response includes reasoning', async () => {
     mock.api.planningChatSend = vi.fn(async () => ({
       ok: true,
       sessionId: 'session-1',
@@ -320,11 +320,8 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Hello. What should we plan?');
     });
-    const thinking = screen.getByTestId('invoker-terminal-thinking');
-    expect(thinking).toBeInTheDocument();
-    expect(thinking).not.toHaveAttribute('open');
-    expect(thinking).toHaveTextContent('Thinking');
-    expect(thinking).toHaveTextContent('Greet the user and ask what to plan.');
+    expect(screen.queryByTestId('invoker-terminal-thinking')).not.toBeInTheDocument();
+    expect(screen.queryByText('Greet the user and ask what to plan.')).not.toBeInTheDocument();
     expect(screen.queryByText('thread.started')).not.toBeInTheDocument();
   });
 
@@ -653,8 +650,6 @@ describe('Invoker terminal (component)', () => {
     });
 
     fireEvent.click(homeButton);
-
-    expect(await screen.findByText('4 planning chats.')).toBeInTheDocument();
     expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('4 chats');
   });
 
@@ -666,13 +661,10 @@ describe('Invoker terminal (component)', () => {
     expect(within(homeButton).queryByText('0')).not.toBeInTheDocument();
 
     fireEvent.click(homeButton);
-
-    expect(await screen.findByText('1 planning chat.')).toBeInTheDocument();
+    expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('1 chat');
     fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
 
-    await waitFor(() => {
-      expect(screen.getByText('2 planning chats.')).toBeInTheDocument();
-    });
+    await waitFor(() => expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('2 chats'));
     expect(within(screen.getByTestId('sidebar-home')).queryByText('0')).not.toBeInTheDocument();
     expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('2 chats');
   });
@@ -709,7 +701,7 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
-  it('shows the sticky ready bar and submits without starting execution', async () => {
+  it('reviews a draft before explicitly creating the workflow', async () => {
     mock.api.planningChatSend = vi.fn(async () => ({
       ok: true,
       sessionId: 'session-1',
@@ -723,25 +715,33 @@ describe('Invoker terminal (component)', () => {
     submitPlanningText('draft the full plan');
 
     await waitFor(() => {
-      expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('draft ready · "Mock Plan" · 2 tasks');
+      expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('Draft ready · Mock Plan · 2 tasks');
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
 
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Plan graph' })).toBeInTheDocument();
+      expect(screen.getByTestId('planning-create-workflow')).toBeInTheDocument();
+    });
+    expect(mock.api.planningChatSubmit).not.toHaveBeenCalled();
+    expect(mock.api.start).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('planning-create-workflow'));
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });
       expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
-      expect(screen.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
-      expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
-      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
     });
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+    expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
     expect(screen.queryByRole('heading', { name: 'Plan graph' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Submit to Invoker' })).not.toBeInTheDocument();
     expect(mock.api.start).not.toHaveBeenCalled();
   });
 
-  it('shows stacked workflow counts and submit messaging', async () => {
+  it('shows stacked workflow counts before creating the workflow', async () => {
     mock.api.planningChatSend = vi.fn(async () => ({
       ok: true,
       sessionId: 'session-1',
@@ -772,33 +772,28 @@ describe('Invoker terminal (component)', () => {
     submitPlanningText('draft the Workers Surface plan');
 
     await waitFor(() => {
-      expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('draft ready · "Workers Surface" · 2 workflows · 4 tasks');
+      expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('Draft ready · Workers Surface · 2 workflows · 4 tasks');
     });
 
-    const tasks = screen.getByTestId('invoker-terminal-plan-tasks');
-    expect(tasks).toHaveTextContent('Workers Surface Contracts');
-    expect(tasks).toHaveTextContent('Define contracts');
-    expect(tasks).toHaveTextContent('Verify contracts');
-    expect(tasks).toHaveTextContent('Build UI');
-    expect(tasks).toHaveTextContent('Verify UI');
-
-    fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
+    await screen.findByTestId('planning-create-workflow');
+    fireEvent.click(screen.getByTestId('planning-create-workflow'));
 
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });
       expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
-      expect(screen.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
-      expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
-      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(
-        'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then use Start ready work.',
-      );
     });
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+    expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(
+      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then use Start ready work.',
+    );
     expect(screen.queryByRole('heading', { name: 'Plan graph' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Submit to Invoker' })).not.toBeInTheDocument();
   });
 
-  it('shows submit errors beside the ready draft and allows retry', async () => {
+  it('keeps a draft reviewable when workflow creation fails', async () => {
     const submitError = 'Task "make-selected-lists-scroll" uses "autoFix", which is no longer supported.';
     mock.api.planningChatSend = vi.fn(async () => ({
       ok: true,
@@ -818,36 +813,27 @@ describe('Invoker terminal (component)', () => {
     submitPlanningText('draft the full plan');
     await screen.findByTestId('invoker-terminal-ready-bar');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
+    fireEvent.click(await screen.findByTestId('planning-create-workflow'));
 
-    const errorPanel = await screen.findByTestId('invoker-terminal-submit-error');
-    expect(errorPanel).toHaveTextContent('Plan could not be submitted');
-    expect(errorPanel).toHaveTextContent(submitError);
-    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(`Plan could not be submitted: ${submitError}`);
-    expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('draft ready · "Selected lists scroll" · 4 tasks');
+    expect(screen.getByTestId('planning-create-workflow')).toBeInTheDocument();
     expect(mock.api.refreshTaskGraph).not.toHaveBeenCalled();
 
-    fireEvent.click(within(errorPanel).getByRole('button', { name: 'Retry submit' }));
+    fireEvent.click(screen.getByTestId('planning-create-workflow'));
 
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(2);
       expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
-      expect(screen.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page');
-      expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
-      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. Review it, then use Start ready work.');
     });
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+    expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. Review it, then use Start ready work.');
     expect(screen.queryByRole('heading', { name: 'Plan graph' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Submit to Invoker' })).not.toBeInTheDocument();
-    expect(screen.queryByTestId('invoker-terminal-submit-error')).not.toBeInTheDocument();
   });
 
-  it('surfaces a planner failure on the first message even before a draft exists', async () => {
-    // Regression: the "Planner could not respond" error card used to be nested
-    // inside the draft-ready branch, so a first-message failure (the common
-    // case) hid the raw error message behind only a red transcript line. The
-    // card must now render as soon as the send fails, even when no draft plan
-    // exists yet, so users see the full stderr tail and the Copy error button.
+  it('surfaces a planner failure in the transcript before a draft exists', async () => {
     const plannerError = 'agent exited 0 but produced no output after 3 attempts — stderr tail: cursor: session expired; run `cursor login` to re-authenticate';
     mock.api.planningChatSend = vi.fn(async () => ({ ok: false, sessionId: 'session-1', error: plannerError })) as any;
 
@@ -856,12 +842,9 @@ describe('Invoker terminal (component)', () => {
 
     submitPlanningText('Draft me an Invoker plan');
 
-    const errorPanel = await screen.findByTestId('invoker-terminal-submit-error');
-    expect(errorPanel).toHaveTextContent('Planner could not respond');
-    expect(errorPanel).toHaveTextContent(plannerError);
-    expect(within(errorPanel).getByRole('button', { name: 'Keep chatting' })).toBeInTheDocument();
-    expect(within(errorPanel).getByRole('button', { name: 'Copy error' })).toBeInTheDocument();
-    expect(within(errorPanel).queryByRole('button', { name: 'Retry submit' })).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(plannerError);
+    });
     expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
   });
 
@@ -889,7 +872,8 @@ describe('Invoker terminal (component)', () => {
 
     submitPlanningText('draft the full plan');
     await screen.findByTestId('invoker-terminal-ready-bar');
-    fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
+    fireEvent.click(await screen.findByTestId('planning-create-workflow'));
     await waitFor(() => expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' }));
 
     fireEvent.click(screen.getByTestId('sidebar-home'));

--- a/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
@@ -30,6 +30,9 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
 
   async function openPlanningTerminal() {
     fireEvent.click(await screen.findByTestId('sidebar-home'));
+    const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+    if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+    fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
     });
@@ -67,7 +70,8 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
 
     submitPlanningText('draft the full plan');
     await screen.findByTestId('invoker-terminal-ready-bar');
-    fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
+    fireEvent.click(await screen.findByTestId('planning-create-workflow'));
 
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });
@@ -97,7 +101,7 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
 
     const stream = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(stream).toHaveAttribute('data-state', 'streaming');
-    expect(stream).toHaveTextContent('live planner thinking after submit');
+    expect(stream).toHaveTextContent('Drafting your plan…');
 
     await act(async () => {
       resolveSecondSend?.({
@@ -111,7 +115,6 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('invoker-terminal-planner-stream')).not.toBeInTheDocument();
       expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Final assistant reply for the new turn.');
-      expect(screen.getByTestId('invoker-terminal-transcript')).not.toHaveTextContent('live planner thinking after submit');
     });
   });
 });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -56,7 +56,6 @@ interface InvokerTerminalProps {
     taskGroups?: { workflow: string | null; tasks: string[] }[];
   };
   planningStream?: InvokerTerminalPlanningStream | null;
-  submitError?: SubmitErrorView | null;
   readOnly?: boolean;
   expanded?: boolean;
   mode?: PlanningTerminalMode;
@@ -65,22 +64,13 @@ interface InvokerTerminalProps {
   terminalError?: string | null;
   onValueChange: (value: string) => void;
   onSubmit: () => void;
-  onSubmitDraft: () => void;
   onPresetChange: (presetKey: string) => void;
   onModeChange?: (mode: PlanningTerminalMode) => void;
   onExpand: () => void;
   onCloseExpanded?: () => void;
-  onCollapse?: () => void;
   onOpenGraph?: () => void;
-  onFinishSetup?: () => void;
-  setupIncomplete?: boolean;
   submittedPlanName?: string;
   activeConversationKey: string;
-}
-
-interface SubmitErrorView {
-  title: string;
-  message: string;
 }
 
 function roleLabel(role: InvokerTerminalLine['role']): string {
@@ -119,17 +109,14 @@ function MessageBody({ text, toneClass }: { text: string; toneClass: string }): 
       {segments.map((segment, index) => {
         if (segment.kind === 'code') {
           return (
-            <pre
-              key={`code-${index}`}
-              className="overflow-x-auto rounded-lg border border-border bg-card/80 px-3 py-2.5 font-mono text-[12px] leading-5 text-foreground"
-            >
-              {segment.language ? (
-                <div className="mb-1.5 font-sans text-[10px] uppercase tracking-wide text-muted-foreground">
-                  {segment.language}
-                </div>
-              ) : null}
-              <code className="whitespace-pre">{segment.text.replace(/\n$/, '')}</code>
-            </pre>
+            <details key={`code-${index}`} className="rounded-lg border border-border bg-card/80">
+              <summary className="cursor-pointer select-none px-3 py-2 text-xs font-medium text-muted-foreground hover:text-foreground">
+                {segment.language ? `View ${segment.language.toUpperCase()}` : 'View details'}
+              </summary>
+              <pre className="overflow-x-auto border-t border-border px-3 py-2.5 font-mono text-[12px] leading-5 text-foreground">
+                <code className="whitespace-pre">{segment.text.replace(/\n$/, '')}</code>
+              </pre>
+            </details>
           );
         }
         const prose = segment.text.replace(/^\n+|\n+$/g, '');
@@ -341,7 +328,6 @@ export function InvokerTerminal({
   draftPlanAvailable,
   draftPlanSummary,
   planningStream,
-  submitError,
   readOnly = false,
   expanded = false,
   mode = 'chat',
@@ -350,15 +336,11 @@ export function InvokerTerminal({
   terminalError = null,
   onValueChange,
   onSubmit,
-  onSubmitDraft,
   onPresetChange,
   onModeChange,
   onExpand,
   onCloseExpanded,
-  onCollapse,
   onOpenGraph,
-  onFinishSetup,
-  setupIncomplete = false,
   submittedPlanName,
   activeConversationKey,
 }: InvokerTerminalProps): JSX.Element {
@@ -366,6 +348,7 @@ export function InvokerTerminal({
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const transcriptRef = useRef<HTMLDivElement | null>(null);
   const [shouldFollowTranscript, setShouldFollowTranscript] = useState(true);
+  const [showComposerOptions, setShowComposerOptions] = useState(false);
   const inputSequenceRef = useRef(0);
   const latestLineCountRef = useRef(lines.length);
   const perfContextRef = useRef({ activeConversationKey, expanded });
@@ -424,6 +407,13 @@ export function InvokerTerminal({
       readOnly,
     });
   }, [activeConversationKey, busy, expanded, lines.length, readOnly, value]);
+
+  useLayoutEffect(() => {
+    const input = inputRef.current;
+    if (!input || expanded) return;
+    input.style.height = '0px';
+    input.style.height = `${Math.min(input.scrollHeight, 144)}px`;
+  }, [expanded, value]);
 
   useLayoutEffect(() => {
     const lastLine = lines.at(-1);
@@ -542,19 +532,6 @@ export function InvokerTerminal({
             <div className="text-[11px] font-medium tracking-wide text-muted-foreground">
               {roleLabel(line.role)}
             </div>
-            {line.reasoning ? (
-              <details
-                data-testid="invoker-terminal-thinking"
-                className="rounded-md border border-border/60 bg-background/40 px-2.5 py-1.5 text-muted-foreground"
-              >
-                <summary className="cursor-pointer select-none text-[11px] text-muted-foreground">
-                  Thinking
-                </summary>
-                <div className="mt-1 whitespace-pre-wrap font-sans text-[12px] leading-5 text-muted-foreground">
-                  {line.reasoning}
-                </div>
-              </details>
-            ) : null}
             <MessageBody text={line.text} toneClass={toneClass} />
           </div>
         );
@@ -563,21 +540,14 @@ export function InvokerTerminal({
         <div
           data-testid="invoker-terminal-planner-stream"
           data-state={planningStream.status}
-          className={`rounded-xl border px-3.5 py-2.5 ${
+          className={`flex items-center gap-2 text-xs ${
             planningStream.status === 'failed'
-              ? 'border-destructive/50 bg-destructive/10'
-              : 'border-border-strong bg-card/70'
+              ? 'text-destructive'
+              : 'text-muted-foreground'
           }`}
         >
-          <div className="flex items-center justify-between gap-3">
-            <div className="text-[11px] font-medium text-muted-foreground">Planner stream</div>
-            <div className={`text-[11px] ${planningStream.status === 'failed' ? 'text-destructive' : 'text-muted-foreground'}`}>
-              {planningStream.status === 'failed' ? 'failed' : 'live'}
-            </div>
-          </div>
-          <div className={`mt-2 whitespace-pre-wrap font-sans text-[13.5px] leading-6 ${planningStream.status === 'failed' ? 'text-destructive' : 'text-foreground'}`}>
-            {planningStream.text}
-          </div>
+          <span aria-hidden="true" className={planningStream.status === 'failed' ? '' : 'animate-pulse'}>●</span>
+          <span>{planningStream.status === 'failed' ? 'Planning stopped. Try again when ready.' : 'Drafting your plan…'}</span>
         </div>
       ) : null}
     </>
@@ -609,18 +579,9 @@ export function InvokerTerminal({
                 onClick={() => onModeChange('tmux')}
                 className={`border-l border-border px-2.5 py-1 text-xs ${mode === 'tmux' ? 'bg-secondary text-foreground' : 'text-muted-foreground hover:bg-secondary/60 hover:text-foreground'}`}
               >
-                tmux
+                Tmux
               </button>
             </div>
-          )}
-          {mode === 'chat' && busy && (
-            <span className="text-[11px] text-muted-foreground">working…</span>
-          )}
-          {mode === 'tmux' && terminalBusy && (
-            <span className="text-[11px] text-muted-foreground">starting…</span>
-          )}
-          {mode === 'chat' && readOnly && (
-            <span className="text-[11px] text-muted-foreground">submitted</span>
           )}
           {expanded ? (
             <button
@@ -632,26 +593,14 @@ export function InvokerTerminal({
               Close
             </button>
           ) : (
-            <>
-              {onCollapse && (
-                <button
-                  type="button"
-                  aria-label="Collapse planning chat"
-                  onClick={onCollapse}
-                  className="rounded-sm border border-border px-2.5 py-1 text-xs text-muted-foreground hover:border-border-strong hover:text-foreground"
-                >
-                  Collapse
-                </button>
-              )}
-              <button
-                type="button"
-                aria-label="Expand planning chat"
-                onClick={onExpand}
-                className="rounded-sm border border-border px-2.5 py-1 text-xs text-muted-foreground hover:border-border-strong hover:text-foreground"
-              >
-                Expand
-              </button>
-            </>
+            <button
+              type="button"
+              aria-label="Expand planning chat"
+              onClick={onExpand}
+              className="rounded-sm border border-border px-2.5 py-1 text-xs text-muted-foreground hover:border-border-strong hover:text-foreground"
+            >
+              Expand
+            </button>
           )}
         </div>
       </div>
@@ -690,111 +639,31 @@ export function InvokerTerminal({
                     </button>
                   ))}
                 </div>
-                {setupIncomplete && onFinishSetup && (
-                  <div className="rounded-md border border-amber-700/50 bg-amber-950/30 px-3 py-2 text-xs text-amber-100">
-                    <div className="font-medium">Finish setup once, then plan from here.</div>
-                    <button
-                      type="button"
-                      data-testid="invoker-terminal-finish-setup"
-                      onClick={onFinishSetup}
-                      className="mt-2 rounded-md bg-amber-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-amber-500"
-                    >
-                      Finish setup
-                    </button>
-                  </div>
-                )}
               </div>
             ) : (
               transcriptContent
             )}
           </div>
 
-          {submitError && !readOnly && (
-            <div
-              data-testid="invoker-terminal-submit-error"
-              className="sticky bottom-0 z-10 border-t border-destructive/40 bg-background px-4 py-3 text-destructive-foreground"
-            >
-              <div className="text-sm font-medium text-destructive">{submitError.title}</div>
-              <div className="mt-2 whitespace-pre-wrap font-sans text-xs leading-5 text-destructive/90">{submitError.message}</div>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {draftPlanAvailable && (
-                  <button
-                    type="button"
-                    onClick={onSubmitDraft}
-                    disabled={busy}
-                    className="rounded-sm bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground hover:bg-destructive/85 disabled:cursor-wait disabled:opacity-50"
-                  >
-                    Retry submit
-                  </button>
-                )}
-                <button
-                  type="button"
-                  onClick={focusComposer}
-                  className="rounded-sm border border-border px-3 py-1.5 text-xs text-muted-foreground hover:border-border-strong hover:text-foreground"
-                >
-                  Keep chatting
-                </button>
-                <button
-                  type="button"
-                  onClick={() => void navigator.clipboard?.writeText(submitError.message)}
-                  className="rounded-sm border border-border px-3 py-1.5 text-xs text-muted-foreground hover:border-border-strong hover:text-foreground"
-                >
-                  Copy error
-                </button>
-              </div>
-            </div>
-          )}
-
           {draftPlanAvailable && !readOnly && (
             <div
               data-testid="invoker-terminal-ready-bar"
               className="sticky bottom-0 z-10 border-t border-border bg-card/80 px-4 py-3.5 text-sm text-foreground backdrop-blur-sm"
             >
-              <div className="mb-1 text-sm font-semibold tracking-tight text-foreground">Plan draft ready</div>
               <p className="mb-3 text-xs text-muted-foreground">
                 {draftPlanSummary
-                  ? `draft ready · "${draftPlanSummary.name}" · ${draftPlanSummary.workflowCount && draftPlanSummary.workflowCount > 1 ? `${draftPlanSummary.workflowCount} workflows · ${draftPlanSummary.taskCount} task${draftPlanSummary.taskCount === 1 ? '' : 's'}` : `${draftPlanSummary.taskCount} task${draftPlanSummary.taskCount === 1 ? '' : 's'}`}`
-                  : 'draft ready'}
+                  ? `Draft ready · ${draftPlanSummary.name} · ${draftPlanSummary.workflowCount && draftPlanSummary.workflowCount > 1 ? `${draftPlanSummary.workflowCount} workflows · ${draftPlanSummary.taskCount} task${draftPlanSummary.taskCount === 1 ? '' : 's'}` : `${draftPlanSummary.taskCount} task${draftPlanSummary.taskCount === 1 ? '' : 's'}`}`
+                  : 'Draft ready'}
               </p>
-              {draftPlanSummary?.taskGroups && draftPlanSummary.taskGroups.length > 0 && (
-                <div
-                  data-testid="invoker-terminal-plan-tasks"
-                  className="mb-3 max-h-52 overflow-y-auto rounded-lg border border-border/70 bg-background/60 px-3 py-2 pr-1"
-                >
-                  {draftPlanSummary.taskGroups.map((group, groupIndex) => (
-                    <div key={group.workflow ?? `group-${groupIndex}`} className="mb-2 last:mb-0">
-                      {group.workflow ? (
-                        <div className="text-xs font-semibold text-foreground">{group.workflow}</div>
-                      ) : null}
-                      <ul className={group.workflow ? 'mt-0.5 border-l border-border-strong pl-3' : ''}>
-                        {group.tasks.map((task, taskIndex) => (
-                          <li key={taskIndex} className="flex gap-2 text-xs text-muted-foreground">
-                            <span aria-hidden="true">–</span>
-                            <span>{task}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  ))}
-                </div>
-              )}
               <div className="flex flex-wrap items-center gap-2">
-                <button
-                  type="button"
-                  onClick={onSubmitDraft}
-                  disabled={busy}
-                  className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-wait disabled:opacity-50"
-                >
-                  Submit to Invoker
-                </button>
                 {onOpenGraph && (
                   <button
                     type="button"
                     data-testid="invoker-terminal-open-graph"
                     onClick={onOpenGraph}
-                    className="rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground hover:border-border-strong hover:text-foreground"
+                    className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
                   >
-                    Open graph
+                    Review draft
                   </button>
                 )}
                 <button
@@ -833,33 +702,45 @@ export function InvokerTerminal({
             className="border-t border-border bg-background px-4 py-3.5"
             onSubmit={handleFormSubmit}
           >
-            <div className="rounded-xl border border-border bg-card/40 px-3 py-2 focus-within:border-border-strong">
+            <div className="rounded-xl border border-border bg-card/40 px-3 py-1.5 focus-within:border-border-strong">
               <textarea
                 ref={inputRef}
                 data-testid="invoker-terminal-input"
                 value={value}
                 disabled={busy || readOnly}
-                rows={expanded ? 8 : 3}
+                rows={expanded ? 5 : 1}
                 onChange={handleValueChange}
                 onKeyDown={handleInputKeyDown}
-                placeholder={readOnly ? 'This planning session was already submitted.' : 'Describe the change, ask questions, or say “draft the full plan”.'}
-                className={`min-h-[4.5rem] w-full resize-none border-0 bg-transparent py-1.5 font-sans text-[13.5px] leading-6 text-foreground outline-none placeholder:text-muted-foreground focus:ring-0 ${composerDisabledCursorClass}`}
+                placeholder={readOnly ? 'This planning session was already submitted.' : 'Describe what you want to build'}
+                className={`min-h-9 w-full resize-none border-0 bg-transparent py-1 font-sans text-[13.5px] leading-6 text-foreground outline-none placeholder:text-muted-foreground focus:ring-0 ${composerDisabledCursorClass}`}
               />
-              <div className="mt-1 flex flex-wrap items-center justify-between gap-3 border-t border-border/60 pt-2">
-                <label className="flex items-center gap-2 text-xs text-muted-foreground">
-                  <span>Agent</span>
-                  <select
-                    data-testid="invoker-terminal-harness"
-                    value={selectedPresetKey}
-                    onChange={(event) => onPresetChange(event.target.value)}
-                    disabled={readOnly}
-                    className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none hover:border-border-strong focus:border-ring"
+              <div className="mt-1 flex flex-wrap items-center justify-between gap-3 pt-2">
+                <div>
+                  <button
+                    type="button"
+                    aria-expanded={showComposerOptions}
+                    onClick={() => setShowComposerOptions((visible) => !visible)}
+                    className="text-xs text-muted-foreground hover:text-foreground"
                   >
-                    {presetOptions.map((option) => (
-                      <option key={option.key} value={option.key}>{option.label}</option>
-                    ))}
-                  </select>
-                </label>
+                    Options
+                  </button>
+                  {showComposerOptions && (
+                    <label className="ml-3 text-xs text-muted-foreground">
+                      Agent
+                      <select
+                        data-testid="invoker-terminal-harness"
+                        value={selectedPresetKey}
+                        onChange={(event) => onPresetChange(event.target.value)}
+                        disabled={readOnly}
+                        className="ml-2 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none hover:border-border-strong focus:border-ring"
+                      >
+                        {presetOptions.map((option) => (
+                          <option key={option.key} value={option.key}>{option.label}</option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
+                </div>
                 <button
                   type="submit"
                   aria-label="Send"

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -6,6 +6,7 @@ import {
   AttentionIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
+  GraphIcon,
   InvokerIcon,
   MoonIcon,
   SettingsIcon,
@@ -151,13 +152,13 @@ export function LeftStatusColumn({
       >
         {collapsed ? (
           <div className="relative inline-flex h-9 w-9 items-center justify-center">
-            <span><WorkflowsIcon className={ICON_CLASS} /></span>
+            <span><GraphIcon className={ICON_CLASS} /></span>
           </div>
         ) : (
           <>
             <span className="flex min-w-0 items-center gap-3">
               <span className="inline-flex rounded-md border border-border bg-sidebar-accent/40 p-1.5 text-muted-foreground">
-                <WorkflowsIcon className={ICON_CLASS} />
+                <GraphIcon className={ICON_CLASS} />
               </span>
               <span className="truncate">Plan graph</span>
             </span>

--- a/packages/ui/src/components/icons/index.tsx
+++ b/packages/ui/src/components/icons/index.tsx
@@ -11,6 +11,7 @@ import {
   GitPullRequest,
   Layers,
   Moon,
+  Network,
   Play,
   Settings,
   Sun,
@@ -37,6 +38,7 @@ export const AttentionIcon = withDefaults(AlertTriangle);
 export const RunningIcon = withDefaults(Clock);
 export const WorkerIcon = withDefaults(Cpu);
 export const WorkflowsIcon = withDefaults(Layers);
+export const GraphIcon = withDefaults(Network);
 export const PlanningTerminalIcon = withDefaults(TerminalSquare);
 export const SettingsIcon = withDefaults(Settings);
 export const InvokerIcon = withDefaults(Compass);


### PR DESCRIPTION
## Summary

Planning now opens around the active conversation, while navigation and plan context stay available as compact rails.

The composer shows the task first and keeps optional agent controls and raw YAML out of the default reading path.

## Review Claim

Planning chat has one calm primary surface, with explicit expansion and review controls rather than duplicated status, phase, and configuration chrome.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Chat and tmux remain peer modes, review still precedes workflow creation, and no workflow is created by the planning walkthrough.

## Slice Rationale

This isolates the final planning-shell interaction changes from the upcoming Workers redesign, so each user-facing flow can be reviewed independently.

## Non-goals

- Does not change planner request, draft validation, or workflow runtime behavior.
- Does not change worker controls or the workflow graph data model.

## Architecture

### Before

Planning exposed phase, agent, stream, and draft information across the main surface and side panels, competing with the conversation.

### After

The conversation is primary. Rails and advanced composer controls are explicit disclosures, and draft review is the only transition into the graph.

```mermaid
flowchart LR
  NavRail["Navigation rail"] --> Planning["Planning chat"]
  SessionRail["Planning session rail"] --> Planning
  Planning --> Composer["Compact composer"]
  Planning --> DraftReview["Review draft"]
  DraftReview --> Graph["Plan graph"]
  ContextRail["Collapsed current plan rail"] --> Graph
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --dir packages/ui test`
- [x] `pnpm --dir packages/app run test:e2e -- planning-chat-typography-demo.spec.ts`
- [x] `bash scripts/ui-visual-proof.sh capture-after --spec planning-chat-typography-demo.spec.ts --output-dir .tmp/planning-home-ux-proof`
- [x] `pnpm --dir packages/ui build`
- [x] `pnpm --dir packages/app build`

</details>

## Visual Proof

Planning empty state starts with the conversation and session rail visible while navigation and Current plan are compact.

![Planning empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-de5d47/demo-planning-empty.png)

Draft review keeps the creation boundary explicit without submitting a workflow.

![Planning review draft](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-de5d47/demo-planning-review-draft.png)

Walkthrough of typing, drafting, opening YAML, and reviewing the draft without creating a workflow.

[Planning walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-de5d47/walkthrough.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a1c9d27`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #5070