### PR TITLE
Remove In-App Auto-Fix Trigger Step 1 (3) Delete GUI auto-fix scheduler

### DIFF
--- a/packages/app/src/__tests__/no-autofix-outside-worker.test.ts
+++ b/packages/app/src/__tests__/no-autofix-outside-worker.test.ts
@@ -73,13 +73,10 @@ const TRIGGER_SIGNALS: ReadonlyArray<{ name: string; pattern: RegExp }> = [
  *
  *  (A) the shared auto-fix worker engine in `@invoker/execution-engine`,
  *  (B) the shared fix action / operator-facing `fix ... --auto-fix` command
- *      route in `@invoker/app`, and
- *  (C) one legacy helper module that is no longer wired into `main.ts`.
+ *      route in `@invoker/app`.
  *
  * Adding an entry here is a deliberate act: it either declares a sanctioned
- * auto-fix site or documents an unreachable legacy file that still needs its
- * own cleanup slice. Anything not listed here that trips a signal fails the
- * build.
+ * auto-fix site. Anything not listed here that trips a signal fails the build.
  */
 const ALLOWLIST: ReadonlySet<string> = new Set([
   // (A) shared worker engine — now extracted into @invoker/execution-engine
@@ -92,9 +89,6 @@ const ALLOWLIST: ReadonlySet<string> = new Set([
   'packages/app/src/workers/auto-fix-recovery.ts',
   'packages/app/src/workflow-actions.ts',
   'packages/app/src/headless.ts',
-  // (C) dead legacy helper not imported by main.ts; tracked separately so this
-  // guard still catches any new live in-app auto-fix path.
-  'packages/app/src/ipc/gui-mutation-handlers.ts',
   'packages/execution-engine/src/review-gate-ci-repair.ts',
 ]);
 
@@ -264,10 +258,10 @@ describe('no auto-fix outside the shared worker engine', () => {
   });
 
   it('catches the incident-2026-07-12 pattern: app scheduling an automatic fix', () => {
-    // The removed main.ts scheduleAutoFix built an automatic fix intent and
-    // enqueued it directly on a failed-task delta — bypassing the worker.
+    // The removed GUI scheduler built an automatic fix intent and enqueued it
+    // directly on a failed-task delta, bypassing the worker.
     const planted: SourceFile = {
-      path: 'packages/app/src/main.ts',
+      path: 'packages/app/src/ipc/gui-mutation-handlers.ts',
       content: [
         'const scheduleAutoFix = (taskId: string): void => {',
         "  void runWorkflowMutation(wf, 'normal', 'invoker:fix-with-agent',",

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -64,7 +64,6 @@ import { submitWorkflowMutationOrAcknowledgeDeleted } from '../workflow-mutation
 import type { WorkflowMutationContext } from '../persisted-workflow-mutation-coordinator.js';
 import {
   buildHeadlessFixArgs,
-  listOpenFixIntentsForTask,
   parseFixWithAgentMutationArgs,
   type ReviewGateCiContext,
 } from '../auto-fix-intents.js';
@@ -109,11 +108,6 @@ import { createRendererTaskFeed } from '../window/renderer-task-feed.js';
 import { createTaskGraphEventPublisher } from '../task-graph-event-publisher.js';
 import type { GuiMutationPayload, GuiMutationRegistrars } from './ipc-registration.js';
 import { resolveInvokerHomeRoot } from '../delete-all-snapshot.js';
-import {
-  buildRecoveryWorkerAuditPayload,
-  classifyAutoFixRecoveryPhase,
-  recoveryWorkerEventType,
-} from '../recovery-worker-observability.js';
 
 export interface HeadlessRunMutationPayload {
   planPath: string;
@@ -226,8 +220,6 @@ type RendererTaskFeed = ReturnType<typeof createRendererTaskFeed>;
 type TaskGraphEventPublisher = ReturnType<typeof createTaskGraphEventPublisher>;
 
 export interface GuiMutationTaskActions {
-  scheduleAutoFix: (taskId: string) => void;
-  logAutoFixDebug: (taskId: string, phase: string, details?: Record<string, unknown>) => void;
   performDeleteWorkflow: (workflowId: string) => Promise<void>;
   performDetachWorkflow: (workflowId: string, upstreamWorkflowId: string) => Promise<void>;
   performCancelTask: (taskId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
@@ -376,72 +368,6 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
     orchestrator = context.getOrchestrator();
     commandService = context.getCommandService();
   };
-  const buildAutoFixQueueSnapshot = (taskId: string): Record<string, unknown> => {
-    const workflowId = workflowIdForTaskArg(taskId);
-    if (!workflowId) {
-      return {
-        workflowId: null,
-        openIntentCountForWorkflow: 0,
-        openFixIntentCountForWorkflow: 0,
-        openFixIntentCountForTask: 0,
-        openFixIntentForTask: false,
-        openFixIntentHead: null,
-        openFixIntentPreview: [],
-      };
-    }
-    const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
-    const openFixIntents = openIntents.filter((intent) => (
-      intent.channel === 'invoker:fix-with-agent' || intent.channel === 'headless.exec'
-    ));
-    const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
-    return {
-      workflowId,
-      openIntentCountForWorkflow: openIntents.length,
-      openFixIntentCountForWorkflow: openFixIntents.length,
-      openFixIntentCountForTask: openTaskFixIntents.length,
-      openFixIntentForTask: openTaskFixIntents.length > 0,
-      openFixIntentHead: openTaskFixIntents[0]
-        ? {
-          id: openTaskFixIntents[0].id,
-          status: openTaskFixIntents[0].status,
-          channel: openTaskFixIntents[0].channel,
-        }
-        : null,
-      openFixIntentPreview: openTaskFixIntents.slice(0, 5).map((intent) => ({
-        id: intent.id,
-        status: intent.status,
-        channel: intent.channel,
-      })),
-    };
-  };
-
-  const logAutoFixDebug = (
-    taskId: string,
-    phase: string,
-    details: Record<string, unknown> = {},
-  ): void => {
-    const task = orchestrator.getTask(taskId);
-    const payload = {
-      phase,
-      status: task?.status ?? 'missing',
-      ...buildAutoFixQueueSnapshot(taskId),
-      ...details,
-    };
-    persistence.logEvent?.(taskId, 'debug.auto-fix', payload);
-    const recoveryAction = classifyAutoFixRecoveryPhase(phase, payload);
-    if (recoveryAction) {
-      persistence.logEvent?.(
-        taskId,
-        recoveryWorkerEventType(recoveryAction),
-        buildRecoveryWorkerAuditPayload(recoveryAction, phase, payload),
-      );
-    }
-    logger.info(
-      `[auto-fix-debug] task="${taskId}" phase=${phase} payload=${JSON.stringify(payload)}`,
-      { module: 'auto-fix' },
-    );
-  };
-
   const executeFixWithAgentMutation = async (
     taskId: string,
     agentName?: string,
@@ -480,64 +406,6 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
       },
     );
     return result.started;
-  };
-
-  const scheduleAutoFix = (taskId: string): void => {
-    logAutoFixDebug(taskId, 'schedule-enter');
-    const workflowMutationCoordinator = getWorkflowMutationCoordinator();
-    if (!workflowMutationCoordinator) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'no-workflow-mutation-coordinator' });
-      return;
-    }
-    if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'fix-handler-not-ready' });
-      return;
-    }
-    const workflowId = workflowIdForTaskArg(taskId);
-    if (!workflowId) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'workflow-not-found' });
-      return;
-    }
-    const shouldAutoFixNow = orchestrator.shouldAutoFix(taskId);
-    if (!shouldAutoFixNow) {
-      logAutoFixDebug(taskId, 'schedule-skip', {
-        reason: 'shouldAutoFix-false',
-        shouldAutoFix: shouldAutoFixNow,
-      });
-      return;
-    }
-    const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
-    const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
-    if (openTaskFixIntents.length > 0) {
-      logAutoFixDebug(taskId, 'schedule-skip', {
-        reason: 'already-queued-intent',
-        existingIntentIds: openTaskFixIntents.map((intent) => intent.id),
-      });
-      return;
-    }
-    const configuredAgent = loadConfig().autoFixAgent?.trim();
-    const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
-    logAutoFixDebug(taskId, 'schedule-enqueue');
-    logAutoFixDebug(taskId, 'schedule-enqueued');
-    void runWorkflowMutation(
-      workflowId,
-      'normal',
-      'invoker:fix-with-agent',
-      [taskId, selectedAgent],
-      async () => executeFixWithAgentMutation(taskId, selectedAgent, 'auto-fix'),
-    )
-      .then(() => {
-        logAutoFixDebug(taskId, 'schedule-dispatch-finished');
-      })
-      .catch((err) => {
-        if (err instanceof StaleLineageError) {
-          logger.info(`auto-fix discarded stale result for "${taskId}": ${err.message}`, { module: 'auto-fix' });
-          return;
-        }
-        logAutoFixDebug(taskId, 'schedule-dispatch-error', {
-          error: err instanceof Error ? err.stack ?? err.message : String(err),
-        });
-      });
   };
 
   /** Cancel a task and cascade-kill all downstream DAG dependents. Shared by IPC, headless, and API. */
