### PR TITLE
[CI Runner Routing] Make required-fast playwright deps install non-fatal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,7 @@ jobs:
           git update-ref refs/remotes/origin/main refs/remotes/origin/master || true
 
       - name: Install Playwright system dependencies
+        continue-on-error: true
         run: pnpm --filter @invoker/app exec playwright install-deps chromium
 
       - name: Run suite group


### PR DESCRIPTION
## Summary

On Runner_2_4_core the required-fast job dies at Install Playwright system dependencies: playwright install-deps chromium calls sudo internally and the runner has no passwordless sudo (sudo: a password is required).

The required suites do not need chromium. Guardrails (five guard scripts) and Submit Workflow Chain pass locally with no playwright system deps installed.

This marks the step continue-on-error so a runner sudo limitation cannot fail the required checks. A suite that genuinely needs a browser still fails at its own Run suite group step.

## Review Claim

Approve marking the required-fast playwright deps install step continue-on-error.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only a step-level continue-on-error flag changes; no product code, test, or suite command is altered, and browser-dependent suites still fail loudly at their own step.

## Slice Rationale

Minimal unblock for the required checks on a runner without passwordless sudo, complementing the routing fix in the prior PR.

## Non-goals

Does not provision sudo/browsers on the runner, change other jobs, or alter suite commands.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
- [ ] Next master CI run: required-fast / Guardrails and Submit Workflow Chain pass their Run suite group step

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: git revert <sha>
- Post-revert steps: None
- Data migration? No

</details>