### PR TITLE
[Slack Stacked Workflows](1) Default Slack planning to stacks

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -974,10 +974,9 @@ describe('PlanConversation prompt construction', () => {
     expect(prompt).toContain('"automatic"');
   });
 
-  it('buildCursorPrompt can prefer stacked workflows', () => {
+  it('buildCursorPrompt prefers stacked workflows by default', () => {
     const conv = new PlanConversation({
       repoUrl: 'git@github.com:test/repo.git',
-      preferStackedWorkflows: true,
     });
     (conv as any).messages.push({ role: 'user', content: 'Build the Workers Surface' });
     const prompt = conv.buildCursorPrompt();
@@ -986,6 +985,15 @@ describe('PlanConversation prompt construction', () => {
     expect(prompt).toContain('workflows:');
     expect(prompt).toContain('Each downstream workflow is based on the previous workflow');
     expect(prompt).toContain('Build the Workers Surface');
+  });
+
+  it('buildCursorPrompt can opt out of stacked workflows', () => {
+    const conv = new PlanConversation({
+      preferStackedWorkflows: false,
+    });
+    (conv as any).messages.push({ role: 'user', content: 'Implement a small feature' });
+
+    expect(conv.buildCursorPrompt()).not.toContain('prefer a workflow stack');
   });
 
   it('agent mode refuses Invoker YAML and redirects within the same thread', () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -254,7 +254,7 @@ export interface BuildPlanSystemPromptOptions {
 function buildDirectPlanSystemPrompt(
   defaultBranch: string,
   repoUrl?: string,
-  preferStackedWorkflows = false,
+  preferStackedWorkflows = true,
   planFilePath?: string,
 ): string {
   const repoUrlLine = repoUrl
@@ -338,7 +338,7 @@ function buildConversationalPlanSystemPrompt(
 The user has explicitly approved drafting. You may now produce the YAML task plan.
 
 Use the authorized drafting contract below:
-${buildDirectPlanSystemPrompt(defaultBranch, repoUrl, options.preferStackedWorkflows ?? false, options.planFilePath)}`
+${buildDirectPlanSystemPrompt(defaultBranch, repoUrl, options.preferStackedWorkflows ?? true, options.planFilePath)}`
     : `
 Drafting is not authorized yet. Do NOT output a \`\`\`yaml code block, do NOT write a draft plan file, and do NOT tell the user the plan can be executed.
 
@@ -376,7 +376,7 @@ export function buildPlanSystemPrompt(
   return buildDirectPlanSystemPrompt(
     defaultBranch,
     repoUrl,
-    resolvedOptions.preferStackedWorkflows ?? false,
+    resolvedOptions.preferStackedWorkflows ?? true,
     resolvedOptions.planFilePath,
   );
 }
@@ -449,7 +449,7 @@ export class PlanConversation {
     this.defaultBranch = config.defaultBranch;
     this.repoUrl = config.repoUrl;
     this.experimentalPlanner = config.experimentalPlanner;
-    this.preferStackedWorkflows = config.preferStackedWorkflows;
+    this.preferStackedWorkflows = config.preferStackedWorkflows ?? true;
     this.conversationalPlanning = config.conversationalPlanning ?? false;
     this.onRawPlannerOutput = config.onRawPlannerOutput;
     this.plannerRetryLimit = Math.max(0, config.plannerRetryLimit ?? DEFAULT_PLANNER_RETRY_LIMIT);


### PR DESCRIPTION
## Summary

Slack plan prompts now default to stacked workflows, matching the in-app planner.

Explicitly disabling the preference still omits stack guidance.

## Review Claim

Slack planning sessions guide reviewable multi-slice work into stacked workflows unless a caller explicitly opts out.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The opt-out remains supported, and focused tests cover both the default and explicit false behavior.

## Slice Rationale

The prompt default and its regression coverage form one behavior change.

## Non-goals

This does not alter plan YAML validation, workflow execution, or in-app planner behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces test -- src/__tests__/plan-conversation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c11efb288`
- Post-revert steps: None
- Data migration? No

</details>
