### PR TITLE
[Slack Plan Submission](4) Prove restart-safe thread submission gaps

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -820,20 +820,21 @@ describe('PlanConversation prompt construction', () => {
 
     expect(prompt).toContain('mergeMode: external_review');
     expect(prompt).toContain('Prefer small reviewable slices');
-    expect(prompt).toContain('The orchestrator handles plan execution automatically after explicit Slack approval.');
+    expect(prompt).toContain('The Slack orchestrator validates and executes the plan after the user replies `submit` and approves it.');
   });
 
-  it('reproduces the Slack planner CLI handoff escape hatch', () => {
+  it('delegates Slack plan submission to the orchestrator', () => {
     const conv = new PlanConversation({});
     (conv as any).messages.push({ role: 'user', content: 'Build a feature' });
     const prompt = conv.buildCursorPrompt();
 
-    expect(prompt).toContain('The orchestrator handles plan execution automatically after explicit Slack approval.');
-    expect(prompt).not.toContain('invoker-cli');
-    expect(prompt).not.toContain('invoker_submit_plan');
-    expect(prompt).not.toContain('invoker_validate_plan');
-    expect(prompt).not.toContain('submit-plan.sh');
-    expect(prompt).not.toContain('Harness handoff mode');
+    expect(prompt).toContain('Do NOT invoke `invoker-cli` (with any flags)');
+    expect(prompt).toContain('`invoker_submit_plan`');
+    expect(prompt).toContain('`invoker_validate_plan`');
+    expect(prompt).toContain('`submit-plan.sh`');
+    expect(prompt).toContain('Harness handoff mode');
+    expect(prompt).toContain('This rule overrides that skill\'s handoff instructions in this Slack thread');
+    expect(prompt).toContain('remind them to reply with `submit`; never run it yourself');
   });
 
   it('system prompt requires discovered verification commands for target repos', () => {
@@ -890,6 +891,11 @@ describe('PlanConversation prompt construction', () => {
     // The old loophole permitted YAML "unless the user explicitly asks" — that
     // produced drafts Slack silently rejects on submit.
     expect(prompt).not.toContain('unless the user explicitly asks');
+    expect(prompt).toContain('Do NOT invoke `invoker-cli`');
+    expect(prompt).toContain('`invoker_submit_plan`');
+    expect(prompt).toContain('`invoker_validate_plan`');
+    expect(prompt).toContain('`submit-plan.sh`');
+    expect(prompt).toContain('Harness handoff mode');
   });
 });
 

--- a/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
@@ -1,0 +1,338 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import * as childProcess from 'node:child_process';
+import { ConversationRepository, SQLiteAdapter, WorkflowChannelRepository } from '@invoker/data-store';
+import { SlackSurface } from '../slack/slack-surface.js';
+import type { SurfaceCommand } from '../surface.js';
+import { SessionIdentifier } from '../slack/thread-session-manager.js';
+
+interface MockHandler {
+  pattern: string | RegExp;
+  handler: Function;
+}
+
+const sharedSlack = vi.hoisted(() => ({
+  client: {
+    auth: { test: vi.fn().mockResolvedValue({ user_id: 'UBOT' }) },
+    chat: {
+      postMessage: vi.fn().mockResolvedValue({ ts: 'posted' }),
+      update: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    },
+    reactions: { add: vi.fn().mockResolvedValue({}), remove: vi.fn().mockResolvedValue({}) },
+  },
+}));
+
+vi.mock('@slack/bolt', () => {
+  class MockApp {
+    _eventHandlers: MockHandler[] = [];
+    _actionHandlers: MockHandler[] = [];
+    command = vi.fn();
+    event = vi.fn((pattern: string, handler: Function) => this._eventHandlers.push({ pattern, handler }));
+    action = vi.fn((pattern: string | RegExp, handler: Function) => this._actionHandlers.push({ pattern, handler }));
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    client = sharedSlack.client;
+  }
+  return { App: MockApp };
+});
+
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:child_process')>()),
+  spawn: vi.fn(),
+}));
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+const silentLog = () => {};
+const plan = `\`\`\`yaml
+name: "Proof plan"
+tasks:
+  - id: proof
+    description: "Exercise the submission flow"
+    command: "pnpm test"
+    dependencies: []
+\`\`\``;
+
+function processWith(stdout: string): any {
+  const process = new EventEmitter() as any;
+  process.stdout = new EventEmitter();
+  process.stderr = new EventEmitter();
+  process.kill = vi.fn();
+  queueMicrotask(() => {
+    process.stdout.emit('data', Buffer.from(stdout));
+    process.emit('close', 0);
+  });
+  return process;
+}
+
+function handler(surface: SlackSurface, pattern: string): Function {
+  const found = (surface.getApp() as any)._eventHandlers.find((entry: MockHandler) => entry.pattern === pattern);
+  if (!found) throw new Error(`Missing ${pattern} handler`);
+  return found.handler;
+}
+
+function config(repo: ConversationRepository, extra: Partial<ConstructorParameters<typeof SlackSurface>[0]> = {}) {
+  return {
+    botToken: 'xoxb-proof',
+    appToken: 'xapp-proof',
+    signingSecret: 'proof',
+    channelId: 'C_DEFAULT',
+    lobbyChannelId: 'C_LOBBY',
+    conversationRepo: repo,
+    enableImmediateAck: false,
+    planningHeartbeatIntervalSeconds: 0,
+    log: silentLog,
+    ...extra,
+  };
+}
+
+async function start(surface: SlackSurface, commands: SurfaceCommand[]) {
+  await surface.start(async (command) => { commands.push(command); });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function mention(surface: SlackSurface, text: string, ts: string, threadTs?: string) {
+  const say = vi.fn().mockResolvedValue({ ts: `${ts}-reply` });
+  await handler(surface, 'app_mention')({
+    event: { text: `<@UBOT> ${text}`, ts, thread_ts: threadTs, user: 'U_PROOF', channel: 'C_LOBBY' },
+    say,
+  });
+  return say;
+}
+
+async function reply(surface: SlackSurface, text: string, threadTs: string) {
+  const say = vi.fn().mockResolvedValue({ ts: `${threadTs}-reply` });
+  await handler(surface, 'message')({
+    event: { text, ts: `${threadTs}-child`, thread_ts: threadTs, user: 'U_PROOF', channel: 'C_LOBBY' },
+    say,
+  });
+  return say;
+}
+
+describe('Slack plan submission restart repro contracts', () => {
+  let adapter: SQLiteAdapter;
+  let repo: ConversationRepository;
+  let workflowChannels: WorkflowChannelRepository;
+  let surfaces: SlackSurface[];
+
+  beforeEach(async () => {
+    mockSpawn.mockReset();
+    sharedSlack.client.auth.test.mockClear();
+    sharedSlack.client.chat.postMessage.mockClear();
+    sharedSlack.client.chat.update.mockClear();
+    sharedSlack.client.chat.delete.mockClear();
+    adapter = await SQLiteAdapter.create(':memory:');
+    repo = new ConversationRepository(adapter, { info: silentLog, warn: silentLog, error: silentLog });
+    workflowChannels = new WorkflowChannelRepository(adapter);
+    surfaces = [];
+  });
+
+  afterEach(async () => {
+    await Promise.all(surfaces.map((surface) => surface.stop()));
+    adapter.close();
+  });
+
+  function surface(commands: SurfaceCommand[], extra: Partial<ConstructorParameters<typeof SlackSurface>[0]> = {}) {
+    const created = new SlackSurface(config(repo, extra));
+    surfaces.push(created);
+    return created;
+  }
+
+  it.fails('promotes an agent thread when a bare plan: reply requests an Invoker plan', async () => {
+    const commands: SurfaceCommand[] = [];
+    const slack = surface(commands);
+    await start(slack, commands);
+    mockSpawn.mockImplementationOnce(() => processWith('Agent response'));
+    await mention(slack, 'fix the agent routing', 'thread-agent');
+    mockSpawn.mockImplementationOnce(() => processWith('Still an agent response'));
+    const say = await reply(slack, 'plan: draft a real migration plan', 'thread-agent');
+    const current = (slack as any).sessionManager.findSession(new SessionIdentifier('C_LOBBY', 'thread-agent'));
+    expect(current?.conversationMode).toBe('agent');
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: 'Still an agent response' }));
+    await mention(slack, 'submit', 'submit-agent', 'thread-agent');
+    expect(commands).toContainEqual(expect.objectContaining({ type: 'start_plan' }));
+  });
+
+  it.fails('stages a bare thread submit for confirmation instead of routing it to the planner', async () => {
+    const commands: SurfaceCommand[] = [];
+    const slack = surface(commands);
+    await start(slack, commands);
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await mention(slack, 'plan: create a proof', 'thread-submit');
+    mockSpawn.mockImplementationOnce(() => processWith('Planner received the submit message'));
+    const say = await reply(slack, 'submit', 'thread-submit');
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: 'Planner received the submit message' }));
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Approve to proceed') }));
+  });
+
+  it.fails('restores non-default repo and preset context after a SlackSurface restart', async () => {
+    const commands: SurfaceCommand[] = [];
+    const first = surface(commands, {
+      repoAliases: { proof: 'https://example.test/proof.git' },
+      harnessPresets: { special: { tool: 'special-tool', model: 'special-model' } },
+      defaultHarnessPreset: 'special',
+    });
+    await start(first, commands);
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await mention(first, '[special] [repo:proof] plan: preserve context', 'thread-context');
+    expect((first as any).planningContexts.get('thread-context')).toEqual(expect.objectContaining({
+      repoUrl: 'https://example.test/proof.git',
+      presetKey: 'special',
+    }));
+    await first.stop();
+    surfaces = surfaces.filter((candidate) => candidate !== first);
+
+    const second = surface(commands, {
+      repoAliases: { proof: 'https://example.test/proof.git' },
+      harnessPresets: { special: { tool: 'special-tool', model: 'special-model' } },
+      defaultRepoUrl: 'https://example.test/default.git',
+    });
+    await start(second, commands);
+    const say = await mention(second, 'submit', 'submit-context', 'thread-context');
+    expect((second as any).planningContexts.get('thread-context')).toBeUndefined();
+    expect((second as any).sessionManager.findSession(new SessionIdentifier('C_LOBBY', 'thread-context'))?.conversationMode).toBe('plan');
+    await reply(second, 'yes', 'thread-context');
+    expect(commands).toContainEqual(expect.objectContaining({
+      type: 'start_plan',
+      repoUrl: undefined,
+      harnessPreset: undefined,
+    }));
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Approve to proceed') }));
+    expect(commands).toContainEqual(expect.objectContaining({
+      type: 'start_plan',
+      repoUrl: 'https://example.test/proof.git',
+      harnessPreset: 'special',
+    }));
+  });
+
+  it.fails('restores a staged submit confirmation after a SlackSurface restart', async () => {
+    const commands: SurfaceCommand[] = [];
+    const first = surface(commands);
+    await start(first, commands);
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await mention(first, 'plan: stage a submission', 'thread-confirm');
+    await mention(first, 'submit', 'submit-confirm', 'thread-confirm');
+    expect((first as any).pendingConfirms.get('thread-confirm')).toEqual(expect.objectContaining({ kind: 'submit' }));
+    await first.stop();
+    surfaces = surfaces.filter((candidate) => candidate !== first);
+
+    const second = surface(commands);
+    await start(second, commands);
+    expect((second as any).pendingConfirms.get('thread-confirm')).toBeUndefined();
+    mockSpawn.mockImplementationOnce(() => processWith('Planner received the lost confirmation'));
+    const say = await reply(second, 'yes', 'thread-confirm');
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: 'Planner received the lost confirmation' }));
+    expect(commands).toContainEqual(expect.objectContaining({ type: 'start_plan' }));
+  });
+
+  it.fails('recovers an evicted session from a thread reply and submit', async () => {
+    const commands: SurfaceCommand[] = [];
+    const slack = surface(commands);
+    await start(slack, commands);
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await mention(slack, 'plan: recover me', 'thread-evicted');
+    const manager = (slack as any).sessionManager;
+    const id = new SessionIdentifier('C_LOBBY', 'thread-evicted');
+    expect(repo.loadConversation('thread-evicted')?.messages).toHaveLength(2);
+    expect(manager.evictSession(id)).toBe(true);
+    expect(manager.findSession(id)).toBeNull();
+    mockSpawn.mockImplementationOnce(() => processWith('Recovered reply'));
+    const replySay = await reply(slack, 'continue', 'thread-evicted');
+    const submitSay = await mention(slack, 'submit', 'submit-evicted', 'thread-evicted');
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(replySay).not.toHaveBeenCalled();
+    expect(submitSay).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('No Invoker plan draft') }));
+    expect(commands).toContainEqual(expect.objectContaining({ type: 'start_plan' }));
+  });
+
+  it.fails('cleans up a submitted session using its actual channel ID', async () => {
+    const commands: SurfaceCommand[] = [];
+    const slack = surface(commands);
+    await start(slack, commands);
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await mention(slack, 'plan: clean up in the lobby', 'thread-cleanup');
+    await mention(slack, 'submit', 'submit-cleanup', 'thread-cleanup');
+    await reply(slack, 'yes', 'thread-cleanup');
+    const manager = (slack as any).sessionManager;
+    const actualId = new SessionIdentifier('C_LOBBY', 'thread-cleanup');
+    expect(manager.findSession(actualId)).not.toBeNull();
+    expect(manager.findSession(new SessionIdentifier('C_DEFAULT', 'thread-cleanup'))).toBeNull();
+    expect(manager.getMetrics().submitted).toBe(0);
+    expect(manager.findSession(actualId)).toBeNull();
+  });
+
+  it.fails('preserves a staged submit after a non-confirmation reply', async () => {
+    const commands: SurfaceCommand[] = [];
+    const slack = surface(commands);
+    await start(slack, commands);
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await mention(slack, 'plan: keep my confirmation', 'thread-reply');
+    await mention(slack, 'submit', 'submit-reply', 'thread-reply');
+    expect((slack as any).pendingConfirms.get('thread-reply')).toEqual(expect.objectContaining({ kind: 'submit' }));
+    mockSpawn.mockImplementationOnce(() => processWith('Planner received the non-confirmation'));
+    const nonConfirmationSay = await reply(slack, 'add a note before submitting', 'thread-reply');
+    expect((slack as any).pendingConfirms.get('thread-reply')).toBeUndefined();
+    expect(nonConfirmationSay).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Dropped the pending approval') }));
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    mockSpawn.mockImplementationOnce(() => processWith('Planner received yes after the drop'));
+    const yesSay = await reply(slack, 'yes', 'thread-reply');
+    expect(yesSay).toHaveBeenCalledWith(expect.objectContaining({ text: 'Planner received yes after the drop' }));
+    expect(commands).toContainEqual(expect.objectContaining({ type: 'start_plan' }));
+  });
+
+  it.fails('preserves explicit repo and preset when an agent thread is promoted to plan mode', async () => {
+    // Promotion does not exist on this base, so this contract records the required context precedence.
+    const commands: SurfaceCommand[] = [];
+    const slack = surface(commands, {
+      repoAliases: { proof: 'https://example.test/proof.git' },
+      harnessPresets: { special: { tool: 'special-tool', model: 'special-model' } },
+      defaultHarnessPreset: 'default',
+      defaultRepoUrl: 'https://example.test/default.git',
+    });
+    await start(slack, commands);
+    mockSpawn.mockImplementationOnce(() => processWith('Agent response'));
+    await mention(slack, '[special] [repo:proof] fix this first', 'thread-promotion');
+    mockSpawn.mockImplementationOnce(() => processWith('Still an agent response'));
+    await reply(slack, 'plan: preserve the explicit target context', 'thread-promotion');
+    expect((slack as any).sessionManager.findSession(new SessionIdentifier('C_LOBBY', 'thread-promotion'))?.conversationMode).toBe('agent');
+    expect((slack as any).planningContexts.get('thread-promotion')).toBeUndefined();
+    await mention(slack, 'submit', 'submit-promotion', 'thread-promotion');
+    await reply(slack, 'yes', 'thread-promotion');
+    expect(commands).toContainEqual(expect.objectContaining({
+      type: 'start_plan',
+      repoUrl: 'https://example.test/proof.git',
+      harnessPreset: 'special',
+    }));
+  });
+
+  it('posts a duplicate progress card after SlackSurface restart', async () => {
+    const commands: SurfaceCommand[] = [];
+    workflowChannels.save({
+      workflowId: 'wf-proof',
+      channelId: 'C_PRIVATE_PROOF',
+      createdAt: new Date().toISOString(),
+    });
+    const first = surface(commands, { workflowChannelRepo: workflowChannels });
+    await start(first, commands);
+    const progress = {
+      workflowId: 'wf-proof',
+      name: 'Proof workflow',
+      percentComplete: 50,
+      counts: { total: 2, completed: 1, failed: 0, closed: 0, running: 1, pending: 0 },
+      tasks: [],
+    };
+    await first.handleEvent({ type: 'workflow_progress', progress });
+    expect(sharedSlack.client.chat.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      channel: 'C_PRIVATE_PROOF',
+    }));
+    await first.stop();
+    surfaces = surfaces.filter((candidate) => candidate !== first);
+
+    const second = surface(commands, { workflowChannelRepo: workflowChannels });
+    await start(second, commands);
+    await second.handleEvent({ type: 'workflow_progress', progress });
+    expect(sharedSlack.client.chat.postMessage).toHaveBeenCalledTimes(2);
+    expect(sharedSlack.client.chat.postMessage.mock.calls.every(([message]: any[]) => message.channel === 'C_PRIVATE_PROOF')).toBe(true);
+  });
+});

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -182,7 +182,7 @@ Default behavior:
 - Treat the thread like an ordinary OMP/Codex coding session.
 - Answer questions, run local commands, inspect files, edit code, and run focused verification when useful.
 - Do NOT generate Invoker YAML in this thread. If the user asks for an Invoker plan, tell them to start a new plan thread with \`plan: <request>\` — plan drafts from an agent thread cannot be submitted.
-- Do NOT submit or start an Invoker workflow. Agent threads reject \`submit\`; only a \`plan:\` thread can be submitted.
+- Do NOT submit or start an Invoker workflow. Do NOT invoke \`invoker-cli\`, \`invoker_submit_plan\`, \`invoker_validate_plan\`, \`submit-plan.sh\`, or the \`plan-to-invoker\` skill's Harness handoff mode to do so. Agent threads reject \`submit\`; only a \`plan:\` thread can be submitted.
 - Keep Slack replies short and concrete: changed files, verification, and any remaining risk.
 - To share a generated file (screenshot, diagram, report), write it inside your worktree and link it by absolute path as a markdown link, e.g. \`[chart](/abs/path/in/worktree/chart.png)\`. Files linked that way are uploaded to the thread. Files written outside your worktree cannot be shared, so do not put artifacts in /tmp.`;
 }
