### PR TITLE
Raise autofix-worker-ui Playwright test timeout for bare-restart path.

### DIFF
--- a/packages/app/e2e/autofix-worker-ui.spec.ts
+++ b/packages/app/e2e/autofix-worker-ui.spec.ts
@@ -21,6 +21,8 @@ const PLAN = {
 };
 
 test('worker-triggered autofix reaches approval UI with mocked Claude', async ({ page }) => {
+  // Bare-restart then escalate can exceed the default 120s Playwright budget on CI.
+  test.setTimeout(240_000);
   await page.evaluate(async () => {
     await window.invoker.startWorker('autofix');
   });


### PR DESCRIPTION
## Summary

Worker autofix can take the full 120s awaiting_approval wait on CI.

The Playwright default test budget is also 120s.

Setup plus the wait then closes the Electron app mid-poll.

This raises the test timeout to 240s for that case only.

## Review Claim

Approve raising the autofix-worker-ui Playwright test timeout so the bare-restart worker path can finish under the existing 120s status wait.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. No product runtime code changes.

## Slice Rationale

Isolates the Playwright test timeout from hitch sampling and launcher unit expectation fixes.

## Non-goals

Does not change autoFixRetries or the awaiting_approval status wait itself.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] CI `playwright / 4-of-7` passes `autofix-worker-ui.spec.ts`
- [ ] `rg -n "240_000" packages/app/e2e/autofix-worker-ui.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
