### PR TITLE
[Playwright Green](5) Align Playwright e2e with Plan graph chrome

### DIFF
--- a/packages/app/e2e/attention-click-hitch-responsiveness.spec.ts
+++ b/packages/app/e2e/attention-click-hitch-responsiveness.spec.ts
@@ -1,4 +1,4 @@
-import { expect, injectTaskStates, test } from './fixtures/electron-app.js';
+import { expect, injectTaskStates, openPlanGraph, test } from './fixtures/electron-app.js';
 
 const MAX_P95_RTT_MS = 100;
 const MAX_SAMPLE_RTT_MS = 250;
@@ -38,6 +38,7 @@ test('Needs Attention list clicks keep listWorkflows IPC responsive under a fat 
     })),
   );
 
+  await openPlanGraph(page);
   await page.getByRole('button', { name: 'Refresh' }).click();
   await page.getByTestId('sidebar-attention').click();
   await expect(page.getByTestId('browser-rail').getByRole('heading', { name: 'Needs Attention' })).toBeVisible({

--- a/packages/app/e2e/dag-click-hitch-responsiveness.spec.ts
+++ b/packages/app/e2e/dag-click-hitch-responsiveness.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, E2E_REPO_URL } from './fixtures/electron-app.js';
+import { expect, openPlanGraph, test, E2E_REPO_URL } from './fixtures/electron-app.js';
 import { stringify as yamlStringify } from 'yaml';
 import type { Page } from '@playwright/test';
 
@@ -43,6 +43,8 @@ test('workflow select shows mini-DAG within 100ms under a fat events table', asy
     return window.invoker.seedMainProcessHitchFixture();
   });
   expect(seeded.eventCount).toBeGreaterThanOrEqual(10_000);
+
+  await openPlanGraph(page);
 
   // Small plan so React Flow paint cost is not the variable under test; the fat
   // hitch fixture keeps the main-thread SQLite poll busy in the background.
