### PR TITLE
Bound the Slack agent to local repro, route execution through Invoker

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -771,6 +771,17 @@ describe('PlanConversation prompt construction', () => {
     expect(prompt).not.toContain('Conversation History');
   });
 
+  it('agent-mode system prompt allows local repro but bans mutating shared state', () => {
+    const conv = new PlanConversation({ mode: 'agent' });
+    (conv as any).messages.push({ role: 'user', content: 'Why do we get extra merge stacks?' });
+    const prompt = conv.buildCursorPrompt();
+    expect(prompt).toContain('Inside your worktree you are unrestricted');
+    expect(prompt).toContain('Reproducing a bug locally is always allowed');
+    expect(prompt).toContain('mergify stack push');
+    expect(prompt).toContain('scripts/land-stack.mjs --execute');
+    expect(prompt).toContain('ask the user to confirm');
+  });
+
   it('buildCursorPrompt includes history for multi-turn', () => {
     const conv = new PlanConversation({});
     (conv as any).messages.push(

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -529,6 +529,48 @@ describe('lobby verb routing', () => {
     expect(prompt).toContain('Do NOT generate a YAML plan');
   });
 
+  it('lets a lobby question repro locally but hands off anything that mutates shared state', () => {
+    const prompt = buildLobbyQuestionPrompt('can you land the top of the stack for me?');
+    expect(prompt).toContain('Reproducing a bug locally is always allowed');
+    expect(prompt).toContain('mergify stack push');
+    expect(prompt).toContain('scripts/land-stack.mjs --execute');
+    expect(prompt).toContain('plan: <request>');
+  });
+
+  // Repro: the Slack thread that prompted this asked the bot to investigate a
+  // landing failure. It routed as `question` — the one lobby path whose prompt
+  // never told it to keep its hands off shared state.
+  it('carries the execution boundary into the planner command a lobby question actually spawns', async () => {
+    const prompts: string[] = [];
+    mockSpawn
+      .mockImplementationOnce(() => mockProcess('{"intent":"question","operation":"none","target":"none"}'))
+      .mockImplementationOnce(() => mockProcess('Here is what went wrong.'));
+    const surface = lobbySurface(true, {
+      planningCommandBuilder: ({ prompt }: { prompt: string }) => {
+        prompts.push(prompt);
+        return { command: 'cursor', args: ['--print', prompt] };
+      },
+    });
+    await surface.start(async (cmd) => { received.push(cmd); });
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+
+    await mentionHandler(surface)({
+      event: {
+        text: '<@BOT> why do we get extra merge stacks when we babysit landing these workflows?',
+        ts: 't1', user: 'U1', channel: 'CLOBBY',
+      },
+      say,
+    });
+
+    expect(prompts).toHaveLength(2);
+    const answerPrompt = prompts[1];
+    expect(answerPrompt).toContain('Never run anything that changes state outside your worktree');
+    expect(answerPrompt).toContain('mergify stack push');
+    expect(answerPrompt).toContain('scripts/land-stack.mjs --execute');
+    expect(answerPrompt).toContain('Reproducing a bug locally is always allowed');
+    expect(received).toHaveLength(0);
+  });
+
   it('stages a bulk verb for confirmation, then runs it on a plain `yes`', async () => {
     runWorkflowOp.mockResolvedValue({ ok: true, summary: 'recreate: 3 ok' });
     const surface = lobbySurface();

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -175,6 +175,11 @@ export function isNegation(text: string): boolean {
 
 // ── System Prompt ───────────────────────────────────────────
 
+export const SLACK_LOCAL_REPRO_POLICY = `Execution boundary:
+- Inside your worktree you are unrestricted. Read, grep, edit, build, and run tests freely. Reproducing a bug locally is always allowed and never needs permission.
+- Never run anything that changes state outside your worktree: \`git push\`, \`gh pr create\`/\`edit\`/\`merge\`, \`gh\` label writes, \`mergify stack push\`, \`scripts/safe-stack-push.mjs\`, or \`scripts/land-stack.mjs --execute\`.
+- If the request needs any of those, stop and hand off: describe the change, post the plan, and ask the user to confirm. Do not perform it yourself and do not offer a manual workaround for it.`;
+
 function buildAgentSystemPrompt(): string {
   return `You are a normal coding agent running in a git worktree for a Slack thread.
 
@@ -184,7 +189,9 @@ Default behavior:
 - Do NOT generate Invoker YAML in this thread. If the user asks for an Invoker plan, tell them to start a new plan thread with \`plan: <request>\` — plan drafts from an agent thread cannot be submitted.
 - Do NOT submit or start an Invoker workflow. Agent threads reject \`submit\`; only a \`plan:\` thread can be submitted.
 - Keep Slack replies short and concrete: changed files, verification, and any remaining risk.
-- To share a generated file (screenshot, diagram, report), write it inside your worktree and link it by absolute path as a markdown link, e.g. \`[chart](/abs/path/in/worktree/chart.png)\`. Files linked that way are uploaded to the thread. Files written outside your worktree cannot be shared, so do not put artifacts in /tmp.`;
+- To share a generated file (screenshot, diagram, report), write it inside your worktree and link it by absolute path as a markdown link, e.g. \`[chart](/abs/path/in/worktree/chart.png)\`. Files linked that way are uploaded to the thread. Files written outside your worktree cannot be shared, so do not put artifacts in /tmp.
+
+${SLACK_LOCAL_REPRO_POLICY}`;
 }
 
 function buildStackedWorkflowPrompt(repoUrlLine: string, defaultBranch: string): string {

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_PLANNER_RETRY_BASE_DELAY_MS,
   DEFAULT_PLANNER_RETRY_LIMIT,
   PlanConversation,
+  SLACK_LOCAL_REPRO_POLICY,
   buildEmptyPlannerOutputError,
   defaultPlanningCommand,
   isConfirmation,
@@ -259,7 +260,7 @@ ${text}
 
 /** Q&A prompt for a lobby question: answer directly, never emit a plan. */
 export function buildLobbyQuestionPrompt(text: string): string {
-  return `Answer the user's question about this repository and Invoker. Explore the codebase if needed. ${SLACK_DIRECT_ANSWER_GUIDANCE} Do NOT generate a YAML plan and do NOT create a workflow. Question:\n${text}`;
+  return `Answer the user's question about this repository and Invoker. Explore the codebase if needed. ${SLACK_DIRECT_ANSWER_GUIDANCE} Do NOT generate a YAML plan and do NOT create a workflow. If answering well requires changing code, say in prose what the fix would be and tell the user to start a plan thread with \`plan: <request>\`.\n\n${SLACK_LOCAL_REPRO_POLICY}\n\nQuestion:\n${text}`;
 }
 
 /** Parse the classifier's raw stdout into a validated classification; never throws. */


### PR DESCRIPTION
## Summary

The Slack bot could change shared state while it was only meant to be investigating.

It has three prompt paths. Only the plan-drafting one told it not to act on its own.

The other two invited it to run local commands and edit code. Neither said anything about pushing branches, opening PRs, or publishing a Mergify stack.

An investigation request lands on the weakest of the three. A bot asked to diagnose a landing failure was free to create a merge stack while looking around.

That is how babysitting a landing produced extra stacks nobody asked for, and why it became hard to tell which diffs were meant to land.

Now the worktree stays unrestricted. Reproducing a bug locally never needs permission.

Anything that changes shared state outside the worktree is barred. The bot describes the change, posts the plan, and waits for a human.

## Review Claim

Approve one shared policy string wired into the two Slack prompt builders that lacked it.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Prompt text only. No runtime gate is added and no command is intercepted.

The existing approval path is untouched. Submitting still requires the explicit `submit` verb plus an Approve click, and a bare "yes" still cannot ship a plan.

## Slice Rationale

The policy string and the tests proving it reaches the agent belong in one slice. The tests fail without the prompt change, so landing them apart would leave a red branch behind.

## Non-goals

- No hard block in the spawn path and no per-command gating.
- No change to the plan-drafting prompt, which already carried this rule.
- No change to the confirm or submit machinery.
- No change to what the bot may do inside its own worktree.
- No docs change; the `CLAUDE.md` note follows as its own slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm install --frozen-lockfile && cd packages/surfaces && pnpm test` — 403 passed
- [ ] `cd packages/surfaces && npx vitest run -t "execution boundary"` — drives a Slack mention end to end and asserts the policy reaches the command the planner spawns
- [ ] `cd packages/surfaces && npx vitest run -t "mutates shared state"` — covers both prompt builders
- [ ] Repro check: with `packages/surfaces/src/slack/` reverted, all three above fail; with the change applied, all pass

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert aa7e07172`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Improvements**
  * Clarified local reproduction guidance for Slack conversations.
  * Agents may reproduce issues safely within the worktree but must not modify shared state.
  * State-changing actions require user confirmation and are routed through the appropriate workflow commands.

* **Tests**
  * Added coverage to verify these execution boundaries for both agent planning and lobby questions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->