### PR TITLE
[Slack Plan Submission](1) Reproduce CLI handoff escape hatch

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -823,6 +823,19 @@ describe('PlanConversation prompt construction', () => {
     expect(prompt).toContain('The orchestrator handles plan execution automatically after explicit Slack approval.');
   });
 
+  it('reproduces the Slack planner CLI handoff escape hatch', () => {
+    const conv = new PlanConversation({});
+    (conv as any).messages.push({ role: 'user', content: 'Build a feature' });
+    const prompt = conv.buildCursorPrompt();
+
+    expect(prompt).toContain('The orchestrator handles plan execution automatically after explicit Slack approval.');
+    expect(prompt).not.toContain('invoker-cli');
+    expect(prompt).not.toContain('invoker_submit_plan');
+    expect(prompt).not.toContain('invoker_validate_plan');
+    expect(prompt).not.toContain('submit-plan.sh');
+    expect(prompt).not.toContain('Harness handoff mode');
+  });
+
   it('system prompt requires discovered verification commands for target repos', () => {
     const conv = new PlanConversation({});
     (conv as any).messages.push({ role: 'user', content: 'Add a small pre-commit lint gate' });


### PR DESCRIPTION
## Summary

This adds a passing regression test that demonstrates the Slack planning prompt does not name CLI or MCP handoff paths.

It establishes the instruction gap that allowed a Slack agent to bypass the orchestrator and create an isolated workflow.

## Review Claim

The regression test accurately captures the prompt-level root cause before the safeguard changes it.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The test asserts existing behavior only and changes no production instruction or execution path.

## Slice Rationale

The evidence is reviewed first so the safeguard change has a concrete, independently visible root cause.

## Non-goals

This does not prevent CLI submission or modify Slack execution behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile && cd packages/surfaces && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8602b3035`
- Post-revert steps: None
- Data migration? No

</details>
