### PR TITLE
[Fix Git E2E Tests Step 2 Bootstrap](1) Extend run.sh bootstrap repro coverage

### DIFF
--- a/scripts/repro/repro-run-sh-preprovisioned-bootstrap.sh
+++ b/scripts/repro/repro-run-sh-preprovisioned-bootstrap.sh
@@ -34,8 +34,14 @@ TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-run-sh-bootstrap-repro.XXXXXX")"
 FAKE_ROOT="$TMP_DIR/repo"
 STUB_BIN="$TMP_DIR/bin"
 PNPM_CALLS="$TMP_DIR/pnpm.calls"
+STALE_PNPM_CALLS="$TMP_DIR/pnpm-stale.calls"
+FORCE_PNPM_CALLS="$TMP_DIR/pnpm-force.calls"
 RUN_STDOUT="$TMP_DIR/run.stdout"
 RUN_STDERR="$TMP_DIR/run.stderr"
+STALE_RUN_STDOUT="$TMP_DIR/run-stale.stdout"
+STALE_RUN_STDERR="$TMP_DIR/run-stale.stderr"
+FORCE_RUN_STDOUT="$TMP_DIR/run-force.stdout"
+FORCE_RUN_STDERR="$TMP_DIR/run-force.stderr"
 
 cleanup() {
   if [[ "$KEEP_TEMP" == true ]]; then
@@ -54,7 +60,14 @@ mkdir -p \
 
 cp "$ROOT_DIR/run.sh" "$FAKE_ROOT/run.sh"
 
-printf 'preprovisioned pnpm workspace marker\n' > "$FAKE_ROOT/node_modules/.modules.yaml"
+PNPM_LOCK="$FAKE_ROOT/pnpm-lock.yaml"
+PNPM_MODULES_METADATA="$FAKE_ROOT/node_modules/.modules.yaml"
+
+printf 'lockfileVersion: 9.0\n' > "$PNPM_LOCK"
+touch -t 202001010000 "$PNPM_LOCK"
+printf 'preprovisioned pnpm workspace marker\n' > "$PNPM_MODULES_METADATA"
+touch -t 202001010001 "$PNPM_MODULES_METADATA"
+
 cat > "$FAKE_ROOT/node_modules/.bin/tsup" <<'SH'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "--version" ]]; then
@@ -90,38 +103,68 @@ if [[ -e "$FAKE_ROOT/node_modules/.invoker-bootstrap-stamp" ]]; then
   exit 1
 fi
 
-status=0
-HOME="$TMP_DIR/home" \
-  INVOKER_DB_DIR="$TMP_DIR/db" \
-  INVOKER_REPO_CONFIG_PATH="$TMP_DIR/config.json" \
-  INVOKER_REPRO_PNPM_CALLS="$PNPM_CALLS" \
-  PATH="$STUB_BIN:$PATH" \
-  "$FAKE_ROOT/run.sh" --headless delete-all >"$RUN_STDOUT" 2>"$RUN_STDERR" || status=$?
+RUN_STATUS=0
+run_headless_delete_all() {
+  local calls_file="$1"
+  local stdout_file="$2"
+  local stderr_file="$3"
+  local force_bootstrap="${4:-0}"
 
-pnpm_call_count=0
-if [[ -f "$PNPM_CALLS" ]]; then
-  pnpm_call_count="$(wc -l < "$PNPM_CALLS" | tr -d '[:space:]')"
-fi
+  rm -f "$calls_file"
+  RUN_STATUS=0
+  HOME="$TMP_DIR/home" \
+    INVOKER_DB_DIR="$TMP_DIR/db" \
+    INVOKER_FORCE_BOOTSTRAP="$force_bootstrap" \
+    INVOKER_REPO_CONFIG_PATH="$TMP_DIR/config.json" \
+    INVOKER_REPRO_PNPM_CALLS="$calls_file" \
+    PATH="$STUB_BIN:$PATH" \
+    "$FAKE_ROOT/run.sh" --headless delete-all >"$stdout_file" 2>"$stderr_file" || RUN_STATUS=$?
+}
 
