### PR TITLE
[Admin Bypass Babysitter Step 1 - Root Cause Proof](1) Add stack-expansion requeue repro

### DIFF
--- a/scripts/repro/repro-mergify-admin-requeue-missing-bottom-label.sh
+++ b/scripts/repro/repro-mergify-admin-requeue-missing-bottom-label.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec bash "$ROOT/scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh" "$@"

--- a/scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh
+++ b/scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+REPO="Neko-Catpital-Labs/Invoker"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-mergify-admin-stack-expansion.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+
+cat > "$TMP/bin/gh" <<'PY'
+#!/usr/bin/env python3
+import json
+import sys
+
+HEAD = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+REQUIRED = [
+    "build-artifacts",
+    "quality / Dependency Cruise",
+    "PR Body",
+    "quality / TypeScript Types",
+    "required-fast / Guardrails",
+    "required-fast / Submit Workflow Chain",
+    "UI Vitest",
+]
+REPO = "Neko-Catpital-Labs/Invoker"
+
+
+def contexts():
+    return {
+        "contexts": {
+            "nodes": [
+                {
+                    "__typename": "CheckRun",
+                    "name": name,
+                    "conclusion": "SUCCESS",
+                    "status": "COMPLETED",
+                    "completedAt": "2026-07-19T00:00:00Z",
+                    "startedAt": "2026-07-19T00:00:00Z",
+                    "detailsUrl": "https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/1/job/2",
+                    "checkSuite": {"commit": {"oid": HEAD}},
+                }
+                for name in REQUIRED
+            ]
+        }
+    }
+
+
+def pr(number):
+    if number == 100:
+        base = "master"
+        head = "stack/bottom"
+        labels = ["dequeued"]
+    elif number == 101:
+        base = "stack/bottom"
+        head = "stack/top"
+        labels = ["admin-bypass", "dequeued"]
+    else:
+        raise SystemExit(f"unexpected PR #{number}")
+    return {
+        "number": number,
+        "title": f"Stack PR {number}",
+        "url": f"https://github.com/{REPO}/pull/{number}",
+        "isDraft": False,
+        "state": "OPEN",
+        "baseRefName": base,
+        "headRefName": head,
+        "headRefOid": HEAD,
+        "mergeStateStatus": "CLEAN",
+        "mergeable": "MERGEABLE",
+        "labels": {"nodes": [{"name": label} for label in labels]},
+        "reviewThreads": {"pageInfo": {"hasNextPage": False}, "nodes": []},
+        "statusCheckRollup": contexts(),
+    }
+
+
+args = sys.argv[1:]
+if args[:2] == ["pr", "list"]:
+    if "--label" not in args or "admin-bypass" not in args:
+        print(f"expected admin-bypass label seed, got: {args}", file=sys.stderr)
+        raise SystemExit(2)
+    print(json.dumps([pr(101)]))
+    raise SystemExit(0)
+
+if args[:2] == ["api", "graphql"]:
+    number = 0
+    for arg in args:
+        if arg.startswith("number="):
+            number = int(arg.split("=", 1)[1])
+    print(json.dumps({"data": {"repository": {"pullRequest": pr(number)}}}))
+    raise SystemExit(0)
+
+if args[:2] == ["api", f"repos/{REPO}/issues/101/comments"]:
+    body = '<!-- mergify-stack-data: {"stack_id":"stack-expansion","pull_numbers_bottom_to_top":[100,101]} -->'
+    print(json.dumps([{"id": "stack-meta", "created_at": "2026-07-19T00:00:00Z", "body": body}]))
+    raise SystemExit(0)
+
+if args[:2] == ["api", f"repos/{REPO}/issues/100/comments"]:
+    print("[]")
+    raise SystemExit(0)
+
+print(f"unexpected gh args: {args}", file=sys.stderr)
+raise SystemExit(2)
+PY
+chmod +x "$TMP/bin/gh"
+
+export PATH="$TMP/bin:$PATH"
+out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo "$REPO" --author EdbertChan --state-file "$TMP/ledger.jsonl")"
+printf '%s\n' "$out"
+
+case "$out" in
+  *"DRY-RUN add-admin-bypass-label PR #100"*) ;;
+  *) echo "[repro] expected stack expansion to surface unlabeled bottom PR #100" >&2; exit 1 ;;
+esac
+
+case "$out" in
+  *"no current bottom"*) echo "[repro] saw pre-fix failure mode: upper PR was processed without its bottom" >&2; exit 1 ;;
+esac
+
+echo "[repro] passed"

--- a/scripts/repro/repro-mergify-admin-requeue.sh
+++ b/scripts/repro/repro-mergify-admin-requeue.sh
@@ -22,6 +22,7 @@ REQUIRED = [
     "required-fast / Guardrails",
     "required-fast / Vitest Workspace",
     "required-fast / Submit Workflow Chain",
+    "UI Vitest",
     "e2e-proof / aggregate",
     "playwright / 1-of-6",
     "playwright / 2-of-6",


### PR DESCRIPTION
## Summary

This adds a deterministic repro for the admin-bypass stack gap.

The repro seeds only the upper stack PR with `admin-bypass`, then expects the unlabeled bottom PR to be surfaced.

It also keeps the existing requeue repro aligned with the current required Mergify checks.

## Review Claim

The new repro captures the partial-stack candidate-loading failure before the loader fix lands.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds repro shell fixtures and does not wire the new stack-expansion repro into required CI yet.

## Slice Rationale

The failure proof lands before the loader change so reviewers can inspect the broken case separately from the fix.

## Non-goals

- This does not change `GhClient` candidate loading.
- This does not requeue, label, or edit live GitHub PRs.
- This does not change required-suite execution.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `PYTHONDONTWRITEBYTECODE=1 bash scripts/repro/repro-mergify-admin-requeue.sh`
- [x] `! PYTHONDONTWRITEBYTECODE=1 bash scripts/repro/repro-mergify-admin-requeue-missing-bottom-label.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e286545cf`
- Post-revert steps: None
- Data migration? No

</details>
