### PR TITLE
[Slack Repo Binding Step 2: First-message binding](2) Harden surfaces vitest runner

### DIFF
--- a/packages/surfaces/scripts/vitest-run.cjs
+++ b/packages/surfaces/scripts/vitest-run.cjs
@@ -1,14 +1,92 @@
 #!/usr/bin/env node
 
-const { spawn } = require('node:child_process');
+const { spawn, spawnSync } = require('node:child_process');
+const { existsSync, readFileSync } = require('node:fs');
+const { dirname, resolve } = require('node:path');
 
 const args = process.argv.slice(2);
 const passthroughArgs = args[0] === '--' ? args.slice(1) : args;
-const command = process.platform === 'win32' ? 'vitest.cmd' : 'vitest';
+const packageDir = resolve(__dirname, '..');
+const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
 
-const child = spawn(command, ['run', ...passthroughArgs], {
+function findWorkspaceRoot(startDir) {
+  let current = startDir;
+  while (true) {
+    if (existsSync(resolve(current, 'pnpm-lock.yaml'))) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function readPackageName() {
+  const manifestPath = resolve(packageDir, 'package.json');
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  if (typeof manifest.name !== 'string' || manifest.name.length === 0) {
+    throw new Error(`Package manifest at ${manifestPath} does not define a package name`);
+  }
+  return manifest.name;
+}
+
+function runPnpmSync(args, options = {}) {
+  return spawnSync(pnpmCommand, args, {
+    cwd: options.cwd ?? packageDir,
+    stdio: options.stdio ?? 'inherit',
+    env: process.env,
+    shell: process.platform === 'win32',
+  });
+}
+
+function canRunVitest() {
+  const result = runPnpmSync(['exec', 'vitest', '--version'], { stdio: 'ignore' });
+  return result.status === 0;
+}
+
+function ensureVitestAvailable() {
+  if (canRunVitest()) return;
+
+  const workspaceRoot = findWorkspaceRoot(packageDir);
+  if (!workspaceRoot) {
+    console.error('Failed to start vitest: could not find pnpm workspace root');
+    process.exit(1);
+  }
+
+  let packageName;
+  try {
+    packageName = readPackageName();
+  } catch (error) {
+    console.error(`Failed to start vitest: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  console.log(`Vitest binary is unavailable; installing filtered workspace dependencies for ${packageName}`);
+  const install = runPnpmSync(
+    ['--filter', `${packageName}...`, 'install', '--frozen-lockfile', '--ignore-scripts', '--prod=false'],
+    { cwd: workspaceRoot },
+  );
+  if (install.error) {
+    console.error(`Failed to install filtered workspace dependencies: ${install.error.message}`);
+    process.exit(1);
+  }
+  if ((install.status ?? 1) !== 0) {
+    process.exit(install.status ?? 1);
+  }
+
+  if (!canRunVitest()) {
+    console.error(`Failed to start vitest: binary is still unavailable after filtered install for ${packageName}`);
+    process.exit(1);
+  }
+}
+
+ensureVitestAvailable();
+
+const child = spawn(pnpmCommand, ['exec', 'vitest', 'run', ...passthroughArgs], {
+  cwd: packageDir,
   stdio: 'inherit',
   env: process.env,
+  shell: process.platform === 'win32',
 });
 
 child.on('error', (error) => {

--- a/packages/surfaces/src/__tests__/vitest-runner.test.ts
+++ b/packages/surfaces/src/__tests__/vitest-runner.test.ts
@@ -1,0 +1,68 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+describe('vitest runner', () => {
+  it('installs filtered workspace dependencies when the Vitest binary is missing', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'surfaces-vitest-runner-'));
+    const binDir = join(tempDir, 'bin');
+    const callsPath = join(tempDir, 'pnpm.calls');
+    const readyPath = join(tempDir, 'pnpm.ready');
+    const runnerPath = fileURLToPath(new URL('../../scripts/vitest-run.cjs', import.meta.url));
+
+    try {
+      mkdirSync(binDir, { recursive: true });
+      writeFileSync(
+        join(binDir, 'pnpm'),
+        `#!/usr/bin/env bash
+set -eu
+printf '%s\\n' "$*" >> "$PNPM_CALLS"
+case "$*" in
+  "exec vitest --version")
+    if [ -f "$PNPM_READY" ]; then
+      exit 0
+    fi
+    exit 1
+    ;;
+  "--filter @invoker/surfaces... install --frozen-lockfile --ignore-scripts --prod=false")
+    touch "$PNPM_READY"
+    exit 0
+    ;;
+  "exec vitest run sample.test.ts")
+    exit 0
+    ;;
+esac
+echo "unexpected pnpm args: $*" >&2
+exit 42
+`,
+      );
+      chmodSync(join(binDir, 'pnpm'), 0o755);
+
+      const result = spawnSync(process.execPath, [runnerPath, '--', 'sample.test.ts'], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ''}`,
+          PNPM_CALLS: callsPath,
+          PNPM_READY: readyPath,
+        },
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(
+        'Vitest binary is unavailable; installing filtered workspace dependencies for @invoker/surfaces',
+      );
+      expect(readFileSync(callsPath, 'utf8').trim().split('\n')).toEqual([
+        'exec vitest --version',
+        '--filter @invoker/surfaces... install --frozen-lockfile --ignore-scripts --prod=false',
+        'exec vitest --version',
+        'exec vitest run sample.test.ts',
+      ]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This slice makes the surfaces Vitest command self-prepare when a sparse merge clone lacks the local Vitest binary.

It installs only the filtered surfaces workspace dependencies, then reruns Vitest with the original arguments.

## Review Claim

Approve the surfaces test command fallback for missing Vitest binaries.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The fallback runs only after `pnpm exec vitest --version` fails. Existing installs still execute the same `pnpm exec vitest run ...` command.

## Slice Rationale

This verification support stays separate from the Slack behavior slice so the runner fallback can be reviewed on its own.

## Non-goals

- No changes to Slack planning behavior.
- No production dependency changes.
- No changes to test assertions outside the runner fallback coverage.

## Architecture

### Before

The package script spawned Vitest directly, so sparse clones without package binaries failed before test selection.

### After

The package script checks `pnpm exec vitest --version`, performs a filtered workspace install only when missing, then invokes the same Vitest command.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/surfaces test -- vitest-runner`
- [x] `pnpm --filter @invoker/surfaces test -- slack-surface-workflows`
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp-pr-body-step2-2.md --changed-files-file .tmp-pr-files-step2-2.txt --diff-file .tmp-pr-diff-step2-2.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d4dde14f2fe2eb2ba6a101f9fd20555aa6329bfe`
- Post-revert steps: Rerun `pnpm --filter @invoker/surfaces test -- vitest-runner`
- Data migration? No

</details>

## Workflow Summary

Slack Repo Binding Step 2: First-message binding — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784693264455-4/implement-first-message-binding | Bind a new thread to the repo-root URL in the first message, with tag > URL > default precedence | completed |
| wf-1784693264455-4/verify-first-message-binding | Run workflow-routing and multi-repo isolation tests | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784693264455-4/implement-first-message-binding — Bind a new thread to the repo-root URL in the first message, with tag > URL > default precedence

- `packages/surfaces/src/slack/slack-surface.ts`
- `packages/surfaces/src/__tests__/slack-surface-workflows.test.ts`

### wf-1784693264455-4/verify-first-message-binding — Run workflow-routing and multi-repo isolation tests

- `packages/surfaces/scripts/vitest-run.cjs`
- `packages/surfaces/src/__tests__/vitest-runner.test.ts`

</details>
