### PR TITLE
[Fix Task Context Menu Layering](master) Raise task context menus above graph panels

### DIFF
--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -242,6 +242,19 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
     expect(mock.api.deleteWorkflow).not.toHaveBeenCalled();
   });
 
+  it('task context menu opened from the selected workflow mini DAG layers above the floating graph panel', async () => {
+    await setup();
+    fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
+    const panel = await screen.findByTestId('selected-workflow-mini-dag');
+
+    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+
+    const menu = await screen.findByRole('menu');
+    expect(panel).toBeInTheDocument();
+    expect(menu).toHaveStyle({ zIndex: String(FLOATING_GRAPH_PANEL_Z_INDEX + 100) });
+    expect(Number(menu.style.zIndex)).toBeGreaterThan(FLOATING_GRAPH_PANEL_Z_INDEX);
+  });
+
   it('workflow context menu retries workflow', async () => {
     await setup();
     fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-1'));

--- a/packages/ui/src/components/ContextMenu.tsx
+++ b/packages/ui/src/components/ContextMenu.tsx
@@ -41,6 +41,8 @@ function stopMenuKeyboardEvent(e: KeyboardEvent | React.KeyboardEvent) {
   }
 }
 
+const TASK_CONTEXT_MENU_Z_INDEX = 1100;
+
 export function ContextMenu({
   x,
   y,
@@ -286,8 +288,8 @@ export function ContextMenu({
       ref={menuRef}
       role="menu"
       data-testid="task-context-menu"
-      className="fixed z-50 bg-secondary border border-border-strong rounded-lg shadow-xl py-1 min-w-[160px]"
-      style={{ left: position.left, top: position.top }}
+      className="fixed bg-secondary border border-border-strong rounded-lg shadow-xl py-1 min-w-[160px]"
+      style={{ left: position.left, top: position.top, zIndex: TASK_CONTEXT_MENU_Z_INDEX }}
       onKeyDown={handleKeyDown}
       onClick={(event) => event.stopPropagation()}
       tabIndex={-1}


### PR DESCRIPTION
## Summary

Task context menus now use an explicit top-level z-index so they render above the selected-workflow mini DAG.

This is the exact diff from PR #4871, which was accidentally merged into the stale `main` branch instead of `master`. `main` is ~1275 commits behind `master` and isn't part of the trunk, so the fix never reached `master`. GitHub does not allow reopening a merged PR, so this recreates the same change on top of current `master`.

## Review Claim

Task context menus render above task graph surfaces, including the floating selected-workflow mini DAG.

## Review Lane

behavior

## Review Unit

activation-surface
## Safety Invariant

Only task context-menu overlay ordering and direct regression coverage change; TaskDAG click/context-menu dispatch stays intact.

## Slice Rationale

Same slice as #4871: `ContextMenu` used `z-50` while `FloatingGraphPanel` renders at `z-[1000]`. Rebased the two-line fix and its regression test onto `master`'s current `ContextMenu.tsx` (which had since picked up `data-testid` and design-token classes), keeping master's existing "still works in mini DAG" test intact and adding the new z-index regression test alongside it.

## Non-goals

This does not redesign context-menu actions, graph layout, task selection, or workflow mutation behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile && cd packages/ui && pnpm test -- --run context-menu-e2e` (24 passed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit for this PR>`
- Post-revert steps: rerun the focused context-menu test if the context menu changes again.
- Data migration? No

</details>

