### PR TITLE
[CI e2e-proof](1) Keep delegating query queue to a busy live owner

### DIFF
--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -362,14 +362,18 @@ async function delegateReadOnlyQuery(
   const ownerResult = await resolver.waitForAny(
     isUiPerf ? READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS : OPTIONAL_READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS,
   );
-  if (!ownerResult.resolved) {
+  let messageBus = bus;
+  if (ownerResult.resolved) {
+    messageBus = ownerResult.bus;
+  } else if (
+    !isQueue ||
+    !hasLiveWritableOwner(resolve(resolveInvokerHomeRoot(), 'invoker.db'))
+  ) {
     if (isQueue || isActionGraph) return false;
     throw new Error(isUiPerf
       ? 'query ui-perf requires a running shared owner process'
       : 'query queue requires a running shared owner process');
   }
-
-  let messageBus = ownerResult.bus;
   const deadline = Date.now() + READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS;
   let response: Record<string, unknown> | null = null;
   while (Date.now() < deadline) {


### PR DESCRIPTION
## Summary

Query queue could fall back to a read-only DB open after owner discovery timed out.

That path fails when a live owner still holds the writable DB and WAL sidecars.

This change keeps query-queue reads delegated to the live owner instead of opening the file locally.

## Review Claim

Approve keeping busy-owner query-queue delegation in the retry loop so reads do not open a live WAL read-only.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the query-queue busy-owner fallback changes. Mutation/UI-perf/action-graph paths keep their prior behavior.

## Slice Rationale

This is the minimal query-queue fix needed to stop CI and live owners from hitting read-only WAL failures.

## Non-goals

- Changing dependency-cruiser layer rules
- Changing mutation queue delegation
- Changing owner discovery timeouts

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- src/__tests__/headless-client`
- [ ] Reproduce with a live owner holding the DB and a timed-out discovery path; confirm query queue still delegates

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 57b713bfb`
- Post-revert steps: None
- Data migration? No

</details>
