### PR TITLE
Align slack-manager owner override argv unit expectation

### DIFF
--- a/packages/slack-manager/src/__tests__/invoker-launcher.test.ts
+++ b/packages/slack-manager/src/__tests__/invoker-launcher.test.ts
@@ -15,7 +15,7 @@ describe('resolveOwnerLaunch', () => {
     });
     expect(spec).toEqual({
       command: '/opt/invoker-owner',
-      args: ['--flag'],
+      args: ['--flag', '--headless', 'owner-serve'],
     });
   });
 


### PR DESCRIPTION
## Summary

A Slack manager owner override argv unit expectation went stale.

Required-fast Vitest failed on that one assertion after recent owner-serve work.

This updates the expected argv in the unit suite to the current shape.

## Review Claim

Approve updating the stale owner override argv unit expectation.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. No product runtime code changes.

## Slice Rationale

Isolates the stale unit expectation from other green work.

## Non-goals

Does not change owner-serve launch product behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/slack-manager exec vitest run src/__tests__/invoker-launcher.test.ts`
- [ ] CI `required-fast / Vitest Workspace` passes

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated launch behavior coverage to verify that configured GUI commands include headless owner-serving options alongside existing arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->