### PR TITLE
[CI e2e-proof](3) Allow 23d proof the full scenario budget

### DIFF
--- a/scripts/test-suites/required/23d-same-workflow-tracked-fix-vs-recreate.sh
+++ b/scripts/test-suites/required/23d-same-workflow-tracked-fix-vs-recreate.sh
@@ -5,7 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
 
 export REPRO_TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-180}"
-export INVOKER_REPRO_TIMEOUT_SECONDS="${INVOKER_REPRO_TIMEOUT_SECONDS:-600}"
+export INVOKER_REPRO_TIMEOUT_SECONDS="${INVOKER_REPRO_TIMEOUT_SECONDS:-1260}"
 
 if command -v xvfb-run >/dev/null 2>&1; then
   exec xvfb-run --auto-servernum \


### PR DESCRIPTION
## Summary

The 23d same-workflow tracked-fix proof wraps a deterministic chaos scenario.

That scenario already budgets up to 1200 seconds for seed waits and recovery.

The suite wrapper still killed the process at 600 seconds.

CI failed the e2e-proof shard before the scenario could finish.

This raises only the wrapper default to 1260 seconds so the proof can use its budget.

## Review Claim

Approve raising the 23d proof wrapper timeout so it matches the deterministic chaos scenario budget.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Test harness timeout only. No product runtime code changes.

## Slice Rationale

Isolates the e2e-proof shard-2 timeout mismatch from Playwright green fixes.

## Non-goals

Does not change the chaos scenario itself or weaken hang detection criteria.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash -n scripts/test-suites/required/23d-same-workflow-tracked-fix-vs-recreate.sh`
- [ ] CI `e2e-proof / shard 2` passes `required/23d-same-workflow-tracked-fix-vs-recreate.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
