### PR TITLE
[Slack] Infer plans from thread conversation

### DIFF
--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -87,7 +87,7 @@
   },
   "defaultSlackHarnessPreset": "cursor+claude",
   "slackRepos": {
-    "comment": "Slack repo aliases: alias -> git URL, resolved from a [repo:<alias>] tag",
+    "comment": "Slack repo aliases: alias -> git URL, selected with [repo:<alias>] in a tagged request",
     "web": "git@github.com:acme/web.git",
     "api": "git@github.com:acme/api.git"
   },

--- a/docs/slack-native-workflows.md
+++ b/docs/slack-native-workflows.md
@@ -4,8 +4,8 @@ Drive Invoker from Slack: mention `@Invoker` in a shared **lobby** channel to st
 
 ## Flow
 
-1. **Start a normal agent thread.** In the lobby channel: `@Invoker [omp+codex] [repo:web] fix the Slack routing bug`. Invoker checks out the repo and runs a normal OMP/Codex-style conversation in the thread.
-2. **Opt into Invoker planning.** Use `@Invoker plan: add a /health endpoint` when you want YAML for an Invoker workflow instead of direct local agent work. You can also reply `plan: add a /health endpoint` in an existing agent thread; Invoker promotes that same thread to planning and retains its selected repo and harness preset.
+1. **Start a normal agent thread.** In the lobby channel: `@Invoker [omp+codex] [repo:web] fix the Slack routing bug` or `@Invoker fix this in https://github.com/acme/web`. Invoker checks out the selected repo and runs a normal OMP/Codex-style conversation in the thread.
+2. **Opt into Invoker planning.** Use `@Invoker plan: add a /health endpoint` when you want YAML for an Invoker workflow instead of direct local agent work. In an existing agent thread, reply `plan: add a /health endpoint`, `plan add a /health endpoint`, or `add a /health endpoint via Invoker`; Invoker promotes that same thread to planning and retains its selected repo and harness preset.
 3. **Submit only when ready.** Run `@Invoker submit` in that plan thread, then approve the short summary. That starts the generated YAML plan as a workflow.
 4. **Workflow channel appears.** Invoker creates private `workflow-<id>`, invites you, posts the workflow summary there, and links it from the lobby thread.
 5. **Operate in the channel.** `@Invoker status`, `@Invoker approve <task>`, `@Invoker reject <task>`, `@Invoker retry <task>`, `@Invoker input <task>: <text>`, or ask a free-form question (answered only from this workflow's planning + task transcripts).
@@ -15,9 +15,11 @@ Drive Invoker from Slack: mention `@Invoker` in a shared **lobby** channel to st
 Leading `[...]` tags select how planning runs. Order does not matter; everything after the tags is the request.
 
 - `[<preset>]` — pick a harness preset (CLI tool + model). No tag ⇒ the default preset.
-- `[repo:<alias|git-url>]` — pick the target repo. No tag ⇒ `defaultRepoUrl`.
+- `[repo:<alias|git-url>]` — explicitly pick the target repo. One unambiguous GitHub or git URL in the tagged request also selects that repo. Multiple URLs, or a URL that conflicts with `[repo:…]`, are rejected. No selector ⇒ `defaultRepoUrl`.
 
 `@Invoker raise a PR that adds rate limiting` (no tags) uses the default preset and default repo as a normal agent thread.
+
+The repository and harness are pinned when the thread starts. Start a new thread to use another repository or preset.
 
 ## Local and plan modes
 
@@ -29,6 +31,7 @@ Normal lobby mentions are local agent sessions. They can answer, edit, and run f
 - `@Invoker exec local: pnpm --filter @invoker/surfaces test -- slack-surface-workflows.test.ts` — runs that exact shell command and reports the exit code and output. It does **not** edit files.
 - `@Invoker plan: fix the typo in the Slack docs` — drafts Invoker YAML. Use `@Invoker submit` (or bare `submit`) in that thread to start the approval flow.
 - `plan: turn the discussion above into a migration plan` — promotes the current agent thread to plan mode, keeping its repo and harness selection. This works after a Slack service restart as well.
+- `turn the discussion above into a plan` — promotes the current agent thread without requiring a second thread.
 
 ## Harness presets
 

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -585,7 +585,7 @@ describe('PlanConversation', () => {
 
     const reply = await conversational.sendMessage('yes');
 
-    expect(reply).toBe(VALID_YAML_PLAN);
+    expect(reply).toBe(`${VALID_YAML_PLAN}\n\nReply \`submit\` to submit it.`);
     expect(conversational.planSubmitted).toBe(false);
     expect(conversational.submittedPlanText).toBeNull();
     expect(mockSpawn).toHaveBeenCalledTimes(1);
@@ -982,30 +982,18 @@ describe('PlanConversation prompt construction', () => {
   });
 
   it('agent mode refuses Invoker YAML and redirects within the same thread', () => {
-    // Agent threads can never submit a plan — handleLobbySubmit rejects a submit
-    // unless conversationMode === 'plan'. So the agent prompt must not offer to
-    // draft Invoker YAML (which would be an un-submittable dead end); it must
-    // steer the user to a `plan:` thread instead.
     const conv = new PlanConversation({ mode: 'agent' });
     (conv as any).messages.push({ role: 'user', content: 'Make me an Invoker plan to add a REST API' });
     const prompt = conv.buildCursorPrompt();
 
     // Never the plan-mode system prompt in an agent thread.
     expect(prompt).not.toContain('Invoker orchestrator');
-    // Agent mode must refuse YAML unconditionally and point at `plan:`.
-    expect(prompt).toContain('Do NOT generate Invoker YAML');
-    expect(prompt).toContain('plan:');
+    expect(prompt).toContain('Do NOT generate or submit Invoker YAML yourself');
+    expect(prompt).toContain('promotes planning requests');
     expect(prompt).toContain('same thread');
     expect(prompt).not.toContain('start a new plan thread');
     expect(prompt).toContain('only the final user-facing message');
-    // The old loophole permitted YAML "unless the user explicitly asks" — that
-    // produced drafts Slack silently rejects on submit.
     expect(prompt).not.toContain('unless the user explicitly asks');
-    expect(prompt).toContain('Do NOT invoke `invoker-cli`');
-    expect(prompt).toContain('`invoker_submit_plan`');
-    expect(prompt).toContain('`invoker_validate_plan`');
-    expect(prompt).toContain('`submit-plan.sh`');
-    expect(prompt).toContain('Harness handoff mode');
   });
 });
 

--- a/packages/surfaces/src/__tests__/slack-do1-ux-sanitize.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-do1-ux-sanitize.e2e.test.ts
@@ -32,4 +32,10 @@ describe('DO1 e2e: sanitizeSlashCommands leaves Invoker plan prose alone', () =>
       'reply with "yes", "go", or "execute" to confirm now',
     );
   });
