### PR TITLE
[Slack] Approve compact plan drafts inline

### DIFF
--- a/packages/slack-manager/src/__tests__/slack-consumer-lock.test.ts
+++ b/packages/slack-manager/src/__tests__/slack-consumer-lock.test.ts
@@ -1,0 +1,20 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { acquireSlackConsumerLock, SlackConsumerLockHeldError } from '../slack-consumer-lock.js';
+
+describe('Slack consumer lock', () => {
+  it('refuses a second live Socket Mode owner and releases cleanly', () => {
+    const home = mkdtempSync(join(tmpdir(), 'invoker-slack-lock-'));
+    const first = acquireSlackConsumerLock(home, 'first', process.pid);
+
+    expect(() => acquireSlackConsumerLock(home, 'second', process.pid)).toThrow(SlackConsumerLockHeldError);
+
+    first.release();
+    const second = acquireSlackConsumerLock(home, 'second', process.pid);
+    expect(second.record.instanceId).toBe('second');
+    second.release();
+  });
+});

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -9,6 +9,7 @@
  */
 
 import { execSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
@@ -26,6 +27,7 @@ import { startEventSubscription } from './event-subscription.js';
 import { createPlanningCommandBuilder, createPrepareRepoCheckout, createGatherWorkflowContext } from './host-seams.js';
 import { createWatchdog } from './watchdog.js';
 import { errMessage } from './util.js';
+import { acquireSlackConsumerLock } from './slack-consumer-lock.js';
 const VERSION = '0.0.7';
 
 const REQUIRED_ENV = ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_SIGNING_SECRET', 'SLACK_CHANNEL_ID'];
@@ -47,9 +49,9 @@ over IPC. Install via: npm i -g @neko-catpital-labs/invoker-slack
   process.exit(0);
 }
 
