### PR TITLE
[Slack Repo Binding Step 2: First-message binding](1) Bind first-message repo URLs

### DIFF
--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -310,7 +310,11 @@ describe('harness routing', () => {
 
   it('constructs the planning conversation with the preset tool/model and injected builder', async () => {
     const builder = vi.fn(() => ({ command: 'cursor', args: [] }));
-    const surface = new SlackSurface({ ...baseConfig(), planningCommandBuilder: builder });
+    const surface = new SlackSurface({
+      ...baseConfig(),
+      defaultRepoUrl: 'git@github.com:default/repo.git',
+      planningCommandBuilder: builder,
+    });
     await surface.start(async () => {});
 
     await mentionHandler(surface)({
@@ -1008,7 +1012,7 @@ describe('lobby verb routing', () => {
   });
 
   it('routes a build request to an inferred Invoker plan thread', async () => {
-    const surface = lobbySurface();
+    const surface = lobbySurface(true, { defaultRepoUrl: 'git@github.com:default/repo.git' });
     await surface.start(async () => {});
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     await mentionHandler(surface)({ event: { text: '<@BOT> add a /health endpoint', ts: 't1', user: 'U1' }, say });
@@ -1019,7 +1023,7 @@ describe('lobby verb routing', () => {
   });
 
   it('routes an explicit plan request to an Invoker plan thread', async () => {
-    const surface = lobbySurface();
+    const surface = lobbySurface(true, { defaultRepoUrl: 'git@github.com:default/repo.git' });
     await surface.start(async () => {});
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     await mentionHandler(surface)({ event: { text: '<@BOT> plan: add a /health endpoint', ts: 't1', user: 'U1' }, say });
@@ -1053,24 +1057,40 @@ describe('lobby verb routing', () => {
     }));
   });
 
-  it('rejects conflicting or multiple repository selectors before creating a session', async () => {
+  it('uses a repo-root URL in the first plan message instead of defaultRepoUrl and announces it', async () => {
+    mockSpawn.mockImplementationOnce(() => mockProcess('{"intent":"plan","operation":"none","target":"none"}'));
+    const surface = lobbySurface(true, {
+      defaultRepoUrl: 'git@github.com:default/repo.git',
+      enableImmediateAck: true,
+    });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+
+    await mentionHandler(surface)({
+      event: {
+        text: '<@BOT> add a /health endpoint to https://github.com/openai/invoker',
+        ts: 't1',
+        user: 'U1',
+        channel: 'CLOBBY',
+      },
+      say,
+    });
+
+    expect(planConversationConfigs).toHaveLength(1);
+    expect(planConversationConfigs[0].repoUrl).toBe('https://github.com/openai/invoker');
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(say).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      text: expect.stringContaining('I picked repo `https://github.com/openai/invoker`'),
+      thread_ts: 't1',
+    }));
+  });
+
+  it('rejects multiple repository selectors before creating a session', async () => {
     const surface = lobbySurface(true, {
       repoAliases: { proof: 'https://github.com/example/proof.git' },
     });
     await surface.start(async () => {});
-    const conflictSay = vi.fn().mockResolvedValue({ ts: 'a' });
-    await mentionHandler(surface)({
-      event: {
-        text: '<@BOT> [repo:proof] plan https://github.com/example/other',
-        ts: 'repo-conflict',
-        user: 'U1',
-      },
-      say: conflictSay,
-    });
-    expect(conflictSay).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('disagree') }));
-    expect(planConversationConfigs).toHaveLength(0);
-
-    const multipleSay = vi.fn().mockResolvedValue({ ts: 'b' });
+    const multipleSay = vi.fn().mockResolvedValue({ ts: 'a' });
     await mentionHandler(surface)({
       event: {
         text: '<@BOT> plan https://github.com/example/one and https://github.com/example/two',
@@ -1081,6 +1101,68 @@ describe('lobby verb routing', () => {
     });
     expect(multipleSay).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('multiple repository URLs') }));
     expect(planConversationConfigs).toHaveLength(0);
+  });
+
+  it('lets a [repo:] tag win over a repo URL in the same first plan message', async () => {
+    const surface = lobbySurface(true, {
+      defaultRepoUrl: 'git@github.com:default/repo.git',
+      repoAliases: { foo: 'git@github.com:me/foo.git' },
+    });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+
+    await mentionHandler(surface)({
+      event: {
+        text: '<@BOT> [repo:foo] plan: add a /health endpoint to https://github.com/openai/invoker',
+        ts: 't1',
+        user: 'U1',
+        channel: 'CLOBBY',
+      },
+      say,
+    });
+
+    expect(planConversationConfigs).toHaveLength(1);
+    expect(planConversationConfigs[0].repoUrl).toBe('git@github.com:me/foo.git');
+    expect(say.mock.calls.map((call) => call[0].text).join('\n')).not.toContain('from the URL in your message');
+  });
+
+  it('ignores a deep link in the first plan message and falls through to defaultRepoUrl', async () => {
+    const surface = lobbySurface(true, { defaultRepoUrl: 'git@github.com:default/repo.git' });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+
+    await mentionHandler(surface)({
+      event: {
+        text: '<@BOT> plan: fix the issue at https://github.com/openai/invoker/pull/123',
+        ts: 't1',
+        user: 'U1',
+        channel: 'CLOBBY',
+      },
+      say,
+    });
+
+    expect(planConversationConfigs).toHaveLength(1);
+    expect(planConversationConfigs[0].repoUrl).toBe('git@github.com:default/repo.git');
+    expect(say.mock.calls.map((call) => call[0].text).join('\n')).not.toContain('from the URL in your message');
+  });
+
+  it('asks for a repo instead of planning when a plan mention has no tag, repo URL, or default', async () => {
+    const surface = lobbySurface();
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> plan: add a /health endpoint', ts: 't1', user: 'U1', channel: 'CLOBBY' },
+      say,
+    });
+
+    expect(planConversationConfigs).toHaveLength(0);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('[repo:<alias>]'),
+      thread_ts: 't1',
+    }));
+    expect(say.mock.calls[0][0].text).toContain('git URL');
   });
 
 
