### PR TITLE
[Mergify Babysitter](1) Repair and advance admin-bypass stacks

### DIFF
--- a/scripts/mergify_admin_requeue.py
+++ b/scripts/mergify_admin_requeue.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 from typing import Sequence
 
 try:
@@ -16,19 +15,18 @@ except ImportError:
     from mergify_admin_requeue_plan import classify_pr, plan_stack_actions
     from mergify_admin_requeue_snapshot import group_stack_prs, parse_mergify_queue_event, parse_stack_metadata
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
 parse_args = exec_impl.parse_args
 run_once = exec_impl.run_once
-subprocess = exec_impl.subprocess
-execute_action = exec_impl.execute_action
-resolve_workflow = exec_impl.resolve_workflow
-repair_conflict = exec_impl.repair_conflict
-repair_check = exec_impl.repair_check
+run_loop = exec_impl.run_loop
+REPO_ROOT = exec_impl.REPO_ROOT
+_repair_conflict = exec_impl.repair_conflict
+_repair_check = exec_impl.repair_check
+_execute_action = exec_impl.execute_action
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
-    return run_once(args)
+    return run_loop(args) if args.loop else run_once(args)
 
 
 if __name__ == "__main__":

--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import replace
 import json
 import os
 from pathlib import Path
@@ -10,12 +9,13 @@ import subprocess
 import sys
 import tempfile
 import time
+from typing import Mapping, Sequence
 try:
-    from .mergify_admin_requeue_model import Action, GH_ACTIONS_JOB_RE, Ledger, MergifyQueueEvent, PrSnapshot, load_mergify_rules
+    from .mergify_admin_requeue_model import Action, GH_ACTIONS_JOB_RE, Ledger, MergifyQueueEvent, PrSnapshot, StackGroup, load_mergify_rules
     from .mergify_admin_requeue_plan import plan_stack_actions
     from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head, group_stack_prs, parse_stack_metadata, snapshot_from_detail
 except ImportError:
-    from mergify_admin_requeue_model import Action, GH_ACTIONS_JOB_RE, Ledger, MergifyQueueEvent, PrSnapshot, load_mergify_rules
+    from mergify_admin_requeue_model import Action, GH_ACTIONS_JOB_RE, Ledger, MergifyQueueEvent, PrSnapshot, StackGroup, load_mergify_rules
     from mergify_admin_requeue_plan import plan_stack_actions
     from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head, group_stack_prs, parse_stack_metadata, snapshot_from_detail
 
@@ -29,20 +29,6 @@ def admin_bypass_nudge_body() -> str:
         "but it is missing the `admin-bypass` label. Please tag this PR with `admin-bypass` "
         "before babysitting can continue."
     )
-
-
-def resolve_workflow(pr_number: int) -> tuple[str, str]:
-    try:
-        out = subprocess.run(["./run.sh", "--headless", "query", "review-gate", str(pr_number), "--output", "json"], cwd=str(REPO_ROOT), check=True, text=True, capture_output=True).stdout
-    except subprocess.CalledProcessError as exc:
-        detail = exc.stderr.strip() or exc.stdout.strip() or str(exc)
-        raise RuntimeError(f"cannot resolve local workflow for PR #{pr_number}: {detail}") from exc
-    value = json.loads(out) if out.strip() else {}
-    workflow = str(value.get("workflowId") or "")
-    generation = str(value.get("workflowGeneration") or "0")
-    if not workflow:
-        raise RuntimeError(f"no local workflow for PR #{pr_number}")
-    return workflow, generation
 
 
 def github_job_log(repo: str, details_url: str, pr_number: int, check_name: str) -> str:
@@ -65,6 +51,15 @@ def mergify_check_urls(event: MergifyQueueEvent | None, check_name: str) -> tupl
     return ()
 
 
+def run_claude_repair(work_root: Path, prompt: str) -> None:
+    subprocess.run(
+        ["claude", "-p", prompt, "--dangerously-skip-permissions"],
+        cwd=str(work_root),
+        check=True,
+        text=True,
+    )
+
+
 def repair_check(repo: str, pr: PrSnapshot, check_name: str) -> None:
     ctx = pr.checks.get(check_name)
     mergify_urls = mergify_check_urls(pr.latest_mergify, check_name)
@@ -80,7 +75,7 @@ def repair_check(repo: str, pr: PrSnapshot, check_name: str) -> None:
         f"PR: #{pr.number}\nFailed check: {check_name}\nDetails URL: {details_url}\nJob log path: {log_path}\n"
         f"Latest Mergify event: {json.dumps(latest.__dict__ if latest else None, sort_keys=True)}\n"
     )
-    subprocess.run(["omp", "--no-title", "--auto-approve", "-p", prompt], cwd=str(work_root), check=True, text=True)
+    run_claude_repair(work_root, prompt)
 
 
 def repair_conflict(repo: str, pr: PrSnapshot, reason: str) -> None:
