### PR TITLE
[Running Actions Left Rail](1) Show running actions in the left sidebar

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4102,9 +4102,12 @@ export function App() {
           workerStatus={workerStatus}
           planningSessionCount={planningSessions.length}
           planningAttentionCount={planningAttentionCount}
+          runningEntries={runningEntries}
+          selectedTaskId={selectedTaskId}
           selectedSurface={sidebarSurface}
           collapsed={sidebarCollapsed}
           onSelectSurface={handleSelectSidebarSurface}
+          onSelectTask={selectTaskById}
           onToggleCollapsed={() => setSidebarCollapsed((value) => !value)}
           onOpenSettings={() => {
             cancelPendingSystemSetupAutoOpen();

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act, cleanup, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
-import type { WorkflowMeta } from '../types.js';
+import type { TaskState, WorkflowMeta } from '../types.js';
 
 vi.mock('@xyflow/react', async () => {
   // Dynamic import is required because Vitest hoists mock factories before test imports.
@@ -50,6 +50,68 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
     expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
+  });
+
+  it('shows running actions in the expanded sidebar and selects tasks from that list', async () => {
+    const workflows: WorkflowMeta[] = [
+      { id: 'wf-alpha', name: 'Alpha workflow', status: 'running' },
+      { id: 'wf-beta', name: 'Beta workflow', status: 'fixing_with_ai' },
+    ];
+    const queuedTask = makeUITask({
+      id: 'task-queued',
+      description: 'Queued setup task',
+      status: 'queued' as unknown as TaskState['status'],
+      workflowId: 'wf-alpha',
+    });
+    const runningTask = makeUITask({
+      id: 'task-running',
+      description: 'Run integration suite',
+      status: 'running',
+      workflowId: 'wf-alpha',
+    });
+    const fixingTask = makeUITask({
+      id: 'task-fixing',
+      description: 'Fix review failure',
+      status: 'fixing_with_ai',
+      workflowId: 'wf-beta',
+    });
+    const completedTask = makeUITask({
+      id: 'task-completed',
+      description: 'Completed task',
+      status: 'completed',
+      workflowId: 'wf-beta',
+    });
+
+    mock.cleanup();
+    mock = createMockInvoker([queuedTask, runningTask, fixingTask, completedTask], workflows);
+    mock.install();
+
+    render(<App />);
+
+    const runningSection = await screen.findByTestId('sidebar-running-section');
+    expect(runningSection).toHaveTextContent('Running actions');
+    expect(runningSection).toHaveTextContent('3');
+
+    const runningList = await screen.findByTestId('sidebar-running-list');
+    expect(runningList).toHaveTextContent('Queued setup task');
+    expect(runningList).toHaveTextContent('queued · Alpha workflow');
+    expect(runningList).toHaveTextContent('Run integration suite');
+    expect(runningList).toHaveTextContent('running · Alpha workflow');
+    expect(runningList).toHaveTextContent('Fix review failure');
+    expect(runningList).toHaveTextContent('fixing with ai · Beta workflow');
+    expect(runningList).not.toHaveTextContent('Completed task');
+
+    fireEvent.click(screen.getByTestId('sidebar-running-action-task-fixing'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Fix review failure');
+    });
+
+    fireEvent.click(screen.getByTestId('sidebar-collapse-toggle'));
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
+    expect(screen.queryByTestId('sidebar-running-section')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sidebar-running-list')).not.toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
   });
 
   it('hides the collapsed Planning Terminal badge for the idle initial chat', async () => {

--- a/packages/ui/src/__tests__/command-palette.test.tsx
+++ b/packages/ui/src/__tests__/command-palette.test.tsx
@@ -111,9 +111,13 @@ function Harness({
         workerStatus={null}
         selectedSurface="home"
         collapsed={false}
+        runningEntries={runningEntries}
+        selectedTaskId={null}
         onSelectSurface={() => {}}
+        onSelectTask={() => {}}
         onToggleCollapsed={() => {}}
         planningSessionCount={0}
+        planningAttentionCount={0}
         onOpenSettings={() => {}}
         theme="dark"
         onToggleTheme={() => {}}

--- a/packages/ui/src/components/BrowserListRows.tsx
+++ b/packages/ui/src/components/BrowserListRows.tsx
@@ -10,6 +10,7 @@ interface BrowserTaskRowProps {
   tone: BrowserTaskRowTone;
   selected: boolean;
   onSelect: (taskId: string) => void;
+  testId?: string;
 }
 
 export const BrowserTaskRow = memo(function BrowserTaskRow({
@@ -20,6 +21,7 @@ export const BrowserTaskRow = memo(function BrowserTaskRow({
   tone,
   selected,
   onSelect,
+  testId,
 }: BrowserTaskRowProps) {
   const accent = tone === 'attention'
     ? selected ? 'bg-amber-500/15 text-amber-100 ring-1 ring-amber-500/40' : 'text-foreground hover:bg-accent/30'
@@ -27,6 +29,7 @@ export const BrowserTaskRow = memo(function BrowserTaskRow({
   return (
     <button
       type="button"
+      data-testid={testId}
       onClick={() => onSelect(taskId)}
       className={`block w-full rounded-md px-2.5 py-1.5 text-left transition-colors ${accent}`}
     >

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -1,7 +1,9 @@
 import type { JSX } from 'react';
 import type { WorkerStatusSnapshot } from '../types.js';
-import type { SidebarSurface } from '../lib/workflow-progress-surfaces.js';
+import type { SidebarSurface, WorkflowTaskEntry } from '../lib/workflow-progress-surfaces.js';
+import { formatTaskStatus } from '../lib/workflow-progress-surfaces.js';
 import { countActiveWorkerActions } from '../lib/worker-display.js';
+import { BrowserTaskRow } from './BrowserListRows.js';
 import {
   AttentionIcon,
   ChevronLeftIcon,
@@ -22,7 +24,10 @@ interface LeftStatusColumnProps {
   workerStatus: WorkerStatusSnapshot | null;
   selectedSurface: SidebarSurface;
   collapsed: boolean;
+  runningEntries: WorkflowTaskEntry[];
+  selectedTaskId: string | null;
   onSelectSurface: (surface: SidebarSurface) => void;
+  onSelectTask: (taskId: string) => void;
   onToggleCollapsed: () => void;
   planningSessionCount: number;
   planningAttentionCount: number;
@@ -68,7 +73,10 @@ export function LeftStatusColumn({
   workerStatus,
   selectedSurface,
   collapsed,
+  runningEntries,
+  selectedTaskId,
   onSelectSurface,
+  onSelectTask,
   onToggleCollapsed,
   planningSessionCount,
   planningAttentionCount,
@@ -79,6 +87,7 @@ export function LeftStatusColumn({
   const runningWorkers = workerStatus?.workers.filter((worker) => worker.lifecycle === 'running').length ?? 0;
   const registeredWorkers = workerStatus?.workers.length ?? 0;
   const activeWorkerActions = workerStatus ? countActiveWorkerActions(workerStatus.workers) : 0;
+  const runningCount = runningEntries.length;
 
   const sources: SourceItem[] = [
     { key: 'attention', label: 'Needs Attention', count: attentionCount, tone: 'attention', icon: <AttentionIcon className={ICON_CLASS} /> },
@@ -205,24 +214,60 @@ export function LeftStatusColumn({
       <span data-testid="sidebar-running" hidden aria-hidden="true">Running</span>
 
       {!collapsed && (
-        <div className="mt-6 flex-1 overflow-y-auto scrollbar-sleek px-2.5 text-xs text-muted-foreground">
-          {selectedSurface === 'workflows' && (
-            workflowCount === 0
-              ? 'No workflows yet'
-              : `${workflowCount} workflow${workflowCount === 1 ? '' : 's'} ready to browse.`
-          )}
-          {selectedSurface === 'attention' && (
-            attentionCount === 0
-              ? 'Nothing needs a decision right now.'
-              : `${attentionCount} item${attentionCount === 1 ? ' needs' : 's need'} attention.`
-          )}
-          {selectedSurface === 'workers' && (
-            workerStatus === null
-              ? 'Worker status is not available yet.'
-              : `${runningWorkers} process${runningWorkers === 1 ? '' : 'es'} running · ${activeWorkerActions} active action${activeWorkerActions === 1 ? '' : 's'}`
-          )}
-          {selectedSurface === 'home' && 'Plan graph details live here.'}
-          {selectedSurface === 'planning' && `${planningSessionCount} planning chat${planningSessionCount === 1 ? '' : 's'}.`}
+        <div className="mt-5 flex min-h-0 flex-1 flex-col overflow-hidden px-2.5">
+          <section data-testid="sidebar-running-section" className="flex min-h-0 min-w-0 flex-1 flex-col">
+            <div className="flex items-center justify-between gap-2">
+              <div className="truncate text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/70">
+                Running actions
+              </div>
+              <span className={`shrink-0 rounded-full px-1.5 py-0 text-[10px] leading-4 ${countClass(runningCount > 0 ? 'running' : 'neutral')}`}>
+                {runningCount}
+              </span>
+            </div>
+            {runningCount === 0 ? (
+              <div data-testid="sidebar-running-empty" className="mt-2 truncate text-xs text-muted-foreground">
+                No running actions
+              </div>
+            ) : (
+              <div data-testid="sidebar-running-list" className="mt-2 min-h-0 flex-1 overflow-y-auto pr-1 scrollbar-sleek">
+                <div className="space-y-1">
+                  {runningEntries.map((entry) => (
+                    <BrowserTaskRow
+                      key={entry.task.id}
+                      taskId={entry.task.id}
+                      title={entry.task.description || entry.task.id}
+                      workflowName={entry.workflow?.name}
+                      statusLabel={formatTaskStatus(entry.task.status)}
+                      tone="running"
+                      selected={selectedTaskId === entry.task.id}
+                      onSelect={onSelectTask}
+                      testId={`sidebar-running-action-${entry.task.id}`}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </section>
+
+          <div className="mt-4 border-t border-sidebar-border pt-3 text-xs text-muted-foreground">
+            {selectedSurface === 'workflows' && (
+              workflowCount === 0
+                ? 'No workflows yet'
+                : `${workflowCount} workflow${workflowCount === 1 ? '' : 's'} ready to browse.`
+            )}
+            {selectedSurface === 'attention' && (
+              attentionCount === 0
+                ? 'Nothing needs a decision right now.'
+                : `${attentionCount} item${attentionCount === 1 ? ' needs' : 's need'} attention.`
+            )}
+            {selectedSurface === 'workers' && (
+              workerStatus === null
+                ? 'Worker status is not available yet.'
+                : `${runningWorkers} process${runningWorkers === 1 ? '' : 'es'} running · ${activeWorkerActions} active action${activeWorkerActions === 1 ? '' : 's'}`
+            )}
+            {selectedSurface === 'home' && 'Plan graph details live here.'}
+            {selectedSurface === 'planning' && `${planningSessionCount} planning chat${planningSessionCount === 1 ? '' : 's'}.`}
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary

The left sidebar now has a Running actions section that shows work currently in flight.

Each row is a queued, running, or fixing-with-AI task, with its workflow name and status.

Clicking a row selects that task, the same as clicking it anywhere else in the app.

Until now you had to open the palette, the Queue view, or the Workers surface to see running work.

That meant leaving whatever you were doing just to answer "what is running right now?".

The section reuses the running-task projection the palette already reads, so no new data path was added.

## Review Claim

Approve exposing the existing running-task projection as a Running actions section in the expanded left sidebar, where clicking a row selects that task.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice only takes the `runningEntries` projection that `App.tsx` already computes and hands it to the sidebar. It adds no queries, no new state, and no scheduler, queue, worker, or persistence behavior. The collapsed sidebar keeps its icon-only layout and its existing `sidebar-running` marker.

## Slice Rationale

The left rail already owns workflow, attention, worker, and planning navigation, so the running section belongs there rather than in a new browser surface. The change is one cohesive UI claim: one projection wired into one component, plus the `testId` prop `BrowserTaskRow` needed to stay reusable. There is nothing here that could land earlier as standalone foundation.

## Non-goals

- No change to worker action persistence or worker controls.
- No change to task execution states, scheduler behavior, or queue ordering.
- No change to palette behavior or its running entries.
- No change to terminal drawer or right-side inspector behavior.
- No new navigation surface or routing mode.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test`
- [x] `cd packages/ui && pnpm build`

</details>

## Visual Proof

![Expanded left sidebar with a RUNNING ACTIONS group showing a count badge of 3 and rows for "Fix review failure — fixing with ai", "Queued setup task — queued", and "Run integration suite — running", each labeled with the Running Actions Left Rail workflow](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260720-5b37cc/running-actions-left-rail-expanded.png)

Look at the left rail: the RUNNING ACTIONS group sits under LIBRARY with a `3` badge, and the highlighted row "Fix review failure" matches the task shown in the right-hand inspector.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4aca9dd69`
- Post-revert steps: None. The sidebar returns to its prior surface-summary text.
- Data migration? No

</details>
