### PR TITLE
Promote on-disk plan drafts when drafting is authorized

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { PlanConversation } from '../../../surfaces/src/index.ts';
 import {
   createInAppPlanningChatSessions,
@@ -353,6 +356,63 @@ describe('planning chat', () => {
       loadGeneratedPlan,
     })).resolves.toMatchObject({ ok: false });
     expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
+  it('promotes an existing on-disk draft when the user authorizes drafting', async () => {
+    const workingDir = mkdtempSync(join(tmpdir(), 'in-app-draft-'));
+    try {
+      const sessions = createInAppPlanningChatSessions();
+      const created = await createPlanningChatSession({}, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        workingDir,
+      });
+      if (!created.ok) throw new Error(created.error);
+      const session = sessions.get(created.session.id);
+      if (!session) throw new Error('expected session in map');
+
+      const draftPath = session.conversation.planDraftFilePath();
+      if (!draftPath) throw new Error('expected draft path');
+      mkdirSync(dirname(draftPath), { recursive: true });
+      writeFileSync(draftPath, VALID_PLAN_TEXT, 'utf8');
+
+      vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(
+        `Plan written.${PLAN_SUBMIT_HINT}`,
+      );
+
+      const result = await sendPlanningChatMessage({
+        sessionId: session.id,
+        message: 'draft it',
+        presetKey: 'codex',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        workingDir,
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        draftPlanAvailable: true,
+        draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+      });
+      expect(sessions.get(session.id)?.draftPlanText).toContain('name: Mock Plan');
+
+      const loadGeneratedPlan = vi.fn().mockResolvedValue({
+        planName: 'Mock Plan',
+        workflowId: 'wf-1',
+      } satisfies LoadedGeneratedPlan);
+      await expect(submitPlanningChatDraft({ sessionId: session.id }, {
+        sessions,
+        loadGeneratedPlan,
+      })).resolves.toMatchObject({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
+      expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+    }
   });
 
   it('accepts short confirmation only after the assistant asks whether to draft', async () => {

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -539,6 +539,9 @@ export async function sendPlanningChatMessage(
       try {
         const { extractYamlPlan, summarizePlanText } = await loadPlannerSurfaces();
         const formattedMessage = formatConversationalPlanningMessage(message);
+        const priorDraftText = draftingAuthorized
+          ? getConversationDraftedPlan(activeSession.conversation)
+          : null;
         const reply = deps.plannerReplyOverride
           ? await deps.plannerReplyOverride(formattedMessage)
           : await activeSession.conversation.sendMessage(formattedMessage);
@@ -549,7 +552,9 @@ export async function sendPlanningChatMessage(
           ? []
           : activeSession.conversation.lastTurnReasoning;
         const reasoning = reasoningParts.length > 0 ? reasoningParts.join('\n\n') : undefined;
-        const candidatePlanText = getConversationDraftedPlan(activeSession.conversation) ?? extractYamlPlan(reply);
+        const candidatePlanText = getConversationDraftedPlan(activeSession.conversation)
+          ?? extractYamlPlan(reply)
+          ?? priorDraftText;
         if (!candidatePlanText || !draftingAuthorized) {
           activeSession.status = hasDraftPlan(activeSession)
             ? 'draft_ready'


### PR DESCRIPTION
## Summary

In-app planning could persist a complete YAML draft to disk before the user said draft it.

Saying draft it then wiped that file, so the approved session draft stayed empty even though a plan already existed.

This change keeps the prior on-disk draft across an authorize turn and promotes it into the approved session draft.

Unauthorized drafts stay non-approved until the user authorizes drafting.

## Review Claim

Authorizing drafting promotes an already-written on-disk plan draft into the session so the approved draft becomes available.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Unauthorized planner YAML still cannot become the approved session draft; only an explicit draft authorization turn can promote a prior file draft.

## Slice Rationale

One planning-session behavior change with its focused regression coverage; no UI or Slack path edits are required for this claim.

## Non-goals

- Changing Slack planning conversation behavior
- Approving drafts without drafting authorization
- Changing when the planner is allowed to persist draft files

## Architecture

### Before

```mermaid
graph TD
    A["Planner persists draft file early"] --> B["User says draft it"]
    B --> C["sendMessage deletes draft file"]
    C --> D["Summary-only reply"]
    D --> E["draftPlanText stays empty"]
    E --> F["Approved draft unavailable"]
```

### After

```mermaid
graph TD
    A["Planner persists draft file early"] --> B["User says draft it"]
    B --> C["Capture prior draft text"]
    C --> D["sendMessage may delete file"]
    D --> E["Promote prior draft when authorized"]
    E --> F["Approved draft available"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/in-app-planner.test.ts`
- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/in-app-planner.test.ts -t 'promotes an existing on-disk draft'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert HEAD`
- Post-revert steps: None
- Data migration? No

</details>
