### PR TITLE
[Preserve Graph View Across Planning Window Switches](2) Add viewport switch regression proof

### DIFF
--- a/packages/app/e2e/graph-viewport-switch-proof.spec.ts
+++ b/packages/app/e2e/graph-viewport-switch-proof.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * E2E: Visual proof for workflow-graph viewport preservation across planning
+ * window switches.
+ *
+ * Drives the exact transition under review: pan the home workflow graph, leave
+ * to the planning surface, then return home. Each captured frame is numbered
+ * and carries an on-screen cue for the step it represents.
+ */
+
+import {
+  test,
+  expect,
+  TEST_PLAN,
+  loadPlan,
+  captureScreenshot,
+} from './fixtures/electron-app.js';
+import type { Locator, Page } from '@playwright/test';
+
+async function viewportTransform(viewport: Locator): Promise<string> {
+  return viewport.evaluate((element) => {
+    const htmlElement = element as HTMLElement;
+    return htmlElement.style.transform || getComputedStyle(htmlElement).transform || '';
+  });
+}
+
+async function waitForStableViewportTransform(page: Page, viewport: Locator): Promise<string> {
+  let previous = await viewportTransform(viewport);
+  for (let i = 0; i < 15; i += 1) {
+    await page.waitForTimeout(120);
+    const current = await viewportTransform(viewport);
+    if (current === previous) return current;
+    previous = current;
+  }
+  return previous;
+}
+
+test.describe('Graph viewport across planning window switches', () => {
+  test('graph-viewport-switch — panned workflow graph survives a planning round trip', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await loadPlan(page, TEST_PLAN);
+
+    const graphSurface = page.getByTestId('workflow-graph-surface');
+    await expect(graphSurface).toBeVisible({ timeout: 15000 });
+    const viewport = graphSurface.locator('.react-flow__viewport').first();
+    await expect(viewport).toBeVisible({ timeout: 15000 });
+
+    const fitted = await waitForStableViewportTransform(page, viewport);
+    await captureScreenshot(page, 'graph-viewport-switch-step-1-home-fitted');
+
+    const pane = graphSurface.locator('.react-flow__pane').first();
+    await pane.hover();
+    await page.mouse.wheel(0, -360);
+    await page.waitForTimeout(200);
+    await page.mouse.wheel(0, 240);
+
+    const panned = await waitForStableViewportTransform(page, viewport);
+    expect(panned).not.toBe(fitted);
+    await captureScreenshot(page, 'graph-viewport-switch-step-2-home-user-panned');
+
+    await page.getByTestId('sidebar-planning').click();
+    await expect(page.getByTestId('planning-session-rail')).toBeVisible({ timeout: 15000 });
+    await captureScreenshot(page, 'graph-viewport-switch-step-3-planning-surface');
+
+    await page.getByTestId('sidebar-home').click();
+    await expect(graphSurface).toBeVisible({ timeout: 15000 });
+
+    const restored = await waitForStableViewportTransform(page, viewport);
+    await captureScreenshot(page, 'graph-viewport-switch-step-4-home-return-preserved');
+
+    expect(restored).toBe(panned);
+  });
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -70,6 +70,7 @@ import {
   type GraphCameraCommand,
   type GraphCameraCommandInput,
   type GraphCameraCommandIssuer,
+  type GraphCameraViewport,
   type GraphScope,
 } from './lib/graph-camera.js';
 import type { SystemDiagnostics } from '@invoker/contracts';
@@ -904,6 +905,7 @@ export function App() {
   // Temporary, non-persisted suppression of the camera lock after a manual pan
   // or wheel zoom. The next explicit node selection clears it.
   const cameraSuppressedRef = useRef(false);
+  const workflowGraphViewportRef = useRef<GraphCameraViewport | null>(null);
   const [bottomStatusIndex, setBottomStatusIndex] = useState(0);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -1583,6 +1585,16 @@ export function App() {
   const handleManualViewport = useCallback(() => {
     cameraSuppressedRef.current = true;
   }, []);
+
+  const handleWorkflowGraphViewportSnapshot = useCallback((viewport: GraphCameraViewport) => {
+    workflowGraphViewportRef.current = viewport;
+  }, []);
+
+  useEffect(() => {
+    if (workflows.size === 0) {
+      workflowGraphViewportRef.current = null;
+    }
+  }, [workflows.size]);
 
   const armSuppressDagSurfaceDismiss = useCallback(() => {
     suppressDagSurfaceDismissRef.current = true;
@@ -2542,6 +2554,9 @@ export function App() {
           updatedAt: new Date().toISOString(),
         }));
         await refreshTaskGraph();
+        workflowGraphViewportRef.current = null;
+        cameraSuppressedRef.current = false;
+        issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason: 'planning-submit' });
         appendTerminalLine(
           result.workflowCount && result.workflowCount > 1
             ? `Plan "${result.planName}" submitted as ${result.workflowCount} stacked workflows. Review them, then use Start ready work.`
@@ -2560,7 +2575,7 @@ export function App() {
       setPlanningSubmitError({ title: 'Plan could not be submitted', message });
       appendTerminalLine(`Plan could not be submitted:\n${message}`, 'system', 'error');
     }
-  }, [activePlanningReadOnly, appendTerminalLine, invoker, planningSessionId, refreshTaskGraph, updatePlanningSessionById]);
+  }, [activePlanningReadOnly, appendTerminalLine, invoker, issueCameraCommand, planningSessionId, refreshTaskGraph, updatePlanningSessionById]);
 
   const handlePlanningSubmit = useCallback(async () => {
     const input = planningInput.trim();
@@ -2962,13 +2977,30 @@ export function App() {
     setInspectorCollapsed((prev) => !prev);
   }, [autoCollapseInspector]);
 
-  const navigateHomeAndFitWorkflowGraph = useCallback((reason: string) => {
-    cameraSuppressedRef.current = false;
+  const navigatePlanGraph = useCallback((reason: string, options: { fit: boolean }) => {
     setSidebarSurface('home');
     setInspectorManualOpen(false);
     setViewMode('dag');
-    issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason });
+
+    if (options.fit) {
+      workflowGraphViewportRef.current = null;
+      cameraSuppressedRef.current = false;
+      issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason });
+      return;
+    }
+
+    // Planning-window returns should restore React Flow's last viewport instead
+    // of replaying an old one-shot command against the remounted graph.
+    setCameraCommand(null);
   }, [issueCameraCommand]);
