### PR TITLE
Reject invalid repository URLs before SSH startup

### DIFF
--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { parsePlan, parsePlanSubmissionBundle, PlanParseError, detectDefaultBranch, applyPlanDefinitionDefaults, applyConfiguredPlanDefaults } from '../plan-parser.js';
+import { parsePlan, parsePlanFile, parsePlanSubmissionBundle, PlanParseError, detectDefaultBranch, applyPlanDefinitionDefaults, applyConfiguredPlanDefaults } from '../plan-parser.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { writeFileSync } from 'node:fs';
+import * as childProcess from 'node:child_process';
 
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>();
@@ -64,6 +65,41 @@ describe('applyPlanDefinitionDefaults', () => {
 });
 
 describe('parsePlan', () => {
+  it('rejects a bare repo name before the workflow is created', async () => {
+    const planPath = join(tmpdir(), `invoker-invalid-repo-${process.pid}.yaml`);
+    writeFileSync(planPath, `
+name: Bare Repo
+repoUrl: invoker
+tasks:
+  - id: greet
+    description: Say hello
+    command: echo "Hello"
+`);
+
+    await expect(parsePlanFile(planPath)).rejects.toThrow(
+      'repoUrl "invoker" is not a valid git repository',
+    );
+  });
+
+  it('rejects an unreachable remote during plan file validation', async () => {
+    const planPath = join(tmpdir(), `invoker-unreachable-repo-${process.pid}.yaml`);
+    writeFileSync(planPath, `
+name: Unreachable Repo
+repoUrl: https://example.invalid/repo.git
+tasks:
+  - id: greet
+    description: Say hello
+    command: echo "Hello"
+`);
+    vi.spyOn(childProcess, 'execFileSync').mockImplementation(() => {
+      throw new Error('unreachable');
+    });
+
+    await expect(parsePlanFile(planPath)).rejects.toThrow(
+      'repoUrl "https://example.invalid/repo.git" is not a readable git repository',
+    );
+  });
+
   it('rejects plan without repoUrl', () => {
     const yaml = `
 name: No Repo Plan

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -5,7 +5,8 @@
  * Uses the `yaml` npm package for parsing.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { parse as parseYaml } from 'yaml';
 import type { PlanDefinition } from '@invoker/workflow-core';
 import { loadConfig, resolveDefaultExecutionAgent } from './config.js';
@@ -157,6 +158,37 @@ export function detectDefaultBranchRemote(repoUrl: string): string {
     // Network error or timeout
   }
   return 'main';
+}
+
+export function assertRepoUrlCloneable(repoUrl: string): void {
+  const trimmed = repoUrl.trim();
+  const isLocalPath = trimmed.startsWith('/') || trimmed.startsWith('./') || trimmed.startsWith('../');
+  const isRemoteUrl = /^(?:git@|https?:\/\/|ssh:\/\/|file:\/\/)/.test(trimmed);
+
+  if (!isLocalPath && !isRemoteUrl) {
+    throw new PlanParseError(
+      `repoUrl "${repoUrl}" is not a valid git repository. Use a full clone URL or a configured Slack alias.`,
+    );
+  }
+
+  try {
+    if (isLocalPath) {
+      if (!existsSync(trimmed)) throw new Error('Path does not exist');
+      execFileSync('git', ['-C', trimmed, 'rev-parse', '--git-dir'], {
+        stdio: ['ignore', 'ignore', 'ignore'],
+        timeout: 10_000,
+      });
+      return;
+    }
+    execFileSync('git', ['ls-remote', '--exit-code', '--', trimmed, 'HEAD'], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+      timeout: 10_000,
+    });
+  } catch {
+    throw new PlanParseError(
+      `repoUrl "${repoUrl}" is not a readable git repository. Check its clone URL and credentials.`,
+    );
+  }
 }
 
 export class PlanParseError extends Error {
@@ -505,5 +537,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
 export async function parsePlanFile(filePath: string): Promise<PlanDefinition> {
   const { readFile } = await import('node:fs/promises');
   const content = await readFile(filePath, 'utf-8');
-  return parsePlan(content);
+  const plan = parsePlan(content);
+  assertRepoUrlCloneable(plan.repoUrl!);
+  return plan;
 }

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -1636,6 +1636,43 @@ tasks:
     expect(startPlan!.planText).toContain('Health API');
   });
 
+  it('resolves a conversational repo alias and rewrites the drafted plan repoUrl before submit', async () => {
+    const surface = lobbySurface(true, {
+      defaultRepoUrl: 'git@github.com:default/repo.git',
+      repoAliases: { invoker: 'git@github.com:Neko-Catpital-Labs/Invoker.git' },
+    });
+    await surface.start(async (cmd) => { received.push(cmd); });
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> plan a validation fix in invoker', ts: 't1', user: 'U1' },
+      say,
+    });
+    expect(planConversationConfigs.at(-1)).toEqual(expect.objectContaining({
+      repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
+    }));
+
+    draftedPlanForMock = `
+name: Repo alias plan
+repoUrl: invoker
+tasks:
+  - id: validate
+    description: Validate the repository
+    command: pnpm test
+    dependencies: []
+`;
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> submit', thread_ts: 't1', ts: 't2', user: 'U1' },
+      say: vi.fn().mockResolvedValue({ ts: 'b' }),
+    });
+    await messageHandler(surface)({
+      event: { thread_ts: 't1', ts: 't3', user: 'U1', text: 'yes' },
+      say: vi.fn().mockResolvedValue({ ts: 'c' }),
+    });
+
+    const startPlan = received.find((command) => command.type === 'start_plan') as Extract<SurfaceCommand, { type: 'start_plan' }>;
+    expect(startPlan.planText).toContain('repoUrl: git@github.com:Neko-Catpital-Labs/Invoker.git');
+  });
+
   it('reports when workflow operations are not wired in this deployment', async () => {
     const surface = lobbySurface(false);
     await surface.start(async () => {});

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -9,6 +9,7 @@ import { App, type RespondFn } from '@slack/bolt';
 import { spawn } from 'node:child_process';
 import { readFileSync, statSync } from 'node:fs';
 import { basename } from 'node:path';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import type { Surface, CommandHandler, SurfaceCommand, SurfaceEvent, LogFn, WorkflowOp, WorkflowOpResult, WorkflowOpProgress, WorkflowOpName } from '../surface.js';
 import { parseSlackCommand } from './slack-commands.js';
 import type { ConversationCommand } from './slack-commands.js';
@@ -243,6 +244,10 @@ type RepoParts = {
 
 function stripGitSuffix(path: string): string {
   return path.replace(/\/+$/g, '').replace(/\.git$/i, '');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function parseRepoParts(repoUrl: string): RepoParts | undefined {
@@ -1032,7 +1037,14 @@ export class SlackSurface implements Surface {
       await say({ text: detectedRepoResolution.error, thread_ts: event.ts });
       return;
     }
-    const routeRepoUrl = explicitRepoResolution.url ?? detectedRepoResolution.url ?? this.resolveRepoUrl().url;
+    const mentionedRepoAlias = !parsed.repo && repositoryUrls.length === 0
+      ? this.findMentionedRepoAlias(parsed.text)
+      : undefined;
+    const mentionedRepoResolution = mentionedRepoAlias ? this.resolveRepoUrl(mentionedRepoAlias) : {};
+    const routeRepoUrl = explicitRepoResolution.url
+      ?? detectedRepoResolution.url
+      ?? mentionedRepoResolution.url
+      ?? this.resolveRepoUrl().url;
 
     const threadTs = event.thread_ts ?? event.ts;
     const requiresPlanningRepo = !!this.planningCommandBuilder;
@@ -1041,7 +1053,7 @@ export class SlackSurface implements Surface {
       : undefined;
     let planningRepoResolution: PlanningRepoResolution | undefined;
     const resolvePlanningRepo = (): PlanningRepoResolution => {
-      planningRepoResolution ??= this.resolvePlanningRepoUrl(parsed.repo, messageRepoUrl);
+      planningRepoResolution ??= this.resolvePlanningRepoUrl(parsed.repo ?? mentionedRepoAlias, messageRepoUrl);
       return planningRepoResolution;
     };
 
@@ -1390,13 +1402,14 @@ export class SlackSurface implements Surface {
       await say({ text: "I don't see a complete plan drafted yet. Ask me to draft it in this thread, then submit again.", thread_ts: threadTs });
       return;
     }
-    const summary = summarizePlanText(planText);
+    const normalizedPlanText = this.normalizeDraftedPlanRepoUrl(planText, this.loadPlanningContext(threadTs)?.repoUrl);
+    const summary = summarizePlanText(normalizedPlanText);
     if (!summary) {
       await say({ text: "I found a draft plan but couldn't read it. Ask me to regenerate the plan, then submit again.", thread_ts: threadTs });
       return;
     }
     const ctx = this.loadPlanningContext(threadTs);
-    await this.stageConfirm(threadTs, channel, { kind: 'submit', planText, ctx, channel, lobbyThreadTs: threadTs }, this.renderPlanSummary(summary), say);
+    await this.stageConfirm(threadTs, channel, { kind: 'submit', planText: normalizedPlanText, ctx, channel, lobbyThreadTs: threadTs }, this.renderPlanSummary(summary), say);
   }
 
   private renderPlanSummary(summary: PlanSummary): string {
@@ -1961,6 +1974,36 @@ ${text}`;
     const known = Object.keys(this.repoAliases);
     const list = known.length ? known.join(', ') : '(none configured)';
     return { error: `Unknown repo "${repo}". Known aliases: ${list}. Or pass a full git URL.` };
+  }
+
+  private findMentionedRepoAlias(text: string): string | undefined {
+    return Object.keys(this.repoAliases).find((alias) => (
+      new RegExp(`\\b${escapeRegExp(alias)}\\b`, 'i').test(text)
+    ));
+  }
+
+  private normalizeDraftedPlanRepoUrl(planText: string, contextRepoUrl: string | undefined): string {
+    let raw: unknown;
+    try {
+      raw = parseYaml(planText);
+    } catch {
+      return planText;
+    }
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return planText;
+
+    const plan = raw as Record<string, unknown>;
+    if (typeof plan.repoUrl !== 'string') return planText;
+    const repoUrl = plan.repoUrl.trim();
+    const aliasKey = Object.keys(this.repoAliases).find((key) => key.toLowerCase() === repoUrl.toLowerCase());
+    if (aliasKey) {
+      plan.repoUrl = this.normalizeRepositoryUrl(this.repoAliases[aliasKey]);
+      return stringifyYaml(plan);
+    }
+    if (!/^(?:git@|https?:\/\/|ssh:\/\/|file:\/\/|\/|\.{1,2}\/)/.test(repoUrl) && contextRepoUrl) {
+      plan.repoUrl = contextRepoUrl;
+      return stringifyYaml(plan);
+    }
+    return planText;
   }
 
   private normalizeRepositoryUrl(repoUrl: string): string {


### PR DESCRIPTION
## Summary

Plan-file intake now checks repository targets before SSH workspace startup.

## Review Claim

The plan-loading route halts malformed or unreachable repository targets before a workflow is created.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only cloneable repositories reach executor startup.

## Slice Rationale

Repository checks belong in the plan-loading route so SSH bootstrap never becomes the first failure point.

## Non-goals

This does not alter SSH clone behavior or Slack repository alias handling.

## Architecture

### Before

```mermaid
flowchart LR
  planYaml["Plan YAML"] --> workflow["Create workflow"]
  workflow --> ssh["SSH clone"]
```

### After

```mermaid
flowchart LR
  planYaml["Plan YAML"] --> validation["Verify cloneable repo URL"]
  validation --> workflow["Create workflow"]
  validation --> rejection["Reject invalid plan"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/plan-parser.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <commit-sha>`
- Post-revert steps: None.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plan files now reject invalid or unsupported repository URLs during validation.
  * Unreachable or unreadable Git repositories now produce clearer validation errors.
  * Local repository paths and supported remote URLs are checked for accessibility before use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->