@@ -295,7 +295,7 @@ Rules:
 10. After generating a plan, include a short post-plan summary that tells the user they can confirm execution. The confirmation instruction MUST be exactly this standalone line:
 Reply \`submit\` to submit it.
 Do NOT place that line inline in a sentence.
-11. NEVER generate bash commands or shell scripts to execute plans. The orchestrator handles plan execution automatically after explicit Slack approval.
+11. NEVER submit, validate, or execute this plan yourself. Do NOT invoke \`invoker-cli\` (with any flags), \`invoker_submit_plan\`, \`invoker_validate_plan\`, \`submit-plan.sh\`, or the \`plan-to-invoker\` skill's Harness handoff mode. This rule overrides that skill's handoff instructions in this Slack thread. The Slack orchestrator validates and executes the plan after the user replies \`submit\` and approves it. If the user instead says \`execute\`, \`run it\`, \`yes\`, or \`go\` before submitting, remind them to reply with \`submit\`; never run it yourself.
 12. Choose \`mergeMode\` deliberately. For reviewable implementation plans, set \`mergeMode: external_review\` so changes land through the canonical GitHub-backed review gate. Keep \`mergeMode: manual\` (the default) for verification-only plans that should not open a review, and use \`mergeMode: automatic\` only when the user explicitly wants changes merged without review.`;
 }
 