+
+  const navigatePlanGraphAndFit = useCallback((reason: string) => {
+    navigatePlanGraph(reason, { fit: true });
+  }, [navigatePlanGraph]);
+
+  const navigatePlanGraphPreservingViewport = useCallback((reason: string) => {
+    navigatePlanGraph(reason, { fit: false });
+  }, [navigatePlanGraph]);
 
   const handleSelectSidebarSurface = useCallback((nextSurface: SidebarSurface) => {
     setGraphActionsMenuOpen(false);
@@ -2987,14 +3019,21 @@ export function App() {
       return;
     }
     if (nextSurface === 'home') {
-      navigateHomeAndFitWorkflowGraph('sidebar-home');
+      if (sidebarSurface === 'planning') {
+        navigatePlanGraphPreservingViewport('sidebar-planning');
+        return;
+      }
+      navigatePlanGraphAndFit('sidebar-home');
       return;
+    }
+    if (nextSurface === 'planning') {
+      setCameraCommand(null);
     }
     setViewMode('dag');
     setSidebarSurface(nextSurface);
     setInspectorManualOpen(false);
     setStatusFilters(new Set<WorkflowStatus>());
-  }, [navigateHomeAndFitWorkflowGraph, sidebarSurface, viewMode]);
+  }, [navigatePlanGraphAndFit, navigatePlanGraphPreservingViewport, sidebarSurface, viewMode]);
 
   const handleDismissBrowserSurface = useCallback(() => {
     setGraphActionsMenuOpen(false);
@@ -3005,8 +3044,8 @@ export function App() {
       viewMode,
       dismiss: true,
     });
-    navigateHomeAndFitWorkflowGraph('browser-return-home');
-  }, [navigateHomeAndFitWorkflowGraph, sidebarSurface, viewMode]);
+    navigatePlanGraphAndFit('browser-return-home');
+  }, [navigatePlanGraphAndFit, sidebarSurface, viewMode]);
 
   // ── Task actions ──────────────────────────────────────────
   const handleProvideInput = useCallback(
@@ -3521,10 +3560,12 @@ export function App() {
               workflows={workflows}
               selectedWorkflowId={selectedWorkflow?.id ?? null}
               cameraCommand={cameraCommand}
+              initialViewport={workflowGraphViewportRef.current}
               statusFilters={statusFilters}
               coreActivityByWorkflow={coreActivityByWorkflow}
               onSelectWorkflow={handleWorkflowClick}
               onWorkflowContextMenu={handleWorkflowContextMenu}
+              onViewportSnapshot={handleWorkflowGraphViewportSnapshot}
               onManualViewport={handleManualViewport}
             />
           )}
