### PR TITLE
[Planning] Close unterminated YAML fences before follow-up prompt

### DIFF
--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -525,6 +525,13 @@ export class PlanConversation {
     const formatted = formatCodexPlannerStdout(response);
     let message = formatted.message;
     if (this.mode === 'plan' && extractYamlPlan(message) && !message.includes('Reply `submit` to submit it.')) {
+      const fenceStart = message.lastIndexOf('```yaml\n');
+      if (fenceStart !== -1) {
+        const afterFence = message.slice(fenceStart + '```yaml\n'.length);
+        if (!/^```\s*$/m.test(afterFence)) {
+          message = `${message.trimEnd()}\n\`\`\``;
+        }
+      }
       message = `${message.trimEnd()}\n\nReply \`submit\` to submit it.`;
     }
     const repoStateAfter = this.mode === 'agent'


### PR DESCRIPTION
## Summary

Plan-mode replies append a short follow-up prompt after valid YAML drafts.

When the draft fence was still open, that prompt became part of the YAML text.

Plan extraction then failed, so unfinished fences never became ready.

This closes an open YAML fence before the follow-up prompt is appended.

## Review Claim

Approve closing unterminated YAML fences before the plan follow-up prompt.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

Only changes how the follow-up prompt is appended around open fences. Non-YAML replies are unchanged.

## Slice Rationale

Product fix is separate from the in-app planner proof updates.

## Non-goals

Does not change in-app planner unit expectations. Does not change Slack UI copy beyond fence handling. Does not enqueue or create workflows.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm test -- src/__tests__/plan-conversation.test.ts`
- [ ] `cd packages/app && pnpm test -- src/__tests__/in-app-planner.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
