### PR TITLE
[PR babysit](1) Add fake-gh battle harness for PR-babysitting crons

### DIFF
--- a/scripts/repro/fixtures/fake-gh/bin/gh
+++ b/scripts/repro/fixtures/fake-gh/bin/gh
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Reusable fake `gh` for PR-babysitting battle tests.
+
+Reads/writes a single JSON state file at $FAKE_GH_STATE_DIR/state.json and
+appends every invocation (argv, plus stdin when piped) to
+$FAKE_GH_STATE_DIR/calls.log so repro scripts can assert exactly what the code
+under test asked GitHub for. Mutating verbs update state.json so subsequent
+reads observe the mutation. Unknown argv exits 64 with the argv echoed: a
+scenario gap fails tests loudly instead of silently succeeding.
+
+State schema (see scripts/repro/fixtures/fake-gh/scenarios/*.json):
+  {
+    "prs": [{
+      "number": 501, "title": "...", "url": "...", "state": "OPEN",
+      "isDraft": false, "baseRefName": "master", "headRefName": "stack/501",
+      "headRefOid": "<40-hex>", "mergeStateStatus": "DIRTY",
+      "mergeable": "CONFLICTING", "labels": ["admin-bypass"],
+      "reviewThreads": [], "checks": {"*": "SUCCESS", "PR Body": "FAILURE"}
+    }],
+    "issue_comments": {"501": [ ...gh api issues/N/comments shape... ]}
+  }
+
+`checks` maps check name -> conclusion; "*" applies to every required check
+named in $FAKE_GH_REQUIRED_CHECKS (newline-separated; check names contain
+spaces and slashes, never newlines).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+STATE_DIR = os.environ.get("FAKE_GH_STATE_DIR", "")
+if not STATE_DIR:
+    print("fake gh: FAKE_GH_STATE_DIR not set", file=sys.stderr)
+    sys.exit(64)
+
+ARGS = sys.argv[1:]
+STDIN = "" if sys.stdin.isatty() else sys.stdin.read()
+with open(Path(STATE_DIR) / "calls.log", "a", encoding="utf-8") as log:
+    log.write("gh " + " ".join(ARGS) + ("\n<<< " + STDIN.replace("\n", "\\n") if STDIN else "") + "\n")
+
+STATE_PATH = Path(STATE_DIR) / "state.json"
+
+
+def load_state() -> dict:
+    with open(STATE_PATH, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def save_state(state: dict) -> None:
+    with open(STATE_PATH, "w", encoding="utf-8") as handle:
+        json.dump(state, handle, indent=2)
+
+
+def required_checks() -> list[str]:
+    raw = os.environ.get("FAKE_GH_REQUIRED_CHECKS", "")
+    return [name for name in raw.split("\n") if name.strip()]
+
+
+def unhandled() -> None:
+    print(f"fake gh: unhandled argv: {ARGS}", file=sys.stderr)
+    sys.exit(64)
+
+
+def flag_value(name: str) -> str | None:
+    for index, arg in enumerate(ARGS):
+        if arg == name and index + 1 < len(ARGS):
+            return ARGS[index + 1]
+        if arg.startswith(name + "="):
+            return arg.split("=", 1)[1]
+    return None
+
+
+def check_nodes(pr: dict) -> list[dict]:
+    checks = pr.get("checks") or {}
+    default = checks.get("*")
+    names: set[str] = {name for name in checks if name != "*"}
+    if default is not None:
+        names.update(required_checks())
+    nodes = []
+    for name in sorted(names):
+        conclusion = checks.get(name, default)
+        if conclusion is None:
+            continue
+        nodes.append({
+            "__typename": "CheckRun",
+            "name": name,
+            "conclusion": conclusion,
+            "status": "COMPLETED",
+            "completedAt": "2026-07-20T00:00:00Z",
+            "startedAt": "2026-07-20T00:00:00Z",
+            "detailsUrl": "https://github.com/fake/repo/actions/runs/1/job/2",
+            "checkSuite": {"commit": {"oid": pr.get("headRefOid", "")}},
+        })
+    return nodes
+
+
+def project_pr(pr: dict, fields: list[str]) -> dict:
+    out: dict = {}
+    for field in fields:
+        if field == "labels":
+            out["labels"] = [{"name": name} for name in pr.get("labels", [])]
+        elif field == "statusCheckRollup":
+            out["statusCheckRollup"] = check_nodes(pr)
+        elif field == "reviewDecision":
+            out["reviewDecision"] = pr.get("reviewDecision", "")
+        else:
+            out[field] = pr.get(field)
+    return out
+
+
+def graphql_detail(pr: dict) -> dict:
+    return {
+        "number": pr.get("number"),
+        "title": pr.get("title", ""),
+        "url": pr.get("url", ""),
+        "isDraft": pr.get("isDraft", False),
+        "state": pr.get("state", "OPEN"),
+        "baseRefName": pr.get("baseRefName", ""),
+        "headRefName": pr.get("headRefName", ""),
+        "headRefOid": pr.get("headRefOid", ""),
+        "mergeStateStatus": pr.get("mergeStateStatus", ""),
+        "mergeable": pr.get("mergeable", ""),
+        "labels": {"nodes": [{"name": name} for name in pr.get("labels", [])]},
+        "reviewThreads": {"pageInfo": {"hasNextPage": False}, "nodes": pr.get("reviewThreads", [])},
+        "statusCheckRollup": {"contexts": {"nodes": check_nodes(pr)}},
+    }
+
+
+def find_pr(state: dict, number: int) -> dict | None:
+    for pr in state.get("prs", []):
+        if int(pr.get("number", 0)) == number:
+            return pr
+    return None
+
+
+def main() -> None:
+    state = load_state()
+
+    if ARGS[:2] == ["pr", "list"]:
+        fields = (flag_value("--json") or "number").split(",")
+        label = flag_value("--label")
+        state_filter = flag_value("--state") or "open"
+        prs = state.get("prs", [])
+        if state_filter == "open":
+            prs = [pr for pr in prs if pr.get("state", "OPEN") == "OPEN"]
+        if label:
+            prs = [pr for pr in prs if label in pr.get("labels", [])]
+        print(json.dumps([project_pr(pr, fields) for pr in prs]))
+        return
+
+    if ARGS[:2] == ["pr", "view"]:
+        number = int(ARGS[2])
+        pr = find_pr(state, number)
+        if pr is None:
+            print(f"fake gh: no PR #{number} in state", file=sys.stderr)
+            sys.exit(1)
+        fields = (flag_value("--json") or "number").split(",")
+        print(json.dumps(project_pr(pr, fields)))
+        return
+
+    if ARGS[:2] == ["pr", "comment"]:
+        number = ARGS[2]
+        body = flag_value("--body") or ""
+        comments = state.setdefault("issue_comments", {}).setdefault(str(number), [])
+        comments.append({
+            "id": f"fake-comment-{len(comments) + 1}",
+            "user": {"login": "invoker-bot"},
+            "body": body,
+            "updated_at": "2026-07-20T00:00:00Z",
+            "html_url": f"https://github.com/fake/repo/pull/{number}#fake",
+        })
+        save_state(state)
+        return
+
+    if ARGS[:2] == ["api", "graphql"]:
+        number = 0
+        for arg in ARGS:
+            if arg.startswith("number="):
+                number = int(arg.split("=", 1)[1])
+        if number:
+            pr = find_pr(state, number)
+            if pr is None:
+                print(f"fake gh: no PR #{number} in state", file=sys.stderr)
+                sys.exit(1)
+            print(json.dumps({"data": {"repository": {"pullRequest": graphql_detail(pr)}}}))
+            return
+        if any("resolveReviewThread" in arg for arg in ARGS):
+            # Thread resolution is observable via calls.log only.
+            print(json.dumps({"data": {"resolveReviewThread": {"thread": {"isResolved": True}}}}))
+            return
+        unhandled()
+
+    if ARGS[0] == "api":
+        path = next((arg for arg in ARGS[1:] if not arg.startswith("-")), "")
+        comments_match = re.fullmatch(r"repos/[^/]+/[^/]+/issues/(\d+)/comments", path)
+        if comments_match and flag_value("--method") in (None, "GET"):
+            print(json.dumps(state.get("issue_comments", {}).get(comments_match.group(1), [])))
+            return
+        add_label_match = re.fullmatch(r"repos/[^/]+/[^/]+/issues/(\d+)/labels", path)
+        if add_label_match and flag_value("--method") == "POST":
+            pr = find_pr(state, int(add_label_match.group(1)))
+            label = (flag_value("-f") or "").split("=", 1)[-1]
+            if pr is not None and label and label not in pr.setdefault("labels", []):
+                pr["labels"].append(label)
+                save_state(state)
+            return
+        remove_label_match = re.fullmatch(r"repos/[^/]+/[^/]+/issues/(\d+)/labels/(.+)", path)
+        if remove_label_match and flag_value("--method") == "DELETE":
+            pr = find_pr(state, int(remove_label_match.group(1)))
+            if pr is not None:
+                pr["labels"] = [l for l in pr.get("labels", []) if l != remove_label_match.group(2)]
+                save_state(state)
+            return
+        unhandled()
+
+    if ARGS[:2] == ["auth", "status"]:
+        return
+
+    unhandled()
+
+
+main()

--- a/scripts/repro/fixtures/fake-gh/bin/omp
+++ b/scripts/repro/fixtures/fake-gh/bin/omp
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Fake `omp` agent for PR-babysitting battle tests: records the invocation
+# (cwd + argv, including the -p prompt) to $FAKE_GH_STATE_DIR/omp-calls.log and
+# exits 0. Set FAKE_OMP_SCRIPT to a script to simulate agent side effects
+# (e.g. pushing a fix); it runs with the same argv and cwd.
+set -euo pipefail
+: "${FAKE_GH_STATE_DIR:?FAKE_GH_STATE_DIR not set}"
+printf 'omp cwd=%s args=%s\n' "$PWD" "$*" >> "$FAKE_GH_STATE_DIR/omp-calls.log"
+if [ -n "${FAKE_OMP_SCRIPT:-}" ]; then
+  bash "$FAKE_OMP_SCRIPT" "$@"
+fi

--- a/scripts/repro/fixtures/fake-gh/scenarios/pr-ci-failed.json
+++ b/scripts/repro/fixtures/fake-gh/scenarios/pr-ci-failed.json
@@ -1,0 +1,46 @@
+{
+  "prs": [
+    {
+      "number": 601,
+      "title": "CI-failed PR",
+      "url": "https://github.com/fake/repo/pull/601",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "master",
+      "headRefName": "stack/601",
+      "headRefOid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "mergeStateStatus": "BLOCKED",
+      "mergeable": "MERGEABLE",
+      "labels": ["admin-bypass", "dequeued"],
+      "reviewThreads": [],
+      "checks": {"*": "SUCCESS", "PR Body": "FAILURE"}
+    },
+    {
+      "number": 602,
+      "title": "Conflicting PR the CI scan must skip",
+      "url": "https://github.com/fake/repo/pull/602",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "master",
+      "headRefName": "stack/602",
+      "headRefOid": "cccccccccccccccccccccccccccccccccccccccc",
+      "mergeStateStatus": "DIRTY",
+      "mergeable": "CONFLICTING",
+      "labels": [],
+      "reviewThreads": [],
+      "checks": {"*": "SUCCESS"}
+    }
+  ],
+  "issue_comments": {
+    "601": [
+      {
+        "id": "m601",
+        "user": {"login": "mergify[bot]"},
+        "updated_at": "2026-07-20T00:00:00Z",
+        "html_url": "https://github.com/fake/repo/pull/601#m601",
+        "body": "Left the queue `admin-bypass` at `bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`.\n-*- Mergify Payload -*-\n{\"state\":\"dequeued\",\"queue_rule_name\":\"admin-bypass\"}\n"
+      }
+    ],
+    "602": []
+  }
+}

--- a/scripts/repro/fixtures/fake-gh/scenarios/pr-dirty.json
+++ b/scripts/repro/fixtures/fake-gh/scenarios/pr-dirty.json
@@ -1,0 +1,22 @@
+{
+  "prs": [
+    {
+      "number": 501,
+      "title": "Conflicting stack PR",
+      "url": "https://github.com/fake/repo/pull/501",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "master",
+      "headRefName": "stack/501",
+      "headRefOid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "mergeStateStatus": "DIRTY",
+      "mergeable": "CONFLICTING",
+      "labels": ["admin-bypass"],
+      "reviewThreads": [],
+      "checks": {"*": "SUCCESS"}
+    }
+  ],
+  "issue_comments": {
+    "501": []
+  }
+}

--- a/scripts/repro/fixtures/fake-gh/scenarios/stack-landable.json
+++ b/scripts/repro/fixtures/fake-gh/scenarios/stack-landable.json
@@ -1,0 +1,46 @@
+{
+  "prs": [
+    {
+      "number": 701,
+      "title": "Landable stack bottom",
+      "url": "https://github.com/fake/repo/pull/701",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "master",
+      "headRefName": "stack/701",
+      "headRefOid": "dddddddddddddddddddddddddddddddddddddddd",
+      "mergeStateStatus": "CLEAN",
+      "mergeable": "MERGEABLE",
+      "labels": ["admin-bypass", "dequeued"],
+      "reviewThreads": [],
+      "checks": {"*": "SUCCESS"}
+    },
+    {
+      "number": 702,
+      "title": "Landable stack top",
+      "url": "https://github.com/fake/repo/pull/702",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "stack/701",
+      "headRefName": "stack/702",
+      "headRefOid": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "mergeStateStatus": "BLOCKED",
+      "mergeable": "MERGEABLE",
+      "labels": ["admin-bypass"],
+      "reviewThreads": [],
+      "checks": {"*": "SUCCESS"}
+    }
+  ],
+  "issue_comments": {
+    "701": [
+      {
+        "id": "m701",
+        "user": {"login": "mergify[bot]"},
+        "updated_at": "2026-07-20T00:00:00Z",
+        "html_url": "https://github.com/fake/repo/pull/701#m701",
+        "body": "Left the queue `admin-bypass` at `dddddddddddddddddddddddddddddddddddddddd`.\n-*- Mergify Payload -*-\n{\"state\":\"dequeued\",\"queue_rule_name\":\"admin-bypass\"}\n"
+      }
+    ],
+    "702": []
+  }
+}

--- a/scripts/repro/repro-babysit-ci-cron.sh
+++ b/scripts/repro/repro-babysit-ci-cron.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Battle-test: the CI-failure cron scans open PRs against a fake GitHub and
+# dispatches repair-review-gate-ci for the CI-failed PR while SKIPPING the
+# conflicted (DIRTY) PR — the conflict-rebase worker owns conflicts.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-ci.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+mkdir -p "$TMP/bin" "$TMP/state" "$TMP/home"
+export FAKE_GH_STATE_DIR="$TMP/state"
+cp "$ROOT/scripts/repro/fixtures/fake-gh/scenarios/pr-ci-failed.json" "$FAKE_GH_STATE_DIR/state.json"
+
+ln -s "$ROOT/scripts/repro/fixtures/fake-gh/bin/gh" "$TMP/bin/gh"
+NODE_LOG="$TMP/node-calls.log"; : > "$NODE_LOG"
+cat > "$TMP/bin/node" <<EOF
+#!/usr/bin/env bash
+printf 'node %s\n' "\$*" >> "$NODE_LOG"
+exit 0
+EOF
+chmod +x "$TMP/bin/node"
+
+out="$(
+  PATH="$TMP/bin:$PATH" \
+  HOME="$TMP/home" \
+  INVOKER_GITHUB_TARGET_REPO="fake/repo" \
+  INVOKER_PR_CRON_LOCK="$TMP/crons.lock" \
+  bash "$ROOT/packages/execution-engine/scripts/cron-pr-ci-failure.sh" 2>&1
+)" || fail "CI scan exited non-zero" "$out"
+
+grep -q "exec -- repair-review-gate-ci 601" "$NODE_LOG" \
+  || fail "expected repair-review-gate-ci dispatch for CI-failed PR #601" "$out"
+grep -q "repair-review-gate-ci 602" "$NODE_LOG" \
+  && fail "conflicted PR #602 must be skipped (rebase worker owns it)" "$out"
+echo "$out" | grep -q "PR #602: skip conflicted PR" \
+  || fail "expected explicit skip log for conflicted PR #602" "$out"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-babysit-conflict-cron.sh
+++ b/scripts/repro/repro-babysit-conflict-cron.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Battle-test: the conflict-rebase cron babysits a DIRTY PR end-to-end against
+# a fake GitHub — one rebase-recreate dispatch per tick, a hard attempt cap
+# when the workflow generation never advances, and exactly one "exhausted"
+# PR comment after the cap.
+#
+# Seams stubbed (no owner process is booted):
+#   gh    -> scripts/repro/fixtures/fake-gh/bin/gh serving pr-dirty.json
+#   node  -> PATH shim recording the headless-ipc rebase-recreate dispatch
+#   resolve_workflow_for_pr -> INVOKER_PR_CRON_REVIEW_GATE_CMD stub whose
+#            generation NEVER advances (the workflow is stuck)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-conflict.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+mkdir -p "$TMP/bin" "$TMP/state" "$TMP/home"
+export FAKE_GH_STATE_DIR="$TMP/state"
+cp "$ROOT/scripts/repro/fixtures/fake-gh/scenarios/pr-dirty.json" "$FAKE_GH_STATE_DIR/state.json"
+
+ln -s "$ROOT/scripts/repro/fixtures/fake-gh/bin/gh" "$TMP/bin/gh"
+NODE_LOG="$TMP/node-calls.log"; : > "$NODE_LOG"
+cat > "$TMP/bin/node" <<EOF
+#!/usr/bin/env bash
+# Record the accepted headless-ipc dispatch; the owner is not booted here.
+printf 'node %s\n' "\$*" >> "$NODE_LOG"
+exit 0
+EOF
+cat > "$TMP/review-gate.sh" <<'RG'
+#!/usr/bin/env bash
+# Workflow lookup for PR #501; the generation never advances.
+printf '{"workflowId":"wf-babysit-1","workflowGeneration":0,"baseBranch":"master"}\n'
+RG
+chmod +x "$TMP/bin/node" "$TMP/review-gate.sh"
+
+run_cron() {
+  PATH="$TMP/bin:$PATH" \
+  HOME="$TMP/home" \
+  INVOKER_GITHUB_TARGET_REPO="fake/repo" \
+  INVOKER_PR_CRON_AUTHOR="fake-bot" \
+  INVOKER_PR_CRON_LOCK="$TMP/crons.lock" \
+  INVOKER_PR_CONFLICT_STATE_FILE="$TMP/ledger.tsv" \
+  INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh" \
+  INVOKER_PR_REBASE_MAX_ATTEMPTS=3 \
+  INVOKER_PR_REBASE_CONFIRM_TIMEOUT=0 \
+  bash "$ROOT/scripts/cron-pr-conflict-rebase.sh" 2>&1 || true
+}
+
+# Ticks 1-3: each dispatches exactly one rebase-recreate for the stuck workflow.
+for i in 1 2 3; do
+  out="$(run_cron)"
+  echo "$out" | grep -q "rebase-recreate wf-babysit-1" \
+    || fail "tick $i: expected a rebase-recreate dispatch" "$out"
+  dispatches="$(grep -c "exec -- rebase-recreate wf-babysit-1" "$NODE_LOG" || true)"
+  [ "$dispatches" -eq "$i" ] \
+    || fail "tick $i: expected exactly $i cumulative dispatches, got $dispatches"
+done
+
+# Ticks 4-5: cap reached — no new dispatch, one-time exhausted comment posted once.
+for i in 4 5; do
+  out="$(run_cron)"
+  echo "$out" | grep -q "giving up" \
+    || fail "tick $i: expected the attempt cap to fire" "$out"
+done
+dispatches="$(grep -c "exec -- rebase-recreate wf-babysit-1" "$NODE_LOG" || true)"
+[ "$dispatches" -eq 3 ] || fail "cap breached: expected 3 dispatches total, got $dispatches"
+
+comments="$(grep -c "^gh pr comment 501" "$FAKE_GH_STATE_DIR/calls.log" || true)"
+[ "$comments" -eq 1 ] || fail "expected exactly one exhausted PR comment, got $comments"
+grep -q "gave up after 3 rebase-recreate attempts" "$FAKE_GH_STATE_DIR/state.json" \
+  || fail "exhausted comment body missing from fake GitHub state"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-babysit-land-dryrun.sh
+++ b/scripts/repro/repro-babysit-land-dryrun.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Battle-test: the mergify admin-bypass landing brain plans the right action
+# per scenario against a fake GitHub, in dry-run (no mutations):
+#   pr-dirty.json       -> rebase_recreate (merge conflict)
+#   pr-ci-failed.json   -> repair_check (failed required check after dequeue)
+#   stack-landable.json -> requeue (clean dequeued bottom PR)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-land.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+mkdir -p "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+# The fake gh expands the "*" checks default to the repo's real required-check
+# names, so the landing brain sees every .mergify.yml-required check green.
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, "scripts")
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path(".mergify.yml"))
+print("\n".join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+run_land() {
+  local scenario="$1"
+  cp "$ROOT/scripts/repro/fixtures/fake-gh/scenarios/$scenario" "$FAKE_GH_STATE_DIR/state.json"
+  : > "$FAKE_GH_STATE_DIR/calls.log"
+  python3 scripts/mergify_admin_requeue.py --once --dry-run \
+    --repo fake/repo --author fake-bot --state-file "$TMP/ledger.jsonl" 2>&1
+}
+
+out="$(run_land pr-dirty.json)"
+echo "$out" | grep -q "DRY-RUN rebase-recreate PR #501" \
+  || fail "pr-dirty: expected rebase_recreate plan" "$out"
+
+out="$(run_land pr-ci-failed.json)"
+echo "$out" | grep -q 'DRY-RUN repair-check PR #601 check="PR Body"' \
+  || fail "pr-ci-failed: expected repair_check plan" "$out"
+
+out="$(run_land stack-landable.json)"
+echo "$out" | grep -q "DRY-RUN requeue PR #701 head=dddddddddddddddddddddddddddddddddddddddd reason=eligible-after-dequeue" \
+  || fail "stack-landable: expected requeue plan for the bottom PR" "$out"
+echo "$out" | grep -q "PR #702" && fail "stack top must not be actioned before the bottom lands" "$out"
+
+# Dry-run must not mutate the fake GitHub: no comments, no label edits.
+if grep -Eq "^gh (pr comment|api --method)" "$FAKE_GH_STATE_DIR/calls.log"; then
+  fail "dry-run performed a mutating gh call" "$(cat "$FAKE_GH_STATE_DIR/calls.log")"
+fi
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

Invoker's PR-babysitting crons had no way to be tested against GitHub without a live repo. This adds an offline battle harness.

A reusable fake `gh` under `scripts/repro/fixtures/fake-gh/` serves PR state from JSON fixtures and records every call.

Fixtures cover a DIRTY PR, a CI-failed PR, and a landable stack.

Three repros drive the real cron entrypoints against it: conflict-rebase dispatch with attempt cap and one-time exhausted comment, the CI sweep, and mergify landing dry-run plans.
## Review Claim

The PR-babysitting cron entrypoints and the mergify landing dry-run are now exercised offline against a committed fake GitHub, with loud failure on any unmodeled `gh` invocation.
## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only test fixtures and repro scripts are added. No product code changes; the fake `gh` exits 64 on unknown argv so gaps fail loudly.

## Slice Rationale

Evidence before change: this harness proves current cron and landing behavior so the later planner fix and worker boot wiring are reviewed against a working test rig. Suite wiring is the next slice.
## Non-goals

- No change to the cron scripts or the mergify planner.
- No worker auto-start wiring (later slice).
- No live-GitHub testing (opt-in dangerous suite comes later).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-babysit-conflict-cron.sh`
- [x] `bash scripts/repro/repro-babysit-ci-cron.sh`
- [x] `bash scripts/repro/repro-babysit-land-dryrun.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
