### PR TITLE
[Slack Artifact Upload](2) Upload agent-linked artifacts into the thread

### DIFF
--- a/packages/surfaces/src/__tests__/slack-artifact-extraction.test.ts
+++ b/packages/surfaces/src/__tests__/slack-artifact-extraction.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { resolve } from 'node:path';
+import { MAX_ARTIFACT_UPLOADS, extractArtifactPaths } from '../slack/slack-message-helpers.js';
+
+const WORKTREE = resolve('/tmp/slack-thread-worktree');
+
+describe('extractArtifactPaths', () => {
+  it('extracts an absolute link inside the worktree', () => {
+    const png = `${WORKTREE}/artifacts/inbox.png`;
+    const { paths, rejected } = extractArtifactPaths(`Here it is: [inbox](${png})`, WORKTREE);
+    expect(paths).toEqual([png]);
+    expect(rejected).toEqual([]);
+  });
+
+  it('accepts file:// links', () => {
+    const png = `${WORKTREE}/a.png`;
+    expect(extractArtifactPaths(`[a](file://${png})`, WORKTREE).paths).toEqual([png]);
+  });
+
+  it('returns a repeated link only once', () => {
+    const png = `${WORKTREE}/a.png`;
+    expect(extractArtifactPaths(`[a](${png}) and again [a](${png})`, WORKTREE).paths).toEqual([png]);
+  });
+
+  it('rejects paths outside the worktree and says why', () => {
+    const { paths, rejected } = extractArtifactPaths('[key](/Users/someone/.ssh/id_rsa)', WORKTREE);
+    expect(paths).toEqual([]);
+    expect(rejected).toEqual([
+      { path: '/Users/someone/.ssh/id_rsa', reason: 'outside thread worktree' },
+    ]);
+  });
+
+  it('rejects traversal that escapes the worktree', () => {
+    const { paths, rejected } = extractArtifactPaths(`[x](${WORKTREE}/../../etc/passwd)`, WORKTREE);
+    expect(paths).toEqual([]);
+    expect(rejected[0].reason).toBe('outside thread worktree');
+  });
+
+  it('does not treat a sibling directory sharing the prefix as inside', () => {
+    const { paths, rejected } = extractArtifactPaths(`[x](${WORKTREE}-other/secret.png)`, WORKTREE);
+    expect(paths).toEqual([]);
+    expect(rejected[0].reason).toBe('outside thread worktree');
+  });
+
+  it('ignores relative source-file references in prose', () => {
+    const { paths, rejected } = extractArtifactPaths(
+      '[helpers](packages/surfaces/src/slack/slack-message-helpers.ts:162)',
+      WORKTREE,
+    );
+    expect(paths).toEqual([]);
+    expect(rejected).toEqual([]);
+  });
+
+  it('ignores http links', () => {
+    expect(extractArtifactPaths('[docs](https://example.com/a.png)', WORKTREE).paths).toEqual([]);
+  });
+
+  it('caps the batch and reports what it dropped', () => {
+    const links = Array.from(
+      { length: MAX_ARTIFACT_UPLOADS + 3 },
+      (_, i) => `[f${i}](${WORKTREE}/f${i}.png)`,
+    ).join('\n');
+    const { paths, rejected } = extractArtifactPaths(links, WORKTREE);
+    expect(paths).toHaveLength(MAX_ARTIFACT_UPLOADS);
+    expect(rejected).toHaveLength(3);
+    expect(rejected[0].reason).toContain('limit');
+  });
+});

