### PR TITLE
[Draft Review Sidebar](5) Capture draft review visual proof

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -739,8 +739,7 @@ test.describe('Visual proof capture', () => {
     }, { planYaml: plannedYaml, planName: 'Terminal Planned Flow', reply: fullPlanReply });
 
     await page.getByTestId('sidebar-home').click();
-    await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-60/);
-    await expect(page.getByTestId('planning-session-rail')).toHaveClass(/w-64/);
+    await page.getByRole('button', { name: 'Options' }).click();
     await expect(page.getByRole('heading', { name: 'Planning chat' })).toBeVisible();
     await page.getByTestId('invoker-terminal-input').fill('Draft a YAML plan to add a README');
     await page.getByRole('button', { name: 'Send' }).click();
@@ -768,6 +767,7 @@ test.describe('Visual proof capture', () => {
       return el.scrollHeight - el.scrollTop - el.clientHeight;
     });
     expect(scrollGap).toBeLessThanOrEqual(1);
+    await expandedTranscript.locator('details').last().locator('summary').click();
     const codePanel = expandedTranscript.locator('pre code').last();
     await expect(codePanel).toBeVisible();
     await expect(codePanel).toContainText('command: echo B');
@@ -778,13 +778,11 @@ test.describe('Visual proof capture', () => {
     await expect(page.getByTestId('invoker-terminal-expanded')).toHaveCount(0);
 
     await expect(page.getByTestId('invoker-terminal-ready-bar')).toBeVisible();
-    await page.getByRole('button', { name: 'Submit to Invoker' }).click();
-
-    await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible();
-    await expect(page.locator('.react-flow__node[data-testid$="task-alpha"]')).toBeVisible();
-    await expect(page.getByTestId('workflow-inspector-title')).toContainText('Terminal Planned Flow');
-    await expect(page.getByText('What to expect')).toHaveCount(0);
-    await captureScreenshot(page, 'terminal-planned-graph');
+    await page.getByRole('button', { name: 'Review draft' }).click();
+    await expect(page.getByRole('heading', { name: 'Review draft' })).toBeVisible();
+    await expect(page.getByTestId('draft-raw-yaml')).toContainText('name: Terminal Planned Flow');
+    await captureScreenshot(page, 'terminal-planned-draft-review');
+    await page.getByTestId('planning-create-workflow').click();
 
     // Returning to Planning home keeps the full conversation:
     // submitting must not clear or truncate the transcript.

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -315,6 +315,7 @@ describe('planning chat', () => {
       reply: VALID_PLAN_REPLY,
       draftPlanAvailable: true,
       draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+      draftPlanText: expect.stringContaining('name: Mock Plan'),
     });
     expect(result.ok && result.reply).toContain('```yaml');
     expect(result.ok && result.reply).toContain('name: Mock Plan');

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -242,6 +242,7 @@ function sessionToSummary(session: InAppPlanningChatSession): InAppPlanningSessi
     messages: session.messages,
     draftPlanAvailable: hasDraftPlan(session),
     draftPlanSummary: session.draftPlanSummary,
+    draftPlanText: session.draftPlanText,
     submittedWorkflowId: session.submittedWorkflowId,
     submittedPlanName: session.submittedPlanName,
     terminalMode: session.terminalMode ?? 'chat',
@@ -564,6 +565,7 @@ export async function sendPlanningChatMessage(
             reasoning,
             draftPlanAvailable: hasDraftPlan(activeSession),
             draftPlanSummary: activeSession.draftPlanSummary,
+            draftPlanText: activeSession.draftPlanText,
           } as InAppPlanningChatResponse;
         }
 
@@ -579,6 +581,7 @@ export async function sendPlanningChatMessage(
             reply: fallbackReply,
             draftPlanAvailable: hasDraftPlan(activeSession),
             draftPlanSummary: activeSession.draftPlanSummary,
+            draftPlanText: activeSession.draftPlanText,
           };
         }
         activeSession.draftPlanSummary = summary;
