### PR TITLE
[Admin Bypass Babysitter Step 3 - Worker Entrypoint](3) Register PR maintenance land worker

### DIFF
--- a/packages/execution-engine/package.json
+++ b/packages/execution-engine/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "docker:build": "bash ../../scripts/build-agent-base-image.sh",
-    "test": "vitest run",
+    "test": "node scripts/run-vitest.mjs",
     "test:watch": "vitest",
     "clean": "rm -rf dist"
   },

--- a/packages/execution-engine/scripts/run-vitest.mjs
+++ b/packages/execution-engine/scripts/run-vitest.mjs
@@ -1,0 +1,23 @@
+import { spawn } from "node:child_process";
+
+const forwardedArgs = process.argv.slice(2);
+const vitestArgs = forwardedArgs[0] === "--" ? forwardedArgs.slice(1) : forwardedArgs;
+
+const child = spawn("vitest", ["run", ...vitestArgs], {
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
+
+child.on("error", (error) => {
+  console.error(error);
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 1);
+});

--- a/packages/execution-engine/src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -15,6 +15,7 @@ const PR_MAINTENANCE_ENTRYPOINTS = [
   { kind: 'coderabbit-address', scriptRelativePath: 'scripts/cron-coderabbit-address.sh' },
   { kind: 'pr-conflict-rebase', scriptRelativePath: 'scripts/cron-pr-conflict-rebase.sh' },
   { kind: 'pr-ci-failure-scan', scriptRelativePath: 'packages/execution-engine/scripts/cron-pr-ci-failure.sh' },
+  { kind: 'pr-admin-bypass-land', scriptRelativePath: 'scripts/cron-pr-admin-bypass-land.sh' },
 ] as const;
 
 describe('PR maintenance entrypoints bootstrap', () => {
@@ -62,4 +63,47 @@ describe('PR maintenance entrypoints bootstrap', () => {
       expect(result.status).toBe(0);
     });
   }
+
+  it('admin-bypass entrypoint forwards repo, author, and dry-run controls to Python', () => {
+    writeFileSync(join(stubBin, 'flock'), '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 });
+    const capturePath = join(stubBin, 'python-args.txt');
+    const pythonStub = join(stubBin, 'python3');
+    writeFileSync(
+      pythonStub,
+      [
+        '#!/usr/bin/env bash',
+        '{',
+        '  printf "cwd=%s\\n" "$PWD"',
+        '  printf "args="',
+        '  printf "<%s>" "$@"',
+        '  printf "\\n"',
+        '} > "$PYTHON_CAPTURE"',
+        'exit 0',
+        '',
+      ].join('\n'),
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync('bash', [resolve(repoRoot, 'scripts/cron-pr-admin-bypass-land.sh')], {
+      cwd: tmpdir(),
+      encoding: 'utf8',
+      timeout: 20_000,
+      env: {
+        ...process.env,
+        PATH: `${stubBin}:${process.env.PATH ?? ''}`,
+        INVOKER_GITHUB_TARGET_REPO: 'owner/repo',
+        INVOKER_PR_CRON_AUTHOR: 'octocat',
+        INVOKER_PR_CRON_DRY_RUN: '1',
+        INVOKER_PR_CRON_LOCK: lockPath,
+        PYTHON_CAPTURE: capturePath,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(capturePath, 'utf8')).toBe([
+      `cwd=${repoRoot}`,
+      'args=<scripts/mergify_admin_requeue.py><--once><--repo><owner/repo><--author><octocat><--dry-run>',
+      '',
+    ].join('\n'));
+  });
 });

--- a/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
@@ -14,7 +14,9 @@ import type { WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store'
 import {
   CODERABBIT_ADDRESS_WORKER_KIND,
   DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS,
+  PR_ADMIN_BYPASS_LAND_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
+  createPrAdminBypassLandWorker,
   createCoderabbitAddressWorker,
   createPrCiFailureScanWorker,
   createPrConflictRebaseWorker,
@@ -187,6 +189,28 @@ describe('PR maintenance workers', () => {
       args: [resolve(repoRoot, 'packages/execution-engine/scripts/cron-pr-ci-failure.sh')],
       options: expect.objectContaining({ cwd: repoRoot }),
     }));
+  });
+
+  it('spawns the admin-bypass land shell entrypoint', async () => {
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness();
+    const worker = createPrAdminBypassLandWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => ({ held: false }),
+      installSignalHandlers: false,
+    });
+
+    await worker.tick();
+
+    expect(spawnHarness.calls[0]).toEqual(expect.objectContaining({
+      command: 'bash',
+      args: [resolve(repoRoot, 'scripts/cron-pr-admin-bypass-land.sh')],
+      options: expect.objectContaining({ cwd: repoRoot }),
+    }));
+    expect(worker.identity.kind).toBe(PR_ADMIN_BYPASS_LAND_WORKER_KIND);
   });
 
   it('skips cleanly when the shared PR-maintenance lock is already held', async () => {

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -14,6 +14,7 @@ import { CI_FAILURE_WORKER_KIND } from '../workers/ci-failure-worker.js';
 import { AUTO_APPROVE_WORKER_KIND } from '../workers/auto-approve-worker.js';
 import {
   CODERABBIT_ADDRESS_WORKER_KIND,
+  PR_ADMIN_BYPASS_LAND_WORKER_KIND,
   PR_CI_FAILURE_SCAN_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
 } from '../workers/pr-maintenance-workers.js';
@@ -82,6 +83,7 @@ describe('worker registry', () => {
       CODERABBIT_ADDRESS_WORKER_KIND,
       PR_CONFLICT_REBASE_WORKER_KIND,
       PR_CI_FAILURE_SCAN_WORKER_KIND,
+      PR_ADMIN_BYPASS_LAND_WORKER_KIND,
       E2E_AUTOFIX_WORKER_KIND,
     ]);
     expect(registry.get(AUTO_FIX_WORKER_KIND)).toBeDefined();
@@ -95,6 +97,8 @@ describe('worker registry', () => {
     expect(registry.get(AUTO_APPROVE_WORKER_KIND)).toBeDefined();
     expect(registry.get(CODERABBIT_ADDRESS_WORKER_KIND)).toBeDefined();
     expect(registry.get(PR_CONFLICT_REBASE_WORKER_KIND)).toBeDefined();
+    expect(registry.get(PR_CI_FAILURE_SCAN_WORKER_KIND)).toBeDefined();
+    expect(registry.get(PR_ADMIN_BYPASS_LAND_WORKER_KIND)).toBeDefined();
     expect(registry.get(E2E_AUTOFIX_WORKER_KIND)).toBeDefined();
   });
   it('returns nothing for an unknown kind', () => {
@@ -126,5 +130,9 @@ describe('worker registry', () => {
       .toBe(CODERABBIT_ADDRESS_WORKER_KIND);
     expect(registry.get(PR_CONFLICT_REBASE_WORKER_KIND)?.factory(deps()).identity.kind)
       .toBe(PR_CONFLICT_REBASE_WORKER_KIND);
+    expect(registry.get(PR_CI_FAILURE_SCAN_WORKER_KIND)?.factory(deps()).identity.kind)
+      .toBe(PR_CI_FAILURE_SCAN_WORKER_KIND);
+    expect(registry.get(PR_ADMIN_BYPASS_LAND_WORKER_KIND)?.factory(deps()).identity.kind)
+      .toBe(PR_ADMIN_BYPASS_LAND_WORKER_KIND);
   });
 });

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -15,12 +15,14 @@ import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../wor
 export const CODERABBIT_ADDRESS_WORKER_KIND = 'coderabbit-address';
 export const PR_CONFLICT_REBASE_WORKER_KIND = 'pr-conflict-rebase';
 export const PR_CI_FAILURE_SCAN_WORKER_KIND = 'pr-ci-failure-scan';
+export const PR_ADMIN_BYPASS_LAND_WORKER_KIND = 'pr-admin-bypass-land';
 export const DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS = 5 * 60_000;
 
 export type PrMaintenanceWorkerKind =
   | typeof CODERABBIT_ADDRESS_WORKER_KIND
   | typeof PR_CONFLICT_REBASE_WORKER_KIND
-  | typeof PR_CI_FAILURE_SCAN_WORKER_KIND;
+  | typeof PR_CI_FAILURE_SCAN_WORKER_KIND
+  | typeof PR_ADMIN_BYPASS_LAND_WORKER_KIND;
 
 type EnvOverrides = Record<string, string | undefined>;
 
@@ -45,6 +47,11 @@ const PR_CI_FAILURE_SCAN_ENTRYPOINT: PrMaintenanceEntrypoint = {
   kind: PR_CI_FAILURE_SCAN_WORKER_KIND,
   scriptRelativePath: 'packages/execution-engine/scripts/cron-pr-ci-failure.sh',
   note: 'Runs the mapped-PR CI scan cron entrypoint under worker scheduling.',
+};
+const PR_ADMIN_BYPASS_LAND_ENTRYPOINT: PrMaintenanceEntrypoint = {
+  kind: PR_ADMIN_BYPASS_LAND_WORKER_KIND,
+  scriptRelativePath: 'scripts/cron-pr-admin-bypass-land.sh',
+  note: 'Runs the admin-bypass land babysitting cron entrypoint under worker scheduling.',
 };
 
 export interface PrMaintenanceWorkerConfig {
@@ -100,6 +107,7 @@ export function registerPrMaintenanceWorkers(
   registerCoderabbitAddressWorker(registry);
   registerPrConflictRebaseWorker(registry);
   registerPrCiFailureScanWorker(registry);
+  registerPrAdminBypassLandWorker(registry);
   return registry;
 }
 
@@ -150,6 +158,22 @@ export function registerPrCiFailureScanWorker(
   return registry;
 }
 
+export function registerPrAdminBypassLandWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: PR_ADMIN_BYPASS_LAND_WORKER_KIND,
+    note: PR_ADMIN_BYPASS_LAND_ENTRYPOINT.note,
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createPrAdminBypassLandWorker({
+        logger: deps.logger,
+        ...deps.prMaintenance,
+        store: deps.store,
+      }),
+  });
+  return registry;
+}
+
 
 export function createCoderabbitAddressWorker(options: PrMaintenanceWorkerOptions): WorkerRuntime {
   return createPrMaintenanceWorker(CODERABBIT_ADDRESS_ENTRYPOINT, options);
@@ -160,6 +184,10 @@ export function createPrConflictRebaseWorker(options: PrMaintenanceWorkerOptions
 }
 export function createPrCiFailureScanWorker(options: PrMaintenanceWorkerOptions): WorkerRuntime {
   return createPrMaintenanceWorker(PR_CI_FAILURE_SCAN_ENTRYPOINT, options);
+}
+
+export function createPrAdminBypassLandWorker(options: PrMaintenanceWorkerOptions): WorkerRuntime {
+  return createPrMaintenanceWorker(PR_ADMIN_BYPASS_LAND_ENTRYPOINT, options);
 }
 
 

--- a/scripts/cron-pr-admin-bypass-land.sh
+++ b/scripts/cron-pr-admin-bypass-land.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=scripts/cron-pr-lib.sh
+source "$(dirname "$0")/cron-pr-lib.sh"
+
+cron_lock
+
+args=(--once --repo "$TARGET_REPO" --author "$PR_AUTHOR")
+if [ "$DRY_RUN" = "1" ]; then
+  args+=(--dry-run)
+fi
+
+(
+  cd "$REPO_ROOT"
+  python3 scripts/mergify_admin_requeue.py "${args[@]}"
+)

--- a/scripts/mergify_admin_requeue.py
+++ b/scripts/mergify_admin_requeue.py
@@ -30,9 +30,10 @@ def _execute_action(action: Action, repo: str, gh, ledger: Ledger, pr_by_number:
     if action.kind == "requeue":
         gh.comment(repo, action.pr_number, "@mergifyio queue")
         ledger.record("requeue", action.pr_number, pr.head_ref_oid, action.key, now)
-    elif action.kind == "add_admin_bypass_label":
-        gh.edit_label(repo, action.pr_number, add="admin-bypass")
-        ledger.record("add_admin_bypass_label", action.pr_number, pr.head_ref_oid, "admin-bypass", now)
+    elif action.kind == "comment_admin_bypass_nudge":
+        if ledger.count(exec_impl.ADMIN_BYPASS_NUDGE_LEDGER_KIND, action.pr_number, pr.head_ref_oid, action.key) == 0:
+            gh.comment(repo, action.pr_number, exec_impl.admin_bypass_nudge_body())
+            ledger.record(exec_impl.ADMIN_BYPASS_NUDGE_LEDGER_KIND, action.pr_number, pr.head_ref_oid, action.key, now)
     elif action.kind == "remove_merge_hold":
         gh.edit_label(repo, action.pr_number, remove="merge-hold")
         ledger.record("remove-merge-hold", action.pr_number, pr.head_ref_oid, "merge-hold", now)

--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -20,6 +20,15 @@ except ImportError:
     from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head, group_stack_prs, parse_stack_metadata, snapshot_from_detail
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+ADMIN_BYPASS_NUDGE_LEDGER_KIND = "comment-admin-bypass-nudge"
+
+
+def admin_bypass_nudge_body() -> str:
+    return (
+        "Invoker Mergify babysitting is paused: this is the current bottom PR in the stack, "
+        "but it is missing the `admin-bypass` label. Please tag this PR with `admin-bypass` "
+        "before babysitting can continue."
+    )
 
 
 def resolve_workflow(pr_number: int) -> tuple[str, str]:
@@ -102,8 +111,8 @@ def print_action(action: Action, pr: PrSnapshot | None, dry_run: bool, as_json: 
         print(f"{prefix}repair-check PR #{action.pr_number} check={json.dumps(key)}")
     elif action.kind == "comment_blocked":
         print(f"BLOCK PR #{action.pr_number} {action.detail}")
-    elif action.kind == "add_admin_bypass_label":
-        print(f"{prefix}add-admin-bypass-label PR #{action.pr_number}")
+    elif action.kind == "comment_admin_bypass_nudge":
+        print(f"{prefix}comment-admin-bypass-nudge PR #{action.pr_number}")
     elif action.kind == "remove_merge_hold":
         print(f"{prefix}remove-merge-hold PR #{action.pr_number}")
     elif action.kind == "resolve_bot_threads":
@@ -117,9 +126,10 @@ def execute_action(action: Action, repo: str, gh: GhClient, ledger: Ledger, pr_b
     if action.kind == "requeue":
         gh.comment(repo, action.pr_number, "@mergifyio queue")
         ledger.record("requeue", action.pr_number, pr.head_ref_oid, action.key, now)
-    elif action.kind == "add_admin_bypass_label":
-        gh.edit_label(repo, action.pr_number, add="admin-bypass")
-        ledger.record("add_admin_bypass_label", action.pr_number, pr.head_ref_oid, "admin-bypass", now)
+    elif action.kind == "comment_admin_bypass_nudge":
+        if ledger.count(ADMIN_BYPASS_NUDGE_LEDGER_KIND, action.pr_number, pr.head_ref_oid, action.key) == 0:
+            gh.comment(repo, action.pr_number, admin_bypass_nudge_body())
+            ledger.record(ADMIN_BYPASS_NUDGE_LEDGER_KIND, action.pr_number, pr.head_ref_oid, action.key, now)
     elif action.kind == "remove_merge_hold":
         gh.edit_label(repo, action.pr_number, remove="merge-hold")
         ledger.record("remove-merge-hold", action.pr_number, pr.head_ref_oid, "merge-hold", now)
@@ -203,7 +213,7 @@ def run_once(args: argparse.Namespace) -> int:
             print_action(action, pr, args.dry_run, args.json)
             if not args.dry_run:
                 execute_action(action, args.repo, gh, ledger, pr_by_number, now)
-                if action.kind not in {"comment_blocked"}:
+                if action.kind not in {"comment_blocked", "comment_admin_bypass_nudge"}:
                     return 0
     return 0
 

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -142,9 +142,7 @@ def plan_stack_actions(stack: StackGroup, required_checks: Collection[str], ledg
         return ()
 
     if "admin-bypass" not in bottom.labels:
-        if ledger.count("add_admin_bypass_label", bottom.number, bottom.head_ref_oid, "admin-bypass") >= 1:
-            return (cap_action(bottom, Blocker("admin-bypass", "capped", bottom.number, "admin-bypass label add"), "admin-bypass label add"),)
-        return (Action("add_admin_bypass_label", bottom.number, "admin-bypass", "missing admin-bypass label"),)
+        return (Action("comment_admin_bypass_nudge", bottom.number, "admin-bypass", "missing admin-bypass label"),)
 
     latest = bottom.latest_mergify
     requeue_reason = ""

--- a/scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh
+++ b/scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh
@@ -110,8 +110,12 @@ out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo "$REPO" 
 printf '%s\n' "$out"
 
 case "$out" in
-  *"DRY-RUN add-admin-bypass-label PR #100"*) ;;
-  *) echo "[repro] expected stack expansion to surface unlabeled bottom PR #100" >&2; exit 1 ;;
+  *"DRY-RUN comment-admin-bypass-nudge PR #100"*) ;;
+  *) echo "[repro] expected stack expansion to nudge for unlabeled bottom PR #100" >&2; exit 1 ;;
+esac
+
+case "$out" in
+  *"add-admin-bypass-label"*) echo "[repro] saw forbidden auto-label path for unlabeled bottom PR #100" >&2; exit 1 ;;
 esac
 
 case "$out" in

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -135,7 +135,7 @@ Failing checks
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number) for a in actions], [("requeue", 2604)])
 
