### PR TITLE
Draft Review Sidebar Step 2 - Review Draft Opens Right Sidebar (2) - Add optional taskGroups to plan summary contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -220,6 +220,14 @@ export interface InAppPlanningPlanSummary {
   taskCount: number;
   workflowCount?: number;
   steps: string[];
+  taskGroups?: Array<{
+    name?: string;
+    title?: string;
+    workflowName?: string;
+    taskCount?: number;
+    steps: string[];
+    tasks?: string[];
+  }>;
 }
 
 export type InAppPlanningSessionStatus =


### PR DESCRIPTION
Depends-On: #5179

## Summary

Draft Review Sidebar Step 2 - Review Draft Opens Right Sidebar — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784443178322-5/implement-right-sidebar-draft-review | Change Review draft to open Home right sidebar with YAML and per-step summary instead of navigating to Plan graph | completed |
| wf-1784443178322-5/verify-right-sidebar-draft-review | Verify Home review-draft UX and submit flow | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784443178322-5/implement-right-sidebar-draft-review — Change Review draft to open Home right sidebar with YAML and per-step summary instead of navigating to Plan graph

### wf-1784443178322-5/verify-right-sidebar-draft-review — Verify Home review-draft UX and submit flow

</details>

Planning summaries can now carry optional per-workflow task groups.

This is a dormant contract expansion. Producers and consumers land in later slices.

## Review Claim

`InAppPlanningPlanSummary` accepts optional task groups for per-workflow draft review summaries without requiring existing sessions to provide them.

## Review Lane

`behavior`

## Review Unit

`planner-summary-contract`

## Safety Invariant

The field is optional. Existing summary payloads with only `steps` remain valid and continue to render through the old path.

## Slice Rationale

The contract lands before producer and renderer changes so each later slice can rely on a typed field.

## Non-goals

- Populate `taskGroups` in planner summaries.
- Render task groups in the Home right sidebar.
- Change draft submission behavior.

## Architecture

### Before

```mermaid
graph TD
    A["draftPlanSummary"] --> B["flat steps[]"]
```

### After

```mermaid
graph TD
    A["draftPlanSummary"] --> B["flat steps[]"]
    A --> C["optional taskGroups[]"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-bodies/draft-review-sidebar-step-2-2.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 54ea4b64ca4feadfd24da0a2d67f50024903f605`
- Post-revert steps: Rerun `pnpm --filter @invoker/ui build`.
- Data migration? No. The field is optional IPC payload data.

</details>
