### PR TITLE
Fix Slack workflow assistant prompt transport

### DIFF
--- a/packages/execution-engine/src/__tests__/agent-prompt-transport-write-failure.test.ts
+++ b/packages/execution-engine/src/__tests__/agent-prompt-transport-write-failure.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('materializeLocalAgentPrompt write failure cleanup', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('node:fs');
+  });
+
+  it('removes the temporary directory when prompt file writing fails', async () => {
+    const writeError = new Error('disk full');
+    const rmSync = vi.fn();
+    const mkdtempSync = vi.fn(() => '/tmp/invoker-agent-prompt-test-1234');
+    const writeFileSync = vi.fn(() => {
+      throw writeError;
+    });
+
+    vi.doMock('node:fs', async (importOriginal) => {
+      const actual = (await importOriginal()) as Record<string, unknown>;
+      return {
+        ...actual,
+        mkdtempSync,
+        rmSync,
+        writeFileSync,
+      };
+    });
+
+    // Dynamic import is required here because this test replaces node:fs before loading the module under test.
+    const { materializeLocalAgentPrompt } = await import('../agent-prompt-transport.js');
+
+    expect(() => materializeLocalAgentPrompt('running task context\n'.repeat(10_000))).toThrow(writeError);
+    expect(rmSync).toHaveBeenCalledOnce();
+    expect(rmSync).toHaveBeenCalledWith('/tmp/invoker-agent-prompt-test-1234', { recursive: true, force: true });
+  });
+
+  it('returns cleanup metadata when removing the spilled prompt directory fails', async () => {
+    const cleanupError = new Error('device busy');
+    const rmSync = vi.fn(() => {
+      throw cleanupError;
+    });
+    const mkdtempSync = vi.fn(() => '/tmp/invoker-agent-prompt-test-5678');
+    const writeFileSync = vi.fn();
+
+    vi.doMock('node:fs', async (importOriginal) => {
+      const actual = (await importOriginal()) as Record<string, unknown>;
+      return {
+        ...actual,
+        mkdtempSync,
+        rmSync,
+        writeFileSync,
+      };
+    });
+
+    const { materializeLocalAgentPrompt } = await import('../agent-prompt-transport.js');
+    const transport = materializeLocalAgentPrompt('running task context\n'.repeat(10_000));
+
+    expect(transport.cleanup()).toEqual({
+      directory: '/tmp/invoker-agent-prompt-test-5678',
+      error: cleanupError,
+    });
+    expect(rmSync).toHaveBeenCalledOnce();
+    expect(rmSync).toHaveBeenCalledWith('/tmp/invoker-agent-prompt-test-5678', { recursive: true, force: true });
+  });
+});

--- a/packages/execution-engine/src/__tests__/agent-prompt-transport.test.ts
+++ b/packages/execution-engine/src/__tests__/agent-prompt-transport.test.ts
@@ -1,0 +1,29 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_MAX_INLINE_AGENT_PROMPT_BYTES,
+  materializeLocalAgentPrompt,
+} from '../agent-prompt-transport.js';
+
+describe('materializeLocalAgentPrompt', () => {
+  it('keeps prompts at the inline threshold unchanged', () => {
+    const prompt = 'a'.repeat(DEFAULT_MAX_INLINE_AGENT_PROMPT_BYTES);
+    const transport = materializeLocalAgentPrompt(prompt);
+
+    expect(transport.effectivePrompt).toBe(prompt);
+    transport.cleanup();
+  });
+
+  it('writes oversized prompts to a temporary file and removes it on cleanup', () => {
+    const prompt = 'running task context\n'.repeat(10_000);
+    const transport = materializeLocalAgentPrompt(prompt);
+    const match = transport.effectivePrompt.match(/file: (.+)\n/);
+
+    expect(match?.[1]).toContain('invoker-agent-prompt-');
+    expect(readFileSync(match![1], 'utf8')).toBe(prompt);
+
+    transport.cleanup();
+
+    expect(existsSync(match![1])).toBe(false);
+  });
+});

