### PR TITLE
[CI] Allow Playwright a 30-minute duration invariant

### DIFF
--- a/scripts/test-ci-duration-invariant.mjs
+++ b/scripts/test-ci-duration-invariant.mjs
@@ -8,8 +8,9 @@ const BUDGETED_JOBS = new Set([
   'quality-required',
   'ui-vitest',
   'quality-extra',
-  'playwright',
 ]);
+
+const MAX_PLAYWRIGHT_TIMEOUT_MINUTES = 30;
 
 const EXEMPT_JOBS = new Set([
   'build-artifacts',
@@ -21,6 +22,7 @@ const EXEMPT_JOBS = new Set([
   'optional-other',
   'docker',
   'scheduled-repros',
+  'playwright',
   'playwright-nightly-perf',
   'reset-rulebook-repro',
 ]);
@@ -50,13 +52,22 @@ for (const jobName of BUDGETED_JOBS) {
 
 const playwright = jobs.playwright;
 if (playwright) {
+  const playwrightTimeout = playwright['timeout-minutes'];
+  assert(
+    typeof playwrightTimeout === 'number',
+    'playwright must declare timeout-minutes',
+  );
+  assert(
+    playwrightTimeout <= MAX_PLAYWRIGHT_TIMEOUT_MINUTES,
+    `playwright timeout-minutes=${playwrightTimeout} exceeds hard invariant of ${MAX_PLAYWRIGHT_TIMEOUT_MINUTES} minutes`,
+  );
   const shards = playwright.strategy?.matrix?.include ?? [];
-  assert(shards.length >= 6, `playwright must use at least 6 shards to stay under ${MAX_PR_FACING_TIMEOUT_MINUTES}m (found ${shards.length})`);
+  assert(shards.length >= 6, `playwright must use at least 6 shards (found ${shards.length})`);
   for (const shard of shards) {
     const files = String(shard.files ?? '').trim().split(/\s+/).filter(Boolean);
     assert(
       files.length > 0 && files.length <= 6,
-      `playwright shard ${shard.name} has ${files.length} specs; keep <= 6 per shard for the ${MAX_PR_FACING_TIMEOUT_MINUTES}m budget`,
+      `playwright shard ${shard.name} has ${files.length} specs; keep <= 6 per shard`,
     );
   }
   const listed = shards.flatMap((shard) => String(shard.files).trim().split(/\s+/).filter(Boolean));
@@ -91,5 +102,5 @@ if (errors.length > 0) {
 }
 
 console.log(
-  `CI duration invariant ok: budgeted jobs <= ${MAX_PR_FACING_TIMEOUT_MINUTES}m; playwright shards include hitch e2e.`,
+  `CI duration invariant ok: budgeted jobs <= ${MAX_PR_FACING_TIMEOUT_MINUTES}m; playwright <= ${MAX_PLAYWRIGHT_TIMEOUT_MINUTES}m; hitch e2e shards present.`,
 );


### PR DESCRIPTION
## Summary

PR #5594 raised the Playwright workflow `timeout-minutes` to 30 so Dockerized shards stop dying at five minutes. Vitest Workspace then failed because `scripts/test-ci-duration-invariant.mjs` still hard-capped Playwright at five minutes.

This updates the invariant: cheap PR-facing jobs stay at five minutes, and Playwright gets its own thirty-minute budget while keeping the hitch-spec shard inventory checks.

## Review Claim

Approve raising the Playwright-specific CI duration invariant to 30 minutes so it matches the workflow timeout landed in #5594.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the duration-invariant script changes. Quality job budgets remain five minutes. Playwright shard inventory and hitch-spec requirements stay enforced.

## Slice Rationale

#5594 already changed the workflow timeout; this follow-up unblocks Vitest Workspace so trunk CI can go green.

## Non-goals

Does not change shard file lists, runner labels, or e2e-proof budgets.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-ci-duration-invariant.mjs` exits 0 on this branch.
- [ ] Master `required-fast / Vitest Workspace` passes after merge.
- [ ] Playwright shards no longer cancel at ~5 minutes.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

Revert this commit and restore Playwright to the 5-minute budgeted-job set if the 30-minute allowance must be withdrawn.

</details>

Made with [Cursor](https://cursor.com)