### PR TITLE
[Playwright Green](6) Harden graph-drag Plan graph navigation

### DIFF
--- a/packages/app/e2e/ui-graph-drag-performance.spec.ts
+++ b/packages/app/e2e/ui-graph-drag-performance.spec.ts
@@ -74,12 +74,20 @@ function buildPlan(index: number) {
 }
 
 async function dismissKnownOverlays(page: Page): Promise<void> {
-  const dismissButtons = page.getByRole('button', { name: /^(Dismiss|Close|Skip for now|Not now)$/i });
-  const count = await dismissButtons.count();
-  for (let index = 0; index < count; index += 1) {
-    const button = dismissButtons.nth(index);
-    if (await button.isVisible().catch(() => false)) {
-      await button.dispatchEvent('click', { bubbles: true, cancelable: true });
+  while (true) {
+    const dismissButtons = page.getByRole('button', { name: /^(Dismiss|Close|Skip for now|Not now)$/i });
+    const count = await dismissButtons.count();
+    let dismissed = false;
+    for (let index = 0; index < count; index += 1) {
+      const button = dismissButtons.nth(index);
+      if (await button.isVisible().catch(() => false)) {
+        await button.dispatchEvent('click', { bubbles: true, cancelable: true });
+        dismissed = true;
+        break;
+      }
+    }
+    if (!dismissed) {
+      return;
     }
   }
 }

--- a/packages/app/e2e/ui-graph-drag-performance.spec.ts
+++ b/packages/app/e2e/ui-graph-drag-performance.spec.ts
@@ -73,6 +73,22 @@ function buildPlan(index: number) {
   };
 }
 
+async function dismissKnownOverlays(page: Page): Promise<void> {
+  const dismissButtons = page.getByRole('button', { name: /^(Dismiss|Close|Skip for now|Not now)$/i });
+  const count = await dismissButtons.count();
+  for (let index = 0; index < count; index += 1) {
+    const button = dismissButtons.nth(index);
+    if (await button.isVisible().catch(() => false)) {
+      await button.dispatchEvent('click', { bubbles: true, cancelable: true });
+    }
+  }
+}
+
+async function openPlanGraph(page: Page): Promise<void> {
+  await dismissKnownOverlays(page);
+  await page.getByTestId('sidebar-planning').dispatchEvent('click', { bubbles: true, cancelable: true });
+  await page.getByRole('heading', { name: 'Plan graph' }).waitFor({ state: 'visible', timeout: 30_000 });
+}
 
 async function seedLargeWorkflowGraph(page: Page): Promise<void> {
   const plans = Array.from({ length: WORKFLOW_COUNT }, (_, index) => yamlStringify(buildPlan(index)));
@@ -86,14 +102,10 @@ async function seedLargeWorkflowGraph(page: Page): Promise<void> {
     WORKFLOW_COUNT,
     { timeout: 30_000 },
   );
-  const dismiss = page.getByRole('button', { name: 'Dismiss' });
-  if (await dismiss.isVisible().catch(() => false)) {
-    await dismiss.click();
-  }
-  await page.getByTestId('sidebar-planning').click({ force: true });
-  await page.getByRole('heading', { name: 'Plan graph' }).waitFor({ state: 'visible', timeout: 15_000 });
-  await page.getByRole('button', { name: 'Refresh' }).click();
-  await page.locator('[data-testid^="workflow-node-"]:visible').first().waitFor({ state: 'visible', timeout: 15_000 });
+  await openPlanGraph(page);
+  await dismissKnownOverlays(page);
+  await page.getByRole('button', { name: 'Refresh' }).dispatchEvent('click', { bubbles: true, cancelable: true });
+  await page.locator('[data-testid^="workflow-node-"]:visible').first().waitFor({ state: 'visible', timeout: 30_000 });
 }
 
 async function recordDragPerformance(

--- a/scripts/repro/repro-coderabbit-pr5665-overlay-dismiss-requery.sh
+++ b/scripts/repro/repro-coderabbit-pr5665-overlay-dismiss-requery.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+spec_path="packages/app/e2e/ui-graph-drag-performance.spec.ts"
+
+echo "[repro] Running PR #5665 overlay dismiss re-query regression."
+echo "[repro] Scenario: dismissKnownOverlays must keep dismissing visible overlay buttons after earlier buttons remove themselves."
+
+node --input-type=module - "$spec_path" <<'NODE'
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+const specPath = process.argv[2];
+const source = readFileSync(specPath, 'utf8');
+const match = source.match(/async function dismissKnownOverlays\(page: Page\): Promise<void> \{[\s\S]*?^\}/m);
+if (!match) {
+  console.error('[repro] FAIL: could not locate dismissKnownOverlays in target spec.');
+  process.exit(1);
+}
+
+const executable = `${match[0]
+  .replace('(page: Page)', '(page)')
+  .replace('): Promise<void>', ')')}
+this.__dismissKnownOverlays = dismissKnownOverlays;`;
+
+const context = { console };
+vm.runInNewContext(executable, context, { filename: specPath });
+const dismissKnownOverlays = context.__dismissKnownOverlays;
+
+const state = {
+  buttons: [
+    { name: 'Dismiss', visible: true },
+    { name: 'Close', visible: true },
+  ],
+  clicks: [],
+};
+
+function buttonAt(index) {
+  return {
+    async isVisible() {
+      return Boolean(state.buttons[index]?.visible);
+    },
+    async dispatchEvent(type) {
+      if (type !== 'click') {
+        throw new Error(`unexpected event: ${type}`);
+      }
+      const button = state.buttons[index];
+      if (!button) {
+        throw new Error(`missing button at dynamic index ${index}`);
+      }
+      state.clicks.push(button.name);
+      state.buttons.splice(index, 1);
+    },
+    async click() {
+      const button = state.buttons[index];
+      if (!button) {
+        throw new Error(`missing button at dynamic index ${index}`);
+      }
+      state.clicks.push(button.name);
+      state.buttons.splice(index, 1);
+    },
+  };
+}
+
+const page = {
+  getByRole(role, options) {
+    if (role !== 'button') {
+      throw new Error(`unexpected role: ${role}`);
+    }
+    const matcher = options?.name;
+    const matchingIndexes = () => state.buttons
+      .map((button, index) => ({ button, index }))
+      .filter(({ button }) => matcher.test(button.name))
+      .map(({ index }) => index);
+    return {
+      async count() {
+        return matchingIndexes().length;
+      },
+      nth(queryIndex) {
+        return buttonAt(matchingIndexes()[queryIndex]);
+      },
+    };
+  },
+};
+
+await dismissKnownOverlays(page);
+
+if (state.buttons.length !== 0) {
+  console.error(`[repro] FAIL: ${state.buttons.length} dismissible overlay button(s) remained after dismissKnownOverlays: ${state.buttons.map((button) => button.name).join(', ')}.`);
+  process.exit(1);
+}
+
+if (state.clicks.join(',') !== 'Dismiss,Close') {
+  console.error(`[repro] FAIL: expected dismiss order Dismiss,Close; saw ${state.clicks.join(',') || '(none)'}.`);
+  process.exit(1);
+}
+
+console.log('[repro] PASS: dismissKnownOverlays re-queries dismiss buttons until none remain.');
+NODE


### PR DESCRIPTION
## Summary

The graph drag performance e2e still timed out opening Plan graph.

Startup overlays can sit above the sidebar even after a force click.

A large seeded graph also needs a longer settle window after navigation.

This dismisses known overlays, uses dispatched clicks, and waits longer for Plan graph chrome.

## Review Claim

Approve hardening Plan graph navigation in the graph-drag Playwright proof against startup overlays.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. No product runtime code changes.

## Slice Rationale

Isolates navigation flake hardening from hitch/autofix behavior fixes.

## Non-goals

Does not loosen drag FPS/frame-gap budgets or change React Flow product code.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] CI `playwright / 3-of-7` reaches the drag measurement phase for `ui-graph-drag-performance.spec.ts`
- [ ] `rg -n "dispatchEvent|dismissKnownOverlays|30_000" packages/app/e2e/ui-graph-drag-performance.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test setup for the Plan graph view.
  * Added more reliable handling of dismissible overlays and sidebar navigation.
  * Increased the wait time for workflow content to appear, improving test stability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->