### PR TITLE
[Planning Terminal Yellow Send Arrow](4) Refresh PR metadata after branch updates

### DIFF
--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -85,6 +85,8 @@ node scripts/create-pr.mjs --title "<title>" --base master --body-file /tmp/my-p
 
 Update an existing PR with:
 
+After any branch update, rebase, force-push, or stacked-branch reshuffle, refresh the PR title and body so they still match the live diff. Re-check `## Summary`, test commands, revert guidance, and any visual proof section; old copy is stale the moment the branch meaning changes.
+
 ```bash
 node scripts/create-pr.mjs --title "<title>" --base master --body-file /tmp/my-pr.md --update <pr-number>
 ```
@@ -120,8 +122,10 @@ Do not generalize this to unrelated repos.
 
 ## Validation
 
-Before creating a PR:
+Before creating or updating a PR:
 
+- ensure the PR title still matches the current slice after any branch update or force-push
+- ensure the `## Summary` section still describes the current diff, not the earlier version
 - ensure the branch is pushed
 - ensure the body sections are present and concrete
 - ensure test commands are real commands that were actually run when possible


### PR DESCRIPTION
## Summary

This slice updates the make-pr skill to refresh PR title, summary, test, revert, and proof text after branch updates.

The goal is to prevent stale GitHub metadata after a force-push, rebase, or stack branch reshuffle.

## Review Claim

Approve the make-pr instruction that branch updates require immediate PR metadata refresh before yielding.

## Review Lane

policy

## Review Unit

make-pr-skill-metadata-refresh

## Safety Invariant

The change is limited to skill documentation. It does not alter runtime code, PR creation scripts, or validator behavior.

## Slice Rationale

This instruction lands separately from trigger wording so reviewers can assess the stale-metadata refresh requirement on its own.

## Non-goals

This does not change GitHub APIs, Mergify behavior, PR body validation rules, or visual proof capture tooling.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-validator.mjs`
- [x] `node scripts/test-pr-body-rollout.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c31a80a49`
- Post-revert steps: None.
- Data migration? No

</details>