### PR TITLE
[Pool Member Pin Across Types](2) Pin selection across all member kinds

### DIFF
--- a/packages/execution-engine/src/__tests__/pool-member-pin-across-types.test.ts
+++ b/packages/execution-engine/src/__tests__/pool-member-pin-across-types.test.ts
@@ -2,19 +2,15 @@
  * Regression coverage for execution-pool member pinning across ALL member
  * types, not only SSH.
  *
- * `selectExecutor()` currently (a) drops the picked member's id whenever the
- * pick is not type `ssh`, so nothing is ever pinned back onto a task that
- * first ran on a `worktree` member, and (b) only matches an explicit
+ * `selectExecutor()` used to (a) drop the picked member's id whenever the
+ * pick was not type `ssh`, so nothing was ever pinned back onto a task that
+ * first ran on a `worktree` member, and (b) only match an explicit
  * `poolMemberId` pin against `ssh` candidates, silently ignoring pins that
- * point at a `worktree` member. Together this lets a task that started on
+ * point at a `worktree` member. Together this let a task that started on
  * the local worktree member get re-routed to an unrelated SSH host on a
  * later call to `selectExecutor()` (e.g. during `publishApprovedFix`),
- * which then tries to run git commands against a workspace path that only
+ * which then tried to run git commands against a workspace path that only
  * exists on the original machine.
