### PR TITLE
[Headless Server Owner](6) Align GUI override argv unit expectation

### DIFF
--- a/packages/contracts/src/__tests__/headless-owner-launch.test.ts
+++ b/packages/contracts/src/__tests__/headless-owner-launch.test.ts
@@ -35,7 +35,7 @@ describe('resolveHeadlessOwnerLaunchSpec', () => {
       existsSync: () => false,
     })).toEqual({
       command: '/usr/local/bin/custom-owner',
-      args: ['--flag'],
+      args: ['--flag', '--headless', 'owner-serve'],
     });
   });
 


### PR DESCRIPTION
## Summary

A GUI override argv unit expectation went stale.

Required-fast Vitest failed on that one assertion after recent owner-serve work.

This updates the expected argv in the unit suite to the current shape.

## Review Claim

Approve updating the stale GUI override argv unit expectation.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. No product runtime code changes.

## Slice Rationale

Isolates the stale unit expectation from Slack and Playwright green fixes.

## Non-goals

Does not change owner-serve launch product behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/contracts exec vitest run src/__tests__/headless-owner-launch.test.ts`
- [ ] CI `required-fast / Vitest Workspace` passes

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
