### PR TITLE
Draft Review Sidebar Step 1 - Expose Draft YAML (2) - SSH blank provisioning fallback

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -482,6 +482,48 @@ branch refs/heads/${targetBranch}
     // The actual exit code propagation is tested by integration tests with real SSH.
   });
 
+  it('falls back to default managed provisioning when provisionCommand is blank', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+      provisionCommand: '   ',
+    }) as any;
+
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return '__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=abc123';
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      return '';
+    });
+
+    vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+
+    let capturedScript = '';
+    vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
+      (_executionId: string, _request: any, handle: any, script: string) => {
+        capturedScript = script;
+        return handle;
+      },
+    );
+
+    const req = makeRequest({
+      actionType: 'command',
+      inputs: {
+        command: 'echo test',
+        description: 'test',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    });
+
+    await ssh.start(req);
+
+    expect(capturedScript).toContain('[ ! -f package.json ]');
+  });
+
   it('does not return a handle until managed remote bootstrap/setup has finished', async () => {
     const ssh = new SshExecutor({
       host: 'localhost',

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -99,7 +99,8 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
     this.agentRegistry = config.agentRegistry;
     this.managedWorkspaces = config.managedWorkspaces ?? false;
     this.remoteInvokerHome = config.remoteInvokerHome ?? '~/.invoker';
-    this.provisionCommand = config.provisionCommand ?? DEFAULT_WORKTREE_PROVISION_COMMAND;
+    const provisionCommand = config.provisionCommand?.trim() ? config.provisionCommand : undefined;
+    this.provisionCommand = provisionCommand ?? DEFAULT_WORKTREE_PROVISION_COMMAND;
     const configuredRemoteHeartbeatInterval = config.remoteHeartbeatIntervalSeconds;
     this.remoteHeartbeatIntervalSeconds =
       typeof configuredRemoteHeartbeatInterval === 'number'


### PR DESCRIPTION
Depends-On: #5098

## Summary

Draft Review Sidebar Step 1 - Expose Draft YAML — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784443178312-4/implement-draft-yaml-plumbing | Expose drafted plan YAML text alongside draft summary in planning session payloads | completed |
| wf-1784443178312-4/verify-draft-yaml-plumbing | Verify planner contract/data plumbing behavior | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784443178312-4/implement-draft-yaml-plumbing — Expose drafted plan YAML text alongside draft summary in planning session payloads

### wf-1784443178312-4/verify-draft-yaml-plumbing — Verify planner contract/data plumbing behavior

</details>

This slice treats a whitespace-only SSH `provisionCommand` as unset.

Managed remote workspaces keep the default provisioning command instead of replacing setup with a blank script.

## Review Claim

Blank SSH managed-workspace provisioning config falls back to the default provision command.

## Review Lane

`behavior`

## Review Unit

`ssh-managed-provisioning`

## Safety Invariant

Non-blank custom provisioning still wins. Only all-whitespace values use the existing default path.

## Slice Rationale

This verification support slice is isolated from planner YAML plumbing because it changes SSH executor provisioning behavior.

## Non-goals

- Change non-blank custom `provisionCommand` behavior.
- Change SSH clone, fetch, or worktree setup.
- Add remote integration coverage for managed provisioning.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-executor.test.ts -t "falls back to default managed provisioning when provisionCommand is blank"`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-bodies/draft-review-sidebar-step-1-2.md`

</details>

## Visual Proof

No new UI in this slice. Stack proof for the planning draft flow lives in #5098:

- [Restart walkthrough (gif)](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260720-a868a8/pr5098-planning-terminal-restart.gif)
- ![Planning transcript stays visible after submit while the workflow is created](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260720-a868a8/pr5098-terminal-planned-conversation-after-submit.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert daef239668d83c25566119aa859fd39bd65469ad`
- Post-revert steps: Rerun `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-executor.test.ts -t "falls back to default managed provisioning when provisionCommand is blank"`.
- Data migration? No.

</details>
