### PR TITLE
[Planner Submit Line Break](1) Require standalone submit instruction

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -418,6 +418,7 @@ describe('isConfirmation', () => {
   it('detects "proceed"', () => expect(isConfirmation('proceed')).toBe(true));
   it('detects "do it"', () => expect(isConfirmation('do it')).toBe(true));
   it('detects "confirm"', () => expect(isConfirmation('confirm')).toBe(true));
+  it('detects "submit"', () => expect(isConfirmation('submit')).toBe(true));
   it('detects "lgtm"', () => expect(isConfirmation('lgtm')).toBe(true));
   it('detects "yes!" with trailing punctuation', () => expect(isConfirmation('yes!')).toBe(true));
   it('detects " yes " with whitespace', () => expect(isConfirmation(' yes ')).toBe(true));
@@ -796,6 +797,28 @@ describe('PlanConversation prompt construction', () => {
     (conv as any).messages.push({ role: 'user', content: 'Hello' });
     const prompt = conv.buildCursorPrompt();
     expect(prompt).toContain('repoUrl: "git@github.com:user/repo.git"');
+  });
+
+  it('requires the submit instruction as a standalone post-plan summary line', () => {
+    const conv = new PlanConversation({});
+    (conv as any).messages.push({ role: 'user', content: 'Build a feature' });
+    const prompt = conv.buildCursorPrompt();
+    const submitLine = 'Reply `submit` to submit it.';
+
+    expect(prompt.split('\n').filter((line) => line === submitLine)).toHaveLength(1);
+    expect(prompt.match(/Reply `submit` to submit it\./g)).toHaveLength(1);
+    expect(prompt).toContain('short post-plan summary');
+    expect(prompt).toContain('Do NOT place that line inline in a sentence.');
+  });
+
+  it('keeps existing plan delivery, stack, and merge mode guidance', () => {
+    const conv = new PlanConversation({});
+    (conv as any).messages.push({ role: 'user', content: 'Build a feature' });
+    const prompt = conv.buildCursorPrompt();
+
+    expect(prompt).toContain('mergeMode: external_review');
+    expect(prompt).toContain('Prefer small reviewable slices');
+    expect(prompt).toContain('The orchestrator handles plan execution automatically after explicit Slack approval.');
   });
 
   it('system prompt requires discovered verification commands for target repos', () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -145,6 +145,7 @@ const CONFIRMATION_PATTERNS = [
   /^proceed$/i,
   /^do it$/i,
   /^confirm$/i,
+  /^submit$/i,
   /^lgtm$/i,
   /^ship it$/i,
   /^approved$/i,
@@ -287,7 +288,9 @@ Rules:
 7. Use meaningful task IDs (kebab-case).
 8. ${outputInstruction}
 9. Always include \`dependencies\` (even if empty array).
-10. After generating a plan, tell the user they can submit it by replying with \`submit\`.
+10. After generating a plan, include a short post-plan summary that tells the user they can confirm execution. The confirmation instruction MUST be exactly this standalone line:
+Reply \`submit\` to submit it.
+Do NOT place that line inline in a sentence.
 11. NEVER generate bash commands or shell scripts to execute plans. The orchestrator handles plan execution automatically after explicit Slack approval.
 12. Choose \`mergeMode\` deliberately. For reviewable implementation plans, set \`mergeMode: external_review\` so changes land through the canonical GitHub-backed review gate. Keep \`mergeMode: manual\` (the default) for verification-only plans that should not open a review, and use \`mergeMode: automatic\` only when the user explicitly wants changes merged without review.`;
 }


### PR DESCRIPTION
## Summary

Planner submit guidance now names `submit` as a valid confirmation and requires the final instruction to render as its own post-plan line.

This keeps the existing plan delivery and merge-mode guidance intact while removing the older inline confirmation wording.

## Review Claim

Approve the planner prompt and confirmation behavior that makes ``Reply `submit` to submit it.`` the one standalone submission instruction.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

The change is limited to the Slack plan-conversation prompt text, confirmation matcher, and focused prompt tests. Existing plan YAML guidance remains covered.

## Slice Rationale

This slice changes the user-visible planner submission instruction first, so the verification harness can be reviewed separately on top of the new expected behavior.

## Non-goals

This does not change workflow execution, plan parsing, Mergify publication, or non-Slack surfaces.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test -- src/__tests__/plan-conversation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a2c5e7912`
- Post-revert steps: Rerun the focused surfaces tests if the stack still includes follow-up verification.
- Data migration? No

</details>
