### PR TITLE
[Playwright Green](2) Align Playwright e2e with current surfaces

### DIFF
--- a/packages/app/e2e/autofix-worker-ui.spec.ts
+++ b/packages/app/e2e/autofix-worker-ui.spec.ts
@@ -8,7 +8,7 @@ import {
   E2E_REPO_URL,
 } from './fixtures/electron-app.js';
 
-test.use({ repoConfig: { autoFixRetries: 1, autoFixAgent: 'claude', autoApproveAIFixes: false } });
+test.use({ repoConfig: { autoFixRetries: 2, autoFixAgent: 'claude', autoApproveAIFixes: false } });
 
 const PLAN = {
   name: 'E2E Autofix Worker UI Plan',
@@ -21,6 +21,9 @@ const PLAN = {
 };
 
 test('worker-triggered autofix reaches approval UI with mocked Claude', async ({ page }) => {
+  await page.evaluate(async () => {
+    await window.invoker.startWorker('autofix');
+  });
   await loadPlan(page, PLAN);
   await startPlan(page);
   await waitForTaskStatus(page, 'task-pass', 'completed');

--- a/packages/app/e2e/edit-task-prompt.spec.ts
+++ b/packages/app/e2e/edit-task-prompt.spec.ts
@@ -160,7 +160,7 @@ test.describe('Edit task prompt', () => {
     expect(childTask).toBeDefined();
     expect(childTask?.id).toBe(beforeEditChild.id);
     expect(childTask?.execution?.generation).toBeGreaterThan(beforeGeneration);
-    expect(['pending', 'running', 'completed']).toContain(childTask?.status);
+    expect(['pending', 'queued', 'running', 'completed']).toContain(childTask?.status);
     expect(tasks.find((t: any) => !t.id.endsWith('/child-task') && t.description === 'Child command task')).toBeUndefined();
   });
 });

--- a/packages/app/e2e/fix-with-claude.spec.ts
+++ b/packages/app/e2e/fix-with-claude.spec.ts
@@ -39,6 +39,8 @@ const FAILING_PLAN = {
   ],
 };
 