-if [[ "$EXPECTATION" == "bug" ]]; then
+count_pnpm_calls() {
+  local calls_file="$1"
+  if [[ -f "$calls_file" ]]; then
+    wc -l < "$calls_file" | tr -d '[:space:]'
+  else
+    echo 0
+  fi
+}
+
+assert_pnpm_install_attempted() {
+  local calls_file="$1"
+  local stdout_file="$2"
+  local stderr_file="$3"
+  local status="$4"
+  local context="$5"
+  local pnpm_call_count
+  pnpm_call_count="$(count_pnpm_calls "$calls_file")"
+
   if [[ "$pnpm_call_count" -lt 1 ]]; then
-    echo "repro: expected run.sh to call pnpm while the bootstrap stamp is missing" >&2
+    echo "repro: expected run.sh to call pnpm for $context" >&2
     echo "stdout:" >&2
-    cat "$RUN_STDOUT" >&2 || true
+    cat "$stdout_file" >&2 || true
     echo "stderr:" >&2
-    cat "$RUN_STDERR" >&2 || true
+    cat "$stderr_file" >&2 || true
     exit 1
   fi
   if [[ "$status" -ne 73 ]]; then
-    echo "repro: expected pnpm stub exit 73, got $status" >&2
-    cat "$RUN_STDERR" >&2 || true
+    echo "repro: expected pnpm stub exit 73 for $context, got $status" >&2
+    cat "$stderr_file" >&2 || true
     exit 1
   fi
-  if ! grep -Fq 'install --frozen-lockfile' "$PNPM_CALLS"; then
-    echo "repro: expected pnpm install --frozen-lockfile, saw:" >&2
-    cat "$PNPM_CALLS" >&2 || true
+  if ! grep -Fq 'install --frozen-lockfile' "$calls_file"; then
+    echo "repro: expected pnpm install --frozen-lockfile for $context, saw:" >&2
+    cat "$calls_file" >&2 || true
     exit 1
   fi
+}
+
+run_headless_delete_all "$PNPM_CALLS" "$RUN_STDOUT" "$RUN_STDERR"
+status="$RUN_STATUS"
+pnpm_call_count="$(count_pnpm_calls "$PNPM_CALLS")"
+
+if [[ "$EXPECTATION" == "bug" ]]; then
+  assert_pnpm_install_attempted "$PNPM_CALLS" "$RUN_STDOUT" "$RUN_STDERR" "$status" "a healthy install with a missing bootstrap stamp"
   echo "repro: confirmed bug"
   echo "repro: healthy artifacts were present, bootstrap stamp was absent, and run.sh called pnpm install"
   cat "$PNPM_CALLS"
@@ -142,5 +185,16 @@ else
     cat "$RUN_STDOUT" >&2 || true
     exit 1
   fi
+
+  touch -t 202001010002 "$PNPM_LOCK"
+  run_headless_delete_all "$STALE_PNPM_CALLS" "$STALE_RUN_STDOUT" "$STALE_RUN_STDERR"
+  assert_pnpm_install_attempted "$STALE_PNPM_CALLS" "$STALE_RUN_STDOUT" "$STALE_RUN_STDERR" "$RUN_STATUS" "a lockfile newer than pnpm installed metadata"
+
+  touch -t 202001010000 "$PNPM_LOCK"
+  touch -t 202001010001 "$PNPM_MODULES_METADATA"
+  run_headless_delete_all "$FORCE_PNPM_CALLS" "$FORCE_RUN_STDOUT" "$FORCE_RUN_STDERR" 1
+  assert_pnpm_install_attempted "$FORCE_PNPM_CALLS" "$FORCE_RUN_STDOUT" "$FORCE_RUN_STDERR" "$RUN_STATUS" "INVOKER_FORCE_BOOTSTRAP=1"
+
   echo "repro: confirmed fixed behavior"
+  echo "repro: healthy preprovisioned install skipped pnpm; stale lockfile and forced bootstrap still invoked pnpm"
 fi


### PR DESCRIPTION
## Summary

The bootstrap repro now covers the preprovisioned cases this fix must keep working.

It proves three paths separately: healthy pnpm metadata skips reinstall, a newer lockfile still reinstalls, and `INVOKER_FORCE_BOOTSTRAP=1` still reinstalls.

This lands first so reviewers can read the expected launcher behavior before the launcher code changes.

## Review Claim

The run.sh preprovisioning repro now captures the launcher bootstrap behavior the fix must preserve.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the repro script changes, and `--expect-bug` still proves the current base branch reinstalls when the bootstrap stamp is missing.

## Slice Rationale

This proof slice lands before the launcher freshness change so reviewers can inspect the expected cases separately from the behavior flip.

## Non-goals

Does not change `run.sh`, required suite wiring, or package dependencies.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-run-sh-preprovisioned-bootstrap.sh --expect-bug`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 090318440`
- Post-revert steps: None
- Data migration? No

</details>

