### PR TITLE
[Draft Review Sidebar](1) Add draftPlanText to planning IPC

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -480,6 +480,7 @@ export interface InAppPlanningSessionSummary {
   messages: InAppPlanningChatLine[];
   draftPlanAvailable: boolean;
   draftPlanSummary?: InAppPlanningPlanSummary;
+  draftPlanText?: string;
   submittedWorkflowId?: string;
   submittedPlanName?: string;
   terminalMode?: PlanningTerminalMode;
@@ -530,6 +531,7 @@ export type InAppPlanningChatResponse =
       reply: string;
       draftPlanAvailable: boolean;
       draftPlanSummary?: InAppPlanningPlanSummary;
+      draftPlanText?: string;
     }
   | {
       ok: false;


### PR DESCRIPTION
## Summary

Adds optional draft plan YAML text to the planning IPC session and chat response contracts.

Callers can read the raw drafted plan without inventing a parallel payload shape.

## Review Claim

Approve the IPC contract field that carries draft plan YAML text.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This slice only widens optional contract fields. Existing callers keep compiling without reading the new field.

## Slice Rationale

Contract changes stay alone so planner wiring and UI can review against a stable IPC shape.

## Non-goals

- No planner response population changes.
- No UI draft review changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/contracts && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 03995bccd`
- Data migration? No

</details>
