### PR TITLE
[Preserve Graph View Across Planning Window Switches](1) Restore the workflow graph viewport on planning return

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -70,6 +70,7 @@ import {
   type GraphCameraCommand,
   type GraphCameraCommandInput,
   type GraphCameraCommandIssuer,
+  type GraphCameraViewport,
   type GraphScope,
 } from './lib/graph-camera.js';
 import type { SystemDiagnostics } from '@invoker/contracts';
@@ -900,6 +901,7 @@ export function App() {
   // Temporary, non-persisted suppression of the camera lock after a manual pan
   // or wheel zoom. The next explicit node selection clears it.
   const cameraSuppressedRef = useRef(false);
+  const workflowGraphViewportRef = useRef<GraphCameraViewport | null>(null);
   const [bottomStatusIndex, setBottomStatusIndex] = useState(0);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -1579,6 +1581,16 @@ export function App() {
   const handleManualViewport = useCallback(() => {
     cameraSuppressedRef.current = true;
   }, []);
+
+  const handleWorkflowGraphViewportSnapshot = useCallback((viewport: GraphCameraViewport) => {
+    workflowGraphViewportRef.current = viewport;
+  }, []);
+
+  useEffect(() => {
+    if (workflows.size === 0) {
+      workflowGraphViewportRef.current = null;
+    }
+  }, [workflows.size]);
 
   const armSuppressDagSurfaceDismiss = useCallback(() => {
     suppressDagSurfaceDismissRef.current = true;
@@ -2561,6 +2573,8 @@ export function App() {
           updatedAt: new Date().toISOString(),
         }));
         await refreshTaskGraph();
+        workflowGraphViewportRef.current = null;
+        cameraSuppressedRef.current = false;
         appendTerminalLine(
           result.workflowCount && result.workflowCount > 1
             ? `Plan "${result.planName}" submitted as ${result.workflowCount} stacked workflows. Review them, then use Start ready work.`
@@ -2994,14 +3008,29 @@ export function App() {
     focusKeyboardRegion('planning');
   }, [focusKeyboardRegion]);
 
-  const navigatePlanGraphAndFit = useCallback((reason: string) => {
-    cameraSuppressedRef.current = false;
+  const navigatePlanGraph = useCallback((reason: string, options: { fit: boolean }) => {
     setSidebarSurface('planning');
     setInspectorManualOpen(false);
     setViewMode('dag');
     focusKeyboardRegion('workflowGraph');
-    issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason });
+
+    if (options.fit) {
+      workflowGraphViewportRef.current = null;
+      cameraSuppressedRef.current = false;
+      issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason });
+      return;
+    }
+
+    setCameraCommand(null);
   }, [focusKeyboardRegion, issueCameraCommand]);
