### PR TITLE
[Slack Artifact Upload](3) Require files:write for Slack app installs

### DIFF
--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -265,6 +265,7 @@ export function runDoctor(argv: string[]): number {
 export const REQUIRED_BOT_SCOPES = [
   'app_mentions:read',
   'chat:write',
+  'files:write',
   'channels:history',
   'channels:read',
   'groups:write',


### PR DESCRIPTION
## Summary

The Slack app asks for the permissions it needs at install time. Sending a file is not among them.

This adds that permission to the generated app manifest and to the startup check.

Without it the attachment path fails against real Slack while every test still passes, because tests stand in for the Slack client.

## Review Claim

Approve adding the file-sending permission to the Slack app manifest and startup check.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

One entry is added to an existing permission array. The array feeds both the generated manifest and the startup comparison, so the two cannot drift apart.

Nothing is removed, and no existing permission changes.

## Slice Rationale

Kept apart from the runtime work because it changes what an operator must grant, not what the code does. It is the one part of this stack that needs action outside the repository.

## Non-goals

Does not change any runtime behavior on its own. Does not repair already-installed Slack apps, which still need the permission granted and the app reinstalled. Does not alter the accompanying setup guides.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/cli exec vitest run src/__tests__/onboarding.test.ts`
- [ ] `pnpm --filter @invoker/cli build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


