### PR TITLE
[PR babysit](5) Gate PR-maintenance auto-start on prMaintenance.enabled

### DIFF
--- a/packages/app/src/__tests__/headless-pr-maintenance.test.ts
+++ b/packages/app/src/__tests__/headless-pr-maintenance.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } fr
 import {
   CODERABBIT_ADDRESS_WORKER_KIND,
   PR_CI_FAILURE_SCAN_WORKER_KIND,
+  PR_ADMIN_BYPASS_LAND_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
 } from '@invoker/execution-engine';
 import { runHeadless } from '../headless.js';
@@ -100,6 +101,15 @@ describe('headless worker PR-maintenance', () => {
     expect(stdout).toContain(`${PR_CI_FAILURE_SCAN_WORKER_KIND} worker scan completed.`);
   });
 
+  it('runs the pr-admin-bypass-land worker one-shot with the threaded config', async () => {
+    writeCronScript(repoRoot, 'scripts/cron-pr-admin-bypass-land.sh', 'land.marker');
+
+    await runHeadless(['worker', PR_ADMIN_BYPASS_LAND_WORKER_KIND], makeWorkerDeps(repoRoot, 'land-token') as never);
+
+    expect(readFileSync(join(repoRoot, 'land.marker'), 'utf8')).toBe('land-token');
+    expect(stdout).toContain(`${PR_ADMIN_BYPASS_LAND_WORKER_KIND} worker scan completed.`);
+  });
+
 
   it('lists all PR-maintenance worker kinds from the manual entrypoint', async () => {
     await runHeadless(['worker', 'list'], { invokerConfig: {} } as never);
@@ -108,5 +118,6 @@ describe('headless worker PR-maintenance', () => {
     expect(stdout).toContain(CODERABBIT_ADDRESS_WORKER_KIND);
     expect(stdout).toContain(PR_CONFLICT_REBASE_WORKER_KIND);
     expect(stdout).toContain(PR_CI_FAILURE_SCAN_WORKER_KIND);
+    expect(stdout).toContain(PR_ADMIN_BYPASS_LAND_WORKER_KIND);
   });
 });

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   AUTO_FIX_WORKER_KIND,
   CI_FAILURE_WORKER_KIND,
+  PR_ADMIN_BYPASS_LAND_WORKER_KIND,
   CODERABBIT_ADDRESS_WORKER_KIND,
   E2E_AUTOFIX_WORKER_KIND,
   createWorkerRegistry,
