### PR TITLE
[E2E Chrome Cleanup](1) Ensure teardown cleans automation Chrome

### DIFF
--- a/packages/app/e2e/global-teardown.ts
+++ b/packages/app/e2e/global-teardown.ts
@@ -1,18 +1,20 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, rmSync } from 'node:fs';
+import { rmSync } from 'node:fs';
 import * as path from 'node:path';
 import { E2E_BROWSER_REGISTRY_ENV } from './fixtures/browser-process-registry.js';
 
 export default async function globalTeardown(): Promise<void> {
   const registryPath = process.env[E2E_BROWSER_REGISTRY_ENV];
-  if (!registryPath || !existsSync(registryPath)) return;
 
   const repoRoot = path.resolve(__dirname, '..', '..', '..');
   const cleanupScript = path.join(repoRoot, 'scripts', 'cleanup-orphaned-automation-chrome.mjs');
+  const cleanupArgs = registryPath ? [cleanupScript, '--registry', registryPath] : [cleanupScript];
 
   try {
-    execFileSync(process.execPath, [cleanupScript, '--registry', registryPath], { stdio: 'inherit' });
+    execFileSync(process.execPath, cleanupArgs, { stdio: 'inherit' });
   } finally {
-    rmSync(path.dirname(registryPath), { recursive: true, force: true });
+    if (registryPath) {
+      rmSync(path.dirname(registryPath), { recursive: true, force: true });
+    }
   }
 }

--- a/packages/app/e2e/global-teardown.ts
+++ b/packages/app/e2e/global-teardown.ts
@@ -1,7 +1,20 @@
 import { execFileSync } from 'node:child_process';
 import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { E2E_BROWSER_REGISTRY_ENV } from './fixtures/browser-process-registry.js';
