### PR TITLE
Promote retained drafts after authorization

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { PlanConversation } from '../../../surfaces/src/index.ts';
 import {
   createInAppPlanningChatSessions,
@@ -349,6 +352,112 @@ describe('planning chat', () => {
     await expect(submitPlanningChatDraft({
       sessionId: result.sessionId,
     }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toMatchObject({ ok: false });
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
+  it('promotes a plan written before an intervening summary-only turn when the user authorizes drafting', async () => {
+    const workingDir = mkdtempSync(join(tmpdir(), 'in-app-draft-'));
+    try {
+      const sessions = createInAppPlanningChatSessions();
+      const created = await createPlanningChatSession({}, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        workingDir,
+      });
+      if (!created.ok) throw new Error(created.error);
+      const session = sessions.get(created.session.id);
+      if (!session) throw new Error('expected session in map');
+
+      const draftPath = session.conversation.planDraftFilePath();
+      if (!draftPath) throw new Error('expected draft path');
+      mkdirSync(dirname(draftPath), { recursive: true });
+
+      vi.spyOn(PlanConversation.prototype, 'spawnPlanner')
+        .mockImplementationOnce(async () => {
+          writeFileSync(draftPath, VALID_PLAN_TEXT, 'utf8');
+          return `Plan written.${PLAN_SUBMIT_HINT}`;
+        })
+        .mockResolvedValueOnce('Plan summary.')
+        .mockResolvedValueOnce('Plan summary.');
+
+      const draftedBeforeAuthorization = await sendPlanningChatMessage({
+        sessionId: session.id,
+        message: 'What would this plan do?',
+        presetKey: 'codex',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        workingDir,
+      });
+      expect(draftedBeforeAuthorization).toMatchObject({ ok: true, draftPlanAvailable: false });
+
+      await sendPlanningChatMessage({
+        sessionId: session.id,
+        message: 'Can you summarize it?',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        workingDir,
+      });
+
+      const result = await sendPlanningChatMessage({
+        sessionId: session.id,
+        message: 'draft it',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        workingDir,
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        draftPlanAvailable: true,
+        draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+      });
+      expect(sessions.get(session.id)?.draftPlanText).toContain('name: Mock Plan');
+
+      const loadGeneratedPlan = vi.fn().mockResolvedValue({
+        planName: 'Mock Plan',
+        workflowId: 'wf-1',
+      } satisfies LoadedGeneratedPlan);
+      await expect(submitPlanningChatDraft({ sessionId: session.id }, {
+        sessions,
+        loadGeneratedPlan,
+      })).resolves.toMatchObject({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
+      expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+    }
+  });
+
+  it('requires the planner to recreate a plan when no prior plan exists', async () => {
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue('Plan summary.');
+    const sessions = createInAppPlanningChatSessions();
+    const loadGeneratedPlan = vi.fn();
+
+    const result = await sendPlanningChatMessage({
+      message: 'draft it',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan,
+      sessions,
+      planningCommandBuilder,
+    });
+
+    expect(result).toMatchObject({ ok: true, draftPlanAvailable: false });
+    await expect(submitPlanningChatDraft({ sessionId: result.sessionId }, {
       sessions,
       loadGeneratedPlan,
     })).resolves.toMatchObject({ ok: false });

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -549,7 +549,8 @@ export async function sendPlanningChatMessage(
           ? []
           : activeSession.conversation.lastTurnReasoning;
         const reasoning = reasoningParts.length > 0 ? reasoningParts.join('\n\n') : undefined;
-        const candidatePlanText = getConversationDraftedPlan(activeSession.conversation) ?? extractYamlPlan(reply);
+        const candidatePlanText = getConversationDraftedPlan(activeSession.conversation)
+          ?? extractYamlPlan(reply);
         if (!candidatePlanText || !draftingAuthorized) {
           activeSession.status = hasDraftPlan(activeSession)
             ? 'draft_ready'

--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -90,18 +90,30 @@ describe('plan draft file - activation side', () => {
     expect(prompt).toContain('output the plan inside a ```yaml code block');
   });
 
-  it('clears a stale plan file before the turn so getDraftedPlan cannot return it', async () => {
+  it('keeps the last valid plan after a later turn clears its draft file', async () => {
     const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', plannerRetryLimit: 0 });
     const path = conversation.planDraftFilePath();
     if (!path) throw new Error('expected a plan draft path');
-    mkdirSync(join(workingDir, '.invoker', 'plan-drafts'), { recursive: true });
-    writeFileSync(path, 'name: Stale plan\ntasks: []', 'utf8');
 
-    // The planner replies with only a summary and does NOT write a new file.
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(
+      'Drafted the plan.\n\nReply `submit` to submit it.',
+      () => writeFileSync(path, VALID_PLAN_YAML, 'utf8'),
+    ));
+    await conversation.sendMessage('Draft it');
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the plan. Summary: one step.'));
+    await conversation.sendMessage('What does it do?');
+
+    expect(existsSync(path)).toBe(false);
+    expect(conversation.getDraftedPlan()).toBe(VALID_PLAN_YAML.trim());
+  });
+
+  it('does not expose a plan when a summary-only turn has no prior draft', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', plannerRetryLimit: 0 });
+
     mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the plan. Summary: one step.'));
     await conversation.sendMessage('Draft it');
 
-    expect(existsSync(path)).toBe(false);
     expect(conversation.getDraftedPlan()).toBeNull();
   });
 

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -24,6 +24,7 @@ import {
   looksLikeCompletionClaim,
   repoStateUnchanged,
 } from './agent-turn-verification.js';
+import { summarizePlanText } from './plan-summary.js';
 
 // ── Types ───────────────────────────────────────────────────
 
@@ -435,6 +436,7 @@ export class PlanConversation {
   private plannerRetryBaseDelayMs: number;
   private _initialized = false;
   private _lastTurnReasoning: string[] = [];
+  private lastKnownGoodPlanText: string | null = null;
 
   constructor(config: PlanConversationConfig) {
     this.cursorCommand = config.cursorCommand ?? 'agent';
@@ -540,6 +542,12 @@ export class PlanConversation {
     if (looksLikeCompletionClaim(message) && repoStateUnchanged(repoStateBefore, repoStateAfter)) {
       message = `${message}\n\n${buildUnverifiedNotice()}`;
     }
+    const fileDraft = this.readPlanDraftFile();
+    const inlineDraft = extractYamlPlan(message);
+    const nextDraft = fileDraft && summarizePlanText(fileDraft)
+      ? fileDraft
+      : inlineDraft;
+    if (nextDraft) this.lastKnownGoodPlanText = nextDraft;
     this._lastTurnReasoning = formatted.reasoning;
     this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: responseLen=${response.length}, messageLen=${message.length}, reasoningParts=${formatted.reasoning.length}, responsePreview="${message.slice(0, 500).replace(/\n/g, '\\n')}"`);
 
@@ -572,7 +580,7 @@ export class PlanConversation {
 
   /** Returns the last complete YAML plan drafted in this conversation, or null. */
   getDraftedPlan(): string | null {
-    return this.readPlanDraftFile() ?? this.extractLastPlanFromMessages();
+    return this.readPlanDraftFile() ?? this.extractLastPlanFromMessages() ?? this.lastKnownGoodPlanText;
   }
 
   // The planner writes the full YAML plan here so its chat reply can stay a
@@ -622,6 +630,7 @@ export class PlanConversation {
     this.messages = [];
     this._submittedPlanText = null;
     this._planSubmitted = false;
+    this.lastKnownGoodPlanText = null;
     if (this.conversationRepo && this.threadTs) {
       this.conversationRepo.deleteConversation(this.threadTs);
     }


### PR DESCRIPTION
## Summary

The in-app planner now uses the conversation's retained valid plan after explicit drafting authorization.

A summary-only authorization turn no longer loses an earlier plan.

When no plan exists, the user must receive a real regenerated plan before one becomes available.

## Review Claim

The in-app planner makes a retained valid plan available only after an explicit drafting turn, while an empty conversation remains unavailable.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Unauthorized YAML never becomes an approved in-app draft, and a summary without an earlier valid plan cannot create one.

## Slice Rationale

This is the in-app routing consumer of the retained conversation plan established by the preceding slice.

## Non-goals

- Broadening drafting-intent matching
- Changing Slack authorization behavior
- Creating plans from summary text alone

## Architecture

### Before

```mermaid
graph TD
    authorizeTurn["Authorized draft turn"] --> summaryReply["Summary-only reply"]
    summaryReply --> unavailableDraft["In-app draft unavailable"]
```

### After

```mermaid
graph TD
    retainedPlan["Retained valid conversation plan"] --> authorizeTurn["Authorized draft turn"]
    authorizeTurn --> approvedDraft["Approved in-app draft available"]
    emptyConversation["No retained plan"] --> unavailableDraft["Draft remains unavailable"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/in-app-planner.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert cc378e43a`
- Post-revert steps: None
- Data migration? No

</details>
