### PR TITLE
Draft Review Sidebar Step 2 - Review Draft Opens Right Sidebar (4) - Tighten task group summary shape

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -6,6 +6,7 @@ import {
   listPlanningChatSessions,
   sendPlanningChatMessage,
   submitPlanningChatDraft,
+  summarizePlanText,
 } from '../in-app-planner.js';
 
 const VALID_PLAN_REPLY = `Here is the plan.
@@ -22,6 +23,23 @@ tasks:
     dependencies: [first]
     command: echo second
 \`\`\``;
+
+const VALID_GROUPED_PLAN_TEXT = `
+name: Grouped Plan
+workflows:
+  - id: api
+    name: API workflow
+    tasks:
+      - id: first
+        description: First grouped task
+        command: echo first
+  - id: ui
+    name: UI workflow
+    tasks:
+      - id: second
+        description: Second grouped task
+        command: echo second
+`;
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -80,6 +98,19 @@ describe('planning chat draft YAML plumbing', () => {
         draftPlanAvailable: true,
         draftPlanText: expect.stringContaining('name: Mock Plan'),
       },
+    });
+  });
+
+  it('summarizes grouped workflow plans with taskGroups', () => {
+    expect(summarizePlanText(VALID_GROUPED_PLAN_TEXT)).toMatchObject({
+      name: 'Grouped Plan',
+      taskCount: 2,
+      workflowCount: 2,
+      steps: ['API workflow', 'UI workflow'],
+      taskGroups: [
+        { name: 'API workflow', workflowId: 'api', taskCount: 1, steps: ['First grouped task'] },
+        { name: 'UI workflow', workflowId: 'ui', taskCount: 1, steps: ['Second grouped task'] },
+      ],
     });
   });
 

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -345,7 +345,24 @@ function createLoadedResponse(loaded: LoadedGeneratedPlan): Extract<InAppPlanRes
   };
 }
 
