### PR TITLE
Planning Terminal Always-Visible Agent Selector (2) Cover selector interactions

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "NODE_OPTIONS='--max-old-space-size=512' vite build",
-    "test": "vitest run"
+    "test": "node scripts/run-vitest.mjs"
   },
   "dependencies": {
     "@invoker/contracts": "workspace:*",

--- a/packages/ui/scripts/run-vitest.mjs
+++ b/packages/ui/scripts/run-vitest.mjs
@@ -1,0 +1,61 @@
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+process.on('uncaughtException', (error) => {
+  console.error(error);
+  process.exit(1);
+});
+
+process.on('unhandledRejection', (error) => {
+  console.error(error);
+  process.exit(1);
+});
+
+const forwardedArgs = process.argv.slice(2);
+const vitestArgs = forwardedArgs[0] === '--' ? forwardedArgs.slice(1) : forwardedArgs;
+const uiDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const workspaceRoot = resolve(uiDir, '../..');
+const vitestBin = resolve(
+  uiDir,
+  process.platform === 'win32' ? 'node_modules/.bin/vitest.cmd' : 'node_modules/.bin/vitest',
+);
+
+async function run(command, args, options = {}) {
+  return await new Promise((resolveProcess, rejectProcess) => {
+    const child = spawn(command, args, {
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+      ...options,
+    });
+
+    child.on('error', rejectProcess);
+    child.on('exit', (code, signal) => {
+      resolveProcess({ code: code ?? 1, signal });
+    });
+  });
+}
+
+function forwardSignal(signal) {
+  if (!signal) return;
+  process.kill(process.pid, signal);
+  process.exit(1);
+}
+
+if (!existsSync(vitestBin)) {
+  const install = await run('pnpm', ['install', '--frozen-lockfile'], { cwd: workspaceRoot });
+  forwardSignal(install.signal);
+  if (install.code !== 0) {
+    process.exit(install.code);
+  }
+}
+
+if (!existsSync(vitestBin)) {
+  console.error(`Vitest binary was not found after install: ${vitestBin}`);
+  process.exit(1);
+}
+
+const test = await run(vitestBin, ['run', ...vitestArgs], { cwd: uiDir });
+forwardSignal(test.signal);
+process.exit(test.code);

--- a/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  InvokerTerminalHarness,
+  createTerminalHarnessController,
+} from './helpers/invoker-terminal-harness.js';
+
+describe('CodeRabbit PR #3050 - draft state cleared after submit', () => {
+  it('dismisses the ready bar and disables the composer after a successful submit', async () => {
+    const controller = createTerminalHarnessController();
+    render(
+      <InvokerTerminalHarness
+        controller={controller}
+        initialDraftPlanAvailable={true}
+      />,
+    );
+
+    expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent(
+      'draft ready - "Mock Plan" - 2 tasks',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+
+    await waitFor(() => {
+      expect(controller.onSubmitDraft).toHaveBeenCalledTimes(1);
+      expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    expect(screen.getByLabelText('Agent')).toBeDisabled();
+  });
+});

--- a/packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  InvokerTerminalHarness,
+  createTerminalHarnessController,
+} from './helpers/invoker-terminal-harness.js';
+
+describe('CodeRabbit PR #3050 - Enter-to-submit ignores IME composition', () => {
+  it('does not submit while an IME composition is in progress', async () => {
+    const controller = createTerminalHarnessController();
+    render(<InvokerTerminalHarness controller={controller} />);
+
+    const input = screen.getByTestId('invoker-terminal-input');
+    fireEvent.change(input, { target: { value: 'こんにちは' } });
+
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
+    await Promise.resolve();
+    expect(controller.onSubmit).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await waitFor(() => {
+      expect(controller.onSubmit).toHaveBeenCalledWith({
+        message: 'こんにちは',
+        presetKey: 'codex',
+      });
+    });
+  });
+});

--- a/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  InvokerTerminalHarness,
+  createTerminalHarnessController,
+} from './helpers/invoker-terminal-harness.js';
+
+describe('CodeRabbit PR #3050 - submitted planning stays guarded', () => {
+  it('keeps submitted planning read-only and prevents message or draft resubmission', async () => {
+    const controller = createTerminalHarnessController();
+    render(
+      <InvokerTerminalHarness
+        controller={controller}
+        readOnly={true}
+        initialValue="run"
+        initialDraftPlanAvailable={true}
+      />,
+    );
+
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    expect(screen.getByLabelText('Agent')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+    fireEvent.keyDown(screen.getByTestId('invoker-terminal-input'), { key: 'Enter' });
+    await Promise.resolve();
+
+    expect(controller.onSubmit).not.toHaveBeenCalled();
+    expect(controller.onSubmitDraft).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/__tests__/helpers/invoker-terminal-harness.tsx
+++ b/packages/ui/src/__tests__/helpers/invoker-terminal-harness.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { vi } from 'vitest';
+import { InvokerTerminal, type InvokerTerminalLine } from '../../components/InvokerTerminal.js';
+
+export interface SubmittedPlanningMessage {
+  message: string;
+  presetKey: string;
+}
+
+export interface TerminalHarnessController {
+  onSubmit: ReturnType<typeof vi.fn>;
+  onSubmitDraft: ReturnType<typeof vi.fn>;
+  onPresetChange: ReturnType<typeof vi.fn>;
+  submissions: SubmittedPlanningMessage[];
+}
+
+interface TerminalHarnessProps {
+  controller?: TerminalHarnessController;
+  initialPresetKey?: string;
+  initialValue?: string;
+  initialDraftPlanAvailable?: boolean;
+  readOnly?: boolean;
+  busy?: boolean;
+  lines?: InvokerTerminalLine[];
+}
+
+export function createTerminalHarnessController(): TerminalHarnessController {
+  return {
+    onSubmit: vi.fn(),
+    onSubmitDraft: vi.fn(),
+    onPresetChange: vi.fn(),
+    submissions: [],
+  };
+}
+
+export function InvokerTerminalHarness({
+  controller = createTerminalHarnessController(),
+  initialPresetKey = 'codex',
+  initialValue = '',
+  initialDraftPlanAvailable = false,
+  readOnly = false,
+  busy = false,
+  lines = [],
+}: TerminalHarnessProps): JSX.Element {
+  const [value, setValue] = useState(initialValue);
+  const [presetKey, setPresetKey] = useState(initialPresetKey);
+  const [draftPlanAvailable, setDraftPlanAvailable] = useState(initialDraftPlanAvailable);
+  const [submitted, setSubmitted] = useState(readOnly);
+
+  const effectiveReadOnly = readOnly || submitted;
+
+  return (
+    <InvokerTerminal
+      activeConversationKey="planning-chat-1"
+      lines={lines}
+      busy={busy}
+      value={value}
+      selectedPresetKey={presetKey}
+      presetOptions={[
+        { key: 'codex', label: 'Codex' },
+        { key: 'claude', label: 'Claude' },
+        { key: 'omp+claude', label: 'OMP + Claude' },
+      ]}
+      draftPlanAvailable={draftPlanAvailable}
+      draftPlanSummary={{ name: 'Mock Plan', taskCount: 2 }}
+      readOnly={effectiveReadOnly}
+      onValueChange={setValue}
+      onSubmit={() => {
+        controller.submissions.push({ message: value, presetKey });
+        controller.onSubmit({ message: value, presetKey });
+        setValue('');
+      }}
+      onSubmitDraft={() => {
+        controller.onSubmitDraft();
+        setDraftPlanAvailable(false);
+        setSubmitted(true);
+      }}
+      onPresetChange={(nextPresetKey) => {
+        setPresetKey(nextPresetKey);
+        controller.onPresetChange(nextPresetKey);
+      }}
+      onExpand={() => {}}
+    />
+  );
+}

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  InvokerTerminalHarness,
+  createTerminalHarnessController,
+} from './helpers/invoker-terminal-harness.js';
+
+describe('InvokerTerminal agent selector', () => {
+  it('renders the agent selector directly in the composer without an options toggle', () => {
+    render(<InvokerTerminalHarness />);
+
+    const selector = screen.getByLabelText('Agent');
+    expect(selector).toBe(screen.getByTestId('invoker-terminal-harness'));
+    expect(selector).toHaveValue('codex');
+    expect(screen.queryByRole('button', { name: 'Options' })).not.toBeInTheDocument();
+  });
+
+  it('uses the selected agent preset when submitting from the visible composer controls', async () => {
+    const controller = createTerminalHarnessController();
+    render(<InvokerTerminalHarness controller={controller} />);
+
+    fireEvent.change(screen.getByLabelText('Agent'), { target: { value: 'claude' } });
+    expect(controller.onPresetChange).toHaveBeenCalledWith('claude');
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), {
+      target: { value: 'draft a focused selector plan' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() => {
+      expect(controller.onSubmit).toHaveBeenCalledWith({
+        message: 'draft a focused selector plan',
+        presetKey: 'claude',
+      });
+    });
+  });
+
+  it('keeps the selector visible after typing and clearing a submitted message', async () => {
+    const controller = createTerminalHarnessController();
+    render(<InvokerTerminalHarness controller={controller} />);
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), {
+      target: { value: 'hello' },
+    });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => expect(controller.onSubmit).toHaveBeenCalledTimes(1));
+    expect(screen.getByLabelText('Agent')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Options' })).not.toBeInTheDocument();
+    expect(screen.getByTestId('invoker-terminal-input')).toHaveValue('');
+  });
+});


### PR DESCRIPTION
## Summary

Planning Terminal Always-Visible Agent Selector — 2 tasks completed, 0 failed, 0 closed, 0 skipped

Focused UI tests now cover the visible selector, preset submission, clearing after submit, IME Enter handling, and submitted-session guards.

The package test wrapper keeps the verification command reliable when the UI package dependencies are not installed yet.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784442683294-2/implement-visible-agent-selector | Remove planning terminal Options toggle and always show agent selector in the composer | completed |
| wf-1784442683294-2/verify-visible-agent-selector | Run focused UI tests covering planning terminal agent selector interactions | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784442683294-2/implement-visible-agent-selector — Remove planning terminal Options toggle and always show agent selector in the composer

- Implemented in the previous stack slice.

### wf-1784442683294-2/verify-visible-agent-selector — Run focused UI tests covering planning terminal agent selector interactions

- `packages/ui/package.json`
- `packages/ui/scripts/run-vitest.mjs`
- `packages/ui/src/__tests__/helpers/invoker-terminal-harness.tsx`
- `packages/ui/src/__tests__/invoker-terminal.test.tsx`
- `packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx`
- `packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx`
- `packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx`

</details>

## Review Claim

The always-visible planning terminal agent selector is covered by focused component tests and the verification command can run from the UI package script.

## Review Lane

proof

## Review Unit

planning-terminal-composer

## Safety Invariant

This slice adds tests, a test harness, and the package test wrapper only. It does not change the runtime component behavior from the previous slice.

## Slice Rationale

Verification is split from the behavior slice so the reviewer can inspect the selector contract first, then review the focused coverage and test-command support.

## Non-goals

- Do not change the selector styling or composer layout.
- Do not change planner submission IPC behavior.
- Do not broaden the UI test suite beyond the planning terminal selector and adjacent guardrails.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a0f2cb35f7fc3064e5be90af09531a7da370d42f`
- Post-revert steps: None
- Data migration? No

</details>
