### PR TITLE
[Restore Explicit SSH Bootstrap Before PNPM Tests Step 1](1) Add provisionCommand app config

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -240,8 +240,8 @@ export interface InvokerConfig {
     port?: number;
     /**
      * When true, use managed workspace mode: clone/fetch repo, create/reset worktrees,
-     * and provision per-task workspaces. When false (default), BYO mode: user provides
-     * pre-cloned repo path and handles all git/setup operations.
+     * then run the task in that checkout. When false (default), BYO mode: user provides
+     * pre-cloned repo path and handles git/setup operations.
      */
     managedWorkspaces?: boolean;
     /**
@@ -249,9 +249,14 @@ export interface InvokerConfig {
      * Default: ~/.invoker
      *
      * Invoker does not run repo bootstrap automatically. If a repo needs hydration,
-     * make the task command run the repo-owned setup explicitly.
+     * configure provisionCommand explicitly or make the task command run setup.
      */
     remoteInvokerHome?: string;
+    /**
+     * Explicit remote bootstrap command to run inside the task workspace before
+     * each SSH task payload. Unset by default; no provisioning is inferred.
+     */
+    provisionCommand?: string;
     /**
      * When true, export agent API keys from the local secrets file into SSH task/fix
      * shells. Default false so remote Claude/Codex CLI account auth is preserved.


### PR DESCRIPTION
## Summary

Remote target configuration now has an optional `provisionCommand` field.

Omitting it keeps SSH task setup unchanged.

## Review Claim

Approve the optional remote target setting that carries an explicit SSH bootstrap step.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

The field is optional, so existing configs keep the same runtime behavior when it is absent.

## Slice Rationale

This slice names the setting before later runtime code consumes it.

## Non-goals

- Do not run provisioning.
- Do not change CLI parsing.
- Do not change docs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/ssh-executor.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts src/__tests__/task-runner.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-bodies-1784443297749-8/pr1.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0a1f51f11`
- Post-revert steps: None
- Data migration? No

</details>
