### PR TITLE
[Owner auto-fix e2e](2) Prove failed task stays inactive

### DIFF
--- a/scripts/e2e-chaos/run-matrix.sh
+++ b/scripts/e2e-chaos/run-matrix.sh
@@ -21,7 +21,7 @@ cancel-downstream-standalone
 reset-race-coalesced
 timeout-deadlock-guard
 retry-vs-recreate-window
-owner-autofix-intent
+owner-no-autofix-trigger
 owner-approve-delegated
 owner-reject-delegated
 stale-late-completion-both
@@ -54,7 +54,7 @@ cancel-downstream-standalone|headless-standalone|sequential|running_task|cancel_
 reset-race-coalesced|headless-standalone|fan-in|failed_upstream|recreate_vs_rebase|off|overlap|delta-reset-coalescing|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.13-rebase-recreate-coalesced.sh
 timeout-deadlock-guard|headless-standalone|single|owner_timeout_guard|rebase_and_retry|off|timeout_window|owner-timeout-liveness|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.14-standalone-timeout-deadlock-guard.sh
 retry-vs-recreate-window|headless-standalone|single|late_reset_window|retry_vs_recreate|off|five_second_window|retry-burst-race|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh
-owner-autofix-intent|gui-owner|single|task_failed|autofix_enqueue|autofix_retry_1|none|gui-owner-autofix|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh
+owner-no-autofix-trigger|gui-owner|single|task_failed|no_autofix_enqueue|off|none|gui-owner-no-autofix|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh
 owner-approve-delegated|gui-owner|single|awaiting_approval|approve|off|delegated|gui-owner-delegation|bash __ROOT__/scripts/e2e-chaos/cases/case-owner-approve-delegated.sh
 owner-reject-delegated|gui-owner|single|awaiting_approval|reject|off|delegated|gui-owner-delegation|bash __ROOT__/scripts/e2e-chaos/cases/case-owner-reject-delegated.sh
 stale-late-completion-both|gui-owner|sequential|stale_worker_response|recreate_and_retry_task|off|late_completion|late-completion-delta-flow|bash __ROOT__/scripts/repro/repro-stale-late-completion-after-reset.sh --mode=both --expect-fixed

--- a/scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh
+++ b/scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Group 2.17 — owner-mode auto-fix must enqueue persisted fix mutation intents.
+# Group 2.17 — owner task failures must not trigger in-app auto-fix.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
@@ -92,29 +92,43 @@ if [ -z "$WF_ID" ]; then
 fi
 TASK_ID="$WF_ID/fail-for-autofix"
 
-echo "==> case 2.17: verify failed delta enqueued persisted fix intent"
-FOUND=0
+echo "==> case 2.17: wait for failed task"
+FAILED=0
 for i in $(seq 1 90); do
+  if python3 - <<'PY' "$DB_PATH" "$TASK_ID"
+import sqlite3
+import sys
+
+db_path, task_id = sys.argv[1], sys.argv[2]
+conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+has_failed = conn.execute(
+    "SELECT 1 FROM events WHERE task_id = ? AND event_type = 'task.failed' LIMIT 1",
+    (task_id,),
+).fetchone()
+raise SystemExit(0 if has_failed else 1)
+PY
+  then
+    FAILED=1
+    break
+  fi
+  sleep 1
+done
+
+if [ "$FAILED" -ne 1 ]; then
+  echo "FAIL case 2.17: expected task.failed"
+  cat "$OWNER_LOG"
+  exit 1
+fi
+
+echo "==> case 2.17: verify failed task does not auto-enqueue fix intent"
+UNEXPECTED=0
+for i in $(seq 1 10); do
   if python3 - <<'PY' "$DB_PATH" "$TASK_ID"
 import json
 import sqlite3
 import sys
 
 db_path, task_id = sys.argv[1], sys.argv[2]
-
-def parse_payload(raw):
-    if not raw:
-        return {}
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        return {}
-    if isinstance(parsed, str):
-        try:
-            parsed = json.loads(parsed)
-        except json.JSONDecodeError:
-            return {}
-    return parsed if isinstance(parsed, dict) else {}
 conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
 conn.row_factory = sqlite3.Row
 
@@ -122,11 +136,12 @@ events = conn.execute(
     "SELECT event_type, payload FROM events WHERE task_id = ? ORDER BY id ASC",
     (task_id,),
 ).fetchall()
-
-has_failed = any(row["event_type"] == "task.failed" for row in events)
 has_worker_submit = False
 for row in events:
