### PR TITLE
Remove In-App Auto-Fix Trigger Step 1 (1) Preserve SSH provision fallback

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -4,9 +4,10 @@ import type { ChildProcess } from 'node:child_process';
 import { SshExecutor } from '../ssh-executor.js';
 import type { WorkRequest } from '@invoker/contracts';
 import type { PersistedTaskMeta } from '../executor.js';
-import { createSshRemoteScriptError } from '../ssh-git-exec.js';
+import { base64Encode, createSshRemoteScriptError } from '../ssh-git-exec.js';
 import { computeRepoUrlHash } from '../git-utils.js';
 import { computeContentHash, buildExperimentBranchName, formatLifecycleTag } from '../branch-utils.js';
+import { DEFAULT_WORKTREE_PROVISION_COMMAND } from '../default-worktree-provision-command.js';
 
 function makeRequest(overrides: Partial<WorkRequest> = {}): WorkRequest {
   return {
@@ -210,6 +211,54 @@ describe('SshExecutor managed workspace mode', () => {
     expect(callScript).toMatch(/base64 -d/);
     expect(callAgentId).toBeUndefined();
     expect(callFinalize).toEqual({ branch: handle.branch, worktreePath: handle.workspacePath });
+  });
+
+  it('uses the default provision command when config contains only whitespace', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+      provisionCommand: '  \n\t  ',
+    }) as any;
+
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return [
+          '__INVOKER_BASE_REF__=origin/main',
+          '__INVOKER_BASE_HEAD__=abc123def456abc123def456abc123def456abc1',
+        ].join('\n');
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      return '';
+    });
+
+    vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+
+    let capturedScript = '';
+    vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
+      (_executionId: string, _request: any, handle: any, script: string) => {
+        capturedScript = script;
+        return handle;
+      },
+    );
+
+    await ssh.start(makeRequest({
+      actionType: 'command',
+      inputs: {
+        command: 'pnpm test',
+        description: 'run tests',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    }));
+
+    expect(capturedScript).toContain(
+      `echo ${base64Encode(DEFAULT_WORKTREE_PROVISION_COMMAND)} | base64 -d`,
+    );
+    expect(capturedScript).toContain(
+      '[SshExecutor] Provisioning remote worktree with: if [ ! -f package.json ]',
+    );
   });
 
   it('reuses a managed SSH worktree by actionId when the old base is still compatible', async () => {

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -99,7 +99,11 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
     this.agentRegistry = config.agentRegistry;
     this.managedWorkspaces = config.managedWorkspaces ?? false;
     this.remoteInvokerHome = config.remoteInvokerHome ?? '~/.invoker';
-    this.provisionCommand = config.provisionCommand ?? DEFAULT_WORKTREE_PROVISION_COMMAND;
+    const configuredProvisionCommand = config.provisionCommand;
+    this.provisionCommand =
+      typeof configuredProvisionCommand === 'string' && configuredProvisionCommand.trim().length > 0
+        ? configuredProvisionCommand
+        : DEFAULT_WORKTREE_PROVISION_COMMAND;
     const configuredRemoteHeartbeatInterval = config.remoteHeartbeatIntervalSeconds;
     this.remoteHeartbeatIntervalSeconds =
       typeof configuredRemoteHeartbeatInterval === 'number'


### PR DESCRIPTION
## Summary

Remove In-App Auto-Fix Trigger Step 1 — 3 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784694716801-6/delete-in-app-trigger | Delete the live in-app auto-fix trigger and scheduler, tighten the guard test | completed |
| wf-1784694716801-6/verify-guard-test | Run the no-autofix-outside-worker guard test with the tightened allowlist | completed (passed) |
| wf-1784694716801-6/verify-types-step-1 | Typecheck the workspace after removing the trigger path | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784694716801-6/delete-in-app-trigger — Delete the live in-app auto-fix trigger and scheduler, tighten the guard test

### wf-1784694716801-6/verify-guard-test — Run the no-autofix-outside-worker guard test with the tightened allowlist

### wf-1784694716801-6/verify-types-step-1 — Typecheck the workspace after removing the trigger path

</details>

This slice treats whitespace-only managed SSH provision commands as absent, so the default bootstrap still runs before remote task payloads.

## Review Claim

Whitespace-only `provisionCommand` values now fall back to the default managed SSH worktree bootstrap.

## Review Lane

behavior

## Review Unit

runtime-configuration

## Safety Invariant

Explicit non-empty provision commands are unchanged, and absent or whitespace-only values now share the existing default path.

## Slice Rationale

This foundation keeps the workspace typecheck and remote bootstrap behavior stable before reviewing the app auto-fix trigger deletion.

## Non-goals

- Do not change the default provision command.
- Do not change remote target configuration shape.
- Do not remove any app auto-fix trigger path in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types` (workflow task `wf-1784694716801-6/verify-types-step-1`, passed)
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-5539-body.md`
- [ ] `pnpm --filter @invoker/execution-engine test -- ssh-executor.test.ts` (local rerun blocked in this merge clone: `node_modules` is not installed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 706426bcf2c1b310960c28b974ce50aaf19bc133`
- Post-revert steps: Re-run `pnpm run check:types`, then run the focused execution-engine test after dependencies are installed.
- Data migration? No

</details>
