### PR TITLE
[Planning tmux output survives Home/Planning switches](2) Preserve hidden planning tmux output

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
-import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, StartReadyRequest, StartReadyResult, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
+import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, StartReadyRequest, StartReadyResult, TerminalOutputEvent, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus, WorkerActionSummary, WorkerLogEntry, WorkerStatusEntry } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
 import { reportUiNavigation } from './lib/report-ui-navigation.js';
@@ -114,6 +114,7 @@ const EDITABLE_SELECTOR = [
 const SYSTEM_SETUP_AUTO_OPEN_DELAY_MS = 1200;
 const RAIL_LIST_FRAME_CLASS = 'flex min-h-0 flex-1 flex-col';
 const RAIL_SCROLL_BODY_CLASS = 'min-h-0 flex-1 overflow-y-auto';
+const MAX_TERMINAL_OUTPUT_SNAPSHOT_CHARS = 64 * 1024;
 
 function notifyMutationError(rawTitle: string, err: unknown): void {
   console.error(rawTitle, err);
@@ -172,6 +173,17 @@ function planningSessionFromSummary(
     terminalError: null,
     ...overrides,
   };
+}
+
+function appendTerminalOutputSnapshot(
+  snapshot: string | undefined,
+  chunk: string,
+): string {
+  if (!chunk) return snapshot ?? '';
+  const nextSnapshot = `${snapshot ?? ''}${chunk}`;
+  return nextSnapshot.length <= MAX_TERMINAL_OUTPUT_SNAPSHOT_CHARS
+    ? nextSnapshot
+    : nextSnapshot.slice(nextSnapshot.length - MAX_TERMINAL_OUTPUT_SNAPSHOT_CHARS);
 }
 
 type PlanningStreamState = {
@@ -1097,6 +1109,45 @@ export function App() {
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [graphMaximized, planningTerminalExpanded]);
 
+  useEffect(() => {
+    const unsubscribe = window.invoker?.onTerminalOutput?.((event: TerminalOutputEvent) => {
+      if (event.kind !== 'planning' || !event.data) return;
+
+      setPlanningSessions((prev) => {
+        let changed = false;
+        const planningSessionId = event.planningSessionId?.trim() ?? '';
+        const hasPlanningSessionMatch = planningSessionId
+          ? prev.some((session) => session.id === planningSessionId)
+          : false;
+        const next = prev.map((session) => {
+          const terminalSession = session.terminalSession ?? null;
+          const matchesPlanningSession = hasPlanningSessionMatch
+            && session.id === planningSessionId;
+          const matchesTerminalSession = !hasPlanningSessionMatch
+            && terminalSession?.sessionId === event.sessionId;
+          if (!terminalSession || (!matchesPlanningSession && !matchesTerminalSession)) {
+            return session;
+          }
+
+          const outputSnapshot = appendTerminalOutputSnapshot(terminalSession.outputSnapshot, event.data);
+          if (outputSnapshot === (terminalSession.outputSnapshot ?? '')) {
+            return session;
+          }
+
+          changed = true;
+          return {
+            ...session,
+            terminalSession: {
+              ...terminalSession,
+              outputSnapshot,
+            },
+          };
+        });
+        return changed ? next : prev;
+      });
+    });
+    return () => { unsubscribe?.(); };
+  }, []);
 
   useEffect(() => {
     const unsubscribe = window.invoker?.onTerminalExit?.((event) => {

--- a/packages/ui/src/__tests__/planning-terminal-tmux.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-tmux.test.tsx
@@ -74,7 +74,7 @@ describe('Planning terminal tmux history sync', () => {
     vi.restoreAllMocks();
   });
 
-  it.fails('restores planning tmux output received while the terminal surface is hidden', async () => {
+  it('restores planning tmux output received while the terminal surface is hidden', async () => {
     render(<App />);
 
     fireEvent.click(await screen.findByTestId('sidebar-home'));

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -134,7 +134,6 @@ function MessageBody({ text, toneClass }: { text: string; toneClass: string }): 
 
 type SeededOutputSnapshot = {
   sessionId: string;
-  snapshot: string;
   term: XTermTerminal;
 };
 
@@ -146,27 +145,32 @@ function seedTerminalOutputSnapshot(
   const outputSnapshot = session.outputSnapshot;
   const seededSnapshot = seededSnapshotRef.current;
   if (
-    outputSnapshot &&
-    (
-      !seededSnapshot ||
-      seededSnapshot.sessionId !== session.sessionId ||
-      seededSnapshot.snapshot !== outputSnapshot ||
-      seededSnapshot.term !== term
-    )
+    seededSnapshot &&
+    seededSnapshot.sessionId === session.sessionId &&
+    seededSnapshot.term === term
   ) {
-    try {
-      term.write(outputSnapshot);
-      seededSnapshotRef.current = {
-        sessionId: session.sessionId,
-        snapshot: outputSnapshot,
-        term,
-      };
-    } catch (err) {
-      console.warn(
-        `Failed to seed output snapshot for planning terminal session ${session.sessionId}:`,
-        err,
-      );
-    }
+    return;
+  }
+
+  if (!outputSnapshot) {
+    seededSnapshotRef.current = {
+      sessionId: session.sessionId,
+      term,
+    };
+    return;
+  }
+
+  try {
+    term.write(outputSnapshot);
+    seededSnapshotRef.current = {
+      sessionId: session.sessionId,
+      term,
+    };
+  } catch (err) {
+    console.warn(
+      `Failed to seed output snapshot for planning terminal session ${session.sessionId}:`,
+      err,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

Planning tmux output survives Home/Planning switches — both workflow tasks completed with no failures.

Planning tmux output now keeps a bounded renderer snapshot while Home/Planning navigation hides the pane.

When Planning remounts the same tmux session, the pane replays output that arrived while hidden.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784340495515-7/implement-planning-tmux-history-sync | Keep planning tmux output snapshot in renderer state while the Planning surface is hidden, so remount restores scrollback/history | completed |
| wf-1784340495515-7/verify-planning-tmux-surface-switch-regression | Run focused UI regression test for planning tmux history across sidebar surface switches | completed (passed) |

</details>

## Review Claim

Approve preserving planning tmux scrollback across Home and Planning surface switches without reopening the underlying tmux session.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only planning terminal output events update a bounded 64 KiB renderer snapshot, and remount reuses the existing session ID.

## Slice Rationale

The lower slice locks the failing regression; this slice contains the behavior change and flips that regression to passing.

## Non-goals

- Do not change task terminal behavior.
- Do not alter backend tmux session lifecycle or IPC contracts.
- Do not change Planning chat persistence.

## Architecture

### Before

```mermaid
graph TD
    A["Planning tmux pane unmounts"] --> B["hidden output reaches no terminal"]
    B --> C["remount starts from the old snapshot"]
```

### After

```mermaid
graph TD
    A["Planning tmux pane unmounts"] --> B["renderer stores hidden output in the session snapshot"]
    B --> C["remount seeds InvokerTerminal from the updated snapshot"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/planning-terminal-tmux.test.tsx -t "restores planning tmux output received while the terminal surface is hidden"`
- [x] `node scripts/validate-pr-body.mjs --body-file <this file>`

</details>

## Visual Proof

Captured on this branch (fix applied) with a real Electron build and a real embedded PTY, driving the exact Home → Planning → Home switch the new regression asserts on.

![Walkthrough: Planning tmux pane replays MARKER output that arrived while hidden across a Home → Planning → Home switch](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-67fbfa/planning-tmux-hidden-output-restored-walkthrough.gif)

Frame 1 shows `MARKER_ALPHA_ONE_VISIBLE` output in the Tmux tab prior to switching away. Frame 2, captured once Home remounts the same session, shows a "Restored session" banner plus the original marker and all five `MARKER_BETA_HIDDEN_LINE_1..5` lines that were produced while the pane was hidden — the fix in this slice.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9c3cc2aa`
- Post-revert steps: Re-run `pnpm --filter @invoker/ui exec vitest run src/__tests__/planning-terminal-tmux.test.tsx -t "restores planning tmux output received while the terminal surface is hidden"`.
- Data migration? No

</details>
