### PR TITLE
[Fix Git E2E Tests Step 2 Bootstrap](2) Trust fresh pnpm workspace metadata

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -10,9 +10,10 @@ cd "$REPO_ROOT"
 export INVOKER_ENABLE_WORKSPACE_CLEANUP=0
 
 BOOTSTRAP_STAMP="$REPO_ROOT/node_modules/.invoker-bootstrap-stamp"
+PNPM_MODULES_METADATA="$REPO_ROOT/node_modules/.modules.yaml"
 
 has_bootstrap_artifacts() {
-  [ -f "$REPO_ROOT/node_modules/.modules.yaml" ] \
+  [ -f "$PNPM_MODULES_METADATA" ] \
     && [ -x "$REPO_ROOT/packages/app/node_modules/.bin/electron" ]
 }
 
@@ -21,13 +22,11 @@ bootstrap_tools_are_healthy() {
 }
 
 # An existing install goes stale when the lockfile changes (e.g. a git pull
-# adds a dependency) but node_modules is left untouched. The artifacts check
-# above only proves *some* install exists, so without this check run.sh would
-# skip the reinstall and then fail the build on the now-missing package. Treat
-# the install as stale when we have no record of it, or when pnpm-lock.yaml is
-# newer than the stamp written after the last successful install.
+# adds a dependency) but node_modules is left untouched. pnpm's installed
+# metadata is the durable freshness signal because preprovisioned checkouts may
+# not have run.sh's private bootstrap stamp.
 workspace_install_is_stale() {
-  [ ! -f "$BOOTSTRAP_STAMP" ] || [ "$REPO_ROOT/pnpm-lock.yaml" -nt "$BOOTSTRAP_STAMP" ]
+  [ ! -f "$PNPM_MODULES_METADATA" ] || [ "$REPO_ROOT/pnpm-lock.yaml" -nt "$PNPM_MODULES_METADATA" ]
 }
 
 ensure_workspace_bootstrapped() {

--- a/scripts/test-suites/required/08-electron-preprovision-repro.sh
+++ b/scripts/test-suites/required/08-electron-preprovision-repro.sh
@@ -3,4 +3,5 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
-exec bash "$ROOT/scripts/repro/repro-mece-04-remote-electron-provisioning.sh"
+bash "$ROOT/scripts/repro/repro-mece-04-remote-electron-provisioning.sh"
+bash "$ROOT/scripts/repro/repro-run-sh-preprovisioned-bootstrap.sh"


### PR DESCRIPTION
## Summary

Headless `run.sh` no longer reinstalls dependencies in a checkout that already has a healthy pnpm install.

The old check trusted only Invoker's private bootstrap stamp. Preprovisioned clones, CI, and worktrees can have a valid install without that file.

The launcher now trusts pnpm's own workspace metadata instead. A newer lockfile, missing metadata, missing required tools, or forced bootstrap still runs pnpm.

The required Electron preprovisioning guard now also runs the focused repro, so this path stays covered.

## Review Claim

`run.sh` should treat a healthy pnpm install as fresh even when the Invoker-specific bootstrap stamp was never written.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Staleness detection is preserved: the launcher still reinstalls when `pnpm-lock.yaml` is newer than pnpm's installed workspace metadata, when that metadata is missing, when required tools are missing, or when `INVOKER_FORCE_BOOTSTRAP=1` is set.

## Slice Rationale

The repro landed in slice (1), so this slice only flips the launcher freshness source and wires the required guard that keeps the fix covered.

## Non-goals

Does not change package dependencies, git e2e scenario assertions, headless command semantics, or later Vitest and e2e fixes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-run-sh-preprovisioned-bootstrap.sh`
- [x] `bash scripts/test-suites/required/08-electron-preprovision-repro.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert fc7ec25db`
- Post-revert steps: None. Reverting restores the stamp-based freshness check, which reinstalls more often but keeps the old behavior.
- Data migration? No

</details>

