### PR TITLE
Fix in-app planner tests after submit hint UX

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -17,6 +17,8 @@ import {
 } from '../in-app-planner.js';
 import { ConversationRepository, SQLiteAdapter, type InAppPlanningSessionRecord } from '@invoker/data-store';
 
+const PLAN_SUBMIT_HINT = '\n\nReply `submit` to submit it.';
+
 const VALID_PLAN = `Here is the plan.
 
 \`\`\`yaml
@@ -31,6 +33,8 @@ tasks:
     dependencies: [first]
     command: echo second
 \`\`\``;
+
+const VALID_PLAN_REPLY = `${VALID_PLAN}${PLAN_SUBMIT_HINT}`;
 
 const VALID_PLAN_TEXT = `name: Mock Plan
 onFinish: none
@@ -308,13 +312,13 @@ describe('planning chat', () => {
 
     expect(result).toMatchObject({
       ok: true,
-      reply: VALID_PLAN,
+      reply: VALID_PLAN_REPLY,
       draftPlanAvailable: true,
       draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
     });
     expect(result.ok && result.reply).toContain('```yaml');
     expect(result.ok && result.reply).toContain('name: Mock Plan');
-    expect(result.ok && sessions.get(result.sessionId)?.messages.at(-1)?.text).toBe(VALID_PLAN);
+    expect(result.ok && sessions.get(result.sessionId)?.messages.at(-1)?.text).toBe(VALID_PLAN_REPLY);
   });
 
   it('keeps unauthorized YAML from becoming draft-ready or submittable', async () => {
@@ -334,7 +338,7 @@ describe('planning chat', () => {
 
     expect(result).toMatchObject({
       ok: true,
-      reply: VALID_PLAN,
+      reply: VALID_PLAN_REPLY,
       draftPlanAvailable: false,
     });
     if (!result.ok) throw new Error(result.error);

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -525,6 +525,13 @@ export class PlanConversation {
     const formatted = formatCodexPlannerStdout(response);
     let message = formatted.message;
     if (this.mode === 'plan' && extractYamlPlan(message) && !message.includes('Reply `submit` to submit it.')) {
+      const fenceStart = message.lastIndexOf('```yaml\n');
+      if (fenceStart !== -1) {
+        const afterFence = message.slice(fenceStart + '```yaml\n'.length);
+        if (!/^```\s*$/m.test(afterFence)) {
+          message = `${message.trimEnd()}\n\`\`\``;
+        }
+      }
       message = `${message.trimEnd()}\n\nReply \`submit\` to submit it.`;
     }
     const repoStateAfter = this.mode === 'agent'


### PR DESCRIPTION
## Summary

Post-#5561 planning replies now append a submit hint when YAML is present.

In-app planner tests still expected the raw assistant text without that hint.

This change aligns those expectations and closes unterminated YAML fences before appending the hint.

That keeps EOF-recovered plans submittable after the hint is added.

## Review Claim

Approve aligning in-app planner tests with the submit hint UX and closing unterminated YAML fences before the hint is appended.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

The diff is limited to planner reply formatting and matching app tests. No workflow execution or persistence paths change.

## Slice Rationale

This is a single CI fix for planner reply regressions introduced with the planning-core bundle. Test and fence handling belong together because the hint caused the fence failure.

## Non-goals

- No changes to hourly snapshot WAL safety tests.
- No changes to planner authorization heuristics beyond reply formatting.
- No changes to Slack-only submission flows.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- src/__tests__/in-app-planner.test.ts`
- [x] `cd packages/surfaces && pnpm test -- src/__tests__/plan-conversation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plan responses by ensuring YAML code blocks are properly closed before submission instructions are added.
  * Added the “Reply `submit` to submit it.” guidance when a valid plan is detected.
  * Updated plan handling to preserve the complete assistant response while keeping unauthorized plans non-submittable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->