### PR TITLE
[CI] Raise Playwright shard budget and keep master CI from cancelling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'mergify/merge-queue/') && format('merge-queue-{0}', github.head_ref) || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read
@@ -581,7 +581,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu, Runner_Heavy_Docker]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
-    timeout-minutes: 5
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Playwright matrix jobs on heavy Docker runners were dying at exactly five minutes. That matches the job `timeout-minutes: 5`, so shards reported `cancelled` before the suite finished.

Master CI was also never completing while merges landed every few minutes. `cancel-in-progress: true` on `refs/heads/master` aborted in-flight suites mid-run.

This raises the Playwright job budget to 30 minutes and disables cancel-in-progress for trunk refs only. PR and merge-queue concurrency still cancel superseded runs.

## Review Claim

Approve raising the Playwright shard job timeout to 30 minutes and disabling cancel-in-progress for master/main so trunk CI can finish.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only workflow timeout and concurrency knobs change. No product code, tests, or runner labels change.

## Slice Rationale

Both knobs are required for a green master CI signal right now: Playwright was timing out inside a single run, and trunk pushes were cancelling each other before aggregate finished.

## Non-goals

Does not change e2e-proof budgets, runner labels, Playwright shard file lists, or merge-queue concurrency behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] After merge, `workflow_dispatch` CI on master shows `playwright / 1-of-7` … `7-of-7` as success (not cancelled at ~5m).
- [ ] A second master push while CI is running does not cancel the first trunk run.
- [ ] Ordinary PR pushes still cancel superseded PR CI via concurrency.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

Revert this commit to restore `timeout-minutes: 5` on Playwright and `cancel-in-progress: true` for all refs.

</details>