+
+  it('does not splice a replacement into a backtick-adjacent confirmation word', () => {
+    expect(sanitizeSlashCommands('reply with "yes", "go", or "execute" to confirm`/invoker submit`')).toBe(
+      'reply with "yes", "go", or "execute" to confirm`/invoker submit`',
+    );
+  });
 });

--- a/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
@@ -20,6 +20,7 @@ const sharedSlack = vi.hoisted(() => ({
       delete: vi.fn().mockResolvedValue({}),
     },
     reactions: { add: vi.fn().mockResolvedValue({}), remove: vi.fn().mockResolvedValue({}) },
+    conversations: { replies: vi.fn().mockResolvedValue({ messages: [] }) },
   },
 }));
 
@@ -128,6 +129,8 @@ describe('Slack plan submission restart repro contracts', () => {
     sharedSlack.client.chat.postMessage.mockClear();
     sharedSlack.client.chat.update.mockClear();
     sharedSlack.client.chat.delete.mockClear();
+    sharedSlack.client.conversations.replies.mockReset();
+    sharedSlack.client.conversations.replies.mockResolvedValue({ messages: [] });
     adapter = await SQLiteAdapter.create(':memory:');
     repo = new ConversationRepository(adapter, { info: silentLog, warn: silentLog, error: silentLog });
     slackSessions = new SlackSessionRepository(adapter);
@@ -156,9 +159,34 @@ describe('Slack plan submission restart repro contracts', () => {
     const say = await reply(slack, 'plan: draft a real migration plan', 'thread-agent');
     const current = (slack as any).sessionManager.findSession(new SessionIdentifier('C_LOBBY', 'thread-agent'));
     expect(current?.conversationMode).toBe('plan');
-    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: plan }));
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: `${plan}\n\nReply \`submit\` to submit it.` }));
     const submitSay = await mention(slack, 'submit', 'submit-agent', 'thread-agent');
     expect(submitSay).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Approve to proceed') }));
