### PR TITLE
[Merge Gate Open Artifacts](3) Refuse gate approval while required PRs are open

### DIFF
--- a/packages/workflow-core/src/__tests__/merge-gate-approval-open-artifacts.test.ts
+++ b/packages/workflow-core/src/__tests__/merge-gate-approval-open-artifacts.test.ts
@@ -285,23 +285,22 @@ function makeResponse(overrides: Partial<WorkResponse>): WorkResponse {
 }
 
 /**
- * Repro for: "Admin Bypass Babysitter Step 2" reported completed while
- * PRs #5127 / #5128 were still open.
+ * Merge-gate completion invariant.
  *
- * Observed sequence (~/.invoker/merge-trace.log, 2026-07-20):
- *   07:54:41.715  GATE_WS_SET_FIX_AWAITING          (merge gate enters fix session)
- *   07:54:41.721  worker-autoapprove-submitted      (approve intent queued, channel invoker:approve)
- *   07:54:54      PUBLISH_AFTER_FIX_ENTER
- *   08:08:48.889  GATE_WS_SET_TASK_REVIEW_READY     (fresh, unmerged PRs published)
- *   08:08:48.977  APPROVE_ENTER  status=review_ready
- *   08:08:49.013  APPROVE_DONE   status=completed
+ * Regression origin: "Admin Bypass Babysitter Step 2" reported completed while
+ * PRs #5127 / #5128 were still open (~/.invoker/merge-trace.log, 2026-07-20):
  *
- * The approve intent was validated against "awaiting_approval + pendingFixError"
- * (approve the AI fix) but consumed 14 minutes later against "review_ready"
- * (approve the review gate), because Orchestrator.approve accepts both states
- * and re-validates nothing at consumption time.
+ *   07:54:41.715  GATE_WS_SET_FIX_AWAITING        merge gate enters fix session
+ *   07:54:41.721  worker-autoapprove-submitted    approve intent 93969 queued
+ *   08:08:48.889  GATE_WS_SET_TASK_REVIEW_READY   fresh, unmerged PRs published
+ *   08:08:48.977  APPROVE_ENTER status=review_ready   (queueWaitMs 847256)
+ *   08:08:49.013  APPROVE_DONE  status=completed
+ *
+ * The intent was validated against "awaiting_approval + pendingFixError"
+ * (approve the AI fix) and spent 14 minutes later on "review_ready" (approve
+ * the review gate). approve() accepted both states and re-validated nothing.
  */
