### PR TITLE
[Slack Repo Binding Step 3: Mid-thread rebind](1) Rebind thread repo from follow-up URL

### DIFF
--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SlackSurface, extractRepoUrlFromMessage, parsePlanningRequest, parseLobbyClassification, parseLocalRequest, parseThreadRequest, parseWorkflowStatusQuery, BUILTIN_HARNESS_PRESETS, buildLobbyQuestionPrompt } from '../slack/slack-surface.js';
-import { SQLiteAdapter, ConversationRepository, WorkflowChannelRepository } from '@invoker/data-store';
+import { SQLiteAdapter, ConversationRepository, SlackSessionRepository, WorkflowChannelRepository } from '@invoker/data-store';
 import type { SurfaceCommand } from '../surface.js';
 import type { WorkflowContext } from '../slack/workflow-assistant.js';
 
@@ -676,6 +676,14 @@ describe('lobby verb routing', () => {
     });
   }
 
+  async function persistentLobbySurface(extra: Partial<ConstructorParameters<typeof SlackSurface>[0]> = {}) {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    const conversationRepo = new ConversationRepository(adapter, { info: silentLog, warn: silentLog, error: silentLog });
+    const slackSessionRepo = new SlackSessionRepository(adapter);
+    const surface = lobbySurface(true, { conversationRepo, slackSessionRepo, ...extra });
+    return { adapter, slackSessionRepo, surface };
+  }
+
   it('asks lobby question answers to be short ELI5 Slack prose except for clearly technical questions', () => {
     const prompt = buildLobbyQuestionPrompt('how many workflows are running?');
     expect(prompt).toContain('ELI5 Slack prose');
@@ -1144,6 +1152,140 @@ describe('lobby verb routing', () => {
     expect(planConversationConfigs).toHaveLength(1);
     expect(planConversationConfigs[0].repoUrl).toBe('git@github.com:default/repo.git');
     expect(say.mock.calls.map((call) => call[0].text).join('\n')).not.toContain('from the URL in your message');
+  });
+
+  it('rebinds a follow-up repo-root URL, clears workingDir, and checks out the new repo on the next turn', async () => {
+    const oldRepo = 'https://github.com/openai/old-repo';
+    const newRepo = 'https://github.com/openai/new-repo';
+    const prepareRepoCheckout = vi.fn().mockResolvedValue('/checkouts/new-repo');
+    const { adapter, slackSessionRepo, surface } = await persistentLobbySurface({
+      defaultRepoUrl: oldRepo,
+      workingDir: '/checkouts/old-repo',
+      prepareRepoCheckout,
+    });
+
+    try {
+      await surface.start(async () => {});
+      await mentionHandler(surface)({
+        event: { text: '<@BOT> local: start in the current repo', ts: 't1', user: 'U1', channel: 'CLOBBY' },
+        say: vi.fn().mockResolvedValue({ ts: 'a' }),
+      });
+      expect(slackSessionRepo.getLaunchContext('t1')).toEqual(expect.objectContaining({
+        repoUrl: oldRepo,
+        workingDir: '/checkouts/old-repo',
+      }));
+
+      const rebindSay = vi.fn().mockResolvedValue({ ts: 'b' });
+      await messageHandler(surface)({
+        event: { thread_ts: 't1', ts: 't2', user: 'U1', text: `Please use ${newRepo} instead`, channel: 'CLOBBY' },
+        say: rebindSay,
+      });
+
+      expect(prepareRepoCheckout).not.toHaveBeenCalled();
+      expect(slackSessionRepo.getLaunchContext('t1')).toEqual(expect.objectContaining({
+        repoUrl: newRepo,
+        workingDir: '',
+      }));
+      expect(rebindSay).toHaveBeenCalledWith(expect.objectContaining({
+        text: expect.stringContaining('openai/new-repo'),
+        thread_ts: 't1',
+      }));
+      expect(rebindSay.mock.calls[0][0].text).toContain('previous working state for this thread was discarded');
+      expect(planConversationConfigs).toHaveLength(1);
+
+      await messageHandler(surface)({
+        event: { thread_ts: 't1', ts: 't3', user: 'U1', text: 'run local: make the update now', channel: 'CLOBBY' },
+        say: vi.fn().mockResolvedValue({ ts: 'c' }),
+      });
+
+      expect(prepareRepoCheckout).toHaveBeenCalledWith(newRepo);
+      expect(slackSessionRepo.getLaunchContext('t1')).toEqual(expect.objectContaining({
+        repoUrl: newRepo,
+        workingDir: '/checkouts/new-repo',
+      }));
+      expect(planConversationConfigs.at(-1)).toEqual(expect.objectContaining({
+        mode: 'agent',
+        repoUrl: newRepo,
+        workingDir: '/checkouts/new-repo',
+      }));
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
+  });
+
+  it('treats a follow-up URL for the already-bound repo as a no-op', async () => {
+    const boundRepo = 'git@github.com:openai/invoker.git';
+    const prepareRepoCheckout = vi.fn().mockResolvedValue('/checkouts/unused');
+    const { adapter, slackSessionRepo, surface } = await persistentLobbySurface({
+      defaultRepoUrl: boundRepo,
+      workingDir: '/checkouts/invoker',
+      prepareRepoCheckout,
+    });
+
+    try {
+      await surface.start(async () => {});
+      await mentionHandler(surface)({
+        event: { text: '<@BOT> local: start in invoker', ts: 't1', user: 'U1', channel: 'CLOBBY' },
+        say: vi.fn().mockResolvedValue({ ts: 'a' }),
+      });
+
+      const sameRepoSay = vi.fn().mockResolvedValue({ ts: 'b' });
+      await messageHandler(surface)({
+        event: { thread_ts: 't1', ts: 't2', user: 'U1', text: 'run local: continue in https://github.com/openai/invoker', channel: 'CLOBBY' },
+        say: sameRepoSay,
+      });
+
+      expect(prepareRepoCheckout).not.toHaveBeenCalled();
+      expect(slackSessionRepo.getLaunchContext('t1')).toEqual(expect.objectContaining({
+        repoUrl: boundRepo,
+        workingDir: '/checkouts/invoker',
+      }));
+      expect(planConversationConfigs).toHaveLength(1);
+      const texts = sameRepoSay.mock.calls.map((call) => call[0].text).join('\n');
+      expect(texts).not.toContain('switched this thread');
+      expect(texts).not.toContain('previous working state');
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
+  });
+
+  it('does not rebind a follow-up deep link', async () => {
+    const boundRepo = 'https://github.com/openai/invoker';
+    const prepareRepoCheckout = vi.fn().mockResolvedValue('/checkouts/unused');
+    const { adapter, slackSessionRepo, surface } = await persistentLobbySurface({
+      defaultRepoUrl: boundRepo,
+      workingDir: '/checkouts/invoker',
+      prepareRepoCheckout,
+    });
+
+    try {
+      await surface.start(async () => {});
+      await mentionHandler(surface)({
+        event: { text: '<@BOT> local: start in invoker', ts: 't1', user: 'U1', channel: 'CLOBBY' },
+        say: vi.fn().mockResolvedValue({ ts: 'a' }),
+      });
+
+      const deepLinkSay = vi.fn().mockResolvedValue({ ts: 'b' });
+      await messageHandler(surface)({
+        event: { thread_ts: 't1', ts: 't2', user: 'U1', text: 'run local: inspect https://github.com/openai/new-repo/pull/123', channel: 'CLOBBY' },
+        say: deepLinkSay,
+      });
+
+      expect(prepareRepoCheckout).not.toHaveBeenCalled();
+      expect(slackSessionRepo.getLaunchContext('t1')).toEqual(expect.objectContaining({
+        repoUrl: boundRepo,
+        workingDir: '/checkouts/invoker',
+      }));
+      expect(planConversationConfigs).toHaveLength(1);
+      const texts = deepLinkSay.mock.calls.map((call) => call[0].text).join('\n');
+      expect(texts).not.toContain('switched this thread');
+      expect(texts).not.toContain('previous working state');
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
   });
 
   it('asks for a repo instead of planning when a plan mention has no tag, repo URL, or default', async () => {

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -1213,6 +1213,46 @@ describe('lobby verb routing', () => {
       adapter.close();
     }
   });
+  it('refuses a repo rebind from a different non-admin participant', async () => {
+    const oldRepo = 'https://github.com/openai/old-repo';
+    const newRepo = 'https://github.com/openai/new-repo';
+    const prepareRepoCheckout = vi.fn().mockResolvedValue('/checkouts/new-repo');
+    const { adapter, slackSessionRepo, surface } = await persistentLobbySurface({
+      defaultRepoUrl: oldRepo,
+      workingDir: '/checkouts/old-repo',
+      adminUserIds: ['U_ADMIN'],
+      prepareRepoCheckout,
+    });
+
+    try {
+      await surface.start(async () => {});
+      await mentionHandler(surface)({
+        event: { text: '<@BOT> local: start in the current repo', ts: 't1', user: 'U1', channel: 'CLOBBY' },
+        say: vi.fn().mockResolvedValue({ ts: 'a' }),
+      });
+
+      const deniedSay = vi.fn().mockResolvedValue({ ts: 'b' });
+      await messageHandler(surface)({
+        event: { thread_ts: 't1', ts: 't2', user: 'U2', text: `Please use ${newRepo} instead`, channel: 'CLOBBY' },
+        say: deniedSay,
+      });
+
+      expect(prepareRepoCheckout).not.toHaveBeenCalled();
+      expect(slackSessionRepo.getLaunchContext('t1')).toEqual(expect.objectContaining({
+        repoUrl: oldRepo,
+        workingDir: '/checkouts/old-repo',
+      }));
+      expect(deniedSay).toHaveBeenCalledWith(expect.objectContaining({
+        text: expect.stringContaining('Permission denied'),
+        thread_ts: 't1',
+      }));
+      expect(deniedSay.mock.calls.map((call) => call[0].text).join('\n')).not.toContain('switched this thread');
+      expect(planConversationConfigs).toHaveLength(1);
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
+  });
 
   it('treats a follow-up URL for the already-bound repo as a no-op', async () => {
     const boundRepo = 'git@github.com:openai/invoker.git';

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -681,7 +681,7 @@ describe('lobby verb routing', () => {
     const conversationRepo = new ConversationRepository(adapter, { info: silentLog, warn: silentLog, error: silentLog });
     const slackSessionRepo = new SlackSessionRepository(adapter);
     const surface = lobbySurface(true, { conversationRepo, slackSessionRepo, ...extra });
-    return { adapter, slackSessionRepo, surface };
+    return { adapter, conversationRepo, slackSessionRepo, surface };
   }
 
   it('asks lobby question answers to be short ELI5 Slack prose except for clearly technical questions', () => {
@@ -1245,6 +1245,72 @@ describe('lobby verb routing', () => {
       const texts = sameRepoSay.mock.calls.map((call) => call[0].text).join('\n');
       expect(texts).not.toContain('switched this thread');
       expect(texts).not.toContain('previous working state');
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
+  });
+
+  it('accepts an equivalent non-GitHub repo URL in a thread mention', async () => {
+    const boundRepo = 'git@gitlab.com:openai/invoker.git';
+    const prepareRepoCheckout = vi.fn().mockResolvedValue('/checkouts/unused');
+    const { adapter, surface } = await persistentLobbySurface({
+      defaultRepoUrl: boundRepo,
+      workingDir: '/checkouts/invoker',
+      prepareRepoCheckout,
+    });
+
+    try {
+      await surface.start(async () => {});
+      await mentionHandler(surface)({
+        event: { text: '<@BOT> local: start in invoker', ts: 't1', user: 'U1', channel: 'CLOBBY' },
+        say: vi.fn().mockResolvedValue({ ts: 'a' }),
+      });
+
+      const sameRepoSay = vi.fn().mockResolvedValue({ ts: 'b' });
+      await mentionHandler(surface)({
+        event: {
+          text: '<@BOT> local: continue in https://gitlab.com/openai/invoker',
+          thread_ts: 't1',
+          ts: 't2',
+          user: 'U1',
+          channel: 'CLOBBY',
+        },
+        say: sameRepoSay,
+      });
+
+      expect(prepareRepoCheckout).not.toHaveBeenCalled();
+      expect(planConversationConfigs).toHaveLength(1);
+      expect(sameRepoSay.mock.calls.map((call) => call[0].text).join('\n')).not.toContain('already pinned to a different repository');
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
+  });
+
+  it('clears persisted conversation state when rebinding a thread repo', async () => {
+    const { adapter, conversationRepo, surface } = await persistentLobbySurface();
+
+    try {
+      conversationRepo.saveConversation(
+        't1',
+        [
+          { role: 'user', content: 'old repo question' },
+          { role: 'assistant', content: 'old repo answer' },
+        ],
+        null,
+        false,
+        'CLOBBY',
+        'U1',
+        'agent',
+      );
+
+      expect(conversationRepo.loadConversation('t1')).not.toBeNull();
+      const discardThreadSession = surface as unknown as {
+        discardThreadSession(channel: string, threadTs: string): void;
+      };
+      discardThreadSession.discardThreadSession('CLOBBY', 't1');
+      expect(conversationRepo.loadConversation('t1')).toBeNull();
     } finally {
       await surface.stop();
       adapter.close();

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -1329,9 +1329,19 @@ describe('lobby verb routing', () => {
   });
 
   it('clears persisted conversation state when rebinding a thread repo', async () => {
-    const { adapter, conversationRepo, surface } = await persistentLobbySurface();
+    const oldRepo = 'https://github.com/openai/old-repo';
+    const newRepo = 'https://github.com/openai/new-repo';
+    const { adapter, conversationRepo, surface } = await persistentLobbySurface({
+      defaultRepoUrl: oldRepo,
+      workingDir: '/checkouts/old-repo',
+    });
 
     try {
+      await surface.start(async () => {});
+      await mentionHandler(surface)({
+        event: { text: '<@BOT> local: start in the current repo', ts: 't1', user: 'U1', channel: 'CLOBBY' },
+        say: vi.fn().mockResolvedValue({ ts: 'a' }),
+      });
       conversationRepo.saveConversation(
         't1',
         [
@@ -1344,12 +1354,18 @@ describe('lobby verb routing', () => {
         'U1',
         'agent',
       );
-
       expect(conversationRepo.loadConversation('t1')).not.toBeNull();
-      const discardThreadSession = surface as unknown as {
-        discardThreadSession(channel: string, threadTs: string): void;
-      };
-      discardThreadSession.discardThreadSession('CLOBBY', 't1');
+
+      const rebindSay = vi.fn().mockResolvedValue({ ts: 'b' });
+      await messageHandler(surface)({
+        event: { thread_ts: 't1', ts: 't2', user: 'U1', text: `Please use ${newRepo} instead`, channel: 'CLOBBY' },
+        say: rebindSay,
+      });
+
+      expect(rebindSay).toHaveBeenCalledWith(expect.objectContaining({
+        text: expect.stringContaining('openai/new-repo'),
+        thread_ts: 't1',
+      }));
       expect(conversationRepo.loadConversation('t1')).toBeNull();
     } finally {
       await surface.stop();

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -264,16 +264,8 @@ function parseRepoParts(repoUrl: string): RepoParts | undefined {
   }
 }
 
-function repoIdentity(repoUrl: string): string {
-  const parts = parseRepoParts(repoUrl);
-  if (!parts) return stripGitSuffix(repoUrl.trim()).toLowerCase();
-  const host = parts.host.toLowerCase();
-  const path = host === 'github.com' ? parts.path.toLowerCase() : parts.path;
-  return `${host}/${path}`;
-}
-
 function sameRepoUrl(a: string, b: string): boolean {
-  return repoIdentity(a) === repoIdentity(b);
+  return repositoryIdentity(a) === repositoryIdentity(b);
 }
 
 function repoDisplayName(repoUrl: string): string {
@@ -351,10 +343,11 @@ function extractRepositoryUrls(text: string): string[] {
 }
 
 function repositoryIdentity(repoUrl: string): string {
-  const github = repoUrl.trim().match(/^(?:https?:\/\/|ssh:\/\/git@|git@)github\.com(?::|\/)([^/]+)\/(.+?)(?:\.git)?\/?$/i);
-  return github
-    ? `github.com/${github[1].toLowerCase()}/${github[2].toLowerCase()}`
-    : repoUrl.trim().replace(/\/+$/, '').toLowerCase();
+  const parts = parseRepoParts(repoUrl);
+  if (!parts) return stripGitSuffix(repoUrl.trim()).toLowerCase();
+  const host = parts.host.toLowerCase();
+  const path = host === 'github.com' ? parts.path.toLowerCase() : parts.path;
+  return `${host}/${path}`;
 }
 
 // ── Lobby intent routing ─────────────────────────────────────
@@ -1671,8 +1664,8 @@ export class SlackSurface implements Surface {
       requestedBy: context.requestedBy ?? userId,
       lobbyChannel: context.lobbyChannel ?? channel,
     };
-    this.savePlanningContext(threadTs, updated);
     this.discardThreadSession(channel, threadTs);
+    this.savePlanningContext(threadTs, updated);
 
     await say({
       text: `I switched this thread to repo \`${repoDisplayName(repoUrl)}\`. The previous working state for this thread was discarded.`,
@@ -1682,6 +1675,7 @@ export class SlackSurface implements Surface {
   }
 
   private discardThreadSession(channel: string, threadTs: string): void {
+    this.conversationRepo?.deleteConversation(threadTs);
     if (this.sessionManager) {
       this.sessionManager.evictSession(new SessionIdentifier(channel, threadTs));
       return;
@@ -2318,7 +2312,7 @@ ${text}`;
             channel,
             msg.thread_ts,
             msg.user ?? 'unknown',
-            false,
+            !!preparedContext,
             preparedContext ? this.sessionOptionsFromContext(preparedContext, 'agent') : undefined,
           );
           if (!conversation) return;

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -1651,11 +1651,18 @@ export class SlackSurface implements Surface {
     userId: string | undefined,
     text: string,
     say: SayFn,
-  ): Promise<{ context?: PlanningContext; rebound: boolean }> {
+  ): Promise<{ context?: PlanningContext; rebound: boolean; blocked: boolean }> {
     const context = this.loadPlanningContext(threadTs);
     const repoUrl = extractRepoUrlFromMessage(text);
-    if (!repoUrl || !context?.repoUrl) return { context, rebound: false };
-    if (sameRepoUrl(context.repoUrl, repoUrl)) return { context, rebound: false };
+    if (!repoUrl || !context?.repoUrl) return { context, rebound: false, blocked: false };
+    if (sameRepoUrl(context.repoUrl, repoUrl)) return { context, rebound: false, blocked: false };
+    if (!userId || (context.requestedBy !== userId && !this.adminUserIds.has(userId))) {
+      await say({
+        text: 'Permission denied. Only the user who started this thread or an admin can switch it to a different repository.',
+        thread_ts: threadTs,
+      });
+      return { context, rebound: false, blocked: true };
+    }
 
     const updated: PlanningContext = {
       ...context,
@@ -1671,7 +1678,7 @@ export class SlackSurface implements Surface {
       text: `I switched this thread to repo \`${repoDisplayName(repoUrl)}\`. The previous working state for this thread was discarded.`,
       thread_ts: threadTs,
     });
-    return { context: updated, rebound: true };
+    return { context: updated, rebound: true, blocked: false };
   }
 
   private discardThreadSession(channel: string, threadTs: string): void {
@@ -2298,7 +2305,7 @@ ${text}`;
       if (!text) return;
 
       const rebind = await this.maybeRebindThreadRepo(channel, msg.thread_ts, msg.user, text, say);
-      if (rebind.rebound) return;
+      if (rebind.rebound || rebind.blocked) return;
 
       const localRequest = parseLocalRequest(text);
       if (localRequest) {

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -236,6 +236,53 @@ export function extractRepoUrlFromMessage(text: string): string | undefined {
   return undefined;
 }
 
+type RepoParts = {
+  host: string;
+  path: string;
+};
+
+function stripGitSuffix(path: string): string {
+  return path.replace(/\/+$/g, '').replace(/\.git$/i, '');
+}
+
+function parseRepoParts(repoUrl: string): RepoParts | undefined {
+  const trimmed = repoUrl.trim().replace(/\/+$/g, '');
+  const scpLike = /^git@([^:]+):(.+)$/.exec(trimmed);
+  if (scpLike) return { host: scpLike[1], path: stripGitSuffix(scpLike[2]) };
+
+  const sshUrl = /^ssh:\/\/git@([^/]+)\/(.+)$/i.exec(trimmed);
+  if (sshUrl) return { host: sshUrl[1], path: stripGitSuffix(sshUrl[2]) };
+
+  try {
+    const parsed = new URL(trimmed);
+    if (!parsed.host || !['http:', 'https:', 'ssh:'].includes(parsed.protocol)) return undefined;
+    const path = parsed.pathname.replace(/^\/+/, '');
+    if (!path) return undefined;
+    return { host: parsed.host, path: stripGitSuffix(path) };
+  } catch {
+    return undefined;
+  }
+}
+
+function repoIdentity(repoUrl: string): string {
+  const parts = parseRepoParts(repoUrl);
+  if (!parts) return stripGitSuffix(repoUrl.trim()).toLowerCase();
+  const host = parts.host.toLowerCase();
+  const path = host === 'github.com' ? parts.path.toLowerCase() : parts.path;
+  return `${host}/${path}`;
+}
+
+function sameRepoUrl(a: string, b: string): boolean {
+  return repoIdentity(a) === repoIdentity(b);
+}
+
+function repoDisplayName(repoUrl: string): string {
+  const parts = parseRepoParts(repoUrl);
+  if (!parts) return repoUrl;
+  const segments = parts.path.split('/').filter(Boolean);
+  return segments.length >= 2 ? segments.slice(-2).join('/') : parts.path;
+}
+
 /** Peel leading `[preset]` and `[repo:]` tags off a lobby mention; the rest is the request text. A preset-shaped tag matching no key is returned as `unknownPreset` so the caller can reject it instead of silently using the default. */
 export function parsePlanningRequest(
   text: string,
@@ -518,6 +565,14 @@ type PlanningRepoResolution = {
   url?: string;
   error?: string;
   source: 'tag' | 'message-url' | 'default' | 'none';
+};
+
+type ConversationSessionOptions = {
+  tool?: string;
+  model?: string;
+  workingDir?: string;
+  mode?: ConversationMode;
+  repoUrl?: string;
 };
 
 interface SlackMentionEvent {
@@ -997,7 +1052,7 @@ export class SlackSurface implements Surface {
     const routeRepoUrl = explicitRepoResolution.url ?? detectedRepoResolution.url ?? this.resolveRepoUrl().url;
 
     const threadTs = event.thread_ts ?? event.ts;
-    const requiresPlanningRepo = channel === this.lobbyChannelId;
+    const requiresPlanningRepo = channel === this.lobbyChannelId && !!this.planningCommandBuilder;
     const messageRepoUrl = requiresPlanningRepo && !parsed.repo
       ? extractRepoUrlFromMessage(event.text ?? '')
       : undefined;
@@ -1597,6 +1652,72 @@ export class SlackSurface implements Surface {
     });
   }
 
+  private async maybeRebindThreadRepo(
+    channel: string,
+    threadTs: string,
+    userId: string | undefined,
+    text: string,
+    say: SayFn,
+  ): Promise<{ context?: PlanningContext; rebound: boolean }> {
+    const context = this.loadPlanningContext(threadTs);
+    const repoUrl = extractRepoUrlFromMessage(text);
+    if (!repoUrl || !context?.repoUrl) return { context, rebound: false };
+    if (sameRepoUrl(context.repoUrl, repoUrl)) return { context, rebound: false };
+
+    const updated: PlanningContext = {
+      ...context,
+      repoUrl,
+      workingDir: undefined,
+      requestedBy: context.requestedBy ?? userId,
+      lobbyChannel: context.lobbyChannel ?? channel,
+    };
+    this.savePlanningContext(threadTs, updated);
+    this.discardThreadSession(channel, threadTs);
+
+    await say({
+      text: `I switched this thread to repo \`${repoDisplayName(repoUrl)}\`. The previous working state for this thread was discarded.`,
+      thread_ts: threadTs,
+    });
+    return { context: updated, rebound: true };
+  }
+
+  private discardThreadSession(channel: string, threadTs: string): void {
+    if (this.sessionManager) {
+      this.sessionManager.evictSession(new SessionIdentifier(channel, threadTs));
+      return;
+    }
+    this.planConversations.delete(threadTs);
+  }
+
+  private async preparePlanningContextForSession(
+    threadTs: string,
+    context: PlanningContext,
+    say: SayFn,
+  ): Promise<PlanningContext | undefined> {
+    if (!context.repoUrl || context.workingDir || !this.prepareRepoCheckout) return context;
+    try {
+      const workingDir = await this.prepareRepoCheckout(context.repoUrl);
+      const updated = { ...context, workingDir };
+      this.savePlanningContext(threadTs, updated);
+      return updated;
+    } catch (err) {
+      this.log('slack', 'error', `Failed to prepare repo checkout for ${context.repoUrl}: ${err}`);
+      await say({ text: `Failed to check out repo: ${err instanceof Error ? err.message : String(err)}`, thread_ts: threadTs });
+      return undefined;
+    }
+  }
+
+  private sessionOptionsFromContext(context: PlanningContext, mode?: ConversationMode): ConversationSessionOptions {
+    const preset = this.resolveHarnessPreset(context.presetKey);
+    return {
+      tool: preset.tool,
+      model: preset.model,
+      workingDir: context.workingDir,
+      mode,
+      repoUrl: context.repoUrl,
+    };
+  }
+
   private getPendingConfirm(key: string): PendingConfirm | undefined {
     const inMemory = this.pendingConfirms.get(key);
     if (inMemory) return inMemory;
@@ -1660,7 +1781,7 @@ export class SlackSurface implements Surface {
     threadTs: string,
     say: SayFn,
     channel: string,
-    opts: { userId?: string; repoUrl?: string } = {},
+    opts: { userId?: string; repoUrl?: string; workingDir?: string } = {},
   ): Promise<void> {
     if (request.kind === 'command') {
       // Raw shell on the host is admin-only: this runs `/bin/bash -lc` with the
@@ -1669,7 +1790,7 @@ export class SlackSurface implements Surface {
         await say({ text: 'Permission denied. Raw local shell commands (`exec local:`) require admin access.', thread_ts: threadTs });
         return;
       }
-      const dir = await this.resolveLocalWorkingDir(opts.repoUrl, threadTs, say);
+      const dir = await this.resolveLocalWorkingDir(opts.repoUrl, threadTs, say, opts.workingDir);
       if (!dir.ok) return;
       await say({ text: `Running locally on DO1: \`${truncateWords(request.text, 12)}\``, thread_ts: threadTs });
       try {
@@ -1689,7 +1810,7 @@ export class SlackSurface implements Surface {
       return;
     }
 
-    const dir = await this.resolveLocalWorkingDir(opts.repoUrl, threadTs, say);
+    const dir = await this.resolveLocalWorkingDir(opts.repoUrl, threadTs, say, opts.workingDir);
     if (!dir.ok) return;
     await say({ text: 'Making that local change on DO1. I will not create or submit an Invoker plan.', thread_ts: threadTs });
     try {
@@ -1717,9 +1838,10 @@ export class SlackSurface implements Surface {
     repoUrl: string | undefined,
     threadTs: string,
     say: SayFn,
+    existingWorkingDir?: string,
   ): Promise<{ ok: true; workingDir?: string } | { ok: false }> {
-    let workingDir = this.workingDir;
-    if (repoUrl && this.prepareRepoCheckout) {
+    let workingDir = existingWorkingDir ?? this.workingDir;
+    if (repoUrl && this.prepareRepoCheckout && existingWorkingDir === undefined) {
       try {
         workingDir = await this.prepareRepoCheckout(repoUrl);
       } catch (err) {
@@ -2179,9 +2301,41 @@ ${text}`;
         await this.handleLobbySubmit(channel, msg.thread_ts, msg.user ?? 'unknown', say);
         return;
       }
+      if (!text) return;
+
+      const rebind = await this.maybeRebindThreadRepo(channel, msg.thread_ts, msg.user, text, say);
+      if (rebind.rebound) return;
+
+      const localRequest = parseLocalRequest(text);
+      if (localRequest) {
+        const context = rebind.context;
+        const preparedContext = context
+          ? await this.preparePlanningContextForSession(msg.thread_ts, context, say)
+          : undefined;
+        if (context && !preparedContext) return;
+        if (localRequest.kind !== 'command') {
+          const conversation = await this.getSession(
+            channel,
+            msg.thread_ts,
+            msg.user ?? 'unknown',
+            false,
+            preparedContext ? this.sessionOptionsFromContext(preparedContext, 'agent') : undefined,
+          );
+          if (!conversation) return;
+          await this.handleConversationMessage(conversation, localRequest.text, msg.thread_ts, say, channel);
+          return;
+        }
+        const preset = this.resolveHarnessPreset(preparedContext?.presetKey ?? this.defaultHarnessPreset);
+        await this.handleLocalRequest(localRequest, preset, msg.thread_ts, say, channel, {
+          userId: msg.user,
+          repoUrl: preparedContext?.repoUrl,
+          workingDir: preparedContext?.workingDir,
+        });
+        return;
+      }
+
       const conversation = await this.getSession(channel, msg.thread_ts, msg.user ?? 'unknown', false);
       if (!conversation) return;
-      if (!text) return;
 
       this.log('slack', 'info', `[PASSIVE_THREAD_CONTEXT] thread_ts=${msg.thread_ts} user=${msg.user} preview="${text.slice(0, 100)}${text.length > 100 ? '...' : ''}"`);
     });
@@ -2542,7 +2696,7 @@ ${text}`;
     threadTs: string,
     userId: string,
     create = true,
-    opts?: { tool?: string; model?: string; workingDir?: string; mode?: ConversationMode; repoUrl?: string },
+    opts?: ConversationSessionOptions,
   ): Promise<ConversationLike | null> {
     this.log('slack', 'info', `[TRACE] getSession (channelId=${channelId}, threadTs=${threadTs}, userId=${userId}, create=${create}, hasSessionManager=${!!this.sessionManager})`);
     if (this.sessionManager) {
@@ -2553,6 +2707,7 @@ ${text}`;
         const found = await this.sessionManager.getSession(
           new SessionIdentifier(channelId, threadTs),
           userId,
+          opts,
         );
         this.log('slack', 'info', `[TRACE] findSession returned ${found ? 'session' : 'null'} (threadTs=${threadTs})`);
         return found;

--- a/packages/surfaces/src/slack/thread-session-manager.ts
+++ b/packages/surfaces/src/slack/thread-session-manager.ts
@@ -190,6 +190,8 @@ export interface SessionMetrics {
   active: number;
 }
 
+type SessionOptions = { tool?: string; model?: string; workingDir?: string; mode?: ConversationMode; repoUrl?: string };
+
 const defaultLog: LogFn = (component, level, message) => {
   const prefix = `[${component}]`;
   if (level === 'error') console.error(prefix, message);
@@ -275,7 +277,7 @@ export class SessionManager {
   async getOrCreateSession(
     id: SessionIdentifier,
     userId: string,
-    opts?: { tool?: string; model?: string; workingDir?: string; mode?: ConversationMode; repoUrl?: string },
+    opts?: SessionOptions,
   ): Promise<SessionHandle | null> {
     const key = id.toString();
 
@@ -466,14 +468,14 @@ export class SessionManager {
    * Look up an existing session without creating a new persisted conversation.
    * Rehydrates an active persisted conversation after memory eviction.
    */
-  async getSession(id: SessionIdentifier, userId: string): Promise<SessionHandle | null> {
+  async getSession(id: SessionIdentifier, userId: string, opts?: SessionOptions): Promise<SessionHandle | null> {
     const existing = this.sessions.get(id.toString());
     if (existing) return existing;
     const persisted = this.conversationRepo.loadConversation(id.threadTs);
     if (!persisted || persisted.planSubmitted || (persisted.channelId && persisted.channelId !== id.channelId)) {
       return null;
     }
-    return this.getOrCreateSession(id, userId);
+    return this.getOrCreateSession(id, userId, opts);
   }
 
   findSession(id: SessionIdentifier): SessionHandle | null {

--- a/scripts/repro/repro-coderabbit-pr5622-non-github-repo-identity.sh
+++ b/scripts/repro/repro-coderabbit-pr5622-non-github-repo-identity.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "Repro: equivalent non-GitHub repo URLs must not be treated as different thread bindings"
+if pnpm --filter @invoker/surfaces test -- src/__tests__/slack-surface-workflows.test.ts -t "accepts an equivalent non-GitHub repo URL in a thread mention"; then
+  echo "PASS: equivalent non-GitHub repo URLs stay bound to the same thread repo"
+else
+  echo "FAIL: equivalent non-GitHub repo URLs were treated as different repositories"
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr5622-rebind-clears-persisted-conversation.sh
+++ b/scripts/repro/repro-coderabbit-pr5622-rebind-clears-persisted-conversation.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "Repro: repo rebind must clear persisted conversation state"
+if pnpm --filter @invoker/surfaces test -- src/__tests__/slack-surface-workflows.test.ts -t "clears persisted conversation state when rebinding a thread repo"; then
+  echo "PASS: repo rebind clears persisted conversation state"
+else
+  echo "FAIL: repo rebind left persisted conversation state behind"
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr5622-rebind-flow-test-coverage.sh
+++ b/scripts/repro/repro-coderabbit-pr5622-rebind-flow-test-coverage.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "Repro: persisted-conversation cleanup must be exercised through the rebind flow"
+TEST_FILE="packages/surfaces/src/__tests__/slack-surface-workflows.test.ts"
+if grep -q 'discardThreadSession.discardThreadSession(' "$TEST_FILE"; then
+  echo "FAIL: test bypasses maybeRebindThreadRepo by calling discardThreadSession directly"
+  exit 1
+fi
+if pnpm --filter @invoker/surfaces test -- src/__tests__/slack-surface-workflows.test.ts -t "clears persisted conversation state when rebinding a thread repo"; then
+  echo "PASS: authorized follow-up rebind clears persisted conversation state"
+else
+  echo "FAIL: follow-up rebind flow did not clear persisted conversation state"
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr5622-unauthorized-thread-rebind.sh
+++ b/scripts/repro/repro-coderabbit-pr5622-unauthorized-thread-rebind.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "Repro: non-owners must not be able to rebind a thread to a different repo"
+if pnpm --filter @invoker/surfaces test -- src/__tests__/slack-surface-workflows.test.ts -t "refuses a repo rebind from a different non-admin participant"; then
+  echo "PASS: non-owners cannot rebind a thread repo"
+else
+  echo "FAIL: a different non-admin participant rebound the thread repo"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

A follow-up Slack message with a different repo-root URL rebinds the thread to that repository.

The old working state is discarded, and the next explicit local request prepares the new checkout. Passive replies remain inert.

## Review Claim

Approve mid-thread repository rebinding from a follow-up repo-root URL.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Deep links do not rebind threads, and an equivalent repository URL is a no-op.

## Slice Rationale

Rebinding, session eviction, checkout preparation, and regression coverage form one observable routing change.

## Non-goals

- No changes to first-message binding precedence.
- No workflow execution changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test -- slack-surface-workflows slack-plan-submission-repros`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a05a42c76`
- Data migration? No

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack threads can now rebind to a different repository when a new repository URL is posted.
  * Prepared working directories can be carried forward across thread session updates and restarts.
* **Bug Fixes**
  * Equivalent repository URLs (including non-GitHub formats) no longer trigger unnecessary thread rebindings or re-checkouts.
  * Unauthorized participants can’t rebind a thread to a different repository.
  * Deep links to follow-up messages preserve prior launch context without triggering rebind behavior.
* **Tests**
  * Added targeted workflow coverage for repository rebind, authorization, and no-op equivalence cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->