### PR TITLE
Scope CI git config writes to a per-job temporary file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,8 @@ jobs:
 
       - name: Configure git identity and HTTPS auth
         run: |
+          echo "GIT_CONFIG_GLOBAL=$RUNNER_TEMP/gitconfig" >> "$GITHUB_ENV"
+          export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/gitconfig"
           git config --global user.name "CI Bot"
           git config --global user.email "ci@invoker.dev"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -345,6 +347,8 @@ jobs:
 
       - name: Configure git identity and HTTPS auth
         run: |
+          echo "GIT_CONFIG_GLOBAL=$RUNNER_TEMP/gitconfig" >> "$GITHUB_ENV"
+          export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/gitconfig"
           git config --global user.name "CI Bot"
           git config --global user.email "ci@invoker.dev"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -416,6 +420,8 @@ jobs:
 
       - name: Configure git identity and HTTPS auth
         run: |
+          echo "GIT_CONFIG_GLOBAL=$RUNNER_TEMP/gitconfig" >> "$GITHUB_ENV"
+          export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/gitconfig"
           git config --global user.name "CI Bot"
           git config --global user.email "ci@invoker.dev"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -478,6 +484,8 @@ jobs:
 
       - name: Configure git identity and HTTPS auth
         run: |
+          echo "GIT_CONFIG_GLOBAL=$RUNNER_TEMP/gitconfig" >> "$GITHUB_ENV"
+          export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/gitconfig"
           git config --global user.name "CI Bot"
           git config --global user.email "ci@invoker.dev"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -534,6 +542,8 @@ jobs:
 
       - name: Configure git identity and HTTPS auth
         run: |
+          echo "GIT_CONFIG_GLOBAL=$RUNNER_TEMP/gitconfig" >> "$GITHUB_ENV"
+          export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/gitconfig"
           git config --global user.name "CI Bot"
           git config --global user.email "ci@invoker.dev"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -690,6 +700,8 @@ jobs:
 
       - name: Configure git identity for E2E repos
         run: |
+          echo "GIT_CONFIG_GLOBAL=$RUNNER_TEMP/gitconfig" >> "$GITHUB_ENV"
+          export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/gitconfig"
           git config --global user.name "CI Bot"
           git config --global user.email "ci@invoker.dev"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -766,6 +778,8 @@ jobs:
 
       - name: Configure git identity for E2E repos
         run: |
+          echo "GIT_CONFIG_GLOBAL=$RUNNER_TEMP/gitconfig" >> "$GITHUB_ENV"
+          export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/gitconfig"
           git config --global user.name "CI Bot"
           git config --global user.email "ci@invoker.dev"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -840,6 +854,8 @@ jobs:
 
       - name: Configure git identity and HTTPS auth
         run: |
+          echo "GIT_CONFIG_GLOBAL=$RUNNER_TEMP/gitconfig" >> "$GITHUB_ENV"
+          export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/gitconfig"
           git config --global user.name "CI Bot"
           git config --global user.email "ci@invoker.dev"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -958,6 +974,8 @@ jobs:
 
       - name: Configure git identity and HTTPS auth
         run: |
+          echo "GIT_CONFIG_GLOBAL=$RUNNER_TEMP/gitconfig" >> "$GITHUB_ENV"
+          export GIT_CONFIG_GLOBAL="$RUNNER_TEMP/gitconfig"
           git config --global user.name "CI Bot"
           git config --global user.email "ci@invoker.dev"
           git config --global --add safe.directory "$GITHUB_WORKSPACE"


### PR DESCRIPTION
## Summary

CI jobs on self-hosted runners now keep their git configuration in a per-job temporary file instead of the runner's shared home directory.

## Review Claim

Every `git config --global` write in CI lands in `$RUNNER_TEMP/gitconfig`, so no credential outlives the job that created it.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

`GIT_CONFIG_GLOBAL` is exported before the first write and published through `$GITHUB_ENV`, so every later step in the same job reads the same file. Behavior inside a job is unchanged.

## Slice Rationale

Workflow configuration only; no product code is touched.

## Architecture

### Before

Each job wrote a `url.<token>.insteadOf` rewrite carrying a one-hour `github.token` into `/home/invoker/.gitconfig`. That file is shared across jobs and across the Invoker agent, so the rewrite outlived the token and redirected later git operations through a credential that no longer worked.

### After

Those writes land in a per-job temporary file that disappears with the job.

## Non-goals

No change to what CI runs, and no product code changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`

</details>

## Visual Proof

Not applicable; no user-facing surface changes.

## Revert Plan

Revert this commit. CI returns to writing git configuration into the runner's home directory, and the recurring credential problem returns with it.