@@ -89,13 +84,13 @@ def repair_conflict(repo: str, pr: PrSnapshot, reason: str) -> None:
     checkout_pr_head(repo, pr, work_root)
     prompt = (
         f"Resolve only the merge conflict that keeps this PR from merging. "
-        f"Rebase or recreate the PR head branch onto its base branch, keep the PR's intended changes, "
+        f"Rebase the PR head branch onto its base branch, preserve the PR's intended changes, "
         f"run the narrow proof for the conflict resolution, then commit and push to the PR head branch. "
         f"If the PR is already closed or merged, or the head branch no longer exists, make no commit and exit 0.\n\n"
         f"PR: #{pr.number}\nBase branch: {pr.base_ref_name}\nHead branch: {pr.head_ref_name}\n"
         f"Head SHA: {pr.head_ref_oid}\nReason: {reason}\n"
     )
-    subprocess.run(["omp", "--no-title", "--auto-approve", "-p", prompt], cwd=str(work_root), check=True, text=True)
+    run_claude_repair(work_root, prompt)
 
 
 def print_action(action: Action, pr: PrSnapshot | None, dry_run: bool, as_json: bool) -> None:
@@ -117,8 +112,8 @@ def print_action(action: Action, pr: PrSnapshot | None, dry_run: bool, as_json: 
         print(f"{prefix}remove-merge-hold PR #{action.pr_number}")
     elif action.kind == "resolve_bot_threads":
         print(f"{prefix}resolve-bot-threads PR #{action.pr_number} thread={action.key}")
-    elif action.kind == "rebase_recreate":
-        print(f"{prefix}rebase-recreate PR #{action.pr_number} {action.detail}")
+    elif action.kind == "repair_conflict":
+        print(f"{prefix}repair-conflict PR #{action.pr_number} {action.detail}")
 
 
 def execute_action(action: Action, repo: str, gh: GhClient, ledger: Ledger, pr_by_number: Mapping[int, PrSnapshot], now: int) -> None:
@@ -140,98 +135,143 @@ def execute_action(action: Action, repo: str, gh: GhClient, ledger: Ledger, pr_b
         kind = "repair-bot-thread" if action.key.startswith("bot_review_thread:") else "repair-check"
         ledger.record(kind, action.pr_number, pr.head_ref_oid, check_name, now)
         repair_check(repo, pr, check_name)
-    elif action.kind == "rebase_recreate":
+    elif action.kind == "repair_conflict":
         ledger.record("conflict-repair", action.pr_number, pr.head_ref_oid, action.key, now)
-        try:
-            workflow, _generation = resolve_workflow(action.pr_number)
-        except RuntimeError as exc:
-            repair_conflict(repo, pr, str(exc))
-            return
-        subprocess.run(["node", "scripts/headless-ipc.js", "exec", "--", "rebase-recreate", workflow], cwd=str(REPO_ROOT), check=True, text=True, capture_output=True)
+        repair_conflict(repo, pr, action.detail)
     elif action.kind == "comment_blocked" and action.key == "capped":
         key = f"capped:{action.detail}"
         if ledger.count("comment-blocked", action.pr_number, pr.head_ref_oid, key) == 0:
-            gh.comment(repo, action.pr_number, f"Invoker Mergify repair stopped: {action.detail}")
+            gh.comment(repo, action.pr_number, f"Mergify repair stopped: {action.detail}")
             ledger.record("comment-blocked", action.pr_number, pr.head_ref_oid, key, now)
 
 
-def run_once(args: argparse.Namespace) -> int:
-    rule_path = REPO_ROOT / ".mergify.yml"
-    try:
-        trunk, _labels, required_checks = load_mergify_rules(rule_path)
-    except ValueError:
-        print("ERROR: failed to load admin-bypass Mergify rule", file=sys.stderr)
-        return 2
+def load_candidate_stacks(
+    gh: GhClient,
+    repo: str,
+    author: str | None,
+    pr_numbers: Sequence[int],
+    required_checks: Sequence[str],
+    trunk: str,
+) -> tuple[StackGroup, ...]:
+    candidates = gh.list_candidate_prs(repo, author, pr_numbers)
+    candidate_numbers = {int(pr.get("number") or 0) for pr in candidates}
+    if not candidate_numbers:
+        return ()
 
-    gh = GhClient()
-    raw_prs = gh.list_candidate_prs(args.repo, args.author, args.pr)
+    raw_by_number = {
+        int(pr.get("number") or 0): pr
+        for pr in gh.list_open_prs(repo)
+    }
+    raw_by_number.update({int(pr.get("number") or 0): pr for pr in candidates})
+
+    comments_cache: dict[int, list[dict]] = {}
+
+    def comments_for(number: int) -> list[dict]:
+        if number not in comments_cache:
+            comments_cache[number] = gh.issue_comments(repo, number)
+        return comments_cache[number]
+
+    # Lightweight grouping pass: use only the list-level fields (state, head/base
+    # refs) plus candidate stack metadata to discover which open PRs actually
+    # belong to a candidate's stack. This avoids an O(open-PR-count) fan-out of
+    # pr_detail/issue_comments calls every cycle.
+    lite_snapshots = [snapshot_from_detail(raw, [], required_checks) for raw in raw_by_number.values()]
+    lite_metadata: dict[int, tuple[str, tuple[int, ...]]] = {}
+    for number in candidate_numbers:
+        meta = parse_stack_metadata(comments_for(number))
+        if not meta:
+            continue
+        for pr_number in meta[1]:
+            lite_metadata[pr_number] = meta
+        lite_metadata[number] = meta
+
+    relevant_numbers: set[int] = set()
+    for stack in group_stack_prs(lite_snapshots, lite_metadata, trunk):
+        if any(pr.number in candidate_numbers for pr in stack.prs):
+            relevant_numbers.update(pr.number for pr in stack.prs)
+
+    # Full detail pass: fetch pr_detail/issue_comments only for PRs linked to a
+    # candidate stack.
     details: list[tuple[Mapping[str, object], list[dict]]] = []
-    for raw in raw_prs:
-        number = int(raw.get("number") or 0)
-        detail = raw if "reviewThreads" in raw else gh.pr_detail(args.repo, number)
-        comments = gh.issue_comments(args.repo, number)
-        details.append((detail, comments))
+    for number in sorted(relevant_numbers):
+        raw = raw_by_number.get(number)
+        detail = raw if raw is not None and "reviewThreads" in raw else gh.pr_detail(repo, number)
+        details.append((detail, comments_for(number)))
 
     snapshots = [snapshot_from_detail(detail, comments, required_checks) for detail, comments in details]
-    if args.pr:
-        manual = set(args.pr)
-        snapshots = [
-            replace(
-                item,
-                latest_mergify=MergifyQueueEvent(
-                    "manual",
-                    "dequeued",
-                    "manual",
-                    "",
-                    item.head_ref_oid,
-                    (),
-                    (),
-                    "",
-                ),
-            ) if (
-                item.number in manual
-                and not ((item.latest_mergify and item.latest_mergify.state == "dequeued") or "dequeued" in item.labels)
-            ) else item
-            for item in snapshots
-        ]
     metadata: dict[int, tuple[str, tuple[int, ...]]] = {}
     for detail, comments in details:
         number = int(detail.get("number") or 0)
         meta = parse_stack_metadata(comments)
-        if meta:
-            for pr_num in meta[1]:
-                metadata[pr_num] = meta
-            if number not in metadata:
-                metadata[number] = meta
-    stacks = group_stack_prs(snapshots, metadata, trunk)
+        if not meta:
+            continue
+        for pr_number in meta[1]:
+            metadata[pr_number] = meta
+        metadata[number] = meta
+
+    return tuple(
+        stack
+        for stack in group_stack_prs(snapshots, metadata, trunk)
+        if any(pr.number in candidate_numbers for pr in stack.prs)
+    )
+
+
+def run_cycle(args: argparse.Namespace) -> bool:
+    rule_path = REPO_ROOT / ".mergify.yml"
+    try:
+        trunk, _labels, required_checks = load_mergify_rules(rule_path)
+    except ValueError as exc:
+        print("ERROR: failed to load admin-bypass Mergify rule", file=sys.stderr)
+        raise RuntimeError("failed to load admin-bypass Mergify rule") from exc
+
+    gh = GhClient()
+    stacks = load_candidate_stacks(gh, args.repo, args.author, args.pr, required_checks, trunk)
     ledger = Ledger(Path(args.state_file).expanduser())
     now = int(time.time())
-    pr_by_number = {pr.number: pr for pr in snapshots}
+    pr_by_number = {pr.number: pr for stack in stacks for pr in stack.prs}
+    should_poll = False
     for stack in stacks:
-        for action in plan_stack_actions(
-            stack,
-            required_checks,
-            ledger,
-            now,
-            trunk=trunk,
-            max_repair_attempts=args.max_repair_attempts,
-            max_requeue_attempts=args.max_requeue_attempts,
-        ):
+        actions = plan_stack_actions(stack, required_checks, ledger, now, args.max_requeue_attempts, args.max_repair_attempts)
+        if not actions:
+            should_poll = True
+            continue
+        for action in actions:
             pr = pr_by_number.get(action.pr_number)
             print_action(action, pr, args.dry_run, args.json)
-            if not args.dry_run:
-                execute_action(action, args.repo, gh, ledger, pr_by_number, now)
-                if action.kind not in {"comment_blocked", "comment_admin_bypass_nudge"}:
-                    return 0
+            if args.dry_run:
+                continue
+            execute_action(action, args.repo, gh, ledger, pr_by_number, now)
+            if action.kind not in {"comment_blocked", "comment_admin_bypass_nudge"}:
+                return True
+    return should_poll
+
+
+def run_once(args: argparse.Namespace) -> int:
+    try:
+        run_cycle(args)
+    except RuntimeError:
+        return 2
+    return 0
+
+
+def run_loop(args: argparse.Namespace) -> int:
+    try:
+        while run_cycle(args):
+            time.sleep(args.poll_seconds)
+    except RuntimeError:
+        return 2
     return 0
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Repair and requeue eligible admin-bypass PRs after Mergify dequeue events.")
-    parser.add_argument("--once", action="store_true", help="Run one scan/action cycle and exit. Cron uses this.")
-    parser.add_argument("--dry-run", action="store_true", help="Print planned actions; perform no GitHub/Invoker mutations.")
+    parser = argparse.ArgumentParser(description="Repair and queue open admin-bypass Mergify stacks.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--once", action="store_true", help="Run one scan/action cycle and exit. Cron uses this.")
+    mode.add_argument("--loop", action="store_true", help="Poll until no actionable stack remains.")
+    parser.add_argument("--poll-seconds", type=float, default=60, help="Seconds to wait between loop scans. Default: 60.")
+    parser.add_argument("--dry-run", action="store_true", help="Print planned actions; perform no GitHub mutations.")
     parser.add_argument("--repo", default="Neko-Catpital-Labs/Invoker", help="Default: Neko-Catpital-Labs/Invoker.")
-    parser.add_argument("--author", default="EdbertChan", help="Default: EdbertChan.")
+    parser.add_argument("--author", help="Limit scan to one author. Default: all authors.")
     parser.add_argument("--state-file", default=str(Path.home() / ".invoker" / "mergify-admin-requeue-state.jsonl"), help="Ledger JSONL path.")
     parser.add_argument("--pr", type=int, action="append", default=[], help="Limit to a PR; repeatable.")
     parser.add_argument("--max-requeue-attempts", type=int, default=2, help="Default: 2 per PR/head/dequeue event.")

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -8,6 +8,9 @@ except ImportError:
     from mergify_admin_requeue_model import Action, BOT_OR_SELF_AUTHORS, Blocker, Ledger, MergifyQueueEvent, PrSnapshot, StackGroup
 
 
+TRUNK = "master"
+
+
 def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) -> tuple[Blocker, ...]:
     blockers: list[Blocker] = []
     if pr.state != "OPEN":
@@ -72,12 +75,12 @@ def effective_blockers(pr: PrSnapshot, required_checks: Collection[str], trunk: 
     )
 
 
-def mergify_failed_check_actions(pr: PrSnapshot, ledger: Ledger, max_repair_attempts: int = 3) -> tuple[Action, ...]:
+def mergify_failed_check_actions(pr: PrSnapshot, ledger: Ledger) -> tuple[Action, ...]:
     latest = pr.latest_mergify
     if not latest or latest.state != "dequeued" or latest.head_sha != pr.head_ref_oid:
         return ()
     for name in latest.failing_checks:
-        if ledger.count("repair-check", pr.number, pr.head_ref_oid, name) >= max_repair_attempts:
+        if ledger.count("repair-check", pr.number, pr.head_ref_oid, name) >= 3:
             return (cap_action(pr, Blocker(name, "failed_check", pr.number, f"Mergify queue check failed: {name}"), f"Mergify queue check failed: {name}"),)
         return (Action("repair_check", pr.number, name, f"Mergify queue check failed: {name}"),)
     return ()
@@ -88,16 +91,15 @@ def plan_stack_actions(
     required_checks: Collection[str],
     ledger: Ledger,
     now_epoch: int,
-    trunk: str = "master",
-    max_repair_attempts: int = 3,
     max_requeue_attempts: int = 2,
+    max_repair_attempts: int = 3,
 ) -> tuple[Action, ...]:
     del now_epoch
-    blockers_by_pr = {pr.number: effective_blockers(pr, required_checks, trunk) for pr in stack.prs}
+    blockers_by_pr = {pr.number: effective_blockers(pr, required_checks, TRUNK) for pr in stack.prs}
     all_blockers = [b for blockers in blockers_by_pr.values() for b in blockers]
 
     for pr in stack.prs:
-        actions = mergify_failed_check_actions(pr, ledger, max_repair_attempts)
+        actions = mergify_failed_check_actions(pr, ledger)
         if actions:
             return actions
 
@@ -107,7 +109,7 @@ def plan_stack_actions(
                 key = f"conflict:{pr.number}"
                 if ledger.count("conflict-repair", pr.number, pr.head_ref_oid, key) >= max_repair_attempts:
                     return (cap_action(pr, blocker, blocker.detail),)
-                return (Action("rebase_recreate", pr.number, key, blocker.detail),)
+                return (Action("repair_conflict", pr.number, key, blocker.detail),)
             if blocker.kind == "failed_check":
                 if ledger.count("repair-check", pr.number, pr.head_ref_oid, blocker.key) >= max_repair_attempts:
                     return (cap_action(pr, blocker, blocker.detail),)
@@ -129,10 +131,10 @@ def plan_stack_actions(
             if blocker.kind in {"draft", "human_review_thread", "missing_check", "closed"}:
                 return (Action("comment_blocked", pr.number, blocker.key, public_blocker_kind(blocker.kind)),)
 
-    current_bottoms = [pr for pr in stack.prs if pr.state == "OPEN" and pr.base_ref_name == trunk]
+    current_bottoms = [pr for pr in stack.prs if pr.state == "OPEN" and pr.base_ref_name == TRUNK]
     if not current_bottoms:
         first = stack.prs[0]
-        return (Action("comment_blocked", first.number, "no-current-bottom", f"no current bottom on {trunk}"),)
+        return (Action("comment_blocked", first.number, "no-current-bottom", "no current bottom on master"),)
     bottom = current_bottoms[0]
 
     non_hold_blockers = [b for b in all_blockers if b.kind != "merge_hold"]
@@ -150,15 +152,16 @@ def plan_stack_actions(
         return (Action("comment_admin_bypass_nudge", bottom.number, "admin-bypass", "missing admin-bypass label"),)
 
     latest = bottom.latest_mergify
-    requeue_reason = ""
-    requeue_key = "manual"
+    if latest and latest.head_sha == bottom.head_ref_oid and latest.state in {"queued", "merging"}:
+        return ()
+    requeue_reason = "eligible-when-ready"
+    requeue_key = "ready"
     if latest and latest.state == "dequeued":
         requeue_reason = "eligible-after-dequeue"
         requeue_key = latest.comment_id or "manual"
     elif "dequeued" in bottom.labels:
         requeue_reason = "eligible-after-dequeued-label"
-    if not requeue_reason:
-        return ()
-    if ledger.count("requeue", bottom.number, bottom.head_ref_oid, requeue_key) >= max_requeue_attempts:
+    attempts = ledger.count("requeue", bottom.number, bottom.head_ref_oid, requeue_key)
+    if attempts >= max_requeue_attempts:
         return (cap_action(bottom, Blocker(requeue_key, "capped", bottom.number, "requeue"), "requeue"),)
     return (Action("requeue", bottom.number, requeue_key, requeue_reason),)

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -50,14 +50,16 @@ class GhClient:
     def _run(self, args: Sequence[str]) -> str:
         return run_logged(args)
 
-    def list_candidate_prs(self, repo: str, author: str, pr_numbers: Sequence[int]) -> list[dict]:
+    def list_candidate_prs(self, repo: str, author: str | None, pr_numbers: Sequence[int]) -> list[dict]:
         if pr_numbers:
             return [self.pr_detail(repo, number) for number in pr_numbers]
         args = [
-            "gh", "pr", "list", "--repo", repo, "--author", author, "--state", "open",
+            "gh", "pr", "list", "--repo", repo, "--state", "open",
             "--label", "admin-bypass", "--limit", "200", "--json",
             "number,title,url,headRefName,headRefOid,baseRefName,state,isDraft,labels,mergeStateStatus,mergeable,reviewDecision,statusCheckRollup",
         ]
+        if author:
+            args[5:5] = ["--author", author]
         value = self._run_json(args)
         seeds = value if isinstance(value, list) else []
         by_number: dict[int, dict] = {}
@@ -90,6 +92,13 @@ class GhClient:
             remember(number, self.pr_detail(repo, number))
 
         return [by_number[number] for number in ordered_numbers]
+
+    def list_open_prs(self, repo: str) -> list[dict]:
+        value = self._run_json([
+            "gh", "pr", "list", "--repo", repo, "--state", "open", "--limit", "200", "--json",
+            "number,title,url,headRefName,headRefOid,baseRefName,state,isDraft,labels,mergeStateStatus,mergeable,reviewDecision,statusCheckRollup",
+        ])
+        return value if isinstance(value, list) else []
 
     def pr_detail(self, repo: str, number: int) -> dict:
         owner, name = repo.split("/", 1)

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -1,9 +1,10 @@
 import os
-import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 import scripts.mergify_admin_requeue as requeue
+import scripts.mergify_admin_requeue_exec as exec_impl
 
 from scripts.mergify_admin_requeue import (
     Action,
@@ -208,29 +209,17 @@ Failing checks
         actions = plan_stack_actions(stack, REQUIRED, ledger, 2)
         self.assertEqual([(a.kind, a.key) for a in actions], [("resolve_bot_threads", "tbot")])
 
-    def test_conflict_uses_rebase_recreate_cap(self):
+    def test_conflict_uses_claude_repair_cap(self):
         stack = StackGroup("s", (pr(2609, merge_state="DIRTY", latest=mergify()),))
         ledger = self.ledger()
         actions = plan_stack_actions(stack, REQUIRED, ledger, 1)
-        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("rebase_recreate", 2609)])
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("repair_conflict", 2609)])
         for epoch in range(3):
             ledger.record("conflict-repair", 2609, HEAD, "conflict:2609", epoch)
         actions = plan_stack_actions(stack, REQUIRED, ledger, 4)
         self.assertEqual([(a.kind, a.key) for a in actions], [("comment_blocked", "capped")])
 
-    def test_resolve_workflow_turns_command_failure_into_runtime_error(self):
-        original_run = requeue.subprocess.run
-        try:
-            requeue.subprocess.run = lambda *args, **kwargs: (_ for _ in ()).throw(
-                subprocess.CalledProcessError(1, ["./run.sh"], stderr="missing workflow")
-            )
-            with self.assertRaisesRegex(RuntimeError, "missing workflow"):
-                requeue.resolve_workflow(2647)
-        finally:
-            requeue.subprocess.run = original_run
-
-
-    def test_rebase_recreate_without_local_workflow_records_and_caps(self):
+    def test_conflict_repair_records_and_caps_without_invoker(self):
         class FakeGh:
             def __init__(self):
                 self.comments = []
@@ -240,24 +229,70 @@ Failing checks
 
         ledger = self.ledger()
         item = pr(2647, merge_state="DIRTY", latest=mergify())
-        action = Action("rebase_recreate", 2647, "conflict:2647", "GitHub reports merge conflict")
+        action = Action("repair_conflict", 2647, "conflict:2647", "GitHub reports merge conflict")
         fake = FakeGh()
         repairs = []
-        original_resolve = requeue.exec_impl.resolve_workflow
-        original_repair = requeue.exec_impl.repair_conflict
-        try:
-            requeue.exec_impl.resolve_workflow = lambda pr_number: (_ for _ in ()).throw(RuntimeError(f"no local workflow for PR #{pr_number}"))
-            requeue.exec_impl.repair_conflict = lambda repo, pr, reason: repairs.append((repo, pr.number, reason))
+        with mock.patch.object(exec_impl, "repair_conflict", side_effect=lambda repo, pr, reason: repairs.append((repo, pr.number, reason))):
             for epoch in range(3):
-                requeue.execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, epoch)
-        finally:
-            requeue.exec_impl.resolve_workflow = original_resolve
-            requeue.exec_impl.repair_conflict = original_repair
+                requeue._execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, epoch)
         self.assertEqual(ledger.count("conflict-repair", 2647, HEAD, "conflict:2647"), 3)
         self.assertEqual([repair[1] for repair in repairs], [2647, 2647, 2647])
         self.assertEqual(fake.comments, [])
         actions = plan_stack_actions(StackGroup("s", (item,)), REQUIRED, ledger, 4)
         self.assertEqual([(a.kind, a.key) for a in actions], [("comment_blocked", "capped")])
