### PR TITLE
Remove In-App Auto-Fix Trigger Step 1 (1) Stop feed activation

### DIFF
--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -3,7 +3,6 @@ import type { Logger, WorkResponse } from '@invoker/contracts';
 import type { Workflow } from '@invoker/data-store';
 import { Channels, type MessageBus } from '@invoker/transport';
 import type { TaskDelta, TaskState } from '@invoker/workflow-core';
-import { shouldSkipAutoFixForError } from '../auto-fix-gating.js';
 import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from '../delta-merge.js';
 import { evaluateExecutingStall, taskNeedsExecutingStallCheck } from '../executing-stall.js';
 import { persistShutdownDiagnostic, type ShutdownDiagnosticDb } from '../shutdown-diagnostic.js';
@@ -36,7 +35,6 @@ export interface RendererTaskFeedPersistence extends ShutdownDiagnosticDb {
 export interface RendererTaskFeedOrchestrator {
   getAllTasks(): TaskState[];
   getMergeNode(workflowId: string): TaskState | undefined;
-  shouldAutoFix(taskId: string): boolean;
   syncAllFromDb(): void;
   handleWorkerResponse(response: WorkResponse): void;
   reclaimStalledFixSession(
@@ -71,8 +69,8 @@ export interface RendererTaskFeedDeps {
   getMainWindow: () => BrowserWindow | null;
   setStartupWorkflowId: (workflowId: string | null) => void;
   requestWorkflowMetadataPublish: (reason: string) => void;
-  scheduleAutoFix: (taskId: string) => void;
-  logAutoFixDebug: (taskId: string, phase: string, details?: Record<string, unknown>) => void;
+  scheduleAutoFix?: (taskId: string) => void;
+  logAutoFixDebug?: (taskId: string, phase: string, details?: Record<string, unknown>) => void;
   uiPerfStats: RendererTaskFeedUiPerfStats;
   traceUiDeltaFlow: boolean;
   traceDbPollPerTask: boolean;
@@ -226,31 +224,12 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
   );
 
   // Apply one owner task delta to the local cache and forward results to the
-  // renderer (and drive owner-side auto-fix). Extracted so the detached viewer
-  // can replay deltas that were buffered during hydration.
+  // renderer. Extracted so the detached viewer can replay deltas that were
+  // buffered during hydration.
   const processIncomingTaskDelta = (delta: TaskDelta): void => {
     deps.uiPerfStats.mainDeltaToUi += 1;
     if (deps.traceUiDeltaFlow) {
       deps.logger.debug(`delta→ui: ${JSON.stringify(delta)}`, { module: 'ui' });
-    }
-    const deltaTaskId = delta.type === 'updated' || delta.type === 'removed' ? delta.taskId : undefined;
-    if (delta.type === 'updated' && delta.changes.status === 'failed') {
-      const cancellationError = shouldSkipAutoFixForError(delta.changes.execution?.error);
-      const shouldAutoFixFromOrchestrator = deps.getOrchestrator().shouldAutoFix(delta.taskId);
-      deps.logAutoFixDebug(delta.taskId, 'delta-failed', {
-        shouldSkipForCancellation: cancellationError,
-        shouldAutoFixFromOrchestrator,
-      });
-      if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
-        deps.logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
-        deps.scheduleAutoFix(deltaTaskId);
-      } else if (deltaTaskId) {
-        deps.logAutoFixDebug(deltaTaskId, 'delta-skip', {
-          reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
-          shouldSkipForCancellation: cancellationError,
-          shouldAutoFixFromOrchestrator,
-        });
-      }
     }
     for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(delta)) {
       publishTaskDeltaToRenderer(rendererDelta);


### PR DESCRIPTION
## Summary

Failed task deltas stay as renderer feed updates. App-side scheduler callback activation is absent from this feed path.

## Review Claim

The renderer task feed no longer activates app-side auto-fix scheduling from a failed task delta.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Failed task status still publishes to the renderer and task graph; only app-side auto-fix callback activation changes.

## Slice Rationale

This isolates the renderer activation point before main-process wiring and GUI IPC surfaces change in later slices.

## Non-goals

- Do not change worker-driven recovery.
- Do not change operator-triggered fix-with-agent mutations.
- Do not change SSH executor behavior in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/no-autofix-outside-worker.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Revert commit `b3820214f7a9bab9e2d4b1b1be98fc05f722686a` to restore failed-delta scheduler activation.

</details>