+
+  const navigatePlanGraphAndFit = useCallback((reason: string) => {
+    navigatePlanGraph(reason, { fit: true });
+  }, [navigatePlanGraph]);
+
+  const navigatePlanGraphPreservingViewport = useCallback((reason: string) => {
+    navigatePlanGraph(reason, { fit: false });
+  }, [navigatePlanGraph]);
 
   const handleSelectSidebarSurface = useCallback((nextSurface: SidebarSurface) => {
     setGraphActionsMenuOpen(false);
@@ -3024,6 +3053,10 @@ export function App() {
       return;
     }
     if (nextSurface === 'planning') {
+      if (sidebarSurface === 'home') {
+        navigatePlanGraphPreservingViewport('sidebar-planning');
+        return;
+      }
       navigatePlanGraphAndFit('sidebar-planning');
       return;
     }
@@ -3031,7 +3064,7 @@ export function App() {
     setSidebarSurface(nextSurface);
     setInspectorManualOpen(false);
     setStatusFilters(new Set<WorkflowStatus>());
-  }, [navigatePlanGraphAndFit, navigatePlanningHome, sidebarSurface, viewMode]);
+  }, [navigatePlanGraphAndFit, navigatePlanGraphPreservingViewport, navigatePlanningHome, sidebarSurface, viewMode]);
 
   const handleDismissBrowserSurface = useCallback(() => {
     setGraphActionsMenuOpen(false);
@@ -3568,10 +3601,12 @@ export function App() {
               workflows={workflows}
               selectedWorkflowId={selectedWorkflow?.id ?? null}
               cameraCommand={cameraCommand}
+              initialViewport={workflowGraphViewportRef.current}
               statusFilters={statusFilters}
               coreActivityByWorkflow={coreActivityByWorkflow}
               onSelectWorkflow={handleWorkflowClick}
               onWorkflowContextMenu={handleWorkflowContextMenu}
+              onViewportSnapshot={handleWorkflowGraphViewportSnapshot}
               onManualViewport={handleManualViewport}
             />
           )}
@@ -4451,10 +4486,12 @@ export function App() {
                 workflows={workflows}
                 selectedWorkflowId={selectedWorkflow?.id ?? null}
                 cameraCommand={cameraCommand}
+                initialViewport={workflowGraphViewportRef.current}
                 statusFilters={statusFilters}
                 coreActivityByWorkflow={coreActivityByWorkflow}
                 onSelectWorkflow={handleWorkflowClick}
                 onWorkflowContextMenu={handleWorkflowContextMenu}
+                onViewportSnapshot={handleWorkflowGraphViewportSnapshot}
                 onManualViewport={handleManualViewport}
               />
             )}

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -51,7 +51,9 @@ vi.mock('../components/WorkflowGraph.js', async () => {
 
 const fitViewMock = (ReactFlowModule as unknown as { __fitViewMock: Mock }).__fitViewMock;
 const setCenterMock = (ReactFlowModule as unknown as { __setCenterMock: Mock }).__setCenterMock;
+const setViewportMock = (ReactFlowModule as unknown as { __setViewportMock: Mock }).__setViewportMock;
 const getZoomMock = (ReactFlowModule as unknown as { __getZoomMock: Mock }).__getZoomMock;
+const getViewportMock = (ReactFlowModule as unknown as { __getViewportMock: Mock }).__getViewportMock;
 
 // App must be imported AFTER vi.mock registers so it binds the mocked react-flow.
 const { App } = await import('../App.js');
@@ -117,8 +119,11 @@ describe('Browser-surface camera (component)', () => {
     mock.install();
     fitViewMock.mockClear();
     setCenterMock.mockClear();
+    setViewportMock.mockClear();
     getZoomMock.mockReset();
     getZoomMock.mockReturnValue(1);
+    getViewportMock.mockReset();
+    getViewportMock.mockReturnValue({ x: 0, y: 0, zoom: 1 });
     workflowGraphSpy.reset();
   });
 
@@ -190,5 +195,42 @@ describe('Browser-surface camera (component)', () => {
     await flushFrames(4);
 
     expect(fitViewMock).toHaveBeenCalled();
+  });
+
+  it('returns to the workflow graph from the planning-home chat rail by restoring the saved viewport instead of fitting', async () => {
+    const savedViewport = { x: -360, y: 144, zoom: 0.68 };
+    mock.setTasks([], workflows);
+    render(<App />);
+
+    // The workflow graph lives on the `planning` surface; App boots on `home`
+    // (the planning chat rail), so open the graph and let the first-fit settle.
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    await screen.findByTestId('workflow-node-wf-a');
+    await settleCamera();
+
+    // Simulate the user having panned/zoomed the graph before leaving it.
+    getViewportMock.mockReturnValue(savedViewport);
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+    await screen.findByTestId('planning-session-rail');
+
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    setViewportMock.mockClear();
+    workflowGraphSpy.reset();
+
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+
+    await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
+    await waitFor(() => expect(setViewportMock).toHaveBeenCalledWith(savedViewport, { duration: 0 }));
+    await flushFrames(4);
+
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(workflowGraphSpy.commands.some((command) => (
+      command?.kind === 'fitInitial'
+      && command.scope === 'workflow'
+      && command.reason === 'sidebar-planning'
+    ))).toBe(false);
   });
 });

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -326,6 +326,26 @@ describe('WorkflowGraph', () => {
     expect(setCenterMock).not.toHaveBeenCalled();
   });
 