+
+    def test_claude_repair_uses_claude_cli(self):
+        with mock.patch.object(exec_impl.subprocess, "run") as run:
+            exec_impl.run_claude_repair(Path("/tmp/work"), "repair this")
+        run.assert_called_once_with(
+            ["claude", "-p", "repair this", "--dangerously-skip-permissions"],
+            cwd="/tmp/work",
+            check=True,
+            text=True,
+        )
+
+    def test_candidate_stack_includes_unlabeled_upper_prs(self):
+        def raw(number, base, head, labels):
+            return {
+                "number": number,
+                "title": f"PR {number}",
+                "url": f"https://example.invalid/{number}",
+                "state": "OPEN",
+                "isDraft": False,
+                "baseRefName": base,
+                "headRefName": head,
+                "headRefOid": HEAD,
+                "mergeStateStatus": "CLEAN",
+                "mergeable": "MERGEABLE",
+                "labels": {"nodes": [{"name": label} for label in labels]},
+                "reviewThreads": {"pageInfo": {"hasNextPage": False}, "nodes": []},
+                "statusCheckRollup": {"contexts": {"nodes": []}},
+            }
+
+        bottom = raw(1, "master", "stack/one", {"admin-bypass"})
+        upper = raw(2, "stack/one", "stack/two", set())
+
+        class FakeGh:
+            def list_candidate_prs(self, repo, author, pr_numbers):
+                return [bottom]
+
+            def list_open_prs(self, repo):
+                return [bottom, upper]
+
+            def issue_comments(self, repo, number):
+                return []
+
+        stacks = exec_impl.load_candidate_stacks(FakeGh(), "owner/repo", None, [], REQUIRED, "master")
+        self.assertEqual(len(stacks), 1)
+        self.assertEqual([item.number for item in stacks[0].prs], [1, 2])
+
+    def test_loop_rescans_after_action_then_stops(self):
+        args = requeue.parse_args(["--loop", "--poll-seconds", "0"])
+        with mock.patch.object(exec_impl, "run_cycle", side_effect=[True, False]) as cycle:
+            with mock.patch.object(exec_impl.time, "sleep") as sleep:
+                self.assertEqual(requeue.run_loop(args), 0)
+        self.assertEqual(cycle.call_count, 2)
+        sleep.assert_called_once_with(0.0)
 
     def test_capped_comment_records_once(self):
         class FakeGh:
