### PR TITLE
[Slack Thread Planning](1) Promote same-thread plans and hide reasoning

### DIFF
--- a/packages/execution-engine/src/__tests__/format-codex-planner-stdout.test.ts
+++ b/packages/execution-engine/src/__tests__/format-codex-planner-stdout.test.ts
@@ -69,7 +69,7 @@ describe('formatCodexPlannerStdout', () => {
     });
   });
 
-  it('joins multiple agent_message items', () => {
+  it('returns only the final agent_message', () => {
     const raw = [
       JSON.stringify({ type: 'turn.started' }),
       JSON.stringify({
@@ -82,6 +82,26 @@ describe('formatCodexPlannerStdout', () => {
       }),
     ].join('\n');
 
-    expect(formatCodexPlannerStdout(raw).message).toBe('First part.\n\nSecond part.');
+    expect(formatCodexPlannerStdout(raw).message).toBe('Second part.');
+  });
+
+  it('finds Codex JSONL after a non-JSON preamble', () => {
+    const raw = [
+      'Codex CLI v1.0',
+      JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'reasoning', text: 'Inspecting the repository.' },
+      }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'agent_message', text: 'The final answer.' },
+      }),
+    ].join('\n');
+
+    expect(looksLikeCodexJsonl(raw)).toBe(true);
+    expect(formatCodexPlannerStdout(raw)).toEqual({
+      message: 'The final answer.',
+      reasoning: ['Inspecting the repository.'],
+    });
   });
 });

--- a/packages/execution-engine/src/codex-session.ts
+++ b/packages/execution-engine/src/codex-session.ts
@@ -151,14 +151,16 @@ export function looksLikeCodexJsonl(raw: string): boolean {
     if (!trimmed) continue;
     try {
       const entry = JSON.parse(trimmed);
-      return Boolean(
+      if (
         entry
         && typeof entry === 'object'
         && typeof entry.type === 'string'
-        && CODEX_JSONL_EVENT_TYPES.has(entry.type),
-      );
+        && CODEX_JSONL_EVENT_TYPES.has(entry.type)
+      ) {
+        return true;
+      }
     } catch {
-      return false;
+      continue;
     }
   }
   return false;
@@ -213,7 +215,7 @@ export function formatCodexPlannerStdout(raw: string): CodexPlannerStdout {
   }
 
   return {
-    message: messages.join('\n\n'),
+    message: messages.at(-1) ?? '',
     reasoning,
   };
 }

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -981,7 +981,7 @@ describe('PlanConversation prompt construction', () => {
     expect(prompt).toContain('Build the Workers Surface');
   });
 
