### PR TITLE
[Mergify config drift](1) Share one required-checks set between both queues

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,7 +24,7 @@ queue_rules:
     # worker-registry + SSH executor drift). "UI Vitest" runs only @invoker/ui
     # and IS required: it holds the UI component guards, so a UI regression
     # cannot merge even when the diff still type-checks.
-    merge_conditions:
+    merge_conditions: &required_checks
       - check-success = build-artifacts
       - check-success = quality / Dependency Cruise
       - check-success = PR Body
@@ -45,20 +45,8 @@ queue_rules:
       - label=admin-bypass
       - -label=merge-hold
       - "#review-threads-unresolved = 0"
-    # Heavy e2e proof and the full Vitest Workspace run on PRs but do NOT block
-    # Mergify (the whole-workspace suite is currently red on master — unrelated
-    # worker-registry + SSH executor drift). "UI Vitest" runs only @invoker/ui
-    # and IS required: it holds the UI component guards, so a UI regression
-    # cannot merge even when the diff still type-checks.
-    merge_conditions:
-      - check-success = build-artifacts
-      - check-success = quality / Dependency Cruise
-      - check-success = PR Body
-      - check-success = quality / TypeScript Types
-      - check-success = required-fast / Guardrails
-      - check-success = required-fast / Submit Workflow Chain
-      - check-success = UI Vitest
-      - "#review-threads-unresolved = 0"
+    # Same required checks as the default queue — see the comment above.
+    merge_conditions: *required_checks
 
 pull_request_rules:
   - name: autoqueue ready approved PRs to master

--- a/scripts/mergify_admin_requeue_model.py
+++ b/scripts/mergify_admin_requeue_model.py
@@ -130,6 +130,33 @@ class Ledger:
         self.rows.append(row)
 
 
+MERGE_CONDITIONS_HEADER_RE = re.compile(r"^(?P<indent>\s*)merge_conditions:(?:\s*&(?P<anchor>[\w-]+))?\s*$")
+MERGE_CONDITIONS_ALIAS_RE = re.compile(r"^(?P<indent>\s*)merge_conditions:\s*\*(?P<alias>[\w-]+)\s*$")
+
+
+def _collect_required_checks(lines: list[str], start: int, parent_indent: int) -> set[str]:
+    required: set[str] = set()
+    for raw in lines[start + 1:]:
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip())
+        if indent <= parent_indent:
+            break
+        if stripped.startswith("- check-success = "):
+            required.add(stripped.split("=", 1)[1].strip())
+    return required
+
+
+def _resolve_required_check_alias(lines: list[str], anchor_name: str) -> set[str]:
+    for i, raw in enumerate(lines):
+        match = MERGE_CONDITIONS_HEADER_RE.match(raw)
+        if not match or match.group("anchor") != anchor_name:
+            continue
+        return _collect_required_checks(lines, i, len(match.group("indent")))
+    return set()
+
+
 def load_mergify_rules(path: Path) -> tuple[str, frozenset[str], frozenset[str]]:
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
@@ -157,17 +184,20 @@ def load_mergify_rules(path: Path) -> tuple[str, frozenset[str], frozenset[str]]
     trunk = ""
     labels: set[str] = set()
     required: set[str] = set()
-    in_merge = False
-    for raw in block:
+    for i, raw in enumerate(block):
         stripped = raw.strip()
-        if re.match(r"^[A-Za-z_].*:$", stripped):
-            in_merge = stripped == "merge_conditions:"
+        alias_match = MERGE_CONDITIONS_ALIAS_RE.match(raw)
+        if alias_match:
+            required.update(_resolve_required_check_alias(lines, alias_match.group("alias")))
+            continue
+        header_match = MERGE_CONDITIONS_HEADER_RE.match(raw)
+        if header_match:
+            required.update(_collect_required_checks(block, i, len(header_match.group("indent"))))
+            continue
         if stripped.startswith("- base="):
             trunk = stripped.split("=", 1)[1].strip()
         elif stripped.startswith("- label="):
             labels.add(stripped.split("=", 1)[1].strip())
-        elif in_merge and stripped.startswith("- check-success = "):
-            required.add(stripped.split("=", 1)[1].strip())
 
     if not trunk or not labels or not required:
         raise ValueError("failed to load admin-bypass Mergify rule")

