### PR TITLE
Remove In-App Auto-Fix Trigger Step 1 (4) Preserve SSH bootstrap fallback

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -304,6 +304,43 @@ describe('SshExecutor managed workspace mode', () => {
     }
   });
 
+  it('ignores a legacy whitespace provisionCommand and keeps managed pnpm bootstrap', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+      provisionCommand: '  \n\t  ',
+    } as any) as any;
+
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return '__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=abc123def456abc123def456abc123def456abc1';
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      return '';
+    });
+    vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+    const spawnStub = vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
+      (_executionId: string, _request: any, handle: any) => handle,
+    );
+
+    await ssh.start(makeRequest({
+      actionType: 'command',
+      inputs: {
+        command: 'pnpm test',
+        description: 'run tests',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    }));
+
+    const [, , , callScript] = spawnStub.mock.calls[0]!;
+    expect(callScript).toContain('ensure_managed_pnpm_workspace');
+    expect(callScript).toContain('pnpm install --frozen-lockfile');
+    expect(callScript).not.toContain('PROVISION_PATH="$STAGING_DIR/provision.sh"');
+  });
+
   it('reuses a managed SSH worktree by actionId when the old base is still compatible', async () => {
     const ssh = new SshExecutor({
       host: 'localhost',


### PR DESCRIPTION
## Summary

SSH managed-workspace coverage now proves legacy whitespace provisionCommand config still uses managed pnpm bootstrap.

## Review Claim

The SSH executor has regression proof for whitespace legacy provisionCommand config preserving managed pnpm bootstrap.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This is test-only coverage; production SSH executor behavior is unchanged.

## Slice Rationale

The old runtime provisionCommand path is gone on master, so the current risk is only guarding managed bootstrap behavior.

## Non-goals

- Do not reintroduce runtime provisionCommand support.
- Do not change managed worktree setup.
- Do not change app auto-fix behavior in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- ssh-executor.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Revert commit `336ba58067647abcffaa49e9d8e70191db00740f` to drop the regression proof.

</details>

Depends-On: #5542