@@ -271,8 +306,8 @@ Failing checks
         item = pr(2647, merge_state="DIRTY", latest=mergify())
         action = Action("comment_blocked", 2647, "capped", "GitHub reports merge conflict. The retry cap was reached for current head " + HEAD + ".")
         fake = FakeGh()
-        requeue.execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 1)
-        requeue.execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 2)
+        requeue._execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 1)
+        requeue._execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 2)
         self.assertEqual(len(fake.comments), 1)
 
     def test_missing_admin_bypass_nudge_comments_once_without_label_edit(self):
@@ -288,7 +323,7 @@ Failing checks
                 self.label_edits.append((repo, pr_number, add, remove))
 
         action = Action("comment_admin_bypass_nudge", 2647, "admin-bypass", "missing admin-bypass label")
-        for execute in (requeue.execute_action,):
+        for execute in (requeue._execute_action, requeue.exec_impl.execute_action):
             ledger = self.ledger()
             item = pr(2647, labels={"dequeued"}, latest=mergify())
             fake = FakeGh()

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -116,9 +116,9 @@ class PlanStackActions(unittest.TestCase):
     def test_pending_check_means_wait_do_nothing(self):
         self.assertEqual(self._plan(pr(checks={"build": check("pending")})), ())
 
-    def test_conflict_triggers_rebase_recreate(self):
+    def test_conflict_triggers_claude_repair(self):
         actions = self._plan(pr(merge_state_status="DIRTY"))
