### PR TITLE
[Planning submit](2) Start ready work on submit

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -325,10 +325,13 @@ describe('planning chat', () => {
     expect(result.ok && sessions.get(result.sessionId)?.messages.at(-1)?.text).toBe(VALID_PLAN_REPLY);
   });
 
-  it('keeps unauthorized YAML from becoming draft-ready or submittable', async () => {
+  it('keeps unauthorized YAML from becoming draft-ready until explicit submit promotes it', async () => {
     vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
     const sessions = createInAppPlanningChatSessions();
-    const loadGeneratedPlan = vi.fn();
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+    } satisfies LoadedGeneratedPlan);
 
     const result = await sendPlanningChatMessage({
       message: 'What would this involve?',
@@ -354,11 +357,11 @@ describe('planning chat', () => {
     }, {
       sessions,
       loadGeneratedPlan,
-    })).resolves.toMatchObject({ ok: false });
-    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+    })).resolves.toMatchObject({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
+    expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
   });
 
-  it('promotes a plan written before an intervening summary-only turn when the user authorizes drafting', async () => {
+  it('promotes a plan written before an intervening summary-only turn when the user submits it', async () => {
     const workingDir = mkdtempSync(join(tmpdir(), 'in-app-draft-'));
     try {
       const sessions = createInAppPlanningChatSessions();
@@ -382,7 +385,6 @@ describe('planning chat', () => {
           writeFileSync(draftPath, VALID_PLAN_TEXT, 'utf8');
           return `Plan written.${PLAN_SUBMIT_HINT}`;
         })
-        .mockResolvedValueOnce('Plan summary.')
         .mockResolvedValueOnce('Plan summary.');
 
       const draftedBeforeAuthorization = await sendPlanningChatMessage({
@@ -409,23 +411,7 @@ describe('planning chat', () => {
         workingDir,
       });
 
-      const result = await sendPlanningChatMessage({
-        sessionId: session.id,
-        message: 'draft it',
-      }, {
-        config: {},
-        loadGeneratedPlan: vi.fn(),
-        sessions,
-        planningCommandBuilder,
-        workingDir,
-      });
-
-      expect(result).toMatchObject({
-        ok: true,
-        draftPlanAvailable: true,
-        draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
-      });
-      expect(sessions.get(session.id)?.draftPlanText).toContain('name: Mock Plan');
+      expect(sessions.get(session.id)?.draftPlanText).toBeUndefined();
 
       const loadGeneratedPlan = vi.fn().mockResolvedValue({
         planName: 'Mock Plan',
@@ -436,6 +422,7 @@ describe('planning chat', () => {
         loadGeneratedPlan,
       })).resolves.toMatchObject({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
       expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
+      expect(sessions.get(session.id)?.draftPlanText).toContain('name: Mock Plan');
     } finally {
       rmSync(workingDir, { recursive: true, force: true });
     }
@@ -742,7 +729,7 @@ tasks:
       workflowCount: 2,
     });
     expect(sessions.get(sent.sessionId)?.messages.at(-1)?.text).toBe(
-      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then use Start ready work.',
+      'Plan "Workers Surface" submitted as 2 stacked workflows.',
     );
   });
 
@@ -838,7 +825,7 @@ tasks:
     }
   });
 
-  it('does not submit hidden planner context without approved session draft text', async () => {
+  it('promotes hidden planner context when the user explicitly submits it', async () => {
     const sessions = createInAppPlanningChatSessions();
     const conversation = new PlanConversation({}) as PlanConversation & { getDraftedPlan: () => string };
     conversation.getDraftedPlan = () => VALID_PLAN_TEXT;
@@ -853,15 +840,18 @@ tasks:
       updatedAt: '2026-07-07T00:00:00.000Z',
       nextMessageId: 1,
     });
-    const loadGeneratedPlan = vi.fn();
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+    } satisfies LoadedGeneratedPlan);
 
     const result = await submitPlanningChatDraft({ sessionId: 'hidden-yaml' }, {
       sessions,
       loadGeneratedPlan,
     });
 
-    expect(result).toMatchObject({ ok: false });
-    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
+    expect(loadGeneratedPlan).toHaveBeenCalledWith(VALID_PLAN_TEXT);
   });
 
   it('restores draft-ready sessions and submits from persisted approved draft text', async () => {

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -640,16 +640,22 @@ export async function submitPlanningChatDraft(
     return session.pendingSubmit;
   }
 
-  const planText = session.draftPlanText;
-  if (!planText) {
-    return { ok: false, error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.' };
-  }
-
   const submitAttempt = (async (): Promise<InAppPlanningSubmitResponse> => {
     try {
       const { summarizePlanText } = await loadPlannerSurfaces();
-      if (!summarizePlanText(planText)) {
+      const planText = session.draftPlanText ?? getConversationDraftedPlan(session.conversation);
+      if (!planText) {
+        return { ok: false, error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.' };
+      }
+      const summary = summarizePlanText(planText);
+      if (!summary) {
         return { ok: false, error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.' };
+      }
+      if (!session.draftPlanText) {
+        session.draftPlanText = planText;
+        session.draftPlanSummary = summary;
+        session.status = 'draft_ready';
+        persistPlanningSession(session, deps.planningSessionStore, false);
       }
 
       const loaded = await deps.loadGeneratedPlan(planText);
@@ -661,8 +667,8 @@ export async function submitPlanningChatDraft(
         session,
         'system',
         loaded.workflowCount && loaded.workflowCount > 1
-          ? `Plan "${loaded.planName}" submitted as ${loaded.workflowCount} stacked workflows. Review them, then use Start ready work.`
-          : `Plan "${loaded.planName}" submitted to Invoker. Review it, then use Start ready work.`,
+          ? `Plan "${loaded.planName}" submitted as ${loaded.workflowCount} stacked workflows.`
+          : `Plan "${loaded.planName}" submitted to Invoker.`,
         'success',
       );
       persistPlanningSession(session, deps.planningSessionStore, false);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2574,10 +2574,16 @@ export function App() {
         }));
         await refreshTaskGraph();
         workflowGraphViewportRef.current = null;
+        const startResult = await handleStartReadyAction();
+        const startMessage = startResult
+          ? startResult.started.length > 0
+            ? ` Started ${startResult.started.length} ready task${startResult.started.length === 1 ? '' : 's'}.`
+            : ' No ready work to start.'
+          : ' Ready work could not be started.';
         appendTerminalLine(
           result.workflowCount && result.workflowCount > 1
-            ? `Plan "${result.planName}" submitted as ${result.workflowCount} stacked workflows. Review them, then use Start ready work.`
-            : `Plan "${result.planName}" submitted to Invoker. Review it, then use Start ready work.`,
+            ? `Plan "${result.planName}" submitted as ${result.workflowCount} stacked workflows.${startMessage}`
+            : `Plan "${result.planName}" submitted to Invoker.${startMessage}`,
           'system',
           'success',
         );
@@ -2592,7 +2598,7 @@ export function App() {
       setPlanningSubmitError({ title: 'Plan could not be submitted', message });
       appendTerminalLine(`Plan could not be submitted:\n${message}`, 'system', 'error');
     }
-  }, [activePlanningReadOnly, appendTerminalLine, invoker, issueCameraCommand, planningSessionId, refreshTaskGraph, updatePlanningSessionById]);
+  }, [activePlanningReadOnly, appendTerminalLine, handleStartReadyAction, invoker, issueCameraCommand, planningSessionId, refreshTaskGraph, updatePlanningSessionById]);
 
   const handlePlanningSubmit = useCallback(async () => {
     const input = planningInput.trim();

--- a/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
@@ -61,7 +61,7 @@ describe('CodeRabbit PR #3050 — draft state cleared after submit', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });
-    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
+    await screen.findByText('Plan "Mock Plan" submitted to Invoker. No ready work to start.');
     // The submit succeeded; the ready bar must be gone so it cannot resubmit the same session.
     await waitFor(() => {
       expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();

--- a/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
@@ -56,13 +56,14 @@ describe('CodeRabbit PR #3050 — submitted planning stays read-only after start
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });
 
-    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
+    await screen.findByText('Plan "Mock Plan" submitted to Invoker. No ready work to start.');
     expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    expect(mock.api.startReady).toHaveBeenCalledTimes(1);
 
     fireEvent.click(screen.getByTestId('sidebar-planning'));
     fireEvent.click(await screen.findByTestId('rail-start-ready'));
     await waitFor(() => {
-      expect(mock.api.startReady).toHaveBeenCalledTimes(1);
+      expect(mock.api.startReady).toHaveBeenCalledTimes(2);
     });
     expect(screen.queryByTestId('rail-start')).not.toBeInTheDocument();
     expect(screen.queryByTestId('rail-stop')).not.toBeInTheDocument();

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -701,7 +701,7 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
-  it('reviews a draft before explicitly creating the workflow', async () => {
+  it('submits a draft and starts ready work when the user types submit', async () => {
     mock.api.planningChatSend = vi.fn(async () => ({
       ok: true,
       sessionId: 'session-1',
@@ -718,23 +718,18 @@ describe('Invoker terminal (component)', () => {
       expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('Draft ready · Mock Plan · 2 tasks');
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
-
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Review draft' })).toBeInTheDocument();
-      expect(screen.getByTestId('planning-create-workflow')).toBeInTheDocument();
-    });
     expect(mock.api.planningChatSubmit).not.toHaveBeenCalled();
-    expect(mock.api.start).not.toHaveBeenCalled();
+    expect(mock.api.startReady).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByTestId('planning-create-workflow'));
+    submitPlanningText('submit');
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });
       expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
+      expect(mock.api.startReady).toHaveBeenCalledWith({});
     });
     fireEvent.click(screen.getByTestId('sidebar-home'));
     expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
-    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.');
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. No ready work to start.');
     expect(screen.queryByRole('heading', { name: 'Plan graph' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Submit to Invoker' })).not.toBeInTheDocument();
@@ -782,11 +777,12 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });
       expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
+      expect(mock.api.startReady).toHaveBeenCalledWith({});
     });
     fireEvent.click(screen.getByTestId('sidebar-home'));
     expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
     expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(
-      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then use Start ready work.',
+      'Plan "Workers Surface" submitted as 2 stacked workflows. No ready work to start.',
     );
     expect(screen.queryByRole('heading', { name: 'Plan graph' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
@@ -824,10 +820,11 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(2);
       expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
+      expect(mock.api.startReady).toHaveBeenCalledWith({});
     });
     fireEvent.click(screen.getByTestId('sidebar-home'));
     expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
-    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. Review it, then use Start ready work.');
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. No ready work to start.');
     expect(screen.queryByRole('heading', { name: 'Plan graph' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Submit to Invoker' })).not.toBeInTheDocument();

--- a/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
@@ -76,7 +76,7 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });
     });
-    expect(await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then use Start ready work.')).toBeInTheDocument();
+    expect(await screen.findByText('Plan "Mock Plan" submitted to Invoker. No ready work to start.')).toBeInTheDocument();
     expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
     expect(screen.getByTestId('invoker-terminal-harness')).toBeDisabled();
 


### PR DESCRIPTION
## Summary

The planning terminal now starts ready work immediately after it loads a drafted plan.

Its confirmation says whether work started instead of directing users to run the same action again.

## Review Claim

The planning terminal invokes the existing ready-work scheduler once after loading a drafted plan.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Plan loading succeeds before scheduling starts. The existing start-ready handler owns scheduler errors and refreshes the task graph.

## Slice Rationale

This slice activates ready-work scheduling in the terminal after its plan-loading action.

## Non-goals

This does not change Slack confirmation, alter scheduler eligibility, or retry failed starts.

## Architecture

### Before

```mermaid
flowchart LR
  action["Terminal plan action"] --> load["Load workflow"]
  load --> prompt["Prompt user to start ready work"]
```

### After

```mermaid
flowchart LR
  action["Terminal plan action"] --> load["Load workflow"]
  load --> start["Existing start-ready handler"]
  start --> message["Report started task count"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- invoker-terminal.test.tsx planning-draft-submit-new-turn-stream-repro.test.tsx coderabbit-pr3050-run-guard-repro.test.tsx coderabbit-pr3050-draft-clear-repro.test.tsx`
- [x] `bash scripts/ui-visual-proof.sh capture-before`
- [x] `bash scripts/ui-visual-proof.sh capture-after`

</details>

## Visual Proof

Before: the terminal confirms loading and tells the user to use Start ready work.

![Before loading](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260724-1d5fd3/planning-start-before.png)

After: the terminal confirms that the action started one ready task, and the notification confirms the start.

![After loading](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260724-1d5fd3/planning-start-after.png)

[Terminal plan-loading walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260724-1d5fd3/planning-start-transition.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f0d68eb5c`
- Post-revert steps: None
- Data migration? No

</details>
