### PR TITLE
Remove In-App Auto-Fix Trigger Step 1 (2) Drop feed scheduler wiring

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2389,9 +2389,6 @@ function createEmbeddedTerminalBackendFromConfig(
       getMainWindow: () => mainWindow,
       setStartupWorkflowId: (workflowId) => { startupWorkflowId = workflowId; },
       requestWorkflowMetadataPublish,
-      scheduleAutoFix: (taskId) => requireGuiMutationTaskActions().scheduleAutoFix(taskId),
-      logAutoFixDebug: (taskId, phase, details) =>
-        requireGuiMutationTaskActions().logAutoFixDebug(taskId, phase, details),
       uiPerfStats,
       traceUiDeltaFlow,
       traceDbPollPerTask,


### PR DESCRIPTION
## Summary
Stop routing auto-fix scheduler hooks from `main.ts` into the renderer task feed.

## Review Claim
The main-process feed construction no longer routes unused scheduler callbacks into the renderer feed.

## Review Lane
refactor

## Review Unit
routing

## Safety Invariant
The feed treats those callbacks as optional after slice 1, so dropping the arguments preserves behavior.

## Slice Rationale
This separates the main-process dependency edit from the feed behavior slice.

## Architecture
### Before
`main.ts` supplied auto-fix scheduler callbacks when constructing the renderer task feed.

### After
`main.ts` constructs the renderer task feed without auto-fix scheduler callbacks.

## Non-goals
- Behavior unchanged after slice 1.
- Do not change renderer delta handling.
- Do not change GUI mutation handlers.

## Test Plan
<details>
<summary>Test Plan</summary>

- `pnpm run check:types`

</details>

## Revert Plan
<details>
<summary>Revert Plan</summary>

- `git revert 3fbb3edbb6790982c4a513e65d1bfb4962194ff6`

</details>

Depends-On: #5525
