### PR TITLE
[PR babysit](3) Thread caps and trunk into the mergify landing planner

### DIFF
--- a/scripts/mergify_admin_requeue.py
+++ b/scripts/mergify_admin_requeue.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Mapping, Sequence
+from typing import Sequence
 
 try:
     from . import mergify_admin_requeue_exec as exec_impl
@@ -20,43 +20,10 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 parse_args = exec_impl.parse_args
 run_once = exec_impl.run_once
 subprocess = exec_impl.subprocess
-_repair_conflict = exec_impl.repair_conflict
-_repair_check = exec_impl.repair_check
-_resolve_workflow = exec_impl.resolve_workflow
-
-
-def _execute_action(action: Action, repo: str, gh, ledger: Ledger, pr_by_number: Mapping[int, PrSnapshot], now: int) -> None:
-    pr = pr_by_number[action.pr_number]
-    if action.kind == "requeue":
-        gh.comment(repo, action.pr_number, "@mergifyio queue")
-        ledger.record("requeue", action.pr_number, pr.head_ref_oid, action.key, now)
-    elif action.kind == "comment_admin_bypass_nudge":
-        if ledger.count(exec_impl.ADMIN_BYPASS_NUDGE_LEDGER_KIND, action.pr_number, pr.head_ref_oid, action.key) == 0:
-            gh.comment(repo, action.pr_number, exec_impl.admin_bypass_nudge_body())
-            ledger.record(exec_impl.ADMIN_BYPASS_NUDGE_LEDGER_KIND, action.pr_number, pr.head_ref_oid, action.key, now)
-    elif action.kind == "remove_merge_hold":
-        gh.edit_label(repo, action.pr_number, remove="merge-hold")
-        ledger.record("remove-merge-hold", action.pr_number, pr.head_ref_oid, "merge-hold", now)
-    elif action.kind == "resolve_bot_threads":
-        gh.resolve_review_thread(action.key)
-    elif action.kind == "repair_check":
-        check_name = action.key.split(":", 1)[-1]
-        kind = "repair-bot-thread" if action.key.startswith("bot_review_thread:") else "repair-check"
-        ledger.record(kind, action.pr_number, pr.head_ref_oid, check_name, now)
-        _repair_check(repo, pr, check_name)
-    elif action.kind == "rebase_recreate":
-        ledger.record("conflict-repair", action.pr_number, pr.head_ref_oid, action.key, now)
-        try:
-            workflow, _generation = _resolve_workflow(action.pr_number)
-        except RuntimeError as exc:
-            _repair_conflict(repo, pr, str(exc))
-            return
-        subprocess.run(["node", "scripts/headless-ipc.js", "exec", "--", "rebase-recreate", workflow], cwd=str(REPO_ROOT), check=True, text=True, capture_output=True)
-    elif action.kind == "comment_blocked" and action.key == "capped":
-        key = f"capped:{action.detail}"
-        if ledger.count("comment-blocked", action.pr_number, pr.head_ref_oid, key) == 0:
-            gh.comment(repo, action.pr_number, f"Invoker Mergify repair stopped: {action.detail}")
-            ledger.record("comment-blocked", action.pr_number, pr.head_ref_oid, key, now)
+execute_action = exec_impl.execute_action
+resolve_workflow = exec_impl.resolve_workflow
+repair_conflict = exec_impl.repair_conflict
+repair_check = exec_impl.repair_check
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -208,7 +208,15 @@ def run_once(args: argparse.Namespace) -> int:
     now = int(time.time())
     pr_by_number = {pr.number: pr for pr in snapshots}
     for stack in stacks:
-        for action in plan_stack_actions(stack, required_checks, ledger, now):
+        for action in plan_stack_actions(
+            stack,
+            required_checks,
+            ledger,
+            now,
+            trunk=trunk,
+            max_repair_attempts=args.max_repair_attempts,
+            max_requeue_attempts=args.max_requeue_attempts,
+        ):
             pr = pr_by_number.get(action.pr_number)
             print_action(action, pr, args.dry_run, args.json)
             if not args.dry_run:

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -8,9 +8,6 @@ except ImportError:
     from mergify_admin_requeue_model import Action, BOT_OR_SELF_AUTHORS, Blocker, Ledger, MergifyQueueEvent, PrSnapshot, StackGroup
 
 
-TRUNK = "master"
-
-
 def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) -> tuple[Blocker, ...]:
     blockers: list[Blocker] = []
     if pr.state != "OPEN":
@@ -75,24 +72,32 @@ def effective_blockers(pr: PrSnapshot, required_checks: Collection[str], trunk: 
     )
 
 
-def mergify_failed_check_actions(pr: PrSnapshot, ledger: Ledger) -> tuple[Action, ...]:
+def mergify_failed_check_actions(pr: PrSnapshot, ledger: Ledger, max_repair_attempts: int = 3) -> tuple[Action, ...]:
     latest = pr.latest_mergify
     if not latest or latest.state != "dequeued" or latest.head_sha != pr.head_ref_oid:
         return ()
     for name in latest.failing_checks:
