### PR TITLE
[Disk headroom](2) Enable remote worker runs

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -129,6 +129,22 @@ describe('headless-client', () => {
     expect(runElectronHeadless).toHaveBeenCalledWith(argv);
   });
 
+  it('runs a named worker directly in standalone mode', async () => {
+    process.env.INVOKER_HEADLESS_STANDALONE = '1';
+    const runElectronHeadless = vi.fn(async () => 23);
+    const argv = ['worker', 'disk-headroom'];
+
+    const exitCode = await runHeadlessClientCommand(argv, {
+      messageBus: new LocalBus(),
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      refreshMessageBus: vi.fn(async () => new LocalBus()),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(23);
+    expect(runElectronHeadless).toHaveBeenCalledWith(argv);
+  });
+
   it('keeps delegating a read when the ping misses but a live owner marker exists', async () => {
     process.env.INVOKER_HEADLESS_STANDALONE = '1';
     // A live owner holds the DB (marker names this process, sidecars present),

--- a/packages/app/src/__tests__/headless-command-classification.test.ts
+++ b/packages/app/src/__tests__/headless-command-classification.test.ts
@@ -37,6 +37,9 @@ describe('headless-command-classification', () => {
     expect(isHeadlessReadOnlyCommand(['list'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['session'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['open-terminal'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['worker'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['worker', 'status'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['worker', 'disk-headroom'])).toBe(false);
     expect(isHeadlessReadOnlyCommand(['run'])).toBe(false);
   });
 
@@ -53,6 +56,9 @@ describe('headless-command-classification', () => {
     expect(isHeadlessMutatingCommand(['set', 'agent'])).toBe(true);
     expect(isHeadlessMutatingCommand(['set', 'fix-context'])).toBe(true);
     expect(isHeadlessMutatingCommand(['set', 'xyz'])).toBe(false);
+    expect(isHeadlessMutatingCommand(['worker'])).toBe(false);
+    expect(isHeadlessMutatingCommand(['worker', 'status'])).toBe(false);
+    expect(isHeadlessMutatingCommand(['worker', 'disk-headroom'])).toBe(true);
   });
 
   it('classifies every registered set subcommand as mutating', () => {

--- a/packages/app/src/__tests__/headless-worker.test.ts
+++ b/packages/app/src/__tests__/headless-worker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { PR_SUMMARY_REFRESH_WORKER_KIND } from '@invoker/execution-engine';
-import { runHeadless } from '../headless.js';
+import { resolveHeadlessDiskHeadroomConfig, runHeadless } from '../headless.js';
 
 describe('headless worker registry', () => {
   it('lists the PR summary refresh worker kind', async () => {
@@ -18,5 +18,29 @@ describe('headless worker registry', () => {
 
     expect(stdout).toContain('Worker kinds');
     expect(stdout).toContain(PR_SUMMARY_REFRESH_WORKER_KIND);
+  });
+
+  it('maps configured SSH targets into disk-headroom worker dependencies', () => {
+    const config = resolveHeadlessDiskHeadroomConfig({
+      remoteTargets: {
+        digitalOcean: {
+          host: '203.0.113.10',
+          user: 'invoker',
+          sshKeyPath: '/tmp/test-key',
+          port: 2222,
+        },
+      },
+    });
+
+    expect(config.remoteTargets).toEqual([{
+      name: 'digitalOcean',
+      connection: {
+        host: '203.0.113.10',
+        user: 'invoker',
+        sshKeyPath: '/tmp/test-key',
+        port: 2222,
+      },
+      remotePath: '~/.invoker',
+    }]);
   });
 });

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -621,7 +621,11 @@ export async function runHeadlessClientCommand(
     return typeof exitCode === 'number' ? exitCode : 0;
   }
 
-  if (!internalOwnerServe && await delegateReadOnlyQuery(args, deps.messageBus, deps.refreshMessageBus)) {
+  if (
+    !internalOwnerServe
+    && !isHeadlessMutatingCommand(args)
+    && await delegateReadOnlyQuery(args, deps.messageBus, deps.refreshMessageBus)
+  ) {
     const exitCode = process.exitCode;
     return typeof exitCode === 'number' ? exitCode : 0;
   }

--- a/packages/app/src/headless-command-classification.ts
+++ b/packages/app/src/headless-command-classification.ts
@@ -99,6 +99,10 @@ export function resolveHeadlessTargetWorkflowId(
 export function isHeadlessReadOnlyCommand(args: string[]): boolean {
   const command = args[0];
   if (!command || command === '--help' || command === '-h') return true;
+  if (command === 'worker') {
+    const subcommand = args[1] ?? 'list';
+    return subcommand === 'list' || subcommand === 'status';
+  }
   return findHeadlessCommandDefinition(command)?.kind === 'read';
 }
 
@@ -108,6 +112,10 @@ export function isHeadlessMutatingCommand(args: string[]): boolean {
 
   if (command === 'set') {
     return isMutatingSetSubcommand(args[1]);
+  }
+  if (command === 'worker') {
+    const subcommand = args[1] ?? 'list';
+    return subcommand !== 'list' && subcommand !== 'status';
   }
 
   return findHeadlessCommandDefinition(command)?.kind === 'write';

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -426,6 +426,24 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
   }
 }
 
+export function resolveHeadlessDiskHeadroomConfig(
+  invokerConfig: HeadlessDeps['invokerConfig'],
+): NonNullable<WorkerRuntimeDependencies['diskHeadroom']> {
+  return {
+    localPath: resolveInvokerHomeRoot(),
+    remoteTargets: Object.entries(invokerConfig.remoteTargets ?? {}).map(([name, target]) => ({
+      name,
+      connection: {
+        host: target.host,
+        user: target.user,
+        sshKeyPath: target.sshKeyPath,
+        port: target.port,
+      },
+      remotePath: '~/.invoker',
+    })),
+  };
+}
+
 async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0] ?? 'list';
   const registry = registerExternalWorkersFromConfig(
@@ -478,6 +496,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
         getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
       },
       prMaintenance: resolvePrMaintenanceWorkerConfig(deps.invokerConfig),
+      diskHeadroom: resolveHeadlessDiskHeadroomConfig(deps.invokerConfig),
       mergeGateProvider: new GitHubMergeGateProvider(),
     });
     await worker.tick('manual');


### PR DESCRIPTION
## Summary

Named worker invocations receive configured SSH target data through headless execution.

Informational worker views retain query behavior, while named worker invocations use the writable command path.

## Review Claim

Manual disk-headroom worker invocations reach configured SSH hosts.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only named worker invocations use the writable command path; list and status behavior is unchanged.

## Slice Rationale

This exposes the already-defined worker behavior through the CLI after the foundational worker change.

## Non-goals

- Change SSH pool scheduling.
- Alter disk-pressure worker rules.
- Change UI behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-worker.test.ts src/__tests__/headless-command-classification.test.ts src/__tests__/headless-client.test.ts`
- [x] `pnpm --filter @invoker/app build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert e612111a7`.
- Post-revert steps: None.
- Data migration? No.

</details>
