### PR TITLE
[E2E] Fix executor clone in CI containers via safe.directory wildcard

### DIFF
--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -53,6 +53,13 @@ invoker_e2e_ensure_branch_aliases() {
 invoker_e2e_allow_repo_git_ops() {
   (
     cd "$INVOKER_E2E_REPO_ROOT"
+    # Executors clone the repo with `git clone file://<root>`. In CI containers
+    # the checkout is owned by a different uid than the container user, so git
+    # rejects the source with "detected dubious ownership in repository at
+    # <root>/.git". safe.directory=<root> does NOT cover the check on <root>/.git
+    # — only the "*" wildcard does — so set both. Executors inherit this global
+    # config through the shared HOME.
+    git config --global --add safe.directory "*" >/dev/null 2>&1 || true
     git config --global --add safe.directory "$INVOKER_E2E_REPO_ROOT" >/dev/null 2>&1 || true
   )
 }


### PR DESCRIPTION
## Summary

CI e2e-proof, reset-rulebook, and ssh jobs fail because the task executor cannot start.

Its `git clone file://<root>` is rejected in CI containers with `detected dubious ownership in repository at <root>/.git`, since the checkout is owned by a different uid than the container user (exposed when #5336 routed these jobs to self-hosted runners).

The executor fails, so every merge-gate and e2e case cascades to a `failed` status.

`invoker_e2e_allow_repo_git_ops` already marked the repo root as a safe directory, but that does not cover the ownership check on `<root>/.git` — only the `*` wildcard does. This adds the wildcard.

Proven in the CI container image: case-4.2 goes from executor-startup-failed to passing with tasks completed and the gate approved.

## Review Claim

Approve adding a `safe.directory=*` wildcard so executors can clone the repo in CI containers with mismatched ownership.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The change only adds a git safe.directory entry in the e2e helper's global config; it does not alter executor logic, task behavior, or any product code path.

## Slice Rationale

This is the minimal fix that unblocks the container e2e jobs; the separate docker-socket "Initialize containers" host issue is out of scope.

## Non-goals

Does not change the executor, task runner, or product git behavior, and does not address the host-level docker-socket failures on the heavy runners.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash -n scripts/e2e-dry-run/lib/common.sh`
- [ ] In the CI container image, `bash scripts/e2e-dry-run/run-all.sh case-4.2-github-pr.sh` -> `PASS case 4.2`
- [ ] Next master CI run: e2e-proof shards that reach the container pass their cases

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