--- a/packages/surfaces/src/__tests__/slack-surface-artifact-upload.integration.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-artifact-upload.integration.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SlackSurface } from '../slack/slack-surface.js';
+
+interface MockHandler {
+  pattern: string | RegExp;
+  handler: Function;
+}
+
+const uploadV2 = vi.fn().mockResolvedValue({ ok: true });
+const posted: { text?: string; thread_ts?: string }[] = [];
+
+vi.mock('@slack/bolt', () => {
+  class MockApp {
+    _commandHandlers: MockHandler[] = [];
+    _actionHandlers: MockHandler[] = [];
+    _eventHandlers: MockHandler[] = [];
+    command = vi.fn((name: string, handler: Function) => {
+      this._commandHandlers.push({ pattern: name, handler });
+    });
+    action = vi.fn((pattern: string | RegExp, handler: Function) => {
+      this._actionHandlers.push({ pattern, handler });
+    });
+    event = vi.fn((name: string, handler: Function) => {
+      this._eventHandlers.push({ pattern: name, handler });
+    });
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    client = {
+      chat: {
+        postMessage: vi.fn().mockImplementation(async ({ text, thread_ts }) => {
+          posted.push({ text, thread_ts });
+          return { ts: '111.222', ok: true };
+        }),
+        update: vi.fn().mockResolvedValue({ ok: true }),
+        delete: vi.fn().mockResolvedValue({ ok: true }),
+      },
+      auth: { test: vi.fn().mockResolvedValue({ user_id: 'UBOT123456' }) },
+      reactions: {
+        add: vi.fn().mockResolvedValue({ ok: true }),
+        remove: vi.fn().mockResolvedValue({ ok: true }),
+      },
+      files: { uploadV2 },
+    };
+  }
+  return { App: MockApp };
+});
+
+const mockSendMessage = vi.fn();
+let workingDir: string;
+const mockPlanConversation = {
+  sendMessage: mockSendMessage,
+  getDraftedPlan: () => null,
+  submittedPlanText: null as any,
+  planSubmitted: false,
+  conversationMode: 'agent' as const,
+  init: vi.fn().mockResolvedValue(undefined),
+  get workingDir() {
+    return workingDir;
+  },
+};
+
+vi.mock('../slack/plan-conversation.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../slack/plan-conversation.js')>()),
+  PlanConversation: vi.fn(() => mockPlanConversation),
+}));
+
+async function replyWith(surface: SlackSurface, reply: string): Promise<void> {
+  mockSendMessage.mockResolvedValue(reply);
+  const app = surface.getApp() as any;
+  const mentionHandler = app._eventHandlers.find(
+    (h: MockHandler) => h.pattern === 'app_mention',
+  )?.handler;
+  await mentionHandler({
+    event: {
+      text: '<@UBOT123456> show me the mockups',
+      ts: '1234567890.123456',
+      thread_ts: undefined,
+      user: 'U123',
+      channel: 'C-test',
+    },
+    say: vi.fn().mockResolvedValue({ ts: '999.888', ok: true }),
+  });
+}
+
+describe('SlackSurface artifact upload', () => {
+  let surface: SlackSurface;
+
+  beforeEach(() => {
+    uploadV2.mockClear();
+    uploadV2.mockResolvedValue({ ok: true });
+    posted.length = 0;
+    mockSendMessage.mockReset();
+    workingDir = mkdtempSync(join(tmpdir(), 'slack-artifact-'));
+    surface = new SlackSurface({
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      signingSecret: 'test-secret',
+      channelId: 'C-test',
+      anthropicApiKey: 'test-anthropic-key',
+    });
+  });
+
+  afterEach(async () => {
+    if (surface) await surface.stop();
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  it('uploads a linked artifact into the same thread', async () => {
+    const png = join(workingDir, 'inbox.png');
+    writeFileSync(png, 'not-really-a-png');
+
+    await surface.start(async () => {});
+    await replyWith(surface, `Here you go: [inbox](${png})`);
+
+    expect(uploadV2).toHaveBeenCalledTimes(1);
+    const call = uploadV2.mock.calls[0][0];
+    expect(call.channel_id).toBe('C-test');
+    expect(call.thread_ts).toBe('1234567890.123456');
+    expect(call.file_uploads).toEqual([{ file: png, filename: 'inbox.png' }]);
+  });
+
+  it('uploads a repeated link only once', async () => {
+    const png = join(workingDir, 'a.png');
+    writeFileSync(png, 'x');
+
+    await surface.start(async () => {});
+    await replyWith(surface, `[a](${png}) and again [a](${png})`);
+
+    expect(uploadV2.mock.calls[0][0].file_uploads).toHaveLength(1);
+  });
+
+  it('does not upload a path outside the worktree', async () => {
+    const outside = mkdtempSync(join(tmpdir(), 'slack-outside-'));
+    const secret = join(outside, 'id_rsa');
+    writeFileSync(secret, 'PRIVATE KEY');
+
+    await surface.start(async () => {});
+    await replyWith(surface, `[key](${secret})`);
+
+    expect(uploadV2).not.toHaveBeenCalled();
+    rmSync(outside, { recursive: true, force: true });
+  });
+
+  it('does not upload when the reply links nothing', async () => {
+    await surface.start(async () => {});
+    await replyWith(surface, 'No files this time, just an Invoker plan summary.');
+    expect(uploadV2).not.toHaveBeenCalled();
+  });
+
+  it('skips directories and unreadable paths without calling Slack', async () => {
+    mkdirSync(join(workingDir, 'artifacts'));
+    await surface.start(async () => {});
+    await replyWith(
+      surface,
+      `[dir](${join(workingDir, 'artifacts')}) [missing](${join(workingDir, 'nope.png')})`,
+    );
+    expect(uploadV2).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an upload failure in the thread instead of swallowing it', async () => {
+    const png = join(workingDir, 'a.png');
+    writeFileSync(png, 'x');
+    uploadV2.mockRejectedValue(new Error('missing_scope'));
+
+    await surface.start(async () => {});
+    await replyWith(surface, `[a](${png})`);
+
+    const failure = posted.find((p) => p.text?.includes('missing_scope'));
+    expect(failure).toBeDefined();
+    expect(failure?.thread_ts).toBe('1234567890.123456');
+  });
+});

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -183,7 +183,8 @@ Default behavior:
 - Answer questions, run local commands, inspect files, edit code, and run focused verification when useful.
 - Do NOT generate Invoker YAML in this thread. If the user asks for an Invoker plan, tell them to start a new plan thread with \`plan: <request>\` — plan drafts from an agent thread cannot be submitted.
 - Do NOT submit or start an Invoker workflow. Agent threads reject \`submit\`; only a \`plan:\` thread can be submitted.
-- Keep Slack replies short and concrete: changed files, verification, and any remaining risk.`;
+- Keep Slack replies short and concrete: changed files, verification, and any remaining risk.
+- To share a generated file (screenshot, diagram, report), write it inside your worktree and link it by absolute path as a markdown link, e.g. \`[chart](/abs/path/in/worktree/chart.png)\`. Files linked that way are uploaded to the thread. Files written outside your worktree cannot be shared, so do not put artifacts in /tmp.`;
 }
 
 function buildStackedWorkflowPrompt(repoUrlLine: string, defaultBranch: string): string {
@@ -337,7 +338,7 @@ export class PlanConversation {
   private messages: ConversationMessage[] = [];
   private _submittedPlanText: string | null = null;
   private _planSubmitted = false;
-  private workingDir?: string;
+  readonly workingDir?: string;
   private timeoutMs: number;
   private threadTs?: string;
   private conversationRepo?: ConversationRepository;

--- a/packages/surfaces/src/slack/slack-message-helpers.ts
+++ b/packages/surfaces/src/slack/slack-message-helpers.ts
@@ -4,7 +4,60 @@
  * These functions have ZERO Slack API dependencies — they operate only on strings.
  */
 
+import { isAbsolute, resolve, sep } from 'node:path';
+
 const SLACK_CHUNK_LIMIT = 3_800;
+
+export const MAX_ARTIFACT_UPLOADS = 10;
+export const MAX_ARTIFACT_BATCH_BYTES = 25 * 1024 * 1024;
+
+export interface ArtifactExtraction {
+  paths: string[];
+  rejected: { path: string; reason: string }[];
+}
+
+const MARKDOWN_LINK = /\[[^\]]*\]\(([^)\s]+)\)/g;
+
+/**
+ * Collect artifact paths an agent deliberately markdown-linked in its reply, keeping
+ * only those inside the thread's own worktree.
+ *
+ * The reply text is influenced by untrusted content the agent may have read, and the
+ * caller uploads these paths using a token the agent does not own. Confining them to
+ * `workingDir` is what stops a linked `~/.ssh/id_rsa` from reaching Slack, so the
+ * boundary check must run on the resolved path and must not be relaxed.
+ *
+ * Only absolute links are considered: relative ones are ordinary prose references to
+ * repo files, not a request to share them.
+ */
+export function extractArtifactPaths(text: string, workingDir: string): ArtifactExtraction {
+  const root = resolve(workingDir);
+  const prefix = root + sep;
+  const paths: string[] = [];
+  const rejected: { path: string; reason: string }[] = [];
+  const seen = new Set<string>();
+
+  for (const match of text.matchAll(MARKDOWN_LINK)) {
+    const raw = match[1].startsWith('file://') ? match[1].slice('file://'.length) : match[1];
+    if (!isAbsolute(raw)) continue;
+
+    const candidate = resolve(raw);
+    if (candidate !== root && !candidate.startsWith(prefix)) {
+      rejected.push({ path: candidate, reason: 'outside thread worktree' });
+      continue;
+    }
+    if (seen.has(candidate)) continue;
+    seen.add(candidate);
+
+    if (paths.length >= MAX_ARTIFACT_UPLOADS) {
+      rejected.push({ path: candidate, reason: `exceeds ${MAX_ARTIFACT_UPLOADS}-file limit` });
+      continue;
+    }
+    paths.push(candidate);
+  }
+
+  return { paths, rejected };
+}
 
 /**
  * Split text into Slack-safe chunks, preserving formatting.

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -7,11 +7,18 @@
 
 import { App, type RespondFn } from '@slack/bolt';
 import { spawn } from 'node:child_process';
+import { statSync } from 'node:fs';
+import { basename } from 'node:path';
 import type { Surface, CommandHandler, SurfaceCommand, SurfaceEvent, LogFn, WorkflowOp, WorkflowOpResult, WorkflowOpProgress, WorkflowOpName } from '../surface.js';
 import { parseSlackCommand } from './slack-commands.js';
 import type { ConversationCommand } from './slack-commands.js';
 import { formatSurfaceEvent, formatWorkflowStatus } from './slack-formatter.js';
-import { splitForSlack, sanitizeSlackOutbound } from './slack-message-helpers.js';
+import {
+  splitForSlack,
+  sanitizeSlackOutbound,
+  extractArtifactPaths,
+  MAX_ARTIFACT_BATCH_BYTES,
+} from './slack-message-helpers.js';
 import type { SlackMessage } from './slack-formatter.js';
 import {
   DEFAULT_PLANNER_RETRY_BASE_DELAY_MS,
@@ -379,7 +386,7 @@ interface ConversationLike {
   getDraftedPlan(): string | null;
   readonly conversationMode: ConversationMode;
   readonly planSubmitted: boolean;
-  readonly submittedPlanText: string | null;
+  readonly submittedPlanText: string | null;  readonly workingDir?: string;
 }
 
 /** An action staged for a thread, awaiting a yes/no (text or button) confirmation. */
@@ -1805,6 +1812,8 @@ ${text}`;
       }
       const tPosting = Date.now();
 
+      await this.uploadLinkedArtifacts(reply, conversation.workingDir, channel, threadTs);
+
       const tEnd = Date.now();
 
       this.log('slack', 'info', `[PERF] thread_ts=${threadTs} setup=${tSetup - tEntry}ms cursor=${tCursor - tSetup}ms heartbeatCleanup=${tHeartbeatCleanup - tCursor}ms posting=${tPosting - tHeartbeatCleanup}ms chunks=${chunks.length} total=${tEnd - tEntry}ms`);
@@ -2205,18 +2214,75 @@ ${text}`;
     }
   }
 