--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -276,7 +276,7 @@ export function classifyReviewUnitsForPath(filePath) {
   ) return ['tooling-policy'];
   if (path.startsWith('packages/app/e2e/visual-proof/')) return ['activation-surface'];
   if (/(benchmark|performance|visual-proof)/.test(lowerPath)) return ['proof'];
-  if (path === 'skills/make-pr/SKILL.md') return ['tooling-policy'];
+  if (path === 'skills/make-pr/SKILL.md' || path === 'skills/plan-to-invoker/SKILL.md') return ['tooling-policy'];
   if (path.startsWith('docs/') || path.startsWith('skills/') || path.endsWith('.md')) return ['docs'];
   if (path.startsWith('.github/')) return ['tooling-policy'];
   if (

--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -133,6 +133,8 @@ must_contain "$SKILL_MD" "\"invoker-plan-to-invoker\"" "SKILL frontmatter must t
 must_contain "$SKILL_MD" "\"/invoker-plan-to-invoker\"" "SKILL frontmatter must trigger on the slash handoff command"
 must_contain "$SKILL_MD" "## Harness handoff mode" "SKILL must document harness handoff mode"
 must_contain "$SKILL_MD" "Use this mode when invoked by the installed command or MCP prompt." "SKILL must define when handoff mode applies"
+must_contain "$SKILL_MD" "Do not use this mode from a Slack \`plan:\` or agent thread." "SKILL must defer Slack threads to the orchestrator"
+must_contain "$SKILL_MD" "do not invoke CLI or MCP handoff tools yourself." "SKILL must forbid Slack-thread CLI and MCP submission"
 must_contain "$SKILL_MD" "First produce a Markdown planning artifact at \`plans/invoker-handoff.md\`." "SKILL handoff mode must require a Markdown plan"
 must_contain "$SKILL_MD" "In an Invoker source checkout, still run \`bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>\` before submission." "SKILL handoff mode must keep checkout-local skill-doctor validation"
 must_contain "$SKILL_MD" "Outside an Invoker source checkout, \`invoker_validate_plan\` is the deterministic validation gate." "SKILL handoff mode must keep outside-checkout MCP validation"

--- a/scripts/test-review-unit-classification.mjs
+++ b/scripts/test-review-unit-classification.mjs
@@ -36,6 +36,7 @@ const stillToolingPolicy = [
   'scripts/review-unit-rules.mjs',
   '.github/workflows/ci.yml',
   'skills/make-pr/SKILL.md',
+  'skills/plan-to-invoker/SKILL.md',
 ];
 for (const path of stillToolingPolicy) {
   assert.deepEqual(

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -58,6 +58,8 @@ For implementation benchmark plans, switch `onFinish` and `mergeMode` only when 
 
 Use this mode when invoked by the installed command or MCP prompt.
 
+Do not use this mode from a Slack `plan:` or agent thread. In Slack, write the draft requested by the Slack orchestrator and let its `submit` and approval flow validate and execute it; do not invoke CLI or MCP handoff tools yourself.
+
 - First produce a Markdown planning artifact at `plans/invoker-handoff.md`.
 - Convert the approved Markdown plan to `plans/invoker-handoff.yaml`.
 - Prefer the MCP tools `invoker_validate_plan` and `invoker_submit_plan` when available.

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -58,8 +58,6 @@ For implementation benchmark plans, switch `onFinish` and `mergeMode` only when 
 
 Use this mode when invoked by the installed command or MCP prompt.
 
-Do not use this mode from a Slack `plan:` or agent thread. In Slack, write the draft requested by the Slack orchestrator and let its `submit` and approval flow validate and execute it; do not invoke CLI or MCP handoff tools yourself.
-
 - First produce a Markdown planning artifact at `plans/invoker-handoff.md`.
 - Convert the approved Markdown plan to `plans/invoker-handoff.yaml`.
 - Prefer the MCP tools `invoker_validate_plan` and `invoker_submit_plan` when available.


### PR DESCRIPTION
## Summary

This proof slice captures the Slack thread states that previously lost or misrouted plan submissions.

It keeps the failures reproducible before the recovery behavior lands.

## Review Claim

The Slack lifecycle gaps are represented by deterministic reproduction tests.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The tests mock only Slack and planner boundaries while exercising the real surface, persistence, and session classes.

## Slice Rationale

Review the failure tests before the behavior changes they justify.

## Non-goals

This slice does not alter Slack runtime behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces test -- slack-plan-submission-repros.e2e.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e8d22f7a1`
- Post-revert steps: None
- Data migration? No

</details>
