### PR TITLE
[Pid lock reclaim](2) Document the pid-lock reclaim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Invoker will be documented in this file.
 
 ## Unreleased
 
+- Stop stale pid locks from blocking launch after a hard kill. If Invoker died without releasing `~/.invoker/gui-window.lock` or `invoker.db.lock` (e.g. SIGKILL from `kill-all-electron.sh`) and the OS later reused the recorded pid for an unrelated process (a Chrome renderer, in the reported case), launch failed with the "only one instance of the Invoker GUI" dialog or a `[db-writer-lock] already held by PID …` error with no Invoker running. Both locks' staleness checks now also compare the holder's process start time (`ps -o etime=`, shared `process-start-time.ts`) against the lock file's mtime: a process that started after the lock was written cannot be its owner, so the lock is reclaimed. Unknown start time (Windows, `ps` failure) stays conservative and keeps the lock.
+
 ## 0.0.8
 
 - Improve Slack thread planning: promote same-thread plan requests, infer plans from conversation, share a transport-neutral planning lifecycle, pin repository/harness context across manager restarts, and approve compact plan drafts inline.

--- a/packages/app/src/__tests__/gui-instance-lock.test.ts
+++ b/packages/app/src/__tests__/gui-instance-lock.test.ts
@@ -47,4 +47,42 @@ describe('GUI instance lock', () => {
     expect(next).not.toBeNull();
     next?.release();
   });
+
+  it('reclaims the lock when the recorded pid was recycled by a newer process', () => {
+    const root = makeRoot();
+    const stale = tryAcquireGuiInstanceLock(root, 999_999);
+    expect(stale).not.toBeNull();
+
+    // Pid is "alive" (recycled by an unrelated process)…
+    vi.spyOn(process, 'kill').mockImplementation(() => true);
+    // …but that process started well after the lock was written.
+    const next = tryAcquireGuiInstanceLock(root, process.pid, () => Date.now() + 60_000);
+
+    expect(next).not.toBeNull();
+    next?.release();
+  });
+
+  it('keeps the lock when the holder is alive and its start time is unknown', () => {
+    const root = makeRoot();
+    const first = tryAcquireGuiInstanceLock(root, 999_999);
+    expect(first).not.toBeNull();
+
+    vi.spyOn(process, 'kill').mockImplementation(() => true);
+    const second = tryAcquireGuiInstanceLock(root, process.pid, () => null);
+
+    expect(second).toBeNull();
+    first?.release();
+  });
+
+  it('keeps the lock when the holder started before the lock was written', () => {
+    const root = makeRoot();
+    // Real path: this test process acquired the lock, so ps-derived start
+    // time predates the lock file.
+    const first = tryAcquireGuiInstanceLock(root, process.pid);
+    const second = tryAcquireGuiInstanceLock(root, process.pid);
+
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+    first?.release();
+  });
 });

