### PR TITLE
[Fix Git E2E Tests Step 3 Vitest Guard](2) Prove stale filters fail the guard

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -10,9 +10,10 @@ cd "$REPO_ROOT"
 export INVOKER_ENABLE_WORKSPACE_CLEANUP=0
 
 BOOTSTRAP_STAMP="$REPO_ROOT/node_modules/.invoker-bootstrap-stamp"
+WORKSPACE_INSTALL_METADATA="$REPO_ROOT/node_modules/.modules.yaml"
 
 has_bootstrap_artifacts() {
-  [ -f "$REPO_ROOT/node_modules/.modules.yaml" ] \
+  [ -f "$WORKSPACE_INSTALL_METADATA" ] \
     && [ -x "$REPO_ROOT/packages/app/node_modules/.bin/electron" ]
 }
 
@@ -23,11 +24,11 @@ bootstrap_tools_are_healthy() {
 # An existing install goes stale when the lockfile changes (e.g. a git pull
 # adds a dependency) but node_modules is left untouched. The artifacts check
 # above only proves *some* install exists, so without this check run.sh would
-# skip the reinstall and then fail the build on the now-missing package. Treat
-# the install as stale when we have no record of it, or when pnpm-lock.yaml is
-# newer than the stamp written after the last successful install.
+# skip the reinstall and then fail the build on the now-missing package. Use
+# pnpm's workspace metadata as the durable freshness signal so preprovisioned
+# installs do not need run.sh's private stamp.
 workspace_install_is_stale() {
-  [ ! -f "$BOOTSTRAP_STAMP" ] || [ "$REPO_ROOT/pnpm-lock.yaml" -nt "$BOOTSTRAP_STAMP" ]
+  [ ! -f "$WORKSPACE_INSTALL_METADATA" ] || [ "$REPO_ROOT/pnpm-lock.yaml" -nt "$WORKSPACE_INSTALL_METADATA" ]
 }
 
 ensure_workspace_bootstrapped() {
@@ -37,6 +38,7 @@ ensure_workspace_bootstrapped() {
 
   echo "Bootstrapping workspace dependencies..." >&2
   pnpm install --frozen-lockfile >&2
+  # Keep the historical launcher marker; freshness is based on pnpm metadata.
   touch "$BOOTSTRAP_STAMP"
 }
 

--- a/scripts/lib/required-vitest.sh
+++ b/scripts/lib/required-vitest.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+
+_required_vitest_has_binary() {
+  local package_dir="$1"
+  (
+    cd "$package_dir" \
+      && pnpm exec vitest --version >/dev/null 2>&1
+  )
+}
+
+_required_vitest_package_name() {
+  local package_dir="$1"
+  node - "$package_dir/package.json" <<'NODE'
+const fs = require('node:fs');
+
+const packagePath = process.argv[2];
+const manifest = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+
+if (typeof manifest.name !== 'string' || manifest.name.length === 0) {
+  process.exit(1);
+}
+
+process.stdout.write(manifest.name);
+NODE
+}
+
+ensure_required_vitest_available() {
+  if [[ $# -ne 1 ]]; then
+    echo "usage: ensure_required_vitest_available <package-dir>" >&2
+    return 2
+  fi
+
+  local package_dir="$1"
+  if [[ ! -d "$package_dir" ]]; then
+    echo "required-vitest: package directory does not exist: $package_dir" >&2
+    return 2
+  fi
+
+  if _required_vitest_has_binary "$package_dir"; then
+    return 0
+  fi
+
+  local workspace_root
+  workspace_root="$(git -C "$package_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -z "$workspace_root" || ! -f "$workspace_root/pnpm-lock.yaml" ]]; then
+    echo "required-vitest: could not find workspace root for $package_dir" >&2
+    return 1
+  fi
+
+  local package_name
+  package_name="$(_required_vitest_package_name "$package_dir" 2>/dev/null || true)"
+  if [[ -z "$package_name" ]]; then
+    echo "required-vitest: could not read package name from $package_dir/package.json" >&2
+    return 1
+  fi
+
+  echo "required-vitest: Vitest binary is unavailable; installing filtered workspace dependencies for $package_name"
+  (
+    cd "$workspace_root" \
+      && pnpm --filter "$package_name..." install --frozen-lockfile --ignore-scripts --prod=false
+  ) || return $?
+
+  if ! _required_vitest_has_binary "$package_dir"; then
+    echo "required-vitest: Vitest binary is still unavailable after filtered install for $package_name" >&2
+    return 1
+  fi
+}
+
+run_required_vitest_filter() {
+  if [[ $# -ne 3 ]]; then
+    echo "usage: run_required_vitest_filter <package-dir> <test-target> <test-name>" >&2
+    return 2
+  fi
+
+  local package_dir="$1"
+  local test_target="$2"
+  local test_name="$3"
+
+  if [[ ! -d "$package_dir" ]]; then
+    echo "required-vitest: package directory does not exist: $package_dir" >&2
+    return 2
+  fi
+
+  if [[ ! -f "$package_dir/$test_target" ]]; then
+    echo "required-vitest: test target does not exist: $test_target" >&2
+    return 2
+  fi
+
+  ensure_required_vitest_available "$package_dir" || return $?
+
+  local report_file
+  local log_file
+  report_file="$(mktemp "${TMPDIR:-/tmp}/required-vitest-report.XXXXXX.json")"
+  log_file="$(mktemp "${TMPDIR:-/tmp}/required-vitest-output.XXXXXX.log")"
+
+  local had_errexit=0
+  case "$-" in
+    *e*) had_errexit=1 ;;
+  esac
+
+  set +e
+  (
+    cd "$package_dir" \
+      && pnpm exec vitest run "$test_target" -t "$test_name" \
+        --reporter=json \
+        --outputFile="$report_file"
+  ) >"$log_file" 2>&1
+  local vitest_status=$?
+
+  if [[ -s "$log_file" ]]; then
+    cat "$log_file"
+  fi
+
+  local validator_status=0
+  if [[ -s "$report_file" ]]; then
+    python3 - "$report_file" "$test_target" "$test_name" <<'PY'
+import json
+import sys
+
+report_path, test_target, test_name = sys.argv[1:]
+
+try:
+    with open(report_path, encoding="utf-8") as fh:
+        report = json.load(fh)
+except Exception as exc:
+    print(f"required-vitest: could not read Vitest JSON report: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+
+def optional_int(name):
+    value = report.get(name)
+    return value if isinstance(value, int) else None
+
+
+assertions = []
+for suite in report.get("testResults", []):
+    if not isinstance(suite, dict):
+        continue
+    for result in suite.get("assertionResults", []):
+        if isinstance(result, dict):
+            assertions.append(result)
+
+assertion_passed = sum(1 for result in assertions if result.get("status") == "passed")
+assertion_failed = sum(1 for result in assertions if result.get("status") == "failed")
+
+passed = optional_int("numPassedTests")
+failed = optional_int("numFailedTests")
+failed_suites = optional_int("numFailedTestSuites")
+
+if passed is None:
+    passed = assertion_passed
+if failed is None:
+    failed = assertion_failed
+if failed_suites is None:
+    failed_suites = 0
+
+problems = []
+if report.get("success") is False:
+    problems.append("Vitest reported success=false")
+if failed != 0:
+    problems.append(f"expected zero failed tests, got {failed}")
+if failed_suites != 0:
+    problems.append(f"expected zero failed test suites, got {failed_suites}")
+if passed < 1:
+    problems.append("expected at least one passed active test, got 0")
+
+if problems:
+    print(
+        f"required-vitest: {test_target} -t {test_name!r} did not execute the required active test",
+        file=sys.stderr,
+    )
+    for problem in problems:
+        print(f"required-vitest: {problem}", file=sys.stderr)
+    sys.exit(1)
+
+print(
+    f"required-vitest: {test_target} -t {test_name!r} passed {passed} active test(s) with {failed} failure(s)"
+)
+PY
+    validator_status=$?
+  elif [[ $vitest_status -eq 0 ]]; then
+    echo "required-vitest: Vitest exited successfully but did not write a JSON report" >&2
+    validator_status=1
+  fi
+
+  if [[ $had_errexit -eq 1 ]]; then
+    set -e
+  fi
+
+  rm -f "$report_file" "$log_file"
+
+  if [[ $vitest_status -ne 0 ]]; then
+    return "$vitest_status"
+  fi
+  return "$validator_status"
+}

--- a/scripts/repro/repro-required-vitest-filter-zero-active.sh
+++ b/scripts/repro/repro-required-vitest-filter-zero-active.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 REQUIRED_SCRIPT="$ROOT_DIR/scripts/test-suites/required/17-merge-gate-concurrency-repro.sh"
+HELPER="$ROOT_DIR/scripts/lib/required-vitest.sh"
 TEST_NAME="starts an independent merge gate while another merge gate is still preparing review"
 BUG_TARGET="src/__tests__/task-runner.test.ts"
 FIXED_TARGET="src/__tests__/task-runner-fix-publish-and-ssh.test.ts"
@@ -10,6 +11,76 @@ EXPECTATION="fixed"
 
 usage() {
   echo "usage: $0 [--expect-bug|--expect-fixed]" >&2
+}
+
+confirm_raw_vitest_zero_active_bug() {
+  ensure_required_vitest_available "$ROOT_DIR/packages/execution-engine" || return $?
+
+  local report_file
+  local log_file
+  report_file="$(mktemp "${TMPDIR:-/tmp}/raw-vitest-report.XXXXXX.json")"
+  log_file="$(mktemp "${TMPDIR:-/tmp}/raw-vitest-output.XXXXXX.log")"
+
+  set +e
+  (
+    cd "$ROOT_DIR/packages/execution-engine" \
+      && pnpm exec vitest run "$BUG_TARGET" -t "$TEST_NAME" \
+        --reporter=json \
+        --outputFile="$report_file"
+  ) >"$log_file" 2>&1
+  local vitest_status=$?
+  set -e
+
+  if [[ -s "$log_file" ]]; then
+    cat "$log_file"
+  fi
+
+  if [[ $vitest_status -ne 0 ]]; then
+    echo "repro: expected unguarded stale Vitest target to exit 0, got $vitest_status" >&2
+    rm -f "$report_file" "$log_file"
+    return 1
+  fi
+
+  if [[ ! -s "$report_file" ]]; then
+    echo "repro: unguarded stale Vitest run did not write a JSON report" >&2
+    rm -f "$report_file" "$log_file"
+    return 1
+  fi
+
+  if ! python3 - "$report_file" "$BUG_TARGET" "$TEST_NAME" <<'PY'
+import json
+import sys
+
+report_path, test_target, test_name = sys.argv[1:]
+
+with open(report_path, encoding="utf-8") as fh:
+    report = json.load(fh)
+
+passed = report.get("numPassedTests")
+failed = report.get("numFailedTests")
+if not isinstance(passed, int):
+    passed = -1
+if not isinstance(failed, int):
+    failed = -1
+
+if report.get("success") is not True or passed != 0 or failed != 0:
+    print(
+        f"repro: expected raw Vitest stale filter to pass with 0 active tests for {test_target} -t {test_name!r}; "
+        f"success={report.get('success')!r}, passed={passed}, failed={failed}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print(
+    f"repro: raw Vitest accepted stale target {test_target} -t {test_name!r} with {passed} passed and {failed} failed tests"
+)
+PY
+  then
+    rm -f "$report_file" "$log_file"
+    return 1
+  fi
+
+  rm -f "$report_file" "$log_file"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -33,6 +104,13 @@ if [[ ! -f "$REQUIRED_SCRIPT" ]]; then
   echo "repro: missing required suite script: $REQUIRED_SCRIPT" >&2
   exit 1
 fi
+
+if [[ ! -f "$HELPER" ]]; then
+  echo "repro: missing required Vitest helper: $HELPER" >&2
+  exit 1
+fi
+
+source "$HELPER"
 
 target_rel="$(grep -Eo 'src/__tests__/[^[:space:]]+\.test\.ts' "$REQUIRED_SCRIPT" | head -n1 || true)"
 if [[ -z "$target_rel" ]]; then
@@ -58,29 +136,59 @@ if [[ -f "$ROOT_DIR/packages/execution-engine/$FIXED_TARGET" ]]; then
 fi
 
 if [[ "$EXPECTATION" == "bug" ]]; then
-  if [[ "$target_rel" != "$BUG_TARGET" ]]; then
-    echo "repro: expected required/17 to target $BUG_TARGET before the fix, got $target_rel" >&2
-    exit 1
-  fi
-  if [[ "$active_matches" -ne 0 ]]; then
-    echo "repro: expected zero active matches in $BUG_TARGET, got $active_matches" >&2
+  bug_matches="$( (grep -F "$TEST_NAME" "$ROOT_DIR/packages/execution-engine/$BUG_TARGET" || true) | wc -l | tr -d '[:space:]' )"
+  if [[ "$bug_matches" -ne 0 ]]; then
+    echo "repro: expected zero active matches in $BUG_TARGET, got $bug_matches" >&2
     exit 1
   fi
   if [[ "$fixed_matches" -lt 1 ]]; then
     echo "repro: expected relocated test name in $FIXED_TARGET, got $fixed_matches matches" >&2
     exit 1
   fi
+
+  confirm_raw_vitest_zero_active_bug
+
   echo "repro: confirmed bug"
-  echo "repro: required/17 targets packages/execution-engine/$BUG_TARGET"
   echo "repro: active matches in that target for the -t filter: 0"
   echo "repro: relocated matches in packages/execution-engine/$FIXED_TARGET: $fixed_matches"
 else
+  if [[ "$target_rel" != "$FIXED_TARGET" ]]; then
+    echo "repro: expected required/17 to target $FIXED_TARGET after the fix, got $target_rel" >&2
+    exit 1
+  fi
   if [[ "$active_matches" -lt 1 ]]; then
     echo "repro: expected fixed required/17 target to contain at least one active test for the -t filter" >&2
     echo "repro: current target: packages/execution-engine/$target_rel" >&2
     echo "repro: active matches: $active_matches" >&2
     exit 1
   fi
+
+  echo "repro: verifying stale target fails the active-test guard"
+  set +e
+  stale_output="$(run_required_vitest_filter "$ROOT_DIR/packages/execution-engine" "$BUG_TARGET" "$TEST_NAME" 2>&1)"
+  stale_status=$?
+  set -e
+
+  if [[ -n "$stale_output" ]]; then
+    printf '%s\n' "$stale_output"
+  fi
+
+  if [[ "$stale_status" -eq 0 ]]; then
+    echo "repro: stale target unexpectedly passed the active-test guard" >&2
+    exit 1
+  fi
+  if ! grep -Fq "did not execute the required active test" <<<"$stale_output"; then
+    echo "repro: stale target failed for an unexpected reason" >&2
+    exit 1
+  fi
+  if ! grep -Fq "expected at least one passed active test, got 0" <<<"$stale_output"; then
+    echo "repro: stale target did not prove the zero-active filter failure" >&2
+    exit 1
+  fi
+
+  echo "repro: verifying required/17 executes the relocated active test"
+  bash "$REQUIRED_SCRIPT"
+
   echo "repro: confirmed fixed behavior"
   echo "repro: required/17 target packages/execution-engine/$target_rel contains $active_matches active match(es)"
 fi

--- a/scripts/repro/repro-run-sh-preprovisioned-bootstrap.sh
+++ b/scripts/repro/repro-run-sh-preprovisioned-bootstrap.sh
@@ -55,6 +55,10 @@ mkdir -p \
 cp "$ROOT_DIR/run.sh" "$FAKE_ROOT/run.sh"
 
 printf 'preprovisioned pnpm workspace marker\n' > "$FAKE_ROOT/node_modules/.modules.yaml"
+printf 'lockfileVersion: 9.0\n' > "$FAKE_ROOT/pnpm-lock.yaml"
+touch -t 202001010000 "$FAKE_ROOT/pnpm-lock.yaml"
+touch -t 202001010001 "$FAKE_ROOT/node_modules/.modules.yaml"
+
 cat > "$FAKE_ROOT/node_modules/.bin/tsup" <<'SH'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "--version" ]]; then
@@ -90,22 +94,33 @@ if [[ -e "$FAKE_ROOT/node_modules/.invoker-bootstrap-stamp" ]]; then
   exit 1
 fi
 
-status=0
-HOME="$TMP_DIR/home" \
-  INVOKER_DB_DIR="$TMP_DIR/db" \
-  INVOKER_REPO_CONFIG_PATH="$TMP_DIR/config.json" \
-  INVOKER_REPRO_PNPM_CALLS="$PNPM_CALLS" \
-  PATH="$STUB_BIN:$PATH" \
-  "$FAKE_ROOT/run.sh" --headless delete-all >"$RUN_STDOUT" 2>"$RUN_STDERR" || status=$?
+run_fake_headless() {
+  local force_bootstrap="${1:-0}"
+  rm -f "$PNPM_CALLS" "$RUN_STDOUT" "$RUN_STDERR"
+  status=0
+  HOME="$TMP_DIR/home" \
+    INVOKER_FORCE_BOOTSTRAP="$force_bootstrap" \
+    INVOKER_DB_DIR="$TMP_DIR/db" \
+    INVOKER_REPO_CONFIG_PATH="$TMP_DIR/config.json" \
+    INVOKER_REPRO_PNPM_CALLS="$PNPM_CALLS" \
+    PATH="$STUB_BIN:$PATH" \
+    "$FAKE_ROOT/run.sh" --headless delete-all >"$RUN_STDOUT" 2>"$RUN_STDERR" || status=$?
+}
 
-pnpm_call_count=0
-if [[ -f "$PNPM_CALLS" ]]; then
-  pnpm_call_count="$(wc -l < "$PNPM_CALLS" | tr -d '[:space:]')"
-fi
+pnpm_call_count() {
+  if [[ -f "$PNPM_CALLS" ]]; then
+    wc -l < "$PNPM_CALLS" | tr -d '[:space:]'
+  else
+    printf '0\n'
+  fi
+}
 
-if [[ "$EXPECTATION" == "bug" ]]; then
-  if [[ "$pnpm_call_count" -lt 1 ]]; then
-    echo "repro: expected run.sh to call pnpm while the bootstrap stamp is missing" >&2
+assert_pnpm_install_attempted() {
+  local reason="$1"
+  local count
+  count="$(pnpm_call_count)"
+  if [[ "$count" -lt 1 ]]; then
+    echo "repro: expected run.sh to call pnpm for $reason" >&2
     echo "stdout:" >&2
     cat "$RUN_STDOUT" >&2 || true
     echo "stderr:" >&2
@@ -113,20 +128,26 @@ if [[ "$EXPECTATION" == "bug" ]]; then
     exit 1
   fi
   if [[ "$status" -ne 73 ]]; then
-    echo "repro: expected pnpm stub exit 73, got $status" >&2
+    echo "repro: expected pnpm stub exit 73 for $reason, got $status" >&2
     cat "$RUN_STDERR" >&2 || true
     exit 1
   fi
   if ! grep -Fq 'install --frozen-lockfile' "$PNPM_CALLS"; then
-    echo "repro: expected pnpm install --frozen-lockfile, saw:" >&2
+    echo "repro: expected pnpm install --frozen-lockfile for $reason, saw:" >&2
     cat "$PNPM_CALLS" >&2 || true
     exit 1
   fi
+}
+
+run_fake_headless
+
+if [[ "$EXPECTATION" == "bug" ]]; then
+  assert_pnpm_install_attempted "a missing bootstrap stamp"
   echo "repro: confirmed bug"
   echo "repro: healthy artifacts were present, bootstrap stamp was absent, and run.sh called pnpm install"
   cat "$PNPM_CALLS"
 else
-  if [[ "$pnpm_call_count" -ne 0 ]]; then
+  if [[ "$(pnpm_call_count)" -ne 0 ]]; then
     echo "repro: expected fixed run.sh to skip pnpm for healthy preprovisioned artifacts" >&2
     cat "$PNPM_CALLS" >&2 || true
     exit 1
@@ -142,5 +163,13 @@ else
     cat "$RUN_STDOUT" >&2 || true
     exit 1
   fi
+
+  run_fake_headless 1
+  assert_pnpm_install_attempted "INVOKER_FORCE_BOOTSTRAP=1"
+
+  touch -t 202001010002 "$FAKE_ROOT/pnpm-lock.yaml"
+  run_fake_headless
+  assert_pnpm_install_attempted "a stale install metadata timestamp"
+
   echo "repro: confirmed fixed behavior"
 fi

--- a/scripts/test-suites/required/08-electron-preprovision-repro.sh
+++ b/scripts/test-suites/required/08-electron-preprovision-repro.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Regression: Electron launcher must verify pre-provisioning without running installers.
+# Regression: launchers must verify pre-provisioning without running installers.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
-exec bash "$ROOT/scripts/repro/repro-mece-04-remote-electron-provisioning.sh"
+bash "$ROOT/scripts/repro/repro-mece-04-remote-electron-provisioning.sh"
+bash "$ROOT/scripts/repro/repro-run-sh-preprovisioned-bootstrap.sh"

--- a/scripts/test-suites/required/17-merge-gate-concurrency-repro.sh
+++ b/scripts/test-suites/required/17-merge-gate-concurrency-repro.sh
@@ -2,6 +2,9 @@
 # Regression proof for merge gates running as normal executor actions.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-cd "$ROOT/packages/execution-engine"
-exec pnpm exec vitest run src/__tests__/task-runner.test.ts \
-  -t "starts an independent merge gate while another merge gate is still preparing review"
+source "$ROOT/scripts/lib/required-vitest.sh"
+
+run_required_vitest_filter \
+  "$ROOT/packages/execution-engine" \
+  "src/__tests__/task-runner-fix-publish-and-ssh.test.ts" \
+  "starts an independent merge gate while another merge gate is still preparing review"


### PR DESCRIPTION
## Summary

The zero-active repro now verifies both sides of the guard: stale target failure and required/17 success.

It checks the stale-target error text so failures prove the skipped-test condition, not an unrelated setup problem.

## Review Claim

The required/17 git e2e guard now executes active tests and catches stale filters.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Verification is restricted to the repro and required suite wrapper.

## Slice Rationale

This focused proof comes after the harness guard so stale filters are checked with the same helper required/17 uses.

## Non-goals

Do not run dry-run Electron cases in this slice.

Do not change TaskRunner merge-gate behavior in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-required-vitest-filter-zero-active.sh --expect-fixed`
- [x] `bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/fix-git-e2e-tests-step-3-vitest-guard-2.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 388ac2e01`
- Post-revert steps: Re-run `bash scripts/repro/repro-required-vitest-filter-zero-active.sh --expect-fixed`
- Data migration? No

</details>
