### PR TITLE
[CI Runner Hygiene] Install libatomic1 for Node 26 on required-fast heavy runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,6 +336,9 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
+      - name: Install system libraries for Node
+        run: sudo apt-get update -qq && sudo apt-get install -y libatomic1
+
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

The `required-fast` job's required checks (Guardrails, Submit Workflow Chain, Vitest Workspace) fail in about 20 seconds, before any test runs.

PR #5336 routed `required-fast` onto the bare self-hosted `Runner_Heavy_Ubuntu` pool, which is not provisioned with `libatomic1`.

Node 26 links `libatomic.so.1` dynamically, so it dies at the "Use Node.js" step with `error while loading shared libraries: libatomic.so.1: cannot open shared object file`.

This installs `libatomic1` before the Node step in that one bare job, mirroring what the container jobs already do for themselves.

Proven locally: in a bare `ubuntu:24.04` container, Node 26.5.0 reproduces the exact error with no `libatomic1`, and prints `v26.5.0` after `apt-get install -y libatomic1`.

## Review Claim

Approve installing `libatomic1` before the Node step in the bare `required-fast` heavy-runner job.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The step only installs a system library on the CI runner before Node starts; it changes no product code, test, or workflow logic.

## Slice Rationale

This is the minimal fix that unblocks the required merge checks on the heavy-runner pool. Container jobs' remaining docker-socket/dbus gaps are host-level and out of scope for this diff.

## Non-goals

Does not change job routing, the container jobs, or fix the docker-socket/dbus provisioning gaps on the heavy runners. Does not touch product code.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
- [ ] `docker run --rm ubuntu:24.04 bash -c 'apt-get update -qq; apt-get install -y curl xz-utils; curl -fsSL https://nodejs.org/dist/v26.5.0/node-v26.5.0-linux-x64.tar.xz | tar -xJ -C /tmp; /tmp/node-v26.5.0-linux-x64/bin/node --version || true; apt-get install -y libatomic1; /tmp/node-v26.5.0-linux-x64/bin/node --version'`
- [ ] Next master CI run: `required-fast / Guardrails` and `Submit Workflow Chain` reach the test step (no libatomic error)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the continuous integration setup to support more reliable automated builds and validation.
  * No customer-facing features or behavior were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->