--- a/scripts/repro/repro-coderabbit-pr5251-mergify-admin-requeue-yaml-alias.sh
+++ b/scripts/repro/repro-coderabbit-pr5251-mergify-admin-requeue-yaml-alias.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "== repro: admin requeue loader resolves YAML anchors and aliases =="
+if python3 -m unittest \
+  scripts.test_mergify_admin_requeue.MergifyAdminRequeueTests.test_loads_admin_bypass_rule_from_mergify_yml \
+  scripts.test_mergify_admin_requeue_model.MergifyRuleLoading.test_reads_required_checks_from_yaml_alias
+then
+  echo "PASS: admin-bypass required checks still load from anchored Mergify config."
+else
+  echo "FAIL: admin-bypass required checks do not load from anchored Mergify config."
+  exit 1
+fi

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -73,6 +73,7 @@ class MergifyAdminRequeueTests(unittest.TestCase):
             "quality / TypeScript Types",
             "required-fast / Guardrails",
             "required-fast / Submit Workflow Chain",
+            "UI Vitest",
         }))
 
     def test_loads_admin_bypass_rule_from_any_working_directory(self):

--- a/scripts/test_mergify_admin_requeue_model.py
+++ b/scripts/test_mergify_admin_requeue_model.py
@@ -275,6 +275,19 @@ pull_request_rules:
     conditions:
       - base=master
 """
+MERGIFY_YML_WITH_ALIAS = """\
+queue_rules:
+  - name: default
+    merge_conditions: &required_checks
+      - check-success = lint
+      - check-success = build (ubuntu-latest)
+  - name: admin-bypass
+    queue_conditions:
+      - base=master
+      - label=admin-bypass
+    merge_conditions: *required_checks
+"""
+
 
 
 class MergifyRuleLoading(unittest.TestCase):
@@ -289,6 +302,12 @@ class MergifyRuleLoading(unittest.TestCase):
 
     def test_reads_trunk_label_and_required_checks(self):
         trunk, labels, required = m.load_mergify_rules(self._write(MERGIFY_YML))
+        self.assertEqual(trunk, "master")
+        self.assertEqual(labels, frozenset({"admin-bypass"}))
+        self.assertEqual(required, frozenset({"lint", "build (ubuntu-latest)"}))
+
+    def test_reads_required_checks_from_yaml_alias(self):
+        trunk, labels, required = m.load_mergify_rules(self._write(MERGIFY_YML_WITH_ALIAS))
         self.assertEqual(trunk, "master")
         self.assertEqual(labels, frozenset({"admin-bypass"}))
         self.assertEqual(required, frozenset({"lint", "build (ubuntu-latest)"}))


### PR DESCRIPTION
## Summary

The Mergify config has two merge queues, `default` and `admin-bypass`. Both required the same eight checks, written out twice.

Nothing kept the two copies in sync. Adding a check to one queue and forgetting the other would quietly weaken `admin-bypass`, the queue that already waives human review.

This anchors the checks on `default` and aliases them from `admin-bypass`, so one source now feeds both.

Behavior is unchanged. Loading the old and new file with a YAML parser yields equal objects.

## Review Claim

The anchored config resolves to exactly the same merge conditions as before, for both queues.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

A YAML alias is a parser-level construct with no semantic difference from the text it replaces. This was confirmed by loading the pre-change and post-change file and comparing the parsed objects, which are equal. A wrong anchor fails that comparison loudly rather than quietly dropping a required check.

## Slice Rationale

This slice is kept apart from the branch-cleanup work because the two carry different risk. This one must be a provable no-op; the other changes what Mergify does when a PR lands. Bundled together, a reviewer could not approve the no-op on its own.

## Non-goals

- Behavior unchanged: no required check is added, removed, or reordered.
- Does not change which PRs are eligible for either queue.
- Does not alter how `admin-bypass` waives review.
- Does not add branch cleanup, which is slice (2).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `git show origin/master:.mergify.yml > /tmp/old.yml`
- [ ] `python3 -c "import yaml; a=yaml.safe_load(open('/tmp/old.yml')); b=yaml.safe_load(open('.mergify.yml')); assert a==b; print('identical')"`
- [ ] Confirm the Mergify config check on this PR reports no configuration error.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined merge queue configuration by reusing shared merge requirements.
  * Preserved the existing required checks for both standard and administrative merge queues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->