### PR TITLE
Draft Review Sidebar Step 2 - Review Draft Opens Right Sidebar (3) - Populate per-workflow draft task groups

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -5,6 +5,7 @@ import {
   getPlanningChatSession,
   listPlanningChatSessions,
   sendPlanningChatMessage,
+  summarizePlanText,
   submitPlanningChatDraft,
 } from '../in-app-planner.js';
 
@@ -132,5 +133,33 @@ describe('planning chat draft YAML plumbing', () => {
       loadGeneratedPlan,
     })).resolves.toEqual({ ok: true, planName: 'Stored YAML', workflowId: 'wf-1' });
     expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Stored YAML'));
+  });
+
+  it('summarizes multi-workflow drafts with task groups', () => {
+    expect(summarizePlanText(`
+name: Grouped plan
+workflows:
+  - id: backend
+    name: Backend workflow
+    tasks:
+      - id: api
+        description: Add API endpoint
+  - id: frontend
+    name: Frontend workflow
+    tasks:
+      - id: sidebar
+        description: Add review sidebar
+      - id: actions
+        description: Wire ready bar actions
+`)).toMatchObject({
+      name: 'Grouped plan',
+      taskCount: 3,
+      workflowCount: 2,
+      steps: ['Backend workflow', 'Frontend workflow'],
+      taskGroups: [
+        { name: 'Backend workflow', workflowId: 'backend', taskCount: 1, steps: ['Add API endpoint'] },
+        { name: 'Frontend workflow', workflowId: 'frontend', taskCount: 2, steps: ['Add review sidebar', 'Wire ready bar actions'] },
+      ],
+    });
   });
 });

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -345,7 +345,24 @@ function createLoadedResponse(loaded: LoadedGeneratedPlan): Extract<InAppPlanRes
   };
 }
 
-function summarizePlanText(planText: string): InAppPlanningPlanSummary | null {
+function summarizeTaskSteps(rawTasks: unknown): string[] | null {
+  if (!Array.isArray(rawTasks)) return [];
+  const steps: string[] = [];
+  for (const task of rawTasks) {
+    if (!task || typeof task !== 'object' || Array.isArray(task)) return null;
+    const candidate = task as Record<string, unknown>;
+    if (typeof candidate.description === 'string' && candidate.description.trim()) {
+      steps.push(candidate.description.trim());
+    } else if (typeof candidate.id === 'string' && candidate.id.trim()) {
+      steps.push(candidate.id.trim());
+    } else {
+      return null;
+    }
+  }
+  return steps;
+}
+
+export function summarizePlanText(planText: string): InAppPlanningPlanSummary | null {
   try {
     const raw = parseYaml(planText) as unknown;
     if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
@@ -358,35 +375,40 @@ function summarizePlanText(planText: string): InAppPlanningPlanSummary | null {
       if (workflows.length === 0) return null;
       let taskCount = 0;
       const steps: string[] = [];
-      for (const workflow of workflows) {
-        if (typeof workflow.name === 'string' && workflow.name.trim()) {
-          steps.push(workflow.name.trim());
+      const taskGroups: NonNullable<InAppPlanningPlanSummary['taskGroups']> = [];
+      workflows.forEach((workflow, index) => {
+        const workflowName =
+          typeof workflow.name === 'string' && workflow.name.trim()
+            ? workflow.name.trim()
+            : typeof workflow.id === 'string' && workflow.id.trim()
+              ? workflow.id.trim()
+              : `Workflow ${index + 1}`;
+        steps.push(workflowName);
+        const taskSteps = summarizeTaskSteps(workflow.tasks);
+        if (taskSteps === null) {
+          return;
         }
-        if (Array.isArray(workflow.tasks)) {
-          taskCount += workflow.tasks.length;
-        }
-      }
+        taskCount += Array.isArray(workflow.tasks) ? workflow.tasks.length : 0;
+        taskGroups.push({
+          name: workflowName,
+          ...(typeof workflow.id === 'string' && workflow.id.trim() ? { workflowId: workflow.id.trim() } : {}),
+          taskCount: taskSteps.length,
+          steps: taskSteps,
+        });
+      });
+      if (taskGroups.length !== workflows.length) return null;
       return {
         name: typeof plan.name === 'string' && plan.name.trim() ? plan.name.trim() : 'Untitled plan',
         taskCount,
         workflowCount: workflows.length,
         steps,
+        taskGroups,
       };
     }
 
     if (!Array.isArray(plan.tasks) || plan.tasks.length === 0) return null;
-    const steps: string[] = [];
-    for (const task of plan.tasks) {
-      if (!task || typeof task !== 'object' || Array.isArray(task)) return null;
-      const candidate = task as Record<string, unknown>;
-      if (typeof candidate.description === 'string' && candidate.description.trim()) {
-        steps.push(candidate.description.trim());
-      } else if (typeof candidate.id === 'string' && candidate.id.trim()) {
-        steps.push(candidate.id.trim());
-      } else {
-        return null;
-      }
-    }
+    const steps = summarizeTaskSteps(plan.tasks);
+    if (!steps) return null;
     return {
       name: typeof plan.name === 'string' && plan.name.trim() ? plan.name.trim() : 'Untitled plan',
       taskCount: plan.tasks.length,


### PR DESCRIPTION
Depends-On: #5298

## Summary

Draft Review Sidebar Step 2 - Review Draft Opens Right Sidebar — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784443178322-5/implement-right-sidebar-draft-review | Change Review draft to open Home right sidebar with YAML and per-step summary instead of navigating to Plan graph | completed |
| wf-1784443178322-5/verify-right-sidebar-draft-review | Verify Home review-draft UX and submit flow | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784443178322-5/implement-right-sidebar-draft-review — Change Review draft to open Home right sidebar with YAML and per-step summary instead of navigating to Plan graph

### wf-1784443178322-5/verify-right-sidebar-draft-review — Verify Home review-draft UX and submit flow

</details>

Multi-workflow planning drafts now summarize each workflow as its own task group.

Flat single-workflow plans still return the existing `steps` shape.

## Review Claim

`summarizePlanText` populates per-workflow task groups for multi-workflow draft YAML while preserving legacy flat task summaries.

## Review Lane

`behavior`

## Review Unit

`planner-summary-generation`

## Safety Invariant

Malformed workflow task entries still return no summary. Single-workflow `tasks` drafts keep the existing summary contract.

## Slice Rationale

The producer lands after the optional contract and before UI rendering so reviewers can verify the data shape independently.

## Non-goals

- Change draft YAML extraction.
- Change draft submission or persistence behavior.
- Render grouped summaries in the UI.

## Architecture

### Before

```mermaid
graph TD
    A["multi-workflow YAML"] --> B["workflow names in steps[]"]
```

### After

```mermaid
graph TD
    A["multi-workflow YAML"] --> B["workflow names in steps[]"]
    A --> C["taskGroups[] with workflow titles and task steps"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-bodies/draft-review-sidebar-step-2-3.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 04cefd0e5309204d233020f11e68212cadcc9b18`
- Post-revert steps: Rerun `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`.
- Data migration? No.

</details>