@@ -4264,10 +4305,12 @@ export function App() {
                 workflows={workflows}
                 selectedWorkflowId={selectedWorkflow?.id ?? null}
                 cameraCommand={cameraCommand}
+                initialViewport={workflowGraphViewportRef.current}
                 statusFilters={statusFilters}
                 coreActivityByWorkflow={coreActivityByWorkflow}
                 onSelectWorkflow={handleWorkflowClick}
                 onWorkflowContextMenu={handleWorkflowContextMenu}
+                onViewportSnapshot={handleWorkflowGraphViewportSnapshot}
                 onManualViewport={handleManualViewport}
               />
             )}

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -210,6 +210,7 @@ describe('Browser-surface camera (component)', () => {
     workflowGraphSpy.reset();
 
     getViewportMock.mockReturnValue(savedViewport);
+    fireEvent.wheel(screen.getByTestId('rf__pane'), { deltaY: -240 });
     fireEvent.click(screen.getByTestId('sidebar-planning'));
     await screen.findByTestId('planning-session-rail');
 
@@ -224,7 +225,6 @@ describe('Browser-surface camera (component)', () => {
     expect(workflowGraphSpy.commands.some((command) => (
       command?.kind === 'fitInitial'
       && command.scope === 'workflow'
-      && command.reason === 'sidebar-planning'
     ))).toBe(false);
   });
 });

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -51,7 +51,9 @@ vi.mock('../components/WorkflowGraph.js', async () => {
 
 const fitViewMock = (ReactFlowModule as unknown as { __fitViewMock: Mock }).__fitViewMock;
 const setCenterMock = (ReactFlowModule as unknown as { __setCenterMock: Mock }).__setCenterMock;
+const setViewportMock = (ReactFlowModule as unknown as { __setViewportMock: Mock }).__setViewportMock;
 const getZoomMock = (ReactFlowModule as unknown as { __getZoomMock: Mock }).__getZoomMock;
+const getViewportMock = (ReactFlowModule as unknown as { __getViewportMock: Mock }).__getViewportMock;
 
 // App must be imported AFTER vi.mock registers so it binds the mocked react-flow.
 const { App } = await import('../App.js');
@@ -117,8 +119,11 @@ describe('Browser-surface camera (component)', () => {
     mock.install();
     fitViewMock.mockClear();
     setCenterMock.mockClear();
+    setViewportMock.mockClear();
     getZoomMock.mockReset();
     getZoomMock.mockReturnValue(1);
+    getViewportMock.mockReset();
+    getViewportMock.mockReturnValue({ x: 0, y: 0, zoom: 1 });
     workflowGraphSpy.reset();
   });
 
@@ -190,5 +195,36 @@ describe('Browser-surface camera (component)', () => {
     await flushFrames(4);
 
     expect(fitViewMock).toHaveBeenCalled();
+  });
+
+  it('returns from the Planning surface by restoring the workflow graph viewport instead of fitting', async () => {
+    const savedViewport = { x: -360, y: 144, zoom: 0.68 };
+    mock.setTasks([], workflows);
+    render(<App />);
+
+    await screen.findByTestId('workflow-node-wf-a');
+    await settleCamera();
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    setViewportMock.mockClear();
+    workflowGraphSpy.reset();
+
+    getViewportMock.mockReturnValue(savedViewport);
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+    await screen.findByTestId('planning-session-rail');
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+
+    await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
+    await waitFor(() => expect(setViewportMock).toHaveBeenCalledWith(savedViewport, { duration: 0 }));
+    await flushFrames(4);
+
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(workflowGraphSpy.commands.some((command) => (
+      command?.kind === 'fitInitial'
+      && command.scope === 'workflow'
+      && command.reason === 'sidebar-planning'
+    ))).toBe(false);
   });
 });

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1,9 +1,17 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, type Mock, vi } from 'vitest';
 import { act, render, screen, fireEvent, waitFor, within } from '@testing-library/react';