@@ -593,6 +596,7 @@ export async function sendPlanningChatMessage(
           reasoning,
           draftPlanAvailable: true,
           draftPlanSummary: summary,
+          draftPlanText: candidatePlanText,
         } as InAppPlanningChatResponse;
       } catch (error) {
         persistPlanningSession(activeSession, deps.planningSessionStore, false);

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -480,6 +480,7 @@ export interface InAppPlanningSessionSummary {
   messages: InAppPlanningChatLine[];
   draftPlanAvailable: boolean;
   draftPlanSummary?: InAppPlanningPlanSummary;
+  draftPlanText?: string;
   submittedWorkflowId?: string;
   submittedPlanName?: string;
   terminalMode?: PlanningTerminalMode;
@@ -530,6 +531,7 @@ export type InAppPlanningChatResponse =
       reply: string;
       draftPlanAvailable: boolean;
       draftPlanSummary?: InAppPlanningPlanSummary;
+      draftPlanText?: string;
     }
   | {
       ok: false;

--- a/packages/execution-engine/src/__tests__/remote-fix-worktree-repair.test.ts
+++ b/packages/execution-engine/src/__tests__/remote-fix-worktree-repair.test.ts
@@ -8,7 +8,7 @@ import { registerBuiltinAgents } from '../agents/index.js';
 
 vi.mock('node:child_process');
 
-function mockSshChild(stdoutData: string, exitCode: number) {
+function mockSshChild(stdoutData: string, exitCode: number, stderrData = '') {
   const { EventEmitter } = require('events');
   const stdout = new EventEmitter();
   const stderr = new EventEmitter();
@@ -19,6 +19,7 @@ function mockSshChild(stdoutData: string, exitCode: number) {
 
   setTimeout(() => {
     if (stdoutData) stdout.emit('data', Buffer.from(stdoutData));
+    if (stderrData) stderr.emit('data', Buffer.from(stderrData));
     child.emit('close', exitCode);
   }, 0);
 
@@ -246,5 +247,50 @@ branch refs/heads/${branch}
       branch,
       commit: 'deadbeef',
     });
+  });
+
+  it('continues with the recorded remote workspace when branch-owner lookup cannot list worktrees', async () => {
+    const { spawn } = await import('node:child_process');
+    const workspacePath = '/home/invoker/.invoker/worktrees/647faa73e90e/experiment-test-task-deadbeef';
+    const branch = 'experiment/test-task/deadbeef';
+    const task = {
+      id: 'wf-1/test-task',
+      status: 'failed' as const,
+      execution: {
+        error: 'Test failed',
+        workspacePath,
+        branch,
+      },
+      config: {
+        command: 'pnpm test',
+        runnerKind: 'ssh' as const,
+        poolMemberId: 'remote-1',
+      },
+    };
+
+    const { host, updateTask, appendTaskOutput } = makeHost(task);
+    const listFailure = mockSshChild(
+      '',
+      128,
+      "fatal: cannot change to '/home/invoker/.invoker/repos/647faa73e90e': No such file or directory\n",
+    );
+    const fixSession = mockSshChild('Codex session: real-session-456\nremote fix applied', 0);
+    vi.mocked(spawn)
+      .mockReturnValueOnce(listFailure as any)
+      .mockReturnValueOnce(fixSession as any);
+
+    await fixWithAgentImpl(host, task.id, 'error output', 'codex');
+
+    expect(updateTask).not.toHaveBeenCalledWith(task.id, {
+      execution: {
+        workspacePath: expect.any(String),
+      },
+    });
+    const remoteFixScript = ((fixSession as any).stdin.write as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+    expect(remoteFixScript).toContain(`WT="${workspacePath}"`);
+    expect(appendTaskOutput).toHaveBeenCalledWith(
+      task.id,
+      expect.stringContaining('[Fix with codex (remote)] Output:'),
+    );
   });
 });

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -148,15 +148,19 @@ export async function resolveRemoteBranchOwnerPath(
   if (!branch) return undefined;
   const info = deriveRemoteManagedWorkspaceInfo(workspacePath, target);
   if (!info) return undefined;
-  const porcelain = await execRemoteSsh(
-    target,
-    buildWorktreeListScript({
-      repoHash: info.repoHash,
-      invokerHome: info.invokerHome,
-    }),
-    'list_worktrees',
-  );
-  return findManagedWorktreeForBranch(porcelain, branch, [info.managedPrefix]);
+  try {
+    const porcelain = await execRemoteSsh(
+      target,
+      buildWorktreeListScript({
+        repoHash: info.repoHash,
+        invokerHome: info.invokerHome,
+      }),
+      'list_worktrees',
+    );
+    return findManagedWorktreeForBranch(porcelain, branch, [info.managedPrefix]);
+  } catch {
+    return undefined;
+  }
 }
 
 // ── Extracted functions ──────────────────────────────────

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -845,6 +845,7 @@ export function App() {
   const [selectedPlanningPresetKey, setSelectedPlanningPresetKey] = useState('');
   const [planningSubmitError, setPlanningSubmitError] = useState<{ title: string; message: string } | null>(null);
   const [planningTerminalExpanded, setPlanningTerminalExpanded] = useState(false);
+  const [reviewDraftSessionId, setReviewDraftSessionId] = useState<string | null>(null);
   const activePlanningSession = useMemo(
     () => planningSessions.find((session) => session.id === activePlanningSessionId) ?? planningSessions[0] ?? makeInitialPlanningSession(),
     [activePlanningSessionId, planningSessions],
@@ -856,6 +857,7 @@ export function App() {
   const planningSessionId = activePlanningSession.id.startsWith('local-') ? null : activePlanningSession.id;
   const draftPlanAvailable = activePlanningSession.draftPlanAvailable;
   const draftPlanSummary = activePlanningSession.draftPlanSummary;
+  const draftPlanText = activePlanningSession.draftPlanText;
   const activePlanningSessionBusy = activePlanningSession.busy;
   const activePlanningSessionSubmitted = activePlanningSession.status === 'submitted';
   const activePlanningMode = activePlanningSession.mode ?? 'chat';
@@ -2553,8 +2555,11 @@ export function App() {
         setHasLoadedPlan(true);
         setWorkflowSelectionDismissed(false);
         setGraphActionsMenuOpen(false);
+        setReviewDraftSessionId(null);
         setPlanName(result.planName);
         setSelectedWorkflowId(result.workflowId);
+        setSidebarSurface('home');
+        setViewMode('dag');
         issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason: 'planning-submit' });
         updatePlanningSessionById(planningSessionId, (session) => ({
           ...session,
@@ -2564,6 +2569,7 @@ export function App() {
           submittedPlanName: result.planName,
           draftPlanAvailable: false,
           draftPlanSummary: undefined,
+          draftPlanText: undefined,
           updatedAt: new Date().toISOString(),
         }));
         await refreshTaskGraph();
@@ -2662,6 +2668,7 @@ export function App() {
             messages: [...session.messages, { id: replyLineId, text: result.reply, role: 'assistant', ...((result as { reasoning?: string }).reasoning ? { reasoning: (result as { reasoning?: string }).reasoning } : {}) }],
             draftPlanAvailable: result.draftPlanAvailable,
             draftPlanSummary: result.draftPlanAvailable ? result.draftPlanSummary : undefined,
+            draftPlanText: result.draftPlanAvailable ? result.draftPlanText : undefined,
             updatedAt,
           };
         }));