@@ -1002,8 +870,6 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
 
 
   return {
-    scheduleAutoFix,
-    logAutoFixDebug,
     performDeleteWorkflow,
     performDetachWorkflow,
     performCancelTask,

--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -69,8 +69,6 @@ export interface RendererTaskFeedDeps {
   getMainWindow: () => BrowserWindow | null;
   setStartupWorkflowId: (workflowId: string | null) => void;
   requestWorkflowMetadataPublish: (reason: string) => void;
-  scheduleAutoFix?: (taskId: string) => void;
-  logAutoFixDebug?: (taskId: string, phase: string, details?: Record<string, unknown>) => void;
   uiPerfStats: RendererTaskFeedUiPerfStats;
   traceUiDeltaFlow: boolean;
   traceDbPollPerTask: boolean;


### PR DESCRIPTION
## Summary
Retire the now-unwired GUI auto-fix activation surface and close the source-sweep allowlist gap.

## Review Claim
The GUI mutation action set no longer exposes an automatic auto-fix activation helper.

## Review Lane
refactor

## Review Unit
activation-surface

## Safety Invariant
Behavior unchanged after slices 1 and 2; the deleted helper has no remaining caller.

## Slice Rationale
This follows after no caller depends on the GUI scheduler.

## Architecture
### Before
GUI mutation actions still exposed an automatic auto-fix scheduler helper even after the renderer feed stopped using it.

### After
GUI mutation actions expose only explicit operator fix handling, and the guard test no longer allowlists the old helper file.

## Non-goals
- Behavior unchanged after the prior slices.
- Do not change explicit operator `fix-with-agent` requests.
- Do not change worker recovery behavior.

## Test Plan
<details>
<summary>Test Plan</summary>

- `pnpm --filter @invoker/app exec vitest run src/__tests__/no-autofix-outside-worker.test.ts`
- `pnpm run check:types`

</details>

## Revert Plan
<details>
<summary>Revert Plan</summary>

- `git revert 89608336cd2a441bb40ac568e04bbd3d5d66c639`

</details>

Depends-On: #5534
