### PR TITLE
[Guided CLI Setup](2) Write the planner flag through the atomic writer

### DIFF
--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -16,6 +16,7 @@ import {
   REQUIRED_BOT_SCOPES,
   slackCredsFromEnv,
   runSetup,
+  setExperimentalPlannerFlag,
   upsertEnvLines,
   validateSlackCredentials,
   type CliConfigState,
@@ -365,3 +366,53 @@ function restoreEnv(key: string, value: string | undefined): void {
   if (value === undefined) delete process.env[key];
   else process.env[key] = value;
 }
+
+describe('setExperimentalPlannerFlag', () => {
+  function makeConfigPath(): string {
+    return join(mkdtempSync(join(tmpdir(), 'invoker-planner-flag-')), 'config.json');
+  }
+
+  it('preserves unrelated config keys when toggling the flag', () => {
+    const configPath = makeConfigPath();
+    writeFileSync(configPath, JSON.stringify({ maxConcurrency: 9, futureKey: { nested: true } }));
+
+    setExperimentalPlannerFlag(true, configPath);
+
+    expect(JSON.parse(readFileSync(configPath, 'utf8'))).toEqual({
+      maxConcurrency: 9,
+      futureKey: { nested: true },
+      experimentalPlanner: true,
+    });
+  });
+
+  it('writes the config with owner-only permissions', () => {
+    const configPath = makeConfigPath();
+    setExperimentalPlannerFlag(true, configPath);
+    expect(statSync(configPath).mode & 0o777).toBe(0o600);
+  });
+
+  it('tightens permissions on a previously world-readable config', () => {
+    const configPath = makeConfigPath();
+    writeFileSync(configPath, JSON.stringify({ webToken: 'secret' }));
+    chmodSync(configPath, 0o644);
+
+    setExperimentalPlannerFlag(false, configPath);
+
+    expect(statSync(configPath).mode & 0o777).toBe(0o600);
+  });
+
+  it('backs up the previous config before overwriting it', () => {
+    const configPath = makeConfigPath();
+    writeFileSync(configPath, JSON.stringify({ experimentalPlanner: false }));
+
+    setExperimentalPlannerFlag(true, configPath);
+
+    expect(JSON.parse(readFileSync(`${configPath}.bak`, 'utf8'))).toEqual({ experimentalPlanner: false });
+  });
+
+  it('creates the config directory when it does not exist', () => {
+    const configPath = join(mkdtempSync(join(tmpdir(), 'invoker-planner-flag-')), 'nested', 'config.json');
+    setExperimentalPlannerFlag(true, configPath);
+    expect(JSON.parse(readFileSync(configPath, 'utf8'))).toEqual({ experimentalPlanner: true });
+  });
+});

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -13,6 +13,7 @@ import {
   type IsInstalled,
   type PlanningPresetSpec,
   type PrerequisiteCheck,
+  updateInvokerConfigFile,
 } from '@invoker/contracts';
 import { formatCaughtException, logCaughtException } from './logging.js';
 
@@ -166,11 +167,9 @@ export interface ExperimentalPlannerSetupState {
 }
 
 export function setExperimentalPlannerFlag(enabled: boolean, configPath: string = defaultConfigPath()): string {
-  const config = readMutableJson(configPath, {});
-  config.experimentalPlanner = enabled;
-  mkdirSync(dirname(configPath), { recursive: true });
-  writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
-  return configPath;
+  return updateInvokerConfigFile(configPath, (config) => {
+    config.experimentalPlanner = enabled;
+  });
 }
 
 export function readExperimentalPlannerSetup(options: ExperimentalPlannerSetupOptions = {}): ExperimentalPlannerSetupState {


### PR DESCRIPTION
## Summary

`setExperimentalPlannerFlag` was the only production config write in the repo. It rewrote `config.json` in place with no backup and no file mode.

This points it at the writer added in slice 1.

Toggling the planner flag now writes through a temp file, keeps a backup of the previous config, and leaves the result owner-only.

A config that was already world-readable gets tightened on the next write, which matters because the same file can carry a web token.

## Review Claim

Toggling the planner flag through `invoker-cli` can no longer truncate `config.json` or leave it readable by other users on the machine.

## Review Lane

behavior

## Review Unit

activation-surface

## Slice Rationale

Slice 1 added the writer with no callers. This is the first caller, and it is the one existing code path whose behavior actually changes.

Keeping them apart lets a reviewer confirm the writer's properties first, then confirm this command adopts them.

## Safety Invariant

The function keeps its exact signature and return value, so every caller is unaffected.

`updateInvokerConfigFile` reads through an untyped record and mutates one key, so unrecognized config keys round-trip unchanged, matching the previous `readMutableJson` behavior.

## Non-goals

Does not change what the planner flag means or when it is set. Does not touch the sibling `mcp.json` write, which already sets its own mode.

Does not alter the guided setup flow or any prompt.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/cli && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the previous in-place write.
- Data migration? No

</details>
