### PR TITLE
[Guided CLI Setup](3) Add non-throwing Invoker config diagnostics

### DIFF
--- a/packages/contracts/src/__tests__/config-diagnostics.test.ts
+++ b/packages/contracts/src/__tests__/config-diagnostics.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectInvokerConfigDiagnostics,
+  hasBlockingConfigDiagnostic,
+  type ConfigDiagnostic,
+} from '../config-diagnostics.js';
+
+function errorPaths(config: unknown): string[] {
+  return collectInvokerConfigDiagnostics(config)
+    .filter((diagnostic) => diagnostic.severity === 'error')
+    .map((diagnostic) => diagnostic.path);
+}
+
+function warnings(config: unknown): ConfigDiagnostic[] {
+  return collectInvokerConfigDiagnostics(config).filter((diagnostic) => diagnostic.severity === 'warning');
+}
+
+const sshTarget = { host: 'build-1', user: 'ci', sshKeyPath: '/home/ci/.ssh/id_ed25519' };
+
+describe('collectInvokerConfigDiagnostics', () => {
+  it('accepts an empty config', () => {
+    expect(collectInvokerConfigDiagnostics({})).toEqual([]);
+  });
+
+  it('rejects a config that is not an object', () => {
+    expect(hasBlockingConfigDiagnostic(collectInvokerConfigDiagnostics([]))).toBe(true);
+  });
+
+  describe('remoteTargets', () => {
+    it('requires host, user, and sshKeyPath', () => {
+      expect(errorPaths({ remoteTargets: { box: {} } })).toEqual([
+        'remoteTargets.box.host',
+        'remoteTargets.box.user',
+        'remoteTargets.box.sshKeyPath',
+      ]);
+    });
+
+    it('rejects a port outside the valid range', () => {
+      expect(errorPaths({ remoteTargets: { box: { ...sshTarget, port: 70000 } } })).toEqual([
+        'remoteTargets.box.port',
+      ]);
+    });
+
+    it('rejects a non-positive maxConcurrentTasks instead of silently defaulting it', () => {
+      expect(errorPaths({ remoteTargets: { box: { ...sshTarget, maxConcurrentTasks: 0 } } })).toEqual([
+        'remoteTargets.box.maxConcurrentTasks',
+      ]);
+    });
+
+    it('rejects a capacity supplied as a string', () => {
+      expect(errorPaths({ remoteTargets: { box: { ...sshTarget, maxConcurrentTasks: '4' } } })).toEqual([
+        'remoteTargets.box.maxConcurrentTasks',
+      ]);
+    });
+
+    it('accepts a fully specified target', () => {
+      expect(collectInvokerConfigDiagnostics({ remoteTargets: { box: { ...sshTarget, port: 22 } } })).toEqual([]);
+    });
+  });
+
+  describe('executionPools', () => {
+    it('rejects an empty member list', () => {
+      expect(errorPaths({ executionPools: { fast: { members: [] } } })).toEqual(['executionPools.fast.members']);
+    });
+
+    it('rejects an unknown member type', () => {
+      expect(errorPaths({ executionPools: { fast: { members: [{ type: 'vm', id: 'a' }] } } })).toEqual([
+        'executionPools.fast.members[0].type',
+      ]);
+    });
+
+    it('rejects an ssh member with no matching remote target', () => {
+      expect(errorPaths({ executionPools: { fast: { members: [{ type: 'ssh', id: 'ghost' }] } } })).toEqual([
+        'executionPools.fast.members[0].id',
+      ]);
+    });
+
+    it('accepts an ssh member backed by a declared remote target', () => {
+      expect(collectInvokerConfigDiagnostics({
+        remoteTargets: { box: sshTarget },
+        executionPools: { fast: { members: [{ type: 'ssh', id: 'box' }] } },
+      })).toEqual([]);
+    });
+
+    it('rejects a member duplicated inside one pool', () => {
+      expect(errorPaths({
+        executionPools: { fast: { members: [{ type: 'worktree', id: 'local' }, { type: 'worktree', id: 'local' }] } },
+      })).toEqual(['executionPools.fast.members[1]']);
+    });
+
+    it('warns when one member is shared across pools, because capacity is de-duplicated', () => {
+      const shared = warnings({
+        executionPools: {
+          fast: { members: [{ type: 'worktree', id: 'local' }] },
+          slow: { members: [{ type: 'worktree', id: 'local' }] },
+        },
+      });
+      expect(shared).toHaveLength(1);
+      expect(shared[0].message).toContain('multiple pools');
+    });
+
+    it('rejects an unknown selection strategy', () => {
+      expect(errorPaths({
+        executionPools: { fast: { members: [{ type: 'worktree', id: 'local' }], selectionStrategy: 'random' } },
+      })).toEqual(['executionPools.fast.selectionStrategy']);
+    });
+  });
+
+  describe('defaultPoolId', () => {
+    it('rejects a default pool id when no pools are configured', () => {
+      expect(errorPaths({ defaultPoolId: 'fast' })).toEqual(['defaultPoolId']);
+    });
+
+    it('rejects a default pool id that does not match a configured pool', () => {
+      expect(errorPaths({
+        executionPools: { fast: { members: [{ type: 'worktree', id: 'local' }] } },
+        defaultPoolId: 'slow',
+      })).toEqual(['defaultPoolId']);
+    });
+
+    it('accepts a default pool id that matches a configured pool', () => {
+      expect(collectInvokerConfigDiagnostics({
+        executionPools: { fast: { members: [{ type: 'worktree', id: 'local' }] } },
+        defaultPoolId: 'fast',
+      })).toEqual([]);
+    });
+  });
+
+  describe('executorRoutingRules', () => {
+    const pools = { fast: { members: [{ type: 'worktree', id: 'local' }] } };
+
+    it('rejects an uncompilable regex at config time', () => {
+      expect(errorPaths({
+        executionPools: pools,
+        executorRoutingRules: [{ regex: '([unclosed', poolId: 'fast' }],
+      })).toEqual(['executorRoutingRules[0].regex']);
+    });
+
+    it('rejects a rule that defines neither pattern nor regex', () => {
+      expect(errorPaths({ executionPools: pools, executorRoutingRules: [{ poolId: 'fast' }] })).toEqual([
+        'executorRoutingRules[0]',
+      ]);
+    });
+
+    it('rejects a rule pointing at an unknown pool', () => {
+      expect(errorPaths({
+        executionPools: pools,
+        executorRoutingRules: [{ pattern: 'build', poolId: 'ghost' }],
+      })).toEqual(['executorRoutingRules[0].poolId']);
+    });
+
+    it('rejects an unknown routing strategy', () => {
+      expect(errorPaths({
+        executionPools: pools,
+        executorRoutingRules: [{ pattern: 'build', poolId: 'fast', strategy: 'prefer' }],
+      })).toEqual(['executorRoutingRules[0].strategy']);
+    });
+
+    it('accepts a well-formed rule', () => {
+      expect(collectInvokerConfigDiagnostics({
+        executionPools: pools,
+        executorRoutingRules: [{ regex: '^pnpm ', poolId: 'fast', strategy: 'route' }],
+      })).toEqual([]);
+    });
+  });
+
+  describe('heavyweightCommandRouting', () => {
+    const pools = { fast: { members: [{ type: 'worktree', id: 'local' }] } };
+
+    it('rejects a missing poolId', () => {
+      expect(errorPaths({ executionPools: pools, heavyweightCommandRouting: { enabled: true } })).toEqual([
+        'heavyweightCommandRouting.poolId',
+      ]);
+    });
+
+    it('rejects a poolId that is not configured', () => {
+      expect(errorPaths({ executionPools: pools, heavyweightCommandRouting: { poolId: 'ghost' } })).toEqual([
+        'heavyweightCommandRouting.poolId',
+      ]);
+    });
+
+    it('rejects an uncompilable matcher regex', () => {
+      expect(errorPaths({
+        executionPools: pools,
+        heavyweightCommandRouting: { poolId: 'fast', matchers: [{ regex: '([unclosed' }] },
+      })).toEqual(['heavyweightCommandRouting.matchers[0].regex']);
+    });
+  });
+
+  it('rejects a non-positive maxConcurrency', () => {
+    expect(errorPaths({ maxConcurrency: 0 })).toEqual(['maxConcurrency']);
+  });
+
+  it('reports every problem in one pass rather than stopping at the first', () => {
+    const diagnostics = collectInvokerConfigDiagnostics({
+      maxConcurrency: -1,
+      remoteTargets: { box: { host: 'h' } },
+      defaultPoolId: 'missing',
+    });
+    expect(diagnostics.filter((entry) => entry.severity === 'error').length).toBeGreaterThan(3);
+  });
+});

