### PR TITLE
Draft Review Sidebar Step 2 - Review Draft Opens Right Sidebar (1) - Tolerate remote worktree lookup failure

### DIFF
--- a/packages/execution-engine/src/__tests__/remote-fix-worktree-repair.test.ts
+++ b/packages/execution-engine/src/__tests__/remote-fix-worktree-repair.test.ts
@@ -6,7 +6,7 @@ import { registerBuiltinAgents } from '../agents/index.js';
 
 vi.mock('node:child_process');
 
-function mockSshChild(stdoutData: string, exitCode: number) {
+function mockSshChild(stdoutData: string, exitCode: number, stderrData = '') {
   const { EventEmitter } = require('events');
   const stdout = new EventEmitter();
   const stderr = new EventEmitter();
@@ -17,6 +17,7 @@ function mockSshChild(stdoutData: string, exitCode: number) {
 
   setTimeout(() => {
     if (stdoutData) stdout.emit('data', Buffer.from(stdoutData));
+    if (stderrData) stderr.emit('data', Buffer.from(stderrData));
     child.emit('close', exitCode);
   }, 0);
 
@@ -110,6 +111,51 @@ branch refs/heads/${branch}
     });
     const remoteFixScript = ((secondChild as any).stdin.write as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
     expect(remoteFixScript).toContain(`WT="${ownerPath}"`);
+    expect(appendTaskOutput).toHaveBeenCalledWith(
+      task.id,
+      expect.stringContaining('[Fix with codex (remote)] Output:'),
+    );
+  });
+
+  it('continues with the recorded remote workspace when branch-owner lookup cannot list worktrees', async () => {
+    const { spawn } = await import('node:child_process');
+    const workspacePath = '/home/invoker/.invoker/worktrees/647faa73e90e/experiment-test-task-deadbeef';
+    const branch = 'experiment/test-task/deadbeef';
+    const task = {
+      id: 'wf-1/test-task',
+      status: 'failed' as const,
+      execution: {
+        error: 'Test failed',
+        workspacePath,
+        branch,
+      },
+      config: {
+        command: 'pnpm test',
+        runnerKind: 'ssh' as const,
+        poolMemberId: 'remote-1',
+      },
+    };
+
+    const { host, updateTask, appendTaskOutput } = makeHost(task);
+    const listFailure = mockSshChild(
+      '',
+      128,
+      "fatal: cannot change to '/home/invoker/.invoker/repos/647faa73e90e': No such file or directory\n",
+    );
+    const fixSession = mockSshChild('Codex session: real-session-456\nremote fix applied', 0);
+    vi.mocked(spawn)
+      .mockReturnValueOnce(listFailure as any)
+      .mockReturnValueOnce(fixSession as any);
+
+    await fixWithAgentImpl(host, task.id, 'error output', 'codex');
+
+    expect(updateTask).not.toHaveBeenCalledWith(task.id, {
+      execution: {
+        workspacePath: expect.any(String),
+      },
+    });
+    const remoteFixScript = ((fixSession as any).stdin.write as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+    expect(remoteFixScript).toContain(`WT="${workspacePath}"`);
     expect(appendTaskOutput).toHaveBeenCalledWith(
       task.id,
       expect.stringContaining('[Fix with codex (remote)] Output:'),

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -145,15 +145,19 @@ async function resolveRemoteBranchOwnerPath(
   if (!branch) return undefined;
   const info = deriveRemoteManagedWorkspaceInfo(workspacePath, target);
   if (!info) return undefined;
-  const porcelain = await execRemoteSsh(
-    target,
-    buildWorktreeListScript({
-      repoHash: info.repoHash,
-      invokerHome: info.invokerHome,
-    }),
-    'list_worktrees',
-  );
-  return findManagedWorktreeForBranch(porcelain, branch, [info.managedPrefix]);
+  try {
+    const porcelain = await execRemoteSsh(
+      target,
+      buildWorktreeListScript({
+        repoHash: info.repoHash,
+        invokerHome: info.invokerHome,
+      }),
+      'list_worktrees',
+    );
+    return findManagedWorktreeForBranch(porcelain, branch, [info.managedPrefix]);
+  } catch {
+    return undefined;
+  }
 }
 
 // ── Extracted functions ──────────────────────────────────


### PR DESCRIPTION
## Summary

Draft Review Sidebar Step 2 - Review Draft Opens Right Sidebar — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784443178322-5/implement-right-sidebar-draft-review | Change Review draft to open Home right sidebar with YAML and per-step summary instead of navigating to Plan graph | completed |
| wf-1784443178322-5/verify-right-sidebar-draft-review | Verify Home review-draft UX and submit flow | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784443178322-5/implement-right-sidebar-draft-review — Change Review draft to open Home right sidebar with YAML and per-step summary instead of navigating to Plan graph

### wf-1784443178322-5/verify-right-sidebar-draft-review — Verify Home review-draft UX and submit flow

</details>

Remote Fix with agent now keeps using the task's recorded remote workspace when branch-owner lookup cannot list worktrees.

That keeps verification repairs from blocking on a missing managed repo listing.

## Review Claim

Remote fix sessions tolerate branch-owner worktree-list failures by falling back to the recorded task workspace path.

## Review Lane

`behavior`

## Review Unit

`remote-fix-worktree-repair`

## Safety Invariant

The fallback only applies when branch-owner lookup throws. Successful lookup still repairs the workspace path from branch ownership.

## Slice Rationale

This verification-support behavior is isolated before the draft review UI slices because it changes remote fix recovery, not planner rendering.

## Non-goals

- Change successful branch-owner lookup behavior.
- Change local fix-with-agent execution.
- Change draft review UI or planner summary data.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/remote-fix-worktree-repair.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-bodies/draft-review-sidebar-step-2-1.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert dc85fa4e3d80fc0e81b5404e6f1a6621a9c634a1`
- Post-revert steps: Rerun `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/remote-fix-worktree-repair.test.ts`.
- Data migration? No.

</details>
