### PR TITLE
[Planning Chat Hitch Proof Gate](1) Prove planning chat send IPC responsiveness

### DIFF
--- a/docs/architecture/main-process-read-hot-paths.md
+++ b/docs/architecture/main-process-read-hot-paths.md
@@ -1,0 +1,27 @@
+# Main-Process Read Hot Paths
+
+The Electron main process owns persistence, workflow state, and IPC handlers. Cheap reads must stay cheap even when an unrelated UI action is doing heavier work.
+
+## Current Cheap Probe
+
+`invoker:list-workflows` is the primary read hot path used by responsiveness gates. It returns workflow metadata and rollups through the normal renderer IPC bridge. Because it is cheap and common, delayed `listWorkflows` round trips are a strong signal that the main process is blocked by synchronous work elsewhere.
+
+## Planning Chat Send
+
+`invoker:planning-chat-send` is a main-process responsiveness hot path. It restores and persists `PlanConversation` state through the conversation repository, builds the planner prompt, and waits for the planner response. The planner/model wait is asynchronous, but transcript load, prompt construction, and persistence bookkeeping run on the main process.
+
+The main risk is full-transcript persistence work during a send. With a long planning history, reloading or rewriting every message can block the main process and delay unrelated reads such as `listWorkflows`. That is the same failure mode users experience as a beachball: the renderer may still be painted, but its IPC calls queue behind main-process synchronous work.
+
+## Gate Coverage
+
+`packages/app/e2e/planning-chat-hitch-responsiveness.spec.ts` covers this path by seeding long transcript pressure, opening the planning chat, sending one deterministic planner message, and sampling `listWorkflows` while the send is in flight.
+
+The gate fails if:
+
+- p95 `listWorkflows` RTT exceeds 150 ms,
+- max `listWorkflows` RTT exceeds 750 ms,
+- the send path does not append the user and assistant turn deterministically.
+
+This maps the persistence invariant to user-visible responsiveness: planning chat send may append a turn and build a prompt, but it must not perform main-thread full-history replay work that stalls unrelated workflow reads.
+
+See also: [UI action responsiveness invariant](./ui-action-responsiveness-invariant.md).

--- a/docs/architecture/ui-action-responsiveness-invariant.md
+++ b/docs/architecture/ui-action-responsiveness-invariant.md
@@ -1,0 +1,31 @@
+# UI Action Responsiveness Invariant
+
+Invoker desktop UI actions must not monopolize the Electron main process. A renderer action may perform durable work, but it must keep unrelated cheap IPC reads responsive while that work is in flight.
+
+## Invariant
+
+For user-triggered main-process actions, cheap read IPC must continue to round-trip within explicit hitch budgets while the action is running. The current cheap probe is `window.invoker.listWorkflows()`, because it exercises the renderer-to-main IPC path and the workflow metadata read path without starting task execution.
+
+The responsiveness budget is:
+
+- p95 `listWorkflows` RTT at or below 150 ms.
+- max `listWorkflows` RTT at or below 750 ms.
+
+These budgets are intended to catch main-process stalls before they become visible macOS beachballs or Linux compositor freezes. A single long synchronous database replay, transcript serialization pass, or terminal/session upsert can block all renderer IPC even when the renderer itself is healthy.
+
+## Planning Chat Gate
+
+`packages/app/e2e/planning-chat-hitch-responsiveness.spec.ts` is the planning-specific proof gate. It:
+
+- seeds a long persisted planning transcript before measurement,
+- opens the planning chat so the transcript is restored,
+- starts `planningChatSend` with a deterministic test response override,
+- samples `listWorkflows` RTT while the send is in flight,
+- asserts p95 and max RTT against the hitch budgets,
+- emits one JSON evidence line named `planning_chat_hitch_responsiveness`.
+
+The test has no model or network dependency. The deterministic response override keeps the send alive long enough to sample IPC while preserving the real prompt construction and conversation persistence path.
+
+## Beachball Mapping
+
+`planningChatSend` is a hot UI action because it runs in the Electron main process and touches a potentially large persisted transcript. Regressions that reload or rewrite the full transcript during send can block unrelated IPC and make the window appear hung. The gate proves that long-transcript planning sends only do bounded synchronous work on the main thread and keep cheap workflow reads responsive.

