### PR TITLE
[E2E SSH] Complete case-3.6 merge gate via pr-status poll

### DIFF
--- a/scripts/e2e-ssh/cases/case-3.6-ssh-merge-gate.sh
+++ b/scripts/e2e-ssh/cases/case-3.6-ssh-merge-gate.sh
@@ -64,12 +64,25 @@ if ! grep -q "api.*repos.*pulls.*POST" "$GHLOG"; then
 fi
 echo "==> case 3.6: confirmed gh PR creation API was called"
 
-echo "==> case 3.6: approve merge gate"
-invoker_e2e_run_headless approve "$MERGE_ID"
+# A github-mode merge gate completes only when every required PR is MERGED
+# (orchestrator.assertReviewGateApprovable). Simulate the operator merging the
+# stub PR, then run the pr-status worker so the poll reconciles the required
+# artifact to approved and the gate lands. This is the production path: a github
+# gate is finished by the PR-status poll, not by a manual approve on an open PR.
+echo "==> case 3.6: merge stub PR + reconcile via pr-status worker"
+touch "$INVOKER_E2E_MARKER_ROOT/pr-merged"
+for _ in $(seq 1 120); do
+  invoker_e2e_run_headless worker pr-status >/dev/null 2>&1 || true
+  STM=$(invoker_e2e_task_status "$MERGE_ID")
+  if [ "$STM" = "completed" ]; then
+    break
+  fi
+  sleep 2
+done
 
 STM=$(invoker_e2e_task_status "$MERGE_ID")
 if [ "$STM" != "completed" ]; then
-  echo "FAIL case 3.6: expected merge gate=completed after approve, got '$STM'"
+  echo "FAIL case 3.6: expected merge gate=completed after PR merge, got '$STM'"
   invoker_e2e_run_headless status 2>&1 || true
   exit 1
 fi


### PR DESCRIPTION
## Summary

case-3.6-ssh-merge-gate approved a github-mode merge gate while the stub PR was still open. PR #5263's invariant now refuses that (`1 required review artifact not approved (99 is open)`).

This marks the stub PR merged and runs the pr-status worker so the poll reconciles the artifact to approved and the gate completes, matching the production path adopted for case-4.2/4.3.

With the SSH executor clone fix (safe.directory), this was the last failing SSH case; e2e-ssh went from 0/3 to 2/3 and this lands the third.

## Review Claim

Approve completing the ssh merge-gate case via the pr-status poll instead of a manual approve on an open PR.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the e2e case's completion step changes to the production reconcile path; the approval invariant and executors are untouched.

## Slice Rationale

Final ssh case fix after the executor clone fix; kept separate from the clone change.

## Non-goals

Does not change the merge-gate invariant, executors, or host-level docker-socket failures.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash -n scripts/e2e-ssh/cases/case-3.6-ssh-merge-gate.sh`
- [ ] Next master CI run: ssh shard-31 -> e2e-ssh 3/3 passed

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>