### PR TITLE
Planning Terminal Always-Visible Agent Selector (2) Cover selector interactions

### DIFF
--- a/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  InvokerTerminalHarness,
+  createTerminalHarnessController,
+} from './helpers/invoker-terminal-harness.js';
+
+describe('CodeRabbit PR #3050 - draft state cleared after submit', () => {
+  it('dismisses the ready bar and disables the composer after a successful submit', async () => {
+    const controller = createTerminalHarnessController();
+    render(
+      <InvokerTerminalHarness
+        controller={controller}
+        initialDraftPlanAvailable={true}
+      />,
+    );
+
+    expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent(
+      'draft ready - "Mock Plan" - 2 tasks',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+
+    await waitFor(() => {
+      expect(controller.onSubmitDraft).toHaveBeenCalledTimes(1);
+      expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    expect(screen.getByLabelText('Agent')).toBeDisabled();
+  });
+});

--- a/packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  InvokerTerminalHarness,
+  createTerminalHarnessController,
+} from './helpers/invoker-terminal-harness.js';
+
+describe('CodeRabbit PR #3050 - Enter-to-submit ignores IME composition', () => {
+  it('does not submit while an IME composition is in progress', async () => {
+    const controller = createTerminalHarnessController();
+    render(<InvokerTerminalHarness controller={controller} />);
+
+    const input = screen.getByTestId('invoker-terminal-input');
+    fireEvent.change(input, { target: { value: 'hello' } });
+
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
+    await Promise.resolve();
+    expect(controller.onSubmit).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await waitFor(() => {
+      expect(controller.onSubmit).toHaveBeenCalledWith({
+        message: 'hello',
+        presetKey: 'codex',
+      });
+    });
+  });
+});

--- a/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  InvokerTerminalHarness,
+  createTerminalHarnessController,
+} from './helpers/invoker-terminal-harness.js';
+
+describe('CodeRabbit PR #3050 - submitted planning stays guarded', () => {
+  it('keeps submitted planning read-only and prevents message or draft resubmission', async () => {
+    const controller = createTerminalHarnessController();
+    render(
+      <InvokerTerminalHarness
+        controller={controller}
+        readOnly={true}
+        initialValue="run"
+        initialDraftPlanAvailable={true}
+      />,
+    );
+
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    expect(screen.getByLabelText('Agent')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+    fireEvent.keyDown(screen.getByTestId('invoker-terminal-input'), { key: 'Enter' });
+    await Promise.resolve();
+
+    expect(controller.onSubmit).not.toHaveBeenCalled();
+    expect(controller.onSubmitDraft).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/__tests__/helpers/invoker-terminal-harness.tsx
+++ b/packages/ui/src/__tests__/helpers/invoker-terminal-harness.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { vi } from 'vitest';
+import { InvokerTerminal, type InvokerTerminalLine } from '../../components/InvokerTerminal.js';
+
+export interface SubmittedPlanningMessage {
+  message: string;
+  presetKey: string;
+}
+
+export interface TerminalHarnessController {
+  onSubmit: ReturnType<typeof vi.fn>;
+  onSubmitDraft: ReturnType<typeof vi.fn>;
+  onPresetChange: ReturnType<typeof vi.fn>;
+  submissions: SubmittedPlanningMessage[];
+}
+
+interface TerminalHarnessProps {
+  controller?: TerminalHarnessController;
+  initialPresetKey?: string;
+  initialValue?: string;
+  initialDraftPlanAvailable?: boolean;
+  readOnly?: boolean;
+  busy?: boolean;
+  lines?: InvokerTerminalLine[];
+}
+
+export function createTerminalHarnessController(): TerminalHarnessController {
+  return {
+    onSubmit: vi.fn(),
+    onSubmitDraft: vi.fn(),
+    onPresetChange: vi.fn(),
+    submissions: [],
+  };
+}
+
+export function InvokerTerminalHarness({
+  controller = createTerminalHarnessController(),
+  initialPresetKey = 'codex',
+  initialValue = '',
+  initialDraftPlanAvailable = false,
+  readOnly = false,
+  busy = false,
+  lines = [],
+}: TerminalHarnessProps): JSX.Element {
+  const [value, setValue] = useState(initialValue);
+  const [presetKey, setPresetKey] = useState(initialPresetKey);
+  const [draftPlanAvailable, setDraftPlanAvailable] = useState(initialDraftPlanAvailable);
+  const [submitted, setSubmitted] = useState(readOnly);
+
+  const effectiveReadOnly = readOnly || submitted;
+
+  return (
+    <InvokerTerminal
+      activeConversationKey="planning-chat-1"
+      lines={lines}
+      busy={busy}
+      value={value}
+      selectedPresetKey={presetKey}
+      presetOptions={[
+        { key: 'codex', label: 'Codex' },
+        { key: 'claude', label: 'Claude' },
+        { key: 'omp+claude', label: 'OMP + Claude' },
+      ]}
+      draftPlanAvailable={draftPlanAvailable}
+      draftPlanSummary={{ name: 'Mock Plan', taskCount: 2 }}
+      readOnly={effectiveReadOnly}
+      onValueChange={setValue}
+      onSubmit={() => {
+        controller.submissions.push({ message: value, presetKey });
+        controller.onSubmit({ message: value, presetKey });
+        setValue('');
+      }}
+      onSubmitDraft={() => {
+        controller.onSubmitDraft();
+        setDraftPlanAvailable(false);
+        setSubmitted(true);
+      }}
+      onPresetChange={(nextPresetKey) => {
+        setPresetKey(nextPresetKey);
+        controller.onPresetChange(nextPresetKey);
+      }}
+      onExpand={() => {}}
+    />
+  );
+}

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  InvokerTerminalHarness,
+  createTerminalHarnessController,
+} from './helpers/invoker-terminal-harness.js';
+
+describe('InvokerTerminal agent selector', () => {
+  it('renders the agent selector directly in the composer without an options toggle', () => {
+    render(<InvokerTerminalHarness />);
+
+    const selector = screen.getByLabelText('Agent');
+    expect(selector).toBe(screen.getByTestId('invoker-terminal-harness'));
+    expect(selector).toHaveValue('codex');
+    expect(screen.queryByRole('button', { name: 'Options' })).not.toBeInTheDocument();
+  });
+
+  it('uses the selected agent preset when submitting from the visible composer controls', async () => {
+    const controller = createTerminalHarnessController();
+    render(<InvokerTerminalHarness controller={controller} />);
+
+    fireEvent.change(screen.getByLabelText('Agent'), { target: { value: 'claude' } });
+    expect(controller.onPresetChange).toHaveBeenCalledWith('claude');
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), {
+      target: { value: 'draft a focused selector plan' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() => {
+      expect(controller.onSubmit).toHaveBeenCalledWith({
+        message: 'draft a focused selector plan',
+        presetKey: 'claude',
+      });
+    });
+  });
+
+  it('keeps the selector visible after typing and clearing a submitted message', async () => {
+    const controller = createTerminalHarnessController();
+    render(<InvokerTerminalHarness controller={controller} />);
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), {
+      target: { value: 'hello' },
+    });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => expect(controller.onSubmit).toHaveBeenCalledTimes(1));
+    expect(screen.getByLabelText('Agent')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Options' })).not.toBeInTheDocument();
+    expect(screen.getByTestId('invoker-terminal-input')).toHaveValue('');
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused component tests for the `InvokerTerminal` planning terminal introduced in the previous slice.

The tests cover the visible agent selector, preset submission, input clearing after submit, IME Enter handling, and guards on already-submitted sessions.

A shared harness renders the component directly and drives it through the same composer props that carry preset selection and read-only state.

These are component-level tests only. The component is still not rendered by any app surface, so this coverage proves the component contract, not an end-to-end user flow.

## Review Claim

The planning terminal component's selector, submission, clearing, IME, and submitted-session behavior are covered by focused component tests.

## Review Lane

proof

## Review Unit

planning-terminal-composer

## Safety Invariant

This slice adds test files and a test harness only. It does not change the component's runtime behavior from the previous slice.

## Slice Rationale

Verification is split from the component slice so the reviewer can read the composer contract first, then review the coverage against it.

## Non-goals

- Does not wire the component into any app surface.
- Does not change selector styling or composer layout.
- Does not change planner submission IPC behavior.
- Does not add e2e or visual-proof coverage; neither is reachable while the component is unrendered.
- Does not broaden the UI suite beyond this component and its adjacent guardrails.

## Visual Proof

None, and none is possible for this slice.

This slice adds only tests, and the component under test is not mounted by any app surface. There is no user-reachable screen to capture. The component's rendered structure is asserted by the tests listed below instead.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test`
- [x] `cd packages/ui && pnpm test -- src/__tests__/invoker-terminal.test.tsx src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 668922f0f7760ca2f86a6b10d3b162b2d5aaa6a2`
- Post-revert steps: None
- Data migration? No

</details>
