### PR TITLE
[CI Runner Routing] Route required-fast to Runner_2_4_core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,8 @@ jobs:
   required-fast:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
-    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu]
+    runs-on:
+      labels: Runner_2_4_core
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -335,9 +336,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-
-      - name: Install system libraries for Node
-        run: sudo apt-get update -qq && sudo apt-get install -y libatomic1
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

The `required-fast` required checks (Guardrails, Submit Workflow Chain, Vitest Workspace) were failing before any test ran.

PR #5336 routed the job onto the bare `Runner_Heavy_Ubuntu` pool, which is not provisioned for these builds.

Node 26 there could not start (missing `libatomic1`), and once that was worked around, `pnpm install` failed on node-pty native compilation and the Electron installer.

This routes `required-fast` to `Runner_2_4_core`, the pool where `required-fast-extra` and `build-artifacts` already pass, so it has the full build toolchain.

It also drops the now-redundant `libatomic1` install step, since that pool already provides it.

## Review Claim

Approve routing the `required-fast` job to `Runner_2_4_core` and removing the redundant libatomic install step.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the job's runner label and a redundant setup step change; no product code, test, or job logic is altered.

## Slice Rationale

This is the single-change fix for the required checks, replacing the whack-a-mole of installing each missing system dependency on an under-provisioned pool.

## Non-goals

Does not change the container jobs, their runner pool, or the host-level docker-socket and dbus gaps on the heavy runners.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
- [ ] Next master CI run: `required-fast / Guardrails` and `Submit Workflow Chain` reach and pass their test step on `Runner_2_4_core`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
