### PR TITLE
[Docker Comprehensive] Parse task status from noisy standalone stdout

### DIFF
--- a/scripts/test-docker-comprehensive.sh
+++ b/scripts/test-docker-comprehensive.sh
@@ -188,12 +188,26 @@ task_output() {
   ./run.sh --headless query task-output "$1" 2>/dev/null || true
 }
 
+# In standalone headless mode the query CLI interleaves diagnostic lines
+# (`[delegation] …`, `Effective configuration …`, `[init] …`, SQLite
+# ExperimentalWarning) with the actual result on stdout. Extract just the
+# result token so exact-match comparisons and the terminal wait loop are not
+# defeated by that noise.
 task_status() {
-  ./run.sh --headless query task "$1" 2>/dev/null || echo "unknown"
+  local raw status
+  raw="$(./run.sh --headless query task "$1" 2>/dev/null || true)"
+  status="$(printf '%s\n' "$raw" | grep -Ex 'pending|queued|running|launching|fixing_with_ai|completed|failed|needs_input|awaiting_approval|review_ready|blocked|stale|cancelled' | tail -1 || true)"
+  if [[ -z "$status" ]]; then
+    echo "unknown"
+  else
+    echo "$status"
+  fi
 }
 
 task_container_id() {
-  ./run.sh --headless query container-id "$1" 2>/dev/null || echo ""
+  local raw
+  raw="$(./run.sh --headless query container-id "$1" 2>/dev/null || true)"
+  printf '%s\n' "$raw" | grep -Eo '^[0-9a-f]{12,64}$' | tail -1 || true
 }
 
 wait_for_task_terminal() {


### PR DESCRIPTION
## Summary

#4867 moved the docker proof test's state reads from sqlite3 to `./run.sh --headless query task`. In this test's standalone headless mode, the query CLI interleaves diagnostic lines with the result on stdout, so `task_status` captured the whole blob and the terminal-wait's exact-match case never matched, timing out after 300s.

The merge node legitimately stays pending on failed deps (intended review-gate behavior) — that is not the cause. This extracts just the status/container-id token from stdout; assertions still compare the true DB status.

Verified: `bash scripts/test-docker-comprehensive.sh` -> Passed 24, Failed 0.

## Review Claim

Approve parsing the task-status/container-id token out of noisy standalone-headless stdout in the docker proof test.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the test's stdout parsing changes; real failure semantics and the review-gate invariant are untouched (the 3 intended task failures still fail).

## Slice Rationale

Isolated harness fix for the docker-comprehensive job after the #4867 sqlite3->headless-query migration.

## Non-goals

Does not change the DockerExecutor, the state machine, or the merge-gate behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash -n scripts/test-docker-comprehensive.sh`
- [ ] `bash scripts/test-docker-comprehensive.sh` -> Failed: 0
- [ ] Next master CI: docker / comprehensive passes

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>