### PR TITLE
[PR babysit](8) Add offline pr-babysit-conflict chaos case

### DIFF
--- a/scripts/e2e-chaos/cases/case-pr-babysit-conflict.sh
+++ b/scripts/e2e-chaos/cases/case-pr-babysit-conflict.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# PR babysitting end-to-end under a live owner, fully offline:
+#   merge gate opens against a stub gh -> flip PR to DIRTY -> the pr-status
+#   poll publishes review_gate.merge_conflict -> the auto-started
+#   review-gate-merge-conflict worker submits invoker:rebase-recreate and the
+#   workflow GENERATION ADVANCES -> flip PR to CI-FAILED -> the ci-failure
+#   worker records a repair decision (invoker:fix-with-agent intent).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+# shellcheck disable=SC1091
+source "$ROOT/scripts/e2e-dry-run/lib/common.sh"
+
+export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=512"
+unset INVOKER_HEADLESS_STANDALONE
+unset ELECTRON_RUN_AS_NODE
+
+# Short /tmp base: the owner binds a UNIX socket at $INVOKER_DB_DIR/
+# ipc-transport.sock, and macOS truncates sun_path beyond ~104 bytes — a long
+# ${TMPDIR}-based HOME silently breaks socket exposure.
+TMP="$(mktemp -d /tmp/inv-pbb.XXXXXX)"
+export HOME="$TMP/home"
+mkdir -p "$HOME/.invoker"
+export INVOKER_DB_DIR="$HOME/.invoker"
+export INVOKER_REPO_CONFIG_PATH="$TMP/config.json"
+printf '{\n  "autoFixRetries": 1\n}\n' > "$INVOKER_REPO_CONFIG_PATH"
+export INVOKER_GITHUB_TARGET_REPO="fake/repo"
+
+MARKER_ROOT="$TMP/markers"
+mkdir -p "$MARKER_ROOT" "$TMP/bin"
+export CHAOS_GH_MARKER_ROOT="$MARKER_ROOT"
+
+# --- Stub gh: PR lifecycle driven by marker files -------------------------
+cat > "$TMP/bin/gh" <<'GH'
+#!/usr/bin/env bash
+# Stub gh for the pr-babysit chaos case. Marker files under
+# $CHAOS_GH_MARKER_ROOT flip the PR between CLEAN, DIRTY, and CI-FAILED.
+set -eu
+M="${CHAOS_GH_MARKER_ROOT:?}"
+echo "gh $*" >> "$M/gh-calls.log"
+SUBCMD="${1:-}"; shift || true
+rollup() {
+  local conclusion="$1"
+  printf '[{"__typename":"CheckRun","name":"unit","conclusion":"%s","status":"COMPLETED","completedAt":"2026-07-20T00:00:00Z","detailsUrl":"https://github.com/fake/repo/actions/runs/1/job/2"}]' "$conclusion"
+}
+case "$SUBCMD" in
+  pr)
+    ACTION="${1:-}"; shift || true
+    case "$ACTION" in
+      view)
+        PR_NUM="${1:-99}"
+        MERGE_STATE="CLEAN"; CHECKS="$(rollup SUCCESS)"
+        [ -f "$M/pr-ci-failed" ] && CHECKS="$(rollup FAILURE)"
+        [ -f "$M/pr-dirty" ] && MERGE_STATE="DIRTY"
+        printf '{"state":"OPEN","reviewDecision":null,"url":"https://github.com/fake/repo/pull/%s","headRefOid":"ffffffffffffffffffffffffffffffffffffffff","headRefName":"stack/%s","mergeStateStatus":"%s","statusCheckRollup":%s}\n' "$PR_NUM" "$PR_NUM" "$MERGE_STATE" "$CHECKS"
+        ;;
+      *) echo "{}" ;;
+    esac
+    ;;
+  api)
+    ENDPOINT="${1:-}"; shift || true
+    if echo "$ENDPOINT" | grep -qE 'pulls$'; then
+      METHOD="GET"; prev=""
+      for arg in "$@"; do
+        [ "$prev" = "--method" ] && { METHOD="$arg"; break; }
+        prev="$arg"
+      done
+      if [ "$METHOD" = "GET" ]; then echo '[]'; else echo '{"html_url":"https://github.com/fake/repo/pull/99","number":99}'; fi
+    else
+      echo '{}'
+    fi
+    ;;
+  *) echo "{}" ;;
+esac
+exit 0
+GH
+chmod +x "$TMP/bin/gh"
+ln -sf "$ROOT/scripts/e2e-dry-run/fixtures/claude-marker.sh" "$TMP/bin/claude"
+export INVOKER_CLAUDE_FIX_COMMAND="$TMP/bin/claude"
+export PATH="$TMP/bin:$PATH"
+
+# --- Local scratch repo the workflow clones ------------------------------
+SCRATCH="$TMP/scratch-repo"
+git init -q "$SCRATCH"
+git -C "$SCRATCH" -c user.email=e2e@invoker -c user.name=e2e commit -q --allow-empty -m init
+
+OWNER_LOG="$TMP/owner.log"
+OWNER_PID=""
+cleanup() {
+  if [ -n "$OWNER_PID" ]; then
+    kill "$OWNER_PID" 2>/dev/null || true
+    wait "$OWNER_PID" 2>/dev/null || true
+  fi
+  # run.sh spawns Electron as a grandchild; kill any owner still bound to this
+  # case's temp DB dir so failed runs never leave orphaned GUI owners behind.
+  local pid
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    if invoker_e2e_pid_has_env "$pid" "INVOKER_DB_DIR" "$INVOKER_DB_DIR"; then
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  done < <(pgrep -f 'packages/app/dist/main.js' 2>/dev/null || true)
+  rm -rf "$TMP" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL pr-babysit-conflict: $1"
+  echo "----- owner log tail -----"
+  tail -n 80 "$OWNER_LOG" 2>/dev/null || true
+  echo "----- gh calls tail -----"
+  tail -n 20 "$MARKER_ROOT/gh-calls.log" 2>/dev/null || true
+  exit 1
+}
+
+echo "==> pr-babysit: start owner"
+./run.sh >"$OWNER_LOG" 2>&1 &
+OWNER_PID=$!
+
+READY=0
+for _ in $(seq 1 240); do
+  [ -S "$HOME/.invoker/ipc-transport.sock" ] && { READY=1; break; }
+  sleep 1
+done
+[ "$READY" -eq 1 ] || fail "owner never exposed ipc socket"
+
+PLAN_PATH="$TMP/plan.yaml"
+cat > "$PLAN_PATH" <<EOF
+name: chaos pr babysit conflict
+repoUrl: file://$SCRATCH
+onFinish: none
+mergeMode: external_review
+featureBranch: experiment/pr-babysit
+baseBranch: HEAD
+tasks:
+  - id: babysit-task
+    description: trivial task feeding the merge gate
+    command: echo ok
+    dependencies: []
+EOF
+
+echo "==> pr-babysit: submit plan"
+SUBMIT_LOG="$TMP/submit.log"
+./submit-plan.sh "$PLAN_PATH" 2>&1 | tee "$SUBMIT_LOG"
+WF_ID="$(grep -oE 'wf-[0-9]+-[0-9]+' "$SUBMIT_LOG" | tail -1 || true)"
+[ -n "$WF_ID" ] || fail "could not resolve workflow id from submit output"
+
+echo "==> pr-babysit: wait for merge gate to open (PR created via stub gh)"
+MERGE_ID=""
+for _ in $(seq 1 120); do
+  MERGE_ID="$(invoker_e2e_merge_gate_id || true)"
+  if [ -n "$MERGE_ID" ]; then
+    STM="$(invoker_e2e_task_status "$MERGE_ID" || true)"
+    if [ "$STM" = "review_ready" ] || [ "$STM" = "awaiting_approval" ]; then
+      break
+    fi
+  fi
+  sleep 2
+done
+[ -n "$MERGE_ID" ] || fail "merge gate never appeared"
+STM="$(invoker_e2e_task_status "$MERGE_ID" || true)"
+{ [ "$STM" = "review_ready" ] || [ "$STM" = "awaiting_approval" ]; } \
+  || fail "merge gate never opened (status='$STM')"
+
+workflow_generation() {
+  invoker_e2e_run_headless query workflow "$WF_ID" --output json 2>/dev/null \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin).get("generation", 0))' 2>/dev/null || echo 0
+}
+GEN0="$(workflow_generation)"
+echo "==> pr-babysit: baseline generation=$GEN0; flip PR to DIRTY"
+touch "$MARKER_ROOT/pr-dirty"
+
+# pr-status polls every 60s; the merge-conflict worker wakes on the event and
+# submits invoker:rebase-recreate, which advances the workflow generation.
+ADVANCED=0
+for _ in $(seq 1 120); do
+  GEN_NOW="$(workflow_generation)"
+  if [ "${GEN_NOW:-0}" -gt "${GEN0:-0}" ] 2>/dev/null; then
+    ADVANCED=1
+    break
+  fi
+  sleep 3
+done
+[ "$ADVANCED" -eq 1 ] || fail "workflow generation never advanced after merge conflict (still $GEN0)"
+echo "==> pr-babysit: generation advanced ($GEN0 -> $GEN_NOW) via rebase-recreate"
+
+rm -f "$MARKER_ROOT/pr-dirty"
+
+echo "==> pr-babysit: wait for the gate to re-open, then flip PR to CI-FAILED"
+GATE_REOPENED=0
+for _ in $(seq 1 120); do
+  MERGE_ID="$(invoker_e2e_merge_gate_id || true)"
+  if [ -n "$MERGE_ID" ]; then
+    STM="$(invoker_e2e_task_status "$MERGE_ID" || true)"
+    if [ "$STM" = "review_ready" ] || [ "$STM" = "awaiting_approval" ]; then
+      GATE_REOPENED=1
+      break
+    fi
+  fi
+  sleep 2
+done
+[ "$GATE_REOPENED" -eq 1 ] || fail "merge gate did not reopen after conflict repair"
+touch "$MARKER_ROOT/pr-ci-failed"
+
+CI_DECIDED=0
+for _ in $(seq 1 120); do
+  DECISIONS_JSON="$(invoker_e2e_run_headless query worker-decisions --workflow "$WF_ID" --output json 2>/dev/null || true)"
+  if python3 - "$WF_ID" "$MERGE_ID" "$DECISIONS_JSON" <<'PY'
+import json
+import sys
+
+workflow_id, task_id, decisions_json = sys.argv[1:4]
+try:
+    decisions = json.loads(decisions_json)
+except json.JSONDecodeError:
+    raise SystemExit(1)
+
+if not isinstance(decisions, list):
+    raise SystemExit(1)
+
+for action in decisions:
+    if not isinstance(action, dict):
+        continue
+    if action.get("decision") != "act":
+        continue
+    if action.get("workflowId") != workflow_id:
+        continue
+    if action.get("taskId") != task_id:
+        continue
+    if action.get("workerKind") != "ci-failure":
+        continue
+    if action.get("actionType") != "fix-ci-failure":
+        continue
+    if action.get("intentId"):
+        raise SystemExit(0)
+
+raise SystemExit(1)
+PY
+  then
+    CI_DECIDED=1
+    break
+  fi
+  sleep 3
+done
+[ "$CI_DECIDED" -eq 1 ] || fail "no ci-failure worker decision after CI failure"
+echo "==> pr-babysit: ci-failure worker recorded a repair decision"
+
+# The repair intent is deliberately in flight; let the PR read green again so
+# the fix path can finish, then wait for open intents to drain before the
+# liveness gate (retrying rides out transient sqlite lock contention too).
+rm -f "$MARKER_ROOT/pr-ci-failed"
+LIVENESS_OK=0
+for _ in $(seq 1 60); do
+  if invoker_e2e_assert_liveness_clean 15 30 0 2>/dev/null; then
+    LIVENESS_OK=1
+    break
+  fi
+  sleep 5
+done
+if [ "$LIVENESS_OK" -ne 1 ]; then
+  invoker_e2e_assert_liveness_clean 15 30 0 || fail "liveness not clean after repair drain"
+fi
+
+echo "PASS pr-babysit-conflict (generation $GEN0 -> $GEN_NOW; ci-failure repair decision present)"

