### PR TITLE
[App Launch](1) Bundle planning-core into Electron build

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -166,15 +166,15 @@ module.exports = {
     {
       name: 'layer-3-deps',
       comment:
-        'Layer 3 packages (execution-engine, surfaces) can only depend on Layers 0, 1, and 2.',
+        'Layer 3 packages (execution-engine, surfaces, planning-core) can only depend on Layers 0, 1, and 2.',
       severity: 'error',
       from: {
-        path: '^packages/(execution-engine|surfaces)/',
+        path: '^packages/(execution-engine|surfaces|planning-core)/',
       },
       to: {
         path: '^packages/',
         pathNot: [
-          '^packages/(execution-engine|surfaces)/',
+          '^packages/(execution-engine|surfaces|planning-core)/',
           '^packages/(data-store|persistence|core)/',
           '^packages/(workflow-core|protocol|runtime-adapters|graph)/',
           '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
@@ -193,7 +193,7 @@ module.exports = {
         path: '^packages/',
         pathNot: [
           '^packages/(test-kit|app)/',
-          '^packages/(execution-engine|surfaces)/',
+          '^packages/(execution-engine|surfaces|planning-core)/',
           '^packages/(data-store|persistence|core)/',
           '^packages/(workflow-core|protocol|runtime-adapters|graph)/',
           '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',

--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     '@invoker/runtime-service',
     '@invoker/transport',
     '@invoker/execution-engine',
+    '@invoker/planning-core',
     'yaml',
   ],
   clean: true,


### PR DESCRIPTION
## Summary

Electron failed to load after `@invoker/planning-core` became an app dependency.

The app bundle left that package as a runtime require of TypeScript source. Node then looked for `lifecycle.js` and crashed.

This change bundles `@invoker/planning-core` into the Electron main build, matching the surfaces package.

It also classifies `planning-core` as Layer 3 in dependency-cruiser so app and surfaces imports stay valid.

## Review Claim

Approve bundling `@invoker/planning-core` into the app tsup build and classifying it as a Layer 3 package so Electron launches and Dependency Cruise stays green.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This only changes bundler and dependency-layer config. It does not alter planning lifecycle logic, IPC, or persisted state.

## Slice Rationale

Keep the launch and layer-config fix together because both are required for the same planning-core import path to ship.

## Non-goals

- Changing `@invoker/planning-core` source or package exports
- Changing planning UI or query-queue behavior
- Reworking other package layer assignments

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `rg -n 'require\("@invoker/planning-core"\)' packages/app/dist/main.js` (no matches; package is inlined)
- [x] `pnpm exec depcruise --config .dependency-cruiser.js packages` (0 errors)
- [x] `./scripts/kill-all-electron.sh; ./run.sh` (app loads without `ERR_MODULE_NOT_FOUND` for `lifecycle.js`)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2c674f9ca`
- Post-revert steps: None
- Data migration? No

</details>
