### PR TITLE
[Planning Terminal Yellow Send Arrow](3) Forward focused UI test arguments

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "NODE_OPTIONS='--max-old-space-size=512' vite build",
-    "test": "vitest run"
+    "test": "sh -c 'vitest run \"$@\"'"
   },
   "dependencies": {
     "@invoker/contracts": "workspace:*",


### PR DESCRIPTION
## Summary

This slice makes the UI package test script forward Vitest filters from pnpm.

Reviewers can run the planning terminal component spec directly through the package-level test command.

## Review Claim

Approve the UI package test script forwarding change so focused Vitest paths work through `pnpm --filter @invoker/ui test -- ...`.

## Review Lane

policy

## Review Unit

ui-test-command

## Safety Invariant

The script still runs `vitest run`; it only forwards positional arguments through the shell wrapper. The focused package command passed after the change.

## Slice Rationale

This stays separate from the component slices because it changes the review and verification command surface, not terminal UI behavior.

## Non-goals

This does not change Vitest configuration, add dependencies, alter package build output, or broaden the workspace test suite.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c02fc1368`
- Post-revert steps: Use `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx` for focused local runs.
- Data migration? No

</details>