### PR TITLE
[Planning tmux output survives Home/Planning switches](1) Add surface-switch regression

### DIFF
--- a/packages/ui/src/__tests__/planning-terminal-tmux.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-tmux.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const xtermMock = vi.hoisted(() => {
+  type DataHandler = (data: string) => void;
+
+  const instances: MockTerminal[] = [];
+  const writeLog: string[] = [];
+
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    dataHandler: DataHandler | null = null;
+    loadAddon = vi.fn();
+    open = vi.fn((host: HTMLElement) => {
+      const terminalElement = document.createElement('div');
+      terminalElement.className = 'xterm';
+      terminalElement.textContent = 'mock planning terminal';
+      host.appendChild(terminalElement);
+    });
+    write = vi.fn((data: string) => {
+      writeLog.push(data);
+    });
+    onData = vi.fn((cb: DataHandler) => {
+      this.dataHandler = cb;
+      return { dispose: vi.fn() };
+    });
+    focus = vi.fn();
+    dispose = vi.fn();
+
+    constructor() {
+      instances.push(this);
+    }
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+  }
+
+  return {
+    Terminal: MockTerminal,
+    FitAddon: MockFitAddon,
+    instances,
+    writeLog,
+    reset: () => {
+      instances.length = 0;
+      writeLog.length = 0;
+    },
+  };
+});
+
+vi.mock('xterm', () => ({ Terminal: xtermMock.Terminal }));
+vi.mock('xterm-addon-fit', () => ({ FitAddon: xtermMock.FitAddon }));
+
+const { App } = await import('../App.js');
+
+describe('Planning terminal tmux history sync', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    xtermMock.reset();
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it.fails('restores planning tmux output received while the terminal surface is hidden', async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    fireEvent.click(await screen.findByRole('tab', { name: 'Tmux' }));
+
+    await waitFor(() => {
+      expect(mock.api.planningTerminalOpen).toHaveBeenCalledTimes(1);
+    });
+    const initialPane = await screen.findByTestId('invoker-terminal-tmux-pane');
+    const sessionId = initialPane.getAttribute('data-session-id');
+    expect(sessionId).toBe('mock-planning-terminal-session-1');
+    expect(xtermMock.writeLog).toEqual([]);
+
+    act(() => {
+      mock.fireTerminalOutput({
+        sessionId: sessionId!,
+        taskId: 'planning:session-1',
+        kind: 'planning',
+        planningSessionId: 'session-1',
+        data: 'visible before hiding\n',
+      });
+    });
+    await waitFor(() => {
+      expect(xtermMock.writeLog).toEqual(['visible before hiding\n']);
+    });
+
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+    await waitFor(() => {
+      expect(screen.queryByTestId('invoker-terminal-tmux-pane')).not.toBeInTheDocument();
+    });
+
+    act(() => {
+      mock.fireTerminalOutput({
+        sessionId: sessionId!,
+        taskId: 'planning:session-1',
+        kind: 'planning',
+        planningSessionId: 'session-1',
+        data: 'hidden via planning id\n',
+      });
+      mock.fireTerminalOutput({
+        sessionId: sessionId!,
+        taskId: 'planning:session-1',
+        kind: 'planning',
+        data: 'hidden via session id\n',
+      });
+      mock.fireTerminalOutput({
+        sessionId: 'mock-session-task-alpha',
+        taskId: 'task-alpha',
+        kind: 'task',
+        data: 'task drawer output must stay separate\n',
+      });
+    });
+    expect(xtermMock.writeLog).toEqual(['visible before hiding\n']);
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-tmux-pane')).toHaveAttribute('data-session-id', sessionId);
+      expect(xtermMock.writeLog).toContain('visible before hiding\nhidden via planning id\nhidden via session id\n');
+    });
+    expect(xtermMock.writeLog.join('')).not.toContain('task drawer output');
+    expect(mock.api.planningTerminalOpen).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Planning tmux output survives Home/Planning switches — 2 tasks completed, 0 failed, 0 closed, 0 skipped.

This slice adds a focused regression for hidden planning tmux output while the terminal pane is unmounted.

It records the current failure with `it.fails`, so this slice stays green before the fix lands in the next PR.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784340495515-7/implement-planning-tmux-history-sync | Keep planning tmux output snapshot in renderer state while the Planning surface is hidden, so remount restores scrollback/history | completed |
| wf-1784340495515-7/verify-planning-tmux-surface-switch-regression | Run focused UI regression test for planning tmux history across sidebar surface switches | completed (passed) |

</details>

## Review Claim

Approve the regression that proves hidden planning tmux output is lost across Home and Planning surface switches, before the fix.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only a Vitest regression file is added, and the expected failure (`it.fails`) keeps this slice green without changing product behavior.

## Slice Rationale

The failing proof lands before the behavior change so reviewers can see the bug demonstrated before approving the fix in the next PR.

## Non-goals

- Do not change Planning terminal behavior in this slice.
- Do not change tmux session lifecycle, IPC contracts, or renderer snapshot storage.
- Do not update release artifacts.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/planning-terminal-tmux.test.tsx -t "restores planning tmux output received while the terminal surface is hidden"`
- [x] `node scripts/validate-pr-body.mjs --body-file <this file>`

</details>

## Visual Proof

Captured on the pre-fix base commit (531ac970a) with a real Electron build and a real embedded PTY, driving the exact Home → Planning → Home switch this regression asserts on.

![Walkthrough: Planning tmux pane loses MARKER output across a Home → Planning → Home switch](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-079f74/planning-tmux-hidden-output-lost-BUG-walkthrough.gif)

Frame 1 shows `MARKER_ALPHA_ONE_VISIBLE` output in the Tmux tab prior to switching away. Frame 2, captured once Home remounts the same session, shows the pane blank except for a bare cursor — the marker line and everything produced while hidden is gone. This is the bug this slice's regression pins down.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b7c92114`
- Post-revert steps: None; this slice only adds a test file.
- Data migration? No

</details>