+  });
+
+  it('drafts a submittable plan from the incident wording and its source thread context', async () => {
+    const commands: SurfaceCommand[] = [];
+    const slack = surface(commands);
+    sharedSlack.client.conversations.replies.mockResolvedValue({
+      messages: [
+        { text: 'Please prioritize the Orca-inspired reply: attention inbox, workflow cards, gates, batch review notes, presets, mobile polish, and usage chips.' },
+        { text: '@Invoker Can you create a plan for this to submit to invoker for all these features?' },
+      ],
+    });
+    await start(slack, commands);
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+
+    const say = await mention(
+      slack,
+      'Can you create a plan for this to submit to invoker for all these features?',
+      'incident-thread',
+    );
+
+    expect((slack as any).sessionManager.findSession(new SessionIdentifier('C_LOBBY', 'incident-thread'))?.conversationMode).toBe('plan');
+    expect(JSON.stringify(mockSpawn.mock.calls[0])).toContain('attention inbox');
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('Reply `submit` to submit it.'),
+    }));
   });
 
   it('stages a bare thread submit for confirmation instead of routing it to the planner', async () => {
@@ -290,7 +318,7 @@ describe('Slack plan submission restart repro contracts', () => {
     mockSpawn.mockImplementationOnce(() => processWith('Planner received the non-confirmation'));
     const nonConfirmationSay = await reply(slack, 'add a note before submitting', 'thread-reply');
     expect((slack as any).pendingConfirms.get('thread-reply')).toEqual(expect.objectContaining({ kind: 'submit' }));
-    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(mockSpawn).toHaveBeenCalledTimes(3);
     const yesSay = await reply(slack, 'yes', 'thread-reply');
     expect(yesSay).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Starting plan execution') }));
     expect(commands).toContainEqual(expect.objectContaining({ type: 'start_plan' }));

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -192,6 +192,10 @@ describe('parseThreadRequest', () => {
       mode: 'plan',
       text: 'turn the discussion above into a plan',
     });
+    expect(parseThreadRequest('Can you create a plan for this to submit to Invoker for all these features?')).toEqual({
+      mode: 'plan',
+      text: 'Can you create a plan for this to submit to Invoker for all these features?',
+    });
     expect(parseThreadRequest('why are you dumping the chain of thought')).toEqual({
       mode: 'agent',
       text: 'why are you dumping the chain of thought',

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -549,7 +549,7 @@ describe('lobby verb routing', () => {
     expect(prompt).toContain('Reproducing a bug locally is always allowed');
     expect(prompt).toContain('mergify stack push');
     expect(prompt).toContain('scripts/land-stack.mjs --execute');
-    expect(prompt).toContain('plan: <request>');
+    expect(prompt).toContain('draft a plan in this same thread');
     expect(prompt).toContain('same thread');
     expect(prompt).toContain('only the final user-facing answer');
     expect(prompt).not.toContain('start a plan thread');
@@ -871,14 +871,14 @@ describe('lobby verb routing', () => {
     expect(received).toHaveLength(0);
   });
 
-  it('routes a build request to a normal agent thread without classifying', async () => {
+  it('routes a build request to an inferred Invoker plan thread', async () => {
     const surface = lobbySurface();
     await surface.start(async () => {});
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     await mentionHandler(surface)({ event: { text: '<@BOT> add a /health endpoint', ts: 't1', user: 'U1' }, say });
     expect(planConversationConfigs).toHaveLength(1);
-    expect(planConversationConfigs[0].mode).toBe('agent');
-    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(planConversationConfigs[0].mode).toBe('plan');
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
     expect(runWorkflowOp).not.toHaveBeenCalled();
   });
 

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -223,8 +223,7 @@ function buildAgentSystemPrompt(): string {
 Default behavior:
 - Treat the thread like an ordinary OMP/Codex coding session.
 - Answer questions, run local commands, inspect files, edit code, and run focused verification when useful.
-- Do NOT generate Invoker YAML in this thread. If the user asks for an Invoker plan, tell them to ask in this same thread with \`plan: <request>\`, \`plan <request>\`, or \`<request> via Invoker\` — plan drafts from an agent thread cannot be submitted.
-- Do NOT submit or start an Invoker workflow. Do NOT invoke \`invoker-cli\`, \`invoker_submit_plan\`, \`invoker_validate_plan\`, \`submit-plan.sh\`, or the \`plan-to-invoker\` skill's Harness handoff mode to do so. Agent threads reject \`submit\`; only a \`plan:\` thread can be submitted.
+- Do NOT generate or submit Invoker YAML yourself. Slack routing promotes planning requests to a planning conversation automatically, where the user can submit the resulting draft in this same thread.
 - Keep Slack replies short and concrete: changed files, verification, and any remaining risk. Return only the final user-facing message; never include chain-of-thought, reasoning traces, tool output, or raw planner JSONL.
 - To share a generated file (screenshot, diagram, report), write it inside your worktree and link it by absolute path as a markdown link, e.g. \`[chart](/abs/path/in/worktree/chart.png)\`. Files linked that way are uploaded to the thread. Files written outside your worktree cannot be shared, so do not put artifacts in /tmp.
 
@@ -547,6 +546,9 @@ export class PlanConversation {
     const tCursor = Date.now();
     const formatted = formatCodexPlannerStdout(response);
     let message = formatted.message;
+    if (this.mode === 'plan' && extractYamlPlan(message) && !message.includes('Reply `submit` to submit it.')) {
+      message = `${message.trimEnd()}\n\nReply \`submit\` to submit it.`;
+    }
     const repoStateAfter = this.mode === 'agent'
       ? await captureRepoState(this.workingDir)
       : null;

--- a/packages/surfaces/src/slack/slack-message-helpers.ts
+++ b/packages/surfaces/src/slack/slack-message-helpers.ts
@@ -214,8 +214,8 @@ export function splitCodeBlockChunk(text: string, limit: number): string[] {
  */
 export function sanitizeSlashCommands(text: string): string {
   return text.replace(
-    /(?:use |run |type |try )?`?\/invoker\s+(?!conversations\b)\w+[^`\n]*`?/gi,
-    'reply with "yes", "go", or "execute" to confirm',
+    /(^|[\s([])(?:use |run |type |try )?`?\/invoker\s+(?!conversations\b)\w+[^`\n]*`?/gim,
+    (_match, boundary: string) => `${boundary}reply with "yes", "go", or "execute" to confirm`,
   );
 }
 

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -379,6 +379,10 @@ export function parseThreadRequest(text: string): ThreadRequest | null {
     }
   }
 
+  if (/^(?:can|could|would)\s+you\s+(?:please\s+)?(?:create|make|draft|write)\s+(?:an?\s+)?plan\b[\s\S]*\bsubmit(?:\s+(?:it|this))?\s+to\s+invoker\b/i.test(trimmed)) {
+    return { mode: 'plan', text: trimmed };
+  }
+
   const viaInvoker = /^(.*?\S)\s+(?:via|with)\s+invoker[.!]?$/i.exec(trimmed);
   if (viaInvoker) {
     return { mode: 'plan', text: viaInvoker[1] };

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -266,7 +266,7 @@ ${text}
 
 /** Q&A prompt for a lobby question: answer directly, never emit a plan. */
 export function buildLobbyQuestionPrompt(text: string): string {
-  return `Answer the user's question about this repository and Invoker. Explore the codebase if needed. ${SLACK_DIRECT_ANSWER_GUIDANCE} Do NOT generate a YAML plan and do NOT create a workflow. If answering well requires changing code, say in prose what the fix would be and tell the user they can ask for a plan in this same thread with \`plan: <request>\`, \`plan <request>\`, or \`<request> via Invoker\`. Return only the final user-facing answer; never include chain-of-thought, reasoning traces, tool output, or raw planner JSONL.\n\n${SLACK_LOCAL_REPRO_POLICY}\n\nQuestion:\n${text}`;
+  return `Answer the user's question about this repository and Invoker. Explore the codebase if needed. ${SLACK_DIRECT_ANSWER_GUIDANCE} Do NOT generate a YAML plan and do NOT create a workflow. If answering well requires changing code, say in prose what the fix would be and tell the user that Invoker can draft a plan in this same thread. Return only the final user-facing answer; never include chain-of-thought, reasoning traces, tool output, or raw planner JSONL.\n\n${SLACK_LOCAL_REPRO_POLICY}\n\nQuestion:\n${text}`;
 }
 
 /** Parse the classifier's raw stdout into a validated classification; never throws. */
@@ -901,14 +901,13 @@ export class SlackSurface implements Surface {
     }
 
     const explicitLocalAgent = localRequest?.kind === 'agent' || localRequest?.kind === 'change';
-    const requestedThreadMode = parseThreadRequest(parsed.text);
+    let threadRequest = parseThreadRequest(parsed.text);
 
     // Slower paths (LLM classifier, repo checkout, agent) acknowledge receipt up front.
     if (this.enableImmediateAck) await this.sendImmediateAck(threadTs, say);
 
     try {
-      // Fallback classifier: only when a non-verb message looks operational.
-      if (!explicitLocalAgent && requestedThreadMode?.mode !== 'plan' && looksOperational(parsed.text)) {
+      if (!explicitLocalAgent && threadRequest?.mode !== 'plan') {
         const cls = await this.classifyLobbyIntent(parsed.text, preset);
         this.log('slack', 'info', `[CLASSIFY] thread_ts=${threadTs} intent=${cls.intent}`);
         if (cls.intent === 'command') {
@@ -921,10 +920,11 @@ export class SlackSurface implements Surface {
           await this.answerLobbyQuestion(parsed.text, preset, threadTs, say);
           return;
         }
-        // invalid-command / plan → fall through to a planning conversation.
+        if (cls.intent === 'plan') {
+          threadRequest = { mode: 'plan', text: parsed.text };
+        }
       }
 
-      const threadRequest = requestedThreadMode;
       if (!threadRequest) return;
 
       const storedContext = this.loadPlanningContext(threadTs);
@@ -976,7 +976,10 @@ export class SlackSurface implements Surface {
         this.persistLaunchContext(threadTs, { ...context, workingDir });
       }
 
-      await this.handleConversationMessage(conversation, threadRequest.text, threadTs, say, channel);
+      const messageText = threadRequest.mode === 'plan'
+        ? await this.withThreadContext(channel, threadTs, threadRequest.text)
+        : threadRequest.text;
+      await this.handleConversationMessage(conversation, messageText, threadTs, say, channel);
     } finally {
       // Drop any leftover Processing… ack (success paths already replace/delete it).
       await this.clearImmediateAck(channel, threadTs);
@@ -1011,6 +1014,26 @@ export class SlackSurface implements Surface {
       return { intent: 'plan' };
     }
     return parseLobbyClassification(raw);
+  }
+
+  private async withThreadContext(channel: string, threadTs: string, request: string): Promise<string> {
+    try {
+      const replies = await this.app.client.conversations.replies({ channel, ts: threadTs, limit: 100 });
+      const context = (replies.messages ?? [])
+        .filter((message) => !message.bot_id && !message.subtype && typeof message.text === 'string')
+        .map((message) => message.text.trim())
+        .filter((text) => text && text !== request)
+        .slice(-20)
+        .map((text) => `- ${text.slice(0, 1_000)}`)
+        .join('\n')
+        .slice(-12_000);
+      return context
+        ? `Slack thread context:\n${context}\n\nCurrent plan request:\n${request}`
+        : request;
+    } catch (err) {
+      this.log('slack', 'warn', `[THREAD_CONTEXT] Failed to load thread ${threadTs}: ${err}`);
+      return request;
+    }
   }
 
   private async handleLobbyOp(
@@ -1866,7 +1889,17 @@ ${text}`;
         return;
       }
 
-      const threadRequest = parseThreadRequest(text);
+      let threadRequest = parseThreadRequest(text);
+      const explicitLocalAgent = localRequest?.kind === 'agent' || localRequest?.kind === 'change';
+      if (!explicitLocalAgent && threadRequest?.mode !== 'plan') {
+        const context = this.loadPlanningContext(msg.thread_ts);
+        const preset = this.resolveHarnessPreset(context?.presetKey ?? this.defaultHarnessPreset);
+        const cls = await this.classifyLobbyIntent(text, preset);
+        this.log('slack', 'info', `[CLASSIFY] thread_ts=${msg.thread_ts} intent=${cls.intent}`);
+        if (cls.intent === 'plan') {
+          threadRequest = { mode: 'plan', text };
+        }
+      }
       let messageText = text;
       if (threadRequest?.mode === 'plan') {
         const id = new SessionIdentifier(channel, msg.thread_ts);
@@ -1900,6 +1933,9 @@ ${text}`;
 
       this.log('slack', 'info', `[SESSION_MESSAGE] Thread reply (thread_ts=${msg.thread_ts}, user=${msg.user}, preview="${text.slice(0, 100)}${text.length > 100 ? '...' : ''}")`);
 
+      if (threadRequest?.mode === 'plan') {
+        messageText = await this.withThreadContext(channel, msg.thread_ts, messageText);
+      }
       await this.handleConversationMessage(conversation, messageText, msg.thread_ts, say, channel);
     });
   }
@@ -1961,6 +1997,9 @@ ${text}`;
       }
 
       const chunks = splitForSlack(sanitizeSlackOutbound(reply));
+      const revision = process.env.INVOKER_REVISION ?? process.env.GIT_COMMIT ?? 'unknown';
+      this.log('slack', 'info',
+        `[RESPONSE_PROVENANCE] thread_ts=${threadTs} mode=${conversation.conversationMode} revision=${revision} reply_chars=${reply.length} chunks=${chunks.length}`);
 
       const ackTs = this.ackMessages.get(threadTs);
       if (ackTs) {


### PR DESCRIPTION
## Summary

Slack planning can infer a plan request from ordinary thread conversation.

Users no longer need a rigid command shape once a thread is already in planning.

## Review Claim

Approve inferring plan intent from natural thread replies in an active planning conversation.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Non-planning threads stay unchanged. Inference only runs when the thread is already in planning.

## Slice Rationale

Natural-language recognition lands before shared lifecycle extraction so reviewers can judge Slack message routing on its own.

## Non-goals

- Do not extract shared planning packages.
- Do not change plan submission or approval UX.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test -- plan-conversation.test.ts slack-surface-workflows.test.ts slack-plan-submission-repros.e2e.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert HEAD`
- Post-revert steps: Restart Slack manager if deployed.
- Data migration? No

</details>

Depends-On: #5511