### PR TITLE
Scope visual-proof review-unit classifier to the e2e proof pipeline

### DIFF
--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -275,7 +275,8 @@ export function classifyReviewUnitsForPath(filePath) {
     || path.startsWith('scripts/fixtures/')
   ) return ['tooling-policy'];
   if (path.startsWith('packages/app/e2e/visual-proof/')) return ['activation-surface'];
-  if (/(benchmark|performance|visual-proof)/.test(lowerPath)) return ['proof'];
+  if (/(benchmark|performance)/.test(lowerPath)) return ['proof'];
+  if (/visual-proof/.test(lowerPath) && path.includes('/e2e/')) return ['proof'];
   if (path === 'skills/make-pr/SKILL.md' || path === 'skills/plan-to-invoker/SKILL.md') return ['tooling-policy'];
   if (path.startsWith('docs/') || path.startsWith('skills/') || path.endsWith('.md')) return ['docs'];
   if (path.startsWith('.github/')) return ['tooling-policy'];


### PR DESCRIPTION
## Summary

The PR body Review Unit classifier flagged any changed file path containing \"visual-proof\" as the `proof` unit.

That caught ordinary component tests like `visual-proof-snapshots.test.tsx`, not just the dedicated e2e proof pipeline it was meant for.

A behavior PR that must update that test alongside the UI it covers then fails validation for mixing review units, even though the change is atomic.

## Review Claim

The `visual-proof` keyword only classifies files as the `proof` review unit when they are under an `e2e/` path, matching the actual e2e proof pipeline.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the classifier's keyword scoping changes. `benchmark`/`performance` keyword matching, and every other classification branch, are unchanged.

## Slice Rationale

This is a standalone tooling fix, unrelated to any in-flight feature stack, so it lands and reviews independently.

## Non-goals

- Does not change PR body schema requirements or required sections.
- Does not change how e2e visual-proof files are classified.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node -e \"import('./scripts/review-unit-rules.mjs').then(m => console.log(m.classifyReviewUnitsForPath('packages/app/e2e/visual-proof.spec.ts'), m.classifyReviewUnitsForPath('packages/ui/src/__tests__/visual-proof-snapshots.test.tsx'), m.classifyReviewUnitsForPath('scripts/ui-visual-proof.sh')))\"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d8c8f8041`
- Post-revert steps: None
- Data migration? No

</details>