### PR TITLE
[CI] Raise hourly-snapshot WAL safety proof timeout

### DIFF
--- a/packages/app/src/__tests__/delete-all-snapshot-wal-safety.test.ts
+++ b/packages/app/src/__tests__/delete-all-snapshot-wal-safety.test.ts
@@ -44,7 +44,7 @@ function makeWorkflow(id: string): Workflow {
 }
 
 describe('hourly snapshot with a live WAL owner', () => {
-  it('the primary connection can still write after createHourlySnapshot runs (WAL safety)', async () => {
+  it('the primary connection can still write after createHourlySnapshot runs (WAL safety)', { timeout: 60_000 }, async () => {
     const root = makeRoot();
     const dbPath = join(root, 'invoker.db');
     const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });


### PR DESCRIPTION
## Summary

The hourly-snapshot WAL safety proof flakes under CI load.

Vitest's default 20s ceiling is too short for the online backup path.

This raises that one case to 60 seconds.

## Review Claim

Approve raising the hourly-snapshot WAL safety proof timeout to 60s.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only timeout change. No product code changes.

## Slice Rationale

Isolates the CI flake fix from e2e proof and planner work.

## Non-goals

Does not change snapshot or backup behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- src/__tests__/delete-all-snapshot-wal-safety.test.ts`
- [ ] Next CI `required-fast / Vitest Workspace` no longer times out on this case

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for a WAL-safety regression test to 60 seconds, improving reliability in slower test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->