### PR TITLE
[Purge Auto-Follow Camera Lock](3) Document camera-lock purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Invoker will be documented in this file.
 
 ## Unreleased
 
+- Stop graph node selection from moving the camera. Clicking a workflow or task node now changes only selection/focus; camera movement is limited to explicit fit/framing commands, Home navigation, and F1 as a one-shot center-on-selection. The persisted camera-lock preference has been removed, and stale `localStorage` entries are ignored.
+
 - Make SSH pool capacity lease-backed. Member admission for SSH hosts is decided by unexpired host-keyed rows in `execution_resource_leases` (claimed at select time, counted up to `maxConcurrentTasksPerMember`), not by in-memory `activeExecutions` / `pendingPoolSelections` ghosts. Worktree members still use in-memory load. Inspect live holders with `./run.sh --headless query execution-leases` (owner-delegated). Reclaim helpers still kill orphan executors, but they are no longer the capacity safety net. Gate regressions with `bash scripts/repro/repro-ssh-lease-capacity-battery.sh --gate`.
 
 - Stop auto-starting the `workflow-resume` worker. It is removed from `AUTO_STARTED_OWNER_WORKER_KINDS`, so the owner no longer launches it on boot; it stays registered and startable on demand from the Workers tab. Guarded by an updated `worker-control` auto-start assertion (`stopped` but `startable`).

--- a/packages/ui/scripts/run-vitest.mjs
+++ b/packages/ui/scripts/run-vitest.mjs
@@ -1,11 +1,67 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const scriptDir = dirname(fileURLToPath(import.meta.url));
 
 const forwardedArgs = process.argv.slice(2);
 const vitestArgs = forwardedArgs[0] === "--" ? forwardedArgs.slice(1) : forwardedArgs;
 
