### PR TITLE
Remove In-App Auto-Fix Trigger Step 1 (1) Remove in-app auto-fix trigger

### DIFF
--- a/packages/app/src/__tests__/no-autofix-outside-worker.test.ts
+++ b/packages/app/src/__tests__/no-autofix-outside-worker.test.ts
@@ -71,15 +71,12 @@ const TRIGGER_SIGNALS: ReadonlyArray<{ name: string; pattern: RegExp }> = [
 /**
  * The ONLY files permitted to contain auto-fix trigger signals. Two categories:
  *
- *  (A) the shared auto-fix worker engine in `@invoker/execution-engine`,
+ *  (A) the shared auto-fix worker engine in `@invoker/execution-engine`, and
  *  (B) the shared fix action / operator-facing `fix ... --auto-fix` command
- *      route in `@invoker/app`, and
- *  (C) one legacy helper module that is no longer wired into `main.ts`.
+ *      route in `@invoker/app`.
  *
- * Adding an entry here is a deliberate act: it either declares a sanctioned
- * auto-fix site or documents an unreachable legacy file that still needs its
- * own cleanup slice. Anything not listed here that trips a signal fails the
- * build.
+ * Adding an entry here is a deliberate act: it declares a sanctioned auto-fix
+ * site. Anything not listed here that trips a signal fails the build.
  */
 const ALLOWLIST: ReadonlySet<string> = new Set([
   // (A) shared worker engine — now extracted into @invoker/execution-engine
@@ -87,15 +84,12 @@ const ALLOWLIST: ReadonlySet<string> = new Set([
   'packages/execution-engine/src/worker-runtime.ts',
   'packages/execution-engine/src/auto-fix-intents.ts',
   'packages/execution-engine/src/workers/ci-failure-worker.ts',
+  'packages/execution-engine/src/review-gate-ci-repair.ts',
   // (B) shared fix action + operator command route in @invoker/app
   // (`workers/auto-fix-recovery.ts` is the thin re-export shim for the engine).
   'packages/app/src/workers/auto-fix-recovery.ts',
   'packages/app/src/workflow-actions.ts',
   'packages/app/src/headless.ts',
-  // (C) dead legacy helper not imported by main.ts; tracked separately so this
-  // guard still catches any new live in-app auto-fix path.
-  'packages/app/src/ipc/gui-mutation-handlers.ts',
-  'packages/execution-engine/src/review-gate-ci-repair.ts',
 ]);
 
 /** Locate the monorepo root by walking up to the `pnpm-workspace.yaml` marker. */

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -482,63 +482,7 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
     return result.started;
   };
 
-  const scheduleAutoFix = (taskId: string): void => {
-    logAutoFixDebug(taskId, 'schedule-enter');
-    const workflowMutationCoordinator = getWorkflowMutationCoordinator();
-    if (!workflowMutationCoordinator) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'no-workflow-mutation-coordinator' });
-      return;
-    }
-    if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'fix-handler-not-ready' });
-      return;
-    }
-    const workflowId = workflowIdForTaskArg(taskId);
-    if (!workflowId) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'workflow-not-found' });
-      return;
-    }
-    const shouldAutoFixNow = orchestrator.shouldAutoFix(taskId);
-    if (!shouldAutoFixNow) {
-      logAutoFixDebug(taskId, 'schedule-skip', {
-        reason: 'shouldAutoFix-false',
-        shouldAutoFix: shouldAutoFixNow,
-      });
-      return;
-    }
-    const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
-    const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
-    if (openTaskFixIntents.length > 0) {
-      logAutoFixDebug(taskId, 'schedule-skip', {
-        reason: 'already-queued-intent',
-        existingIntentIds: openTaskFixIntents.map((intent) => intent.id),
-      });
-      return;
-    }
-    const configuredAgent = loadConfig().autoFixAgent?.trim();
-    const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
-    logAutoFixDebug(taskId, 'schedule-enqueue');
-    logAutoFixDebug(taskId, 'schedule-enqueued');
-    void runWorkflowMutation(
-      workflowId,
-      'normal',
-      'invoker:fix-with-agent',
-      [taskId, selectedAgent],
-      async () => executeFixWithAgentMutation(taskId, selectedAgent, 'auto-fix'),
-    )
-      .then(() => {
-        logAutoFixDebug(taskId, 'schedule-dispatch-finished');
-      })
-      .catch((err) => {
-        if (err instanceof StaleLineageError) {
-          logger.info(`auto-fix discarded stale result for "${taskId}": ${err.message}`, { module: 'auto-fix' });
-          return;
-        }
-        logAutoFixDebug(taskId, 'schedule-dispatch-error', {
-          error: err instanceof Error ? err.stack ?? err.message : String(err),
-        });
-      });
-  };
+  const scheduleAutoFix = (_taskId: string): void => {};
 
   /** Cancel a task and cascade-kill all downstream DAG dependents. Shared by IPC, headless, and API. */
   async function performCancelTask(taskId: string): Promise<{ cancelled: string[]; runningCancelled: string[] }> {

--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -3,7 +3,6 @@ import type { Logger, WorkResponse } from '@invoker/contracts';
 import type { Workflow } from '@invoker/data-store';
 import { Channels, type MessageBus } from '@invoker/transport';
 import type { TaskDelta, TaskState } from '@invoker/workflow-core';
-import { shouldSkipAutoFixForError } from '../auto-fix-gating.js';
 import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from '../delta-merge.js';
 import { evaluateExecutingStall, taskNeedsExecutingStallCheck } from '../executing-stall.js';
 import { persistShutdownDiagnostic, type ShutdownDiagnosticDb } from '../shutdown-diagnostic.js';
@@ -36,7 +35,6 @@ export interface RendererTaskFeedPersistence extends ShutdownDiagnosticDb {
 export interface RendererTaskFeedOrchestrator {
   getAllTasks(): TaskState[];
   getMergeNode(workflowId: string): TaskState | undefined;
-  shouldAutoFix(taskId: string): boolean;
   syncAllFromDb(): void;
   handleWorkerResponse(response: WorkResponse): void;
   reclaimStalledFixSession(
@@ -226,31 +224,12 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
   );
 
   // Apply one owner task delta to the local cache and forward results to the
-  // renderer (and drive owner-side auto-fix). Extracted so the detached viewer
-  // can replay deltas that were buffered during hydration.
+  // renderer. Extracted so the detached viewer can replay deltas that were
+  // buffered during hydration.
   const processIncomingTaskDelta = (delta: TaskDelta): void => {
     deps.uiPerfStats.mainDeltaToUi += 1;
     if (deps.traceUiDeltaFlow) {
       deps.logger.debug(`delta→ui: ${JSON.stringify(delta)}`, { module: 'ui' });
-    }
-    const deltaTaskId = delta.type === 'updated' || delta.type === 'removed' ? delta.taskId : undefined;
-    if (delta.type === 'updated' && delta.changes.status === 'failed') {
-      const cancellationError = shouldSkipAutoFixForError(delta.changes.execution?.error);
-      const shouldAutoFixFromOrchestrator = deps.getOrchestrator().shouldAutoFix(delta.taskId);
-      deps.logAutoFixDebug(delta.taskId, 'delta-failed', {
-        shouldSkipForCancellation: cancellationError,
-        shouldAutoFixFromOrchestrator,
-      });
-      if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
-        deps.logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
-        deps.scheduleAutoFix(deltaTaskId);
-      } else if (deltaTaskId) {
-        deps.logAutoFixDebug(deltaTaskId, 'delta-skip', {
-          reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
-          shouldSkipForCancellation: cancellationError,
-          shouldAutoFixFromOrchestrator,
-        });
-      }
     }
     for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(delta)) {
       publishTaskDeltaToRenderer(rendererDelta);


### PR DESCRIPTION
## Summary

Cuts the in-app path that scheduled auto-fix directly when a task's failed delta reached the renderer task feed.

That path duplicated the shared worker engine's own auto-fix path, so a failed task could be auto-fixed from two places at once.

This slice turns the app-side scheduling hook into an inert stub, keeping `main.ts`'s wiring intact, and keeps the guard test's allowlist honest.

## Review Claim

Approve cutting the in-app auto-fix activation surface (the renderer's reactive scheduling hook) down to an inert no-op, so auto-fix only ever runs through the shared worker engine.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The shared worker engine (`execution-engine`'s `auto-fix-recovery`) is untouched and stays the only live auto-fix site; `no-autofix-outside-worker.test.ts` statically enforces this allowlist.

## Slice Rationale

Kept apart from a follow-up Orchestrator slice so this activation-surface change and that one land as independently revertable changes.

## Non-goals

Does not touch `main.ts`'s wiring or any `scripts/**` policy files. Does not change `Orchestrator.shouldAutoFix` / `getAutoFixRetryBudget` (a later slice). Does not change the shared worker engine's auto-fix behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/no-autofix-outside-worker.test.ts`
- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
