### PR TITLE
[Slack] Pin repository context across restarts

### DIFF
--- a/packages/slack-manager/src/__tests__/runtime-config.test.ts
+++ b/packages/slack-manager/src/__tests__/runtime-config.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 
 import { describe, expect, it } from 'vitest';
 
-import { readDefaultSlackHarnessPreset, resolveDefaultHarnessPreset } from '../runtime-config.js';
+import { readDefaultSlackHarnessPreset, readSlackRuntimeConfig, resolveDefaultHarnessPreset } from '../runtime-config.js';
 
 describe('runtime-config', () => {
   it('reads defaultSlackHarnessPreset from ~/.invoker/config.json shape', () => {
@@ -15,6 +15,25 @@ describe('runtime-config', () => {
     writeFileSync(configPath, JSON.stringify({ defaultSlackHarnessPreset: 'codex' }));
 
     expect(readDefaultSlackHarnessPreset(configPath)).toBe('codex');
+  });
+
+  it('reads the documented Slack repository aliases and default repository', () => {
+    const home = mkdtempSync(join(tmpdir(), 'invoker-slack-repos-'));
+    const configDir = join(home, '.invoker');
+    mkdirSync(configDir, { recursive: true });
+    const configPath = join(configDir, 'config.json');
+    writeFileSync(configPath, JSON.stringify({
+      defaultRepoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+      slackRepos: {
+        notarepo: 'https://github.com/EdbertChan/notarepo.git',
+        invalid: 42,
+      },
+    }));
+
+    expect(readSlackRuntimeConfig(configPath)).toEqual({
+      defaultRepoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+      repoAliases: { notarepo: 'https://github.com/EdbertChan/notarepo.git' },
+    });
   });
 
   it('falls back to the owner env preset when no config default is present', () => {

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -15,11 +15,11 @@ import path from 'node:path';
 import dotenv from 'dotenv';
 
 import { SlackSurface, type SlackSurfaceConfig } from '@invoker/surfaces';
-import { ConversationRepository, SQLiteAdapter, WorkflowChannelRepository } from '@invoker/data-store';
+import { ConversationRepository, SlackSessionRepository, SQLiteAdapter, WorkflowChannelRepository } from '@invoker/data-store';
 
 import { IpcInvokerClient } from './invoker-client.js';
 import { createInvokerLauncher } from './invoker-launcher.js';
-import { resolveDefaultHarnessPreset, readDefaultSlackHarnessPreset } from './runtime-config.js';
+import { readSlackRuntimeConfig, resolveDefaultHarnessPreset } from './runtime-config.js';
 import { createRunWorkflowOp } from './workflow-ops.js';
 import { createCommandHandler } from './command-handler.js';
 import { startEventSubscription } from './event-subscription.js';
@@ -86,12 +86,13 @@ async function main(): Promise<void> {
   // Manager-owned store — survives while Invoker's DB is owned or its process is down.
   const adapter = await SQLiteAdapter.create(path.join(managerHome, 'slack-manager.db'), { ownerCapability: true });
   const conversationRepo = new ConversationRepository(adapter);
+  const slackSessionRepo = new SlackSessionRepository(adapter);
   const workflowChannelRepo = new WorkflowChannelRepository(adapter);
 
   const repoRoot = process.env.INVOKER_REPO_ROOT ?? process.cwd();
-  const repoUrl = detectRepoUrl(repoRoot, log);
-  const configDefaultHarnessPreset = readDefaultSlackHarnessPreset();
-  const defaultHarnessPreset = resolveDefaultHarnessPreset(process.env.INVOKER_SLACK_DEFAULT_PRESET, configDefaultHarnessPreset);
+  const runtimeConfig = readSlackRuntimeConfig();
+  const repoUrl = process.env.INVOKER_REPO_URL ?? runtimeConfig.defaultRepoUrl ?? detectRepoUrl(repoRoot, log);
+  const defaultHarnessPreset = resolveDefaultHarnessPreset(process.env.INVOKER_SLACK_DEFAULT_PRESET, runtimeConfig.defaultHarnessPreset);
 
   const launcher = createInvokerLauncher({
     repoRoot,
@@ -114,12 +115,14 @@ async function main(): Promise<void> {
     defaultHarnessPreset,
     workingDir: repoRoot,
     conversationRepo,
+    slackSessionRepo,
     workflowChannelRepo,
     planningCommandBuilder: createPlanningCommandBuilder(),
     prepareRepoCheckout: createPrepareRepoCheckout(path.join(managerHome, 'planning-clones')),
     defaultBranch: process.env.INVOKER_DEFAULT_BRANCH ?? 'master',
     repoUrl,
     defaultRepoUrl: repoUrl,
+    repoAliases: runtimeConfig.repoAliases,
     runWorkflowOp,
     gatherWorkflowContext,
     onRestartInvoker: async () => {

--- a/packages/slack-manager/src/runtime-config.ts
+++ b/packages/slack-manager/src/runtime-config.ts
@@ -7,14 +7,46 @@ export function resolveInvokerConfigPath(): string {
 }
 
 export function readDefaultSlackHarnessPreset(configPath = resolveInvokerConfigPath()): string | undefined {
-  if (!existsSync(configPath)) return undefined;
+  return readSlackRuntimeConfig(configPath).defaultHarnessPreset;
+}
+
+export interface SlackRuntimeConfig {
+  defaultHarnessPreset?: string;
+  defaultRepoUrl?: string;
+  repoAliases: Record<string, string>;
+}
+
+export function readSlackRuntimeConfig(configPath = resolveInvokerConfigPath()): SlackRuntimeConfig {
+  const empty: SlackRuntimeConfig = { repoAliases: {} };
+  if (!existsSync(configPath)) return empty;
   try {
     const raw = JSON.parse(readFileSync(configPath, 'utf8'));
-    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
-    const preset = (raw as { defaultSlackHarnessPreset?: unknown }).defaultSlackHarnessPreset;
-    return typeof preset === 'string' && preset.trim().length > 0 ? preset.trim() : undefined;
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return empty;
+    const config = raw as {
+      defaultSlackHarnessPreset?: unknown;
+      defaultRepoUrl?: unknown;
+      slackRepos?: unknown;
+    };
+    const repoAliases = Object.fromEntries(
+      Object.entries(
+        config.slackRepos && typeof config.slackRepos === 'object' && !Array.isArray(config.slackRepos)
+          ? config.slackRepos
+          : {},
+      ).filter(
+        (entry): entry is [string, string] => typeof entry[0] === 'string' && typeof entry[1] === 'string' && entry[1].trim().length > 0,
+      ),
+    );
+    return {
+      defaultHarnessPreset: typeof config.defaultSlackHarnessPreset === 'string' && config.defaultSlackHarnessPreset.trim().length > 0
+        ? config.defaultSlackHarnessPreset.trim()
+        : undefined,
+      defaultRepoUrl: typeof config.defaultRepoUrl === 'string' && config.defaultRepoUrl.trim().length > 0
+        ? config.defaultRepoUrl.trim()
+        : undefined,
+      repoAliases,
+    };
   } catch {
-    return undefined;
+    return empty;
   }
 }
 

--- a/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
@@ -268,6 +268,57 @@ describe('Slack plan submission restart repro contracts', () => {
     }));
   });
 
+  it('reacquires an external repository checkout before restoring its thread', async () => {
+    const commands: SurfaceCommand[] = [];
+    const firstCheckout = vi.fn().mockResolvedValue('/planning-clones/proof-first');
+    const first = surface(commands, {
+      repoAliases: { proof: 'https://example.test/proof.git' },
+      defaultRepoUrl: 'https://example.test/default.git',
+      prepareRepoCheckout: firstCheckout,
+    });
+    await start(first, commands);
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await mention(first, '[repo:proof] plan: preserve checkout', 'thread-reacquire');
+    expect(firstCheckout).toHaveBeenCalledWith('https://example.test/proof.git');
+    await first.stop();
+    surfaces = surfaces.filter((candidate) => candidate !== first);
+
+    const restoredCheckout = vi.fn().mockResolvedValue('/planning-clones/proof-restored');
+    const second = surface(commands, {
+      repoAliases: { proof: 'https://example.test/proof.git' },
+      defaultRepoUrl: 'https://example.test/default.git',
+      prepareRepoCheckout: restoredCheckout,
+    });
+    await start(second, commands);
+
+    expect(restoredCheckout).toHaveBeenCalledWith('https://example.test/proof.git');
+    expect((second as any).planningContexts.get('thread-reacquire')).toEqual(expect.objectContaining({
+      workingDir: '/planning-clones/proof-restored',
+    }));
+  });
+
+  it('refuses an owned thread retarget to a different repository', async () => {
+    const commands: SurfaceCommand[] = [];
+    const slack = surface(commands, {
+      repoAliases: {
+        proof: 'https://example.test/proof.git',
+        other: 'https://example.test/other.git',
+      },
+      defaultRepoUrl: 'https://example.test/default.git',
+    });
+    await start(slack, commands);
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await mention(slack, '[repo:proof] plan: pin this repository', 'thread-retarget');
+
+    const say = await mention(slack, '[repo:other] plan: switch repositories', 'retarget-turn', 'thread-retarget');
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('already pinned to a different repository'),
+    }));
+    expect((slack as any).planningContexts.get('thread-retarget')).toEqual(expect.objectContaining({
+      repoUrl: 'https://example.test/proof.git',
+    }));
+  });
+
   it('restores a staged submit confirmation after a SlackSurface restart', async () => {
     const commands: SurfaceCommand[] = [];
     const first = surface(commands);

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -109,6 +109,7 @@ describe('parsePlanningRequest', () => {
     expect(parsePlanningRequest('<@BOT> [omp+claude] [repo:web] do X', keys, 'cursor+claude')).toEqual({
       presetKey: 'omp+claude',
       repo: 'web',
+      hasExplicitPreset: true,
       text: 'do X',
     });
   });
@@ -126,6 +127,7 @@ describe('parsePlanningRequest', () => {
     expect(parsePlanningRequest('[plain codex] go', keys, 'cursor+claude')).toEqual({
       presetKey: 'codex',
       repo: undefined,
+      hasExplicitPreset: true,
       text: 'go',
     });
     expect(parsePlanningRequest('[unknown] go', keys, 'cursor+claude')).toEqual({
@@ -139,6 +141,7 @@ describe('parsePlanningRequest', () => {
     expect(parsePlanningRequest('[omp] add a /health endpoint', keys, 'cursor+claude')).toEqual({
       presetKey: 'omp',
       repo: undefined,
+      hasExplicitPreset: true,
       text: 'add a /health endpoint',
     });
   });
@@ -155,6 +158,24 @@ describe('parsePlanningRequest', () => {
       repo: undefined,
       text: 'go',
       unknownPreset: 'omp+gpt5',
+    });
+  });
+
+  it('extracts one direct repository URL from Slack markup or prose', () => {
+    expect(parsePlanningRequest(
+      '<@BOT> plan this in <https://github.com/EdbertChan/notarepo/|notarepo>',
+      keys,
+      'cursor+claude',
+    )).toMatchObject({
+      presetKey: 'cursor+claude',
+      repositoryUrls: ['https://github.com/EdbertChan/notarepo/'],
+    });
+    expect(parsePlanningRequest(
+      'plan this in git@github.com:EdbertChan/notarepo.git',
+      keys,
+      'cursor+claude',
+    )).toMatchObject({
+      repositoryUrls: ['git@github.com:EdbertChan/notarepo.git'],
     });
   });
 });
@@ -228,6 +249,7 @@ describe('BUILTIN_HARNESS_PRESETS', () => {
     expect(parsePlanningRequest('<@BOT> [omp+codex] add a /health endpoint', keys, 'cursor+claude')).toEqual({
       presetKey: 'omp+codex',
       repo: undefined,
+      hasExplicitPreset: true,
       text: 'add a /health endpoint',
     });
   });
@@ -890,6 +912,61 @@ describe('lobby verb routing', () => {
     expect(planConversationConfigs).toHaveLength(1);
     expect(planConversationConfigs[0].mode).toBe('plan');
     expect(runWorkflowOp).not.toHaveBeenCalled();
+  });
+
+  it('uses a direct repository URL for a clone-backed planning session', async () => {
+    const prepareRepoCheckout = vi.fn().mockResolvedValue('/planning-clones/notarepo');
+    const surface = lobbySurface(true, {
+      defaultRepoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+      workingDir: '/manager/Invoker',
+      prepareRepoCheckout,
+    });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({
+      event: {
+        text: '<@BOT> plan this in <https://github.com/EdbertChan/notarepo/|notarepo>',
+        ts: 'direct-repo',
+        user: 'U1',
+      },
+      say,
+    });
+
+    expect(prepareRepoCheckout).toHaveBeenCalledWith('https://github.com/EdbertChan/notarepo');
+    expect(planConversationConfigs.at(-1)).toEqual(expect.objectContaining({
+      repoUrl: 'https://github.com/EdbertChan/notarepo',
+      workingDir: '/planning-clones/notarepo',
+    }));
+  });
+
+  it('rejects conflicting or multiple repository selectors before creating a session', async () => {
+    const surface = lobbySurface(true, {
+      repoAliases: { proof: 'https://github.com/example/proof.git' },
+    });
+    await surface.start(async () => {});
+    const conflictSay = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({
+      event: {
+        text: '<@BOT> [repo:proof] plan https://github.com/example/other',
+        ts: 'repo-conflict',
+        user: 'U1',
+      },
+      say: conflictSay,
+    });
+    expect(conflictSay).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('disagree') }));
+    expect(planConversationConfigs).toHaveLength(0);
+
+    const multipleSay = vi.fn().mockResolvedValue({ ts: 'b' });
+    await mentionHandler(surface)({
+      event: {
+        text: '<@BOT> plan https://github.com/example/one and https://github.com/example/two',
+        ts: 'repo-multiple',
+        user: 'U1',
+      },
+      say: multipleSay,
+    });
+    expect(multipleSay).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('multiple repository URLs') }));
+    expect(planConversationConfigs).toHaveLength(0);
   });
 
 

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -192,11 +192,19 @@ export function parsePlanningRequest(
   text: string,
   presetKeys: string[],
   defaultPresetKey: string,
-): { presetKey: string; repo?: string; text: string; unknownPreset?: string } {
+): {
+  presetKey: string;
+  repo?: string;
+  repositoryUrls?: string[];
+  hasExplicitPreset?: boolean;
+  text: string;
+  unknownPreset?: string;
+} {
   let rest = text.replace(/<@[^>]+>/g, '').trim();
   let presetKey = defaultPresetKey;
   let repo: string | undefined;
   let unknownPreset: string | undefined;
+  let hasExplicitPreset = false;
   const keyset = new Set(presetKeys.map((k) => k.toLowerCase()));
   const tagRe = /^\[([^\]]*)\]\s*/;
 
@@ -212,6 +220,7 @@ export function parsePlanningRequest(
     const normalized = raw.toLowerCase().replace(/\s+/g, '').replace(/^plain/, '');
     if (keyset.has(normalized)) {
       presetKey = normalized;
+      hasExplicitPreset = true;
       rest = rest.slice(m[0].length);
       continue;
     }
@@ -222,7 +231,34 @@ export function parsePlanningRequest(
     break;
   }
 
-  return { presetKey, repo, text: rest.trim(), unknownPreset };
+  const repositoryUrls = extractRepositoryUrls(rest);
+  return {
+    presetKey,
+    repo,
+    text: rest.trim(),
+    ...(repositoryUrls.length > 0 ? { repositoryUrls } : {}),
+    ...(hasExplicitPreset ? { hasExplicitPreset } : {}),
+    ...(unknownPreset ? { unknownPreset } : {}),
+  };
+}
+
+function extractRepositoryUrls(text: string): string[] {
+  const slackLinks = [...text.matchAll(/<((?:https?|ssh):\/\/[^|>\s]+)(?:\|[^>]+)?>/gi)];
+  const withoutSlackLinks = text.replace(/<(?:(?:https?|ssh):\/\/[^>]+)>/gi, ' ');
+  const candidates = [
+    ...slackLinks,
+    ...withoutSlackLinks.matchAll(/\bhttps?:\/\/[^\s<>]+/gi),
+    ...withoutSlackLinks.matchAll(/\bssh:\/\/[^\s<>]+/gi),
+    ...withoutSlackLinks.matchAll(/\bgit@[\w.-]+:[^\s<>]+/gi),
+  ].map((match) => (match[1] ?? match[0]).replace(/[),.;]+$/, ''));
+  return [...new Set(candidates)];
+}
+
+function repositoryIdentity(repoUrl: string): string {
+  const github = repoUrl.trim().match(/^(?:https?:\/\/|ssh:\/\/git@|git@)github\.com(?::|\/)([^/]+)\/(.+?)(?:\.git)?\/?$/i);
+  return github
+    ? `github.com/${github[1].toLowerCase()}/${github[2].toLowerCase()}`
+    : repoUrl.trim().replace(/\/+$/, '').toLowerCase();
 }
 
 // ── Lobby intent routing ─────────────────────────────────────
