### PR TITLE
[Slack Repo Binding](5) Configure defaultRepoUrl for host integration test

### DIFF
--- a/packages/slack-manager/src/__tests__/slack-host-integration.test.ts
+++ b/packages/slack-manager/src/__tests__/slack-host-integration.test.ts
@@ -135,6 +135,7 @@ describe('Slack manager host integration', () => {
       lobbyChannelId: 'C_LOBBY',
       conversationRepo: conversations,
       workflowChannelRepo: workflowChannels,
+      defaultRepoUrl: 'https://github.com/example/repo.git',
       enableImmediateAck: false,
       planningHeartbeatIntervalSeconds: 0,
       log: silentLog,


### PR DESCRIPTION
## Summary

Lobby Slack planning now requires a repository before a session starts.

The slack-manager host integration Vitest never set `defaultRepoUrl` after that gate landed.

Without it, the lobby plan mention exits early and never reaches `client.run`.

This adds the same fixture pattern already used by the Slack surface tests.

## Review Claim

Approve adding `defaultRepoUrl` to the slack-manager host integration Vitest fixture so lobby plan submission can reach `client.run`.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. No product runtime code changes.

## Slice Rationale

Isolates the missed slack-manager fixture from the earlier surfaces fixture migration.

## Non-goals

Does not change lobby repo-binding product rules or stacked planning defaults.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/slack-manager && pnpm exec vitest run src/__tests__/slack-host-integration.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