-        if ledger.count("repair-check", pr.number, pr.head_ref_oid, name) >= 3:
+        if ledger.count("repair-check", pr.number, pr.head_ref_oid, name) >= max_repair_attempts:
             return (cap_action(pr, Blocker(name, "failed_check", pr.number, f"Mergify queue check failed: {name}"), f"Mergify queue check failed: {name}"),)
         return (Action("repair_check", pr.number, name, f"Mergify queue check failed: {name}"),)
     return ()
 
 
-def plan_stack_actions(stack: StackGroup, required_checks: Collection[str], ledger: Ledger, now_epoch: int) -> tuple[Action, ...]:
+def plan_stack_actions(
+    stack: StackGroup,
+    required_checks: Collection[str],
+    ledger: Ledger,
+    now_epoch: int,
+    trunk: str = "master",
+    max_repair_attempts: int = 3,
+    max_requeue_attempts: int = 2,
+) -> tuple[Action, ...]:
     del now_epoch
-    blockers_by_pr = {pr.number: effective_blockers(pr, required_checks, TRUNK) for pr in stack.prs}
+    blockers_by_pr = {pr.number: effective_blockers(pr, required_checks, trunk) for pr in stack.prs}
     all_blockers = [b for blockers in blockers_by_pr.values() for b in blockers]
 
     for pr in stack.prs:
-        actions = mergify_failed_check_actions(pr, ledger)
+        actions = mergify_failed_check_actions(pr, ledger, max_repair_attempts)
         if actions:
             return actions
 
