### PR TITLE
[E2E Review Gate] Wire reviewGate into standalone worker; fix e2e 4.2/4.3

### DIFF
--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -481,6 +481,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
     throw err;
   }
   const autoFixAttemptLedger = createAutoFixAttemptLedger();
+  const reviewGateExecutor = createHeadlessExecutor(deps);
   try {
     const worker = definition.factory({
       store: deps.persistence,
@@ -490,6 +491,9 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
         ),
       },
       logger: deps.logger,
+      reviewGate: {
+        checkMergeGateStatuses: () => reviewGateExecutor.checkMergeGateStatuses(),
+      },
       autoFix: {
         defaultAutoFixRetries: deps.invokerConfig.autoFixRetries,
         attemptLedger: autoFixAttemptLedger,

--- a/scripts/e2e-dry-run/cases/case-4.2-github-pr.sh
+++ b/scripts/e2e-dry-run/cases/case-4.2-github-pr.sh
@@ -65,9 +65,15 @@ if ! grep -q "api.*repos.*pulls.*POST" "$GHLOG"; then
 fi
 echo "==> case 4.2: confirmed gh PR creation API was called"
 
-echo "==> case 4.2: approve merge gate"
-invoker_e2e_run_headless approve "$MERGE_ID"
+# A github-mode merge gate completes only when every required PR is MERGED
+# (orchestrator.assertReviewGateApprovable). Simulate the operator merging the
+# stub PR, then run the pr-status worker so the poll reconciles the required
+# artifact to approved and the gate lands. This is the production path: a github
+# gate is finished by the PR-status poll, not by a manual approve on an open PR.
+echo "==> case 4.2: merge stub PR + reconcile via pr-status worker"
+touch "$INVOKER_E2E_MARKER_ROOT/pr-merged"
 for _ in $(seq 1 120); do
+  invoker_e2e_run_headless worker pr-status >/dev/null 2>&1 || true
   STM=$(invoker_e2e_task_status "$MERGE_ID")
   if [ "$STM" = "completed" ]; then
     break
@@ -76,7 +82,7 @@ for _ in $(seq 1 120); do
 done
 
 if [ "$STM" != "completed" ]; then
-  echo "FAIL case 4.2: expected merge gate=completed after approve, got '$STM'"
+  echo "FAIL case 4.2: expected merge gate=completed after PR merge, got '$STM'"
   invoker_e2e_run_headless status 2>&1 || true
   exit 1
 fi

--- a/scripts/e2e-dry-run/cases/case-4.3-fix-then-pr.sh
+++ b/scripts/e2e-dry-run/cases/case-4.3-fix-then-pr.sh
@@ -142,14 +142,17 @@ if ! grep -q "api.*repos.*pulls.*POST" "$GHLOG"; then
   exit 1
 fi
 echo "==> case 4.3: confirmed gh PR creation calls in stub log"
-echo "DIAG case 4.3: before final approve, merge gate status='$(invoker_e2e_case43_task_status "$MERGE_ID")'"
+echo "DIAG case 4.3: before final merge, merge gate status='$(invoker_e2e_case43_task_status "$MERGE_ID")'"
 
-echo "==> case 4.3: approve merge gate"
-invoker_e2e_run_headless approve "$MERGE_ID"
-echo "DIAG case 4.3: final approve command completed, merge gate status='$(invoker_e2e_case43_task_status "$MERGE_ID")'"
-invoker_e2e_wait_settled "$MERGE_ID"
-echo "DIAG case 4.3: final wait settled completed, merge gate status='$(invoker_e2e_case43_task_status "$MERGE_ID")'"
+# A github-mode merge gate completes only when every required PR is MERGED
+# (orchestrator.assertReviewGateApprovable). Simulate the operator merging the
+# stub PR, then run the pr-status worker so the poll reconciles the required
+# artifact to approved and the gate lands. This is the production path: a github
+# gate is finished by the PR-status poll, not by a manual approve on an open PR.
+echo "==> case 4.3: merge stub PR + reconcile via pr-status worker"
+touch "$INVOKER_E2E_MARKER_ROOT/pr-merged"
 for _ in $(seq 1 120); do
+  invoker_e2e_run_headless worker pr-status >/dev/null 2>&1 || true
   STM=$(invoker_e2e_case43_task_status "$MERGE_ID")
   if [ "$STM" = "completed" ]; then
     break
@@ -159,8 +162,8 @@ done
 
 STM=$(invoker_e2e_case43_task_status "$MERGE_ID")
 if [ "$STM" != "completed" ]; then
-  echo "FAIL case 4.3: expected merge gate=completed after approve, got '$STM'"
-  invoker_e2e_case43_dump_state "merge gate was not completed after final approve"
+  echo "FAIL case 4.3: expected merge gate=completed after PR merge, got '$STM'"
+  invoker_e2e_case43_dump_state "merge gate was not completed after PR merge"
   exit 1
 fi
 echo "PASS case 4.3 (fix A → approve → B completed → PR created → gate approved)"

--- a/scripts/e2e-dry-run/fixtures/gh-marker.sh
+++ b/scripts/e2e-dry-run/fixtures/gh-marker.sh
@@ -35,9 +35,17 @@ case "$SUBCMD" in
         exit 1
         ;;
       view)
-        # gh pr view N --json state,reviewDecision,url
+        # gh pr view N --json state,reviewDecision,url,...
+        # The PR stays OPEN until the case "merges" it by touching
+        # $INVOKER_E2E_MARKER_ROOT/pr-merged. Once merged, the merge-gate poll
+        # sees state=MERGED and reconciles the required artifact to approved,
+        # which is the only path that legitimately lets the gate complete.
         PR_NUM="${1:-99}"
-        echo '{"state":"OPEN","reviewDecision":null,"url":"https://github.com/test/repo/pull/'"$PR_NUM"'"}'
+        if [ -n "$ROOT" ] && [ -f "$ROOT/pr-merged" ]; then
+          echo '{"state":"MERGED","reviewDecision":"APPROVED","url":"https://github.com/test/repo/pull/'"$PR_NUM"'"}'
+        else
+          echo '{"state":"OPEN","reviewDecision":null,"url":"https://github.com/test/repo/pull/'"$PR_NUM"'"}'
+        fi
         ;;
       *)
         echo "{}" ;;