- *
- * These three cases are marked `it.fails` because the underlying defect is
- * still present; the follow-up fix flips them to `it` once
- * `selectExecutor()`'s pinning logic is made type-agnostic.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
@@ -71,7 +67,7 @@ function makeRunner() {
 }
 
 describe('selectExecutor pool member pinning across types', () => {
-  it.fails('returns a defined selectedPoolMemberId for a fresh worktree pick, not just SSH', () => {
+  it('returns a defined selectedPoolMemberId for a fresh worktree pick, not just SSH', () => {
     const runner = makeRunner();
 
     const task = makeTask({
@@ -85,7 +81,7 @@ describe('selectExecutor pool member pinning across types', () => {
     expect(selected.selectedPoolMemberId).toBe('member-local');
   });
 
-  it.fails('honors a persisted worktree pin instead of rotating to the SSH member', () => {
+  it('honors a persisted worktree pin instead of rotating to the SSH member', () => {
     const runner = makeRunner();
 
     // Step 1: original run picks the worktree member (RR cursor=0 → member-local).
@@ -122,7 +118,7 @@ describe('selectExecutor pool member pinning across types', () => {
     expect(publishSelection.selectedPoolMemberId).toBe('member-local');
   });
 
-  it.fails('honors an explicit poolMemberId pinned to a non-SSH member without re-rolling selection', () => {
+  it('honors an explicit poolMemberId pinned to a non-SSH member without re-rolling selection', () => {
     const runner = makeRunner();
 
     const task = makeTask({

--- a/packages/execution-engine/src/task-runner-dispatch.ts
+++ b/packages/execution-engine/src/task-runner-dispatch.ts
@@ -190,13 +190,13 @@ export async function dispatchExecutor(
         }
         if (meta.containerId) execution.containerId = meta.containerId;
         const poolSelection = host.pendingPoolSelections.get(task.id);
-        const selectedSshTargetId = executor.type === 'ssh'
+        const selectedPoolMemberId = executor.type === 'ssh'
           ? host.selectedRemoteTargetId(task, poolSelection)
-          : undefined;
+          : poolSelection?.member.id;
         host.persistence.updateTask(task.id, {
           config: {
             runnerKind: executor.type as RunnerKind,
-            ...(selectedSshTargetId ? { poolMemberId: selectedSshTargetId } : {}),
+            ...(selectedPoolMemberId ? { poolMemberId: selectedPoolMemberId } : {}),
           },
           execution: execution as any,
         });
@@ -304,15 +304,15 @@ export async function dispatchExecutor(
       poolSelection,
     );
 
-    const selectedSshTargetId = executor.type === 'ssh'
+    const selectedPoolMemberId = executor.type === 'ssh'
       ? host.selectedRemoteTargetId(task, poolSelection)
-      : undefined;
+      : poolSelection?.member.id;
     const changes = {
       config: {
         runnerKind: executor.type as RunnerKind,
         executionAgent: resolvedExecution.executionAgent,
         executionModel: resolvedExecution.executionModel,
-        ...(selectedSshTargetId ? { poolMemberId: selectedSshTargetId } : {}),
+        ...(selectedPoolMemberId ? { poolMemberId: selectedPoolMemberId } : {}),
       },
       execution: {
         workspacePath: handle.workspacePath,

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -609,7 +609,7 @@ export function selectExecutor(
 
   if (task.config.poolId && explicitPoolMemberId) {
     const pool = host.getExecutionPools()[task.config.poolId];
-    const member = pool?.members.find((candidate) => candidate.type === 'ssh' && candidate.id === explicitPoolMemberId);
+    const member = pool?.members.find((candidate) => candidate.id === explicitPoolMemberId);
     if (pool && member) {
       if (
         excludedPoolMemberKeys.has(poolMemberKey(member))
@@ -632,7 +632,7 @@ export function selectExecutor(
         reserved = reservePoolMemberSelection(host, task, task.config.poolId, pool, member, resolvedExecution);
         if (reserved) {
           effectiveType = member.type;
-          selectedPoolMemberId = member.type === 'ssh' ? member.id : undefined;
+          selectedPoolMemberId = member.id;
           break;
         }
         attempted.add(poolMemberKey(member));


### PR DESCRIPTION
## Summary

This fixes the defect proven in the previous PR in this stack: `selectExecutor()` treated SSH pool members specially when pinning a task to the member it already ran on.

A fresh pick now always records the chosen member's id, not just for `ssh`. An explicit pin now matches by id alone, regardless of what kind of member it is.

Dispatch already persisted the picked member id back onto the task for SSH picks so later calls stay pinned. It now does the same for `worktree`/`docker` picks.

Together this stops a task's later git operations (like publishing an AI-approved fix) from silently landing on a different machine than the one holding its workspace.

## Review Claim

Approve making execution-pool member pinning in `selectExecutor()` work the same for every kind of member, so a task that first ran on a non-SSH member is never silently switched to a different member on a later call.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Existing SSH-only pinning behavior (explicit `poolMemberId` for an SSH member, capacity/lease checks, round-robin cursor advance) is unchanged; only the type filter that excluded non-SSH members from pinning is removed. The full `packages/execution-engine` suite passes except one pre-existing, unrelated timeout flake (`ssh-pool-member-capacity.test.ts`'s preempted-task test) that also times out on a clean `origin/master` checkout with no changes at all.

## Slice Rationale

This is the fix half of the repro/fix stack: the previous PR proved the bug with a test marked `it.fails`; this PR corrects the root cause and flips those cases to `it`.

## Non-goals

No refactor of `selectPoolMember`, lease/capacity math, or the round-robin cursor. No changes to `SshExecutor`, `WorktreeExecutor`, or `DockerExecutor` themselves. No changes to the existing SSH-only stale-workspace-path repair logic in `conflict-resolver.ts`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile && cd packages/execution-engine && npx vitest run src/__tests__/pool-member-pin-across-types.test.ts` — all 3 cases now pass as `it` (defect fixed)
- [x] `pnpm install --frozen-lockfile && cd packages/execution-engine && pnpm test` — 1322 passed, 1 pre-existing unrelated flake, 1 skipped

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed execution-pool member pinning across different executor types.
  * Explicitly selected non-SSH pool members are now honored correctly.
  * Persisted pool-member selections are retained instead of being replaced during execution.
  * Improved task metadata so selected pool members are recorded consistently for startup failures and successful executions.
* **Tests**
  * Expanded regression coverage for worktree and SSH member selection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->