@@ -1139,7 +1221,7 @@ describe('lobby verb routing', () => {
   });
 
   it('submit shows every task in the plan summary and emits start_plan on confirmation', async () => {
-    const surface = lobbySurface();
+    const surface = lobbySurface(true, { defaultRepoUrl: 'git@github.com:default/repo.git' });
     await surface.start(async (cmd) => { received.push(cmd); });
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     // Open a planning conversation in the thread, then arm its drafted plan.

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -4,7 +4,7 @@ import * as child_process from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { SlackSurface, parsePlanningRequest, parseLobbyClassification, parseLocalRequest, parseThreadRequest, parseWorkflowStatusQuery, BUILTIN_HARNESS_PRESETS, buildLobbyQuestionPrompt } from '../slack/slack-surface.js';
+import { SlackSurface, extractRepoUrlFromMessage, parsePlanningRequest, parseLobbyClassification, parseLocalRequest, parseThreadRequest, parseWorkflowStatusQuery, BUILTIN_HARNESS_PRESETS, buildLobbyQuestionPrompt } from '../slack/slack-surface.js';
 import { SQLiteAdapter, ConversationRepository, WorkflowChannelRepository } from '@invoker/data-store';
 import type { SurfaceCommand } from '../surface.js';
 import type { WorkflowContext } from '../slack/workflow-assistant.js';
@@ -182,6 +182,45 @@ describe('parsePlanningRequest', () => {
     )).toMatchObject({
       repositoryUrls: ['git@github.com:EdbertChan/notarepo.git'],
     });
+  });
+});
+
+describe('extractRepoUrlFromMessage', () => {
+  it('extracts wrapped and labeled Slack links', () => {
+    expect(extractRepoUrlFromMessage('use <https://github.com/openai/invoker> please')).toBe('https://github.com/openai/invoker');
+    expect(extractRepoUrlFromMessage('use <https://github.com/openai/invoker|repo> please')).toBe('https://github.com/openai/invoker');
+  });
+
+  it('extracts a plain repo URL', () => {
+    expect(extractRepoUrlFromMessage('repo is https://github.com/openai/invoker')).toBe('https://github.com/openai/invoker');
+  });
+
+  it('normalizes a trailing slash', () => {
+    expect(extractRepoUrlFromMessage('repo is https://github.com/EdbertChan/notarepo/')).toBe('https://github.com/EdbertChan/notarepo');
+  });
+
+  it('keeps a .git suffix', () => {
+    expect(extractRepoUrlFromMessage('repo is https://github.com/EdbertChan/notarepo.git')).toBe('https://github.com/EdbertChan/notarepo.git');
+  });
+
+  it('rejects credential-bearing URLs', () => {
+    expect(extractRepoUrlFromMessage('https://token@github.com/openai/invoker')).toBeUndefined();
+    expect(extractRepoUrlFromMessage('https://token:secret@github.com/openai/invoker.git')).toBeUndefined();
+  });
+
+  it('rejects deep links', () => {
+    expect(extractRepoUrlFromMessage('https://github.com/openai/invoker/issues/12')).toBeUndefined();
+    expect(extractRepoUrlFromMessage('https://github.com/openai/invoker/pull/5')).toBeUndefined();
+    expect(extractRepoUrlFromMessage('https://github.com/openai/invoker/tree/main')).toBeUndefined();
+    expect(extractRepoUrlFromMessage('https://github.com/openai/invoker/blob/main/README.md')).toBeUndefined();
+  });
+
+  it('returns the first repo-root URL when multiple are present', () => {
+    expect(extractRepoUrlFromMessage('try https://gitlab.com/first/repo then https://github.com/second/repo')).toBe('https://gitlab.com/first/repo');
+  });
+
+  it('returns undefined when no repo URL is present', () => {
+    expect(extractRepoUrlFromMessage('please plan this without a repo link')).toBeUndefined();
   });
 });
 

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -181,10 +181,59 @@ function capTailChars(value: string, max: number): string {
 // ── Planning request parsing ─────────────────────────────────
 
 const PRESET_TOOL_HINTS = ['cursor', 'omp', 'codex', 'claude'];
+const URL_TOKEN_TERMINATORS = new Set([' ', '\t', '\n', '\r', '<', '>', '(', ')', '[', ']', '{', '}', '"', "'", '|']);
+const TRAILING_URL_PUNCTUATION = new Set(['.', ',', ';', ':', '!', '?']);
 
 /** A leading bracket tag is a likely preset attempt when it names a known tool or uses the tool+model form. */
 function looksLikePreset(normalized: string): boolean {
   return normalized.includes('+') || PRESET_TOOL_HINTS.some((hint) => normalized.includes(hint));
+}
+
+export function extractRepoUrlFromMessage(text: string): string | undefined {
+  let start = 0;
+  while (start < text.length) {
+    const httpIndex = text.indexOf('http://', start);
+    const httpsIndex = text.indexOf('https://', start);
+    const candidateStart = httpIndex === -1
+      ? httpsIndex
+      : httpsIndex === -1
+        ? httpIndex
+        : Math.min(httpIndex, httpsIndex);
+    if (candidateStart === -1) return undefined;
+    let candidateEnd = candidateStart;
+    while (candidateEnd < text.length && !URL_TOKEN_TERMINATORS.has(text[candidateEnd])) {
+      candidateEnd += 1;
+    }
+    let candidate = text.slice(candidateStart, candidateEnd);
+    while (candidate && TRAILING_URL_PUNCTUATION.has(candidate.at(-1)!)) {
+      candidate = candidate.slice(0, -1);
+    }
+    let url: URL;
+    try {
+      url = new URL(candidate);
+    } catch {
+      start = candidateEnd + 1;
+      continue;
+    }
+    if (!url.host || (url.protocol !== 'http:' && url.protocol !== 'https:')) {
+      start = candidateEnd + 1;
+      continue;
+    }
+    if (url.username || url.password) {
+      start = candidateEnd + 1;
+      continue;
+    }
+    if (url.search || url.hash) {
+      start = candidateEnd + 1;
+      continue;
+    }
+    if (!/^\/[^/]+\/[^/]+(?:\.git|\/)?$/.test(url.pathname)) {
+      start = candidateEnd + 1;
+      continue;
+    }
+    return candidate.endsWith('/') ? candidate.slice(0, -1) : candidate;
+  }
+  return undefined;
 }
 
 /** Peel leading `[preset]` and `[repo:]` tags off a lobby mention; the rest is the request text. A preset-shaped tag matching no key is returned as `unknownPreset` so the caller can reject it instead of silently using the default. */

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -514,6 +514,12 @@ interface SayResult {
 
 type SayFn = (msg: { text: string; thread_ts: string; blocks?: unknown[] }) => Promise<SayResult>;
 
+type PlanningRepoResolution = {
+  url?: string;
+  error?: string;
+  source: 'tag' | 'message-url' | 'default' | 'none';
+};
+
 interface SlackMentionEvent {
   text?: string;
   ts: string;
@@ -988,17 +994,18 @@ export class SlackSurface implements Surface {
       await say({ text: detectedRepoResolution.error, thread_ts: event.ts });
       return;
     }
-    if (
-      explicitRepoResolution.url
-      && detectedRepoResolution.url
-      && repositoryIdentity(explicitRepoResolution.url) !== repositoryIdentity(detectedRepoResolution.url)
-    ) {
-      await say({ text: 'The `[repo:…]` selector and repository URL disagree. Use one repository target per request.', thread_ts: event.ts });
-      return;
-    }
-    const repoUrl = explicitRepoResolution.url ?? detectedRepoResolution.url ?? this.resolveRepoUrl().url;
+    const routeRepoUrl = explicitRepoResolution.url ?? detectedRepoResolution.url ?? this.resolveRepoUrl().url;
 
     const threadTs = event.thread_ts ?? event.ts;
+    const requiresPlanningRepo = channel === this.lobbyChannelId;
+    const messageRepoUrl = requiresPlanningRepo && !parsed.repo
+      ? extractRepoUrlFromMessage(event.text ?? '')
+      : undefined;
+    let planningRepoResolution: PlanningRepoResolution | undefined;
+    const resolvePlanningRepo = (): PlanningRepoResolution => {
+      planningRepoResolution ??= this.resolvePlanningRepoUrl(parsed.repo, messageRepoUrl);
+      return planningRepoResolution;
+    };
 
     // Confirm/cancel a staged action first (plain yes/no in-thread).
     if (await this.resolveConfirm(threadTs, parsed.text, say, channel)) return;
@@ -1020,7 +1027,7 @@ export class SlackSurface implements Surface {
 
     const localRequest = parseLocalRequest(parsed.text);
     if (localRequest?.kind === 'command') {
-      await this.handleLocalRequest(localRequest, preset, threadTs, say, channel, { userId: event.user, repoUrl });
+      await this.handleLocalRequest(localRequest, preset, threadTs, say, channel, { userId: event.user, repoUrl: routeRepoUrl });
       return;
     }
 
@@ -1034,8 +1041,19 @@ export class SlackSurface implements Surface {
     let threadRequest = parseThreadRequest(parsed.text);
     const barePlanPrefix = /^(?:invoker\s+)?plan\s*:\s*$/i.test(parsed.text.trim());
 
+    if (requiresPlanningRepo && threadRequest?.mode === 'plan' && !resolvePlanningRepo().url) {
+      await say({ text: this.missingPlanningRepoMessage(), thread_ts: threadTs });
+      return;
+    }
+
     // Slower paths (LLM classifier, repo checkout, agent) acknowledge receipt up front.
-    if (this.enableImmediateAck) await this.sendImmediateAck(threadTs, say);
+    if (
+      this.enableImmediateAck
+      && !(threadRequest?.mode === 'plan' && resolvePlanningRepo().source === 'message-url')
+      && !(!explicitLocalAgent && threadRequest?.mode !== 'plan' && messageRepoUrl)
+    ) {
+      await this.sendImmediateAck(threadTs, say);
+    }
 
     try {
       // Bare `plan:` has no body. Clear the Processing ack and stop — do not classify or plan.
@@ -1063,9 +1081,25 @@ export class SlackSurface implements Surface {
 
       if (!threadRequest) return;
 
+      let planningRepo: PlanningRepoResolution | undefined;
+      if (threadRequest.mode === 'plan') {
+        planningRepo = resolvePlanningRepo();
+        if (requiresPlanningRepo && !planningRepo.url) {
+          await this.clearImmediateAck(channel, threadTs);
+          await say({ text: this.missingPlanningRepoMessage(), thread_ts: threadTs });
+          return;
+        }
+        if (planningRepo.source === 'message-url') {
+          await say({
+            text: `I picked repo \`${planningRepo.url}\` from the URL in your message. If that's wrong, start the planning request again with a \`[repo:<alias>]\` tag or a git URL.`,
+            thread_ts: threadTs,
+          });
+        }
+      }
+
       const storedContext = this.loadPlanningContext(threadTs);
       if (storedContext) {
-        if ((parsed.repo || repositoryUrls.length > 0) && repoUrl && storedContext.repoUrl && repositoryIdentity(repoUrl) !== repositoryIdentity(storedContext.repoUrl)) {
+        if ((parsed.repo || repositoryUrls.length > 0) && routeRepoUrl && storedContext.repoUrl && repositoryIdentity(routeRepoUrl) !== repositoryIdentity(storedContext.repoUrl)) {
           await say({ text: 'This thread is already pinned to a different repository. Start a new thread to use another repository.', thread_ts: threadTs });
           return;
         }
@@ -1079,7 +1113,7 @@ export class SlackSurface implements Surface {
       const context = storedContext
         ? storedContext
         : {
-            repoUrl,
+            repoUrl: threadRequest.mode === 'plan' ? planningRepo?.url : routeRepoUrl,
             presetKey: parsed.presetKey,
             workingDir: this.workingDir,
             requestedBy: event.user,
@@ -1168,8 +1202,9 @@ export class SlackSurface implements Surface {
       const replies = await this.app.client.conversations.replies({ channel, ts: threadTs, limit: 100 });
       const messages = (replies.messages ?? []) as Array<{ bot_id?: string; subtype?: string; text?: string }>;
       const context = messages
-        .filter((message) => !message.bot_id && !message.subtype && typeof message.text === 'string')
-        .map((message) => message.text!.trim())
+        .filter((message): message is { text: string; bot_id?: string; subtype?: string } =>
+          !message.bot_id && !message.subtype && typeof message.text === 'string')
+        .map((message) => message.text.trim())
         .filter((text) => text && text !== request)
         .slice(-20)
         .map((text) => `- ${text.slice(0, 1_000)}`)
@@ -1787,6 +1822,20 @@ ${text}`;
     return !!repoUrl
       && !!this.prepareRepoCheckout
       && (!this.defaultRepoUrl || repositoryIdentity(repoUrl) !== repositoryIdentity(this.defaultRepoUrl));
+  }
+
+  private resolvePlanningRepoUrl(repo: string | undefined, messageRepoUrl: string | undefined): PlanningRepoResolution {
+    if (repo) {
+      const resolved = this.resolveRepoUrl(repo);
+      return { ...resolved, source: 'tag' };
+    }
+    if (messageRepoUrl) return { url: messageRepoUrl, source: 'message-url' };
+    if (this.defaultRepoUrl) return { url: this.resolveRepoUrl().url, source: 'default' };
+    return { source: 'none' };
+  }
+
+  private missingPlanningRepoMessage(): string {
+    return 'I need a repository before drafting an Invoker plan. Add a `[repo:<alias>]` tag or include a repo-root git URL like `https://github.com/org/repo` in the first message.';
   }
 
   // ── In-channel workflow assistant ──────────────────────


### PR DESCRIPTION
## Summary

New Slack planning threads now bind to a repo-root URL in their first message.

`[repo:]` tags take precedence, `defaultRepoUrl` remains the fallback, and Slack asks for a repository when all three are absent.

## Review Claim

Approve first-message Slack planning repository selection.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only planning repo selection changes; local commands and existing aliases continue through their existing resolution paths.

## Slice Rationale

This follows the parser foundation and precedes the test-runner and follow-up rebind slices.

## Non-goals

- No workflow channel routing changes.
- No mid-thread rebind changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test -- slack-surface-workflows slack-plan-submission-repros`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4ab80756d`
- Data migration? No

</details>

Depends-On: #5619