--- a/scripts/e2e-chaos/cases/case-pr-babysit-conflict.sh
+++ b/scripts/e2e-chaos/cases/case-pr-babysit-conflict.sh
@@ -206,24 +206,30 @@ touch "$MARKER_ROOT/pr-ci-failed"
 
 CI_DECIDED=0
 for _ in $(seq 1 120); do
-  DECISIONS_JSON="$(invoker_e2e_run_headless query worker-decisions --workflow "$WF_ID" --output json 2>/dev/null || true)"
-  if python3 - "$WF_ID" "$MERGE_ID" "$DECISIONS_JSON" <<'PY'
+  # worker-actions (not worker-decisions) because its JSON serializes the raw
+  # row payload, which carries the submitted intent channel. The owner holds
+  # the sqlite DB with locking_mode=EXCLUSIVE, so the intent row itself is
+  # unreadable from this process while the owner lives.
+  ACTIONS_JSON="$(invoker_e2e_run_headless query worker-actions --workflow "$WF_ID" --output json 2>/dev/null || true)"
+  if python3 - "$WF_ID" "$MERGE_ID" "$ACTIONS_JSON" <<'PY'
 import json
 import sys
 
-workflow_id, task_id, decisions_json = sys.argv[1:4]
+workflow_id, task_id, actions_json = sys.argv[1:4]
 try:
