### PR TITLE
Draft Review Sidebar Step 2 - Review Draft Opens Right Sidebar (3) - Populate per-workflow task groups in draft summaries

### DIFF
--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -358,12 +358,29 @@ function summarizePlanText(planText: string): InAppPlanningPlanSummary | null {
       if (workflows.length === 0) return null;
       let taskCount = 0;
       const steps: string[] = [];
-      for (const workflow of workflows) {
-        if (typeof workflow.name === 'string' && workflow.name.trim()) {
-          steps.push(workflow.name.trim());
-        }
+      const taskGroups: NonNullable<InAppPlanningPlanSummary['taskGroups']> = [];
+      for (const [index, workflow] of workflows.entries()) {
+        const workflowName = typeof workflow.name === 'string' && workflow.name.trim()
+          ? workflow.name.trim()
+          : `Workflow ${index + 1}`;
+        steps.push(workflowName);
         if (Array.isArray(workflow.tasks)) {
           taskCount += workflow.tasks.length;
+          const workflowSteps: string[] = [];
+          for (const task of workflow.tasks) {
+            if (!task || typeof task !== 'object' || Array.isArray(task)) continue;
+            const candidate = task as Record<string, unknown>;
+            if (typeof candidate.description === 'string' && candidate.description.trim()) {
+              workflowSteps.push(candidate.description.trim());
+            } else if (typeof candidate.id === 'string' && candidate.id.trim()) {
+              workflowSteps.push(candidate.id.trim());
+            }
+          }
+          taskGroups.push({
+            name: workflowName,
+            taskCount: workflow.tasks.length,
+            steps: workflowSteps,
+          });
         }
       }
       return {
@@ -371,6 +388,7 @@ function summarizePlanText(planText: string): InAppPlanningPlanSummary | null {
         taskCount,
         workflowCount: workflows.length,
         steps,
+        ...(taskGroups.length > 0 ? { taskGroups } : {}),
       };
     }
 


### PR DESCRIPTION
Depends-On: #5180

## Summary

Draft Review Sidebar Step 2 - Review Draft Opens Right Sidebar — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784443178322-5/implement-right-sidebar-draft-review | Change Review draft to open Home right sidebar with YAML and per-step summary instead of navigating to Plan graph | completed |
| wf-1784443178322-5/verify-right-sidebar-draft-review | Verify Home review-draft UX and submit flow | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784443178322-5/implement-right-sidebar-draft-review — Change Review draft to open Home right sidebar with YAML and per-step summary instead of navigating to Plan graph

### wf-1784443178322-5/verify-right-sidebar-draft-review — Verify Home review-draft UX and submit flow

</details>

The in-app planner now derives per-workflow task groups while summarizing drafted YAML.

Each group keeps the workflow name, task count, and readable per-task descriptions for the review surface.

## Review Claim

Draft plan summaries include per-workflow task groups derived from the drafted YAML.

## Review Lane

`behavior`

## Review Unit

`planner-draft-summary`

## Safety Invariant

The existing flat `steps` summary still exists. If task groups cannot be derived, consumers can keep using the legacy summary shape.

## Slice Rationale

The producer lands after the optional contract and before UI rendering so reviewers can inspect data derivation independently.

## Non-goals

- Render the task groups in the Home right sidebar.
- Change draft YAML persistence.
- Change submitted workflow execution.

## Architecture

### Before

```mermaid
graph TD
    A["drafted YAML workflows"] --> B["flat workflow-name steps[]"]
```

### After

```mermaid
graph TD
    A["drafted YAML workflows"] --> B["flat workflow-name steps[]"]
    A --> C["taskGroups[] with per-task summaries"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-bodies/draft-review-sidebar-step-2-3.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert c475b6c19f05b4b508345db92757da4d77af3e3f`
- Post-revert steps: Rerun `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`.
- Data migration? No. Summaries are derived from draft YAML.

</details>
