### PR TITLE
fix(ui): mount queue view on workers surface

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3739,6 +3739,24 @@ export function App() {
   );
 
   const renderWorkersDetail = (): JSX.Element => {
+    if (viewMode === 'queue') {
+      return (
+        <QueueView
+          tasks={tasks}
+          workflows={workflows}
+          queueStatus={queueStatus}
+          workerStatus={workerStatus}
+          readOnly={runtimeStatus?.readOnly === true}
+          onStartWorker={handleStartWorker}
+          onStopWorker={handleStopWorker}
+          onTaskClick={handleTaskClick}
+          selectedTaskId={selectedTaskId}
+          selectedWorkerKind={selectedWorkerKind}
+          onSelectWorker={setSelectedWorkerKind}
+        />
+      );
+    }
+
     if (!selectedWorker) {
       return renderBrowserEmptyState('No workers found', 'Invoker has not returned any worker registry rows yet.');
     }


### PR DESCRIPTION
## Summary

Queue chips switch into queue mode on the workers surface.

The workers detail pane still rendered registry detail only.

QueueView never appeared after the chip click.

Playwright could not find the Worker Actions heading.

This mounts QueueView in the workers detail pane whenever queue mode is active.

## Review Claim

Approve mounting QueueView in the workers detail pane for queue mode so queue chips open the in-flight and queued sections.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only changes which workers-surface detail pane mounts in queue mode. No persistence or orchestration changes.

## Slice Rationale

Isolates the missing QueueView mount from hitch proof budget adjustments.

## Non-goals

Does not change queue chip copy, concurrency accounting, or hitch budgets.

## Visual Proof

Queue capacity chips before opening the pane:

![chips before open](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260724-e3c2bc/queue-chips-before-click.png)

After chip click, QueueView shows Worker Actions with in-flight and queued sections:

![QueueView after click](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260724-e3c2bc/queueview-worker-actions-after-click.png)

Animated chip click to QueueView:

![chip to QueueView](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260724-e3c2bc/queue-chip-before-after.gif)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app run test:e2e -- e2e/queue-running-vs-queued.spec.ts`
- [ ] CI `playwright / 3-of-7` passes `queue-running-vs-queued.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a queue view option to the worker details panel.
  * Queue view displays task and workflow information along with queue and worker status.
  * Preserves available worker controls and task selection interactions in queue view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->