### PR TITLE
[Slack Repo Binding Step 2: First-message binding](1) Bind first-message repo URLs

### DIFF
--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -274,7 +274,11 @@ describe('harness routing', () => {
 
   it('constructs the planning conversation with the preset tool/model and injected builder', async () => {
     const builder = vi.fn(() => ({ command: 'cursor', args: [] }));
-    const surface = new SlackSurface({ ...baseConfig(), planningCommandBuilder: builder });
+    const surface = new SlackSurface({
+      ...baseConfig(),
+      defaultRepoUrl: 'git@github.com:default/repo.git',
+      planningCommandBuilder: builder,
+    });
     await surface.start(async () => {});
 
     await mentionHandler(surface)({
@@ -906,7 +910,7 @@ describe('lobby verb routing', () => {
   });
 
   it('routes a build request to an inferred Invoker plan thread', async () => {
-    const surface = lobbySurface();
+    const surface = lobbySurface(true, { defaultRepoUrl: 'git@github.com:default/repo.git' });
     await surface.start(async () => {});
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     await mentionHandler(surface)({ event: { text: '<@BOT> add a /health endpoint', ts: 't1', user: 'U1' }, say });
@@ -917,13 +921,103 @@ describe('lobby verb routing', () => {
   });
 
   it('routes an explicit plan request to an Invoker plan thread', async () => {
-    const surface = lobbySurface();
+    const surface = lobbySurface(true, { defaultRepoUrl: 'git@github.com:default/repo.git' });
     await surface.start(async () => {});
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     await mentionHandler(surface)({ event: { text: '<@BOT> plan: add a /health endpoint', ts: 't1', user: 'U1' }, say });
     expect(planConversationConfigs).toHaveLength(1);
     expect(planConversationConfigs[0].mode).toBe('plan');
     expect(runWorkflowOp).not.toHaveBeenCalled();
+  });
+
+  it('uses a repo-root URL in the first plan message instead of defaultRepoUrl and announces it', async () => {
+    mockSpawn.mockImplementationOnce(() => mockProcess('{"intent":"plan","operation":"none","target":"none"}'));
+    const surface = lobbySurface(true, {
+      defaultRepoUrl: 'git@github.com:default/repo.git',
+      enableImmediateAck: true,
+    });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+
+    await mentionHandler(surface)({
+      event: {
+        text: '<@BOT> add a /health endpoint to https://github.com/openai/invoker',
+        ts: 't1',
+        user: 'U1',
+        channel: 'CLOBBY',
+      },
+      say,
+    });
+
+    expect(planConversationConfigs).toHaveLength(1);
+    expect(planConversationConfigs[0].repoUrl).toBe('https://github.com/openai/invoker');
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(say).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      text: expect.stringContaining('I picked repo `https://github.com/openai/invoker`'),
+      thread_ts: 't1',
+    }));
+  });
+
+  it('lets a [repo:] tag win over a repo URL in the same first plan message', async () => {
+    const surface = lobbySurface(true, {
+      defaultRepoUrl: 'git@github.com:default/repo.git',
+      repoAliases: { foo: 'git@github.com:me/foo.git' },
+    });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+
+    await mentionHandler(surface)({
+      event: {
+        text: '<@BOT> [repo:foo] plan: add a /health endpoint to https://github.com/openai/invoker',
+        ts: 't1',
+        user: 'U1',
+        channel: 'CLOBBY',
+      },
+      say,
+    });
+
+    expect(planConversationConfigs).toHaveLength(1);
+    expect(planConversationConfigs[0].repoUrl).toBe('git@github.com:me/foo.git');
+    expect(say.mock.calls.map((call) => call[0].text).join('\n')).not.toContain('from the URL in your message');
+  });
+
+  it('ignores a deep link in the first plan message and falls through to defaultRepoUrl', async () => {
+    const surface = lobbySurface(true, { defaultRepoUrl: 'git@github.com:default/repo.git' });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+
+    await mentionHandler(surface)({
+      event: {
+        text: '<@BOT> plan: fix the issue at https://github.com/openai/invoker/pull/123',
+        ts: 't1',
+        user: 'U1',
+        channel: 'CLOBBY',
+      },
+      say,
+    });
+
+    expect(planConversationConfigs).toHaveLength(1);
+    expect(planConversationConfigs[0].repoUrl).toBe('git@github.com:default/repo.git');
+    expect(say.mock.calls.map((call) => call[0].text).join('\n')).not.toContain('from the URL in your message');
+  });
+
+  it('asks for a repo instead of planning when a plan mention has no tag, repo URL, or default', async () => {
+    const surface = lobbySurface();
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> plan: add a /health endpoint', ts: 't1', user: 'U1', channel: 'CLOBBY' },
+      say,
+    });
+
+    expect(planConversationConfigs).toHaveLength(0);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('[repo:<alias>]'),
+      thread_ts: 't1',
+    }));
+    expect(say.mock.calls[0][0].text).toContain('git URL');
   });
 
 
