### PR TITLE
[Admin Bypass Babysitter Step 2 - Bottom Label Nudge](1) Nudge humans for missing bottom labels

### DIFF
--- a/scripts/mergify_admin_requeue.py
+++ b/scripts/mergify_admin_requeue.py
@@ -30,9 +30,10 @@ def _execute_action(action: Action, repo: str, gh, ledger: Ledger, pr_by_number:
     if action.kind == "requeue":
         gh.comment(repo, action.pr_number, "@mergifyio queue")
         ledger.record("requeue", action.pr_number, pr.head_ref_oid, action.key, now)
-    elif action.kind == "add_admin_bypass_label":
-        gh.edit_label(repo, action.pr_number, add="admin-bypass")
-        ledger.record("add_admin_bypass_label", action.pr_number, pr.head_ref_oid, "admin-bypass", now)
+    elif action.kind == "comment_admin_bypass_nudge":
+        if ledger.count(exec_impl.ADMIN_BYPASS_NUDGE_LEDGER_KIND, action.pr_number, pr.head_ref_oid, action.key) == 0:
+            gh.comment(repo, action.pr_number, exec_impl.admin_bypass_nudge_body())
+            ledger.record(exec_impl.ADMIN_BYPASS_NUDGE_LEDGER_KIND, action.pr_number, pr.head_ref_oid, action.key, now)
     elif action.kind == "remove_merge_hold":
         gh.edit_label(repo, action.pr_number, remove="merge-hold")
         ledger.record("remove-merge-hold", action.pr_number, pr.head_ref_oid, "merge-hold", now)

--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -20,6 +20,15 @@ except ImportError:
     from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head, group_stack_prs, parse_stack_metadata, snapshot_from_detail
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+ADMIN_BYPASS_NUDGE_LEDGER_KIND = "comment-admin-bypass-nudge"
+
+
+def admin_bypass_nudge_body() -> str:
+    return (
+        "Invoker Mergify babysitting is paused: this is the current bottom PR in the stack, "
+        "but it is missing the `admin-bypass` label. Please tag this PR with `admin-bypass` "
+        "before babysitting can continue."
+    )
 
 
 def resolve_workflow(pr_number: int) -> tuple[str, str]:
@@ -102,8 +111,8 @@ def print_action(action: Action, pr: PrSnapshot | None, dry_run: bool, as_json: 
         print(f"{prefix}repair-check PR #{action.pr_number} check={json.dumps(key)}")
     elif action.kind == "comment_blocked":
         print(f"BLOCK PR #{action.pr_number} {action.detail}")
-    elif action.kind == "add_admin_bypass_label":
-        print(f"{prefix}add-admin-bypass-label PR #{action.pr_number}")
+    elif action.kind == "comment_admin_bypass_nudge":
+        print(f"{prefix}comment-admin-bypass-nudge PR #{action.pr_number}")
     elif action.kind == "remove_merge_hold":
         print(f"{prefix}remove-merge-hold PR #{action.pr_number}")
     elif action.kind == "resolve_bot_threads":
@@ -117,9 +126,10 @@ def execute_action(action: Action, repo: str, gh: GhClient, ledger: Ledger, pr_b
     if action.kind == "requeue":
         gh.comment(repo, action.pr_number, "@mergifyio queue")
         ledger.record("requeue", action.pr_number, pr.head_ref_oid, action.key, now)
-    elif action.kind == "add_admin_bypass_label":
-        gh.edit_label(repo, action.pr_number, add="admin-bypass")
-        ledger.record("add_admin_bypass_label", action.pr_number, pr.head_ref_oid, "admin-bypass", now)
+    elif action.kind == "comment_admin_bypass_nudge":
+        if ledger.count(ADMIN_BYPASS_NUDGE_LEDGER_KIND, action.pr_number, pr.head_ref_oid, action.key) == 0:
+            gh.comment(repo, action.pr_number, admin_bypass_nudge_body())
+            ledger.record(ADMIN_BYPASS_NUDGE_LEDGER_KIND, action.pr_number, pr.head_ref_oid, action.key, now)
     elif action.kind == "remove_merge_hold":
         gh.edit_label(repo, action.pr_number, remove="merge-hold")
         ledger.record("remove-merge-hold", action.pr_number, pr.head_ref_oid, "merge-hold", now)
@@ -203,7 +213,7 @@ def run_once(args: argparse.Namespace) -> int:
             print_action(action, pr, args.dry_run, args.json)
             if not args.dry_run:
                 execute_action(action, args.repo, gh, ledger, pr_by_number, now)
-                if action.kind not in {"comment_blocked"}:
+                if action.kind not in {"comment_blocked", "comment_admin_bypass_nudge"}:
                     return 0
     return 0
 

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -142,9 +142,7 @@ def plan_stack_actions(stack: StackGroup, required_checks: Collection[str], ledg
         return ()
 
     if "admin-bypass" not in bottom.labels:
-        if ledger.count("add_admin_bypass_label", bottom.number, bottom.head_ref_oid, "admin-bypass") >= 1:
-            return (cap_action(bottom, Blocker("admin-bypass", "capped", bottom.number, "admin-bypass label add"), "admin-bypass label add"),)
-        return (Action("add_admin_bypass_label", bottom.number, "admin-bypass", "missing admin-bypass label"),)
+        return (Action("comment_admin_bypass_nudge", bottom.number, "admin-bypass", "missing admin-bypass label"),)
 
     latest = bottom.latest_mergify
     requeue_reason = ""

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -135,7 +135,7 @@ Failing checks
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number) for a in actions], [("requeue", 2604)])
 
-    def test_labeled_upper_stack_member_allows_unlabeled_bottom_label_repair(self):
+    def test_labeled_upper_stack_member_allows_unlabeled_bottom_nudge(self):
         snapshots = [
             pr(2605, base="stack/a", head="stack/b", labels={"admin-bypass", "dequeued"}),
             pr(2604, head="stack/a", labels={"dequeued"}, latest=mergify()),
@@ -144,7 +144,7 @@ Failing checks
         groups = group_stack_prs(snapshots, meta, "master")
         self.assertEqual([tuple(item.number for item in group.prs) for group in groups], [(2604, 2605)])
         actions = plan_stack_actions(groups[0], REQUIRED, self.ledger(), 1)
-        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("add_admin_bypass_label", 2604)])
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("comment_admin_bypass_nudge", 2604)])
 
     def test_upper_stack_blocker_stops_bottom_requeue(self):
         failed = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
