### PR TITLE
[Guided CLI Setup](4b) Feed the parsed config into invoker-cli doctor

### DIFF
--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -98,6 +98,7 @@ export interface CliConfigState {
   error?: string;
   presets: Record<string, PlanningPresetSpec>;
   defaultPreset?: string;
+  contents?: JsonRecord;
 }
 
 export function loadCliConfig(configPath: string = defaultConfigPath()): CliConfigState {
@@ -107,7 +108,13 @@ export function loadCliConfig(configPath: string = defaultConfigPath()): CliConf
       slackHarnessPresets?: Record<string, PlanningPresetSpec>;
       defaultSlackHarnessPreset?: string;
     };
-    return { path: configPath, exists: true, presets: cfg.slackHarnessPresets ?? {}, defaultPreset: cfg.defaultSlackHarnessPreset };
+    return {
+      path: configPath,
+      exists: true,
+      presets: cfg.slackHarnessPresets ?? {},
+      defaultPreset: cfg.defaultSlackHarnessPreset,
+      contents: cfg as JsonRecord,
+    };
   } catch (err) {
     logCaughtException(`Failed to read Invoker config at ${configPath}`, err);
     return { path: configPath, exists: true, error: err instanceof Error ? err.message : String(err), presets: {} };
@@ -227,6 +234,7 @@ export function buildDoctorChecks(cfg: CliConfigState, isInstalled: IsInstalled 
     tools: DEFAULT_TOOL_REQUIREMENTS,
     isInstalled,
     config: { path: cfg.path, exists: cfg.exists, error: cfg.error },
+    configContents: cfg.contents,
     presets: cfg.presets,
     defaultPreset: cfg.defaultPreset,
   });


### PR DESCRIPTION
## Summary

Slice 4a added the config-contents readiness entry but left it dormant, because nothing handed it a parsed config.

This threads the parsed config from `loadCliConfig` through `buildDoctorChecks`, which turns the entry on for `invoker-cli doctor`.

Checked against a config whose pool names an undeclared remote target, whose `defaultPoolId` is a typo, and whose command-matching expression cannot compile.

The doctor command reports all three in one pass and exits 1. Before this change it reported none of them and exited 0.

A healthy config reports that execution targets, pools, and command-matching entries are consistent.

## Review Claim

`invoker-cli doctor` now fails on a config whose execution topology is broken, instead of reporting success because the file happened to parse.

## Review Lane

behavior

## Review Unit

activation-surface

## Slice Rationale

Slice 4a put the shared readiness entry in one package. This is the single call site that activates it, so the user-visible change is reviewable on its own.

## Safety Invariant

`CliConfigState` gains one optional field, so every existing consumer of that shape is unaffected.

When the config file is absent or unparseable the field stays undefined, and the readiness entry is omitted exactly as before, so the existing parse-failure path is untouched.

## Non-goals

Does not change which tools the doctor command probes, nor the `--fix` behavior. Does not make config loading throw.

Does not alter the guided setup flow.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/cli && pnpm test`
- [ ] `pnpm run check:types`
- [ ] `INVOKER_REPO_CONFIG_PATH=/tmp/bad-config.json node packages/cli/dist/index.js doctor` reports the broken entries and exits 1

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. The readiness entry goes dormant again.
- Data migration? No

</details>
