### PR TITLE
[Slack Artifact Upload](4) Document the files:write Slack scope

### DIFF
--- a/docs/slack-native-workflows.md
+++ b/docs/slack-native-workflows.md
@@ -109,6 +109,7 @@ The bot runs in Socket Mode. Add these bot scopes to the app manifest (reinstall
 
 - `app_mentions:read` — receive `@Invoker` mentions.
 - `chat:write` — post messages.
+- `files:write` — upload artifacts an agent links from its worktree.
 - `channels:history` — read lobby thread replies (public lobby channel).
 - `channels:read` — resolve the lobby channel via `conversations.info` during setup checks.
 - `groups:write` — **create** private `workflow-<id>` channels and invite users.

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -265,6 +265,7 @@ export function runDoctor(argv: string[]): number {
 export const REQUIRED_BOT_SCOPES = [
   'app_mentions:read',
   'chat:write',
+  'files:write',
   'channels:history',
   'channels:read',
   'groups:write',

--- a/skills/invoker-setup/SKILL.md
+++ b/skills/invoker-setup/SKILL.md
@@ -54,7 +54,7 @@ invoker-cli setup slack
 If you are doing it on the user's behalf (you cannot click api.slack.com), drive it manually:
 
 1. Generate the manifest (the wizard writes it, or you can): it requests bot scopes
-   `app_mentions:read, chat:write, channels:history, channels:read, groups:write, groups:history, users:read`,
+   `app_mentions:read, chat:write, files:write, channels:history, channels:read, groups:write, groups:history, users:read`,
    enables Socket Mode, and subscribes to the `app_mention` event.
 2. Tell the user: open https://api.slack.com/apps → **Create New App → From a manifest**, pick the
    workspace, paste the manifest JSON, create the app.


### PR DESCRIPTION
## Summary

The setup guide and the setup skill both print the Slack permission list an operator grants by hand.

Neither mentions the file-sending permission the previous slice began requiring.

This adds it to both, so a fresh workspace install grants it up front instead of hitting a runtime failure later.

## Review Claim

Approve adding the file-sending permission to the two written setup guides.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Prose only. No code path reads either file, so this cannot change behavior.

The two written lists now match the array the setup command actually enforces.

## Slice Rationale

Written guidance lands last, once the permission it describes is already required by the code.

## Non-goals

Does not change code, the generated manifest, or the startup check. Does not alter any other permission in either guide.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `git diff --name-only origin/master..HEAD -- docs skills`
- [ ] `grep -n "files:write" docs/slack-native-workflows.md skills/invoker-setup/SKILL.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


