### PR TITLE
[Guided CLI Setup](1) Add atomic Invoker config writer

### DIFF
--- a/packages/contracts/src/__tests__/invoker-config-io.test.ts
+++ b/packages/contracts/src/__tests__/invoker-config-io.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  INVOKER_CONFIG_FILE_MODE,
+  invokerConfigBackupPath,
+  readInvokerConfigFile,
+  updateInvokerConfigFile,
+  writeInvokerConfigFile,
+} from '../invoker-config-io.js';
+
+const tempRoots: string[] = [];
+
+function makeConfigPath(): string {
+  const root = mkdtempSync(join(tmpdir(), 'invoker-config-io-'));
+  tempRoots.push(root);
+  return join(root, 'config.json');
+}
+
+afterEach(() => {
+  while (tempRoots.length > 0) {
+    rmSync(tempRoots.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe('Invoker config file IO', () => {
+  it('treats a missing config file as an empty object', () => {
+    expect(readInvokerConfigFile(makeConfigPath())).toEqual({});
+  });
+
+  it('creates parent directories when writing', () => {
+    const configPath = join(mkdtempSync(join(tmpdir(), 'invoker-config-io-')), 'nested', 'config.json');
+    tempRoots.push(join(configPath, '..', '..'));
+    writeInvokerConfigFile(configPath, { maxConcurrency: 4 });
+    expect(readInvokerConfigFile(configPath)).toEqual({ maxConcurrency: 4 });
+  });
+
+  it('preserves keys it does not recognize', () => {
+    const configPath = makeConfigPath();
+    writeFileSync(configPath, JSON.stringify({ futureKey: { nested: true }, experimentalPlanner: false }));
+
+    updateInvokerConfigFile(configPath, (config) => {
+      config.experimentalPlanner = true;
+    });
+
+    expect(readInvokerConfigFile(configPath)).toEqual({
+      futureKey: { nested: true },
+      experimentalPlanner: true,
+    });
+  });
+
+  it('writes the config file with owner-only permissions', () => {
+    const configPath = makeConfigPath();
+    writeInvokerConfigFile(configPath, { webToken: 'secret' });
+    expect(statSync(configPath).mode & 0o777).toBe(INVOKER_CONFIG_FILE_MODE);
+  });
+
+  it('tightens permissions on a config file that was previously world-readable', () => {
+    const configPath = makeConfigPath();
+    writeFileSync(configPath, JSON.stringify({ webToken: 'secret' }));
+    chmodSync(configPath, 0o644);
+
+    updateInvokerConfigFile(configPath, (config) => {
+      config.webPort = 4200;
+    });
+
+    expect(statSync(configPath).mode & 0o777).toBe(INVOKER_CONFIG_FILE_MODE);
+  });
+
+  it('backs up the previous config and keeps the backup owner-only', () => {
+    const configPath = makeConfigPath();
+    writeFileSync(configPath, JSON.stringify({ webToken: 'original' }));
+    chmodSync(configPath, 0o644);
+
+    updateInvokerConfigFile(configPath, (config) => {
+      config.webToken = 'rotated';
+    });
+
+    const backupPath = invokerConfigBackupPath(configPath);
+    expect(JSON.parse(readFileSync(backupPath, 'utf8'))).toEqual({ webToken: 'original' });
+    expect(statSync(backupPath).mode & 0o777).toBe(INVOKER_CONFIG_FILE_MODE);
+  });
+
+  it('does not write a backup on first creation', () => {
+    const configPath = makeConfigPath();
+    writeInvokerConfigFile(configPath, { maxConcurrency: 2 });
+    expect(existsSync(invokerConfigBackupPath(configPath))).toBe(false);
+  });
+
+  it('leaves the existing config intact when serialization fails', () => {
+    const configPath = makeConfigPath();
+    writeFileSync(configPath, JSON.stringify({ maxConcurrency: 2 }));
+
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(() => writeInvokerConfigFile(configPath, circular)).toThrow();
+    expect(readInvokerConfigFile(configPath)).toEqual({ maxConcurrency: 2 });
+  });
+
+  it('does not leave temporary files behind after a failed write', () => {
+    const configPath = makeConfigPath();
+    writeFileSync(configPath, JSON.stringify({ maxConcurrency: 2 }));
+
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => writeInvokerConfigFile(configPath, circular)).toThrow();
+
+    const siblings = readdirSync(join(configPath, '..'));
+    expect(siblings.filter((entry) => entry.endsWith('.config.tmp'))).toEqual([]);
+  });
+
+  it('rejects a config file that is not a JSON object', () => {
+    const configPath = makeConfigPath();
+    writeFileSync(configPath, JSON.stringify([1, 2, 3]));
+    expect(() => readInvokerConfigFile(configPath)).toThrow(/expected a JSON object/);
+  });
+
+  it('reports the path when the config file is malformed JSON', () => {
+    const configPath = makeConfigPath();
+    writeFileSync(configPath, '{ not json');
+    expect(() => readInvokerConfigFile(configPath)).toThrow(new RegExp(configPath.replace(/[/\\]/g, '.')));
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9,5 +9,6 @@ export * from './repo-root.ts';
 export * from './cost-types.ts';
 export * from './launch-timeouts.ts';
 export * from './invoker-home.ts';
+export * from './invoker-config-io.ts';
 export * from './prerequisites.ts';
 export { EXTERNAL_DEPENDENCIES, DEFAULT_DRAFTER_MCP_PACKAGE_SPEC } from './external-dependencies.ts';

--- a/packages/contracts/src/invoker-config-io.ts
+++ b/packages/contracts/src/invoker-config-io.ts
@@ -1,0 +1,69 @@
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export type InvokerConfigRecord = Record<string, unknown>;
+
+export const INVOKER_CONFIG_FILE_MODE = 0o600;
+
+let tempCounter = 0;
+
+function isJsonRecord(value: unknown): value is InvokerConfigRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function readInvokerConfigFile(configPath: string): InvokerConfigRecord {
+  if (!existsSync(configPath)) return {};
+
+  const raw = readFileSync(configPath, 'utf8');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid Invoker config JSON at ${configPath}: ${message}`);
+  }
+
+  if (!isJsonRecord(parsed)) {
+    throw new Error(`Invalid Invoker config at ${configPath}: expected a JSON object`);
+  }
+
+  return parsed;
+}
+
+export function invokerConfigBackupPath(configPath: string): string {
+  return `${configPath}.bak`;
+}
+
+function nextTempPath(configPath: string): string {
+  tempCounter += 1;
+  return join(dirname(configPath), `.${process.pid}-${tempCounter}.config.tmp`);
+}
+
+export function writeInvokerConfigFile(configPath: string, config: InvokerConfigRecord): string {
+  mkdirSync(dirname(configPath), { recursive: true });
+
+  const tempPath = nextTempPath(configPath);
+  try {
+    writeFileSync(tempPath, `${JSON.stringify(config, null, 2)}\n`, { mode: INVOKER_CONFIG_FILE_MODE });
+    chmodSync(tempPath, INVOKER_CONFIG_FILE_MODE);
+    if (existsSync(configPath)) {
+      const backupPath = invokerConfigBackupPath(configPath);
+      copyFileSync(configPath, backupPath);
+      chmodSync(backupPath, INVOKER_CONFIG_FILE_MODE);
+    }
+    renameSync(tempPath, configPath);
+  } finally {
+    rmSync(tempPath, { force: true });
+  }
+
+  return configPath;
+}
+
+export function updateInvokerConfigFile(
+  configPath: string,
+  mutate: (config: InvokerConfigRecord) => void,
+): string {
+  const config = readInvokerConfigFile(configPath);
+  mutate(config);
+  return writeInvokerConfigFile(configPath, config);
+}


### PR DESCRIPTION
## Summary

Invoker has no general writer for `config.json`. Searching every package for a save or persist helper turns up nothing.

The single production write flips one boolean with a bare `writeFileSync`. A crash or a full disk part way through truncates the file.

The next read then throws `Invalid Invoker config JSON`. That is a hard startup failure rather than a graceful degrade.

That same file can hold `webToken` and `imageStorage.secretAccessKey`, yet it is written at default umask. The neighbouring `mcp.json` gets `0600`.

This adds the writer those gaps call for, placed in `@invoker/contracts` because both the app and the terminal tool already depend on it.

A write lands in a sibling temp file, gets `0600`, copies the previous file to a backup, then renames over the target.

Nothing calls it yet.

## Review Claim

`writeInvokerConfigFile` never leaves `config.json` truncated, world-readable, or stripped of keys it did not recognise.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The new module has no callers in this slice, so it cannot alter existing behavior. It only adds exports.

`renameSync` over a same-directory temp file is atomic on POSIX, so a concurrent reader sees either the whole old file or the whole new one.

The backup is written before the rename, so a failure after the copy still leaves a readable config in place.

## Slice Rationale

The writer is kept apart from its first caller so its atomicity, permission, and backup behavior can be judged against the tests alone.

Pointing the planner flag at it is a claim about an existing code path, so that lands next.

## Non-goals

Does not change any existing write path. Does not validate config contents. Does not touch `loadConfig`, `readJsonSafe`, or `validateInvokerConfig`.

Does not add a config-write IPC channel. Does not reconcile the three divergent config-path resolvers.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/contracts && pnpm test`
- [ ] `pnpm run check:types`
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. The module has no callers in this slice.
- Data migration? No

</details>
