### PR TITLE
[Slack] Bundle planning core for manager

### DIFF
--- a/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
@@ -149,14 +149,14 @@ describe('Slack plan submission restart repro contracts', () => {
     return created;
   }
 
-  it('promotes an agent thread when a bare plan: reply requests an Invoker plan', async () => {
+  it('promotes an agent thread when a tagged plan reply requests an Invoker plan', async () => {
     const commands: SurfaceCommand[] = [];
     const slack = surface(commands);
     await start(slack, commands);
     mockSpawn.mockImplementationOnce(() => processWith('Agent response'));
     await mention(slack, 'fix the agent routing', 'thread-agent');
     mockSpawn.mockImplementationOnce(() => processWith(plan));
-    const say = await reply(slack, 'plan: draft a real migration plan', 'thread-agent');
+    const say = await mention(slack, 'plan: draft a real migration plan', 'thread-agent-plan', 'thread-agent');
     const current = (slack as any).sessionManager.findSession(new SessionIdentifier('C_LOBBY', 'thread-agent'));
     expect(current?.conversationMode).toBe('plan');
     expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: `${plan}\n\nReply \`submit\` to submit it.` }));
@@ -189,13 +189,36 @@ describe('Slack plan submission restart repro contracts', () => {
     }));
   });
 
