### PR TITLE
[Fix Git E2E Tests Step 5 Final Gate](1) Keep queued launches active in headless watch

### DIFF
--- a/packages/app/src/__tests__/headless-watch.test.ts
+++ b/packages/app/src/__tests__/headless-watch.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { runHeadless } from '../headless.js';
 import type { HeadlessDeps } from '../headless.js';
-import { Orchestrator, CommandService } from '@invoker/workflow-core';
+import { Orchestrator, CommandService, type TaskState } from '@invoker/workflow-core';
 import { SQLiteAdapter } from '@invoker/data-store';
 import type { MessageBus } from '@invoker/transport';
 import { LocalBus } from '@invoker/transport';
+
+import { trackWorkflow } from '../headless-watch.js';
 
 const noopLogger = {
   debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
@@ -19,6 +21,23 @@ function makeTask(overrides: Record<string, unknown> = {}) {
     dependencies: [],
     createdAt: new Date('2024-01-01T00:00:00Z'),
     config: { workflowId: 'wf-1', runnerKind: 'worktree', isMergeNode: false },
+    execution: {},
+    ...overrides,
+  };
+}
+
+function makeWorkflowTask(
+  id: string,
+  status: TaskState['status'],
+  overrides: Partial<TaskState> = {},
+): TaskState {
+  return {
+    id,
+    description: id,
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    status,
+    config: { workflowId: 'wf-1' },
     execution: {},
     ...overrides,
   };
@@ -88,5 +107,51 @@ describe('headless watch', () => {
     await runHeadless(['watch'], mockDeps);
     expect(stdout.mock.calls[0][0]).toContain('No workflows found');
     stdout.mockRestore();
+  });
+});
+
+describe('trackWorkflow', () => {
+  it('does not settle a failed workflow while a sibling launch is still queued', async () => {
+    const tasks = [
+      makeWorkflowTask('wf-1/a', 'completed'),
+      makeWorkflowTask('wf-1/b', 'failed'),
+      makeWorkflowTask('wf-1/c', 'queued' as TaskState['status'], {
+        dependencies: ['wf-1/a'],
+        execution: { phase: 'launching' },
+      }),
+      makeWorkflowTask('wf-1/d', 'pending', {
+        dependencies: ['wf-1/b', 'wf-1/c'],
+      }),
+    ];
+
+    let notify: (() => void) | undefined;
+    setTimeout(() => {
+      tasks[2] = {
+        ...tasks[2]!,
+        status: 'completed',
+        execution: { ...tasks[2]!.execution, phase: 'completed' },
+      };
+      notify?.();
+    }, 20);
+
+    const result = await trackWorkflow({
+      workflowId: 'wf-1',
+      loadTasks: () => tasks,
+      subscribeToChanges: (next) => {
+        notify = next;
+        return () => {
+          notify = undefined;
+        };
+      },
+      printSnapshot: false,
+      printSummary: false,
+      printTaskOutput: false,
+      setExitCodeOnFailure: false,
+      pollIntervalMs: 5,
+      maxWaitMs: 500,
+    });
+
+    expect(result.tasks.find((task) => task.id === 'wf-1/c')?.status).toBe('completed');
+    expect(result.status.failed).toBe(1);
   });
 });

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -392,8 +392,11 @@ export async function waitForCompletion(
     if (allSettled && !hasBackgroundWork?.()) return;
     // Also settle if nothing is running and at least one task awaits human action.
     // Pending merge gates can't progress until their upstream is approved.
-    const noneRunning = !tasks.some(
-      (t) => t.status === 'running' || t.status === 'fixing_with_ai',
+    const noneRunning = !tasks.some((t) =>
+      t.status === 'running'
+      || t.status === 'fixing_with_ai'
+      || (t.status as string) === 'queued'
+      || (t.status === 'pending' && t.execution.phase === 'launching')
     );
     const hasReadyPending = readyTasks.some((t) => t.status === 'pending');
     const hasHumanBlocked = tasks.some((t) => settledStatuses.includes(t.status) && t.status !== 'completed');

--- a/packages/app/src/headless-watch.ts
+++ b/packages/app/src/headless-watch.ts
@@ -242,9 +242,19 @@ function workflowHasSettled(
     return true;
   }
 
-  const noneRunning = !tasks.some((task) => task.status === 'running' || task.status === 'fixing_with_ai');
+  const noneRunning = !tasks.some(isActiveWorkflowTask);
   const hasHumanBlocked = tasks.some((task) => settledStatuses.has(task.status) && task.status !== 'completed');
   return noneRunning && hasHumanBlocked && !hasBackgroundWork?.();
+}
+
+function isActiveWorkflowTask(task: TaskState): boolean {
+  return task.status === 'running'
+    || task.status === 'fixing_with_ai'
+    || (task.status as string) === 'queued'
+    || (
+      task.status === 'pending'
+      && task.execution.phase === 'launching'
+    );
 }
 
 function summarizeWorkflowTasks(tasks: TaskState[]): Pick<TrackWorkflowResult, 'status' | 'reviewUrl'> {


### PR DESCRIPTION
## Summary

Headless watch now treats queued launches and launching pending tasks as active work.

This keeps final summaries from printing before sibling launches finish after an early task failure.

## Review Claim

Headless watch waits for queued launch work before settling a workflow with failures.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change only extends the existing active-work check. Terminal task statuses and failure exit-code handling stay unchanged.

## Slice Rationale

The final gate exposed the early-settle bug while the required git e2e surface was running as an integrated stack.

## Non-goals

- Changing task scheduling, retry, reset, or merge-gate semantics.
- Changing UI behavior or proof assets.
- Changing required-suite selection.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-watch.test.ts`
- [x] `bash scripts/test-suites/required/20-e2e-dry-run.sh`
- [x] `bash scripts/test-suites/required/21-e2e-dry-run-downstream.sh`
- [x] `bash scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh`
- [x] `bash scripts/test-suites/required/22-e2e-dry-run-github.sh`
- [x] `bash scripts/test-suites/required/50-verify-executor-routing.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: revert this PR from GitHub, or `git revert <merge-commit-sha>` after merge.
- Post-revert steps: Rerun the required git e2e gate before publishing the stack.
- Data migration? No

</details>
