### PR TITLE
[Playwright Green](1) Mount QueueView on queue/workers surface

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3842,6 +3842,23 @@ export function App() {
     : `${workerStatus.workers.length} worker${workerStatus.workers.length === 1 ? '' : 's'} registered.`;
 
   const renderWorkersSurface = (): JSX.Element => (
+    viewMode === 'queue' ? (
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <QueueView
+          tasks={tasks}
+          workflows={workflows}
+          queueStatus={queueStatus}
+          workerStatus={workerStatus}
+          readOnly={runtimeStatus?.readOnly === true}
+          onStartWorker={handleStartWorker}
+          onStopWorker={handleStopWorker}
+          onTaskClick={handleTaskClick}
+          selectedTaskId={selectedTaskId}
+          selectedWorkerKind={selectedWorkerKind}
+          onSelectWorker={setSelectedWorkerKind}
+        />
+      </div>
+    ) : (
     <div className="flex-1 flex overflow-hidden">
       <div data-testid="workers-rail" className="flex h-full w-80 shrink-0 flex-col border-r border-gray-800 bg-gray-950/45">
         <div className="flex items-start justify-between gap-3 border-b border-gray-800 px-4 py-4">
@@ -3874,6 +3891,7 @@ export function App() {
         {renderWorkersDetail()}
       </div>
     </div>
+    )
   );
 
 


### PR DESCRIPTION
## Summary

Opening the running/queue surface from capacity chips switched to the Workers sidebar without mounting QueueView.

Operators saw the worker registry instead of In flight / Queued concurrency panels.

This mounts QueueView whenever queue mode is active on the workers surface.

## Review Claim

Approve mounting QueueView on the workers surface when viewMode is queue so capacity chips open the concurrency panels again.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Workers registry rendering is unchanged when viewMode is not queue. QueueView reuse keeps the existing concurrency UI contract.

## Slice Rationale

Restore the broken chip navigation path before aligning Playwright expectations that depend on QueueView.

## Non-goals

- Does not change autofix worker lifecycle defaults
- Does not rewrite Planning home navigation
- Does not change queue status semantics

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test -- src/__tests__/queue-view.test.tsx`
- [ ] Playwright: `packages/app/e2e/queue-running-vs-queued.spec.ts` (covered by follow-up e2e alignment PR)

</details>

## Visual Proof

Before: capacity chip opens Workers registry (Autofix details) with no QueueView / In flight panels.

![Before: chip opens workers registry](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260723-01c30f/queue-chip-before-workers-only.png)

After: QueueView concurrency panels (Worker Actions with Running/Queued sections) are shown again.

![After: QueueView concurrency panels](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260723-01c30f/queue-chip-after-queueview.png)

Before/after walkthrough:

![Before/after queue chip surface](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260723-01c30f/queue-chip-before-after.gif)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated queue view for queue mode.
  * Queue view displays current tasks, workflows, queue status, and worker status.
  * Added controls for starting and stopping processing and selecting queue items.
  * Preserved read-only behavior when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->