### PR TITLE
[Planning Terminal Yellow Send Arrow](5) Trigger make-pr on branch and PR changes

### DIFF
--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -3,19 +3,21 @@ name: make-pr
 description: >
   Create or update a pull request in this repo using the preferred PR schema,
   upstream-first branch workflow, and repo-specific publication rules. Trigger
-  when asked to make a PR, update a PR body, prepare PR text, or publish a
-  stacked PR branch.
+  when asked to make a PR, update a PR body, prepare PR text, publish a
+  stacked PR branch, or whenever a branch/PR change means the GitHub PR
+  metadata may now be stale.
 ---
 
 # make-pr
 
-Use this skill when the work is already done and the user wants a PR created, updated, or rewritten.
+Use this skill when the work is already done and the user wants a PR created, updated, or rewritten, and also whenever a branch, stack, or PR change could leave GitHub title/body/proof text out of date.
 
 ## What this skill covers
 
 - PR title/body authoring for Invoker
 - The preferred PR section schema
 - Upstream-first branch/PR workflow (explicit base and publish remotes)
+- Mandatory refresh after branch/PR changes that can stale GitHub metadata
 - Repo-specific publication rules:
   - Invoker-on-Invoker stacks may use `mergify stack push`
   - unrelated target repos should keep their own normal PR workflow unless they independently use Mergify Stacks


### PR DESCRIPTION
## Summary

This slice broadens the make-pr skill trigger so branch and PR changes route back through the PR authoring workflow.

It makes stale metadata repair an explicit skill responsibility, not only a user-requested PR creation path.

## Review Claim

Approve the make-pr trigger expansion for branch, stack, or PR changes that can stale live GitHub metadata.

## Review Lane

policy

## Review Unit

make-pr-skill-trigger

## Safety Invariant

The edit is documentation-only and scoped to skill trigger text. It does not change repository scripts, validators, or runtime execution paths.

## Slice Rationale

Trigger wording is split from the refresh instruction so reviewers can isolate when the skill should run from what it should do.

## Non-goals

This does not change Mergify stack publication semantics, PR body schema enforcement, or any UI behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-validator.mjs`
- [x] `node scripts/test-pr-body-rollout.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 072eba7b`
- Post-revert steps: None.
- Data migration? No

</details>