### PR TITLE
[Playwright Green](6) Harden graph-drag Plan graph navigation

### DIFF
--- a/packages/app/e2e/ui-graph-drag-performance.spec.ts
+++ b/packages/app/e2e/ui-graph-drag-performance.spec.ts
@@ -73,6 +73,23 @@ function buildPlan(index: number) {
   };
 }
 
+async function dismissKnownOverlays(page: Page): Promise<void> {
+  // Re-query each iteration: dismissing one overlay shifts the remaining buttons.
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const button = page.getByRole('button', { name: /^(Dismiss|Close|Skip for now|Not now)$/i }).first();
+    if (!(await button.isVisible().catch(() => false))) {
+      return;
+    }
+    await button.dispatchEvent('click', { bubbles: true, cancelable: true });
+    await page.waitForTimeout(100);
+  }
+}
+
+async function openPlanGraph(page: Page): Promise<void> {
+  await dismissKnownOverlays(page);
+  await page.getByTestId('sidebar-planning').dispatchEvent('click', { bubbles: true, cancelable: true });
+  await page.getByRole('heading', { name: 'Plan graph' }).waitFor({ state: 'visible', timeout: 30_000 });
+}
 
 async function seedLargeWorkflowGraph(page: Page): Promise<void> {
   const plans = Array.from({ length: WORKFLOW_COUNT }, (_, index) => yamlStringify(buildPlan(index)));
@@ -86,14 +103,10 @@ async function seedLargeWorkflowGraph(page: Page): Promise<void> {
     WORKFLOW_COUNT,
     { timeout: 30_000 },
   );
-  const dismiss = page.getByRole('button', { name: 'Dismiss' });
-  if (await dismiss.isVisible().catch(() => false)) {
-    await dismiss.click();
-  }
-  await page.getByTestId('sidebar-planning').click({ force: true });
-  await page.getByRole('heading', { name: 'Plan graph' }).waitFor({ state: 'visible', timeout: 15_000 });
-  await page.getByRole('button', { name: 'Refresh' }).click();
-  await page.locator('[data-testid^="workflow-node-"]:visible').first().waitFor({ state: 'visible', timeout: 15_000 });
+  await openPlanGraph(page);
+  await dismissKnownOverlays(page);
+  await page.getByRole('button', { name: 'Refresh' }).dispatchEvent('click', { bubbles: true, cancelable: true });
+  await page.locator('[data-testid^="workflow-node-"]:visible').first().waitFor({ state: 'visible', timeout: 30_000 });
 }
 
 async function recordDragPerformance(


### PR DESCRIPTION
## Summary

The graph drag performance e2e still timed out opening Plan graph.

Startup overlays can sit above the sidebar even after a force click.

A large seeded graph also needs a longer settle window after navigation.

This dismisses known overlays by re-querying each iteration, uses dispatched clicks, and waits longer for Plan graph chrome.

## Review Claim

Approve hardening Plan graph navigation in the graph-drag Playwright proof against startup overlays.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. No product runtime code changes.

## Slice Rationale

Isolates navigation flake hardening from hitch/autofix behavior fixes.

## Non-goals

Does not loosen drag FPS/frame-gap budgets or change React Flow product code.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] CI `playwright / 3-of-7` reaches the drag measurement phase for `ui-graph-drag-performance.spec.ts`
- [ ] `rg -n "dispatchEvent|dismissKnownOverlays|30_000" packages/app/e2e/ui-graph-drag-performance.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
