### PR TITLE
[Vitest Workspace] Keep --json stdout clean; deflake camera-resnap under load

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -370,6 +370,7 @@ async function runPlan(planPath: string, options: CliOptions): Promise<RunResult
   const persistence = await SQLiteAdapter.create(join(dbDir, 'invoker.db'), {
     ownerCapability: true,
     outputDir: join(dbDir, 'outputs'),
+    ...(options.json ? { slowQueryThresholdMs: 0 } : {}),
   });
   const stdoutWrite = process.stdout.write;
   if (options.json) {

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -154,7 +154,7 @@ describe('Browser-surface camera (component)', () => {
     // The camera must not move on a live update that changed no selection.
     expect(setCenterMock).not.toHaveBeenCalled();
     expect(fitViewMock).not.toHaveBeenCalled();
-  });
+  }, 20000);
 
   it('does not re-center or re-fit when the selected task changes while already on a browser surface', async () => {
     mock.setTasks(tasks, workflows);


### PR DESCRIPTION
## Summary

Two failures surfaced only under the full-workspace `pnpm test` run (the ci.yml comment mis-attributed the red to worker-registry/SSH drift; execution-engine is fully green).

The cli `--json` output contract broke because SQLiteAdapter's slow-query diagnostic (console.warn to stderr) fired when an INSERT crossed the 25ms threshold under load, leaking a diagnostic line into stderr. This passes `slowQueryThresholdMs=0` in `--json` mode so machine-readable output stays clean; interactive runs keep the diagnostic.

The camera-resnap test times out only under the saturated concurrent run (~2.3s in isolation, correct assertion). This raises just that one test's timeout.

## Review Claim

Approve keeping cli --json stderr clean and raising one camera-resnap test timeout.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

The cli change only disables a stderr diagnostic sink in --json mode (already gated on threshold>0); the ui change only raises one test's wall-clock budget. No assertion or product logic changes.

## Slice Rationale

Both are the fixes that turn the Vitest Workspace job green; kept together as that job's slice.

## Non-goals

Does not change execution-engine, the slow-query diagnostic in interactive mode, or other tests.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/cli && pnpm test`
- [ ] `cd packages/ui && pnpm test -- src/__tests__/browser-surface-camera-resnap.test.tsx`
- [ ] Next master CI: required-fast / Vitest Workspace passes

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>