@@ -106,6 +108,7 @@ test('DAG task clicks keep listWorkflows IPC responsive under a fat events table
   expect(seeded.eventCount).toBeGreaterThanOrEqual(10_000);
   expect(seeded.taskCount).toBeGreaterThan(0);
 
+  await openPlanGraph(page);
   await page.getByRole('button', { name: 'Refresh' }).click();
   const miniDag = await selectWorkflowForMiniDag(page, seeded.workflowId);
   await expect(miniDag.locator('.react-flow__node').first()).toBeAttached({ timeout: 10_000 });

--- a/packages/app/e2e/embedded-terminal-restart-persistence.spec.ts
+++ b/packages/app/e2e/embedded-terminal-restart-persistence.spec.ts
@@ -185,6 +185,9 @@ base.describe('Embedded terminal restart persistence', () => {
       const after = await page.evaluate(() => window.invoker.terminalList());
       expect(after).toHaveLength(1);
       expect(after[0].sessionId).toBe(sessionId);
+      // Terminal drawer chrome mounts only on Plan graph, not Planning home.
+      await page.getByTestId('sidebar-planning').click();
+      await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible({ timeout: 10000 });
       await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial', { timeout: 10000 });
       await expect(page.getByTestId(`terminal-tab-${fullTaskId}`)).toBeVisible();
       const restoredPane = page.getByTestId(`terminal-pane-${fullTaskId}`);

--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -305,6 +305,12 @@ export async function loadPlan(page: Page, plan: { tasks: readonly { id: string 
   await page.locator(`.react-flow__node[data-testid$="${plan.tasks[0].id}"]`).first().waitFor({ state: 'visible', timeout: 10000 });
 }
 
+/** Open Plan graph so rail Refresh / DAG chrome exist (default surface is Planning home). */
+export async function openPlanGraph(page: Page): Promise<void> {
+  await page.getByTestId('sidebar-planning').click();
+  await page.getByRole('heading', { name: 'Plan graph' }).waitFor({ state: 'visible', timeout: 10000 });
+}
+
 /** Test-only: inject task status/execution into persistence and UI without running commands. */
 export async function injectTaskStates(
   page: Page,

--- a/packages/app/e2e/orphan-relaunch.spec.ts
+++ b/packages/app/e2e/orphan-relaunch.spec.ts
@@ -1,10 +1,6 @@
 /**
- * E2E: Orphan task relaunch — verify that tasks stuck in 'running' from a
- * previous session are automatically relaunched when the app restarts.
- *
- * Simulates an app crash by force-killing the Electron process while a task
- * is still running. On relaunch, startup reconciliation should detect and
- * relaunch the orphaned task.
+ * E2E: Orphan task reconciliation — stale in-flight tasks from a previous
+ * session are failed on boot ("Application quit"), not silently relaunched.
  */
 
 import { test as base, _electron as electron, expect, type Page } from '@playwright/test';
@@ -15,6 +11,7 @@ import { stringify as yamlStringify } from 'yaml';
 import { E2E_REPO_URL } from './fixtures/electron-app.js';
 import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
+import { setTimeout as delay } from 'node:timers/promises';
 
 const MAIN_JS = path.resolve(__dirname, '..', 'dist', 'main.js');
 
@@ -47,7 +44,7 @@ function launchArgs(): string[] {
   ];
 }
 
-function findTask(tasks: Array<{ id: string; status: string }>, taskId: string) {
+function findTask(tasks: Array<{ id: string; status: string; execution?: { error?: string } }>, taskId: string) {
   return tasks.find((t) => t.id === taskId || t.id.endsWith(`/${taskId}`));
 }
 
@@ -57,47 +54,47 @@ async function waitForInvoker(page: Page): Promise<void> {
 }
 
 base.describe('Orphan task relaunch on restart', () => {
-  base('orphaned running task is relaunched after app restart', async () => {
+  base('orphaned running task is failed on app restart', async () => {
     const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-'));
     const configPath = path.join(testDir, 'e2e-config.json');
     const electronUserDataDir = path.join(testDir, 'electron-user-data');
-    writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0 }), 'utf8');
+    writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0, disableAutoRunOnStartup: true }), 'utf8');
     rmSync(electronUserDataDir, { recursive: true, force: true });
     registerTrackedBrowserUserDataDir(electronUserDataDir);
 
+    const env = {
+      ...process.env,
+      NODE_ENV: 'test',
+      INVOKER_TEST_WORKFLOW_IDS: '1',
+      INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
+      INVOKER_DB_DIR: testDir,
+      INVOKER_ALLOW_DELETE_ALL: '1',
+      INVOKER_E2E_ENABLE_COMPOSITOR: '1',
+      INVOKER_REPO_CONFIG_PATH: configPath,
+      INVOKER_USER_DATA_DIR: electronUserDataDir,
+    };
+
+    let app = await electron.launch({
+      args: [`--user-data-dir=${electronUserDataDir}`, ...launchArgs()],
+      env,
+    });
     try {
-      const app1 = await electron.launch({
-        args: [`--user-data-dir=${electronUserDataDir}`, ...launchArgs()],
-        env: {
-          ...process.env,
-          NODE_ENV: 'test',
-          INVOKER_TEST_WORKFLOW_IDS: '1',
-          INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
-          INVOKER_DB_DIR: testDir,
-          INVOKER_ALLOW_DELETE_ALL: '1',
-          INVOKER_E2E_ENABLE_COMPOSITOR: '1',
-          INVOKER_REPO_CONFIG_PATH: configPath,
-          INVOKER_USER_DATA_DIR: electronUserDataDir,
-        },
-      });
-      const page1 = await app1.firstWindow();
+      const page1 = await app.firstWindow();
       await waitForInvoker(page1);
 
-      // Clear any leftover state
       await page1.evaluate(async () => {
         await window.invoker.clear();
         await window.invoker.deleteAllWorkflows();
       });
 
-      // Load the plan and synthesize an orphaned running task with no live handle.
       await page1.evaluate((planYaml) => window.invoker.loadPlan(planYaml), yamlStringify(RELAUNCH_PLAN));
       const loadedResult = await page1.evaluate(() => window.invoker.getTasks());
       const loadedTasks = Array.isArray(loadedResult) ? loadedResult : loadedResult.tasks;
       const loadedSlow = findTask(loadedTasks, 'slow-task');
-      expect(loadedSlow).toBeDefined();
-
       const loadedFast = findTask(loadedTasks, 'fast-task');
+      expect(loadedSlow).toBeDefined();
       expect(loadedFast).toBeDefined();
+
       const staleIso = new Date(Date.now() - ATTEMPT_LEASE_MS - 1_000).toISOString();
       await page1.evaluate(async ({ slowTaskId, fastTaskId, staleIso }) => {
         await window.invoker.injectTaskStates?.([
@@ -129,30 +126,31 @@ base.describe('Orphan task relaunch on restart', () => {
         ]);
       }, { slowTaskId: loadedSlow!.id, fastTaskId: loadedFast!.id, staleIso });
 
-      await page1.evaluate(() => window.invoker.resumeWorkflow());
+      await app.close();
+      app = undefined as never;
+      await delay(1500);
 
-      const deadline2 = Date.now() + 60_000;
-      let observedSlow: any;
-      while (Date.now() < deadline2) {
-        const snapshot = await page1.evaluate(() => window.invoker.getTasks());
+      app = await electron.launch({
+        args: [`--user-data-dir=${electronUserDataDir}`, ...launchArgs()],
+        env,
+      });
+      const page2 = await app.firstWindow();
+      await waitForInvoker(page2);
+
+      await expect.poll(async () => {
+        const snapshot = await page2.evaluate(() => window.invoker.getTasks());
         const tasks = Array.isArray(snapshot) ? snapshot : snapshot.tasks;
-        observedSlow = findTask(tasks, 'slow-task');
-        if (observedSlow?.status === 'running' && observedSlow?.execution?.phase !== 'launching') {
-          break;
-        }
-        await page1.waitForTimeout(300);
-      }
-      expect(observedSlow).toBeDefined();
-      expect(observedSlow?.status).toBe('running');
-      expect(observedSlow?.execution?.phase).not.toBe('launching');
-
-      const postResult = await page1.evaluate(() => window.invoker.getTasks());
-      const postTasks = Array.isArray(postResult) ? postResult : postResult.tasks;
-      const postSlow = findTask(postTasks, 'slow-task');
-      expect(postSlow).toBeDefined();
-      expect(postSlow?.status).toBe('running');
-      await app1.close();
+        const slow = findTask(tasks, 'slow-task');
+        return {
+          status: slow?.status,
+          error: slow?.execution?.error ?? null,
+        };
+      }, { timeout: 30_000 }).toEqual({
+        status: 'failed',
+        error: 'Application quit',
+      });
     } finally {
+      if (app) await app.close().catch(() => undefined);
       if (process.env.INVOKER_E2E_KEEP_TMP !== '1') {
         rmSync(testDir, { recursive: true, force: true });
       }

--- a/packages/app/e2e/planning-terminal-restart-persistence.spec.ts
+++ b/packages/app/e2e/planning-terminal-restart-persistence.spec.ts
@@ -126,7 +126,7 @@ base.describe('Planning Terminal restart persistence', () => {
 
       await openPlanningTerminal(page);
       await submitPlanningText(page, 'Draft a YAML plan to add a README');
-      await expect(page.getByTestId('invoker-terminal-ready-bar')).toContainText('draft ready', { timeout: 10000 });
+      await expect(page.getByTestId('invoker-terminal-ready-bar')).toContainText('Draft ready', { timeout: 10000 });
       const savedSessionId = await page.evaluate(async () => {
         const list = await window.invoker.planningChatList();
         return list.sessions[0]?.id;
@@ -143,7 +143,7 @@ base.describe('Planning Terminal restart persistence', () => {
 
       await expect(page.getByTestId('invoker-terminal-transcript')).toContainText('Draft a YAML plan to add a README', { timeout: 10000 });
       await expect(page.getByTestId('invoker-terminal-transcript')).toContainText('I drafted the restart plan.');
-      await expect(page.getByTestId('invoker-terminal-ready-bar')).toContainText('draft ready · "Planning Terminal Restart"');
+      await expect(page.getByTestId('invoker-terminal-ready-bar')).toContainText('Draft ready · Planning Terminal Restart · 1 task');
       await expect(page.getByTestId('invoker-terminal-input')).toBeEnabled();
       await expect(page.getByText('working…')).toHaveCount(0);
       const restoredSessionId = await page.evaluate(async () => {
@@ -187,7 +187,7 @@ base.describe('Planning Terminal restart persistence', () => {
 
       await openPlanningTerminal(page);
       await submitPlanningText(page, 'Draft a YAML plan to add a README');
-      await expect(page.getByTestId('invoker-terminal-ready-bar')).toContainText('draft ready', { timeout: 10000 });
+      await expect(page.getByTestId('invoker-terminal-ready-bar')).toContainText('Draft ready', { timeout: 10000 });
       const savedSessionId = await page.evaluate(async () => {
         const list = await window.invoker.planningChatList();
         return list.sessions[0]?.id;

--- a/packages/app/src/main-process-hitch-fixture.ts
+++ b/packages/app/src/main-process-hitch-fixture.ts
@@ -21,6 +21,8 @@ export interface MainProcessHitchFixtureOptions {
   taskCount?: number;
   eventsPerTask?: number;
   actionsPerKind?: number;
+  /** Defaults to completed so dbPoll does not keep syncing a perpetual running workflow. */
+  workflowStatus?: Workflow['status'];
 }
 
 export interface MainProcessHitchFixtureResult {
@@ -30,11 +32,11 @@ export interface MainProcessHitchFixtureResult {
   workerActionCount: number;
 }
 
-function makeWorkflow(id: string, name: string): Workflow {
+function makeWorkflow(id: string, name: string, status: Workflow['status']): Workflow {
   return {
     id,
     name,
-    status: 'running',
+    status,
     createdAt: '2026-07-01T00:00:00.000Z',
     updatedAt: '2026-07-01T00:00:00.000Z',
   };
@@ -60,11 +62,12 @@ export function seedMainProcessHitchFixture(
   const taskCount = options.taskCount ?? DEFAULT_TASK_COUNT;
   const eventsPerTask = options.eventsPerTask ?? DEFAULT_EVENTS_PER_TASK;
   const actionsPerKind = options.actionsPerKind ?? DEFAULT_ACTIONS_PER_KIND;
+  const workflowStatus = options.workflowStatus ?? 'completed';
   const workflowId = MAIN_PROCESS_HITCH_FIXTURE_WORKFLOW_ID;
   let workerActionCount = 0;
 
   persistence.runInTransaction(() => {
-    persistence.saveWorkflow(makeWorkflow(workflowId, 'Main-process hitch fixture'));
+    persistence.saveWorkflow(makeWorkflow(workflowId, 'Main-process hitch fixture', workflowStatus));
 
     for (let t = 0; t < taskCount; t += 1) {
       const taskId = `${workflowId}/t${t}`;

--- a/packages/execution-engine/src/__tests__/auto-fix-bare-retry.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-bare-retry.test.ts
@@ -102,7 +102,7 @@ describe('AutoFixWorker attempt-0 bare retry', () => {
     expect(channel).toBe('invoker:restart-task');
     expect(args).toEqual(['wf-1/build']);
 
-    const retryRow = harness.actions.get(`${AUTO_FIX_WORKER_KIND}:${AUTO_FIX_WORKER_KIND}:retry:wf-1/build:2:attempt-1`);
+    const retryRow = harness.actions.get(`${AUTO_FIX_WORKER_KIND}:${AUTO_FIX_WORKER_KIND}:retry:wf-1/build`);
     expect(retryRow).toBeDefined();
     expect(retryRow?.actionType).toBe('auto-retry');
     expect(retryRow?.attemptCount).toBe(1);
@@ -153,11 +153,11 @@ describe('AutoFixWorker attempt-0 bare retry', () => {
 
   it('respects existing bare-retry row across ledger resets (persistence path)', async () => {
     const harness = makeHarness();
-    const retryKey = `${AUTO_FIX_WORKER_KIND}:${AUTO_FIX_WORKER_KIND}:retry:wf-1/build:2:attempt-1`;
+    const retryKey = `${AUTO_FIX_WORKER_KIND}:${AUTO_FIX_WORKER_KIND}:retry:wf-1/build`;
     harness.actions.set(retryKey, toRecord({
       id: retryKey,
       workerKind: AUTO_FIX_WORKER_KIND,
-      externalKey: `${AUTO_FIX_WORKER_KIND}:retry:wf-1/build:2:attempt-1`,
+      externalKey: `${AUTO_FIX_WORKER_KIND}:retry:wf-1/build`,
       actionType: 'auto-retry',
       subjectType: 'task',
       subjectId: 'wf-1/build',
@@ -178,6 +178,37 @@ describe('AutoFixWorker attempt-0 bare retry', () => {
 
     await tick({ reason: 'poll' } as never);
 
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:fix-with-agent');
+  });
+
+  it('escalates after a generation bump once the bare retry row exists', async () => {
+    const harness = makeHarness();
+    const tick = createAutoFixRecoveryTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 3,
+      getAutoFixAgent: () => 'codex',
+    });
+
+    await tick({ reason: 'poll' } as never);
+    expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:restart-task');
+    harness.submit.mockClear();
+
+    // Bare retry succeeded then failed again under a new generation/attempt.
+    harness.tasks.set('wf-1/build', makeFailedTask({
+      execution: {
+        generation: 3,
+        selectedAttemptId: 'attempt-2',
+        branch: 'feature/build',
+        error: 'pnpm build failed with exit code 1',
+      },
+      taskStateVersion: 8,
+    }));
+
+    await tick({ reason: 'poll' } as never);
     expect(harness.submit).toHaveBeenCalledTimes(1);
     expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:fix-with-agent');
   });

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -280,7 +280,9 @@ function autoFixDecisionExternalKey(candidate: AutoFixRecoveryCandidate): string
 }
 
 function autoFixBareRetryExternalKey(candidate: AutoFixRecoveryCandidate): string {
-  return `${AUTO_FIX_WORKER_KIND}:retry:${candidate.taskId}:${candidate.generation}:${candidate.attemptId ?? ''}`;
+  // Bare retry is once-per-task: after restart-task bumps generation, the next
+  // failure must escalate to fix-with-agent instead of another bare retry.
+  return `${AUTO_FIX_WORKER_KIND}:retry:${candidate.taskId}`;
 }
 
 function recordAutoFixDecisionRow(


### PR DESCRIPTION
## Summary

Several Playwright specs still assumed Planning-home chrome that now lives on Plan graph.

Terminal restart asserted outdated draft-ready copy and drawer visibility on home.

Orphan relaunch expected a stale running task to keep running after resume.

Boot reconciliation now fails those orphans with Application quit.

This opens Plan graph where needed, matches Draft ready copy, and asserts fail-on-boot orphans.

## Review Claim

Approve aligning Playwright e2e with Plan graph chrome, draft-ready copy, and fail-on-boot orphan policy.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. No product runtime code changes.

## Slice Rationale

Keeps e2e expectation updates out of the autofix and hitch-fixture behavior slices.

## Non-goals

Does not change orphan reconciliation product policy or terminal drawer mounting rules.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] CI `playwright / 5-of-7` passes terminal restart persistence specs
- [ ] CI `playwright / 6-of-7` passes attention/dag hitch specs after Plan graph open
- [ ] CI `playwright / 4-of-7` passes orphan relaunch fail-on-boot assertion

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
