### PR TITLE
[Slack routing](2) Plan mentions in every non-workflow channel

### DIFF
--- a/packages/surfaces/src/__tests__/slack-do1-ux-non-lobby-mention.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-do1-ux-non-lobby-mention.e2e.test.ts
@@ -51,7 +51,7 @@ describe('DO1 Slack UX e2e — non-workflow mention routing', () => {
     if (surface) await surface.stop();
   });
 
-  it.fails('routes @mentions outside workflow channels to planning', async () => {
+  it('routes @mentions outside workflow channels to planning', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     const repo = new WorkflowChannelRepository(adapter);
     repo.save({

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -935,6 +935,45 @@ describe('lobby verb routing', () => {
     expect(say2).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Invoker is back') }));
   });
 
+  it('refuses lobby controls from non-lobby channels while still accepting planning mentions', async () => {
+    const onRestartInvoker = vi.fn().mockResolvedValue(undefined);
+    const surface = lobbySurface(true, { onRestartInvoker });
+    await surface.start(async () => {});
+    const handlePlanningMention = vi.spyOn(surface as any, 'handlePlanningMention');
+
+    const sayRestart = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> restart', ts: 't-restart', user: 'U1', channel: 'COTHER' },
+      say: sayRestart,
+    });
+    expect(onRestartInvoker).not.toHaveBeenCalled();
+    expect(sayRestart).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('restart/submit/workflow controls only work in the lobby channel or DMs'),
+    }));
+
+    const sayOp = vi.fn().mockResolvedValue({ ts: 'b' });
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> recreate all', ts: 't-op', user: 'U1', channel: 'COTHER' },
+      say: sayOp,
+    });
+    expect(runWorkflowOp).not.toHaveBeenCalled();
+    expect(sayOp).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('restart/submit/workflow controls only work in the lobby channel or DMs'),
+    }));
+
+    handlePlanningMention.mockClear();
+    const sayPlan = vi.fn().mockResolvedValue({ ts: 'c' });
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> draft a plan for a health endpoint', ts: 't-plan', user: 'U1', channel: 'COTHER' },
+      say: sayPlan,
+    });
+    expect(handlePlanningMention).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'COTHER', ts: 't-plan' }),
+      sayPlan,
+      'COTHER',
+    );
+  });
+
   it('reports a restart failure when the relaunch throws', async () => {
     const onRestartInvoker = vi.fn().mockRejectedValue(new Error('no display'));
     const surface = lobbySurface(true, { onRestartInvoker });

--- a/packages/surfaces/src/__tests__/slack-surface.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface.test.ts
@@ -134,7 +134,7 @@ describe('SlackSurface', () => {
       });
 
       expect(log).toHaveBeenCalledWith('slack', 'info', expect.stringContaining('[MENTION_RECEIVED] instance=do1-proof event_ts=event-1'));
-      expect(log).toHaveBeenCalledWith('slack', 'info', expect.stringContaining('[MENTION_ROUTE] instance=do1-proof event_ts=event-1 route=non-lobby'));
+      expect(log).toHaveBeenCalledWith('slack', 'info', expect.stringContaining('[MENTION_ROUTE] instance=do1-proof event_ts=event-1 route=planning'));
     });
   });
 

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -981,17 +981,7 @@ export class SlackSurface implements Surface {
         return;
       }
 
-      const isLobbyOrDm = !channel || channel === this.lobbyChannelId || channel.startsWith('D');
-      if (!isLobbyOrDm) {
-        this.log('slack', 'info', `[MENTION_ROUTE] instance=${this.instanceId} event_ts=${event.ts} route=non-lobby channel=${channel}`);
-        await say({
-          text: 'I only plan in the lobby channel (or DMs), and only run workflow controls in a mapped workflow channel. Mention me there instead.',
-          thread_ts: event.thread_ts ?? event.ts,
-        });
-        return;
-      }
-
-      this.log('slack', 'info', `[MENTION_ROUTE] instance=${this.instanceId} event_ts=${event.ts} route=lobby`);
+      this.log('slack', 'info', `[MENTION_ROUTE] instance=${this.instanceId} event_ts=${event.ts} route=planning`);
       await this.handlePlanningMention(event, say, channel ?? this.lobbyChannelId);
     });
   }
