### PR TITLE
[CI Vitest Workspace](4) Align ssh-pool preempt test with reclaim behaviour

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
@@ -255,15 +255,27 @@ describe('SSH pool member capacity', () => {
     await sshExecutor.kill(handlesByTaskId.get(secondTask.id));
     firstTask.execution = { ...firstTask.execution, selectedAttemptId: `${firstTask.id}-retry-attempt` };
     secondTask.execution = { ...secondTask.execution, selectedAttemptId: `${secondTask.id}-retry-attempt` };
-    await runner.executeTask(thirdTask);
-    expect(deferTask).toHaveBeenCalledWith(thirdTask.id, expect.objectContaining({
-      reason: 'resource-limit',
-      attemptId: thirdTask.execution.selectedAttemptId,
-    }));
-    expect(sshExecutor.start).toHaveBeenCalledTimes(2);
+    // Both executions were killed but the mock never reaped their in-memory
+    // slots, and each task's live attempt has since advanced. Dispatching a new
+    // task must reclaim those superseded slots (their attempt is no longer live)
+    // rather than read both members as full — releasing the wedged pool capacity
+    // so the third task starts instead of deferring.
+    const thirdRun = runner.executeTask(thirdTask);
+    await vi.waitFor(() => expect(sshExecutor.start).toHaveBeenCalledTimes(3));
+    await vi.waitFor(() => expect(completeByTaskId.has(thirdTask.id)).toBe(true));
+    expect(deferTask).not.toHaveBeenCalled();
 
-    expect(await runner.killActiveExecution(firstTask.id)).toBe(true);
-    expect(await runner.killActiveExecution(secondTask.id)).toBe(true);
+    completeByTaskId.get(thirdTask.id)?.({
+      requestId: `complete-${thirdTask.id}`,
+      actionId: thirdTask.id,
+      attemptId: thirdTask.execution.selectedAttemptId,
+      status: 'completed',
+      outputs: { exitCode: 0 },
+    });
+    await thirdRun;
+
+    // A late completion for each reclaimed (superseded) attempt must settle its
+    // original run as a safe no-op without re-wedging member capacity.
     completeByTaskId.get(firstTask.id)?.({
       requestId: `kill-${firstTask.id}`,
       actionId: firstTask.id,
@@ -280,18 +292,6 @@ describe('SSH pool member capacity', () => {
     });
     await firstRun;
     await secondRun;
-
-    const thirdRun = runner.executeTask(thirdTask);
-    await vi.waitFor(() => expect(sshExecutor.start).toHaveBeenCalledTimes(3));
-    await vi.waitFor(() => expect(completeByTaskId.has(thirdTask.id)).toBe(true));
-    completeByTaskId.get(thirdTask.id)?.({
-      requestId: `complete-${thirdTask.id}`,
-      actionId: thirdTask.id,
-      attemptId: thirdTask.execution.selectedAttemptId,
-      status: 'completed',
-      outputs: { exitCode: 0 },
-    });
-    await thirdRun;
   });
 
   it('logs when killActiveExecution cannot kill the executor handle', async () => {


### PR DESCRIPTION
## Summary

Update the ssh pool preempt test to assert the new reclaim behaviour, fixing the last red test in the Vitest Workspace suite.

The Runner Capacity reclaim passes now free a killed-but-unreaped execution slot the moment a new task dispatches. The old test still expected the ghost slot to wedge the member and force a defer, so it hung.

## Review Claim

Assert that a preempted task's superseded slot is reclaimed so a new task starts, instead of the pre-reclaim defer.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the test file changes; no production code. The rewritten case still drives real reclaim behaviour (`reclaimSupersededExecutionSlots`/`reclaimOrphanedExecutionSlots`) and keeps a late-completion no-op check.

## Slice Rationale

Test-only alignment with the reclaim work already on master; belongs on its own so the behaviour change is reviewable in isolation.

## Non-goals

- No change to the reclaim logic or any TaskRunner production code.
- No change to other cases in this file.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && node_modules/.bin/vitest run src/__tests__/ssh-pool-member-capacity.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 965e75da5`
- Post-revert steps: None
- Data migration? No

</details>
