### PR TITLE
[Tmux Summary Bridge Step 3 Task Terminals](1) Wire task terminal summaries

### DIFF
--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -323,6 +323,40 @@ describe('EmbeddedTerminalManager', () => {
     );
   });
 
+  it('seeds display-only bridge output before process output and does not duplicate on reuse', () => {
+    const child = createFakeChild();
+    const bashSpawnFn = vi.fn(() => child) as unknown as BashSpawnFn;
+    const mgr = new EmbeddedTerminalManager({
+      backend: createBashTerminalBackend({ spawnFn: bashSpawnFn }),
+    });
+    const bridge = '=== Invoker task terminal bridge ===\nTask: task-bridge\n=== End Invoker task terminal bridge ===\n\n';
+    const spec: TerminalSpec = {
+      command: 'codex',
+      args: ['resume', 'codex-session-1'],
+      cwd: '/tmp/wt',
+      introText: bridge,
+    };
+
+    const session = mgr.openOrReuse({
+      taskId: 'task-bridge',
+      spec,
+      cwd: '/tmp/wt',
+    });
+
+    expect(session.outputSnapshot).toBe(bridge);
+    child.stdout.emit('data', Buffer.from('agent output\n'));
+    expect(mgr.get(session.sessionId)?.outputSnapshot).toBe(`${bridge}agent output\n`);
+
+    const reused = mgr.openOrReuse({
+      taskId: 'task-bridge',
+      spec,
+      cwd: '/tmp/wt',
+    });
+    expect(reused.sessionId).toBe(session.sessionId);
+    expect(reused.outputSnapshot).toBe(`${bridge}agent output\n`);
+    expect(bashSpawnFn).toHaveBeenCalledTimes(1);
+  });
+
   it('fans bash stdout and stderr through the output event', () => {
     const child = createFakeChild();
     const bashSpawnFn = vi.fn(() => child) as unknown as BashSpawnFn;

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -29,6 +29,7 @@ import {
   MergeGateExecutor,
   BaseExecutor,
   getEffectivePath,
+  registerBuiltinAgents,
   type ExecutorHandle, type TerminalSpec, type PersistedTaskMeta,
 } from '@invoker/execution-engine';
 import type { WorkResponse, WorkRequest } from '@invoker/contracts';
@@ -45,7 +46,9 @@ import {
   buildTerminalShellCommand,
   spawnDetachedTerminal,
 } from '../terminal-external-launch.js';
-import { openExternalTerminalForTask } from '../open-terminal-for-task.js';
+import { openExternalTerminalForTask, resolveTaskTerminalSpec } from '../open-terminal-for-task.js';
+import * as terminalSummaryBridgeModule from '../terminal-summary-bridge.js';
+import { TASK_TERMINAL_SUMMARY_BRIDGE_START } from '../terminal-summary-bridge.js';
 import * as configModule from '../config.js';
 
 vi.mock('node:fs', async (importOriginal) => {
@@ -170,6 +173,25 @@ function openExternalTerminal(spec: TerminalSpec | null): void {
 }
 
 const taskHandles = new Map<string, ExecutorHandle>();
+
+function makeBridgeTask(overrides: Partial<TaskState> = {}): TaskState {
+  const base: TaskState = {
+    id: 'task-bridge',
+    description: 'Restore agent terminal context',
+    status: 'completed',
+    dependencies: [],
+    createdAt: new Date('2026-07-20T00:00:00Z'),
+    config: { workflowId: 'wf-bridge' },
+    execution: {},
+    taskStateVersion: 1,
+  };
+  return {
+    ...base,
+    ...overrides,
+    config: { ...base.config, ...overrides.config },
+    execution: { ...base.execution, ...overrides.execution },
+  };
+}
 
 function executeTaskViaExecutor(
   executor: WorktreeExecutor,
@@ -437,6 +459,264 @@ describe('terminal-external-launch', () => {
     const doScriptArg = args.find(a => a.startsWith('do script'));
     expect(doScriptArg).toBeDefined();
     expect(doScriptArg).toContain('\\"');
+  });
+
+  it('prints display-only intro text before the terminal command', () => {
+    const script = buildLinuxXTerminalBashScript(
+      {
+        cwd: '/tmp/wt',
+        command: 'codex',
+        args: ['resume', 'session-1'],
+        introText: `${TASK_TERMINAL_SUMMARY_BRIDGE_START}\nTask: task-1\n`,
+      },
+      '/fallback',
+    );
+
+    expect(script.indexOf('printf %s')).toBeGreaterThan(-1);
+    expect(script.indexOf('printf %s')).toBeLessThan(script.indexOf("'codex'"));
+    expect(script).toContain("'codex' 'resume' 'session-1'");
+  });
+});
+
+describe('task terminal summary bridge resolution', () => {
+  afterEach(() => {
+    vi.mocked(existsSync).mockReset();
+  });
+
+  function makeWorktreeRegistry(agentRegistry = registerBuiltinAgents()) {
+    const registry = new ExecutorRegistry();
+    registry.register('worktree', new WorktreeExecutor({
+      cacheDir: join(tmpdir(), `cache-${randomUUID()}`),
+      worktreeBaseDir: join(tmpdir(), `wt-${randomUUID()}`),
+      agentRegistry,
+    }));
+    return registry;
+  }
+
+  function makePersistence(task: TaskState, overrides: Record<string, unknown> = {}) {
+    return {
+      getTaskStatus: vi.fn(() => task.status),
+      getRunnerKind: vi.fn(() => task.config.runnerKind ?? 'worktree'),
+      getAgentSessionId: vi.fn(() => task.execution.agentSessionId ?? null),
+      getLastAgentSessionId: vi.fn(() => task.execution.lastAgentSessionId ?? null),
+      getExecutionAgent: vi.fn(() => task.config.executionAgent ?? task.execution.agentName ?? null),
+      getContainerId: vi.fn(() => task.execution.containerId ?? null),
+      getWorkspacePath: vi.fn(() => task.execution.workspacePath ?? null),
+      getBranch: vi.fn(() => task.execution.branch ?? null),
+      getPoolMemberId: vi.fn(() => task.config.poolMemberId ?? null),
+      loadTask: vi.fn(() => task),
+      loadWorkflow: vi.fn((workflowId: string) => ({
+        id: workflowId,
+        name: 'Bridge Workflow',
+        status: 'completed',
+      })),
+      ...overrides,
+    };
+  }
+
+  it('adds a bounded bridge for completed Codex task terminals without changing resume argv', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    const workspacePath = '/tmp/invoker-worktree-codex';
+    const longPrompt = `Explain this task ${'private details '.repeat(40)}tail-marker`;
+    const task = makeBridgeTask({
+      id: 'task-codex',
+      description: 'Open a completed Codex terminal with local context',
+      config: {
+        workflowId: 'wf-bridge',
+        executionAgent: 'codex',
+        problem: 'Task terminals resume into a blank-looking shell.',
+        approach: 'Render a display-only bridge before resuming the agent.',
+        testPlan: 'Run focused app terminal tests.',
+        summary: 'Bridge context rendered before the Codex resume command.',
+        prompt: longPrompt,
+      },
+      execution: {
+        agentName: 'codex',
+        agentSessionId: 'codex-session-1',
+        inputPrompt: longPrompt,
+        branch: 'experiment/task-codex',
+        workspacePath,
+      },
+    });
+    const agentRegistry = registerBuiltinAgents({ codex: { command: 'codex-test' } });
+    vi.spyOn(agentRegistry.getSessionDriver('codex')!, 'loadSession').mockReturnValue('{"type":"thread.started"}\n');
+
+    const resolved = resolveTaskTerminalSpec({
+      taskId: task.id,
+      persistence: makePersistence(task) as never,
+      executorRegistry: makeWorktreeRegistry(agentRegistry),
+      executionAgentRegistry: agentRegistry,
+      repoRoot: '/repo',
+    });
+
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.spec.command).toBe('codex-test');
+    expect(resolved.spec.args).toEqual([
+      'resume',
+      '--dangerously-bypass-approvals-and-sandbox',
+      'codex-session-1',
+    ]);
+    expect(resolved.spec.introText).toContain(TASK_TERMINAL_SUMMARY_BRIDGE_START);
+    expect(resolved.spec.introText).toContain('Workflow: Bridge Workflow (wf-bridge)');
+    expect(resolved.spec.introText).toContain('Agent: codex');
+    expect(resolved.spec.introText).toContain('Session: codex-session-1');
+    expect(resolved.spec.introText).toContain('Last summary: Bridge context rendered before the Codex resume command.');
+    expect(resolved.spec.introText).not.toContain('tail-marker');
+  });
+
+  it('adds an OMP bridge while preserving session-dir continue args', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    const workspacePath = '/tmp/invoker-worktree-omp';
+    const sessionRoot = join(tmpdir(), 'omp-sessions');
+    const task = makeBridgeTask({
+      id: 'task-omp',
+      description: 'Reopen an OMP task terminal',
+      config: { workflowId: 'wf-bridge', executionAgent: 'omp' },
+      execution: {
+        agentName: 'omp',
+        agentSessionId: 'omp-session-1',
+        workspacePath,
+      },
+    });
+    const agentRegistry = registerBuiltinAgents({
+      omp: { command: 'omp-test', sessionDirRoot: sessionRoot },
+    });
+
+    const resolved = resolveTaskTerminalSpec({
+      taskId: task.id,
+      persistence: makePersistence(task) as never,
+      executorRegistry: makeWorktreeRegistry(agentRegistry),
+      executionAgentRegistry: agentRegistry,
+      repoRoot: '/repo',
+    });
+
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.spec.command).toBe('omp-test');
+    expect(resolved.spec.args).toEqual([
+      '--session-dir',
+      join(sessionRoot, 'omp-session-1'),
+      '--continue',
+    ]);
+    expect(resolved.spec.introText).toContain(TASK_TERMINAL_SUMMARY_BRIDGE_START);
+    expect(resolved.spec.introText).toContain('Agent: omp');
+  });
+
+  it('does not add an agent bridge for command-only tasks without agent context', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    const task = makeBridgeTask({
+      id: 'task-command',
+      description: 'Run a command task',
+      config: { workflowId: 'wf-bridge', command: 'pnpm test' },
+      execution: { workspacePath: '/tmp/invoker-worktree-command' },
+    });
+
+    const resolved = resolveTaskTerminalSpec({
+      taskId: task.id,
+      persistence: makePersistence(task) as never,
+      executorRegistry: makeWorktreeRegistry(),
+      repoRoot: '/repo',
+    });
+
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.spec.introText).toBeUndefined();
+  });
+  it('keeps terminal resolution working when task or workflow bridge metadata load throws', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    const task = makeBridgeTask({
+      id: 'task-bridge-load-failure',
+      config: { workflowId: 'wf-bridge', executionAgent: 'codex' },
+      execution: {
+        agentName: 'codex',
+        agentSessionId: 'codex-session-bridge-load-failure',
+        workspacePath: '/tmp/invoker-worktree-bridge-load-failure',
+      },
+    });
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    } as any;
+    const persistence = makePersistence(task, {
+      loadTask: vi.fn(() => {
+        throw new Error('corrupt persisted task');
+      }),
+    });
+    const agentRegistry = registerBuiltinAgents({ codex: { command: 'codex-test' } });
+    vi.spyOn(agentRegistry.getSessionDriver('codex')!, 'loadSession').mockReturnValue('{"type":"thread.started"}\n');
+
+    const resolved = resolveTaskTerminalSpec({
+      taskId: task.id,
+      persistence: persistence as never,
+      executorRegistry: makeWorktreeRegistry(agentRegistry),
+      executionAgentRegistry: agentRegistry,
+      repoRoot: '/repo',
+      logger,
+    });
+
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.spec.command).toBe('codex-test');
+    expect(resolved.spec.introText).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'task terminal bridge metadata load failed for task="task-bridge-load-failure": corrupt persisted task',
+      { module: 'open-terminal' },
+    );
+  });
+
+  it('keeps terminal resolution working when bridge rendering throws', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    const task = makeBridgeTask({
+      id: 'task-bridge-render-failure',
+      config: { workflowId: 'wf-bridge', executionAgent: 'codex' },
+      execution: {
+        agentName: 'codex',
+        agentSessionId: 'codex-session-bridge-render-failure',
+        workspacePath: '/tmp/invoker-worktree-bridge-render-failure',
+      },
+    });
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    } as any;
+    const agentRegistry = registerBuiltinAgents({ codex: { command: 'codex-test' } });
+    vi.spyOn(agentRegistry.getSessionDriver('codex')!, 'loadSession').mockReturnValue('{"type":"thread.started"}\n');
+    const bridgeSpy = vi
+      .spyOn(terminalSummaryBridgeModule, 'buildTaskTerminalSummaryBridge')
+      .mockImplementation(() => {
+        throw new Error('bridge rendering failed');
+      });
+
+    let resolved: ReturnType<typeof resolveTaskTerminalSpec> | undefined;
+    try {
+      resolved = resolveTaskTerminalSpec({
+        taskId: task.id,
+        persistence: makePersistence(task) as never,
+        executorRegistry: makeWorktreeRegistry(agentRegistry),
+        executionAgentRegistry: agentRegistry,
+        repoRoot: '/repo',
+        logger,
+      });
+    } finally {
+      bridgeSpy.mockRestore();
+    }
+    expect(resolved).toBeDefined();
+    if (!resolved) return;
+    expect(resolved.ok).toBe(true);
+    if (!resolved.ok) return;
+    expect(resolved.spec.command).toBe('codex-test');
+    expect(resolved.spec.introText).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'task terminal summary bridge build failed for task="task-bridge-render-failure": bridge rendering failed',
+      { module: 'open-terminal' },
+    );
   });
 });
 

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -320,7 +320,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
       createdAt,
       updatedAt: createdAt,
       status: 'running' as const,
