### PR TITLE
Resolve Slack repository aliases before plan submission

### DIFF
--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -1636,6 +1636,43 @@ tasks:
     expect(startPlan!.planText).toContain('Health API');
   });
 
+  it('resolves a conversational repo alias and rewrites the drafted plan repoUrl before submit', async () => {
+    const surface = lobbySurface(true, {
+      defaultRepoUrl: 'git@github.com:default/repo.git',
+      repoAliases: { invoker: 'git@github.com:Neko-Catpital-Labs/Invoker.git' },
+    });
+    await surface.start(async (cmd) => { received.push(cmd); });
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> plan a validation fix in invoker', ts: 't1', user: 'U1' },
+      say,
+    });
+    expect(planConversationConfigs.at(-1)).toEqual(expect.objectContaining({
+      repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
+    }));
+
+    draftedPlanForMock = `
+name: Repo alias plan
+repoUrl: invoker
+tasks:
+  - id: validate
+    description: Validate the repository
+    command: pnpm test
+    dependencies: []
+`;
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> submit', thread_ts: 't1', ts: 't2', user: 'U1' },
+      say: vi.fn().mockResolvedValue({ ts: 'b' }),
+    });
+    await messageHandler(surface)({
+      event: { thread_ts: 't1', ts: 't3', user: 'U1', text: 'yes' },
+      say: vi.fn().mockResolvedValue({ ts: 'c' }),
+    });
+
+    const startPlan = received.find((command) => command.type === 'start_plan') as Extract<SurfaceCommand, { type: 'start_plan' }>;
+    expect(startPlan.planText).toContain('repoUrl: git@github.com:Neko-Catpital-Labs/Invoker.git');
+  });
+
   it('reports when workflow operations are not wired in this deployment', async () => {
     const surface = lobbySurface(false);
     await surface.start(async () => {});

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -9,6 +9,7 @@ import { App, type RespondFn } from '@slack/bolt';
 import { spawn } from 'node:child_process';
 import { readFileSync, statSync } from 'node:fs';
 import { basename } from 'node:path';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import type { Surface, CommandHandler, SurfaceCommand, SurfaceEvent, LogFn, WorkflowOp, WorkflowOpResult, WorkflowOpProgress, WorkflowOpName } from '../surface.js';
 import { parseSlackCommand } from './slack-commands.js';
 import type { ConversationCommand } from './slack-commands.js';
@@ -243,6 +244,10 @@ type RepoParts = {
 
 function stripGitSuffix(path: string): string {
   return path.replace(/\/+$/g, '').replace(/\.git$/i, '');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function parseRepoParts(repoUrl: string): RepoParts | undefined {
@@ -1032,7 +1037,14 @@ export class SlackSurface implements Surface {
       await say({ text: detectedRepoResolution.error, thread_ts: event.ts });
       return;
     }
-    const routeRepoUrl = explicitRepoResolution.url ?? detectedRepoResolution.url ?? this.resolveRepoUrl().url;
+    const mentionedRepoAlias = !parsed.repo && repositoryUrls.length === 0
+      ? this.findMentionedRepoAlias(parsed.text)
+      : undefined;
+    const mentionedRepoResolution = mentionedRepoAlias ? this.resolveRepoUrl(mentionedRepoAlias) : {};
+    const routeRepoUrl = explicitRepoResolution.url
+      ?? detectedRepoResolution.url
+      ?? mentionedRepoResolution.url
+      ?? this.resolveRepoUrl().url;
 
     const threadTs = event.thread_ts ?? event.ts;
     const requiresPlanningRepo = !!this.planningCommandBuilder;
@@ -1041,7 +1053,7 @@ export class SlackSurface implements Surface {
       : undefined;
     let planningRepoResolution: PlanningRepoResolution | undefined;
     const resolvePlanningRepo = (): PlanningRepoResolution => {
-      planningRepoResolution ??= this.resolvePlanningRepoUrl(parsed.repo, messageRepoUrl);
+      planningRepoResolution ??= this.resolvePlanningRepoUrl(parsed.repo ?? mentionedRepoAlias, messageRepoUrl);
       return planningRepoResolution;
     };
 
@@ -1390,13 +1402,14 @@ export class SlackSurface implements Surface {
       await say({ text: "I don't see a complete plan drafted yet. Ask me to draft it in this thread, then submit again.", thread_ts: threadTs });
       return;
     }
-    const summary = summarizePlanText(planText);
+    const normalizedPlanText = this.normalizeDraftedPlanRepoUrl(planText, this.loadPlanningContext(threadTs)?.repoUrl);
+    const summary = summarizePlanText(normalizedPlanText);
     if (!summary) {
       await say({ text: "I found a draft plan but couldn't read it. Ask me to regenerate the plan, then submit again.", thread_ts: threadTs });
       return;
     }
     const ctx = this.loadPlanningContext(threadTs);
-    await this.stageConfirm(threadTs, channel, { kind: 'submit', planText, ctx, channel, lobbyThreadTs: threadTs }, this.renderPlanSummary(summary), say);
+    await this.stageConfirm(threadTs, channel, { kind: 'submit', planText: normalizedPlanText, ctx, channel, lobbyThreadTs: threadTs }, this.renderPlanSummary(summary), say);
   }
 
   private renderPlanSummary(summary: PlanSummary): string {
@@ -1961,6 +1974,36 @@ ${text}`;
     const known = Object.keys(this.repoAliases);
     const list = known.length ? known.join(', ') : '(none configured)';
     return { error: `Unknown repo "${repo}". Known aliases: ${list}. Or pass a full git URL.` };
+  }
+
+  private findMentionedRepoAlias(text: string): string | undefined {
+    return Object.keys(this.repoAliases).find((alias) => (
+      new RegExp(`\\b${escapeRegExp(alias)}\\b`, 'i').test(text)
+    ));
+  }
+
+  private normalizeDraftedPlanRepoUrl(planText: string, contextRepoUrl: string | undefined): string {
+    let raw: unknown;
+    try {
+      raw = parseYaml(planText);
+    } catch {
+      return planText;
+    }
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return planText;
+
+    const plan = raw as Record<string, unknown>;
+    if (typeof plan.repoUrl !== 'string') return planText;
+    const repoUrl = plan.repoUrl.trim();
+    const aliasKey = Object.keys(this.repoAliases).find((key) => key.toLowerCase() === repoUrl.toLowerCase());
+    if (aliasKey) {
+      plan.repoUrl = this.normalizeRepositoryUrl(this.repoAliases[aliasKey]);
+      return stringifyYaml(plan);
+    }
+    if (!/^(?:git@|https?:\/\/|ssh:\/\/|file:\/\/|\/|\.{1,2}\/)/.test(repoUrl) && contextRepoUrl) {
+      plan.repoUrl = contextRepoUrl;
+      return stringifyYaml(plan);
+    }
+    return planText;
   }
 
   private normalizeRepositoryUrl(repoUrl: string): string {


### PR DESCRIPTION
## Summary

Slack planning requests now recognize configured repository aliases mentioned in ordinary conversation.

Generated plans replace those aliases with clone URLs before executor setup.

## Review Claim

A configured Slack repository alias such as `invoker` selects the intended planning repository and becomes its clone URL in generated YAML.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only configured aliases affect planning context, and generated plans retain a concrete repository URL.

## Slice Rationale

This routes conversational repository selection separately from plan intake checks, keeping each failure boundary independently reviewable.

## Non-goals

This does not add unconfigured aliases or change repository reachability checks.

## Architecture

### Before

```mermaid
flowchart LR
  userMessage["Slack planning request"] --> planner["Planner context"]
  planner --> yaml["Plan YAML with bare alias"]
```

### After

```mermaid
flowchart LR
  userMessage["Slack planning request"] --> alias["Resolve configured alias"]
  alias --> planner["Planner context"]
  planner --> yaml["Plan YAML with clone URL"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces test -- src/__tests__/slack-surface-workflows.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <commit-sha>`
- Post-revert steps: None.
- Data migration? No.

</details>

Depends-On: #5756