### PR TITLE
[Slack] Show drafted plan steps before submit

### DIFF
--- a/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
@@ -159,7 +159,12 @@ describe('Slack plan submission restart repro contracts', () => {
     const say = await mention(slack, 'plan: draft a real migration plan', 'thread-agent-plan', 'thread-agent');
     const current = (slack as any).sessionManager.findSession(new SessionIdentifier('C_LOBBY', 'thread-agent'));
     expect(current?.conversationMode).toBe('plan');
-    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: `${plan}\n\nReply \`submit\` to submit it.` }));
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('*Proof plan* — 1 task:\n• Exercise the submission flow'),
+    }));
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('Reply `submit` to submit it.'),
+    }));
     const submitSay = await mention(slack, 'submit', 'submit-agent', 'thread-agent');
     expect(submitSay).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Approve to proceed') }));
   });
@@ -186,6 +191,9 @@ describe('Slack plan submission restart repro contracts', () => {
     expect(JSON.stringify(mockSpawn.mock.calls[0])).toContain('attention inbox');
     expect(say).toHaveBeenCalledWith(expect.objectContaining({
       text: expect.stringContaining('Reply `submit` to submit it.'),
+    }));
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('*Proof plan* — 1 task:\n• Exercise the submission flow'),
     }));
   });
 

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -46,6 +46,8 @@ function truncateWords(text: string, maxWords: number): string {
   return `${words.slice(0, maxWords).join(' ')} ...`;
 }
 
+const DRAFT_SUBMIT_INSTRUCTION = 'Reply `submit` to submit it.';
+
 // ── Config ──────────────────────────────────────────────────
 
 export interface SlackSurfaceConfig {
@@ -1947,11 +1949,20 @@ ${text}`;
         await this.stopTypingIndicator(channel, threadTs);
       }
 
-      const renderedReply = conversation.conversationMode === 'plan'
-        && conversation.getDraftedPlan()
-        && !reply.includes('Reply `submit` to submit it.')
-        ? `${reply.trimEnd()}\n\nReply \`submit\` to submit it.`
-        : reply;
+      const draftedPlan = conversation.conversationMode === 'plan'
+        ? conversation.getDraftedPlan()
+        : undefined;
+      const summary = draftedPlan ? summarizePlanText(draftedPlan) : null;
+      const replyWithoutSubmitInstruction = reply
+        .replace(/\n*Reply `submit` to submit it\.\s*$/i, '')
+        .trimEnd();
+      const renderedReply = summary
+        ? [replyWithoutSubmitInstruction, this.renderPlanSummary(summary), DRAFT_SUBMIT_INSTRUCTION]
+          .filter(Boolean)
+          .join('\n\n')
+        : draftedPlan && !reply.includes(DRAFT_SUBMIT_INSTRUCTION)
+          ? `${reply.trimEnd()}\n\n${DRAFT_SUBMIT_INSTRUCTION}`
+          : reply;
       const chunks = splitForSlack(sanitizeSlackOutbound(renderedReply));
       const revision = process.env.INVOKER_REVISION ?? process.env.GIT_COMMIT ?? 'unknown';
       this.log('slack', 'info',


### PR DESCRIPTION
## Summary

Slack now shows the ordered steps from a drafted Invoker plan before asking the user to submit it.

Each step comes from the drafted YAML, so it remains accurate even when the planner’s prose is brief.

## Review Claim

Approve rendering the deterministic draft task summary in Slack’s pre-submit response.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

A draft remains non-executing. It still requires `submit` and the existing confirmation before workflow creation.

## Slice Rationale

This is a single Slack rendering behavior with direct end-to-end regression coverage.

## Non-goals

- Does not change Planning Terminal rendering.
- Does not change plan generation or draft parsing.
- Does not execute a draft automatically.

## Architecture

### Before

Slack posted planner prose and a submit instruction. The ordered YAML steps appeared only after `submit`.

### After

Slack derives ordered tasks from the draft YAML and inserts them before one final submit instruction.

```mermaid
flowchart LR
  draftYaml[DraftYaml] --> summary[PlanSummary]
  plannerProse[PlannerProse] --> renderedReply[RenderedSlackReply]
  summary --> renderedReply
  renderedReply --> submitInstruction[SubmitInstruction]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test -- slack-plan-submission-repros.e2e.test.ts slack-surface-workflows.test.ts plan-summary.test.ts`
- [x] `pnpm --filter @invoker/surfaces build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9ea935705`
- Post-revert steps: Restart the Slack manager only if this revision has been deployed.
- Data migration? No

</details>

Depends-On: #5516