### PR TITLE
[Slack Plans](3b) Forward workflow plan file

### DIFF
--- a/packages/slack-manager/src/__tests__/command-handler.test.ts
+++ b/packages/slack-manager/src/__tests__/command-handler.test.ts
@@ -94,6 +94,7 @@ describe('createCommandHandler', () => {
       lobbyThreadTs: '123.45',
       harnessPreset: 'cursor+claude',
       repoUrl: 'git@example:repo.git',
+      planFile: planPath,
     });
   });
 

--- a/packages/slack-manager/src/command-handler.ts
+++ b/packages/slack-manager/src/command-handler.ts
@@ -78,6 +78,7 @@ async function dispatch(deps: CommandHandlerDeps, command: SurfaceCommand): Prom
         lobbyThreadTs: command.lobbyThreadTs,
         harnessPreset: command.harnessPreset,
         repoUrl: command.repoUrl,
+        planFile: planPath,
       });
       return;
     }

--- a/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
@@ -180,13 +180,13 @@ describe('Slack plan submission restart repro contracts', () => {
     expect(commands).toContainEqual(expect.objectContaining({ type: 'start_plan' }));
   });
 
-  it('drafts a submittable plan from the incident wording and its source thread context', async () => {
+  it('drafts a submittable plan from the exact live-thread wording and its source thread context', async () => {
     const commands: SurfaceCommand[] = [];
     const slack = surface(commands);
     sharedSlack.client.conversations.replies.mockResolvedValue({
       messages: [
         { text: 'Please prioritize the Orca-inspired reply: attention inbox, workflow cards, gates, batch review notes, presets, mobile polish, and usage chips.' },
-        { text: '@Invoker Can you create a plan for this to submit to invoker for all these features?' },
+        { text: '@Invoker please draft a plan for this' },
       ],
     });
     await start(slack, commands);
@@ -194,7 +194,7 @@ describe('Slack plan submission restart repro contracts', () => {
 
     const say = await mention(
       slack,
-      'Can you create a plan for this to submit to invoker for all these features?',
+      'please draft a plan for this',
       'incident-thread',
     );
 
@@ -206,6 +206,14 @@ describe('Slack plan submission restart repro contracts', () => {
     expect(say).toHaveBeenCalledWith(expect.objectContaining({
       text: expect.stringContaining('Drafted *Proof plan* (1 task). Delivery order: 1) Exercise the submission flow.'),
     }));
+    expect(say.mock.calls[0][0].blocks).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        elements: expect.arrayContaining([
+          expect.objectContaining({ action_id: 'lobby_confirm', text: expect.objectContaining({ text: 'Approve' }) }),
+          expect.objectContaining({ action_id: 'lobby_cancel', text: expect.objectContaining({ text: 'Reject' }) }),
+        ]),
+      }),
+    ]));
   });
 
   it('uses untagged replies as context only when Invoker is tagged again', async () => {

--- a/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
@@ -386,11 +386,52 @@ describe('Slack plan submission restart repro contracts', () => {
     const respond = vi.fn().mockResolvedValue(undefined);
     await actionHandler(second, 'lobby_confirm')({
       action: { type: 'button', value: 'thread-button-confirm' },
-      body: { channel: { id: 'C_LOBBY' }, message: { thread_ts: 'thread-button-confirm' } },
+      body: {
+        channel: { id: 'C_LOBBY' },
+        message: { ts: 'submitted-plan-message', thread_ts: 'thread-button-confirm' },
+      },
       ack: vi.fn().mockResolvedValue(undefined),
       respond,
     });
-    expect(respond).toHaveBeenCalledWith({ text: '✅ Approved.', replace_original: true });
+    expect(sharedSlack.client.chat.update).toHaveBeenCalledWith(expect.objectContaining({
+      channel: 'C_LOBBY',
+      ts: 'submitted-plan-message',
+      text: expect.stringContaining('✅ Plan submitted.'),
+      blocks: [],
+    }));
+    expect(sharedSlack.client.chat.update.mock.calls[0][0].text).toContain('Drafted *Proof plan* (1 task).');
+    expect(commands).toContainEqual(expect.objectContaining({ type: 'start_plan' }));
+  });
+
+  it('recovers a plan submission from its thread when the pending confirmation is unavailable', async () => {
+    const commands: SurfaceCommand[] = [];
+    const first = surface(commands);
+    await start(first, commands);
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await mention(first, 'plan: recover a missing confirmation', 'thread-recover-confirm');
+    slackSessions.deletePendingConfirmation('thread-recover-confirm');
+    await first.stop();
+    surfaces = surfaces.filter((candidate) => candidate !== first);
+
+    const second = surface(commands);
+    await start(second, commands);
+    await actionHandler(second, 'lobby_confirm')({
+      action: { type: 'button', value: 'thread-recover-confirm' },
+      body: {
+        channel: { id: 'C_LOBBY' },
+        message: { ts: 'recovered-plan-message', thread_ts: 'thread-recover-confirm' },
+        user: { id: 'U_PROOF' },
+      },
+      ack: vi.fn().mockResolvedValue(undefined),
+      respond: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(sharedSlack.client.chat.update).toHaveBeenCalledWith(expect.objectContaining({
+      channel: 'C_LOBBY',
+      ts: 'recovered-plan-message',
+      text: expect.stringContaining('✅ Plan submitted.'),
+      blocks: [],
+    }));
     expect(commands).toContainEqual(expect.objectContaining({ type: 'start_plan' }));
   });
 

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -209,6 +209,10 @@ describe('parseThreadRequest', () => {
     expect(parseThreadRequest('plan fix the Slack routing bug')).toEqual({ mode: 'plan', text: 'fix the Slack routing bug' });
     expect(parseThreadRequest('make that fix via Invoker')).toEqual({ mode: 'plan', text: 'make that fix' });
     expect(parseThreadRequest('draft an Invoker plan for the Slack routing bug')).toEqual({ mode: 'plan', text: 'the Slack routing bug' });
+    expect(parseThreadRequest('please draft a plan for this')).toEqual({
+      mode: 'plan',
+      text: 'please draft a plan for this',
+    });
     expect(parseThreadRequest('turn the discussion above into a plan')).toEqual({
       mode: 'plan',
       text: 'turn the discussion above into a plan',
@@ -1020,7 +1024,8 @@ describe('lobby verb routing', () => {
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     await mentionHandler(surface)({ event: { text: '<@BOT> submit', ts: 't1', user: 'U1' }, say });
     expect(received).toHaveLength(0);
-    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('No Invoker plan draft') }));
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('No complete Invoker draft') }));
+    expect(say.mock.calls[0][0].text).not.toContain('plan:');
   });
 
   it('submit shows every task in the plan summary and emits start_plan on confirmation', async () => {

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -818,7 +818,7 @@ export class SlackSurface implements Surface {
       await ack();
       if (action.type !== 'button' || !action.value) return;
       const key = action.value;
-      const pending = this.getPendingConfirm(key);
+      const pending = this.getPendingConfirm(key) ?? await this.recoverSubmitConfirmation(key, body);
       if (!pending) {
         await respond?.({ text: 'This confirmation has expired.', replace_original: true });
         return;
@@ -826,9 +826,17 @@ export class SlackSurface implements Surface {
       this.pendingConfirms.delete(key);
       this.slackSessionRepo?.deletePendingConfirmation(key);
       this.log('slack', 'info', `Button: lobby_confirm key=${key} kind=${pending.kind}`);
-      // Acknowledge instantly by replacing the buttons. The op itself can take
-      // minutes (e.g. rebase-recreate all), and silence here reads as "nothing happened".
-      await respond?.({ text: '✅ Approved.', replace_original: true });
+      if (pending.kind === 'submit') {
+        await this.replaceConfirmationMessage(
+          body,
+          respond,
+          this.renderSubmittedPlanSummary(pending.planText),
+        );
+      } else {
+        // Acknowledge instantly by replacing the buttons. The op itself can take
+        // minutes (e.g. rebase-recreate all), and silence here reads as "nothing happened".
+        await respond?.({ text: '✅ Approved.', replace_original: true });
+      }
       // Follow-ups post in-thread via the bot client: a response_url expires after
       // 30 minutes / 5 uses, which a long bulk op can outlast.
       const opChannel = (body as { channel?: { id?: string } })?.channel?.id;
@@ -1201,6 +1209,24 @@ export class SlackSurface implements Surface {
     };
   }
 
+  private renderSubmittedPlanSummary(planText: string): string {
+    const summary = summarizePlanText(planText);
+    return summary
+      ? `✅ Plan submitted.\n\n${this.renderPlanSummary(summary)}`
+      : '✅ Plan submitted.';
+  }
+
+  private async replaceConfirmationMessage(body: unknown, respond: RespondFn | undefined, text: string): Promise<void> {
+    const message = body as { channel?: { id?: string }; message?: { ts?: string } };
+    const channel = message.channel?.id;
+    const ts = message.message?.ts;
+    if (channel && ts) {
+      await this.app.client.chat.update({ channel, ts, text, blocks: [] });
+      return;
+    }
+    await respond?.({ text, replace_original: true });
+  }
+
   private describeOp(op: WorkflowOp): string {
     const target = 'all' in op.target ? 'ALL workflows' : `\`${op.target.workflow}\``;
     return `${op.operation} ${target}`;
@@ -1486,6 +1512,29 @@ export class SlackSurface implements Surface {
     if (!persisted || persisted.kind !== 'submit' || !this.isPendingConfirm(persisted.payload)) return undefined;
     this.pendingConfirms.set(key, persisted.payload);
     return persisted.payload;
+  }
+
+  private async recoverSubmitConfirmation(key: string, body: unknown): Promise<PendingConfirm | undefined> {
+    const action = body as {
+      channel?: { id?: string };
+      message?: { thread_ts?: string };
+      container?: { thread_ts?: string };
+      user?: { id?: string };
+    };
+    const channel = action.channel?.id;
+    const threadTs = action.message?.thread_ts ?? action.container?.thread_ts;
+    if (!channel || !threadTs || key !== threadTs) return undefined;
+    const conversation = await this.getSession(channel, threadTs, action.user?.id ?? 'unknown', false);
+    if (!conversation || conversation.conversationMode !== 'plan' || conversation.planSubmitted) return undefined;
+    const planText = conversation.getDraftedPlan();
+    if (!planText) return undefined;
+    return {
+      kind: 'submit',
+      planText,
+      ctx: this.loadPlanningContext(threadTs),
+      channel,
+      lobbyThreadTs: threadTs,
+    };
   }
 
   private isPendingConfirm(value: unknown): value is PendingConfirm {

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -421,6 +421,10 @@ export function parseThreadRequest(text: string): ThreadRequest | null {
     return { mode: 'plan', text: trimmed };
   }
 
+  if (/^(?:please\s+)?(?:draft|create|make|write)\s+(?:an?\s+)?plan\s+for\s+(?:this|the\s+(?:above|thread|discussion))[.!?]*$/i.test(trimmed)) {
+    return { mode: 'plan', text: trimmed };
+  }
+
   const viaInvoker = /^(.*?\S)\s+(?:via|with)\s+invoker[.!]?$/i.exec(trimmed);
   if (viaInvoker) {
     return { mode: 'plan', text: viaInvoker[1] };
@@ -1206,12 +1210,12 @@ export class SlackSurface implements Surface {
   private async handleLobbySubmit(channel: string, threadTs: string, userId: string, say: SayFn): Promise<void> {
     const conversation = await this.getSession(channel, threadTs, userId, false);
     if (!conversation || conversation.conversationMode !== 'plan') {
-      await say({ text: "No Invoker plan draft here yet. In this thread, reply `plan: ...`, then run `submit`.", thread_ts: threadTs });
+      await say({ text: 'No complete Invoker draft is available in this thread yet. Ask me to draft the plan here, then submit it.', thread_ts: threadTs });
       return;
     }
     const planText = conversation.getDraftedPlan();
     if (!planText) {
-      await say({ text: "I don't see a complete plan drafted yet — use `plan:` to ask for an Invoker plan, then submit again.", thread_ts: threadTs });
+      await say({ text: "I don't see a complete plan drafted yet. Ask me to draft it in this thread, then submit again.", thread_ts: threadTs });
       return;
     }
     const summary = summarizePlanText(planText);
@@ -1234,7 +1238,7 @@ export class SlackSurface implements Surface {
         type: 'actions',
         elements: [
           { type: 'button', action_id: 'lobby_confirm', style: 'primary', text: { type: 'plain_text', text: 'Approve' }, value: confirmKey },
-          { type: 'button', action_id: 'lobby_cancel', text: { type: 'plain_text', text: 'Cancel' }, value: confirmKey },
+          { type: 'button', action_id: 'lobby_cancel', text: { type: 'plain_text', text: 'Reject' }, value: confirmKey },
         ],
       },
     ];

--- a/packages/surfaces/src/surface.ts
+++ b/packages/surfaces/src/surface.ts
@@ -102,6 +102,7 @@ export type SurfaceEvent =
       lobbyThreadTs?: string;
       harnessPreset?: string;
       repoUrl?: string;
+      planFile?: string;
     }
   | { type: 'error'; message: string };
 


### PR DESCRIPTION
## Summary

The Slack manager now forwards the workflow plan-file path to surfaces.

## Review Claim

Approve forwarding the existing workflow plan-file value through the Slack manager.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The forwarded value is the command's existing plan file and is optional.

## Slice Rationale

This connects the manager producer before Slack consumes the file.

## Non-goals

This does not publish Slack plan artifacts or alter workflow execution.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/slack-manager test -- command-handler`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f1142b53a`
- Post-revert steps: None
- Data migration? No

</details>