@@ -3842,23 +3849,6 @@ export function App() {
     : `${workerStatus.workers.length} worker${workerStatus.workers.length === 1 ? '' : 's'} registered.`;
 
   const renderWorkersSurface = (): JSX.Element => (
-    viewMode === 'queue' ? (
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <QueueView
-          tasks={tasks}
-          workflows={workflows}
-          queueStatus={queueStatus}
-          workerStatus={workerStatus}
-          readOnly={runtimeStatus?.readOnly === true}
-          onStartWorker={handleStartWorker}
-          onStopWorker={handleStopWorker}
-          onTaskClick={handleTaskClick}
-          selectedTaskId={selectedTaskId}
-          selectedWorkerKind={selectedWorkerKind}
-          onSelectWorker={setSelectedWorkerKind}
-        />
-      </div>
-    ) : (
     <div className="flex-1 flex overflow-hidden">
       <div data-testid="workers-rail" className="flex h-full w-80 shrink-0 flex-col border-r border-gray-800 bg-gray-950/45">
         <div className="flex items-start justify-between gap-3 border-b border-gray-800 px-4 py-4">
@@ -3891,7 +3881,6 @@ export function App() {
         {renderWorkersDetail()}
       </div>
     </div>
-    )
   );
 
 
@@ -3937,14 +3926,19 @@ export function App() {
     .filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed)
     .map((tool) => tool.name.replace(/\s+CLI$/i, ''));
 
-  const renderPlanningContextPanel = (): JSX.Element => (
-    <aside
+  const renderPlanningContextPanel = (): JSX.Element => {
+    const reviewingDraft = reviewDraftSessionId === activePlanningSession.id && Boolean(draftPlanSummary);
+    const draftTaskGroups = draftPlanSummary?.taskGroups ?? (
+      draftPlanSummary ? [{ workflow: null, tasks: draftPlanSummary.steps }] : []
+    );
+    return (
+      <aside
       data-testid="planning-context-panel"
       className={`${planningContextCollapsed ? 'w-16' : 'w-72'} shrink-0 border-l border-border bg-card/60 transition-all duration-150`}
     >
       <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2.5">
         {!planningContextCollapsed && (
-          <h2 className="text-sm font-semibold text-foreground">Current plan</h2>
+          <h2 className="text-sm font-semibold text-foreground">{reviewingDraft ? 'Review draft' : 'Current plan'}</h2>
         )}
         <button
           type="button"
@@ -3957,7 +3951,43 @@ export function App() {
         </button>
       </div>
       {!planningContextCollapsed && (
-        <div className="space-y-4 p-4 text-sm">
+        reviewingDraft ? (
+          <div className="space-y-4 p-4 text-sm">
+            {draftTaskGroups.map((group, groupIndex) => (
+              <section key={`${group.workflow ?? 'plan'}-${groupIndex}`} data-testid="draft-task-group">
+                {group.workflow && <h3 className="text-xs font-medium text-foreground">{group.workflow}</h3>}
+                <ul className={group.workflow ? 'mt-2 space-y-1.5' : 'space-y-1.5'}>
+                  {group.tasks.map((task, taskIndex) => (
+                    <li key={`${task}-${taskIndex}`} data-testid="draft-step-summary" className="text-xs leading-5 text-muted-foreground">
+                      {task}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ))}
+            {draftPlanText && (
+              <pre data-testid="draft-raw-yaml" className="max-h-56 overflow-auto rounded-md border border-border bg-background p-3 text-[11px] leading-5 text-muted-foreground">
+                {draftPlanText}
+              </pre>
+            )}
+            <Button
+              type="button"
+              data-testid="planning-create-workflow"
+              onClick={() => void handlePlanningSubmitDraft()}
+              className="w-full"
+            >
+              Create workflow
+            </Button>
+            <button
+              type="button"
+              onClick={() => navigatePlanGraphAndFit('planning-draft-review')}
+              className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
+            >
+              Open graph
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-4 p-4 text-sm">
           <div>
             <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Goal</div>
             <p className="mt-1 text-foreground">
@@ -3990,10 +4020,12 @@ export function App() {
               Open graph
             </button>
           )}
-        </div>
+          </div>
+        )
       )}
     </aside>
-  );
+    );
+  };
 
   const renderPlanningTerminalSurface = (): JSX.Element => (
     <div className="flex min-h-0 flex-1 overflow-hidden">
@@ -4103,6 +4135,10 @@ export function App() {
             onModeChange={(mode) => void handlePlanningModeChange(mode)}
             onExpand={() => setPlanningTerminalExpanded(true)}
             onOpenGraph={() => navigatePlanGraphAndFit('planning-open-graph')}
+            onReviewDraft={() => {
+              setReviewDraftSessionId(activePlanningSession.id);
+              setPlanningContextCollapsed(false);
+            }}
           />
         </div>
       </div>
@@ -4434,6 +4470,11 @@ export function App() {
             onOpenGraph={() => {
               setPlanningTerminalExpanded(false);
               navigatePlanGraphAndFit('planning-expanded-open-graph');
+            }}
+            onReviewDraft={() => {
+              setPlanningTerminalExpanded(false);
+              setReviewDraftSessionId(activePlanningSession.id);
+              setPlanningContextCollapsed(false);
             }}
           />
         </div>

--- a/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
@@ -31,6 +31,8 @@ describe('CodeRabbit PR #3050 — draft state cleared after submit', () => {
 
   async function openPlanningTerminal() {
     fireEvent.click(await screen.findByTestId('sidebar-home'));
+    const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+    if (expandPlanningChats) fireEvent.click(expandPlanningChats);
     fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
@@ -59,7 +61,6 @@ describe('CodeRabbit PR #3050 — draft state cleared after submit', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });
-    await openPlanningTerminal();
     await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
     // The submit succeeded; the ready bar must be gone so it cannot resubmit the same session.
     await waitFor(() => {

--- a/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
@@ -24,7 +24,11 @@ describe('CodeRabbit PR #3050 — submitted planning stays read-only after start
 
   async function openPlanningTerminal() {
     fireEvent.click(await screen.findByTestId('sidebar-home'));
-    fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+    const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+    if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+    if (!screen.queryByTestId('invoker-terminal-harness')) {
+      fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+    }
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
     });
@@ -52,8 +56,8 @@ describe('CodeRabbit PR #3050 — submitted planning stays read-only after start
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });
 
-    await openPlanningTerminal();
     await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
+    expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
 
     fireEvent.click(screen.getByTestId('sidebar-planning'));
     fireEvent.click(await screen.findByTestId('rail-start-ready'));

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -721,7 +721,7 @@ describe('Invoker terminal (component)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Plan graph' })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Review draft' })).toBeInTheDocument();
       expect(screen.getByTestId('planning-create-workflow')).toBeInTheDocument();
     });
     expect(mock.api.planningChatSubmit).not.toHaveBeenCalled();

--- a/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { InAppPlanningChatResponse } from '@invoker/contracts';
-import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
 
 vi.mock('@xyflow/react', async () => {
   // Dynamic import is required because Vitest hoists mock factories before test imports.
@@ -76,7 +76,6 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });
     });
-    await openPlanningTerminal();
     expect(await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.')).toBeInTheDocument();
     expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
     expect(screen.getByTestId('invoker-terminal-harness')).toBeDisabled();
@@ -115,6 +114,47 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('invoker-terminal-planner-stream')).not.toBeInTheDocument();
       expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Final assistant reply for the new turn.');
+    });
+  });
+
+  it('opens a draft review sidebar before explicitly submitting the workflow', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [makePlanningSessionSummary({
+        id: 'draft-1',
+        draftPlanSummary: {
+          name: 'Grouped plan',
+          taskCount: 3,
+          steps: ['Backend workflow', 'UI review'],
+          taskGroups: [
+            { workflow: 'Backend workflow', tasks: ['Add API endpoint'] },
+            { workflow: 'UI review', tasks: ['Add review sidebar', 'Wire ready bar actions'] },
+          ],
+        },
+        draftPlanText: 'name: Grouped plan\ntasks:\n  - id: review\n    description: Add review sidebar\n',
+      })],
+    }));
+    mock.api.planningChatSubmit = vi.fn(async () => ({
+      ok: true,
+      planName: 'Grouped plan',
+      workflowId: 'wf-created',
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    fireEvent.click(await screen.findByTestId('invoker-terminal-review-draft'));
+
+    expect(await screen.findByRole('heading', { name: 'Review draft' })).toBeInTheDocument();
+    expect(mock.api.planningChatSubmit).not.toHaveBeenCalled();
+    expect(screen.getAllByTestId('draft-task-group')).toHaveLength(2);
+    expect(screen.getAllByTestId('draft-step-summary')).toHaveLength(3);
+    expect(screen.getByTestId('draft-raw-yaml')).toHaveTextContent('name: Grouped plan');
+
+    fireEvent.click(screen.getByTestId('planning-create-workflow'));
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'draft-1' });
     });
   });
 });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -69,6 +69,7 @@ interface InvokerTerminalProps {
   onExpand: () => void;
   onCloseExpanded?: () => void;
   onOpenGraph?: () => void;
+  onReviewDraft?: () => void;
   submittedPlanName?: string;
   activeConversationKey: string;
 }
