### PR TITLE
[Restore Explicit SSH Bootstrap Before PNPM Tests Step 1](3) Run SSH provisionCommand before task payloads

### DIFF
--- a/packages/execution-engine/package.json
+++ b/packages/execution-engine/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "docker:build": "bash ../../scripts/build-agent-base-image.sh",
-    "test": "vitest run",
+    "test": "node scripts/vitest-run.mjs",
     "test:watch": "vitest",
     "clean": "rm -rf dist"
   },

--- a/packages/execution-engine/scripts/vitest-run.mjs
+++ b/packages/execution-engine/scripts/vitest-run.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const vitestPath = require.resolve('vitest/vitest.mjs');
+const args = process.argv.slice(2);
+const forwardedArgs = args[0] === '--' ? args.slice(1) : args;
+
+const result = spawnSync(process.execPath, [vitestPath, 'run', ...forwardedArgs], {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import type { ChildProcess } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SshExecutor } from '../ssh-executor.js';
@@ -225,6 +225,72 @@ describe('SshExecutor managed workspace mode', () => {
     expect(callScript).toContain("trap 'cleanup_runtime \"$?\"' EXIT");
     expect(callAgentId).toBeUndefined();
     expect(callFinalize).toEqual({ branch: handle.branch, worktreePath: handle.workspacePath });
+  });
+
+  it('managed mode runs configured provision command before payload', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+      remoteInvokerHome: '~/.invoker',
+      provisionCommand: "printf 'provision\\n' >> order.txt",
+    }) as any;
+
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return '__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=abc123def456abc123def456abc123def456abc1';
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      return '';
+    });
+    vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+    vi.spyOn(ssh, 'remoteGitRecordAndPush').mockResolvedValue({ commitHash: 'abc123' });
+
+    const req = makeRequest({
+      actionType: 'command',
+      inputs: {
+        command: "printf 'payload\\n' >> order.txt",
+        description: 'test',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    });
+
+    await ssh.start(req);
+
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+    expect(proc).toBeDefined();
+    const writeMock = (proc.stdin as any).write as ReturnType<typeof vi.fn>;
+    const script = writeMock.mock.calls[0]![0] as string;
+
+    expect(script).toContain('PROVISION_PATH="$STAGING_DIR/provision.sh"');
+    expect(script).toContain('cat > "$PROVISION_PATH" <<');
+    expect(script.indexOf('"$PROVISION_PATH"')).toBeLessThan(script.indexOf('"$RUNNER_PATH" "$PAYLOAD_PATH"'));
+
+    const workspaceMatch = script.match(/WT=\$\(normalize_remote_path '([^']+)'\)/);
+    expect(workspaceMatch?.[1]).toBeDefined();
+
+    const fakeHome = mkdtempSync(join(tmpdir(), 'ssh-managed-provision-home-'));
+    try {
+      const workspacePath = workspaceMatch![1]!.replace(/^~(?=\/|$)/, fakeHome);
+      mkdirSync(workspacePath, { recursive: true });
+
+      const childProcessModule = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+      const result = childProcessModule.spawnSync('/bin/bash', ['-c', script], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: fakeHome },
+      });
+
+      expect(result.status).toBe(0);
+      expect(readFileSync(join(workspacePath, 'order.txt'), 'utf8')).toBe('provision\npayload\n');
+      expect(result.stdout.indexOf('[SshExecutor] Running configured provision command...'))
+        .toBeLessThan(result.stdout.indexOf('[SshExecutor] Running task payload...'));
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+      proc.emit('close', 0, null);
+      await new Promise((r) => setTimeout(r, 50));
+    }
   });
 
   it('reuses a managed SSH worktree by actionId when the old base is still compatible', async () => {
@@ -711,6 +777,112 @@ branch refs/heads/${targetBranch}
     expect(callScript).toContain('WT=$(normalize_remote_path \'/custom/path\')');
     expect(callScript).toContain('"$RUNNER_PATH" "$PAYLOAD_PATH"');
     expect(callScript).toContain('rm -rf "$STAGING_DIR"');
+  });
+
+  it('BYO mode runs configured provision command before payload', async () => {
+    const workspacePath = mkdtempSync(join(tmpdir(), 'ssh-byo-provision-workspace-'));
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: false,
+      provisionCommand: "printf 'provision\\n' >> order.txt",
+    }) as any;
+
+    const req = makeRequest({
+      actionType: 'command',
+      inputs: {
+        command: "printf 'payload\\n' >> order.txt",
+        description: 'test',
+        workspacePath,
+      },
+    });
+
+    await ssh.start(req);
+
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+    expect(proc).toBeDefined();
+    const writeMock = (proc.stdin as any).write as ReturnType<typeof vi.fn>;
+    const script = writeMock.mock.calls[0]![0] as string;
+
+    expect(script).toContain('PROVISION_PATH="$STAGING_DIR/provision.sh"');
+    expect(script.indexOf('"$PROVISION_PATH"')).toBeLessThan(script.indexOf('"$RUNNER_PATH" "$PAYLOAD_PATH"'));
+
+    try {
+      const childProcessModule = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+      const result = childProcessModule.spawnSync('/bin/bash', ['-c', script], {
+        encoding: 'utf8',
+        env: { ...process.env },
+      });
+
+      expect(result.status).toBe(0);
+      expect(readFileSync(join(workspacePath, 'order.txt'), 'utf8')).toBe('provision\npayload\n');
+      expect(result.stdout.indexOf('[SshExecutor] Running configured provision command...'))
+        .toBeLessThan(result.stdout.indexOf('[SshExecutor] Running task payload...'));
+    } finally {
+      proc.emit('close', 0, null);
+      rmSync(workspacePath, { recursive: true, force: true });
+      await new Promise((r) => setTimeout(r, 50));
+    }
+  });
+
+  it('surfaces configured provision command failures as task errors', async () => {
+    const workspacePath = mkdtempSync(join(tmpdir(), 'ssh-byo-provision-fail-'));
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: false,
+      provisionCommand: "printf 'bootstrap preparing\\n'; exit 42",
+    }) as any;
+
+    const req = makeRequest({
+      actionType: 'command',
+      inputs: {
+        command: "printf 'payload should not run\\n'",
+        description: 'test',
+        workspacePath,
+      },
+    });
+
+    try {
+      const handle = await ssh.start(req);
+      const proc = spawnedProcesses[spawnedProcesses.length - 1];
+      const writeMock = (proc.stdin as any).write as ReturnType<typeof vi.fn>;
+      const script = writeMock.mock.calls[0]![0] as string;
+      const completion = new Promise<any>((resolve) => {
+        ssh.onComplete(handle, (response) => resolve(response));
+      });
+
+      const childProcessModule = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+      const result = childProcessModule.spawnSync('/bin/bash', ['-c', script], {
+        encoding: 'utf8',
+        env: { ...process.env },
+      });
+
+      expect(result.status).toBe(42);
+      expect(result.stdout).toContain('[SshExecutor] Running configured provision command...');
+      expect(result.stdout).not.toContain('[SshExecutor] Running task payload...');
+      expect(result.stdout).not.toContain('payload should not run');
+      expect(result.stderr).toContain('[SshExecutor] Configured provision command failed with exit code 42.');
+
+      if (result.stdout) {
+        (proc.stdout as any).emit('data', Buffer.from(result.stdout));
+      }
+      if (result.stderr) {
+        (proc.stderr as any).emit('data', Buffer.from(result.stderr));
+      }
+      proc.emit('close', result.status, null);
+
+      const response = await completion;
+      expect(response.status).toBe('failed');
+      expect(response.outputs.exitCode).toBe(42);
+      expect(response.outputs.error).toContain('Configured provision command failed with exit code 42');
+      expect(response.outputs.error).not.toContain('payload should not run');
+    } finally {
+      rmSync(workspacePath, { recursive: true, force: true });
+      await new Promise((r) => setTimeout(r, 50));
+    }
   });
 
   it('BYO mode throws when workspacePath is missing', async () => {

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2572,6 +2572,41 @@ describe('TaskRunner', () => {
       expect(provider).toHaveBeenCalledTimes(2);
     });
 
+    it('passes provisionCommand into cached SSH executors and refreshes when it changes', () => {
+      const provider = vi.fn()
+        .mockReturnValueOnce({
+          'do-droplet': { host: '1.2.3.4', user: 'root', sshKeyPath: '/key', provisionCommand: 'echo first' },
+        })
+        .mockReturnValueOnce({
+          'do-droplet': { host: '1.2.3.4', user: 'root', sshKeyPath: '/key', provisionCommand: 'echo first' },
+        })
+        .mockReturnValueOnce({
+          'do-droplet': { host: '1.2.3.4', user: 'root', sshKeyPath: '/key', provisionCommand: 'echo second' },
+        });
+
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => undefined } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: provider,
+      });
+
+      const task = makeTask({
+        id: 'ssh-task',
+        config: { runnerKind: 'ssh', poolMemberId: 'do-droplet' },
+      });
+
+      const first = executor.selectExecutor(task);
+      const cached = executor.selectExecutor(task);
+      const changed = executor.selectExecutor(task);
+
+      expect((first.executor as any).provisionCommand).toBe('echo first');
+      expect(cached.executor).toBe(first.executor);
+      expect(changed.executor).not.toBe(first.executor);
+      expect((changed.executor as any).provisionCommand).toBe('echo second');
+    });
+
     it('throws when provider returns no entry for the target ID', () => {
       const provider = vi.fn().mockReturnValue({});
       const executor = new TaskRunner({

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -2208,6 +2208,58 @@ describe('TaskRunner', () => {
     });
   });
 
+  describe('SSH target executor selection', () => {
+    it('prefers configured remote target settings over a generic registered SshExecutor', () => {
+      const genericSsh = new SshExecutor({
+        host: 'generic.example',
+        user: 'runner',
+        sshKeyPath: '/generic/key',
+      });
+      const registeredExecutors = new Map<string, any>([
+        ['ssh', genericSsh],
+      ]);
+      const registry = {
+        getDefault: () => ({ type: 'worktree' }),
+        get: (type: string) => registeredExecutors.get(type),
+        getAll: () => [...registeredExecutors.values()],
+        register: vi.fn((type: string, executor: any) => {
+          registeredExecutors.set(type, executor);
+        }),
+      };
+      const runner = new TaskRunner({
+        orchestrator: { getTask: () => undefined } as any,
+        persistence: {} as any,
+        executorRegistry: registry as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({
+          'remote-with-provision': {
+            host: 'remote.example',
+            user: 'invoker',
+            sshKeyPath: '/target/key',
+            managedWorkspaces: true,
+            provisionCommand: 'pnpm install --frozen-lockfile',
+          },
+        }),
+      });
+
+      const selected = runner.selectExecutor(makeTask({
+        id: 'ssh-targeted-task',
+        config: {
+          command: 'pnpm test',
+          runnerKind: 'ssh' as any,
+          poolId: 'remote-with-provision',
+        },
+      }));
+
+      expect(selected.executor).toBeInstanceOf(SshExecutor);
+      expect(selected.executor).not.toBe(genericSsh);
+      expect((selected.executor as any).host).toBe('remote.example');
+      expect((selected.executor as any).provisionCommand).toBe('pnpm install --frozen-lockfile');
+      expect(selected.selectedPoolMemberId).toBe('remote-with-provision');
+      expect(registry.register).toHaveBeenCalledWith('ssh:remote-with-provision', selected.executor);
+    });
+  });
+
   describe('pre-start heartbeat', () => {
     it('fires onHeartbeat while awaiting a slow executor.start', async () => {
       vi.useFakeTimers();

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -51,6 +51,11 @@ export interface SshExecutorConfig {
    * Default: ~/.invoker
    */
   remoteInvokerHome?: string;
+  /**
+   * Explicit remote bootstrap command to run inside the task workspace before
+   * the task payload. Unset by default; no provisioning/bootstrap is inferred.
+   */
+  provisionCommand?: string;
   /** Opt-in: export agent API keys from secretsFile into remote task shells. */
   useApiKey?: boolean;
   /** Optional local secrets file used when useApiKey is true. */
@@ -87,6 +92,7 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
   private readonly agentRegistry?: AgentRegistry;
   private readonly managedWorkspaces: boolean;
   private readonly remoteInvokerHome: string;
+  private readonly provisionCommand: string | undefined;
   private readonly useApiKey: boolean;
   private readonly secretsFile: string | undefined;
   private readonly remoteHeartbeatIntervalSeconds: number;
@@ -101,6 +107,7 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
     this.agentRegistry = config.agentRegistry;
     this.managedWorkspaces = config.managedWorkspaces ?? false;
     this.remoteInvokerHome = config.remoteInvokerHome ?? '~/.invoker';
+    this.provisionCommand = config.provisionCommand;
     this.useApiKey = config.useApiKey === true;
     this.secretsFile = config.secretsFile;
     const configuredRemoteHeartbeatInterval = config.remoteHeartbeatIntervalSeconds;
@@ -151,8 +158,13 @@ INVOKER_HEARTBEAT_MARKER=${this.shellQuote(SshExecutor.REMOTE_HEARTBEAT_MARKER)}
 INVOKER_HEARTBEAT_INTERVAL_SECONDS=${intervalSeconds}
 printf '%s %s\\n' "$INVOKER_HEARTBEAT_MARKER" "$(date +%s)"
 (
+  SLEEP_PID=""
+  trap 'if [ -n "\${SLEEP_PID:-}" ]; then kill "$SLEEP_PID" >/dev/null 2>&1 || true; fi; exit 0' TERM INT
   while kill -0 "$PAYLOAD_PID" 2>/dev/null; do
-    sleep "$INVOKER_HEARTBEAT_INTERVAL_SECONDS"
+    sleep "$INVOKER_HEARTBEAT_INTERVAL_SECONDS" &
+    SLEEP_PID=$!
+    wait "$SLEEP_PID" 2>/dev/null || exit 0
+    SLEEP_PID=""
     kill -0 "$PAYLOAD_PID" 2>/dev/null || break
     printf '%s %s\\n' "$INVOKER_HEARTBEAT_MARKER" "$(date +%s)"
   done
@@ -174,6 +186,13 @@ exit "$PAYLOAD_EXIT"
     return `#!/usr/bin/env bash
 set -e
 ${payload}
+`;
+  }
+
+  private buildProvisionScript(provisionCommand: string): string {
+    return `#!/usr/bin/env bash
+set -e
+${provisionCommand}
 `;
   }
 
@@ -229,9 +248,23 @@ ${content}${content.endsWith('\n') ? '' : '\n'}${delimiter}
   }): string {
     const runner = this.buildRunnerScript();
     const payload = this.buildPayloadScript(options.payload);
+    const provision = this.provisionCommand ? this.buildProvisionScript(this.provisionCommand) : undefined;
     const heartbeatMarker = this.shellQuote(SshExecutor.REMOTE_HEARTBEAT_MARKER);
     const heartbeatIntervalSeconds = this.remoteHeartbeatIntervalSeconds;
     const stagingTokenExpression = this.buildStagingDirExpression(options.executionId, options.actionId);
+    const provisionPathDefinition = provision ? `PROVISION_PATH="$STAGING_DIR/provision.sh"
+` : '';
+    const renderProvisionSection = provision ? this.renderHeredocFile('"$PROVISION_PATH"', provision, 'provision') : '';
+    const chmodProvisionPath = provision ? ' "$PROVISION_PATH"' : '';
+    const runProvisionSection = provision ? `echo "[SshExecutor] Running configured provision command..."
+if "$PROVISION_PATH"; then
+  echo "[SshExecutor] Configured provision command completed."
+else
+  PROVISION_EXIT=$?
+  echo "[SshExecutor] Configured provision command failed with exit code $PROVISION_EXIT." >&2
+  exit "$PROVISION_EXIT"
+fi
+` : '';
     const runPayloadSection = `echo "[SshExecutor] Running task payload..."
 `;
 
@@ -241,6 +274,7 @@ INVOKER_HOME=$(normalize_remote_path ${this.shellQuote(this.remoteInvokerHome)})
 STAGING_DIR="$INVOKER_HOME/runtime/ssh-executor/${stagingTokenExpression}"
 RUNNER_PATH="$STAGING_DIR/runner.sh"
 PAYLOAD_PATH="$STAGING_DIR/payload.sh"
+${provisionPathDefinition}
 cleanup_runtime() {
   local status="$1"
   trap - EXIT HUP INT TERM
@@ -254,8 +288,13 @@ INVOKER_HEARTBEAT_INTERVAL_SECONDS=${heartbeatIntervalSeconds}
 start_bootstrap_heartbeat() {
   printf '%s %s\\n' "$INVOKER_HEARTBEAT_MARKER" "$(date +%s)"
   (
+    SLEEP_PID=""
+    trap 'if [ -n "\${SLEEP_PID:-}" ]; then kill "$SLEEP_PID" >/dev/null 2>&1 || true; fi; exit 0' TERM INT
     while true; do
-      sleep "$INVOKER_HEARTBEAT_INTERVAL_SECONDS"
+      sleep "$INVOKER_HEARTBEAT_INTERVAL_SECONDS" &
+      SLEEP_PID=$!
+      wait "$SLEEP_PID" 2>/dev/null || exit 0
+      SLEEP_PID=""
       printf '%s %s\\n' "$INVOKER_HEARTBEAT_MARKER" "$(date +%s)"
     done
   ) &
@@ -275,12 +314,12 @@ trap 'cleanup_runtime 143' TERM
 rm -rf "$STAGING_DIR" 2>/dev/null || true
 mkdir -p "$STAGING_DIR"
 chmod 700 "$STAGING_DIR"
-${this.renderHeredocFile('"$RUNNER_PATH"', runner, 'runner')}${this.renderHeredocFile('"$PAYLOAD_PATH"', payload, 'payload')}chmod 700 "$RUNNER_PATH" "$PAYLOAD_PATH"
+${this.renderHeredocFile('"$RUNNER_PATH"', runner, 'runner')}${this.renderHeredocFile('"$PAYLOAD_PATH"', payload, 'payload')}${renderProvisionSection}chmod 700 "$RUNNER_PATH" "$PAYLOAD_PATH"${chmodProvisionPath}
 WT=$(normalize_remote_path ${this.shellQuote(options.workspacePath)})
 cd "$WT"
 ${options.envExports}
 start_bootstrap_heartbeat
-${runPayloadSection}stop_bootstrap_heartbeat
+${runProvisionSection}${runPayloadSection}stop_bootstrap_heartbeat
 "$RUNNER_PATH" "$PAYLOAD_PATH"
 `;
   }
@@ -533,7 +572,8 @@ ${runPayloadSection}stop_bootstrap_heartbeat
   }
 
   /**
-   * Managed workspace mode: clone, fetch, create worktrees, provision, then execute.
+   * Managed workspace mode: clone/fetch, create/reset worktrees, optionally run
+   * an explicitly configured provision command, then execute.
    */
   private async startManagedWorkspace(
     request: WorkRequest,

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -73,6 +73,7 @@ export type RemoteTargetDisplay = {
   port?: number;
   managedWorkspaces?: boolean;
   remoteInvokerHome?: string;
+  provisionCommand?: string;
   use_api_key?: boolean;
   secretsFile?: string;
   remoteHeartbeatIntervalSeconds?: number;
@@ -652,6 +653,73 @@ export function selectExecutor(
     effectiveType = 'worktree';
   }
 
+  if (effectiveType === 'ssh') {
+    const registered = host.executorRegistry.get('ssh');
+    if (registered && !(registered instanceof SshExecutor)) {
+      traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=ssh → ${registered.type}`);
+      return { executor: registered, resolvedExecution, selectedPoolMemberId };
+    }
+
+    const remoteTargets = host.getRemoteTargets();
+    const targetId =
+      selectedPoolMemberId
+      ?? (task.config as { poolMemberId?: string }).poolMemberId
+      ?? (task.config.poolId && remoteTargets[task.config.poolId] ? task.config.poolId : undefined);
+    if (targetId) {
+      const target = remoteTargets[targetId];
+      if (!target) {
+        throw new Error(
+          `Task ${task.id} references poolMemberId="${targetId}" but no matching ` +
+          `entry exists in remoteTargets config. Available: [${Object.keys(remoteTargets).join(', ')}]`,
+        );
+      }
+
+      const configFingerprint = JSON.stringify({
+        host: target.host,
+        user: target.user,
+        sshKeyPath: target.sshKeyPath,
+        port: target.port,
+        managedWorkspaces: target.managedWorkspaces,
+        remoteInvokerHome: target.remoteInvokerHome,
+        provisionCommand: target.provisionCommand,
+        use_api_key: target.use_api_key === true,
+        secretsFile: target.secretsFile ?? host.dockerConfig.secretsFile,
+        remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
+      });
+      const cacheKey = `${targetId}|${configFingerprint}`;
+
+      const cached = host.sshExecutorCache.get(cacheKey);
+      if (cached) {
+        traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=ssh remoteTarget=${targetId} → ssh (cached)`);
+        return { executor: cached, resolvedExecution, selectedPoolMemberId: targetId };
+      }
+
+      for (const key of host.sshExecutorCache.keys()) {
+        if (key.startsWith(`${targetId}|`)) {
+          host.sshExecutorCache.delete(key);
+        }
+      }
+
+      const ssh = new SshExecutor({
+        host: target.host,
+        user: target.user,
+        sshKeyPath: target.sshKeyPath,
+        port: target.port,
+        agentRegistry: host.executionAgentRegistry,
+        managedWorkspaces: target.managedWorkspaces,
+        remoteInvokerHome: target.remoteInvokerHome,
+        provisionCommand: target.provisionCommand,
+        useApiKey: target.use_api_key,
+        secretsFile: target.secretsFile ?? host.dockerConfig.secretsFile,
+        remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
+      });
+      host.executorRegistry.register(`ssh:${targetId}`, ssh);
+      host.sshExecutorCache.set(cacheKey, ssh);
+      traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=ssh remoteTarget=${targetId} → ssh (lazy registered)`);
+      return { executor: ssh, resolvedExecution, selectedPoolMemberId: targetId };
+    }
+  }
+
   if (effectiveType) {
     const registered = host.executorRegistry.get(effectiveType);
     if (registered && (effectiveType !== 'merge' || registered.type === 'merge')) {
@@ -691,63 +759,7 @@ export function selectExecutor(
     }
 
     if (effectiveType === 'ssh') {
-      const remoteTargets = host.getRemoteTargets();
-      const targetId =
-        selectedPoolMemberId
-        ?? (task.config as { poolMemberId?: string }).poolMemberId
-        ?? (task.config.poolId && remoteTargets[task.config.poolId] ? task.config.poolId : undefined);
-      if (!targetId) {
-        throw new Error(`Task ${task.id} has runnerKind=ssh but no poolMemberId`);
-      }
-
-      const target = remoteTargets[targetId];
-      if (!target) {
-        throw new Error(
-          `Task ${task.id} references poolMemberId="${targetId}" but no matching ` +
-          `entry exists in remoteTargets config. Available: [${Object.keys(remoteTargets).join(', ')}]`,
-        );
-      }
-
-      const configFingerprint = JSON.stringify({
-        host: target.host,
-        user: target.user,
-        sshKeyPath: target.sshKeyPath,
-        port: target.port,
-        managedWorkspaces: target.managedWorkspaces,
-        remoteInvokerHome: target.remoteInvokerHome,
-        use_api_key: target.use_api_key === true,
-        secretsFile: target.secretsFile ?? host.dockerConfig.secretsFile,
-        remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
-      });
-      const cacheKey = `${targetId}|${configFingerprint}`;
-
-      const cached = host.sshExecutorCache.get(cacheKey);
-      if (cached) {
-        traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=ssh remoteTarget=${targetId} → ssh (cached)`);
-        return { executor: cached, resolvedExecution, selectedPoolMemberId: targetId };
-      }
-
-      for (const key of host.sshExecutorCache.keys()) {
-        if (key.startsWith(`${targetId}|`)) {
-          host.sshExecutorCache.delete(key);
-        }
-      }
-
-      const ssh = new SshExecutor({
-        host: target.host,
-        user: target.user,
-        sshKeyPath: target.sshKeyPath,
-        port: target.port,
-        agentRegistry: host.executionAgentRegistry,
-        managedWorkspaces: target.managedWorkspaces,
-        useApiKey: target.use_api_key,
-        secretsFile: target.secretsFile ?? host.dockerConfig.secretsFile,
-        remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
-      });
-      host.executorRegistry.register(`ssh:${targetId}`, ssh);
-      host.sshExecutorCache.set(cacheKey, ssh);
-      traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=ssh remoteTarget=${targetId} → ssh (lazy registered)`);
-      return { executor: ssh, resolvedExecution, selectedPoolMemberId: targetId };
+      throw new Error(`Task ${task.id} has runnerKind=ssh but no poolMemberId`);
     }
   }
 


### PR DESCRIPTION
## Summary

SSH executors now write an optional provision script next to the payload script.

Remote target selection passes the configured bootstrap step into per-target SSH executors and refreshes cached executors when it changes.

## Review Claim

Approve running configured SSH `provisionCommand` scripts before task payloads.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Unset `provisionCommand` produces the same payload path. Failure exits before payload with the provision exit code.

## Slice Rationale

This slice contains executor behavior so surrounding declaration and guide slices stay small.

## Non-goals

- Do not infer provisioning when the setting is absent.
- Do not change git checkout behavior.
- Do not change docs.

## Architecture

### Before

```mermaid
graph TD
    A["TaskRunner selects SSH executor"] --> B["SshExecutor writes payload script"]
    B --> C["Payload runs"]
```

### After

```mermaid
graph TD
    A["TaskRunner selects SSH executor with remote target settings"] --> B["SshExecutor writes provision and payload scripts"]
    B --> C["Provision script runs first"]
    C --> D["Payload runs only after provision succeeds"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/ssh-executor.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts src/__tests__/task-runner.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-bodies-1784443297749-8/pr3.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7cebf51e8`
- Post-revert steps: None
- Data migration? No

</details>
