### PR TITLE
[In-App Planning Chat Draft Gate Step 1](1) Add opt-in conversational planner prompt mode

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { PlanConversation, extractYamlPlan, globToRegex, isDangerousCommand, isConfirmation } from '../slack/plan-conversation.js';
+import { PlanConversation, buildPlanSystemPrompt, extractYamlPlan, globToRegex, isDangerousCommand, isConfirmation } from '../slack/plan-conversation.js';
 import { parse as parseYaml } from 'yaml';
 import * as child_process from 'node:child_process';
 import { EventEmitter } from 'node:events';
@@ -554,6 +554,44 @@ describe('PlanConversation', () => {
     expect(prompt).not.toContain('generate the YAML plan directly');
   });
 
+  it('conversational planning asks for scope before drafting', async () => {
+    const conversational = new PlanConversation({ conversationalPlanning: true });
+    mockCursorResponse('What behavior should change first?');
+
+    await conversational.sendMessage('Build better planning');
+
+    const prompt = mockSpawn.mock.calls[0][1][1] as string;
+    expect(prompt).toContain('conversational planning mode');
+    expect(prompt).toContain('Drafting is not authorized yet');
+    expect(prompt).toContain('Ask scoping questions first');
+    expect(prompt).toContain('edge cases, corner cases, architecture choices, ambiguity');
+    expect(prompt).toContain('explain like the user is five');
+    expect(prompt).toContain('asking whether the user wants you to draft the YAML plan');
+    expect(prompt).not.toContain('name: "Plan Name"');
+    expect(prompt).not.toContain('Generate a YAML task plan');
+  });
+
+  it('conversational planning treats confirmation without YAML as draft approval', async () => {
+    const conversational = new PlanConversation({ conversationalPlanning: true });
+    (conversational as any).messages.push({
+      role: 'assistant',
+      content: 'I understand the scope. Would you like me to draft the YAML plan?',
+    });
+    mockCursorResponse(VALID_YAML_PLAN);
+
+    const reply = await conversational.sendMessage('yes');
+
+    expect(reply).toBe(VALID_YAML_PLAN);
+    expect(conversational.planSubmitted).toBe(false);
+    expect(conversational.submittedPlanText).toBeNull();
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const prompt = mockSpawn.mock.calls[0][1][1] as string;
+    expect(prompt).toContain('The user has explicitly approved drafting');
+    expect(prompt).toContain('name: "Plan Name"');
+    expect(prompt).toContain('Generate a YAML task plan');
+    expect(prompt).toContain('Reply `submit` to submit it.');
+  });
+
   it('submittedPlanText is null before confirmation', async () => {
     expect(conversation.submittedPlanText).toBeNull();
     mockCursorResponse(VALID_YAML_PLAN);
@@ -761,6 +799,14 @@ describe('PlanConversation', () => {
 });
 
 describe('PlanConversation prompt construction', () => {
+  it('buildPlanSystemPrompt defaults to direct YAML draft behavior', () => {
+    const prompt = buildPlanSystemPrompt('main');
+    expect(prompt).toContain('YAML task plan');
+    expect(prompt).toContain('name: "Plan Name"');
+    expect(prompt).toContain('Generate a YAML task plan');
+    expect(prompt).toContain('Every implementation task MUST have a corresponding test task');
+  });
+
   it('buildCursorPrompt includes system prompt for first message', () => {
     const conv = new PlanConversation({ defaultBranch: 'master' });
     (conv as any).messages.push({ role: 'user', content: 'Hello' });

--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import * as child_process from 'node:child_process';
-import { PlanConversation, isConfirmation } from '../slack/plan-conversation.js';
+import { buildPlanSystemPrompt, PlanConversation, isConfirmation } from '../slack/plan-conversation.js';
 
 // Activation side: the planner is told to write the full plan to the draft file
 // and reply with a summary, and each turn starts from a cleared file so a prior
@@ -54,7 +54,7 @@ tasks:
 
 Reply \`submit\` to submit it.`;
 
-describe('plan draft file — activation side', () => {
+describe('plan draft file - activation side', () => {
   let workingDir: string;
 
   beforeEach(() => {
@@ -150,5 +150,48 @@ describe('plan draft file — activation side', () => {
     expect(draftedPlan).not.toBeNull();
     const parsedDraft = parseYaml(draftedPlan!) as Record<string, unknown>;
     expect(parsedDraft.name).toBe('Draft Activation');
+  });
+});
+
+describe('plan draft-file activation prompt policy', () => {
+  it('keeps direct plan mode ready to draft YAML by default', () => {
+    const prompt = buildPlanSystemPrompt('main', 'git@github.com:test/repo.git');
+
+    expect(prompt).toContain('Generate a YAML task plan');
+    expect(prompt).toContain('repoUrl: "git@github.com:test/repo.git"');
+    expect(prompt).toContain('name: "Plan Name"');
+    expect(prompt).toContain('When ready, output the plan inside a ```yaml code block');
+    expect(prompt).toContain('After generating a plan, include a short post-plan summary');
+  });
+
+  it('keeps YAML and draft-file mechanics unavailable before conversational authorization', () => {
+    const prompt = buildPlanSystemPrompt('main', undefined, {
+      conversationalPlanning: true,
+      draftingAuthorized: false,
+    });
+
+    expect(prompt).toContain('conversational planning mode');
+    expect(prompt).toContain('Drafting is not authorized yet');
+    expect(prompt).toContain('do NOT write a draft plan file');
+    expect(prompt).toContain('Ask scoping questions first');
+    expect(prompt).toContain('edge cases, corner cases, architecture choices, ambiguity');
+    expect(prompt).toContain('explain like the user is five');
+    expect(prompt).not.toContain('name: "Plan Name"');
+    expect(prompt).not.toContain('When ready, output the plan inside a ```yaml code block');
+    expect(prompt).not.toContain('Reply `submit` to submit it.');
+  });
+
+  it('restores YAML drafting instructions after conversational authorization', () => {
+    const prompt = buildPlanSystemPrompt('develop', undefined, {
+      conversationalPlanning: true,
+      draftingAuthorized: true,
+    });
+
+    expect(prompt).toContain('The user has explicitly approved drafting');
+    expect(prompt).toContain('baseBranch: develop');
+    expect(prompt).toContain('name: "Plan Name"');
+    expect(prompt).toContain('When ready, output the plan inside a ```yaml code block');
+    expect(prompt).toContain('After generating a plan, include a short post-plan summary');
+    expect(prompt).toContain('Every implementation task MUST have a corresponding test task');
   });
 });

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -112,6 +112,8 @@ export interface PlanConversationConfig {
   preferStackedWorkflows?: boolean;
   /** Optional callback for raw stdout chunks emitted by the planner subprocess. */
   onRawPlannerOutput?: RawPlannerOutputHandler;
+  /** Opt in to a scoping-first planning conversation before YAML drafting. Default: false. */
+  conversationalPlanning?: boolean;
   /** Logging callback. Defaults to console.log/console.error. */
   log?: LogFn;
   /**
@@ -173,6 +175,35 @@ export function isNegation(text: string): boolean {
   return NEGATION_PATTERNS.some((re) => re.test(trimmed));
 }
 
+function isExplicitDraftRequest(text: string): boolean {
+  const normalized = text.trim().toLowerCase();
+  return [
+    /\bdraft\b.*\b(yaml\s+)?plan\b/,
+    /\b(generate|write|create|produce)\b.*\b(yaml\s+)?plan\b/,
+    /\b(yaml\s+)?plan\b.*\b(draft|yaml)\b/,
+    /\bgo ahead\b.*\bdraft\b/,
+    /\bdraft it\b/,
+  ].some((re) => re.test(normalized));
+}
+
+function previousAssistantAskedToDraft(messages: ConversationMessage[]): boolean {
+  for (let i = messages.length - 2; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== 'assistant') continue;
+    return /\bdraft\b/i.test(msg.content)
+      && /\b(plan|yaml)\b/i.test(msg.content)
+      && msg.content.includes('?');
+  }
+  return false;
+}
+
+function isDraftingAuthorizedForPrompt(messages: ConversationMessage[]): boolean {
+  const latest = messages[messages.length - 1];
+  if (!latest || latest.role !== 'user') return false;
+  if (isExplicitDraftRequest(latest.content)) return true;
+  return isConfirmation(latest.content) && previousAssistantAskedToDraft(messages);
+}
+
 // ── System Prompt ───────────────────────────────────────────
 
 export const SLACK_LOCAL_REPRO_POLICY = `Execution boundary:
@@ -230,7 +261,14 @@ workflows:
 When submitted, Invoker creates one workflow per child in listed order. Each downstream workflow is based on the previous workflow's feature branch and waits on the previous merge gate.`;
 }
 
-function buildPlanSystemPrompt(
+export interface BuildPlanSystemPromptOptions {
+  conversationalPlanning?: boolean;
+  draftingAuthorized?: boolean;
+  preferStackedWorkflows?: boolean;
+  planFilePath?: string;
+}
+
+function buildDirectPlanSystemPrompt(
   defaultBranch: string,
   repoUrl?: string,
   preferStackedWorkflows = false,
@@ -306,6 +344,60 @@ Do NOT place that line inline in a sentence.
 12. Choose \`mergeMode\` deliberately. For reviewable implementation plans, set \`mergeMode: external_review\` so changes land through the canonical GitHub-backed review gate. Keep \`mergeMode: manual\` (the default) for verification-only plans that should not open a review, and use \`mergeMode: automatic\` only when the user explicitly wants changes merged without review.`;
 }
 
+function buildConversationalPlanSystemPrompt(
+  defaultBranch: string,
+  repoUrl: string | undefined,
+  options: BuildPlanSystemPromptOptions,
+): string {
+  const draftingAuthorized = options.draftingAuthorized ?? false;
+  const draftingInstructions = draftingAuthorized
+    ? `
+The user has explicitly approved drafting. You may now produce the YAML task plan.
+
+Use the authorized drafting contract below:
+${buildDirectPlanSystemPrompt(defaultBranch, repoUrl, options.preferStackedWorkflows ?? false, options.planFilePath)}`
+    : `
+Drafting is not authorized yet. Do NOT output a \`\`\`yaml code block, do NOT write a draft plan file, and do NOT tell the user the plan can be executed.
+
+Before drafting is authorized:
+1. Ask scoping questions first when the request is broad, ambiguous, risky, or missing constraints.
+2. Discuss relevant edge cases, corner cases, architecture choices, ambiguity, and likely historic reasons for the current code shape.
+3. Explore the codebase as needed, then use what you learned by referencing specific files, components, and patterns.
+4. When enough information exists, explain like the user is five: summarize assumptions, goals, and a high-level task outline in plain language.
+5. End by asking whether the user wants you to draft the YAML plan.`;
+
+  return `You are an assistant for the Invoker orchestrator in conversational planning mode.
+
+This session is a planning conversation before any task plan exists. Your job is to help scope the work clearly before drafting.
+
+For simple, self-contained requests (counting lines of code, checking versions, running a quick command, answering questions about the codebase), answer directly without drafting a plan.
+
+For implementation work, prefer a scoping conversation first. Do not rush directly to YAML unless the user has clearly approved drafting a plan.
+${draftingInstructions}
+
+When responding in conversational planning mode, be concrete, call out tradeoffs, and keep the next question or draft-authorization request easy to answer.`;
+}
+
+export function buildPlanSystemPrompt(
+  defaultBranch: string,
+  repoUrl?: string,
+  options: BuildPlanSystemPromptOptions | boolean = {},
+  planFilePath?: string,
+): string {
+  const resolvedOptions: BuildPlanSystemPromptOptions = typeof options === 'boolean'
+    ? { preferStackedWorkflows: options, planFilePath }
+    : options;
+  if (resolvedOptions.conversationalPlanning) {
+    return buildConversationalPlanSystemPrompt(defaultBranch, repoUrl, resolvedOptions);
+  }
+  return buildDirectPlanSystemPrompt(
+    defaultBranch,
+    repoUrl,
+    resolvedOptions.preferStackedWorkflows ?? false,
+    resolvedOptions.planFilePath,
+  );
+}
+
 // ── Dangerous Command Detection ─────────────────────────────
 
 export const DANGEROUS_PATTERNS: RegExp[] = [
@@ -353,6 +445,7 @@ export class PlanConversation {
   private repoUrl?: string;
   private experimentalPlanner?: boolean;
   private preferStackedWorkflows?: boolean;
+  private conversationalPlanning: boolean;
   private log: LogFn;
   private onRawPlannerOutput?: RawPlannerOutputHandler;
   private plannerRetryLimit: number;
@@ -374,6 +467,7 @@ export class PlanConversation {
     this.repoUrl = config.repoUrl;
     this.experimentalPlanner = config.experimentalPlanner;
     this.preferStackedWorkflows = config.preferStackedWorkflows;
+    this.conversationalPlanning = config.conversationalPlanning ?? false;
     this.onRawPlannerOutput = config.onRawPlannerOutput;
     this.plannerRetryLimit = Math.max(0, config.plannerRetryLimit ?? DEFAULT_PLANNER_RETRY_LIMIT);
     this.plannerRetryBaseDelayMs = Math.max(0, config.plannerRetryBaseDelayMs ?? DEFAULT_PLANNER_RETRY_BASE_DELAY_MS);
@@ -539,7 +633,12 @@ export class PlanConversation {
    */
   buildCursorPrompt(): string {
     const systemPrompt = this.mode === 'plan'
-      ? buildPlanSystemPrompt(this.defaultBranch ?? 'main', this.repoUrl, this.preferStackedWorkflows, this.planDraftFilePath() ?? undefined)
+      ? buildPlanSystemPrompt(this.defaultBranch ?? 'main', this.repoUrl, {
+          conversationalPlanning: this.conversationalPlanning,
+          draftingAuthorized: this.conversationalPlanning && isDraftingAuthorizedForPrompt(this.messages),
+          preferStackedWorkflows: this.preferStackedWorkflows,
+          planFilePath: this.planDraftFilePath() ?? undefined,
+        })
       : buildAgentSystemPrompt();
     const parts: string[] = [systemPrompt];
 
@@ -556,7 +655,9 @@ export class PlanConversation {
     if (lastMessage) {
       parts.push(`\nUser's latest message:\n${lastMessage.content}`);
       parts.push(this.mode === 'plan'
-        ? '\nRespond to the latest message. If it requires a plan, explore the codebase and generate one.'
+        ? (this.conversationalPlanning
+            ? '\nRespond to the latest message in conversational planning mode. Scope first, and only draft YAML when the user has explicitly approved drafting.'
+            : '\nRespond to the latest message. If it requires a plan, explore the codebase and generate one.')
         : '\nRespond to the latest message as a normal coding agent in this worktree.');
     }
 

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -86,6 +86,8 @@ export interface SlackSurfaceConfig {
   plannerRetryLimit?: number;
   /** Base delay in milliseconds between empty-output retry attempts (doubles per retry). Default: 500. */
   plannerRetryBaseDelayMs?: number;
+  /** Opt in to scoping-first conversational planning before YAML drafting. Default: false. */
+  conversationalPlanning?: boolean;
 
   // ── Slack-native workflow extensions ──────────────────────
   /** Lobby channel where `@Invoker` starts planning. Defaults to channelId. */
@@ -442,6 +444,7 @@ export class SlackSurface implements Surface {
   private planningHeartbeatIntervalSeconds?: number;
   private plannerRetryLimit: number;
   private plannerRetryBaseDelayMs: number;
+  private conversationalPlanning: boolean;
   /** Minimum spacing between thread message posts to avoid Slack burst limits. */
   private readonly messagePacingMs = 1_100;
   /** Session lifecycle metrics */
@@ -495,6 +498,7 @@ export class SlackSurface implements Surface {
     this.planningHeartbeatIntervalSeconds = config.planningHeartbeatIntervalSeconds;
     this.plannerRetryLimit = Math.max(0, config.plannerRetryLimit ?? DEFAULT_PLANNER_RETRY_LIMIT);
     this.plannerRetryBaseDelayMs = Math.max(0, config.plannerRetryBaseDelayMs ?? DEFAULT_PLANNER_RETRY_BASE_DELAY_MS);
+    this.conversationalPlanning = config.conversationalPlanning ?? false;
     this.lobbyChannelId = config.lobbyChannelId ?? config.channelId;
     this.planningCommandBuilder = config.planningCommandBuilder;
     this.prepareRepoCheckout = config.prepareRepoCheckout;
@@ -525,6 +529,7 @@ export class SlackSurface implements Surface {
         planningCommandBuilder: config.planningCommandBuilder,
         plannerRetryLimit: this.plannerRetryLimit,
         plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
+        conversationalPlanning: this.conversationalPlanning,
       });
     }
   }
@@ -2094,6 +2099,7 @@ ${text}`;
         timeoutMs: (this.planningTimeoutSeconds ?? 7_200) * 1_000,
         plannerRetryLimit: this.plannerRetryLimit,
         plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
+        conversationalPlanning: this.conversationalPlanning,
       });
       this.planConversations.set(threadTs, conversation);
     }
@@ -2161,6 +2167,7 @@ ${text}`;
             repoUrl: this.defaultRepoUrl,
             plannerRetryLimit: this.plannerRetryLimit,
             plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
+            conversationalPlanning: this.conversationalPlanning,
           });
           await conversation.init();
           this.planConversations.set(entry.threadTs, conversation);

--- a/packages/surfaces/src/slack/thread-session-manager.ts
+++ b/packages/surfaces/src/slack/thread-session-manager.ts
@@ -179,6 +179,8 @@ export interface SessionManagerConfig {
   plannerRetryLimit?: number;
   /** Forwarded to PlanConversation for silent-success retries. */
   plannerRetryBaseDelayMs?: number;
+  /** Opt in to scoping-first conversational planning before YAML drafting. Default: false. */
+  conversationalPlanning?: boolean;
 }
 
 export interface SessionMetrics {
@@ -219,6 +221,7 @@ export class SessionManager {
   private readonly mode: ConversationMode;
   private readonly plannerRetryLimit?: number;
   private readonly plannerRetryBaseDelayMs?: number;
+  private readonly conversationalPlanning: boolean;
 
   constructor(config: SessionManagerConfig) {
     this.cursorCommand = config.cursorCommand ?? 'agent';
@@ -236,6 +239,7 @@ export class SessionManager {
     this.mode = config.mode ?? 'agent';
     this.plannerRetryLimit = config.plannerRetryLimit;
     this.plannerRetryBaseDelayMs = config.plannerRetryBaseDelayMs;
+    this.conversationalPlanning = config.conversationalPlanning ?? false;
   }
 
   /**
@@ -327,6 +331,7 @@ export class SessionManager {
         timeoutMs: this.timeoutMs,
         plannerRetryLimit: this.plannerRetryLimit,
         plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
+        conversationalPlanning: this.conversationalPlanning,
       });
       await conversation.init(); // Load state from database
       this.log('session-manager', 'info', `[TRACE] Recovery init() done (threadTs=${id.threadTs})`);
@@ -360,6 +365,7 @@ export class SessionManager {
         timeoutMs: this.timeoutMs,
         plannerRetryLimit: this.plannerRetryLimit,
         plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
+        conversationalPlanning: this.conversationalPlanning,
       });
       // Don't call init() for new sessions — nothing to load
 


### PR DESCRIPTION
## Summary

This slice adds an opt-in conversational planning prompt mode.

Default plan requests keep their existing direct draft behavior. In-app chat can now ask clarifying questions before a draft.

## Review Claim

PlanConversation exposes an opt-in conversational prompt contract without changing direct planning threads.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The new behavior is only enabled through `conversationalPlanning`; existing callers keep the direct planning prompt unless they opt in.

## Slice Rationale

This slice establishes the prompt contract before app/session enforcement uses it.

## Non-goals

- Do not change YAML parsing.
- Do not change draft file activation.
- Do not change Slack submission behavior.
- Do not change app session state.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/plan-conversation.test.ts src/__tests__/plan-draft-file-activation.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 69d2dd7c0`
- Post-revert steps: Re-run the focused surfaces test command from the test plan.
- Data migration? No

</details>