-  it('agent mode refuses Invoker YAML and redirects to plan:', () => {
+  it('agent mode refuses Invoker YAML and redirects within the same thread', () => {
     // Agent threads can never submit a plan — handleLobbySubmit rejects a submit
     // unless conversationMode === 'plan'. So the agent prompt must not offer to
     // draft Invoker YAML (which would be an un-submittable dead end); it must
@@ -995,6 +995,9 @@ describe('PlanConversation prompt construction', () => {
     // Agent mode must refuse YAML unconditionally and point at `plan:`.
     expect(prompt).toContain('Do NOT generate Invoker YAML');
     expect(prompt).toContain('plan:');
+    expect(prompt).toContain('same thread');
+    expect(prompt).not.toContain('start a new plan thread');
+    expect(prompt).toContain('only the final user-facing message');
     // The old loophole permitted YAML "unless the user explicitly asks" — that
     // produced drafts Slack silently rejects on submit.
     expect(prompt).not.toContain('unless the user explicitly asks');

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -179,12 +179,23 @@ describe('parseWorkflowStatusQuery', () => {
   });
 });
 describe('parseThreadRequest', () => {
-  it('defaults to a normal agent thread and requires an explicit plan prefix for Invoker YAML', () => {
+  it('defaults to a normal agent thread unless the request clearly asks for an Invoker plan', () => {
     expect(parseThreadRequest('fix the Slack routing bug')).toEqual({ mode: 'agent', text: 'fix the Slack routing bug' });
     expect(parseThreadRequest('local: fix the Slack routing bug')).toEqual({ mode: 'agent', text: 'fix the Slack routing bug' });
     expect(parseThreadRequest('run local: report back how many workflows are running')).toEqual({ mode: 'agent', text: 'report back how many workflows are running' });
     expect(parseThreadRequest('plan: fix the Slack routing bug')).toEqual({ mode: 'plan', text: 'fix the Slack routing bug' });
     expect(parseThreadRequest('draft an Invoker plan: fix the Slack routing bug')).toEqual({ mode: 'plan', text: 'fix the Slack routing bug' });
+    expect(parseThreadRequest('plan fix the Slack routing bug')).toEqual({ mode: 'plan', text: 'fix the Slack routing bug' });
+    expect(parseThreadRequest('make that fix via Invoker')).toEqual({ mode: 'plan', text: 'make that fix' });
+    expect(parseThreadRequest('draft an Invoker plan for the Slack routing bug')).toEqual({ mode: 'plan', text: 'the Slack routing bug' });
+    expect(parseThreadRequest('turn the discussion above into a plan')).toEqual({
+      mode: 'plan',
+      text: 'turn the discussion above into a plan',
+    });
+    expect(parseThreadRequest('why are you dumping the chain of thought')).toEqual({
+      mode: 'agent',
+      text: 'why are you dumping the chain of thought',
+    });
   });
 
   it('treats a sole fenced plan: block as plan mode', () => {
@@ -535,6 +546,33 @@ describe('lobby verb routing', () => {
     expect(prompt).toContain('mergify stack push');
     expect(prompt).toContain('scripts/land-stack.mjs --execute');
     expect(prompt).toContain('plan: <request>');
+    expect(prompt).toContain('same thread');
+    expect(prompt).toContain('only the final user-facing answer');
+    expect(prompt).not.toContain('start a plan thread');
+  });
+
+  it('returns only the final Codex message from one-shot Slack replies', async () => {
+    const raw = [
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-1' }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'reasoning', text: 'Inspecting the repository.' },
+      }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'agent_message', text: 'Progress update.' },
+      }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'agent_message', text: 'Final user-facing answer.' },
+      }),
+    ].join('\n');
+    mockSpawn.mockImplementationOnce(() => mockProcess(raw));
+    const surface = lobbySurface();
+
+    await expect((surface as any).runOneShotPlanner({ tool: 'codex' }, 'answer this')).resolves.toBe(
+      'Final user-facing answer.',
+    );
   });
 
   // Repro: the Slack thread that prompted this asked the bot to investigate a

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -223,9 +223,9 @@ function buildAgentSystemPrompt(): string {
 Default behavior:
 - Treat the thread like an ordinary OMP/Codex coding session.
 - Answer questions, run local commands, inspect files, edit code, and run focused verification when useful.
-- Do NOT generate Invoker YAML in this thread. If the user asks for an Invoker plan, tell them to start a new plan thread with \`plan: <request>\` — plan drafts from an agent thread cannot be submitted.
+- Do NOT generate Invoker YAML in this thread. If the user asks for an Invoker plan, tell them to ask in this same thread with \`plan: <request>\`, \`plan <request>\`, or \`<request> via Invoker\` — plan drafts from an agent thread cannot be submitted.
 - Do NOT submit or start an Invoker workflow. Do NOT invoke \`invoker-cli\`, \`invoker_submit_plan\`, \`invoker_validate_plan\`, \`submit-plan.sh\`, or the \`plan-to-invoker\` skill's Harness handoff mode to do so. Agent threads reject \`submit\`; only a \`plan:\` thread can be submitted.
-- Keep Slack replies short and concrete: changed files, verification, and any remaining risk.
+- Keep Slack replies short and concrete: changed files, verification, and any remaining risk. Return only the final user-facing message; never include chain-of-thought, reasoning traces, tool output, or raw planner JSONL.
 - To share a generated file (screenshot, diagram, report), write it inside your worktree and link it by absolute path as a markdown link, e.g. \`[chart](/abs/path/in/worktree/chart.png)\`. Files linked that way are uploaded to the thread. Files written outside your worktree cannot be shared, so do not put artifacts in /tmp.
 
 ${SLACK_LOCAL_REPRO_POLICY}`;

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -38,6 +38,7 @@ import { SessionManager, SessionIdentifier } from './thread-session-manager.js';
 import { buildAssistantPrompt, parseWorkflowControl, SLACK_DIRECT_ANSWER_GUIDANCE } from './workflow-assistant.js';
 import type { WorkflowContext, WorkflowControl } from './workflow-assistant.js';
 import type { ConversationRepository, SlackSessionRepository, WorkflowChannelRepository, WorkflowChannel } from '@invoker/data-store';
+import { formatCodexPlannerStdout } from '@invoker/execution-engine';
 
 function truncateWords(text: string, maxWords: number): string {
   const words = text.replace(/\s+/g, ' ').trim().split(' ').filter(Boolean);
@@ -265,7 +266,7 @@ ${text}
 
 /** Q&A prompt for a lobby question: answer directly, never emit a plan. */
 export function buildLobbyQuestionPrompt(text: string): string {
-  return `Answer the user's question about this repository and Invoker. Explore the codebase if needed. ${SLACK_DIRECT_ANSWER_GUIDANCE} Do NOT generate a YAML plan and do NOT create a workflow. If answering well requires changing code, say in prose what the fix would be and tell the user to start a plan thread with \`plan: <request>\`.\n\n${SLACK_LOCAL_REPRO_POLICY}\n\nQuestion:\n${text}`;
+  return `Answer the user's question about this repository and Invoker. Explore the codebase if needed. ${SLACK_DIRECT_ANSWER_GUIDANCE} Do NOT generate a YAML plan and do NOT create a workflow. If answering well requires changing code, say in prose what the fix would be and tell the user they can ask for a plan in this same thread with \`plan: <request>\`, \`plan <request>\`, or \`<request> via Invoker\`. Return only the final user-facing answer; never include chain-of-thought, reasoning traces, tool output, or raw planner JSONL.\n\n${SLACK_LOCAL_REPRO_POLICY}\n\nQuestion:\n${text}`;
 }
 
 /** Parse the classifier's raw stdout into a validated classification; never throws. */
@@ -367,6 +368,8 @@ export function parseThreadRequest(text: string): ThreadRequest | null {
   const planPatterns = [
     /^(?:invoker\s+)?plan\s*:\s*/i,
     /^draft\s+(?:an?\s+)?invoker\s+plan\s*:\s*/i,
+    /^(?:invoker\s+)?plan\s+(?!mode\b)/i,
+    /^(?:draft|write|create|make)\s+(?:an?\s+)?invoker\s+plan(?:\s+(?:for|to))?\s*/i,
   ];
   for (const pattern of planPatterns) {
     const match = pattern.exec(trimmed);
@@ -374,6 +377,15 @@ export function parseThreadRequest(text: string): ThreadRequest | null {
       const rest = trimmed.slice(match[0].length).trim();
       return rest ? { mode: 'plan', text: rest } : null;
     }
+  }
+
+  const viaInvoker = /^(.*?\S)\s+(?:via|with)\s+invoker[.!]?$/i.exec(trimmed);
+  if (viaInvoker) {
+    return { mode: 'plan', text: viaInvoker[1] };
+  }
+
+  if (/^turn\s+(?:this|the (?:discussion|thread) above)\s+into\s+(?:an?\s+)?(?:invoker\s+)?plan[.!]?$/i.test(trimmed)) {
+    return { mode: 'plan', text: trimmed };
   }
 
   const localRequest = parseLocalRequest(trimmed);
@@ -885,13 +897,14 @@ export class SlackSurface implements Surface {
     }
 
     const explicitLocalAgent = localRequest?.kind === 'agent' || localRequest?.kind === 'change';
+    const requestedThreadMode = parseThreadRequest(parsed.text);
 
     // Slower paths (LLM classifier, repo checkout, agent) acknowledge receipt up front.
     if (this.enableImmediateAck) await this.sendImmediateAck(threadTs, say);
 
     try {
       // Fallback classifier: only when a non-verb message looks operational.
-      if (!explicitLocalAgent && looksOperational(parsed.text)) {
+      if (!explicitLocalAgent && requestedThreadMode?.mode !== 'plan' && looksOperational(parsed.text)) {
         const cls = await this.classifyLobbyIntent(parsed.text, preset);
         this.log('slack', 'info', `[CLASSIFY] thread_ts=${threadTs} intent=${cls.intent}`);
         if (cls.intent === 'command') {
@@ -907,7 +920,7 @@ export class SlackSurface implements Surface {
         // invalid-command / plan → fall through to a planning conversation.
       }
 
-      const threadRequest = parseThreadRequest(parsed.text);
+      const threadRequest = requestedThreadMode;
       if (!threadRequest) return;
 
       const storedContext = this.loadPlanningContext(threadTs);
@@ -1087,7 +1100,7 @@ export class SlackSurface implements Surface {
   private async handleLobbySubmit(channel: string, threadTs: string, userId: string, say: SayFn): Promise<void> {
     const conversation = await this.getSession(channel, threadTs, userId, false);
     if (!conversation || conversation.conversationMode !== 'plan') {
-      await say({ text: "No Invoker plan draft here yet. Start one with `@Invoker plan: ...`, then run `submit`.", thread_ts: threadTs });
+      await say({ text: "No Invoker plan draft here yet. In this thread, reply `plan: ...`, then run `submit`.", thread_ts: threadTs });
       return;
     }
     const planText = conversation.getDraftedPlan();
@@ -1709,7 +1722,8 @@ ${text}`;
         if (code === 0) {
           const trimmed = stdout.trim();
           if (trimmed) {
-            resolve(trimmed);
+            const message = formatCodexPlannerStdout(trimmed).message;
+            resolve(message || 'The planner completed without a final user-facing reply.');
           } else {
             reject(new EmptyOutputAttemptError(stderr));
           }


### PR DESCRIPTION
## Summary

Slack plan requests can now promote the existing thread when users use clear natural-language phrasing.

Slack posts only the final Codex agent message, keeping reasoning and protocol output out of customer-visible replies.

## Review Claim

Slack reliably promotes explicit natural-language plan intent in the existing thread and never posts Codex reasoning as a reply.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Ordinary coding requests remain agent-mode conversations; only clear plan intent changes mode, and only final agent messages reach Slack.

## Slice Rationale

Parser, prompt, formatter, and direct regression coverage form one routing contract: same-thread planning without reasoning leakage.

## Non-goals

- Do not make every coding request an Invoker workflow.
- Do not stream planner progress into Slack.
- Do not permit agent-mode threads to submit plans.

## Architecture

### Before

```mermaid
flowchart LR
  userMessage["Slack thread message"] --> agentSession["Agent session"]
  agentSession --> rawOutput["Raw one-shot planner stdout"]
  rawOutput --> slackReply["Slack reply"]
```

### After

```mermaid
flowchart LR
  userMessage["Slack thread message"] --> parser["Thread intent parser"]
  parser -->|"clear plan intent"| planSession["Existing thread promoted to plan session"]
  parser -->|"ordinary request"| agentSession["Agent session"]
  planSession --> plannerOutput["Planner stdout"]
  agentSession --> plannerOutput
  plannerOutput --> finalReply["Final agent message only"]
  finalReply --> slackReply["Slack reply"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test -- slack-surface-workflows.test.ts plan-conversation.test.ts`
- [x] `cd packages/execution-engine && pnpm test -- format-codex-planner-stdout.test.ts`
- [ ] `CI_VERIFY_TARGETS=remote_digital_ocean_1 bash skills/remote-ci-verify/scripts/run-remote-ci-verify.sh` (running)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f350195b2`
- Post-revert steps: None
- Data migration? No

</details>