@@ -100,11 +105,11 @@ def plan_stack_actions(stack: StackGroup, required_checks: Collection[str], ledg
         for blocker in blockers_by_pr[pr.number]:
             if blocker.kind == "conflict":
                 key = f"conflict:{pr.number}"
-                if ledger.count("conflict-repair", pr.number, pr.head_ref_oid, key) >= 3:
+                if ledger.count("conflict-repair", pr.number, pr.head_ref_oid, key) >= max_repair_attempts:
                     return (cap_action(pr, blocker, blocker.detail),)
                 return (Action("rebase_recreate", pr.number, key, blocker.detail),)
             if blocker.kind == "failed_check":
-                if ledger.count("repair-check", pr.number, pr.head_ref_oid, blocker.key) >= 3:
+                if ledger.count("repair-check", pr.number, pr.head_ref_oid, blocker.key) >= max_repair_attempts:
                     return (cap_action(pr, blocker, blocker.detail),)
                 return (Action("repair_check", pr.number, blocker.key, blocker.detail),)
 
@@ -113,7 +118,7 @@ def plan_stack_actions(stack: StackGroup, required_checks: Collection[str], ledg
             if blocker.kind == "bot_review_thread":
                 if ledger.has_different_head("repair-bot-thread", pr.number, pr.head_ref_oid, blocker.key):
                     return (Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail),)
-                if ledger.count("repair-bot-thread", pr.number, pr.head_ref_oid, blocker.key) >= 3:
+                if ledger.count("repair-bot-thread", pr.number, pr.head_ref_oid, blocker.key) >= max_repair_attempts:
                     return (cap_action(pr, blocker, blocker.detail),)
                 return (Action("repair_check", pr.number, "bot_review_thread:" + blocker.key, blocker.detail),)
 
@@ -124,10 +129,10 @@ def plan_stack_actions(stack: StackGroup, required_checks: Collection[str], ledg
             if blocker.kind in {"draft", "human_review_thread", "missing_check", "closed"}:
                 return (Action("comment_blocked", pr.number, blocker.key, public_blocker_kind(blocker.kind)),)
 
-    current_bottoms = [pr for pr in stack.prs if pr.state == "OPEN" and pr.base_ref_name == TRUNK]
+    current_bottoms = [pr for pr in stack.prs if pr.state == "OPEN" and pr.base_ref_name == trunk]
     if not current_bottoms:
         first = stack.prs[0]
-        return (Action("comment_blocked", first.number, "no-current-bottom", "no current bottom on master"),)
+        return (Action("comment_blocked", first.number, "no-current-bottom", f"no current bottom on {trunk}"),)
     bottom = current_bottoms[0]
 
     non_hold_blockers = [b for b in all_blockers if b.kind != "merge_hold"]
@@ -154,6 +159,6 @@ def plan_stack_actions(stack: StackGroup, required_checks: Collection[str], ledg
         requeue_reason = "eligible-after-dequeued-label"
     if not requeue_reason:
         return ()
-    if ledger.count("requeue", bottom.number, bottom.head_ref_oid, requeue_key) >= 2:
+    if ledger.count("requeue", bottom.number, bottom.head_ref_oid, requeue_key) >= max_requeue_attempts:
         return (cap_action(bottom, Blocker(requeue_key, "capped", bottom.number, "requeue"), "requeue"),)
     return (Action("requeue", bottom.number, requeue_key, requeue_reason),)

--- a/scripts/repro/fixtures/fake-gh/bin/gh
+++ b/scripts/repro/fixtures/fake-gh/bin/gh
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Reusable fake `gh` for PR-babysitting battle tests.
+
+Reads/writes a single JSON state file at $FAKE_GH_STATE_DIR/state.json and
+appends every invocation (argv, plus stdin when piped) to
+$FAKE_GH_STATE_DIR/calls.log so repro scripts can assert exactly what the code
+under test asked GitHub for. Mutating verbs update state.json so subsequent
+reads observe the mutation. Unknown argv exits 64 with the argv echoed: a
+scenario gap fails tests loudly instead of silently succeeding.
+
+State schema (see scripts/repro/fixtures/fake-gh/scenarios/*.json):
+  {
+    "prs": [{
+      "number": 501, "title": "...", "url": "...", "state": "OPEN",
+      "isDraft": false, "baseRefName": "master", "headRefName": "stack/501",
+      "headRefOid": "<40-hex>", "mergeStateStatus": "DIRTY",
+      "mergeable": "CONFLICTING", "labels": ["admin-bypass"],
+      "reviewThreads": [], "checks": {"*": "SUCCESS", "PR Body": "FAILURE"}
+    }],
+    "issue_comments": {"501": [ ...gh api issues/N/comments shape... ]}
+  }
+
+`checks` maps check name -> conclusion; "*" applies to every required check
+named in $FAKE_GH_REQUIRED_CHECKS (newline-separated; check names contain
+spaces and slashes, never newlines).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+STATE_DIR = os.environ.get("FAKE_GH_STATE_DIR", "")
+if not STATE_DIR:
+    print("fake gh: FAKE_GH_STATE_DIR not set", file=sys.stderr)
+    sys.exit(64)
+
+ARGS = sys.argv[1:]
+STDIN = "" if sys.stdin.isatty() else sys.stdin.read()
+with open(Path(STATE_DIR) / "calls.log", "a", encoding="utf-8") as log:
+    log.write("gh " + " ".join(ARGS) + ("\n<<< " + STDIN.replace("\n", "\\n") if STDIN else "") + "\n")
+
+STATE_PATH = Path(STATE_DIR) / "state.json"
+
+
+def load_state() -> dict:
+    with open(STATE_PATH, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def save_state(state: dict) -> None:
+    with open(STATE_PATH, "w", encoding="utf-8") as handle:
+        json.dump(state, handle, indent=2)
+
+
+def required_checks() -> list[str]:
+    raw = os.environ.get("FAKE_GH_REQUIRED_CHECKS", "")
+    return [name for name in raw.split("\n") if name.strip()]
+
+
+def unhandled() -> None:
+    print(f"fake gh: unhandled argv: {ARGS}", file=sys.stderr)
+    sys.exit(64)
+
+
+def flag_value(name: str) -> str | None:
+    for index, arg in enumerate(ARGS):
+        if arg == name and index + 1 < len(ARGS):
+            return ARGS[index + 1]
+        if arg.startswith(name + "="):
+            return arg.split("=", 1)[1]
+    return None
+
+
+def check_nodes(pr: dict) -> list[dict]:
+    checks = pr.get("checks") or {}
+    default = checks.get("*")
+    names: set[str] = {name for name in checks if name != "*"}
+    if default is not None:
+        names.update(required_checks())
+    nodes = []
+    for name in sorted(names):
+        conclusion = checks.get(name, default)
+        if conclusion is None:
+            continue
+        nodes.append({
+            "__typename": "CheckRun",
+            "name": name,
+            "conclusion": conclusion,
+            "status": "COMPLETED",
+            "completedAt": "2026-07-20T00:00:00Z",
+            "startedAt": "2026-07-20T00:00:00Z",
+            "detailsUrl": "https://github.com/fake/repo/actions/runs/1/job/2",
+            "checkSuite": {"commit": {"oid": pr.get("headRefOid", "")}},
+        })
+    return nodes
+
+
+def project_pr(pr: dict, fields: list[str]) -> dict:
+    out: dict = {}
+    for field in fields:
+        if field == "labels":
+            out["labels"] = [{"name": name} for name in pr.get("labels", [])]
+        elif field == "statusCheckRollup":
+            out["statusCheckRollup"] = check_nodes(pr)
+        elif field == "reviewDecision":
+            out["reviewDecision"] = pr.get("reviewDecision", "")
+        else:
+            out[field] = pr.get(field)
+    return out
+
+
+def graphql_detail(pr: dict) -> dict:
+    return {
+        "number": pr.get("number"),
+        "title": pr.get("title", ""),
+        "url": pr.get("url", ""),
+        "isDraft": pr.get("isDraft", False),
+        "state": pr.get("state", "OPEN"),
+        "baseRefName": pr.get("baseRefName", ""),
+        "headRefName": pr.get("headRefName", ""),
+        "headRefOid": pr.get("headRefOid", ""),
+        "mergeStateStatus": pr.get("mergeStateStatus", ""),
+        "mergeable": pr.get("mergeable", ""),
+        "labels": {"nodes": [{"name": name} for name in pr.get("labels", [])]},
+        "reviewThreads": {"pageInfo": {"hasNextPage": False}, "nodes": pr.get("reviewThreads", [])},
+        "statusCheckRollup": {"contexts": {"nodes": check_nodes(pr)}},
+    }
+
+
+def find_pr(state: dict, number: int) -> dict | None:
+    for pr in state.get("prs", []):
+        if int(pr.get("number", 0)) == number:
+            return pr
+    return None
+
+
+def main() -> None:
+    state = load_state()
+
+    if ARGS[:2] == ["pr", "list"]:
+        fields = (flag_value("--json") or "number").split(",")
+        label = flag_value("--label")
+        state_filter = flag_value("--state") or "open"
+        prs = state.get("prs", [])
+        if state_filter == "open":
+            prs = [pr for pr in prs if pr.get("state", "OPEN") == "OPEN"]
+        if label:
+            prs = [pr for pr in prs if label in pr.get("labels", [])]
+        print(json.dumps([project_pr(pr, fields) for pr in prs]))
+        return
+
+    if ARGS[:2] == ["pr", "view"]:
+        number = int(ARGS[2])
+        pr = find_pr(state, number)
+        if pr is None:
+            print(f"fake gh: no PR #{number} in state", file=sys.stderr)
+            sys.exit(1)
+        fields = (flag_value("--json") or "number").split(",")
+        print(json.dumps(project_pr(pr, fields)))
+        return
+
+    if ARGS[:2] == ["pr", "comment"]:
+        number = ARGS[2]
+        body = flag_value("--body") or ""
+        comments = state.setdefault("issue_comments", {}).setdefault(str(number), [])
+        comments.append({
+            "id": f"fake-comment-{len(comments) + 1}",
+            "user": {"login": "invoker-bot"},
+            "body": body,
+            "updated_at": "2026-07-20T00:00:00Z",
+            "html_url": f"https://github.com/fake/repo/pull/{number}#fake",
+        })
+        save_state(state)
+        return
+
+    if ARGS[:2] == ["api", "graphql"]:
+        number = 0
+        for arg in ARGS:
+            if arg.startswith("number="):
+                number = int(arg.split("=", 1)[1])
+        if number:
+            pr = find_pr(state, number)
+            if pr is None:
+                print(f"fake gh: no PR #{number} in state", file=sys.stderr)
+                sys.exit(1)
+            print(json.dumps({"data": {"repository": {"pullRequest": graphql_detail(pr)}}}))
+            return
+        if any("resolveReviewThread" in arg for arg in ARGS):
+            # Thread resolution is observable via calls.log only.
+            print(json.dumps({"data": {"resolveReviewThread": {"thread": {"isResolved": True}}}}))
+            return
+        unhandled()
+
+    if ARGS[0] == "api":
+        path = next((arg for arg in ARGS[1:] if not arg.startswith("-")), "")
+        comments_match = re.fullmatch(r"repos/[^/]+/[^/]+/issues/(\d+)/comments", path)
+        if comments_match and flag_value("--method") in (None, "GET"):
+            print(json.dumps(state.get("issue_comments", {}).get(comments_match.group(1), [])))
+            return
+        add_label_match = re.fullmatch(r"repos/[^/]+/[^/]+/issues/(\d+)/labels", path)
+        if add_label_match and flag_value("--method") == "POST":
+            pr = find_pr(state, int(add_label_match.group(1)))
+            label = (flag_value("-f") or "").split("=", 1)[-1]
+            if pr is not None and label and label not in pr.setdefault("labels", []):
+                pr["labels"].append(label)
+                save_state(state)
+            return
+        remove_label_match = re.fullmatch(r"repos/[^/]+/[^/]+/issues/(\d+)/labels/(.+)", path)
+        if remove_label_match and flag_value("--method") == "DELETE":
+            pr = find_pr(state, int(remove_label_match.group(1)))
+            if pr is not None:
+                pr["labels"] = [l for l in pr.get("labels", []) if l != remove_label_match.group(2)]
+                save_state(state)
+            return
+        unhandled()
+
+    if ARGS[:2] == ["auth", "status"]:
+        return
+
+    unhandled()
+
+
+main()

--- a/scripts/repro/fixtures/fake-gh/bin/omp
+++ b/scripts/repro/fixtures/fake-gh/bin/omp
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Fake `omp` agent for PR-babysitting battle tests: records the invocation
+# (cwd + argv, including the -p prompt) to $FAKE_GH_STATE_DIR/omp-calls.log and
+# exits 0. Set FAKE_OMP_SCRIPT to a script to simulate agent side effects
+# (e.g. pushing a fix); it runs with the same argv and cwd.
+set -euo pipefail
+: "${FAKE_GH_STATE_DIR:?FAKE_GH_STATE_DIR not set}"
+printf 'omp cwd=%s args=%s\n' "$PWD" "$*" >> "$FAKE_GH_STATE_DIR/omp-calls.log"
+if [ -n "${FAKE_OMP_SCRIPT:-}" ]; then
+  bash "$FAKE_OMP_SCRIPT" "$@"
+fi

--- a/scripts/repro/fixtures/fake-gh/scenarios/pr-ci-failed.json
+++ b/scripts/repro/fixtures/fake-gh/scenarios/pr-ci-failed.json
@@ -1,0 +1,46 @@
+{
+  "prs": [
+    {
+      "number": 601,
+      "title": "CI-failed PR",
+      "url": "https://github.com/fake/repo/pull/601",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "master",
+      "headRefName": "stack/601",
+      "headRefOid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "mergeStateStatus": "BLOCKED",
+      "mergeable": "MERGEABLE",
+      "labels": ["admin-bypass", "dequeued"],
+      "reviewThreads": [],
+      "checks": {"*": "SUCCESS", "PR Body": "FAILURE"}
+    },
+    {
+      "number": 602,
+      "title": "Conflicting PR the CI scan must skip",
+      "url": "https://github.com/fake/repo/pull/602",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "master",
+      "headRefName": "stack/602",
+      "headRefOid": "cccccccccccccccccccccccccccccccccccccccc",
+      "mergeStateStatus": "DIRTY",
+      "mergeable": "CONFLICTING",
+      "labels": [],
+      "reviewThreads": [],
+      "checks": {"*": "SUCCESS"}
+    }
+  ],
+  "issue_comments": {
+    "601": [
+      {
+        "id": "m601",
+        "user": {"login": "mergify[bot]"},
+        "updated_at": "2026-07-20T00:00:00Z",
+        "html_url": "https://github.com/fake/repo/pull/601#m601",
+        "body": "Left the queue `admin-bypass` at `bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`.\n-*- Mergify Payload -*-\n{\"state\":\"dequeued\",\"queue_rule_name\":\"admin-bypass\"}\n"
+      }
+    ],
+    "602": []
+  }
+}

--- a/scripts/repro/fixtures/fake-gh/scenarios/pr-dirty.json
+++ b/scripts/repro/fixtures/fake-gh/scenarios/pr-dirty.json
@@ -1,0 +1,22 @@
+{
+  "prs": [
+    {
+      "number": 501,
+      "title": "Conflicting stack PR",
+      "url": "https://github.com/fake/repo/pull/501",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "master",
+      "headRefName": "stack/501",
+      "headRefOid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "mergeStateStatus": "DIRTY",
+      "mergeable": "CONFLICTING",
+      "labels": ["admin-bypass"],
+      "reviewThreads": [],
+      "checks": {"*": "SUCCESS"}
+    }
+  ],
+  "issue_comments": {
+    "501": []
+  }
+}

--- a/scripts/repro/fixtures/fake-gh/scenarios/stack-landable.json
+++ b/scripts/repro/fixtures/fake-gh/scenarios/stack-landable.json
@@ -1,0 +1,46 @@
+{
+  "prs": [
+    {
+      "number": 701,
+      "title": "Landable stack bottom",
+      "url": "https://github.com/fake/repo/pull/701",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "master",
+      "headRefName": "stack/701",
+      "headRefOid": "dddddddddddddddddddddddddddddddddddddddd",
+      "mergeStateStatus": "CLEAN",
+      "mergeable": "MERGEABLE",
+      "labels": ["admin-bypass", "dequeued"],
+      "reviewThreads": [],
+      "checks": {"*": "SUCCESS"}
+    },
+    {
+      "number": 702,
+      "title": "Landable stack top",
+      "url": "https://github.com/fake/repo/pull/702",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "stack/701",
+      "headRefName": "stack/702",
+      "headRefOid": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "mergeStateStatus": "BLOCKED",
+      "mergeable": "MERGEABLE",
+      "labels": ["admin-bypass"],
+      "reviewThreads": [],
+      "checks": {"*": "SUCCESS"}
+    }
+  ],
+  "issue_comments": {
+    "701": [
+      {
+        "id": "m701",
+        "user": {"login": "mergify[bot]"},
+        "updated_at": "2026-07-20T00:00:00Z",
+        "html_url": "https://github.com/fake/repo/pull/701#m701",
+        "body": "Left the queue `admin-bypass` at `dddddddddddddddddddddddddddddddddddddddd`.\n-*- Mergify Payload -*-\n{\"state\":\"dequeued\",\"queue_rule_name\":\"admin-bypass\"}\n"
+      }
+    ],
+    "702": []
+  }
+}

--- a/scripts/repro/repro-babysit-ci-cron.sh
+++ b/scripts/repro/repro-babysit-ci-cron.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Battle-test: the CI-failure cron scans open PRs against a fake GitHub and
+# dispatches repair-review-gate-ci for the CI-failed PR while SKIPPING the
+# conflicted (DIRTY) PR — the conflict-rebase worker owns conflicts.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-ci.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+mkdir -p "$TMP/bin" "$TMP/state" "$TMP/home"
+export FAKE_GH_STATE_DIR="$TMP/state"
+cp "$ROOT/scripts/repro/fixtures/fake-gh/scenarios/pr-ci-failed.json" "$FAKE_GH_STATE_DIR/state.json"
+
+ln -s "$ROOT/scripts/repro/fixtures/fake-gh/bin/gh" "$TMP/bin/gh"
+NODE_LOG="$TMP/node-calls.log"; : > "$NODE_LOG"
+cat > "$TMP/bin/node" <<EOF
+#!/usr/bin/env bash
+printf 'node %s\n' "\$*" >> "$NODE_LOG"
+exit 0
+EOF
+chmod +x "$TMP/bin/node"
+
+out="$(
+  PATH="$TMP/bin:$PATH" \
+  HOME="$TMP/home" \
+  INVOKER_GITHUB_TARGET_REPO="fake/repo" \
+  INVOKER_PR_CRON_LOCK="$TMP/crons.lock" \
+  bash "$ROOT/packages/execution-engine/scripts/cron-pr-ci-failure.sh" 2>&1
+)" || fail "CI scan exited non-zero" "$out"
+
+grep -q "exec -- repair-review-gate-ci 601" "$NODE_LOG" \
+  || fail "expected repair-review-gate-ci dispatch for CI-failed PR #601" "$out"
+grep -q "repair-review-gate-ci 602" "$NODE_LOG" \
+  && fail "conflicted PR #602 must be skipped (rebase worker owns it)" "$out"
+echo "$out" | grep -q "PR #602: skip conflicted PR" \
+  || fail "expected explicit skip log for conflicted PR #602" "$out"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-babysit-conflict-cron.sh
+++ b/scripts/repro/repro-babysit-conflict-cron.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Battle-test: the conflict-rebase cron babysits a DIRTY PR end-to-end against
+# a fake GitHub — one rebase-recreate dispatch per tick, a hard attempt cap
+# when the workflow generation never advances, and exactly one "exhausted"
+# PR comment after the cap.
+#
+# Seams stubbed (no owner process is booted):
+#   gh    -> scripts/repro/fixtures/fake-gh/bin/gh serving pr-dirty.json
+#   node  -> PATH shim recording the headless-ipc rebase-recreate dispatch
+#   resolve_workflow_for_pr -> INVOKER_PR_CRON_REVIEW_GATE_CMD stub whose
+#            generation NEVER advances (the workflow is stuck)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-conflict.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+mkdir -p "$TMP/bin" "$TMP/state" "$TMP/home"
+export FAKE_GH_STATE_DIR="$TMP/state"
+cp "$ROOT/scripts/repro/fixtures/fake-gh/scenarios/pr-dirty.json" "$FAKE_GH_STATE_DIR/state.json"
+
+ln -s "$ROOT/scripts/repro/fixtures/fake-gh/bin/gh" "$TMP/bin/gh"
+NODE_LOG="$TMP/node-calls.log"; : > "$NODE_LOG"
+cat > "$TMP/bin/node" <<EOF
+#!/usr/bin/env bash
+# Record the accepted headless-ipc dispatch; the owner is not booted here.
+printf 'node %s\n' "\$*" >> "$NODE_LOG"
+exit 0
+EOF
+cat > "$TMP/review-gate.sh" <<'RG'
+#!/usr/bin/env bash
+# Workflow lookup for PR #501; the generation never advances.
+printf '{"workflowId":"wf-babysit-1","workflowGeneration":0,"baseBranch":"master"}\n'
+RG
+chmod +x "$TMP/bin/node" "$TMP/review-gate.sh"
+
+run_cron() {
+  PATH="$TMP/bin:$PATH" \
+  HOME="$TMP/home" \
+  INVOKER_GITHUB_TARGET_REPO="fake/repo" \
+  INVOKER_PR_CRON_AUTHOR="fake-bot" \
+  INVOKER_PR_CRON_LOCK="$TMP/crons.lock" \
+  INVOKER_PR_CONFLICT_STATE_FILE="$TMP/ledger.tsv" \
+  INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh" \
+  INVOKER_PR_REBASE_MAX_ATTEMPTS=3 \
+  INVOKER_PR_REBASE_CONFIRM_TIMEOUT=0 \
+  bash "$ROOT/scripts/cron-pr-conflict-rebase.sh" 2>&1 || true
+}
+
+# Ticks 1-3: each dispatches exactly one rebase-recreate for the stuck workflow.
+for i in 1 2 3; do
+  out="$(run_cron)"
+  echo "$out" | grep -q "rebase-recreate wf-babysit-1" \
+    || fail "tick $i: expected a rebase-recreate dispatch" "$out"
+  dispatches="$(grep -c "exec -- rebase-recreate wf-babysit-1" "$NODE_LOG" || true)"
+  [ "$dispatches" -eq "$i" ] \
+    || fail "tick $i: expected exactly $i cumulative dispatches, got $dispatches"
+done
+
+# Ticks 4-5: cap reached — no new dispatch, one-time exhausted comment posted once.
+for i in 4 5; do
+  out="$(run_cron)"
+  echo "$out" | grep -q "giving up" \
+    || fail "tick $i: expected the attempt cap to fire" "$out"
+done
+dispatches="$(grep -c "exec -- rebase-recreate wf-babysit-1" "$NODE_LOG" || true)"
+[ "$dispatches" -eq 3 ] || fail "cap breached: expected 3 dispatches total, got $dispatches"
+
+comments="$(grep -c "^gh pr comment 501" "$FAKE_GH_STATE_DIR/calls.log" || true)"
+[ "$comments" -eq 1 ] || fail "expected exactly one exhausted PR comment, got $comments"
+grep -q "gave up after 3 rebase-recreate attempts" "$FAKE_GH_STATE_DIR/state.json" \
+  || fail "exhausted comment body missing from fake GitHub state"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-babysit-land-dryrun.sh
+++ b/scripts/repro/repro-babysit-land-dryrun.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Battle-test: the mergify admin-bypass landing brain plans the right action
+# per scenario against a fake GitHub, in dry-run (no mutations):
+#   pr-dirty.json       -> rebase_recreate (merge conflict)
+#   pr-ci-failed.json   -> repair_check (failed required check after dequeue)
+#   stack-landable.json -> requeue (clean dequeued bottom PR)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-land.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+mkdir -p "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+# The fake gh expands the "*" checks default to the repo's real required-check
+# names, so the landing brain sees every .mergify.yml-required check green.
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, "scripts")
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path(".mergify.yml"))
+print("\n".join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+run_land() {
+  local scenario="$1"
+  cp "$ROOT/scripts/repro/fixtures/fake-gh/scenarios/$scenario" "$FAKE_GH_STATE_DIR/state.json"
+  : > "$FAKE_GH_STATE_DIR/calls.log"
+  python3 scripts/mergify_admin_requeue.py --once --dry-run \
+    --repo fake/repo --author fake-bot --state-file "$TMP/ledger.jsonl" 2>&1
+}
+
+out="$(run_land pr-dirty.json)"
+echo "$out" | grep -q "DRY-RUN rebase-recreate PR #501" \
+  || fail "pr-dirty: expected rebase_recreate plan" "$out"
+
+out="$(run_land pr-ci-failed.json)"
+echo "$out" | grep -q 'DRY-RUN repair-check PR #601 check="PR Body"' \
+  || fail "pr-ci-failed: expected repair_check plan" "$out"
+
+out="$(run_land stack-landable.json)"
+echo "$out" | grep -q "DRY-RUN requeue PR #701 head=dddddddddddddddddddddddddddddddddddddddd reason=eligible-after-dequeue" \
+  || fail "stack-landable: expected requeue plan for the bottom PR" "$out"
+echo "$out" | grep -q "PR #702" && fail "stack top must not be actioned before the bottom lands" "$out"
+
+# Dry-run must not mutate the fake GitHub: no comments, no label edits.
+if grep -Eq "^gh (pr comment|api --method)" "$FAKE_GH_STATE_DIR/calls.log"; then
+  fail "dry-run performed a mutating gh call" "$(cat "$FAKE_GH_STATE_DIR/calls.log")"
+fi
+
+echo "[repro] passed"

--- a/scripts/test-suites/required/28-pr-babysit-harness.sh
+++ b/scripts/test-suites/required/28-pr-babysit-harness.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Offline battle harness for the PR-babysitting chain: conflict-rebase cron,
+# CI-failure scan cron, and the mergify admin-bypass landing brain, all driven
+# against the reusable fake gh in scripts/repro/fixtures/fake-gh/.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+bash scripts/repro/repro-babysit-conflict-cron.sh
+bash scripts/repro/repro-babysit-ci-cron.sh
+bash scripts/repro/repro-babysit-land-dryrun.sh

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -225,7 +225,7 @@ Failing checks
                 subprocess.CalledProcessError(1, ["./run.sh"], stderr="missing workflow")
             )
             with self.assertRaisesRegex(RuntimeError, "missing workflow"):
-                requeue._resolve_workflow(2647)
+                requeue.resolve_workflow(2647)
         finally:
             requeue.subprocess.run = original_run
 
@@ -243,16 +243,16 @@ Failing checks
         action = Action("rebase_recreate", 2647, "conflict:2647", "GitHub reports merge conflict")
         fake = FakeGh()
         repairs = []
-        original_resolve = requeue._resolve_workflow
-        original_repair = requeue._repair_conflict
+        original_resolve = requeue.exec_impl.resolve_workflow
+        original_repair = requeue.exec_impl.repair_conflict
         try:
-            requeue._resolve_workflow = lambda pr_number: (_ for _ in ()).throw(RuntimeError(f"no local workflow for PR #{pr_number}"))
-            requeue._repair_conflict = lambda repo, pr, reason: repairs.append((repo, pr.number, reason))
+            requeue.exec_impl.resolve_workflow = lambda pr_number: (_ for _ in ()).throw(RuntimeError(f"no local workflow for PR #{pr_number}"))
+            requeue.exec_impl.repair_conflict = lambda repo, pr, reason: repairs.append((repo, pr.number, reason))
             for epoch in range(3):
-                requeue._execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, epoch)
+                requeue.execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, epoch)
         finally:
-            requeue._resolve_workflow = original_resolve
-            requeue._repair_conflict = original_repair
+            requeue.exec_impl.resolve_workflow = original_resolve
+            requeue.exec_impl.repair_conflict = original_repair
         self.assertEqual(ledger.count("conflict-repair", 2647, HEAD, "conflict:2647"), 3)
         self.assertEqual([repair[1] for repair in repairs], [2647, 2647, 2647])
         self.assertEqual(fake.comments, [])
@@ -271,8 +271,8 @@ Failing checks
         item = pr(2647, merge_state="DIRTY", latest=mergify())
         action = Action("comment_blocked", 2647, "capped", "GitHub reports merge conflict. The retry cap was reached for current head " + HEAD + ".")
         fake = FakeGh()
-        requeue._execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 1)
-        requeue._execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 2)
+        requeue.execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 1)
+        requeue.execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 2)
         self.assertEqual(len(fake.comments), 1)
 
     def test_missing_admin_bypass_nudge_comments_once_without_label_edit(self):
@@ -288,7 +288,7 @@ Failing checks
                 self.label_edits.append((repo, pr_number, add, remove))
 
         action = Action("comment_admin_bypass_nudge", 2647, "admin-bypass", "missing admin-bypass label")
-        for execute in (requeue._execute_action, requeue.exec_impl.execute_action):
+        for execute in (requeue.execute_action,):
             ledger = self.ledger()
             item = pr(2647, labels={"dequeued"}, latest=mergify())
             fake = FakeGh()

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -147,6 +147,34 @@ class PlanStackActions(unittest.TestCase):
         actions = self._plan(snapshot, ledger)
         self.assertEqual((actions[0].kind, actions[0].key), ("comment_blocked", "capped"))
 
+    def test_max_repair_attempts_parameter_caps_conflict_repair(self):
+        # cap=1: one prior conflict-repair attempt on this head -> next plan is capped.
+        ledger = self._ledger()
+        snapshot = pr(merge_state_status="DIRTY")
+        first = p.plan_stack_actions(m.StackGroup("s", (snapshot,)), REQUIRED, ledger, now_epoch=0, max_repair_attempts=1)
+        self.assertEqual(first[0].kind, "rebase_recreate")
+        ledger.record("conflict-repair", 1, HEAD, "conflict:1")
+        second = p.plan_stack_actions(m.StackGroup("s", (snapshot,)), REQUIRED, ledger, now_epoch=1, max_repair_attempts=1)
+        self.assertEqual((second[0].kind, second[0].key), ("comment_blocked", "capped"))
+        self.assertIn("The retry cap was reached", second[0].detail)
+
+    def test_max_requeue_attempts_parameter_caps_requeue(self):
+        ledger = self._ledger()
+        ledger.record("requeue", 1, HEAD, "cm1")
+        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued", comment_id="cm1"))
+        actions = p.plan_stack_actions(m.StackGroup("s", (snapshot,)), REQUIRED, ledger, now_epoch=0, max_requeue_attempts=1)
+        self.assertEqual((actions[0].kind, actions[0].key), ("comment_blocked", "capped"))
+
+    def test_trunk_parameter_decides_current_bottom(self):
+        # Same PR based on "main": with trunk=main it is the bottom (nudge);
+        # with the default master trunk it is not (no current bottom).
+        snapshot = pr(base_ref_name="main")
+        on_main = p.plan_stack_actions(m.StackGroup("s", (snapshot,)), REQUIRED, self._ledger(), now_epoch=0, trunk="main")
+        self.assertEqual(on_main[0].kind, "comment_admin_bypass_nudge")
+        on_master = p.plan_stack_actions(m.StackGroup("s", (snapshot,)), REQUIRED, self._ledger(), now_epoch=0)
+        self.assertEqual((on_master[0].kind, on_master[0].key), ("comment_blocked", "no-current-bottom"))
+        self.assertIn("no current bottom on master", on_master[0].detail)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

The mergify landing planner drifted from its own flags. `--max-repair-attempts` and `--max-requeue-attempts` were parsed but never used; the caps were hardcoded.

The planner also assumed the trunk is `master` via a module constant, ignoring the trunk already derived from `.mergify.yml` at startup.

`plan_stack_actions` now takes both caps and the trunk as parameters, and `run_once` threads the parsed flags and derived trunk in.

`mergify_admin_requeue.py` also carried a near-copy `_execute_action` shadow of the live executor. It now re-exports `execute_action` from `mergify_admin_requeue_exec.py`.
## Review Claim

The mergify landing planner honors its attempt-cap flags and the `.mergify.yml`-derived trunk, and there is exactly one action executor implementation.
## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Parameter defaults match the previous hardcoded values (`3`/`2`, `master`), so behavior is unchanged unless flags or a non-master trunk are supplied. New unit tests pin the cap and trunk parameters; all 43 planner/exec tests pass.

## Slice Rationale

This is the one landing-brain policy fix in the stack; it stands alone so the planner semantics can be reviewed without the harness or worker boot wiring.
## Non-goals

- No change to which actions exist or their ordering.
- No change to the JSONL ledger format.
- No worker auto-start changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue_plan scripts.test_mergify_admin_requeue`
- [x] `bash scripts/test-suites/required/12-mergify-admin-requeue.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
