### PR TITLE
Remove In-App Auto-Fix Trigger Step 2 (1) Strip orchestrator auto-fix surface

### DIFF
--- a/packages/app/src/__tests__/no-autofix-outside-worker.test.ts
+++ b/packages/app/src/__tests__/no-autofix-outside-worker.test.ts
@@ -71,15 +71,12 @@ const TRIGGER_SIGNALS: ReadonlyArray<{ name: string; pattern: RegExp }> = [
 /**
  * The ONLY files permitted to contain auto-fix trigger signals. Two categories:
  *
- *  (A) the shared auto-fix worker engine in `@invoker/execution-engine`,
+ *  (A) the shared auto-fix worker engine in `@invoker/execution-engine`, and
  *  (B) the shared fix action / operator-facing `fix ... --auto-fix` command
- *      route in `@invoker/app`, and
- *  (C) one legacy helper module that is no longer wired into `main.ts`.
+ *      route in `@invoker/app`.
  *
- * Adding an entry here is a deliberate act: it either declares a sanctioned
- * auto-fix site or documents an unreachable legacy file that still needs its
- * own cleanup slice. Anything not listed here that trips a signal fails the
- * build.
+ * Adding an entry here is a deliberate act: it declares a sanctioned auto-fix
+ * site. Anything not listed here that trips a signal fails the build.
  */
 const ALLOWLIST: ReadonlySet<string> = new Set([
   // (A) shared worker engine — now extracted into @invoker/execution-engine
@@ -87,15 +84,12 @@ const ALLOWLIST: ReadonlySet<string> = new Set([
   'packages/execution-engine/src/worker-runtime.ts',
   'packages/execution-engine/src/auto-fix-intents.ts',
   'packages/execution-engine/src/workers/ci-failure-worker.ts',
+  'packages/execution-engine/src/review-gate-ci-repair.ts',
   // (B) shared fix action + operator command route in @invoker/app
   // (`workers/auto-fix-recovery.ts` is the thin re-export shim for the engine).
   'packages/app/src/workers/auto-fix-recovery.ts',
   'packages/app/src/workflow-actions.ts',
   'packages/app/src/headless.ts',
-  // (C) dead legacy helper not imported by main.ts; tracked separately so this
-  // guard still catches any new live in-app auto-fix path.
-  'packages/app/src/ipc/gui-mutation-handlers.ts',
-  'packages/execution-engine/src/review-gate-ci-repair.ts',
 ]);
 
 /** Locate the monorepo root by walking up to the `pnpm-workspace.yaml` marker. */

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -482,63 +482,7 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
     return result.started;
   };
 
-  const scheduleAutoFix = (taskId: string): void => {
-    logAutoFixDebug(taskId, 'schedule-enter');
-    const workflowMutationCoordinator = getWorkflowMutationCoordinator();
-    if (!workflowMutationCoordinator) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'no-workflow-mutation-coordinator' });
-      return;
-    }
-    if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'fix-handler-not-ready' });
-      return;
-    }
-    const workflowId = workflowIdForTaskArg(taskId);
-    if (!workflowId) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'workflow-not-found' });
-      return;
-    }
-    const shouldAutoFixNow = orchestrator.shouldAutoFix(taskId);
-    if (!shouldAutoFixNow) {
-      logAutoFixDebug(taskId, 'schedule-skip', {
-        reason: 'shouldAutoFix-false',
-        shouldAutoFix: shouldAutoFixNow,
-      });
-      return;
-    }
-    const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
-    const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
-    if (openTaskFixIntents.length > 0) {
-      logAutoFixDebug(taskId, 'schedule-skip', {
-        reason: 'already-queued-intent',
-        existingIntentIds: openTaskFixIntents.map((intent) => intent.id),
-      });
-      return;
-    }
-    const configuredAgent = loadConfig().autoFixAgent?.trim();
-    const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
-    logAutoFixDebug(taskId, 'schedule-enqueue');
-    logAutoFixDebug(taskId, 'schedule-enqueued');
-    void runWorkflowMutation(
-      workflowId,
-      'normal',
-      'invoker:fix-with-agent',
-      [taskId, selectedAgent],
-      async () => executeFixWithAgentMutation(taskId, selectedAgent, 'auto-fix'),
-    )
-      .then(() => {
-        logAutoFixDebug(taskId, 'schedule-dispatch-finished');
-      })
-      .catch((err) => {
-        if (err instanceof StaleLineageError) {
-          logger.info(`auto-fix discarded stale result for "${taskId}": ${err.message}`, { module: 'auto-fix' });
-          return;
-        }
-        logAutoFixDebug(taskId, 'schedule-dispatch-error', {
-          error: err instanceof Error ? err.stack ?? err.message : String(err),
-        });
-      });
-  };
+  const scheduleAutoFix = (_taskId: string): void => {};
 
   /** Cancel a task and cascade-kill all downstream DAG dependents. Shared by IPC, headless, and API. */
   async function performCancelTask(taskId: string): Promise<{ cancelled: string[]; runningCancelled: string[] }> {

--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -3,7 +3,6 @@ import type { Logger, WorkResponse } from '@invoker/contracts';
 import type { Workflow } from '@invoker/data-store';
 import { Channels, type MessageBus } from '@invoker/transport';
 import type { TaskDelta, TaskState } from '@invoker/workflow-core';
-import { shouldSkipAutoFixForError } from '../auto-fix-gating.js';
 import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from '../delta-merge.js';
 import { evaluateExecutingStall, taskNeedsExecutingStallCheck } from '../executing-stall.js';
 import { persistShutdownDiagnostic, type ShutdownDiagnosticDb } from '../shutdown-diagnostic.js';
@@ -36,7 +35,6 @@ export interface RendererTaskFeedPersistence extends ShutdownDiagnosticDb {
 export interface RendererTaskFeedOrchestrator {
   getAllTasks(): TaskState[];
   getMergeNode(workflowId: string): TaskState | undefined;
-  shouldAutoFix(taskId: string): boolean;
   syncAllFromDb(): void;
   handleWorkerResponse(response: WorkResponse): void;
   reclaimStalledFixSession(
@@ -226,31 +224,12 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
   );
 
   // Apply one owner task delta to the local cache and forward results to the
-  // renderer (and drive owner-side auto-fix). Extracted so the detached viewer
-  // can replay deltas that were buffered during hydration.
+  // renderer. Extracted so the detached viewer can replay deltas that were
+  // buffered during hydration.
   const processIncomingTaskDelta = (delta: TaskDelta): void => {
     deps.uiPerfStats.mainDeltaToUi += 1;
     if (deps.traceUiDeltaFlow) {
       deps.logger.debug(`delta→ui: ${JSON.stringify(delta)}`, { module: 'ui' });
-    }
-    const deltaTaskId = delta.type === 'updated' || delta.type === 'removed' ? delta.taskId : undefined;
-    if (delta.type === 'updated' && delta.changes.status === 'failed') {
-      const cancellationError = shouldSkipAutoFixForError(delta.changes.execution?.error);
-      const shouldAutoFixFromOrchestrator = deps.getOrchestrator().shouldAutoFix(delta.taskId);
-      deps.logAutoFixDebug(delta.taskId, 'delta-failed', {
-        shouldSkipForCancellation: cancellationError,
-        shouldAutoFixFromOrchestrator,
-      });
-      if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
-        deps.logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
-        deps.scheduleAutoFix(deltaTaskId);
-      } else if (deltaTaskId) {
-        deps.logAutoFixDebug(deltaTaskId, 'delta-skip', {
-          reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
-          shouldSkipForCancellation: cancellationError,
-          shouldAutoFixFromOrchestrator,
-        });
-      }
     }
     for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(delta)) {
       publishTaskDeltaToRenderer(rendererDelta);

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -743,38 +743,6 @@ describe('Orchestrator', () => {
       expect(persistence.listWorkflows().find((workflow) => workflow.id === workflowId)?.status).toBe('running');
     });
 
-    it('keeps auto-fix eligibility after a workflow is recreated', () => {
-      orchestrator = new Orchestrator({
-        persistence,
-        messageBus: bus,
-        maxConcurrency: 3,
-        defaultAutoFixRetries: 1,
-      });
-
-      orchestrator.loadPlan({
-        name: 'Recreate workflow resets auto-fix',
-        onFinish: 'none',
-        tasks: [
-          { id: 't1', description: 'First', command: 'exit 1' },
-          { id: 't2', description: 'Second', command: 'echo 2', dependencies: ['t1'] },
-        ],
-      });
-
-      const workflowId = orchestrator.getWorkflowIds()[0]!;
-      const taskId = orchestrator.getAllTasks().find(
-        (task) => task.config.workflowId === workflowId && task.id.endsWith('/t1'),
-      )!.id;
-
-      persistence.updateTask(taskId, { status: 'failed' });
-      orchestrator.syncAllFromDb();
-      expect(orchestrator.shouldAutoFix(taskId)).toBe(true);
-
-      orchestrator.recreateWorkflow(workflowId);
-      persistence.updateTask(taskId, { status: 'failed' });
-      orchestrator.syncAllFromDb();
-      expect(orchestrator.shouldAutoFix(taskId)).toBe(true);
-    });
-
     it('ignores a stale completed response after recreateWorkflow resets descendants', () => {
       const reproPersistence = new InMemoryPersistence();
       const reproBus = new InMemoryBus();
@@ -3519,57 +3487,6 @@ describe('Orchestrator', () => {
   // ── Auto-Fix ────────────────────────────────────────────
 
   describe('auto-fix via synthetic spawn_experiments', () => {
-    it('shouldAutoFix only depends on failed eligible tasks and positive retry config', () => {
-      const hydratePersistence = new InMemoryPersistence();
-      const hydrateBus = new InMemoryBus();
-
-      hydratePersistence.saveTask('wf-hydrated', {
-        id: 't1',
-        description: 'Hydrated failed task',
-        status: 'failed',
-        dependencies: [],
-        createdAt: new Date(),
-        config: {},
-        execution: {
-          exitCode: 1,
-          error: 'boom',
-        },
-      });
-
-      const disabledOrchestrator = new Orchestrator({
-        persistence: hydratePersistence,
-        messageBus: hydrateBus,
-        defaultAutoFixRetries: 0,
-      });
-      disabledOrchestrator.syncFromDb('wf-hydrated');
-      expect(disabledOrchestrator.shouldAutoFix('t1')).toBe(false);
-
-      const enabledOrchestrator = new Orchestrator({
-        persistence: hydratePersistence,
-        messageBus: hydrateBus,
-        defaultAutoFixRetries: 3,
-      });
-      enabledOrchestrator.syncFromDb('wf-hydrated');
-      expect(enabledOrchestrator.shouldAutoFix('t1')).toBe(true);
-    });
-
-    it('shouldAutoFix is false for a liveness stall even with retry budget', () => {
-      const p = new InMemoryPersistence();
-      const b = new InMemoryBus();
-      p.saveTask('wf-stall', {
-        id: 't1',
-        description: 'stalled task',
-        status: 'failed',
-        dependencies: [],
-        createdAt: new Date(),
-        config: {},
-        execution: { exitCode: 1, error: 'Execution stalled: ...', failureClass: 'liveness_stall' },
-      });
-      const o = new Orchestrator({ persistence: p, messageBus: b, defaultAutoFixRetries: 3 });
-      o.syncFromDb('wf-stall');
-      expect(o.shouldAutoFix('t1')).toBe(false);
-    });
-
     it('escalateStalledToNeedsInput parks a failed liveness task and is idempotent/scoped', () => {
       const p = new InMemoryPersistence();
       const b = new InMemoryBus();
@@ -3582,7 +3499,7 @@ describe('Orchestrator', () => {
         config: {},
         execution: { exitCode: 1, error: 'Execution stalled: ...', failureClass: 'liveness_stall' },
       });
-      const o = new Orchestrator({ persistence: p, messageBus: b, defaultAutoFixRetries: 3 });
+      const o = new Orchestrator({ persistence: p, messageBus: b });
       o.syncFromDb('wf-stall');
 
       o.escalateStalledToNeedsInput('t1', 'stalled too many times');
@@ -3608,7 +3525,7 @@ describe('Orchestrator', () => {
         config: {},
         execution: { exitCode: 1, error: 'assertion failed' },
       });
-      const o = new Orchestrator({ persistence: p, messageBus: b, defaultAutoFixRetries: 3 });
+      const o = new Orchestrator({ persistence: p, messageBus: b });
       o.syncFromDb('wf-bug');
       o.escalateStalledToNeedsInput('t1', 'nope');
       expect(o.getTask('t1')!.status).toBe('failed');
@@ -3618,7 +3535,6 @@ describe('Orchestrator', () => {
         persistence,
         messageBus: bus,
         maxConcurrency: 3,
-        defaultAutoFixRetries: 3,
       });
       orchestrator.loadPlan({
         name: 'autofix-test',
@@ -3650,7 +3566,6 @@ describe('Orchestrator', () => {
         persistence,
         messageBus: bus,
         maxConcurrency: 3,
-        defaultAutoFixRetries: 3,
       });
       orchestrator.loadPlan({
         name: 'autofix-recon-test',

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -594,7 +594,7 @@ export interface OrchestratorConfig {
   /** Optional; defaults to an adapter wrapping `persistence`. */
   taskRepository?: TaskRepository;
   maxConcurrency?: number;
-  /** Maximum auto-fix attempts per failed task. Positive finite values are caps; zero disables auto-fix. */
+  /** Unused; accepted only so existing callers keep compiling. */
   defaultAutoFixRetries?: number;
   /**
    * Rules that validate task execution environment against command patterns.
@@ -661,7 +661,6 @@ export class Orchestrator {
   private readonly executorRoutingRules: ExecutorRoutingRule[];
   private readonly availablePoolIds: Set<string>;
   private readonly defaultPoolId: string | undefined;
-  private readonly defaultAutoFixRetries: number;
   private readonly deferRunningUntilLaunch: boolean;
   private readonly launchDeferralBackoffMs?: number;
   private readonly resolveRepoDefaultBranch: (repoUrl: string) => string;
@@ -720,7 +719,6 @@ export class Orchestrator {
     ];
     this.availablePoolIds = new Set(config.availablePoolIds ?? []);
     this.defaultPoolId = config.defaultPoolId;
-    this.defaultAutoFixRetries = Math.max(0, Math.floor(config.defaultAutoFixRetries ?? 0));
     this.deferRunningUntilLaunch = config.deferRunningUntilLaunch ?? false;
     this.launchDeferralBackoffMs = config.launchDeferralBackoffMs;
     this.resolveRepoDefaultBranch = config.resolveRepoDefaultBranch ?? requireDefaultBranchRemote;
@@ -3006,27 +3004,6 @@ export class Orchestrator {
     const updated = this.writeAndSync(task.id, changes, { skipWorkflowStatusSync: true });
     this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updated, changes));
     return updated;
-  }
-
-  getAutoFixRetryBudget(taskId: string): number {
-    return this.defaultAutoFixRetries;
-  }
-
-
-  private isRuntimeAutoFixEligibleTask(task: TaskState): boolean {
-    if (task.config.isReconciliation) return false;
-    if (task.config.parentTask) return false;
-    return true;
-  }
-
-  shouldAutoFix(taskId: string): boolean {
-    const task = this.stateGetTask(taskId);
-    if (!task) return false;
-    if (task.status !== 'failed') return false;
-    // Liveness stalls are requeued by the requeue worker, never AI-auto-fixed.
-    if (isLivenessFailureClass(task.execution.failureClass)) return false;
-    if (!this.isRuntimeAutoFixEligibleTask(task)) return false;
-    return this.getAutoFixRetryBudget(taskId) > 0;
   }
 
   getAllTasks(): TaskState[] {


### PR DESCRIPTION
## Summary

Strips two Orchestrator methods and a private helper that only existed to answer whether the in-app call site cut in the prior slice should fire.

They had no remaining callers once that call site stopped invoking them.

`OrchestratorConfig.defaultAutoFixRetries` stays declared but now goes unread, so existing constructor call sites keep compiling unchanged.

## Review Claim

Approve stripping the now-unreachable Orchestrator auto-fix decision methods, since their in-app call site is now inert.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`execution-engine`'s own auto-fix worker keeps its own independent config on its worker deps; only the Orchestrator's unreachable decision methods go away, so worker-driven auto-fix is unaffected.

## Slice Rationale

Kept apart from the prior slice so the call-site change and this orchestrator change land as independently revertable commits.

## Non-goals

Does not touch `main.ts`, `gui-mutation-handlers.ts`, `headless.ts`, or `packages/cli/src/index.ts`; their existing constructor argument keeps compiling against the still-declared (now unread) config field. Does not change `execution-engine`'s own auto-fix worker retry policy.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/orchestrator.test.ts`
- [ ] `cd packages/workflow-core && pnpm test`
- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