+
+const E2E_BROWSER_REGISTRY_DIR_PREFIX = 'invoker-e2e-browser-registry-';
+const E2E_BROWSER_REGISTRY_FILE = 'user-data-dirs.txt';
+
+export function isManagedBrowserRegistryPath(registryPath: string | undefined): boolean {
+  if (!registryPath) return false;
+  const resolvedRegistryPath = path.resolve(registryPath);
+  const registryDir = path.dirname(resolvedRegistryPath);
+  return path.basename(resolvedRegistryPath) === E2E_BROWSER_REGISTRY_FILE
+    && path.basename(registryDir).startsWith(E2E_BROWSER_REGISTRY_DIR_PREFIX)
+    && path.dirname(registryDir) === path.resolve(tmpdir());
+}
 
 export default async function globalTeardown(): Promise<void> {
   const registryPath = process.env[E2E_BROWSER_REGISTRY_ENV];
@@ -13,8 +26,8 @@ export default async function globalTeardown(): Promise<void> {
   try {
     execFileSync(process.execPath, cleanupArgs, { stdio: 'inherit' });
   } finally {
-    if (registryPath) {
-      rmSync(path.dirname(registryPath), { recursive: true, force: true });
+    if (isManagedBrowserRegistryPath(registryPath)) {
+      rmSync(path.dirname(path.resolve(registryPath)), { recursive: true, force: true });
     }
   }
 }

--- a/packages/app/src/__tests__/global-teardown.test.ts
+++ b/packages/app/src/__tests__/global-teardown.test.ts
@@ -1,0 +1,18 @@
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { isManagedBrowserRegistryPath } from '../../e2e/global-teardown';
+
+describe('global teardown browser registry cleanup guard', () => {
+  it('accepts the Playwright-managed browser registry path', () => {
+    const registryPath = path.join(tmpdir(), 'invoker-e2e-browser-registry-abc123', 'user-data-dirs.txt');
+
+    expect(isManagedBrowserRegistryPath(registryPath)).toBe(true);
+  });
+
+  it('rejects arbitrary env-derived parent directories', () => {
+    expect(isManagedBrowserRegistryPath(path.join(tmpdir(), 'workspace', 'user-data-dirs.txt'))).toBe(false);
+    expect(isManagedBrowserRegistryPath('/var/tmp/invoker-e2e-browser-registry-abc123/user-data-dirs.txt')).toBe(false);
+    expect(isManagedBrowserRegistryPath(path.join(tmpdir(), 'invoker-e2e-browser-registry-abc123', 'other.txt'))).toBe(false);
+  });
+});

--- a/scripts/cleanup-orphaned-automation-chrome.mjs
+++ b/scripts/cleanup-orphaned-automation-chrome.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import process from 'node:process';
 import { execFile as execFileCb } from 'node:child_process';
-import { readFileSync as fsReadFileSync } from 'node:fs';
+import { existsSync, readFileSync as fsReadFileSync } from 'node:fs';
 import { promisify } from 'node:util';
 
 const execFile = promisify(execFileCb);
@@ -68,6 +68,7 @@ export function findOrphanedAutomationChromeGroups(rows) {
 
 export function readTrackedUserDataDirs(registryPath) {
   if (!registryPath) return [];
+  if (!existsSync(registryPath)) return [];
   return [...new Set(
     fsReadFileSync(registryPath, 'utf8')
       .split('\n')

--- a/scripts/cleanup-orphaned-automation-chrome.mjs
+++ b/scripts/cleanup-orphaned-automation-chrome.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import process from 'node:process';
 import { execFile as execFileCb } from 'node:child_process';
-import { existsSync, readFileSync as fsReadFileSync } from 'node:fs';
+import { readFileSync as fsReadFileSync } from 'node:fs';
 import { promisify } from 'node:util';
 
 const execFile = promisify(execFileCb);
@@ -68,13 +68,17 @@ export function findOrphanedAutomationChromeGroups(rows) {
 
 export function readTrackedUserDataDirs(registryPath) {
   if (!registryPath) return [];
-  if (!existsSync(registryPath)) return [];
-  return [...new Set(
-    fsReadFileSync(registryPath, 'utf8')
-      .split('\n')
-      .map((line) => line.trim())
-      .filter(Boolean),
-  )].sort();
+  try {
+    return [...new Set(
+      fsReadFileSync(registryPath, 'utf8')
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean),
+    )].sort();
+  } catch (error) {
+    if (error?.code === 'ENOENT') return [];
+    throw error;
+  }
 }
 
 export function findTrackedBrowserGroups(rows, trackedUserDataDirs) {

--- a/scripts/cleanup-orphaned-automation-chrome.test.mjs
+++ b/scripts/cleanup-orphaned-automation-chrome.test.mjs
@@ -74,6 +74,12 @@ describe('cleanup-orphaned-automation-chrome', () => {
     assert.deepEqual(readTrackedUserDataDirs(registryPath), ['/tmp/a', '/tmp/b']);
   });
 
+  it('treats a missing registry file as no tracked user-data-dirs', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-registry-test-'));
+    const registryPath = path.join(dir, 'missing-user-data-dirs.txt');
+    assert.deepEqual(readTrackedUserDataDirs(registryPath), []);
+  });
+
   it('merges orphaned and tracked groups by process group', () => {
     const merged = mergeGroups(
       [{ pgid: 58744, pids: [58744], profiles: ['/tmp/puppeteer_dev_chrome_profile-abc'] }],

--- a/scripts/repro/repro-coderabbit-pr5197-registry-parent-delete.sh
+++ b/scripts/repro/repro-coderabbit-pr5197-registry-parent-delete.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+TARGET="$ROOT/packages/app/e2e/global-teardown.ts"
+echo "[repro] problem: global teardown must not recursively delete an arbitrary env-derived parent directory"
+echo "[repro] check: only the Playwright-managed browser registry temp dir may be removed"
+node - "$TARGET" <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const targetPath = process.argv[2];
+let source = fs.readFileSync(targetPath, 'utf8');
+source = source
+  .replace(/^import .*$/gm, '')
+  .replace('export function isManagedBrowserRegistryPath(registryPath: string | undefined): boolean {', 'function isManagedBrowserRegistryPath(registryPath) {')
+  .replace('export default async function globalTeardown(): Promise<void> {', 'async function globalTeardown() {');
+source += '\nglobalThis.__exports = { globalTeardown, isManagedBrowserRegistryPath };\n';
+
+const rmCalls = [];
+const execCalls = [];
+const context = {
+  execFileSync: (...args) => execCalls.push(args),
+  rmSync: (target, options) => rmCalls.push({ target, options }),
+  tmpdir: () => '/tmp',
+  path,
+  process: {
+    env: {},
+    execPath: process.execPath,
+  },
+  __dirname: path.dirname(targetPath),
+  E2E_BROWSER_REGISTRY_ENV: 'INVOKER_E2E_BROWSER_PROCESS_REGISTRY',
+  console,
+  globalThis: null,
+};
+context.globalThis = context;
+vm.runInNewContext(source, context, { filename: targetPath });
+
+const { globalTeardown, isManagedBrowserRegistryPath } = context.__exports;
+
+(async () => {
+  const unsafeRegistryPath = '/tmp/workspace/user-data-dirs.txt';
+  context.process.env.INVOKER_E2E_BROWSER_PROCESS_REGISTRY = unsafeRegistryPath;
+  await globalTeardown();
+  if (rmCalls.length !== 0) {
+    console.error(`[repro] FAIL: teardown tried to remove ${rmCalls[0].target} for unsafe registry path ${unsafeRegistryPath}`);
+    process.exit(1);
+  }
+  if (execCalls.length !== 1) {
+    console.error('[repro] FAIL: teardown did not invoke the cleanup script once for the unsafe path case');
+    process.exit(1);
+  }
+
+  rmCalls.length = 0;
+  const safeRegistryPath = '/tmp/invoker-e2e-browser-registry-abc123/user-data-dirs.txt';
+  context.process.env.INVOKER_E2E_BROWSER_PROCESS_REGISTRY = safeRegistryPath;
+  await globalTeardown();
+  if (!isManagedBrowserRegistryPath(safeRegistryPath)) {
+    console.error('[repro] FAIL: managed registry path was not recognized as safe to remove');
+    process.exit(1);
+  }
+  if (rmCalls.length !== 1 || rmCalls[0].target !== '/tmp/invoker-e2e-browser-registry-abc123') {
+    console.error('[repro] FAIL: teardown did not remove the managed registry temp dir');
+    process.exit(1);
+  }
+
+  console.log('[repro] PASS: teardown skips arbitrary parents and still removes the managed registry dir');
+})().catch((error) => {
+  console.error(`[repro] FAIL: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+  process.exit(1);
+});
+NODE

--- a/scripts/repro/repro-coderabbit-pr5197-registry-read-race.sh
+++ b/scripts/repro/repro-coderabbit-pr5197-registry-read-race.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+TARGET="$ROOT/scripts/cleanup-orphaned-automation-chrome.mjs"
+echo "[repro] problem: registry reads must survive the file disappearing after the caller picked the path"
+echo "[repro] check: ENOENT becomes an empty registry, but other read errors still fail"
+node - "$TARGET" <<'NODE'
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+const targetPath = process.argv[2];
+let source = fs.readFileSync(targetPath, 'utf8');
+source = source
+  .replace(/^#!.*\n/, '')
+  .replace(/^import .*$/gm, '')
+  .replace(/^export async function /gm, 'async function ')
+  .replace(/^export function /gm, 'function ')
+  .replace(/if \(import\.meta\.url === `file:\/\/\$\{process\.argv\[1\]\}`\) \{[\s\S]*$/, '');
+source += '\nglobalThis.__exports = { readTrackedUserDataDirs };\n';
+
+const context = {
+  process: { argv: [], env: {}, kill: () => {} },
+  execFileCb: () => {},
+  existsSync: () => true,
+  fsReadFileSync: () => '',
+  promisify: (fn) => fn,
+  console,
+  setTimeout,
+  clearTimeout,
+  Date,
+  Set,
+  Map,
+  Promise,
+  globalThis: null,
+};
+context.globalThis = context;
+vm.runInNewContext(source, context, { filename: targetPath });
+
+const { readTrackedUserDataDirs } = context.__exports;
+
+const enoent = new Error('missing');
+enoent.code = 'ENOENT';
+context.fsReadFileSync = () => {
+  throw enoent;
+};
+const tracked = readTrackedUserDataDirs('/tmp/invoker-e2e-browser-registry-abc123/user-data-dirs.txt');
+if (!Array.isArray(tracked) || tracked.length !== 0) {
+  console.error('[repro] FAIL: ENOENT did not become an empty registry');
+  process.exit(1);
+}
+
+const eacces = new Error('denied');
+eacces.code = 'EACCES';
+context.fsReadFileSync = () => {
+  throw eacces;
+};
+let rethrew = false;
+try {
+  readTrackedUserDataDirs('/tmp/invoker-e2e-browser-registry-abc123/user-data-dirs.txt');
+} catch (error) {
+  rethrew = error === eacces;
+}
+if (!rethrew) {
+  console.error('[repro] FAIL: non-ENOENT read errors were swallowed');
+  process.exit(1);
+}
+
+console.log('[repro] PASS: disappearing registry files are ignored, other read failures still stop cleanup');
+NODE


### PR DESCRIPTION
## Summary

Playwright global teardown now runs the automation Chrome cleanup script even when no browser registry file was created.

The cleanup helper also treats a missing registry file as an empty registry, so the orphaned Chrome sweep still runs.

## Review Claim

Approve that E2E teardown no longer skips orphaned headless Chrome cleanup when the registry file is missing.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The cleanup script still only targets tracked browser profiles or orphaned `puppeteer_dev_chrome_profile-*` Chrome process groups.

## Slice Rationale

This is one focused teardown fix plus the regression coverage needed to lock the missing-registry behavior.

## Non-goals

- Does not change app runtime behavior.
- Does not change Playwright browser launch configuration.
- Does not kill active non-orphaned automation Chrome processes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --test scripts/cleanup-orphaned-automation-chrome.test.mjs`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/startup-window-liveness.spec.ts --workers=1`
- [x] `git diff --check`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 33cc2cec9`
- Post-revert steps: None
- Data migration? No

</details>