-    decisions = json.loads(decisions_json)
+    actions = json.loads(actions_json)
 except json.JSONDecodeError:
     raise SystemExit(1)
 
-if not isinstance(decisions, list):
+if not isinstance(actions, list):
     raise SystemExit(1)
 
-for action in decisions:
+for action in actions:
     if not isinstance(action, dict):
         continue
-    if action.get("decision") != "act":
+    # Raw rows carry no decision field; skipped status is the 'skip' decision
+    # class, everything else is 'act'.
+    if action.get("status") == "skipped":
         continue
     if action.get("workflowId") != workflow_id:
         continue
@@ -233,7 +239,15 @@ for action in decisions:
         continue
     if action.get("actionType") != "fix-ci-failure":
         continue
-    if action.get("intentId"):
+    if not action.get("intentId"):
+        continue
+    payload = action.get("payload")
+    if not isinstance(payload, dict):
+        continue
+    # Require the invoker:fix-with-agent repair channel recorded with the
+    # submitted intent, so a no-op or unrelated decision cannot satisfy the
+    # scenario.
+    if payload.get("channel") == "invoker:fix-with-agent":
         raise SystemExit(0)
 
 raise SystemExit(1)
@@ -244,8 +258,8 @@ PY
   fi
   sleep 3
 done
