### PR TITLE
[Guided CLI Setup](4a) Add a config-contents readiness check

### DIFF
--- a/packages/contracts/src/__tests__/prerequisites.test.ts
+++ b/packages/contracts/src/__tests__/prerequisites.test.ts
@@ -7,8 +7,10 @@ import {
 
 
 import {
+  assembleReadinessChecks,
   buildReport,
   checkConfig,
+  checkConfigContents,
   checkDefaultPresetTool,
   checkPlanningToolsPresent,
   checkTool,
@@ -142,5 +144,52 @@ describe('buildReport / formatReport', () => {
     const report = buildReport([checkPlanningToolsPresent(presets, installed())]);
     expect(JSON.parse(formatReport(report, { json: true }))).toEqual(report);
     expect(formatReport(report)).toContain('-> Install at least one');
+  });
+});
+
+describe('checkConfigContents', () => {
+  it('passes a config with consistent targets, pools, and routing', () => {
+    const check = checkConfigContents({
+      remoteTargets: { box: { host: 'h', user: 'u', sshKeyPath: '/k' } },
+      executionPools: { fast: { members: [{ type: 'ssh', id: 'box' }] } },
+      defaultPoolId: 'fast',
+    });
+    expect(check.status).toBe('ok');
+  });
+
+  it('fails when a pool references a remote target that is not configured', () => {
+    const check = checkConfigContents({
+      executionPools: { fast: { members: [{ type: 'ssh', id: 'ghost' }] } },
+    });
+    expect(check.status).toBe('error');
+    expect(check.detail).toContain('ghost');
+  });
+
+  it('fails a defaultPoolId that points nowhere even when no pools exist', () => {
+    expect(checkConfigContents({ defaultPoolId: 'fast' }).status).toBe('error');
+  });
+
+  it('warns without failing when one member is shared across pools', () => {
+    const check = checkConfigContents({
+      executionPools: {
+        fast: { members: [{ type: 'worktree', id: 'local' }] },
+        slow: { members: [{ type: 'worktree', id: 'local' }] },
+      },
+    });
+    expect(check.status).toBe('warn');
+  });
+});
+
+describe('assembleReadinessChecks config contents wiring', () => {
+  const noTools = { tools: [], isInstalled: () => true };
+
+  it('omits the semantic check when no config contents are supplied', () => {
+    const ids = assembleReadinessChecks(noTools).map((check) => check.id);
+    expect(ids).not.toContain('config-contents');
+  });
+
+  it('includes the semantic check when config contents are supplied', () => {
+    const checks = assembleReadinessChecks({ ...noTools, configContents: { defaultPoolId: 'missing' } });
+    expect(checks.find((check) => check.id === 'config-contents')?.status).toBe('error');
   });
 });

--- a/packages/contracts/src/prerequisites.ts
+++ b/packages/contracts/src/prerequisites.ts
@@ -2,6 +2,7 @@
 // Pure and browser-safe: callers inject the `isInstalled` probe (Node `spawn`) and the parsed
 // config, so this module never imports `node:child_process`/`node:fs` (the UI bundles contracts).
 
+import { collectInvokerConfigDiagnostics, type ConfigDiagnostic } from './config-diagnostics.ts';
 import { DEFAULT_TOOL_REQUIREMENTS, type ToolRequirement } from './external-dependencies.ts';
 
 export type PrerequisiteStatus = 'ok' | 'warn' | 'error';
@@ -49,6 +50,40 @@ export function checkConfig(state: { path: string; exists: boolean; error?: stri
     status: 'error',
     detail: `Invalid JSON at ${state.path}`,
     remediation: `Fix the JSON syntax: ${state.error}`,
+  };
+}
+
+function describeDiagnostics(diagnostics: readonly ConfigDiagnostic[]): string {
+  return diagnostics.map((entry) => (entry.path ? `${entry.path}: ${entry.message}` : entry.message)).join('; ');
+}
+
+export function checkConfigContents(config: unknown): PrerequisiteCheck {
+  const diagnostics = collectInvokerConfigDiagnostics(config);
+  const errors = diagnostics.filter((entry) => entry.severity === 'error');
+  const warnings = diagnostics.filter((entry) => entry.severity === 'warning');
+
+  if (errors.length > 0) {
+    return {
+      id: 'config-contents',
+      name: 'Config contents',
+      status: 'error',
+      detail: describeDiagnostics(errors),
+      remediation: 'Correct the listed config entries, then re-run `invoker-cli doctor`.',
+    };
+  }
+  if (warnings.length > 0) {
+    return {
+      id: 'config-contents',
+      name: 'Config contents',
+      status: 'warn',
+      detail: describeDiagnostics(warnings),
+    };
+  }
+  return {
+    id: 'config-contents',
+    name: 'Config contents',
+    status: 'ok',
+    detail: 'Execution targets, pools, and routing rules are consistent',
   };
 }
 
@@ -135,6 +170,7 @@ export interface ReadinessInput {
   tools: ToolRequirement[];
   isInstalled: IsInstalled;
   config?: { path: string; exists: boolean; error?: string };
+  configContents?: unknown;
   /** Effective Slack planning presets (config or built-ins); empty skips preset checks. */
   presets?: Record<string, PlanningPresetSpec>;
   defaultPreset?: string;
@@ -144,6 +180,7 @@ export interface ReadinessInput {
 export function assembleReadinessChecks(input: ReadinessInput): PrerequisiteCheck[] {
   const checks: PrerequisiteCheck[] = [];
   if (input.config) checks.push(checkConfig(input.config));
+  if (input.configContents !== undefined) checks.push(checkConfigContents(input.configContents));
   for (const tool of input.tools) checks.push(checkTool(tool, input.isInstalled));
   const presets = input.presets ?? {};
   if (Object.keys(presets).length > 0) {


### PR DESCRIPTION
## Summary

The readiness report could tell you `config.json` parsed, but not whether its contents made sense.

An execution pool naming a remote target that was never declared looked perfectly healthy right up until a task tried to launch on it.

This adds `checkConfigContents`, a readiness entry driven by the findings from slice 3, plus an optional input on `ReadinessInput` so a caller can opt in by supplying the parsed config.

Findings that break execution fail the entry. A pool member shared between two pools only warns, because that config still runs, just with capacity folded together.

The probing style follows the existing `isInstalled` seam: the caller supplies the parsed config, so this module still touches no files.

Callers are unchanged here, so no report output moves yet.

## Review Claim

`checkConfigContents` reports a broken execution topology as an error and a merely surprising one as a warning, and the readiness report is unchanged unless a caller opts in.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The new input is optional and defaults to absent, so `assembleReadinessChecks` produces byte-identical output for every existing caller.

The module still performs no file access, preserving the browser-safe property its header documents.

## Slice Rationale

This is the shared readiness entry; the next slice is the terminal tool opting into it. Keeping them apart holds this diff inside one package.

Bundling both would mix a shared readiness addition with a user-visible output change in a single review.

## Non-goals

Does not turn the entry on for anybody. Does not change existing readiness entries, their ids, or their ordering.

Does not probe SSH or Docker reachability.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/contracts && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Revert the follow-up slice first if it has landed, since it supplies the parsed config.
- Data migration? No

</details>
