### PR TITLE
[Bugfix: TaskDAG watchdog fitView gating](1) Add regression proof for pre-recovery refits

### DIFF
--- a/packages/ui/src/__tests__/task-dag-stability.test.ts
+++ b/packages/ui/src/__tests__/task-dag-stability.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vite
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createElement } from 'react';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { applyNodeChanges, type Node, type NodeChange } from '@xyflow/react';
 import * as ReactFlowModule from '@xyflow/react';
 import { TaskDAG } from '../components/TaskDAG.js';
@@ -509,5 +509,48 @@ describe('TaskDAG camera ownership', () => {
     // A manual move must never autofocus the graph.
     expect(setCenterMock).not.toHaveBeenCalled();
     expect(fitViewMock).not.toHaveBeenCalled();
+  });
+
+  it.fails('does not let pre-recovery watchdog misses refit after a manual pan and graph data change', async () => {
+    const onManualViewport = vi.fn();
+
+    const { rerender } = await renderDagAndSettleInitialFit({
+      tasks: tasksMap('task-a'),
+      selectedTaskId: 'task-a',
+      onManualViewport,
+    });
+
+    const pane = screen.getByTestId('rf__pane');
+    fireEvent.pointerDown(pane);
+    fireEvent.pointerUp(pane);
+    expect(onManualViewport).toHaveBeenCalled();
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+
+    vi.useFakeTimers();
+    rerender(
+      createElement(TaskDAG, {
+        tasks: tasksMap('task-a', 'task-b'),
+        selectedTaskId: 'task-a',
+        onManualViewport,
+      }),
+    );
+
+    expect(screen.getByTestId('rf__node-task-b')).toBeInTheDocument();
+    for (const element of document.querySelectorAll<HTMLElement>('.react-flow__node')) {
+      element.style.visibility = 'hidden';
+    }
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(fitViewMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(fitViewMock).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary

Add a regression proof for TaskDAG's watchdog refit bug.

The test recreates a manual pan, a graph data change, and two hidden-node watchdog ticks.

This slice keeps the expectation under `it.fails` so the current bug is proven without breaking the stack.

## Review Claim

Approve that the new TaskDAG regression proof captures the pre-recovery watchdog refit bug after manual camera movement.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes only the TaskDAG stability test and marks the new failing expectation with `it.fails`, so runtime behavior is unchanged.

## Slice Rationale

The regression proof lands before the behavior change so reviewers can see the exact bug before approving the fix.

## Non-goals

No product behavior changes, no TaskDAG implementation changes, no React Flow watchdog policy changes, and no unrelated test cleanup.

## Visual Proof

![TaskDAG graph surface](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-afc4d8/neutral-chrome-home-graph.png)

The screenshot identifies the TaskDAG graph surface whose camera behavior is covered by the timer-driven regression test.

The refit bug itself is verified by the test because the hidden-node interval state is not distinguishable in a still image.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- task-dag-stability`
- [x] `pnpm install --frozen-lockfile && cd packages/ui && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3c1f6a9c9e4bd60de091b848b04eb2c60cf65738`
- Post-revert steps: None
- Data migration? No

</details>
