### PR TITLE
[Slack routing](3) Document non-workflow mention planning

### DIFF
--- a/docs/slack-native-workflows.md
+++ b/docs/slack-native-workflows.md
@@ -1,16 +1,16 @@
 # Slack-native coding workflows
 
-Drive Invoker from Slack: mention `@Invoker` in a shared **lobby** channel to start a normal agent thread in a checked-out repo. If you want an Invoker workflow, say `plan:` first, then submit the drafted plan. When a workflow starts, Invoker creates a **private `workflow-<id>` channel**, invites you, and posts the workflow there. Mentioning `@Invoker` inside that channel answers using **only that workflow's context** (its planning conversation plus every task transcript) and runs control actions on it.
+Drive Invoker from Slack: mention `@Invoker` in any channel where the bot is present to start a normal agent thread in a checked-out repo. If you want an Invoker workflow, say `plan:` first, then submit the drafted plan. When a workflow starts, Invoker creates a **private `workflow-<id>` channel**, invites you, and posts the workflow there. Mentioning `@Invoker` inside that mapped channel answers using **only that workflow's context** (its planning conversation plus every task transcript) and runs control actions on it.
 
 ## Flow
 
-1. **Start a normal agent thread.** In the lobby channel: `@Invoker [omp+codex] [repo:web] fix the Slack routing bug` or `@Invoker fix this in https://github.com/acme/web`. Invoker checks out the selected repo and runs a normal OMP/Codex-style conversation in the thread.
+1. **Start a normal agent thread.** In any channel where Invoker is present: `@Invoker [omp+codex] [repo:web] fix the Slack routing bug` or `@Invoker fix this in https://github.com/acme/web`. Invoker checks out the selected repo and runs a normal OMP/Codex-style conversation in the thread.
 2. **Opt into Invoker planning.** Use `@Invoker plan: add a /health endpoint` when you want YAML for an Invoker workflow instead of direct local agent work. In an existing agent thread, reply `plan: add a /health endpoint`, `plan add a /health endpoint`, or `add a /health endpoint via Invoker`; Invoker promotes that same thread to planning and retains its selected repo and harness preset.
 3. **Submit only when ready.** Run `@Invoker submit` in that plan thread, then approve the short summary. That starts the generated YAML plan as a workflow.
-4. **Workflow channel appears.** Invoker creates private `workflow-<id>`, invites you, posts the workflow summary there, and links it from the lobby thread.
+4. **Workflow channel appears.** Invoker creates private `workflow-<id>`, invites you, posts the workflow summary there, and links it from the originating plan thread.
 5. **Operate in the channel.** `@Invoker status`, `@Invoker approve <task>`, `@Invoker reject <task>`, `@Invoker retry <task>`, `@Invoker input <task>: <text>`, or ask a free-form question (answered only from this workflow's planning + task transcripts).
 
-## Message tags (lobby only)
+## Message tags
 
 Leading `[...]` tags select how planning runs. Order does not matter; everything after the tags is the request.
 
@@ -23,7 +23,7 @@ The repository and harness are pinned when the thread starts. Start a new thread
 
 ## Local and plan modes
 
-Normal lobby mentions are local agent sessions. They can answer, edit, and run focused checks in their repo worktree.
+Normal mentions outside mapped workflow channels are local agent sessions. They can answer, edit, and run focused checks in their repo worktree.
 
 - `@Invoker fix the typo in the Slack docs` — starts or continues a normal agent thread.
 - `@Invoker local: fix the typo in the Slack docs` — kept as an alias for the same normal agent thread.
@@ -97,8 +97,8 @@ To configure by hand, put these credential values in `~/.invoker/.env`
 SLACK_BOT_TOKEN=xoxb-...
 SLACK_APP_TOKEN=xapp-...
 SLACK_SIGNING_SECRET=...
-SLACK_CHANNEL_ID=C...            # lobby channel (fallback for SLACK_LOBBY_CHANNEL_ID)
-SLACK_LOBBY_CHANNEL_ID=C...      # optional; defaults to SLACK_CHANNEL_ID
+SLACK_CHANNEL_ID=C...            # default channel (fallback for SLACK_LOBBY_CHANNEL_ID)
+SLACK_LOBBY_CHANNEL_ID=C...      # optional default/home channel
 INVOKER_REPO_URL=git@github.com:acme/web.git   # optional; default repo (else git remote origin)
 CURSOR_COMMAND=cursor            # optional planning CLI override
 CURSOR_MODEL=...                 # optional planning model override
@@ -114,8 +114,8 @@ The bot runs in Socket Mode. Add these bot scopes to the app manifest (reinstall
 - `app_mentions:read` — receive `@Invoker` mentions.
 - `chat:write` — post messages.
 - `files:write` — upload artifacts an agent links from its worktree.
-- `channels:history` — read lobby thread replies (public lobby channel).
-- `channels:read` — resolve the lobby channel via `conversations.info` during setup checks.
+- `channels:history` — read thread replies in public channels where Invoker is used.
+- `channels:read` — resolve the configured default channel via `conversations.info` during setup checks.
 - `groups:write` — **create** private `workflow-<id>` channels and invite users.
 - `groups:history` — receive mentions/replies **inside** the private workflow channels.
 - `users:read` — resolve users for invites.


### PR DESCRIPTION
## Summary

The Slack workflow guide now explains that Invoker can plan from any channel where it is present.

It clarifies that mapped workflow channels remain reserved for workflow-scoped interactions.

## Review Claim

The documentation accurately describes the new channel behavior and default channel configuration.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice changes documentation only and does not alter product behavior.

## Slice Rationale

Documentation follows the behavior slice so the guide describes an already-reviewed interaction model.

## Non-goals

This does not alter Slack configuration values or workflow channel behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `git diff --check origin/master...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c32b0b6a`
- Post-revert steps: None
- Data migration? No

</details>