-[ "$CI_DECIDED" -eq 1 ] || fail "no ci-failure worker decision after CI failure"
-echo "==> pr-babysit: ci-failure worker recorded a repair decision"
+[ "$CI_DECIDED" -eq 1 ] || fail "no ci-failure invoker:fix-with-agent repair decision after CI failure"
+echo "==> pr-babysit: ci-failure worker recorded an invoker:fix-with-agent repair decision"
 
 # The repair intent is deliberately in flight; let the PR read green again so
 # the fix path can finish, then wait for open intents to drain before the

--- a/scripts/e2e-chaos/repros/repro-chaos-ci-repair-decision-match.sh
+++ b/scripts/e2e-chaos/repros/repro-chaos-ci-repair-decision-match.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+echo "Repro: ci-failure decision check must reject unrelated worker decisions"
+TARGET="scripts/e2e-chaos/cases/case-pr-babysit-conflict.sh"
+python3 - "$TARGET" <<'PY'
+from pathlib import Path
+import json
+import re
+import subprocess
+import sys
+
+text = Path(sys.argv[1]).read_text()
+match = re.search(r'python3 - "\$WF_ID" "\$MERGE_ID" "\$DECISIONS_JSON" <<\'PY\'\n(.*?)\nPY', text, re.S)
+if not match:
+    print('FAIL: case no longer parses worker-decisions JSON for the ci-failure assertion')
+    raise SystemExit(1)
+
+script = match.group(1)
+workflow_id = 'wf-current'
+task_id = '__merge__/wf-current'
+
+unrelated = json.dumps([{
+    'decision': 'act',
+    'workflowId': 'wf-other',
+    'taskId': '__merge__/wf-other',
+    'workerKind': 'ci-failure',
+    'actionType': 'fix-ci-failure',
+    'intentId': '7',
+}])
+wrong = subprocess.run(
+    ['python3', '-c', script, workflow_id, task_id, unrelated],
+    check=False,
+    capture_output=True,
+    text=True,
+)
+if wrong.returncode == 0:
+    print('FAIL: unrelated ci-failure decision still satisfies the assertion')
+    raise SystemExit(1)
+
+matching = json.dumps([
+    {
+        'decision': 'act',
+        'workflowId': 'wf-other',
+        'taskId': '__merge__/wf-other',
+        'workerKind': 'ci-failure',
+        'actionType': 'fix-ci-failure',
+        'intentId': '7',
+    },
+    {
+        'decision': 'act',
+        'workflowId': workflow_id,
+        'taskId': task_id,
+        'workerKind': 'ci-failure',
+        'actionType': 'fix-ci-failure',
+        'intentId': '42',
+    },
+])
+good = subprocess.run(
+    ['python3', '-c', script, workflow_id, task_id, matching],
+    check=False,
+    capture_output=True,
+    text=True,
+)
+if good.returncode != 0:
+    print('FAIL: matching ci-failure repair decision does not satisfy the assertion')
+    if good.stderr:
+        print(good.stderr.strip())
+    raise SystemExit(1)
+
+print('PASS: ci-failure assertion requires the current workflow/task repair decision')
+PY