@@ -341,6 +342,7 @@ export function InvokerTerminal({
   onExpand,
   onCloseExpanded,
   onOpenGraph,
+  onReviewDraft,
   submittedPlanName,
   activeConversationKey,
 }: InvokerTerminalProps): JSX.Element {
@@ -656,11 +658,11 @@ export function InvokerTerminal({
                   : 'Draft ready'}
               </p>
               <div className="flex flex-wrap items-center gap-2">
-                {onOpenGraph && (
+                {(onReviewDraft ?? onOpenGraph) && (
                   <button
                     type="button"
-                    data-testid="invoker-terminal-open-graph"
-                    onClick={onOpenGraph}
+                    data-testid="invoker-terminal-review-draft"
+                    onClick={onReviewDraft ?? onOpenGraph}
                     className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
                   >
                     Review draft


### PR DESCRIPTION
## Summary

Updates the planning visual proof flow to open Review draft before creating the workflow.

The capture shows the draft sidebar with raw YAML, then creates the workflow.

## Review Claim

Approve the visual proof coverage for draft review sidebar activation.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only changes the e2e visual proof scenario path. Product behavior is unchanged here.

## Slice Rationale

Proof capture stays after the UI activation slice so the screenshot matches the shipped flow.

## Non-goals

- No product behavior changes outside the proof scenario.
- No IPC or planner changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Visual proof scenario path updated in `packages/app/e2e/visual-proof.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 01fbedaa8`
- Data migration? No

</details>