@@ -572,10 +608,7 @@ export class SlackSurface implements Surface {
     // Start SessionManager eviction loop
     this.sessionManager?.start();
 
-    // Run post-connect initialization in background — don't block event delivery
-    this.postConnectInit().catch((err) => {
-      this.log('slack', 'error', `Post-connect initialization failed: ${err}`);
-    });
+    await this.postConnectInit();
   }
 
   private async postConnectInit(): Promise<void> {
@@ -863,12 +896,32 @@ export class SlackSurface implements Surface {
     }
 
     const preset = this.resolveHarnessPreset(parsed.presetKey);
-    const repoResolution = this.resolveRepoUrl(parsed.repo);
-    if (repoResolution.error) {
-      await say({ text: repoResolution.error, thread_ts: event.ts });
+    const explicitRepoResolution = parsed.repo ? this.resolveRepoUrl(parsed.repo) : {};
+    if (explicitRepoResolution.error) {
+      await say({ text: explicitRepoResolution.error, thread_ts: event.ts });
       return;
     }
-    const repoUrl = repoResolution.url;
+    const repositoryUrls = parsed.repositoryUrls ?? [];
+    if (repositoryUrls.length > 1) {
+      await say({ text: 'I found multiple repository URLs. Use one repository URL or one `[repo:…]` selector per request.', thread_ts: event.ts });
+      return;
+    }
+    const detectedRepoResolution = repositoryUrls.length === 1
+      ? this.resolveRepoUrl(repositoryUrls[0])
+      : {};
+    if (detectedRepoResolution.error) {
+      await say({ text: detectedRepoResolution.error, thread_ts: event.ts });
+      return;
+    }
+    if (
+      explicitRepoResolution.url
+      && detectedRepoResolution.url
+      && repositoryIdentity(explicitRepoResolution.url) !== repositoryIdentity(detectedRepoResolution.url)
+    ) {
+      await say({ text: 'The `[repo:…]` selector and repository URL disagree. Use one repository target per request.', thread_ts: event.ts });
+      return;
+    }
+    const repoUrl = explicitRepoResolution.url ?? detectedRepoResolution.url ?? this.resolveRepoUrl().url;
 
     const threadTs = event.thread_ts ?? event.ts;
 
@@ -930,9 +983,19 @@ export class SlackSurface implements Surface {
       if (!threadRequest) return;
 
       const storedContext = this.loadPlanningContext(threadTs);
+      if (storedContext) {
+        if ((parsed.repo || repositoryUrls.length > 0) && repoUrl && storedContext.repoUrl && repositoryIdentity(repoUrl) !== repositoryIdentity(storedContext.repoUrl)) {
+          await say({ text: 'This thread is already pinned to a different repository. Start a new thread to use another repository.', thread_ts: threadTs });
+          return;
+        }
+        if (parsed.hasExplicitPreset && parsed.presetKey !== storedContext.presetKey) {
+          await say({ text: 'This thread is already pinned to a different planner preset. Start a new thread to use another preset.', thread_ts: threadTs });
+          return;
+        }
+      }
       const isPromotion = threadRequest.mode === 'plan'
         && this.sessionManager?.findSession(new SessionIdentifier(channel, threadTs))?.conversationMode === 'agent';
-      const context = isPromotion && storedContext
+      const context = storedContext
         ? storedContext
         : {
             repoUrl,
@@ -943,9 +1006,10 @@ export class SlackSurface implements Surface {
           };
       const contextPreset = this.resolveHarnessPreset(context.presetKey);
       let workingDir = context.workingDir ?? this.workingDir;
-      if (context.repoUrl && this.prepareRepoCheckout && !context.workingDir) {
+      const prepareRepoCheckout = this.prepareRepoCheckout;
+      if (this.shouldPrepareRepoCheckout(context.repoUrl) && prepareRepoCheckout) {
         try {
-          workingDir = await this.prepareRepoCheckout(context.repoUrl);
+          workingDir = await prepareRepoCheckout(context.repoUrl);
         } catch (err) {
           this.log('slack', 'error', `Failed to prepare repo checkout for ${context.repoUrl}: ${err}`);
           await say({ text: `Failed to check out repo: ${err instanceof Error ? err.message : String(err)}`, thread_ts: threadTs });
@@ -1585,13 +1649,24 @@ ${text}`;
   }
 
   private resolveRepoUrl(repo?: string): { url?: string; error?: string } {
-    if (!repo) return { url: this.defaultRepoUrl };
-    const alias = this.repoAliases[repo];
-    if (alias) return { url: alias };
-    if (/^(git@|https?:\/\/|ssh:\/\/)/.test(repo)) return { url: repo };
+    if (!repo) return { url: this.defaultRepoUrl && this.normalizeRepositoryUrl(this.defaultRepoUrl) };
+    const aliasKey = Object.keys(this.repoAliases).find((key) => key.toLowerCase() === repo.toLowerCase());
+    const alias = aliasKey && this.repoAliases[aliasKey];
+    if (alias) return { url: this.normalizeRepositoryUrl(alias) };
+    if (/^(git@|https?:\/\/|ssh:\/\/)/.test(repo)) return { url: this.normalizeRepositoryUrl(repo) };
     const known = Object.keys(this.repoAliases);
     const list = known.length ? known.join(', ') : '(none configured)';
     return { error: `Unknown repo "${repo}". Known aliases: ${list}. Or pass a full git URL.` };
+  }
+
+  private normalizeRepositoryUrl(repoUrl: string): string {
+    return repoUrl.trim().replace(/^<([^|>]+)(?:\|[^>]+)?>$/, '$1').replace(/\/+$/, '');
+  }
+
+  private shouldPrepareRepoCheckout(repoUrl: string | undefined): repoUrl is string {
+    return !!repoUrl
+      && !!this.prepareRepoCheckout
+      && (!this.defaultRepoUrl || repositoryIdentity(repoUrl) !== repositoryIdentity(this.defaultRepoUrl));
   }
 
   // ── In-channel workflow assistant ──────────────────────
@@ -2319,7 +2394,14 @@ ${text}`;
         // Delegate recovery to SessionManager
         for (const entry of active) {
           const context = this.loadPlanningContext(entry.threadTs);
+          if (context && !this.harnessPresets[context.presetKey]) {
+            this.log('slack', 'error', `[SESSION_RECOVERY] Unknown persisted harness preset "${context.presetKey}" for ${entry.threadTs}`);
+            this.sessionMetrics.errors++;
+            continue;
+          }
           const harness = this.resolveHarnessPreset(context?.presetKey ?? this.defaultHarnessPreset);
+          const workingDir = await this.prepareRecoveredWorkingDir(entry.threadTs, context);
+          if (workingDir === undefined && this.shouldPrepareRepoCheckout(context?.repoUrl)) continue;
           const id = new SessionIdentifier(
             entry.channelId || this.channelId,
             entry.threadTs,
@@ -2327,7 +2409,8 @@ ${text}`;
           await this.sessionManager.getOrCreateSession(id, entry.userId, {
             tool: harness.tool,
             model: harness.model,
-            workingDir: context?.workingDir ?? this.workingDir,
+            workingDir,
+            mode: entry.mode ?? 'plan',
             repoUrl: context?.repoUrl ?? this.defaultRepoUrl,
           });
           this.sessionMetrics.recovered++;
@@ -2336,14 +2419,21 @@ ${text}`;
         // Fallback: direct Map recovery
         for (const entry of active) {
           const context = this.loadPlanningContext(entry.threadTs);
+          if (context && !this.harnessPresets[context.presetKey]) {
+            this.log('slack', 'error', `[SESSION_RECOVERY] Unknown persisted harness preset "${context.presetKey}" for ${entry.threadTs}`);
+            this.sessionMetrics.errors++;
+            continue;
+          }
           const harness = this.resolveHarnessPreset(context?.presetKey ?? this.defaultHarnessPreset);
+          const workingDir = await this.prepareRecoveredWorkingDir(entry.threadTs, context);
+          if (workingDir === undefined && this.shouldPrepareRepoCheckout(context?.repoUrl)) continue;
           const conversation = new PlanConversation({
             cursorCommand: this.cursorCommand,
             tool: harness.tool,
             model: harness.model,
             mode: entry.mode ?? 'plan',
             planningCommandBuilder: this.planningCommandBuilder,
-            workingDir: context?.workingDir ?? this.workingDir,
+            workingDir,
             threadTs: entry.threadTs,
             conversationRepo: this.conversationRepo,
             defaultBranch: this.defaultBranch,
@@ -2362,6 +2452,21 @@ ${text}`;
     } catch (err) {
       this.log('slack', 'error', `[SESSION_ERROR] Failed to recover conversations from DB: ${err}`);
       this.sessionMetrics.errors++;
+    }
+  }
+
+  private async prepareRecoveredWorkingDir(threadTs: string, context: PlanningContext | undefined): Promise<string | undefined> {
+    const prepareRepoCheckout = this.prepareRepoCheckout;
+    if (!this.shouldPrepareRepoCheckout(context?.repoUrl) || !prepareRepoCheckout) {
+      return context?.workingDir ?? this.workingDir;
+    }
+    try {
+      const workingDir = await prepareRepoCheckout(context.repoUrl);
+      if (context) this.savePlanningContext(threadTs, { ...context, workingDir });
+      return workingDir;
+    } catch (err) {
+      this.log('slack', 'error', `[SESSION_RECOVERY] Failed to prepare repo checkout for ${threadTs}: ${err instanceof Error ? err.message : String(err)}`);
+      return undefined;
     }
   }
 


### PR DESCRIPTION
## Summary

Slack threads pin a selected repository and restore it after a manager restart.

Direct GitHub URLs, aliases, and persisted harness context resolve the same way. Mid-thread retargeting is not allowed.

## Review Claim

A Slack planning thread keeps one repository and harness context for its lifetime and across recovery.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A thread cannot silently switch repositories or fall back to the default checkout after restart.

## Slice Rationale

Repository selection, checkout recovery, and regression coverage stay together in this slice.

## Non-goals

- No new repository selector UI.
- No change to plan execution semantics.
- No documentation updates in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Slack repository pin and restoration regression tests
- [x] `pnpm --filter @invoker/surfaces build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert HEAD`
- Post-revert steps: Redeploy the Slack manager bundle.
- Data migration? No

</details>

Depends-On: #5532