### PR TITLE
[Restore Explicit SSH Bootstrap Before PNPM Tests Step 1](2) Pass provisionCommand through CLI config

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -87,6 +87,7 @@ type CliRuntimeConfig = {
     port?: number;
     managedWorkspaces?: boolean;
     remoteInvokerHome?: string;
+    provisionCommand?: string;
     use_api_key?: boolean;
     secretsFile?: string;
     remoteHeartbeatIntervalSeconds?: number;


### PR DESCRIPTION
## Summary

CLI runtime config now keeps `provisionCommand` when remote target settings flow through the command surface.

No command behavior changes in this slice.

## Review Claim

Approve the CLI config surface carrying the explicit SSH bootstrap setting.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This is declaration-only and does not alter parsing or executor behavior.

## Slice Rationale

The command surface accepts the setting before executor wiring consumes it.

## Non-goals

- Do not run provisioning.
- Do not change remote target validation.
- Do not change docs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/ssh-executor.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts src/__tests__/task-runner.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-bodies-1784443297749-8/pr2.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3c26b70c7`
- Post-revert steps: None
- Data migration? No

</details>
