### PR TITLE
[Worker CLI Offline Control](3) Read live worker state from a running owner

### DIFF
--- a/packages/app/src/__tests__/worker-cli-live-status.test.ts
+++ b/packages/app/src/__tests__/worker-cli-live-status.test.ts
@@ -1,0 +1,82 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LocalBus } from '@invoker/transport';
+
+import { runHeadlessClientCommand } from '../headless-client.js';
+
+/**
+ * `query workers` must report the owner's runtime liveness when an owner is
+ * running. The generic `cli-query` path cannot: the owner rebuilds the
+ * snapshot from persistence there, so every worker reads back as stopped.
+ */
+describe('query workers against a live owner', () => {
+  const savedStandalone = process.env.INVOKER_HEADLESS_STANDALONE;
+  const savedDbDir = process.env.INVOKER_DB_DIR;
+  let dbDir: string;
+  let stdout: string;
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+
+  const makeDeps = (bus: LocalBus) => ({
+    messageBus: bus,
+    ensureStandaloneOwner: vi.fn(async () => {}),
+    runElectronHeadless: vi.fn(async () => 0),
+  });
+
+  beforeEach(() => {
+    delete process.env.INVOKER_HEADLESS_STANDALONE;
+    dbDir = mkdtempSync(join(tmpdir(), 'worker-live-status-'));
+    process.env.INVOKER_DB_DIR = dbDir;
+    stdout = '';
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdout += String(chunk);
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+    if (savedStandalone === undefined) {
+      delete process.env.INVOKER_HEADLESS_STANDALONE;
+    } else {
+      process.env.INVOKER_HEADLESS_STANDALONE = savedStandalone;
+    }
+    if (savedDbDir === undefined) {
+      delete process.env.INVOKER_DB_DIR;
+    } else {
+      process.env.INVOKER_DB_DIR = savedDbDir;
+    }
+    rmSync(dbDir, { recursive: true, force: true });
+  });
+
+  it('reports the running lifecycle the owner reports', async () => {
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    bus.onRequest('headless.query', async (request: { kind: string }) => {
+      expect(request.kind).toBe('workers');
+      return {
+        generatedAt: '2026-07-21T00:00:00.000Z',
+        workers: [
+          { kind: 'autofix', lifecycle: 'running', policy: 'enabled', desiredEnabled: true, running: true },
+          { kind: 'ci-failure', lifecycle: 'stopped', policy: 'enabled', desiredEnabled: false, running: false },
+        ],
+      };
+    });
+
+    await expect(runHeadlessClientCommand(['query', 'workers'], makeDeps(bus))).resolves.toBe(0);
+
+    expect(stdout).toContain('autofix: running');
+    expect(stdout).toContain('ci-failure: stopped');
+  });
+
+  it('falls back to the local snapshot when no owner answers', async () => {
+    const bus = new LocalBus();
+
+    await expect(runHeadlessClientCommand(['query', 'workers'], makeDeps(bus))).resolves.toBe(0);
+
+    expect(stdout).toContain('autofix');
+  });
+});

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -469,6 +469,34 @@ function writeWorkerSnapshot(snapshot: WorkerStatusSnapshot, args: string[]): vo
   }
 }
 
+/**
+ * Ask a live owner for its worker snapshot.
+ *
+ * Uses the structured `workers` query kind rather than the generic `cli-query`
+ * path: `cli-query` rebuilds the snapshot from persistence on the owner side,
+ * which cannot see runtime liveness. Only the owner's runtime controller knows
+ * which workers are actually running.
+ */
+async function tryDelegateWorkersQuery(
+  args: string[],
+  bus: MessageBus,
+  refreshMessageBus?: () => Promise<MessageBus>,
+): Promise<boolean> {
+  let messageBus = bus;
+  let owner = await discoverOwner(messageBus, GENERIC_READ_OWNER_PING_TIMEOUT_MS);
+  if (!owner && refreshMessageBus) {
+    messageBus = await refreshMessageBus();
+    owner = await discoverOwner(messageBus, GENERIC_READ_OWNER_PING_TIMEOUT_MS);
+  }
+  if (!owner) return false;
+
+  const response = await tryDelegateQuery(messageBus, { kind: 'workers' });
+  if (!response || !Array.isArray(response.workers)) return false;
+
+  writeWorkerSnapshot(response as unknown as WorkerStatusSnapshot, args);
+  return true;
+}
+
 async function runLocalWorkersQuery(args: string[], invokerConfig: InvokerConfig): Promise<number> {
   const dbPath = join(resolveInvokerHomeRoot(), 'invoker.db');
   const persistence = await openMainProcessDatabase({
@@ -683,6 +711,9 @@ export async function runHeadlessClientCommand(
   }
 
   if (!internalOwnerServe && isLocalWorkersQuery(args)) {
+    if (await tryDelegateWorkersQuery(args, deps.messageBus, deps.refreshMessageBus)) {
+      return 0;
+    }
     return runLocalWorkersQuery(args, invokerConfig);
   }
 


### PR DESCRIPTION
## Summary

Asking for worker state now reports what is really happening when the app is running.

The answer used to be rebuilt from the database, even when a live owner could have answered. Rebuilt answers cannot see which workers actually hold a running runtime.

So every worker read back as off, whether or not it was busy. An operator checking whether they had really disabled something got the same answer either way.

Now the request goes to a reachable owner and returns that owner's own view, which knows its running runtimes.

With no owner reachable, the rebuilt answer is still produced as before.

## Review Claim

The workers query should be answered by a reachable owner over the structured query kind, falling back to the rebuilt answer only when no owner is reachable.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Fallback is preserved: an unreachable or non-answering owner produces exactly the previous output, so the query never becomes unavailable.

## Slice Rationale

Read accuracy is a separate claim from the write gap fixed in the previous slice. Bundling them would mix two independently reviewable concerns.

## Non-goals

Does not change worker behavior. Does not change the desktop worker panel. Does not change what the rebuilt answer contains.

## Architecture

### Before

```mermaid
graph TD
    A["query workers"] --> B["rebuild from database"]
    B --> C["every worker reads as off"]
```

### After

```mermaid
graph TD
    A["query workers"] --> B{"owner reachable?"}
    B -->|yes| C["owner answers from its runtime view"]
    B -->|no| D["rebuild from database"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm install --frozen-lockfile && cd packages/app && pnpm test`
- [ ] `cd packages/app && pnpm vitest run src/__tests__/worker-cli-live-status.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
