### PR TITLE
[Slack Multi-Repo Routing](2) Thread each Slack thread's resolved target repo into its planning session

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -792,11 +792,13 @@ describe('PlanConversation prompt construction', () => {
     expect(prompt).toContain('repoUrl: "git@github.com:test/repo.git"');
   });
 
-  it('system prompt includes generic repoUrl placeholder when not configured', () => {
+  it('system prompt tells the model to ask the user for the repo when none is configured', () => {
     const conv = new PlanConversation({});
     (conv as any).messages.push({ role: 'user', content: 'Hello' });
     const prompt = conv.buildCursorPrompt();
-    expect(prompt).toContain('repoUrl: "git@github.com:user/repo.git"');
+    expect(prompt).toContain('NO REPO CONFIGURED');
+    expect(prompt).toContain('ask the user which repository this plan targets');
+    expect(prompt).not.toContain('repoUrl: "git@github.com:user/repo.git"');
   });
 
   it('requires the submit instruction as a standalone post-plan summary line', () => {

--- a/packages/surfaces/src/__tests__/slack-surface.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface.test.ts
@@ -696,7 +696,7 @@ describe('SlackSurface', () => {
   });
 
   describe('multi-repo [repo:] tag resolution', () => {
-    it('BUG: a [repo:<alias>] tag changes the working directory but not the repoUrl the planning LLM is told to write', async () => {
+    it('threads a [repo:<alias>] tag into the created session instead of the default repo', async () => {
       const MockedPlanConversation = vi.mocked((await import('../slack/plan-conversation.js')).PlanConversation);
       MockedPlanConversation.mockClear();
 
@@ -719,14 +719,39 @@ describe('SlackSurface', () => {
         say,
       });
 
-      // Reproduces the bug: the tag is resolved (it changed the checkout dir
-      // via prepareRepoCheckout upstream), but the session is still built
-      // with the surface-level default repoUrl, not the resolved alias.
       expect(MockedPlanConversation).toHaveBeenCalledWith(
-        expect.objectContaining({ repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git' }),
+        expect.objectContaining({ repoUrl: 'git@github.com:EdbertChan/notarepo.git' }),
       );
       expect(MockedPlanConversation).not.toHaveBeenCalledWith(
-        expect.objectContaining({ repoUrl: 'git@github.com:EdbertChan/notarepo.git' }),
+        expect.objectContaining({ repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git' }),
+      );
+    });
+
+    it('falls back to the default repoUrl when the mention carries no [repo:] tag', async () => {
+      const MockedPlanConversation = vi.mocked((await import('../slack/plan-conversation.js')).PlanConversation);
+      MockedPlanConversation.mockClear();
+
+      const multiRepoSurface = new SlackSurface({
+        botToken: 'xoxb-test',
+        appToken: 'xapp-test',
+        signingSecret: 'test-secret',
+        channelId: 'C-test',
+        repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
+        repoAliases: { notarepo: 'git@github.com:EdbertChan/notarepo.git' },
+      });
+
+      await multiRepoSurface.start(async () => {});
+      const app = multiRepoSurface.getApp() as any;
+      const mentionHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')?.handler;
+
+      const say = vi.fn().mockResolvedValue({ ts: '6666.001' });
+      await mentionHandler({
+        event: { text: '<@U_BOT> plan: add a health endpoint', ts: '6666', thread_ts: undefined, user: 'U1' },
+        say,
+      });
+
+      expect(MockedPlanConversation).toHaveBeenCalledWith(
+        expect.objectContaining({ repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git' }),
       );
     });
   });

--- a/packages/surfaces/src/__tests__/thread-session-manager.test.ts
+++ b/packages/surfaces/src/__tests__/thread-session-manager.test.ts
@@ -217,7 +217,7 @@ describe('SessionManager', () => {
     );
   });
 
-  it('BUG: a per-session repoUrl override is ignored — the manager-level default always wins', async () => {
+  it('a per-session repoUrl override wins over the manager-level default (multi-repo threads)', async () => {
     mockSpawn.mockClear();
     const multiRepoManager = new SessionManager({
       cursorCommand: 'cursor',
@@ -231,26 +231,46 @@ describe('SessionManager', () => {
     multiRepoManager.start();
 
     // Simulates a Slack thread that resolved a `[repo:notarepo]` tag to a
-    // different repo. `getOrCreateSession`'s opts type has no `repoUrl` field
-    // today, so a caller has no way to override the manager-level default for
-    // this one thread — `as any` stands in for that missing capability.
+    // different repo than the manager-level default.
     const id = new SessionIdentifier('C123', '1234.5678');
     const handle = await multiRepoManager.getOrCreateSession(id, 'U001', {
       workingDir: '/checkouts/notarepo',
       repoUrl: 'git@github.com:EdbertChan/notarepo.git',
-    } as any);
+    });
     expect(handle).not.toBeNull();
 
     await handle!.sendMessage('Add a health endpoint');
     const prompt = mockSpawn.mock.calls[0][1]![1] as string;
 
-    // Reproduces the bug: even though this thread asked for notarepo, the
-    // system prompt still tells the planning LLM to write Invoker's repoUrl
-    // into the YAML plan.
-    expect(prompt).toContain('repoUrl: "git@github.com:Neko-Catpital-Labs/Invoker.git"');
-    expect(prompt).not.toContain('EdbertChan/notarepo.git');
+    // The thread's own resolved repo, not the manager-level default, must
+    // reach the planning LLM's system prompt.
+    expect(prompt).toContain('repoUrl: "git@github.com:EdbertChan/notarepo.git"');
+    expect(prompt).not.toContain('Neko-Catpital-Labs/Invoker.git');
 
     multiRepoManager.stop();
+  });
+
+  it('falls back to the manager-level default repoUrl when a session omits its own', async () => {
+    mockSpawn.mockClear();
+    const singleRepoManager = new SessionManager({
+      cursorCommand: 'cursor',
+      workingDir: '/fake',
+      conversationRepo: mockRepo as any,
+      evictionIntervalMs: 60_000,
+      repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
+      mode: 'plan',
+    });
+    singleRepoManager.start();
+
+    const id = new SessionIdentifier('C123', '9999.0000');
+    const handle = await singleRepoManager.getOrCreateSession(id, 'U001');
+    expect(handle).not.toBeNull();
+
+    await handle!.sendMessage('Add a health endpoint');
+    const prompt = mockSpawn.mock.calls[0][1]![1] as string;
+    expect(prompt).toContain('repoUrl: "git@github.com:Neko-Catpital-Labs/Invoker.git"');
+
+    singleRepoManager.stop();
   });
 
   it('getMetrics returns correct counts', async () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -230,7 +230,7 @@ function buildPlanSystemPrompt(
 ): string {
   const repoUrlLine = repoUrl
     ? `repoUrl: "${repoUrl}"          # git clone URL for the repository`
-    : `repoUrl: "git@github.com:user/repo.git"  # git clone URL for the repository`;
+    : 'repoUrl: "<ask the user for this>"  # no repo is configured for this thread';
   const stackedWorkflowSection = preferStackedWorkflows
     ? `\n${buildStackedWorkflowPrompt(repoUrlLine, defaultBranch)}\n`
     : '';
@@ -240,9 +240,12 @@ function buildPlanSystemPrompt(
   const deliveryDirective = planFilePath
     ? `HOW TO DELIVER THE PLAN (read first): write the COMPLETE YAML plan to the file at \`${planFilePath}\` using your file-writing tool, then reply in chat with ONLY a short summary — one or two sentences. NEVER paste the YAML plan into your chat reply; Invoker reads it from the file and shows the user a per-task summary. Every YAML block below is the format for that file, not for your chat reply. A pasted plan gets cut off at your output limit, which is the exact problem the file avoids.\n\n`
     : '';
+  const repoUrlDirective = repoUrl
+    ? ''
+    : 'NO REPO CONFIGURED (read first): this thread has no target repository configured — not via a `[repo:]` tag and not via a default. Before drafting any YAML, ask the user which repository this plan targets (a `[repo:<alias>]` tag, or a full git clone URL) and wait for their reply. Never invent, guess, or copy the `repoUrl` placeholder shown below literally into a plan.\n\n';
   return `You are an assistant for the Invoker orchestrator. The user explicitly requested an Invoker plan.
 
-${deliveryDirective}Generate a YAML task plan as described below. Answer simple follow-up questions directly only when they are about the plan being drafted.
+${repoUrlDirective}${deliveryDirective}Generate a YAML task plan as described below. Answer simple follow-up questions directly only when they are about the plan being drafted.
 
 A plan has this structure:
 \`\`\`yaml

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -888,6 +888,7 @@ export class SlackSurface implements Surface {
         model: preset.model,
         workingDir,
         mode: threadRequest.mode,
+        repoUrl,
       });
       if (!conversation) {
         await say({ text: 'Too many active conversations. Please wait.', thread_ts: threadTs });
@@ -2040,7 +2041,7 @@ ${text}`;
     threadTs: string,
     userId: string,
     create = true,
-    opts?: { tool?: string; model?: string; workingDir?: string; mode?: ConversationMode },
+    opts?: { tool?: string; model?: string; workingDir?: string; mode?: ConversationMode; repoUrl?: string },
   ): Promise<ConversationLike | null> {
     this.log('slack', 'info', `[TRACE] getSession (channelId=${channelId}, threadTs=${threadTs}, userId=${userId}, create=${create}, hasSessionManager=${!!this.sessionManager})`);
     if (this.sessionManager) {
@@ -2079,7 +2080,7 @@ ${text}`;
         threadTs,
         conversationRepo: this.conversationRepo,
         defaultBranch: this.defaultBranch,
-        repoUrl: this.repoUrl,
+        repoUrl: opts?.repoUrl ?? this.defaultRepoUrl,
         timeoutMs: (this.planningTimeoutSeconds ?? 7_200) * 1_000,
         plannerRetryLimit: this.plannerRetryLimit,
         plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
@@ -2147,7 +2148,7 @@ ${text}`;
             threadTs: entry.threadTs,
             conversationRepo: this.conversationRepo,
             defaultBranch: this.defaultBranch,
-            repoUrl: this.repoUrl,
+            repoUrl: this.defaultRepoUrl,
             plannerRetryLimit: this.plannerRetryLimit,
             plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
           });

--- a/packages/surfaces/src/slack/thread-session-manager.ts
+++ b/packages/surfaces/src/slack/thread-session-manager.ts
@@ -271,7 +271,7 @@ export class SessionManager {
   async getOrCreateSession(
     id: SessionIdentifier,
     userId: string,
-    opts?: { tool?: string; model?: string; workingDir?: string; mode?: ConversationMode },
+    opts?: { tool?: string; model?: string; workingDir?: string; mode?: ConversationMode; repoUrl?: string },
   ): Promise<SessionHandle | null> {
     const key = id.toString();
 
@@ -322,7 +322,7 @@ export class SessionManager {
         threadTs: id.threadTs,
         conversationRepo: this.conversationRepo,
         defaultBranch: this.defaultBranch,
-        repoUrl: this.repoUrl,
+        repoUrl: opts?.repoUrl ?? this.repoUrl,
         log: this.log,
         timeoutMs: this.timeoutMs,
         plannerRetryLimit: this.plannerRetryLimit,
@@ -355,7 +355,7 @@ export class SessionManager {
         threadTs: id.threadTs,
         conversationRepo: this.conversationRepo,
         defaultBranch: this.defaultBranch,
-        repoUrl: this.repoUrl,
+        repoUrl: opts?.repoUrl ?? this.repoUrl,
         log: this.log,
         timeoutMs: this.timeoutMs,
         plannerRetryLimit: this.plannerRetryLimit,


### PR DESCRIPTION
## Summary

`SessionManager.getOrCreateSession` and `SlackSurface.getSession` both built each thread's `PlanConversation` with the manager/surface-level default repo, ignoring any per-thread override.

A `[repo:<alias>] tag` resolved a different checkout directory correctly, but the planning LLM was still told to write the default repo's URL into the YAML plan.

This slice threads the resolved `repoUrl` through both call sites as a real option, so each thread's own repo reaches its own prompt.

Separately, when no repo resolves at all, the prompt handed the model a fake-looking placeholder URL it could copy into a plan by mistake.

The prompt now tells the model to stop and ask the user instead.

## Review Claim

Each Slack thread's planning prompt now reflects that thread's own resolved target repo, not a single process-wide default; and a thread with no resolved repo is told to ask rather than guess.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change only widens existing optional parameters (`opts?.repoUrl`) with a `??` fallback to the prior default, so any caller that never passes `repoUrl` keeps today's exact behavior. The proof slice's two repro tests (previous PR in this stack) flip from asserting the buggy outcome to asserting the fixed one, in the same diff as the fix that makes them true.

## Slice Rationale

This is the behavior fix for the bug demonstrated in the prior proof slice, kept as its own diff per `skills/review-compression/SKILL.md`.

## Non-goals

Does not add a new default/inference mechanism for choosing a repo per channel — that's a separate, still-open design discussion. Does not change how `[repo:<alias>]` tags are parsed or how `slackRepos`/`defaultRepoUrl` config is loaded.

## Architecture

### Before

```mermaid
graph TD
    A["[repo:notarepo] tag resolved"] --> B["prepareRepoCheckout(notarepo) picks working dir"]
    B --> C["getSession(..., opts) — repoUrl NOT in opts"]
    C --> D["PlanConversation({ repoUrl: this.defaultRepoUrl })"]
    D --> E["LLM prompt always shows the default repo"]
```

### After

```mermaid
graph TD
    A["[repo:notarepo] tag resolved"] --> B["prepareRepoCheckout(notarepo) picks working dir"]
    B --> C["getSession(..., { ...opts, repoUrl })"]
    C --> D["PlanConversation({ repoUrl: opts.repoUrl ?? this.defaultRepoUrl })"]
    D --> E["LLM prompt shows this thread's own resolved repo"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm install --frozen-lockfile && cd packages/surfaces && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>