### PR TITLE
Remove In-App Auto-Fix Trigger Step 1 (2) Drop main scheduler wiring

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2389,9 +2389,6 @@ function createEmbeddedTerminalBackendFromConfig(
       getMainWindow: () => mainWindow,
       setStartupWorkflowId: (workflowId) => { startupWorkflowId = workflowId; },
       requestWorkflowMetadataPublish,
-      scheduleAutoFix: (taskId) => requireGuiMutationTaskActions().scheduleAutoFix(taskId),
-      logAutoFixDebug: (taskId, phase, details) =>
-        requireGuiMutationTaskActions().logAutoFixDebug(taskId, phase, details),
       uiPerfStats,
       traceUiDeltaFlow,
       traceDbPollPerTask,


### PR DESCRIPTION
## Summary

Main-process bootstrap stops passing scheduler callbacks into renderer task feed construction.

## Review Claim

The main process no longer routes auto-fix scheduler callbacks into renderer feed setup.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Renderer task feed setup still receives its publishing, metadata, and performance dependencies.

## Slice Rationale

This keeps the main-process dependency route separate from the renderer activation change.

## Non-goals

- Do not change worker-driven recovery.
- Do not change operator-triggered fix-with-agent mutations.
- Do not change GUI IPC handler internals in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Revert commit `d691e775b813acd77e16fa6b35b8d4cee8a8f8c1` to pass scheduler callbacks from main bootstrap again.

</details>

Depends-On: #5537
