### PR TITLE
[Admin Bypass Babysitter Step 2 - Bottom Label Nudge](2) Prove bottom-label nudge semantics

### DIFF
--- a/scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh
+++ b/scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh
@@ -110,8 +110,12 @@ out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo "$REPO" 
 printf '%s\n' "$out"
 
 case "$out" in
-  *"DRY-RUN add-admin-bypass-label PR #100"*) ;;
-  *) echo "[repro] expected stack expansion to surface unlabeled bottom PR #100" >&2; exit 1 ;;
+  *"DRY-RUN comment-admin-bypass-nudge PR #100"*) ;;
+  *) echo "[repro] expected stack expansion to nudge for unlabeled bottom PR #100" >&2; exit 1 ;;
+esac
+
+case "$out" in
+  *"add-admin-bypass-label"*) echo "[repro] saw forbidden auto-label path for unlabeled bottom PR #100" >&2; exit 1 ;;
 esac
 
 case "$out" in


### PR DESCRIPTION
## Summary

Admin Bypass Babysitter Step 2 - Bottom Label Nudge — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784443765019-14/implement-bottom-label-nudge | Change bottom-missing-label handling from auto-label to human nudge comment. | completed |
| wf-1784443765019-14/verify-bottom-label-nudge | Run planner/executor tests and the missing-bottom-label repro for nudge semantics. | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784443765019-14/implement-bottom-label-nudge — Change bottom-missing-label handling from auto-label to human nudge comment.

### wf-1784443765019-14/verify-bottom-label-nudge — Run planner/executor tests and the missing-bottom-label repro for nudge semantics.

</details>

This slice proves the new bottom-label behavior in the stack-expansion repro.

It asserts the dry-run output nudges a human and rejects the old auto-label path.

## Review Claim

Approve the regression proof that the stack-expansion repro now surfaces a human nudge instead of automatic label repair.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the standalone repro script changes.

It exercises the published CLI output without changing planner or executor behavior.

## Slice Rationale

The proof stays separate from the policy change so reviewers can inspect the executable expectation on its own.

That keeps the behavior diff small and lets this slice answer only whether the missing-label output is now correct.

## Non-goals

- Do not change the babysitter planner or executor logic in this slice.
- Do not add new queue rules or labels.
- Do not change UI surfaces or workflow submission.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/admin-bypass-step2-pr2.md --changed-files-file /tmp/admin-bypass-step2-pr2-files.txt --diff-file /tmp/admin-bypass-step2-pr2.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9e66efae9`
- Post-revert steps: Re-run the stack-expansion repro.
- Data migration? No

</details>
