### PR TITLE
[Worker CLI Offline Control](2) Record worker desired state when no owner is running

### DIFF
--- a/packages/app/src/__tests__/worker-cli-offline-control.test.ts
+++ b/packages/app/src/__tests__/worker-cli-offline-control.test.ts
@@ -7,16 +7,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LocalBus } from '@invoker/transport';
 
 import { runHeadlessClientCommand } from '../headless-client.js';
+import { openMainProcessDatabase } from '../viewer-db-boundary.js';
 
 /**
- * Repro for the owner-only worker control lockout.
- *
- * `worker stop <kind>` only changes the persisted `desiredEnabled` row that
- * `startAutoStartedWorkers()` reads on boot. That row is reachable offline,
- * but the CLI refuses the command whenever no owner process answers the ping,
- * so an operator cannot disable a worker while the app is down.
+ * `worker start/stop <kind>` only changes the persisted `desiredEnabled` row
+ * that `startAutoStartedWorkers()` reads on boot. That row is reachable with
+ * no owner process running, so the CLI must not refuse the command just
+ * because nothing answers the owner ping.
  */
-describe('worker CLI offline control (repro)', () => {
+describe('worker CLI offline control', () => {
   const savedStandalone = process.env.INVOKER_HEADLESS_STANDALONE;
   const savedDbDir = process.env.INVOKER_DB_DIR;
   let dbDir: string;
@@ -47,24 +46,47 @@ describe('worker CLI offline control (repro)', () => {
     rmSync(dbDir, { recursive: true, force: true });
   });
 
-  it('currently refuses `worker stop` when no owner process is running', async () => {
+  const readDesiredState = async (kind: string): Promise<boolean | undefined> => {
+    const persistence = await openMainProcessDatabase({
+      dbPath: join(dbDir, 'invoker.db'),
+      detachedViewer: false,
+      readOnly: true,
+      exclusiveLocking: false,
+    });
+    try {
+      return persistence.getWorkerDesiredState(kind)?.desiredEnabled;
+    } finally {
+      persistence.close();
+    }
+  };
+
+  it('records `worker stop` as disabled when no owner process is running', async () => {
     const bus = new LocalBus();
     const deps = makeDeps(bus);
 
-    await expect(runHeadlessClientCommand(['worker', 'stop', 'autofix'], deps))
-      .rejects.toThrow(/No running Invoker owner found to stop the "autofix" worker/);
+    await expect(runHeadlessClientCommand(['worker', 'stop', 'autofix'], deps)).resolves.toBe(0);
 
+    expect(await readDesiredState('autofix')).toBe(false);
     expect(deps.runElectronHeadless).not.toHaveBeenCalled();
   });
 
-  it('currently refuses `worker start` when no owner process is running', async () => {
+  it('records `worker start` as enabled when no owner process is running', async () => {
     const bus = new LocalBus();
     const deps = makeDeps(bus);
 
-    await expect(runHeadlessClientCommand(['worker', 'start', 'autofix'], deps))
-      .rejects.toThrow(/No running Invoker owner found to start the "autofix" worker/);
+    await expect(runHeadlessClientCommand(['worker', 'start', 'autofix'], deps)).resolves.toBe(0);
 
+    expect(await readDesiredState('autofix')).toBe(true);
     expect(deps.runElectronHeadless).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown worker kind instead of writing a junk row', async () => {
+    const bus = new LocalBus();
+
+    await expect(runHeadlessClientCommand(['worker', 'stop', 'not-a-worker'], makeDeps(bus)))
+      .rejects.toThrow(/Unknown worker kind: "not-a-worker"/);
+
+    expect(await readDesiredState('not-a-worker')).toBeUndefined();
   });
 
   it('still delegates worker control to a reachable owner', async () => {

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -35,7 +35,7 @@ import {
 } from './owner-endpoint.js';
 import { createOwnerResolver, type ResolvedOwner } from './owner-resolver.js';
 import { AUTO_STARTED_OWNER_WORKER_KINDS, createLocalWorkerStatusSnapshot } from './worker-control.js';
-import { resolveWorkerControlMutation } from './worker-control-delegation.js';
+import { resolveWorkerControlMutation, type WorkerControlMutation } from './worker-control-delegation.js';
 import { openMainProcessDatabase } from './viewer-db-boundary.js';
 import {
   canAcknowledgeNoTrackTaskMutationWithoutDb,
@@ -260,9 +260,48 @@ async function delegateGenericReadQuery(
   throw new Error('Live owner is present but did not serve cli-query');
 }
 
+/**
+ * Persist `desiredEnabled` directly when no owner process is reachable.
+ *
+ * Safe precisely because there is no owner: with no live runtime there is
+ * nothing for the persisted desire to diverge from, and `startAutoStartedWorkers()`
+ * reads this same row on the next boot.
+ */
+async function applyOfflineWorkerDesiredState(
+  mutation: WorkerControlMutation,
+  invokerConfig: InvokerConfig,
+): Promise<void> {
+  const registry = registerExternalWorkersFromConfig(
+    invokerConfig.externalWorkers,
+    registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
+  );
+  if (!registry.get(mutation.kind)) {
+    const knownKinds = registry.list().map((worker) => worker.kind).join(', ');
+    throw new Error(`Unknown worker kind: "${mutation.kind}". Use: ${knownKinds}`);
+  }
+
+  const persistence = await openMainProcessDatabase({
+    dbPath: join(resolveInvokerHomeRoot(), 'invoker.db'),
+    detachedViewer: false,
+    readOnly: false,
+    exclusiveLocking: false,
+  });
+  try {
+    const desiredEnabled = mutation.action === 'start';
+    persistence.setWorkerDesiredState(mutation.kind, desiredEnabled);
+    process.stdout.write(
+      `[headless] no owner running; recorded "${mutation.kind}" as ${desiredEnabled ? 'enabled' : 'disabled'}. `
+      + `Takes effect when the app next starts.\n`,
+    );
+  } finally {
+    persistence.close();
+  }
+}
+
 async function delegateWorkerControl(
   args: string[],
   bus: MessageBus,
+  invokerConfig: InvokerConfig,
   refreshMessageBus?: () => Promise<MessageBus>,
 ): Promise<boolean> {
   const mutation = resolveWorkerControlMutation(args);
@@ -275,7 +314,8 @@ async function delegateWorkerControl(
     owner = await discoverOwner(messageBus, GENERIC_READ_OWNER_PING_TIMEOUT_MS);
   }
   if (!owner) {
-    throw new Error(`No running Invoker owner found to ${mutation.action} the "${mutation.kind}" worker. Start the app first.`);
+    await applyOfflineWorkerDesiredState(mutation, invokerConfig);
+    return true;
   }
 
   const result = await messageBus.request('headless.gui-mutation', {
@@ -616,7 +656,7 @@ export async function runHeadlessClientCommand(
   const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1';
   const internalOwnerServe = args[0] === 'owner-serve';
 
-  if (!internalOwnerServe && await delegateWorkerControl(args, deps.messageBus, deps.refreshMessageBus)) {
+  if (!internalOwnerServe && await delegateWorkerControl(args, deps.messageBus, invokerConfig, deps.refreshMessageBus)) {
     const exitCode = process.exitCode;
     return typeof exitCode === 'number' ? exitCode : 0;
   }


### PR DESCRIPTION
## Summary

An operator can now turn a worker on or off while the app is down.

Turning a worker on or off writes one persisted row. Boot reads that row to decide which workers auto-start.

Previously the operator path refused unless an owner process answered first. So the only time you could disable a worker was while it was able to run.

Now, when no owner answers, the row is written in place and the operator is told the change takes effect at the next app start.

When an owner does answer, nothing changes: it still handles the request, so a live worker is genuinely started or stopped rather than only having its intent recorded.

An unrecognized worker kind is refused before anything is written.

## Review Claim

Worker enable and disable should write the persisted desired-state row directly when no owner process answers, while keeping the existing owner-handled path untouched.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The direct write happens only when no owner answers. With no live runtime there is nothing for the persisted intent to disagree with, and boot reads this same row.

## Slice Rationale

This is the one behavior change that closes the operator gap pinned by the previous slice. Read-side accuracy is a separate concern and lands separately.

## Non-goals

Does not change what any worker does once running. Does not change the desktop worker panel. Does not change which workers boot enables by default.

## Architecture

### Before

```mermaid
graph TD
    A["worker stop <kind>"] --> B{"owner answers?"}
    B -->|yes| C["owner writes desiredEnabled"]
    B -->|no| D["error: start the app first"]
```

### After

```mermaid
graph TD
    A["worker stop <kind>"] --> B{"owner answers?"}
    B -->|yes| C["owner writes desiredEnabled"]
    B -->|no| E["write desiredEnabled in place"]
    E --> F["takes effect at next app start"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm install --frozen-lockfile && cd packages/app && pnpm test`
- [ ] `cd packages/app && pnpm vitest run src/__tests__/worker-cli-offline-control.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
