### PR TITLE
[CI Runner Hygiene] Reclaim self-hosted workspace before checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - name: Reclaim workspace
+        run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" "$HOME/.invoker" "$HOME/.claude" 2>/dev/null || true
+        shell: bash
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -80,6 +83,9 @@ jobs:
     name: quality / ${{ matrix.name }}
 
     steps:
+      - name: Reclaim workspace
+        run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" "$HOME/.invoker" "$HOME/.claude" 2>/dev/null || true
+        shell: bash
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -115,6 +121,9 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      - name: Reclaim workspace
+        run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" "$HOME/.invoker" "$HOME/.claude" 2>/dev/null || true
+        shell: bash
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -316,6 +325,9 @@ jobs:
     name: required-fast / ${{ matrix.name }}
 
     steps:
+      - name: Reclaim workspace
+        run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" "$HOME/.invoker" "$HOME/.claude" 2>/dev/null || true
+        shell: bash
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Self-hosted CI runners reuse a persistent workspace between jobs.

A prior job leaves `node_modules`, `.claude/plugins`, and `$HOME/.invoker` owned by a different uid.

`actions/checkout` then dies with `EACCES: permission denied rmdir '.claude/plugins'`, and guardrail scripts die with `EACCES mkdir '/home/invoker/.invoker/plans'`.

Both failures land on the merge-queue required checks `required-fast / Guardrails` and `required-fast / Submit Workflow Chain`, so Mergify dequeues every admin-bypass PR.

This adds a pre-checkout step that chowns the workspace and `$HOME/.invoker`/`.claude` back to the runner user on the four merge-gating jobs.

## Review Claim

Approve adding a pre-checkout `chown` reclaim step to the four merge-gating CI jobs.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The step only chowns paths to the current runner user and swallows errors (`|| true`), so it cannot fail a job or touch anything outside the runner's own workspace and home.

## Slice Rationale

This is the minimal infra fix that unblocks the required merge checks. Test-flake and known-red-on-master fixes are separate concerns and ship as their own slices.

## Non-goals

Does not fix the docker-socket `permission denied` runner issue (runner-host config), the UI Vitest focus flake, or the known-red-on-master SSH/e2e merge-gate drift.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
- [ ] `git grep -c 'name: Reclaim workspace' .github/workflows/ci.yml` returns `4`
- [ ] Merge-queue run of `required-fast / Guardrails` and `Submit Workflow Chain` reaches `check-success` (no `EACCES` in Checkout)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
