### PR TITLE
[Guided CLI Setup](6) End setup with one ready/fix-this-first summary

### DIFF
--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -6,21 +6,49 @@ import { join } from 'node:path';
 import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, EXTERNAL_DEPENDENCIES } from '@invoker/contracts';
 
 import {
+  checkGithubAuth,
   defaultExperimentalPlannerMcpPath,
   ensureExperimentalPlannerMcp,
   buildDoctorChecks,
+  firstSetupFailure,
+  formatSetupEnding,
   generateSlackManifest,
   installExperimentalPlannerMcp,
   loadInvokerEnv,
   readExperimentalPlannerSetup,
   REQUIRED_BOT_SCOPES,
+  runPlanValidationSmoke,
   slackCredsFromEnv,
+  skippedGithubAuthCheck,
   runSetup,
   setExperimentalPlannerFlag,
   upsertEnvLines,
   validateSlackCredentials,
   type CliConfigState,
+  type SetupDeps,
 } from '../onboarding.js';
+
+import type { PrerequisiteCheck } from '@invoker/contracts';
+
+type Check = PrerequisiteCheck;
+
+function okCheck(id: string, name: string, detail = 'ok'): Check {
+  return { id, name, status: 'ok', detail };
+}
+
+function errorCheck(id: string, name: string, detail: string, remediation?: string): Check {
+  return { id, name, status: 'error', detail, remediation };
+}
+
+/** Keep setup oneshot tests offline and independent of the host PATH / gh login. */
+function readySetupDeps(overrides: SetupDeps = {}): SetupDeps {
+  return {
+    isInstalled: () => true,
+    githubAuthCheck: async () => okCheck('github-auth', 'GitHub auth', 'gh is authenticated'),
+    smokePlanValidation: async () => okCheck('smoke-plan', 'Smoke plan validation', 'Parsed 1 task(s)'),
+    ...overrides,
+  };
+}
 
 describe('generateSlackManifest', () => {
   it('requests the required bot scopes, socket mode, and app_mention events', () => {
@@ -141,21 +169,22 @@ describe('runSetup', () => {
       const code = await runSetup([], {
         print: (line) => lines.push(line),
         prompt: async () => 'n',
-      });
+      }, readySetupDeps());
 
       const mcpPath = join(home, '.invoker', 'mcp.json');
       const invokerConfigPath = join(home, '.invoker', 'config.json');
-      expect(lines.join('\n')).toContain('Invoker setup');
-      expect(lines.join('\n')).toContain(`Experimental planner MCP installed into ${mcpPath}`);
-      expect(lines.join('\n')).toContain('experimentalPlanner flag: off');
-      expect(lines.join('\n')).toContain('Run `invoker-cli setup slack` later');
+      const output = lines.join('\n');
+      expect(output).toContain('Invoker setup');
+      expect(output).toContain(`Experimental planner MCP installed into ${mcpPath}`);
+      expect(output).toContain('experimentalPlanner flag: off');
+      expect(output).toContain("You're ready.");
       expect(JSON.parse(readFileSync(mcpPath, 'utf8')).mcpServers['experimental-planner']).toEqual({
         type: 'stdio',
         command: 'uvx',
         args: ['--from', DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, EXTERNAL_DEPENDENCIES.drafterMcp.commandName],
       });
       expect(existsSync(invokerConfigPath)).toBe(false);
-      expect(typeof code).toBe('number');
+      expect(code).toBe(0);
     } finally {
       restoreEnv('HOME', saved.HOME);
       restoreEnv('INVOKER_MCP_CONFIG_PATH', saved.target);
@@ -191,7 +220,7 @@ describe('runSetup', () => {
           prompts.push(question);
           return '';
         },
-      });
+      }, readySetupDeps());
 
       expect(code).toBe(0);
       expect(prompts).toEqual([]);
@@ -472,10 +501,11 @@ describe('runSetup in a non-interactive shell', () => {
       prompt: async () => { throw new Error('should not prompt under --yes'); },
     });
 
-    const code = await runSetup(['--yes'], io);
+    const code = await runSetup(['--yes'], io, readySetupDeps());
 
-    expect(code).not.toBe(1);
+    expect(code).toBe(0);
     expect(lines.join('\n')).toContain('Enable the experimental planner now?');
+    expect(lines.join('\n')).toContain("You're ready.");
   });
 
   it('skips Slack under --yes rather than starting a flow it cannot finish', async () => {
@@ -483,11 +513,11 @@ describe('runSetup in a non-interactive shell', () => {
       prompt: async () => { throw new Error('should not prompt under --yes'); },
     });
 
-    await runSetup(['--yes'], io);
+    await runSetup(['--yes'], io, readySetupDeps());
 
     const output = lines.join('\n');
     expect(output).not.toContain('Bot User OAuth Token');
-    expect(output).toContain('invoker-cli setup slack');
+    expect(output).toContain("You're ready.");
   });
 
   it('writes only inside the configured Invoker home', async () => {
@@ -495,8 +525,100 @@ describe('runSetup in a non-interactive shell', () => {
       prompt: async () => { throw new Error('should not prompt under --yes'); },
     });
 
-    await runSetup(['--yes'], io);
+    await runSetup(['--yes'], io, readySetupDeps());
 
     expect(existsSync(join(home, 'mcp.json'))).toBe(true);
+  });
+});
+
+describe('GitHub auth check', () => {
+  it('passes when gh auth status exits 0', () => {
+    const check = checkGithubAuth(() => ({ status: 0, stdout: 'Logged in', stderr: '' }));
+    expect(check).toMatchObject({ id: 'github-auth', status: 'ok' });
+  });
+
+  it('fails when gh auth status exits non-zero', () => {
+    const check = checkGithubAuth(() => ({ status: 1, stdout: '', stderr: 'not logged in to any GitHub hosts' }));
+    expect(check.status).toBe('error');
+    expect(check.detail).toContain('not logged in');
+    expect(check.remediation).toContain('gh auth login');
+  });
+
+  it('warns and skips when gh is missing', () => {
+    expect(skippedGithubAuthCheck()).toMatchObject({ id: 'github-auth', status: 'warn' });
+  });
+});
+
+describe('setup oneshot ending', () => {
+  it('selects the first error for Fix this first', () => {
+    const checks: Check[] = [
+      okCheck('a', 'A'),
+      errorCheck('github-auth', 'GitHub auth', 'not logged in', 'Run `gh auth login`'),
+      errorCheck('smoke-plan', 'Smoke plan validation', 'boom'),
+    ];
+    expect(firstSetupFailure(checks)?.id).toBe('github-auth');
+    expect(formatSetupEnding(checks)).toContain('Fix this first: GitHub auth: not logged in.');
+    expect(formatSetupEnding(checks)).toContain('gh auth login');
+    expect(formatSetupEnding([okCheck('a', 'A')])).toBe("You're ready.");
+  });
+
+  it('returns exit code 1 when smoke validation fails', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'invoker-setup-smoke-fail-'));
+    const lines: string[] = [];
+    const savedHome = process.env.HOME;
+    try {
+      process.env.HOME = home;
+      const code = await runSetup([], {
+        print: (line) => lines.push(line),
+        prompt: async () => 'n',
+      }, readySetupDeps({
+        smokePlanValidation: async () => errorCheck(
+          'smoke-plan',
+          'Smoke plan validation',
+          'parse failed',
+          'Reinstall invoker-cli',
+        ),
+      }));
+
+      expect(code).toBe(1);
+      expect(lines.join('\n')).toContain('Fix this first: Smoke plan validation: parse failed.');
+      expect(lines.join('\n')).not.toContain("You're ready.");
+    } finally {
+      if (savedHome === undefined) delete process.env.HOME;
+      else process.env.HOME = savedHome;
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('skips GitHub auth with a warning when gh is not installed', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'invoker-setup-no-gh-'));
+    const lines: string[] = [];
+    const savedHome = process.env.HOME;
+    try {
+      process.env.HOME = home;
+      const code = await runSetup([], {
+        print: (line) => lines.push(line),
+        prompt: async () => 'n',
+      }, readySetupDeps({
+        isInstalled: (command) => command !== 'gh',
+        githubAuthCheck: async () => {
+          throw new Error('should not probe gh auth when gh is missing');
+        },
+      }));
+
+      expect(code).toBe(0);
+      expect(lines.join('\n')).toContain('gh not installed; skipped auth check');
+      expect(lines.join('\n')).toContain("You're ready.");
+    } finally {
+      if (savedHome === undefined) delete process.env.HOME;
+      else process.env.HOME = savedHome;
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('runs the real offline smoke parser successfully', async () => {
+    const check = await runPlanValidationSmoke();
+    expect(check.status).toBe('ok');
+    expect(check.detail).toMatch(/Parsed 1 task/);
   });
 });

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 import {
@@ -15,6 +15,7 @@ import {
   type PrerequisiteCheck,
   updateInvokerConfigFile,
 } from '@invoker/contracts';
+import { parsePlanFile } from '@invoker/workflow-core';
 import { formatCaughtException, logCaughtException } from './logging.js';
 
 // ── Paths ────────────────────────────────────────────────────
@@ -265,6 +266,121 @@ export function runDoctor(argv: string[]): number {
     process.stdout.write('\nFix the items above, then re-run `invoker-cli doctor`. For planner MCP, run `invoker-cli setup planner`; for Slack, run `invoker-cli setup slack`.\n');
   }
   return report.ok ? 0 : 1;
+}
+
+// ── setup readiness extras (GitHub auth + smoke + oneshot ending) ─
+
+export interface CommandRunnerResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export type CommandRunner = (command: string, args: readonly string[]) => CommandRunnerResult;
+
+export function defaultCommandRunner(command: string, args: readonly string[]): CommandRunnerResult {
+  const result = spawnSync(command, [...args], { encoding: 'utf8' });
+  return {
+    status: result.status,
+    stdout: typeof result.stdout === 'string' ? result.stdout : '',
+    stderr: typeof result.stderr === 'string' ? result.stderr : '',
+  };
+}
+
+export function skippedGithubAuthCheck(): PrerequisiteCheck {
+  return {
+    id: 'github-auth',
+    name: 'GitHub auth',
+    status: 'warn',
+    detail: 'gh not installed; skipped auth check',
+    remediation: 'Install GitHub CLI (`brew install gh` or `apt-get install gh`), then run `gh auth login`',
+  };
+}
+
+/** Probe `gh auth status`. Injectable `runner` keeps tests offline. */
+export function checkGithubAuth(runner: CommandRunner = defaultCommandRunner): PrerequisiteCheck {
+  const result = runner('gh', ['auth', 'status']);
+  if (result.status === 0) {
+    return {
+      id: 'github-auth',
+      name: 'GitHub auth',
+      status: 'ok',
+      detail: 'gh is authenticated',
+    };
+  }
+  const detail = (result.stderr || result.stdout || 'gh auth status failed').trim().split('\n')[0]
+    || 'gh auth status failed';
+  return {
+    id: 'github-auth',
+    name: 'GitHub auth',
+    status: 'error',
+    detail,
+    remediation: 'Run `gh auth login` and re-run `invoker-cli setup`',
+  };
+}
+
+const SETUP_SMOKE_PLAN = `name: Setup Smoke
+description: Tiny offline plan used by invoker-cli setup.
+repoUrl: .
+onFinish: none
+tasks:
+  - id: smoke
+    description: Validate plan parsing during setup.
+    command: echo setup-smoke
+`;
+
+/** Parse a one-task temp plan with no network. Confirms the local plan pipeline works. */
+export async function runPlanValidationSmoke(): Promise<PrerequisiteCheck> {
+  const dir = mkdtempSync(join(tmpdir(), 'invoker-setup-smoke-'));
+  const planPath = join(dir, 'smoke.yaml');
+  try {
+    writeFileSync(planPath, SETUP_SMOKE_PLAN);
+    const plan = await parsePlanFile(planPath);
+    if (!plan.tasks.length) {
+      return {
+        id: 'smoke-plan',
+        name: 'Smoke plan validation',
+        status: 'error',
+        detail: 'Parsed plan has no tasks',
+        remediation: 'Reinstall invoker-cli; plan parsing returned an empty task list',
+      };
+    }
+    return {
+      id: 'smoke-plan',
+      name: 'Smoke plan validation',
+      status: 'ok',
+      detail: `Parsed ${plan.tasks.length} task(s) from a local smoke plan`,
+    };
+  } catch (error) {
+    return {
+      id: 'smoke-plan',
+      name: 'Smoke plan validation',
+      status: 'error',
+      detail: formatCaughtException(error),
+      remediation: 'Reinstall invoker-cli or report a plan-parser regression',
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** First hard failure — the single thing setup tells the user to fix. */
+export function firstSetupFailure(checks: readonly PrerequisiteCheck[]): PrerequisiteCheck | undefined {
+  return checks.find((check) => check.status === 'error');
+}
+
+export function formatSetupEnding(checks: readonly PrerequisiteCheck[]): string {
+  const failure = firstSetupFailure(checks);
+  if (!failure) return "You're ready.";
+  const remediation = failure.remediation ? ` ${failure.remediation}` : '';
+  return `Fix this first: ${failure.name}: ${failure.detail}.${remediation}`;
+}
+
+export interface SetupDeps {
+  isInstalled?: IsInstalled;
+  commandRunner?: CommandRunner;
+  githubAuthCheck?: (runner: CommandRunner) => PrerequisiteCheck | Promise<PrerequisiteCheck>;
+  smokePlanValidation?: () => Promise<PrerequisiteCheck>;
 }
 
 // ── Slack manifest ───────────────────────────────────────────
@@ -622,11 +738,47 @@ async function promptYes(io: SetupIO, question: string, assumeYes = false): Prom
   return answer === 'y' || answer === 'yes';
 }
 
-export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promise<number> {
+function plannerMcpCheck(state: ExperimentalPlannerSetupState): PrerequisiteCheck {
+  return {
+    id: 'planner-mcp',
+    name: 'Experimental planner MCP',
+    status: state.installed ? 'ok' : 'error',
+    detail: state.installed
+      ? `Installed into ${state.targetPath} (experimentalPlanner ${state.experimentalPlanner ? 'on' : 'off'})`
+      : `Missing at ${state.targetPath}`,
+    remediation: state.installed ? undefined : 'Re-run `invoker-cli setup` or `invoker-cli setup planner`',
+  };
+}
+
+async function collectGithubAndSmokeChecks(options: SetupDeps): Promise<PrerequisiteCheck[]> {
+  const isInstalled = options.isInstalled ?? commandExists;
+  const commandRunner = options.commandRunner ?? defaultCommandRunner;
+  const runGithubAuth = options.githubAuthCheck ?? checkGithubAuth;
+  const runSmokePlanValidation = options.smokePlanValidation ?? (() => runPlanValidationSmoke());
+
+  const checks: PrerequisiteCheck[] = [];
+  checks.push(isInstalled('gh') ? await runGithubAuth(commandRunner) : skippedGithubAuthCheck());
+  checks.push(await runSmokePlanValidation());
+  return checks;
+}
+
+function printSetupEnding(io: SetupIO, checks: readonly PrerequisiteCheck[]): number {
+  const report = buildReport([...checks]);
+  io.print('');
+  io.print(formatSetupEnding(report.checks));
+  return report.ok ? 0 : 1;
+}
+
+export async function runSetup(
+  argv: string[],
+  io: SetupIO = defaultIO(),
+  options: SetupDeps = {},
+): Promise<number> {
   const parsed = parseSetupArgs(argv);
   const wantSlack = parsed.subcommand === 'slack';
   const fromEnv = parsed.fromEnv;
   const rl = (io as { rl?: { close: () => void } }).rl;
+  const isInstalled = options.isInstalled ?? commandExists;
   try {
     if (parsed.subcommand === 'planner') {
       return await maybeInstallPlanner(parsed, io);
@@ -641,8 +793,9 @@ export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promi
     }
 
     io.print('Invoker setup\n');
-    const core = buildReport(buildDoctorChecks(loadCliConfig()));
-    io.print(formatReport(core));
+    const doctorChecks = buildDoctorChecks(loadCliConfig(), isInstalled);
+    const checks: PrerequisiteCheck[] = [...doctorChecks];
+    io.print(formatReport(buildReport(doctorChecks)));
     io.print('');
 
     const plannerState = ensureExperimentalPlannerMcp({
@@ -652,30 +805,30 @@ export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promi
     io.print(`Experimental planner MCP installed into ${plannerState.targetPath}.`);
     io.print(`experimentalPlanner flag: ${plannerState.experimentalPlanner ? 'on' : 'off'}`);
     io.print('');
+    checks.push(plannerMcpCheck(plannerState));
 
     if (!wantSlack && !fromEnv && await promptYes(io, 'Enable the experimental planner now? [y/N] ', parsed.assumeYes)) {
       await maybeInstallPlanner(parsed, io);
       io.print('');
+      checks.push(plannerMcpCheck(readExperimentalPlannerSetup({ targetPath: parsed.targetPath })));
     }
 
     let doSlack = wantSlack || fromEnv;
     if (!wantSlack && !fromEnv) {
       doSlack = parsed.assumeYes ? false : await promptYes(io, 'Set up the Slack integration now? [y/N] ');
     }
-    if (!doSlack) {
-      io.print('\nYou are good to go for CLI and UI workflows. Run `invoker-cli setup planner` later to enable the experimental planner. Run `invoker-cli setup slack` later to add Slack.');
-      return core.ok ? 0 : 1;
-    }
 
-    if (fromEnv) {
+    if (doSlack && fromEnv) {
       loadInvokerEnv();
       const creds = slackCredsFromEnv();
-      const checks = await validateSlackCredentials(creds);
-      const report = buildReport(checks);
+      const slackChecks = await validateSlackCredentials(creds);
+      checks.push(...slackChecks);
+      const report = buildReport(slackChecks);
       io.print(`\n${formatReport(report, { json: parsed.json })}`);
       if (!creds.botToken || !creds.appToken || !creds.signingSecret || !creds.channelId || !report.ok) {
-        io.print('Nothing written. Fix the items above and re-run setup.');
-        return 1;
+        io.print('Nothing written.');
+        checks.push(...await collectGithubAndSmokeChecks(options));
+        return printSetupEnding(io, checks);
       }
       const envPath = writeSlackEnv({
         botToken: creds.botToken,
@@ -684,34 +837,41 @@ export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promi
         channelId: creds.channelId,
       });
       io.print(`\nWrote Slack credentials to ${envPath}. Restart Invoker (or it picks them up on next launch).`);
-      return 0;
-    }
+    } else if (doSlack) {
+      const manifestPath = manifestFilePath();
+      mkdirSync(invokerHomeDir(), { recursive: true });
+      writeFileSync(manifestPath, `${JSON.stringify(generateSlackManifest(), null, 2)}\n`);
+      io.print(`\n${manifestSteps(manifestPath)}\n`);
 
-    const manifestPath = manifestFilePath();
-    mkdirSync(invokerHomeDir(), { recursive: true });
-    writeFileSync(manifestPath, `${JSON.stringify(generateSlackManifest(), null, 2)}\n`);
-    io.print(`\n${manifestSteps(manifestPath)}\n`);
+      const botToken = await askLine(io, 'Bot User OAuth Token (xoxb-...): ');
+      const appToken = await askLine(io, 'App-Level Token (xapp-...): ');
+      const signingSecret = await askLine(io, 'Signing Secret: ');
+      const channelId = await askLine(io, 'Lobby channel ID (C...): ');
 
-    const botToken = await askLine(io, 'Bot User OAuth Token (xoxb-...): ');
-    const appToken = await askLine(io, 'App-Level Token (xapp-...): ');
-    const signingSecret = await askLine(io, 'Signing Secret: ');
-    const channelId = await askLine(io, 'Lobby channel ID (C...): ');
+      const slackChecks = await validateSlackCredentials({ botToken, appToken, signingSecret, channelId });
+      checks.push(...slackChecks);
+      const report = buildReport(slackChecks);
+      io.print(`\n${formatReport(report)}`);
 
-    const checks = await validateSlackCredentials({ botToken, appToken, signingSecret, channelId });
-    const report = buildReport(checks);
-    io.print(`\n${formatReport(report)}`);
-
-    if (!report.ok) {
-      const proceed = await promptYes(io, '\nSome checks failed. Save these values anyway? [y/N] ', parsed.assumeYes);
-      if (!proceed) {
-        io.print('Nothing written. Fix the items above and re-run `invoker-cli setup slack`.');
-        return 1;
+      if (!report.ok) {
+        const proceed = await promptYes(io, '\nSome checks failed. Save these values anyway? [y/N] ', parsed.assumeYes);
+        if (!proceed) {
+          io.print('Nothing written.');
+          checks.push(...await collectGithubAndSmokeChecks(options));
+          return printSetupEnding(io, checks);
+        }
       }
+
+      const envPath = writeSlackEnv({ botToken, appToken, signingSecret, channelId });
+      io.print(`\nWrote Slack credentials to ${envPath}. Restart Invoker (or it picks them up on next launch).`);
     }
 
-    const envPath = writeSlackEnv({ botToken, appToken, signingSecret, channelId });
-    io.print(`\nWrote Slack credentials to ${envPath}. Restart Invoker (or it picks them up on next launch).`);
-    return report.ok ? 0 : 1;
+    const extras = await collectGithubAndSmokeChecks(options);
+    checks.push(...extras);
+    io.print('');
+    io.print(formatReport(buildReport(extras)));
+
+    return printSetupEnding(io, checks);
   } catch (error) {
     if (!(error instanceof NonInteractiveSetupError)) throw error;
     io.print(error.message);


### PR DESCRIPTION
## Summary

`invoker-cli setup` now finishes with one clear outcome instead of several soft goodbye messages.

It still installs the planner MCP and can optionally configure Slack. After that, it checks GitHub auth and parses a tiny local smoke plan.

If everything passes, it prints `You're ready.` If something hard-fails, it prints only the first failure to fix.

## Review Claim

Approve that general `invoker-cli setup` ends with a single ready/fix-this-first summary backed by GitHub auth and offline plan-parse checks.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

GitHub auth and smoke checks are injectable, so tests stay offline. Missing `gh` is a warning, not a hard failure. Planner and Slack subcommands keep their existing focused paths.

## Slice Rationale

This continues the Guided CLI Setup series as the oneshot ending behavior. It does not touch Slack surfaces, SSH executors, or app locks.

## Non-goals

- Auto-installing or logging into GitHub on remote machines
- Changing `invoker-cli doctor` output shape
- Fixing SSH finalize / remote provisioning failures

## Architecture

### Before

```mermaid
graph TD
    A["invoker-cli setup"] --> B["doctor report"]
    B --> C["ensure planner MCP"]
    C --> D["optional Slack"]
    D --> E["You are good to go... messages"]
```

### After

```mermaid
graph TD
    A["invoker-cli setup"] --> B["doctor checks"]
    B --> C["ensure planner MCP"]
    C --> D["optional Slack checks"]
    D --> E["GitHub auth check"]
    E --> F["offline smoke plan parse"]
    F --> G["You're ready. or Fix this first: ..."]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/cli && ./node_modules/.bin/vitest run src/__tests__/onboarding.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1e2140213`
- Post-revert steps: None
- Data migration? No

</details>