-    payload = parse_payload(row["payload"])
+    try:
+        payload = json.loads(row["payload"]) if row["payload"] else {}
+    except json.JSONDecodeError:
+        payload = {}
     if row["event_type"] == "debug.auto-fix" and payload.get("phase") == "worker-autofix-submitted":
         has_worker_submit = True
         break
@@ -135,29 +150,24 @@ for row in events:
         break
 
 intents = conn.execute(
-    "SELECT channel, args_json, status FROM workflow_mutation_intents ORDER BY id ASC",
+    "SELECT args_json FROM workflow_mutation_intents WHERE channel = 'invoker:fix-with-agent'",
 ).fetchall()
+has_fix_intent = any(
+    (json.loads(row["args_json"]) if row["args_json"] else [])[0:1] == [task_id]
+    for row in intents
+)
 
-has_fix_intent = False
-for row in intents:
-    if row["channel"] != "invoker:fix-with-agent":
-        continue
-    args = json.loads(row["args_json"]) if row["args_json"] else []
-    if len(args) > 0 and args[0] == task_id and row["status"] in ("queued", "running", "completed", "failed"):
-        has_fix_intent = True
-        break
-
-raise SystemExit(0 if (has_failed and has_worker_submit and has_fix_intent) else 1)
+raise SystemExit(0 if has_worker_submit or has_fix_intent else 1)
 PY
   then
-    FOUND=1
+    UNEXPECTED=1
     break
   fi
   sleep 1
 done
 
-if [ "$FOUND" -ne 1 ]; then
-  echo "FAIL case 2.17: expected task.failed + worker-autofix-submitted/recovery.worker.submit + persisted invoker:fix-with-agent intent"
+if [ "$UNEXPECTED" -ne 0 ]; then
+  echo "FAIL case 2.17: task failure unexpectedly auto-enqueued worker autofix or invoker:fix-with-agent intent"
   python3 - <<'PY' "$DB_PATH" "$TASK_ID"
 import sqlite3, sys
 db_path, task_id = sys.argv[1], sys.argv[2]
@@ -172,4 +182,4 @@ PY
   exit 1
 fi
 
-echo "PASS case 2.17 (owner-mode auto-fix intent persisted and observed in workflow_mutation_intents)"
+echo "PASS case 2.17 (failed task did not trigger in-app auto-fix)"

--- a/scripts/repro/repro-daemon-autofix-persisted-intent.sh
+++ b/scripts/repro/repro-daemon-autofix-persisted-intent.sh
@@ -1,15 +1,13 @@
 #!/usr/bin/env bash
-# Repro: delegated no-track runs must persist auto-fix mutation intent.
+# Repro: delegated no-track runs must not activate removed in-app auto-fix.
 #
-# Root cause guarded here:
-#   In daemon/owner mode, a delegated no-track run could fail a task without the
-#   standalone owner enqueueing the persisted `invoker:fix-with-agent` workflow
-#   mutation intent. The failure event existed, but the auto-fix intent was not
-#   durable.
+# Regression guarded here:
+#   In daemon/owner mode, a delegated no-track run must not enqueue an
+#   `invoker:fix-with-agent` workflow mutation when a task fails.
 #
-# Fixed behavior:
-#   The failing task records task.failed, debug.auto-fix worker-autofix-submitted,
-#   and a persisted invoker:fix-with-agent row in workflow_mutation_intents.
+# Expected behavior:
+#   The failing task records task.failed without a worker-autofix submission or
+#   persisted invoker:fix-with-agent intent from the removed in-app path.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"


### PR DESCRIPTION
## Summary

Updates the owner-mode e2e proof for the former in-app auto-fix path.

A failed delegated task now proves it records `task.failed` without worker auto-fix activity or `invoker:fix-with-agent` activity.

## Review Claim

Approve the e2e proof that a failed GUI-owner task does not activate the former in-app auto-fix path.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The proof observes only the GUI-owner path. It does not change the shared worker engine's auto-fix behavior.

## Slice Rationale

This keeps the e2e expectation aligned with the current owner behavior.

## Non-goals

Does not modify task execution or worker-driven auto-fix.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash -n scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh && bash -n scripts/test-suites/required/21-e2e-dry-run-downstream.sh && bash -n scripts/repro/repro-daemon-autofix-persisted-intent.sh`
- [ ] `bash scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh` (local Electron owner did not reach `task.failed` before the existing 90-attempt timeout)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 48836322e`
- Post-revert steps: None
- Data migration? No

</details>