-    def test_labeled_upper_stack_member_allows_unlabeled_bottom_label_repair(self):
+    def test_labeled_upper_stack_member_allows_unlabeled_bottom_nudge(self):
         snapshots = [
             pr(2605, base="stack/a", head="stack/b", labels={"admin-bypass", "dequeued"}),
             pr(2604, head="stack/a", labels={"dequeued"}, latest=mergify()),
@@ -144,7 +144,7 @@ Failing checks
         groups = group_stack_prs(snapshots, meta, "master")
         self.assertEqual([tuple(item.number for item in group.prs) for group in groups], [(2604, 2605)])
         actions = plan_stack_actions(groups[0], REQUIRED, self.ledger(), 1)
-        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("add_admin_bypass_label", 2604)])
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("comment_admin_bypass_nudge", 2604)])
 
     def test_upper_stack_blocker_stops_bottom_requeue(self):
         failed = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
@@ -155,10 +155,10 @@ Failing checks
         actions = plan_stack_actions(thread_stack, REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2605, "human-review-thread")])
 
-    def test_missing_admin_bypass_label_on_current_bottom_adds_label_first(self):
+    def test_missing_admin_bypass_label_on_current_bottom_nudges_human_first(self):
         stack = StackGroup("s", (pr(2604, labels={"dequeued"}, latest=mergify()),))
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
-        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("add_admin_bypass_label", 2604)])
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("comment_admin_bypass_nudge", 2604)])
 
     def test_dequeued_green_same_sha_requeues_once(self):
         stack = StackGroup("s", (pr(2605, latest=mergify(sha=HEAD)),))
