### PR TITLE
[Fix Git E2E Tests Step 4 Reset Shard](1) Stabilize reset dry-run shard

### DIFF
--- a/scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh
+++ b/scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh
@@ -32,18 +32,23 @@ tasks:
 EOF
 # The recreate client is intentionally still alive while this case samples the
 # first five seconds. In WAL mode a read-only sampler can lose that race; retry
-# only that transient busy-open failure so the assertion still checks reset
-# timing instead of failing on the harness read.
+# transient busy/empty reads so the assertion still checks reset timing instead
+# of failing on the harness read.
 invoker_e2e_case_216_query_json() {
   local out err status attempt
   err="$(mktemp "${TMPDIR:-/tmp}/invoker-e2e-2.16-query.err.XXXXXX")"
-  for attempt in 1 2 3 4 5; do
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
     if out="$(invoker_e2e_run_headless "$@" --output json 2>"$err")"; then
-      rm -f "$err"
-      printf '%s' "$out"
-      return 0
+      if printf '%s' "$out" | python3 -m json.tool >/dev/null 2>&1; then
+        rm -f "$err"
+        printf '%s' "$out"
+        return 0
+      fi
+      sleep 0.25
+      continue
+    else
+      status=$?
     fi
-    status=$?
     if grep -Fq 'Read-only file open refused while WAL sidecars exist' "$err"; then
       sleep 0.25
       continue
@@ -52,6 +57,9 @@ invoker_e2e_case_216_query_json() {
     rm -f "$err"
     return "$status"
   done
+  if [ -n "${out:-}" ]; then
+    printf '%s\n' "$out" >&2
+  fi
   cat "$err" >&2
   rm -f "$err"
   return 75

--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -245,6 +245,31 @@ invoker_e2e_app_ui_build_is_fresh() {
   return 0
 }
 
+invoker_e2e_workspace_install_is_stale() {
+  local install_metadata="$INVOKER_E2E_REPO_ROOT/node_modules/.modules.yaml"
+  [ ! -f "$install_metadata" ] || [ "$INVOKER_E2E_REPO_ROOT/pnpm-lock.yaml" -nt "$install_metadata" ]
+}
+
+invoker_e2e_workspace_dependencies_are_ready() {
+  [ -f "$INVOKER_E2E_REPO_ROOT/node_modules/.modules.yaml" ] \
+    && [ -x "$INVOKER_E2E_REPO_ROOT/packages/ui/node_modules/.bin/vite" ] \
+    && [ -x "$INVOKER_E2E_REPO_ROOT/node_modules/.bin/tsup" ] \
+    && [ -x "$INVOKER_E2E_REPO_ROOT/packages/app/node_modules/.bin/electron" ] \
+    && ! invoker_e2e_workspace_install_is_stale
+}
+
+invoker_e2e_ensure_workspace_dependencies() {
+  if invoker_e2e_workspace_dependencies_are_ready; then
+    return 0
+  fi
+
+  echo "==> e2e: bootstrapping workspace dependencies"
+  (
+    cd "$INVOKER_E2E_REPO_ROOT" && \
+    pnpm install --frozen-lockfile
+  )
+}
+
 invoker_e2e_ensure_app_built() {
   # Containerized CI steps can lose checkout's temporary safe.directory config
   # before this helper runs, so re-establish it before the first git call.
@@ -253,7 +278,7 @@ invoker_e2e_ensure_app_built() {
   git_dir="$(git -C "$INVOKER_E2E_REPO_ROOT" rev-parse --git-dir)"
   local build_lock_dir="$git_dir/invoker-e2e-build.lock"
   local wait_secs=0
-  if [ "${INVOKER_E2E_FORCE_BUILD:-0}" != "1" ] && invoker_e2e_app_ui_build_is_fresh; then
+  if [ "${INVOKER_E2E_FORCE_BUILD:-0}" != "1" ] && invoker_e2e_workspace_dependencies_are_ready && invoker_e2e_app_ui_build_is_fresh; then
     echo "==> e2e: reusing existing app/ui build artifacts"
     return 0
   fi
@@ -262,7 +287,7 @@ invoker_e2e_ensure_app_built() {
   else
     echo "==> e2e: waiting for shared app/ui build lock"
     while [ -d "$build_lock_dir" ]; do
-      if [ "${INVOKER_E2E_FORCE_BUILD:-0}" != "1" ] && invoker_e2e_app_ui_build_is_fresh; then
+      if [ "${INVOKER_E2E_FORCE_BUILD:-0}" != "1" ] && invoker_e2e_workspace_dependencies_are_ready && invoker_e2e_app_ui_build_is_fresh; then
         echo "==> e2e: shared build completed by another shard"
         return 0
       fi
@@ -273,7 +298,7 @@ invoker_e2e_ensure_app_built() {
         return 1
       fi
     done
-    if [ "${INVOKER_E2E_FORCE_BUILD:-0}" != "1" ] && invoker_e2e_app_ui_build_is_fresh; then
+    if [ "${INVOKER_E2E_FORCE_BUILD:-0}" != "1" ] && invoker_e2e_workspace_dependencies_are_ready && invoker_e2e_app_ui_build_is_fresh; then
       echo "==> e2e: shared build completed by another shard"
       return 0
     fi
@@ -283,6 +308,7 @@ invoker_e2e_ensure_app_built() {
     fi
     trap 'rmdir "$build_lock_dir" 2>/dev/null || true' RETURN
   fi
+  invoker_e2e_ensure_workspace_dependencies
   echo "==> e2e: building @invoker/ui and @invoker/app"
   (
     cd "$INVOKER_E2E_REPO_ROOT" && \

--- a/scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh
+++ b/scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh
@@ -4,23 +4,6 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
 
-is_merge_queue() {
-  [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" && "${GITHUB_HEAD_REF:-}" == mergify/merge-queue/* ]]
-}
-
-if is_merge_queue; then
-  # Disabled 2026-07-03: case-2.15-recreate-preempt-attempt-refresh.sh and
-  # case-2.16-retry-vs-recreate-five-second-window.sh are flaky in merge-queue
-  # e2e-proof shard 0. Keep the rest of this required shard active.
-  exec bash "$ROOT/scripts/e2e-dry-run/run-all.sh" \
-    'case-2.11-edit-restart-downstream.sh' \
-    'case-2.13-rebase-recreate-coalesced.sh' \
-    'case-2.3-parallel-success.sh' \
-    'case-2.5-fan-in-partial-fail.sh' \
-    'case-2.6-diamond-success.sh' \
-    'case-2.8-fix-reject-downstream.sh'
-fi
-
 exec bash "$ROOT/scripts/e2e-dry-run/run-all.sh" \
   'case-2.11-edit-restart-downstream.sh' \
   'case-2.13-rebase-recreate-coalesced.sh' \


### PR DESCRIPTION
## Summary

Fix Git E2E Tests Step 4 Reset Shard completed the reset dry-run stabilization and verification tasks.

The required downstream-reset shard now runs cases 2.15 and 2.16 for merge-queue refs instead of quarantining them.

The harness now retries transient reset-window read races and ensures workspace dependencies before the shared build.

## Review Claim

Reset-window dry-run cases 2.15 and 2.16 are stable enough to run in the required merge-queue shard.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This only changes e2e shell harness behavior and required-suite membership. The reset assertions still require recreate and retry to expose the expected task states.

## Slice Rationale

This slice depends on the earlier bootstrap and Vitest guard fixes. Keeping it here isolates the remaining reset-shard quarantine removal.

## Non-goals

- Do not change product reset semantics outside the e2e harness.
- Do not add sleeps as the only fix.
- Do not weaken accepted task statuses or touch unrelated e2e shards.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/prove-reset-assertions.sh`
- [x] `bash scripts/repro/prove-reset-rulebook.sh`
- [x] `GITHUB_EVENT_NAME=pull_request GITHUB_HEAD_REF=mergify/merge-queue/reset-shard bash scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/fix-git-e2e-tests-step-4-reset-shard-pr.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 19f0b3394`
- Post-revert steps: Re-run the reset repro wrappers if the downstream-reset shard changes again.
- Data migration? No

</details>
