### PR TITLE
[Keep Planning Terminal On Submit](1) Verify planning submit context

### DIFF
--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1124,3 +1124,100 @@ describe('Invoker terminal (component)', () => {
     expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
   });
 });
+
+function submitContextWorkflow(id: string, name = id): WorkflowMeta {
+  return {
+    id,
+    name,
+    status: 'pending',
+  };
+}
+
+describe('Invoker terminal submit context (component)', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker(
+      [makeUITask({ id: 'task-a', workflowId: 'workflow-a', description: 'Initial task' })],
+      [submitContextWorkflow('workflow-a', 'Initial Plan')],
+    );
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  function stubSubmitStyleRefresh() {
+    const nextTasks = [
+      makeUITask({ id: 'task-a', workflowId: 'workflow-a', description: 'Initial task' }),
+      makeUITask({ id: 'task-b', workflowId: 'workflow-b', description: 'Submitted planning task' }),
+    ];
+    const nextWorkflows = [
+      submitContextWorkflow('workflow-a', 'Initial Plan'),
+      submitContextWorkflow('workflow-b', 'Submitted Plan'),
+    ];
+    vi.mocked(mock.api.refreshTaskGraph).mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          queueMicrotask(() => {
+            mock.fireGraphEvent({
+              type: 'snapshot',
+              tasks: nextTasks,
+              workflows: nextWorkflows,
+              reason: 'submit-style-refresh',
+              streamSequence: 1,
+            });
+            resolve();
+          });
+        }),
+    );
+  }
+
+  it('preserves a cleared graph selection when submit-style refresh adds a workflow', async () => {
+    render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+
+    expect(await screen.findByTestId('workflow-node-workflow-a')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('workflow-graph-surface'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('selected-workflow-mini-dag')).not.toBeInTheDocument();
+    });
+
+    stubSubmitStyleRefresh();
+    fireEvent.click(screen.getByTestId('rail-refresh'));
+
+    expect(await screen.findByTestId('workflow-node-workflow-b')).toBeInTheDocument();
+    expect(screen.queryByTestId('selected-workflow-mini-dag')).not.toBeInTheDocument();
+    expect(screen.getByTestId('workflow-node-workflow-a').className).not.toContain('ring-2');
+    expect(screen.getByTestId('workflow-node-workflow-b').className).not.toContain('ring-2');
+    expect(mock.api.start).not.toHaveBeenCalled();
+  });
+
+  it('keeps an existing workflow selection stable across submit-style refresh', async () => {
+    render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+
+    expect(await screen.findByTestId('workflow-node-workflow-a')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('workflow-node-workflow-a'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toBeInTheDocument();
+    });
+
+    stubSubmitStyleRefresh();
+    fireEvent.click(screen.getByTestId('rail-refresh'));
+
+    expect(await screen.findByTestId('workflow-node-workflow-b')).toBeInTheDocument();
+    expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Initial Plan task DAG');
+    expect(screen.getByTestId('workflow-node-workflow-a').className).toContain('ring-2');
+    expect(screen.getByTestId('workflow-node-workflow-b').className).not.toContain('ring-2');
+    expect(mock.api.start).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused UI regression coverage that submit-style graph refresh preserves cleared selection and existing workflow selection.

## Review Claim

Approve the proof that submit-style refresh does not steal or invent graph selection.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice adds component regression coverage only. It does not change runtime UI behavior or backend submit contracts.

## Slice Rationale

Verification is isolated from behavior work so reviewers can approve the selection-stability proof on its own.

## Non-goals

Do not change App runtime behavior, Planning Terminal UI, explicit workflow clicks, graph camera fitting, Start ready work, or backend planning submit contracts.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/invoker-terminal.test.tsx -t "submit context"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert HEAD`
- Post-revert steps: rerun the focused submit-context vitest filter if this path changes again.
- Data migration? No

</details>
