### PR TITLE
[SSH Remote PATH](1) Use remote login shells for task PATH

### DIFF
--- a/packages/execution-engine/src/__tests__/conflict-resolver.test.ts
+++ b/packages/execution-engine/src/__tests__/conflict-resolver.test.ts
@@ -785,13 +785,7 @@ describe('conflict-resolver fail-fast workspace invariant', () => {
 });
 
 describe('remoteAgentShellInvocation', () => {
-  it('forwards PATH so a bare agent binary resolves on the remote, like task execution', () => {
-    expect(remoteAgentShellInvocation('/opt/stub:/usr/bin')).toEqual([
-      'env', 'PATH=/opt/stub:/usr/bin', 'bash', '-s',
-    ]);
-  });
-
-  it('falls back to a bare bash invocation when no PATH is available', () => {
-    expect(remoteAgentShellInvocation('')).toEqual(['bash', '-s']);
+  it('uses a remote login shell so ~/.profile PATH (flutter, agents) applies', () => {
+    expect(remoteAgentShellInvocation()).toEqual(['bash', '-l', '-s']);
   });
 });

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -304,13 +304,12 @@ function shellQuote(s: string): string {
 }
 
 /**
- * Remote `bash -s` invocation for an agent command, forwarding the local PATH so
- * a bare agent binary (e.g. `codex`) resolves on the remote — mirroring how
- * ssh-executor runs task payloads. Without this the fix/resolve agent dies with
- * "command not found" even though normal task execution on the same host works.
+ * Remote shell for agent fix/resolve commands. Use a login shell so the remote
+ * user's ~/.profile PATH is applied (same as SshExecutor task payloads). Do not
+ * forward the local host PATH — that clobbers Linux remotes with macOS paths.
  */
-export function remoteAgentShellInvocation(remotePath: string = process.env.PATH ?? ''): string[] {
-  return remotePath ? ['env', `PATH=${remotePath}`, 'bash', '-s'] : ['bash', '-s'];
+export function remoteAgentShellInvocation(): string[] {
+  return ['bash', '-l', '-s'];
 }
 
 /**

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -90,7 +90,6 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
   private readonly useApiKey: boolean;
   private readonly secretsFile: string | undefined;
   private readonly remoteHeartbeatIntervalSeconds: number;
-  private readonly remotePath: string;
 
   constructor(config: SshExecutorConfig) {
     super();
@@ -110,7 +109,6 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
       && configuredRemoteHeartbeatInterval > 0
         ? configuredRemoteHeartbeatInterval
         : SshExecutor.DEFAULT_REMOTE_HEARTBEAT_INTERVAL_SECONDS;
-    this.remotePath = process.env.PATH ?? '';
   }
 
   private buildSshArgs(): string[] {
@@ -303,9 +301,13 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
 `;
   }
 
+  /**
+   * Remote shell for task scripts. Use a login shell so the remote user's
+   * ~/.profile PATH (flutter, android-sdk, etc.) is applied. Never forward the
+   * local host PATH — that clobbers Linux remotes with macOS Homebrew paths.
+   */
   private buildRemoteCommand(): string[] {
-    if (!this.remotePath) return ['bash', '-s'];
-    return ['env', `PATH=${this.remotePath}`, 'bash', '-s'];
+    return ['bash', '-l', '-s'];
   }
 
   private async execRemoteCapture(script: string, phase?: string): Promise<string> {


### PR DESCRIPTION
## Summary

SSH tasks were failing because Flutter was missing from PATH, even though it was already installed on every droplet.

Invoker was forwarding the owner Mac's `PATH` into remote `bash -s` sessions. That replaced the Linux profile PATH with Homebrew paths.

This change runs SSH task and agent shells as `bash -l -s`, so the remote `~/.profile` PATH wins.

## Review Claim

Approve replacing local-PATH forwarding with a remote login shell for SSH task and agent invocation.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the remote shell argv changes. Git bootstrap, workspace layout, and task payloads are unchanged.

## Slice Rationale

This is one behavior fix with its matching unit-test expectation update. No stack split is needed.

## Non-goals

- Installing Flutter or other tools on SSH hosts
- Changing `~/.invoker/config.json` or `provisionCommand`
- Changing non-SSH executors

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/conflict-resolver.test.ts src/__tests__/ssh-executor.test.ts`
- [x] Manual check: all six droplets resolve `flutter` under `bash -l -s`, and fail under `env PATH=<mac PATH> bash -s`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5d171079e38245ae40bfb404b8571add41ca9a7f`
- Post-revert steps: Restart the Invoker owner process so SSH sessions use the previous shell argv
- Data migration? No

</details>
