### PR TITLE
[Planning] Expect follow-up prompt in in-app planner draft replies

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -17,6 +17,8 @@ import {
 } from '../in-app-planner.js';
 import { ConversationRepository, SQLiteAdapter, type InAppPlanningSessionRecord } from '@invoker/data-store';
 
+const PLAN_SUBMIT_HINT = '\n\nReply `submit` to submit it.';
+
 const VALID_PLAN = `Here is the plan.
 
 \`\`\`yaml
@@ -31,6 +33,8 @@ tasks:
     dependencies: [first]
     command: echo second
 \`\`\``;
+
+const VALID_PLAN_REPLY = `${VALID_PLAN}${PLAN_SUBMIT_HINT}`;
 
 const VALID_PLAN_TEXT = `name: Mock Plan
 onFinish: none
@@ -308,13 +312,13 @@ describe('planning chat', () => {
 
     expect(result).toMatchObject({
       ok: true,
-      reply: VALID_PLAN,
+      reply: VALID_PLAN_REPLY,
       draftPlanAvailable: true,
       draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
     });
     expect(result.ok && result.reply).toContain('```yaml');
     expect(result.ok && result.reply).toContain('name: Mock Plan');
-    expect(result.ok && sessions.get(result.sessionId)?.messages.at(-1)?.text).toBe(VALID_PLAN);
+    expect(result.ok && sessions.get(result.sessionId)?.messages.at(-1)?.text).toBe(VALID_PLAN_REPLY);
   });
 
   it('keeps unauthorized YAML from becoming draft-ready or submittable', async () => {
@@ -334,7 +338,7 @@ describe('planning chat', () => {
 
     expect(result).toMatchObject({
       ok: true,
-      reply: VALID_PLAN,
+      reply: VALID_PLAN_REPLY,
       draftPlanAvailable: false,
     });
     if (!result.ok) throw new Error(result.error);

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -525,6 +525,13 @@ export class PlanConversation {
     const formatted = formatCodexPlannerStdout(response);
     let message = formatted.message;
     if (this.mode === 'plan' && extractYamlPlan(message) && !message.includes('Reply `submit` to submit it.')) {
+      const fenceStart = message.lastIndexOf('```yaml\n');
+      if (fenceStart !== -1) {
+        const afterFence = message.slice(fenceStart + '```yaml\n'.length);
+        if (!/^```\s*$/m.test(afterFence)) {
+          message = `${message.trimEnd()}\n\`\`\``;
+        }
+      }
       message = `${message.trimEnd()}\n\nReply \`submit\` to submit it.`;
     }
     const repoStateAfter = this.mode === 'agent'


### PR DESCRIPTION
## Summary

In-app planner proofs still expected the raw YAML reply alone.

Plan-mode replies now append a follow-up prompt after valid YAML.

This updates those proofs to include that prompt suffix.

## Review Claim

Approve aligning in-app planner draft reply proofs with the follow-up prompt.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. No product code changes in this slice.

## Slice Rationale

Keeps proof updates apart from the fence-closing product fix.

## Non-goals

Does not change PlanConversation product logic.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- src/__tests__/in-app-planner.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
