### PR TITLE
[Planning Terminal Yellow Send Arrow](1) Add arrow-style planning terminal composer

### DIFF
--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1086,4 +1086,33 @@ describe('Invoker terminal (component)', () => {
     await expectSurfaceRailList('attention', 'attention-rail-list');
     expect(screen.queryByTestId('running-rail-list')).not.toBeInTheDocument();
   });
+
+  it('keeps the submit button accessible as Send while rendering an icon-only affordance', () => {
+    render(<InvokerTerminal {...terminalProps({ value: 'draft a plan' })} />);
+
+    const sendButton = screen.getByRole('button', { name: 'Send' });
+    expect(sendButton).toBeEnabled();
+    expect(sendButton).not.toHaveTextContent('Send');
+    expect(within(sendButton).getByTestId('invoker-terminal-send-icon')).toBeInTheDocument();
+  });
+
+  it('uses the amber send-button styling in the enabled state', () => {
+    render(<InvokerTerminal {...terminalProps({ value: 'draft a plan' })} />);
+
+    const sendButton = screen.getByRole('button', { name: 'Send' });
+    expect(sendButton).toHaveClass('bg-amber-400');
+    expect(sendButton).toHaveClass('text-white');
+    expect(sendButton).toHaveClass('hover:bg-amber-300');
+  });
+
+  it('keeps the icon-only Send button disabled for empty input, busy state, and read-only sessions', () => {
+    const { rerender } = render(<InvokerTerminal {...terminalProps({ value: '' })} />);
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+
+    rerender(<InvokerTerminal {...terminalProps({ busy: true, value: 'draft a plan' })} />);
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+
+    rerender(<InvokerTerminal {...terminalProps({ readOnly: true, value: 'draft a plan' })} />);
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+  });
 });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useStat
 import { Terminal as XTermTerminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import type { TerminalSessionDescriptor } from '@invoker/contracts';
-import { Button } from './primitives/index.js';
+import { SendIcon } from './icons/index.js';
 
 export interface InvokerTerminalLine {
   id: number;
@@ -402,6 +402,8 @@ export function InvokerTerminal({
   };
 
   const composerDisabledCursorClass = busy ? 'disabled:cursor-wait' : readOnly ? 'disabled:cursor-not-allowed' : '';
+  const sendButtonDisabled = busy || readOnly || !value.trim();
+  const sendButtonDisabledCursorClass = busy ? 'disabled:cursor-wait' : 'disabled:cursor-not-allowed';
 
   const handleValueChange = (event: ChangeEvent<HTMLTextAreaElement>): void => {
     const startedAt = nowMs();
@@ -720,13 +722,17 @@ export function InvokerTerminal({
                   ))}
                 </select>
               </label>
-              <Button
+              <button
                 type="submit"
-                size="sm"
-                disabled={busy || readOnly || !value.trim()}
+                aria-label="Send"
+                disabled={sendButtonDisabled}
+                className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-amber-400 text-white shadow-sm transition-colors hover:bg-amber-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-amber-300 disabled:bg-gray-700 disabled:text-gray-400 disabled:shadow-none disabled:hover:bg-gray-700 disabled:opacity-50 ${sendButtonDisabledCursorClass}`}
               >
-                Send
-              </Button>
+                <SendIcon
+                  data-testid="invoker-terminal-send-icon"
+                  className="h-4 w-4"
+                />
+              </button>
             </div>
           </form>
         </>

--- a/packages/ui/src/components/icons/index.tsx
+++ b/packages/ui/src/components/icons/index.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react';
+import type { JSX, SVGProps } from 'react';
 import {
   AlertTriangle,
   ChevronDown,
@@ -48,3 +48,16 @@ export const GitPullRequestIcon = withDefaults(GitPullRequest);
 export const GitMergeIcon = withDefaults(GitMerge);
 export const SunIcon = withDefaults(Sun);
 export const MoonIcon = withDefaults(Moon);
+
+export function SendIcon(props: SVGProps<SVGSVGElement>): JSX.Element {
+  return (
+    <svg
+      aria-hidden={props['aria-hidden'] ?? 'true'}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      {...props}
+    >
+      <path d="M2.23 3.27a.75.75 0 0 1 .8-.12l14 6a.75.75 0 0 1 0 1.38l-14 6A.75.75 0 0 1 2 15.84V11l7.24-1L2 9V4.16a.75.75 0 0 1 .23-.89Z" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

Replace the planning terminal composer's text "Send" button with an icon-only, amber-styled affordance (`SendIcon`).

The button keeps its accessible name as `Send` for screen readers and tests, and stays disabled while busy, read-only, or the input is empty. `InvokerTerminal` and its test suite already exist on `master`; this slice only changes the button's rendering.

## Review Claim

Approve replacing the composer's text Send button with an icon-only amber affordance, covered by component tests asserting the accessible `Send` name, amber/white styling, and disabled states.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice only changes the submit button's markup and styling inside `InvokerTerminal.tsx`, plus adds `SendIcon` to the shared icon module. It does not change the composer's submit handlers, guards, or any other component, so existing planning-chat behavior is unaffected.

## Slice Rationale

The button styling change is isolated from the rest of the composer so a reviewer can approve the visual/accessibility change alone.

## Non-goals

- Does not change any existing planning surface behavior, submit guards, or wiring.
- Does not modify workflow execution, plan parsing, or Mergify publication.
- Does not touch any component other than `InvokerTerminal.tsx` and the shared icon module.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- src/__tests__/invoker-terminal.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <squash-merge-sha>`
- Post-revert steps: None; reverting restores the previous text Send button.
- Data migration? No

</details>