-function makeLog(): { log: (level: string, message: string) => void; logFn: (source: string, level: string, message: string) => void } {
+function makeLog(instanceId: string): { log: (level: string, message: string) => void; logFn: (source: string, level: string, message: string) => void } {
   const log = (level: string, message: string): void => {
-    const line = `[slack-manager] ${new Date().toISOString()} ${level.toUpperCase()} ${message}`;
+    const line = `[slack-manager] ${new Date().toISOString()} ${level.toUpperCase()} instance=${instanceId} ${message}`;
     if (level === 'error') console.error(line);
     else console.log(line);
   };
@@ -67,7 +69,8 @@ function detectRepoUrl(repoRoot: string, log: (level: string, message: string) =
 }
 
 async function main(): Promise<void> {
-  const { log, logFn } = makeLog();
+  const instanceId = randomUUID();
+  const { log, logFn } = makeLog(instanceId);
 
   const ownerEnvPath = process.env.INVOKER_SLACK_OWNER_ENV ?? path.join(homedir(), '.invoker', '.slack-owner.env');
   dotenv.config({ path: ownerEnvPath });
@@ -80,6 +83,7 @@ async function main(): Promise<void> {
 
   const managerHome = process.env.INVOKER_SLACK_MANAGER_DIR ?? path.join(homedir(), '.invoker', 'slack-manager');
   mkdirSync(managerHome, { recursive: true });
+  const consumerLock = acquireSlackConsumerLock(path.join(homedir(), '.invoker'), instanceId);
   const checkoutsRoot = path.join(managerHome, 'checkouts');
   const plansDir = path.join(homedir(), '.invoker', 'plans');
 
@@ -113,6 +117,7 @@ async function main(): Promise<void> {
     cursorCommand: process.env.CURSOR_COMMAND ?? 'agent',
     model: process.env.CURSOR_MODEL,
     defaultHarnessPreset,
+    instanceId,
     workingDir: repoRoot,
     conversationRepo,
     slackSessionRepo,
@@ -158,6 +163,7 @@ async function main(): Promise<void> {
     await slack.stop().catch((err) => log('warn', `slack.stop failed: ${errMessage(err)}`));
     client.disconnect();
     adapter.close();
+    consumerLock.release();
     process.exit(0);
   };
   process.on('SIGINT', () => void shutdown('SIGINT'));

--- a/packages/slack-manager/src/slack-consumer-lock.ts
+++ b/packages/slack-manager/src/slack-consumer-lock.ts
@@ -1,0 +1,90 @@
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, unlinkSync, writeSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface SlackConsumerLockRecord {
+  pid: number;
+  instanceId: string;
+  acquiredAt: number;
+}
+
+export interface SlackConsumerLock {
+  readonly path: string;
+  readonly record: SlackConsumerLockRecord;
+  release(): void;
+}
+
+export class SlackConsumerLockHeldError extends Error {
+  constructor(readonly holder: SlackConsumerLockRecord, readonly lockPath: string) {
+    super(`Slack Socket Mode is already owned by pid ${holder.pid} (instance ${holder.instanceId}). Lock: ${lockPath}`);
+    this.name = 'SlackConsumerLockHeldError';
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function readRecord(lockPath: string): SlackConsumerLockRecord | undefined {
+  try {
+    const record = JSON.parse(readFileSync(lockPath, 'utf8')) as Partial<SlackConsumerLockRecord>;
+    if (
+      !Number.isInteger(record.pid)
+      || record.pid! <= 0
+      || typeof record.instanceId !== 'string'
+      || !Number.isFinite(record.acquiredAt)
+    ) return undefined;
+    return record as SlackConsumerLockRecord;
+  } catch {
+    return undefined;
+  }
+}
+
+export function acquireSlackConsumerLock(
+  invokerHome: string,
+  instanceId: string,
+  pid = process.pid,
+): SlackConsumerLock {
+  const locksDir = join(invokerHome, 'locks');
+  const lockPath = join(locksDir, 'slack-socket-consumer.lock');
+  const record: SlackConsumerLockRecord = { pid, instanceId, acquiredAt: Date.now() };
+  mkdirSync(locksDir, { recursive: true });
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      const fd = openSync(lockPath, 'wx');
+      try {
+        writeSync(fd, JSON.stringify(record));
+      } finally {
+        closeSync(fd);
+      }
+      let released = false;
+      return {
+        path: lockPath,
+        record,
+        release(): void {
+          if (released) return;
+          released = true;
+          const current = existsSync(lockPath) ? readRecord(lockPath) : undefined;
+          if (current?.pid === record.pid && current.acquiredAt === record.acquiredAt) {
+            unlinkSync(lockPath);
+          }
+        },
+      };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+      const holder = readRecord(lockPath);
+      if (holder && isProcessAlive(holder.pid)) throw new SlackConsumerLockHeldError(holder, lockPath);
+      try {
+        unlinkSync(lockPath);
+      } catch (unlinkErr) {
+        if ((unlinkErr as NodeJS.ErrnoException).code !== 'ENOENT') throw unlinkErr;
+      }
+    }
+  }
+  throw new Error(`Could not acquire Slack Socket Mode lock: ${lockPath}`);
+}

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -527,6 +527,13 @@ describe('PlanConversation', () => {
     );
   });
 
+  it('refuses to silently fall back to cursor for a selected non-cursor tool', async () => {
+    const conv = new PlanConversation({ tool: 'omp', cursorCommand: 'cursor' });
+
+    await expect(conv.sendMessage('Hello')).rejects.toThrow('Planner command builder is required for selected tool "omp"');
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
   it('falls back to cursor --print shape when no builder is injected', async () => {
     const conv = new PlanConversation({ cursorCommand: 'agent', model: 'sonnet' });
     mockCursorResponse('Hi');

--- a/packages/surfaces/src/__tests__/plan-summary.test.ts
+++ b/packages/surfaces/src/__tests__/plan-summary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { summarizePlanText, formatPlanSummaryLines } from '../slack/plan-summary.js';
+import { summarizePlanText, formatPlanSummaryLines, formatSlackPlanBrief } from '../slack/plan-summary.js';
 
 describe('summarizePlanText', () => {
   it('returns name, one step per task, and taskCount for a valid 2-task plan', () => {
@@ -238,5 +238,48 @@ tasks:
     expect(summary).not.toBeNull();
     expect(summary!.steps).toEqual(['Task A', 'Task B']);
     expect(summary!.taskCount).toBe(2);
+  });
+});
+
+describe('formatSlackPlanBrief', () => {
+  it('renders ordered delivery slices under 100 words and omits paired verification tasks', () => {
+    const summary = summarizePlanText(`
+name: Orca-inspired Invoker UX Control Plane
+tasks:
+  - id: attention
+    description: "Goal: Ship an attention inbox and workflow command center. Layer: ui_activation"
+  - id: attention-verify
+    description: "Goal: Run focused attention inbox tests. Layer: app_regression"
+  - id: gates
+    description: "Goal: Surface decision gates and resume affordances. Layer: ui_activation"
+  - id: gates-verify
+    description: "Goal: Verify gate and resume projections. Layer: app_regression"
+  - id: review-notes
+    description: "Goal: Batch review notes into a consolidated agent instruction. Layer: domain"
+  - id: review-notes-verify
+    description: "Goal: Run review-note batching tests. Layer: app_regression"
+  - id: presets
+    description: "Goal: Let Slack users choose repository and harness presets. Layer: contact_surface"
+  - id: presets-verify
+    description: "Goal: Verify Slack picker routing. Layer: app_regression"
+  - id: mobile
+    description: "Goal: Improve mobile Slack control cards and artifact presentation. Layer: contact_surface"
+  - id: mobile-verify
+    description: "Goal: Run mobile Slack formatting tests. Layer: app_regression"
+  - id: usage
+    description: "Goal: Expose provider-agnostic cost and rate-limit risk chips. Layer: ui_activation"
+  - id: usage-verify
+    description: "Goal: Verify usage chips. Layer: app_regression"
+  - id: final-verify
+    description: "Goal: Build all touched packages. Layer: app_regression"
+`)!;
+
+    const brief = formatSlackPlanBrief(summary);
+
+    expect(brief.split(/\s+/).length).toBeLessThan(100);
+    expect(brief).toContain('1) Ship an attention inbox and workflow command');
+    expect(brief).toContain('2) Surface decision gates and resume affordances');
+    expect(brief).toContain('6) Expose provider-agnostic cost and rate-limit risk');
+    expect(brief).not.toContain('Run focused attention inbox tests');
   });
 });

--- a/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
@@ -155,18 +155,29 @@ describe('Slack plan submission restart repro contracts', () => {
     await start(slack, commands);
     mockSpawn.mockImplementationOnce(() => processWith('Agent response'));
     await mention(slack, 'fix the agent routing', 'thread-agent');
-    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    mockSpawn.mockImplementationOnce(() => processWith(`${plan}\n\nInternal planner prose that must not reach Slack.`));
     const say = await mention(slack, 'plan: draft a real migration plan', 'thread-agent-plan', 'thread-agent');
     const current = (slack as any).sessionManager.findSession(new SessionIdentifier('C_LOBBY', 'thread-agent'));
     expect(current?.conversationMode).toBe('plan');
     expect(say).toHaveBeenCalledWith(expect.objectContaining({
-      text: expect.stringContaining('*Proof plan* — 1 task:\n• Exercise the submission flow'),
+      text: expect.stringContaining('Drafted *Proof plan* (1 task). Delivery order: 1) Exercise the submission flow.'),
     }));
     expect(say).toHaveBeenCalledWith(expect.objectContaining({
-      text: expect.stringContaining('Reply `submit` to submit it.'),
+      text: expect.stringContaining('Approve to execute'),
     }));
-    const submitSay = await mention(slack, 'submit', 'submit-agent', 'thread-agent');
-    expect(submitSay).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Approve to proceed') }));
+    expect(say.mock.calls[0][0].text.split(/\s+/).length).toBeLessThan(100);
+    expect(say.mock.calls[0][0].text).not.toContain('• Exercise the submission flow');
+    expect(say.mock.calls[0][0].text).not.toContain('Internal planner prose');
+    expect(say.mock.calls[0][0].blocks).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'actions' }),
+    ]));
+    await actionHandler(slack, 'lobby_confirm')({
+      action: { type: 'button', value: 'thread-agent' },
+      body: { channel: { id: 'C_LOBBY' }, message: { thread_ts: 'thread-agent' } },
+      ack: vi.fn().mockResolvedValue(undefined),
+      respond: vi.fn().mockResolvedValue(undefined),
+    });
+    expect(commands).toContainEqual(expect.objectContaining({ type: 'start_plan' }));
   });
 
   it('drafts a submittable plan from the incident wording and its source thread context', async () => {
@@ -190,10 +201,10 @@ describe('Slack plan submission restart repro contracts', () => {
     expect((slack as any).sessionManager.findSession(new SessionIdentifier('C_LOBBY', 'incident-thread'))?.conversationMode).toBe('plan');
     expect(JSON.stringify(mockSpawn.mock.calls[0])).toContain('attention inbox');
     expect(say).toHaveBeenCalledWith(expect.objectContaining({
-      text: expect.stringContaining('Reply `submit` to submit it.'),
+      text: expect.stringContaining('Approve to execute'),
     }));
     expect(say).toHaveBeenCalledWith(expect.objectContaining({
-      text: expect.stringContaining('*Proof plan* — 1 task:\n• Exercise the submission flow'),
+      text: expect.stringContaining('Drafted *Proof plan* (1 task). Delivery order: 1) Exercise the submission flow.'),
     }));
   });
 
@@ -220,15 +231,34 @@ describe('Slack plan submission restart repro contracts', () => {
     expect(JSON.stringify(mockSpawn.mock.calls.at(-1))).toContain('Please also include the mobile workflow.');
   });
 
-  it('stages a tagged thread submit for confirmation instead of routing it to the planner', async () => {
+  it('stages the drafted plan for approval without routing another message to the planner', async () => {
     const commands: SurfaceCommand[] = [];
     const slack = surface(commands);
     await start(slack, commands);
     mockSpawn.mockImplementationOnce(() => processWith(plan));
-    await mention(slack, 'plan: create a proof', 'thread-submit');
-    const say = await mention(slack, 'submit', 'submit-thread', 'thread-submit');
+    const say = await mention(slack, 'plan: create a proof', 'thread-submit');
     expect(mockSpawn).toHaveBeenCalledTimes(1);
-    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Approve to proceed') }));
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Approve to execute') }));
+    expect((slack as any).pendingConfirms.get('thread-submit')).toEqual(expect.objectContaining({ kind: 'submit' }));
+  });
+
+  it('cancels an inline plan approval without starting the plan', async () => {
+    const commands: SurfaceCommand[] = [];
+    const slack = surface(commands);
+    await start(slack, commands);
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await mention(slack, 'plan: cancel this draft', 'thread-cancel');
+
+    const respond = vi.fn().mockResolvedValue(undefined);
+    await actionHandler(slack, 'lobby_cancel')({
+      action: { type: 'button', value: 'thread-cancel' },
+      ack: vi.fn().mockResolvedValue(undefined),
+      respond,
+    });
+
+    expect(respond).toHaveBeenCalledWith({ text: '❌ Cancelled.', replace_original: true });
+    expect((slack as any).pendingConfirms.get('thread-cancel')).toBeUndefined();
+    expect(commands).not.toContainEqual(expect.objectContaining({ type: 'start_plan' }));
   });
 
   it('restores non-default repo and preset context after a SlackSurface restart', async () => {
@@ -258,9 +288,7 @@ describe('Slack plan submission restart repro contracts', () => {
     expect(restored?.conversationMode).toBe('plan');
     expect((restored?.conversation as any).tool).toBe('special-tool');
     expect((restored?.conversation as any).model).toBe('special-model');
-    const say = await mention(second, 'submit', 'submit-context', 'thread-context');
     await mention(second, 'yes', 'confirm-context', 'thread-context');
-    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Approve to proceed') }));
     expect(commands).toContainEqual(expect.objectContaining({
       type: 'start_plan',
       repoUrl: 'https://example.test/proof.git',
@@ -325,7 +353,6 @@ describe('Slack plan submission restart repro contracts', () => {
     await start(first, commands);
     mockSpawn.mockImplementationOnce(() => processWith(plan));
     await mention(first, 'plan: stage a submission', 'thread-confirm');
-    await mention(first, 'submit', 'submit-confirm', 'thread-confirm');
     expect((first as any).pendingConfirms.get('thread-confirm')).toEqual(expect.objectContaining({ kind: 'submit' }));
     await first.stop();
     surfaces = surfaces.filter((candidate) => candidate !== first);
@@ -343,7 +370,6 @@ describe('Slack plan submission restart repro contracts', () => {
     await start(first, commands);
     mockSpawn.mockImplementationOnce(() => processWith(plan));
     await mention(first, 'plan: stage a button submission', 'thread-button-confirm');
-    await mention(first, 'submit', 'submit-button-confirm', 'thread-button-confirm');
     await first.stop();
     surfaces = surfaces.filter((candidate) => candidate !== first);
 
@@ -372,9 +398,7 @@ describe('Slack plan submission restart repro contracts', () => {
     expect(manager.evictSession(id)).toBe(true);
     expect(manager.findSession(id)).toBeNull();
     const replySay = await reply(slack, 'continue', 'thread-evicted');
-    const submitSay = await mention(slack, 'submit', 'submit-evicted', 'thread-evicted');
     expect(replySay).not.toHaveBeenCalled();
-    expect(submitSay).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Approve to proceed') }));
   });
 
   it('cleans up a submitted session using its actual channel ID', async () => {
@@ -383,7 +407,6 @@ describe('Slack plan submission restart repro contracts', () => {
     await start(slack, commands);
     mockSpawn.mockImplementationOnce(() => processWith(plan));
     await mention(slack, 'plan: clean up in the lobby', 'thread-cleanup');
-    await mention(slack, 'submit', 'submit-cleanup', 'thread-cleanup');
     await mention(slack, 'yes', 'confirm-cleanup', 'thread-cleanup');
     const manager = (slack as any).sessionManager;
     const actualId = new SessionIdentifier('C_LOBBY', 'thread-cleanup');
@@ -398,7 +421,6 @@ describe('Slack plan submission restart repro contracts', () => {
     await start(slack, commands);
     mockSpawn.mockImplementationOnce(() => processWith(plan));
     await mention(slack, 'plan: keep my confirmation', 'thread-reply');
-    await mention(slack, 'submit', 'submit-reply', 'thread-reply');
     expect((slack as any).pendingConfirms.get('thread-reply')).toEqual(expect.objectContaining({ kind: 'submit' }));
     const nonConfirmationSay = await reply(slack, 'add a note before submitting', 'thread-reply');
     expect((slack as any).pendingConfirms.get('thread-reply')).toEqual(expect.objectContaining({ kind: 'submit' }));
@@ -424,7 +446,6 @@ describe('Slack plan submission restart repro contracts', () => {
     await mention(slack, 'plan: preserve the explicit target context', 'promote-thread', 'thread-promotion');
     expect((slack as any).sessionManager.findSession(new SessionIdentifier('C_LOBBY', 'thread-promotion'))?.conversationMode).toBe('plan');
     expect((slack as any).planningContexts.get('thread-promotion')).toEqual(expect.objectContaining({ presetKey: 'special' }));
-    await mention(slack, 'submit', 'submit-promotion', 'thread-promotion');
     await mention(slack, 'yes', 'confirm-promotion', 'thread-promotion');
     expect(commands).toContainEqual(expect.objectContaining({
       type: 'start_plan',

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -1048,13 +1048,11 @@ tasks:
 
     const say2 = vi.fn().mockResolvedValue({ ts: 'b' });
     await mentionHandler(surface)({ event: { text: '<@BOT> submit', thread_ts: 't1', ts: 't2', user: 'U1' }, say: say2 });
-    // Shows a deterministic per-task summary in execution order, does not submit yet.
     const confirmationText = say2.mock.calls[0][0].text as string;
-    expect(confirmationText).toContain('4 tasks');
-    expect(confirmationText).toContain('Add a simple /health endpoint for uptime checks');
-    expect(confirmationText).toContain('Wire the new /health route through the HTTP server');
-    expect(confirmationText).toContain('Add regression coverage for healthy and unhealthy responses');
-    expect(confirmationText).toContain('Run the focused surface test suite and record the result');
+    expect(confirmationText).toContain('Drafted *Health API rollout with several detailed implementation tasks* (4 tasks).');
+    expect(confirmationText).toContain('1) Add a simple /health endpoint for uptime');
+    expect(confirmationText).toContain('2) Wire the new /health route through the');
+    expect(confirmationText.split(/\s+/).length).toBeLessThan(100);
     expect(received.some((c) => c.type === 'start_plan')).toBe(false);
 
     const say3 = vi.fn().mockResolvedValue({ ts: 'c' });

--- a/packages/surfaces/src/__tests__/slack-surface.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface.test.ts
@@ -110,6 +110,30 @@ describe('SlackSurface', () => {
       const app = surface.getApp() as any;
       expect(app.client.auth.test).toHaveBeenCalled();
     });
+
+    it('logs receipt and route for every app mention before replying', async () => {
+      const log = vi.fn();
+      surface = new SlackSurface({
+        botToken: 'xoxb-test',
+        appToken: 'xapp-test',
+        signingSecret: 'test-secret',
+        channelId: 'C-lobby',
+        lobbyChannelId: 'C-lobby',
+        instanceId: 'do1-proof',
+        log,
+      });
+      await surface.start(async () => {});
+      const app = surface.getApp() as any;
+      const mention = app._eventHandlers.find((handler: MockHandler) => handler.pattern === 'app_mention').handler;
+
+      await mention({
+        event: { text: '<@U_BOT> hello', ts: 'event-1', user: 'U1', channel: 'C-other' },
+        say: vi.fn().mockResolvedValue(undefined),
+      });
+
+      expect(log).toHaveBeenCalledWith('slack', 'info', expect.stringContaining('[MENTION_RECEIVED] instance=do1-proof event_ts=event-1'));
+      expect(log).toHaveBeenCalledWith('slack', 'info', expect.stringContaining('[MENTION_ROUTE] instance=do1-proof event_ts=event-1 route=non-lobby'));
+    });
   });
 
   describe('stop', () => {
@@ -505,7 +529,7 @@ describe('SlackSurface', () => {
       });
     });
 
-    it('submits the drafted plan only after an explicit submit + confirmation', async () => {
+    it('submits the drafted plan from its inline approval button', async () => {
       const planText = 'name: "Test Plan"\ntasks:\n  - id: t1\n    description: "Do something useful"\n    dependencies: []\n';
       mockSendMessage.mockResolvedValue('Here is your plan.');
       mockDraftedPlan = planText;
@@ -516,22 +540,23 @@ describe('SlackSurface', () => {
 
       const app = surfaceWithApi.getApp() as any;
       const mentionHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')?.handler;
-      const messageHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'message')?.handler;
+      const confirmHandler = app._actionHandlers.find((h: MockHandler) => h.pattern === 'lobby_confirm')?.handler;
 
-      // Explicit plan request → a planning conversation in the thread; nothing submitted.
+      // Explicit plan request → a planning conversation with inline approval; nothing submitted.
       const say1 = vi.fn().mockResolvedValue({ ts: '1111.001' });
       await mentionHandler({ event: { text: '<@U_BOT> plan: build me a REST API', ts: '1111', thread_ts: undefined }, say: say1 });
       expect(receivedCommands).toHaveLength(0);
+      expect(app.client.chat.update).toHaveBeenCalledWith(expect.objectContaining({
+        text: expect.stringContaining('Approve to execute'),
+        blocks: expect.arrayContaining([expect.objectContaining({ type: 'actions' })]),
+      }));
 
-      // Explicit submit → plain-English summary + confirmation, still no start_plan.
-      const say2 = vi.fn().mockResolvedValue({ ts: '1111.002' });
-      await mentionHandler({ event: { text: '<@UBOT> submit', ts: '1111.5', thread_ts: '1111' }, say: say2 });
-      expect(say2).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Do something useful') }));
-      expect(receivedCommands).toHaveLength(0);
-
-      // Confirm → start_plan with the raw plan text.
-      const say3 = vi.fn().mockResolvedValue({ ts: '1111.003' });
-      await messageHandler({ event: { text: 'yes', ts: '1111.6', thread_ts: '1111', user: 'U1' }, say: say3 });
+      await confirmHandler({
+        action: { type: 'button', value: '1111' },
+        body: { channel: { id: 'C-test' }, message: { thread_ts: '1111' } },
+        ack: vi.fn().mockResolvedValue(undefined),
+        respond: vi.fn().mockResolvedValue(undefined),
+      });
       expect(receivedCommands).toEqual([
         expect.objectContaining({ type: 'start_plan', planText }),
       ]);

--- a/packages/surfaces/src/__tests__/slack-thread-isolation.test.ts
+++ b/packages/surfaces/src/__tests__/slack-thread-isolation.test.ts
@@ -99,6 +99,13 @@ function getMessageHandler(surface: SlackSurface): Function {
   return handler;
 }
 
+function getActionHandler(surface: SlackSurface, pattern: string): Function {
+  const app = surface.getApp() as any;
+  const handler = app._actionHandlers.find((h: MockHandler) => h.pattern === pattern)?.handler;
+  if (!handler) throw new Error(`Missing action handler: ${pattern}`);
+  return handler;
+}
+
 // ── Tests ───────────────────────────────────────────────────
 
 describe('Slack thread isolation', () => {
@@ -154,7 +161,6 @@ describe('Slack thread isolation', () => {
     it('reuses same PlanConversation for replies in same thread', async () => {
       await surface.start(async () => {});
       const mentionHandler = getMentionHandler(surface);
-      const messageHandler = getMessageHandler(surface);
       const say = vi.fn();
 
       // Initial @mention creates the conversation
@@ -167,8 +173,8 @@ describe('Slack thread isolation', () => {
       expect(initialConversation).toBeDefined();
 
       // Reply in same thread — should reuse the same conversation
-      await messageHandler({
-        event: { text: 'Add authentication too', ts: '999.999', thread_ts: 'thread-C', user: 'U1' },
+      await mentionHandler({
+        event: { text: '<@U_BOT> Add authentication too', ts: '999.999', thread_ts: 'thread-C', user: 'U1' },
         say,
       });
 
@@ -181,7 +187,6 @@ describe('Slack thread isolation', () => {
     it('does not cross-contaminate messages between threads', async () => {
       await surface.start(async () => {});
       const mentionHandler = getMentionHandler(surface);
-      const messageHandler = getMessageHandler(surface);
       const say = vi.fn();
 
       // Thread D
@@ -197,8 +202,8 @@ describe('Slack thread isolation', () => {
       });
 
       // Reply to thread D — should only go to thread D's conversation
-      await messageHandler({
-        event: { text: 'Follow-up for D', ts: '100.100', thread_ts: 'thread-D', user: 'U1' },
+      await mentionHandler({
+        event: { text: '<@U_BOT> Follow-up for D', ts: '100.100', thread_ts: 'thread-D', user: 'U1' },
         say,
       });
 
@@ -346,10 +351,9 @@ describe('Slack thread isolation', () => {
       );
     });
 
-    it('all messages go through sendMessage (no confirmation shortcut)', async () => {
+    it('routes tagged replies through sendMessage when no confirmation is pending', async () => {
       await surface.start(async (cmd) => { receivedCommands.push(cmd); });
       const mentionHandler = getMentionHandler(surface);
-      const messageHandler = getMessageHandler(surface);
       const say = vi.fn();
 
       await mentionHandler({
@@ -359,9 +363,8 @@ describe('Slack thread isolation', () => {
 
       const conv = conversationInstances.get('thread-confirm');
 
-      // "yes" goes through sendMessage just like any other message
-      await messageHandler({
-        event: { text: 'yes', ts: '600.600', thread_ts: 'thread-confirm', user: 'U1' },
+      await mentionHandler({
+        event: { text: '<@U_BOT> yes', ts: '600.600', thread_ts: 'thread-confirm', user: 'U1' },
         say,
       });
 
@@ -392,9 +395,8 @@ describe('Slack thread isolation', () => {
       convI.sendMessage.mockRejectedValueOnce(new Error('API timeout'));
 
       // Reply to thread I (will fail)
-      const messageHandler = getMessageHandler(surface);
-      await messageHandler({
-        event: { text: 'continue I', ts: '700.700', thread_ts: 'thread-I', user: 'U2' },
+      await mentionHandler({
+        event: { text: '<@U_BOT> continue I', ts: '700.700', thread_ts: 'thread-I', user: 'U2' },
         say,
       });
 
@@ -409,8 +411,8 @@ describe('Slack thread isolation', () => {
       // Thread H should still work
       const convH = conversationInstances.get('thread-H');
       convH.sendMessage.mockClear();
-      await messageHandler({
-        event: { text: 'continue H', ts: '800.800', thread_ts: 'thread-H', user: 'U1' },
+      await mentionHandler({
+        event: { text: '<@U_BOT> continue H', ts: '800.800', thread_ts: 'thread-H', user: 'U1' },
         say,
       });
       expect(convH.sendMessage).toHaveBeenCalledWith('continue H');
@@ -612,10 +614,9 @@ Want me to execute this?`;
     });
   });
 
-  it('mention → plan drafted → explicit submit → confirm → start_plan', async () => {
+  it('mention → plan draft with approval button → start_plan', async () => {
     await surface.start(async (cmd) => { receivedCommands.push(cmd); });
     const mentionHandler = getMentionHandler(surface);
-    const messageHandler = getMessageHandler(surface);
     const say = vi.fn();
 
     // Step 1: User explicitly asks for an Invoker plan.
@@ -627,37 +628,28 @@ Want me to execute this?`;
     expect(conv).toBeDefined();
     expect(conv.sendMessage).toHaveBeenCalledTimes(1);
 
-    // Step 2: Bot drafts a YAML plan; nothing submitted.
+    // Step 2: Bot drafts a YAML plan and stages its approval in the same response.
     say.mockClear();
     conv.sendMessage.mockResolvedValueOnce(YAML_PLAN);
-    await messageHandler({
-      event: { text: 'I want GET and POST for /users', ts: '100.100', thread_ts: 'thread-e2e', user: 'U1' },
-      say,
-    });
-    expect(say).toHaveBeenCalledWith(
-      expect.objectContaining({ text: YAML_PLAN, thread_ts: 'thread-e2e' }),
-    );
-    expect(receivedCommands).not.toContainEqual(expect.objectContaining({ type: 'start_plan' }));
-
-    // Step 3: Explicit submit → plain-English summary + confirmation, still no start_plan.
-    say.mockClear();
     const expectedPlanText = 'name: "Add REST API"\ntasks:\n  - id: implement\n    description: "Implement the REST API endpoints"\n    dependencies: []\n';
-    conv.submittedPlanText = expectedPlanText; // exposed via getDraftedPlan()
+    conv.submittedPlanText = expectedPlanText;
     await mentionHandler({
-      event: { text: '<@UBOT> submit', ts: '150.150', thread_ts: 'thread-e2e', user: 'U1' },
-      say,
-    });
-    expect(receivedCommands).not.toContainEqual(expect.objectContaining({ type: 'start_plan' }));
-
-    // Step 4: User confirms → start_plan with the raw plan text.
-    say.mockClear();
-    await messageHandler({
-      event: { text: 'yes', ts: '200.200', thread_ts: 'thread-e2e', user: 'U1' },
+      event: { text: '<@U_BOT> I want GET and POST for /users', ts: '100.100', thread_ts: 'thread-e2e', user: 'U1' },
       say,
     });
     expect(say).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringContaining('Starting') }),
+      expect.objectContaining({ text: expect.stringContaining('Approve to execute'), thread_ts: 'thread-e2e' }),
     );
+    expect(receivedCommands).not.toContainEqual(expect.objectContaining({ type: 'start_plan' }));
+
+    // Step 3: Approve the original draft → start_plan with the raw plan text.
+    say.mockClear();
+    await getActionHandler(surface, 'lobby_confirm')({
+      action: { type: 'button', value: 'thread-e2e' },
+      body: { channel: { id: 'C-test' }, message: { thread_ts: 'thread-e2e' } },
+      ack: vi.fn().mockResolvedValue(undefined),
+      respond: vi.fn().mockResolvedValue(undefined),
+    });
     expect(receivedCommands).toHaveLength(1);
     expect(receivedCommands[0]).toEqual(
       expect.objectContaining({ type: 'start_plan', planText: expectedPlanText }),

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -12,7 +12,7 @@
 
 import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import type { ConversationRepository } from '@invoker/data-store';
 import { formatCodexPlannerStdout } from '@invoker/execution-engine';
@@ -670,9 +670,16 @@ export class PlanConversation {
   // ── Planner CLI Subprocess ─────────────────────────────
 
   async spawnPlanner(prompt: string): Promise<string> {
+    const requiresRegisteredBuilder = this.tool === 'omp' || this.tool === 'codex';
+    if (requiresRegisteredBuilder && !this.planningCommandBuilder) {
+      throw new Error(`Planner command builder is required for selected tool "${this.tool}"`);
+    }
     const { command, args } = this.planningCommandBuilder
       ? this.planningCommandBuilder({ tool: this.tool ?? 'cursor', model: this.model, prompt })
       : defaultPlanningCommand(this.cursorCommand, { model: this.model, prompt });
+    if (requiresRegisteredBuilder && this.planningCommandBuilder && basename(command) !== this.tool) {
+      throw new Error(`Planner command mismatch: selected tool "${this.tool}" resolved to "${command}"`);
+    }
     const plannerLabel = this.tool ?? command;
     const totalAttempts = this.plannerRetryLimit + 1;
     let lastStderrTail = '';
@@ -723,7 +730,7 @@ export class PlanConversation {
       let stdoutChunks = 0;
       let stderrChunks = 0;
 
-      this.log('plan-conversation', 'info', `[PERF] cursor_spawn: pid=${child.pid ?? 'none'}, cmd="${command} ${args.slice(0, -1).join(' ')} <prompt>", promptLen=${prompt.length}, cwd=${this.workingDir ?? process.cwd()}, attempt=${attemptNumber}/${totalAttempts}`);
+      this.log('plan-conversation', 'info', `[PERF] cursor_spawn: pid=${child.pid ?? 'none'}, tool=${plannerLabel}, model=${this.model ?? 'default'}, cmd="${command} ${args.slice(0, -1).join(' ')} <prompt>", promptLen=${prompt.length}, cwd=${this.workingDir ?? process.cwd()}, attempt=${attemptNumber}/${totalAttempts}`);
 
       child.stdout?.on('data', (chunk: Buffer) => {
         const chunkStr = chunk.toString();

--- a/packages/surfaces/src/slack/plan-summary.ts
+++ b/packages/surfaces/src/slack/plan-summary.ts
@@ -93,6 +93,23 @@ export function formatPlanSummaryLines(summary: PlanSummary): string[] {
   return lines;
 }
 
+export function formatSlackPlanBrief(summary: PlanSummary): string {
+  const deliverySlices = summary.taskGroups
+    .flatMap((group) => group.tasks)
+    .filter((task) => !isVerificationOnly(task))
+    .map(summarizeDeliverySlice)
+    .filter(Boolean);
+  const slices = dedupe(deliverySlices).slice(0, 6);
+  const fallbackSlices = summary.steps.map(summarizeDeliverySlice).filter(Boolean).slice(0, 3);
+  const orderedSlices = slices.length > 0 ? slices : fallbackSlices;
+  const title = truncateWords(summary.name, 8);
+  const order = orderedSlices
+    .map((slice, index) => `${index + 1}) ${slice}`)
+    .join('; ');
+  const brief = `Drafted *${title}* (${summary.taskCount} task${summary.taskCount === 1 ? '' : 's'}). Delivery order: ${order}. Each slice includes focused verification.`;
+  return truncateWords(brief, 72);
+}
+
 // ── Internals ───────────────────────────────────────────────
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -168,4 +185,32 @@ function topoSort(tasks: PlanTask[]): PlanTask[] {
 
 function summarizeDescription(description: string): string {
   return description.replace(/\s+/g, ' ').trim();
+}
+
+function isVerificationOnly(description: string): boolean {
+  return /\bLayer:\s*app_regression\b/i.test(description)
+    || /\bGoal:\s*(?:run|verify|build|type-check)\b/i.test(description);
+}
+
+function summarizeDeliverySlice(description: string): string {
+  const normalized = summarizeDescription(description);
+  const goal = normalized.match(/\bGoal:\s*(.+?)(?=\s+(?:Motivation|Alternative considerations|Implementation details|Acceptance criteria|Non-goals|Layer|Feature state):|$)/i)?.[1]
+    ?? normalized.split(/(?<=[.!?])\s+/)[0];
+  return truncateWords(goal.replace(/[.:;]+$/, ''), 7);
+}
+
+function dedupe(values: string[]): string[] {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    const key = value.toLowerCase();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function truncateWords(text: string, maxWords: number): string {
+  const words = text.replace(/\s+/g, ' ').trim().split(' ').filter(Boolean);
+  if (words.length <= maxWords) return words.join(' ');
+  return `${words.slice(0, maxWords).join(' ')}…`;
 }

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -33,7 +33,7 @@ import {
 import type { ConversationMode, PlanningCommandBuilder } from './plan-conversation.js';
 import { parseLobbyControl } from './lobby-control.js';
 import type { LobbyControl } from './lobby-control.js';
-import { summarizePlanText, formatPlanSummaryLines, type PlanSummary } from './plan-summary.js';
+import { summarizePlanText, formatSlackPlanBrief, type PlanSummary } from './plan-summary.js';
 import { SessionManager, SessionIdentifier } from './thread-session-manager.js';
 import { buildAssistantPrompt, parseWorkflowControl, SLACK_DIRECT_ANSWER_GUIDANCE } from './workflow-assistant.js';
 import type { WorkflowContext, WorkflowControl } from './workflow-assistant.js';
@@ -45,8 +45,6 @@ function truncateWords(text: string, maxWords: number): string {
   if (words.length <= maxWords) return words.join(' ');
   return `${words.slice(0, maxWords).join(' ')} ...`;
 }
-
-const DRAFT_SUBMIT_INSTRUCTION = 'Reply `submit` to submit it.';
 
 // ── Config ──────────────────────────────────────────────────
 
@@ -117,6 +115,8 @@ export interface SlackSurfaceConfig {
   runWorkflowOp?: (op: WorkflowOp, onProgress?: (p: WorkflowOpProgress) => void) => Promise<WorkflowOpResult>;
   /** Relaunches Invoker (host-owned). Enables the `restart` lobby verb. */
   onRestartInvoker?: () => Promise<void>;
+  /** Identifies the owning Slack manager process in request and reply logs. */
+  instanceId?: string;
 }
 
 export interface HarnessPreset {
@@ -531,6 +531,7 @@ export class SlackSurface implements Surface {
   private gatherWorkflowContext?: (workflowId: string) => Promise<WorkflowContext>;
   private runWorkflowOp?: (op: WorkflowOp, onProgress?: (p: WorkflowOpProgress) => void) => Promise<WorkflowOpResult>;
   private onRestartInvoker?: () => Promise<void>;
+  private instanceId: string;
 
   constructor(config: SlackSurfaceConfig) {
     this.app = new App({
@@ -569,6 +570,7 @@ export class SlackSurface implements Surface {
     this.gatherWorkflowContext = config.gatherWorkflowContext;
     this.runWorkflowOp = config.runWorkflowOp;
     this.onRestartInvoker = config.onRestartInvoker;
+    this.instanceId = config.instanceId ?? 'local';
     this.log = config.log ?? ((source, level, msg) => {
       const fn = level === 'error' ? console.error : console.log;
       fn(`[${source}] ${msg}`);
@@ -846,16 +848,19 @@ export class SlackSurface implements Surface {
   private registerMentionHandler(): void {
     this.app.event('app_mention', async ({ event, say }) => {
       const channel: string | undefined = event.channel;
+      const threadTs = event.thread_ts ?? event.ts;
+      this.log('slack', 'info', `[MENTION_RECEIVED] instance=${this.instanceId} event_ts=${event.ts} thread_ts=${threadTs} channel=${channel ?? 'unknown'} user=${event.user ?? 'unknown'}`);
 
       const mapping = channel ? this.workflowChannelRepo?.getByChannelId(channel) : null;
       if (mapping) {
+        this.log('slack', 'info', `[MENTION_ROUTE] instance=${this.instanceId} event_ts=${event.ts} route=workflow workflow=${mapping.workflowId}`);
         await this.handleWorkflowAssistantMention(mapping, event, say);
         return;
       }
 
       const isLobbyOrDm = !channel || channel === this.lobbyChannelId || channel.startsWith('D');
       if (!isLobbyOrDm) {
-        this.log('slack', 'info', `Ignoring @mention in non-lobby channel ${channel}`);
+        this.log('slack', 'info', `[MENTION_ROUTE] instance=${this.instanceId} event_ts=${event.ts} route=non-lobby channel=${channel}`);
         await say({
           text: 'I only plan in the lobby channel (or DMs), and only run workflow controls in a mapped workflow channel. Mention me there instead.',
           thread_ts: event.thread_ts ?? event.ts,
@@ -863,6 +868,7 @@ export class SlackSurface implements Surface {
         return;
       }
 
+      this.log('slack', 'info', `[MENTION_ROUTE] instance=${this.instanceId} event_ts=${event.ts} route=lobby`);
       await this.handlePlanningMention(event, say, channel ?? this.lobbyChannelId);
     });
   }
@@ -879,7 +885,7 @@ export class SlackSurface implements Surface {
       Object.keys(this.harnessPresets),
       this.defaultHarnessPreset,
     );
-    this.log('slack', 'info', `@mention: "${parsed.text.slice(0, 100)}${parsed.text.length > 100 ? '...' : ''}" (user=${event.user}, preset=${parsed.presetKey}, repo=${parsed.repo ?? 'default'})`);
+    this.log('slack', 'info', `@mention: instance=${this.instanceId} event_ts=${event.ts} "${parsed.text.slice(0, 100)}${parsed.text.length > 100 ? '...' : ''}" (user=${event.user}, preset=${parsed.presetKey}, repo=${parsed.repo ?? 'default'})`);
     if (parsed.unknownPreset) {
       await say({
         text: `Unknown preset \`[${parsed.unknownPreset}]\`. Valid presets: ${Object.keys(this.harnessPresets).join(', ')}. Omit the tag to use the default (\`${this.defaultHarnessPreset}\`).`,
@@ -1211,14 +1217,8 @@ export class SlackSurface implements Surface {
     await this.stageConfirm(threadTs, channel, { kind: 'submit', planText, ctx, channel, lobbyThreadTs: threadTs }, this.renderPlanSummary(summary), say);
   }
 
-  /** Per-task plan view: the user approves this, not YAML. */
   private renderPlanSummary(summary: PlanSummary): string {
-    const title = truncateWords(summary.name, 8);
-    const workflowNote = summary.workflowCount && summary.workflowCount > 1
-      ? `${summary.workflowCount} workflows, `
-      : '';
-    const header = `*${title}* — ${workflowNote}${summary.taskCount} task${summary.taskCount === 1 ? '' : 's'}:`;
-    return [header, ...formatPlanSummaryLines(summary)].join('\n');
+    return formatSlackPlanBrief(summary);
   }
 
   private buildConfirmBlocks(prompt: string, confirmKey: string): unknown[] {
@@ -1242,6 +1242,15 @@ export class SlackSurface implements Surface {
     prompt: string,
     say: SayFn,
   ): Promise<void> {
+    this.stagePendingConfirm(threadTs, channel, pending);
+    await say({
+      text: `${prompt}\n_Approve to proceed, or reply \`no\` to cancel._`,
+      thread_ts: threadTs,
+      blocks: this.buildConfirmBlocks(prompt, threadTs),
+    });
+  }
+
+  private stagePendingConfirm(threadTs: string, channel: string, pending: PendingConfirm): void {
     this.pendingConfirms.set(threadTs, pending);
     if (pending.kind === 'submit') {
       this.slackSessionRepo?.createPendingConfirmation({
@@ -1253,11 +1262,6 @@ export class SlackSurface implements Surface {
         payload: pending,
       });
     }
-    await say({
-      text: `${prompt}\n_Approve to proceed, or reply \`no\` to cancel._`,
-      thread_ts: threadTs,
-      blocks: this.buildConfirmBlocks(prompt, threadTs),
-    });
   }
 
 
@@ -1678,6 +1682,7 @@ ${text}`;
   ): Promise<void> {
     const threadTs = event.thread_ts ?? event.ts;
     const text = (event.text ?? '').replace(/<@[A-Z0-9]+>/g, '').trim();
+    this.log('slack', 'info', `[WORKFLOW_MENTION] instance=${this.instanceId} event_ts=${event.ts} thread_ts=${threadTs} workflow=${mapping.workflowId}`);
     if (!text) {
       await say({
         text: `I answer questions about workflow \`${mapping.workflowId}\` and run controls: \`status\`, \`approve <id>\`, \`reject <id>\`, \`retry <id>\`, \`input <id>: <text>\`.`,
@@ -1700,6 +1705,7 @@ ${text}`;
     try {
       const ctx = await this.gatherWorkflowContext(mapping.workflowId);
       const harness = this.resolveHarnessPreset(mapping.harnessPreset ?? this.defaultHarnessPreset);
+      this.log('slack', 'info', `[WORKFLOW_PLANNER] instance=${this.instanceId} event_ts=${event.ts} tool=${harness.tool} model=${harness.model ?? 'default'}`);
       const reply = await this.runOneShotPlanner(harness, buildAssistantPrompt(text, ctx));
       const chunks = splitForSlack(sanitizeSlackOutbound(reply));
       for (let i = 0; i < chunks.length; i++) {
@@ -2028,39 +2034,55 @@ ${text}`;
         ? conversation.getDraftedPlan()
         : undefined;
       const summary = draftedPlan ? summarizePlanText(draftedPlan) : null;
-      const replyWithoutSubmitInstruction = reply
-        .replace(/\n*Reply `submit` to submit it\.\s*$/i, '')
-        .trimEnd();
-      const renderedReply = summary
-        ? [replyWithoutSubmitInstruction, this.renderPlanSummary(summary), DRAFT_SUBMIT_INSTRUCTION]
-          .filter(Boolean)
-          .join('\n\n')
-        : draftedPlan && !reply.includes(DRAFT_SUBMIT_INSTRUCTION)
-          ? `${reply.trimEnd()}\n\n${DRAFT_SUBMIT_INSTRUCTION}`
-          : reply;
+      const planPrompt = summary ? this.renderPlanSummary(summary) : undefined;
+      if (draftedPlan && planPrompt) {
+        const ctx = this.loadPlanningContext(threadTs);
+        this.stagePendingConfirm(threadTs, channel, {
+          kind: 'submit',
+          planText: draftedPlan,
+          ctx,
+          channel,
+          lobbyThreadTs: threadTs,
+        });
+      }
+      const renderedReply = planPrompt
+        ? `${planPrompt}\n_Approve to execute, or reply \`no\` to cancel._`
+        : reply;
       const chunks = splitForSlack(sanitizeSlackOutbound(renderedReply));
+      const blocks = planPrompt ? this.buildConfirmBlocks(planPrompt, threadTs) : [];
+      const firstMessage = {
+        text: chunks[0],
+        thread_ts: threadTs,
+        ...(blocks.length > 0 ? { blocks } : {}),
+      };
       const revision = process.env.INVOKER_REVISION ?? process.env.GIT_COMMIT ?? 'unknown';
       this.log('slack', 'info',
-        `[RESPONSE_PROVENANCE] thread_ts=${threadTs} source_event_ts=${sourceEventTs ?? threadTs} mode=${conversation.conversationMode} revision=${revision} reply_chars=${renderedReply.length} chunks=${chunks.length}`);
+        `[RESPONSE_PROVENANCE] instance=${this.instanceId} thread_ts=${threadTs} source_event_ts=${sourceEventTs ?? threadTs} mode=${conversation.conversationMode} revision=${revision} reply_chars=${renderedReply.length} chunks=${chunks.length}`);
 
       const ackTs = this.ackMessages.get(threadTs);
       if (ackTs) {
-        const updated = await this.updateMessage(channel, ackTs, { text: chunks[0], blocks: [] });
+        const updated = await this.updateMessage(channel, ackTs, {
+          text: chunks[0],
+          blocks: blocks as SlackMessage['blocks'],
+        });
         this.ackMessages.delete(threadTs);
         if (updated) {
-          this.log('slack', 'info', `[ACK] Replaced immediate acknowledgment with actual response (thread_ts=${threadTs}, ack_ts=${ackTs}, chunks=${chunks.length})`);
+          this.log('slack', 'info', `[RESPONSE_POSTED] instance=${this.instanceId} thread_ts=${threadTs} source_event_ts=${sourceEventTs ?? threadTs} reply_ts=${ackTs} disposition=ack-replaced`);
         } else {
           this.log('slack', 'warn', `[ACK] Failed to replace ack, falling back to new message (thread_ts=${threadTs}, ack_ts=${ackTs})`);
           await this.deleteMessage(channel, ackTs);
-          await this.sayWithRateLimitRetry(say, { text: chunks[0], thread_ts: threadTs });
+          const posted = await this.sayWithRateLimitRetry(say, firstMessage);
+          this.logResponsePosted(threadTs, sourceEventTs, posted?.ts, 'new-message');
         }
       } else {
-        await this.sayWithRateLimitRetry(say, { text: chunks[0], thread_ts: threadTs });
+        const posted = await this.sayWithRateLimitRetry(say, firstMessage);
+        this.logResponsePosted(threadTs, sourceEventTs, posted?.ts, 'new-message');
       }
 
       for (let i = 1; i < chunks.length; i++) {
         await this.sleep(this.messagePacingMs);
-        await this.sayWithRateLimitRetry(say, { text: chunks[i], thread_ts: threadTs });
+        const posted = await this.sayWithRateLimitRetry(say, { text: chunks[i], thread_ts: threadTs });
+        this.logResponsePosted(threadTs, sourceEventTs, posted?.ts, 'chunk');
       }
       const tPosting = Date.now();
 
@@ -2097,6 +2119,10 @@ ${text}`;
         thread_ts: threadTs,
       });
     }
+  }
+
+  private logResponsePosted(threadTs: string, sourceEventTs: string | undefined, replyTs: string | undefined, disposition: string): void {
+    this.log('slack', 'info', `[RESPONSE_POSTED] instance=${this.instanceId} thread_ts=${threadTs} source_event_ts=${sourceEventTs ?? threadTs} reply_ts=${replyTs ?? 'unknown'} disposition=${disposition}`);
   }
 
   private async sleep(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary

Slack now presents a compact plan brief with its Approve button in one message.

Clicking Approve starts the existing plan submission flow. Users no longer need to send a separate `submit` message.

The manager now records a per-process identity and refuses a second local Slack consumer. Non-Cursor planner selections fail clearly instead of falling back to Cursor.

## Review Claim

Slack plan drafts are concise, approval-ready messages that execute only through the existing confirmation path.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The raw YAML, pinned repository, selected harness, pending-confirmation persistence, and `start_plan` dispatch remain unchanged. Only when the confirmation is staged and rendered moves earlier.

## Slice Rationale

The concise brief, inline controls, and confirmation persistence must ship together: each is required for one draft response to be safely executable.

## Non-goals

- No plan execution without an explicit button or existing text-confirmation fallback.
- No new workflow state or Slack command route.
- No change to plan YAML or repository/harness selection.

## Architecture

### Before

A drafted plan was posted first. A later `submit` message created the durable confirmation card.

### After

The draft response itself persists the confirmation and renders the existing controls.

```mermaid
flowchart TD
  Draft["Drafted plan"] --> Pending["Persist pending confirmation"]
  Pending --> Card["Compact brief with Approve and Cancel"]
  Card --> Approve["Existing start_plan dispatch"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces test -- src/__tests__/plan-summary.test.ts src/__tests__/slack-plan-submission-repros.e2e.test.ts src/__tests__/slack-thread-isolation.test.ts src/__tests__/slack-surface-workflows.test.ts src/__tests__/slack-surface.test.ts`
- [x] `pnpm --filter @invoker/surfaces build`

</details>

## Visual Proof

Focused Slack Block Kit contracts assert the compact draft card contains the Approve and Cancel actions, and an end-to-end action test proves Approve emits `start_plan`. Slack cards cannot be captured by the Electron visual-proof harness.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c64975e18`
- Post-revert steps: Redeploy the Slack manager bundle.
- Data migration? No

</details>
