### PR TITLE
[E2E] Authorize draft prompts and open Plan graph from Planning home

### DIFF
--- a/packages/app/e2e/action-graph-visual-proof.spec.ts
+++ b/packages/app/e2e/action-graph-visual-proof.spec.ts
@@ -14,6 +14,8 @@ test.describe('Action Graph visual proof', () => {
       return graph.nodes.length > 0;
     });
 
+    await page.getByTestId('sidebar-planning').click();
+    await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible();
     await page.getByTestId('graph-more-button').click();
     await expect(page.getByTestId('graph-more-menu')).toBeVisible();
     await page.getByTestId('rail-action-graph').click();

--- a/packages/app/e2e/embedded-terminal-restart-persistence.spec.ts
+++ b/packages/app/e2e/embedded-terminal-restart-persistence.spec.ts
@@ -88,6 +88,8 @@ async function loadPlan(page: Page): Promise<void> {
     const tasks = Array.isArray(result) ? result : result.tasks;
     return tasks.some((task: { id: string }) => task.id.endsWith('/terminal-task'));
   }), null, { timeout: 10000 });
+  await page.getByTestId('sidebar-planning').click();
+  await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible({ timeout: 10000 });
   await page.getByRole('button', { name: 'Refresh' }).click();
   await page.locator('.react-flow__node[data-testid$="terminal-task"]').first().waitFor({ state: 'visible', timeout: 10000 });
 }

