### PR TITLE
[Approved Fix SSH Capacity](1) Add proof for wrapped approved-fix SSH capacity waits

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -801,7 +801,7 @@ describe('TaskRunner', () => {
         commit: 'abc1234',
       });
     });
-    it('waits for SSH capacity instead of failing approved-fix publish', async () => {
+    it('waits for wrapped SSH capacity errors instead of failing approved-fix publish', async () => {
       vi.useFakeTimers();
       const publishSpy = vi.spyOn(SshExecutor.prototype, 'publishApprovedFix').mockResolvedValue({
         commitHash: 'queued123',
@@ -846,7 +846,8 @@ describe('TaskRunner', () => {
       const selectExecutorSpy = vi.spyOn(runner, 'selectExecutor');
       const originalSelectExecutor = TaskRunner.prototype.selectExecutor.bind(runner);
       selectExecutorSpy.mockImplementationOnce(() => {
-        throw new ResourceLimitError('Execution pool "pnpm-ssh" has no member capacity available');
+        const message = 'Execution pool "pnpm-ssh" has no member capacity available';
+        throw new Error(message, { cause: new ResourceLimitError(message) });
       });
       selectExecutorSpy.mockImplementation((selectedTask, excludedPoolMemberKeys = new Set()) =>
         originalSelectExecutor(selectedTask, excludedPoolMemberKeys)


### PR DESCRIPTION
## Summary

This adds a regression test for the approved-fix SSH capacity wait path.

The old proof only threw a bare resource-limit error. The real pool-full path wraps that error in `Error.cause`.

This keeps the repro honest. If approved-fix publish stops waiting on wrapped pool-capacity failures, this test fails.

## Review Claim

The approved-fix SSH capacity proof now covers the real wrapped pool-capacity error shape.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. No runtime behavior, queueing, or executor selection code changed.

## Slice Rationale

This stays as a proof-only slice because the behavior already exists in `TaskRunner.publishApprovedFix`. The missing part was coverage for the exact failing error shape.

## Non-goals

No runtime fix.

No change to remote dependency provisioning or the separate `vitest: not found` failure.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts -t "waits for wrapped SSH capacity errors instead of failing approved-fix publish"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- [x] Safe to revert? Yes.
- [x] Revert command: `git revert bb8ee31e6`
- [x] Post-revert steps: None.
- [x] Data migration? No.

</details>
