### PR TITLE
[Slack] Preserve planner harness across restarts

### DIFF
--- a/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
@@ -254,8 +254,11 @@ describe('Slack plan submission restart repro contracts', () => {
       defaultRepoUrl: 'https://example.test/default.git',
     });
     await start(second, commands);
+    const restored = (second as any).sessionManager.findSession(new SessionIdentifier('C_LOBBY', 'thread-context'));
+    expect(restored?.conversationMode).toBe('plan');
+    expect((restored?.conversation as any).tool).toBe('special-tool');
+    expect((restored?.conversation as any).model).toBe('special-model');
     const say = await mention(second, 'submit', 'submit-context', 'thread-context');
-    expect((second as any).sessionManager.findSession(new SessionIdentifier('C_LOBBY', 'thread-context'))?.conversationMode).toBe('plan');
     await mention(second, 'yes', 'confirm-context', 'thread-context');
     expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Approve to proceed') }));
     expect(commands).toContainEqual(expect.objectContaining({

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -2318,25 +2318,36 @@ ${text}`;
       if (this.sessionManager) {
         // Delegate recovery to SessionManager
         for (const entry of active) {
+          const context = this.loadPlanningContext(entry.threadTs);
+          const harness = this.resolveHarnessPreset(context?.presetKey ?? this.defaultHarnessPreset);
           const id = new SessionIdentifier(
             entry.channelId || this.channelId,
             entry.threadTs,
           );
-          await this.sessionManager.getOrCreateSession(id, entry.userId);
+          await this.sessionManager.getOrCreateSession(id, entry.userId, {
+            tool: harness.tool,
+            model: harness.model,
+            workingDir: context?.workingDir ?? this.workingDir,
+            repoUrl: context?.repoUrl ?? this.defaultRepoUrl,
+          });
           this.sessionMetrics.recovered++;
         }
       } else {
         // Fallback: direct Map recovery
         for (const entry of active) {
+          const context = this.loadPlanningContext(entry.threadTs);
+          const harness = this.resolveHarnessPreset(context?.presetKey ?? this.defaultHarnessPreset);
           const conversation = new PlanConversation({
             cursorCommand: this.cursorCommand,
-            model: this.model,
+            tool: harness.tool,
+            model: harness.model,
             mode: entry.mode ?? 'plan',
-            workingDir: this.workingDir,
+            planningCommandBuilder: this.planningCommandBuilder,
+            workingDir: context?.workingDir ?? this.workingDir,
             threadTs: entry.threadTs,
             conversationRepo: this.conversationRepo,
             defaultBranch: this.defaultBranch,
-            repoUrl: this.defaultRepoUrl,
+            repoUrl: context?.repoUrl ?? this.defaultRepoUrl,
             plannerRetryLimit: this.plannerRetryLimit,
             plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
             conversationalPlanning: this.conversationalPlanning,


### PR DESCRIPTION
## Summary

Slack now restores a thread’s saved planner harness when the service restarts.

An OMP + Codex thread stays on OMP + Codex instead of falling back to Cursor.

## Review Claim

Approve preserving the persisted Slack planner harness during eager session recovery.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

Restarting Slack does not change an active thread’s planner tool, model, repository, or working directory.

## Slice Rationale

This is a single restart-recovery behavior with a regression test that reproduces the former Cursor fallback.

## Non-goals

- Does not change fresh-session preset selection.
- Does not change plan generation or draft parsing.
- Does not execute a draft automatically.

## Architecture

### Before

Eager session recovery created conversations without their saved harness, causing the planning runner to select Cursor.

### After

Recovery loads launch context, resolves its named preset, and passes its tool and model into the restored session.

```mermaid
flowchart LR
  savedContext[SavedLaunchContext] --> preset[NamedHarnessPreset]
  preset --> restoredSession[RestoredPlanningSession]
  restoredSession --> planner[PlannerCommand]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test -- slack-plan-submission-repros.e2e.test.ts slack-surface-workflows.test.ts thread-session-manager.test.ts`
- [x] `pnpm --filter @invoker/surfaces build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7564837`
- Post-revert steps: Restart the Slack manager only if this revision has been deployed.
- Data migration? No

</details>
