### PR TITLE
[Restore Explicit SSH Bootstrap Before PNPM Tests Step 2](1) Require explicit bootstrap planner guidance

### DIFF
--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -538,6 +538,7 @@ tasks:
 `;
     expect(() => parsePlan(yaml)).toThrow(PlanParseError);
     expect(() => parsePlan(yaml)).toThrow('npx vitest run');
+    expect(() => parsePlan(yaml)).toThrow('Use the repo/package test script instead');
   });
 
   it('parses task with prompt instead of command', () => {

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -358,7 +358,7 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
     if (task.command && /\bnpx vitest run\b/.test(task.command)) {
       throw new PlanParseError(
         `Task "${task.id}" uses 'npx vitest run' which may not resolve correctly. ` +
-        `Use 'pnpm test' instead.`,
+        `Use the repo/package test script instead, such as 'pnpm --filter <package> test' when a package script owns the runner flags.`,
       );
     }
 

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -210,7 +210,7 @@ name: "Preserve Commands"
 tasks:
   - id: run-vitest
     description: "Run Vitest"
-    command: "cd packages/surfaces && npx vitest run"
+    command: "pnpm --filter @invoker/surfaces test"
     dependencies: []
   - id: run-root-package-test
     description: "Run package test"
@@ -226,7 +226,7 @@ tasks:
     const result = extractYamlPlan(text);
     expect(result).not.toBeNull();
     const plan = parsePlanText(result!);
-    expect(plan.tasks[0].command).toBe('cd packages/surfaces && npx vitest run');
+    expect(plan.tasks[0].command).toBe('pnpm --filter @invoker/surfaces test');
     expect(plan.tasks[1].command).toBe('pnpm test packages/protocol/src/__tests__/validation.test.ts');
     expect(plan.tasks[2].command).toBe('npm test -- src/foo.test.ts');
   });
@@ -806,6 +806,15 @@ describe('PlanConversation prompt construction', () => {
     expect(prompt).toContain('Inspect repo manifests and existing docs/scripts before choosing commands');
     expect(prompt).toContain('do not impose Invoker-specific commands on external repos');
     expect(prompt).toContain('reserve broad/full-suite commands for the final gate only when the target repo documents such a command');
+    expect(prompt).toContain('For package-manager commands that may run on managed SSH');
+    expect(prompt).toContain('make bootstrap ownership explicit');
+    expect(prompt).toContain('provisionCommand');
+    expect(prompt).toContain('If you cannot verify a target `provisionCommand`');
+    expect(prompt).toContain('Prefer repo/package scripts over raw test-runner binaries in remote commands');
+    expect(prompt).toContain('Avoid raw `vitest`, `npx vitest`, or `pnpm exec vitest`');
+    expect(prompt).toContain('packages/ui/package.json');
+    expect(prompt).toContain('node scripts/run-vitest.mjs');
+    expect(prompt).toContain('pnpm --filter @invoker/ui test');
   });
 
   it('system prompt advertises external_review as the GitHub-backed review gate', () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -282,6 +282,8 @@ Rules:
    - For focused package tests in a monorepo, run from the relevant package/workspace directory or use the repo's documented workspace filter.
    - To target a specific test file, use the syntax supported by the discovered test script.
    - Prefer focused verification during iteration and reserve broad/full-suite commands for the final gate only when the target repo documents such a command.
+   - For package-manager commands that may run on managed SSH, make bootstrap ownership explicit. Either the selected/configured target has a \`provisionCommand\` that installs repo dependencies before each task payload, or the task command itself must run the repo-owned bootstrap first (for example \`pnpm install --frozen-lockfile && pnpm --filter @scope/pkg test\`). If you cannot verify a target \`provisionCommand\`, include the bootstrap in the command or ask the user to configure it before relying on remote package-manager commands.
+   - Prefer repo/package scripts over raw test-runner binaries in remote commands. Avoid raw \`vitest\`, \`npx vitest\`, or \`pnpm exec vitest\` when a package script exists; for example, \`packages/ui/package.json\` uses \`node scripts/run-vitest.mjs\`, so use \`pnpm --filter @invoker/ui test\` instead of bypassing that wrapper.
    - If Invoker config auto-routes heavyweight commands, keep discovered test/build commands as normal command tasks unless the task must name a specific remote target
    - NEVER invent test file names. Verify the test file exists before referencing it in a command.
 7. Use meaningful task IDs (kebab-case).


### PR DESCRIPTION
## Summary

The remote task planner now names setup expectations before pnpm or Vitest work.

The parser message now points to package scripts so wrapper flags stay visible.

## Review Claim

Remote package-manager task guidance now names the setup owner before pnpm or Vitest payloads.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This only changes planner prompt text, parser guidance, and focused assertions. Existing valid plan commands still parse and execute through the same task routing path.

## Slice Rationale

This executable wording lands first. The example-only slice follows separately.

## Non-goals

- Changing SSH executor provisioning behavior.
- Changing package manager installation behavior.
- Renaming plan fields or remote target configuration.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/plan-parser.test.ts`
- [x] `pnpm --filter @invoker/surfaces test -- src/__tests__/plan-conversation.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ssh-bootstrap-pr1.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <pr-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
