### PR TITLE
[Fix Submit-to-Invoker Auto-Navigation Regression](1) Keep Planning Terminal after submit

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2527,9 +2527,7 @@ export function App() {
       if (result.ok) {
         setPlanningSubmitError(null);
         setHasLoadedPlan(true);
-        setSidebarSurface('home');
         setWorkflowSelectionDismissed(false);
-        setViewMode('dag');
         setGraphActionsMenuOpen(false);
         setPlanName(result.planName);
         setSelectedWorkflowId(result.workflowId);

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -708,10 +708,13 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });
       expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
-      expect(screen.getByText('Plan graph')).toBeInTheDocument();
+      expect(screen.getByTestId('sidebar-planning')).toHaveAttribute('aria-current', 'page');
+      expect(screen.getByRole('heading', { name: 'Planning chat window' })).toBeInTheDocument();
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
     });
-    fireEvent.click(screen.getByTestId('sidebar-planning'));
-    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
+    expect(screen.queryByRole('heading', { name: 'Plan graph' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Submit to Invoker' })).not.toBeInTheDocument();
     expect(mock.api.start).not.toHaveBeenCalled();
   });
 
@@ -761,12 +764,15 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });
       expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
-      expect(screen.getByText('Plan graph')).toBeInTheDocument();
+      expect(screen.getByTestId('sidebar-planning')).toHaveAttribute('aria-current', 'page');
+      expect(screen.getByRole('heading', { name: 'Planning chat window' })).toBeInTheDocument();
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(
+        'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then use Start ready work.',
+      );
     });
-    fireEvent.click(screen.getByTestId('sidebar-planning'));
-    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(
-      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then use Start ready work.',
-    );
+    expect(screen.queryByRole('heading', { name: 'Plan graph' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Submit to Invoker' })).not.toBeInTheDocument();
   });
 
   it('shows submit errors beside the ready draft and allows retry', async () => {
@@ -803,10 +809,13 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(2);
       expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
-      expect(screen.getByText('Plan graph')).toBeInTheDocument();
+      expect(screen.getByTestId('sidebar-planning')).toHaveAttribute('aria-current', 'page');
+      expect(screen.getByRole('heading', { name: 'Planning chat window' })).toBeInTheDocument();
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. Review it, then use Start ready work.');
     });
-    fireEvent.click(screen.getByTestId('sidebar-planning'));
-    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. Review it, then use Start ready work.');
+    expect(screen.queryByRole('heading', { name: 'Plan graph' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Submit to Invoker' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoker-terminal-submit-error')).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

After a plan handoff succeeds, the Planning Terminal stays selected.

The terminal transcript remains visible, and the graph refresh still runs in the background.

## Review Claim

Approve removing the success-path surface flip so the planning session stays in view.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The slice only removes the UI surface change on success; graph refresh, selection state, and existing handoff calls still run.

## Slice Rationale

This isolates the user-visible surface behavior with the component assertions that cover single-plan, stacked-plan, and second-attempt paths.

## Non-goals

- No workflow creation changes.
- No Start ready work changes.
- No graph data model changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- invoker-terminal.test.tsx`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`
- [x] `cd packages/app && CAPTURE_MODE=/tmp/invoker-auto-nav-proof CAPTURE_VIDEO=1 npx playwright test e2e/visual-proof.spec.ts --grep "terminal planning submits Workers Surface as stacked workflows without jumping surfaces"`

</details>

## Visual Proof

![Submitted planning session remains selected in the Planning Terminal](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-498e7d/planning-submit-no-jump-stacked-workflows.png)

The screenshot shows the submitted chat still selected with the submitted state visible.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert c88bcac60`
- Post-revert steps: Re-run the focused UI terminal test.
- Data migration? No.

</details>
