### PR TITLE
[Guided CLI Setup](5) Fail setup loudly when stdin is not a TTY

### DIFF
--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -414,5 +414,89 @@ describe('setExperimentalPlannerFlag', () => {
     const configPath = join(mkdtempSync(join(tmpdir(), 'invoker-planner-flag-')), 'nested', 'config.json');
     setExperimentalPlannerFlag(true, configPath);
     expect(JSON.parse(readFileSync(configPath, 'utf8'))).toEqual({ experimentalPlanner: true });
+  });
+});
+
+describe('runSetup in a non-interactive shell', () => {
+  let home: string;
+  let previousConfig: string | undefined;
+  let previousMcp: string | undefined;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'invoker-setup-tty-'));
+    previousConfig = process.env.INVOKER_REPO_CONFIG_PATH;
+    previousMcp = process.env.INVOKER_MCP_CONFIG_PATH;
+    process.env.INVOKER_REPO_CONFIG_PATH = join(home, 'config.json');
+    process.env.INVOKER_MCP_CONFIG_PATH = join(home, 'mcp.json');
+  });
+
+  afterEach(() => {
+    if (previousConfig === undefined) delete process.env.INVOKER_REPO_CONFIG_PATH;
+    else process.env.INVOKER_REPO_CONFIG_PATH = previousConfig;
+    if (previousMcp === undefined) delete process.env.INVOKER_MCP_CONFIG_PATH;
+    else process.env.INVOKER_MCP_CONFIG_PATH = previousMcp;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function collectingIO(overrides: Partial<{ prompt: () => Promise<string> }> = {}) {
+    const lines: string[] = [];
+    return {
+      lines,
+      io: {
+        interactive: false,
+        print: (line: string) => { lines.push(line); },
+        prompt: overrides.prompt ?? (async () => ''),
+      },
+    };
+  }
+
+  it('fails loudly instead of silently answering no to every prompt', async () => {
+    const { lines, io } = collectingIO();
+    const code = await runSetup([], io);
+
+    expect(code).toBe(1);
+    expect(lines.join('\n')).toContain('stdin is not a TTY');
+  });
+
+  it('names the non-interactive escape hatches in the failure message', async () => {
+    const { lines, io } = collectingIO();
+    await runSetup([], io);
+
+    const output = lines.join('\n');
+    expect(output).toContain('--yes');
+    expect(output).toContain('--from-env');
+  });
+
+  it('accepts the planner prompt under --yes without reading stdin', async () => {
+    const { lines, io } = collectingIO({
+      prompt: async () => { throw new Error('should not prompt under --yes'); },
+    });
+
+    const code = await runSetup(['--yes'], io);
+
+    expect(code).not.toBe(1);
+    expect(lines.join('\n')).toContain('Enable the experimental planner now?');
+  });
+
+  it('skips Slack under --yes rather than starting a flow it cannot finish', async () => {
+    const { lines, io } = collectingIO({
+      prompt: async () => { throw new Error('should not prompt under --yes'); },
+    });
+
+    await runSetup(['--yes'], io);
+
+    const output = lines.join('\n');
+    expect(output).not.toContain('Bot User OAuth Token');
+    expect(output).toContain('invoker-cli setup slack');
+  });
+
+  it('writes only inside the configured Invoker home', async () => {
+    const { io } = collectingIO({
+      prompt: async () => { throw new Error('should not prompt under --yes'); },
+    });
+
+    await runSetup(['--yes'], io);
+
+    expect(existsSync(join(home, 'mcp.json'))).toBe(true);
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -130,7 +130,7 @@ function usage(): string {
     'Usage:',
     '  invoker-cli run <plan.yaml> [--live|--standalone] [--db-dir <path>] [--config <path>] [--json]',
     '  invoker-cli doctor [--fix] [--json]',
-    '  invoker-cli setup [planner|slack] [--check|--from-env] [--json]',
+    '  invoker-cli setup [planner|slack] [--check|--from-env] [--yes] [--json]',
     '  invoker-cli mcp',
     '  invoker-cli worker [autofix|list]',
     '  invoker-cli --help',

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -438,15 +438,33 @@ export function writeSlackEnv(creds: Required<Pick<SlackCredentials, 'botToken' 
 export interface SetupIO {
   print: (line: string) => void;
   prompt: (question: string) => Promise<string>;
+  interactive?: boolean;
+}
+
+export class NonInteractiveSetupError extends Error {
+  constructor(question: string) {
+    super(
+      `Cannot ask "${question.trim()}" because stdin is not a TTY.\n`
+      + 'Re-run with --yes to accept the guided defaults, or use a non-interactive path: '
+      + '`invoker-cli setup planner`, or `invoker-cli setup slack --from-env` with SLACK_* set.',
+    );
+    this.name = 'NonInteractiveSetupError';
+  }
 }
 
 function defaultIO(): SetupIO & { rl: ReturnType<typeof createInterface> } {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   return {
     rl,
+    interactive: Boolean(process.stdin.isTTY),
     print: (line) => process.stdout.write(`${line}\n`),
     prompt: async (q) => (await rl.question(q)).trim(),
   };
+}
+
+function askLine(io: SetupIO, question: string): Promise<string> {
+  if (io.interactive === false) throw new NonInteractiveSetupError(question);
+  return io.prompt(question);
 }
 
 function manifestSteps(manifestPath: string): string {
@@ -514,10 +532,11 @@ interface ParsedSetupArgs {
   accessToken?: string;
   plannerPackage?: string;
   fromEnv: boolean;
+  assumeYes: boolean;
 }
 
 function parseSetupArgs(argv: string[]): ParsedSetupArgs {
-  const parsed: ParsedSetupArgs = { checkOnly: false, json: false, uninstall: false, fromEnv: false };
+  const parsed: ParsedSetupArgs = { checkOnly: false, json: false, uninstall: false, fromEnv: false, assumeYes: false };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === 'slack' || arg === 'planner') {
@@ -529,6 +548,8 @@ function parseSetupArgs(argv: string[]): ParsedSetupArgs {
       parsed.json = true;
     } else if (arg === '--from-env') {
       parsed.fromEnv = true;
+    } else if (arg === '--yes' || arg === '-y') {
+      parsed.assumeYes = true;
     } else if (arg === '--uninstall') {
       parsed.uninstall = true;
     } else if (arg === '--target') {
@@ -591,8 +612,12 @@ async function maybeInstallPlanner(parsed: ParsedSetupArgs, io: SetupIO): Promis
   return 0;
 }
 
-async function promptYes(io: SetupIO, question: string): Promise<boolean> {
-  const answer = (await io.prompt(question)).toLowerCase();
+async function promptYes(io: SetupIO, question: string, assumeYes = false): Promise<boolean> {
+  if (assumeYes) {
+    io.print(`${question}y`);
+    return true;
+  }
+  const answer = (await askLine(io, question)).toLowerCase();
   return answer === 'y' || answer === 'yes';
 }
 
@@ -627,14 +652,14 @@ export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promi
     io.print(`experimentalPlanner flag: ${plannerState.experimentalPlanner ? 'on' : 'off'}`);
     io.print('');
 
-    if (!wantSlack && !fromEnv && await promptYes(io, 'Enable the experimental planner now? [y/N] ')) {
+    if (!wantSlack && !fromEnv && await promptYes(io, 'Enable the experimental planner now? [y/N] ', parsed.assumeYes)) {
       await maybeInstallPlanner(parsed, io);
       io.print('');
     }
 
     let doSlack = wantSlack || fromEnv;
     if (!wantSlack && !fromEnv) {
-      doSlack = await promptYes(io, 'Set up the Slack integration now? [y/N] ');
+      doSlack = parsed.assumeYes ? false : await promptYes(io, 'Set up the Slack integration now? [y/N] ');
     }
     if (!doSlack) {
       io.print('\nYou are good to go for CLI and UI workflows. Run `invoker-cli setup planner` later to enable the experimental planner. Run `invoker-cli setup slack` later to add Slack.');
@@ -666,17 +691,17 @@ export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promi
     writeFileSync(manifestPath, `${JSON.stringify(generateSlackManifest(), null, 2)}\n`);
     io.print(`\n${manifestSteps(manifestPath)}\n`);
 
-    const botToken = await io.prompt('Bot User OAuth Token (xoxb-...): ');
-    const appToken = await io.prompt('App-Level Token (xapp-...): ');
-    const signingSecret = await io.prompt('Signing Secret: ');
-    const channelId = await io.prompt('Lobby channel ID (C...): ');
+    const botToken = await askLine(io, 'Bot User OAuth Token (xoxb-...): ');
+    const appToken = await askLine(io, 'App-Level Token (xapp-...): ');
+    const signingSecret = await askLine(io, 'Signing Secret: ');
+    const channelId = await askLine(io, 'Lobby channel ID (C...): ');
 
     const checks = await validateSlackCredentials({ botToken, appToken, signingSecret, channelId });
     const report = buildReport(checks);
     io.print(`\n${formatReport(report)}`);
 
     if (!report.ok) {
-      const proceed = await promptYes(io, '\nSome checks failed. Save these values anyway? [y/N] ');
+      const proceed = await promptYes(io, '\nSome checks failed. Save these values anyway? [y/N] ', parsed.assumeYes);
       if (!proceed) {
         io.print('Nothing written. Fix the items above and re-run `invoker-cli setup slack`.');
         return 1;
@@ -686,6 +711,10 @@ export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promi
     const envPath = writeSlackEnv({ botToken, appToken, signingSecret, channelId });
     io.print(`\nWrote Slack credentials to ${envPath}. Restart Invoker (or it picks them up on next launch).`);
     return report.ok ? 0 : 1;
+  } catch (error) {
+    if (!(error instanceof NonInteractiveSetupError)) throw error;
+    io.print(error.message);
+    return 1;
   } finally {
     rl?.close();
   }


### PR DESCRIPTION
## Summary

`invoker-cli setup` never checked whether stdin was a terminal. Under CI, or behind a pipe, readline handed back empty strings.

The yes-or-no helper read every empty string as No. Setup then quietly enabled nothing, configured nothing, and exited on the readiness report.

That is a silent wrong answer. The run looks like a guided setup that succeeded, having asked the user nothing at all.

Prompting now fails with a message naming the unattended paths that do work.

This also adds `--yes`, which takes the guided default and turns the planner on.

It deliberately steps around Slack, which still needs api.slack.com and tokens that cannot be fetched unattended.

## Review Claim

`invoker-cli setup` can no longer report success in a non-terminal shell after silently answering No to every question on the user's behalf.

## Review Lane

behavior

## Review Unit

activation-surface

## Slice Rationale

This is the one user-facing bug in the guided setup entry point, and it is independent of the config work in the earlier slices.

It ships last because the earlier slices give the readiness report something worth printing before the flow reaches its first question.

## Safety Invariant

`SetupIO.interactive` is optional, and the guard fires only on an explicit `false`, so any caller that omits it keeps the old prompting behavior.

In a real terminal `process.stdin.isTTY` is true, so an interactive run is unchanged.

The new failure is caught inside `runSetup` and turned into exit code 1 with a printed message, so it surfaces as a clean failure rather than a stack trace.

## Non-goals

Does not add `--answers`, `--dry-run`, or JSON output for the guided flow. Does not broaden which questions setup asks.

Does not change `setup planner` or `setup slack --from-env`, both of which were already unattended.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/cli && pnpm test`
- [ ] `pnpm run check:types`
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the previous silent-No behavior.
- Data migration? No

</details>