@@ -155,10 +155,10 @@ Failing checks
         actions = plan_stack_actions(thread_stack, REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2605, "human-review-thread")])
 
-    def test_missing_admin_bypass_label_on_current_bottom_adds_label_first(self):
+    def test_missing_admin_bypass_label_on_current_bottom_nudges_human_first(self):
         stack = StackGroup("s", (pr(2604, labels={"dequeued"}, latest=mergify()),))
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
-        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("add_admin_bypass_label", 2604)])
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("comment_admin_bypass_nudge", 2604)])
 
     def test_dequeued_green_same_sha_requeues_once(self):
         stack = StackGroup("s", (pr(2605, latest=mergify(sha=HEAD)),))
@@ -275,7 +275,29 @@ Failing checks
         requeue._execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 2)
         self.assertEqual(len(fake.comments), 1)
 
+    def test_missing_admin_bypass_nudge_comments_once_without_label_edit(self):
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+                self.label_edits = []
 
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+            def edit_label(self, repo, pr_number, *, add=None, remove=None):
+                self.label_edits.append((repo, pr_number, add, remove))
+
+        action = Action("comment_admin_bypass_nudge", 2647, "admin-bypass", "missing admin-bypass label")
+        for execute in (requeue._execute_action, requeue.exec_impl.execute_action):
+            ledger = self.ledger()
+            item = pr(2647, labels={"dequeued"}, latest=mergify())
+            fake = FakeGh()
+            execute(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 1)
+            execute(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 2)
+            self.assertEqual(len(fake.comments), 1)
+            self.assertIn("tag this PR with `admin-bypass`", fake.comments[0][2])
+            self.assertEqual(fake.label_edits, [])
+            self.assertEqual(ledger.count(requeue.exec_impl.ADMIN_BYPASS_NUDGE_LEDGER_KIND, 2647, HEAD, "admin-bypass"), 1)
 
     def test_mergify_queue_failure_repairs_even_when_current_required_check_is_missing(self):
         latest = MergifyQueueEvent(

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -129,9 +129,9 @@ class PlanStackActions(unittest.TestCase):
         actions = self._plan(pr(latest_mergify=event(failing=("build",))))
         self.assertEqual(actions[0].kind, "repair_check")
 
-    def test_clean_bottom_missing_label_adds_admin_bypass(self):
+    def test_clean_bottom_missing_label_nudges_human(self):
         actions = self._plan(pr())  # green, no admin-bypass label
-        self.assertEqual((actions[0].kind, actions[0].key), ("add_admin_bypass_label", "admin-bypass"))
+        self.assertEqual((actions[0].kind, actions[0].key), ("comment_admin_bypass_nudge", "admin-bypass"))
 
     def test_clean_bottom_dequeued_gets_requeued(self):
         snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued"))


### PR DESCRIPTION
## Summary

Admin Bypass Babysitter Step 2 - Bottom Label Nudge — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784443765019-14/implement-bottom-label-nudge | Change bottom-missing-label handling from auto-label to human nudge comment. | completed |
| wf-1784443765019-14/verify-bottom-label-nudge | Run planner/executor tests and the missing-bottom-label repro for nudge semantics. | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784443765019-14/implement-bottom-label-nudge — Change bottom-missing-label handling from auto-label to human nudge comment.

### wf-1784443765019-14/verify-bottom-label-nudge — Run planner/executor tests and the missing-bottom-label repro for nudge semantics.

</details>

The babysitter now leaves a human nudge when the current bottom stack PR lacks `admin-bypass`.

The nudge is ledger-capped per head SHA, so repeated runs do not spam comments.

## Review Claim

Approve the Mergify babysitter policy change from automatic `admin-bypass` label edits to one nudge comment for the current bottom PR.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change stays inside the Mergify babysitting scripts and their existing unittest coverage.

It does not change queue rules, GitHub authentication, or merge eligibility.

## Slice Rationale

This keeps the missing-bottom-label remediation policy separate from the executable repro update in the next slice.

Reviewers can inspect the action change here without also reading the shell repro assertions.

## Non-goals

- Do not change Mergify queue eligibility or required checks.
- Do not auto-apply `admin-bypass` from the babysitter.
- Do not change UI surfaces or workflow submission.

## Architecture

### Before

```mermaid
graph TD
    A["Bottom PR lacks admin-bypass"] --> B["Babysitter edits admin-bypass label"]
    B --> C["Ledger records add_admin_bypass_label"]
```

### After

```mermaid
graph TD
    A["Bottom PR lacks admin-bypass"] --> B["Babysitter posts one nudge comment per head SHA"]
    B --> C["Ledger records comment-admin-bypass-nudge"]
    C --> D["Later runs keep scanning the stack"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/test_mergify_admin_requeue.py scripts/test_mergify_admin_requeue_plan.py`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/admin-bypass-step2-pr1.md --changed-files-file /tmp/admin-bypass-step2-pr1-files.txt --diff-file /tmp/admin-bypass-step2-pr1.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert fcd910731`
- Post-revert steps: Re-run the Mergify admin requeue unit tests.
- Data migration? No

</details>
