### PR TITLE
[Playwright Green](3) Key autofix bare-retry once per task

### DIFF
--- a/packages/execution-engine/src/__tests__/auto-fix-bare-retry.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-bare-retry.test.ts
@@ -102,7 +102,7 @@ describe('AutoFixWorker attempt-0 bare retry', () => {
     expect(channel).toBe('invoker:restart-task');
     expect(args).toEqual(['wf-1/build']);
 
-    const retryRow = harness.actions.get(`${AUTO_FIX_WORKER_KIND}:${AUTO_FIX_WORKER_KIND}:retry:wf-1/build:2:attempt-1`);
+    const retryRow = harness.actions.get(`${AUTO_FIX_WORKER_KIND}:${AUTO_FIX_WORKER_KIND}:retry:wf-1/build`);
     expect(retryRow).toBeDefined();
     expect(retryRow?.actionType).toBe('auto-retry');
     expect(retryRow?.attemptCount).toBe(1);
@@ -153,11 +153,11 @@ describe('AutoFixWorker attempt-0 bare retry', () => {
 
   it('respects existing bare-retry row across ledger resets (persistence path)', async () => {
     const harness = makeHarness();
-    const retryKey = `${AUTO_FIX_WORKER_KIND}:${AUTO_FIX_WORKER_KIND}:retry:wf-1/build:2:attempt-1`;
+    const retryKey = `${AUTO_FIX_WORKER_KIND}:${AUTO_FIX_WORKER_KIND}:retry:wf-1/build`;
     harness.actions.set(retryKey, toRecord({
       id: retryKey,
       workerKind: AUTO_FIX_WORKER_KIND,
-      externalKey: `${AUTO_FIX_WORKER_KIND}:retry:wf-1/build:2:attempt-1`,
+      externalKey: `${AUTO_FIX_WORKER_KIND}:retry:wf-1/build`,
       actionType: 'auto-retry',
       subjectType: 'task',
       subjectId: 'wf-1/build',
@@ -178,6 +178,37 @@ describe('AutoFixWorker attempt-0 bare retry', () => {
 
     await tick({ reason: 'poll' } as never);
 
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:fix-with-agent');
+  });
+
+  it('escalates after a generation bump once the bare retry row exists', async () => {
+    const harness = makeHarness();
+    const tick = createAutoFixRecoveryTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 3,
+      getAutoFixAgent: () => 'codex',
+    });
+
+    await tick({ reason: 'poll' } as never);
+    expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:restart-task');
+    harness.submit.mockClear();
+
+    // Bare retry succeeded then failed again under a new generation/attempt.
+    harness.tasks.set('wf-1/build', makeFailedTask({
+      execution: {
+        generation: 3,
+        selectedAttemptId: 'attempt-2',
+        branch: 'feature/build',
+        error: 'pnpm build failed with exit code 1',
+      },
+      taskStateVersion: 8,
+    }));
+
+    await tick({ reason: 'poll' } as never);
     expect(harness.submit).toHaveBeenCalledTimes(1);
     expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:fix-with-agent');
   });

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -280,7 +280,9 @@ function autoFixDecisionExternalKey(candidate: AutoFixRecoveryCandidate): string
 }
 
 function autoFixBareRetryExternalKey(candidate: AutoFixRecoveryCandidate): string {
-  return `${AUTO_FIX_WORKER_KIND}:retry:${candidate.taskId}:${candidate.generation}:${candidate.attemptId ?? ''}`;
+  // Bare retry is once-per-task: after restart-task bumps generation, the next
+  // failure must escalate to fix-with-agent instead of another bare retry.
+  return `${AUTO_FIX_WORKER_KIND}:retry:${candidate.taskId}`;
 }
 
 function recordAutoFixDecisionRow(


### PR DESCRIPTION
## Summary

The autofix worker queues one bare restart before opening a fix agent.

That bare restart changes the task generation.

The worker-action key for the bare restart still included generation.

The next failure looked brand new and queued another bare restart.

The worker never escalated to the fix-agent path used by the UI e2e.

This keys the bare-restart row once per task so the second tick escalates.

## Review Claim

Approve keying autofix bare-restart once per task so a later failure escalates to the fix-agent path.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Changes only the bare-restart external key and unit coverage. No UI surface changes.

## Slice Rationale

Isolates the recovery escalation bug from Playwright navigation proof updates.

## Non-goals

Does not change approval UI, hitch fixtures, or Plan graph navigation.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/auto-fix-bare-retry.test.ts`
- [ ] CI `playwright / 4-of-7` passes `autofix-worker-ui.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