-describe('repro: queued fix-approval intent completes an unmerged external_review gate', () => {
+describe('merge gate approval requires approved artifacts', () => {
   let orchestrator: Orchestrator;
   let persistence: InMemoryPersistence;
 
@@ -332,21 +331,26 @@ describe('repro: queued fix-approval intent completes an unmerged external_revie
     return orchestrator.getAllTasks().find(t => t.config.isMergeNode)!;
   }
 
-  const openPrGate = {
-    activeGeneration: 11,
-    completion: { required: 'all' as const, status: 'approved' as const },
-    artifacts: [
-      { id: '5127', providerId: '5127', required: true, status: 'open' as const, generation: 11 },
-      { id: '5128', providerId: '5128', required: true, status: 'open' as const, generation: 11 },
-    ],
-  };
+  function gate(statuses: Array<'open' | 'approved'>) {
+    return {
+      activeGeneration: 11,
+      completion: { required: 'all' as const, status: 'approved' as const },
+      artifacts: statuses.map((status, i) => ({
+        id: String(5127 + i),
+        providerId: String(5127 + i),
+        required: true,
+        status,
+        generation: 11,
+      })),
+    };
+  }
 
   /**
-   * Drives the merge gate along the observed path: CI failure → fix session →
-   * fix awaiting approval (where the auto-approve worker queues its intent) →
-   * publishAfterFix → review_ready with freshly published, unmerged PRs.
+   * Drives the merge gate along the observed path: CI failure -> fix session ->
+   * fix awaiting approval (where the auto-approve worker queues its intent) ->
+   * publishAfterFix -> review_ready with freshly published PRs.
    */
-  function driveToReviewReadyWithOpenPrs(mergeId: string): void {
+  function driveToReviewReady(mergeId: string, statuses: Array<'open' | 'approved'>): void {
     orchestrator.handleWorkerResponse(
       makeResponse({ actionId: mergeId, status: 'failed', outputs: { exitCode: 1, error: 'ci failed' } }),
     );
@@ -360,56 +364,61 @@ describe('repro: queued fix-approval intent completes an unmerged external_revie
         reviewId: '5127',
         reviewUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/5127',
         reviewStatus: 'Awaiting review',
-        reviewGate: openPrGate,
+        reviewGate: gate(statuses),
       },
     } as any);
   }
 
-  it('approve() marks the gate completed even though every required PR is still open', async () => {
+  it('refuses a stale fix-approval that lands on a gate whose PRs are still open', async () => {
     const merge = loadExternalReviewWorkflow();
-    driveToReviewReadyWithOpenPrs(merge.id);
+    driveToReviewReady(merge.id, ['open', 'open']);
 
-    const beforeApprove = orchestrator.getTask(merge.id)!;
-    expect(beforeApprove.status).toBe('review_ready');
-    expect(beforeApprove.execution.pendingFixError).toBeUndefined();
-    expect(beforeApprove.execution.reviewGate!.artifacts.every(a => a.status === 'open')).toBe(true);
-
-    // The stale intent lands. Nothing re-validates what it was approving.
-    await orchestrator.approve(merge.id);
+    await expect(orchestrator.approve(merge.id)).rejects.toThrow(/not approved/i);
 
     const after = orchestrator.getTask(merge.id)!;
+    expect(after.status).toBe('review_ready');
     expect(after.execution.reviewGate!.artifacts.every(a => a.status === 'open')).toBe(true);
-    expect(after.status).toBe('completed'); // BUG: unmerged stack reported as landed
   });
 
-  it('the approve hook performs no merge for external_review, so nothing lands', async () => {
+  it('reports which artifacts blocked the approval', async () => {
     const merge = loadExternalReviewWorkflow();
-    const approveMerge = vi.fn();
+    driveToReviewReady(merge.id, ['approved', 'open']);
 
-    // Mirrors packages/app/src/execution/task-runner-wiring.ts:70-80
-    orchestrator.setBeforeApproveHook(async (task: TaskState) => {
-      if (!task.config.isMergeNode || !task.config.workflowId) return;
-      if (task.execution.pendingFixError !== undefined) return;
-      const workflow = persistence.loadWorkflow(task.config.workflowId);
-      if (!workflow) return;
-      if (workflow.onFinish !== 'merge') return;
-      if (workflow.mergeMode === 'external_review') return;
-      approveMerge(task.config.workflowId);
-    });
+    await expect(orchestrator.approve(merge.id)).rejects.toThrow(/5128 is open/);
+    expect(orchestrator.getTask(merge.id)!.status).toBe('review_ready');
+  });
 
-    driveToReviewReadyWithOpenPrs(merge.id);
+  it('does not fire the approve hook when the gate is refused', async () => {
+    const merge = loadExternalReviewWorkflow();
+    const hook = vi.fn();
+    orchestrator.setBeforeApproveHook(hook);
+    driveToReviewReady(merge.id, ['open', 'open']);
+
+    await expect(orchestrator.approve(merge.id)).rejects.toThrow();
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it('completes the gate once every required artifact is approved', async () => {
+    const merge = loadExternalReviewWorkflow();
+    driveToReviewReady(merge.id, ['approved', 'approved']);
+
     await orchestrator.approve(merge.id);
 
-    expect(approveMerge).not.toHaveBeenCalled();
     expect(orchestrator.getTask(merge.id)!.status).toBe('completed');
   });
 
-  it('downstream workflows gated on this merge node unblock as if the stack had landed', async () => {
+  it('still completes a merge gate that has no review artifacts', async () => {
     const merge = loadExternalReviewWorkflow();
-    driveToReviewReadyWithOpenPrs(merge.id);
+    orchestrator.handleWorkerResponse(
+      makeResponse({ actionId: merge.id, status: 'failed', outputs: { exitCode: 1, error: 'boom' } }),
+    );
+    orchestrator.beginFixSession(merge.id);
+    orchestrator.setFixAwaitingApproval(merge.id, 'boom');
+    orchestrator.resumeTaskAfterFixApproval(merge.id);
+    orchestrator.setTaskAwaitingApproval(merge.id);
+
     await orchestrator.approve(merge.id);
 
-    // externalDependencies use requiredStatus: 'completed' on '__merge__'.
     expect(orchestrator.getTask(merge.id)!.status).toBe('completed');
   });
 });

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -35,6 +35,7 @@ import {
   type HeavyweightCommandRoutingPolicy,
 } from './executor-routing.js';
 import { requireDefaultBranchRemote } from './repo-default-branch.js';
+import { unapprovedRequiredReviewArtifacts } from './review-gate-artifacts.js';
 
 const MERGE_TRACE_LOG = resolve(homedir(), '.invoker', 'merge-trace.log');
 function mergeTrace(tag: string, data: Record<string, unknown>): void {
@@ -49,6 +50,7 @@ export const OrchestratorErrorCode = {
   TASK_NOT_FOUND: 'TASK_NOT_FOUND',
   TASK_ALREADY_TERMINAL: 'TASK_ALREADY_TERMINAL',
   WORKFLOW_NOT_FOUND: 'WORKFLOW_NOT_FOUND',
+  REVIEW_GATE_NOT_APPROVED: 'REVIEW_GATE_NOT_APPROVED',
 } as const;
 
 export type OrchestratorErrorCode = (typeof OrchestratorErrorCode)[keyof typeof OrchestratorErrorCode];
@@ -1774,6 +1776,40 @@ export class Orchestrator {
   }
 
   /**
+   * Completion invariant for review-backed merge gates: a merge node may only
+   * reach `completed` once every current required artifact is `approved`.
+   *
+   * Without this, an approval minted for one state can be spent on another —
+   * an auto-approve intent queued for a fix session drains behind that same
+   * fix session's republish and lands on the freshly published, still-open
+   * gate, reporting an unmerged stack as landed.
+   */
+  private assertReviewGateApprovable(task: TaskState): void {
+    if (!task.config.isMergeNode) return;
+    const unapproved = unapprovedRequiredReviewArtifacts(task);
+    if (unapproved.length === 0) return;
+
+    mergeTrace('APPROVE_SKIPPED_GATE_NOT_APPROVED', {
+      taskId: task.id,
+      workflowId: task.config.workflowId,
+      status: task.status,
+      pendingFixError: task.execution.pendingFixError !== undefined,
+      unapproved: unapproved.map((artifact) => ({ id: artifact.id, status: artifact.status })),
+    });
+    this.logger.warn('[orchestrator.approve] refused: review gate not approved', {
+      taskId: task.id,
+      workflowId: task.config.workflowId,
+      status: task.status,
+      unapproved: unapproved.map((artifact) => `${artifact.id}:${artifact.status}`),
+    });
+    throw new OrchestratorError(
+      OrchestratorErrorCode.REVIEW_GATE_NOT_APPROVED,
+      `Cannot approve merge gate ${task.id}: ${unapproved.length} required review artifact(s) are not approved `
+      + `(${unapproved.map((artifact) => `${artifact.id} is ${artifact.status}`).join(', ')}).`,
+    );
+  }
+
+  /**
    * Approve a task awaiting approval. Fires beforeApproveHook (if set)
    * before transitioning state, so merge nodes get git-merged automatically.
    */
@@ -1797,6 +1833,8 @@ export class Orchestrator {
       });
       return [];
     }
+
+    this.assertReviewGateApprovable(task);
 
     if (this.beforeApproveHook) {
       mergeTrace('APPROVE_HOOK_FIRING', { taskId, workflowId: task.config.workflowId });

--- a/packages/workflow-core/src/review-gate-artifacts.ts
+++ b/packages/workflow-core/src/review-gate-artifacts.ts
@@ -40,6 +40,11 @@ export function getCurrentRequiredReviewArtifacts(task: TaskState): ReviewGateAr
     .filter((artifact) => artifact.required && !!artifact.providerId);
 }
 
+export function unapprovedRequiredReviewArtifacts(task: TaskState): ReviewGateArtifact[] {
+  return getCurrentRequiredReviewArtifacts(task)
+    .filter((artifact) => artifact.status !== 'approved');
+}
+
 export function reviewGateIsApproved(gate: ReviewGateState): boolean {
   const currentRequired = gate.artifacts.filter((artifact) =>
     isCurrentReviewGateArtifact(gate, artifact) && artifact.required,


### PR DESCRIPTION
## Summary

A merge gate may now only finish once every required pull request in its stack is merged.

If any is still open, approval is refused with an error naming the ones that blocked it.

This closes a real incident. Workflow `wf-1784443765019-14` reported completed while PRs #5127 and #5128 sat open, and the workflow chained behind it started early.

The cause was an approval meant for something else. The auto-approve worker queued an approval for an agent fix while the gate was mid-fix.

That approval sat in the per-workflow queue for 847 seconds, behind the very republish it was waiting on.

It drained 88 milliseconds after the gate published two fresh, unmerged pull requests.

`Orchestrator.approve` accepts both `awaiting_approval` and `review_ready` and re-checked nothing when the approval ran. So the fix approval landed on the gate instead.

The approve hook does no merging for `external_review`, so nothing merged and the gate was marked done anyway.

The worker's own staleness comparison could not catch this. It runs when the approval is queued, not when it runs, and both `generation` and `attemptId` were unchanged across the republish.

Reading artifact state at approval time does not care how the approval arrived, which is why this closes the whole family rather than one path.

## Review Claim

`Orchestrator.approve` should refuse to complete a merge node while any current required review artifact is not approved.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The refusal reads only current task state and applies solely to merge nodes that carry required review artifacts. Gates with no artifacts are untouched, and the poll loop already requires GitHub `MERGED` on every required artifact before approving, so its path still satisfies the new rule.

## Slice Rationale

The guard lands alone, after its evidence and after its helpers are in place, so the only new reasoning a reviewer carries is the refusal condition itself.

## Non-goals

Does not change the auto-approve worker. Does not add a forced-completion escape. Does not alter how artifacts reach `approved`.

## Architecture

### Before

```mermaid
graph TD
    A["approve(taskId)"] --> B{"status is awaiting_approval or review_ready?"}
    B -->|no| C["return []"]
    B -->|yes| D["beforeApproveHook (no-op for external_review)"]
    D --> E["status = completed"]
```

### After

```mermaid
graph TD
    A["approve(taskId)"] --> B{"status is awaiting_approval or review_ready?"}
    B -->|no| C["return []"]
    B -->|yes| F{"merge node with unapproved required artifacts?"}
    F -->|yes| G["throw REVIEW_GATE_NOT_APPROVED"]
    F -->|no| D["beforeApproveHook"]
    D --> E["status = completed"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/workflow-core && npx vitest run src/__tests__/merge-gate-approval-open-artifacts.test.ts`
- [ ] `cd packages/workflow-core && npx vitest run`
- [ ] `cd packages/execution-engine && npx vitest run`
- [ ] `cd packages/app && npx vitest run`
- [ ] `cd packages/ui && npx vitest run`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the prior permissive behavior; no state written under the guard needs repair.
- Data migration? No

</details>
