### PR TITLE
Preserve draft continuity across planner turns

### DIFF
--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -90,18 +90,30 @@ describe('plan draft file - activation side', () => {
     expect(prompt).toContain('output the plan inside a ```yaml code block');
   });
 
-  it('clears a stale plan file before the turn so getDraftedPlan cannot return it', async () => {
+  it('keeps the last valid plan after a later turn clears its draft file', async () => {
     const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', plannerRetryLimit: 0 });
     const path = conversation.planDraftFilePath();
     if (!path) throw new Error('expected a plan draft path');
-    mkdirSync(join(workingDir, '.invoker', 'plan-drafts'), { recursive: true });
-    writeFileSync(path, 'name: Stale plan\ntasks: []', 'utf8');
 
-    // The planner replies with only a summary and does NOT write a new file.
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(
+      'Drafted the plan.\n\nReply `submit` to submit it.',
+      () => writeFileSync(path, VALID_PLAN_YAML, 'utf8'),
+    ));
+    await conversation.sendMessage('Draft it');
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the plan. Summary: one step.'));
+    await conversation.sendMessage('What does it do?');
+
+    expect(existsSync(path)).toBe(false);
+    expect(conversation.getDraftedPlan()).toBe(VALID_PLAN_YAML.trim());
+  });
+
+  it('does not expose a plan when a summary-only turn has no prior draft', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', plannerRetryLimit: 0 });
+
     mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the plan. Summary: one step.'));
     await conversation.sendMessage('Draft it');
 
-    expect(existsSync(path)).toBe(false);
     expect(conversation.getDraftedPlan()).toBeNull();
   });
 

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -24,6 +24,7 @@ import {
   looksLikeCompletionClaim,
   repoStateUnchanged,
 } from './agent-turn-verification.js';
+import { summarizePlanText } from './plan-summary.js';
 
 // ── Types ───────────────────────────────────────────────────
 
@@ -435,6 +436,7 @@ export class PlanConversation {
   private plannerRetryBaseDelayMs: number;
   private _initialized = false;
   private _lastTurnReasoning: string[] = [];
+  private lastKnownGoodPlanText: string | null = null;
 
   constructor(config: PlanConversationConfig) {
     this.cursorCommand = config.cursorCommand ?? 'agent';
@@ -540,6 +542,12 @@ export class PlanConversation {
     if (looksLikeCompletionClaim(message) && repoStateUnchanged(repoStateBefore, repoStateAfter)) {
       message = `${message}\n\n${buildUnverifiedNotice()}`;
     }
+    const fileDraft = this.readPlanDraftFile();
+    const inlineDraft = extractYamlPlan(message);
+    const nextDraft = fileDraft && summarizePlanText(fileDraft)
+      ? fileDraft
+      : inlineDraft;
+    if (nextDraft) this.lastKnownGoodPlanText = nextDraft;
     this._lastTurnReasoning = formatted.reasoning;
     this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: responseLen=${response.length}, messageLen=${message.length}, reasoningParts=${formatted.reasoning.length}, responsePreview="${message.slice(0, 500).replace(/\n/g, '\\n')}"`);
 
@@ -572,7 +580,7 @@ export class PlanConversation {
 
   /** Returns the last complete YAML plan drafted in this conversation, or null. */
   getDraftedPlan(): string | null {
-    return this.readPlanDraftFile() ?? this.extractLastPlanFromMessages();
+    return this.readPlanDraftFile() ?? this.extractLastPlanFromMessages() ?? this.lastKnownGoodPlanText;
   }
 
   // The planner writes the full YAML plan here so its chat reply can stay a
@@ -622,6 +630,7 @@ export class PlanConversation {
     this.messages = [];
     this._submittedPlanText = null;
     this._planSubmitted = false;
+    this.lastKnownGoodPlanText = null;
     if (this.conversationRepo && this.threadTs) {
       this.conversationRepo.deleteConversation(this.threadTs);
     }


### PR DESCRIPTION
## Summary

The planner resets its draft file before every turn.

A valid plan now remains available when a later turn only returns a summary.

## Review Claim

A plan produced in the current conversation survives later summary-only turns despite the required draft-file reset.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only a valid plan written during the current conversation is retained; an arbitrary stale file is still discarded at turn start.

## Slice Rationale

This shared conversation behavior must land before the in-app approval path can rely on it.

## Non-goals

- Persisting retained plans across process restart
- Changing the per-turn draft-file reset
- Changing authorization rules

## Architecture

### Before

```mermaid
graph TD
    turnStart["New turn"] --> resetFile["Reset draft file"]
    resetFile --> summaryReply["Summary-only reply"]
    summaryReply --> noPlan["No plan available"]
```

### After

```mermaid
graph TD
    validPlan["Valid plan from current conversation"] --> retainPlan["Retain in memory"]
    turnStart["New turn"] --> resetFile["Reset draft file"]
    resetFile --> summaryReply["Summary-only reply"]
    retainPlan --> availablePlan["Plan remains available"]
    summaryReply --> availablePlan
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm exec vitest run src/__tests__/plan-draft-file-activation.test.ts src/__tests__/plan-draft-file.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4da00f2cc`
- Post-revert steps: None
- Data migration? No

</details>
