### PR TITLE
[Bugfix: TaskDAG watchdog fitView gating](2) Gate watchdog refit on recovery

### DIFF
--- a/packages/ui/src/__tests__/task-dag-stability.test.ts
+++ b/packages/ui/src/__tests__/task-dag-stability.test.ts
@@ -511,7 +511,7 @@ describe('TaskDAG camera ownership', () => {
     expect(fitViewMock).not.toHaveBeenCalled();
   });
 
-  it.fails('does not let pre-recovery watchdog misses refit after a manual pan and graph data change', async () => {
+  it('does not let pre-recovery watchdog misses refit after a manual pan and graph data change', async () => {
     const onManualViewport = vi.fn();
 
     const { rerender } = await renderDagAndSettleInitialFit({

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -610,9 +610,9 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
             recoveryTriggered: shouldRecover,
           },
         );
-        fitView({ padding: 0.2 });
         if (shouldRecover) {
           watchdogRecoveryAttemptedRef.current = true;
+          fitView({ padding: 0.2 });
           setFlowInstanceKey((key) => key + 1);
         }
       } else {


### PR DESCRIPTION
## Summary

Gate TaskDAG's watchdog refit behind the existing recovery threshold.

Pre-recovery hidden-node ticks now warn and count misses without moving the camera.

The third miss still runs the existing recovery path and remounts React Flow.

## Review Claim

Approve that TaskDAG only calls `fitView({ padding: 0.2 })` when the watchdog actually enters recovery.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The only runtime change moves the existing `fitView` call into the existing `shouldRecover` block; the miss counter and remount threshold stay unchanged.

## Slice Rationale

This slice contains the behavior fix and flips the prior proof from `it.fails` to a normal passing regression test.

## Non-goals

No watchdog threshold changes, no warning text changes, no WorkflowGraph changes, no layout refactor, and no unrelated UI behavior changes.

## Visual Proof

![TaskDAG graph surface](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260719-c406b1/neutral-chrome-home-graph.png)

The screenshot identifies the TaskDAG graph surface whose camera no longer refits during pre-recovery watchdog misses.

The two-tick no-refit behavior is verified by the regression test because the timer path is not visible in a still image.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- task-dag-stability`
- [x] `pnpm install --frozen-lockfile && cd packages/ui && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 60df673b214085af4409145c74c78f347d043463`
- Post-revert steps: None
- Data migration? No

</details>
