### PR TITLE
[Fix Git E2E Tests Step 1 Repros](1) Add deterministic repro scripts

### DIFF
--- a/scripts/repro/prove-reset-assertions.sh
+++ b/scripts/repro/prove-reset-assertions.sh
@@ -4,4 +4,53 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
+EXPECTATION="fixed"
+CASE_NAME="case-2.15-recreate-preempt-attempt-refresh.sh"
+REQUIRED_RESET_SUITE="$ROOT_DIR/scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh"
+
+usage() {
+  echo "usage: $0 [--expect-bug|--expect-fixed]" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect-bug)
+      EXPECTATION="bug"
+      shift
+      ;;
+    --expect-fixed)
+      EXPECTATION="fixed"
+      shift
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" == "bug" ]]; then
+  merge_queue_block="$(awk '/if is_merge_queue; then/{inside=1} inside{print} inside && /^fi$/{exit}' "$REQUIRED_RESET_SUITE")"
+  merge_queue_cases="$(printf '%s\n' "$merge_queue_block" | sed '/^[[:space:]]*#/d')"
+  required_cases="$(sed '/^[[:space:]]*#/d' "$REQUIRED_RESET_SUITE")"
+  if [[ -z "$merge_queue_block" ]]; then
+    echo "repro: could not find merge-queue branch in required/21 reset shard" >&2
+    exit 1
+  fi
+  if printf '%s\n' "$merge_queue_cases" | grep -Fq "$CASE_NAME"; then
+    echo "repro: expected merge-queue branch to omit $CASE_NAME before the fix" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$required_cases" | grep -Fq "$CASE_NAME"; then
+    echo "repro: expected default required/21 reset shard to include $CASE_NAME" >&2
+    exit 1
+  fi
+  echo "repro: confirmed merge-queue quarantine for $CASE_NAME"
+  echo "repro: reproduce with:"
+  echo "GITHUB_EVENT_NAME=pull_request GITHUB_HEAD_REF=mergify/merge-queue/repro bash scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh"
+  echo "repro: the merge-queue branch omits $CASE_NAME; the default wrapper still runs it with:"
+  echo "bash scripts/repro/prove-reset-assertions.sh"
+  exit 0
+fi
+
 exec bash scripts/e2e-dry-run/run-all.sh case-2.15-recreate-preempt-attempt-refresh.sh

--- a/scripts/repro/prove-reset-rulebook.sh
+++ b/scripts/repro/prove-reset-rulebook.sh
@@ -4,4 +4,53 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
+EXPECTATION="fixed"
+CASE_NAME="case-2.16-retry-vs-recreate-five-second-window.sh"
+REQUIRED_RESET_SUITE="$ROOT_DIR/scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh"
+
+usage() {
+  echo "usage: $0 [--expect-bug|--expect-fixed]" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect-bug)
+      EXPECTATION="bug"
+      shift
+      ;;
+    --expect-fixed)
+      EXPECTATION="fixed"
+      shift
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" == "bug" ]]; then
+  merge_queue_block="$(awk '/if is_merge_queue; then/{inside=1} inside{print} inside && /^fi$/{exit}' "$REQUIRED_RESET_SUITE")"
+  merge_queue_cases="$(printf '%s\n' "$merge_queue_block" | sed '/^[[:space:]]*#/d')"
+  required_cases="$(sed '/^[[:space:]]*#/d' "$REQUIRED_RESET_SUITE")"
+  if [[ -z "$merge_queue_block" ]]; then
+    echo "repro: could not find merge-queue branch in required/21 reset shard" >&2
+    exit 1
+  fi
+  if printf '%s\n' "$merge_queue_cases" | grep -Fq "$CASE_NAME"; then
+    echo "repro: expected merge-queue branch to omit $CASE_NAME before the fix" >&2
+    exit 1
+  fi
+  if ! printf '%s\n' "$required_cases" | grep -Fq "$CASE_NAME"; then
+    echo "repro: expected default required/21 reset shard to include $CASE_NAME" >&2
+    exit 1
+  fi
+  echo "repro: confirmed merge-queue quarantine for $CASE_NAME"
+  echo "repro: reproduce with:"
+  echo "GITHUB_EVENT_NAME=pull_request GITHUB_HEAD_REF=mergify/merge-queue/repro bash scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh"
+  echo "repro: the merge-queue branch omits $CASE_NAME; the default wrapper still runs it with:"
+  echo "bash scripts/repro/prove-reset-rulebook.sh"
+  exit 0
+fi
+
 exec bash scripts/e2e-dry-run/run-all.sh case-2.16-retry-vs-recreate-five-second-window.sh