### PR DESCRIPTION
## Summary

GitHub CI's e2e-proof suite had two red cases: `case-4.2-github-pr` and `case-4.3-fix-then-pr`.

Both hung at the final step where a github-mode merge gate is approved but never reaches `completed`.

PR #5263 made a github merge gate completable only once every required PR review artifact is `approved`, which happens when the PR reaches `MERGED`.

The standalone `worker <kind>` headless command never passed the `reviewGate` dependency, so `worker pr-status` silently did nothing and could not reconcile a merged PR's artifact. The gate stayed stuck.

This wires `reviewGate.checkMergeGateStatuses` into the headless worker and updates the e2e harness to mark the PR merged and poll `worker pr-status`, so the artifact legitimately reaches `approved` and the gate completes through the existing invariant.

## Review Claim

Approve wiring the `reviewGate` reconciliation dependency into the standalone headless worker command so github merge gates can complete.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The `assertReviewGateApprovable` invariant is untouched; the merge trace confirms the gate completes via a legitimate `approved` artifact (no `APPROVE_SKIPPED_GATE_NOT_APPROVED`), not a bypass.

## Slice Rationale

This is the minimal fix that turns the e2e-proof suite green: one product wiring gap plus the harness/stub updates that PR #5263 should have carried.

## Non-goals

Does not change the approval invariant, the review-gate reconciliation logic, or any non-github merge mode. Does not touch unrelated e2e cases.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm run check:types`
- [ ] `bash scripts/e2e-dry-run/run-all.sh` → `e2e-dry-run: 29 passed, 0 failed`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge-gate status handling so gates can complete automatically after a required pull request is merged.
  * Ensured merge status updates are detected and reconciled reliably.

* **Tests**
  * Updated end-to-end scenarios to validate completion through the pull-request merge flow.
  * Added coverage for detecting merged pull requests during status checks.
  * Improved diagnostic messages when merge-gate completion fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->