### PR TITLE
[Draft Review Sidebar](3) Keep recorded remote workspace on lookup failure

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -315,6 +315,7 @@ describe('planning chat', () => {
       reply: VALID_PLAN_REPLY,
       draftPlanAvailable: true,
       draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+      draftPlanText: expect.stringContaining('name: Mock Plan'),
     });
     expect(result.ok && result.reply).toContain('```yaml');
     expect(result.ok && result.reply).toContain('name: Mock Plan');

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -242,6 +242,7 @@ function sessionToSummary(session: InAppPlanningChatSession): InAppPlanningSessi
     messages: session.messages,
     draftPlanAvailable: hasDraftPlan(session),
     draftPlanSummary: session.draftPlanSummary,
+    draftPlanText: session.draftPlanText,
     submittedWorkflowId: session.submittedWorkflowId,
     submittedPlanName: session.submittedPlanName,
     terminalMode: session.terminalMode ?? 'chat',
@@ -564,6 +565,7 @@ export async function sendPlanningChatMessage(
             reasoning,
             draftPlanAvailable: hasDraftPlan(activeSession),
             draftPlanSummary: activeSession.draftPlanSummary,
+            draftPlanText: activeSession.draftPlanText,
           } as InAppPlanningChatResponse;
         }
 
@@ -579,6 +581,7 @@ export async function sendPlanningChatMessage(
             reply: fallbackReply,
             draftPlanAvailable: hasDraftPlan(activeSession),
             draftPlanSummary: activeSession.draftPlanSummary,
+            draftPlanText: activeSession.draftPlanText,
           };
         }
         activeSession.draftPlanSummary = summary;
@@ -593,6 +596,7 @@ export async function sendPlanningChatMessage(
           reasoning,
           draftPlanAvailable: true,
           draftPlanSummary: summary,
+          draftPlanText: candidatePlanText,
         } as InAppPlanningChatResponse;
       } catch (error) {
         persistPlanningSession(activeSession, deps.planningSessionStore, false);

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -480,6 +480,7 @@ export interface InAppPlanningSessionSummary {
   messages: InAppPlanningChatLine[];
   draftPlanAvailable: boolean;
   draftPlanSummary?: InAppPlanningPlanSummary;
+  draftPlanText?: string;
   submittedWorkflowId?: string;
   submittedPlanName?: string;
   terminalMode?: PlanningTerminalMode;
@@ -530,6 +531,7 @@ export type InAppPlanningChatResponse =
       reply: string;
       draftPlanAvailable: boolean;
       draftPlanSummary?: InAppPlanningPlanSummary;
+      draftPlanText?: string;
     }
   | {
       ok: false;

--- a/packages/execution-engine/src/__tests__/remote-fix-worktree-repair.test.ts
+++ b/packages/execution-engine/src/__tests__/remote-fix-worktree-repair.test.ts
@@ -8,7 +8,7 @@ import { registerBuiltinAgents } from '../agents/index.js';
 
 vi.mock('node:child_process');
 
-function mockSshChild(stdoutData: string, exitCode: number) {
+function mockSshChild(stdoutData: string, exitCode: number, stderrData = '') {
   const { EventEmitter } = require('events');
   const stdout = new EventEmitter();
   const stderr = new EventEmitter();
@@ -19,6 +19,7 @@ function mockSshChild(stdoutData: string, exitCode: number) {
 
   setTimeout(() => {
     if (stdoutData) stdout.emit('data', Buffer.from(stdoutData));
+    if (stderrData) stderr.emit('data', Buffer.from(stderrData));
     child.emit('close', exitCode);
   }, 0);
 
@@ -246,5 +247,50 @@ branch refs/heads/${branch}
       branch,
       commit: 'deadbeef',
     });
+  });
+
+  it('continues with the recorded remote workspace when branch-owner lookup cannot list worktrees', async () => {
+    const { spawn } = await import('node:child_process');
+    const workspacePath = '/home/invoker/.invoker/worktrees/647faa73e90e/experiment-test-task-deadbeef';
+    const branch = 'experiment/test-task/deadbeef';
+    const task = {
+      id: 'wf-1/test-task',
+      status: 'failed' as const,
+      execution: {
+        error: 'Test failed',
+        workspacePath,
+        branch,
+      },
+      config: {
+        command: 'pnpm test',
+        runnerKind: 'ssh' as const,
+        poolMemberId: 'remote-1',
+      },
+    };
+
+    const { host, updateTask, appendTaskOutput } = makeHost(task);
+    const listFailure = mockSshChild(
+      '',
+      128,
+      "fatal: cannot change to '/home/invoker/.invoker/repos/647faa73e90e': No such file or directory\n",
+    );
+    const fixSession = mockSshChild('Codex session: real-session-456\nremote fix applied', 0);
+    vi.mocked(spawn)
+      .mockReturnValueOnce(listFailure as any)
+      .mockReturnValueOnce(fixSession as any);
+
+    await fixWithAgentImpl(host, task.id, 'error output', 'codex');
+
+    expect(updateTask).not.toHaveBeenCalledWith(task.id, {
+      execution: {
+        workspacePath: expect.any(String),
+      },
+    });
+    const remoteFixScript = ((fixSession as any).stdin.write as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+    expect(remoteFixScript).toContain(`WT="${workspacePath}"`);
+    expect(appendTaskOutput).toHaveBeenCalledWith(
+      task.id,
+      expect.stringContaining('[Fix with codex (remote)] Output:'),
+    );
   });
 });

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -148,15 +148,19 @@ export async function resolveRemoteBranchOwnerPath(
   if (!branch) return undefined;
   const info = deriveRemoteManagedWorkspaceInfo(workspacePath, target);
   if (!info) return undefined;
-  const porcelain = await execRemoteSsh(
-    target,
-    buildWorktreeListScript({
-      repoHash: info.repoHash,
-      invokerHome: info.invokerHome,
-    }),
-    'list_worktrees',
-  );
-  return findManagedWorktreeForBranch(porcelain, branch, [info.managedPrefix]);
+  try {
+    const porcelain = await execRemoteSsh(
+      target,
+      buildWorktreeListScript({
+        repoHash: info.repoHash,
+        invokerHome: info.invokerHome,
+      }),
+      'list_worktrees',
+    );
+    return findManagedWorktreeForBranch(porcelain, branch, [info.managedPrefix]);
+  } catch {
+    return undefined;
+  }
 }
 
 // ── Extracted functions ──────────────────────────────────


### PR DESCRIPTION
## Summary

Remote fix sessions keep the recorded worktree when branch-owner lookup cannot inspect managed worktrees.

A missing remote repo directory no longer clears the workspace path used for the fix agent.

## Review Claim

Approve routing remote fixes through the recorded workspace when worktree discovery fails.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Lookup failures return undefined and leave the existing workspace path untouched.

## Slice Rationale

This recovery path is independent of draft-plan IPC and UI review work.

## Non-goals

- No local worktree repair changes.
- No planning draft UI changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- remote-fix-worktree-repair`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 496292fbd`
- Data migration? No

</details>