--- a/packages/app/e2e/pending-review-gate-target-repo.proof.spec.ts
+++ b/packages/app/e2e/pending-review-gate-target-repo.proof.spec.ts
@@ -1,5 +1,4 @@
-import { test, expect, captureScreenshot } from './fixtures/electron-app.js';
-import { stringify as yamlStringify } from 'yaml';
+import { test, expect, captureScreenshot, loadPlan } from './fixtures/electron-app.js';
 
 const REVIEW_GATE_PROOF_PLAN = {
   name: 'Pending review gate target repo proof',
@@ -18,7 +17,7 @@ const REVIEW_GATE_PROOF_PLAN = {
 };
 
 test('pending review gate target repo row', async ({ page }) => {
-  await page.evaluate((yaml) => window.invoker.loadPlan(yaml), yamlStringify(REVIEW_GATE_PROOF_PLAN));
+  await loadPlan(page, REVIEW_GATE_PROOF_PLAN);
   await page.locator('.react-flow__node[data-testid$="review-gate-proof-task"]').first().waitFor({ state: 'visible', timeout: 15000 });
 
   const mergeGateTaskId = await page.evaluate(async () => {
@@ -50,7 +49,7 @@ test('pending review gate target repo row', async ({ page }) => {
 });
 
 test('pending review gate merge mode selector', async ({ page }) => {
-  await page.evaluate((yaml) => window.invoker.loadPlan(yaml), yamlStringify(REVIEW_GATE_PROOF_PLAN));
+  await loadPlan(page, REVIEW_GATE_PROOF_PLAN);
   await page.locator('.react-flow__node[data-testid$="review-gate-proof-task"]').first().waitFor({ state: 'visible', timeout: 15000 });
 
   const mergeGateTaskId = await page.evaluate(async () => {

--- a/packages/app/e2e/planning-terminal-restart-persistence.spec.ts
+++ b/packages/app/e2e/planning-terminal-restart-persistence.spec.ts
@@ -125,7 +125,7 @@ base.describe('Planning Terminal restart persistence', () => {
       }, { yaml: planYaml });
 
       await openPlanningTerminal(page);
-      await submitPlanningText(page, 'Add README');
+      await submitPlanningText(page, 'Draft a YAML plan to add a README');
       await expect(page.getByTestId('invoker-terminal-ready-bar')).toContainText('draft ready', { timeout: 10000 });
       const savedSessionId = await page.evaluate(async () => {
         const list = await window.invoker.planningChatList();
@@ -141,7 +141,7 @@ base.describe('Planning Terminal restart persistence', () => {
       ({ app, page } = await launchApp({ dbDir: testDir, userDataDir, ipcSocketPath, configPath }));
       await openPlanningTerminal(page);
 
-      await expect(page.getByTestId('invoker-terminal-transcript')).toContainText('Add README', { timeout: 10000 });
+      await expect(page.getByTestId('invoker-terminal-transcript')).toContainText('Draft a YAML plan to add a README', { timeout: 10000 });
       await expect(page.getByTestId('invoker-terminal-transcript')).toContainText('I drafted the restart plan.');
       await expect(page.getByTestId('invoker-terminal-ready-bar')).toContainText('draft ready · "Planning Terminal Restart"');
       await expect(page.getByTestId('invoker-terminal-input')).toBeEnabled();
@@ -186,7 +186,7 @@ base.describe('Planning Terminal restart persistence', () => {
       }, { yaml: planYaml });
 
       await openPlanningTerminal(page);
-      await submitPlanningText(page, 'Add README');
+      await submitPlanningText(page, 'Draft a YAML plan to add a README');
       await expect(page.getByTestId('invoker-terminal-ready-bar')).toContainText('draft ready', { timeout: 10000 });
       const savedSessionId = await page.evaluate(async () => {
         const list = await window.invoker.planningChatList();

--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -174,6 +174,8 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
       await page.waitForLoadState('domcontentloaded');
       await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10_000 });
 
+      await page.getByTestId('sidebar-planning').click();
+      await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible({ timeout: 10_000 });
       await waitForWorkflowGraphVisible(page, 5000);
       await dragGraphAndAssertViewportMoves(page);
 

--- a/packages/app/e2e/ui-graph-drag-performance.spec.ts
+++ b/packages/app/e2e/ui-graph-drag-performance.spec.ts
@@ -86,6 +86,8 @@ async function seedLargeWorkflowGraph(page: Page): Promise<void> {
     WORKFLOW_COUNT,
     { timeout: 30_000 },
   );
+  await page.getByTestId('sidebar-planning').click();
+  await page.getByRole('heading', { name: 'Plan graph' }).waitFor({ state: 'visible', timeout: 10_000 });
   await page.getByRole('button', { name: 'Refresh' }).click();
   await page.locator('[data-testid^="workflow-node-"]:visible').first().waitFor({ state: 'visible', timeout: 10_000 });
 }

--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -742,13 +742,13 @@ test.describe('Visual proof capture', () => {
     await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-60/);
     await expect(page.getByTestId('planning-session-rail')).toHaveClass(/w-64/);
     await expect(page.getByRole('heading', { name: 'Planning chat' })).toBeVisible();
-    await page.getByTestId('invoker-terminal-input').fill('Add README');
+    await page.getByTestId('invoker-terminal-input').fill('Draft a YAML plan to add a README');
     await page.getByRole('button', { name: 'Send' }).click();
 
     // The conversation renders in the terminal transcript: the user message,
     // the assistant prose, and the drafted plan YAML from first to last line.
     const transcript = page.getByTestId('invoker-terminal-transcript');
-    await expect(transcript).toContainText('Add README');
+    await expect(transcript).toContainText('Draft a YAML plan to add a README');
     await expect(transcript).toContainText('I drafted the plan.');
     await expect(transcript).toContainText('name: Terminal Planned Flow');
     await expect(transcript).toContainText('sleep 5 && echo hello-alpha');
@@ -789,7 +789,7 @@ test.describe('Visual proof capture', () => {
     // Returning to Planning home keeps the full conversation:
     // submitting must not clear or truncate the transcript.
     await page.getByTestId('sidebar-home').click();
-    await expect(transcript).toContainText('Add README');
+    await expect(transcript).toContainText('Draft a YAML plan to add a README');
     await expect(transcript).toContainText('sleep 2 && echo hello-gamma');
     await expect(transcript).toContainText('Plan "Terminal Planned Flow" submitted to Invoker. Review it, then use Start ready work.');
     await captureScreenshot(page, 'terminal-planned-conversation-after-submit');
@@ -1003,7 +1003,7 @@ test.describe('Visual proof capture', () => {
     await expect(page.getByText('What do you want to build?')).toBeVisible();
     await expect(page.getByText('Ask Invoker what you want to build.')).toHaveCount(0);
     await expect(page.getByTestId('invoker-terminal-input')).toBeVisible();
-    await page.getByTestId('invoker-terminal-input').fill('Build the Workers Surface');
+    await page.getByTestId('invoker-terminal-input').fill('Draft a YAML plan for the Workers Surface');
     await page.getByRole('button', { name: 'Send' }).click();
     await expect(page.getByTestId('invoker-terminal-ready-bar')).toBeVisible();
     await page.getByRole('button', { name: 'Submit to Invoker' }).click();


### PR DESCRIPTION
## Summary

Playwright shards started failing after planning-home and draft-authorization changes. Specs still typed messages like `Add README`, which no longer mark a session `draft_ready`, so the ready bar never appeared.

Other specs called `loadPlan` while still on Planning home, then clicked Plan graph controls that are not mounted there.

This updates draft prompts to explicit YAML-plan intent and opens Plan graph before graph assertions in the affected specs.

## Review Claim

Approve updating Playwright e2e prompts and navigation so draft-ready and Plan graph assertions match current Planning-home behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only Playwright e2e specs change. Product runtime behavior is unchanged.

## Slice Rationale

These failures blocked master CI after the Playwright timeout and concurrency fixes landed. Keeping the proof updates together keeps one review claim: e2e matches current planning UX contracts.

## Non-goals

Does not change draft-authorization product rules, Planning home IA, or e2e-proof headless suites.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `playwright / 2-of-7` and `playwright / 5-of-7` pass on master after merge.
- [ ] Planning restart persistence shows `Draft ready` after the authorized prompt.
- [ ] Action graph / embedded terminal specs reach Plan graph controls after load.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

Revert this commit to restore the previous e2e prompts and navigation assumptions.

</details>