### PR TITLE
Remove In-App Auto-Fix Trigger Step 1 (1) Stop renderer auto-fix activation

### DIFF
--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -3,7 +3,6 @@ import type { Logger, WorkResponse } from '@invoker/contracts';
 import type { Workflow } from '@invoker/data-store';
 import { Channels, type MessageBus } from '@invoker/transport';
 import type { TaskDelta, TaskState } from '@invoker/workflow-core';
-import { shouldSkipAutoFixForError } from '../auto-fix-gating.js';
 import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from '../delta-merge.js';
 import { evaluateExecutingStall, taskNeedsExecutingStallCheck } from '../executing-stall.js';
 import { persistShutdownDiagnostic, type ShutdownDiagnosticDb } from '../shutdown-diagnostic.js';
@@ -36,7 +35,6 @@ export interface RendererTaskFeedPersistence extends ShutdownDiagnosticDb {
 export interface RendererTaskFeedOrchestrator {
   getAllTasks(): TaskState[];
   getMergeNode(workflowId: string): TaskState | undefined;
-  shouldAutoFix(taskId: string): boolean;
   syncAllFromDb(): void;
   handleWorkerResponse(response: WorkResponse): void;
   reclaimStalledFixSession(
@@ -71,8 +69,8 @@ export interface RendererTaskFeedDeps {
   getMainWindow: () => BrowserWindow | null;
   setStartupWorkflowId: (workflowId: string | null) => void;
   requestWorkflowMetadataPublish: (reason: string) => void;
-  scheduleAutoFix: (taskId: string) => void;
-  logAutoFixDebug: (taskId: string, phase: string, details?: Record<string, unknown>) => void;
+  scheduleAutoFix?: (taskId: string) => void;
+  logAutoFixDebug?: (taskId: string, phase: string, details?: Record<string, unknown>) => void;
   uiPerfStats: RendererTaskFeedUiPerfStats;
   traceUiDeltaFlow: boolean;
   traceDbPollPerTask: boolean;
@@ -226,31 +224,12 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
   );
 
   // Apply one owner task delta to the local cache and forward results to the
-  // renderer (and drive owner-side auto-fix). Extracted so the detached viewer
-  // can replay deltas that were buffered during hydration.
+  // renderer. Extracted so the detached viewer can replay deltas that were
+  // buffered during hydration.
   const processIncomingTaskDelta = (delta: TaskDelta): void => {
     deps.uiPerfStats.mainDeltaToUi += 1;
     if (deps.traceUiDeltaFlow) {
       deps.logger.debug(`delta→ui: ${JSON.stringify(delta)}`, { module: 'ui' });
-    }
-    const deltaTaskId = delta.type === 'updated' || delta.type === 'removed' ? delta.taskId : undefined;
-    if (delta.type === 'updated' && delta.changes.status === 'failed') {
-      const cancellationError = shouldSkipAutoFixForError(delta.changes.execution?.error);
-      const shouldAutoFixFromOrchestrator = deps.getOrchestrator().shouldAutoFix(delta.taskId);
-      deps.logAutoFixDebug(delta.taskId, 'delta-failed', {
-        shouldSkipForCancellation: cancellationError,
-        shouldAutoFixFromOrchestrator,
-      });
-      if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
-        deps.logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
-        deps.scheduleAutoFix(deltaTaskId);
-      } else if (deltaTaskId) {
-        deps.logAutoFixDebug(deltaTaskId, 'delta-skip', {
-          reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
-          shouldSkipForCancellation: cancellationError,
-          shouldAutoFixFromOrchestrator,
-        });
-      }
     }
     for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(delta)) {
       publishTaskDeltaToRenderer(rendererDelta);


### PR DESCRIPTION
## Summary
Stop renderer task-feed failure deltas from activating in-app auto-fix.

Keep legacy scheduler plumbing present until later slices disconnect and retire it.

## Review Claim
The renderer feed no longer activates auto-fix when a task delta enters `failed` status.

## Review Lane
behavior

## Review Unit
activation-surface

## Safety Invariant
Auto-fix remains available through worker recovery and explicit operator fix requests.

## Slice Rationale
This isolates the live activation change before wiring and retired-code slices.

## Architecture
### Before
Renderer task-feed failure deltas could start an in-app auto-fix request.

### After
Renderer task-feed failure deltas only update task state and publish renderer deltas.

## Non-goals
- Do not remove the worker auto-fix recovery engine.
- Do not change explicit operator `fix-with-agent` commands.
- Do not change recovery-worker retry policy.

## Test Plan
<details>
<summary>Test Plan</summary>

- `pnpm --filter @invoker/app exec vitest run src/__tests__/no-autofix-outside-worker.test.ts`
- `pnpm run check:types`

</details>

## Revert Plan
<details>
<summary>Revert Plan</summary>

- `git revert 3156b2f4b3d8111b98f6106cedd6e725ad1d1cf3`

</details>
