### PR TITLE
[CI] Require Runner_Heavy_Docker for container jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
   e2e-proof:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
-    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu]
+    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu, Runner_Heavy_Docker]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60
@@ -272,7 +272,7 @@ jobs:
   e2e-proof-aggregate:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: e2e-proof
-    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu]
+    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu, Runner_Heavy_Docker]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 15
@@ -457,7 +457,7 @@ jobs:
   reset-rulebook-repro:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
-    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu]
+    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu, Runner_Heavy_Docker]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 45
@@ -578,7 +578,7 @@ jobs:
   playwright:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
-    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu]
+    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu, Runner_Heavy_Docker]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 5
@@ -744,7 +744,7 @@ jobs:
   playwright-nightly-perf:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     needs: build-artifacts
-    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu]
+    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu, Runner_Heavy_Docker]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 30
@@ -819,7 +819,7 @@ jobs:
   ssh:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
-    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu]
+    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu, Runner_Heavy_Docker]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60


### PR DESCRIPTION
## Summary

Containerized heavy CI jobs were landing on hosts that cannot open the Docker socket.

Those hosts still share the broad heavy Ubuntu label with healthy machines.

Jobs then fail during container startup before any end-to-end suite runs.

This adds a second required label so only docker-capable heavy hosts accept those jobs.

## Review Claim

Approve requiring `Runner_Heavy_Docker` on containerized heavy CI jobs.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the job `runs-on` label list changes. No product code or job steps change.

## Slice Rationale

Host labels for healthy heavy machines already include `Runner_Heavy_Docker`. This workflow change matches that fleet state.

## Non-goals

Does not provision docker on ssh-heavy hosts. Does not change Slack or Vitest product failures. Does not split product packages.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
- [ ] `git grep -c 'Runner_Heavy_Docker' .github/workflows/ci.yml` returns `6`
- [ ] Next CI run: `e2e-proof` and `playwright` jobs start on `gh-heavy-*` hosts without docker.sock permission denied

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI environments for end-to-end, Playwright, performance, and SSH validation jobs.
  * No user-facing product behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->