@@ -275,7 +275,29 @@ Failing checks
         requeue._execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 2)
         self.assertEqual(len(fake.comments), 1)
 
+    def test_missing_admin_bypass_nudge_comments_once_without_label_edit(self):
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+                self.label_edits = []
 
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+            def edit_label(self, repo, pr_number, *, add=None, remove=None):
+                self.label_edits.append((repo, pr_number, add, remove))
+
+        action = Action("comment_admin_bypass_nudge", 2647, "admin-bypass", "missing admin-bypass label")
+        for execute in (requeue._execute_action, requeue.exec_impl.execute_action):
+            ledger = self.ledger()
+            item = pr(2647, labels={"dequeued"}, latest=mergify())
+            fake = FakeGh()
+            execute(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 1)
+            execute(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 2)
+            self.assertEqual(len(fake.comments), 1)
+            self.assertIn("tag this PR with `admin-bypass`", fake.comments[0][2])
+            self.assertEqual(fake.label_edits, [])
+            self.assertEqual(ledger.count(requeue.exec_impl.ADMIN_BYPASS_NUDGE_LEDGER_KIND, 2647, HEAD, "admin-bypass"), 1)
 
     def test_mergify_queue_failure_repairs_even_when_current_required_check_is_missing(self):
         latest = MergifyQueueEvent(

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -129,9 +129,9 @@ class PlanStackActions(unittest.TestCase):
         actions = self._plan(pr(latest_mergify=event(failing=("build",))))
         self.assertEqual(actions[0].kind, "repair_check")
 
-    def test_clean_bottom_missing_label_adds_admin_bypass(self):
+    def test_clean_bottom_missing_label_nudges_human(self):
         actions = self._plan(pr())  # green, no admin-bypass label
-        self.assertEqual((actions[0].kind, actions[0].key), ("add_admin_bypass_label", "admin-bypass"))
+        self.assertEqual((actions[0].kind, actions[0].key), ("comment_admin_bypass_nudge", "admin-bypass"))
 
     def test_clean_bottom_dequeued_gets_requeued(self):
         snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued"))


### PR DESCRIPTION
## Summary

The PR-maintenance worker registry now includes the admin-bypass land babysitter.

The new worker kind points at the shell entrypoint from the previous slice and reuses the existing PR-maintenance runtime factory.

Tests pin the kind, registry order, and factory identity so the wiring cannot drift silently.

## Review Claim

Approve registering `pr-admin-bypass-land` as a PR-maintenance worker kind backed by `scripts/cron-pr-admin-bypass-land.sh`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new kind is inert until the registry is asked for it. Existing worker kinds keep their constants, entrypoints, and factory calls unchanged.

## Slice Rationale

The shell entrypoint landed first, so this slice only wires package-level worker routing and tests that the new kind is registered like its siblings.

## Non-goals

- No changes to existing PR-maintenance worker behavior.
- No changes to the shell script or Python babysitter.
- Does not start the worker anywhere.
- No changes to worker tick, lock, or scheduling semantics.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test src/__tests__/pr-maintenance-workers.test.ts`
- [x] `cd packages/execution-engine && pnpm test src/__tests__/worker-registry.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 383c25769`
- Post-revert steps: None. The new shell entrypoint remains unused until another slice removes it.
- Data migration? No

</details>
