### PR TITLE
[CI e2e-proof](2) Tolerate transient query-queue read in same-workflow overload

### DIFF
--- a/scripts/e2e-chaos/run-overload.sh
+++ b/scripts/e2e-chaos/run-overload.sh
@@ -1761,6 +1761,12 @@ run_same_workflow_tracked_fix_vs_recreate() {
     ov_wait_task_status "$workflow_id/root" failed "$seed_timeout_seconds"
   done
 
+  # The `query-queue` diagnostic probe below is fired into a deliberate overload
+  # storm. When the live owner is momentarily too busy to serve it, the headless
+  # client keeps delegating (rather than a doomed file read) and surfaces a clean,
+  # transient "did not serve queue query". Tolerate only that message so a real
+  # crash (a different message) still fails the storm.
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_PATTERN="did not serve queue query"
   echo "==> overload: starting tracked fix against same-workflow recreate pressure"
   ov_spawn_command_timed "tracked-fix" 120 invoker_e2e_run_headless fix "$target_task" codex
   ov_wait_task_status_any "$target_task" "fixing_with_ai,awaiting_approval,completed,failed" 30


### PR DESCRIPTION
## Summary

Let the same-workflow overload storm tolerate a clean transient `query queue` read, so e2e-proof shard 2 stays green once the owner-busy read path lands.

The diagnostic `query-queue` probe fired into the storm can surface `did not serve queue query` when the live owner is momentarily too busy. That transient is expected under a deliberate storm.

## Review Claim

Allow only the `did not serve queue query` message from the storm's background commands, so a real crash still fails.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the exact transient string is tolerated via `OVERLOAD_ALLOWED_BACKGROUND_FAILURE_PATTERN`; any other message still fails the storm as before.

## Slice Rationale

A one-scenario tolerance in the overload harness; the paired headless read change ships separately.

## Non-goals

- No change to any other overload scenario.
- No change to how background commands are spawned or awaited.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash -n scripts/e2e-chaos/run-overload.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 84e57099d`
- Post-revert steps: None
- Data migration? No

</details>