-const child = spawn("vitest", ["run", ...vitestArgs], {
+function findRepoRoot(startDir) {
+  let current = startDir;
+  while (true) {
+    if (existsSync(join(current, "pnpm-lock.yaml"))) return current;
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function resolveVitestBin() {
+  try {
+    const packageJsonPath = require.resolve("vitest/package.json");
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    const binPath = typeof packageJson.bin === "string" ? packageJson.bin : packageJson.bin?.vitest;
+    return join(dirname(packageJsonPath), binPath ?? "vitest.mjs");
+  } catch {
+    return null;
+  }
+}
+
+function ensureVitestInstalled() {
+  if (resolveVitestBin()) return;
+
+  const repoRoot = findRepoRoot(scriptDir);
+  if (!repoRoot) return;
+
+  console.error("[run-vitest] Vitest is not installed; running pnpm install --frozen-lockfile...");
+  const install = spawnSync("pnpm", ["install", "--frozen-lockfile"], {
+    cwd: repoRoot,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+  });
+
+  if (install.error) {
+    console.error(install.error);
+    process.exit(1);
+  }
+
+  if (install.status !== 0) {
+    process.exit(install.status ?? 1);
+  }
+}
+
+ensureVitestInstalled();
+
+const vitestBin = resolveVitestBin();
+const command = vitestBin ? process.execPath : "vitest";
+const args = vitestBin ? [vitestBin, "run", ...vitestArgs] : ["run", ...vitestArgs];
+const child = spawn(command, args, {
   stdio: "inherit",
-  shell: process.platform === "win32",
+  shell: !vitestBin && process.platform === "win32",
 });
 
 child.on("error", (error) => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -64,9 +64,6 @@ import {
 } from './isExperimentSpawnPivot.js';
 import {
   createGraphCameraCommandIssuer,
-  loadCameraLockPreference,
-  saveCameraLockPreference,
-  type CameraLockPreference,
   type GraphCameraCommand,
   type GraphCameraCommandInput,
   type GraphCameraCommandIssuer,
@@ -824,6 +821,8 @@ export function App() {
   const [sidebarSurface, setSidebarSurface] = useState<SidebarSurface>('home');
   const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const selectedTaskIdRef = useRef<string | null>(selectedTaskId);
+  selectedTaskIdRef.current = selectedTaskId;
   const [selectedWorkerKind, setSelectedWorkerKind] = useState<string | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
   const [reviewGateByWorkflowId, setReviewGateByWorkflowId] = useState<Record<string, ReviewGateQueryResponse | null>>({});
@@ -927,18 +926,6 @@ export function App() {
     cameraIssuerRef.current = createGraphCameraCommandIssuer();
   }
   const [cameraCommand, setCameraCommand] = useState<GraphCameraCommand | null>(null);
-  const [cameraPreference, setCameraPreference] = useState<CameraLockPreference>(() =>
-    loadCameraLockPreference(),
-  );
-  // Mirror preference into a ref so event handlers read the live value without
-  // being re-created on every preference change.
-  const cameraPreferenceRef = useRef(cameraPreference);
-  useEffect(() => {
-    cameraPreferenceRef.current = cameraPreference;
-  }, [cameraPreference]);
-  // Temporary, non-persisted suppression of the camera lock after a manual pan
-  // or wheel zoom. The next explicit node selection clears it.
-  const cameraSuppressedRef = useRef(false);
   const workflowGraphViewportRef = useRef<GraphCameraViewport | null>(null);
   const [bottomStatusIndex, setBottomStatusIndex] = useState(0);
   const [searchOpen, setSearchOpen] = useState(false);
@@ -1605,21 +1592,6 @@ export function App() {
     return command;
   }, []);
 
-  // An explicit node selection (mouse click or arrow key) clears any temporary
-  // manual suppression and re-centers the targeted graph when the lock is on.
-  const recenterForSelection = useCallback((scope: GraphScope, target: string) => {
-    cameraSuppressedRef.current = false;
-    if (cameraPreferenceRef.current.enabled) {
-      issueCameraCommand({ kind: 'centerSelection', scope, target, reason: 'selection' });
-    }
-  }, [issueCameraCommand]);
-
-  // A manual pan or wheel zoom temporarily suppresses the lock and must not
-  // autofocus the graph — no camera command is issued here.
-  const handleManualViewport = useCallback(() => {
-    cameraSuppressedRef.current = true;
-  }, []);
-
   const handleWorkflowGraphViewportSnapshot = useCallback((viewport: GraphCameraViewport) => {
     workflowGraphViewportRef.current = viewport;
   }, []);
@@ -1644,9 +1616,8 @@ export function App() {
     setSelectedTaskId(null);
     setContextMenu(null);
     setWorkflowContextMenu(null);
-    recenterForSelection('workflow', workflowId);
     focusKeyboardRegion('workflowGraph');
-  }, [armSuppressDagSurfaceDismiss, focusKeyboardRegion, recenterForSelection]);
+  }, [armSuppressDagSurfaceDismiss, focusKeyboardRegion]);
 
   const selectTaskById = useCallback((taskId: string) => {
     const task = tasksRef.current.get(taskId);
@@ -1660,9 +1631,8 @@ export function App() {
     setInspectorManualOpen(true);
     setContextMenu(null);
     setWorkflowContextMenu(null);
-    recenterForSelection('task', task.id);
     focusKeyboardRegion('taskGraph');
-  }, [focusKeyboardRegion, recenterForSelection]);
+  }, [focusKeyboardRegion]);
 
   useEffect(() => {
     const unsubscribe = window.invoker?.onWorkflowMutationFailed?.((event) => {
@@ -1798,28 +1768,15 @@ export function App() {
       }
       if (isEditableKeyboardTarget(event.target) || modal.type !== 'none') return;
 
-      // F1 is the keyboard-only camera lock control. It is already ignored for
-      // input/modal/terminal/editable targets by the guard above.
+      // F1 is the keyboard-only one-shot center on selection. It is already
+      // ignored for input/modal/terminal/editable targets by the guard above.
       if (event.key === 'F1') {
         event.preventDefault();
         const inTaskGraph = keyboardRegion === 'taskGraph';
         const scope: GraphScope = inTaskGraph ? 'task' : 'workflow';
         const target = inTaskGraph ? selectedTaskId : (selectedWorkflow?.id ?? selectedWorkflowId);
-        const preference = cameraPreferenceRef.current;
-        cameraSuppressedRef.current = false;
-        if (preference.mode === 'toggle') {
-          // Toggle mode flips the lock; enabling it immediately centers the
-          // current selection.
-          const nextEnabled = !preference.enabled;
-          const nextPreference: CameraLockPreference = { mode: preference.mode, enabled: nextEnabled };
-          setCameraPreference(nextPreference);
-          saveCameraLockPreference(nextPreference);
-          if (nextEnabled && target) {
-            issueCameraCommand({ kind: 'centerSelection', scope, target, reason: 'f1-toggle-enable' });
-          }
-        } else if (target) {
-          // Once mode centers a single time without changing the preference.
-          issueCameraCommand({ kind: 'centerSelection', scope, target, reason: 'f1-once' });
+        if (target) {
+          issueCameraCommand({ kind: 'centerSelection', scope, target, reason: 'f1-center' });
         }
         return;
       }
@@ -2034,8 +1991,7 @@ export function App() {
     setSelectedTaskId(null);
     setContextMenu(null);
     setWorkflowContextMenu(null);
-    recenterForSelection('workflow', workflowId);
-  }, [armSuppressDagSurfaceDismiss, recenterForSelection]);
+  }, [armSuppressDagSurfaceDismiss]);
 
   const handleWorkflowContextMenu = useCallback((event: React.MouseEvent<Element>, workflowId: string) => {
     event.preventDefault();
@@ -2116,6 +2072,7 @@ export function App() {
       if (cancelled) return;
       issueCameraCommand({ kind: 'fitInitial', scope: 'task', reason: 'browser-surface' });
 
+      const selectedTaskId = selectedTaskIdRef.current;
       if (!selectedTaskId) return;
       requestAnimationFrame(() => {
         if (cancelled) return;
@@ -2132,7 +2089,6 @@ export function App() {
     };
   }, [
     issueCameraCommand,
-    selectedTaskId,
     selectedWorkflowGraphAvailable,
     sidebarSurface,
     viewMode,
@@ -2612,7 +2568,6 @@ export function App() {
         }));
         await refreshTaskGraph();
         workflowGraphViewportRef.current = null;
-        cameraSuppressedRef.current = false;
         appendTerminalLine(
           result.workflowCount && result.workflowCount > 1
             ? `Plan "${result.planName}" submitted as ${result.workflowCount} stacked workflows. Review them, then use Start ready work.`
@@ -3054,7 +3009,6 @@ export function App() {
 
     if (options.fit) {
       workflowGraphViewportRef.current = null;
-      cameraSuppressedRef.current = false;
       issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason });
       return;
     }
@@ -3547,7 +3501,6 @@ export function App() {
           onTaskClick={handleTaskClick}
           onTaskDoubleClick={handleTaskDoubleClick}
           onTaskContextMenu={handleTaskContextMenu}
-          onManualViewport={handleManualViewport}
           statusFilters={new Set<string>()}
           runningTaskIds={runningTaskIds}
           surfaceMode={floating ? 'default' : 'browser'}
@@ -3646,7 +3599,6 @@ export function App() {
                 onSelectWorkflow={handleWorkflowClick}
                 onWorkflowContextMenu={handleWorkflowContextMenu}
                 onViewportSnapshot={handleWorkflowGraphViewportSnapshot}
-                onManualViewport={handleManualViewport}
               />
             </div>
           )}
@@ -4500,7 +4452,6 @@ export function App() {
                 onTaskClick={handleTaskClick}
                 onTaskDoubleClick={handleTaskDoubleClick}
                 onTaskContextMenu={handleTaskContextMenu}
-                onManualViewport={handleManualViewport}
                 statusFilters={new Set<string>()}
                 runningTaskIds={runningTaskIds}
                 surfaceMode="overlay"
@@ -4516,7 +4467,6 @@ export function App() {
                 onSelectWorkflow={handleWorkflowClick}
                 onWorkflowContextMenu={handleWorkflowContextMenu}
                 onViewportSnapshot={handleWorkflowGraphViewportSnapshot}
-                onManualViewport={handleManualViewport}
               />
             )}
           </div>

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -6,9 +6,8 @@
  * `displayedSelectedWorkflowGraph`, which is a brand-new object on every streamed
  * task delta. Each tick therefore re-issued fitInitial + centerSelection and
  * yanked the viewport back to the selection while the user was panning the graph.
- * The effect now keys off a stable "graph available" boolean, so a live update
- * that changes neither the selection nor the graph topology issues no camera
- * command.
+ * The effect now keys off stable surface-entry signals, so live updates and
+ * selection changes while already on the surface issue no camera command.
  *
  * The effect is shared by every non-home browser surface (its guard only excludes
  * `home`), so this drives the Workflows surface — the jsdom harness cannot render
@@ -102,19 +101,6 @@ describe('Browser-surface camera (component)', () => {
   let mock: MockInvoker;
 
   beforeEach(() => {
-    // jsdom here ships without localStorage; App persists the camera lock there.
-    const store = new Map<string, string>();
-    Object.defineProperty(globalThis, 'localStorage', {
-      configurable: true,
-      value: {
-        getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
-        setItem: (k: string, v: string) => { store.set(k, String(v)); },
-        removeItem: (k: string) => { store.delete(k); },
-        clear: () => { store.clear(); },
-        key: (i: number) => [...store.keys()][i] ?? null,
-        get length() { return store.size; },
-      },
-    });
     mock = createMockInvoker();
     mock.install();
     fitViewMock.mockClear();
@@ -129,17 +115,16 @@ describe('Browser-surface camera (component)', () => {
 
   afterEach(() => {
     mock.cleanup();
-    delete (globalThis as { localStorage?: unknown }).localStorage;
   });
 
   it('does not re-center or re-fit on a live task update that leaves selection and topology unchanged', async () => {
     mock.setTasks(tasks, workflows);
     render(<App />);
 
-    // Open the Workflows browser surface and select a task node so the camera
-    // lock has a target. The initial framing is intentionally drained below
-    // instead of asserted as a setup requirement; jsdom can coalesce that camera
-    // move differently under the full parallel Vitest run.
+    // Open the Workflows browser surface and select a task node. The initial
+    // framing is intentionally drained below instead of asserted as a setup
+    // requirement; jsdom can coalesce that camera move differently under the
+    // full parallel Vitest run.
     fireEvent.click(await screen.findByTestId('sidebar-workflows'));
     await screen.findByTestId('selected-workflow-mini-dag');
     fireEvent.click(await screen.findByTestId('rf__node-wf-a/one'));
@@ -170,6 +155,29 @@ describe('Browser-surface camera (component)', () => {
     expect(setCenterMock).not.toHaveBeenCalled();
     expect(fitViewMock).not.toHaveBeenCalled();
   });
+
+  it('does not re-center or re-fit when the selected task changes while already on a browser surface', async () => {
+    mock.setTasks(tasks, workflows);
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId('sidebar-workflows'));
+    await screen.findByTestId('selected-workflow-mini-dag');
+    fireEvent.click(await screen.findByTestId('rf__node-wf-a/one'));
+    await settleCamera();
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+
+    fireEvent.click(screen.getByTestId('rf__node-wf-a/two'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Task Two');
+    });
+    await flushFrames(6);
+
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(fitViewMock).not.toHaveBeenCalled();
+  });
+
   it('clicking the left-nav home icon returns to the workflow graph and issues the Home fit command', async () => {
     mock.setTasks(tasks, workflows);
     render(<App />);

--- a/packages/ui/src/__tests__/graph-camera.test.ts
+++ b/packages/ui/src/__tests__/graph-camera.test.ts
@@ -1,121 +1,18 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
-  CAMERA_LOCK_PREFERENCE_STORAGE_KEY,
-  DEFAULT_CAMERA_LOCK_PREFERENCE,
   createGraphCameraCommandIssuer,
-  isCameraMode,
   isGraphScope,
-  loadCameraLockPreference,
-  saveCameraLockPreference,
-  type CameraLockPreference,
-  type PreferenceStorage,
 } from '../lib/graph-camera.js';
 
-/** In-memory storage double matching the {@link PreferenceStorage} surface. */
-function createMemoryStorage(seed?: Record<string, string>): PreferenceStorage & {
-  raw: Map<string, string>;
-} {
-  const raw = new Map<string, string>(Object.entries(seed ?? {}));
-  return {
-    raw,
-    getItem: (key) => (raw.has(key) ? (raw.get(key) as string) : null),
-    setItem: (key, value) => {
-      raw.set(key, value);
-    },
-  };
-}
-
-describe('graph-camera defaults', () => {
-  it('defaults to toggle mode with the lock enabled', () => {
-    expect(DEFAULT_CAMERA_LOCK_PREFERENCE.mode).toBe('toggle');
-    expect(DEFAULT_CAMERA_LOCK_PREFERENCE.enabled).toBe(true);
-  });
-
-  it('freezes the default so callers cannot mutate the shared constant', () => {
-    expect(Object.isFrozen(DEFAULT_CAMERA_LOCK_PREFERENCE)).toBe(true);
-  });
-
-  it('returns the default for empty storage', () => {
-    const storage = createMemoryStorage();
-    expect(loadCameraLockPreference(storage)).toEqual({ mode: 'toggle', enabled: true });
-  });
-
-  it('returns a fresh copy, not the shared frozen default', () => {
-    const loaded = loadCameraLockPreference(createMemoryStorage());
-    expect(loaded).not.toBe(DEFAULT_CAMERA_LOCK_PREFERENCE);
-    expect(Object.isFrozen(loaded)).toBe(false);
-  });
-});
-
 describe('graph-camera type guards', () => {
-  it('recognizes valid camera modes and scopes', () => {
-    expect(isCameraMode('toggle')).toBe(true);
-    expect(isCameraMode('once')).toBe(true);
+  it('recognizes valid graph scopes', () => {
     expect(isGraphScope('workflow')).toBe(true);
     expect(isGraphScope('task')).toBe(true);
   });
 
-  it('rejects invalid camera modes and scopes', () => {
-    expect(isCameraMode('always')).toBe(false);
-    expect(isCameraMode(undefined)).toBe(false);
-    expect(isCameraMode(2)).toBe(false);
+  it('rejects invalid graph scopes', () => {
     expect(isGraphScope('graph')).toBe(false);
     expect(isGraphScope(null)).toBe(false);
-  });
-});
-
-describe('graph-camera persistence', () => {
-  it('loads a valid persisted preference', () => {
-    const stored: CameraLockPreference = { mode: 'once', enabled: false };
-    const storage = createMemoryStorage({
-      [CAMERA_LOCK_PREFERENCE_STORAGE_KEY]: JSON.stringify(stored),
-    });
-    expect(loadCameraLockPreference(storage)).toEqual(stored);
-  });
-
-  it('round-trips through save and load', () => {
-    const storage = createMemoryStorage();
-    const preference: CameraLockPreference = { mode: 'once', enabled: false };
-
-    expect(saveCameraLockPreference(preference, storage)).toBe(true);
-    expect(storage.raw.has(CAMERA_LOCK_PREFERENCE_STORAGE_KEY)).toBe(true);
-    expect(loadCameraLockPreference(storage)).toEqual(preference);
-  });
-
-  it.each([
-    ['not json at all', 'this is not json{'],
-    ['a json primitive', '42'],
-    ['a json null', 'null'],
-    ['a json array', '[]'],
-    ['an unknown mode', JSON.stringify({ mode: 'always', enabled: true })],
-    ['a non-boolean enabled', JSON.stringify({ mode: 'toggle', enabled: 'yes' })],
-    ['a missing mode', JSON.stringify({ enabled: true })],
-    ['a missing enabled', JSON.stringify({ mode: 'toggle' })],
-  ])('falls back to defaults for malformed storage: %s', (_label, rawValue) => {
-    const storage = createMemoryStorage({
-      [CAMERA_LOCK_PREFERENCE_STORAGE_KEY]: rawValue,
-    });
-    expect(loadCameraLockPreference(storage)).toEqual(DEFAULT_CAMERA_LOCK_PREFERENCE);
-  });
-
-  it('falls back to defaults when storage getItem throws', () => {
-    const throwingStorage: PreferenceStorage = {
-      getItem: () => {
-        throw new Error('storage disabled');
-      },
-      setItem: () => {},
-    };
-    expect(loadCameraLockPreference(throwingStorage)).toEqual(DEFAULT_CAMERA_LOCK_PREFERENCE);
-  });
-
-  it('reports failure when saving to storage that throws', () => {
-    const throwingStorage: PreferenceStorage = {
-      getItem: () => null,
-      setItem: () => {
-        throw new Error('quota exceeded');
-      },
-    };
-    expect(saveCameraLockPreference({ mode: 'toggle', enabled: true }, throwingStorage)).toBe(false);
   });
 });
 

--- a/packages/ui/src/__tests__/keyboard-controls.test.tsx
+++ b/packages/ui/src/__tests__/keyboard-controls.test.tsx
@@ -9,7 +9,6 @@ import { describe, it, expect, beforeEach, afterEach, type Mock } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
-import { CAMERA_LOCK_PREFERENCE_STORAGE_KEY } from '../lib/graph-camera.js';
 import type { WorkflowMeta } from '../types.js';
 import * as ReactFlowModule from '@xyflow/react';
 
@@ -488,13 +487,13 @@ describe('Sidebar keyboard navigation (component)', () => {
 });
 
 /**
- * Camera-lock keyboard/mouse contract at the App level. These prove the App
- * owns camera intent (selection, active scope, lock preference, suppression)
- * and that React Flow only moves when the App issues a typed command. Each
- * setCenter call here flows from App → the correctly-scoped graph component.
+ * Graph camera keyboard/mouse contract at the App level. These prove the App
+ * owns camera intent: selection never moves the viewport, and React Flow only
+ * moves when the App issues a typed command for an explicit camera action.
  */
-describe('Camera lock controls (component)', () => {
+describe('Graph camera controls (component)', () => {
   let mock: MockInvoker;
+  let localStorageSetItemMock: Mock;
   /** Active getBoundingClientRect spy, restored after each test. */
   let rectSpy: ReturnType<typeof vi.spyOn> | null = null;
 
@@ -511,15 +510,15 @@ describe('Camera lock controls (component)', () => {
   ];
 
   beforeEach(() => {
-    // jsdom in this project ships without localStorage, but the App persists
-    // the camera-lock preference there. Install a fresh in-memory shim so seeded
-    // preferences load and toggles round-trip within a test.
+    // App's theme hook touches localStorage; keep a shim so F1 can assert it
+    // does not perform storage writes after the initial render settles.
     const store = new Map<string, string>();
+    localStorageSetItemMock = vi.fn((k: string, v: string) => { store.set(k, String(v)); });
     Object.defineProperty(globalThis, 'localStorage', {
       configurable: true,
       value: {
         getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
-        setItem: (k: string, v: string) => { store.set(k, String(v)); },
+        setItem: localStorageSetItemMock,
         removeItem: (k: string) => { store.delete(k); },
         clear: () => { store.clear(); },
         key: (i: number) => [...store.keys()][i] ?? null,
@@ -544,7 +543,7 @@ describe('Camera lock controls (component)', () => {
   /**
    * Render the App, wait for both graph surfaces to finish their initial fit,
    * then clear the viewport spies so a test asserts only on post-mount camera
-   * moves. Seed localStorage BEFORE calling this to control the lock.
+   * moves.
    */
   async function renderAndSettle(
     wfs: WorkflowMeta[] = workflows,
@@ -562,6 +561,7 @@ describe('Camera lock controls (component)', () => {
     await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
     fitViewMock.mockClear();
     setCenterMock.mockClear();
+    localStorageSetItemMock.mockClear();
   }
 
   /** Flush a single animation frame so any scheduled camera move can run. */
@@ -597,45 +597,33 @@ describe('Camera lock controls (component)', () => {
     );
   }
 
-  it('F1 toggle mode defaults on, toggles off then on, and re-centers the selection when re-enabled', async () => {
+  it('F1 issues exactly one centerSelection for the selected node in the focused region', async () => {
     await renderAndSettle();
 
-    // Default region is the workflow graph with wf-a selected. The lock is on
-    // by default, so the first F1 toggles it OFF (no camera move).
-    key('F1');
-    await flushFrame();
-    expect(setCenterMock).not.toHaveBeenCalled();
-
-    // The second F1 toggles the lock back ON and immediately centers wf-a.
     key('F1');
     await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(1));
-    // Lock-driven centering preserves zoom; it never whole-graph fits.
+    expect(setCenterMock).toHaveBeenCalledWith(190, 125, { zoom: 1, duration: 180 });
     expect(fitViewMock).not.toHaveBeenCalled();
-    // The toggled preference is persisted.
-    expect(JSON.parse(localStorage.getItem(CAMERA_LOCK_PREFERENCE_STORAGE_KEY)!)).toEqual({
-      mode: 'toggle',
-      enabled: true,
-    });
   });
 
-  it('F1 once mode centers once without changing the lock preference', async () => {
-    localStorage.setItem(
-      CAMERA_LOCK_PREFERENCE_STORAGE_KEY,
-      JSON.stringify({ mode: 'once', enabled: true }),
-    );
+  it('a second F1 press issues another one-shot center instead of toggling off', async () => {
     await renderAndSettle();
 
     key('F1');
     await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(1));
-    // Once mode must not rewrite the persisted preference.
-    expect(JSON.parse(localStorage.getItem(CAMERA_LOCK_PREFERENCE_STORAGE_KEY)!)).toEqual({
-      mode: 'once',
-      enabled: true,
-    });
 
-    // Once mode re-centers on each press (it never disables the lock).
     key('F1');
     await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(2));
+    expect(fitViewMock).not.toHaveBeenCalled();
+  });
+
+  it('F1 does not write to localStorage', async () => {
+    await renderAndSettle();
+
+    key('F1');
+    await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(1));
+
+    expect(localStorageSetItemMock).not.toHaveBeenCalled();
   });
 
   it('a manual background pan or wheel does not autofocus the graph', async () => {
@@ -650,35 +638,40 @@ describe('Camera lock controls (component)', () => {
     expect(fitViewMock).not.toHaveBeenCalled();
   });
 
-  it('clicking a workflow node centers it when the lock is enabled', async () => {
+  it('clicking a workflow node selects it without centering the camera', async () => {
     await renderAndSettle();
 
     fireEvent.click(screen.getByTestId('workflow-node-wf-b'));
 
-    // Selecting wf-b re-centers the workflow graph on it. (A fresh mini-dag for
-    // wf-b legitimately fits once on mount, so we assert only the recenter.)
-    await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(1));
-  });
-
-  it('clicking a workflow node does not center when the lock is disabled', async () => {
-    localStorage.setItem(
-      CAMERA_LOCK_PREFERENCE_STORAGE_KEY,
-      JSON.stringify({ mode: 'toggle', enabled: false }),
-    );
-    await renderAndSettle();
-
-    fireEvent.click(screen.getByTestId('workflow-node-wf-b'));
-
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Beta Workflow task DAG');
+    });
     await flushFrame();
     expect(setCenterMock).not.toHaveBeenCalled();
   });
 
-  it('arrow navigation re-centers the newly selected node when the lock is enabled', async () => {
+  it('clicking a task node selects it without centering the camera', async () => {
+    await renderAndSettle();
+
+    fireEvent.click(screen.getByTestId('rf__node-wf-a/task-b'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Second Task');
+    });
+    await flushFrame();
+    expect(setCenterMock).not.toHaveBeenCalled();
+  });
+
+  it('arrow navigation selects the newly targeted node without centering the camera', async () => {
     await renderAndSettle();
 
     key('ArrowRight');
 
-    await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Beta Workflow task DAG');
+    });
+    await flushFrame();
+    expect(setCenterMock).not.toHaveBeenCalled();
   });
 
   it('keyboard-opened workflow menu handles arrows and restores workflow graph control', async () => {
@@ -713,7 +706,8 @@ describe('Camera lock controls (component)', () => {
     await waitFor(() => {
       expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Beta Workflow task DAG');
     });
-    await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(1));
+    await flushFrame();
+    expect(setCenterMock).not.toHaveBeenCalled();
   });
 
   it('keyboard-opened task menu handles arrows and restores task graph control', async () => {
@@ -724,7 +718,8 @@ describe('Camera lock controls (component)', () => {
     await waitFor(() => {
       expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Second Task');
     });
-    await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(1));
+    await flushFrame();
+    expect(setCenterMock).not.toHaveBeenCalled();
     fitViewMock.mockClear();
     setCenterMock.mockClear();
 
@@ -758,7 +753,8 @@ describe('Camera lock controls (component)', () => {
     await waitFor(() => {
       expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Alpha Task');
     });
-    await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(1));
+    await flushFrame();
+    expect(setCenterMock).not.toHaveBeenCalled();
   });
 
   it('arrow navigation selects the geometrically nearest node, not the alphabetical neighbor', async () => {
@@ -792,19 +788,20 @@ describe('Camera lock controls (component)', () => {
       'workflow-node-wf-c': 400,
     });
 
-    // Select the rightmost node first, and wait for its recenter to fire so the
-    // pending animation frame can't leak into the assertion below.
+    // Select the rightmost node first, and drain frames so any accidental
+    // selection-driven camera move would be caught before the boundary check.
     fireEvent.click(screen.getByTestId('workflow-node-wf-c'));
     await waitFor(() => {
       expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Gamma Workflow task DAG');
     });
-    await waitFor(() => expect(setCenterMock).toHaveBeenCalled());
+    await flushFrame();
+    expect(setCenterMock).not.toHaveBeenCalled();
     setCenterMock.mockClear();
 
     key('ArrowRight');
 
     await flushFrame();
-    // Selection unchanged and no recenter was issued.
+    // Selection unchanged and no center command was issued.
     expect(setCenterMock).not.toHaveBeenCalled();
     expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Gamma Workflow task DAG');
   });

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -184,6 +184,8 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
   const browserRemountDoneRef = useRef(false);
   const initFitFrameRef = useRef(0);
   const nodesRef = useRef<typeof nodes>([]);
+  const selectedTaskIdRef = useRef<string | null>(selectedTaskId ?? null);
+  selectedTaskIdRef.current = selectedTaskId ?? null;
   const [layoutState, setLayoutState] = useState<LayoutState | null>(null);
   const lastLayoutRef = useRef<TaskGraphLayout | null>(null);
   const [flowInstanceKey, setFlowInstanceKey] = useState(0);
@@ -523,6 +525,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
     const frame = requestAnimationFrame(() => {
       if (cancelled) return;
       fitView({ padding: 0.2 });
+      const selectedTaskId = selectedTaskIdRef.current;
       if (!selectedTaskId) return;
       const node = nodesRef.current.find((candidate) => candidate.id === selectedTaskId);
       if (!node) return;
@@ -537,7 +540,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
       cancelled = true;
       cancelAnimationFrame(frame);
     };
-  }, [fitView, getZoom, rawGraph.layoutKey, selectedTaskId, setCenter, surfaceMode]);
+  }, [fitView, getZoom, rawGraph.layoutKey, setCenter, surfaceMode]);
 
   useEffect(() => {
     if (surfaceMode !== 'browser' || nodesRef.current.length === 0 || browserRemountDoneRef.current) return;

--- a/packages/ui/src/lib/graph-camera.ts
+++ b/packages/ui/src/lib/graph-camera.ts
@@ -4,37 +4,18 @@
  *
  * This module is the single source of truth for:
  *  - which graph a camera command targets (`GraphScope`),
- *  - whether the camera re-centres on every selection or only once
- *    (`CameraMode`),
- *  - the persisted camera-lock preference (`CameraLockPreference`),
  *  - one-shot viewport commands (`GraphCameraCommand`), and
  *  - the monotonic command sequence.
  *
  * Crucially, the monotonic `sequence` only ever increments inside the issuer
  * returned by {@link createGraphCameraCommandIssuer}. No App-level selection
- * handler should keep its own `event++` / `requestId++` counter — they consume
- * commands from an issuer instead. React Flow keeps owning x/y/zoom locally;
- * these commands are intent ("centre this selection"), not a controlled
- * viewport.
+ * handler should keep its own `event++` / `requestId++` counter. Selection
+ * alone is not a camera command: React Flow keeps owning x/y/zoom locally, and
+ * the App issues commands only for explicit navigation/framing intents.
  */
 
 /** Which graph a camera command applies to. */
 export type GraphScope = 'workflow' | 'task';
-
-/**
- * How aggressively the camera follows selection.
- *  - `toggle`: re-centre whenever the selection changes (lock stays on).
- *  - `once`: centre a single time, then release until re-armed.
- */
-export type CameraMode = 'toggle' | 'once';
-
-/** Persisted camera-lock preference. */
-export interface CameraLockPreference {
-  /** Follow-selection behaviour. */
-  mode: CameraMode;
-  /** Whether the camera lock is engaged at all. */
-  enabled: boolean;
-}
 
 /** The kinds of one-shot viewport commands the UI can issue. */
 export type GraphCameraCommandKind = 'centerSelection' | 'fitInitial';
@@ -63,109 +44,12 @@ export interface GraphCameraViewport {
   zoom: number;
 }
 
-/** Valid {@link CameraMode} values. */
-const CAMERA_MODES: ReadonlySet<CameraMode> = new Set<CameraMode>(['toggle', 'once']);
-
 /** Valid {@link GraphScope} values. */
 const GRAPH_SCOPES: ReadonlySet<GraphScope> = new Set<GraphScope>(['workflow', 'task']);
-
-/** localStorage key for the persisted camera-lock preference. */
-export const CAMERA_LOCK_PREFERENCE_STORAGE_KEY = 'invoker.ui.cameraLockPreference';
-
-/**
- * Default preference: follow selection on every change, lock engaged.
- * Frozen so callers cannot mutate the shared default in place.
- */
-export const DEFAULT_CAMERA_LOCK_PREFERENCE: CameraLockPreference = Object.freeze({
-  mode: 'toggle',
-  enabled: true,
-});
-
-/** Narrow an arbitrary value to a {@link CameraMode}. */
-export function isCameraMode(value: unknown): value is CameraMode {
-  return typeof value === 'string' && CAMERA_MODES.has(value as CameraMode);
-}
 
 /** Narrow an arbitrary value to a {@link GraphScope}. */
 export function isGraphScope(value: unknown): value is GraphScope {
   return typeof value === 'string' && GRAPH_SCOPES.has(value as GraphScope);
-}
-
-/**
- * Validate a parsed value as a {@link CameraLockPreference}. Returns a fresh,
- * fully-typed preference, or `null` if the shape is malformed.
- */
-function parseCameraLockPreference(value: unknown): CameraLockPreference | null {
-  if (typeof value !== 'object' || value === null) return null;
-  const candidate = value as Record<string, unknown>;
-  if (!isCameraMode(candidate.mode)) return null;
-  if (typeof candidate.enabled !== 'boolean') return null;
-  return { mode: candidate.mode, enabled: candidate.enabled };
-}
-
-/**
- * Minimal storage surface so this module works against `window.localStorage`,
- * a test double, or `undefined` (e.g. SSR / disabled storage).
- */
-export interface PreferenceStorage {
-  getItem(key: string): string | null;
-  setItem(key: string, value: string): void;
-}
-
-/**
- * Resolve the storage to use. Falls back to `globalThis.localStorage` when
- * available, otherwise `undefined` so callers degrade to defaults safely.
- */
-function resolveStorage(storage?: PreferenceStorage): PreferenceStorage | undefined {
-  if (storage) return storage;
-  const globalStorage = (globalThis as { localStorage?: PreferenceStorage }).localStorage;
-  return globalStorage ?? undefined;
-}
-
-/**
- * Load the persisted camera-lock preference, falling back to
- * {@link DEFAULT_CAMERA_LOCK_PREFERENCE} for missing, unparseable, or malformed
- * values. Never throws.
- */
-export function loadCameraLockPreference(storage?: PreferenceStorage): CameraLockPreference {
-  const store = resolveStorage(storage);
-  if (!store) return { ...DEFAULT_CAMERA_LOCK_PREFERENCE };
-
-  let raw: string | null;
-  try {
-    raw = store.getItem(CAMERA_LOCK_PREFERENCE_STORAGE_KEY);
-  } catch {
-    return { ...DEFAULT_CAMERA_LOCK_PREFERENCE };
-  }
-  if (raw === null) return { ...DEFAULT_CAMERA_LOCK_PREFERENCE };
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return { ...DEFAULT_CAMERA_LOCK_PREFERENCE };
-  }
-
-  return parseCameraLockPreference(parsed) ?? { ...DEFAULT_CAMERA_LOCK_PREFERENCE };
-}
-
-/**
- * Persist the camera-lock preference. Swallows storage errors (quota, disabled
- * storage) so a failed save never breaks the UI. Returns whether the write
- * succeeded.
- */
-export function saveCameraLockPreference(
-  preference: CameraLockPreference,
-  storage?: PreferenceStorage,
-): boolean {
-  const store = resolveStorage(storage);
-  if (!store) return false;
-  try {
-    store.setItem(CAMERA_LOCK_PREFERENCE_STORAGE_KEY, JSON.stringify(preference));
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 /** Fields required to issue a command; `sequence` is supplied by the issuer. */


### PR DESCRIPTION
## Summary

The Unreleased changelog now records the graph camera behavior change.

It tells operators that selection no longer moves the camera.

## Review Claim

Approve the changelog entry for the camera-lock purge.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Only `CHANGELOG.md` changes. It documents behavior already landed earlier in the stack.

## Slice Rationale

Docs land last so the note describes the final camera behavior.

## Non-goals

- No product code changes.
- No test changes.
- No release version change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/purge-auto-follow-pr-proof/pr3.md --changed-files-file /tmp/pr3-files.txt --diff-file /tmp/pr3-diff.patch`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 8823db91b`
- Post-revert steps: None.
- Data migration? No.

</details>

## Workflow Summary

Purge Auto-Follow Camera Lock — 4 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784693010203-2/purge-auto-follow | Remove selection-driven camera moves; camera moves only on explicit commands | completed |
| wf-1784693010203-2/verify-purge-grep | Prove no auto-follow identifiers survive in packages/ui/src | completed (passed) |
| wf-1784693010203-2/verify-camera-tests | Run the three rewritten camera test files | completed (passed) |
| wf-1784693010203-2/verify-ui-suite | Full @invoker/ui vitest suite as the final gate | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784693010203-2/purge-auto-follow — Remove selection-driven camera moves; camera moves only on explicit commands

### wf-1784693010203-2/verify-purge-grep — Prove no auto-follow identifiers survive in packages/ui/src

### wf-1784693010203-2/verify-camera-tests — Run the three rewritten camera test files

### wf-1784693010203-2/verify-ui-suite — Full @invoker/ui vitest suite as the final gate

</details>
