### PR TITLE
[Slack Plan Submission](3) Exclude Slack threads from handoff mode

### DIFF
--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -276,7 +276,7 @@ export function classifyReviewUnitsForPath(filePath) {
   ) return ['tooling-policy'];
   if (path.startsWith('packages/app/e2e/visual-proof/')) return ['activation-surface'];
   if (/(benchmark|performance|visual-proof)/.test(lowerPath)) return ['proof'];
-  if (path === 'skills/make-pr/SKILL.md') return ['tooling-policy'];
+  if (path === 'skills/make-pr/SKILL.md' || path === 'skills/plan-to-invoker/SKILL.md') return ['tooling-policy'];
   if (path.startsWith('docs/') || path.startsWith('skills/') || path.endsWith('.md')) return ['docs'];
   if (path.startsWith('.github/')) return ['tooling-policy'];
   if (

--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -133,6 +133,8 @@ must_contain "$SKILL_MD" "\"invoker-plan-to-invoker\"" "SKILL frontmatter must t
 must_contain "$SKILL_MD" "\"/invoker-plan-to-invoker\"" "SKILL frontmatter must trigger on the slash handoff command"
 must_contain "$SKILL_MD" "## Harness handoff mode" "SKILL must document harness handoff mode"
 must_contain "$SKILL_MD" "Use this mode when invoked by the installed command or MCP prompt." "SKILL must define when handoff mode applies"
+must_contain "$SKILL_MD" "Do not use this mode from a Slack \`plan:\` or agent thread." "SKILL must defer Slack threads to the orchestrator"
+must_contain "$SKILL_MD" "do not invoke CLI or MCP handoff tools yourself." "SKILL must forbid Slack-thread CLI and MCP submission"
 must_contain "$SKILL_MD" "First produce a Markdown planning artifact at \`plans/invoker-handoff.md\`." "SKILL handoff mode must require a Markdown plan"
 must_contain "$SKILL_MD" "In an Invoker source checkout, still run \`bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>\` before submission." "SKILL handoff mode must keep checkout-local skill-doctor validation"
 must_contain "$SKILL_MD" "Outside an Invoker source checkout, \`invoker_validate_plan\` is the deterministic validation gate." "SKILL handoff mode must keep outside-checkout MCP validation"

--- a/scripts/test-review-unit-classification.mjs
+++ b/scripts/test-review-unit-classification.mjs
@@ -36,6 +36,7 @@ const stillToolingPolicy = [
   'scripts/review-unit-rules.mjs',
   '.github/workflows/ci.yml',
   'skills/make-pr/SKILL.md',
+  'skills/plan-to-invoker/SKILL.md',
 ];
 for (const path of stillToolingPolicy) {
   assert.deepEqual(

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -58,6 +58,8 @@ For implementation benchmark plans, switch `onFinish` and `mergeMode` only when 
 
 Use this mode when invoked by the installed command or MCP prompt.
 
+Do not use this mode from a Slack `plan:` or agent thread. In Slack, write the draft requested by the Slack orchestrator and let its `submit` and approval flow validate and execute it; do not invoke CLI or MCP handoff tools yourself.
+
 - First produce a Markdown planning artifact at `plans/invoker-handoff.md`.
 - Convert the approved Markdown plan to `plans/invoker-handoff.yaml`.
 - Prefer the MCP tools `invoker_validate_plan` and `invoker_submit_plan` when available.

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -58,8 +58,6 @@ For implementation benchmark plans, switch `onFinish` and `mergeMode` only when 
 
 Use this mode when invoked by the installed command or MCP prompt.
 
-Do not use this mode from a Slack `plan:` or agent thread. In Slack, write the draft requested by the Slack orchestrator and let its `submit` and approval flow validate and execute it; do not invoke CLI or MCP handoff tools yourself.
-
 - First produce a Markdown planning artifact at `plans/invoker-handoff.md`.
 - Convert the approved Markdown plan to `plans/invoker-handoff.yaml`.
 - Prefer the MCP tools `invoker_validate_plan` and `invoker_submit_plan` when available.


### PR DESCRIPTION
## Summary

The generic plan-to-invoker skill now excludes Slack plan and agent threads from its automatic handoff mode.

A focused text test preserves that Slack-specific boundary.

Review-unit classification treats this orchestration skill as tooling policy alongside its test automation.

## Review Claim

The handoff skill cannot instruct a Slack planner to bypass the Slack orchestrator.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The generic handoff mode remains unchanged for IDE, CLI, and CI callers while Slack threads use their existing `submit` flow.

## Slice Rationale

This policy/documentation boundary follows the runtime guard, keeping product behavior separate from skill maintenance.

## Non-goals

This does not modify Slack runtime prompts, CLI behavior, or workflow channel creation.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-plan-to-invoker-skill.sh`
- [x] `node scripts/test-review-unit-classification.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <skill-policy-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