--- a/packages/execution-engine/src/agent-prompt-transport.ts
+++ b/packages/execution-engine/src/agent-prompt-transport.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export const DEFAULT_MAX_INLINE_AGENT_PROMPT_BYTES = 64 * 1024;
+
+export interface LocalPromptCleanupResult {
+  directory: string;
+  error: Error;
+}
+
+export interface LocalPromptTransport {
+  effectivePrompt: string;
+  cleanup: () => LocalPromptCleanupResult | undefined;
+}
+
+export function maxInlineAgentPromptBytes(): number {
+  const raw = process.env.INVOKER_MAX_INLINE_AGENT_PROMPT_BYTES;
+  if (!raw) return DEFAULT_MAX_INLINE_AGENT_PROMPT_BYTES;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_INLINE_AGENT_PROMPT_BYTES;
+}
+
+export function shouldInlineAgentPrompt(prompt: string): boolean {
+  return Buffer.byteLength(prompt, 'utf8') <= maxInlineAgentPromptBytes();
+}
+
+export function buildAgentPromptFileBootstrap(promptPath: string): string {
+  return [
+    `The full task instructions are in this file: ${promptPath}`,
+    'Read the file completely, then execute those instructions in this workspace.',
+    'Do not ask for the file contents.',
+  ].join('\n');
+}
+
+
+function removePromptDirectory(directory: string): LocalPromptCleanupResult | undefined {
+  try {
+    rmSync(directory, { recursive: true, force: true });
+    return undefined;
+  } catch (error) {
+    return {
+      directory,
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+}
+
+export function materializeLocalAgentPrompt(
+  prompt: string,
+  directoryPrefix: string = 'invoker-agent-prompt-',
+): LocalPromptTransport {
+  if (shouldInlineAgentPrompt(prompt)) {
+    return { effectivePrompt: prompt, cleanup: () => undefined };
+  }
+  const directory = mkdtempSync(join(tmpdir(), directoryPrefix));
+  const promptPath = join(directory, 'prompt.md');
+  try {
+    writeFileSync(promptPath, prompt, 'utf8');
+  } catch (error) {
+    removePromptDirectory(directory);
+    throw error;
+  }
+  return {
+    effectivePrompt: buildAgentPromptFileBootstrap(promptPath),
+    cleanup: () => removePromptDirectory(directory),
+  };
+}

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -7,9 +7,7 @@
 
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { existsSync } from 'node:fs';
 
 import type { Orchestrator } from '@invoker/workflow-core';
 import { OrchestratorError, OrchestratorErrorCode, parseMergeConflictError } from '@invoker/workflow-core';
@@ -22,6 +20,11 @@ import { buildWorktreeListScript, createSshRemoteScriptError } from './ssh-git-e
 import { buildSshConnectionArgs } from './ssh-transport-options.js';
 import { findManagedWorktreeForBranch } from './worktree-discovery.js';
 import { buildRemoteAgentEnvExports } from './remote-agent-env.js';
+import {
+  buildAgentPromptFileBootstrap,
+  materializeLocalAgentPrompt,
+  shouldInlineAgentPrompt,
+} from './agent-prompt-transport.js';
 
 // ── Host interface ───────────────────────────────────────
 
@@ -54,13 +57,6 @@ export interface ConflictResolverHost {
   getRemoteTargetConfig?(targetId: string): RemoteTargetConfig | undefined;
 }
 
-const DEFAULT_MAX_INLINE_PROMPT_BYTES = 64 * 1024;
-const MAX_INLINE_PROMPT_BYTES = (() => {
-  const raw = process.env.INVOKER_MAX_INLINE_AGENT_PROMPT_BYTES;
-  if (!raw) return DEFAULT_MAX_INLINE_PROMPT_BYTES;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_INLINE_PROMPT_BYTES;
-})();
 const DEBUG_IO_TAIL_CHARS = 2000;
 
 function tailText(value: unknown, maxChars: number = DEBUG_IO_TAIL_CHARS): string | undefined {
@@ -69,44 +65,13 @@ function tailText(value: unknown, maxChars: number = DEBUG_IO_TAIL_CHARS): strin
   return value.slice(-maxChars);
 }
 
-function promptByteLength(prompt: string): number {
-  return Buffer.byteLength(prompt, 'utf8');
-}
-
-function buildPromptFileBootstrap(promptPath: string): string {
-  return [
-    `The full task instructions are in this file: ${promptPath}`,
-    `Read the file completely, then execute those instructions in this workspace.`,
-    `Do not ask for the file contents.`,
-  ].join('\n');
-}
-
-function materializeLocalPrompt(prompt: string): { effectivePrompt: string; cleanup: () => void } {
-  if (promptByteLength(prompt) <= MAX_INLINE_PROMPT_BYTES) {
-    return { effectivePrompt: prompt, cleanup: () => {} };
-  }
-  const dir = mkdtempSync(join(tmpdir(), 'invoker-agent-prompt-'));
-  const promptPath = join(dir, 'prompt.md');
-  writeFileSync(promptPath, prompt, 'utf8');
-  return {
-    effectivePrompt: buildPromptFileBootstrap(promptPath),
-    cleanup: () => {
-      try {
-        rmSync(dir, { recursive: true, force: true });
-      } catch {
-        /* best effort */
-      }
-    },
-  };
-}
-
 function materializeRemotePrompt(prompt: string): { effectivePrompt: string; remotePromptFilePath?: string; promptB64?: string } {
-  if (promptByteLength(prompt) <= MAX_INLINE_PROMPT_BYTES) {
+  if (shouldInlineAgentPrompt(prompt)) {
     return { effectivePrompt: prompt };
   }
   const remotePromptFilePath = `/tmp/invoker-agent-prompt-${randomUUID()}.md`;
   return {
-    effectivePrompt: buildPromptFileBootstrap(remotePromptFilePath),
+    effectivePrompt: buildAgentPromptFileBootstrap(remotePromptFilePath),
     remotePromptFilePath,
     promptB64: Buffer.from(prompt, 'utf8').toString('base64'),
   };
@@ -770,7 +735,7 @@ export function spawnAgentFixViaRegistry(
   executionModel?: string,
 ): Promise<{ stdout: string; sessionId: string }> {
   assertExecutionModelSupported(agent, executionModel);
-  const promptTransport = materializeLocalPrompt(prompt);
+  const promptTransport = materializeLocalAgentPrompt(prompt);
   const spec = agent.buildFixCommand?.(promptTransport.effectivePrompt, { executionModel });
   if (!spec) {
     promptTransport.cleanup();

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -11,6 +11,7 @@ export {
 export * from './executor.js';
 export * from './base-executor.js';
 export * from './process-utils.js';
+export * from './agent-prompt-transport.js';
 export * from './docker-executor.js';
 export * from './worktree-executor.js';
 export * from './merge-gate-executor.js';

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -1,12 +1,13 @@
 import { spawn } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
-import { homedir, tmpdir } from 'node:os';
+import { homedir } from 'node:os';
 
 import type { ExecutionAgent } from './agent.js';
 import type { SessionDriver } from './session-driver.js';
 import { buildAgentExitFailureDetail, cleanElectronEnv, killProcessGroup, resolveExecutableOnCurrentPath, SIGKILL_TIMEOUT_MS } from './process-utils.js';
+import { materializeLocalAgentPrompt } from './agent-prompt-transport.js';
 
 export interface MakePrStackArtifactOutput {
   readonly id: string;
@@ -82,14 +83,7 @@ const REVIEW_STACK_METADATA_SECTIONS = [
   '## Slice Rationale',
 ] as const;
 const DISCOURAGED_HEADINGS = ['## Testing', '## Notes'] as const;
-const DEFAULT_MAX_INLINE_PROMPT_BYTES = 64 * 1024;
 const DEFAULT_PR_AUTHORING_TIMEOUT_MS = 20 * 60 * 1000;
-const MAX_INLINE_PROMPT_BYTES = (() => {
-  const raw = process.env.INVOKER_MAX_INLINE_AGENT_PROMPT_BYTES;
-  if (!raw) return DEFAULT_MAX_INLINE_PROMPT_BYTES;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_INLINE_PROMPT_BYTES;
-})();
 
 function getPrAuthoringTimeoutMs(): number {
   const raw = process.env.INVOKER_PR_AUTHORING_TIMEOUT_MS?.trim();
@@ -257,37 +251,6 @@ export function validateReviewStackPrBody(body: string): string[] {
   }
 
   return errors;
-}
-
-function promptByteLength(prompt: string): number {
-  return Buffer.byteLength(prompt, 'utf8');
-}
-
-function buildPromptFileBootstrap(promptPath: string): string {
-  return [
-    `The full task instructions are in this file: ${promptPath}`,
-    'Read the file completely, then execute those instructions in this workspace.',
-    'Do not ask for the file contents.',
-  ].join('\n');
-}
-
-function materializeLocalPrompt(prompt: string): { effectivePrompt: string; cleanup: () => void } {
-  if (promptByteLength(prompt) <= MAX_INLINE_PROMPT_BYTES) {
-    return { effectivePrompt: prompt, cleanup: () => {} };
-  }
-  const dir = mkdtempSync(join(tmpdir(), 'invoker-pr-author-prompt-'));
-  const promptPath = join(dir, 'prompt.md');
-  writeFileSync(promptPath, prompt, 'utf8');
-  return {
-    effectivePrompt: buildPromptFileBootstrap(promptPath),
-    cleanup: () => {
-      try {
-        rmSync(dir, { recursive: true, force: true });
-      } catch {
-        /* best effort */
-      }
-    },
-  };
 }
 
 function extractAssistantBody(driver: SessionDriver | undefined, sessionId: string, fallback: string): string {
@@ -727,7 +690,7 @@ export function spawnAgentPrAuthorViaRegistry(
   agent: ExecutionAgent,
   driver?: SessionDriver,
 ): Promise<{ body: string; stdout: string; sessionId: string }> {
-  const promptTransport = materializeLocalPrompt(prompt);
+  const promptTransport = materializeLocalAgentPrompt(prompt, 'invoker-pr-author-prompt-');
   const spec = agent.buildCommand(promptTransport.effectivePrompt);
   const sessionId = spec.sessionId ?? randomUUID();
   const cmd = resolveExecutableOnCurrentPath(spec.cmd) ?? spec.cmd;

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import * as child_process from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SlackSurface, extractRepoUrlFromMessage, parsePlanningRequest, parseLobbyClassification, parseLocalRequest, parseThreadRequest, parseWorkflowStatusQuery, BUILTIN_HARNESS_PRESETS, buildLobbyQuestionPrompt } from '../slack/slack-surface.js';
 import { SQLiteAdapter, ConversationRepository, SlackSessionRepository, WorkflowChannelRepository } from '@invoker/data-store';
+import * as executionEngine from '@invoker/execution-engine';
 import type { SurfaceCommand } from '../surface.js';
 import type { WorkflowContext } from '../slack/workflow-assistant.js';
 
@@ -596,6 +597,79 @@ describe('in-channel workflow assistant', () => {
     expect(gather).toHaveBeenCalledWith('wf-1-2');
     expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('/health') }));
     expect(received).toHaveLength(0);
+  });
+
+  it('uses a temporary prompt file for oversized workflow assistant context', async () => {
+    const hugeOutput = 'running task details\n'.repeat(10_000);
+    const gather = vi.fn(async (): Promise<WorkflowContext> => ({
+      workflowId: 'wf-1-2',
+      planning: [{ role: 'user', content: 'track progress' }],
+      tasks: [{ id: 'wf-1-2/api', status: 'running', agentName: 'omp', transcript: [], output: hugeOutput }],
+    }));
+    let promptFile = '';
+    const planningCommandBuilder = vi.fn(({ prompt }: { prompt: string }) => {
+      const match = prompt.match(/file: (.+)\n/);
+      promptFile = match?.[1] ?? '';
+      const promptContents = readFileSync(promptFile, 'utf8');
+      expect(prompt).toContain('The full task instructions are in this file:');
+      expect(promptContents).toContain('Task wf-1-2/api (status=running');
+      expect(promptContents).toContain(hugeOutput);
+      return { command: 'cursor', args: ['--print', prompt] };
+    });
+    mockSpawn.mockImplementationOnce(() => mockProcess('The running task is wf-1-2/api.') as any);
+    const surface = new SlackSurface({
+      ...baseConfig(),
+      conversationRepo: convoRepo,
+      workflowChannelRepo: repo,
+      planningCommandBuilder,
+      gatherWorkflowContext: gather,
+    });
+    await surface.start(async (cmd) => { received.push(cmd); });
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> how are we doing', ts: 't1', user: 'U1', channel: 'C123' },
+      say,
+    });
+
+    expect(planningCommandBuilder).toHaveBeenCalledOnce();
+    expect(promptFile).toContain('invoker-slack-prompt-');
+    expect(existsSync(promptFile)).toBe(false);
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('wf-1-2/api') }));
+  });
+
+  it('logs prompt cleanup failures after workflow assistant planning', async () => {
+    const cleanupError = new Error('device busy');
+    const logSpy = vi.fn();
+    const materializeSpy = vi.spyOn(executionEngine, 'materializeLocalAgentPrompt').mockReturnValue({
+      effectivePrompt: 'materialized prompt',
+      cleanup: () => ({ directory: '/tmp/invoker-slack-prompt-test-1234', error: cleanupError }),
+    });
+    mockSpawn.mockImplementationOnce(() => mockProcess('The running task is wf-1-2/api.'));
+    const surface = new SlackSurface({
+      ...baseConfig(),
+      log: logSpy,
+      conversationRepo: convoRepo,
+      workflowChannelRepo: repo,
+      planningCommandBuilder: () => ({ command: 'cursor', args: ['--print', 'materialized prompt'] }),
+    });
+    const runOneShotPlanner = Reflect.get(surface, 'runOneShotPlanner') as (
+      harness: { tool: string; model: string },
+      prompt: string,
+    ) => Promise<string>;
+
+    try {
+      await expect(runOneShotPlanner.call(surface, { tool: 'omp', model: 'claude-sonnet-4-5' }, 'ignored prompt')).resolves.toBe(
+        'The running task is wf-1-2/api.',
+      );
+      expect(logSpy).toHaveBeenCalledWith(
+        'slack-surface',
+        'warn',
+        '[PROMPT_CLEANUP] failed to remove materialized planner prompt at /tmp/invoker-slack-prompt-test-1234: device busy',
+      );
+    } finally {
+      materializeSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/surfaces/src/__tests__/workflow-assistant.test.ts
+++ b/packages/surfaces/src/__tests__/workflow-assistant.test.ts
@@ -47,6 +47,13 @@ describe('buildAssistantPrompt', () => {
     expect(prompt).toContain('Answer ONLY from');
   });
 
+  it('directs overall-status questions to list running tasks', () => {
+    const prompt = buildAssistantPrompt('how are we doing?', ctx);
+
+    expect(prompt).toContain('list every task with status=running');
+    expect(prompt).toContain('If none are running, say so.');
+  });
+
   it('asks workflow question answers to be short ELI5 Slack prose except for clearly technical questions', () => {
     const prompt = buildAssistantPrompt('what changed?', ctx);
     expect(prompt).toContain('ELI5 Slack prose');

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -38,7 +38,7 @@ import { SessionManager, SessionIdentifier } from './thread-session-manager.js';
 import { buildAssistantPrompt, parseWorkflowControl, SLACK_DIRECT_ANSWER_GUIDANCE } from './workflow-assistant.js';
 import type { WorkflowContext, WorkflowControl } from './workflow-assistant.js';
 import type { ConversationRepository, SlackSessionRepository, WorkflowChannelRepository, WorkflowChannel } from '@invoker/data-store';
-import { formatCodexPlannerStdout } from '@invoker/execution-engine';
+import { formatCodexPlannerStdout, materializeLocalAgentPrompt } from '@invoker/execution-engine';
 
 function truncateWords(text: string, maxWords: number): string {
   const words = text.replace(/\s+/g, ' ').trim().split(' ').filter(Boolean);
@@ -2086,36 +2086,48 @@ ${text}`;
   }
 
   private async runOneShotPlanner(harness: HarnessPreset, prompt: string): Promise<string> {
-    const { command, args } = this.planningCommandBuilder
-      ? this.planningCommandBuilder({ tool: harness.tool, model: harness.model, prompt })
-      : defaultPlanningCommand(this.cursorCommand, { model: harness.model, prompt });
-    const plannerLabel = harness.tool ?? command;
-    const timeoutMs = (this.planningTimeoutSeconds ?? 7_200) * 1_000;
-    const totalAttempts = this.plannerRetryLimit + 1;
-    let lastStderrTail = '';
+    const promptTransport = materializeLocalAgentPrompt(prompt, 'invoker-slack-prompt-');
+    try {
+      const { command, args } = this.planningCommandBuilder
+        ? this.planningCommandBuilder({ tool: harness.tool, model: harness.model, prompt: promptTransport.effectivePrompt })
+        : defaultPlanningCommand(this.cursorCommand, { model: harness.model, prompt: promptTransport.effectivePrompt });
+      const plannerLabel = harness.tool ?? command;
+      const timeoutMs = (this.planningTimeoutSeconds ?? 7_200) * 1_000;
+      const totalAttempts = this.plannerRetryLimit + 1;
+      let lastStderrTail = '';
 
-    for (let attempt = 0; attempt < totalAttempts; attempt++) {
-      if (attempt > 0) {
-        const backoffMs = this.plannerRetryBaseDelayMs * (2 ** (attempt - 1));
-        this.log?.('slack-surface', 'warn',
-          `[PLANNER_RETRY] backing off ${backoffMs}ms before attempt=${attempt + 1}/${totalAttempts} (planner=${plannerLabel})`);
-        await new Promise((resolve) => setTimeout(resolve, backoffMs));
-      }
-      try {
-        return await this.runOneShotPlannerAttempt(command, args, plannerLabel, timeoutMs, attempt + 1, totalAttempts);
-      } catch (err) {
-        if (isEmptyOutputAttemptError(err)) {
-          lastStderrTail = err.stderrTail;
-          const isLast = attempt >= totalAttempts - 1;
+      for (let attempt = 0; attempt < totalAttempts; attempt++) {
+        if (attempt > 0) {
+          const backoffMs = this.plannerRetryBaseDelayMs * (2 ** (attempt - 1));
           this.log?.('slack-surface', 'warn',
-            `[PLANNER_RETRY] attempt=${attempt + 1}/${totalAttempts} produced no output (planner=${plannerLabel}, willRetry=${!isLast}, stderrBytes=${err.stderrTail.length}, stderrTail="${err.stderrTail.slice(-200).replace(/\n/g, '\\n')}")`);
-          if (!isLast) continue;
-          throw buildEmptyPlannerOutputError(plannerLabel, lastStderrTail, { attemptCount: totalAttempts });
+            `[PLANNER_RETRY] backing off ${backoffMs}ms before attempt=${attempt + 1}/${totalAttempts} (planner=${plannerLabel})`);
+          await new Promise((resolve) => setTimeout(resolve, backoffMs));
         }
-        throw err;
+        try {
+          return await this.runOneShotPlannerAttempt(command, args, plannerLabel, timeoutMs, attempt + 1, totalAttempts);
+        } catch (err) {
+          if (isEmptyOutputAttemptError(err)) {
+            lastStderrTail = err.stderrTail;
+            const isLast = attempt >= totalAttempts - 1;
+            this.log?.('slack-surface', 'warn',
+              `[PLANNER_RETRY] attempt=${attempt + 1}/${totalAttempts} produced no output (planner=${plannerLabel}, willRetry=${!isLast}, stderrBytes=${err.stderrTail.length}, stderrTail="${err.stderrTail.slice(-200).replace(/\n/g, '\\n')}")`);
+            if (!isLast) continue;
+            throw buildEmptyPlannerOutputError(plannerLabel, lastStderrTail, { attemptCount: totalAttempts });
+          }
+          throw err;
+        }
+      }
+      throw buildEmptyPlannerOutputError(plannerLabel, lastStderrTail, { attemptCount: totalAttempts });
+    } finally {
+      const cleanupResult = promptTransport.cleanup();
+      if (cleanupResult) {
+        this.log?.(
+          'slack-surface',
+          'warn',
+          `[PROMPT_CLEANUP] failed to remove materialized planner prompt at ${cleanupResult.directory}: ${cleanupResult.error.message}`,
+        );
       }
     }
-    throw buildEmptyPlannerOutputError(plannerLabel, lastStderrTail, { attemptCount: totalAttempts });
   }
 
   private runOneShotPlannerAttempt(
@@ -2136,14 +2148,19 @@ ${text}`;
         `[PERF] one_shot_spawn: pid=${child.pid ?? 'none'}, planner=${plannerLabel}, attempt=${attemptNumber}/${totalAttempts}`);
       let stdout = '';
       let stderr = '';
+      let timedOut = false;
       child.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
       child.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
       const timer = setTimeout(() => {
+        timedOut = true;
         try { child.kill('SIGTERM'); } catch { /* already dead */ }
-        reject(new Error(`Planner timed out after ${timeoutMs}ms`));
       }, timeoutMs);
       child.on('close', (code) => {
         clearTimeout(timer);
+        if (timedOut) {
+          reject(new Error(`Planner timed out after ${timeoutMs}ms`));
+          return;
+        }
         if (code === 0) {
           const trimmed = stdout.trim();
           if (trimmed) {

--- a/packages/surfaces/src/slack/workflow-assistant.ts
+++ b/packages/surfaces/src/slack/workflow-assistant.ts
@@ -23,6 +23,7 @@ export function buildAssistantPrompt(question: string, ctx: WorkflowContext): st
     "Answer ONLY from this workflow's planning conversation and task transcripts below.",
     'If the answer is not present in this context, say you do not know — never guess or use outside knowledge.',
     SLACK_DIRECT_ANSWER_GUIDANCE,
+    'For overall-status questions such as "how are we doing", list every task with status=running using its task id and status. If none are running, say so.',
     '',
     '=== Planning conversation ===',
   ];


### PR DESCRIPTION
## Summary

Workflow-channel questions can now use large task output without overflowing the planner CLI argument limit.

Oversized prompts are written to a temporary file while the planner receives a short instruction to read it.

Status questions tell the LLM to show the workflow's running tasks.

## Review Claim

Approve file-backed prompt transport for oversized Slack workflow-assistant context.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Small prompts retain the existing inline command path, while temporary prompt files are removed after the planner completes.

## Slice Rationale

The shared transport refactor is required to make the mapped workflow assistant safe without creating a duplicate lifecycle implementation.

## Non-goals

- Does not replace colloquial workflow questions with deterministic status commands.
- Does not truncate workflow context.
- Does not add scripts/repro proof harnesses in this behavior slice.

## Architecture

### Before

```mermaid
flowchart LR
  workflowContext["workflow context"] --> argv["OMP argv prompt"]
  argv --> failure["E2BIG"]
```

### After

```mermaid
flowchart LR
  workflowContext["workflow context"] --> threshold{"prompt exceeds 64 KiB?"}
  threshold -->|no| inline["inline planner prompt"]
  threshold -->|yes| promptFile["temporary prompt file"]
  promptFile --> bootstrap["short planner bootstrap"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- --run src/__tests__/agent-prompt-transport.test.ts src/__tests__/fix-prompt-transport.test.ts`
- [x] `cd packages/surfaces && pnpm test -- --run src/__tests__/workflow-assistant.test.ts src/__tests__/slack-surface-workflows.test.ts`
- [x] `cd packages/execution-engine && pnpm test`
- [ ] `cd packages/surfaces && pnpm test` (blocked by the unrelated `PlanConversation` illustrative-YAML expectation)
- [x] `pnpm --filter @invoker/execution-engine build && pnpm --filter @invoker/surfaces build`

</details>

## Visual Proof

The changed behavior is a Slack Socket Mode event and planner subprocess boundary, so a static desktop screenshot cannot prove it. The focused mapped-workflow regression test demonstrates the exact mention path, temporary-file prompt transport, cleanup, and threaded LLM reply.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 18cdab491`
- Post-revert steps: Redeploy DO1 with `bash scripts/deploy-do1.sh`.
- Data migration? No

</details>
