### PR TITLE
[Tmux Summary Bridge Step 1 Contract](2) Forward focused terminal bridge tests

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -62,7 +62,7 @@
     "dist": "electron-builder --publish never",
     "dist:linux": "electron-builder --linux AppImage deb --publish never",
     "dist:mac": "electron-builder --mac dmg --publish never",
-    "test": "vitest run",
+    "test": "node scripts/run-vitest.mjs",
     "start": "unset ELECTRON_RUN_AS_NODE && node ../../scripts/electron.cjs dist/main.js",
     "dev": "tsup src/main.ts src/preload.ts --format cjs --outDir dist --external electron && unset ELECTRON_RUN_AS_NODE && node ../../scripts/electron.cjs dist/main.js",
     "test:e2e": "sh -c 'if [ \"${1-}\" = \"--\" ]; then shift; fi; if command -v xvfb-run >/dev/null 2>&1; then exec xvfb-run --auto-servernum playwright test \"$@\"; else exec playwright test \"$@\"; fi' --",

--- a/packages/app/scripts/run-vitest.mjs
+++ b/packages/app/scripts/run-vitest.mjs
@@ -1,0 +1,23 @@
+import { spawn } from "node:child_process";
+
+const forwardedArgs = process.argv.slice(2);
+const vitestArgs = forwardedArgs[0] === "--" ? forwardedArgs.slice(1) : forwardedArgs;
+
+const child = spawn("vitest", ["run", ...vitestArgs], {
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
+
+child.on("error", (error) => {
+  console.error(error);
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 1);
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1732,24 +1732,6 @@ function startHeadlessMode(): void {
           );
         }
         workerRuntimeController.startAutoStartedWorkers();
-        if (command === 'owner-serve') {
-          const ownerServeTaskExecutor = createStandaloneTaskExecutor();
-          const apiServerDeps = buildHeadlessApiServerDeps(headlessDeps, ownerServeTaskExecutor);
-          headlessWebBridge = startWebSurfaceForHeadless(
-            {
-              logger,
-              orchestrator,
-              persistence,
-              messageBus,
-              executionAgentRegistry: agentRegistry,
-              invokerConfig,
-              repoRoot,
-              executorRegistry,
-              appRootDir: __dirname,
-            },
-            apiServerDeps,
-          );
-        }
 
         // Owner discovery and exec handlers must exist before dispatch polling starts.
         if (!readOnlyMode) {
@@ -1771,6 +1753,8 @@ function startHeadlessMode(): void {
               messageBus,
               executionAgentRegistry: agentRegistry,
               invokerConfig,
+              repoRoot,
+              executorRegistry,
               appRootDir: __dirname,
             },
             apiServerDeps,


### PR DESCRIPTION
## Summary

The app test wrapper now forwards focused Vitest file arguments through the package script.

Owner-serve startup still wires the web bridge after launch dispatcher startup.

This keeps bridge verification runnable without changing terminal bridge output.

## Review Claim

App routing keeps focused bridge verification files flowing while preserving owner-serve startup order.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice only changes the app test command wrapper and owner-serve startup placement. It does not change terminal bridge rendering, agent argv, or persisted state.

## Slice Rationale

This sits after the bridge output slice so focused verification can run through repo package scripts.

## Non-goals

Do not change terminal bridge rendering.

Do not add planning or task summary generation.

Do not change CI workflow selection or shared Vitest config.

## Architecture

### Before

Focused app test files passed through the package script without a wrapper that normalized pnpm's argument separator.

Owner-serve web startup had a duplicate earlier placement before standalone launch dispatcher startup.

### After

The app test script normalizes forwarded arguments before invoking Vitest.

Owner-serve web startup has one placement after standalone launch dispatcher startup.

## Visual Proof

[Owner-serve startup walkthrough](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30257117201/job/89948179651)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/worktree-executor.test.ts`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/embedded-terminal-manager.test.ts src/__tests__/open-terminal.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 787261516064678a6d2007b74fbc9e8292da33c7`
- Post-revert steps: None
- Data migration? No

</details>