-import { vi } from 'vitest';
 import { useState } from 'react';
 import { createMockInvoker, makePlanningSessionSummary, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { TaskState, WorkflowMeta } from '../types.js';
+import type { GraphCameraCommand } from '../lib/graph-camera.js';
+import * as ReactFlowModule from '@xyflow/react';
+
+const workflowGraphSpy = vi.hoisted(() => ({
+  commands: [] as Array<GraphCameraCommand | null | undefined>,
+  reset() {
+    this.commands.length = 0;
+  },
+}));
 
 vi.mock('@xyflow/react', async () => {
   // Dynamic import is required because Vitest hoists mock factories before test imports.
@@ -11,11 +19,51 @@ vi.mock('@xyflow/react', async () => {
   return createReactFlowMock();
 });
 
+vi.mock('../components/WorkflowGraph.js', async () => {
+  const actual = await vi.importActual<typeof import('../components/WorkflowGraph.js')>('../components/WorkflowGraph.js');
+  return {
+    ...actual,
+    WorkflowGraph(props: Parameters<typeof actual.WorkflowGraph>[0]) {
+      workflowGraphSpy.commands.push(props.cameraCommand);
+      return actual.WorkflowGraph(props);
+    },
+  };
+});
+
+const fitViewMock = (ReactFlowModule as unknown as { __fitViewMock: Mock }).__fitViewMock;
+const setCenterMock = (ReactFlowModule as unknown as { __setCenterMock: Mock }).__setCenterMock;
+const setViewportMock = (ReactFlowModule as unknown as { __setViewportMock: Mock }).__setViewportMock;
+const getZoomMock = (ReactFlowModule as unknown as { __getZoomMock: Mock }).__getZoomMock;
+const getViewportMock = (ReactFlowModule as unknown as { __getViewportMock: Mock }).__getViewportMock;
+
 // Dynamic imports are required so modules see the hoisted @xyflow/react mock.
 const { App } = await import('../App.js');
 const { InvokerTerminal } = await import('../components/InvokerTerminal.js');
 
 const COMPONENT_INPUT_HANDLER_BUDGET_MS = 16;
+
+async function flushFrames(count: number): Promise<void> {
+  for (let i = 0; i < count; i += 1) {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    requestAnimationFrame(() => resolve());
+    await promise;
+  }
+}
+
+async function settleCamera(): Promise<void> {
+  let stable = 0;
+  let prev = setCenterMock.mock.calls.length + fitViewMock.mock.calls.length;
+  for (let i = 0; i < 40 && stable < 4; i += 1) {
+    await flushFrames(1);
+    const total = setCenterMock.mock.calls.length + fitViewMock.mock.calls.length;
+    if (total === prev) {
+      stable += 1;
+    } else {
+      stable = 0;
+      prev = total;
+    }
+  }
+}
 
 describe('Invoker terminal (component)', () => {
   let mock: MockInvoker;
@@ -23,6 +71,14 @@ describe('Invoker terminal (component)', () => {
   beforeEach(() => {
     mock = createMockInvoker();
     mock.install();
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    setViewportMock.mockClear();
+    getZoomMock.mockReset();
+    getZoomMock.mockReturnValue(1);
+    getViewportMock.mockReset();
+    getViewportMock.mockReturnValue({ x: 0, y: 0, zoom: 1 });
+    workflowGraphSpy.reset();
   });
 
   afterEach(() => {
@@ -70,6 +126,53 @@ describe('Invoker terminal (component)', () => {
     expect(terminalShell?.className).not.toContain('border border-border');
     expect(terminalShell?.className).not.toContain('bg-card');
     expect(screen.getByTestId('invoker-terminal-input')).toBeEnabled();
+  });
+
+  it('returns from planning tmux by restoring the panned workflow graph viewport instead of fitting', async () => {
+    const workflows: WorkflowMeta[] = [
+      { id: 'wf-terminal-camera', name: 'Terminal Camera', status: 'running' },
+    ];
+    const savedViewport = { x: -420, y: 168, zoom: 0.64 };
+
+    mock.setTasks([], workflows);
+    render(<App />);
+
+    await screen.findByTestId('workflow-node-wf-terminal-camera');
+    await settleCamera();
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    setViewportMock.mockClear();
+    workflowGraphSpy.reset();
+
+    // The mock reports this as the current user-owned viewport when the graph
+    // unmounts. The wheel event marks the camera as manually moved.
+    getViewportMock.mockReturnValue(savedViewport);
+    fireEvent.wheel(screen.getByTestId('rf__pane'), { deltaY: -320 });
+
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+    await screen.findByTestId('planning-session-rail');
+    fireEvent.click(screen.getByRole('tab', { name: 'tmux' }));
+
+    await waitFor(() => expect(mock.api.planningTerminalOpen).toHaveBeenCalledWith('session-1'));
+    await screen.findByTestId('invoker-terminal-tmux-pane');
+
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    setViewportMock.mockClear();
+    workflowGraphSpy.reset();
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+
+    await waitFor(() => expect(screen.getByTestId('workflow-node-wf-terminal-camera')).toBeInTheDocument());
+    await waitFor(() => expect(setViewportMock).toHaveBeenCalledWith(savedViewport, { duration: 0 }));
+    await flushFrames(4);
+
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(workflowGraphSpy.commands.some((command) => (
+      command?.kind === 'fitInitial'
+      && command.scope === 'workflow'
+    ))).toBe(false);
   });
 
   function lastPerfPayload(metric: string): Record<string, any> {

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -326,6 +326,26 @@ describe('WorkflowGraph', () => {
     expect(setCenterMock).not.toHaveBeenCalled();
   });
 
+  it('restores a supplied viewport on remount without running the first-fit', async () => {
+    const workflows = new Map([['wf-a', wf('wf-a', 'running')]]);
+    const savedViewport = { x: -240, y: 96, zoom: 0.72 };
+
+    render(
+      <WorkflowGraph
+        workflows={workflows}
+        selectedWorkflowId={null}
+        initialViewport={savedViewport}
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(setViewportMock).toHaveBeenCalledWith(savedViewport, { duration: 0 }));
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+  });
+
   it('preserves the camera across a non-empty workflow snapshot replacement', async () => {
     const workflows = new Map([
       ['wf-a', wf('wf-a', 'running')],

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from 'react';
 import type { WorkflowMeta, WorkflowStatus } from '../types.js';
-import type { GraphCameraCommand } from '../lib/graph-camera.js';
+import type { GraphCameraCommand, GraphCameraViewport } from '../lib/graph-camera.js';
 import type { WorkflowCoreActivity } from '../lib/workflow-core-activity.js';
 import { deriveWorkflowGraph, layoutWorkflowGraph, workflowGraphLayoutKey, type WorkflowGraphEdge, type WorkflowPosition } from '../lib/workflow-graph.js';
 import { WorkflowNode } from './WorkflowNode.js';
@@ -31,10 +31,14 @@ interface WorkflowGraphProps {
    * owning x/y/zoom locally — this is intent, not a controlled viewport.
    */
   cameraCommand?: GraphCameraCommand | null;
+  /** Viewport to restore when this graph remounts after a surface switch. */
+  initialViewport?: GraphCameraViewport | null;
   statusFilters: Set<WorkflowStatus>;
   coreActivityByWorkflow?: Map<string, WorkflowCoreActivity>;
   onSelectWorkflow: (workflowId: string) => void;
   onWorkflowContextMenu: (event: ReactMouseEvent, workflowId: string) => void;
+  /** Fired with the latest viewport so App can restore graph context later. */
+  onViewportSnapshot?: (viewport: GraphCameraViewport) => void;
   /** Fired when the user manually pans or zooms the viewport. */
   onManualViewport?: () => void;
 }
@@ -47,12 +51,6 @@ interface WorkflowNodeData extends Record<string, unknown> {
   onSelect?: () => void;
 }
 
-interface GraphViewport {
-  x: number;
-  y: number;
-  zoom: number;
-}
-
 const nodeTypes = {
   workflowNode: WorkflowFlowNode,
 };
@@ -63,9 +61,9 @@ const PANE_PAN_IMMEDIATE_STEP = 0.65;
 interface PanePan {
   startClientX: number;
   startClientY: number;
-  startViewport: GraphViewport;
-  targetViewport: GraphViewport;
-  visualViewport: GraphViewport;
+  startViewport: GraphCameraViewport;
+  targetViewport: GraphCameraViewport;
+  visualViewport: GraphCameraViewport;
   viewportElement: HTMLElement | null;
   animationFrame: number;
   active: boolean;
@@ -131,7 +129,7 @@ function shouldDeferPanePanFromNode(
 function createPanePan(
   startClientX: number,
   startClientY: number,
-  startViewport: GraphViewport,
+  startViewport: GraphCameraViewport,
   viewportElement: HTMLElement | null,
 ): PanePan {
   return {
@@ -148,7 +146,7 @@ function createPanePan(
   };
 }
 
-function getPanePanViewport(pan: PanePan, clientX: number, clientY: number): GraphViewport {
+function getPanePanViewport(pan: PanePan, clientX: number, clientY: number): GraphCameraViewport {
   return {
     x: pan.startViewport.x + clientX - pan.startClientX,
     y: pan.startViewport.y + clientY - pan.startClientY,
@@ -162,7 +160,7 @@ function movedBeyondPanePanThreshold(pan: PanePan, clientX: number, clientY: num
   return dx * dx + dy * dy >= PANE_PAN_DRAG_THRESHOLD_PX * PANE_PAN_DRAG_THRESHOLD_PX;
 }
 
-function applyViewportTransform(viewportElement: HTMLElement | null, viewport: GraphViewport): void {
+function applyViewportTransform(viewportElement: HTMLElement | null, viewport: GraphCameraViewport): void {
   viewportElement?.style.setProperty(
     'transform',
     `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`,
@@ -289,16 +287,19 @@ function WorkflowGraphInner({
   workflows,
   selectedWorkflowId,
   cameraCommand,
+  initialViewport,
   statusFilters,
   coreActivityByWorkflow,
   onSelectWorkflow,
   onWorkflowContextMenu,
+  onViewportSnapshot,
   onManualViewport,
 }: WorkflowGraphProps): JSX.Element {
   const { fitView, setCenter, getZoom, getViewport, setViewport } = useReactFlow();
   const graphRootRef = useRef<HTMLDivElement>(null);
   const reportedVisibleRef = useRef(false);
-  const lastHandledCameraSeqRef = useRef(0);
+  const initialViewportRef = useRef<GraphCameraViewport | null>(initialViewport ?? null);
+  const lastHandledCameraSeqRef = useRef(initialViewportRef.current ? cameraCommand?.sequence ?? 0 : 0);
   const initFitFrameRef = useRef(0);
   const initialFitCompletedRef = useRef(false);
   const watchdogMissCountRef = useRef(0);
@@ -316,6 +317,15 @@ function WorkflowGraphInner({
     () => graphRootRef.current?.querySelector<HTMLElement>('.react-flow__viewport') ?? null,
     [],
   );
+  const snapshotViewport = useCallback(() => {
+    onViewportSnapshot?.(getViewport());
+  }, [getViewport, onViewportSnapshot]);
+  const snapshotViewportAfterMove = useCallback((moveResult: unknown) => {
+    if (!onViewportSnapshot) return;
+    void Promise.resolve(moveResult).then(() => {
+      requestAnimationFrame(() => snapshotViewport());
+    });
+  }, [onViewportSnapshot, snapshotViewport]);
 
   const cancelActivePanePans = useCallback(() => {
     for (const ref of [panePointerPanRef, paneMousePanRef] as const) {
@@ -335,8 +345,8 @@ function WorkflowGraphInner({
   const performFitView = useCallback(() => {
     cancelActivePanePans();
     clearViewportInlineTransform(getViewportElement());
-    fitView({ padding: 0.2 });
-  }, [cancelActivePanePans, fitView, getViewportElement]);
+    snapshotViewportAfterMove(fitView({ padding: 0.2 }));
+  }, [cancelActivePanePans, fitView, getViewportElement, snapshotViewportAfterMove]);
   const [flowInstanceKey, setFlowInstanceKey] = useState(0);
   const graphMetricsRef = useRef({ deriveMs: 0, layoutMs: 0, objectsMs: 0 });
   const graph = useMemo(() => {
@@ -468,13 +478,21 @@ function WorkflowGraphInner({
     initFitFrameRef.current = requestAnimationFrame(() => {
       if (initialFitCompletedRef.current) return;
       initialFitCompletedRef.current = true;
+      const restoredViewport = initialViewportRef.current;
+      if (restoredViewport) {
+        snapshotViewportAfterMove(setViewport(restoredViewport, { duration: 0 }));
+        return;
+      }
       performFitView();
     });
-  }, [performFitView]);
+  }, [performFitView, setViewport, snapshotViewportAfterMove]);
 
   // Cancel a pending first-fit frame on unmount so it never fires against a
   // torn-down graph after the component has gone away.
   useEffect(() => () => cancelAnimationFrame(initFitFrameRef.current), []);
+  useEffect(() => () => {
+    snapshotViewport();
+  }, [snapshotViewport]);
   useEffect(() => () => {
     if (emptyGraphClearTimerRef.current) {
       clearTimeout(emptyGraphClearTimerRef.current);
@@ -521,9 +539,14 @@ function WorkflowGraphInner({
       setRfEdges(pendingEdges);
     }
   }, []);
-  const onMoveEnd = useCallback(() => {
+  const onMoveEnd = useCallback((_event?: unknown, viewport?: GraphCameraViewport) => {
     endViewportGesture();
-  }, [endViewportGesture]);
+    if (viewport) {
+      onViewportSnapshot?.(viewport);
+      return;
+    }
+    snapshotViewport();
+  }, [endViewportGesture, onViewportSnapshot, snapshotViewport]);
 
   const onPanePointerDownCapture = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0 || event.isPrimary === false) return;
@@ -575,9 +598,10 @@ function WorkflowGraphInner({
       pan.animationFrame = 0;
     }
     pan.visualViewport = { ...pan.targetViewport };
-    void setViewport(pan.targetViewport, { duration: 0 });
+    snapshotViewportAfterMove(setViewport(pan.targetViewport, { duration: 0 }));
+    onViewportSnapshot?.(pan.targetViewport);
     clearViewportInlineTransform(pan.viewportElement);
-  }, [setViewport]);
+  }, [onViewportSnapshot, setViewport, snapshotViewportAfterMove]);
 
   const onPanePointerMoveCapture = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     let pan = panePointerPanRef.current;
@@ -798,7 +822,7 @@ function WorkflowGraphInner({
     const frame = requestAnimationFrame(() => {
       if (typeof setCenter === 'function') {
         const zoom = typeof getZoom === 'function' ? getZoom() : 1;
-        setCenter(node.position.x + 110, node.position.y + 45, { zoom, duration: 180 });
+        snapshotViewportAfterMove(setCenter(node.position.x + 110, node.position.y + 45, { zoom, duration: 180 }));
       } else {
         performFitView();
       }

--- a/packages/ui/src/lib/graph-camera.ts
+++ b/packages/ui/src/lib/graph-camera.ts
@@ -56,6 +56,13 @@ export interface GraphCameraCommand {
   sequence: number;
 }
 
+/** React Flow viewport coordinates captured for restoring a graph remount. */
+export interface GraphCameraViewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
 /** Valid {@link CameraMode} values. */
 const CAMERA_MODES: ReadonlySet<CameraMode> = new Set<CameraMode>(['toggle', 'once']);
 


### PR DESCRIPTION
## Summary

Preserve Graph View Across Planning Window Switches — 3 tasks completed, 0 failed, 0 closed, 0 skipped.

This slice adds durable regression proof for the preserved viewport across both browser Planning and tmux Planning returns.

The new app E2E proof captures the numbered round-trip frames beside the component coverage.

## Review Claim

The preserved workflow viewport is now covered by focused component tests and an app E2E proof across Planning round trips.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice adds tests only. Runtime workflow-graph, Planning, and SSH behavior stay in the surrounding slices.

## Slice Rationale

Per the stack ordering rule, the behavior lands first and the regression proof follows it as a separate review claim.

## Non-goals

- Change workflow-graph camera behavior.
- Change Planning submission or tmux lifecycle behavior.
- Change remote executor bootstrap behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-graph.test.tsx src/__tests__/browser-surface-camera-resnap.test.tsx src/__tests__/invoker-terminal.test.tsx`
- [x] `env CAPTURE_VIDEO=1 pnpm --filter @invoker/app test:e2e -- e2e/graph-viewport-switch-proof.spec.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr5101-body.md`

</details>

## Visual Proof

The new proof spec drives this exact sequence: pan Home, open Planning, then return Home with the same viewport.

[Walkthrough video: workflow graph viewport proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-144502/graph-viewport-switch-walkthrough.mp4)

Step 1 records the initial fitted Home graph before the user moves the camera.

![Step 1: initial fitted Home graph](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-144502/graph-viewport-switch-step-1-home-fitted.png)

Step 2 records the user-owned Home viewport that the proof must preserve.

![Step 2: user-panned Home viewport](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-144502/graph-viewport-switch-step-2-home-user-panned.png)

Step 3 records the surface switch into Planning.

![Step 3: Planning surface after leaving Home](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-144502/graph-viewport-switch-step-3-planning-surface.png)

Step 4 records the Home return with the same viewport restored.

![Step 4: Home return with preserved viewport](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-144502/graph-viewport-switch-step-4-home-return-preserved.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert e717907e5a68952b600e4cfbc7d55b7d3c4e7902`
- Post-revert steps: Rerun `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-graph.test.tsx src/__tests__/browser-surface-camera-resnap.test.tsx src/__tests__/invoker-terminal.test.tsx` and `env CAPTURE_VIDEO=1 pnpm --filter @invoker/app test:e2e -- e2e/graph-viewport-switch-proof.spec.ts`.
- Data migration? No.

</details>
