### PR TITLE
[Slack Repo Binding](4) Configure default repo fixtures for surface tests

### DIFF
--- a/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
@@ -84,6 +84,7 @@ function config(repo: ConversationRepository, extra: Partial<ConstructorParamete
     appToken: 'xapp-proof',
     signingSecret: 'proof',
     channelId: 'C_DEFAULT',
+    defaultRepoUrl: 'https://github.com/example/repo.git',
     lobbyChannelId: 'C_LOBBY',
     conversationRepo: repo,
     enableImmediateAck: false,

--- a/packages/surfaces/src/__tests__/slack-surface-artifact-upload.integration.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-artifact-upload.integration.test.ts
@@ -95,6 +95,7 @@ describe('SlackSurface artifact upload', () => {
     mockSendMessage.mockReset();
     workingDir = mkdtempSync(join(tmpdir(), 'slack-artifact-'));
     surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/repo.git',
       botToken: 'xoxb-test',
       appToken: 'xapp-test',
       signingSecret: 'test-secret',

--- a/packages/surfaces/src/__tests__/slack-surface-heartbeat.integration.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-heartbeat.integration.test.ts
@@ -117,6 +117,7 @@ describe('SlackSurface Heartbeat - Integration Tests', () => {
 
   it('sends heartbeat messages at configured interval during processing', async () => {
     surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/repo.git',
       botToken: 'xoxb-test',
       appToken: 'xapp-test',
       signingSecret: 'test-secret',
@@ -150,6 +151,7 @@ describe('SlackSurface Heartbeat - Integration Tests', () => {
 
   it('clears heartbeat timer after successful response', async () => {
     surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/repo.git',
       botToken: 'xoxb-test',
       appToken: 'xapp-test',
       signingSecret: 'test-secret',
@@ -184,6 +186,7 @@ describe('SlackSurface Heartbeat - Integration Tests', () => {
 
   it('clears heartbeat timer on error', async () => {
     surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/repo.git',
       botToken: 'xoxb-test',
       appToken: 'xapp-test',
       signingSecret: 'test-secret',
@@ -216,6 +219,7 @@ describe('SlackSurface Heartbeat - Integration Tests', () => {
 
   it('does not send heartbeats when interval is 0', async () => {
     surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/repo.git',
       botToken: 'xoxb-test',
       appToken: 'xapp-test',
       signingSecret: 'test-secret',
@@ -236,6 +240,7 @@ describe('SlackSurface Heartbeat - Integration Tests', () => {
 
   it('does not send heartbeats when using default (120s) and response is fast', async () => {
     surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/repo.git',
       botToken: 'xoxb-test',
       appToken: 'xapp-test',
       signingSecret: 'test-secret',

--- a/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
@@ -143,6 +143,7 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
     it('sends immediate ack, processes request, then replaces ack with actual response', async () => {
       // Setup: Create surface with immediate ack enabled (default)
       surface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -202,6 +203,7 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
 
     it('handles the explicit plan submission flow correctly', async () => {
       surface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -250,6 +252,7 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
 
     it('clears a leftover Processing ack when plan: is empty', async () => {
       surface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -281,6 +284,7 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
 
     it('clears a leftover Processing ack when the planner throws', async () => {
       surface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -313,6 +317,7 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
   describe('Configuration Options', () => {
     it('disables immediate ack when enableImmediateAck is false', async () => {
       surface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -360,6 +365,7 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
       const customMessage = 'Hold on, thinking...';
 
       surface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -401,6 +407,7 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
   describe('Typing Indicator Integration', () => {
     it('adds reaction before processing, removes after response', async () => {
       surface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -463,6 +470,7 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
 
     it('does not add reactions when useTypingIndicator is false', async () => {
       surface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -505,6 +513,7 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
 
     it('removes reaction even when message processing fails', async () => {
       surface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -551,6 +560,7 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
   describe('Edge Cases and Error Handling', () => {
     it('handles ack posting failure gracefully', async () => {
       surface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -600,6 +610,7 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
 
     it('falls back to new message when chat.update fails (msg_too_long)', async () => {
       surface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -658,6 +669,7 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
 
     it('maintains correct message sequence in threaded conversation', async () => {
       surface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',

--- a/packages/surfaces/src/__tests__/slack-surface.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface.test.ts
@@ -70,6 +70,7 @@ describe('SlackSurface', () => {
   beforeEach(() => {
     receivedCommands = [];
     surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/repo.git',
       botToken: 'xoxb-test',
       appToken: 'xapp-test',
       signingSecret: 'test-secret',
@@ -114,6 +115,7 @@ describe('SlackSurface', () => {
     it('logs receipt and route for every app mention before replying', async () => {
       const log = vi.fn();
       surface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -155,6 +157,7 @@ describe('SlackSurface', () => {
         delete: vi.fn(),
       };
       return new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -268,6 +271,7 @@ describe('SlackSurface', () => {
         delete: vi.fn(),
       };
       const cardSurface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 's',
@@ -400,6 +404,7 @@ describe('SlackSurface', () => {
   describe('conversation admin commands', () => {
     it('denies non-admin users', async () => {
       const adminSurface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -431,6 +436,7 @@ describe('SlackSurface', () => {
       };
 
       const adminSurface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -456,6 +462,7 @@ describe('SlackSurface', () => {
 
     it('returns error when persistence is not configured', async () => {
       const adminSurface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -487,6 +494,7 @@ describe('SlackSurface', () => {
       };
 
       const adminSurface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -519,6 +527,7 @@ describe('SlackSurface', () => {
       };
 
       const adminSurface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -553,6 +562,7 @@ describe('SlackSurface', () => {
       mockDraftedPlan = null;
 
       surfaceWithApi = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -633,6 +643,7 @@ describe('SlackSurface', () => {
       });
 
       const surfaceNoAck = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -665,6 +676,7 @@ describe('SlackSurface', () => {
   describe('typing indicator', () => {
     it('adds and removes reaction when useTypingIndicator is enabled', async () => {
       const surfaceWithTyping = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -709,6 +721,7 @@ describe('SlackSurface', () => {
 
     it('does not add reaction when useTypingIndicator is false', async () => {
       const surfaceNoTyping = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -741,6 +754,7 @@ describe('SlackSurface', () => {
   describe('planning config threading', () => {
     it('accepts planningTimeoutSeconds and planningHeartbeatIntervalSeconds config', () => {
       const configuredSurface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -758,6 +772,7 @@ describe('SlackSurface', () => {
       MockedPlanConversation.mockClear();
 
       const multiRepoSurface = new SlackSurface({
+        defaultRepoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',
@@ -789,6 +804,7 @@ describe('SlackSurface', () => {
       MockedPlanConversation.mockClear();
 
       const multiRepoSurface = new SlackSurface({
+        defaultRepoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
         signingSecret: 'test-secret',

--- a/packages/surfaces/src/__tests__/slack-thread-isolation.test.ts
+++ b/packages/surfaces/src/__tests__/slack-thread-isolation.test.ts
@@ -118,6 +118,7 @@ describe('Slack thread isolation', () => {
     mockPlanConversationCtor.mockClear();
 
     surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/repo.git',
       botToken: 'xoxb-test',
       appToken: 'xapp-test',
       signingSecret: 'test-secret',
@@ -452,6 +453,7 @@ describe('Slack conversation recovery with persistence', () => {
     ]);
 
     surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/repo.git',
       botToken: 'xoxb-test',
       appToken: 'xapp-test',
       signingSecret: 'test-secret',
@@ -479,6 +481,7 @@ describe('Slack conversation recovery with persistence', () => {
     ], { name: 'Plan', tasks: [{ id: 't1', description: 'Test', dependencies: [] }] } as any, true);
 
     surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/repo.git',
       botToken: 'xoxb-test',
       appToken: 'xapp-test',
       signingSecret: 'test-secret',
@@ -497,6 +500,7 @@ describe('Slack conversation recovery with persistence', () => {
 
   it('skips recovery when no conversationRepo is configured', async () => {
     surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/repo.git',
       botToken: 'xoxb-test',
       appToken: 'xapp-test',
       signingSecret: 'test-secret',
@@ -519,6 +523,7 @@ describe('Slack conversation recovery with persistence', () => {
     ]);
 
     surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/repo.git',
       botToken: 'xoxb-test',
       appToken: 'xapp-test',
       signingSecret: 'test-secret',
@@ -551,6 +556,7 @@ describe('Slack conversation recovery with persistence', () => {
 
   it('stop clears in-memory conversations', async () => {
     surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/repo.git',
       botToken: 'xoxb-test',
       appToken: 'xapp-test',
       signingSecret: 'test-secret',
@@ -606,6 +612,7 @@ Want me to execute this?`;
     mockPlanConversationCtor.mockClear();
 
     surface = new SlackSurface({
+      defaultRepoUrl: 'https://github.com/example/repo.git',
       botToken: 'xoxb-test',
       appToken: 'xapp-test',
       signingSecret: 'test-secret',


### PR DESCRIPTION
## Summary

Lobby Slack planning now requires a repository before a session starts.

Several surface Vitest fixtures never set defaultRepoUrl after that gate landed.

Those suites never created a PlanConversation and cascaded into dozens of failures.

This adds the same defaultRepoUrl fixture pattern already used by the workflows tests.

## Review Claim

Approve adding defaultRepoUrl to the remaining Slack surface Vitest fixtures so lobby planning sessions can start.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. No product runtime code changes.

## Slice Rationale

Isolates the Slack fixture migration from Playwright and e2e-proof timeout fixes.

## Non-goals

Does not change the missing-repo product message or repo-binding rules.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Focused surfaces Vitest: 6 files / 99 tests passed
- [ ] CI `required-fast / Vitest Workspace` passes Slack surface suites

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
