### PR TITLE
[Slack Artifact Upload](1) Add worktree-bounded artifact path extraction

### DIFF
--- a/packages/surfaces/src/__tests__/slack-artifact-extraction.test.ts
+++ b/packages/surfaces/src/__tests__/slack-artifact-extraction.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { resolve } from 'node:path';
+import { MAX_ARTIFACT_UPLOADS, extractArtifactPaths } from '../slack/slack-message-helpers.js';
+
+const WORKTREE = resolve('/tmp/slack-thread-worktree');
+
+describe('extractArtifactPaths', () => {
+  it('extracts an absolute link inside the worktree', () => {
+    const png = `${WORKTREE}/artifacts/inbox.png`;
+    const { paths, rejected } = extractArtifactPaths(`Here it is: [inbox](${png})`, WORKTREE);
+    expect(paths).toEqual([png]);
+    expect(rejected).toEqual([]);
+  });
+
+  it('accepts file:// links', () => {
+    const png = `${WORKTREE}/a.png`;
+    expect(extractArtifactPaths(`[a](file://${png})`, WORKTREE).paths).toEqual([png]);
+  });
+
+  it('returns a repeated link only once', () => {
+    const png = `${WORKTREE}/a.png`;
+    expect(extractArtifactPaths(`[a](${png}) and again [a](${png})`, WORKTREE).paths).toEqual([png]);
+  });
+
+  it('rejects paths outside the worktree and says why', () => {
+    const { paths, rejected } = extractArtifactPaths('[key](/Users/someone/.ssh/id_rsa)', WORKTREE);
+    expect(paths).toEqual([]);
+    expect(rejected).toEqual([
+      { path: '/Users/someone/.ssh/id_rsa', reason: 'outside thread worktree' },
+    ]);
+  });
+
+  it('rejects traversal that escapes the worktree', () => {
+    const { paths, rejected } = extractArtifactPaths(`[x](${WORKTREE}/../../etc/passwd)`, WORKTREE);
+    expect(paths).toEqual([]);
+    expect(rejected[0].reason).toBe('outside thread worktree');
+  });
+
+  it('does not treat a sibling directory sharing the prefix as inside', () => {
+    const { paths, rejected } = extractArtifactPaths(`[x](${WORKTREE}-other/secret.png)`, WORKTREE);
+    expect(paths).toEqual([]);
+    expect(rejected[0].reason).toBe('outside thread worktree');
+  });
+
+  it('ignores relative source-file references in prose', () => {
+    const { paths, rejected } = extractArtifactPaths(
+      '[helpers](packages/surfaces/src/slack/slack-message-helpers.ts:162)',
+      WORKTREE,
+    );
+    expect(paths).toEqual([]);
+    expect(rejected).toEqual([]);
+  });
+
+  it('ignores http links', () => {
+    expect(extractArtifactPaths('[docs](https://example.com/a.png)', WORKTREE).paths).toEqual([]);
+  });
+
+  it('caps the batch and reports what it dropped', () => {
+    const links = Array.from(
+      { length: MAX_ARTIFACT_UPLOADS + 3 },
+      (_, i) => `[f${i}](${WORKTREE}/f${i}.png)`,
+    ).join('\n');
+    const { paths, rejected } = extractArtifactPaths(links, WORKTREE);
+    expect(paths).toHaveLength(MAX_ARTIFACT_UPLOADS);
+    expect(rejected).toHaveLength(3);
+    expect(rejected[0].reason).toContain('limit');
+  });
+});

--- a/packages/surfaces/src/slack/slack-message-helpers.ts
+++ b/packages/surfaces/src/slack/slack-message-helpers.ts
@@ -4,7 +4,60 @@
  * These functions have ZERO Slack API dependencies — they operate only on strings.
  */
 
+import { isAbsolute, resolve, sep } from 'node:path';
+
 const SLACK_CHUNK_LIMIT = 3_800;
+
+export const MAX_ARTIFACT_UPLOADS = 10;
+export const MAX_ARTIFACT_BATCH_BYTES = 25 * 1024 * 1024;
+
+export interface ArtifactExtraction {
+  paths: string[];
+  rejected: { path: string; reason: string }[];
+}
+
+const MARKDOWN_LINK = /\[[^\]]*\]\(([^)\s]+)\)/g;
+
+/**
+ * Collect artifact paths an agent deliberately markdown-linked in its reply, keeping
+ * only those inside the thread's own worktree.
+ *
+ * The reply text is influenced by untrusted content the agent may have read, and the
+ * caller uploads these paths using a token the agent does not own. Confining them to
+ * `workingDir` is what stops a linked `~/.ssh/id_rsa` from reaching Slack, so the
+ * boundary check must run on the resolved path and must not be relaxed.
+ *
+ * Only absolute links are considered: relative ones are ordinary prose references to
+ * repo files, not a request to share them.
+ */
+export function extractArtifactPaths(text: string, workingDir: string): ArtifactExtraction {
+  const root = resolve(workingDir);
+  const prefix = root + sep;
+  const paths: string[] = [];
+  const rejected: { path: string; reason: string }[] = [];
+  const seen = new Set<string>();
+
+  for (const match of text.matchAll(MARKDOWN_LINK)) {
+    const raw = match[1].startsWith('file://') ? match[1].slice('file://'.length) : match[1];
+    if (!isAbsolute(raw)) continue;
+
+    const candidate = resolve(raw);
+    if (candidate !== root && !candidate.startsWith(prefix)) {
+      rejected.push({ path: candidate, reason: 'outside thread worktree' });
+      continue;
+    }
+    if (seen.has(candidate)) continue;
+    seen.add(candidate);
+
+    if (paths.length >= MAX_ARTIFACT_UPLOADS) {
+      rejected.push({ path: candidate, reason: `exceeds ${MAX_ARTIFACT_UPLOADS}-file limit` });
+      continue;
+    }
+    paths.push(candidate);
+  }
+
+  return { paths, rejected };
+}
 
 /**
  * Split text into Slack-safe chunks, preserving formatting.


### PR DESCRIPTION
## Summary

A Slack agent that generates a file has no supported way to hand it to the user. It can only print a local path.

This slice adds the decision layer for that: given an agent reply, which linked paths may leave the host.

Nothing calls it yet. The next slice connects it to Slack.

The rule is deliberately narrow. Only markdown-linked absolute paths that resolve inside the thread's own worktree are eligible.

## Review Claim

Approve the eligibility rule that decides which agent-linked paths may be sent to Slack.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

The helper is pure and unreferenced, so this slice cannot change what the bot does today. It touches no Slack call and no I/O.

Path eligibility resolves the candidate first, then requires the worktree prefix, so `..` traversal and a sibling directory sharing the prefix are both refused. Relative links are ignored entirely.

## Slice Rationale

The eligibility rule is the security-relevant part of this feature and deserves review on its own, away from Slack client plumbing.

Agent replies are shaped by untrusted content the agent may have read, and the caller runs with a token the agent does not own.

## Non-goals

Does not call the Slack file API. Does not change any reply the bot posts. Does not grant the Slack app any new permission.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/slack-artifact-extraction.test.ts`
- [ ] `pnpm --filter @invoker/surfaces build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
