### PR TITLE
CI Repair Step 1 - Harden Worker Recovery Path (2) Verify focused CI repair workers

### DIFF
--- a/packages/execution-engine/package.json
+++ b/packages/execution-engine/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
     "docker:build": "bash ../../scripts/build-agent-base-image.sh",
-    "test": "vitest run",
+    "test": "node ./scripts/run-vitest.mjs",
     "test:watch": "vitest",
     "clean": "rm -rf dist"
   },

--- a/packages/execution-engine/scripts/run-vitest.mjs
+++ b/packages/execution-engine/scripts/run-vitest.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+
+const args = process.argv.slice(2);
+const vitestArgs = args[0] === '--' ? args.slice(1) : args;
+const hasTestTimeout = vitestArgs.some((arg, index) =>
+  arg === '--testTimeout'
+  || arg.startsWith('--testTimeout=')
+  || (arg === '--test-timeout' && index < vitestArgs.length - 1)
+  || arg.startsWith('--test-timeout='));
+const defaultArgs = hasTestTimeout ? [] : ['--testTimeout=60000'];
+
+const child = spawn('vitest', ['run', ...defaultArgs, ...vitestArgs], {
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});
+
+child.on('error', (error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync, execSync } from 'node:child_process';
@@ -242,7 +242,30 @@ describe('buildWorktreeListScript', () => {
     expect(script).toContain('H="xyz789"');
     expect(script).toContain('INVOKER_HOME=$(echo');
     expect(script).toContain('CLONE="$INVOKER_HOME/repos/$H"');
+    expect(script).toContain('rev-parse --git-dir');
     expect(script).toContain('git -C "$CLONE" worktree list --porcelain');
+  });
+
+  it('returns an empty list when the remote mirror clone is missing', () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), 'ssh-list-missing-home-'));
+    const script = buildWorktreeListScript({
+      repoHash: 'missing123',
+      invokerHome: '~/.invoker',
+    });
+
+    try {
+      const output = execFileSync('bash', ['-lc', script], {
+        env: {
+          ...process.env,
+          HOME: fakeHome,
+        },
+        encoding: 'utf8',
+      });
+
+      expect(output).toBe('');
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -234,6 +234,9 @@ elif [[ "\${INVOKER_HOME:0:2}" == '~/' ]]; then
   INVOKER_HOME="$HOME/\${INVOKER_HOME:2}"
 fi
 CLONE="$INVOKER_HOME/repos/$H"
+if [ ! -d "$CLONE" ] || ! git -C "$CLONE" rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
 git -C "$CLONE" worktree list --porcelain
 `;
 }


### PR DESCRIPTION
## Summary

CI Repair Step 1 - Harden Worker Recovery Path — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784443619278-10/implement-ci-failure-worker-recovery | Ensure non-conflict review-gate CI failures reliably queue fix-with-agent repairs for workflow-mapped merge tasks | completed |
| wf-1784443619278-10/verify-ci-failure-worker-recovery | Run focused execution-engine CI-repair worker tests | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784443619278-10/implement-ci-failure-worker-recovery — Ensure non-conflict review-gate CI failures reliably queue fix-with-agent repairs for workflow-mapped merge tasks

### wf-1784443619278-10/verify-ci-failure-worker-recovery — Run focused execution-engine CI-repair worker tests

</details>

Adds the focused execution-engine test entrypoint used to verify CI repair worker recovery.

The runner now applies a CI-tolerant default Vitest timeout unless the caller supplies one.

The SSH worktree listing helper now treats a missing remote mirror clone as an empty worktree list, so recovery cleanup probes do not fail before a clone exists.

## Review Claim

Focused execution-engine CI repair worker tests now run through the package test script with a CI-tolerant default timeout, and missing remote mirror clones list as zero worktrees.

## Review Lane

behavior

## Review Unit

test-verification

## Safety Invariant

The runner only adds a default timeout when the caller has not supplied one, and the SSH helper guard is covered by a unit test that expects an empty worktree list for a missing mirror clone.

## Slice Rationale

The verification runner and SSH helper guard are separated from the recovery worker so reviewers can check test invocation and probe behavior independently.

## Non-goals

- Do not change CI failure detection.
- Do not change repair intent deduplication.
- Do not change worker retry budgets.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/pr-ci-workers.test.ts src/__tests__/ci-failure-tick-drops-events.test.ts src/__tests__/ssh-git-exec.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ci-repair-step-1-pr2.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a57f5052e51fc66536ddb37bb7d3f30e1328aac6`
- Post-revert steps: Re-run the focused execution-engine worker tests.
- Data migration? No

</details>

Depends-On: #5168
