### PR TITLE
[Tmux Summary Bridge Step 2 Planning](1) Wire Planning Tmux Summary Bridge

### DIFF
--- a/packages/app/e2e/planning-terminal-restart-persistence.spec.ts
+++ b/packages/app/e2e/planning-terminal-restart-persistence.spec.ts
@@ -99,6 +99,13 @@ async function submitPlanningText(page: Page, text: string): Promise<void> {
   await page.getByTestId('invoker-terminal-input').press('Enter');
 }
 
+async function planningTmuxPaneText(page: Page): Promise<string> {
+  const pane = page.getByTestId('invoker-terminal-tmux-pane');
+  const rowsText = await pane.locator('.xterm-rows').textContent().catch(() => null);
+  const paneText = await pane.textContent().catch(() => '');
+  return rowsText ?? paneText ?? '';
+}
+
 base.describe('Planning Terminal restart persistence', () => {
   base('restores a draft-ready planning chat after relaunch', async () => {
     const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-planning-restart-'));
@@ -221,6 +228,8 @@ base.describe('Planning Terminal restart persistence', () => {
       await expect(page.getByTestId('invoker-terminal-mode-toggle').getByRole('tab', { name: 'tmux' })).toHaveAttribute('aria-selected', 'true', { timeout: 10000 });
       await expect(page.getByTestId('invoker-terminal-tmux-pane')).toBeVisible({ timeout: 10000 });
       await expect(page.getByTestId('invoker-terminal-tmux-pane')).toHaveAttribute('data-session-id', firstTerminalSessionId ?? '');
+      await expect.poll(() => planningTmuxPaneText(page!), { timeout: 10000 }).toContain('Invoker planning tmux bridge');
+      await expect.poll(() => planningTmuxPaneText(page!), { timeout: 10000 }).toContain('Draft plan: Planning Terminal Restart (1 task) - Update README');
       await expect.poll(async () => page!.evaluate(async (sessionId) => {
         const list = await window.invoker.planningChatList();
         const session = list.sessions.find((candidate) => candidate.id === sessionId);

--- a/packages/app/e2e/planning-terminal-restart-persistence.spec.ts
+++ b/packages/app/e2e/planning-terminal-restart-persistence.spec.ts
@@ -101,7 +101,7 @@ async function submitPlanningText(page: Page, text: string): Promise<void> {
 
 async function planningTmuxPaneText(page: Page): Promise<string> {
   const pane = page.getByTestId('invoker-terminal-tmux-pane');
-  const rowsText = await pane.locator('.xterm-rows').textContent().catch(() => null);
+  const rowsText = await pane.locator('.xterm-rows').textContent({ timeout: 1000 }).catch(() => null);
   const paneText = await pane.textContent().catch(() => '');
   return rowsText ?? paneText ?? '';
 }

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -124,6 +124,31 @@ describe('buildPlanningTerminalSummaryBridge', () => {
     expect(bridge).not.toContain('tail-marker');
     expect(bridge).not.toContain('raw assistant draft');
   });
+
+  it('strips ANSI escape and control characters from embedded chat text', () => {
+    const bridge = buildPlanningTerminalSummaryBridge({
+      id: 'planning-bridge-controls',
+      title: 'Planning bridge terminal',
+      presetKey: 'codex',
+      status: 'still_discussing',
+      messages: [
+        {
+          id: 1,
+          role: 'user',
+          text: '\x1b[31mred\x1b[0m text\x07with bell and \x1b]0;title\x07osc',
+          createdAt: '2026-07-07T00:00:00.000Z',
+        },
+      ],
+      conversation: new PlanConversation({}),
+      createdAt: '2026-07-07T00:00:00.000Z',
+      updatedAt: '2026-07-07T00:00:00.000Z',
+      nextMessageId: 2,
+    });
+
+    expect(bridge).toContain('Latest user: [31mred[0m textwith bell and ]0;titleosc');
+    // eslint-disable-next-line no-control-regex
+    expect(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/.test(bridge)).toBe(false);
+  });
 });
 
 describe('planFromGoal', () => {

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { PlanConversation } from '../../../surfaces/src/index.ts';
 import {
+  PLANNING_TERMINAL_SUMMARY_BRIDGE_START,
+  buildPlanningTerminalSummaryBridge,
   createInAppPlanningChatSessions,
   createPlanningChatSession,
   createPlanningCommandBuilderFromRegistry,
@@ -87,6 +89,41 @@ workflows:
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+describe('buildPlanningTerminalSummaryBridge', () => {
+  it('composes bounded planning tmux context from session metadata', () => {
+    const longUserMessage = `Please wire the tmux bridge ${'details '.repeat(40)}tail-marker`;
+    const bridge = buildPlanningTerminalSummaryBridge({
+      id: 'planning-bridge',
+      title: 'Planning bridge terminal',
+      presetKey: 'omp+codex',
+      status: 'draft_ready',
+      messages: [
+        { id: 1, role: 'user', text: longUserMessage, createdAt: '2026-07-07T00:00:00.000Z' },
+        { id: 2, role: 'assistant', text: 'raw assistant draft that should not be copied when a summary exists', createdAt: '2026-07-07T00:00:01.000Z' },
+      ],
+      conversation: new PlanConversation({}),
+      draftPlanSummary: {
+        name: 'Bridge Plan',
+        taskCount: 2,
+        steps: ['Wire helper', 'Persist snapshot'],
+        taskGroups: [],
+      },
+      createdAt: '2026-07-07T00:00:00.000Z',
+      updatedAt: '2026-07-07T00:00:01.000Z',
+      nextMessageId: 3,
+    });
+
+    expect(bridge).toContain(PLANNING_TERMINAL_SUMMARY_BRIDGE_START);
+    expect(bridge).toContain('Planning session: Planning bridge terminal');
+    expect(bridge).toContain('Status: draft ready');
+    expect(bridge).toContain('Preset: Codex via OMP (omp+codex)');
+    expect(bridge).toContain('Draft plan: Bridge Plan (2 tasks) - Wire helper; Persist snapshot');
+    expect(bridge).toContain('Next: Review or submit the draft in chat');
+    expect(bridge).not.toContain('tail-marker');
+    expect(bridge).not.toContain('raw assistant draft');
+  });
 });
 
 describe('planFromGoal', () => {

--- a/packages/app/src/__tests__/terminal-session-persistence.test.ts
+++ b/packages/app/src/__tests__/terminal-session-persistence.test.ts
@@ -3,6 +3,7 @@ import type { IpcMain } from 'electron';
 import { EventEmitter } from 'node:events';
 import {
   EmbeddedTerminalManager,
+  MAX_OUTPUT_SNAPSHOT_CHARS,
   createBashTerminalBackend,
   type BashSpawnFn,
 } from '../embedded-terminal-manager.js';
@@ -613,5 +614,25 @@ describe('planning terminal summary bridge persistence', () => {
     expect(restoredSnapshot).not.toContain('Planning session: Stale title');
     expect(restoredSnapshot).toContain('previous terminal output\n');
     expect(countOccurrences(restoredSnapshot, PLANNING_TERMINAL_SUMMARY_BRIDGE_START)).toBe(1);
+  });
+
+  it('keeps the fresh bridge intact when restoring a near-cap persisted snapshot', () => {
+    const { mgr, planningChatSessions, restorePersistedPlanningTerminals } = setupPlanningTerminal();
+    const previousOutput = 'x'.repeat(MAX_OUTPUT_SNAPSHOT_CHARS);
+    const planningSession = makePlanningSession('plan-near-cap', {
+      terminalMode: 'tmux',
+      terminalSessionId: 'term-planning-near-cap',
+      terminalStatus: 'running',
+      terminalOutputSnapshot: previousOutput,
+      terminalUpdatedAt: '2026-07-07T00:00:02.000Z',
+    });
+    planningChatSessions.set(planningSession.id, planningSession);
+
+    restorePersistedPlanningTerminals();
+
+    const restoredSnapshot = mgr.get('term-planning-near-cap')?.outputSnapshot ?? '';
+    expect(restoredSnapshot.length).toBeLessThanOrEqual(MAX_OUTPUT_SNAPSHOT_CHARS);
+    expect(restoredSnapshot).toContain(PLANNING_TERMINAL_SUMMARY_BRIDGE_START);
+    expect(restoredSnapshot).toContain('Planning session: Planning terminal bridge');
   });
 });

--- a/packages/app/src/__tests__/terminal-session-persistence.test.ts
+++ b/packages/app/src/__tests__/terminal-session-persistence.test.ts
@@ -16,8 +16,11 @@ import {
   restorePersistedTerminalSessions,
 } from '../terminal-session-ipc.js';
 import {
+  PLANNING_TERMINAL_SUMMARY_BRIDGE_START,
+  buildPlanningTerminalSummaryBridge,
   createInAppPlanningChatSessions,
   type InAppPlanningChatSession,
+  type InAppPlanningSessionStore,
 } from '../in-app-planner.js';
 import type { SQLiteAdapter, TerminalSessionRecord } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
@@ -70,24 +73,37 @@ function makeTerminalRow(
 }
 
 function makePlanningSession(
-  id: string,
+  id = 'plan-1',
   overrides: Partial<InAppPlanningChatSession> = {},
 ): InAppPlanningChatSession {
   return {
     id,
-    title: `Planning ${id}`,
+    title: 'Planning terminal bridge',
     presetKey: 'codex',
     confirmationMode: 'require',
-    status: 'still_discussing',
-    messages: [],
+    status: 'draft_ready',
+    messages: [
+      { id: 1, role: 'user', text: 'Add README', createdAt: '2026-07-07T00:00:00.000Z' },
+      { id: 2, role: 'assistant', text: 'I drafted the restart plan.', createdAt: '2026-07-07T00:00:01.000Z' },
+    ],
     conversation: {} as InAppPlanningChatSession['conversation'],
-    createdAt: '2026-07-26T00:00:00.000Z',
-    updatedAt: '2026-07-26T00:00:00.000Z',
-    nextMessageId: 1,
+    draftPlanSummary: {
+      name: 'Planning Terminal Restart',
+      taskCount: 1,
+      steps: ['Update README'],
+      taskGroups: [],
+    },
     terminalMode: 'chat',
     terminalOutputSnapshot: '',
+    createdAt: '2026-07-07T00:00:00.000Z',
+    updatedAt: '2026-07-07T00:00:01.000Z',
+    nextMessageId: 3,
     ...overrides,
   };
+}
+
+function countOccurrences(value: string, needle: string): number {
+  return value.split(needle).length - 1;
 }
 
 describe('registerTerminalSessionPersistence coalesce', () => {
@@ -281,8 +297,10 @@ describe('registerTerminalSessionPersistence coalesce', () => {
       kind: 'planning',
       planningSessionId: 'plan-restore',
       cwd: '/repo',
-      outputSnapshot: 'saved planning tmux output\n',
+      outputSnapshot: expect.stringContaining('saved planning tmux output\n'),
     }));
+    const [restoredArgs] = restoreSpawnSession.mock.calls[0];
+    expect(restoredArgs.outputSnapshot).toContain(PLANNING_TERMINAL_SUMMARY_BRIDGE_START);
   });
 
   it('planning terminal open persists the returned session snapshot onto the planning chat', async () => {
@@ -461,5 +479,139 @@ describe('registerTerminalSessionPersistence coalesce', () => {
       'attached-running',
       expect.objectContaining({ status: 'exited' }),
     );
+  });
+});
+
+describe('planning terminal summary bridge persistence', () => {
+  function setupPlanningTerminal() {
+    const child = createFakeChild();
+    const mgr = new EmbeddedTerminalManager({
+      backend: createBashTerminalBackend({ spawnFn: (() => child) as unknown as BashSpawnFn }),
+    });
+    const planningChatSessions = createInAppPlanningChatSessions();
+    const updateInAppPlanningSession = vi.fn();
+    const planningSessionStore: InAppPlanningSessionStore = {
+      upsertInAppPlanningSession: vi.fn(),
+      updateInAppPlanningSession,
+      deleteInAppPlanningSession: vi.fn(),
+    };
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const handlers = new Map<string, (...args: any[]) => Promise<any>>();
+    const ipcMain = {
+      handle: vi.fn((channel: string, callback: (...args: any[]) => Promise<any>) => {
+        handlers.set(channel, callback);
+      }),
+    };
+
+    const planningTerminalState = bindPlanningTerminalSessionState({
+      embeddedTerminalManager: mgr,
+      logger,
+      planningChatSessions,
+      getPlanningSessionStore: () => planningSessionStore,
+      repoRoot: '/repo',
+    });
+    registerPlanningTerminalSessionIpcHandlers({
+      ipcMain: ipcMain as any,
+      embeddedTerminalManager: mgr,
+      logger,
+      planningChatSessions,
+      getPlanningSessionStore: () => planningSessionStore,
+      repoRoot: '/repo',
+    });
+
+    return {
+      child,
+      handlers,
+      mgr,
+      planningChatSessions,
+      planningSessionStore,
+      restorePersistedPlanningTerminals: planningTerminalState.restorePersistedPlanningTerminals,
+      updateInAppPlanningSession,
+    };
+  }
+
+  it('planningTerminalOpen seeds bridge text into the planning terminal output snapshot', async () => {
+    const {
+      child,
+      handlers,
+      planningChatSessions,
+      updateInAppPlanningSession,
+    } = setupPlanningTerminal();
+    const planningSession = makePlanningSession();
+    planningChatSessions.set(planningSession.id, planningSession);
+
+    const result = await handlers.get('invoker:planning-terminal-open')?.({}, planningSession.id);
+
+    expect(result).toMatchObject({
+      opened: true,
+      session: expect.objectContaining({
+        kind: 'planning',
+        planningSessionId: planningSession.id,
+        outputSnapshot: expect.stringContaining(PLANNING_TERMINAL_SUMMARY_BRIDGE_START),
+      }),
+    });
+    expect(result.session.outputSnapshot).toContain('Planning session: Planning terminal bridge');
+    expect(result.session.outputSnapshot).toContain('Draft plan: Planning Terminal Restart (1 task) - Update README');
+    expect(planningChatSessions.get(planningSession.id)?.terminalOutputSnapshot).toBe(result.session.outputSnapshot);
+    expect(updateInAppPlanningSession).toHaveBeenCalledWith(
+      planningSession.id,
+      expect.objectContaining({
+        terminalMode: 'tmux',
+        terminalSessionId: result.session.sessionId,
+        terminalOutputSnapshot: result.session.outputSnapshot,
+      }),
+    );
+    expect(child.stdin.write).not.toHaveBeenCalled();
+  });
+
+  it('restores a tmux planning session with one bridge copy and previous output', () => {
+    const {
+      child,
+      mgr,
+      planningChatSessions,
+      restorePersistedPlanningTerminals,
+    } = setupPlanningTerminal();
+    const previousOutput = 'previous terminal output\n';
+    const planningSession = makePlanningSession('plan-restored', {
+      terminalMode: 'tmux',
+      terminalSessionId: 'term-planning-restored',
+      terminalStatus: 'running',
+      terminalOutputSnapshot: previousOutput,
+      terminalUpdatedAt: '2026-07-07T00:00:02.000Z',
+    });
+    planningChatSessions.set(planningSession.id, planningSession);
+
+    restorePersistedPlanningTerminals();
+    restorePersistedPlanningTerminals();
+
+    const restoredSnapshot = mgr.get('term-planning-restored')?.outputSnapshot ?? '';
+    expect(restoredSnapshot).toContain(PLANNING_TERMINAL_SUMMARY_BRIDGE_START);
+    expect(restoredSnapshot).toContain(previousOutput);
+    expect(countOccurrences(restoredSnapshot, PLANNING_TERMINAL_SUMMARY_BRIDGE_START)).toBe(1);
+    expect(planningChatSessions.get(planningSession.id)?.terminalOutputSnapshot).toBe(restoredSnapshot);
+    expect(child.stdin.write).not.toHaveBeenCalled();
+  });
+
+  it('does not duplicate a bridge that is already in the restored snapshot', () => {
+    const { mgr, planningChatSessions, restorePersistedPlanningTerminals } = setupPlanningTerminal();
+    const seedSession = makePlanningSession('plan-bridged', { title: 'Stale title' });
+    const alreadyBridgedSnapshot = `${buildPlanningTerminalSummaryBridge(seedSession)}previous terminal output\n`;
+    planningChatSessions.set(seedSession.id, {
+      ...seedSession,
+      title: 'Fresh title',
+      terminalMode: 'tmux',
+      terminalSessionId: 'term-planning-bridged',
+      terminalStatus: 'running',
+      terminalOutputSnapshot: alreadyBridgedSnapshot,
+      terminalUpdatedAt: '2026-07-07T00:00:02.000Z',
+    });
+
+    restorePersistedPlanningTerminals();
+
+    const restoredSnapshot = mgr.get('term-planning-bridged')?.outputSnapshot ?? '';
+    expect(restoredSnapshot).toContain('Planning session: Fresh title');
+    expect(restoredSnapshot).not.toContain('Planning session: Stale title');
+    expect(restoredSnapshot).toContain('previous terminal output\n');
+    expect(countOccurrences(restoredSnapshot, PLANNING_TERMINAL_SUMMARY_BRIDGE_START)).toBe(1);
   });
 });

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -102,6 +102,8 @@ export interface OpenSessionOptions {
   planningSessionId?: string;
   spec: TerminalSpec;
   cwd: string;
+  /** Initial display-only content to seed the terminal snapshot before process output. */
+  outputSnapshot?: string;
   /** When provided, the session attaches to the running executor rather than spawning a child. */
   attach?: AttachContext;
 }
@@ -318,7 +320,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
       createdAt,
       updatedAt: createdAt,
       status: 'running' as const,
-      outputSnapshot: '',
+      outputSnapshot: opts.outputSnapshot ?? '',
     };
 
     if (opts.attach) {

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -25,7 +25,7 @@ import type { Executor, ExecutorHandle, TerminalSpec } from '@invoker/execution-
 export type EmbeddedTerminalBackendName = 'bash' | 'pty';
 export type EmbeddedTerminalSessionKind = 'task' | 'planning';
 
-const MAX_OUTPUT_SNAPSHOT_CHARS = 64 * 1024;
+export const MAX_OUTPUT_SNAPSHOT_CHARS = 64 * 1024;
 
 export interface PtyForkOptionsLike {
   name: string;

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -180,6 +180,127 @@ function labelForPresetKey(key: string): string {
   }
 }
 
+export const PLANNING_TERMINAL_SUMMARY_BRIDGE_START = '=== Invoker planning tmux bridge ===';
+export const PLANNING_TERMINAL_SUMMARY_BRIDGE_END = '=== End Invoker planning tmux bridge ===';
+
+const PLANNING_TERMINAL_BRIDGE_TEXT_LIMIT = 220;
+const PLANNING_TERMINAL_BRIDGE_STEP_LIMIT = 3;
+
+function oneLine(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function truncatedLine(value: string, limit = PLANNING_TERMINAL_BRIDGE_TEXT_LIMIT): string {
+  const normalized = oneLine(value);
+  if (normalized.length <= limit) return normalized;
+  return `${normalized.slice(0, Math.max(0, limit - 3)).trimEnd()}...`;
+}
+
+function planningStatusLabel(status: InAppPlanningSessionStatus): string {
+  switch (status) {
+    case 'still_discussing':
+      return 'still discussing';
+    case 'waiting_for_answer':
+      return 'waiting for answer';
+    case 'draft_ready':
+      return 'draft ready';
+    case 'submitted':
+      return 'submitted';
+  }
+}
+
+function latestMessage(
+  session: InAppPlanningChatSession,
+  role: InAppPlanningChatLine['role'],
+): InAppPlanningChatLine | undefined {
+  for (let index = session.messages.length - 1; index >= 0; index -= 1) {
+    const message = session.messages[index];
+    if (message?.role === role) return message;
+  }
+  return undefined;
+}
+
+function draftSummaryLine(summary: InAppPlanningPlanSummary): string {
+  const workflowText = summary.workflowCount && summary.workflowCount > 1
+    ? `${summary.workflowCount} workflows, `
+    : '';
+  const taskText = `${summary.taskCount} ${summary.taskCount === 1 ? 'task' : 'tasks'}`;
+  const steps = summary.steps
+    .slice(0, PLANNING_TERMINAL_BRIDGE_STEP_LIMIT)
+    .map((step) => truncatedLine(step, 96))
+    .filter(Boolean)
+    .join('; ');
+  return steps
+    ? `${truncatedLine(summary.name, 96)} (${workflowText}${taskText}) - ${steps}`
+    : `${truncatedLine(summary.name, 96)} (${workflowText}${taskText})`;
+}
+
+function planningNextActionLine(session: InAppPlanningChatSession): string {
+  switch (session.status) {
+    case 'still_discussing':
+      return 'Next: Continue the planning chat to resolve the plan, or use this shell for repo inspection.';
+    case 'waiting_for_answer':
+      return 'Next: Answer the planner in chat, or inspect context here before replying.';
+    case 'draft_ready':
+      return 'Next: Review or submit the draft in chat; use this shell for manual context checks.';
+    case 'submitted':
+      return 'Next: Review the submitted workflow in Invoker; submitted planning sessions stay read-only.';
+  }
+}
+
+export function buildPlanningTerminalSummaryBridge(session: InAppPlanningChatSession): string {
+  const presetLabel = labelForPresetKey(session.presetKey);
+  const latestUser = latestMessage(session, 'user');
+  const latestAssistant = latestMessage(session, 'assistant');
+  const lines = [
+    PLANNING_TERMINAL_SUMMARY_BRIDGE_START,
+    `Planning session: ${truncatedLine(session.title, 96)}`,
+    `Status: ${planningStatusLabel(session.status)}`,
+    `Preset: ${presetLabel} (${session.presetKey})`,
+  ];
+
+  if (latestUser) {
+    lines.push(`Latest user: ${truncatedLine(latestUser.text)}`);
+  }
+  if (session.draftPlanSummary) {
+    lines.push(`Draft plan: ${draftSummaryLine(session.draftPlanSummary)}`);
+  } else if (latestAssistant) {
+    lines.push(`Latest assistant: ${truncatedLine(latestAssistant.text)}`);
+  }
+  if (session.submittedPlanName || session.submittedWorkflowId) {
+    const submittedName = session.submittedPlanName
+      ? truncatedLine(session.submittedPlanName, 96)
+      : 'unnamed plan';
+    const workflowText = session.submittedWorkflowId
+      ? ` (workflow ${session.submittedWorkflowId})`
+      : '';
+    lines.push(`Submitted plan: ${submittedName}${workflowText}`);
+  }
+
+  lines.push(planningNextActionLine(session), PLANNING_TERMINAL_SUMMARY_BRIDGE_END, '');
+  return `${lines.join('\n')}\n`;
+}
+
+export function ensurePlanningTerminalSummaryBridge(
+  session: InAppPlanningChatSession,
+  outputSnapshot: string | null | undefined,
+): string {
+  const snapshot = outputSnapshot ?? '';
+  const bridge = buildPlanningTerminalSummaryBridge(session);
+  const startIndex = snapshot.indexOf(PLANNING_TERMINAL_SUMMARY_BRIDGE_START);
+  if (startIndex === -1) {
+    return `${bridge}${snapshot}`;
+  }
+  const endIndex = snapshot.indexOf(PLANNING_TERMINAL_SUMMARY_BRIDGE_END, startIndex);
+  if (endIndex === -1) {
+    return snapshot;
+  }
+  const suffixStartIndex = endIndex + PLANNING_TERMINAL_SUMMARY_BRIDGE_END.length;
+  const prefix = snapshot.slice(0, startIndex);
+  const suffix = snapshot.slice(suffixStartIndex).replace(/^(?:\r?\n){1,2}/, '');
+  return `${prefix}${bridge}${suffix}`;
+}
+
 function titleFromMessage(message: string): string {
   const firstLine = message.split('\n', 1)[0]?.trim() ?? '';
   if (!firstLine) return 'Untitled plan';

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -187,7 +187,10 @@ const PLANNING_TERMINAL_BRIDGE_TEXT_LIMIT = 220;
 const PLANNING_TERMINAL_BRIDGE_STEP_LIMIT = 3;
 
 function oneLine(value: string): string {
-  return value.replace(/\s+/g, ' ').trim();
+  return value
+    .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 function truncatedLine(value: string, limit = PLANNING_TERMINAL_BRIDGE_TEXT_LIMIT): string {
@@ -284,21 +287,37 @@ export function buildPlanningTerminalSummaryBridge(session: InAppPlanningChatSes
 export function ensurePlanningTerminalSummaryBridge(
   session: InAppPlanningChatSession,
   outputSnapshot: string | null | undefined,
+  maxLength?: number,
 ): string {
   const snapshot = outputSnapshot ?? '';
   const bridge = buildPlanningTerminalSummaryBridge(session);
   const startIndex = snapshot.indexOf(PLANNING_TERMINAL_SUMMARY_BRIDGE_START);
+  let prefix = '';
+  let suffix: string;
   if (startIndex === -1) {
-    return `${bridge}${snapshot}`;
+    suffix = snapshot;
+  } else {
+    const endIndex = snapshot.indexOf(PLANNING_TERMINAL_SUMMARY_BRIDGE_END, startIndex);
+    if (endIndex === -1) {
+      return maxLength === undefined || snapshot.length <= maxLength
+        ? snapshot
+        : snapshot.slice(snapshot.length - maxLength);
+    }
+    const suffixStartIndex = endIndex + PLANNING_TERMINAL_SUMMARY_BRIDGE_END.length;
+    prefix = snapshot.slice(0, startIndex);
+    suffix = snapshot.slice(suffixStartIndex).replace(/^(?:\r?\n){1,2}/, '');
   }
-  const endIndex = snapshot.indexOf(PLANNING_TERMINAL_SUMMARY_BRIDGE_END, startIndex);
-  if (endIndex === -1) {
-    return snapshot;
+  if (maxLength === undefined) {
+    return `${prefix}${bridge}${suffix}`;
   }
-  const suffixStartIndex = endIndex + PLANNING_TERMINAL_SUMMARY_BRIDGE_END.length;
-  const prefix = snapshot.slice(0, startIndex);
-  const suffix = snapshot.slice(suffixStartIndex).replace(/^(?:\r?\n){1,2}/, '');
-  return `${prefix}${bridge}${suffix}`;
+  // Reserve room for the full bridge so a near-cap persisted snapshot can't push it
+  // out immediately; trim the older raw output instead of the freshly composed bridge.
+  const rest = `${prefix}${suffix}`;
+  const keepableRestLength = Math.max(0, maxLength - bridge.length);
+  const trimmedRest = rest.length <= keepableRestLength
+    ? rest
+    : rest.slice(rest.length - keepableRestLength);
+  return `${bridge}${trimmedRest}`;
 }
 
 function titleFromMessage(message: string): string {

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -1,6 +1,7 @@
 import type { IpcMain } from 'electron';
 import type { TerminalSessionDescriptor } from '@invoker/contracts';
 import type { SQLiteAdapter, TerminalSessionRecord } from '@invoker/data-store';
+import { MAX_OUTPUT_SNAPSHOT_CHARS } from './embedded-terminal-manager.js';
 import type { EmbeddedTerminalManager, TerminalSessionPersistenceRecord } from './embedded-terminal-manager.js';
 import {
   timeTerminalResize,
@@ -439,6 +440,7 @@ export function bindPlanningTerminalSessionState(deps: {
         const outputSnapshot = ensurePlanningTerminalSummaryBridge(
           session,
           session.terminalOutputSnapshot ?? '',
+          MAX_OUTPUT_SNAPSHOT_CHARS,
         );
         embeddedTerminalManager.restoreSpawnSession({
           sessionId: session.terminalSessionId,
@@ -507,6 +509,7 @@ export function registerPlanningTerminalSessionIpcHandlers(deps: {
       const outputSnapshot = ensurePlanningTerminalSummaryBridge(
         planningSession,
         planningSession.terminalOutputSnapshot ?? '',
+        MAX_OUTPUT_SNAPSHOT_CHARS,
       );
       const session = embeddedTerminalManager.openOrReuse({
         kind: 'planning',

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -11,6 +11,7 @@ import {
   type TerminalUiPerfSink,
 } from './terminal-ui-perf.js';
 import {
+  ensurePlanningTerminalSummaryBridge,
   updatePlanningChatTerminalState,
   type InAppPlanningChatSessions,
   type InAppPlanningSessionStore,
@@ -435,6 +436,10 @@ export function bindPlanningTerminalSessionState(deps: {
         continue;
       }
       try {
+        const outputSnapshot = ensurePlanningTerminalSummaryBridge(
+          session,
+          session.terminalOutputSnapshot ?? '',
+        );
         embeddedTerminalManager.restoreSpawnSession({
           sessionId: session.terminalSessionId,
           taskId: `planning:${session.id}`,
@@ -444,7 +449,7 @@ export function bindPlanningTerminalSessionState(deps: {
           spec: { cwd: repoRoot },
           cwd: repoRoot,
           createdAt: session.terminalUpdatedAt ?? session.updatedAt,
-          outputSnapshot: session.terminalOutputSnapshot ?? '',
+          outputSnapshot,
         });
       } catch (err) {
         logger.warn(
@@ -499,12 +504,17 @@ export function registerPlanningTerminalSessionIpcHandlers(deps: {
     }
     logger.info(`invoked for planningSession="${planningSessionId}"`, { module: 'planning-terminal' });
     try {
+      const outputSnapshot = ensurePlanningTerminalSummaryBridge(
+        planningSession,
+        planningSession.terminalOutputSnapshot ?? '',
+      );
       const session = embeddedTerminalManager.openOrReuse({
         kind: 'planning',
         taskId: `planning:${planningSessionId}`,
         planningSessionId,
         spec: { cwd: repoRoot },
         cwd: repoRoot,
+        outputSnapshot,
       });
       updatePlanningChatTerminalState(planningSessionId, {
         terminalMode: 'tmux',


### PR DESCRIPTION
## Summary

Planning tmux now starts with a bounded bridge that names the chat, state, harness, latest ask, draft plan, and next action.

Restored planning tmux sessions reuse the persisted bridge before shell output, so returning users get context without replaying full prompts.

## Review Claim

In-app tmux mode shows a persisted planning summary bridge when a planning terminal is opened or restored.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The bridge is derived only from existing planning session metadata and bounded chat summaries. It does not rewrite planner history, submit plans, or send shell input.

## Slice Rationale

Planning tmux is the named surface for this step, and it can reuse the Step 1 bridge primitive without changing task execution.

## Non-goals

- Do not launch Codex or OMP automatically from planning tmux.
- Do not submit draft plans.
- Do not change Slack planner behavior.
- Do not change chat-mode planning behavior.

## Architecture

### Before

Planning sessions persisted terminal mode, terminal session id, status, and output snapshots. Opening tmux could restore a raw shell without handoff context.

### After

Planning session restore composes a bounded display-only bridge from saved planning metadata and persists that text with the terminal snapshot.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts src/__tests__/terminal-session-persistence.test.ts`
- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app test:e2e -- planning-terminal-restart-persistence.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run the focused app Vitest and planning terminal restart e2e commands.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Planning terminals now inject a concise “planning terminal summary” into terminal output (status, preset, draft plan, and next action).
  * This summary is persisted and restored across terminal reopen and relaunch flows.
* **Bug Fixes**
  * Prevents duplicate summaries when a restored snapshot already contains the summary.
  * Ensures restored output snapshots remain within size limits while keeping the correct summary.
* **Tests**
  * Expanded end-to-end and unit coverage for summary injection, sanitization, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->