### PR TITLE
Raise autofix-worker-ui awaiting_approval wait for bare-retry path.

### DIFF
--- a/packages/app/e2e/autofix-worker-ui.spec.ts
+++ b/packages/app/e2e/autofix-worker-ui.spec.ts
@@ -27,7 +27,7 @@ test('worker-triggered autofix reaches approval UI with mocked Claude', async ({
   await loadPlan(page, PLAN);
   await startPlan(page);
   await waitForTaskStatus(page, 'task-pass', 'completed');
-  await waitForTaskStatus(page, 'task-fail', 'awaiting_approval', 30000);
+  await waitForTaskStatus(page, 'task-fail', 'awaiting_approval', 120_000);
 
   const scopedTaskId = await resolveTaskId(page, 'task-fail');
   await page.waitForFunction(


### PR DESCRIPTION
## Summary

Worker autofix now bare-restarts once before escalating to the AI fix agent.

The autofix UI Playwright proof still waited only 30s for awaiting_approval.

CI often needs the full two-phase sequence under the mocked Claude fixture.

Sibling manual Fix with Claude specs already pass on the same shard.

This raises the worker-path wait to 120s without changing product behavior.

## Review Claim

Approve raising the autofix-worker-ui awaiting_approval wait so the bare-restart-then-escalate worker sequence can finish on CI.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. No product runtime code changes.

## Slice Rationale

Isolates the autofix wait budget from overload query-recover hardening.

## Non-goals

Does not change autoFixRetries, bare-restart keying, or mocked Claude behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] CI `playwright / 4-of-7` passes `autofix-worker-ui.spec.ts`
- [ ] `rg -n "120_000" packages/app/e2e/autofix-worker-ui.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
