### PR TITLE
[PR babysit](7) Drop the deprecated flat auto-start list

### DIFF
--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -53,15 +53,6 @@ export const PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS = [
 ] as const;
 
 /**
- * @deprecated Transitional flat list for callers not yet migrated to
- * `autoStartedOwnerWorkerKindsForConfig`; dropped in the follow-up slice.
- */
-export const AUTO_STARTED_OWNER_WORKER_KINDS = [
-  ...ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS,
-  ...PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS,
-] as const;
-
-/**
  * Compute the owner worker kinds that auto-start on boot. The PR-maintenance
  * cron kinds are gated on `prMaintenance.enabled` (matching the config
  * docstring); everything else always auto-starts. Saved per-worker desired


### PR DESCRIPTION
## Summary

Every caller now goes through `autoStartedOwnerWorkerKinds` or its config-aware wrapper, so the transitional flat `AUTO_STARTED_OWNER_WORKER_KINDS` alias in worker-control has no users left.

This slice drops it.

## Review Claim

The deprecated flat auto-start alias is gone and nothing referenced it.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The alias had zero references after the previous slice; the diff is a pure symbol drop in one file and the workspace typecheck proves no caller breaks.

## Slice Rationale

Retiring the transitional alias is its own step after migration, per the migrate-then-retire ordering rule.

## Non-goals

- No behavior change to auto-start tiers or any caller.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/worker-control.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
