### PR TITLE
[Planning Terminal Yellow Send Arrow](3) Invoke make-pr after branch and PR changes

### DIFF
--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -85,6 +85,8 @@ node scripts/create-pr.mjs --title "<title>" --base master --body-file /tmp/my-p
 
 Update an existing PR with:
 
+After any branch update, rebase, force-push, or stacked-branch reshuffle, refresh the PR title and body so they still match the live diff. Re-check `## Summary`, test commands, revert guidance, and any visual proof section; old copy is stale the moment the branch meaning changes.
+
 ```bash
 node scripts/create-pr.mjs --title "<title>" --base master --body-file /tmp/my-pr.md --update <pr-number>
 ```
@@ -120,8 +122,10 @@ Do not generalize this to unrelated repos.
 
 ## Validation
 
-Before creating a PR:
+Before creating or updating a PR:
 
+- ensure the PR title still matches the current slice after any branch update or force-push
+- ensure the `## Summary` section still describes the current diff, not the earlier version
 - ensure the branch is pushed
 - ensure the body sections are present and concrete
 - ensure test commands are real commands that were actually run when possible

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -3,19 +3,21 @@ name: make-pr
 description: >
   Create or update a pull request in this repo using the preferred PR schema,
   upstream-first branch workflow, and repo-specific publication rules. Trigger
-  when asked to make a PR, update a PR body, prepare PR text, or publish a
-  stacked PR branch.
+  when asked to make a PR, update a PR body, prepare PR text, publish a
+  stacked PR branch, or whenever a branch/PR change means the GitHub PR
+  metadata may now be stale.
 ---
 
 # make-pr
 
-Use this skill when the work is already done and the user wants a PR created, updated, or rewritten.
+Use this skill when the work is already done and the user wants a PR created, updated, or rewritten, and also whenever a branch, stack, or PR change could leave GitHub title/body/proof text out of date.
 
 ## What this skill covers
 
 - PR title/body authoring for Invoker
 - The preferred PR section schema
 - Upstream-first branch/PR workflow (explicit base and publish remotes)
+- Mandatory refresh after branch/PR changes that can stale GitHub metadata
 - Repo-specific publication rules:
   - Invoker-on-Invoker stacks may use `mergify stack push`
   - unrelated target repos should keep their own normal PR workflow unless they independently use Mergify Stacks


### PR DESCRIPTION
## Summary

This slice updates the `make-pr` skill so branch or PR changes must route back through the PR-writing workflow.

After any rebase, force-push, branch reshuffle, or PR edit, the skill now tells agents to invoke `make-pr` again and refresh the GitHub title, summary, and visual proof so the PR still matches the live diff.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `gh pr view 5080 --json title,body`
- [x] `gh pr view 5081 --json title,body`
- [x] `gh pr view 5094 --json title,body`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 072eba7b1`
- Post-revert steps: None.
- Data migration? No

</details>
