### PR TITLE
Disable git auto-gc in fetch-sync test fixtures

### DIFF
--- a/packages/execution-engine/src/__tests__/fetch-failure-visibility.test.ts
+++ b/packages/execution-engine/src/__tests__/fetch-failure-visibility.test.ts
@@ -68,6 +68,7 @@ class TestExecutor extends BaseExecutor<BaseEntry> {
 function createTempRepo(): string {
   const dir = mkdtempSync(join(tmpdir(), 'fetch-failure-test-'));
   execSync('git init -b master', { cwd: dir });
+  execSync('git config gc.auto 0', { cwd: dir });
   execSync('git config user.email "test@test.com"', { cwd: dir });
   execSync('git config user.name "Test"', { cwd: dir });
   writeFileSync(join(dir, 'initial.txt'), 'initial content');
@@ -82,6 +83,7 @@ function createTempRepo(): string {
 function createRemote(localRepo: string): string {
   const remote = mkdtempSync(join(tmpdir(), 'fetch-failure-remote-'));
   execSync('git init --bare -b master', { cwd: remote });
+  execSync('git config gc.auto 0', { cwd: remote });
   execSync(`git remote add origin ${remote}`, { cwd: localRepo });
   execSync('git push -u origin master', { cwd: localRepo });
   return remote;
@@ -208,6 +210,7 @@ describe('syncFromRemote - fetch failure handling', () => {
       // Create a second clone and push commits ahead
       const secondClone = mkdtempSync(join(tmpdir(), 'fetch-failure-clone-'));
       execSync(`git clone --no-local ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
+      execSync('git config gc.auto 0', { cwd: secondClone });
       execSync('git checkout -B master origin/master', { cwd: secondClone });
       execSync('git config user.email "test@test.com"', { cwd: secondClone });
       execSync('git config user.name "Test"', { cwd: secondClone });

--- a/packages/execution-engine/src/__tests__/fetch-status-output.test.ts
+++ b/packages/execution-engine/src/__tests__/fetch-status-output.test.ts
@@ -69,6 +69,7 @@ class TestExecutor extends BaseExecutor<BaseEntry> {
 function createTempRepo(): string {
   const dir = mkdtempSync(join(tmpdir(), 'fetch-status-output-test-'));
   execSync('git init -b master', { cwd: dir });
+  execSync('git config gc.auto 0', { cwd: dir });
   execSync('git config user.email "test@test.com"', { cwd: dir });
   execSync('git config user.name "Test"', { cwd: dir });
   writeFileSync(join(dir, 'initial.txt'), 'initial content');
@@ -83,6 +84,7 @@ function createTempRepo(): string {
 function createRemote(localRepo: string): string {
   const remote = mkdtempSync(join(tmpdir(), 'fetch-status-output-remote-'));
   execSync('git init --bare -b master', { cwd: remote });
+  execSync('git config gc.auto 0', { cwd: remote });
   execSync(`git remote add origin ${remote}`, { cwd: localRepo });
   execSync('git push -u origin master', { cwd: localRepo });
   return remote;
@@ -136,6 +138,7 @@ describe('fetch status visibility in task output', () => {
       // Create a second clone and push commits ahead
       const secondClone = mkdtempSync(join(tmpdir(), 'fetch-status-clone-'));
       execSync(`git clone --no-local ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
+      execSync('git config gc.auto 0', { cwd: secondClone });
       execSync('git checkout -B master origin/master', { cwd: secondClone });
       execSync('git config user.email "test@test.com"', { cwd: secondClone });
       execSync('git config user.name "Test"', { cwd: secondClone });
@@ -166,6 +169,7 @@ describe('fetch status visibility in task output', () => {
       // manufacturing 101 physical commits in CI's temporary git store.
       const secondClone = mkdtempSync(join(tmpdir(), 'fetch-status-clone-'));
       execSync(`git clone --no-local ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
+      execSync('git config gc.auto 0', { cwd: secondClone });
       execSync('git checkout -B master origin/master', { cwd: secondClone });
       execSync('git config user.email "test@test.com"', { cwd: secondClone });
       execSync('git config user.name "Test"', { cwd: secondClone });


### PR DESCRIPTION
## Summary

`fetch-failure-visibility.test.ts` and `fetch-status-output.test.ts` each create several temporary git repos and clones per test run.

Background auto-gc can start on any of those repos mid-test, adding real wall-clock time and an occasional flaky slowdown under load, since these tests never expect gc to run.

This slice sets `gc.auto 0` on every temp repo, bare remote, and clone these two suites create, so gc never kicks in during the run.

## Review Claim

Approve disabling git auto-gc on the throwaway repos created by the fetch-failure and fetch-status-output test suites.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds a `git config gc.auto 0` call next to each existing `git init`/`git init --bare`/`git clone` in two test files. It changes no test assertions and no product code.

## Slice Rationale

This is the minimal remaining piece of a larger flakiness investigation into these two suites; the >100-commits-behind cases were already made fast by mocking the git commands directly, and `--no-local` clones were already in place. Auto-gc was the one still-live source of unpredictable extra time in the remaining real-git test paths.

## Non-goals

- Does not change the `--no-local` clone strategy already in place.
- Does not change how staleness or commits-behind counts are computed or asserted.
- Does not touch any non-test file.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/fetch-failure-visibility.test.ts src/__tests__/fetch-status-output.test.ts` — 19/19 passing

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <squash-merge-sha>`
- Post-revert steps: None; tests keep passing, just with auto-gc re-enabled on their scratch repos.
- Data migration? No

</details>