--- a/packages/app/src/__tests__/process-start-time.test.ts
+++ b/packages/app/src/__tests__/process-start-time.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseEtimeSeconds, pidWasRecycledSince, readProcessStartTimeMs } from '../process-start-time.js';
+
+describe('process start time', () => {
+  it('parses ps etime formats', () => {
+    expect(parseEtimeSeconds('05:42')).toBe(342);
+    expect(parseEtimeSeconds('01:02:03')).toBe(3723);
+    expect(parseEtimeSeconds('2-01:02:03')).toBe(2 * 86_400 + 3723);
+    expect(parseEtimeSeconds('')).toBeNull();
+    expect(parseEtimeSeconds('garbage')).toBeNull();
+  });
+
+  it('reads this process start time as earlier than now', () => {
+    const startedAtMs = readProcessStartTimeMs(process.pid);
+    if (process.platform === 'win32') {
+      expect(startedAtMs).toBeNull();
+      return;
+    }
+    expect(startedAtMs).not.toBeNull();
+    expect(startedAtMs!).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('flags a process that started after the lock as recycled', () => {
+    const lockCreatedAtMs = 1_000_000;
+    expect(pidWasRecycledSince(123, lockCreatedAtMs, () => lockCreatedAtMs + 60_000)).toBe(true);
+  });
+
+  it('stays conservative within skew, on unknown start time, and unknown lock time', () => {
+    const lockCreatedAtMs = 1_000_000;
+    expect(pidWasRecycledSince(123, lockCreatedAtMs, () => lockCreatedAtMs + 1_000)).toBe(false);
+    expect(pidWasRecycledSince(123, lockCreatedAtMs, () => null)).toBe(false);
+    expect(pidWasRecycledSince(123, null, () => lockCreatedAtMs + 60_000)).toBe(false);
+  });
+});

--- a/packages/app/src/__tests__/writer-lock-default.test.ts
+++ b/packages/app/src/__tests__/writer-lock-default.test.ts
@@ -23,6 +23,7 @@ describe('writer lock default-on', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     if (previousDiagnosticDirs === undefined) {
       delete process.env.INVOKER_DIAGNOSTIC_REPORT_DIRS;
     } else {
@@ -70,6 +71,31 @@ describe('writer lock default-on', () => {
     } finally {
       first.release();
     }
+  });
+
+  it('reclaims the lock when the holder pid was recycled by a newer process', () => {
+    mkdirSync(`${dbPath}.lock`);
+    writeFileSync(`${dbPath}.lock/pid`, '999999');
+    // Pid is "alive" (recycled by an unrelated process)…
+    vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    // …but that process started well after the lock was written.
+    const lock = acquireDbWriterLock(dbPath, 'test:recycled', null, () => Date.now() + 60_000);
+
+    expect(lock.acquired).toBe(true);
+    expect(lock.reclaimedDeadOwner?.pid).toBe(999999);
+    lock.release();
+  });
+
+  it('still refuses when the holder is alive and its start time is unknown', () => {
+    mkdirSync(`${dbPath}.lock`);
+    writeFileSync(`${dbPath}.lock/pid`, '999999');
+    vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    expect(() => acquireDbWriterLock(dbPath, 'test:unknown-start', null, () => null))
+      .toThrow(/already held by PID 999999/);
+
+    rmSync(`${dbPath}.lock`, { recursive: true, force: true });
   });
 
   it('finds a crash diagnostic for a stale owner pid', () => {

--- a/packages/app/src/db-writer-lock.ts
+++ b/packages/app/src/db-writer-lock.ts
@@ -10,6 +10,8 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, wri
 import { homedir } from 'node:os';
 import { delimiter, join } from 'node:path';
 
+import { pidWasRecycledSince, readProcessStartTimeMs } from './process-start-time.js';
+
 const ENV_BYPASS = 'INVOKER_UNSAFE_DISABLE_DB_WRITER_LOCK';
 const ENV_DIAGNOSTIC_REPORT_DIRS = 'INVOKER_DIAGNOSTIC_REPORT_DIRS';
 const DIAGNOSTIC_REPORT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
@@ -167,6 +169,7 @@ export function acquireDbWriterLock(
   dbPath: string,
   callerContext?: string,
   reclaimedDeadOwner: ReclaimedDeadOwnerInfo | null = null,
+  readStartTimeMs: (pid: number) => number | null = readProcessStartTimeMs,
 ): DbWriterLockResult {
   const bypassed = process.env[ENV_BYPASS] === '1';
   const lockDir = `${dbPath}.lock`;
@@ -188,17 +191,38 @@ export function acquireDbWriterLock(
           holder = readFileSync(pidFile, 'utf-8').trim();
           const holderPid = parseInt(holder, 10);
           if (!isNaN(holderPid)) {
+            let staleReason: string | null = null;
             try {
               process.kill(holderPid, 0); // signal 0 = check if alive
             } catch {
               // Holding process is dead — stale lock from a crash.
+              staleReason = `Stale lock from dead PID ${holderPid}`;
+            }
+            if (staleReason === null) {
+              // Pid is alive, but it may not be the writer that took the
+              // lock: after a hard kill the OS can recycle the pid for an
+              // unrelated process. A process that started after the lock
+              // was written cannot be its owner.
+              let lockCreatedAtMs: number | null = null;
+              try {
+                lockCreatedAtMs = statSync(pidFile).mtimeMs;
+              } catch (statErr) {
+                // Rare race (owner may be releasing right now): stay
+                // conservative for this attempt. Logged for debuggability.
+                console.warn(`[db-writer-lock] could not stat ${pidFile}:`, statErr);
+              }
+              if (pidWasRecycledSince(holderPid, lockCreatedAtMs, readStartTimeMs)) {
+                staleReason = `Lock PID ${holderPid} was recycled by an unrelated newer process`;
+              }
+            }
+            if (staleReason !== null) {
               const diagnostic = findPreviousOwnerCrashDiagnostic(holderPid);
               const diagnosticSuffix = diagnostic
                 ? `; ${formatPreviousOwnerCrashDiagnostic(diagnostic)}`
                 : '; no matching owner crash report found';
-              console.warn(`[db-writer-lock] Stale lock from dead PID ${holderPid}, reclaiming${callerTag}${diagnosticSuffix}`);
+              console.warn(`[db-writer-lock] ${staleReason}, reclaiming${callerTag}${diagnosticSuffix}`);
               rmSync(lockDir, { recursive: true, force: true });
-              return acquireDbWriterLock(dbPath, callerContext, { pid: holderPid, diagnostic });
+              return acquireDbWriterLock(dbPath, callerContext, { pid: holderPid, diagnostic }, readStartTimeMs);
             }
           }
         } catch { /* best effort */ }

--- a/packages/app/src/gui-instance-lock.ts
+++ b/packages/app/src/gui-instance-lock.ts
@@ -1,5 +1,7 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+
+import { pidWasRecycledSince, readProcessStartTimeMs } from './process-start-time.js';
 
 export interface GuiInstanceLock {
   readonly lockDir: string;
@@ -25,6 +27,7 @@ function processIsAlive(pid: number): boolean {
 export function tryAcquireGuiInstanceLock(
   invokerHomeRoot: string,
   pid: number = process.pid,
+  readStartTimeMs: (pid: number) => number | null = readProcessStartTimeMs,
 ): GuiInstanceLock | null {
   const lockDir = join(invokerHomeRoot, 'gui-window.lock');
   try {
@@ -36,10 +39,20 @@ export function tryAcquireGuiInstanceLock(
 
     const pidPath = join(lockDir, 'pid');
     const existingPid = existsSync(pidPath) ? parsePid(readFileSync(pidPath, 'utf8')) : null;
-    if (existingPid && processIsAlive(existingPid)) return null;
+    if (existingPid && processIsAlive(existingPid)) {
+      let lockCreatedAtMs: number | null = null;
+      try {
+        lockCreatedAtMs = statSync(pidPath).mtimeMs;
+      } catch (statErr) {
+        // Rare race (owner may be releasing right now): keep the lock held
+        // conservatively for this attempt. Logged for debuggability.
+        console.warn(`[gui-instance-lock] could not stat ${pidPath}:`, statErr);
+      }
+      if (!pidWasRecycledSince(existingPid, lockCreatedAtMs, readStartTimeMs)) return null;
+    }
 
     rmSync(lockDir, { recursive: true, force: true });
-    return tryAcquireGuiInstanceLock(invokerHomeRoot, pid);
+    return tryAcquireGuiInstanceLock(invokerHomeRoot, pid, readStartTimeMs);
   }
 
   let released = false;

--- a/packages/app/src/process-start-time.ts
+++ b/packages/app/src/process-start-time.ts
@@ -1,0 +1,71 @@
+/**
+ * PID-recycling detection shared by the mkdir-based lock files
+ * (gui-instance-lock, db-writer-lock).
+ *
+ * A pid sentinel alone cannot prove a lock is still owned: after a hard kill
+ * the OS can hand the recorded pid to an unrelated process, so `kill(pid, 0)`
+ * keeps succeeding forever. Comparing the live process's start time against
+ * the lock's creation time disambiguates — a process that started after the
+ * lock was written cannot be the process that wrote it.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Tolerance when comparing lock-file mtime against a process start time
+ * derived from `ps -o etime=` (1s granularity, plus fs timestamp rounding).
+ */
+const PID_REUSE_SKEW_MS = 2_000;
+
+/** Parse `ps -o etime=` output ([[dd-]hh:]mm:ss) into seconds. */
+export function parseEtimeSeconds(raw: string): number | null {
+  const match = /^(?:(\d+)-)?(?:(\d+):)?(\d{1,2}):(\d{2})$/.exec(raw.trim());
+  if (!match) return null;
+  const [, days, hours, minutes, seconds] = match;
+  return (
+    Number(days ?? 0) * 86_400
+    + Number(hours ?? 0) * 3_600
+    + Number(minutes) * 60
+    + Number(seconds)
+  );
+}
+
+/**
+ * Best-effort start time (epoch ms) of a live process, via `ps -o etime=`.
+ * Returns null when it cannot be determined (Windows, `ps` failure, parse
+ * failure) — callers must treat null conservatively.
+ */
+export function readProcessStartTimeMs(pid: number, now: number = Date.now()): number | null {
+  if (process.platform === 'win32') return null;
+  let raw: string;
+  try {
+    raw = execFileSync('ps', ['-p', String(pid), '-o', 'etime='], { encoding: 'utf8' });
+  } catch (err) {
+    // Not fatal: callers fall back to treating the lock holder as alive.
+    // Logged so a repeatedly-stuck lock can be debugged.
+    console.warn(`[process-start-time] could not read start time of pid ${pid}:`, err);
+    return null;
+  }
+  const seconds = parseEtimeSeconds(raw);
+  if (seconds === null) return null;
+  return now - seconds * 1_000;
+}
+
+/**
+ * True when the live process at `pid` started after the lock was created,
+ * which means the OS recycled the pid after the original owner died (e.g.
+ * the owner was SIGKILLed and an unrelated process later got the same pid).
+ * A genuine lock owner always starts before it writes the lock.
+ *
+ * Conservative: returns false when either timestamp is unknown.
+ */
+export function pidWasRecycledSince(
+  pid: number,
+  lockCreatedAtMs: number | null,
+  readStartTimeMs: (pid: number) => number | null = readProcessStartTimeMs,
+): boolean {
+  if (lockCreatedAtMs === null) return false;
+  const startedAtMs = readStartTimeMs(pid);
+  if (startedAtMs === null) return false;
+  return startedAtMs > lockCreatedAtMs + PID_REUSE_SKEW_MS;
+}


### PR DESCRIPTION
## Summary

Add the Unreleased changelog entry for the recycled-pid lock reclaim shipped in the previous slice.

## Review Claim

The changelog gains one Unreleased entry describing the recycled-pid lock reclaim; nothing else changes.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Markdown-only change to CHANGELOG.md; nothing executable is touched.

## Slice Rationale

Repo review policy keeps changelog text out of the code slice, so it lands here on top of slice (1).

## Non-goals

- No behavior changes.
- No edits to earlier release sections.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `git show --stat HEAD` confirms only CHANGELOG.md changes

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d1d930074`
- Post-revert steps: None
- Data migration? No

</details>
