### PR TITLE
[Slack Thread Planning](3) Recognize natural-language plan requests

### DIFF
--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -87,7 +87,7 @@
   },
   "defaultSlackHarnessPreset": "cursor+claude",
   "slackRepos": {
-    "comment": "Slack repo aliases: alias -> git URL, resolved from a [repo:<alias>] tag",
+    "comment": "Slack repo aliases: alias -> git URL, selected with [repo:<alias>] in a tagged request",
     "web": "git@github.com:acme/web.git",
     "api": "git@github.com:acme/api.git"
   },

--- a/docs/slack-native-workflows.md
+++ b/docs/slack-native-workflows.md
@@ -4,8 +4,8 @@ Drive Invoker from Slack: mention `@Invoker` in a shared **lobby** channel to st
 
 ## Flow
 
-1. **Start a normal agent thread.** In the lobby channel: `@Invoker [omp+codex] [repo:web] fix the Slack routing bug`. Invoker checks out the repo and runs a normal OMP/Codex-style conversation in the thread.
-2. **Opt into Invoker planning.** Use `@Invoker plan: add a /health endpoint` when you want YAML for an Invoker workflow instead of direct local agent work. You can also reply `plan: add a /health endpoint` in an existing agent thread; Invoker promotes that same thread to planning and retains its selected repo and harness preset.
+1. **Start a normal agent thread.** In the lobby channel: `@Invoker [omp+codex] [repo:web] fix the Slack routing bug` or `@Invoker fix this in https://github.com/acme/web`. Invoker checks out the selected repo and runs a normal OMP/Codex-style conversation in the thread.
+2. **Opt into Invoker planning.** Use `@Invoker plan: add a /health endpoint` when you want YAML for an Invoker workflow instead of direct local agent work. In an existing agent thread, reply `plan: add a /health endpoint`, `plan add a /health endpoint`, or `add a /health endpoint via Invoker`; Invoker promotes that same thread to planning and retains its selected repo and harness preset.
 3. **Submit only when ready.** Run `@Invoker submit` in that plan thread, then approve the short summary. That starts the generated YAML plan as a workflow.
 4. **Workflow channel appears.** Invoker creates private `workflow-<id>`, invites you, posts the workflow summary there, and links it from the lobby thread.
 5. **Operate in the channel.** `@Invoker status`, `@Invoker approve <task>`, `@Invoker reject <task>`, `@Invoker retry <task>`, `@Invoker input <task>: <text>`, or ask a free-form question (answered only from this workflow's planning + task transcripts).
@@ -15,9 +15,11 @@ Drive Invoker from Slack: mention `@Invoker` in a shared **lobby** channel to st
 Leading `[...]` tags select how planning runs. Order does not matter; everything after the tags is the request.
 
 - `[<preset>]` — pick a harness preset (CLI tool + model). No tag ⇒ the default preset.
-- `[repo:<alias|git-url>]` — pick the target repo. No tag ⇒ `defaultRepoUrl`.
+- `[repo:<alias|git-url>]` — explicitly pick the target repo. One unambiguous GitHub or git URL in the tagged request also selects that repo. Multiple URLs, or a URL that conflicts with `[repo:…]`, are rejected. No selector ⇒ `defaultRepoUrl`.
 
 `@Invoker raise a PR that adds rate limiting` (no tags) uses the default preset and default repo as a normal agent thread.
+
+The repository and harness are pinned when the thread starts. Start a new thread to use another repository or preset.
 
 ## Local and plan modes
 
@@ -29,6 +31,7 @@ Normal lobby mentions are local agent sessions. They can answer, edit, and run f
 - `@Invoker exec local: pnpm --filter @invoker/surfaces test -- slack-surface-workflows.test.ts` — runs that exact shell command and reports the exit code and output. It does **not** edit files.
 - `@Invoker plan: fix the typo in the Slack docs` — drafts Invoker YAML. Use `@Invoker submit` (or bare `submit`) in that thread to start the approval flow.
 - `plan: turn the discussion above into a migration plan` — promotes the current agent thread to plan mode, keeping its repo and harness selection. This works after a Slack service restart as well.
+- `turn the discussion above into a plan` — promotes the current agent thread without requiring a second thread.
 
 ## Harness presets
 

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -192,6 +192,10 @@ describe('parseThreadRequest', () => {
       mode: 'plan',
       text: 'turn the discussion above into a plan',
     });
+    expect(parseThreadRequest('Can you create a plan for this to submit to Invoker for all these features?')).toEqual({
+      mode: 'plan',
+      text: 'Can you create a plan for this to submit to Invoker for all these features?',
+    });
     expect(parseThreadRequest('why are you dumping the chain of thought')).toEqual({
       mode: 'agent',
       text: 'why are you dumping the chain of thought',

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -379,6 +379,10 @@ export function parseThreadRequest(text: string): ThreadRequest | null {
     }
   }
 
+  if (/^(?:can|could|would)\s+you\s+(?:please\s+)?(?:create|make|draft|write)\s+(?:an?\s+)?plan\b[\s\S]*\bsubmit(?:\s+(?:it|this))?\s+to\s+invoker\b/i.test(trimmed)) {
+    return { mode: 'plan', text: trimmed };
+  }
+
   const viaInvoker = /^(.*?\S)\s+(?:via|with)\s+invoker[.!]?$/i.exec(trimmed);
   if (viaInvoker) {
     return { mode: 'plan', text: viaInvoker[1] };


### PR DESCRIPTION
## Summary

Natural-language requests to create an Invoker plan now enter Slack plan mode.

The full request stays available to the planner, which returns YAML and its next-step instruction in that same thread.

## Review Claim

Approve routing “Can you create a plan for this to Invoker…” directly to the existing same-thread plan workflow.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Ordinary coding requests remain agent-mode conversations; only a request that explicitly asks to create a plan for Invoker submission selects plan mode.

## Slice Rationale

This adds the missing natural-language form after the lower stack slice introduced same-thread promotion and final-message filtering.

## Non-goals

- Do not change plan confirmation behavior.
- Do not treat every coding request as an Invoker plan.
- Do not alter Slack workflow-channel controls.

## Architecture

### Before

```mermaid
flowchart LR
  prosePlan["Create a plan for Invoker"] --> agentMode["Agent mode"]
  agentMode --> refusal["Planner refuses YAML"]
```

### After

```mermaid
flowchart LR
  prosePlan["Create a plan for Invoker"] --> planMode["Plan mode"]
  planMode --> yamlDraft["YAML draft"]
  yamlDraft --> nextStep["In-thread next step"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test -- slack-surface-workflows.test.ts plan-conversation.test.ts slack-do1-ux-sanitize.e2e.test.ts`
- [x] Deploy the published stack head to DO1; rebuild `@invoker/surfaces` and `@invoker/slack-manager`; confirm `slack-manager.service` is active.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 16710e278`
- Post-revert steps: rebuild `@invoker/surfaces` and `@invoker/slack-manager`, then restart `slack-manager.service` on DO1.
- Data migration? No.

</details>

Depends-On: #5510