### PR TITLE
[E2E Proof] Deflake case-4.3 merge-gate under full-suite load

### DIFF
--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -927,6 +927,11 @@ export async function runMergeGateActionImpl(
       logTaskProgress(host, task.id, 'error', 'Merge gate failed', {
         error: err instanceof Error ? err.message : String(err),
       });
+      mergeTrace('GATE_WS_EXECUTE_MERGE_FAILED', {
+        taskId: task.id,
+        workflowId,
+        error: err instanceof Error ? err.message : String(err),
+      });
       response = {
         requestId: `merge-${task.id}`,
         actionId: task.id,

--- a/scripts/e2e-dry-run/cases/case-4.3-fix-then-pr.sh
+++ b/scripts/e2e-dry-run/cases/case-4.3-fix-then-pr.sh
@@ -51,6 +51,17 @@ trap 'invoker_e2e_case43_on_error "$?" "$LINENO" "$BASH_COMMAND"' ERR
 invoker_e2e_init
 trap invoker_e2e_cleanup EXIT
 
+# The `approve` step below drives the whole cascade synchronously in one
+# standalone headless process: it re-runs fixed task A, runs downstream task B,
+# then executes the merge gate — which performs real git work (two full-repo
+# clones of this checkout, a branch consolidation merge, a push, and a PR
+# publish). Under full-suite load that can exceed the default 300s per-command
+# cap, and a SIGTERM mid-merge leaves the gate half-run (task left `running`,
+# which `resume` can recover, but the timed-out command returns non-zero first).
+# Give this case's commands extra wall-clock headroom so the gate finishes
+# within one command window and the flake disappears deterministically.
+export INVOKER_E2E_TIMEOUT="${INVOKER_E2E_TIMEOUT_CASE43:-900}"
+
 cd "$INVOKER_E2E_REPO_ROOT"
 unset ELECTRON_RUN_AS_NODE
 
@@ -81,7 +92,13 @@ fi
 echo "==> case 4.3: confirmed A=awaiting_approval"
 
 echo "==> case 4.3: approve A"
-invoker_e2e_run_headless approve e2e-g443-taskA
+# headlessApprove tracks the workflow until it settles, so this single command
+# also runs downstream task B and the merge gate. If it returns non-zero (e.g.
+# the tracked merge gate outlived the per-command wall clock under load), don't
+# fail the case here: task A's fix is already committed, and the wait_settled +
+# resume logic below is the designed path for driving a not-yet-settled gate to
+# completion. The `!=` status checks that follow are the real assertions.
+invoker_e2e_run_headless approve e2e-g443-taskA || true
 invoker_e2e_wait_settled e2e-g443-taskA
 invoker_e2e_wait_settled e2e-g443-taskB
 
@@ -103,19 +120,31 @@ if [ -z "$MERGE_ID" ]; then
 fi
 echo "==> case 4.3: merge gate ID=$MERGE_ID"
 
-# headlessApprove may exit before the cascading merge node finishes. Resume only
-# when the gate still needs recovery; it may already be review_ready here.
+# Drive the merge gate to review-ready. The gate runs real git consolidation
+# (clone + branch merge + push + PR publish) against the shared file:// origin;
+# under load or origin contention it can be left mid-run (headlessApprove exited
+# before the gate settled → task still `running`) or fail transiently (a git
+# ref/fetch/push race → task `failed`). Both are recoverable by re-running the
+# gate — a `running` gate via `resume`, a `failed` gate via `retry` (which resets
+# the failed merge node to pending and re-runs it). This is a recovery of a
+# transient gate failure, NOT a weakening of the review-gate approval invariant:
+# the gate still only reaches review_ready by completing its own real work.
 WF_ID="${MERGE_ID#__merge__}"
 STM=$(invoker_e2e_case43_task_status "$MERGE_ID")
-if [ "$STM" != "awaiting_approval" ] && [ "$STM" != "review_ready" ]; then
-  echo "==> case 4.3: resume workflow $WF_ID to let merge gate run"
-  invoker_e2e_run_headless resume "$WF_ID"
-else
-  echo "==> case 4.3: merge gate already $STM; resume not needed"
-fi
-invoker_e2e_wait_settled "$MERGE_ID"
+gate_attempt=0
+while [ "$STM" != "awaiting_approval" ] && [ "$STM" != "review_ready" ] && [ "$gate_attempt" -lt 5 ]; do
+  if [ "$STM" = "failed" ]; then
+    echo "==> case 4.3: merge gate failed transiently; retry workflow $WF_ID (attempt $((gate_attempt + 1)))"
+    invoker_e2e_run_headless retry "$WF_ID" || true
+  else
+    echo "==> case 4.3: merge gate $STM; resume workflow $WF_ID to let merge gate run (attempt $((gate_attempt + 1)))"
+    invoker_e2e_run_headless resume "$WF_ID" || true
+  fi
+  invoker_e2e_wait_settled "$MERGE_ID"
+  STM=$(invoker_e2e_case43_task_status "$MERGE_ID")
+  gate_attempt=$((gate_attempt + 1))
+done
 
-STM=$(invoker_e2e_case43_task_status "$MERGE_ID")
 if [ "$STM" != "awaiting_approval" ] && [ "$STM" != "review_ready" ]; then
   echo "FAIL case 4.3: expected merge gate=awaiting_approval|review_ready, got '$STM'"
   invoker_e2e_run_headless status 2>&1 || true


### PR DESCRIPTION
## Summary

The e2e-proof case `case-4.3-fix-then-pr` was flaky under full-suite load.

It is the only case that runs a real merge-gate consolidation synchronously inside the `approve` command: two full-repo clones, a branch merge, a push, and a PR publish.

Under load that work can exceed the 300s per-command cap, or hit a transient git push/ref race that leaves the merge gate in a terminal `failed` state that `resume` cannot recover.

This gives the case more wall-clock and a bounded resume/retry recovery loop so the gate reaches review-ready by finishing its own real work.

It also emits a merge-trace on gate-action failure so future flakes are triageable.

## Review Claim

Approve deflaking case-4.3 via test-harness headroom plus a diagnostic merge-trace, without changing merge-gate behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The review-gate approval invariant in orchestrator.ts is untouched; the gate still only reaches review-ready by completing its own consolidation, and the merge-runner change only adds a trace in the existing catch.

## Slice Rationale

This is the test-stabilization follow-up to #5499; it is kept separate because it changes no product control flow, only the e2e harness plus one trace line.

## Non-goals

Does not change merge-gate consolidation, the approval invariant, or any non-e2e behavior. Does not alter other e2e cases.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm run check:types`
- [ ] `bash scripts/e2e-dry-run/run-all.sh` run 3x → `e2e-dry-run: 29 passed, 0 failed` each

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge failure tracking with detailed execution trace information, making failures easier to diagnose.
  * Strengthened merge-gate recovery during approval and merge workflows by handling transient failures and retrying recovery attempts.

* **Tests**
  * Increased end-to-end workflow timeouts and improved recovery handling for longer-running merge operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->