### PR TITLE
[Bugfix: publish review_gate.merge_conflict from the merge-gate poll](1) Publish merge-conflict review-gate triggers

### DIFF
--- a/packages/app/src/__tests__/task-runner-wiring.test.ts
+++ b/packages/app/src/__tests__/task-runner-wiring.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TaskState } from '@invoker/workflow-core';
-import { publishReviewGateCiFailedLifecycleEvent } from '../lifecycle-event-bridge.js';
+import {
+  publishReviewGateCiFailedLifecycleEvent,
+  publishReviewGateMergeConflictLifecycleEvent,
+} from '../lifecycle-event-bridge.js';
 import { loadConfig, resolveSecretsFilePath } from '../config.js';
 import {
   killRunningTaskExecution,
@@ -45,6 +48,7 @@ vi.mock('@invoker/execution-engine', () => {
 
 vi.mock('../lifecycle-event-bridge.js', () => ({
   publishReviewGateCiFailedLifecycleEvent: vi.fn(),
+  publishReviewGateMergeConflictLifecycleEvent: vi.fn(),
 }));
 
 vi.mock('../config.js', () => ({
@@ -215,6 +219,11 @@ describe('task-runner-wiring', () => {
     const config = taskRunnerConstructor.mock.calls[0]?.[0] as any;
     await config.reviewGateCiFailurePublisher.publish({ taskId: 'merge-task' });
     expect(publishReviewGateCiFailedLifecycleEvent).toHaveBeenCalledWith(
+      { taskId: 'merge-task' },
+      expect.objectContaining({ messageBus: expect.any(Object), getTask: expect.any(Function) }),
+    );
+    await config.reviewGateMergeConflictPublisher.publish({ taskId: 'merge-task' });
+    expect(publishReviewGateMergeConflictLifecycleEvent).toHaveBeenCalledWith(
       { taskId: 'merge-task' },
       expect.objectContaining({ messageBus: expect.any(Object), getTask: expect.any(Function) }),
     );

--- a/packages/app/src/execution/task-runner-wiring.ts
+++ b/packages/app/src/execution/task-runner-wiring.ts
@@ -12,7 +12,10 @@ import {
 } from '@invoker/execution-engine';
 import type { Logger } from '@invoker/contracts';
 import { loadConfig, resolveDefaultTaskExecutionSettings, resolveSecretsFilePath, type InvokerConfig } from '../config.js';
-import { publishReviewGateCiFailedLifecycleEvent } from '../lifecycle-event-bridge.js';
+import {
+  publishReviewGateCiFailedLifecycleEvent,
+  publishReviewGateMergeConflictLifecycleEvent,
+} from '../lifecycle-event-bridge.js';
 
 export type TaskHandleMap = Map<string, { handle: ExecutorHandle; executor: Executor }>;
 
@@ -98,6 +101,14 @@ export function rebuildTaskRunner(deps: TaskRunnerWiringDeps): TaskRunner {
     reviewGateCiFailurePublisher: {
       publish: (trigger) => {
         publishReviewGateCiFailedLifecycleEvent(trigger, {
+          messageBus: deps.messageBus,
+          getTask: (taskId) => deps.orchestrator.getTask(taskId),
+        });
+      },
+    },
+    reviewGateMergeConflictPublisher: {
+      publish: (trigger) => {
+        publishReviewGateMergeConflictLifecycleEvent(trigger, {
           messageBus: deps.messageBus,
           getTask: (taskId) => deps.orchestrator.getTask(taskId),
         });

--- a/packages/execution-engine/src/__tests__/repro-review-gate-merge-conflict-publisher.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-review-gate-merge-conflict-publisher.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SQLiteAdapter, SqliteTaskRepository, type Workflow } from '@invoker/data-store';
+import { Orchestrator, type OrchestratorMessageBus, type TaskState } from '@invoker/workflow-core';
+import { TaskRunner } from '../task-runner.js';
+import type { MergeGateApprovalStatus, MergeGateProvider } from '../merge-gate-provider.js';
+import type { ReviewGateMergeConflictTrigger } from '../task-runner-review-gate.js';
+
+class NoopBus implements OrchestratorMessageBus {
+  publish(): void {}
+}
+
+const WORKFLOW: Workflow = {
+  id: 'wf-merge-conflict-publisher',
+  name: 'Review gate merge conflict publisher proof',
+  status: 'running',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+const REVIEW_ID = 'owner/repo#412';
+const REVIEW_URL = 'https://github.com/owner/repo/pull/412';
+const HEAD_SHA = 'abc123conflict';
+const HEAD_REF = 'feature/conflict';
+const SELECTED_ATTEMPT_ID = 'attempt-merge-conflict-1';
+const WORKSPACE_PATH = '/workspace/merge-conflict-gate';
+
+function mergeNodeTask(id: string = 'merge-conflict-gate'): TaskState {
+  return {
+    id,
+    description: 'Review gate for merge conflict publisher',
+    status: 'review_ready',
+    dependencies: [],
+    createdAt: new Date('2026-07-20T00:00:00.000Z'),
+    config: { workflowId: WORKFLOW.id, isMergeNode: true },
+    execution: {
+      generation: 1,
+      selectedAttemptId: SELECTED_ATTEMPT_ID,
+      reviewId: REVIEW_ID,
+      branch: 'invoker/merge-conflict-gate',
+      workspacePath: WORKSPACE_PATH,
+      reviewGate: {
+        activeGeneration: 1,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [{
+          id: REVIEW_ID,
+          providerId: REVIEW_ID,
+          provider: 'stub-github',
+          required: true,
+          status: 'open',
+          generation: 1,
+        }],
+      },
+    },
+    taskStateVersion: 7,
+  };
+}
+
+function approvalStatus(overrides: Partial<MergeGateApprovalStatus> = {}): MergeGateApprovalStatus {
+  return {
+    lifecycle: 'open',
+    rejected: false,
+    statusText: 'Merge blocked by conflicts',
+    url: REVIEW_URL,
+    headSha: HEAD_SHA,
+    headRef: HEAD_REF,
+    mergeState: 'dirty',
+    hasMergeConflict: true,
+    ...overrides,
+  };
+}
+
+function stubMergeGateProvider(status: MergeGateApprovalStatus): MergeGateProvider {
+  return {
+    name: 'stub-github',
+    createReview: vi.fn(async () => ({ url: REVIEW_URL, identifier: REVIEW_ID })),
+    checkApproval: vi.fn(async () => status),
+  };
+}
+
+describe('review-gate merge-conflict lifecycle publisher', () => {
+  let adapter: SQLiteAdapter;
+  let orchestrator: Orchestrator;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    adapter.saveWorkflow(WORKFLOW);
+    orchestrator = new Orchestrator({
+      persistence: adapter,
+      messageBus: new NoopBus(),
+      taskRepository: new SqliteTaskRepository(adapter),
+      maxConcurrency: 3,
+    });
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function saveAndSync(task: TaskState = mergeNodeTask()): TaskState {
+    adapter.saveTask(WORKFLOW.id, task);
+    orchestrator.syncFromDb(WORKFLOW.id);
+    return task;
+  }
+
+  function createRunner(
+    provider: MergeGateProvider,
+    published: ReviewGateMergeConflictTrigger[] = [],
+  ): TaskRunner {
+    return new TaskRunner({
+      orchestrator,
+      persistence: adapter,
+      executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+      cwd: '/runner-base-cwd',
+      mergeGateProvider: provider,
+      reviewGateMergeConflictPublisher: {
+        publish: (trigger) => {
+          published.push(trigger);
+        },
+      },
+    });
+  }
+
+  it('publishes one merge-conflict trigger for a dirty conflicted review gate', async () => {
+    const task = saveAndSync();
+    const published: ReviewGateMergeConflictTrigger[] = [];
+    const runner = createRunner(stubMergeGateProvider(approvalStatus()), published);
+
+    await runner.checkMergeGateStatuses();
+
+    expect(published).toHaveLength(1);
+    expect(published[0]).toMatchObject({
+      taskId: task.id,
+      workflowId: WORKFLOW.id,
+      reviewId: REVIEW_ID,
+      reviewUrl: REVIEW_URL,
+      headSha: HEAD_SHA,
+      generation: 1,
+      selectedAttemptId: SELECTED_ATTEMPT_ID,
+    });
+  });
+
+  it('persists dirty mergeState onto the polled review artifact', async () => {
+    const task = saveAndSync();
+    const runner = createRunner(stubMergeGateProvider(approvalStatus()));
+
+    await runner.checkMergeGateStatuses();
+
+    const persisted = adapter.loadTasks(WORKFLOW.id).find((candidate) => candidate.id === task.id)!;
+    expect(persisted.execution.reviewGate?.artifacts[0]?.mergeState).toBe('dirty');
+  });
+
+  it('does not publish when the provider reports a clean merge state', async () => {
+    saveAndSync();
+    const published: ReviewGateMergeConflictTrigger[] = [];
+    const runner = createRunner(stubMergeGateProvider(approvalStatus({
+      statusText: 'Ready to merge',
+      mergeState: 'clean',
+      hasMergeConflict: false,
+    })), published);
+
+    await runner.checkMergeGateStatuses();
+
+    expect(published).toHaveLength(0);
+  });
+
+  it('publishes again on a later poll for the same conflict', async () => {
+    saveAndSync();
+    const published: ReviewGateMergeConflictTrigger[] = [];
+    const runner = createRunner(stubMergeGateProvider(approvalStatus()), published);
+
+    await runner.checkMergeGateStatuses();
+    await runner.checkMergeGateStatuses();
+
+    // The producer only collapses concurrent in-flight publishes; durable
+    // per-conflict deduplication belongs to the worker action key.
+    expect(published).toHaveLength(2);
+  });
+});

--- a/packages/execution-engine/src/task-runner-review-gate.ts
+++ b/packages/execution-engine/src/task-runner-review-gate.ts
@@ -4,7 +4,7 @@
  * Owns the poll loop that reconciles each merge-node task's review artifacts
  * against the merge-gate provider, maps provider lifecycle → artifact status,
  * completes approved gates, closes reviews on teardown, and publishes CI-failure
- * lifecycle triggers.
+ * and merge-conflict lifecycle triggers.
  *
  * Stateful functions take a {@link TaskRunnerReviewGateHost} — a
  * `Pick<TaskRunner, …>` — as their first parameter, so the type-only import of
@@ -96,6 +96,8 @@ export type TaskRunnerReviewGateHost = Pick<
   // Review-gate cluster state
   | 'reviewGateCiFailurePublisher'
   | 'reviewGateCiFailureInFlight'
+  | 'reviewGateMergeConflictPublisher'
+  | 'reviewGateMergeConflictInFlight'
 >;
 
 export async function closeWorkflowReview(
@@ -262,6 +264,7 @@ export async function pollMergeGateTask(
         host.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
       } else if (status.lifecycle === 'open') {
         await maybePublishReviewGateCiFailure(host, current!, status, providerId);
+        await maybePublishReviewGateMergeConflict(host, current!, status, providerId);
       }
       continue;
     }
@@ -277,6 +280,7 @@ export async function pollMergeGateTask(
       host.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
     } else if (status.lifecycle === 'open') {
       await maybePublishReviewGateCiFailure(host, current!, status, providerId);
+      await maybePublishReviewGateMergeConflict(host, current!, status, providerId);
     }
   }
 }
@@ -346,5 +350,44 @@ export async function maybePublishReviewGateCiFailure(
     });
   } finally {
     host.reviewGateCiFailureInFlight.delete(key);
+  }
+}
+
+export async function maybePublishReviewGateMergeConflict(
+  host: TaskRunnerReviewGateHost,
+  task: TaskState,
+  status: MergeGateApprovalStatus,
+  reviewId: string = task.execution.reviewId ?? '',
+): Promise<void> {
+  if (!host.reviewGateMergeConflictPublisher) return;
+  if (!task.config.workflowId || !reviewId) return;
+  if (!status.hasMergeConflict && status.mergeState !== 'dirty') return;
+
+  const key = [
+    task.id,
+    task.execution.selectedAttemptId ?? 'no-attempt',
+    task.execution.generation ?? 0,
+    status.headSha ?? 'no-head-sha',
+  ].join(':');
+  if (host.reviewGateMergeConflictInFlight.has(key)) return;
+
+  host.reviewGateMergeConflictInFlight.add(key);
+  try {
+    await host.reviewGateMergeConflictPublisher.publish({
+      taskId: task.id,
+      workflowId: task.config.workflowId,
+      status: task.status,
+      taskStateVersion: task.taskStateVersion,
+      reviewId,
+      reviewUrl: status.url,
+      headSha: status.headSha,
+      headRef: status.headRef,
+      branch: task.execution.branch,
+      selectedAttemptId: task.execution.selectedAttemptId,
+      generation: task.execution.generation ?? 0,
+      statusText: status.statusText,
+    });
+  } finally {
+    host.reviewGateMergeConflictInFlight.delete(key);
   }
 }


### PR DESCRIPTION
## Summary

Invoker now publishes `review_gate.merge_conflict` when the merge-gate poll records a conflicted review artifact.

That lets the existing merge-conflict worker rebase and recreate the stuck PR instead of leaving the workflow at `review_ready`.

The app TaskRunner now receives the same publisher, so both runtime paths emit the event.

## Review Claim

Approve the missing producer call and app wiring that route dirty merge-gate poll results into the existing `review_gate.merge_conflict` lifecycle event.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Existing merge-gate status mapping, approval completion, rejection handling, closure handling, and CI-failure publication stay unchanged. The new publisher only runs for open provider statuses.

## Slice Rationale

This is one routing slice because the lifecycle event, bridge, runner field, and worker already exist. Keeping the producer and app wiring together keeps both runtime paths live.

## Non-goals

- Do not enable or modify the `prMaintenance` shell cron.
- Do not change the merge-conflict worker status gate or action key semantics.
- Do not change CI-failure publication, retry, recreate, or cascade logic.
- Do not add new review-gate event types or module boundaries.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run check:types`
- [x] `cd packages/execution-engine && pnpm test src/__tests__/repro-review-gate-merge-conflict-publisher.test.ts`
- [x] `cd packages/app && pnpm test src/__tests__/task-runner-wiring.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-merge-conflict-pr.md --changed-files-file /tmp/invoker-merge-conflict-changed-files.txt --diff-file /tmp/invoker-merge-conflict-diff.patch`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 6d2c317bad0d2887c6448ce424c8d696efe40f81`
- Post-revert steps: Let the next merge-gate poll run; conflicted workflows will return to the previous no-event behavior.
- Data migration? No.

</details>
