### PR TITLE
[Slack Plan Submission](2) Keep Slack planners on the orchestrator path

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -820,20 +820,21 @@ describe('PlanConversation prompt construction', () => {
 
     expect(prompt).toContain('mergeMode: external_review');
     expect(prompt).toContain('Prefer small reviewable slices');
-    expect(prompt).toContain('The orchestrator handles plan execution automatically after explicit Slack approval.');
+    expect(prompt).toContain('The Slack orchestrator validates and executes the plan after the user replies `submit` and approves it.');
   });
 
-  it('reproduces the Slack planner CLI handoff escape hatch', () => {
+  it('delegates Slack plan submission to the orchestrator', () => {
     const conv = new PlanConversation({});
     (conv as any).messages.push({ role: 'user', content: 'Build a feature' });
     const prompt = conv.buildCursorPrompt();
 
-    expect(prompt).toContain('The orchestrator handles plan execution automatically after explicit Slack approval.');
-    expect(prompt).not.toContain('invoker-cli');
-    expect(prompt).not.toContain('invoker_submit_plan');
-    expect(prompt).not.toContain('invoker_validate_plan');
-    expect(prompt).not.toContain('submit-plan.sh');
-    expect(prompt).not.toContain('Harness handoff mode');
+    expect(prompt).toContain('Do NOT invoke `invoker-cli` (with any flags)');
+    expect(prompt).toContain('`invoker_submit_plan`');
+    expect(prompt).toContain('`invoker_validate_plan`');
+    expect(prompt).toContain('`submit-plan.sh`');
+    expect(prompt).toContain('Harness handoff mode');
+    expect(prompt).toContain('This rule overrides that skill\'s handoff instructions in this Slack thread');
+    expect(prompt).toContain('remind them to reply with `submit`; never run it yourself');
   });
 
   it('system prompt requires discovered verification commands for target repos', () => {
@@ -890,6 +891,11 @@ describe('PlanConversation prompt construction', () => {
     // The old loophole permitted YAML "unless the user explicitly asks" — that
     // produced drafts Slack silently rejects on submit.
     expect(prompt).not.toContain('unless the user explicitly asks');
+    expect(prompt).toContain('Do NOT invoke `invoker-cli`');
+    expect(prompt).toContain('`invoker_submit_plan`');
+    expect(prompt).toContain('`invoker_validate_plan`');
+    expect(prompt).toContain('`submit-plan.sh`');
+    expect(prompt).toContain('Harness handoff mode');
   });
 });
 

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -182,7 +182,7 @@ Default behavior:
 - Treat the thread like an ordinary OMP/Codex coding session.
 - Answer questions, run local commands, inspect files, edit code, and run focused verification when useful.
 - Do NOT generate Invoker YAML in this thread. If the user asks for an Invoker plan, tell them to start a new plan thread with \`plan: <request>\` — plan drafts from an agent thread cannot be submitted.
-- Do NOT submit or start an Invoker workflow. Agent threads reject \`submit\`; only a \`plan:\` thread can be submitted.
+- Do NOT submit or start an Invoker workflow. Do NOT invoke \`invoker-cli\`, \`invoker_submit_plan\`, \`invoker_validate_plan\`, \`submit-plan.sh\`, or the \`plan-to-invoker\` skill's Harness handoff mode to do so. Agent threads reject \`submit\`; only a \`plan:\` thread can be submitted.
 - Keep Slack replies short and concrete: changed files, verification, and any remaining risk.
 - To share a generated file (screenshot, diagram, report), write it inside your worktree and link it by absolute path as a markdown link, e.g. \`[chart](/abs/path/in/worktree/chart.png)\`. Files linked that way are uploaded to the thread. Files written outside your worktree cannot be shared, so do not put artifacts in /tmp.`;
 }
@@ -295,7 +295,7 @@ Rules:
 10. After generating a plan, include a short post-plan summary that tells the user they can confirm execution. The confirmation instruction MUST be exactly this standalone line:
 Reply \`submit\` to submit it.
 Do NOT place that line inline in a sentence.
-11. NEVER generate bash commands or shell scripts to execute plans. The orchestrator handles plan execution automatically after explicit Slack approval.
+11. NEVER submit, validate, or execute this plan yourself. Do NOT invoke \`invoker-cli\` (with any flags), \`invoker_submit_plan\`, \`invoker_validate_plan\`, \`submit-plan.sh\`, or the \`plan-to-invoker\` skill's Harness handoff mode. This rule overrides that skill's handoff instructions in this Slack thread. The Slack orchestrator validates and executes the plan after the user replies \`submit\` and approves it. If the user instead says \`execute\`, \`run it\`, \`yes\`, or \`go\` before submitting, remind them to reply with \`submit\`; never run it yourself.
 12. Choose \`mergeMode\` deliberately. For reviewable implementation plans, set \`mergeMode: external_review\` so changes land through the canonical GitHub-backed review gate. Keep \`mergeMode: manual\` (the default) for verification-only plans that should not open a review, and use \`mergeMode: automatic\` only when the user explicitly wants changes merged without review.`;
 }
 


### PR DESCRIPTION
## Summary

Slack planning agents now name the handoff mechanisms they must not invoke.

They instead direct users to Slack's approval flow.

## Review Claim

Slack plan and agent prompts cannot bypass Slack workflow routing through generic handoff instructions.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The orchestrator remains the only path that creates Slack workflow channels; this changes planner instructions only.

## Slice Rationale

This follows the root-cause proof and isolates the runtime Slack prompt guard from the generic skill policy update.

## Non-goals

This does not change live-mode behavior, Slack channel creation code, standalone workflow execution, or the generic handoff skill.

## Architecture

### Before

```mermaid
flowchart TD
    SlackPlanner["Slack planning agent"] --> GenericHandoff["Generic handoff"]
    GenericHandoff --> StandaloneRun["Standalone workflow without Slack channel"]
```

### After

```mermaid
flowchart TD
    SlackPlanner["Slack planning agent"] --> Draft["Write Slack plan draft"]
    Draft --> SlackApproval["User approves in Slack"]
    SlackApproval --> SlackOrchestrator["Slack orchestrator validates and executes"]
    SlackOrchestrator --> WorkflowChannel["Workflow channel creation path"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile && cd packages/surfaces && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <safeguard-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