+  it('restores a supplied viewport on remount without running the first-fit', async () => {
+    const workflows = new Map([['wf-a', wf('wf-a', 'running')]]);
+    const savedViewport = { x: -240, y: 96, zoom: 0.72 };
+
+    render(
+      <WorkflowGraph
+        workflows={workflows}
+        selectedWorkflowId={null}
+        initialViewport={savedViewport}
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(setViewportMock).toHaveBeenCalledWith(savedViewport, { duration: 0 }));
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+  });
+
   it('preserves the camera across a non-empty workflow snapshot replacement', async () => {
     const workflows = new Map([
       ['wf-a', wf('wf-a', 'running')],

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from 'react';
 import type { WorkflowMeta, WorkflowStatus } from '../types.js';
-import type { GraphCameraCommand } from '../lib/graph-camera.js';
+import type { GraphCameraCommand, GraphCameraViewport } from '../lib/graph-camera.js';
 import type { WorkflowCoreActivity } from '../lib/workflow-core-activity.js';
 import { deriveWorkflowGraph, layoutWorkflowGraph, workflowGraphLayoutKey, type WorkflowGraphEdge, type WorkflowPosition } from '../lib/workflow-graph.js';
 import { WorkflowNode } from './WorkflowNode.js';
@@ -31,10 +31,14 @@ interface WorkflowGraphProps {
    * owning x/y/zoom locally — this is intent, not a controlled viewport.
    */
   cameraCommand?: GraphCameraCommand | null;
+  /** Viewport to restore when this graph remounts after a surface switch. */
+  initialViewport?: GraphCameraViewport | null;
   statusFilters: Set<WorkflowStatus>;
   coreActivityByWorkflow?: Map<string, WorkflowCoreActivity>;
   onSelectWorkflow: (workflowId: string) => void;
   onWorkflowContextMenu: (event: ReactMouseEvent, workflowId: string) => void;
+  /** Fired with the latest viewport so App can restore graph context later. */
+  onViewportSnapshot?: (viewport: GraphCameraViewport) => void;
   /** Fired when the user manually pans or zooms the viewport. */
   onManualViewport?: () => void;
 }
@@ -47,12 +51,6 @@ interface WorkflowNodeData extends Record<string, unknown> {
   onSelect?: () => void;
 }
 
-interface GraphViewport {
-  x: number;
-  y: number;
-  zoom: number;
-}
-
 const nodeTypes = {
   workflowNode: WorkflowFlowNode,
 };
@@ -63,9 +61,9 @@ const PANE_PAN_IMMEDIATE_STEP = 0.65;
 interface PanePan {
   startClientX: number;
   startClientY: number;
-  startViewport: GraphViewport;
-  targetViewport: GraphViewport;
-  visualViewport: GraphViewport;
+  startViewport: GraphCameraViewport;
+  targetViewport: GraphCameraViewport;
+  visualViewport: GraphCameraViewport;
   viewportElement: HTMLElement | null;
   animationFrame: number;
   active: boolean;
@@ -131,7 +129,7 @@ function shouldDeferPanePanFromNode(
 function createPanePan(
   startClientX: number,
   startClientY: number,
-  startViewport: GraphViewport,
+  startViewport: GraphCameraViewport,
   viewportElement: HTMLElement | null,
 ): PanePan {
   return {
@@ -148,7 +146,7 @@ function createPanePan(
   };
 }
 
-function getPanePanViewport(pan: PanePan, clientX: number, clientY: number): GraphViewport {
+function getPanePanViewport(pan: PanePan, clientX: number, clientY: number): GraphCameraViewport {
   return {
     x: pan.startViewport.x + clientX - pan.startClientX,
     y: pan.startViewport.y + clientY - pan.startClientY,
@@ -162,7 +160,7 @@ function movedBeyondPanePanThreshold(pan: PanePan, clientX: number, clientY: num
   return dx * dx + dy * dy >= PANE_PAN_DRAG_THRESHOLD_PX * PANE_PAN_DRAG_THRESHOLD_PX;
 }
 
-function applyViewportTransform(viewportElement: HTMLElement | null, viewport: GraphViewport): void {
+function applyViewportTransform(viewportElement: HTMLElement | null, viewport: GraphCameraViewport): void {
   viewportElement?.style.setProperty(
     'transform',
     `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
@@ -289,16 +287,19 @@ function WorkflowGraphInner({
   workflows,
   selectedWorkflowId,
   cameraCommand,
+  initialViewport,
   statusFilters,
   coreActivityByWorkflow,
   onSelectWorkflow,
   onWorkflowContextMenu,
+  onViewportSnapshot,
   onManualViewport,
 }: WorkflowGraphProps): JSX.Element {
   const { fitView, setCenter, getZoom, getViewport, setViewport } = useReactFlow();
   const graphRootRef = useRef<HTMLDivElement>(null);
   const reportedVisibleRef = useRef(false);
-  const lastHandledCameraSeqRef = useRef(0);
+  const initialViewportRef = useRef<GraphCameraViewport | null>(initialViewport ?? null);
+  const lastHandledCameraSeqRef = useRef(initialViewportRef.current ? cameraCommand?.sequence ?? 0 : 0);
   const initFitFrameRef = useRef(0);
   const initialFitCompletedRef = useRef(false);
   const watchdogMissCountRef = useRef(0);
@@ -316,6 +317,15 @@ function WorkflowGraphInner({
     () => graphRootRef.current?.querySelector<HTMLElement>('.react-flow__viewport') ?? null,
     [],
   );
+  const snapshotViewport = useCallback(() => {
+    onViewportSnapshot?.(getViewport());
+  }, [getViewport, onViewportSnapshot]);
+  const snapshotViewportAfterMove = useCallback((moveResult: unknown) => {
+    if (!onViewportSnapshot) return;
+    void Promise.resolve(moveResult).then(() => {
+      requestAnimationFrame(() => snapshotViewport());
+    });
+  }, [onViewportSnapshot, snapshotViewport]);
 
   const cancelActivePanePans = useCallback(() => {
     for (const ref of [panePointerPanRef, paneMousePanRef] as const) {
@@ -335,8 +345,8 @@ function WorkflowGraphInner({
   const performFitView = useCallback(() => {
     cancelActivePanePans();
     clearViewportInlineTransform(getViewportElement());
-    fitView({ padding: 0.2 });
-  }, [cancelActivePanePans, fitView, getViewportElement]);
+    snapshotViewportAfterMove(fitView({ padding: 0.2 }));
+  }, [cancelActivePanePans, fitView, getViewportElement, snapshotViewportAfterMove]);
   const [flowInstanceKey, setFlowInstanceKey] = useState(0);
   const graphMetricsRef = useRef({ deriveMs: 0, layoutMs: 0, objectsMs: 0 });
   const graph = useMemo(() => {
@@ -468,13 +478,21 @@ function WorkflowGraphInner({
     initFitFrameRef.current = requestAnimationFrame(() => {
       if (initialFitCompletedRef.current) return;
       initialFitCompletedRef.current = true;
+      const restoredViewport = initialViewportRef.current;
+      if (restoredViewport) {
+        snapshotViewportAfterMove(setViewport(restoredViewport, { duration: 0 }));
+        return;
+      }
       performFitView();
     });
-  }, [performFitView]);
+  }, [performFitView, setViewport, snapshotViewportAfterMove]);
 
   // Cancel a pending first-fit frame on unmount so it never fires against a
   // torn-down graph after the component has gone away.
   useEffect(() => () => cancelAnimationFrame(initFitFrameRef.current), []);
+  useEffect(() => () => {
+    snapshotViewport();
+  }, [snapshotViewport]);
   useEffect(() => () => {
     if (emptyGraphClearTimerRef.current) {
       clearTimeout(emptyGraphClearTimerRef.current);
@@ -521,9 +539,14 @@ function WorkflowGraphInner({
       setRfEdges(pendingEdges);
     }
   }, []);
-  const onMoveEnd = useCallback(() => {
+  const onMoveEnd = useCallback((_event?: unknown, viewport?: GraphCameraViewport) => {
     endViewportGesture();
-  }, [endViewportGesture]);
+    if (viewport) {
+      onViewportSnapshot?.(viewport);
+      return;
+    }
+    snapshotViewport();
+  }, [endViewportGesture, onViewportSnapshot, snapshotViewport]);
 
   const onPanePointerDownCapture = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0 || event.isPrimary === false) return;
@@ -575,9 +598,10 @@ function WorkflowGraphInner({
       pan.animationFrame = 0;
     }
     pan.visualViewport = { ...pan.targetViewport };
-    void setViewport(pan.targetViewport, { duration: 0 });
+    snapshotViewportAfterMove(setViewport(pan.targetViewport, { duration: 0 }));
+    onViewportSnapshot?.(pan.targetViewport);
     clearViewportInlineTransform(pan.viewportElement);
-  }, [setViewport]);
+  }, [onViewportSnapshot, setViewport, snapshotViewportAfterMove]);
 
   const onPanePointerMoveCapture = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     let pan = panePointerPanRef.current;
@@ -798,7 +822,7 @@ function WorkflowGraphInner({
     const frame = requestAnimationFrame(() => {
       if (typeof setCenter === 'function') {
         const zoom = typeof getZoom === 'function' ? getZoom() : 1;
-        setCenter(node.position.x + 110, node.position.y + 45, { zoom, duration: 180 });
+        snapshotViewportAfterMove(setCenter(node.position.x + 110, node.position.y + 45, { zoom, duration: 180 }));
       } else {
         performFitView();
       }

--- a/packages/ui/src/lib/graph-camera.ts
+++ b/packages/ui/src/lib/graph-camera.ts
@@ -56,6 +56,13 @@ export interface GraphCameraCommand {
   sequence: number;
 }
 
+/** React Flow viewport coordinates captured for restoring a graph remount. */
+export interface GraphCameraViewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
 /** Valid {@link CameraMode} values. */
 const CAMERA_MODES: ReadonlySet<CameraMode> = new Set<CameraMode>(['toggle', 'once']);
 


### PR DESCRIPTION
## Summary

Preserve Graph View Across Planning Window Switches lands the user-facing camera change in this first slice.

This slice snapshots the workflow graph's last user-owned viewport before the planning chat rail unmounts the canvas.

Returning to the plan graph from the chat rail now restores that saved viewport instead of replaying a fresh fit step.

## Review Claim

Returning to the plan graph from the planning chat rail restores the last workflow-graph viewport instead of refitting the canvas.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The saved viewport is used only for workflow-graph remounts after a chat-rail round trip. Opening the graph from any other surface still clears the snapshot and runs the existing fit command.

## Slice Rationale

This is the user-facing camera slice. Later PRs keep the supporting coverage and managed SSH bootstrap separate.

## Non-goals

- Change task-DAG camera behavior.
- Change Planning draft or tmux session state.
- Change workflow-graph layout or selection rules.

## Architecture

### Before

```mermaid
graph TD
    A["Plan graph surface"] --> B["Chat rail surface unmounts React Flow"]
    B --> C["Graph return issues fitInitial"]
    C --> D["User pan and zoom are lost"]
```

### After

```mermaid
graph TD
    A["Plan graph surface"] --> B["App snapshots x/y/zoom before the chat rail"]
    B --> C["Chat rail surface unmounts React Flow"]
    C --> D["Graph return remounts WorkflowGraph with initialViewport"]
    D --> E["React Flow restores the saved viewport without fitInitial"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/workflow-graph.test.tsx`
- [x] `pnpm --filter @invoker/ui test -- src/__tests__/browser-surface-camera-resnap.test.tsx`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert da0e0be6bc6abbff6c05b2271292780f1fee2780`
- Post-revert steps: Rerun `pnpm --filter @invoker/ui test -- src/__tests__/workflow-graph.test.tsx src/__tests__/browser-surface-camera-resnap.test.tsx`.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow graph camera position and zoom are now preserved when navigating between planning views.
  * Returning to a workflow graph restores the previous viewport instead of resetting the camera.
  * Graph viewport state is restored smoothly when reopening or remounting the graph.

* **Bug Fixes**
  * Prevented unnecessary graph refitting and camera repositioning during navigation.
  * Ensured the graph camera resets appropriately after submitting a planning draft or when no workflows remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->