### PR TITLE
[Admin Bypass Babysitter Step 1 - Root Cause Proof](2) Expand candidate loading through stack metadata

### DIFF
--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -59,7 +59,37 @@ class GhClient:
             "number,title,url,headRefName,headRefOid,baseRefName,state,isDraft,labels,mergeStateStatus,mergeable,reviewDecision,statusCheckRollup",
         ]
         value = self._run_json(args)
-        return value if isinstance(value, list) else []
+        seeds = value if isinstance(value, list) else []
+        by_number: dict[int, dict] = {}
+        ordered_numbers: list[int] = []
+
+        def remember(number: int, detail: dict) -> None:
+            if number not in by_number:
+                ordered_numbers.append(number)
+            by_number[number] = detail
+
+        for item in seeds:
+            if not isinstance(item, dict):
+                continue
+            number = int(item.get("number") or 0)
+            if number:
+                remember(number, item)
+
+        queued_stack_numbers: list[int] = []
+        queued_stack_number_set: set[int] = set()
+        for number in list(ordered_numbers):
+            meta = parse_stack_metadata(self.issue_comments(repo, number))
+            if not meta:
+                continue
+            for stack_number in meta[1]:
+                if stack_number not in by_number and stack_number not in queued_stack_number_set:
+                    queued_stack_number_set.add(stack_number)
+                    queued_stack_numbers.append(stack_number)
+
+        for number in queued_stack_numbers:
+            remember(number, self.pr_detail(repo, number))
+
+        return [by_number[number] for number in ordered_numbers]
 
     def pr_detail(self, repo: str, number: int) -> dict:
         owner, name = repo.split("/", 1)

--- a/scripts/test-suites/required/12-mergify-admin-requeue.sh
+++ b/scripts/test-suites/required/12-mergify-admin-requeue.sh
@@ -4,5 +4,6 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
 python3 -m unittest scripts/test_mergify_admin_requeue.py
 bash scripts/repro/repro-mergify-admin-requeue.sh
+bash scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh
 bash scripts/repro/repro-mergify-rejected-pr.sh
 bash scripts/repro/repro-mergify-closed-pr-guard.sh

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -73,6 +73,7 @@ class MergifyAdminRequeueTests(unittest.TestCase):
             "quality / TypeScript Types",
             "required-fast / Guardrails",
             "required-fast / Submit Workflow Chain",
+            "UI Vitest",
         }))
 
     def test_loads_admin_bypass_rule_from_any_working_directory(self):
@@ -133,6 +134,17 @@ Failing checks
         stack = StackGroup("s", (pr(2604, head="stack/a", latest=mergify()), pr(2605, base="stack/a", head="stack/b"), pr(2601, base="stack/b")))
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number) for a in actions], [("requeue", 2604)])
+
+    def test_labeled_upper_stack_member_allows_unlabeled_bottom_label_repair(self):
+        snapshots = [
+            pr(2605, base="stack/a", head="stack/b", labels={"admin-bypass", "dequeued"}),
+            pr(2604, head="stack/a", labels={"dequeued"}, latest=mergify()),
+        ]
+        meta = {2604: ("s", (2604, 2605)), 2605: ("s", (2604, 2605))}
+        groups = group_stack_prs(snapshots, meta, "master")
+        self.assertEqual([tuple(item.number for item in group.prs) for group in groups], [(2604, 2605)])
+        actions = plan_stack_actions(groups[0], REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("add_admin_bypass_label", 2604)])
 
     def test_upper_stack_blocker_stops_bottom_requeue(self):
         failed = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -203,6 +203,53 @@ class SnapshotFromDetail(unittest.TestCase):
         self.assertEqual(snap.latest_mergify.head_sha, HEAD)
 
 
+class GhClientCandidateDiscovery(unittest.TestCase):
+    def test_label_seed_expands_stack_metadata_to_unlabeled_bottom(self):
+        bottom = {
+            "number": 100,
+            "title": "bottom",
+            "labels": {"nodes": [{"name": "dequeued"}]},
+        }
+        upper = {
+            "number": 101,
+            "title": "upper",
+            "labels": {"nodes": [{"name": "admin-bypass"}]},
+        }
+        comments = {
+            101: [{
+                "created_at": "2026-07-19T00:00:00Z",
+                "body": '<!-- mergify-stack-data: {"stack_id":"s","pull_numbers_bottom_to_top":[100,101]} -->',
+            }],
+        }
+
+        class FakeGh(s.GhClient):
+            def __init__(self):
+                self.list_args = []
+                self.detail_calls = []
+                self.comment_calls = []
+
+            def _run_json(self, args):
+                self.list_args = list(args)
+                return [upper]
+
+            def pr_detail(self, repo, number):
+                self.detail_calls.append((repo, number))
+                return bottom if number == 100 else upper
+
+            def issue_comments(self, repo, number):
+                self.comment_calls.append((repo, number))
+                return comments.get(number, [])
+
+        client = FakeGh()
+        found = client.list_candidate_prs("Neko-Catpital-Labs/Invoker", "EdbertChan", [])
+
+        self.assertIn("--label", client.list_args)
+        self.assertIn("admin-bypass", client.list_args)
+        self.assertEqual([pr["number"] for pr in found], [101, 100])
+        self.assertEqual(client.detail_calls, [("Neko-Catpital-Labs/Invoker", 100)])
+        self.assertEqual(client.comment_calls, [("Neko-Catpital-Labs/Invoker", 101)])
+
+
 class GhClientLabelEdit(unittest.TestCase):
     def test_add_label_uses_rest_issue_labels_endpoint(self):
         client = s.GhClient()


### PR DESCRIPTION
## Summary

This expands admin-bypass candidate loading through Mergify stack metadata.

Label seeding still limits the initial GitHub query, but stack comments now pull in unlabeled stack members before planning actions.

Regression tests cover unlabeled-bottom repair and the required-suite repro now exercises the stack-expansion case.

## Review Claim

Admin-bypass requeue planning includes unlabeled stack members referenced by Mergify stack metadata.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change is limited to the admin requeue script and local tests; explicit PR numbers still bypass the seeded expansion path.

## Slice Rationale

The loader fix lands after the repro so reviewers can compare the new metadata expansion against a focused failure case.

## Non-goals

- This does not change Mergify queue rules or branch publication.
- This does not alter review-thread, merge-state, or check-repair decision logic.
- This does not contact live GitHub in tests.

## Architecture

### Before

```mermaid
graph TD
    A["gh pr list --label admin-bypass"] --> B["candidate PRs"]
    B --> C["stack grouping"]
```

### After

```mermaid
graph TD
    A["gh pr list --label admin-bypass"] --> B["seed PRs"]
    B --> C["Mergify stack metadata"]
    C --> D["unlabeled stack members loaded by PR detail"]
    D --> E["stack grouping"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/test_mergify_admin_requeue_snapshot.py scripts/test_mergify_admin_requeue.py`
- [x] `PYTHONDONTWRITEBYTECODE=1 bash scripts/repro/repro-mergify-admin-requeue.sh`
- [x] `PYTHONDONTWRITEBYTECODE=1 bash scripts/repro/repro-mergify-admin-requeue-missing-bottom-label.sh`
- [x] `PYTHONDONTWRITEBYTECODE=1 bash scripts/test-suites/required/12-mergify-admin-requeue.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b36d960f3`
- Post-revert steps: None
- Data migration? No

</details>
