### PR TITLE
[Tmux Summary Bridge Step 1 Contract](1) Add inert terminal bridge output

### DIFF
--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -257,6 +257,42 @@ describe('EmbeddedTerminalManager', () => {
     expect(reused.outputSnapshot).toBe(firstFrame);
   });
 
+  it('seeds display bridge text before synchronous backend output without changing terminal identity', () => {
+    const backendOutput = 'backend output\n';
+    const bridge = '[invoker] Resuming task context\n';
+    const updatedBridge = '[invoker] Updated task context\n';
+    const spawned = {
+      write: vi.fn(),
+      resize: vi.fn(),
+      close: vi.fn(),
+    };
+    const backend: EmbeddedTerminalBackend = {
+      name: 'pty',
+      spawn: vi.fn((opts) => {
+        opts.emitOutput(backendOutput);
+        return spawned;
+      }),
+    };
+    const mgr = new EmbeddedTerminalManager({ backend });
+
+    const session = mgr.openOrReuse({
+      taskId: 'task-bridge',
+      spec: { cwd: '/tmp/wt', displayBridgeText: bridge },
+      cwd: '/tmp/wt',
+    });
+    const reused = mgr.openOrReuse({
+      taskId: 'task-bridge',
+      spec: { cwd: '/tmp/wt', displayBridgeText: updatedBridge },
+      cwd: '/tmp/wt',
+    });
+
+    expect(session.outputSnapshot).toBe(`${bridge}${backendOutput}`);
+    expect(mgr.getPersistenceRecord(session.sessionId)?.outputSnapshot)
+      .toBe(`${bridge}${backendOutput}`);
+    expect(reused.sessionId).toBe(session.sessionId);
+    expect(backend.spawn).toHaveBeenCalledTimes(1);
+  });
+
   it('opens a distinct session when the same task resolves to a different terminal target', () => {
     const child1 = createFakeChild();
     const child2 = createFakeChild();

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -13,6 +13,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { mkdirSync, rmSync } from 'node:fs';
 import { EventEmitter } from 'node:events';
+import { execFileSync } from 'node:child_process';
 
 import {
   computeWorkflowRollup,
@@ -44,6 +45,7 @@ import {
   buildLinuxXTerminalBashScript,
   buildMacOSOsascriptArgs,
   buildTerminalShellCommand,
+  shellSingleQuoteForPOSIX,
   spawnDetachedTerminal,
 } from '../terminal-external-launch.js';
 import { openEmbeddedTerminalForTask, openExternalTerminalForTask } from '../open-terminal-for-task.js';
@@ -151,7 +153,7 @@ function buildCleanEnv(): Record<string, string> {
 
 function openExternalTerminal(spec: TerminalSpec | null): void {
   const defaultCwd = spec?.cwd ?? process.cwd();
-  const meta = { cwd: spec?.cwd, command: spec?.command, args: spec?.args };
+  const meta = spec ?? {};
 
   if (process.platform === 'linux') {
     const cleanEnv = buildCleanEnv();
@@ -165,7 +167,7 @@ function openExternalTerminal(spec: TerminalSpec | null): void {
     });
     child.unref();
   } else if (process.platform === 'darwin') {
-    if (spec?.command) {
+    if (spec?.command || spec?.displayBridgeText) {
       const osaArgs = buildMacOSOsascriptArgs(meta, defaultCwd);
       const child = mockSpawn('osascript', osaArgs, { detached: true, stdio: 'ignore' });
       child.unref();
@@ -432,6 +434,36 @@ describe('terminal-external-launch', () => {
     // Should use '\'' (backslash-quote) not '"'"' (double-quote idiom)
     expect(line).toContain("\\'");
     expect(line).not.toMatch(/'"'"'/);
+  });
+
+  it('prefixes display bridge text with quoted printf without changing command argv', () => {
+    const cwd = join(tmpdir(), `terminal-bridge-${randomUUID()}`);
+    const injectionMarker = join(cwd, 'injected');
+    mkdirSync(cwd, { recursive: true });
+    const bridge = `bridge '; touch ${injectionMarker}; printf 'unsafe\n`;
+    const argv = ['semi;colon', "quote'value"];
+    const probe = 'process.stdout.write(JSON.stringify(process.argv.slice(1)))';
+    const line = buildTerminalShellCommand(
+      {
+        cwd,
+        command: process.execPath,
+        args: ['-e', probe, ...argv],
+        displayBridgeText: bridge,
+      },
+      '/fallback',
+    );
+
+    try {
+      const output = execFileSync('bash', ['-c', line], { encoding: 'utf8' });
+
+      expect(line).toContain(`printf %s ${shellSingleQuoteForPOSIX(bridge)}`);
+      expect(line).toContain(shellSingleQuoteForPOSIX(process.execPath));
+      expect(line).toContain(shellSingleQuoteForPOSIX("quote'value"));
+      expect(output).toBe(`${bridge}${JSON.stringify(argv)}`);
+      expect(existsSync(injectionMarker)).toBe(false);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 
   it('buildMacOSOsascriptArgs includes activate and uses multi-line AppleScript', () => {

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -20,7 +20,12 @@ import type {
   TerminalExitEvent,
 } from '@invoker/contracts';
 import type { TerminalSessionRecord } from '@invoker/data-store';
-import type { Executor, ExecutorHandle, TerminalSpec } from '@invoker/execution-engine';
+import {
+  normalizeTerminalDisplayBridgeText,
+  type Executor,
+  type ExecutorHandle,
+  type TerminalSpec,
+} from '@invoker/execution-engine';
 
 export type EmbeddedTerminalBackendName = 'bash' | 'pty';
 export type EmbeddedTerminalSessionKind = 'task' | 'planning';
@@ -318,7 +323,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
       createdAt,
       updatedAt: createdAt,
       status: 'running' as const,
-      outputSnapshot: '',
+      outputSnapshot: seedOutputSnapshotWithDisplayBridge(opts.spec, ''),
     };
 
     if (opts.attach) {
@@ -391,7 +396,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
       createdAt: seed.createdAt,
       updatedAt: new Date().toISOString(),
       status: 'running' as const,
-      outputSnapshot: seed.outputSnapshot,
+      outputSnapshot: seedOutputSnapshotWithDisplayBridge(seed.spec, seed.outputSnapshot),
     });
   }
 
@@ -654,6 +659,14 @@ export class EmbeddedTerminalManager extends EventEmitter {
 function trimOutputSnapshot(snapshot: string): string {
   if (snapshot.length <= MAX_OUTPUT_SNAPSHOT_CHARS) return snapshot;
   return snapshot.slice(snapshot.length - MAX_OUTPUT_SNAPSHOT_CHARS);
+}
+
+function seedOutputSnapshotWithDisplayBridge(spec: TerminalSpec, snapshot: string): string {
+  const displayBridgeText = normalizeTerminalDisplayBridgeText(spec.displayBridgeText);
+  if (!displayBridgeText || snapshot.startsWith(displayBridgeText)) {
+    return trimOutputSnapshot(snapshot);
+  }
+  return trimOutputSnapshot(displayBridgeText + snapshot);
 }
 
 function resolveBackend(options: EmbeddedTerminalManagerOptions): EmbeddedTerminalBackend {

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -428,7 +428,7 @@ export async function openExternalTerminalForTask(
   }
 
   if (process.platform === 'darwin') {
-    if (spec.command) {
+    if (spec.command || spec.displayBridgeText) {
       const osaArgs = buildMacOSOsascriptArgs(spec, cwd);
       return spawnDetachedTerminal('osascript', osaArgs, {}, onTerminalClose);
     }

--- a/packages/app/src/terminal-external-launch.ts
+++ b/packages/app/src/terminal-external-launch.ts
@@ -4,6 +4,7 @@
  */
 
 import { spawn, type SpawnOptions } from 'node:child_process';
+import { normalizeTerminalDisplayBridgeText } from '@invoker/execution-engine';
 
 /** Escape one argument for POSIX shell single-quoted strings. */
 export function shellSingleQuoteForPOSIX(s: string): string {
@@ -12,22 +13,38 @@ export function shellSingleQuoteForPOSIX(s: string): string {
 
 export type InteractiveExecShell = 'bash' | 'zsh';
 
+export interface TerminalShellCommandSpec {
+  cwd?: string;
+  command?: string;
+  args?: string[];
+  linuxTerminalTail?: 'exec_bash' | 'pause';
+  displayBridgeText?: string;
+}
+
+function buildDisplayBridgePrefix(displayBridgeText?: string): string | undefined {
+  const bridge = normalizeTerminalDisplayBridgeText(displayBridgeText);
+  return bridge ? `printf %s ${shellSingleQuoteForPOSIX(bridge)}` : undefined;
+}
+
 /**
  * Full shell line: `cd '<cwd>' && ...` plus either `exec bash` / `exec zsh` or `command` with args properly quoted.
  */
 export function buildTerminalShellCommand(
-  spec: { cwd?: string; command?: string; args?: string[] },
+  spec: TerminalShellCommandSpec,
   defaultCwd: string,
   options?: { interactiveExec?: InteractiveExecShell },
 ): string {
   const cwd = spec.cwd ?? defaultCwd;
-  const cd = `cd ${shellSingleQuoteForPOSIX(cwd)}`;
+  const prefix = [
+    `cd ${shellSingleQuoteForPOSIX(cwd)}`,
+    buildDisplayBridgePrefix(spec.displayBridgeText),
+  ].filter((part): part is string => Boolean(part));
   if (!spec.command) {
     const execSh = options?.interactiveExec === 'zsh' ? 'exec zsh' : 'exec bash';
-    return `${cd} && ${execSh}`;
+    return `${prefix.join(' && ')} && ${execSh}`;
   }
   const argv = [spec.command, ...(spec.args ?? [])];
-  return `${cd} && ${argv.map(shellSingleQuoteForPOSIX).join(' ')}`;
+  return `${prefix.join(' && ')} && ${argv.map(shellSingleQuoteForPOSIX).join(' ')}`;
 }
 
 /** Escape for embedding in AppleScript: `tell application "Terminal" to do script "…"`. */
@@ -37,7 +54,7 @@ export function appleScriptEscapeForDoubleQuotedString(s: string): string {
 
 /** argv for `osascript` to run the built shell command in Terminal.app. */
 export function buildMacOSOsascriptArgs(
-  spec: { cwd?: string; command?: string; args?: string[] },
+  spec: TerminalShellCommandSpec,
   defaultCwd: string,
 ): string[] {
   const shellCmd = buildTerminalShellCommand(spec, defaultCwd, { interactiveExec: 'zsh' });
@@ -54,7 +71,7 @@ export function buildMacOSOsascriptArgs(
  * Inner script passed to `bash -c` for Linux x-terminal-emulator (includes optional suffix).
  */
 export function buildLinuxXTerminalBashScript(
-  spec: { cwd?: string; command?: string; args?: string[]; linuxTerminalTail?: 'exec_bash' | 'pause' },
+  spec: TerminalShellCommandSpec,
   defaultCwd: string,
 ): string {
   const base = buildTerminalShellCommand(spec, defaultCwd);

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -669,6 +669,22 @@ describe('WorktreeExecutor', () => {
     taskProcess.emit('close', 0, null);
   });
 
+  it('getTerminalSpec preserves display bridge text without changing command task specs', async () => {
+    const { taskProcess } = setupSpawnMock();
+
+    const request = makeRequest();
+    const handle = await executor.start(request);
+    handle.displayBridgeText = 'Bridge for reopened terminal\n';
+    const spec = executor.getTerminalSpec(handle);
+
+    expect(spec).toEqual({
+      cwd: expect.stringMatching(/^\/fake\/worktrees\//),
+      displayBridgeText: 'Bridge for reopened terminal\n',
+    });
+
+    taskProcess.emit('close', 0, null);
+  });
+
   it('handle.workspacePath is set to worktree directory', async () => {
     const { taskProcess } = setupSpawnMock();
 
@@ -1339,6 +1355,19 @@ describe('WorktreeExecutor', () => {
         workspacePath: '/home/user/.invoker/worktrees/wt-abc',
       });
       expect(spec).toEqual({ cwd: '/home/user/.invoker/worktrees/wt-abc' });
+    });
+
+    it('preserves display bridge text on restored cwd specs', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      const spec = executor.getRestoredTerminalSpec({
+        ...baseMeta,
+        workspacePath: '/home/user/.invoker/worktrees/wt-abc',
+        displayBridgeText: 'Restored context bridge\n',
+      });
+      expect(spec).toEqual({
+        cwd: '/home/user/.invoker/worktrees/wt-abc',
+        displayBridgeText: 'Restored context bridge\n',
+      });
     });
 
     it('returns claude --resume spec with cwd when session exists', () => {

--- a/packages/execution-engine/src/executor.ts
+++ b/packages/execution-engine/src/executor.ts
@@ -9,6 +9,18 @@ export interface ExecutorHandle {
   containerId?: string;
   workspacePath?: string;
   branch?: string;
+  displayBridgeText?: string;
+}
+
+export const MAX_TERMINAL_DISPLAY_BRIDGE_CHARS = 4096;
+
+export function normalizeTerminalDisplayBridgeText(text?: string): string | undefined {
+  if (text === undefined || text.length === 0) return undefined;
+  const printable = text.replace(/\0/g, '');
+  if (printable.length === 0) return undefined;
+  return printable.length <= MAX_TERMINAL_DISPLAY_BRIDGE_CHARS
+    ? printable
+    : printable.slice(0, MAX_TERMINAL_DISPLAY_BRIDGE_CHARS);
 }
 
 export interface TerminalSpec {
@@ -20,6 +32,7 @@ export interface TerminalSpec {
   args?: string[];
   /** Tail command for Linux terminal launch (e.g. 'exec_bash' or 'pause'). */
   linuxTerminalTail?: 'exec_bash' | 'pause';
+  displayBridgeText?: string;
 }
 
 export interface PersistedTaskMeta {
@@ -31,6 +44,7 @@ export interface PersistedTaskMeta {
   containerId?: string;
   workspacePath?: string;
   branch?: string;
+  displayBridgeText?: string;
 }
 
 export interface Executor {

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -3,7 +3,12 @@ import { existsSync, unlinkSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { homedir } from 'node:os';
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
-import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
+import {
+  normalizeTerminalDisplayBridgeText,
+  type ExecutorHandle,
+  type PersistedTaskMeta,
+  type TerminalSpec,
+} from './executor.js';
 import { BaseExecutor, MergeConflictError, type BaseEntry } from './base-executor.js';
 import { RepoPool } from './repo-pool.js';
 import { killProcessGroup, cleanElectronEnv, resolveExecutableOnCurrentPath, SIGKILL_TIMEOUT_MS } from './process-utils.js';
@@ -576,14 +581,20 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
   getTerminalSpec(handle: ExecutorHandle): TerminalSpec | null {
     const entry = this.entries.get(handle.executionId);
     if (!entry) return null;
+    const displayBridgeText = normalizeTerminalDisplayBridgeText(handle.displayBridgeText);
     if (entry.agentSessionId) {
       const agentName = entry.request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
       const resume = this.agentRegistry
         ? this.agentRegistry.getOrThrow(agentName).buildResumeArgs(entry.agentSessionId)
         : { cmd: 'claude', args: ['--resume', entry.agentSessionId, '--dangerously-skip-permissions'] };
-      return { command: resume.cmd, args: resume.args, cwd: entry.worktreeDir };
+      return {
+        command: resume.cmd,
+        args: resume.args,
+        cwd: entry.worktreeDir,
+        ...(displayBridgeText ? { displayBridgeText } : {}),
+      };
     }
-    return { cwd: entry.worktreeDir };
+    return { cwd: entry.worktreeDir, ...(displayBridgeText ? { displayBridgeText } : {}) };
   }
 
   getRestoredTerminalSpec(meta: PersistedTaskMeta): TerminalSpec {
@@ -604,6 +615,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     if (meta.workspacePath) {
       traceExecution(`[WorktreeExecutor] getRestoredTerminalSpec task="${meta.taskId}" — worktree path exists: ${meta.workspacePath}`);
     }
+    const displayBridgeText = normalizeTerminalDisplayBridgeText(meta.displayBridgeText);
     if (meta.agentSessionId) {
       const resume = this.agentRegistry
         ? this.agentRegistry.getOrThrow(meta.executionAgent ?? DEFAULT_EXECUTION_AGENT).buildResumeArgs(meta.agentSessionId)
@@ -612,6 +624,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         command: resume.cmd,
         args: resume.args,
         cwd: meta.workspacePath,
+        ...(displayBridgeText ? { displayBridgeText } : {}),
       };
       traceExecution(
         `[agent-session-trace] WorktreeExecutor.getRestoredTerminalSpec: task="${meta.taskId}" resume with agentSessionId=${meta.agentSessionId}`,
@@ -626,12 +639,13 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         command: sh,
         args: ['-c', `git checkout '${meta.branch}' 2>/dev/null; exec ${sh}`],
         cwd: meta.workspacePath,
+        ...(displayBridgeText ? { displayBridgeText } : {}),
       };
       traceExecution(`[WorktreeExecutor] getRestoredTerminalSpec task="${meta.taskId}" → checkout branch spec, branch="${meta.branch}" cwd="${spec.cwd}"`);
       return spec;
     }
     traceExecution(`[WorktreeExecutor] getRestoredTerminalSpec task="${meta.taskId}" → cwd-only spec, cwd="${meta.workspacePath}"`);
-    return { cwd: meta.workspacePath };
+    return { cwd: meta.workspacePath, ...(displayBridgeText ? { displayBridgeText } : {}) };
   }
 
   /**


### PR DESCRIPTION
## Summary

Terminal reopen routing now carries bounded bridge text before restored output.

Embedded sessions prepend bridge text to saved output, and external shell paths print it before restored output resumes.

The bridge is inert output only. It does not alter argv, cwd, task execution, lifecycle, or persisted state.

## Review Claim

Terminal routing renders bounded display-only bridge text before restored terminal output without changing execution semantics.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The bridge is inert terminal output. It does not alter agent argv, cwd selection, task execution, process lifecycle, or persisted task state.

## Slice Rationale

This slice adds the shared reopen routing primitive before planning or task-specific summary producers use it.

## Non-goals

Do not generate planning or task summaries here.

Do not change Codex, OMP, or Claude resume builders.

Do not add a schema column or persisted state field.

## Architecture

### Before

Reopened terminals started directly at shell or agent output, so context had no shared display-only channel.

### After

Restored terminal routing can carry optional bridge text. Embedded sessions and external launchers render it before backend output while preserving argv and cwd.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/worktree-executor.test.ts`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/embedded-terminal-manager.test.ts src/__tests__/open-terminal.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8129630794544fc6cb5256d91a16720f907649bf`
- Post-revert steps: None
- Data migration? No

</details>