-        self.assertEqual((actions[0].kind, actions[0].pr_number), ("rebase_recreate", 1))
+        self.assertEqual((actions[0].kind, actions[0].pr_number), ("repair_conflict", 1))
 
     def test_failed_check_triggers_repair(self):
         actions = self._plan(pr(checks={"build": check("failure")}))
@@ -138,6 +138,11 @@ class PlanStackActions(unittest.TestCase):
         actions = self._plan(snapshot)
         self.assertEqual((actions[0].kind, actions[0].detail), ("requeue", "eligible-after-dequeue"))
 
+    def test_clean_bottom_queues_without_prior_dequeue(self):
+        snapshot = pr(labels=frozenset({"admin-bypass"}))
+        actions = self._plan(snapshot)
+        self.assertEqual((actions[0].kind, actions[0].detail), ("requeue", "eligible-when-ready"))
+
     def test_requeue_is_capped_after_repeated_attempts(self):
         ledger = self._ledger()
         # Two prior requeue attempts on this head+key -> the third is capped.
@@ -146,34 +151,6 @@ class PlanStackActions(unittest.TestCase):
         snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued", comment_id="cm1"))
         actions = self._plan(snapshot, ledger)
         self.assertEqual((actions[0].kind, actions[0].key), ("comment_blocked", "capped"))
