### PR TITLE
Close planning terminal on GUI delete

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -436,7 +436,6 @@ let runtimeServices: RuntimeServices;
 let workflowMutationCoordinator: PersistedWorkflowMutationCoordinator | null = null;
 let launchDispatcher: LaunchDispatcher | null = null;
 const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
-const planningChatSessions = createInAppPlanningChatSessions();
 /**
  * The mutation context for the currently executing workflow mutation.
  * Set by the coordinator dispatch callback before invoking the handler,
@@ -680,7 +679,6 @@ function updateInvokerCliFromMenu(): void {
     detail,
   });
 }
-
 
 async function initServices(options?: InitServicesOptions): Promise<void> {
   const invokerHomeRoot = resolveInvokerHomeRoot();
@@ -2441,7 +2439,15 @@ function createEmbeddedTerminalBackendFromConfig(
       getMessageBus: () => messageBus,
       refreshOwnerRoute: refreshGuiMutationOwnerRoute,
       onMutationOwnerUnavailable: markDaemonOwnerUnavailable,
-      translateGuiMutationToHeadless: (payload) => mutationActions.translateGuiMutationToHeadless(payload),
+      translateGuiMutationToHeadless: (payload) => {
+        if (
+          payload.channel === 'invoker:planning-chat-delete'
+          || payload.channel === 'invoker:planning-chat-delete-submitted'
+        ) {
+          return { channel: 'headless.gui-mutation', request: payload };
+        }
+        return mutationActions.translateGuiMutationToHeadless(payload);
+      },
       guiMutationHandlers,
     };
 
@@ -2837,6 +2843,32 @@ function createEmbeddedTerminalBackendFromConfig(
       resolveSetupCliPath,
       getBundledSkillsStatus,
       installPackagedSkills,
+    });
+    const guiPlanningConversationRepo = new ConversationRepository(persistence, {
+      info: (message) => logger.info(message, { module: 'planning-chat' }),
+      warn: (message) => logger.warn(message, { module: 'planning-chat' }),
+      error: (message) => logger.error(message, { module: 'planning-chat' }),
+    });
+    const closePlanningTerminalSession = (terminalSessionId: string): void => {
+      embeddedTerminalManager.close(terminalSessionId);
+    };
+    registrars.registerGuiMutationHandler('invoker:planning-chat-delete', async (request: unknown) => {
+      return deletePlanningChat(request as InAppPlanningDeleteRequest, {
+        sessions: planningChatSessions,
+        planningSessionStore: ownerMode ? persistence : undefined,
+        conversationRepo: guiPlanningConversationRepo,
+        closeTerminal: closePlanningTerminalSession,
+        logger,
+      });
+    });
+    registrars.registerGuiMutationHandler('invoker:planning-chat-delete-submitted', async () => {
+      return deleteSubmittedPlanningChats({
+        sessions: planningChatSessions,
+        planningSessionStore: ownerMode ? persistence : undefined,
+        conversationRepo: guiPlanningConversationRepo,
+        closeTerminal: closePlanningTerminalSession,
+        logger,
+      });
     });
     if (ownerMode) {
       planningTerminalState.restorePersistedPlanningTerminals();


### PR DESCRIPTION
## Summary

The GUI planning-chat teardown requests had no owner-mode mutation handler, so they ran only on the standalone path.

That standalone path also lacked a terminal-close capability, so tearing down a planning chat left its embedded terminal running.

Route both teardown requests through the owner-mode GUI mutation path and pass a terminal-close capability into the handler.

## Review Claim

Approve routing the two planning-chat teardown requests through the owner-mode GUI mutation path so the handler runs and closes the embedded terminal.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Teardown stays best-effort: each step is guarded, so a failed terminal close never blocks the memory, store, or conversation steps.

## Slice Rationale

The backend handler already shipped; this slice only routes the GUI path to it so terminals actually stop.

## Non-goals

This slice does not change the standalone headless path, the delete contract types, or the renderer affordance.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c2fe709bd`
- Post-revert steps: None
- Data migration? No

</details>