@@ -1045,7 +1035,7 @@ export class SlackSurface implements Surface {
     const routeRepoUrl = explicitRepoResolution.url ?? detectedRepoResolution.url ?? this.resolveRepoUrl().url;
 
     const threadTs = event.thread_ts ?? event.ts;
-    const requiresPlanningRepo = channel === this.lobbyChannelId && !!this.planningCommandBuilder;
+    const requiresPlanningRepo = !!this.planningCommandBuilder;
     const messageRepoUrl = requiresPlanningRepo && !parsed.repo
       ? extractRepoUrlFromMessage(event.text ?? '')
       : undefined;

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -1050,27 +1050,39 @@ export class SlackSurface implements Surface {
 
     // Deterministic verb commands respond instantly and take priority over agent sessions.
     const ctrl = parseLobbyControl(parsed.text);
-    if (ctrl?.kind === 'op') {
-      await this.handleLobbyOp(ctrl, threadTs, channel, say);
-      return;
-    }
-    if (ctrl?.kind === 'submit') {
-      await this.handleLobbySubmit(channel, threadTs, event.user ?? 'unknown', say);
-      return;
-    }
-    if (ctrl?.kind === 'restart') {
+    if (ctrl?.kind === 'op' || ctrl?.kind === 'submit' || ctrl?.kind === 'restart') {
+      if (!this.allowsLobbyControls(channel)) {
+        await this.rejectNonLobbyControl(threadTs, say);
+        return;
+      }
+      if (ctrl.kind === 'op') {
+        await this.handleLobbyOp(ctrl, threadTs, channel, say);
+        return;
+      }
+      if (ctrl.kind === 'submit') {
+        await this.handleLobbySubmit(channel, threadTs, event.user ?? 'unknown', say);
+        return;
+      }
       await this.handleLobbyRestart(threadTs, channel, say);
       return;
     }
 
     const localRequest = parseLocalRequest(parsed.text);
     if (localRequest?.kind === 'command') {
+      if (!this.allowsLobbyControls(channel)) {
+        await this.rejectNonLobbyControl(threadTs, say);
+        return;
+      }
       await this.handleLocalRequest(localRequest, preset, threadTs, say, channel, { userId: event.user, repoUrl: routeRepoUrl });
       return;
     }
 
     const workflowStatusQuery = parseWorkflowStatusQuery(localRequest?.kind === 'agent' ? localRequest.text : parsed.text);
     if (workflowStatusQuery?.intent === 'command') {
+      if (!this.allowsLobbyControls(channel)) {
+        await this.rejectNonLobbyControl(threadTs, say);
+        return;
+      }
       await this.handleLobbyOp({ kind: 'op', operation: workflowStatusQuery.operation, target: workflowStatusQuery.target }, threadTs, channel, say);
       return;
     }
@@ -1104,6 +1116,10 @@ export class SlackSurface implements Surface {
         this.log('slack', 'info', `[CLASSIFY] thread_ts=${threadTs} intent=${cls.intent}`);
         if (cls.intent === 'command') {
           await this.clearImmediateAck(channel, threadTs);
+          if (!this.allowsLobbyControls(channel)) {
+            await this.rejectNonLobbyControl(threadTs, say);
+            return;
+          }
           await this.proposeLobbyOp(cls, threadTs, channel, say);
           return;
         }
@@ -1431,10 +1447,30 @@ export class SlackSurface implements Surface {
   }
 
 
+  /** Lobby controls stay in the lobby channel or DMs; planning may run elsewhere. */
+  private allowsLobbyControls(channel: string | undefined): boolean {
+    if (!channel) return true;
+    return channel === this.lobbyChannelId || channel.startsWith('D');
+  }
+
+  private async rejectNonLobbyControl(threadTs: string, say: SayFn): Promise<void> {
+    await say({
+      text: 'I can plan here, but restart/submit/workflow controls only work in the lobby channel or DMs.',
+      thread_ts: threadTs,
+    });
+  }
+
   /** Resolve a staged action from a plain-text reply. Returns true if the reply was consumed. */
   private async resolveConfirm(threadTs: string, text: string, say: SayFn, channel?: string): Promise<boolean> {
     const pending = this.getPendingConfirm(threadTs);
     if (!pending) return false;
+    if (
+      (pending.kind === 'op' || pending.kind === 'restart' || pending.kind === 'submit')
+      && !this.allowsLobbyControls(channel)
+    ) {
+      await this.rejectNonLobbyControl(threadTs, say);
+      return true;
+    }
     if (isConfirmation(text)) {
       this.pendingConfirms.delete(threadTs);
       this.slackSessionRepo?.deletePendingConfirmation(threadTs);
@@ -2289,6 +2325,10 @@ ${text}`;
       const text = (msg.text ?? '').replace(/<@[A-Z0-9]+>/g, '').trim();
       if (text && (await this.resolveConfirm(msg.thread_ts, text, say, channel))) return;
       if (parseLobbyControl(text)?.kind === 'submit') {
+        if (!this.allowsLobbyControls(channel)) {
+          await this.rejectNonLobbyControl(msg.thread_ts, say);
+          return;
+        }
         await this.handleLobbySubmit(channel, msg.thread_ts, msg.user ?? 'unknown', say);
         return;
       }


### PR DESCRIPTION
## Summary

Invoker now starts planning or agent conversations from every non-workflow Slack channel.

Mapped workflow channels continue to use workflow-scoped controls and context.

## Review Claim

Non-workflow `@Invoker` mentions route to planning in their originating channel.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Workflow channel mappings are checked before planning routing, so workflow controls remain scoped to their workflow.

## Slice Rationale

This changes the router and its direct assertions in one slice.

## Non-goals

This does not change workflow channel creation, workflow controls, or the configured default Slack channel.

## Architecture

### Before

```mermaid
flowchart TD
  mention["app_mention"]
  workflow{"Mapped workflow channel?"}
  workflowAssistant["Workflow assistant"]
  redirect["Reply with lobby redirect"]
  mention --> workflow
  workflow -->|yes| workflowAssistant
  workflow -->|no| redirect
```

### After

```mermaid
flowchart TD
  mention["app_mention"]
  workflow{"Mapped workflow channel?"}
  workflowAssistant["Workflow assistant"]
  planning["Planning mention in origin channel"]
  mention --> workflow
  workflow -->|yes| workflowAssistant
  workflow -->|no| planning
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test -- --run src/__tests__/slack-do1-ux-non-lobby-mention.e2e.test.ts src/__tests__/slack-surface.test.ts`
- [ ] `cd packages/surfaces && pnpm test` (blocked by unrelated `PlanConversation` illustrative-YAML test failure)

</details>

## Visual Proof

A static screenshot cannot demonstrate Slack event routing without a live workspace and bot credentials. The focused automated test invokes `app_mention` in `COTHER` and verifies that it reaches `handlePlanningMention`.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d5d49474`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mentions outside workflow channels are now routed to planning, including mentions in regular channels.
  * Planning repository requirements are applied consistently across supported mention locations.

* **Bug Fixes**
  * Improved Slack mention handling so valid planning requests are no longer ignored outside lobby channels or direct messages.
  * Updated routing behavior and verification for non-workflow channel mentions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->