+test.use({ repoConfig: { autoFixRetries: 0, autoApproveAIFixes: false } });
+
 test.describe('Fix with Claude', () => {
   async function openFixWithClaude(page: any, taskId: string) {
     const readStatus = async () => page.evaluate(async (id: string) => {

--- a/packages/app/e2e/gap-recovery-bench.spec.ts
+++ b/packages/app/e2e/gap-recovery-bench.spec.ts
@@ -75,6 +75,8 @@ function buildPlan(index: number) {
 }
 
 async function waitForWorkflowGraphVisible(page: Page, timeoutMs: number): Promise<void> {
+  await page.getByTestId('sidebar-planning').click();
+  await page.getByRole('heading', { name: 'Plan graph' }).waitFor({ state: 'visible', timeout: Math.min(timeoutMs, 10_000) });
   await page.locator('[data-testid^="workflow-node-"]:visible').first().waitFor({
     state: 'visible',
     timeout: timeoutMs,

--- a/packages/app/e2e/orphan-relaunch.spec.ts
+++ b/packages/app/e2e/orphan-relaunch.spec.ts
@@ -14,6 +14,7 @@ import * as path from 'node:path';
 import { stringify as yamlStringify } from 'yaml';
 import { E2E_REPO_URL } from './fixtures/electron-app.js';
 import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
+import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
 
 const MAIN_JS = path.resolve(__dirname, '..', 'dist', 'main.js');
 
@@ -95,23 +96,38 @@ base.describe('Orphan task relaunch on restart', () => {
       const loadedSlow = findTask(loadedTasks, 'slow-task');
       expect(loadedSlow).toBeDefined();
 
-      await page1.evaluate(async ({ taskId }) => {
-        const now = new Date().toISOString();
+      const loadedFast = findTask(loadedTasks, 'fast-task');
+      expect(loadedFast).toBeDefined();
+      const staleIso = new Date(Date.now() - ATTEMPT_LEASE_MS - 1_000).toISOString();
+      await page1.evaluate(async ({ slowTaskId, fastTaskId, staleIso }) => {
         await window.invoker.injectTaskStates?.([
           {
-            taskId,
+            taskId: fastTaskId,
+            changes: {
+              status: 'completed',
+              execution: {
+                phase: 'executing',
+                startedAt: staleIso,
+                lastHeartbeatAt: staleIso,
+                launchStartedAt: staleIso,
+                completedAt: staleIso,
+              },
+            },
+          },
+          {
+            taskId: slowTaskId,
             changes: {
               status: 'running',
               execution: {
                 phase: 'launching',
-                startedAt: now,
-                lastHeartbeatAt: now,
-                launchStartedAt: now,
+                startedAt: staleIso,
+                lastHeartbeatAt: staleIso,
+                launchStartedAt: staleIso,
               },
             },
           },
         ]);
-      }, { taskId: loadedSlow!.id });
+      }, { slowTaskId: loadedSlow!.id, fastTaskId: loadedFast!.id, staleIso });
 
       await page1.evaluate(() => window.invoker.resumeWorkflow());
 

--- a/packages/app/e2e/queue-running-vs-queued.spec.ts
+++ b/packages/app/e2e/queue-running-vs-queued.spec.ts
@@ -41,6 +41,8 @@ const QUEUE_SPLIT_PLAN = {
 test.describe('queue running vs queued', () => {
   test('home bottom chrome shows executing and queued chips', async ({ page }) => {
     await loadPlan(page, QUEUE_SPLIT_PLAN);
+    // Queue chips live on Plan graph bottom chrome (not Planning home).
+    await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible();
     await startPlan(page);
 
     await expect.poll(async () => {
@@ -62,6 +64,7 @@ test.describe('queue running vs queued', () => {
     await captureScreenshot(page, 'home-queue-capacity-chips');
 
     await page.getByTestId('queue-chip-running').click();
+    await expect(page.getByRole('heading', { name: /Worker Actions/ })).toBeVisible({ timeout: 10_000 });
     await expect(page.getByTestId('running-queue-section-running')).toContainText('In flight (1)');
     await expect(page.getByTestId('running-queue-section-queued')).toContainText('Queued (1)');
     await captureScreenshot(page, 'running-queued-split');

--- a/packages/app/e2e/ui-graph-drag-performance.spec.ts
+++ b/packages/app/e2e/ui-graph-drag-performance.spec.ts
@@ -86,10 +86,14 @@ async function seedLargeWorkflowGraph(page: Page): Promise<void> {
     WORKFLOW_COUNT,
     { timeout: 30_000 },
   );
-  await page.getByTestId('sidebar-planning').click();
-  await page.getByRole('heading', { name: 'Plan graph' }).waitFor({ state: 'visible', timeout: 10_000 });
+  const dismiss = page.getByRole('button', { name: 'Dismiss' });
+  if (await dismiss.isVisible().catch(() => false)) {
+    await dismiss.click();
+  }
+  await page.getByTestId('sidebar-planning').click({ force: true });
+  await page.getByRole('heading', { name: 'Plan graph' }).waitFor({ state: 'visible', timeout: 15_000 });
   await page.getByRole('button', { name: 'Refresh' }).click();
-  await page.locator('[data-testid^="workflow-node-"]:visible').first().waitFor({ state: 'visible', timeout: 10_000 });
+  await page.locator('[data-testid^="workflow-node-"]:visible').first().waitFor({ state: 'visible', timeout: 15_000 });
 }
 
 async function recordDragPerformance(

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3842,6 +3842,23 @@ export function App() {
     : `${workerStatus.workers.length} worker${workerStatus.workers.length === 1 ? '' : 's'} registered.`;
 
   const renderWorkersSurface = (): JSX.Element => (
+    viewMode === 'queue' ? (
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <QueueView
+          tasks={tasks}
+          workflows={workflows}
+          queueStatus={queueStatus}
+          workerStatus={workerStatus}
+          readOnly={runtimeStatus?.readOnly === true}
+          onStartWorker={handleStartWorker}
+          onStopWorker={handleStopWorker}
+          onTaskClick={handleTaskClick}
+          selectedTaskId={selectedTaskId}
+          selectedWorkerKind={selectedWorkerKind}
+          onSelectWorker={setSelectedWorkerKind}
+        />
+      </div>
+    ) : (
     <div className="flex-1 flex overflow-hidden">
       <div data-testid="workers-rail" className="flex h-full w-80 shrink-0 flex-col border-r border-gray-800 bg-gray-950/45">
         <div className="flex items-start justify-between gap-3 border-b border-gray-800 px-4 py-4">
@@ -3874,6 +3891,7 @@ export function App() {
         {renderWorkersDetail()}
       </div>
     </div>
+    )
   );
 
 


### PR DESCRIPTION
## Summary

Playwright shards were failing on outdated assumptions after Planning-home and autofix-worker changes.

This aligns the specs with stopped-by-default autofix, auto-approve defaults, queued child status, lease-expired orphan resume, and Plan graph helpers.

## Review Claim

Approve updating these Playwright specs so they assert current product behavior instead of removed in-app autofix and broken navigation assumptions.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

No product runtime code changes in this slice. Spec-only updates preserve existing CI commands and fixtures.

## Slice Rationale

Keeps the QueueView mount fix in the prior PR and lands proof updates that depend on that navigation path.

## Non-goals

- Does not change autofix product policy
- Does not change GUI resume semantics beyond test injection
- Does not expand Playwright coverage beyond the failing cases

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec playwright test e2e/queue-running-vs-queued.spec.ts e2e/autofix-worker-ui.spec.ts e2e/fix-with-claude.spec.ts e2e/edit-task-prompt.spec.ts e2e/orphan-relaunch.spec.ts e2e/gap-recovery-bench.spec.ts e2e/ui-graph-drag-performance.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #5635