-
-    def test_max_repair_attempts_parameter_caps_conflict_repair(self):
-        # cap=1: one prior conflict-repair attempt on this head -> next plan is capped.
-        ledger = self._ledger()
-        snapshot = pr(merge_state_status="DIRTY")
-        first = p.plan_stack_actions(m.StackGroup("s", (snapshot,)), REQUIRED, ledger, now_epoch=0, max_repair_attempts=1)
-        self.assertEqual(first[0].kind, "rebase_recreate")
-        ledger.record("conflict-repair", 1, HEAD, "conflict:1")
-        second = p.plan_stack_actions(m.StackGroup("s", (snapshot,)), REQUIRED, ledger, now_epoch=1, max_repair_attempts=1)
-        self.assertEqual((second[0].kind, second[0].key), ("comment_blocked", "capped"))
-        self.assertIn("The retry cap was reached", second[0].detail)
-
-    def test_max_requeue_attempts_parameter_caps_requeue(self):
-        ledger = self._ledger()
-        ledger.record("requeue", 1, HEAD, "cm1")
-        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued", comment_id="cm1"))
-        actions = p.plan_stack_actions(m.StackGroup("s", (snapshot,)), REQUIRED, ledger, now_epoch=0, max_requeue_attempts=1)
-        self.assertEqual((actions[0].kind, actions[0].key), ("comment_blocked", "capped"))
-
-    def test_trunk_parameter_decides_current_bottom(self):
-        # Same PR based on "main": with trunk=main it is the bottom (nudge);
-        # with the default master trunk it is not (no current bottom).
-        snapshot = pr(base_ref_name="main")
-        on_main = p.plan_stack_actions(m.StackGroup("s", (snapshot,)), REQUIRED, self._ledger(), now_epoch=0, trunk="main")
-        self.assertEqual(on_main[0].kind, "comment_admin_bypass_nudge")
-        on_master = p.plan_stack_actions(m.StackGroup("s", (snapshot,)), REQUIRED, self._ledger(), now_epoch=0)
-        self.assertEqual((on_master[0].kind, on_master[0].key), ("comment_blocked", "no-current-bottom"))
-        self.assertIn("no current bottom on master", on_master[0].detail)
 
 
 if __name__ == "__main__":

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -251,6 +251,31 @@ class GhClientCandidateDiscovery(unittest.TestCase):
 
 
 class GhClientLabelEdit(unittest.TestCase):
