### PR TITLE
[Fix Git E2E Tests Step 5 Final Gate](2) Guard branch carry-forward Vitest filter

### DIFF
--- a/scripts/test-suites/required/16-branch-carry-forward.sh
+++ b/scripts/test-suites/required/16-branch-carry-forward.sh
@@ -3,6 +3,9 @@
 # merge/review gates merge only their direct dependency branch.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-cd "$ROOT"
+source "$ROOT/scripts/lib/required-vitest.sh"
 
-pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/branch-chain.test.ts -t 'review gate direct dependency branch'
+run_required_vitest_filter \
+  "$ROOT/packages/execution-engine" \
+  "src/__tests__/branch-chain.test.ts" \
+  "review gate direct dependency branch"


### PR DESCRIPTION
## Summary

Required/16 now runs through the shared required Vitest helper.

The helper fails when the name filter selects no active tests.

## Review Claim

Required/16 uses the required Vitest filter guard for its branch carry-forward test.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The wrapper still runs the same Vitest file and test name. The helper only adds zero-active-test detection.

## Slice Rationale

This is separate from the runtime wait fix because it hardens the required-suite wrapper rather than application behavior.

## Non-goals

- Changing the branch carry-forward assertion.
- Changing merge-gate or executor-routing behavior.
- Adding new required-suite shards.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-suites/required/16-branch-carry-forward.sh`
- [x] `bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh`
- [x] `bash scripts/test-suites/required/20-e2e-dry-run.sh`
- [x] `bash scripts/test-suites/required/21-e2e-dry-run-downstream.sh`
- [x] `bash scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh`
- [x] `bash scripts/test-suites/required/22-e2e-dry-run-github.sh`
- [x] `bash scripts/test-suites/required/50-verify-executor-routing.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: revert this PR from GitHub, or `git revert <merge-commit-sha>` after merge.
- Post-revert steps: Rerun required/16 before republishing the stack.
- Data migration? No

</details>