--- a/scripts/e2e-chaos/repros/repro-chaos-ci-repair-decision-match.sh
+++ b/scripts/e2e-chaos/repros/repro-chaos-ci-repair-decision-match.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
 
-echo "Repro: ci-failure decision check must reject unrelated worker decisions"
+echo "Repro: ci-failure decision check must reject unrelated or non-fix-with-agent decisions"
 TARGET="scripts/e2e-chaos/cases/case-pr-babysit-conflict.sh"
 python3 - "$TARGET" <<'PY'
 from pathlib import Path
@@ -13,62 +13,65 @@ import subprocess
 import sys
 
 text = Path(sys.argv[1]).read_text()
-match = re.search(r'python3 - "\$WF_ID" "\$MERGE_ID" "\$DECISIONS_JSON" <<\'PY\'\n(.*?)\nPY', text, re.S)
+match = re.search(
+    r'python3 - "\$WF_ID" "\$MERGE_ID" "\$ACTIONS_JSON" <<\'PY\'\n(.*?)\nPY',
+    text,
+    re.S,
+)
 if not match:
-    print('FAIL: case no longer parses worker-decisions JSON for the ci-failure assertion')
+    print('FAIL: case no longer parses worker-actions JSON for the ci-failure assertion')
     raise SystemExit(1)
 
 script = match.group(1)
 workflow_id = 'wf-current'
 task_id = '__merge__/wf-current'
 
-unrelated = json.dumps([{
-    'decision': 'act',
-    'workflowId': 'wf-other',
-    'taskId': '__merge__/wf-other',
-    'workerKind': 'ci-failure',
-    'actionType': 'fix-ci-failure',
-    'intentId': '7',
-}])
-wrong = subprocess.run(
-    ['python3', '-c', script, workflow_id, task_id, unrelated],
-    check=False,
-    capture_output=True,
-    text=True,
-)
-if wrong.returncode == 0:
-    print('FAIL: unrelated ci-failure decision still satisfies the assertion')
-    raise SystemExit(1)
 
