### PR TITLE
[Worker CLI Offline Control](4) Print unknown worker lifecycle instead of stopped

### DIFF
--- a/packages/app/src/__tests__/worker-lifecycle-rendering.test.ts
+++ b/packages/app/src/__tests__/worker-lifecycle-rendering.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderWorkerLifecycle } from '../headless-worker-lifecycle.js';
+
+describe('renderWorkerLifecycle', () => {
+  it('reports unknown when runtime liveness was not observable', () => {
+    expect(renderWorkerLifecycle({ lifecycle: 'stopped' })).toBe('unknown');
+  });
+
+  it('reports the owner lifecycle when liveness is known', () => {
+    expect(renderWorkerLifecycle({ lifecycle: 'running', running: true })).toBe('running');
+    expect(renderWorkerLifecycle({ lifecycle: 'stopped', running: false })).toBe('stopped');
+    expect(renderWorkerLifecycle({ lifecycle: 'exited', running: false })).toBe('exited');
+  });
+});

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -35,6 +35,7 @@ import {
 } from './owner-endpoint.js';
 import { createOwnerResolver, type ResolvedOwner } from './owner-resolver.js';
 import { AUTO_STARTED_OWNER_WORKER_KINDS, createLocalWorkerStatusSnapshot } from './worker-control.js';
+import { renderWorkerLifecycle } from './headless-worker-lifecycle.js';
 import { resolveWorkerControlMutation, type WorkerControlMutation } from './worker-control-delegation.js';
 import { openMainProcessDatabase } from './viewer-db-boundary.js';
 import {
@@ -465,7 +466,7 @@ function writeWorkerSnapshot(snapshot: WorkerStatusSnapshot, args: string[]): vo
   process.stdout.write(`  count: ${snapshot.workers.length}\n`);
   for (const worker of snapshot.workers) {
     const source = worker.source ? ` · ${worker.source}` : '';
-    process.stdout.write(`  - ${worker.kind}: ${worker.lifecycle} · ${worker.policy}${source}\n`);
+    process.stdout.write(`  - ${worker.kind}: ${renderWorkerLifecycle(worker)} · ${worker.policy}${source}\n`);
   }
 }
 

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -31,6 +31,7 @@ import { resolveDefaultExecutionAgent } from './config.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 import { loadAllEventsPaged } from './load-all-events-paged.js';
 import { AUTO_STARTED_OWNER_WORKER_KINDS, createLocalWorkerStatusSnapshot, listWorkerDecisions, toWorkerActionSummary } from './worker-control.js';
+import { renderWorkerLifecycle } from './headless-worker-lifecycle.js';
 import { createRendererUiPerfCounters } from './renderer-ui-perf.js';
 import {
   collectRecoveryWorkerStatus,
@@ -889,7 +890,7 @@ function formatWorkerStatusSnapshot(snapshot: WorkerStatusSnapshot): string {
     const policy = worker.policyReason ? `${worker.policy} (${worker.policyReason})` : worker.policy;
     const source = worker.source ? ` · ${worker.source}` : '';
     const desired = worker.desiredEnabled === undefined ? '' : ` · desired=${worker.desiredEnabled}`;
-    lines.push(`  - ${worker.kind}: ${worker.lifecycle} · ${policy}${desired}${source}`);
+    lines.push(`  - ${worker.kind}: ${renderWorkerLifecycle(worker)} · ${policy}${desired}${source}`);
   }
   return lines.join('\n');
 }

--- a/packages/app/src/headless-worker-lifecycle.ts
+++ b/packages/app/src/headless-worker-lifecycle.ts
@@ -1,0 +1,14 @@
+import type { WorkerStatusEntry } from '@invoker/contracts';
+
+/**
+ * Render a worker's lifecycle for operator-facing output.
+ *
+ * A snapshot built outside the owner process omits `running` because it cannot
+ * observe runtime liveness. Its `lifecycle` field still defaults to `stopped`,
+ * which reads as "this worker is off" when the truth is "not known from here".
+ */
+export function renderWorkerLifecycle(
+  worker: Pick<WorkerStatusEntry, 'lifecycle'> & { running?: boolean },
+): string {
+  return worker.running === undefined ? 'unknown' : worker.lifecycle;
+}


### PR DESCRIPTION
## Summary

Worker status printed outside the app now says `unknown` rather than `stopped` when it cannot tell.

An answer built outside the app cannot see which workers hold a running runtime. It leaves each worker's lifecycle at its default, and that default is `stopped`.

Operators read `stopped` as "this worker is off". The honest answer is "not knowable from here".

The two are easy to confuse, and confusing them makes a busy worker look disabled. That misreading is exactly what this changes.

Only the printed wording changes. The underlying snapshot shape is untouched.

## Review Claim

Operator-facing worker status should print `unknown` when runtime liveness was not observable, instead of defaulting to `stopped`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Rendering only. The decision is driven by a field that is already present or absent in the snapshot, so no producer changes and no stored data changes.

## Slice Rationale

Wording honesty is its own claim, independent of where the answer comes from. It lands last so the earlier slices stay narrow.

## Non-goals

Does not change the snapshot shape. Does not change the desktop worker panel. Does not change any worker's behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm install --frozen-lockfile && cd packages/app && pnpm test`
- [ ] `cd packages/app && pnpm vitest run src/__tests__/worker-lifecycle-rendering.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