--- a/packages/contracts/src/config-diagnostics.ts
+++ b/packages/contracts/src/config-diagnostics.ts
@@ -1,0 +1,273 @@
+export type ConfigDiagnosticSeverity = 'error' | 'warning';
+
+export interface ConfigDiagnostic {
+  severity: ConfigDiagnosticSeverity;
+  path: string;
+  message: string;
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+const POOL_MEMBER_TYPES = new Set(['ssh', 'worktree']);
+const SELECTION_STRATEGIES = new Set(['roundRobin', 'leastLoaded']);
+const ROUTING_STRATEGIES = new Set(['enforce', 'route']);
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isPositiveInteger(value: unknown): boolean {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}
+
+class DiagnosticCollector {
+  readonly diagnostics: ConfigDiagnostic[] = [];
+
+  error(path: string, message: string): void {
+    this.diagnostics.push({ severity: 'error', path, message });
+  }
+
+  warning(path: string, message: string): void {
+    this.diagnostics.push({ severity: 'warning', path, message });
+  }
+}
+
+function checkRequiredString(collector: DiagnosticCollector, path: string, value: unknown): void {
+  if (!isNonEmptyString(value)) {
+    collector.error(path, `${path} must be a non-empty string`);
+  }
+}
+
+function checkOptionalPositiveInteger(collector: DiagnosticCollector, path: string, value: unknown): void {
+  if (value === undefined) return;
+  if (!isPositiveInteger(value)) {
+    collector.error(path, `${path} must be a positive integer, received ${JSON.stringify(value)}`);
+  }
+}
+
+function checkRegex(collector: DiagnosticCollector, path: string, value: unknown): void {
+  if (value === undefined) return;
+  if (typeof value !== 'string') {
+    collector.error(path, `${path} must be a string`);
+    return;
+  }
+  try {
+    new RegExp(value);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    collector.error(path, `${path} is not a valid regular expression: ${message}`);
+  }
+}
+
+function collectRemoteTargetIds(collector: DiagnosticCollector, config: UnknownRecord): Set<string> {
+  const ids = new Set<string>();
+  const remoteTargets = config.remoteTargets;
+  if (remoteTargets === undefined) return ids;
+  if (!isRecord(remoteTargets)) {
+    collector.error('remoteTargets', 'remoteTargets must be an object keyed by target id');
+    return ids;
+  }
+
+  for (const [id, target] of Object.entries(remoteTargets)) {
+    ids.add(id);
+    const base = `remoteTargets.${id}`;
+    if (!isRecord(target)) {
+      collector.error(base, `${base} must be an object`);
+      continue;
+    }
+    checkRequiredString(collector, `${base}.host`, target.host);
+    checkRequiredString(collector, `${base}.user`, target.user);
+    checkRequiredString(collector, `${base}.sshKeyPath`, target.sshKeyPath);
+    checkOptionalPositiveInteger(collector, `${base}.maxConcurrentTasks`, target.maxConcurrentTasks);
+    checkOptionalPositiveInteger(collector, `${base}.remoteHeartbeatIntervalSeconds`, target.remoteHeartbeatIntervalSeconds);
+
+    if (target.port !== undefined && (!isPositiveInteger(target.port) || (target.port as number) > 65535)) {
+      collector.error(`${base}.port`, `${base}.port must be an integer between 1 and 65535`);
+    }
+  }
+
+  return ids;
+}
+
+function collectExecutionPoolIds(
+  collector: DiagnosticCollector,
+  config: UnknownRecord,
+  remoteTargetIds: Set<string>,
+): Set<string> {
+  const poolIds = new Set<string>();
+  const executionPools = config.executionPools;
+  if (executionPools === undefined) return poolIds;
+  if (!isRecord(executionPools)) {
+    collector.error('executionPools', 'executionPools must be an object keyed by pool id');
+    return poolIds;
+  }
+
+  const memberOwners = new Map<string, string[]>();
+
+  for (const [poolId, pool] of Object.entries(executionPools)) {
+    poolIds.add(poolId);
+    const base = `executionPools.${poolId}`;
+    if (!isRecord(pool)) {
+      collector.error(base, `${base} must be an object`);
+      continue;
+    }
+
+    checkOptionalPositiveInteger(collector, `${base}.maxConcurrentTasksPerMember`, pool.maxConcurrentTasksPerMember);
+    if (pool.selectionStrategy !== undefined && !SELECTION_STRATEGIES.has(pool.selectionStrategy as string)) {
+      collector.error(
+        `${base}.selectionStrategy`,
+        `${base}.selectionStrategy must be one of ${[...SELECTION_STRATEGIES].join(', ')}`,
+      );
+    }
+
+    const members = pool.members;
+    if (!Array.isArray(members)) {
+      collector.error(`${base}.members`, `${base}.members must be an array`);
+      continue;
+    }
+    if (members.length === 0) {
+      collector.error(`${base}.members`, `${base}.members must list at least one member`);
+      continue;
+    }
+
+    const seenInPool = new Set<string>();
+    members.forEach((member, index) => {
+      const memberPath = `${base}.members[${index}]`;
+      if (!isRecord(member)) {
+        collector.error(memberPath, `${memberPath} must be an object`);
+        return;
+      }
+
+      const type = member.type;
+      const id = member.id;
+      if (!POOL_MEMBER_TYPES.has(type as string)) {
+        collector.error(`${memberPath}.type`, `${memberPath}.type must be one of ${[...POOL_MEMBER_TYPES].join(', ')}`);
+      }
+      checkRequiredString(collector, `${memberPath}.id`, id);
+      checkOptionalPositiveInteger(collector, `${memberPath}.maxConcurrentTasks`, member.maxConcurrentTasks);
+
+      if (type === 'ssh' && isNonEmptyString(id) && !remoteTargetIds.has(id)) {
+        collector.error(`${memberPath}.id`, `${memberPath}.id "${id}" has no matching entry in remoteTargets`);
+      }
+
+      if (!isNonEmptyString(id) || typeof type !== 'string') return;
+      const key = `${type}:${id}`;
+      if (seenInPool.has(key)) {
+        collector.error(memberPath, `${memberPath} duplicates member ${key} already listed in ${base}`);
+        return;
+      }
+      seenInPool.add(key);
+      memberOwners.set(key, [...(memberOwners.get(key) ?? []), poolId]);
+    });
+  }
+
+  for (const [key, owners] of memberOwners) {
+    if (owners.length > 1) {
+      collector.warning(
+        'executionPools',
+        `member ${key} appears in multiple pools (${owners.join(', ')}); capacity is de-duplicated to the highest declared value`,
+      );
+    }
+  }
+
+  return poolIds;
+}
+
+function checkPoolReference(
+  collector: DiagnosticCollector,
+  path: string,
+  poolId: unknown,
+  poolIds: Set<string>,
+): void {
+  if (!isNonEmptyString(poolId)) {
+    collector.error(path, `${path} must be a non-empty string`);
+    return;
+  }
+  if (!poolIds.has(poolId)) {
+    collector.error(path, `${path} "${poolId}" is not a configured execution pool`);
+  }
+}
+
+function checkRoutingRules(collector: DiagnosticCollector, config: UnknownRecord, poolIds: Set<string>): void {
+  const rules = config.executorRoutingRules;
+  if (rules === undefined) return;
+  if (!Array.isArray(rules)) {
+    collector.error('executorRoutingRules', 'executorRoutingRules must be an array');
+    return;
+  }
+
+  rules.forEach((rule, index) => {
+    const base = `executorRoutingRules[${index}]`;
+    if (!isRecord(rule)) {
+      collector.error(base, `${base} must be an object`);
+      return;
+    }
+    if (rule.pattern === undefined && rule.regex === undefined) {
+      collector.error(base, `${base} must define either pattern or regex, otherwise it can never match`);
+    }
+    checkRegex(collector, `${base}.regex`, rule.regex);
+    checkPoolReference(collector, `${base}.poolId`, rule.poolId, poolIds);
+    if (rule.strategy !== undefined && !ROUTING_STRATEGIES.has(rule.strategy as string)) {
+      collector.error(`${base}.strategy`, `${base}.strategy must be one of ${[...ROUTING_STRATEGIES].join(', ')}`);
+    }
+  });
+}
+
+function checkHeavyweightRouting(collector: DiagnosticCollector, config: UnknownRecord, poolIds: Set<string>): void {
+  const routing = config.heavyweightCommandRouting;
+  if (routing === undefined) return;
+  if (!isRecord(routing)) {
+    collector.error('heavyweightCommandRouting', 'heavyweightCommandRouting must be an object');
+    return;
+  }
+
+  checkPoolReference(collector, 'heavyweightCommandRouting.poolId', routing.poolId, poolIds);
+
+  const matchers = routing.matchers;
+  if (matchers === undefined) return;
+  if (!Array.isArray(matchers)) {
+    collector.error('heavyweightCommandRouting.matchers', 'heavyweightCommandRouting.matchers must be an array');
+    return;
+  }
+  matchers.forEach((matcher, index) => {
+    const base = `heavyweightCommandRouting.matchers[${index}]`;
+    if (!isRecord(matcher)) {
+      collector.error(base, `${base} must be an object`);
+      return;
+    }
+    if (matcher.pattern === undefined && matcher.regex === undefined) {
+      collector.error(base, `${base} must define either pattern or regex, otherwise it can never match`);
+    }
+    checkRegex(collector, `${base}.regex`, matcher.regex);
+  });
+}
+
+export function collectInvokerConfigDiagnostics(config: unknown): ConfigDiagnostic[] {
+  const collector = new DiagnosticCollector();
+  if (!isRecord(config)) {
+    collector.error('', 'Invoker config must be a JSON object');
+    return collector.diagnostics;
+  }
+
+  checkOptionalPositiveInteger(collector, 'maxConcurrency', config.maxConcurrency);
+
+  const remoteTargetIds = collectRemoteTargetIds(collector, config);
+  const poolIds = collectExecutionPoolIds(collector, config, remoteTargetIds);
+
+  if (config.defaultPoolId !== undefined) {
+    checkPoolReference(collector, 'defaultPoolId', config.defaultPoolId, poolIds);
+  }
+
+  checkRoutingRules(collector, config, poolIds);
+  checkHeavyweightRouting(collector, config, poolIds);
+
+  return collector.diagnostics;
+}
+
+export function hasBlockingConfigDiagnostic(diagnostics: readonly ConfigDiagnostic[]): boolean {
+  return diagnostics.some((diagnostic) => diagnostic.severity === 'error');
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -10,5 +10,6 @@ export * from './cost-types.ts';
 export * from './launch-timeouts.ts';
 export * from './invoker-home.ts';
 export * from './invoker-config-io.ts';
+export * from './config-diagnostics.ts';
 export * from './prerequisites.ts';
 export { EXTERNAL_DEPENDENCIES, DEFAULT_DRAFTER_MCP_PACKAGE_SPEC } from './external-dependencies.ts';


### PR DESCRIPTION
## Summary

`validateInvokerConfig` covers only the default agent and model pairing. Everything else about a config is enforced far later, when a plan reaches the runner or a task launches.

So a typo in an execution pool surfaces as a failed task minutes or hours after the edit, far from the change that caused it.

This adds `collectInvokerConfigDiagnostics`, which reports problems in remote targets, execution pools, pool members with no matching target, routing expressions that cannot compile, and capacities that today quietly coerce to 1.

It deliberately returns findings instead of throwing.

`loadConfig()` runs per request on IPC and task-runner hot paths. Throwing on a semantic problem there would turn one typo into an app-wide crash loop.

The function is pure and takes a parsed record, so it stays browser-safe and can serve both the app and the terminal tool.

Nothing calls it yet.

## Review Claim

`collectInvokerConfigDiagnostics` reports every problem it finds in one pass and never throws, whatever shape the parsed config has.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The new module has no callers in this slice, so no existing behavior moves. It only adds exports.

It performs no file access and mutates nothing it is given, so it cannot affect config loading even once it is wired up.

Severity is split so that a config which still runs correctly reports a warning rather than an error.

## Slice Rationale

The reporting logic is kept apart from the surfaces that consume it, so its rules can be judged against the tests alone.

Wiring it into the doctor readiness check is a separate claim about user-visible output, and lands next.

## Non-goals

Does not change `validateInvokerConfig`, `loadConfig`, or any startup behavior. Does not make any existing config newly fatal.

Does not probe SSH or Docker reachability; it only inspects the parsed config.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/contracts && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. The module has no callers in this slice.
- Data migration? No

</details>