-function summarizePlanText(planText: string): InAppPlanningPlanSummary | null {
+function summarizeTaskSteps(rawTasks: unknown): string[] | null {
+  if (!Array.isArray(rawTasks)) return [];
+  const steps: string[] = [];
+  for (const task of rawTasks) {
+    if (!task || typeof task !== 'object' || Array.isArray(task)) return null;
+    const candidate = task as Record<string, unknown>;
+    if (typeof candidate.description === 'string' && candidate.description.trim()) {
+      steps.push(candidate.description.trim());
+    } else if (typeof candidate.id === 'string' && candidate.id.trim()) {
+      steps.push(candidate.id.trim());
+    } else {
+      return null;
+    }
+  }
+  return steps;
+}
+
+export function summarizePlanText(planText: string): InAppPlanningPlanSummary | null {
   try {
     const raw = parseYaml(planText) as unknown;
     if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
@@ -359,52 +376,39 @@ function summarizePlanText(planText: string): InAppPlanningPlanSummary | null {
       let taskCount = 0;
       const steps: string[] = [];
       const taskGroups: NonNullable<InAppPlanningPlanSummary['taskGroups']> = [];
-      for (const [index, workflow] of workflows.entries()) {
-        const workflowName = typeof workflow.name === 'string' && workflow.name.trim()
-          ? workflow.name.trim()
-          : `Workflow ${index + 1}`;
+      workflows.forEach((workflow, index) => {
+        const workflowName =
+          typeof workflow.name === 'string' && workflow.name.trim()
+            ? workflow.name.trim()
+            : typeof workflow.id === 'string' && workflow.id.trim()
+              ? workflow.id.trim()
+              : `Workflow ${index + 1}`;
         steps.push(workflowName);
-        if (Array.isArray(workflow.tasks)) {
-          taskCount += workflow.tasks.length;
-          const workflowSteps: string[] = [];
-          for (const task of workflow.tasks) {
-            if (!task || typeof task !== 'object' || Array.isArray(task)) continue;
-            const candidate = task as Record<string, unknown>;
-            if (typeof candidate.description === 'string' && candidate.description.trim()) {
-              workflowSteps.push(candidate.description.trim());
-            } else if (typeof candidate.id === 'string' && candidate.id.trim()) {
-              workflowSteps.push(candidate.id.trim());
-            }
-          }
-          taskGroups.push({
-            name: workflowName,
-            taskCount: workflow.tasks.length,
-            steps: workflowSteps,
-          });
+        const taskSteps = summarizeTaskSteps(workflow.tasks);
+        if (taskSteps === null) {
+          return;
         }
-      }
+        taskCount += Array.isArray(workflow.tasks) ? workflow.tasks.length : 0;
+        taskGroups.push({
+          name: workflowName,
+          ...(typeof workflow.id === 'string' && workflow.id.trim() ? { workflowId: workflow.id.trim() } : {}),
+          taskCount: taskSteps.length,
+          steps: taskSteps,
+        });
+      });
+      if (taskGroups.length !== workflows.length) return null;
       return {
         name: typeof plan.name === 'string' && plan.name.trim() ? plan.name.trim() : 'Untitled plan',
         taskCount,
         workflowCount: workflows.length,
         steps,
-        ...(taskGroups.length > 0 ? { taskGroups } : {}),
+        taskGroups,
       };
     }
 
     if (!Array.isArray(plan.tasks) || plan.tasks.length === 0) return null;
-    const steps: string[] = [];
-    for (const task of plan.tasks) {
-      if (!task || typeof task !== 'object' || Array.isArray(task)) return null;
-      const candidate = task as Record<string, unknown>;
-      if (typeof candidate.description === 'string' && candidate.description.trim()) {
-        steps.push(candidate.description.trim());
-      } else if (typeof candidate.id === 'string' && candidate.id.trim()) {
-        steps.push(candidate.id.trim());
-      } else {
-        return null;
-      }
-    }
+    const steps = summarizeTaskSteps(plan.tasks);
+    if (!steps) return null;
     return {
       name: typeof plan.name === 'string' && plan.name.trim() ? plan.name.trim() : 'Untitled plan',
       taskCount: plan.tasks.length,

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -215,19 +215,21 @@ export interface PlanningPresetOption {
   isDefault: boolean;
 }
 
+export interface InAppPlanningTaskGroupSummary {
+  name?: string;
+  label?: string;
+  title?: string;
+  workflowId?: string;
+  taskCount?: number;
+  steps: string[];
+}
+
 export interface InAppPlanningPlanSummary {
   name: string;
   taskCount: number;
   workflowCount?: number;
   steps: string[];
-  taskGroups?: Array<{
-    name?: string;
-    title?: string;
-    workflowName?: string;
-    taskCount?: number;
-    steps: string[];
-    tasks?: string[];
-  }>;
+  taskGroups?: InAppPlanningTaskGroupSummary[];
 }
 
 export type InAppPlanningSessionStatus =

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -287,6 +287,7 @@ export type {
   InAppPlanningSessionSummary,
   InAppPlanningSubmitRequest,
   InAppPlanningSubmitResponse,
+  InAppPlanningTaskGroupSummary,
   PlanningPresetOption,
 } from '@invoker/contracts';
 


### PR DESCRIPTION
Depends-On: #5185

## Summary

Draft Review Sidebar Step 2 - Review Draft Opens Right Sidebar — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784443178322-5/implement-right-sidebar-draft-review | Change Review draft to open Home right sidebar with YAML and per-step summary instead of navigating to Plan graph | completed |
| wf-1784443178322-5/verify-right-sidebar-draft-review | Verify Home review-draft UX and submit flow | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784443178322-5/implement-right-sidebar-draft-review — Change Review draft to open Home right sidebar with YAML and per-step summary instead of navigating to Plan graph

### wf-1784443178322-5/verify-right-sidebar-draft-review — Verify Home review-draft UX and submit flow

</details>

Grouped draft summaries now use workflow IDs as stable keys and strict task-step rows.

That gives the sidebar renderer one normalized shape without changing workflow submission.

## Review Claim

Draft task groups are normalized around workflow IDs and strict per-task step summaries.

## Review Lane

`behavior`

## Review Unit

`contract`

## Safety Invariant

The legacy flat step summary remains available. This slice only tightens the grouped summary shape consumed by later UI work.

## Slice Rationale

This lands after the optional contract and producer slices so reviewers can inspect the final summary shape before the sidebar consumes it.

## Non-goals

- Render the right-sidebar draft review.
- Add terminal draft actions.
- Change workflow creation from drafted YAML.

## Architecture

### Before

```mermaid
graph TD
    A["draft summary"] --> B["taskGroups keyed by display text"]
    B --> C["loose task step rows"]
```

### After

```mermaid
graph TD
    A["draft summary"] --> B["taskGroups keyed by workflow id"]
    B --> C["strict task step rows"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-bodies/draft-review-sidebar-step-2-4.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 5c3d604fbf1acb5141dea9b5761bba3cbf9879e2`
- Post-revert steps: Rerun `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`.
- Data migration? No.

</details>