--- a/scripts/repro/repro-required-vitest-filter-zero-active.sh
+++ b/scripts/repro/repro-required-vitest-filter-zero-active.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REQUIRED_SCRIPT="$ROOT_DIR/scripts/test-suites/required/17-merge-gate-concurrency-repro.sh"
+TEST_NAME="starts an independent merge gate while another merge gate is still preparing review"
+BUG_TARGET="src/__tests__/task-runner.test.ts"
+FIXED_TARGET="src/__tests__/task-runner-fix-publish-and-ssh.test.ts"
+EXPECTATION="fixed"
+
+usage() {
+  echo "usage: $0 [--expect-bug|--expect-fixed]" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect-bug)
+      EXPECTATION="bug"
+      shift
+      ;;
+    --expect-fixed)
+      EXPECTATION="fixed"
+      shift
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -f "$REQUIRED_SCRIPT" ]]; then
+  echo "repro: missing required suite script: $REQUIRED_SCRIPT" >&2
+  exit 1
+fi
+
+target_rel="$(grep -Eo 'src/__tests__/[^[:space:]]+\.test\.ts' "$REQUIRED_SCRIPT" | head -n1 || true)"
+if [[ -z "$target_rel" ]]; then
+  echo "repro: could not find a vitest test target in required/17" >&2
+  exit 1
+fi
+
+if ! grep -Fq "$TEST_NAME" "$REQUIRED_SCRIPT"; then
+  echo "repro: required/17 no longer contains the expected test-name filter" >&2
+  exit 1
+fi
+
+target_path="$ROOT_DIR/packages/execution-engine/$target_rel"
+if [[ ! -f "$target_path" ]]; then
+  echo "repro: required/17 target file does not exist: packages/execution-engine/$target_rel" >&2
+  exit 1
+fi
+
+active_matches="$( (grep -F "$TEST_NAME" "$target_path" || true) | wc -l | tr -d '[:space:]' )"
+fixed_matches=0
+if [[ -f "$ROOT_DIR/packages/execution-engine/$FIXED_TARGET" ]]; then
+  fixed_matches="$( (grep -F "$TEST_NAME" "$ROOT_DIR/packages/execution-engine/$FIXED_TARGET" || true) | wc -l | tr -d '[:space:]' )"
+fi
+
+if [[ "$EXPECTATION" == "bug" ]]; then
+  if [[ "$target_rel" != "$BUG_TARGET" ]]; then
+    echo "repro: expected required/17 to target $BUG_TARGET before the fix, got $target_rel" >&2
+    exit 1
+  fi
+  if [[ "$active_matches" -ne 0 ]]; then
+    echo "repro: expected zero active matches in $BUG_TARGET, got $active_matches" >&2
+    exit 1
+  fi
+  if [[ "$fixed_matches" -lt 1 ]]; then
+    echo "repro: expected relocated test name in $FIXED_TARGET, got $fixed_matches matches" >&2
+    exit 1
+  fi
+  echo "repro: confirmed bug"
+  echo "repro: required/17 targets packages/execution-engine/$BUG_TARGET"
+  echo "repro: active matches in that target for the -t filter: 0"
+  echo "repro: relocated matches in packages/execution-engine/$FIXED_TARGET: $fixed_matches"
+else
+  if [[ "$active_matches" -lt 1 ]]; then
+    echo "repro: expected fixed required/17 target to contain at least one active test for the -t filter" >&2
+    echo "repro: current target: packages/execution-engine/$target_rel" >&2
+    echo "repro: active matches: $active_matches" >&2
+    exit 1
+  fi
+  echo "repro: confirmed fixed behavior"
+  echo "repro: required/17 target packages/execution-engine/$target_rel contains $active_matches active match(es)"
+fi

