### PR TITLE
Draft Review Sidebar Step 2 - Review Draft Opens Right Sidebar (1) - Tolerate remote worktree lookup failure

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -29,7 +29,6 @@ afterEach(() => {
 
 describe('planning chat draft YAML plumbing', () => {
   it('returns draftPlanText from send responses and stores it on the session', async () => {
-    vi.spyOn(PlanConversation.prototype, 'sendMessage').mockResolvedValue(VALID_PLAN_REPLY);
     const sessions = createInAppPlanningChatSessions();
 
     const result = await sendPlanningChatMessage({
@@ -38,6 +37,7 @@ describe('planning chat draft YAML plumbing', () => {
     }, {
       config: {},
       loadGeneratedPlan: vi.fn(),
+      plannerReplyOverride: vi.fn().mockResolvedValue(VALID_PLAN_REPLY),
       sessions,
     });
 
@@ -53,7 +53,6 @@ describe('planning chat draft YAML plumbing', () => {
   });
 
   it('threads draftPlanText through list and get session responses', async () => {
-    vi.spyOn(PlanConversation.prototype, 'sendMessage').mockResolvedValue(VALID_PLAN_REPLY);
     const sessions = createInAppPlanningChatSessions();
     const sent = await sendPlanningChatMessage({
       message: 'draft',
@@ -61,6 +60,7 @@ describe('planning chat draft YAML plumbing', () => {
     }, {
       config: {},
       loadGeneratedPlan: vi.fn(),
+      plannerReplyOverride: vi.fn().mockResolvedValue(VALID_PLAN_REPLY),
       sessions,
     });
     if (!sent.ok) throw new Error(sent.error);

--- a/packages/execution-engine/src/__tests__/fetch-failure-visibility.test.ts
+++ b/packages/execution-engine/src/__tests__/fetch-failure-visibility.test.ts
@@ -15,6 +15,7 @@ import { execSync } from 'node:child_process';
 import { BaseExecutor, type BaseEntry } from '../base-executor.js';
 import type { WorkRequest, WorkRequestInputs } from '@invoker/contracts';
 import type { ExecutorHandle, TerminalSpec } from '../executor.js';
+import { advanceRemoteBranch } from './git-remote-test-helpers.js';
 
 function makeRequest(actionId: string, inputs: Partial<WorkRequestInputs> = {}): WorkRequest {
   return {
@@ -204,19 +205,7 @@ describe('syncFromRemote - fetch failure handling', () => {
     });
 
     it('warns when local branch is behind remote', async () => {
-      // Create a second clone and push commits ahead
-      const secondClone = mkdtempSync(join(tmpdir(), 'fetch-failure-clone-'));
-      execSync(`git clone ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
-      execSync('git checkout -B master origin/master', { cwd: secondClone });
-      execSync('git config user.email "test@test.com"', { cwd: secondClone });
-      execSync('git config user.name "Test"', { cwd: secondClone });
-
-      // Push 5 commits from second clone
-      for (let i = 1; i <= 5; i++) {
-        writeFileSync(join(secondClone, `file${i}.txt`), `content${i}`);
-        execSync(`git add -A && git commit -m "commit ${i}"`, { cwd: secondClone });
-      }
-      execSync('git push', { cwd: secondClone });
+      advanceRemoteBranch(remoteRepo, 5);
 
       const executionId = 'test-exec-staleness-1';
       executor.registerTestEntry(executionId, makeRequest('test-action'));
@@ -226,25 +215,10 @@ describe('syncFromRemote - fetch failure handling', () => {
       const output = executor.getOutputBuffer(executionId).join('');
       expect(output).toContain('[Git Fetch] Status: success');
       expect(output).toContain('5 commits behind origin/master');
-
-      // Cleanup
-      rmSync(secondClone, { recursive: true, force: true });
     });
 
     it('emits loud warning when >100 commits behind', async () => {
-      // Create a second clone and push many commits ahead
-      const secondClone = mkdtempSync(join(tmpdir(), 'fetch-failure-clone-'));
-      execSync(`git clone ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
-      execSync('git checkout -B master origin/master', { cwd: secondClone });
-      execSync('git config user.email "test@test.com"', { cwd: secondClone });
-      execSync('git config user.name "Test"', { cwd: secondClone });
-
-      // Push 101 commits to trigger loud warning
-      for (let i = 1; i <= 101; i++) {
-        writeFileSync(join(secondClone, `file${i}.txt`), `content${i}`);
-        execSync(`git add -A && git commit -m "commit ${i}"`, { cwd: secondClone });
-      }
-      execSync('git push', { cwd: secondClone });
+      advanceRemoteBranch(remoteRepo, 101);
 
       const executionId = 'test-exec-staleness-loud';
       executor.registerTestEntry(executionId, makeRequest('test-action'));
@@ -254,9 +228,6 @@ describe('syncFromRemote - fetch failure handling', () => {
       const output = executor.getOutputBuffer(executionId).join('');
       expect(output).toContain('101 commits behind origin/master');
       expect(output).toContain('[Git Fetch] WARNING: Local is 101 commits behind origin');
-
-      // Cleanup
-      rmSync(secondClone, { recursive: true, force: true });
     });
 
     it('reports up to date when local matches remote', async () => {

--- a/packages/execution-engine/src/__tests__/fetch-status-output.test.ts
+++ b/packages/execution-engine/src/__tests__/fetch-status-output.test.ts
@@ -16,6 +16,7 @@ import { execSync } from 'node:child_process';
 import { BaseExecutor, type BaseEntry } from '../base-executor.js';
 import type { WorkRequest, WorkRequestInputs } from '@invoker/contracts';
 import type { ExecutorHandle, TerminalSpec } from '../executor.js';
+import { advanceRemoteBranch } from './git-remote-test-helpers.js';
 
 function makeRequest(actionId: string, inputs: Partial<WorkRequestInputs> = {}): WorkRequest {
   return {
@@ -133,19 +134,7 @@ describe('fetch status visibility in task output', () => {
     });
 
     it('shows staleness when commits behind', async () => {
-      // Create a second clone and push commits ahead
-      const secondClone = mkdtempSync(join(tmpdir(), 'fetch-status-clone-'));
-      execSync(`git clone ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
-      execSync('git checkout -B master origin/master', { cwd: secondClone });
-      execSync('git config user.email "test@test.com"', { cwd: secondClone });
-      execSync('git config user.name "Test"', { cwd: secondClone });
-
-      // Push 3 commits from second clone
-      for (let i = 1; i <= 3; i++) {
-        writeFileSync(join(secondClone, `file${i}.txt`), `content${i}`);
-        execSync(`git add -A && git commit -m "commit ${i}"`, { cwd: secondClone });
-      }
-      execSync('git push', { cwd: secondClone });
+      advanceRemoteBranch(remoteRepo, 3);
 
       const executionId = 'test-exec-behind';
       executor.registerTestEntry(executionId, makeRequest('test-action'));
@@ -155,25 +144,10 @@ describe('fetch status visibility in task output', () => {
       const output = executor.getOutputBuffer(executionId).join('');
       expect(output).toContain('Status: success');
       expect(output).toContain('3 commits behind origin/master');
-
-      // Cleanup
-      rmSync(secondClone, { recursive: true, force: true });
     });
 
     it('emits loud warning when >100 commits behind', async () => {
-      // Create a second clone and push many commits ahead
-      const secondClone = mkdtempSync(join(tmpdir(), 'fetch-status-clone-'));
-      execSync(`git clone ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
-      execSync('git checkout -B master origin/master', { cwd: secondClone });
-      execSync('git config user.email "test@test.com"', { cwd: secondClone });
-      execSync('git config user.name "Test"', { cwd: secondClone });
-
-      // Push 101 commits to trigger loud warning
-      for (let i = 1; i <= 101; i++) {
-        writeFileSync(join(secondClone, `file${i}.txt`), `content${i}`);
-        execSync(`git add -A && git commit -m "commit ${i}"`, { cwd: secondClone });
-      }
-      execSync('git push', { cwd: secondClone });
+      advanceRemoteBranch(remoteRepo, 101);
 
       const executionId = 'test-exec-very-behind';
       executor.registerTestEntry(executionId, makeRequest('test-action'));
@@ -184,9 +158,6 @@ describe('fetch status visibility in task output', () => {
       expect(output).toContain('Status: success');
       expect(output).toContain('101 commits behind origin/master');
       expect(output).toContain('[Git Fetch] WARNING: Local is 101 commits behind origin');
-
-      // Cleanup
-      rmSync(secondClone, { recursive: true, force: true });
     });
 
     it('handles new branch without remote tracking', async () => {

--- a/packages/execution-engine/src/__tests__/git-remote-test-helpers.ts
+++ b/packages/execution-engine/src/__tests__/git-remote-test-helpers.ts
@@ -1,0 +1,27 @@
+import { execFileSync } from 'node:child_process';
+
+const TEST_GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: 'Test',
+  GIT_AUTHOR_EMAIL: 'test@test.com',
+  GIT_AUTHOR_DATE: '2000-01-01T00:00:00Z',
+  GIT_COMMITTER_NAME: 'Test',
+  GIT_COMMITTER_EMAIL: 'test@test.com',
+  GIT_COMMITTER_DATE: '2000-01-01T00:00:00Z',
+};
+
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', env: TEST_GIT_ENV }).trim();
+}
+
+export function advanceRemoteBranch(remoteRepo: string, commits: number, branch = 'master'): string {
+  let head = git(['rev-parse', `refs/heads/${branch}`], remoteRepo);
+  const tree = git(['rev-parse', `${head}^{tree}`], remoteRepo);
+
+  for (let i = 1; i <= commits; i++) {
+    head = git(['commit-tree', tree, '-p', head, '-m', `remote advance ${i}`], remoteRepo);
+  }
+
+  git(['update-ref', `refs/heads/${branch}`, head], remoteRepo);
+  return head;
+}

--- a/packages/execution-engine/src/__tests__/remote-fix-worktree-repair.test.ts
+++ b/packages/execution-engine/src/__tests__/remote-fix-worktree-repair.test.ts
@@ -6,7 +6,7 @@ import { registerBuiltinAgents } from '../agents/index.js';
 
 vi.mock('node:child_process');
 
-function mockSshChild(stdoutData: string, exitCode: number) {
+function mockSshChild(stdoutData: string, exitCode: number, stderrData = '') {
   const { EventEmitter } = require('events');
   const stdout = new EventEmitter();
   const stderr = new EventEmitter();
@@ -17,6 +17,7 @@ function mockSshChild(stdoutData: string, exitCode: number) {
 
   setTimeout(() => {
     if (stdoutData) stdout.emit('data', Buffer.from(stdoutData));
+    if (stderrData) stderr.emit('data', Buffer.from(stderrData));
     child.emit('close', exitCode);
   }, 0);
 
@@ -110,6 +111,51 @@ branch refs/heads/${branch}
     });
     const remoteFixScript = ((secondChild as any).stdin.write as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
     expect(remoteFixScript).toContain(`WT="${ownerPath}"`);
+    expect(appendTaskOutput).toHaveBeenCalledWith(
+      task.id,
+      expect.stringContaining('[Fix with codex (remote)] Output:'),
+    );
+  });
+
+  it('continues with the recorded remote workspace when branch-owner lookup cannot list worktrees', async () => {
+    const { spawn } = await import('node:child_process');
+    const workspacePath = '/home/invoker/.invoker/worktrees/647faa73e90e/experiment-test-task-deadbeef';
+    const branch = 'experiment/test-task/deadbeef';
+    const task = {
+      id: 'wf-1/test-task',
+      status: 'failed' as const,
+      execution: {
+        error: 'Test failed',
+        workspacePath,
+        branch,
+      },
+      config: {
+        command: 'pnpm test',
+        runnerKind: 'ssh' as const,
+        poolMemberId: 'remote-1',
+      },
+    };
+
+    const { host, updateTask, appendTaskOutput } = makeHost(task);
+    const listFailure = mockSshChild(
+      '',
+      128,
+      "fatal: cannot change to '/home/invoker/.invoker/repos/647faa73e90e': No such file or directory\n",
+    );
+    const fixSession = mockSshChild('Codex session: real-session-456\nremote fix applied', 0);
+    vi.mocked(spawn)
+      .mockReturnValueOnce(listFailure as any)
+      .mockReturnValueOnce(fixSession as any);
+
+    await fixWithAgentImpl(host, task.id, 'error output', 'codex');
+
+    expect(updateTask).not.toHaveBeenCalledWith(task.id, {
+      execution: {
+        workspacePath: expect.any(String),
+      },
+    });
+    const remoteFixScript = ((fixSession as any).stdin.write as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+    expect(remoteFixScript).toContain(`WT="${workspacePath}"`);
     expect(appendTaskOutput).toHaveBeenCalledWith(
       task.id,
       expect.stringContaining('[Fix with codex (remote)] Output:'),

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -145,15 +145,19 @@ async function resolveRemoteBranchOwnerPath(
   if (!branch) return undefined;
   const info = deriveRemoteManagedWorkspaceInfo(workspacePath, target);
   if (!info) return undefined;
-  const porcelain = await execRemoteSsh(
-    target,
-    buildWorktreeListScript({
-      repoHash: info.repoHash,
-      invokerHome: info.invokerHome,
-    }),
-    'list_worktrees',
-  );
-  return findManagedWorktreeForBranch(porcelain, branch, [info.managedPrefix]);
+  try {
+    const porcelain = await execRemoteSsh(
+      target,
+      buildWorktreeListScript({
+        repoHash: info.repoHash,
+        invokerHome: info.invokerHome,
+      }),
+      'list_worktrees',
+    );
+    return findManagedWorktreeForBranch(porcelain, branch, [info.managedPrefix]);
+  } catch {
+    return undefined;
+  }
 }
 
 // ── Extracted functions ──────────────────────────────────


### PR DESCRIPTION
## Summary

Draft Review Sidebar Step 2 - Review Draft Opens Right Sidebar — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784443178322-5/implement-right-sidebar-draft-review | Change Review draft to open Home right sidebar with YAML and per-step summary instead of navigating to Plan graph | completed |
| wf-1784443178322-5/verify-right-sidebar-draft-review | Verify Home review-draft UX and submit flow | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784443178322-5/implement-right-sidebar-draft-review — Change Review draft to open Home right sidebar with YAML and per-step summary instead of navigating to Plan graph

### wf-1784443178322-5/verify-right-sidebar-draft-review — Verify Home review-draft UX and submit flow

</details>

Remote Fix with agent now keeps using the task's recorded remote workspace when branch-owner lookup cannot list worktrees.

That keeps verification repairs from blocking this stack on a missing managed repo listing.

## Review Claim

Remote fix sessions tolerate branch-owner worktree-list failures by falling back to the recorded task workspace path.

## Review Lane

`behavior`

## Review Unit

`remote-fix-worktree-repair`

## Safety Invariant

The fallback only applies when branch-owner lookup throws. Successful lookup still repairs the workspace path from branch ownership.

## Slice Rationale

This verification-support behavior is isolated before the draft review UI slices because it changes remote fix recovery, not planner rendering.

## Non-goals

- Change successful branch-owner lookup behavior.
- Change local fix-with-agent execution.
- Change draft review UI or planner summary data.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/remote-fix-worktree-repair.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-bodies/draft-review-sidebar-step-2-1.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert ca6225e9b6c860a62e0120650b672b61e9e6629e`
- Post-revert steps: Rerun `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/remote-fix-worktree-repair.test.ts`.
- Data migration? No.

</details>