-  it('stages a bare thread submit for confirmation instead of routing it to the planner', async () => {
+  it('uses untagged replies as context only when Invoker is tagged again', async () => {
+    const commands: SurfaceCommand[] = [];
+    const slack = surface(commands);
+    await start(slack, commands);
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await mention(slack, 'plan: draft the first version', 'passive-context-thread');
+
+    const passiveSay = await reply(slack, 'Please also include the mobile workflow.', 'passive-context-thread');
+    expect(passiveSay).not.toHaveBeenCalled();
+
+    sharedSlack.client.conversations.replies.mockResolvedValue({
+      messages: [
+        { text: 'plan: draft the first version' },
+        { text: 'Please also include the mobile workflow.' },
+        { text: '@Invoker plan: revise the draft' },
+      ],
+    });
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await mention(slack, 'plan: revise the draft', 'passive-context-mention', 'passive-context-thread');
+
+    expect(JSON.stringify(mockSpawn.mock.calls.at(-1))).toContain('Please also include the mobile workflow.');
+  });
+
+  it('stages a tagged thread submit for confirmation instead of routing it to the planner', async () => {
     const commands: SurfaceCommand[] = [];
     const slack = surface(commands);
     await start(slack, commands);
     mockSpawn.mockImplementationOnce(() => processWith(plan));
     await mention(slack, 'plan: create a proof', 'thread-submit');
-    const say = await reply(slack, 'submit', 'thread-submit');
+    const say = await mention(slack, 'submit', 'submit-thread', 'thread-submit');
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Approve to proceed') }));
   });
@@ -225,7 +248,7 @@ describe('Slack plan submission restart repro contracts', () => {
     await start(second, commands);
     const say = await mention(second, 'submit', 'submit-context', 'thread-context');
     expect((second as any).sessionManager.findSession(new SessionIdentifier('C_LOBBY', 'thread-context'))?.conversationMode).toBe('plan');
-    await reply(second, 'yes', 'thread-context');
+    await mention(second, 'yes', 'confirm-context', 'thread-context');
     expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Approve to proceed') }));
     expect(commands).toContainEqual(expect.objectContaining({
       type: 'start_plan',
@@ -247,7 +270,7 @@ describe('Slack plan submission restart repro contracts', () => {
 
     const second = surface(commands);
     await start(second, commands);
-    const say = await reply(second, 'yes', 'thread-confirm');
+    const say = await mention(second, 'yes', 'confirm-thread', 'thread-confirm');
     expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Starting plan execution') }));
     expect(commands).toContainEqual(expect.objectContaining({ type: 'start_plan' }));
   });
@@ -275,7 +298,7 @@ describe('Slack plan submission restart repro contracts', () => {
     expect(commands).toContainEqual(expect.objectContaining({ type: 'start_plan' }));
   });
 
-  it('recovers an evicted session from a thread reply and submit', async () => {
+  it('retains an untagged thread reply as passive context without invoking Invoker', async () => {
     const commands: SurfaceCommand[] = [];
     const slack = surface(commands);
     await start(slack, commands);
@@ -288,7 +311,7 @@ describe('Slack plan submission restart repro contracts', () => {
     expect(manager.findSession(id)).toBeNull();
     const replySay = await reply(slack, 'continue', 'thread-evicted');
     const submitSay = await mention(slack, 'submit', 'submit-evicted', 'thread-evicted');
-    expect(replySay).toHaveBeenCalled();
+    expect(replySay).not.toHaveBeenCalled();
     expect(submitSay).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Approve to proceed') }));
   });
 
@@ -299,7 +322,7 @@ describe('Slack plan submission restart repro contracts', () => {
     mockSpawn.mockImplementationOnce(() => processWith(plan));
     await mention(slack, 'plan: clean up in the lobby', 'thread-cleanup');
     await mention(slack, 'submit', 'submit-cleanup', 'thread-cleanup');
-    await reply(slack, 'yes', 'thread-cleanup');
+    await mention(slack, 'yes', 'confirm-cleanup', 'thread-cleanup');
     const manager = (slack as any).sessionManager;
     const actualId = new SessionIdentifier('C_LOBBY', 'thread-cleanup');
     expect(manager.findSession(new SessionIdentifier('C_DEFAULT', 'thread-cleanup'))).toBeNull();
@@ -315,11 +338,11 @@ describe('Slack plan submission restart repro contracts', () => {
     await mention(slack, 'plan: keep my confirmation', 'thread-reply');
     await mention(slack, 'submit', 'submit-reply', 'thread-reply');
     expect((slack as any).pendingConfirms.get('thread-reply')).toEqual(expect.objectContaining({ kind: 'submit' }));
-    mockSpawn.mockImplementationOnce(() => processWith('Planner received the non-confirmation'));
     const nonConfirmationSay = await reply(slack, 'add a note before submitting', 'thread-reply');
     expect((slack as any).pendingConfirms.get('thread-reply')).toEqual(expect.objectContaining({ kind: 'submit' }));
-    expect(mockSpawn).toHaveBeenCalledTimes(3);
-    const yesSay = await reply(slack, 'yes', 'thread-reply');
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(nonConfirmationSay).not.toHaveBeenCalled();
+    const yesSay = await mention(slack, 'yes', 'confirm-reply', 'thread-reply');
     expect(yesSay).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Starting plan execution') }));
     expect(commands).toContainEqual(expect.objectContaining({ type: 'start_plan' }));
   });
@@ -334,13 +357,13 @@ describe('Slack plan submission restart repro contracts', () => {
     });
     await start(slack, commands);
     mockSpawn.mockImplementationOnce(() => processWith('Agent response'));
-    await mention(slack, '[special] [repo:proof] fix this first', 'thread-promotion');
+    await mention(slack, '[special] [repo:proof] local: fix this first', 'thread-promotion');
     mockSpawn.mockImplementationOnce(() => processWith(plan));
-    await reply(slack, 'plan: preserve the explicit target context', 'thread-promotion');
+    await mention(slack, 'plan: preserve the explicit target context', 'promote-thread', 'thread-promotion');
     expect((slack as any).sessionManager.findSession(new SessionIdentifier('C_LOBBY', 'thread-promotion'))?.conversationMode).toBe('plan');
     expect((slack as any).planningContexts.get('thread-promotion')).toEqual(expect.objectContaining({ presetKey: 'special' }));
     await mention(slack, 'submit', 'submit-promotion', 'thread-promotion');
-    await reply(slack, 'yes', 'thread-promotion');
+    await mention(slack, 'yes', 'confirm-promotion', 'thread-promotion');
     expect(commands).toContainEqual(expect.objectContaining({
       type: 'start_plan',
       repoUrl: 'https://example.test/proof.git',

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -979,7 +979,7 @@ export class SlackSurface implements Surface {
       const messageText = threadRequest.mode === 'plan'
         ? await this.withThreadContext(channel, threadTs, threadRequest.text)
         : threadRequest.text;
-      await this.handleConversationMessage(conversation, messageText, threadTs, say, channel);
+      await this.handleConversationMessage(conversation, messageText, threadTs, say, channel, event.ts);
     } finally {
       // Drop any leftover Processing… ack (success paths already replace/delete it).
       await this.clearImmediateAck(channel, threadTs);
@@ -1019,9 +1019,10 @@ export class SlackSurface implements Surface {
   private async withThreadContext(channel: string, threadTs: string, request: string): Promise<string> {
     try {
       const replies = await this.app.client.conversations.replies({ channel, ts: threadTs, limit: 100 });
-      const context = (replies.messages ?? [])
+      const messages = (replies.messages ?? []) as Array<{ bot_id?: string; subtype?: string; text?: string }>;
+      const context = messages
         .filter((message) => !message.bot_id && !message.subtype && typeof message.text === 'string')
-        .map((message) => message.text.trim())
+        .map((message) => message.text!.trim())
         .filter((text) => text && text !== request)
         .slice(-20)
         .map((text) => `- ${text.slice(0, 1_000)}`)
@@ -1881,62 +1882,11 @@ ${text}`;
         await this.handleLobbySubmit(channel, msg.thread_ts, msg.user ?? 'unknown', say);
         return;
       }
-
-      const localRequest = parseLocalRequest(text);
-      if (localRequest?.kind === 'command') {
-        const preset = this.resolveHarnessPreset(this.defaultHarnessPreset);
-        await this.handleLocalRequest(localRequest, preset, msg.thread_ts, say, channel, { userId: msg.user });
-        return;
-      }
-
-      let threadRequest = parseThreadRequest(text);
-      const explicitLocalAgent = localRequest?.kind === 'agent' || localRequest?.kind === 'change';
-      if (!explicitLocalAgent && threadRequest?.mode !== 'plan') {
-        const context = this.loadPlanningContext(msg.thread_ts);
-        const preset = this.resolveHarnessPreset(context?.presetKey ?? this.defaultHarnessPreset);
-        const cls = await this.classifyLobbyIntent(text, preset);
-        this.log('slack', 'info', `[CLASSIFY] thread_ts=${msg.thread_ts} intent=${cls.intent}`);
-        if (cls.intent === 'plan') {
-          threadRequest = { mode: 'plan', text };
-        }
-      }
-      let messageText = text;
-      if (threadRequest?.mode === 'plan') {
-        const id = new SessionIdentifier(channel, msg.thread_ts);
-        const current = this.sessionManager
-          ? await this.sessionManager.getSession(id, msg.user ?? 'unknown')
-          : undefined;
-        if (current?.conversationMode === 'agent' && this.sessionManager) {
-          const context: PlanningContext = this.loadPlanningContext(msg.thread_ts) ?? {
-            presetKey: this.defaultHarnessPreset,
-            workingDir: this.workingDir,
-            requestedBy: msg.user,
-            lobbyChannel: channel,
-          };
-          const preset = this.resolveHarnessPreset(context.presetKey);
-          const promoted = await this.sessionManager.promoteToPlanSession(id, msg.user ?? 'unknown', {
-            tool: preset.tool,
-            model: preset.model,
-            workingDir: context.workingDir,
-            repoUrl: context.repoUrl,
-          });
-          if (!promoted) return;
-          this.savePlanningContext(msg.thread_ts, context);
-          messageText = threadRequest.text;
-        }
-      }
-
-      // Look up or recover session (don't create new sessions for random thread replies in fallback mode)
       const conversation = await this.getSession(channel, msg.thread_ts, msg.user ?? 'unknown', false);
       if (!conversation) return;
       if (!text) return;
 
-      this.log('slack', 'info', `[SESSION_MESSAGE] Thread reply (thread_ts=${msg.thread_ts}, user=${msg.user}, preview="${text.slice(0, 100)}${text.length > 100 ? '...' : ''}")`);
-
-      if (threadRequest?.mode === 'plan') {
-        messageText = await this.withThreadContext(channel, msg.thread_ts, messageText);
-      }
-      await this.handleConversationMessage(conversation, messageText, msg.thread_ts, say, channel);
+      this.log('slack', 'info', `[PASSIVE_THREAD_CONTEXT] thread_ts=${msg.thread_ts} user=${msg.user} preview="${text.slice(0, 100)}${text.length > 100 ? '...' : ''}"`);
     });
   }
 
@@ -1948,6 +1898,7 @@ ${text}`;
     threadTs: string,
     say: SayFn,
     channel: string = this.lobbyChannelId,
+    sourceEventTs?: string,
   ): Promise<void> {
     const tEntry = Date.now();
     this.log('slack', 'info', `[TRACE] handleConversationMessage (thread_ts=${threadTs}, text="${text.slice(0, 80)}")`);
@@ -1996,10 +1947,15 @@ ${text}`;
         await this.stopTypingIndicator(channel, threadTs);
       }
 
-      const chunks = splitForSlack(sanitizeSlackOutbound(reply));
+      const renderedReply = conversation.conversationMode === 'plan'
+        && conversation.getDraftedPlan()
+        && !reply.includes('Reply `submit` to submit it.')
+        ? `${reply.trimEnd()}\n\nReply \`submit\` to submit it.`
+        : reply;
+      const chunks = splitForSlack(sanitizeSlackOutbound(renderedReply));
       const revision = process.env.INVOKER_REVISION ?? process.env.GIT_COMMIT ?? 'unknown';
       this.log('slack', 'info',
-        `[RESPONSE_PROVENANCE] thread_ts=${threadTs} mode=${conversation.conversationMode} revision=${revision} reply_chars=${reply.length} chunks=${chunks.length}`);
+        `[RESPONSE_PROVENANCE] thread_ts=${threadTs} source_event_ts=${sourceEventTs ?? threadTs} mode=${conversation.conversationMode} revision=${revision} reply_chars=${renderedReply.length} chunks=${chunks.length}`);
 
       const ackTs = this.ackMessages.get(threadTs);
       if (ackTs) {

--- a/packages/surfaces/tsup.config.ts
+++ b/packages/surfaces/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     '@invoker/contracts',
     '@invoker/data-store',
     '@invoker/execution-engine',
+    '@invoker/planning-core',
     '@invoker/transport',
     'yaml',
   ],


### PR DESCRIPTION
## Summary

The Slack surface bundle now includes `@invoker/planning-core`.

This stops the production Slack manager from loading workspace TypeScript sources at runtime.

## Review Claim

Approve bundling the shared planning package into the Slack surface runtime artifact.

## Review Lane

cleanup

## Review Unit

cleanup

## Safety Invariant

Behavior unchanged. The Slack manager loads the same lifecycle code from its built artifact.

## Slice Rationale

Packaging cleanup follows the Slack adapter so it stays a single-file deployment concern.

## Non-goals

- Behavior unchanged.
- Does not alter planning authorization or Slack message routing.
- Does not modify the planner protocol.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces build`
- [x] Built bundle does not leave a runtime import of `@invoker/planning-core`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert HEAD`
- Post-revert steps: Restart the Slack manager only if this revision has been deployed.
- Data migration? No

</details>

Depends-On: #5515