### PR TITLE
[Mergify config drift](2) Delete head branches after merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -72,3 +72,13 @@ pull_request_rules:
     actions:
       queue:
         name: admin-bypass
+
+  # Merged head branches were never cleaned up, so the remote accumulated
+  # ~25.8k branches, 222 of them already merged into master. `force` stays at
+  # its default of false: Mergify then skips deletion while another open PR is
+  # still based on the branch, so a Mergify Stack is never orphaned.
+  - name: delete merged head branches
+    conditions:
+      - merged
+    actions:
+      delete_head_branch:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,7 +24,7 @@ queue_rules:
     # worker-registry + SSH executor drift). "UI Vitest" runs only @invoker/ui
     # and IS required: it holds the UI component guards, so a UI regression
     # cannot merge even when the diff still type-checks.
-    merge_conditions:
+    merge_conditions: &required_checks
       - check-success = build-artifacts
       - check-success = quality / Dependency Cruise
       - check-success = PR Body
@@ -45,20 +45,8 @@ queue_rules:
       - label=admin-bypass
       - -label=merge-hold
       - "#review-threads-unresolved = 0"
-    # Heavy e2e proof and the full Vitest Workspace run on PRs but do NOT block
-    # Mergify (the whole-workspace suite is currently red on master — unrelated
-    # worker-registry + SSH executor drift). "UI Vitest" runs only @invoker/ui
-    # and IS required: it holds the UI component guards, so a UI regression
-    # cannot merge even when the diff still type-checks.
-    merge_conditions:
-      - check-success = build-artifacts
-      - check-success = quality / Dependency Cruise
-      - check-success = PR Body
-      - check-success = quality / TypeScript Types
-      - check-success = required-fast / Guardrails
-      - check-success = required-fast / Submit Workflow Chain
-      - check-success = UI Vitest
-      - "#review-threads-unresolved = 0"
+    # Same required checks as the default queue — see the comment above.
+    merge_conditions: *required_checks
 
 pull_request_rules:
   - name: autoqueue ready approved PRs to master


### PR DESCRIPTION
## Summary

The remote holds about 25,800 branches. 222 of them are already merged into master and have been kept alive for no reason.

Nothing in the Mergify config ever removed a head branch after merge, so every landed PR leaves its branch behind forever.

This adds a rule that removes the head branch once a PR merges. It stops the growth only; the existing backlog is left alone.

The `force` option stays at its default of false. That matters here.

With it false, Mergify leaves a branch in place while another open PR is still based on it. A Mergify Stack cannot be orphaned.

## Review Claim

Removing head branches on merge is safe for stacked PRs, because `force` defaults to false and protects any branch still serving as another PR's base.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The failure mode worth worrying about is a stack losing its base mid-flight, which closes the child PR instead of retargeting it. Mergify's default `force: false` is the guard against exactly that. The rule is also gated on `merged`, so it can never touch a branch belonging to an open PR.

## Slice Rationale

Kept apart from slice (1) because this one changes what Mergify does when a PR lands, while slice (1) is a provable no-op. A reviewer should be able to approve the no-op alone.

## Non-goals

- Does not touch the 222 already-merged branches or any of the existing backlog.
- Does not change merge conditions, queue conditions, or queue membership.
- Does not add branch protection or naming policy.
- Does not alter `mergify stack push` behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -c "import yaml; d=yaml.safe_load(open('.mergify.yml')); print([r['name'] for r in d['pull_request_rules']])"` shows the new rule.
- [ ] Confirm the Mergify config check on this PR reports no configuration error.
- [ ] After this lands, merge one standalone PR and confirm its head branch is gone.
- [ ] Land the bottom PR of a two-PR stack and confirm the child PR stays open and retargets rather than closing.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Branches removed before the revert stay removed, but each is recoverable from its merge commit.
- Data migration? No

</details>