@@ -9,6 +10,7 @@ import {
   PR_CONFLICT_REBASE_WORKER_KIND,
   PR_SUMMARY_REFRESH_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
+  REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
   WORKFLOW_RESUME_WORKER_KIND,
   type WorkerRuntime,
   type WorkerRuntimeDependencies,
@@ -16,7 +18,7 @@ import {
 
 import type { WorkerActionRecord } from '@invoker/data-store';
 import {
-  AUTO_STARTED_OWNER_WORKER_KINDS,
+  autoStartedOwnerWorkerKinds,
   createLocalWorkerStatusSnapshot,
   createWorkerRuntimeController,
   listWorkerActionHistory,
@@ -93,7 +95,7 @@ function deps(): WorkerRuntimeDependencies {
 }
 
 function controller(
-  autoStartKinds: readonly string[] = AUTO_STARTED_OWNER_WORKER_KINDS,
+  autoStartKinds: readonly string[] = autoStartedOwnerWorkerKinds({ prMaintenanceEnabled: true }),
   desiredState: Record<string, boolean> = {},
 ) {
   const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
@@ -119,6 +121,8 @@ function controller(
   register(CODERABBIT_ADDRESS_WORKER_KIND, 'Addresses CodeRabbit review comments.');
   register(PR_CONFLICT_REBASE_WORKER_KIND, 'Rebases conflicted pull requests.');
   register(PR_CI_FAILURE_SCAN_WORKER_KIND, 'Scans mapped PRs for failing CI.');
+  register(PR_ADMIN_BYPASS_LAND_WORKER_KIND, 'Lands eligible PRs via admin bypass.');
+  register(REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND, 'Orders rebase-recreate on merge conflicts.');
   register(WORKFLOW_RESUME_WORKER_KIND, 'Resumes incomplete workflows.');
   register(E2E_AUTOFIX_WORKER_KIND, 'Runs the extended e2e battery on a schedule.');
   register('external-preview', 'External preview worker.');
@@ -146,17 +150,34 @@ describe('createWorkerRuntimeController', () => {
     expect(snapshot.workers.find((worker) => worker.kind === PR_STATUS_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === PR_SUMMARY_REFRESH_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === CI_FAILURE_WORKER_KIND)?.lifecycle).toBe('running');
+    expect(snapshot.workers.find((worker) => worker.kind === REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === CODERABBIT_ADDRESS_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === PR_CONFLICT_REBASE_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === PR_CI_FAILURE_SCAN_WORKER_KIND)?.lifecycle).toBe('running');
+    expect(snapshot.workers.find((worker) => worker.kind === PR_ADMIN_BYPASS_LAND_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === WORKFLOW_RESUME_WORKER_KIND)?.lifecycle).toBe('stopped');
     expect(snapshot.workers.find((worker) => worker.kind === WORKFLOW_RESUME_WORKER_KIND)?.startable).toBe(true);
     expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)?.lifecycle).toBe('stopped');
     expect(snapshot.workers.find((worker) => worker.kind === 'external-preview')?.lifecycle).toBe('stopped');
   });
 
+  it('gates PR-maintenance cron workers on prMaintenance.enabled but always starts review-gate-merge-conflict', () => {
+    const setup = controller(autoStartedOwnerWorkerKinds({ prMaintenanceEnabled: false }));
+
+    setup.controller.startAutoStartedWorkers();
+    const snapshot = setup.controller.snapshot();
+
+    for (const kind of [CODERABBIT_ADDRESS_WORKER_KIND, PR_CONFLICT_REBASE_WORKER_KIND, PR_CI_FAILURE_SCAN_WORKER_KIND, PR_ADMIN_BYPASS_LAND_WORKER_KIND]) {
+      const row = snapshot.workers.find((worker) => worker.kind === kind);
+      expect(row?.lifecycle).toBe('stopped');
+      expect(row?.startable).toBe(true);
+    }
+    expect(snapshot.workers.find((worker) => worker.kind === REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND)?.lifecycle).toBe('running');
+    expect(snapshot.workers.find((worker) => worker.kind === PR_STATUS_WORKER_KIND)?.lifecycle).toBe('running');
+  });
+
   it('restores saved desired worker states over built-in launch defaults', () => {
-    const setup = controller(AUTO_STARTED_OWNER_WORKER_KINDS, {
+    const setup = controller(autoStartedOwnerWorkerKinds({ prMaintenanceEnabled: true }), {
       [PR_STATUS_WORKER_KIND]: false,
       [WORKFLOW_RESUME_WORKER_KIND]: true,
     });
@@ -193,7 +214,7 @@ describe('createWorkerRuntimeController', () => {
   });
 
   it('auto-starts e2e-autofix only when its kind is in autoStartKinds', () => {
-    const gated = controller([...AUTO_STARTED_OWNER_WORKER_KINDS, E2E_AUTOFIX_WORKER_KIND]);
+    const gated = controller([...autoStartedOwnerWorkerKinds({ prMaintenanceEnabled: true }), E2E_AUTOFIX_WORKER_KIND]);
     gated.controller.startAutoStartedWorkers();
     const gatedRow = gated.controller.snapshot().workers.find((worker) => worker.kind === E2E_AUTOFIX_WORKER_KIND);
     expect(gatedRow?.lifecycle).toBe('running');
@@ -316,7 +337,7 @@ describe('createWorkerRuntimeController', () => {
 
     const snapshot = createLocalWorkerStatusSnapshot({
       registry,
-      autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+      autoStartKinds: autoStartedOwnerWorkerKinds({ prMaintenanceEnabled: true }),
       persistence: {
         listWorkerActions: vi.fn(() => [{
           id: 'action-1',

--- a/packages/app/src/main-process-hitch-fixture.ts
+++ b/packages/app/src/main-process-hitch-fixture.ts
@@ -1,6 +1,6 @@
 import type { SQLiteAdapter, Workflow, WorkerActionWrite } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
-import { AUTO_STARTED_OWNER_WORKER_KINDS } from './worker-control.js';
+import { ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS, PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS } from './worker-control.js';
 import {
   buildRecoveryWorkerAuditPayload,
   recoveryWorkerEventType,
@@ -14,7 +14,8 @@ const DEFAULT_ACTIONS_PER_KIND = 80;
 
 const ACTION_WORKER_KINDS = [
   'autofix',
-  ...AUTO_STARTED_OWNER_WORKER_KINDS,
+  ...ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS,
+  ...PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS,
 ] as const;
 
 export interface MainProcessHitchFixtureOptions {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -200,7 +200,7 @@ import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { answerOwnerHeadlessQuery, buildOwnerReadQueryHandlers } from './owner-read-query.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 import {
-  AUTO_STARTED_OWNER_WORKER_KINDS,
+  autoStartedOwnerWorkerKindsForConfig,
   createLocalWorkerStatusSnapshot,
   createWorkerRuntimeController,
   type WorkerRuntimeController,
@@ -1570,12 +1570,12 @@ function startHeadlessMode(): void {
             getWorkerStatus: () => workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
               registry: createRegisteredWorkerRegistry(),
               persistence,
-              autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+              autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
             }),
             getWorkers: () => workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
               registry: createRegisteredWorkerRegistry(),
               persistence,
-              autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+              autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
             }),
             resolveInvokerHomeRoot,
             orchestrator,
@@ -1660,8 +1660,8 @@ function startHeadlessMode(): void {
             },
           ),
           autoStartKinds: invokerConfig.e2eAutoFixEnabled
-            ? [...AUTO_STARTED_OWNER_WORKER_KINDS, E2E_AUTOFIX_WORKER_KIND]
-            : AUTO_STARTED_OWNER_WORKER_KINDS,
+            ? [...autoStartedOwnerWorkerKindsForConfig(invokerConfig), E2E_AUTOFIX_WORKER_KIND]
+            : autoStartedOwnerWorkerKindsForConfig(invokerConfig),
           persistence,
           autoFixRetries: resolveAutoFixRetries(invokerConfig),
           canControl: () => !readOnlyMode,
@@ -2261,7 +2261,7 @@ function createEmbeddedTerminalBackendFromConfig(
           getWorkers: () => workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
             registry: createRegisteredWorkerRegistry(),
             persistence,
-            autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+            autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
           }),
           getSystemDiagnostics: () => collectSystemDiagnostics({
             appVersion: app.getVersion(),
@@ -2565,12 +2565,12 @@ function createEmbeddedTerminalBackendFromConfig(
           getWorkerStatus: () => workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
             registry: createRegisteredWorkerRegistry(),
             persistence,
-            autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+            autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
           }),
           getWorkers: () => workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
             registry: createRegisteredWorkerRegistry(),
             persistence,
-            autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+            autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
           }),
           getStreamSequence: () => getTaskDeltaStreamSequence(),
           resolveInvokerHomeRoot,
@@ -2699,8 +2699,8 @@ function createEmbeddedTerminalBackendFromConfig(
           },
         ),
         autoStartKinds: invokerConfig.e2eAutoFixEnabled
-          ? [...AUTO_STARTED_OWNER_WORKER_KINDS, E2E_AUTOFIX_WORKER_KIND]
-          : AUTO_STARTED_OWNER_WORKER_KINDS,
+          ? [...autoStartedOwnerWorkerKindsForConfig(invokerConfig), E2E_AUTOFIX_WORKER_KIND]
+          : autoStartedOwnerWorkerKindsForConfig(invokerConfig),
         persistence,
         autoFixRetries: resolveAutoFixRetries(invokerConfig),
         canControl: () => ownerMode,
@@ -2890,13 +2890,13 @@ function createEmbeddedTerminalBackendFromConfig(
         return createLocalWorkerStatusSnapshot({
           registry: createRegisteredWorkerRegistry(),
           persistence,
-          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
         });
       }
       return workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
         registry: createRegisteredWorkerRegistry(),
         persistence,
-        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+        autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
       });
     });
 

--- a/packages/app/src/web/start-web-surface.ts
+++ b/packages/app/src/web/start-web-surface.ts
@@ -28,7 +28,7 @@ import { createTaskDeltaStreamSequence } from '../task-delta-stream-sequence.js'
 import { WorkflowRollupProjection } from '../workflow-rollup-projection.js';
 import { buildWebInvokerDispatch } from './web-invoker-dispatch.js';
 import { registerExternalWorkersFromConfig } from '../external-worker-loader.js';
-import { AUTO_STARTED_OWNER_WORKER_KINDS, createLocalWorkerStatusSnapshot } from '../worker-control.js';
+import { autoStartedOwnerWorkerKindsForConfig, createLocalWorkerStatusSnapshot } from '../worker-control.js';
 import { startWebBridge, resolveWebUiDistDir, type WebBridge } from './web-bridge-server.js';
 
 const DEFAULT_WEB_HOST = '127.0.0.1';
@@ -127,7 +127,7 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
         registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
       ),
       persistence: deps.persistence,
-      autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+      autoStartKinds: autoStartedOwnerWorkerKindsForConfig(deps.config),
     }),
     logger: deps.logger,
   });

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -19,11 +19,13 @@ import {
   CODERABBIT_ADDRESS_WORKER_KIND,
   DISK_HEADROOM_WORKER_KIND,
   E2E_AUTOFIX_WORKER_KIND,
+  PR_ADMIN_BYPASS_LAND_WORKER_KIND,
   PR_SUMMARY_REFRESH_WORKER_KIND,
   PR_CI_FAILURE_SCAN_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
   REQUEUE_WORKER_KIND,
+  REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
   WORKFLOW_RESUME_WORKER_KIND,
   type WorkerRegistry,
   type WorkerRuntime,
@@ -31,17 +33,52 @@ import {
 } from '@invoker/execution-engine';
 import { collectRecoveryWorkerStatus } from './recovery-worker-observability.js';
 
-export const AUTO_STARTED_OWNER_WORKER_KINDS = [
+/** Worker kinds auto-started on every owner boot, regardless of config. */
+export const ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS = [
   PR_STATUS_WORKER_KIND,
   PR_SUMMARY_REFRESH_WORKER_KIND,
   CI_FAILURE_WORKER_KIND,
+  REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
   DISK_HEADROOM_WORKER_KIND,
   REQUEUE_WORKER_KIND,
   AUTO_APPROVE_WORKER_KIND,
+] as const;
+
+/** Cron-scan PR-maintenance worker kinds, auto-started only when `prMaintenance.enabled` is true. */
+export const PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS = [
   CODERABBIT_ADDRESS_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
   PR_CI_FAILURE_SCAN_WORKER_KIND,
+  PR_ADMIN_BYPASS_LAND_WORKER_KIND,
 ] as const;
+
+/**
+ * @deprecated Transitional flat list for callers not yet migrated to
+ * `autoStartedOwnerWorkerKindsForConfig`; dropped in the follow-up slice.
+ */
+export const AUTO_STARTED_OWNER_WORKER_KINDS = [
+  ...ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS,
+  ...PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS,
+] as const;
+
+/**
+ * Compute the owner worker kinds that auto-start on boot. The PR-maintenance
+ * cron kinds are gated on `prMaintenance.enabled` (matching the config
+ * docstring); everything else always auto-starts. Saved per-worker desired
+ * state still overrides in both directions.
+ */
+export function autoStartedOwnerWorkerKinds(options: { prMaintenanceEnabled: boolean }): readonly string[] {
+  return options.prMaintenanceEnabled
+    ? [...ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS, ...PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS]
+    : ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS;
+}
+
+/** Convenience wrapper: derive the auto-start list straight from Invoker config. */
+export function autoStartedOwnerWorkerKindsForConfig(
+  config?: { prMaintenance?: { enabled?: boolean } },
+): readonly string[] {
+  return autoStartedOwnerWorkerKinds({ prMaintenanceEnabled: Boolean(config?.prMaintenance?.enabled) });
+}
 
 export interface WorkerRuntimeController {
   startAutoStartedWorkers(): void;

--- a/packages/execution-engine/src/__tests__/review-gate-merge-conflict-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/review-gate-merge-conflict-worker.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  WorkerActionRecord,
+  WorkerActionWrite,
+  WorkflowMutationIntent,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+import type { ReviewGateMergeConflictLifecycleEvent } from '../lifecycle-events.js';
+import {
+  REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
+  createReviewGateMergeConflictTick,
+  reviewGateMergeConflictActionKey,
+} from '../workers/review-gate-merge-conflict-worker.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id: 'wf-1/merge',
+    description: 'merge',
+    status: 'review_ready',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: 'wf-1', isMergeNode: true, ...(config ?? {}) },
+    execution: {
+      generation: 2,
+      selectedAttemptId: 'attempt-1',
+      branch: 'feature/conflict',
+      reviewGate: {
+        activeGeneration: 2,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [{
+          id: 'pr-123',
+          providerId: '123',
+          provider: 'github',
+          required: true,
+          status: 'open',
+          generation: 2,
+          headSha: 'sha-1',
+        }],
+      },
+      ...(execution ?? {}),
+    },
+    taskStateVersion: 10,
+    ...rest,
+  } as TaskState;
+}
+
+function makeEvent(
+  overrides: Partial<ReviewGateMergeConflictLifecycleEvent> = {},
+): ReviewGateMergeConflictLifecycleEvent {
+  return {
+    eventKey: 'review_gate.merge_conflict|workflow:wf-1|task:wf-1/merge',
+    kind: 'review_gate.merge_conflict',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/merge',
+    status: 'review_ready',
+    taskStateVersion: 10,
+    generation: 2,
+    attemptId: 'attempt-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    reviewId: '123',
+    reviewUrl: 'https://github.com/owner/repo/pull/123',
+    headSha: 'sha-1',
+    headRef: 'feature/conflict',
+    branch: 'feature/conflict',
+    statusText: 'merge conflict',
+    ...overrides,
+  } as ReviewGateMergeConflictLifecycleEvent;
+}
+
+function toRecord(write: WorkerActionWrite): WorkerActionRecord {
+  const now = '2026-01-01T00:00:00.000Z';
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? now,
+    updatedAt: write.updatedAt ?? now,
+  };
+}
+
+interface Harness {
+  actions: Map<string, WorkerActionRecord>;
+  intents: WorkflowMutationIntent[];
+  store: {
+    loadTasks: ReturnType<typeof vi.fn>;
+    loadTask: ReturnType<typeof vi.fn>;
+    listWorkflowMutationIntents: ReturnType<typeof vi.fn>;
+    getWorkerAction: ReturnType<typeof vi.fn>;
+    upsertWorkerAction: ReturnType<typeof vi.fn>;
+    logEvent: ReturnType<typeof vi.fn>;
+  };
+  submit: ReturnType<typeof vi.fn>;
+}
+
+function makeHarness(task = makeTask(), intents: WorkflowMutationIntent[] = []): Harness {
+  const tasks = new Map<string, TaskState>([[task.id, task]]);
+  const actions = new Map<string, WorkerActionRecord>();
+  const submit = vi.fn((
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: string,
+    args: unknown[],
+  ) => {
+    expect(workflowId).toBe('wf-1');
+    expect(priority).toBe('high');
+    expect(channel).toBe('invoker:rebase-recreate');
+    expect(args).toEqual(['wf-1']);
+    return 42;
+  });
+  const store = {
+    loadTasks: vi.fn((workflowId: string) => workflowId === 'wf-1' ? Array.from(tasks.values()) : []),
+    loadTask: vi.fn((taskId: string) => tasks.get(taskId)),
+    listWorkflowMutationIntents: vi.fn((_workflowId?: string, statuses?: string[]) =>
+      intents.filter((intent) => !statuses || statuses.includes(intent.status))),
+    getWorkerAction: vi.fn((workerKind: string, externalKey: string) => actions.get(`${workerKind}:${externalKey}`)),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+      const existing = actions.get(`${write.workerKind}:${write.externalKey}`);
+      const saved = toRecord({ ...write, id: existing?.id ?? write.id, createdAt: existing?.createdAt });
+      actions.set(`${write.workerKind}:${write.externalKey}`, saved);
+      return saved;
+    }),
+    logEvent: vi.fn(),
+  };
+  return { actions, intents, store, submit };
+}
+
+function actionFor(harness: Harness, event: ReviewGateMergeConflictLifecycleEvent): WorkerActionRecord | undefined {
+  return harness.actions.get(
+    `${REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND}:${reviewGateMergeConflictActionKey(event)}`,
+  );
+}
+
+describe('review-gate merge-conflict worker tick', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('submits one high-priority rebase-recreate intent and records a durable action row', async () => {
+    const harness = makeHarness();
+    const event = makeEvent();
+    const tick = createReviewGateMergeConflictTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      drainEvents: () => [event],
+    });
+
+    await tick();
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    const row = actionFor(harness, event);
+    expect(row).toMatchObject({
+      workerKind: REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
+      actionType: 'rebase-recreate-review-gate-conflict',
+      status: 'queued',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      intentId: '42',
+    });
+  });
+
+  it('dedupes a duplicate event for the same task/review/headSha', async () => {
+    const harness = makeHarness();
+    const event = makeEvent();
+    const options = {
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+    };
+    await createReviewGateMergeConflictTick({ ...options, drainEvents: () => [event, makeEvent()] })();
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+
+    // A later tick draining the same event again is stopped by the durable row.
+    await createReviewGateMergeConflictTick({ ...options, drainEvents: () => [makeEvent()] })();
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips a stale event whose head SHA no longer matches the persisted task, without a durable row', async () => {
+    const harness = makeHarness();
+    const event = makeEvent({ headSha: 'sha-outdated' });
+    const tick = createReviewGateMergeConflictTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      drainEvents: () => [event],
+    });
+
+    await tick();
+
+    expect(harness.submit).not.toHaveBeenCalled();
+    expect(actionFor(harness, event)).toBeUndefined();
+  });
+
+  it('skips a stale event whose generation advanced past the persisted task', async () => {
+    const harness = makeHarness();
+    const event = makeEvent({ generation: 1 });
+    const tick = createReviewGateMergeConflictTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      drainEvents: () => [event],
+    });
+
+    await tick();
+
+    expect(harness.submit).not.toHaveBeenCalled();
+    expect(actionFor(harness, event)).toBeUndefined();
+  });
+
+  it('does not submit when an open recreate intent already exists for the workflow', async () => {
+    const openIntent = {
+      id: 7,
+      workflowId: 'wf-1',
+      channel: 'invoker:rebase-recreate',
+      args: ['wf-1'],
+      status: 'queued',
+      priority: 'high',
+    } as unknown as WorkflowMutationIntent;
+    const harness = makeHarness(makeTask(), [openIntent]);
+    const event = makeEvent();
+    const tick = createReviewGateMergeConflictTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      drainEvents: () => [event],
+    });
+
+    await tick();
+
+    expect(harness.submit).not.toHaveBeenCalled();
+    expect(actionFor(harness, event)).toMatchObject({ status: 'queued', intentId: '7' });
+  });
+
+  it('reconciles a finished intent back into the durable action row', async () => {
+    const harness = makeHarness();
+    const event = makeEvent();
+    const options = {
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+    };
+    await createReviewGateMergeConflictTick({ ...options, drainEvents: () => [event] })();
+    expect(actionFor(harness, event)?.status).toBe('queued');
+
+    harness.intents.push({
+      id: 42,
+      workflowId: 'wf-1',
+      channel: 'invoker:rebase-recreate',
+      args: ['wf-1'],
+      status: 'failed',
+      priority: 'high',
+      error: 'recreate blew up\nstack trace',
+    } as unknown as WorkflowMutationIntent);
+
+    // Drain a now-stale event (generation moved on): reconcile still folds the
+    // terminal intent into the row, and staleness prevents an immediate retry.
+    await createReviewGateMergeConflictTick({ ...options, drainEvents: () => [makeEvent({ generation: 1 })] })();
+
+    const reconciled = actionFor(harness, event);
+    expect(reconciled?.status).toBe('failed');
+    expect(reconciled?.summary).toContain('recreate blew up');
+    expect(reconciled?.payload).toMatchObject({ reconciledIntentStatus: 'failed' });
+
+    // Draining the original lineage reconciles first, then retries: the row is
+    // rewritten as a fresh queued attempt with a new submit.
+    await createReviewGateMergeConflictTick({ ...options, drainEvents: () => [makeEvent()] })();
+    const row = actionFor(harness, event);
+    expect(row?.status).toBe('queued');
+    expect(harness.store.upsertWorkerAction.mock.calls.some(([write]: [WorkerActionWrite]) =>
+      write.status === 'failed'
+      && typeof write.summary === 'string'
+      && write.summary.includes('recreate blew up')
+      && (write.payload as Record<string, unknown>)?.reconciledIntentStatus === 'failed',
+    )).toBe(true);
+    expect(harness.submit).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -66,6 +66,7 @@ export * from './workers/disk-headroom-monitor.js';
 export * from './workers/disk-headroom-reclaim.js';
 export * from './workers/disk-headroom.js';
 export * from './workers/pr-maintenance-workers.js';
+export * from './workers/review-gate-merge-conflict-worker.js';
 export * from './workers/e2e-autofix-worker.js';
 export * from './workers/requeue-worker.js';
 export * from './workers/workflow-resume-worker.js';

--- a/scripts/mergify_admin_requeue.py
+++ b/scripts/mergify_admin_requeue.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Mapping, Sequence
+from typing import Sequence
 
 try:
     from . import mergify_admin_requeue_exec as exec_impl
@@ -20,43 +20,10 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 parse_args = exec_impl.parse_args
 run_once = exec_impl.run_once
 subprocess = exec_impl.subprocess
-_repair_conflict = exec_impl.repair_conflict
-_repair_check = exec_impl.repair_check
-_resolve_workflow = exec_impl.resolve_workflow
-
-
-def _execute_action(action: Action, repo: str, gh, ledger: Ledger, pr_by_number: Mapping[int, PrSnapshot], now: int) -> None:
-    pr = pr_by_number[action.pr_number]
-    if action.kind == "requeue":
-        gh.comment(repo, action.pr_number, "@mergifyio queue")
-        ledger.record("requeue", action.pr_number, pr.head_ref_oid, action.key, now)
-    elif action.kind == "comment_admin_bypass_nudge":
-        if ledger.count(exec_impl.ADMIN_BYPASS_NUDGE_LEDGER_KIND, action.pr_number, pr.head_ref_oid, action.key) == 0:
-            gh.comment(repo, action.pr_number, exec_impl.admin_bypass_nudge_body())
-            ledger.record(exec_impl.ADMIN_BYPASS_NUDGE_LEDGER_KIND, action.pr_number, pr.head_ref_oid, action.key, now)
-    elif action.kind == "remove_merge_hold":
-        gh.edit_label(repo, action.pr_number, remove="merge-hold")
-        ledger.record("remove-merge-hold", action.pr_number, pr.head_ref_oid, "merge-hold", now)
-    elif action.kind == "resolve_bot_threads":
-        gh.resolve_review_thread(action.key)
-    elif action.kind == "repair_check":
-        check_name = action.key.split(":", 1)[-1]
-        kind = "repair-bot-thread" if action.key.startswith("bot_review_thread:") else "repair-check"
-        ledger.record(kind, action.pr_number, pr.head_ref_oid, check_name, now)
-        _repair_check(repo, pr, check_name)
-    elif action.kind == "rebase_recreate":
-        ledger.record("conflict-repair", action.pr_number, pr.head_ref_oid, action.key, now)
-        try:
-            workflow, _generation = _resolve_workflow(action.pr_number)
-        except RuntimeError as exc:
-            _repair_conflict(repo, pr, str(exc))
-            return
-        subprocess.run(["node", "scripts/headless-ipc.js", "exec", "--", "rebase-recreate", workflow], cwd=str(REPO_ROOT), check=True, text=True, capture_output=True)
-    elif action.kind == "comment_blocked" and action.key == "capped":
-        key = f"capped:{action.detail}"
-        if ledger.count("comment-blocked", action.pr_number, pr.head_ref_oid, key) == 0:
-            gh.comment(repo, action.pr_number, f"Invoker Mergify repair stopped: {action.detail}")
-            ledger.record("comment-blocked", action.pr_number, pr.head_ref_oid, key, now)
+execute_action = exec_impl.execute_action
+resolve_workflow = exec_impl.resolve_workflow
+repair_conflict = exec_impl.repair_conflict
+repair_check = exec_impl.repair_check
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -208,7 +208,15 @@ def run_once(args: argparse.Namespace) -> int:
     now = int(time.time())
     pr_by_number = {pr.number: pr for pr in snapshots}
     for stack in stacks:
-        for action in plan_stack_actions(stack, required_checks, ledger, now):
+        for action in plan_stack_actions(
+            stack,
+            required_checks,
+            ledger,
+            now,
+            trunk=trunk,
+            max_repair_attempts=args.max_repair_attempts,
+            max_requeue_attempts=args.max_requeue_attempts,
+        ):
             pr = pr_by_number.get(action.pr_number)
             print_action(action, pr, args.dry_run, args.json)
             if not args.dry_run:

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -8,9 +8,6 @@ except ImportError:
     from mergify_admin_requeue_model import Action, BOT_OR_SELF_AUTHORS, Blocker, Ledger, MergifyQueueEvent, PrSnapshot, StackGroup
 
 
-TRUNK = "master"
-
-
 def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) -> tuple[Blocker, ...]:
     blockers: list[Blocker] = []
     if pr.state != "OPEN":
@@ -75,24 +72,32 @@ def effective_blockers(pr: PrSnapshot, required_checks: Collection[str], trunk: 
     )
 
 
-def mergify_failed_check_actions(pr: PrSnapshot, ledger: Ledger) -> tuple[Action, ...]:
+def mergify_failed_check_actions(pr: PrSnapshot, ledger: Ledger, max_repair_attempts: int = 3) -> tuple[Action, ...]:
     latest = pr.latest_mergify
     if not latest or latest.state != "dequeued" or latest.head_sha != pr.head_ref_oid:
         return ()
     for name in latest.failing_checks:
-        if ledger.count("repair-check", pr.number, pr.head_ref_oid, name) >= 3:
+        if ledger.count("repair-check", pr.number, pr.head_ref_oid, name) >= max_repair_attempts:
             return (cap_action(pr, Blocker(name, "failed_check", pr.number, f"Mergify queue check failed: {name}"), f"Mergify queue check failed: {name}"),)
         return (Action("repair_check", pr.number, name, f"Mergify queue check failed: {name}"),)
     return ()
 
 
-def plan_stack_actions(stack: StackGroup, required_checks: Collection[str], ledger: Ledger, now_epoch: int) -> tuple[Action, ...]:
+def plan_stack_actions(
+    stack: StackGroup,
+    required_checks: Collection[str],
+    ledger: Ledger,
+    now_epoch: int,
+    trunk: str = "master",
+    max_repair_attempts: int = 3,
+    max_requeue_attempts: int = 2,
+) -> tuple[Action, ...]:
     del now_epoch
-    blockers_by_pr = {pr.number: effective_blockers(pr, required_checks, TRUNK) for pr in stack.prs}
+    blockers_by_pr = {pr.number: effective_blockers(pr, required_checks, trunk) for pr in stack.prs}
     all_blockers = [b for blockers in blockers_by_pr.values() for b in blockers]
 
     for pr in stack.prs:
-        actions = mergify_failed_check_actions(pr, ledger)
+        actions = mergify_failed_check_actions(pr, ledger, max_repair_attempts)
         if actions:
             return actions
 
@@ -100,11 +105,11 @@ def plan_stack_actions(stack: StackGroup, required_checks: Collection[str], ledg
         for blocker in blockers_by_pr[pr.number]:
             if blocker.kind == "conflict":
                 key = f"conflict:{pr.number}"
-                if ledger.count("conflict-repair", pr.number, pr.head_ref_oid, key) >= 3:
+                if ledger.count("conflict-repair", pr.number, pr.head_ref_oid, key) >= max_repair_attempts:
                     return (cap_action(pr, blocker, blocker.detail),)
                 return (Action("rebase_recreate", pr.number, key, blocker.detail),)
             if blocker.kind == "failed_check":
-                if ledger.count("repair-check", pr.number, pr.head_ref_oid, blocker.key) >= 3:
+                if ledger.count("repair-check", pr.number, pr.head_ref_oid, blocker.key) >= max_repair_attempts:
                     return (cap_action(pr, blocker, blocker.detail),)
                 return (Action("repair_check", pr.number, blocker.key, blocker.detail),)
 
@@ -113,7 +118,7 @@ def plan_stack_actions(stack: StackGroup, required_checks: Collection[str], ledg
             if blocker.kind == "bot_review_thread":
                 if ledger.has_different_head("repair-bot-thread", pr.number, pr.head_ref_oid, blocker.key):
                     return (Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail),)
-                if ledger.count("repair-bot-thread", pr.number, pr.head_ref_oid, blocker.key) >= 3:
+                if ledger.count("repair-bot-thread", pr.number, pr.head_ref_oid, blocker.key) >= max_repair_attempts:
                     return (cap_action(pr, blocker, blocker.detail),)
                 return (Action("repair_check", pr.number, "bot_review_thread:" + blocker.key, blocker.detail),)
 
@@ -124,10 +129,10 @@ def plan_stack_actions(stack: StackGroup, required_checks: Collection[str], ledg
             if blocker.kind in {"draft", "human_review_thread", "missing_check", "closed"}:
                 return (Action("comment_blocked", pr.number, blocker.key, public_blocker_kind(blocker.kind)),)
 
-    current_bottoms = [pr for pr in stack.prs if pr.state == "OPEN" and pr.base_ref_name == TRUNK]
+    current_bottoms = [pr for pr in stack.prs if pr.state == "OPEN" and pr.base_ref_name == trunk]
     if not current_bottoms:
         first = stack.prs[0]
-        return (Action("comment_blocked", first.number, "no-current-bottom", "no current bottom on master"),)
+        return (Action("comment_blocked", first.number, "no-current-bottom", f"no current bottom on {trunk}"),)
     bottom = current_bottoms[0]
 
     non_hold_blockers = [b for b in all_blockers if b.kind != "merge_hold"]
@@ -154,6 +159,6 @@ def plan_stack_actions(stack: StackGroup, required_checks: Collection[str], ledg
         requeue_reason = "eligible-after-dequeued-label"
     if not requeue_reason:
         return ()
-    if ledger.count("requeue", bottom.number, bottom.head_ref_oid, requeue_key) >= 2:
+    if ledger.count("requeue", bottom.number, bottom.head_ref_oid, requeue_key) >= max_requeue_attempts:
         return (cap_action(bottom, Blocker(requeue_key, "capped", bottom.number, "requeue"), "requeue"),)
     return (Action("requeue", bottom.number, requeue_key, requeue_reason),)

--- a/scripts/repro/fixtures/fake-gh/bin/gh
+++ b/scripts/repro/fixtures/fake-gh/bin/gh
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Reusable fake `gh` for PR-babysitting battle tests.
+
+Reads/writes a single JSON state file at $FAKE_GH_STATE_DIR/state.json and
+appends every invocation (argv, plus stdin when piped) to
+$FAKE_GH_STATE_DIR/calls.log so repro scripts can assert exactly what the code
+under test asked GitHub for. Mutating verbs update state.json so subsequent
+reads observe the mutation. Unknown argv exits 64 with the argv echoed: a
+scenario gap fails tests loudly instead of silently succeeding.
+
+State schema (see scripts/repro/fixtures/fake-gh/scenarios/*.json):
+  {
+    "prs": [{
+      "number": 501, "title": "...", "url": "...", "state": "OPEN",
+      "isDraft": false, "baseRefName": "master", "headRefName": "stack/501",
+      "headRefOid": "<40-hex>", "mergeStateStatus": "DIRTY",
+      "mergeable": "CONFLICTING", "labels": ["admin-bypass"],
+      "reviewThreads": [], "checks": {"*": "SUCCESS", "PR Body": "FAILURE"}
+    }],
+    "issue_comments": {"501": [ ...gh api issues/N/comments shape... ]}
+  }
+
+`checks` maps check name -> conclusion; "*" applies to every required check
+named in $FAKE_GH_REQUIRED_CHECKS (newline-separated; check names contain
+spaces and slashes, never newlines).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+STATE_DIR = os.environ.get("FAKE_GH_STATE_DIR", "")
+if not STATE_DIR:
+    print("fake gh: FAKE_GH_STATE_DIR not set", file=sys.stderr)
+    sys.exit(64)
+
+ARGS = sys.argv[1:]
+STDIN = "" if sys.stdin.isatty() else sys.stdin.read()
+with open(Path(STATE_DIR) / "calls.log", "a", encoding="utf-8") as log:
+    log.write("gh " + " ".join(ARGS) + ("\n<<< " + STDIN.replace("\n", "\\n") if STDIN else "") + "\n")
+
+STATE_PATH = Path(STATE_DIR) / "state.json"
+
+
+def load_state() -> dict:
+    with open(STATE_PATH, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def save_state(state: dict) -> None:
+    with open(STATE_PATH, "w", encoding="utf-8") as handle:
+        json.dump(state, handle, indent=2)
+
+
+def required_checks() -> list[str]:
+    raw = os.environ.get("FAKE_GH_REQUIRED_CHECKS", "")
+    return [name for name in raw.split("\n") if name.strip()]
+
+
+def unhandled() -> None:
+    print(f"fake gh: unhandled argv: {ARGS}", file=sys.stderr)
+    sys.exit(64)
+
+
+def flag_value(name: str) -> str | None:
+    for index, arg in enumerate(ARGS):
+        if arg == name and index + 1 < len(ARGS):
+            return ARGS[index + 1]
+        if arg.startswith(name + "="):
+            return arg.split("=", 1)[1]
+    return None
+
+
+def check_nodes(pr: dict) -> list[dict]:
+    checks = pr.get("checks") or {}
+    default = checks.get("*")
+    names: set[str] = {name for name in checks if name != "*"}
+    if default is not None:
+        names.update(required_checks())
+    nodes = []
+    for name in sorted(names):
+        conclusion = checks.get(name, default)
+        if conclusion is None:
+            continue
+        nodes.append({
+            "__typename": "CheckRun",
+            "name": name,
+            "conclusion": conclusion,
+            "status": "COMPLETED",
+            "completedAt": "2026-07-20T00:00:00Z",
+            "startedAt": "2026-07-20T00:00:00Z",
+            "detailsUrl": "https://github.com/fake/repo/actions/runs/1/job/2",
+            "checkSuite": {"commit": {"oid": pr.get("headRefOid", "")}},
+        })
+    return nodes
+
+
+def project_pr(pr: dict, fields: list[str]) -> dict:
+    out: dict = {}
+    for field in fields:
+        if field == "labels":
+            out["labels"] = [{"name": name} for name in pr.get("labels", [])]
+        elif field == "statusCheckRollup":
+            out["statusCheckRollup"] = check_nodes(pr)
+        elif field == "reviewDecision":
+            out["reviewDecision"] = pr.get("reviewDecision", "")
+        else:
+            out[field] = pr.get(field)
+    return out
+
+
+def graphql_detail(pr: dict) -> dict:
+    return {
+        "number": pr.get("number"),
+        "title": pr.get("title", ""),
+        "url": pr.get("url", ""),
+        "isDraft": pr.get("isDraft", False),
+        "state": pr.get("state", "OPEN"),
+        "baseRefName": pr.get("baseRefName", ""),
+        "headRefName": pr.get("headRefName", ""),
+        "headRefOid": pr.get("headRefOid", ""),
+        "mergeStateStatus": pr.get("mergeStateStatus", ""),
+        "mergeable": pr.get("mergeable", ""),
+        "labels": {"nodes": [{"name": name} for name in pr.get("labels", [])]},
+        "reviewThreads": {"pageInfo": {"hasNextPage": False}, "nodes": pr.get("reviewThreads", [])},
+        "statusCheckRollup": {"contexts": {"nodes": check_nodes(pr)}},
+    }
+
+
+def find_pr(state: dict, number: int) -> dict | None:
+    for pr in state.get("prs", []):
+        if int(pr.get("number", 0)) == number:
+            return pr
+    return None
+
+
+def main() -> None:
+    state = load_state()
+
+    if ARGS[:2] == ["pr", "list"]:
+        fields = (flag_value("--json") or "number").split(",")
+        label = flag_value("--label")
+        state_filter = flag_value("--state") or "open"
+        prs = state.get("prs", [])
+        if state_filter == "open":
+            prs = [pr for pr in prs if pr.get("state", "OPEN") == "OPEN"]
+        if label:
+            prs = [pr for pr in prs if label in pr.get("labels", [])]
+        print(json.dumps([project_pr(pr, fields) for pr in prs]))
+        return
+
+    if ARGS[:2] == ["pr", "view"]:
+        number = int(ARGS[2])
+        pr = find_pr(state, number)
+        if pr is None:
+            print(f"fake gh: no PR #{number} in state", file=sys.stderr)
+            sys.exit(1)
+        fields = (flag_value("--json") or "number").split(",")
+        print(json.dumps(project_pr(pr, fields)))
+        return
+
+    if ARGS[:2] == ["pr", "comment"]:
+        number = ARGS[2]
+        body = flag_value("--body") or ""
+        comments = state.setdefault("issue_comments", {}).setdefault(str(number), [])
+        comments.append({
+            "id": f"fake-comment-{len(comments) + 1}",
+            "user": {"login": "invoker-bot"},
+            "body": body,
+            "updated_at": "2026-07-20T00:00:00Z",
+            "html_url": f"https://github.com/fake/repo/pull/{number}#fake",
+        })
+        save_state(state)
+        return
+
+    if ARGS[:2] == ["api", "graphql"]:
+        number = 0
+        for arg in ARGS:
+            if arg.startswith("number="):
+                number = int(arg.split("=", 1)[1])
+        if number:
+            pr = find_pr(state, number)
+            if pr is None:
+                print(f"fake gh: no PR #{number} in state", file=sys.stderr)
+                sys.exit(1)
+            print(json.dumps({"data": {"repository": {"pullRequest": graphql_detail(pr)}}}))
+            return
+        if any("resolveReviewThread" in arg for arg in ARGS):
+            # Thread resolution is observable via calls.log only.
+            print(json.dumps({"data": {"resolveReviewThread": {"thread": {"isResolved": True}}}}))
+            return
+        unhandled()
+
+    if ARGS[0] == "api":
+        path = next((arg for arg in ARGS[1:] if not arg.startswith("-")), "")
+        comments_match = re.fullmatch(r"repos/[^/]+/[^/]+/issues/(\d+)/comments", path)
+        if comments_match and flag_value("--method") in (None, "GET"):
+            print(json.dumps(state.get("issue_comments", {}).get(comments_match.group(1), [])))
+            return
+        add_label_match = re.fullmatch(r"repos/[^/]+/[^/]+/issues/(\d+)/labels", path)
+        if add_label_match and flag_value("--method") == "POST":
+            pr = find_pr(state, int(add_label_match.group(1)))
+            label = (flag_value("-f") or "").split("=", 1)[-1]
+            if pr is not None and label and label not in pr.setdefault("labels", []):
+                pr["labels"].append(label)
+                save_state(state)
+            return
+        remove_label_match = re.fullmatch(r"repos/[^/]+/[^/]+/issues/(\d+)/labels/(.+)", path)
+        if remove_label_match and flag_value("--method") == "DELETE":
+            pr = find_pr(state, int(remove_label_match.group(1)))
+            if pr is not None:
+                pr["labels"] = [l for l in pr.get("labels", []) if l != remove_label_match.group(2)]
+                save_state(state)
+            return
+        unhandled()
+
+    if ARGS[:2] == ["auth", "status"]:
+        return
+
+    unhandled()
+
+
+main()

--- a/scripts/repro/fixtures/fake-gh/bin/omp
+++ b/scripts/repro/fixtures/fake-gh/bin/omp
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Fake `omp` agent for PR-babysitting battle tests: records the invocation
+# (cwd + argv, including the -p prompt) to $FAKE_GH_STATE_DIR/omp-calls.log and
+# exits 0. Set FAKE_OMP_SCRIPT to a script to simulate agent side effects
+# (e.g. pushing a fix); it runs with the same argv and cwd.
+set -euo pipefail
+: "${FAKE_GH_STATE_DIR:?FAKE_GH_STATE_DIR not set}"
+printf 'omp cwd=%s args=%s\n' "$PWD" "$*" >> "$FAKE_GH_STATE_DIR/omp-calls.log"
+if [ -n "${FAKE_OMP_SCRIPT:-}" ]; then
+  bash "$FAKE_OMP_SCRIPT" "$@"
+fi

--- a/scripts/repro/fixtures/fake-gh/scenarios/pr-ci-failed.json
+++ b/scripts/repro/fixtures/fake-gh/scenarios/pr-ci-failed.json
@@ -1,0 +1,46 @@
+{
+  "prs": [
+    {
+      "number": 601,
+      "title": "CI-failed PR",
+      "url": "https://github.com/fake/repo/pull/601",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "master",
+      "headRefName": "stack/601",
+      "headRefOid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "mergeStateStatus": "BLOCKED",
+      "mergeable": "MERGEABLE",
+      "labels": ["admin-bypass", "dequeued"],
+      "reviewThreads": [],
+      "checks": {"*": "SUCCESS", "PR Body": "FAILURE"}
+    },
+    {
+      "number": 602,
+      "title": "Conflicting PR the CI scan must skip",
+      "url": "https://github.com/fake/repo/pull/602",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "master",
+      "headRefName": "stack/602",
+      "headRefOid": "cccccccccccccccccccccccccccccccccccccccc",
+      "mergeStateStatus": "DIRTY",
+      "mergeable": "CONFLICTING",
+      "labels": [],
+      "reviewThreads": [],
+      "checks": {"*": "SUCCESS"}
+    }
+  ],
+  "issue_comments": {
+    "601": [
+      {
+        "id": "m601",
+        "user": {"login": "mergify[bot]"},
+        "updated_at": "2026-07-20T00:00:00Z",
+        "html_url": "https://github.com/fake/repo/pull/601#m601",
+        "body": "Left the queue `admin-bypass` at `bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`.\n-*- Mergify Payload -*-\n{\"state\":\"dequeued\",\"queue_rule_name\":\"admin-bypass\"}\n"
+      }
+    ],
+    "602": []
+  }
+}

--- a/scripts/repro/fixtures/fake-gh/scenarios/pr-dirty.json
+++ b/scripts/repro/fixtures/fake-gh/scenarios/pr-dirty.json
@@ -1,0 +1,22 @@
+{
+  "prs": [
+    {
+      "number": 501,
+      "title": "Conflicting stack PR",
+      "url": "https://github.com/fake/repo/pull/501",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "master",
+      "headRefName": "stack/501",
+      "headRefOid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "mergeStateStatus": "DIRTY",
+      "mergeable": "CONFLICTING",
+      "labels": ["admin-bypass"],
+      "reviewThreads": [],
+      "checks": {"*": "SUCCESS"}
+    }
+  ],
+  "issue_comments": {
+    "501": []
+  }
+}

--- a/scripts/repro/fixtures/fake-gh/scenarios/stack-landable.json
+++ b/scripts/repro/fixtures/fake-gh/scenarios/stack-landable.json
@@ -1,0 +1,46 @@
+{
+  "prs": [
+    {
+      "number": 701,
+      "title": "Landable stack bottom",
+      "url": "https://github.com/fake/repo/pull/701",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "master",
+      "headRefName": "stack/701",
+      "headRefOid": "dddddddddddddddddddddddddddddddddddddddd",
+      "mergeStateStatus": "CLEAN",
+      "mergeable": "MERGEABLE",
+      "labels": ["admin-bypass", "dequeued"],
+      "reviewThreads": [],
+      "checks": {"*": "SUCCESS"}
+    },
+    {
+      "number": 702,
+      "title": "Landable stack top",
+      "url": "https://github.com/fake/repo/pull/702",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "stack/701",
+      "headRefName": "stack/702",
+      "headRefOid": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "mergeStateStatus": "BLOCKED",
+      "mergeable": "MERGEABLE",
+      "labels": ["admin-bypass"],
+      "reviewThreads": [],
+      "checks": {"*": "SUCCESS"}
+    }
+  ],
+  "issue_comments": {
+    "701": [
+      {
+        "id": "m701",
+        "user": {"login": "mergify[bot]"},
+        "updated_at": "2026-07-20T00:00:00Z",
+        "html_url": "https://github.com/fake/repo/pull/701#m701",
+        "body": "Left the queue `admin-bypass` at `dddddddddddddddddddddddddddddddddddddddd`.\n-*- Mergify Payload -*-\n{\"state\":\"dequeued\",\"queue_rule_name\":\"admin-bypass\"}\n"
+      }
+    ],
+    "702": []
+  }
+}

--- a/scripts/repro/repro-babysit-ci-cron.sh
+++ b/scripts/repro/repro-babysit-ci-cron.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Battle-test: the CI-failure cron scans open PRs against a fake GitHub and
+# dispatches repair-review-gate-ci for the CI-failed PR while SKIPPING the
+# conflicted (DIRTY) PR — the conflict-rebase worker owns conflicts.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-ci.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+mkdir -p "$TMP/bin" "$TMP/state" "$TMP/home"
+export FAKE_GH_STATE_DIR="$TMP/state"
+cp "$ROOT/scripts/repro/fixtures/fake-gh/scenarios/pr-ci-failed.json" "$FAKE_GH_STATE_DIR/state.json"
+
+ln -s "$ROOT/scripts/repro/fixtures/fake-gh/bin/gh" "$TMP/bin/gh"
+NODE_LOG="$TMP/node-calls.log"; : > "$NODE_LOG"
+cat > "$TMP/bin/node" <<EOF
+#!/usr/bin/env bash
+printf 'node %s\n' "\$*" >> "$NODE_LOG"
+exit 0
+EOF
+chmod +x "$TMP/bin/node"
+
+out="$(
+  PATH="$TMP/bin:$PATH" \
+  HOME="$TMP/home" \
+  INVOKER_GITHUB_TARGET_REPO="fake/repo" \
+  INVOKER_PR_CRON_LOCK="$TMP/crons.lock" \
+  bash "$ROOT/packages/execution-engine/scripts/cron-pr-ci-failure.sh" 2>&1
+)" || fail "CI scan exited non-zero" "$out"
+
+grep -q "exec -- repair-review-gate-ci 601" "$NODE_LOG" \
+  || fail "expected repair-review-gate-ci dispatch for CI-failed PR #601" "$out"
+grep -q "repair-review-gate-ci 602" "$NODE_LOG" \
+  && fail "conflicted PR #602 must be skipped (rebase worker owns it)" "$out"
+echo "$out" | grep -q "PR #602: skip conflicted PR" \
+  || fail "expected explicit skip log for conflicted PR #602" "$out"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-babysit-conflict-cron.sh
+++ b/scripts/repro/repro-babysit-conflict-cron.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Battle-test: the conflict-rebase cron babysits a DIRTY PR end-to-end against
+# a fake GitHub — one rebase-recreate dispatch per tick, a hard attempt cap
+# when the workflow generation never advances, and exactly one "exhausted"
+# PR comment after the cap.
+#
+# Seams stubbed (no owner process is booted):
+#   gh    -> scripts/repro/fixtures/fake-gh/bin/gh serving pr-dirty.json
+#   node  -> PATH shim recording the headless-ipc rebase-recreate dispatch
+#   resolve_workflow_for_pr -> INVOKER_PR_CRON_REVIEW_GATE_CMD stub whose
+#            generation NEVER advances (the workflow is stuck)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-conflict.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+mkdir -p "$TMP/bin" "$TMP/state" "$TMP/home"
+export FAKE_GH_STATE_DIR="$TMP/state"
+cp "$ROOT/scripts/repro/fixtures/fake-gh/scenarios/pr-dirty.json" "$FAKE_GH_STATE_DIR/state.json"
+
+ln -s "$ROOT/scripts/repro/fixtures/fake-gh/bin/gh" "$TMP/bin/gh"
+NODE_LOG="$TMP/node-calls.log"; : > "$NODE_LOG"
+cat > "$TMP/bin/node" <<EOF
+#!/usr/bin/env bash
+# Record the accepted headless-ipc dispatch; the owner is not booted here.
+printf 'node %s\n' "\$*" >> "$NODE_LOG"
+exit 0
+EOF
+cat > "$TMP/review-gate.sh" <<'RG'
+#!/usr/bin/env bash
+# Workflow lookup for PR #501; the generation never advances.
+printf '{"workflowId":"wf-babysit-1","workflowGeneration":0,"baseBranch":"master"}\n'
+RG
+chmod +x "$TMP/bin/node" "$TMP/review-gate.sh"
+
+run_cron() {
+  PATH="$TMP/bin:$PATH" \
+  HOME="$TMP/home" \
+  INVOKER_GITHUB_TARGET_REPO="fake/repo" \
+  INVOKER_PR_CRON_AUTHOR="fake-bot" \
+  INVOKER_PR_CRON_LOCK="$TMP/crons.lock" \
+  INVOKER_PR_CONFLICT_STATE_FILE="$TMP/ledger.tsv" \
+  INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh" \
+  INVOKER_PR_REBASE_MAX_ATTEMPTS=3 \
+  INVOKER_PR_REBASE_CONFIRM_TIMEOUT=0 \
+  bash "$ROOT/scripts/cron-pr-conflict-rebase.sh" 2>&1 || true
+}
+
+# Ticks 1-3: each dispatches exactly one rebase-recreate for the stuck workflow.
+for i in 1 2 3; do
+  out="$(run_cron)"
+  echo "$out" | grep -q "rebase-recreate wf-babysit-1" \
+    || fail "tick $i: expected a rebase-recreate dispatch" "$out"
+  dispatches="$(grep -c "exec -- rebase-recreate wf-babysit-1" "$NODE_LOG" || true)"
+  [ "$dispatches" -eq "$i" ] \
+    || fail "tick $i: expected exactly $i cumulative dispatches, got $dispatches"
+done
+
+# Ticks 4-5: cap reached — no new dispatch, one-time exhausted comment posted once.
+for i in 4 5; do
+  out="$(run_cron)"
+  echo "$out" | grep -q "giving up" \
+    || fail "tick $i: expected the attempt cap to fire" "$out"
+done
+dispatches="$(grep -c "exec -- rebase-recreate wf-babysit-1" "$NODE_LOG" || true)"
+[ "$dispatches" -eq 3 ] || fail "cap breached: expected 3 dispatches total, got $dispatches"
+
+comments="$(grep -c "^gh pr comment 501" "$FAKE_GH_STATE_DIR/calls.log" || true)"
+[ "$comments" -eq 1 ] || fail "expected exactly one exhausted PR comment, got $comments"
+grep -q "gave up after 3 rebase-recreate attempts" "$FAKE_GH_STATE_DIR/state.json" \
+  || fail "exhausted comment body missing from fake GitHub state"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-babysit-land-dryrun.sh
+++ b/scripts/repro/repro-babysit-land-dryrun.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Battle-test: the mergify admin-bypass landing brain plans the right action
+# per scenario against a fake GitHub, in dry-run (no mutations):
+#   pr-dirty.json       -> rebase_recreate (merge conflict)
+#   pr-ci-failed.json   -> repair_check (failed required check after dequeue)
+#   stack-landable.json -> requeue (clean dequeued bottom PR)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-land.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+mkdir -p "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+# The fake gh expands the "*" checks default to the repo's real required-check
+# names, so the landing brain sees every .mergify.yml-required check green.
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, "scripts")
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path(".mergify.yml"))
+print("\n".join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+run_land() {
+  local scenario="$1"
+  cp "$ROOT/scripts/repro/fixtures/fake-gh/scenarios/$scenario" "$FAKE_GH_STATE_DIR/state.json"
+  : > "$FAKE_GH_STATE_DIR/calls.log"
+  python3 scripts/mergify_admin_requeue.py --once --dry-run \
+    --repo fake/repo --author fake-bot --state-file "$TMP/ledger.jsonl" 2>&1
+}
+
+out="$(run_land pr-dirty.json)"
+echo "$out" | grep -q "DRY-RUN rebase-recreate PR #501" \
+  || fail "pr-dirty: expected rebase_recreate plan" "$out"
+
+out="$(run_land pr-ci-failed.json)"
+echo "$out" | grep -q 'DRY-RUN repair-check PR #601 check="PR Body"' \
+  || fail "pr-ci-failed: expected repair_check plan" "$out"
+
+out="$(run_land stack-landable.json)"
+echo "$out" | grep -q "DRY-RUN requeue PR #701 head=dddddddddddddddddddddddddddddddddddddddd reason=eligible-after-dequeue" \
+  || fail "stack-landable: expected requeue plan for the bottom PR" "$out"
+echo "$out" | grep -q "PR #702" && fail "stack top must not be actioned before the bottom lands" "$out"
+
+# Dry-run must not mutate the fake GitHub: no comments, no label edits.
+if grep -Eq "^gh (pr comment|api --method)" "$FAKE_GH_STATE_DIR/calls.log"; then
+  fail "dry-run performed a mutating gh call" "$(cat "$FAKE_GH_STATE_DIR/calls.log")"
+fi
+
+echo "[repro] passed"

--- a/scripts/test-suites/required/28-pr-babysit-harness.sh
+++ b/scripts/test-suites/required/28-pr-babysit-harness.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Offline battle harness for the PR-babysitting chain: conflict-rebase cron,
+# CI-failure scan cron, and the mergify admin-bypass landing brain, all driven
+# against the reusable fake gh in scripts/repro/fixtures/fake-gh/.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+bash scripts/repro/repro-babysit-conflict-cron.sh
+bash scripts/repro/repro-babysit-ci-cron.sh
+bash scripts/repro/repro-babysit-land-dryrun.sh

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -225,7 +225,7 @@ Failing checks
                 subprocess.CalledProcessError(1, ["./run.sh"], stderr="missing workflow")
             )
             with self.assertRaisesRegex(RuntimeError, "missing workflow"):
-                requeue._resolve_workflow(2647)
+                requeue.resolve_workflow(2647)
         finally:
             requeue.subprocess.run = original_run
 
@@ -243,16 +243,16 @@ Failing checks
         action = Action("rebase_recreate", 2647, "conflict:2647", "GitHub reports merge conflict")
         fake = FakeGh()
         repairs = []
-        original_resolve = requeue._resolve_workflow
-        original_repair = requeue._repair_conflict
+        original_resolve = requeue.exec_impl.resolve_workflow
+        original_repair = requeue.exec_impl.repair_conflict
         try:
-            requeue._resolve_workflow = lambda pr_number: (_ for _ in ()).throw(RuntimeError(f"no local workflow for PR #{pr_number}"))
-            requeue._repair_conflict = lambda repo, pr, reason: repairs.append((repo, pr.number, reason))
+            requeue.exec_impl.resolve_workflow = lambda pr_number: (_ for _ in ()).throw(RuntimeError(f"no local workflow for PR #{pr_number}"))
+            requeue.exec_impl.repair_conflict = lambda repo, pr, reason: repairs.append((repo, pr.number, reason))
             for epoch in range(3):
-                requeue._execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, epoch)
+                requeue.execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, epoch)
         finally:
-            requeue._resolve_workflow = original_resolve
-            requeue._repair_conflict = original_repair
+            requeue.exec_impl.resolve_workflow = original_resolve
+            requeue.exec_impl.repair_conflict = original_repair
         self.assertEqual(ledger.count("conflict-repair", 2647, HEAD, "conflict:2647"), 3)
         self.assertEqual([repair[1] for repair in repairs], [2647, 2647, 2647])
         self.assertEqual(fake.comments, [])
@@ -271,8 +271,8 @@ Failing checks
         item = pr(2647, merge_state="DIRTY", latest=mergify())
         action = Action("comment_blocked", 2647, "capped", "GitHub reports merge conflict. The retry cap was reached for current head " + HEAD + ".")
         fake = FakeGh()
-        requeue._execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 1)
-        requeue._execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 2)
+        requeue.execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 1)
+        requeue.execute_action(action, "Neko-Catpital-Labs/Invoker", fake, ledger, {2647: item}, 2)
         self.assertEqual(len(fake.comments), 1)
 
     def test_missing_admin_bypass_nudge_comments_once_without_label_edit(self):
@@ -288,7 +288,7 @@ Failing checks
                 self.label_edits.append((repo, pr_number, add, remove))
 
         action = Action("comment_admin_bypass_nudge", 2647, "admin-bypass", "missing admin-bypass label")
-        for execute in (requeue._execute_action, requeue.exec_impl.execute_action):
+        for execute in (requeue.execute_action,):
             ledger = self.ledger()
             item = pr(2647, labels={"dequeued"}, latest=mergify())
             fake = FakeGh()

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -147,6 +147,34 @@ class PlanStackActions(unittest.TestCase):
         actions = self._plan(snapshot, ledger)
         self.assertEqual((actions[0].kind, actions[0].key), ("comment_blocked", "capped"))
 
+    def test_max_repair_attempts_parameter_caps_conflict_repair(self):
+        # cap=1: one prior conflict-repair attempt on this head -> next plan is capped.
+        ledger = self._ledger()
+        snapshot = pr(merge_state_status="DIRTY")
+        first = p.plan_stack_actions(m.StackGroup("s", (snapshot,)), REQUIRED, ledger, now_epoch=0, max_repair_attempts=1)
+        self.assertEqual(first[0].kind, "rebase_recreate")
+        ledger.record("conflict-repair", 1, HEAD, "conflict:1")
+        second = p.plan_stack_actions(m.StackGroup("s", (snapshot,)), REQUIRED, ledger, now_epoch=1, max_repair_attempts=1)
+        self.assertEqual((second[0].kind, second[0].key), ("comment_blocked", "capped"))
+        self.assertIn("The retry cap was reached", second[0].detail)
+
+    def test_max_requeue_attempts_parameter_caps_requeue(self):
+        ledger = self._ledger()
+        ledger.record("requeue", 1, HEAD, "cm1")
+        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued", comment_id="cm1"))
+        actions = p.plan_stack_actions(m.StackGroup("s", (snapshot,)), REQUIRED, ledger, now_epoch=0, max_requeue_attempts=1)
+        self.assertEqual((actions[0].kind, actions[0].key), ("comment_blocked", "capped"))
+
+    def test_trunk_parameter_decides_current_bottom(self):
+        # Same PR based on "main": with trunk=main it is the bottom (nudge);
+        # with the default master trunk it is not (no current bottom).
+        snapshot = pr(base_ref_name="main")
+        on_main = p.plan_stack_actions(m.StackGroup("s", (snapshot,)), REQUIRED, self._ledger(), now_epoch=0, trunk="main")
+        self.assertEqual(on_main[0].kind, "comment_admin_bypass_nudge")
+        on_master = p.plan_stack_actions(m.StackGroup("s", (snapshot,)), REQUIRED, self._ledger(), now_epoch=0)
+        self.assertEqual((on_master[0].kind, on_master[0].key), ("comment_blocked", "no-current-bottom"))
+        self.assertIn("no current bottom on master", on_master[0].detail)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Two babysitting workers never ran. `review-gate-merge-conflict` was registered but not auto-started, so the native conflict-to-rebase-recreate path was dead. `pr-admin-bypass-land` (landing) never started either.

Meanwhile the `prMaintenance.enabled` config docstring claimed to gate the cron workers, but three cron kinds auto-started unconditionally.

Auto-start now has two tiers. An always tier adds `review-gate-merge-conflict`. A `prMaintenance.enabled`-gated tier holds the four cron kinds, adding `pr-admin-bypass-land`.

A deprecated flat alias keeps not-yet-migrated snapshot callers compiling; two follow-up slices migrate them and drop it.

Behavior flip, intentional: with the flag absent or false, the cron kinds stay registered and startable but no longer start at boot.

Operators relying on the old unconditional start must set `prMaintenance.enabled: true`.
## Review Claim

Owner boot starts the merge-conflict worker unconditionally and the four PR-maintenance cron workers only when `prMaintenance.enabled` is true, with per-worker saved state still overriding both ways.
## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The gate only changes which workers start at boot; registration, manual start/stop, and persisted desired-state overrides are untouched. Updated `worker-control` tests assert both the enabled and disabled lists.

## Slice Rationale

This is the single boot-wiring change the whole stack exists for; it lands after the proof slices so reviewers see the pinned worker behavior before the flip.
## Architecture

### Before

```mermaid
graph TD
    Boot["Owner boot"] --> Always["AUTO_STARTED_OWNER_WORKER_KINDS (flat list)"]
    Always --> Crons["3 cron kinds always started; merge-conflict + landing never started"]
```

### After

```mermaid
graph TD
    Boot["Owner boot"] --> Fn["autoStartedOwnerWorkerKinds({prMaintenanceEnabled})"]
    Fn --> AlwaysTier["Always: pr-status, ci-failure, review-gate-merge-conflict, ..."]
    Fn -->|"prMaintenance.enabled"| CronTier["Cron tier: coderabbit-address, pr-conflict-rebase, pr-ci-failure-scan, pr-admin-bypass-land"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/worker-control.test.ts src/__tests__/registered-owner-workers.test.ts`
- [x] `pnpm run check:types`

</details>

## Non-goals

- No client snapshot-surface migration (next slice) and no alias removal (slice after).
- No changes to the workers' tick logic.
- No periodic-scan additions for event-drain workers (cron backstops cover missed events).
- No CodeRabbit conflict auto-trigger anywhere.

## Visual Proof

Default config (`prMaintenance` absent) — the always tier runs, the cron tier does not:

![Review Gate Merge Conflict worker shows Process: Running under default config](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260724-8ed782/workers-default-mergeconflict-running.png)

Caption: “Review Gate Merge Conflict” card shows **Process: Running** with default config — the new always-tier worker.

![PR CI scan and Pr Admin Bypass Land show Stopped under default config](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260724-8ed782/workers-default-land-stopped.png)

Caption: “PR CI scan” and “Pr Admin Bypass Land” cards show **Process: Stopped / Worker disabled** with default config — the gated cron tier does not auto-start.

With `prMaintenance.enabled: true` in `~/.invoker/config.json`:

![PR CI scan and Pr Admin Bypass Land show Running with prMaintenance enabled](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260724-8ed782/workers-enabled-crons-running.png)

Caption: the same “PR CI scan” and “Pr Admin Bypass Land” cards show **Process: Running** once the flag is set. The two screenshots are separate app boots with different configs, so static frames identify each configuration by the status pills on the same cards.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