-  private async postMessage(message: SlackMessage, channel = this.lobbyChannelId): Promise<string | undefined> {
+  private async postMessage(message: SlackMessage, channel = this.lobbyChannelId, threadTs?: string): Promise<string | undefined> {
     try {
       const result = await this.app.client.chat.postMessage({
         channel,
         text: message.text,
         blocks: message.blocks as any,
+        ...(threadTs ? { thread_ts: threadTs } : {}),
       });
       this.log('slack', 'info', `Posted message: "${message.text.slice(0, 80)}..."`);
       return result.ts;
     } catch (err) {
       this.log('slack', 'error', `Failed to post message: ${err}`);
       return undefined;
+    }
+  }
+
+  private async uploadLinkedArtifacts(
+    reply: string,
+    workingDir: string | undefined,
+    channel: string,
+    threadTs: string,
+  ): Promise<void> {
+    if (!workingDir) return;
+
+    const { paths, rejected } = extractArtifactPaths(reply, workingDir);
+    for (const entry of rejected) {
+      this.log('slack', 'warn', `[UPLOAD] Skipped artifact (thread_ts=${threadTs}, reason=${entry.reason}): ${entry.path}`);
+    }
+
+    const uploads: { file: string; filename: string }[] = [];
+    let batchBytes = 0;
+    for (const filePath of paths) {
+      let size: number;
+      try {
+        const stat = statSync(filePath);
+        if (!stat.isFile()) {
+          this.log('slack', 'warn', `[UPLOAD] Skipped artifact (not a regular file): ${filePath}`);
+          continue;
+        }
+        size = stat.size;
+      } catch (err) {
+        this.log('slack', 'warn', `[UPLOAD] Skipped unreadable artifact ${filePath}: ${err}`);
+        continue;
+      }
+      if (batchBytes + size > MAX_ARTIFACT_BATCH_BYTES) {
+        this.log('slack', 'warn', `[UPLOAD] Skipped artifact (batch would exceed ${MAX_ARTIFACT_BATCH_BYTES} bytes): ${filePath}`);
+        continue;
+      }
+      batchBytes += size;
+      uploads.push({ file: filePath, filename: basename(filePath) });
+    }
+
+    if (uploads.length === 0) return;
+
+    try {
+      await this.app.client.files.uploadV2({
+        channel_id: channel,
+        thread_ts: threadTs,
+        file_uploads: uploads,
+      });
+      this.log('slack', 'info', `[UPLOAD] Uploaded ${uploads.length} artifact(s) (thread_ts=${threadTs})`);
+    } catch (err) {
+      const names = uploads.map((u) => u.filename).join(', ');
+      this.log('slack', 'error', `[UPLOAD] files.uploadV2 failed (channel=${channel}, thread_ts=${threadTs}, files=${names}): ${err}`);
+      await this.postMessage(
+        { text: `Could not upload ${names} to this thread: ${err instanceof Error ? err.message : String(err)}`, blocks: [] },
+        channel,
+        threadTs,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

Asked to show a screenshot it just generated, the Slack bot could only print a path on the host. Nobody else could open it.

Now the file itself arrives in the thread.

After the reply text is posted, any artifact the agent linked is attached to the same channel and thread.

Uploads are additive. They never replace, delay, or gate the text reply.

The agent prompt gains one line telling it to write shareable files inside its worktree and link them.

## Review Claim

Approve attaching agent-linked worktree files to the Slack thread that requested them.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Which paths are eligible was settled in the previous slice and is unchanged here. This slice only carries eligible paths to the Slack client.

Path collection reads the raw agent reply rather than the sanitized text, so attaching a file never depends on redaction behavior, and the posted text still gets the usual absolute-path redaction.

A failure is logged with channel, thread, and filenames, and reported in the thread, so a missing permission surfaces instead of looking like a silent hang.

## Slice Rationale

The path rule shipped separately because it is the security-relevant decision. What remains here is transport: read the file, hand it to the Slack client, report failure.

## Non-goals

Does not widen which paths are eligible. Does not grant the Slack app any new permission, which is why an install without that permission still fails until the next slice. Does not change plan submission or approval behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/slack-surface-artifact-upload.integration.test.ts`
- [ ] `pnpm --filter @invoker/surfaces exec vitest run`
- [ ] `pnpm --filter @invoker/surfaces build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