-matching = json.dumps([
-    {
-        'decision': 'act',
-        'workflowId': 'wf-other',
-        'taskId': '__merge__/wf-other',
-        'workerKind': 'ci-failure',
-        'actionType': 'fix-ci-failure',
-        'intentId': '7',
-    },
-    {
+def run(actions):
+    return subprocess.run(
+        ['python3', '-c', script, workflow_id, task_id, json.dumps(actions)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def action(**overrides):
+    base = {
+        'status': 'queued',
         'decision': 'act',
         'workflowId': workflow_id,
         'taskId': task_id,
         'workerKind': 'ci-failure',
         'actionType': 'fix-ci-failure',
         'intentId': '42',
-    },
-])
-good = subprocess.run(
-    ['python3', '-c', script, workflow_id, task_id, matching],
-    check=False,
-    capture_output=True,
-    text=True,
-)
+        'payload': {'channel': 'invoker:fix-with-agent'},
+    }
+    base.update(overrides)
+    return base
+
+
+unrelated = action(workflowId='wf-other', taskId='__merge__/wf-other', intentId='7')
+if run([unrelated]).returncode == 0:
+    print('FAIL: unrelated ci-failure decision still satisfies the assertion')
+    raise SystemExit(1)
+
+wrong_channel = action(payload={'channel': 'invoker:rebase-recreate'}, intentId='41')
+if run([wrong_channel]).returncode == 0:
+    print('FAIL: a matching decision whose intent is not invoker:fix-with-agent still satisfies the assertion')
+    raise SystemExit(1)
+
+skipped = action(status='skipped', decision='skip', intentId=None)
+if run([skipped]).returncode == 0:
+    print('FAIL: a skipped ci-failure decision still satisfies the assertion')
+    raise SystemExit(1)
+
+good = run([unrelated, wrong_channel, skipped, action()])
 if good.returncode != 0:
-    print('FAIL: matching ci-failure repair decision does not satisfy the assertion')
+    print('FAIL: matching invoker:fix-with-agent repair decision does not satisfy the assertion')
     if good.stderr:
         print(good.stderr.strip())
     raise SystemExit(1)
 
-print('PASS: ci-failure assertion requires the current workflow/task repair decision')
+print("PASS: ci-failure assertion requires this workflow's invoker:fix-with-agent repair decision")
 PY

--- a/scripts/e2e-chaos/repros/repro-chaos-merge-gate-reopen-guard.sh
+++ b/scripts/e2e-chaos/repros/repro-chaos-merge-gate-reopen-guard.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+echo "Repro: conflict chaos case must fail before CI flip when merge gate never reopens"
+TARGET="scripts/e2e-chaos/cases/case-pr-babysit-conflict.sh"
+python3 - "$TARGET" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+required = [
+    'GATE_REOPENED=0',
+    'GATE_REOPENED=1',
+    '[ "$GATE_REOPENED" -eq 1 ] || fail "merge gate did not reopen after conflict repair"',
+    'touch "$MARKER_ROOT/pr-ci-failed"',
+]
+missing = [item for item in required if item not in text]
+if missing:
+    print('FAIL: chaos case can still flip PR to CI-FAILED without proving gate reopen')
+    for item in missing:
+        print(f'missing: {item}')
+    raise SystemExit(1)
+
+guard_pos = text.index(required[2])
+touch_pos = text.index(required[3])
+if guard_pos > touch_pos:
+    print('FAIL: gate reopen guard runs after the CI failure marker')
+    raise SystemExit(1)
+
+print('PASS: chaos case blocks CI failure until the merge gate reopens')
+PY

--- a/scripts/e2e-chaos/run-matrix.sh
+++ b/scripts/e2e-chaos/run-matrix.sh
@@ -58,6 +58,7 @@ owner-no-autofix-trigger|gui-owner|single|task_failed|no_autofix_enqueue|off|non
 owner-approve-delegated|gui-owner|single|awaiting_approval|approve|off|delegated|gui-owner-delegation|bash __ROOT__/scripts/e2e-chaos/cases/case-owner-approve-delegated.sh
 owner-reject-delegated|gui-owner|single|awaiting_approval|reject|off|delegated|gui-owner-delegation|bash __ROOT__/scripts/e2e-chaos/cases/case-owner-reject-delegated.sh
 stale-late-completion-both|gui-owner|sequential|stale_worker_response|recreate_and_retry_task|off|late_completion|late-completion-delta-flow|bash __ROOT__/scripts/repro/repro-stale-late-completion-after-reset.sh --mode=both --expect-fixed
+pr-babysit-conflict|gui-owner|single|merge_conflict+ci_failed|rebase_recreate+fix_intent|default|none|none|bash __ROOT__/scripts/e2e-chaos/cases/case-pr-babysit-conflict.sh
 EOF
 }
 


### PR DESCRIPTION
## Summary

This adds the end-to-end proof that the previous diff's boot wiring works under a live owner, fully offline.

The chaos case boots a real owner with a marker-driven `gh` stub and waits for the merge gate to open against a fake PR.

Flipping the PR to DIRTY drives the native conflict path: the auto-started merge-conflict worker orders a rebase-recreate and the case asserts the workflow generation advances.

Flipping to CI-FAILED then asserts a `ci-failure` worker repair decision, and the case ends with the standard liveness gate.

Two content-guard repros under `scripts/e2e-chaos/repros/` pin the reopen guard and the per-workflow repair-decision match.

One environment fact is codified: macOS truncates UNIX socket paths beyond ~104 bytes, so the case homes itself under a short `/tmp` base.
## Review Claim

Under a live owner with a stubbed GitHub, a merge conflict advances the workflow generation via the auto-started merge-conflict worker and a CI failure yields a ci-failure repair decision.
## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Adds one chaos case script and one catalog line in `run-matrix.sh` (`ui_stall_profile=none`, so `UI_STALL_REQUIRED_SCENARIOS` is untouched). No product code changes.

## Slice Rationale

The e2e proof depends on the boot wiring of the previous diff, so it lands directly after it rather than bundled with the unit-level harness.
## Non-goals

- No live-GitHub interaction (next slice).
- No changes to other chaos cases or matrix policy.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/e2e-chaos/repros/repro-chaos-merge-gate-reopen-guard.sh`
- [x] `bash scripts/e2e-chaos/repros/repro-chaos-ci-repair-decision-match.sh`
- [x] `INVOKER_CHAOS_SCENARIO=pr-babysit bash scripts/e2e-chaos/run-matrix.sh` (results.jsonl row `result: "passed"`, generation 0 → 1, ci-failure decision present)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
