### PR TITLE
[Slack Repo Binding](1) Extract repo-root URLs

### DIFF
--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -4,7 +4,7 @@ import * as child_process from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { SlackSurface, parsePlanningRequest, parseLobbyClassification, parseLocalRequest, parseThreadRequest, parseWorkflowStatusQuery, BUILTIN_HARNESS_PRESETS, buildLobbyQuestionPrompt } from '../slack/slack-surface.js';
+import { SlackSurface, extractRepoUrlFromMessage, parsePlanningRequest, parseLobbyClassification, parseLocalRequest, parseThreadRequest, parseWorkflowStatusQuery, BUILTIN_HARNESS_PRESETS, buildLobbyQuestionPrompt } from '../slack/slack-surface.js';
 import { SQLiteAdapter, ConversationRepository, WorkflowChannelRepository } from '@invoker/data-store';
 import type { SurfaceCommand } from '../surface.js';
 import type { WorkflowContext } from '../slack/workflow-assistant.js';
@@ -182,6 +182,45 @@ describe('parsePlanningRequest', () => {
     )).toMatchObject({
       repositoryUrls: ['git@github.com:EdbertChan/notarepo.git'],
     });
+  });
+});
+
+describe('extractRepoUrlFromMessage', () => {
+  it('extracts wrapped and labeled Slack links', () => {
+    expect(extractRepoUrlFromMessage('use <https://github.com/openai/invoker> please')).toBe('https://github.com/openai/invoker');
+    expect(extractRepoUrlFromMessage('use <https://github.com/openai/invoker|repo> please')).toBe('https://github.com/openai/invoker');
+  });
+
+  it('extracts a plain repo URL', () => {
+    expect(extractRepoUrlFromMessage('repo is https://github.com/openai/invoker')).toBe('https://github.com/openai/invoker');
+  });
+
+  it('normalizes a trailing slash', () => {
+    expect(extractRepoUrlFromMessage('repo is https://github.com/EdbertChan/notarepo/')).toBe('https://github.com/EdbertChan/notarepo');
+  });
+
+  it('keeps a .git suffix', () => {
+    expect(extractRepoUrlFromMessage('repo is https://github.com/EdbertChan/notarepo.git')).toBe('https://github.com/EdbertChan/notarepo.git');
+  });
+
+  it('rejects credential-bearing URLs', () => {
+    expect(extractRepoUrlFromMessage('https://token@github.com/openai/invoker')).toBeUndefined();
+    expect(extractRepoUrlFromMessage('https://token:secret@github.com/openai/invoker.git')).toBeUndefined();
+  });
+
+  it('rejects deep links', () => {
+    expect(extractRepoUrlFromMessage('https://github.com/openai/invoker/issues/12')).toBeUndefined();
+    expect(extractRepoUrlFromMessage('https://github.com/openai/invoker/pull/5')).toBeUndefined();
+    expect(extractRepoUrlFromMessage('https://github.com/openai/invoker/tree/main')).toBeUndefined();
+    expect(extractRepoUrlFromMessage('https://github.com/openai/invoker/blob/main/README.md')).toBeUndefined();
+  });
+
+  it('returns the first repo-root URL when multiple are present', () => {
+    expect(extractRepoUrlFromMessage('try https://gitlab.com/first/repo then https://github.com/second/repo')).toBe('https://gitlab.com/first/repo');
+  });
+
+  it('returns undefined when no repo URL is present', () => {
+    expect(extractRepoUrlFromMessage('please plan this without a repo link')).toBeUndefined();
   });
 });
 

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -181,10 +181,59 @@ function capTailChars(value: string, max: number): string {
 // ── Planning request parsing ─────────────────────────────────
 
 const PRESET_TOOL_HINTS = ['cursor', 'omp', 'codex', 'claude'];
+const URL_TOKEN_TERMINATORS = new Set([' ', '\t', '\n', '\r', '<', '>', '(', ')', '[', ']', '{', '}', '"', "'", '|']);
+const TRAILING_URL_PUNCTUATION = new Set(['.', ',', ';', ':', '!', '?']);
 
 /** A leading bracket tag is a likely preset attempt when it names a known tool or uses the tool+model form. */
 function looksLikePreset(normalized: string): boolean {
   return normalized.includes('+') || PRESET_TOOL_HINTS.some((hint) => normalized.includes(hint));
+}
+
+export function extractRepoUrlFromMessage(text: string): string | undefined {
+  let start = 0;
+  while (start < text.length) {
+    const httpIndex = text.indexOf('http://', start);
+    const httpsIndex = text.indexOf('https://', start);
+    const candidateStart = httpIndex === -1
+      ? httpsIndex
+      : httpsIndex === -1
+        ? httpIndex
+        : Math.min(httpIndex, httpsIndex);
+    if (candidateStart === -1) return undefined;
+    let candidateEnd = candidateStart;
+    while (candidateEnd < text.length && !URL_TOKEN_TERMINATORS.has(text[candidateEnd])) {
+      candidateEnd += 1;
+    }
+    let candidate = text.slice(candidateStart, candidateEnd);
+    while (candidate && TRAILING_URL_PUNCTUATION.has(candidate.at(-1)!)) {
+      candidate = candidate.slice(0, -1);
+    }
+    let url: URL;
+    try {
+      url = new URL(candidate);
+    } catch {
+      start = candidateEnd + 1;
+      continue;
+    }
+    if (!url.host || (url.protocol !== 'http:' && url.protocol !== 'https:')) {
+      start = candidateEnd + 1;
+      continue;
+    }
+    if (url.username || url.password) {
+      start = candidateEnd + 1;
+      continue;
+    }
+    if (url.search || url.hash) {
+      start = candidateEnd + 1;
+      continue;
+    }
+    if (!/^\/[^/]+\/[^/]+(?:\.git|\/)?$/.test(url.pathname)) {
+      start = candidateEnd + 1;
+      continue;
+    }
+    return candidate.endsWith('/') ? candidate.slice(0, -1) : candidate;
+  }
+  return undefined;
 }
 
 /** Peel leading `[preset]` and `[repo:]` tags off a lobby mention; the rest is the request text. A preset-shaped tag matching no key is returned as `unknownPreset` so the caller can reject it instead of silently using the default. */


### PR DESCRIPTION
## Summary

Adds a strict parser for repository-root HTTP(S) URLs in Slack message text.

It accepts Slack-wrapped links, normalizes trailing slashes, and rejects deep links and URLs with query strings or fragments.

## Review Claim

Approve the repo-root URL parsing boundary used by Slack repo binding.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

The helper is covered directly and has no runtime caller beyond the following stack slice.

## Slice Rationale

Keeping parsing separate makes first-message and follow-up binding reviewable without mixing URL validation into routing.

## Non-goals

- No planning context changes.
- No workflow routing changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test -- slack-surface-workflows slack-plan-submission-repros`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7ac115d08`
- Data migration? No

</details>