+    def test_candidate_scan_omits_author_by_default(self):
+        client = s.GhClient()
+        with mock.patch.object(client, "_run_json", return_value=[]) as run_json:
+            client.list_candidate_prs("Neko-Catpital-Labs/Invoker", None, [])
+
+        args = run_json.call_args.args[0]
+        self.assertIn("--label", args)
+        self.assertNotIn("--author", args)
+
+    def test_candidate_scan_includes_explicit_author(self):
+        client = s.GhClient()
+        with mock.patch.object(client, "_run_json", return_value=[]) as run_json:
+            client.list_candidate_prs("Neko-Catpital-Labs/Invoker", "EdbertChan", [])
+
+        args = run_json.call_args.args[0]
+        self.assertEqual(args[args.index("--author") + 1], "EdbertChan")
+
+    def test_list_open_prs_has_no_label_filter(self):
+        client = s.GhClient()
+        with mock.patch.object(client, "_run_json", return_value=[]) as run_json:
+            client.list_open_prs("Neko-Catpital-Labs/Invoker")
+
+        args = run_json.call_args.args[0]
+        self.assertNotIn("--label", args)
+
     def test_add_label_uses_rest_issue_labels_endpoint(self):
         client = s.GhClient()
         with mock.patch("mergify_admin_requeue_snapshot.subprocess.run") as run:


### PR DESCRIPTION
## Summary

The Mergify babysitter now handles all labeled pull requests and follows complete stacks instead of only one author’s work.

It uses Claude CLI for conflict and CI repairs, so it no longer starts local Invoker workflows.

The tool can queue a green stack bottom immediately and keep polling until the next bottom is ready.

## Review Claim

Approve the standalone Mergify babysitter’s repair, queue, and stack-advance policy.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The tool only acts on open `admin-bypass` pull requests, keeps human review threads as hard stops, and caps repeated repairs per head SHA.

## Slice Rationale

This is one cohesive Mergify automation policy: group stacks, repair blockers, queue their bottom PR, and observe the result.

## Non-goals

- Registering an owner-host worker
- Changing Mergify queue configuration
- Automatically resolving human review threads
- Invoking local Invoker workflows

## Architecture

### Before

```mermaid
flowchart TD
  LabelScan["Author scoped labeled scan"] --> Repair["Repair dequeued blockers"]
  Repair --> Queue["Requeue after dequeue"]
```

### After

```mermaid
flowchart TD
  Scan["All labeled PRs"] --> Stack["Expand and group stack"]
  Stack --> Repair["Claude repair conflicts and CI"]
  Repair --> Queue["Queue ready bottom"]
  Queue --> Poll["Poll and rescan"]
  Poll --> Stack
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts/test_mergify_admin_requeue.py scripts/test_mergify_admin_requeue_plan.py scripts/test_mergify_admin_requeue_snapshot.py`
- [x] `bash scripts/repro/repro-mergify-admin-requeue.sh`
- [x] `node scripts/test-land-stack.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: Run the previous cron invocation without `--loop`.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional continuous polling to rescan and process eligible pull requests.
  * Added Claude-assisted conflict repair and enhanced check-repair execution.
  * Improved candidate discovery by considering open and unlabeled pull requests, with optional author filtering.
  * Added configurable retry limits and state-file/PR filtering for requeue and repair planning.
* **Bug Fixes**
  * Updated conflict handling to use Claude repair (with capped retries) instead of the previous rebase/recreate flow.
  * Improved “clean bottom” requeue behavior and prevented unnecessary actions when already queued/merging.
* **Tests**
  * Expanded unit and end-to-end repro coverage for polling, capping behavior, Claude CLI usage, and candidate discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->