### PR TITLE
[Slack Repo Binding Step 3: Mid-thread rebind](1) Rebind thread repo from follow-up URL

### DIFF
--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import * as child_process from 'node:child_process';
 import { SlackSurface, extractRepoUrlFromMessage, parsePlanningRequest, parseLobbyClassification, parseLocalRequest, parseThreadRequest, parseWorkflowStatusQuery, BUILTIN_HARNESS_PRESETS, buildLobbyQuestionPrompt } from '../slack/slack-surface.js';
-import { SQLiteAdapter, ConversationRepository, WorkflowChannelRepository } from '@invoker/data-store';
+import { SQLiteAdapter, ConversationRepository, SlackSessionRepository, WorkflowChannelRepository } from '@invoker/data-store';
 import type { SurfaceCommand } from '../surface.js';
 import type { WorkflowContext } from '../slack/workflow-assistant.js';
 
@@ -574,6 +574,14 @@ describe('lobby verb routing', () => {
     });
   }
 
+  async function persistentLobbySurface(extra: Partial<ConstructorParameters<typeof SlackSurface>[0]> = {}) {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    const conversationRepo = new ConversationRepository(adapter, { info: silentLog, warn: silentLog, error: silentLog });
+    const slackSessionRepo = new SlackSessionRepository(adapter);
+    const surface = lobbySurface(true, { conversationRepo, slackSessionRepo, ...extra });
+    return { adapter, slackSessionRepo, surface };
+  }
+
   it('asks lobby question answers to be short ELI5 Slack prose except for clearly technical questions', () => {
     const prompt = buildLobbyQuestionPrompt('how many workflows are running?');
     expect(prompt).toContain('ELI5 Slack prose');
@@ -999,6 +1007,140 @@ describe('lobby verb routing', () => {
     expect(planConversationConfigs).toHaveLength(1);
     expect(planConversationConfigs[0].repoUrl).toBe('git@github.com:default/repo.git');
     expect(say.mock.calls.map((call) => call[0].text).join('\n')).not.toContain('from the URL in your message');
+  });
+
+  it('rebinds a follow-up repo-root URL, clears workingDir, and checks out the new repo on the next turn', async () => {
+    const oldRepo = 'https://github.com/openai/old-repo';
+    const newRepo = 'https://github.com/openai/new-repo';
+    const prepareRepoCheckout = vi.fn().mockResolvedValue('/checkouts/new-repo');
+    const { adapter, slackSessionRepo, surface } = await persistentLobbySurface({
+      defaultRepoUrl: oldRepo,
+      workingDir: '/checkouts/old-repo',
+      prepareRepoCheckout,
+    });
+
+    try {
+      await surface.start(async () => {});
+      await mentionHandler(surface)({
+        event: { text: '<@BOT> local: start in the current repo', ts: 't1', user: 'U1', channel: 'CLOBBY' },
+        say: vi.fn().mockResolvedValue({ ts: 'a' }),
+      });
+      expect(slackSessionRepo.getLaunchContext('t1')).toEqual(expect.objectContaining({
+        repoUrl: oldRepo,
+        workingDir: '/checkouts/old-repo',
+      }));
+
+      const rebindSay = vi.fn().mockResolvedValue({ ts: 'b' });
+      await messageHandler(surface)({
+        event: { thread_ts: 't1', ts: 't2', user: 'U1', text: `Please use ${newRepo} instead`, channel: 'CLOBBY' },
+        say: rebindSay,
+      });
+
+      expect(prepareRepoCheckout).not.toHaveBeenCalled();
+      expect(slackSessionRepo.getLaunchContext('t1')).toEqual(expect.objectContaining({
+        repoUrl: newRepo,
+        workingDir: '',
+      }));
+      expect(rebindSay).toHaveBeenCalledWith(expect.objectContaining({
+        text: expect.stringContaining('openai/new-repo'),
+        thread_ts: 't1',
+      }));
+      expect(rebindSay.mock.calls[0][0].text).toContain('previous working state for this thread was discarded');
+      expect(planConversationConfigs).toHaveLength(1);
+
+      await messageHandler(surface)({
+        event: { thread_ts: 't1', ts: 't3', user: 'U1', text: 'run local: make the update now', channel: 'CLOBBY' },
+        say: vi.fn().mockResolvedValue({ ts: 'c' }),
+      });
+
+      expect(prepareRepoCheckout).toHaveBeenCalledWith(newRepo);
+      expect(slackSessionRepo.getLaunchContext('t1')).toEqual(expect.objectContaining({
+        repoUrl: newRepo,
+        workingDir: '/checkouts/new-repo',
+      }));
+      expect(planConversationConfigs.at(-1)).toEqual(expect.objectContaining({
+        mode: 'agent',
+        repoUrl: newRepo,
+        workingDir: '/checkouts/new-repo',
+      }));
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
+  });
+
+  it('treats a follow-up URL for the already-bound repo as a no-op', async () => {
+    const boundRepo = 'git@github.com:openai/invoker.git';
+    const prepareRepoCheckout = vi.fn().mockResolvedValue('/checkouts/unused');
+    const { adapter, slackSessionRepo, surface } = await persistentLobbySurface({
+      defaultRepoUrl: boundRepo,
+      workingDir: '/checkouts/invoker',
+      prepareRepoCheckout,
+    });
+
+    try {
+      await surface.start(async () => {});
+      await mentionHandler(surface)({
+        event: { text: '<@BOT> local: start in invoker', ts: 't1', user: 'U1', channel: 'CLOBBY' },
+        say: vi.fn().mockResolvedValue({ ts: 'a' }),
+      });
+
+      const sameRepoSay = vi.fn().mockResolvedValue({ ts: 'b' });
+      await messageHandler(surface)({
+        event: { thread_ts: 't1', ts: 't2', user: 'U1', text: 'run local: continue in https://github.com/openai/invoker', channel: 'CLOBBY' },
+        say: sameRepoSay,
+      });
+
+      expect(prepareRepoCheckout).not.toHaveBeenCalled();
+      expect(slackSessionRepo.getLaunchContext('t1')).toEqual(expect.objectContaining({
+        repoUrl: boundRepo,
+        workingDir: '/checkouts/invoker',
+      }));
+      expect(planConversationConfigs).toHaveLength(1);
+      const texts = sameRepoSay.mock.calls.map((call) => call[0].text).join('\n');
+      expect(texts).not.toContain('switched this thread');
+      expect(texts).not.toContain('previous working state');
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
+  });
+
+  it('does not rebind a follow-up deep link', async () => {
+    const boundRepo = 'https://github.com/openai/invoker';
+    const prepareRepoCheckout = vi.fn().mockResolvedValue('/checkouts/unused');
+    const { adapter, slackSessionRepo, surface } = await persistentLobbySurface({
+      defaultRepoUrl: boundRepo,
+      workingDir: '/checkouts/invoker',
+      prepareRepoCheckout,
+    });
+
+    try {
+      await surface.start(async () => {});
+      await mentionHandler(surface)({
+        event: { text: '<@BOT> local: start in invoker', ts: 't1', user: 'U1', channel: 'CLOBBY' },
+        say: vi.fn().mockResolvedValue({ ts: 'a' }),
+      });
+
+      const deepLinkSay = vi.fn().mockResolvedValue({ ts: 'b' });
+      await messageHandler(surface)({
+        event: { thread_ts: 't1', ts: 't2', user: 'U1', text: 'run local: inspect https://github.com/openai/new-repo/pull/123', channel: 'CLOBBY' },
+        say: deepLinkSay,
+      });
+
+      expect(prepareRepoCheckout).not.toHaveBeenCalled();
+      expect(slackSessionRepo.getLaunchContext('t1')).toEqual(expect.objectContaining({
+        repoUrl: boundRepo,
+        workingDir: '/checkouts/invoker',
+      }));
+      expect(planConversationConfigs).toHaveLength(1);
+      const texts = deepLinkSay.mock.calls.map((call) => call[0].text).join('\n');
+      expect(texts).not.toContain('switched this thread');
+      expect(texts).not.toContain('previous working state');
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
   });
 
   it('asks for a repo instead of planning when a plan mention has no tag, repo URL, or default', async () => {

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -206,6 +206,53 @@ export function extractRepoUrlFromMessage(text: string): string | undefined {
   return undefined;
 }
 
+type RepoParts = {
+  host: string;
+  path: string;
+};
+
+function stripGitSuffix(path: string): string {
+  return path.replace(/\/+$/g, '').replace(/\.git$/i, '');
+}
+
+function parseRepoParts(repoUrl: string): RepoParts | undefined {
+  const trimmed = repoUrl.trim().replace(/\/+$/g, '');
+  const scpLike = /^git@([^:]+):(.+)$/.exec(trimmed);
+  if (scpLike) return { host: scpLike[1], path: stripGitSuffix(scpLike[2]) };
+
+  const sshUrl = /^ssh:\/\/git@([^/]+)\/(.+)$/i.exec(trimmed);
+  if (sshUrl) return { host: sshUrl[1], path: stripGitSuffix(sshUrl[2]) };
+
+  try {
+    const parsed = new URL(trimmed);
+    if (!parsed.host || !['http:', 'https:', 'ssh:'].includes(parsed.protocol)) return undefined;
+    const path = parsed.pathname.replace(/^\/+/, '');
+    if (!path) return undefined;
+    return { host: parsed.host, path: stripGitSuffix(path) };
+  } catch {
+    return undefined;
+  }
+}
+
+function repoIdentity(repoUrl: string): string {
+  const parts = parseRepoParts(repoUrl);
+  if (!parts) return stripGitSuffix(repoUrl.trim()).toLowerCase();
+  const host = parts.host.toLowerCase();
+  const path = host === 'github.com' ? parts.path.toLowerCase() : parts.path;
+  return `${host}/${path}`;
+}
+
+function sameRepoUrl(a: string, b: string): boolean {
+  return repoIdentity(a) === repoIdentity(b);
+}
+
+function repoDisplayName(repoUrl: string): string {
+  const parts = parseRepoParts(repoUrl);
+  if (!parts) return repoUrl;
+  const segments = parts.path.split('/').filter(Boolean);
+  return segments.length >= 2 ? segments.slice(-2).join('/') : parts.path;
+}
+
 /** Peel leading `[preset]` and `[repo:]` tags off a lobby mention; the rest is the request text. A preset-shaped tag matching no key is returned as `unknownPreset` so the caller can reject it instead of silently using the default. */
 export function parsePlanningRequest(
   text: string,
@@ -448,6 +495,14 @@ type PlanningRepoResolution = {
   url?: string;
   error?: string;
   source: 'tag' | 'message-url' | 'default' | 'none';
+};
+
+type ConversationSessionOptions = {
+  tool?: string;
+  model?: string;
+  workingDir?: string;
+  mode?: ConversationMode;
+  repoUrl?: string;
 };
 
 interface SlackMentionEvent {
@@ -896,7 +951,7 @@ export class SlackSurface implements Surface {
     const routeRepoUrl = repoResolution.url;
 
     const threadTs = event.thread_ts ?? event.ts;
-    const requiresPlanningRepo = channel === this.lobbyChannelId;
+    const requiresPlanningRepo = channel === this.lobbyChannelId && !!this.planningCommandBuilder;
     const messageRepoUrl = requiresPlanningRepo && !parsed.repo
       ? extractRepoUrlFromMessage(event.text ?? '')
       : undefined;
@@ -1463,6 +1518,72 @@ export class SlackSurface implements Surface {
     });
   }
 
+  private async maybeRebindThreadRepo(
+    channel: string,
+    threadTs: string,
+    userId: string | undefined,
+    text: string,
+    say: SayFn,
+  ): Promise<{ context?: PlanningContext; rebound: boolean }> {
+    const context = this.loadPlanningContext(threadTs);
+    const repoUrl = extractRepoUrlFromMessage(text);
+    if (!repoUrl || !context?.repoUrl) return { context, rebound: false };
+    if (sameRepoUrl(context.repoUrl, repoUrl)) return { context, rebound: false };
+
+    const updated: PlanningContext = {
+      ...context,
+      repoUrl,
+      workingDir: undefined,
+      requestedBy: context.requestedBy ?? userId,
+      lobbyChannel: context.lobbyChannel ?? channel,
+    };
+    this.savePlanningContext(threadTs, updated);
+    this.discardThreadSession(channel, threadTs);
+
+    await say({
+      text: `I switched this thread to repo \`${repoDisplayName(repoUrl)}\`. The previous working state for this thread was discarded.`,
+      thread_ts: threadTs,
+    });
+    return { context: updated, rebound: true };
+  }
+
+  private discardThreadSession(channel: string, threadTs: string): void {
+    if (this.sessionManager) {
+      this.sessionManager.evictSession(new SessionIdentifier(channel, threadTs));
+      return;
+    }
+    this.planConversations.delete(threadTs);
+  }
+
+  private async preparePlanningContextForSession(
+    threadTs: string,
+    context: PlanningContext,
+    say: SayFn,
+  ): Promise<PlanningContext | undefined> {
+    if (!context.repoUrl || context.workingDir || !this.prepareRepoCheckout) return context;
+    try {
+      const workingDir = await this.prepareRepoCheckout(context.repoUrl);
+      const updated = { ...context, workingDir };
+      this.savePlanningContext(threadTs, updated);
+      return updated;
+    } catch (err) {
+      this.log('slack', 'error', `Failed to prepare repo checkout for ${context.repoUrl}: ${err}`);
+      await say({ text: `Failed to check out repo: ${err instanceof Error ? err.message : String(err)}`, thread_ts: threadTs });
+      return undefined;
+    }
+  }
+
+  private sessionOptionsFromContext(context: PlanningContext, mode?: ConversationMode): ConversationSessionOptions {
+    const preset = this.resolveHarnessPreset(context.presetKey);
+    return {
+      tool: preset.tool,
+      model: preset.model,
+      workingDir: context.workingDir,
+      mode,
+      repoUrl: context.repoUrl,
+    };
+  }
+
   private getPendingConfirm(key: string): PendingConfirm | undefined {
     const inMemory = this.pendingConfirms.get(key);
     if (inMemory) return inMemory;
@@ -1960,6 +2081,7 @@ ${text}`;
         await this.handleLobbySubmit(channel, msg.thread_ts, msg.user ?? 'unknown', say);
         return;
       }
+      if (!text) return;
 
       const localRequest = parseLocalRequest(text);
       if (localRequest?.kind === 'command') {
@@ -1968,11 +2090,16 @@ ${text}`;
         return;
       }
 
+      let planningContext: PlanningContext | undefined;
+      const rebind = await this.maybeRebindThreadRepo(channel, msg.thread_ts, msg.user, text, say);
+      planningContext = rebind.context;
+      if (rebind.rebound) return;
+
       let threadRequest = parseThreadRequest(text);
       const explicitLocalAgent = localRequest?.kind === 'agent' || localRequest?.kind === 'change';
       if (!explicitLocalAgent && threadRequest?.mode !== 'plan') {
-        const context = this.loadPlanningContext(msg.thread_ts);
-        const preset = this.resolveHarnessPreset(context?.presetKey ?? this.defaultHarnessPreset);
+        planningContext ??= this.loadPlanningContext(msg.thread_ts);
+        const preset = this.resolveHarnessPreset(planningContext?.presetKey ?? this.defaultHarnessPreset);
         const cls = await this.classifyLobbyIntent(text, preset);
         this.log('slack', 'info', `[CLASSIFY] thread_ts=${msg.thread_ts} intent=${cls.intent}`);
         if (cls.intent === 'plan') {
@@ -1986,12 +2113,16 @@ ${text}`;
           ? await this.sessionManager.getSession(id, msg.user ?? 'unknown')
           : undefined;
         if (current?.conversationMode === 'agent' && this.sessionManager) {
-          const context: PlanningContext = this.loadPlanningContext(msg.thread_ts) ?? {
+          let context: PlanningContext = planningContext ?? this.loadPlanningContext(msg.thread_ts) ?? {
             presetKey: this.defaultHarnessPreset,
             workingDir: this.workingDir,
             requestedBy: msg.user,
             lobbyChannel: channel,
           };
+          const preparedContext = await this.preparePlanningContextForSession(msg.thread_ts, context, say);
+          if (!preparedContext) return;
+          context = preparedContext;
+          planningContext = context;
           const preset = this.resolveHarnessPreset(context.presetKey);
           const promoted = await this.sessionManager.promoteToPlanSession(id, msg.user ?? 'unknown', {
             tool: preset.tool,
@@ -2006,9 +2137,18 @@ ${text}`;
       }
 
       // Look up or recover session (don't create new sessions for random thread replies in fallback mode)
-      const conversation = await this.getSession(channel, msg.thread_ts, msg.user ?? 'unknown', false);
+      planningContext ??= this.loadPlanningContext(msg.thread_ts);
+      if (planningContext) {
+        const preparedContext = await this.preparePlanningContextForSession(msg.thread_ts, planningContext, say);
+        if (!preparedContext) return;
+        planningContext = preparedContext;
+      }
+      const sessionOpts = planningContext
+        ? this.sessionOptionsFromContext(planningContext, threadRequest?.mode)
+        : undefined;
+      const shouldCreateFallbackSession = !!sessionOpts && !this.sessionManager;
+      const conversation = await this.getSession(channel, msg.thread_ts, msg.user ?? 'unknown', shouldCreateFallbackSession, sessionOpts);
       if (!conversation) return;
-      if (!text) return;
 
       this.log('slack', 'info', `[SESSION_MESSAGE] Thread reply (thread_ts=${msg.thread_ts}, user=${msg.user}, preview="${text.slice(0, 100)}${text.length > 100 ? '...' : ''}")`);
 
@@ -2339,7 +2479,7 @@ ${text}`;
     threadTs: string,
     userId: string,
     create = true,
-    opts?: { tool?: string; model?: string; workingDir?: string; mode?: ConversationMode; repoUrl?: string },
+    opts?: ConversationSessionOptions,
   ): Promise<ConversationLike | null> {
     this.log('slack', 'info', `[TRACE] getSession (channelId=${channelId}, threadTs=${threadTs}, userId=${userId}, create=${create}, hasSessionManager=${!!this.sessionManager})`);
     if (this.sessionManager) {
@@ -2350,6 +2490,7 @@ ${text}`;
         const found = await this.sessionManager.getSession(
           new SessionIdentifier(channelId, threadTs),
           userId,
+          opts,
         );
         this.log('slack', 'info', `[TRACE] findSession returned ${found ? 'session' : 'null'} (threadTs=${threadTs})`);
         return found;

--- a/packages/surfaces/src/slack/thread-session-manager.ts
+++ b/packages/surfaces/src/slack/thread-session-manager.ts
@@ -190,6 +190,8 @@ export interface SessionMetrics {
   active: number;
 }
 
+type SessionOptions = { tool?: string; model?: string; workingDir?: string; mode?: ConversationMode; repoUrl?: string };
+
 const defaultLog: LogFn = (component, level, message) => {
   const prefix = `[${component}]`;
   if (level === 'error') console.error(prefix, message);
@@ -275,7 +277,7 @@ export class SessionManager {
   async getOrCreateSession(
     id: SessionIdentifier,
     userId: string,
-    opts?: { tool?: string; model?: string; workingDir?: string; mode?: ConversationMode; repoUrl?: string },
+    opts?: SessionOptions,
   ): Promise<SessionHandle | null> {
     const key = id.toString();
 
@@ -466,14 +468,14 @@ export class SessionManager {
    * Look up an existing session without creating a new persisted conversation.
    * Rehydrates an active persisted conversation after memory eviction.
    */
-  async getSession(id: SessionIdentifier, userId: string): Promise<SessionHandle | null> {
+  async getSession(id: SessionIdentifier, userId: string, opts?: SessionOptions): Promise<SessionHandle | null> {
     const existing = this.sessions.get(id.toString());
     if (existing) return existing;
     const persisted = this.conversationRepo.loadConversation(id.threadTs);
     if (!persisted || persisted.planSubmitted || (persisted.channelId && persisted.channelId !== id.channelId)) {
       return null;
     }
-    return this.getOrCreateSession(id, userId);
+    return this.getOrCreateSession(id, userId, opts);
   }
 
   findSession(id: SessionIdentifier): SessionHandle | null {


### PR DESCRIPTION
## Summary

Slack Repo Binding Step 3: Mid-thread rebind — 2 tasks completed, 0 failed, 0 closed, 0 sk&#105;pped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784693264462-5/implement-mid-thread-rebind | A repo-root URL in a follow-up message rebinds the running thread to that repo | completed |
| wf-1784693264462-5/verify-mid-thread-rebind | Run workflow-routing and thread-isolation tests | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784693264462-5/implement-mid-thread-rebind — A repo-root URL in a follow-up message rebinds the running thread to that repo

### wf-1784693264462-5/verify-mid-thread-rebind — Run workflow-routing and thread-isolation tests

</details>

Follow-up Slack replies can switch a running planning thread to a different repo when they include a repo-root URL.

The previous working directory is discarded, and the next agent turn checks out the newly bound repo before continuing.

## Review Claim

Approve Slack thread repo rebinding when a follow-up message contains a different repo-root URL.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change is limited to Slack thread routing and session context. It does not alter workflow execution, storage schema, or PR publication behavior.

## Slice Rationale

This slice keeps mid-thread repo handoff, session eviction, checkout preparation, and direct regression coverage together because the behavior is only observable across that routing flow.

## Non-goals

- No changes to first-message repo binding behavior.
- No support for rebinding from deep links.
- No changes to workflow execution, PR publication, or Slack UI formatting beyond the rebind notice.

## Architecture

### Before

```mermaid
graph TD
    A["Slack follow-up contains a different repo URL"] --> B["Existing thread planning context remains bound to the old repo"]
    B --> C["Existing session or working directory continues handling the thread"]
```

### After

```mermaid
graph TD
    A["Slack follow-up contains a different repo-root URL"] --> B["Thread planning context saves the new repo"]
    B --> C["Old thread session is evicted and workingDir is cleared"]
    C --> D["Next agent turn checks out the new repo before continuing"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces test -- src/__tests__/slack-surface-workflows.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-or-stack-sha>`
- Post-revert steps: None
- Data migration? No

</details>