@@ -981,7 +1075,7 @@ describe('lobby verb routing', () => {
   });
 
   it('submit shows every task in the plan summary and emits start_plan on confirmation', async () => {
-    const surface = lobbySurface();
+    const surface = lobbySurface(true, { defaultRepoUrl: 'git@github.com:default/repo.git' });
     await surface.start(async (cmd) => { received.push(cmd); });
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     // Open a planning conversation in the thread, then arm its drafted plan.

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -444,6 +444,12 @@ interface SayResult {
 
 type SayFn = (msg: { text: string; thread_ts: string; blocks?: unknown[] }) => Promise<SayResult>;
 
+type PlanningRepoResolution = {
+  url?: string;
+  error?: string;
+  source: 'tag' | 'message-url' | 'default' | 'none';
+};
+
 interface SlackMentionEvent {
   text?: string;
   ts: string;
@@ -887,9 +893,18 @@ export class SlackSurface implements Surface {
       await say({ text: repoResolution.error, thread_ts: event.ts });
       return;
     }
-    const repoUrl = repoResolution.url;
+    const routeRepoUrl = repoResolution.url;
 
     const threadTs = event.thread_ts ?? event.ts;
+    const requiresPlanningRepo = channel === this.lobbyChannelId;
+    const messageRepoUrl = requiresPlanningRepo && !parsed.repo
+      ? extractRepoUrlFromMessage(event.text ?? '')
+      : undefined;
+    let planningRepoResolution: PlanningRepoResolution | undefined;
+    const resolvePlanningRepo = (): PlanningRepoResolution => {
+      planningRepoResolution ??= this.resolvePlanningRepoUrl(parsed.repo, messageRepoUrl);
+      return planningRepoResolution;
+    };
 
     // Confirm/cancel a staged action first (plain yes/no in-thread).
     if (await this.resolveConfirm(threadTs, parsed.text, say, channel)) return;
@@ -911,7 +926,7 @@ export class SlackSurface implements Surface {
 
     const localRequest = parseLocalRequest(parsed.text);
     if (localRequest?.kind === 'command') {
-      await this.handleLocalRequest(localRequest, preset, threadTs, say, channel, { userId: event.user, repoUrl });
+      await this.handleLocalRequest(localRequest, preset, threadTs, say, channel, { userId: event.user, repoUrl: routeRepoUrl });
       return;
     }
 
@@ -924,8 +939,19 @@ export class SlackSurface implements Surface {
     const explicitLocalAgent = localRequest?.kind === 'agent' || localRequest?.kind === 'change';
     let threadRequest = parseThreadRequest(parsed.text);
 
+    if (requiresPlanningRepo && threadRequest?.mode === 'plan' && !resolvePlanningRepo().url) {
+      await say({ text: this.missingPlanningRepoMessage(), thread_ts: threadTs });
+      return;
+    }
+
     // Slower paths (LLM classifier, repo checkout, agent) acknowledge receipt up front.
-    if (this.enableImmediateAck) await this.sendImmediateAck(threadTs, say);
+    if (
+      this.enableImmediateAck
+      && !(threadRequest?.mode === 'plan' && resolvePlanningRepo().source === 'message-url')
+      && !(!explicitLocalAgent && threadRequest?.mode !== 'plan' && messageRepoUrl)
+    ) {
+      await this.sendImmediateAck(threadTs, say);
+    }
 
     try {
       if (!explicitLocalAgent && threadRequest?.mode !== 'plan') {
@@ -948,13 +974,29 @@ export class SlackSurface implements Surface {
 
       if (!threadRequest) return;
 
+      let planningRepo: PlanningRepoResolution | undefined;
+      if (threadRequest.mode === 'plan') {
+        planningRepo = resolvePlanningRepo();
+        if (requiresPlanningRepo && !planningRepo.url) {
+          await this.clearImmediateAck(channel, threadTs);
+          await say({ text: this.missingPlanningRepoMessage(), thread_ts: threadTs });
+          return;
+        }
+        if (planningRepo.source === 'message-url') {
+          await say({
+            text: `I picked repo \`${planningRepo.url}\` from the URL in your message. If that's wrong, start the planning request again with a \`[repo:<alias>]\` tag or a git URL.`,
+            thread_ts: threadTs,
+          });
+        }
+      }
+
       const storedContext = this.loadPlanningContext(threadTs);
       const isPromotion = threadRequest.mode === 'plan'
         && this.sessionManager?.findSession(new SessionIdentifier(channel, threadTs))?.conversationMode === 'agent';
       const context = isPromotion && storedContext
         ? storedContext
         : {
-            repoUrl,
+            repoUrl: threadRequest.mode === 'plan' ? planningRepo?.url : routeRepoUrl,
             presetKey: parsed.presetKey,
             workingDir: this.workingDir,
             requestedBy: event.user,
@@ -1040,8 +1082,10 @@ export class SlackSurface implements Surface {
   private async withThreadContext(channel: string, threadTs: string, request: string): Promise<string> {
     try {
       const replies = await this.app.client.conversations.replies({ channel, ts: threadTs, limit: 100 });
-      const context = (replies.messages ?? [])
-        .filter((message) => !message.bot_id && !message.subtype && typeof message.text === 'string')
+      const messages = (replies.messages ?? []) as Array<{ bot_id?: string; subtype?: string; text?: string }>;
+      const context = messages
+        .filter((message): message is { text: string; bot_id?: string; subtype?: string } =>
+          !message.bot_id && !message.subtype && typeof message.text === 'string')
         .map((message) => message.text.trim())
         .filter((text) => text && text !== request)
         .slice(-20)
@@ -1610,6 +1654,20 @@ ${text}`;
     const known = Object.keys(this.repoAliases);
     const list = known.length ? known.join(', ') : '(none configured)';
     return { error: `Unknown repo "${repo}". Known aliases: ${list}. Or pass a full git URL.` };
+  }
+
+  private resolvePlanningRepoUrl(repo: string | undefined, messageRepoUrl: string | undefined): PlanningRepoResolution {
+    if (repo) {
+      const resolved = this.resolveRepoUrl(repo);
+      return { ...resolved, source: 'tag' };
+    }
+    if (messageRepoUrl) return { url: messageRepoUrl, source: 'message-url' };
+    if (this.defaultRepoUrl) return { url: this.defaultRepoUrl, source: 'default' };
+    return { source: 'none' };
+  }
+
+  private missingPlanningRepoMessage(): string {
+    return 'I need a repository before drafting an Invoker plan. Add a `[repo:<alias>]` tag or include a repo-root git URL like `https://github.com/org/repo` in the first message.';
   }
 
   // ── In-channel workflow assistant ──────────────────────


### PR DESCRIPTION
## Summary

This slice lets a new Slack planning thread use the repo-root URL from its first message.

`[repo:]` tags still win, and `defaultRepoUrl` remains the fallback when no message URL is present.

Slack asks for a repo before planning when the lobby has no tag, no URL, and no default.

## Review Claim

Approve the planning repo selection behavior for first-message Slack URLs.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only lobby planning repo resolution changes. Local commands and existing `[repo:]` aliases still use the existing resolver, with regression coverage for precedence and missing-repo cases.

## Slice Rationale

This keeps first-message repo binding separate from the URL parser foundation in Step 1 and from verification-runner hardening in the next slice.

## Non-goals

- No changes to repo URL parsing rules from Step 1.
- No changes to workflow channel assistant routing.
- No UI changes.
- No migration.

## Architecture

### Before

Lobby planning used `[repo:]` or `defaultRepoUrl`. Messages without either could still start planning with no repo context.

### After

Lobby planning resolves repos in tag, message URL, then default order. Missing all three asks for a repo before opening a plan session.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/surfaces test -- slack-surface-workflows`
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp-pr-body-step2-1.md --changed-files-file .tmp-pr-files-step2-1.txt --diff-file .tmp-pr-diff-step2-1.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e65f1b1e4eda265267b776cfebad396c7360b8b3`
- Post-revert steps: Rerun `pnpm --filter @invoker/surfaces test -- slack-surface-workflows`
- Data migration? No

</details>

## Workflow Summary

Slack Repo Binding Step 2: First-message binding — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784693264455-4/implement-first-message-binding | Bind a new thread to the repo-root URL in the first message, with tag > URL > default precedence | completed |
| wf-1784693264455-4/verify-first-message-binding | Run workflow-routing and multi-repo isolation tests | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784693264455-4/implement-first-message-binding — Bind a new thread to the repo-root URL in the first message, with tag > URL > default precedence

- `packages/surfaces/src/slack/slack-surface.ts`
- `packages/surfaces/src/__tests__/slack-surface-workflows.test.ts`

### wf-1784693264455-4/verify-first-message-binding — Run workflow-routing and multi-repo isolation tests

- `packages/surfaces/scripts/vitest-run.cjs`
- `packages/surfaces/src/__tests__/vitest-runner.test.ts`

</details>
