### PR TITLE
[Slack Multi-Repo Routing](1) Add regression proof for repoUrl resolution bugs

### DIFF
--- a/packages/surfaces/src/__tests__/slack-surface.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface.test.ts
@@ -694,4 +694,40 @@ describe('SlackSurface', () => {
       expect(configuredSurface).toBeDefined();
     });
   });
+
+  describe('multi-repo [repo:] tag resolution', () => {
+    it('BUG: a [repo:<alias>] tag changes the working directory but not the repoUrl the planning LLM is told to write', async () => {
+      const MockedPlanConversation = vi.mocked((await import('../slack/plan-conversation.js')).PlanConversation);
+      MockedPlanConversation.mockClear();
+
+      const multiRepoSurface = new SlackSurface({
+        botToken: 'xoxb-test',
+        appToken: 'xapp-test',
+        signingSecret: 'test-secret',
+        channelId: 'C-test',
+        repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
+        repoAliases: { notarepo: 'git@github.com:EdbertChan/notarepo.git' },
+      });
+
+      await multiRepoSurface.start(async () => {});
+      const app = multiRepoSurface.getApp() as any;
+      const mentionHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')?.handler;
+
+      const say = vi.fn().mockResolvedValue({ ts: '5555.001' });
+      await mentionHandler({
+        event: { text: '<@U_BOT> [repo:notarepo] plan: add a health endpoint', ts: '5555', thread_ts: undefined, user: 'U1' },
+        say,
+      });
+
+      // Reproduces the bug: the tag is resolved (it changed the checkout dir
+      // via prepareRepoCheckout upstream), but the session is still built
+      // with the surface-level default repoUrl, not the resolved alias.
+      expect(MockedPlanConversation).toHaveBeenCalledWith(
+        expect.objectContaining({ repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git' }),
+      );
+      expect(MockedPlanConversation).not.toHaveBeenCalledWith(
+        expect.objectContaining({ repoUrl: 'git@github.com:EdbertChan/notarepo.git' }),
+      );
+    });
+  });
 });

--- a/packages/surfaces/src/__tests__/thread-session-manager.test.ts
+++ b/packages/surfaces/src/__tests__/thread-session-manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SessionManager, SessionIdentifier, SessionHandle } from '../slack/thread-session-manager.js';
+import * as child_process from 'node:child_process';
 
 // ── Mock child_process.spawn ────────────────────────────────
 
@@ -21,6 +22,8 @@ vi.mock('node:child_process', async (importOriginal) => {
     }),
   };
 });
+
+const mockSpawn = vi.mocked(child_process.spawn);
 
 // ── Mock ConversationRepository ─────────────────────────────
 
@@ -212,6 +215,42 @@ describe('SessionManager', () => {
       'U001',
       'agent',
     );
+  });
+
+  it('BUG: a per-session repoUrl override is ignored — the manager-level default always wins', async () => {
+    mockSpawn.mockClear();
+    const multiRepoManager = new SessionManager({
+      cursorCommand: 'cursor',
+      workingDir: '/fake',
+      conversationRepo: mockRepo as any,
+      evictionIntervalMs: 60_000,
+      // Simulates `defaultRepoUrl` in ~/.invoker/config.json pointed at Invoker.
+      repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
+      mode: 'plan',
+    });
+    multiRepoManager.start();
+
+    // Simulates a Slack thread that resolved a `[repo:notarepo]` tag to a
+    // different repo. `getOrCreateSession`'s opts type has no `repoUrl` field
+    // today, so a caller has no way to override the manager-level default for
+    // this one thread — `as any` stands in for that missing capability.
+    const id = new SessionIdentifier('C123', '1234.5678');
+    const handle = await multiRepoManager.getOrCreateSession(id, 'U001', {
+      workingDir: '/checkouts/notarepo',
+      repoUrl: 'git@github.com:EdbertChan/notarepo.git',
+    } as any);
+    expect(handle).not.toBeNull();
+
+    await handle!.sendMessage('Add a health endpoint');
+    const prompt = mockSpawn.mock.calls[0][1]![1] as string;
+
+    // Reproduces the bug: even though this thread asked for notarepo, the
+    // system prompt still tells the planning LLM to write Invoker's repoUrl
+    // into the YAML plan.
+    expect(prompt).toContain('repoUrl: "git@github.com:Neko-Catpital-Labs/Invoker.git"');
+    expect(prompt).not.toContain('EdbertChan/notarepo.git');
+
+    multiRepoManager.stop();
   });
 
   it('getMetrics returns correct counts', async () => {


### PR DESCRIPTION
## Summary

A Slack thread can resolve its own target repo via a `[repo:<alias>]` tag, separate from the bot's process-wide default.

That resolved repo is supposed to flow all the way into the planning LLM's system prompt, so the drafted YAML plan targets the right repository.

It doesn't. Two call sites silently drop the per-thread value and fall back to a single shared default instead.

This slice adds tests that reproduce both drops against today's code, before any fix. They pass right now because they assert the buggy outcome.

## Review Claim

These two new tests demonstrate, with a passing assertion against unmodified code, that a per-thread resolved repo never reaches the planning LLM's prompt.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only diff. No product code changes, so there is nothing here that can change runtime behavior.

## Slice Rationale

Per `skills/review-compression/SKILL.md`, a proof harness and the fix it justifies are split into separate slices. This slice is the proof; the next slice in the stack is the fix and flips these same assertions to the corrected expectation.

## Non-goals

Does not change `SessionManager`, `SlackSurface`, or `PlanConversation` behavior. Does not address the separate (already-covered) placeholder-repoUrl issue in `plan-conversation.ts` — that one already has an existing test on `master`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm install --frozen-lockfile && cd packages/surfaces && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
