### PR TITLE
[Heavy CI Routing](1) Route heavy jobs to self-hosted Ubuntu runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
   e2e-proof:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60
@@ -263,7 +263,7 @@ jobs:
   e2e-proof-aggregate:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: e2e-proof
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 15
@@ -296,7 +296,7 @@ jobs:
   required-fast:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu]
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -443,7 +443,7 @@ jobs:
   reset-rulebook-repro:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 45
@@ -564,7 +564,7 @@ jobs:
   playwright:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 5
@@ -730,7 +730,7 @@ jobs:
   playwright-nightly-perf:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 30
@@ -805,7 +805,7 @@ jobs:
   ssh:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60


### PR DESCRIPTION
## Summary

This sends the seven slow CI jobs to the self-hosted Ubuntu runner pool instead of GitHub-hosted `ubuntu-latest` machines.

The queue was backed up because the new runner fleet was registered, but the workflow still asked GitHub for hosted machines. Mergify could not use the new boxes.

This change only rewires `runs-on` for the heavy jobs, so merge-queue work can land on the `Runner_Heavy_Ubuntu` fleet that is already online.

## Review Claim

The CI workflow policy now routes the heavy lanes to the registered `Runner_Heavy_Ubuntu` self-hosted fleet.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only runner selection changes. The same jobs, containers, sharding, and timeouts stay in place.

## Slice Rationale

The fleet registration already happened outside this branch. This slice is only the GitHub workflow cutover that makes the live queue use it.

## Non-goals

- Changing job commands, containers, or shard counts.
- Changing the lighter CI lanes.
- Changing Mergify rules.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -c 'from pathlib import Path; text = Path(".github/workflows/ci.yml").read_text(); print("Runner_Heavy_Ubuntu count", text.count("Runner_Heavy_Ubuntu")); print("ubuntu-latest count", text.count("runs-on: ubuntu-latest"))'`
- [x] `gh api orgs/Neko-Catpital-Labs/actions/runners?per_page=100 --jq '[.runners[] | select(.status == "online") | select(any(.labels[]; .name == "Runner_Heavy_Ubuntu"))] | length'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