--- a/packages/app/e2e/planning-chat-hitch-responsiveness.spec.ts
+++ b/packages/app/e2e/planning-chat-hitch-responsiveness.spec.ts
@@ -1,0 +1,176 @@
+import { _electron as electron, expect, test } from '@playwright/test';
+import { resolveRepoRoot } from '@invoker/contracts';
+import * as fs from 'node:fs/promises';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { tmpdir } from 'node:os';
+import { stringify as yamlStringify } from 'yaml';
+
+import { E2E_REPO_URL } from './fixtures/electron-app.js';
+
+const repoRoot = resolveRepoRoot(__dirname);
+const TRANSCRIPT_MESSAGE_COUNT = 2_000;
+const TRANSCRIPT_CONTENT_BYTES = 2_048;
+const PLANNING_RESPONSE_DELAY_MS = 900;
+const SAMPLE_DELAY_MS = 20;
+const MIN_RTT_SAMPLES = 18;
+const P95_RTT_BUDGET_MS = 150;
+const MAX_RTT_BUDGET_MS = 750;
+
+async function launchElectronApp(testDir: string) {
+  const claudeMarker = path.join(repoRoot, 'scripts', 'e2e-dry-run', 'fixtures', 'claude-marker.sh');
+  const stubDir = path.join(testDir, 'claude-stub');
+  const markerRoot = path.join(testDir, 'e2e-markers');
+  const configPath = path.join(testDir, 'e2e-config.json');
+  const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+  await fs.mkdir(stubDir, { recursive: true });
+  await fs.mkdir(markerRoot, { recursive: true });
+  writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0 }), 'utf8');
+  try {
+    await fs.symlink(claudeMarker, path.join(stubDir, 'claude'));
+  } catch {
+    // Ignore symlink failures on restricted platforms.
+  }
+  return electron.launch({
+    args: [
+      ...(process.platform === 'linux'
+        ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-gpu-compositing', '--disable-gpu-sandbox', '--disable-software-rasterizer']
+        : []),
+      path.resolve(__dirname, '..', 'dist', 'main.js'),
+    ],
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      TZ: 'UTC',
+      INVOKER_DB_DIR: testDir,
+      INVOKER_IPC_SOCKET: ipcSocketPath,
+      INVOKER_ALLOW_DELETE_ALL: '1',
+      INVOKER_E2E_ENABLE_COMPOSITOR: '1',
+      INVOKER_REPO_CONFIG_PATH: configPath,
+      INVOKER_E2E_MARKER_ROOT: markerRoot,
+      INVOKER_CLAUDE_COMMAND: claudeMarker,
+      INVOKER_CLAUDE_FIX_COMMAND: claudeMarker,
+      INVOKER_TEST_PLANNING_CHAT_RESPONSE: 'Planner deterministic e2e response.',
+      INVOKER_TEST_PLANNING_CHAT_RESPONSE_DELAY_MS: String(PLANNING_RESPONSE_DELAY_MS),
+      PATH: `${stubDir}${path.delimiter}${process.env.PATH ?? ''}`,
+    },
+  });
+}
+
+function buildWorkflow(index: number) {
+  return {
+    name: `Planning Chat RTT Probe ${index}`,
+    repoUrl: E2E_REPO_URL,
+    onFinish: 'none' as const,
+    tasks: Array.from({ length: 4 }, (_, taskIndex) => ({
+      id: `probe-${index}-${taskIndex}`,
+      description: `Probe task ${index}-${taskIndex}`,
+      command: `echo probe-${index}-${taskIndex}`,
+      dependencies: taskIndex === 0 ? [] : [`probe-${index}-${taskIndex - 1}`],
+    })),
+  };
+}
+
+function percentile(values: number[], percentileRank: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil((percentileRank / 100) * sorted.length) - 1);
+  return sorted[index];
+}
+
+test('planning chat send under long transcript pressure does not hitch cheap main-process IPC', async () => {
+  const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-planning-chat-hitch-'));
+  try {
+    const app = await launchElectronApp(testDir);
+    try {
+      const page = await app.firstWindow({ timeout: 10000 });
+      await page.waitForLoadState('domcontentloaded');
+      await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10000 });
+
+      for (let index = 0; index < 6; index += 1) {
+        await page.evaluate((planText) => window.invoker.loadPlan(planText), yamlStringify(buildWorkflow(index)));
+      }
+      await expect.poll(
+        () => page.evaluate(() => window.invoker.listWorkflows().then((workflows) => workflows.length)),
+        { timeout: 10000 },
+      ).toBe(6);
+
+      const threadTs = 'planning-chat-hitch-proof';
+      const openResult = await page.evaluate(async ({ threadTs, messageCount, contentBytes }) => {
+        const seedTranscript = window.invoker.planningChatSeedTranscript;
+        if (!seedTranscript) {
+          throw new Error('planningChatSeedTranscript test helper is unavailable');
+        }
+        await seedTranscript(threadTs, messageCount, contentBytes);
+        return window.invoker.planningChatOpen(threadTs);
+      }, {
+        threadTs,
+        messageCount: TRANSCRIPT_MESSAGE_COUNT,
+        contentBytes: TRANSCRIPT_CONTENT_BYTES,
+      });
+      expect(openResult.messageCount).toBe(TRANSCRIPT_MESSAGE_COUNT);
+
+      const result = await page.evaluate(async ({ threadTs, sampleDelayMs, minSamples }) => {
+        const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+        const sendStartedAt = performance.now();
+        let sendDone = false;
+        const sendPromise = window.invoker
+          .planningChatSend(threadTs, 'Summarize the next implementation step.')
+          .finally(() => {
+            sendDone = true;
+          });
+
+        const rtts: number[] = [];
+        while ((!sendDone || rtts.length < minSamples) && performance.now() - sendStartedAt < 10_000) {
+          const startedAt = performance.now();
+          await window.invoker.listWorkflows();
+          rtts.push(performance.now() - startedAt);
+          await sleep(sampleDelayMs);
+        }
+
+        const sendResult = await sendPromise;
+        return {
+          rtts,
+          sendElapsedMs: performance.now() - sendStartedAt,
+          sendResult,
+        };
+      }, {
+        threadTs,
+        sampleDelayMs: SAMPLE_DELAY_MS,
+        minSamples: MIN_RTT_SAMPLES,
+      });
+
+      const p95RttMs = percentile(result.rtts, 95);
+      const maxRttMs = Math.max(...result.rtts);
+      const evidence = {
+        metric: 'planning_chat_hitch_responsiveness',
+        transcriptMessageCount: TRANSCRIPT_MESSAGE_COUNT,
+        transcriptContentBytes: TRANSCRIPT_CONTENT_BYTES,
+        workflowCount: 6,
+        sampleCount: result.rtts.length,
+        p95RttMs: Math.round(p95RttMs),
+        maxRttMs: Math.round(maxRttMs),
+        sendElapsedMs: Math.round(result.sendElapsedMs),
+        p95BudgetMs: P95_RTT_BUDGET_MS,
+        maxBudgetMs: MAX_RTT_BUDGET_MS,
+      };
+      console.log(JSON.stringify(evidence));
+
+      expect(result.sendResult.reply).toBe('Planner deterministic e2e response.');
+      expect(result.sendResult.messageCount).toBe(TRANSCRIPT_MESSAGE_COUNT + 2);
+      expect(result.rtts.length).toBeGreaterThanOrEqual(MIN_RTT_SAMPLES);
+      expect(
+        p95RttMs,
+        `p95 listWorkflows RTT ${p95RttMs.toFixed(1)}ms exceeded ${P95_RTT_BUDGET_MS}ms (max=${maxRttMs.toFixed(1)}ms, n=${result.rtts.length})`,
+      ).toBeLessThanOrEqual(P95_RTT_BUDGET_MS);
+      expect(
+        maxRttMs,
+        `max listWorkflows RTT ${maxRttMs.toFixed(1)}ms exceeded ${MAX_RTT_BUDGET_MS}ms (p95=${p95RttMs.toFixed(1)}ms, n=${result.rtts.length})`,
+      ).toBeLessThanOrEqual(MAX_RTT_BUDGET_MS);
+    } finally {
+      await app.close();
+    }
+  } finally {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -228,6 +228,9 @@ let hourlyBackupInterval: ReturnType<typeof setInterval> | null = null;
 let writerLock: DbWriterLockResult | null = null;
 const workflowMutationOwnerId = `owner-${process.pid}-${Date.now()}`;
 const appProcessStartedAt = Date.now();
+let planningConversationRepo: ConversationRepository | null = null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const planningConversations = new Map<string, any>();
 
 interface GuiMutationPayload {
   channel: string;
@@ -460,6 +463,67 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
 function loadSurfaces(): any {
   const req = createRequire(__filename);
   return req('@invoker/surfaces');
+}
+
+function logPlanningConversation(source: string, level: string, message: string): void {
+  const module = source || 'plan-conversation';
+  if (level === 'error') {
+    logger.error(message, { module });
+  } else if (level === 'warn') {
+    logger.warn(message, { module });
+  } else {
+    logger.info(message, { module });
+  }
+}
+
+function getPlanningConversationRepo(): ConversationRepository {
+  if (!planningConversationRepo) {
+    planningConversationRepo = new ConversationRepository(persistence, {
+      info: (msg) => logger.info(msg, { module: 'conversation-repo' }),
+      warn: (msg) => logger.warn(msg, { module: 'conversation-repo' }),
+      error: (msg) => logger.error(msg, { module: 'conversation-repo' }),
+    });
+  }
+  return planningConversationRepo;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getPlanningConversation(threadTs: string): any {
+  const existing = planningConversations.get(threadTs);
+  if (existing) return existing;
+
+  const surfaces = loadSurfaces();
+  const testOverrideResponse = process.env.NODE_ENV === 'test'
+    ? process.env.INVOKER_TEST_PLANNING_CHAT_RESPONSE
+    : undefined;
+  const testOverrideDelayMs = Number(process.env.INVOKER_TEST_PLANNING_CHAT_RESPONSE_DELAY_MS ?? 0);
+  const timeoutMs = invokerConfig.planningTimeoutSeconds
+    ? invokerConfig.planningTimeoutSeconds * 1000
+    : undefined;
+  const conversation = new surfaces.PlanConversation({
+    threadTs,
+    conversationRepo: getPlanningConversationRepo(),
+    cursorCommand: process.env.CURSOR_COMMAND ?? 'agent',
+    model: process.env.CURSOR_MODEL,
+    workingDir: repoRoot,
+    timeoutMs,
+    defaultBranch: invokerConfig.defaultBranch,
+    repoUrl: process.env.INVOKER_REPO_URL,
+    log: logPlanningConversation,
+    testOverrideResponse,
+    testOverrideDelayMs: Number.isFinite(testOverrideDelayMs) ? testOverrideDelayMs : 0,
+  });
+  planningConversations.set(threadTs, conversation);
+  return conversation;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function planningChatSnapshot(threadTs: string, conversation: any) {
+  return {
+    threadTs,
+    messageCount: Array.isArray(conversation.history) ? conversation.history.length : 0,
+    planSubmitted: Boolean(conversation.planSubmitted),
+  };
 }
 
 // ── Shared Slack Bot Wiring ──────────────────────────────────
@@ -2784,6 +2848,37 @@ if (isHeadless) {
 
     if (process.env.NODE_ENV === 'test') {
       ipcMain.handle(
+        'invoker:planning-chat-seed-transcript',
+        async (_event, threadTsArg: string, messageCountArg: number, contentBytesArg?: number) => {
+          const threadTs = String(threadTsArg);
+          const messageCount = Math.max(0, Math.min(10_000, Math.floor(Number(messageCountArg) || 0)));
+          const contentBytes = Math.max(1, Math.min(8192, Math.floor(Number(contentBytesArg) || 512)));
+          const now = new Date().toISOString();
+          persistence.deleteConversation(threadTs);
+          persistence.saveConversation({
+            threadTs,
+            channelId: 'e2e',
+            userId: 'e2e',
+            extractedPlan: null,
+            planSubmitted: false,
+            createdAt: now,
+            updatedAt: now,
+          });
+          for (let index = 0; index < messageCount; index += 1) {
+            const role = index % 2 === 0 ? 'user' : 'assistant';
+            const prefix = `${role}-${index}:`;
+            const content = `${prefix}${'x'.repeat(Math.max(0, contentBytes - prefix.length))}`;
+            persistence.appendMessage(threadTs, role, JSON.stringify(content));
+          }
+          planningConversations.delete(threadTs);
+          logger.info(
+            `planning-chat-seed-transcript: thread="${threadTs}" messages=${messageCount} contentBytes=${contentBytes}`,
+            { module: 'ipc-test' },
+          );
+          return { threadTs, messageCount };
+        },
+      );
+      ipcMain.handle(
         'invoker:inject-task-states',
         async (_event, updates: Array<{ taskId: string; changes: TaskStateChanges }>) => {
           for (const { taskId, changes } of updates) {
@@ -2898,6 +2993,33 @@ if (isHeadless) {
     });
 
     ipcMain.handle('invoker:list-workflows', () => persistence.listWorkflows());
+    ipcMain.handle('invoker:planning-chat-open', async (_event, threadTsArg?: string) => {
+      const threadTs = typeof threadTsArg === 'string' && threadTsArg.length > 0
+        ? threadTsArg
+        : `planning-chat-${Date.now()}`;
+      const conversation = getPlanningConversation(threadTs);
+      await conversation.init();
+      logger.info(`planning-chat-open: thread="${threadTs}" messages=${conversation.history.length}`, { module: 'ipc' });
+      return planningChatSnapshot(threadTs, conversation);
+    });
+    ipcMain.handle('invoker:planning-chat-send', async (_event, threadTsArg: string, messageArg: string) => {
+      const threadTs = String(threadTsArg);
+      const message = String(messageArg);
+      if (!threadTs) throw new Error('planning-chat-send requires a threadTs');
+      if (!message) throw new Error('planning-chat-send requires a non-empty message');
+
+      const conversation = getPlanningConversation(threadTs);
+      const startedAt = Date.now();
+      logger.info(`planning-chat-send begin: thread="${threadTs}" messageBytes=${Buffer.byteLength(message, 'utf8')}`, { module: 'ipc' });
+      const reply = await conversation.sendMessage(message);
+      const elapsedMs = Date.now() - startedAt;
+      logger.info(`planning-chat-send end: thread="${threadTs}" elapsedMs=${elapsedMs} messages=${conversation.history.length}`, { module: 'ipc' });
+      return {
+        ...planningChatSnapshot(threadTs, conversation),
+        reply,
+        submittedPlanText: conversation.submittedPlanText,
+      };
+    });
     ipcMain.handle('invoker:get-execution-pools', () => Object.keys(loadConfig().executionPools ?? {}));
 
     registerGuiMutationHandler('invoker:delete-all-workflows', async () => {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -253,6 +253,20 @@ export interface SystemDiagnostics {
   bundledSkills?: BundledSkillsStatus;
 }
 
+export interface PlanningChatOpenResult {
+  threadTs: string;
+  messageCount: number;
+  planSubmitted: boolean;
+}
+
+export interface PlanningChatSendResult {
+  threadTs: string;
+  reply: string;
+  messageCount: number;
+  planSubmitted: boolean;
+  submittedPlanText: string | null;
+}
+
 // ── Invoke Channel Registry ─────────────────────────────────
 // Each key is the channel name string; value is { request, response }.
 // `request` is a tuple of the arguments passed after the channel name.
@@ -282,6 +296,14 @@ export const IpcChannels = {
   'invoker:list-workflows': {} as {
     request: [];
     response: WorkflowListEntry[];
+  },
+  'invoker:planning-chat-open': {} as {
+    request: [threadTs?: string];
+    response: PlanningChatOpenResult;
+  },
+  'invoker:planning-chat-send': {} as {
+    request: [threadTs: string, message: string];
+    response: PlanningChatSendResult;
   },
   'invoker:delete-all-workflows': {} as {
     request: [];
@@ -531,6 +553,10 @@ export const IpcTestOnlyChannels = {
   'invoker:inject-task-states': {} as {
     request: [updates: Array<{ taskId: string; changes: TaskStateChanges }>];
     response: void;
+  },
+  'invoker:planning-chat-seed-transcript': {} as {
+    request: [threadTs: string, messageCount: number, contentBytes?: number];
+    response: { threadTs: string; messageCount: number };
   },
 } as const;
 

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -41,6 +41,10 @@ export interface PlanConversationConfig {
   repoUrl?: string;
   /** Logging callback. Defaults to console.log/console.error. */
   log?: LogFn;
+  /** Test-only response override used by deterministic app E2E gates. */
+  testOverrideResponse?: string;
+  /** Optional delay before resolving the test override response. */
+  testOverrideDelayMs?: number;
 }
 
 // ── Confirmation Detection ──────────────────────────────────
@@ -170,6 +174,8 @@ export class PlanConversation {
   private repoUrl?: string;
   private log: LogFn;
   private _initialized = false;
+  private testOverrideResponse?: string;
+  private testOverrideDelayMs: number;
 
   constructor(config: PlanConversationConfig) {
     this.cursorCommand = config.cursorCommand ?? 'agent';
@@ -183,6 +189,8 @@ export class PlanConversation {
     this.log = config.log ?? ((src, lvl, msg) => {
       (lvl === 'error' ? console.error : console.log)(`[${src}] ${msg}`);
     });
+    this.testOverrideResponse = config.testOverrideResponse;
+    this.testOverrideDelayMs = Math.max(0, config.testOverrideDelayMs ?? 0);
   }
 
   /**
@@ -333,6 +341,16 @@ export class PlanConversation {
 
   spawnCursor(prompt: string): Promise<string> {
     const spawnStart = Date.now();
+    if (this.testOverrideResponse !== undefined) {
+      this.log('plan-conversation', 'info', `[PERF] cursor_test_override: promptLen=${prompt.length}, delayMs=${this.testOverrideDelayMs}`);
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          this.log('plan-conversation', 'info', `[PERF] cursor_test_override_exit: elapsed=${Date.now() - spawnStart}ms`);
+          resolve(this.testOverrideResponse ?? '');
+        }, this.testOverrideDelayMs);
+      });
+    }
+
     return new Promise((resolve, reject) => {
       const args = ['--print'];
       if (this.model) args.push('--model', this.model);


### PR DESCRIPTION
## Summary

Adds a deterministic Electron E2E gate for planning chat send responsiveness under a long persisted transcript.

The gate samples cheap workflow-list IPC while a planning send is in flight, proving transcript pressure does not stall unrelated main-process reads.

Docs now name planning chat send as a main-process hot path and record the p95 and max RTT budgets.

## Review Claim

Approve the planning chat responsiveness proof gate and test-only IPC hooks that exercise the real send path without model or network dependency.

## Review Lane

proof

## Review Unit

planning-chat-ipc-responsiveness

## Safety Invariant

The production-facing IPC additions only open and send planning conversations through existing PlanConversation behavior; transcript seeding and the deterministic planner override are limited to NODE_ENV=test.

## Slice Rationale

This slice lands the hitch proof on top of the persistence hot-path fix so reviewers can validate the exact regression budget before any broader planning-chat UI work.

## Non-goals

- Does not change the renderer planning chat UI.
- Does not change planner prompt semantics outside deterministic test overrides.
- Does not tune the persistence fix from the base stack.
- Does not add network or model dependencies to E2E.

## Architecture

### Before

```mermaid
graph TD
    A["Planning chat send path had no dedicated long-transcript hitch gate"]
    B["Cheap workflow-list IPC could regress without a planning-specific proof"]
```

### After

```mermaid
graph TD
    A["E2E seeds a long planning transcript through test-only IPC"]
    B["planningChatSend uses PlanConversation with deterministic test response"]
    C["listWorkflows probes main-process responsiveness while send is in flight"]
    D["p95 and max RTT budgets fail the gate on main-process stalls"]
    A --> B
    B --> C
    C --> D
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test:e2e -- e2e/planning-chat-hitch-responsiveness.spec.ts e2e/startup-nonempty-responsiveness.spec.ts` (workflow task `wf-1784314062542-6/verify-planning-chat-hitch-proof-gate` completed with exit code 0)
- [x] `node scripts/validate-pr-body.mjs --body "$(gh pr view 5079 --repo Neko-Catpital-Labs/Invoker --json body --jq .body)"`
- [x] `mergify stack push --dry-run --trunk origin/plan/planning-chat-persistence-hot-path-fix --repository Neko-Catpital-Labs/Invoker --skip-rebase`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert ec9157ba4`
- Post-revert steps: Re-run the planning chat persistence hot-path tests if the base stack is still active.
- Data migration? No.

</details>