--- a/scripts/repro/repro-run-sh-preprovisioned-bootstrap.sh
+++ b/scripts/repro/repro-run-sh-preprovisioned-bootstrap.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPECTATION="fixed"
+KEEP_TEMP=false
+
+usage() {
+  echo "usage: $0 [--expect-bug|--expect-fixed] [--keep-temp]" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect-bug)
+      EXPECTATION="bug"
+      shift
+      ;;
+    --expect-fixed)
+      EXPECTATION="fixed"
+      shift
+      ;;
+    --keep-temp)
+      KEEP_TEMP=true
+      shift
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-run-sh-bootstrap-repro.XXXXXX")"
+FAKE_ROOT="$TMP_DIR/repo"
+STUB_BIN="$TMP_DIR/bin"
+PNPM_CALLS="$TMP_DIR/pnpm.calls"
+RUN_STDOUT="$TMP_DIR/run.stdout"
+RUN_STDERR="$TMP_DIR/run.stderr"
+
+cleanup() {
+  if [[ "$KEEP_TEMP" == true ]]; then
+    echo "temp root: $TMP_DIR"
+  else
+    rm -rf "$TMP_DIR" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p \
+  "$FAKE_ROOT/node_modules/.bin" \
+  "$FAKE_ROOT/packages/app/node_modules/.bin" \
+  "$FAKE_ROOT/packages/app/dist" \
+  "$STUB_BIN"
+
+cp "$ROOT_DIR/run.sh" "$FAKE_ROOT/run.sh"
+
+printf 'preprovisioned pnpm workspace marker\n' > "$FAKE_ROOT/node_modules/.modules.yaml"
+cat > "$FAKE_ROOT/node_modules/.bin/tsup" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  echo "tsup 0.0.0-repro"
+  exit 0
+fi
+exit 0
+SH
+chmod +x "$FAKE_ROOT/node_modules/.bin/tsup"
+
+cat > "$FAKE_ROOT/packages/app/node_modules/.bin/electron" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$FAKE_ROOT/packages/app/node_modules/.bin/electron"
+
+cat > "$FAKE_ROOT/packages/app/dist/headless-client.js" <<'JS'
+#!/usr/bin/env node
+console.log('headless client reached')
+JS
+chmod +x "$FAKE_ROOT/packages/app/dist/headless-client.js"
+
+cat > "$STUB_BIN/pnpm" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${INVOKER_REPRO_PNPM_CALLS:?}"
+echo "pnpm stub invoked: $*" >&2
+exit 73
+SH
+chmod +x "$STUB_BIN/pnpm"
+
+if [[ -e "$FAKE_ROOT/node_modules/.invoker-bootstrap-stamp" ]]; then
+  echo "repro setup error: bootstrap stamp unexpectedly exists in temp fixture" >&2
+  exit 1
+fi
+
+status=0
+HOME="$TMP_DIR/home" \
+  INVOKER_DB_DIR="$TMP_DIR/db" \
+  INVOKER_REPO_CONFIG_PATH="$TMP_DIR/config.json" \
+  INVOKER_REPRO_PNPM_CALLS="$PNPM_CALLS" \
+  PATH="$STUB_BIN:$PATH" \
+  "$FAKE_ROOT/run.sh" --headless delete-all >"$RUN_STDOUT" 2>"$RUN_STDERR" || status=$?
+
+pnpm_call_count=0
+if [[ -f "$PNPM_CALLS" ]]; then
+  pnpm_call_count="$(wc -l < "$PNPM_CALLS" | tr -d '[:space:]')"
+fi
+
+if [[ "$EXPECTATION" == "bug" ]]; then
+  if [[ "$pnpm_call_count" -lt 1 ]]; then
+    echo "repro: expected run.sh to call pnpm while the bootstrap stamp is missing" >&2
+    echo "stdout:" >&2
+    cat "$RUN_STDOUT" >&2 || true
+    echo "stderr:" >&2
+    cat "$RUN_STDERR" >&2 || true
+    exit 1
+  fi
+  if [[ "$status" -ne 73 ]]; then
+    echo "repro: expected pnpm stub exit 73, got $status" >&2
+    cat "$RUN_STDERR" >&2 || true
+    exit 1
+  fi
+  if ! grep -Fq 'install --frozen-lockfile' "$PNPM_CALLS"; then
+    echo "repro: expected pnpm install --frozen-lockfile, saw:" >&2
+    cat "$PNPM_CALLS" >&2 || true
+    exit 1
+  fi
+  echo "repro: confirmed bug"
+  echo "repro: healthy artifacts were present, bootstrap stamp was absent, and run.sh called pnpm install"
+  cat "$PNPM_CALLS"
+else
+  if [[ "$pnpm_call_count" -ne 0 ]]; then
+    echo "repro: expected fixed run.sh to skip pnpm for healthy preprovisioned artifacts" >&2
+    cat "$PNPM_CALLS" >&2 || true
+    exit 1
+  fi
+  if [[ "$status" -ne 0 ]]; then
+    echo "repro: expected fixed run.sh to reach the headless client, got exit $status" >&2
+    cat "$RUN_STDOUT" >&2 || true
+    cat "$RUN_STDERR" >&2 || true
+    exit 1
+  fi
+  if ! grep -Fq 'headless client reached' "$RUN_STDOUT"; then
+    echo "repro: fixed-mode run did not reach the headless client" >&2
+    cat "$RUN_STDOUT" >&2 || true
+    exit 1
+  fi
+  echo "repro: confirmed fixed behavior"
+fi


### PR DESCRIPTION
## Summary

Adds local repro scripts for the current git e2e failures.

Each script has bug-expect mode so later fixes can flip the same command to fixed mode.

## Review Claim

Add deterministic repro scripts for the known git e2e failures before changing behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds repo-local repro scripts. It does not change product runtime behavior or weaken existing e2e assertions.

## Slice Rationale

The proof surface lands first so later behavior fixes can be reviewed against runnable before-state commands.

## Non-goals

- Do not fix `run.sh`.
- Do not retarget required/17.
- Do not re-enable reset cases 2.15 or 2.16 on merge-queue refs.
- Do not change product runtime behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-run-sh-preprovisioned-bootstrap.sh --expect-bug`
- [x] `bash scripts/repro/repro-required-vitest-filter-zero-active.sh --expect-bug`
- [x] `bash scripts/repro/prove-reset-assertions.sh --expect-bug`
- [x] `bash scripts/repro/prove-reset-rulebook.sh --expect-bug`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/fix-git-e2e-step-1-repros-pr1.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e31ccc00fbb88bab4b1cced29a43ae6820abdbb0`
- Post-revert steps: Re-run later stack slices only after restoring their referenced repro commands.
- Data migration? No

</details>
