### PR TITLE
[Autofix Worker Wake](1) Scan failed tasks after draining wake hints

### DIFF
--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -370,7 +370,7 @@ describe('auto-fix recovery candidate validation', () => {
     expect(harness.submit).toHaveBeenCalledTimes(1);
   });
 
-  it('skips stale generation wakeups without submitting a command', async () => {
+  it('still scans and submits when a wake hint is stale after bare-retry generation bump', async () => {
     const task = makeTask({ execution: { error: 'boom', generation: 2, selectedAttemptId: 'attempt-2' } });
     const wakeup = {
       eventKey: 'event-old',
@@ -393,15 +393,13 @@ describe('auto-fix recovery candidate validation', () => {
       tickNumber: 1,
     });
 
-    expect(harness.submit).not.toHaveBeenCalled();
-    expect(harness.logEvent).toHaveBeenCalledWith(
-      'wf-1/task-1',
-      'debug.auto-fix',
-      expect.objectContaining({
-        phase: 'worker-autofix-skip',
-        reason: 'stale-generation',
-        latestGeneration: 2,
-      }),
+    // Stale wake hints must not suppress the authoritative failed-task scan.
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    expect(harness.submit).toHaveBeenCalledWith(
+      'wf-1',
+      'normal',
+      'invoker:restart-task',
+      ['wf-1/task-1'],
     );
   });
 });

--- a/packages/execution-engine/src/__tests__/auto-fix-bare-retry.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-bare-retry.test.ts
@@ -213,6 +213,48 @@ describe('AutoFixWorker attempt-0 bare retry', () => {
     expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:fix-with-agent');
   });
 
+  it('escalates on wake even when drained hints only carry the pre-retry generation', async () => {
+    const harness = makeHarness();
+    const tick = createAutoFixRecoveryTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 2,
+      getAutoFixAgent: () => 'codex',
+      drainWakeupHints: () => [{
+        eventKey: 'stale-failure',
+        eventKind: 'task.failed',
+        workflowId: 'wf-1',
+        taskId: 'wf-1/build',
+        taskStateVersion: 7,
+        generation: 2,
+        attemptId: 'attempt-1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        reason: 'task_failure',
+        authoritative: false,
+      }],
+    });
+
+    await tick({ reason: 'poll' } as never);
+    expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:restart-task');
+    harness.submit.mockClear();
+
+    harness.tasks.set('wf-1/build', makeFailedTask({
+      execution: {
+        generation: 3,
+        selectedAttemptId: 'attempt-2',
+        branch: 'feature/build',
+        error: 'pnpm build failed with exit code 1',
+      },
+      taskStateVersion: 8,
+    }));
+
+    await tick({ reason: 'wake' } as never);
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:fix-with-agent');
+  });
+
   it('records a recovery.worker.submit audit event for the bare retry', async () => {
     const harness = makeHarness();
     const tick = createAutoFixRecoveryTick({

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -211,30 +211,6 @@ function isRuntimeAutoFixEligibleTask(task: TaskState, options: AutoFixRecoveryP
   return true;
 }
 
-function candidateFromWakeup(wakeup: RecoveryWorkerWakeupHint): AutoFixRecoveryCandidate | undefined {
-  if (!wakeup.taskId || wakeup.taskStateVersion == null) return undefined;
-  return {
-    taskId: wakeup.taskId,
-    workflowId: wakeup.workflowId,
-    generation: wakeup.generation,
-    taskStateVersion: wakeup.taskStateVersion,
-    attemptId: wakeup.attemptId,
-    source: 'wakeup',
-  };
-}
-
-function dedupeCandidates(candidates: AutoFixRecoveryCandidate[]): AutoFixRecoveryCandidate[] {
-  const seen = new Set<string>();
-  const deduped: AutoFixRecoveryCandidate[] = [];
-  for (const candidate of candidates) {
-    const key = `${candidate.taskId}:${candidate.generation}:${candidate.taskStateVersion}:${candidate.attemptId ?? ''}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    deduped.push(candidate);
-  }
-  return deduped;
-}
-
 function loadLatestTask(
   candidate: AutoFixRecoveryCandidate,
   options: AutoFixRecoveryPolicyOptions,
@@ -488,13 +464,10 @@ export function collectValidatedAutoFixRecoveryCandidates(
 export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions): WorkerTick {
   return async (ctx) => {
     ctx.signal?.throwIfAborted();
-    const wakeups = options.drainWakeupHints?.() ?? [];
-    const wakeupCandidates = wakeups.map(candidateFromWakeup).filter((c): c is AutoFixRecoveryCandidate => Boolean(c));
-    const candidates = dedupeCandidates(
-      wakeupCandidates.length > 0 && ctx.reason === 'wake'
-        ? wakeupCandidates
-        : listAutoFixRecoveryScanCandidates(options),
-    );
+    // Drain wake hints (coalesce only). Discover work from a fresh scan —
+    // wake snapshots go stale across bare-retry generation bumps.
+    options.drainWakeupHints?.();
+    const candidates = listAutoFixRecoveryScanCandidates(options);
     const submittedThisTick = new Set<string>();
 
     for (const candidate of collectValidatedAutoFixRecoveryCandidates(options, candidates)) {


### PR DESCRIPTION
## Summary

Worker autofix wake ticks only trusted lifecycle snapshots.

After a bare restart bumped generation, those snapshots were outdated, so agent escalation waited for the 60s poll.

That missed the Playwright `awaiting_approval` window even after longer waits.

Wakeups now only coalesce; each tick loads current failed tasks from the store.

## Review Claim

Approve making autofix recovery ticks load failed tasks from the store after draining wake hints, so bare-restart escalation is not delayed by outdated wake snapshots.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Wake hints still drain so they cannot accumulate. Mutations still use the existing coordinator path, bare-restart keying, and durable attempt cap.

## Slice Rationale

One product wakeup/coalesce fix plus focused coverage for the outdated-wake failure mode. No e2e timeout weakening.

## Non-goals

- Does not change autoFixRetries defaults or bare-restart budget accounting
- Does not shorten the recovery poll interval
- Does not alter the manual fix-with-agent IPC path

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test --run src/__tests__/auto-fix-bare-restart.test.ts`
- [x] `pnpm --filter @invoker/app test --run src/__tests__/auto-fix-recovery.test.ts`
- [ ] CI playwright shard 4-of-7 runs `e2e/autofix-worker-ui.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic task recovery after retries.
  * Recovery now performs a fresh status check before restarting or escalating failed tasks, even when wake-up signals are outdated.
  * Fixed cases where stale wake-up information could prevent necessary recovery actions or cause incorrect retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->