### PR TITLE
[Make-PR Skill] Refresh PR title/body after branch updates or force-pushes

### DIFF
--- a/scripts/test-make-pr-skill.sh
+++ b/scripts/test-make-pr-skill.sh
@@ -138,4 +138,14 @@ must_contain "$REVIEW_COMPRESSION_MD" "Dependency-cluster exception:" "review-co
 must_contain "$REVIEW_COMPRESSION_MD" "multiple distinct extractions from one file (one top-level symbol move per slice)" "review-compression must split multiple extractions one symbol per slice"
 # The new grain must NOT split the identical mechanical migration grouping.
 must_contain "$REVIEW_COMPRESSION_MD" "exact same mechanical migration across" "review-compression must keep grouping the same mechanical migration across files"
+
+# Stale GitHub PR metadata after a branch update is a common landing failure.
+# The skill must both trigger on it and tell the author what to re-check.
+must_contain "$SKILL_MD" "whenever a branch/PR change means the GitHub PR" "make-pr skill must trigger when a branch change could stale GitHub PR metadata"
+must_contain "$SKILL_MD" "could leave GitHub title/body/proof text out of date" "make-pr skill must apply to any branch/stack/PR change that can stale title/body/proof text"
+must_contain "$SKILL_MD" "Mandatory refresh after branch/PR changes that can stale GitHub metadata" "make-pr skill must list the metadata-refresh requirement in what it covers"
+must_contain "$SKILL_MD" "After any branch update, rebase, force-push, or stacked-branch reshuffle, refresh the PR title and body" "make-pr skill must require refreshing PR title/body after any branch update, rebase, or force-push"
+must_contain "$SKILL_MD" "ensure the PR title still matches the current slice after any branch update or force-push" "make-pr skill validation checklist must include the PR-title staleness check"
+must_contain "$SKILL_MD" 'ensure the `## Summary` section still describes the current diff, not the earlier version' "make-pr skill validation checklist must include the Summary staleness check"
+
 echo "OK: make-pr skill contract checks passed"

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -3,13 +3,14 @@ name: make-pr
 description: >
   Create or update a pull request in this repo using the preferred PR schema,
   upstream-first branch workflow, and repo-specific publication rules. Trigger
-  when asked to make a PR, update a PR body, prepare PR text, or publish a
-  stacked PR branch.
+  when asked to make a PR, update a PR body, prepare PR text, publish a
+  stacked PR branch, or whenever a branch/PR change means the GitHub PR
+  metadata may now be stale.
 ---
 
 # make-pr
 
-Use this skill when the work is already done and the user wants a PR created, updated, rewritten, split, or republished.
+Use this skill when the work is already done and the user wants a PR created, updated, rewritten, split, or republished, and also whenever a branch, stack, or PR change could leave GitHub title/body/proof text out of date.
 
 Read this skill and `skills/visual-proof/SKILL.md` from the PR's target base branch (for example `git show origin/master:skills/make-pr/SKILL.md`) before authoring proof or PR bodies. Working branches and merge clones can carry stale policy copies, and the validators enforce the base branch's rules.
 
@@ -29,6 +30,7 @@ Order slices so a reviewer reads the evidence before the change it justifies (se
 - PR title/body authoring for Invoker
 - The preferred PR section schema
 - Upstream-first branch/PR workflow (explicit base and publish remotes)
+- Mandatory refresh after branch/PR changes that can stale GitHub metadata
 - Repo-specific publication rules:
   - Invoker-on-Invoker stacks may use `mergify stack push`
   - unrelated target repos should keep their own normal PR workflow unless they independently use Mergify Stacks
@@ -177,6 +179,8 @@ node scripts/validate-pr-body.mjs --body-file /tmp/my-pr.md
 node scripts/create-pr.mjs --title "<title>" --base master --body-file /tmp/my-pr.md
 ```
 
+After any branch update, rebase, force-push, or stacked-branch reshuffle, refresh the PR title and body so they still match the live diff. Re-check `## Summary`, test commands, revert guidance, and any visual proof section; old copy is stale the moment the branch meaning changes.
+
 Update an existing PR with:
 
 ```bash
@@ -255,6 +259,8 @@ Manual `gh pr edit` is the escape hatch when `create-pr --update-existing` canno
 
 
 ## Validation
+- ensure the PR title still matches the current slice after any branch update or force-push
+- ensure the `## Summary` section still describes the current diff, not the earlier version
 - ensure the branch is pushed
 - ensure the body sections are present and concrete
 - ensure test commands are real commands that were actually run when possible


### PR DESCRIPTION
## Summary

Sessions that rebase or force-push a PR branch often leave the GitHub title and body describing the old diff.

The `make-pr` skill only told authors to refresh metadata after a Mergify stack push. Nothing prompted a refresh after an ordinary rebase or force-push outside that flow.

This slice adds that trigger to the skill, plus one checklist line. Authors now re-check the summary, verification steps, and revert guidance any time a branch update changes what the diff means.

## Review Claim

Approve adding "refresh PR title/body after rebase/force-push" guidance to the `make-pr` skill, locked by a new skill guard assertion.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only edits `skills/make-pr/SKILL.md` prose and its matching assertions in `scripts/test-make-pr-skill.sh`. No product code or body-validator logic changes.

## Slice Rationale

This is the smallest self-contained addition to the skill: new trigger wording, one new checklist line, and the guard assertion that locks both. It doesn't touch any other skill section.

## Non-goals

- Does not change `scripts/validate-pr-body.mjs` or any other validator.
- Does not change the preferred PR body sections themselves.
- Does not touch Mergify stack-push behavior or the stack-comment refresh logic.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-make-pr-skill.sh` — passes, including the new assertions

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <squash-merge-sha>`
- Post-revert steps: None; the skill loses the extra reminder but stays otherwise correct.
- Data migration? No

</details>