-      outputSnapshot: opts.outputSnapshot ?? '',
+      outputSnapshot: opts.outputSnapshot ?? opts.spec.introText ?? '',
     };
 
     if (opts.attach) {

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -18,6 +18,7 @@ import {
   type PersistedTaskMeta,
   type TerminalSpec,
 } from '@invoker/execution-engine';
+import type { TaskState } from '@invoker/workflow-core';
 import { loadConfig } from './config.js';
 import {
   buildLinuxXTerminalBashScript,
@@ -26,6 +27,10 @@ import {
   type OpenTerminalResult,
 } from './terminal-external-launch.js';
 import { resolveEffectiveMaxConcurrency } from './execution-capacity.js';
+import {
+  buildTaskTerminalSummaryBridge,
+  type TaskTerminalWorkflowSummary,
+} from './terminal-summary-bridge.js';
 
 /** Persistence methods required to resolve terminal cwd / command for a task. */
 export interface OpenTerminalPersistence {
@@ -38,6 +43,8 @@ export interface OpenTerminalPersistence {
   getWorkspacePath(taskId: string): string | null;
   getBranch(taskId: string): string | null;
   getPoolMemberId?(taskId: string): string | null;
+  loadTask?(taskId: string): TaskState | undefined;
+  loadWorkflow?(workflowId: string): TaskTerminalWorkflowSummary | undefined;
   loadAttempts?(taskId: string): Array<{ id: string; agentSessionId?: string }>;
   updateTask?(taskId: string, changes: { execution?: { agentSessionId?: string; lastAgentSessionId?: string } }): void;
   updateAttempt?(attemptId: string, changes: { agentSessionId?: string }): void;
@@ -180,6 +187,20 @@ export function resolveTaskTerminalSpec(
     };
   }
 
+  let task: TaskState | undefined;
+  let workflow: TaskTerminalWorkflowSummary | undefined;
+  let canBuildBridge = true;
+  try {
+    task = persistence.loadTask?.(taskId);
+    const workflowId = task?.config.workflowId;
+    workflow = workflowId ? persistence.loadWorkflow?.(workflowId) : undefined;
+  } catch (err) {
+    canBuildBridge = false;
+    termLogger?.warn?.(
+      `task terminal bridge metadata load failed for task="${taskId}": ${err instanceof Error ? err.message : String(err)}`,
+      { module: 'open-terminal' },
+    );
+  }
   const meta: PersistedTaskMeta = {
     taskId,
     runnerKind: persistence.getRunnerKind(taskId) ?? 'worktree',
@@ -280,6 +301,28 @@ export function resolveTaskTerminalSpec(
   }
 
   const cwd = spec.cwd ?? repoRoot;
+  let introText: string | undefined;
+  if (canBuildBridge) {
+    try {
+      introText = buildTaskTerminalSummaryBridge({
+        taskId,
+        status: taskStatus,
+        task,
+        workflow,
+        meta: repairedMeta,
+        spec,
+        cwd,
+      });
+    } catch (err) {
+      termLogger?.warn?.(
+        `task terminal summary bridge build failed for task="${taskId}": ${err instanceof Error ? err.message : String(err)}`,
+        { module: 'open-terminal' },
+      );
+    }
+  }
+  if (introText) {
+    spec = { ...spec, introText };
+  }
   termLogger?.info(`effective cwd=${cwd} (repoRoot=${repoRoot})`);
 
   return { ok: true, spec, cwd, meta: repairedMeta, executor };

--- a/packages/app/src/terminal-external-launch.ts
+++ b/packages/app/src/terminal-external-launch.ts
@@ -16,18 +16,21 @@ export type InteractiveExecShell = 'bash' | 'zsh';
  * Full shell line: `cd '<cwd>' && ...` plus either `exec bash` / `exec zsh` or `command` with args properly quoted.
  */
 export function buildTerminalShellCommand(
-  spec: { cwd?: string; command?: string; args?: string[] },
+  spec: { cwd?: string; command?: string; args?: string[]; introText?: string },
   defaultCwd: string,
   options?: { interactiveExec?: InteractiveExecShell },
 ): string {
   const cwd = spec.cwd ?? defaultCwd;
   const cd = `cd ${shellSingleQuoteForPOSIX(cwd)}`;
+  const intro = spec.introText
+    ? `printf %s ${shellSingleQuoteForPOSIX(spec.introText)} && `
+    : '';
   if (!spec.command) {
     const execSh = options?.interactiveExec === 'zsh' ? 'exec zsh' : 'exec bash';
-    return `${cd} && ${execSh}`;
+    return `${cd} && ${intro}${execSh}`;
   }
   const argv = [spec.command, ...(spec.args ?? [])];
-  return `${cd} && ${argv.map(shellSingleQuoteForPOSIX).join(' ')}`;
+  return `${cd} && ${intro}${argv.map(shellSingleQuoteForPOSIX).join(' ')}`;
 }
 
 /** Escape for embedding in AppleScript: `tell application "Terminal" to do script "…"`. */
@@ -37,7 +40,7 @@ export function appleScriptEscapeForDoubleQuotedString(s: string): string {
 
 /** argv for `osascript` to run the built shell command in Terminal.app. */
 export function buildMacOSOsascriptArgs(
-  spec: { cwd?: string; command?: string; args?: string[] },
+  spec: { cwd?: string; command?: string; args?: string[]; introText?: string },
   defaultCwd: string,
 ): string[] {
   const shellCmd = buildTerminalShellCommand(spec, defaultCwd, { interactiveExec: 'zsh' });
@@ -54,7 +57,7 @@ export function buildMacOSOsascriptArgs(
  * Inner script passed to `bash -c` for Linux x-terminal-emulator (includes optional suffix).
  */
 export function buildLinuxXTerminalBashScript(
-  spec: { cwd?: string; command?: string; args?: string[]; linuxTerminalTail?: 'exec_bash' | 'pause' },
+  spec: { cwd?: string; command?: string; args?: string[]; introText?: string; linuxTerminalTail?: 'exec_bash' | 'pause' },
   defaultCwd: string,
 ): string {
   const base = buildTerminalShellCommand(spec, defaultCwd);

--- a/packages/app/src/terminal-summary-bridge.ts
+++ b/packages/app/src/terminal-summary-bridge.ts
@@ -1,0 +1,125 @@
+import {
+  DEFAULT_EXECUTION_AGENT,
+  type PersistedTaskMeta,
+  type TerminalSpec,
+} from '@invoker/execution-engine';
+import type { TaskState } from '@invoker/workflow-core';
+
+export const TASK_TERMINAL_SUMMARY_BRIDGE_START = '=== Invoker task terminal bridge ===';
+export const TASK_TERMINAL_SUMMARY_BRIDGE_END = '=== End Invoker task terminal bridge ===';
+
+const TASK_TERMINAL_BRIDGE_TEXT_LIMIT = 220;
+const TASK_TERMINAL_BRIDGE_PROMPT_LIMIT = 160;
+
+export interface TaskTerminalWorkflowSummary {
+  id: string;
+  name?: string;
+  status?: string;
+}
+
+export interface TaskTerminalSummaryBridgeOptions {
+  taskId: string;
+  status?: string | null;
+  task?: TaskState;
+  workflow?: TaskTerminalWorkflowSummary;
+  meta: PersistedTaskMeta;
+  spec?: TerminalSpec;
+  cwd?: string;
+}
+
+function oneLine(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function truncatedLine(value: string | undefined | null, limit = TASK_TERMINAL_BRIDGE_TEXT_LIMIT): string {
+  const normalized = oneLine(String(value ?? ''));
+  if (normalized.length <= limit) return normalized;
+  return `${normalized.slice(0, Math.max(0, limit - 3)).trimEnd()}...`;
+}
+
+function firstPresent(...values: Array<string | undefined | null>): string | undefined {
+  for (const value of values) {
+    const line = truncatedLine(value);
+    if (line) return line;
+  }
+  return undefined;
+}
+
+function labelWorkflow(workflow: TaskTerminalWorkflowSummary | undefined, workflowId: string | undefined): string | undefined {
+  if (workflow?.name && workflowId) return `${truncatedLine(workflow.name, 96)} (${workflowId})`;
+  if (workflow?.name) return truncatedLine(workflow.name, 96);
+  return workflowId;
+}
+
+function resolveAgentName(
+  task: TaskState | undefined,
+  meta: PersistedTaskMeta,
+): string | undefined {
+  return firstPresent(
+    meta.executionAgent,
+    task?.execution.agentName,
+    task?.execution.lastAgentName,
+    task?.config.executionAgent,
+    meta.agentSessionId ? DEFAULT_EXECUTION_AGENT : undefined,
+  );
+}
+
+function shouldBuildTaskTerminalBridge(
+  task: TaskState | undefined,
+  meta: PersistedTaskMeta,
+  agentName: string | undefined,
+): boolean {
+  const commandOnly = Boolean(task?.config.command) && !task?.config.prompt && !task?.config.experimentPrompt;
+  const hasAgentContext = Boolean(meta.agentSessionId || agentName || task?.execution.agentSessionId || task?.execution.lastAgentSessionId);
+  return hasAgentContext && !(commandOnly && !meta.agentSessionId && !agentName);
+}
+
+export function buildTaskTerminalSummaryBridge(
+  opts: TaskTerminalSummaryBridgeOptions,
+): string | undefined {
+  const { task, meta } = opts;
+  const agentName = resolveAgentName(task, meta);
+  if (!shouldBuildTaskTerminalBridge(task, meta, agentName)) return undefined;
+
+  const workflowId = task?.config.workflowId;
+  const workflowLabel = labelWorkflow(opts.workflow, workflowId);
+  const branch = firstPresent(meta.branch, task?.execution.branch);
+  const workspace = firstPresent(meta.workspacePath, task?.execution.workspacePath, opts.cwd, opts.spec?.cwd);
+  const sessionId = firstPresent(meta.agentSessionId, task?.execution.agentSessionId, task?.execution.lastAgentSessionId);
+  const taskLine = task?.description
+    ? `${opts.taskId} - ${truncatedLine(task.description, 120)}`
+    : opts.taskId;
+
+  const lines = [
+    TASK_TERMINAL_SUMMARY_BRIDGE_START,
+    `Task: ${taskLine}`,
+  ];
+
+  if (workflowLabel) lines.push(`Workflow: ${workflowLabel}`);
+  lines.push(`Status: ${truncatedLine(task?.status ?? opts.status ?? 'unknown', 64)}`);
+  if (agentName) lines.push(`Agent: ${agentName}`);
+  if (sessionId) lines.push(`Session: ${sessionId}`);
+  if (branch) lines.push(`Branch: ${branch}`);
+  if (workspace) lines.push(`Workspace: ${workspace}`);
+
+  const problem = truncatedLine(task?.config.problem);
+  const approach = truncatedLine(task?.config.approach);
+  const testPlan = truncatedLine(task?.config.testPlan);
+  const prompt = truncatedLine(
+    firstPresent(task?.execution.inputPrompt, task?.config.prompt, task?.config.experimentPrompt),
+    TASK_TERMINAL_BRIDGE_PROMPT_LIMIT,
+  );
+  const summary = truncatedLine(task?.config.summary);
+
+  if (problem) lines.push(`Problem: ${problem}`);
+  if (approach) lines.push(`Approach: ${approach}`);
+  if (testPlan) lines.push(`Test plan: ${testPlan}`);
+  if (prompt) lines.push(`Prompt: ${prompt}`);
+  if (summary) lines.push(`Last summary: ${summary}`);
+
+  const next = sessionId
+    ? `Next: Resuming the saved ${agentName ?? 'agent'} session in this terminal.`
+    : 'Next: Opening the task workspace in this terminal.';
+  lines.push(next, TASK_TERMINAL_SUMMARY_BRIDGE_END, '');
+  return `${lines.join('\n')}\n`;
+}

--- a/packages/execution-engine/src/executor.ts
+++ b/packages/execution-engine/src/executor.ts
@@ -20,6 +20,8 @@ export interface TerminalSpec {
   args?: string[];
   /** Tail command for Linux terminal launch (e.g. 'exec_bash' or 'pause'). */
   linuxTerminalTail?: 'exec_bash' | 'pause';
+  /** Display-only text rendered before the terminal command starts. Never sent to process stdin. */
+  introText?: string;
 }
 
 export interface PersistedTaskMeta {


### PR DESCRIPTION
## Summary

Reopening a Codex or OMP task terminal now starts with a short bridge that names the task, workflow, status, agent session, branch, and workspace.

Before this, a returning user saw a resumed agent or a bare shell with no local reminder of what the task was doing.

The bridge is display-only text. It is printed before the terminal argv runs and is never fed into the resumed agent session.

Tasks with no agent context are left alone, and reopening an already-running terminal tab does not print the bridge twice.

## Review Claim

Opening or restoring a Codex/OMP task terminal shows a bounded task summary bridge before the resumed agent or shell, without changing the resumed argv.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The bridge is derived only from already-persisted task and workflow metadata. It does not mutate task state, change stale-session repair, or change branch or worktree resolution. `buildTerminalShellCommand` prepends `printf %s '<intro>' && ` and leaves the existing argv untouched, so Codex and OMP resume argv is byte-identical and nothing reaches the resumed process stdin.

## Slice Rationale

This slice only changes terminal-open routing in the app layer. It reuses the Step 1 bridge primitive but touches different files and a different surface than Step 2's in-app planning tmux, so it is reviewed on its own.

## Non-goals

- Do not change `CodexExecutionAgent.buildResumeArgs` or `OmpExecutionAgent.buildResumeArgs`.
- Do not parse saved Codex JSONL or OMP transcripts.
- Do not change task scheduling or automatic fix behavior.
- Do not change planning tmux behavior from Step 2.

## Architecture

### Before

`resolveTaskTerminalSpec` built a `TerminalSpec` from persisted meta and handed it straight to the external launcher or the embedded terminal manager. The visible terminal began at the resumed agent argv.

### After

`resolveTaskTerminalSpec` loads the task and its workflow, composes a bounded `introText`, and attaches it to the spec. External launches print it before the argv; the embedded terminal manager seeds it as the initial `outputSnapshot` when no snapshot exists.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/open-terminal.test.ts src/__tests__/embedded-terminal-manager.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run `pnpm --filter @invoker/app test -- src/__tests__/open-terminal.test.ts src/__tests__/embedded-terminal-manager.test.ts`
- Data migration? No

</details>

