### PR TITLE
[Purge Auto-Follow Camera Lock](1) Bootstrap UI Vitest runner

### DIFF
--- a/packages/ui/scripts/run-vitest.mjs
+++ b/packages/ui/scripts/run-vitest.mjs
@@ -1,11 +1,67 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const scriptDir = dirname(fileURLToPath(import.meta.url));
 
 const forwardedArgs = process.argv.slice(2);
 const vitestArgs = forwardedArgs[0] === "--" ? forwardedArgs.slice(1) : forwardedArgs;
 
-const child = spawn("vitest", ["run", ...vitestArgs], {
+function findRepoRoot(startDir) {
+  let current = startDir;
+  while (true) {
+    if (existsSync(join(current, "pnpm-lock.yaml"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function resolveVitestBin() {
+  try {
+    const packageJsonPath = require.resolve("vitest/package.json");
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    const binPath = typeof packageJson.bin === "string" ? packageJson.bin : packageJson.bin?.vitest;
+    return join(dirname(packageJsonPath), binPath ?? "vitest.mjs");
+  } catch {
+    return null;
+  }
+}
+
+function ensureVitestInstalled() {
+  if (resolveVitestBin()) return;
+
+  const repoRoot = findRepoRoot(scriptDir);
+  if (!repoRoot) return;
+
+  console.error("[run-vitest] Vitest is not installed; running pnpm install --frozen-lockfile...");
+  const install = spawnSync("pnpm", ["install", "--frozen-lockfile"], {
+    cwd: repoRoot,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+
+  if (install.error) {
+    console.error(install.error);
+    process.exit(1);
+  }
+
+  if (install.status !== 0) {
+    process.exit(install.status ?? 1);
+  }
+}
+
+ensureVitestInstalled();
+
+const vitestBin = resolveVitestBin();
+const command = vitestBin ? process.execPath : "vitest";
+const args = vitestBin ? [vitestBin, "run", ...vitestArgs] : ["run", ...vitestArgs];
+const child = spawn(command, args, {
   stdio: "inherit",
-  shell: process.platform === "win32",
+  shell: !vitestBin && process.platform === "win32",
 });
 
 child.on("error", (error) => {


### PR DESCRIPTION
## Summary

Fresh merge clones now invoke Vitest through the workspace-local binary.

If the binary is missing, the runner installs from the frozen lockfile before starting.

## Review Claim

Approve the UI package runner bootstrap for invoking local Vitest reliably.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only `packages/ui/scripts/run-vitest.mjs` changes. Argument forwarding and process exit status still come from Vitest.

## Slice Rationale

This lands first so every later command uses the same runner entrypoint.

## Non-goals

- No UI rendering behavior changes.
- No package versions or lockfiles change.
- No test assertions change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/ui test -- src/__tests__/graph-camera.test.ts src/__tests__/keyboard-controls.test.tsx src/__tests__/browser-surface-camera-resnap.test.tsx`
- [x] `pnpm --filter @invoker/ui test`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/purge-auto-follow-pr-proof/pr1.md --require-visual-proof --changed-files-file /tmp/pr1-files.txt --diff-file /tmp/pr1-diff.patch`

</details>

## Visual Proof

![Runner bootstrap proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260722-d13c0d/runner-bootstrap-proof.svg)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 2f167cb49`
- Post-revert steps: Re-run the file-scoped UI Vitest command with the previous runner behavior.
- Data migration? No.

</details>

## Workflow Summary

Purge Auto-Follow Camera Lock — 4 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784693010203-2/purge-auto-follow | Remove selection-driven camera moves; camera moves only on explicit commands | completed |
| wf-1784693010203-2/verify-purge-grep | Prove no auto-follow identifiers survive in packages/ui/src | completed (passed) |
| wf-1784693010203-2/verify-camera-tests | Run the three rewritten camera test files | completed (passed) |
| wf-1784693010203-2/verify-ui-suite | Full @invoker/ui vitest suite as the final gate | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784693010203-2/purge-auto-follow — Remove selection-driven camera moves; camera moves only on explicit commands

### wf-1784693010203-2/verify-purge-grep — Prove no auto-follow identifiers survive in packages/ui/src

### wf-1784693010203-2/verify-camera-tests — Run the three rewritten camera test files

### wf-1784693010203-2/verify-ui-suite — Full @invoker/ui vitest suite as the final gate

</details>
