### PR TITLE
[Visual Proof] Point validate at renamed home-visual-snapshots test

### DIFF
--- a/scripts/ui-visual-proof.sh
+++ b/scripts/ui-visual-proof.sh
@@ -269,7 +269,7 @@ case "$SUBCOMMAND" in
     ;;
   validate)
     echo "[visual-proof] Running DOM snapshot tests..." >&2
-    cd packages/ui && pnpm test -- --run src/__tests__/visual-proof-snapshots.test.tsx
+    cd packages/ui && pnpm test -- --run src/__tests__/home-visual-snapshots.test.tsx
     ;;
   compare)
     subcommand_compare


### PR DESCRIPTION
## Summary

#5071 renamed `packages/ui/src/__tests__/visual-proof-snapshots.test.tsx` to `home-visual-snapshots.test.tsx`, but `scripts/ui-visual-proof.sh validate` still ran the old path.

vitest found no matching file and exited 1 (`No test files found`), failing the optional / Visual Proof Validate job. This points it at the new name.

Verified locally: the renamed test passes (4 tests).

## Review Claim

Approve updating the visual-proof validate command to the renamed test file.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the test-file path in the validate command changes; no product code or test content is altered.

## Slice Rationale

Isolated one-line follow-up to the #5071 rename that left the visual-proof suite pointing at a deleted path.

## Non-goals

Does not change the visual-proof tests, product code, or other suites.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test -- --run src/__tests__/home-visual-snapshots.test.tsx`
- [ ] Next master CI run: optional / Visual Proof Validate passes

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>