### PR TITLE
[Worker CLI Offline Control](1) Pin the owner-only worker control lockout

### DIFF
--- a/packages/app/src/__tests__/worker-cli-offline-control.test.ts
+++ b/packages/app/src/__tests__/worker-cli-offline-control.test.ts
@@ -1,0 +1,80 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LocalBus } from '@invoker/transport';
+
+import { runHeadlessClientCommand } from '../headless-client.js';
+
+/**
+ * Repro for the owner-only worker control lockout.
+ *
+ * `worker stop <kind>` only changes the persisted `desiredEnabled` row that
+ * `startAutoStartedWorkers()` reads on boot. That row is reachable offline,
+ * but the CLI refuses the command whenever no owner process answers the ping,
+ * so an operator cannot disable a worker while the app is down.
+ */
+describe('worker CLI offline control (repro)', () => {
+  const savedStandalone = process.env.INVOKER_HEADLESS_STANDALONE;
+  const savedDbDir = process.env.INVOKER_DB_DIR;
+  let dbDir: string;
+
+  const makeDeps = (bus: LocalBus) => ({
+    messageBus: bus,
+    ensureStandaloneOwner: vi.fn(async () => {}),
+    runElectronHeadless: vi.fn(async () => 0),
+  });
+
+  beforeEach(() => {
+    delete process.env.INVOKER_HEADLESS_STANDALONE;
+    dbDir = mkdtempSync(join(tmpdir(), 'worker-offline-control-'));
+    process.env.INVOKER_DB_DIR = dbDir;
+  });
+
+  afterEach(() => {
+    if (savedStandalone === undefined) {
+      delete process.env.INVOKER_HEADLESS_STANDALONE;
+    } else {
+      process.env.INVOKER_HEADLESS_STANDALONE = savedStandalone;
+    }
+    if (savedDbDir === undefined) {
+      delete process.env.INVOKER_DB_DIR;
+    } else {
+      process.env.INVOKER_DB_DIR = savedDbDir;
+    }
+    rmSync(dbDir, { recursive: true, force: true });
+  });
+
+  it('currently refuses `worker stop` when no owner process is running', async () => {
+    const bus = new LocalBus();
+    const deps = makeDeps(bus);
+
+    await expect(runHeadlessClientCommand(['worker', 'stop', 'autofix'], deps))
+      .rejects.toThrow(/No running Invoker owner found to stop the "autofix" worker/);
+
+    expect(deps.runElectronHeadless).not.toHaveBeenCalled();
+  });
+
+  it('currently refuses `worker start` when no owner process is running', async () => {
+    const bus = new LocalBus();
+    const deps = makeDeps(bus);
+
+    await expect(runHeadlessClientCommand(['worker', 'start', 'autofix'], deps))
+      .rejects.toThrow(/No running Invoker owner found to start the "autofix" worker/);
+
+    expect(deps.runElectronHeadless).not.toHaveBeenCalled();
+  });
+
+  it('still delegates worker control to a reachable owner', async () => {
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    bus.onRequest('headless.gui-mutation', async (request: { channel: string; args: string[] }) => {
+      expect(request).toEqual({ channel: 'invoker:stop-worker', args: ['autofix'] });
+      return { kind: 'autofix', desiredEnabled: false, lifecycle: 'stopped' };
+    });
+
+    await expect(runHeadlessClientCommand(['worker', 'stop', 'autofix'], makeDeps(bus))).resolves.toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a regression test for a gap in how operators turn a worker on or off.

Turning a worker off only changes one persisted row. Boot reads that row to decide which workers to auto-start.

That row is reachable even when the app is not running. Today the operator path refuses to touch it unless an owner process answers first.

So an operator who wants a worker disabled must have the app running to say so. When the app is down, there is no way to record the intent.

This slice adds no behavior. It records today's outcome so the following fix has a baseline to flip.

## Review Claim

The regression test faithfully records today's owner-only worker control outcome, including the delegated path that must keep working.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only. No product file changes, so runtime behavior is identical before and after this slice.

## Slice Rationale

Evidence lands before the fix so a reviewer sees the demonstrated gap before approving a behavior change.

## Non-goals

Does not change worker control behavior. Does not touch the desktop worker panel. Does not alter how boot chooses which workers start.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm install --frozen-lockfile && cd packages/app && pnpm test`
- [ ] `cd packages/app && pnpm vitest run src/__tests__/worker-cli-offline-control.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
