### PR TITLE
[Preserve Graph View Across Planning Window Switches](3) Bootstrap managed SSH pnpm before verification

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import type { ChildProcess } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SshExecutor } from '../ssh-executor.js';
@@ -217,6 +217,11 @@ describe('SshExecutor managed workspace mode', () => {
     expect(callScript).toContain('cat > "$RUNNER_PATH" <<');
     expect(callScript).toContain('cat > "$PAYLOAD_PATH" <<');
     expect(callScript).not.toContain('cat > "$PROVISION_PATH" <<');
+    expect(callScript).toContain('ensure_managed_pnpm_workspace');
+    expect(callScript).toContain('pnpm install --frozen-lockfile');
+    expect(callScript.indexOf('pnpm install --frozen-lockfile')).toBeLessThan(
+      callScript.indexOf('echo "[SshExecutor] Running task payload..."'),
+    );
     expect(callScript).toContain('start_bootstrap_heartbeat');
     expect(callScript).toContain('stop_bootstrap_heartbeat');
     expect(callScript.indexOf('stop_bootstrap_heartbeat')).toBeLessThan(callScript.indexOf('"$RUNNER_PATH" "$PAYLOAD_PATH"'));
@@ -225,6 +230,78 @@ describe('SshExecutor managed workspace mode', () => {
     expect(callScript).toContain("trap 'cleanup_runtime \"$?\"' EXIT");
     expect(callAgentId).toBeUndefined();
     expect(callFinalize).toEqual({ branch: handle.branch, worktreePath: handle.workspacePath });
+  });
+
+  it('managed mode installs pnpm dependencies when node_modules is missing before payload', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+      remoteHeartbeatIntervalSeconds: 1,
+      remoteInvokerHome: '~/.invoker',
+    }) as any;
+
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return '__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=abc123def456abc123def456abc123def456abc1';
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      return '';
+    });
+    vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+
+    await ssh.start(makeRequest({
+      actionType: 'command',
+      inputs: {
+        command: "printf 'payload-ran\\n' > payload.out",
+        description: 'run tests',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    }));
+
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+    expect(proc).toBeDefined();
+    const writeMock = (proc.stdin as any).write as ReturnType<typeof vi.fn>;
+    const bootstrapScript = writeMock.mock.calls[0]![0] as string;
+    const workspaceMatch = bootstrapScript.match(/WT=\$\(normalize_remote_path '([^']+)'\)/);
+    if (!workspaceMatch?.[1]) {
+      throw new Error('Managed SSH bootstrap did not embed a workspace path');
+    }
+
+    const fakeHome = mkdtempSync(join(tmpdir(), 'ssh-pnpm-bootstrap-home-'));
+    try {
+      const workspacePath = workspaceMatch[1].replace(/^~(?=\/|$)/, fakeHome);
+      const binDir = join(fakeHome, 'bin');
+      mkdirSync(workspacePath, { recursive: true });
+      mkdirSync(binDir, { recursive: true });
+      writeFileSync(join(workspacePath, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
+      const pnpmPath = join(binDir, 'pnpm');
+      writeFileSync(
+        pnpmPath,
+        '#!/usr/bin/env bash\nprintf "%s\\n" "$*" > "$HOME/pnpm-args.txt"\nprintf "%s\\n" "$PWD" > "$HOME/pnpm-cwd.txt"\nmkdir -p node_modules\n',
+      );
+      chmodSync(pnpmPath, 0o755);
+
+      const childProcessModule = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+      const result = childProcessModule.spawnSync('/bin/bash', ['-c', bootstrapScript], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: fakeHome, PATH: `${binDir}:${process.env.PATH ?? ''}` },
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('[SshExecutor] Installing pnpm dependencies for managed worktree...');
+      expect(result.stdout).toContain('[SshExecutor] Running task payload...');
+      expect(readFileSync(join(fakeHome, 'pnpm-args.txt'), 'utf8')).toBe('install --frozen-lockfile\n');
+      expect(readFileSync(join(fakeHome, 'pnpm-cwd.txt'), 'utf8')).toBe(`${workspacePath}\n`);
+      expect(existsSync(join(workspacePath, 'node_modules'))).toBe(true);
+      expect(readFileSync(join(workspacePath, 'payload.out'), 'utf8')).toBe('payload-ran\n');
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+      proc.emit('close', 0, null);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
   });
 
   it('reuses a managed SSH worktree by actionId when the old base is still compatible', async () => {
@@ -708,6 +785,7 @@ branch refs/heads/${targetBranch}
     expect(callScript).toContain('RUNNER_PATH="$STAGING_DIR/runner.sh"');
     expect(callScript).toContain('PAYLOAD_PATH="$STAGING_DIR/payload.sh"');
     expect(callScript).not.toContain('cat > "$PROVISION_PATH"');
+    expect(callScript).not.toContain('ensure_managed_pnpm_workspace');
     expect(callScript).toContain('WT=$(normalize_remote_path \'/custom/path\')');
     expect(callScript).toContain('"$RUNNER_PATH" "$PAYLOAD_PATH"');
     expect(callScript).toContain('rm -rf "$STAGING_DIR"');

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -232,6 +232,24 @@ ${content}${content.endsWith('\n') ? '' : '\n'}${delimiter}
     const heartbeatMarker = this.shellQuote(SshExecutor.REMOTE_HEARTBEAT_MARKER);
     const heartbeatIntervalSeconds = this.remoteHeartbeatIntervalSeconds;
     const stagingTokenExpression = this.buildStagingDirExpression(options.executionId, options.actionId);
+    const managedWorkspaceBootstrap = options.managed
+      ? `ensure_managed_pnpm_workspace() {
+  if [ "\${INVOKER_SKIP_MANAGED_PNPM_INSTALL:-}" = "1" ]; then
+    return 0
+  fi
+  if [ ! -f pnpm-lock.yaml ] || [ -d node_modules ]; then
+    return 0
+  fi
+  if ! command -v pnpm >/dev/null 2>&1; then
+    echo "[SshExecutor] pnpm-lock.yaml found and node_modules missing, but pnpm is not installed." >&2
+    return 127
+  fi
+  echo "[SshExecutor] Installing pnpm dependencies for managed worktree..."
+  pnpm install --frozen-lockfile
+}
+ensure_managed_pnpm_workspace
+`
+      : '';
     const runPayloadSection = `echo "[SshExecutor] Running task payload..."
 `;
 
@@ -280,7 +298,7 @@ WT=$(normalize_remote_path ${this.shellQuote(options.workspacePath)})
 cd "$WT"
 ${options.envExports}
 start_bootstrap_heartbeat
-${runPayloadSection}stop_bootstrap_heartbeat
+${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
 "$RUNNER_PATH" "$PAYLOAD_PATH"
 `;
   }
@@ -533,7 +551,7 @@ ${runPayloadSection}stop_bootstrap_heartbeat
   }
 
   /**
-   * Managed workspace mode: clone, fetch, create worktrees, provision, then execute.
+   * Managed workspace mode: clone, fetch, create worktrees, then execute.
    */
   private async startManagedWorkspace(
     request: WorkRequest,

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -294,10 +294,9 @@ export interface GitWorktreeSandboxResetOpts {
  *                                   files (e.g. node_modules/, build caches).
  *
  * Why -fd and not -fdx:
- *   Invoker no longer hydrates repos on checkout, so the task payload owns any
- *   repo bootstrap such as `pnpm install` or `flutter pub get`. Keeping
- *   gitignored caches alive with -fd makes repeated task-level hydration faster
- *   without changing tracked files.
+ *   Managed SSH may hydrate package caches such as node_modules/ before task
+ *   execution. Keeping gitignored caches alive with -fd makes repeated
+ *   task-level hydration faster without changing tracked files.
  */
 export function buildWorktreeSandboxResetScript(opts: GitWorktreeSandboxResetOpts): string {
   const wtB64 = base64Encode(opts.worktreePath);


### PR DESCRIPTION
## Summary

Preserve Graph View Across Planning Window Switches lands the remote worktree bootstrap change in this final slice.

This slice restores pnpm hydration for fresh managed SSH worktrees before the remote task payload starts.

Fresh remote clones can now start the viewport-check run without failing on a missing `node_modules` tree.

## Review Claim

Managed SSH worktrees install pnpm dependencies before the payload when `pnpm-lock.yaml` exists and `node_modules` does not.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

BYO workspaces stay unchanged. Managed workspaces skip the install when `node_modules` already exists, when no `pnpm-lock.yaml` exists, or when the caller explicitly disables the bootstrap.

## Slice Rationale

The remote bootstrap needed for the viewport-check run is separate from the UI slice, so the executor change is reviewable on its own.

## Non-goals

- Change workflow-graph or Planning runtime behavior.
- Change SSH clone, fetch, or worktree selection.
- Add package-manager bootstrap for non-pnpm repos.

## Architecture

### Before

```mermaid
graph TD
    A["Managed SSH worktree"] --> B["Payload starts immediately"]
    B --> C["Fresh repo can miss node_modules"]
    C --> D["Viewport-check run can stop before app startup"]
```

### After

```mermaid
graph TD
    A["Managed SSH worktree"] --> B["Bootstrap checks pnpm-lock.yaml and node_modules"]
    B --> C["pnpm install --frozen-lockfile runs only when needed"]
    C --> D["Payload starts in a hydrated workspace"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-executor.test.ts`
- [x] `env CAPTURE_VIDEO=1 pnpm --filter @invoker/app test:e2e -- e2e/graph-viewport-switch-proof.spec.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr5102-body.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 9236dccefcfee22c5e365049e2aae81645a10935`
- Post-revert steps: Rerun `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-executor.test.ts`.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Managed workspaces now automatically set up missing pnpm dependencies before task execution.
  * Dependency installation uses the project’s frozen lockfile for consistent results.
  * Existing dependency caches are preserved to speed up repeated task runs.

* **Bug Fixes**
  * Improved handling of managed SSH tasks when `node_modules` is unavailable.
  * BYO workspaces no longer run managed-specific dependency setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->