### PR TITLE
Add ci_failed to external gate-policy contract types.

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -130,7 +130,7 @@ export interface AgentSessionData {
 export interface ExternalGatePolicyUpdate {
   workflowId: string;
   taskId?: string;
-  gatePolicy: 'completed' | 'review_ready';
+  gatePolicy: 'completed' | 'review_ready' | 'ci_failed';
 }
 
 export interface TaskEvent {

--- a/packages/data-store/src/sqlite-external-dependencies.ts
+++ b/packages/data-store/src/sqlite-external-dependencies.ts
@@ -1,4 +1,9 @@
-import type { ExternalDependency } from '@invoker/workflow-core';
+import type { ExternalDependency, ExternalGatePolicy } from '@invoker/workflow-core';
+
+function normalizeGatePolicy(value: unknown, fallback: ExternalGatePolicy): ExternalGatePolicy {
+  if (value === 'completed' || value === 'review_ready' || value === 'ci_failed') return value;
+  return fallback;
+}
 
 export function normalizeExternalDependencies(raw: unknown): ExternalDependency[] {
   if (!Array.isArray(raw)) return [];
@@ -8,7 +13,7 @@ export function normalizeExternalDependencies(raw: unknown): ExternalDependency[
     const dep = item as Record<string, unknown>;
     if (typeof dep.workflowId !== 'string' || dep.workflowId.trim() === '') continue;
     const taskId = typeof dep.taskId === 'string' && dep.taskId.trim() !== '' ? dep.taskId.trim() : '__merge__';
-    const gatePolicy = dep.gatePolicy === 'review_ready' ? 'review_ready' : 'completed';
+    const gatePolicy = normalizeGatePolicy(dep.gatePolicy, 'completed');
     normalized.push({
       workflowId: dep.workflowId.trim(),
       taskId,
@@ -25,10 +30,11 @@ export function mergeExternalDependencySets(existing: ExternalDependency[], inco
     const taskId = dep.taskId?.trim() || '__merge__';
     const key = `${dep.workflowId}::${taskId}`;
     const previous = byKey.get(key);
+    const depGatePolicy = dep.gatePolicy === undefined ? undefined : normalizeGatePolicy(dep.gatePolicy, 'review_ready');
     const gatePolicy =
-      previous?.gatePolicy === 'completed' || dep.gatePolicy === 'completed'
+      previous?.gatePolicy === 'completed' || depGatePolicy === 'completed'
         ? 'completed'
-        : 'review_ready';
+        : depGatePolicy ?? previous?.gatePolicy ?? 'review_ready';
     byKey.set(key, {
       workflowId: dep.workflowId,
       taskId,

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -49,13 +49,15 @@ export interface TaskConfig {
   readonly externalDependencies?: readonly ExternalDependency[];
 }
 
+export type ExternalGatePolicy = 'completed' | 'review_ready' | 'ci_failed';
+
 export interface ExternalDependency {
   readonly workflowId: string;
   /** Optional task selector within the external workflow. Omit to depend on that workflow's merge gate. */
   readonly taskId?: string;
   readonly requiredStatus: 'completed';
-  /** review_ready (default): merge gate review_ready/awaiting_approval/completed count as satisfied. completed: strict — only 'completed' satisfies. */
-  readonly gatePolicy?: 'completed' | 'review_ready';
+  /** review_ready/ci_failed: merge gate review_ready/awaiting_approval/completed count as satisfied. completed: strict. */
+  readonly gatePolicy?: ExternalGatePolicy;
 }
 
 // ── Task Execution (runtime state) ─────────────────────────

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -89,13 +89,15 @@ export interface MergeTaskConfig extends BaseTaskConfig {
 
 export type TaskConfig = WorktreeTaskConfig | DockerTaskConfig | SshTaskConfig | MergeTaskConfig;
 
+export type ExternalGatePolicy = 'completed' | 'review_ready' | 'ci_failed';
+
 export interface ExternalDependency {
   readonly workflowId: string;
   /** Optional task selector within the external workflow. Omit to depend on that workflow's merge gate. */
   readonly taskId?: string;
   readonly requiredStatus: 'completed';
-  /** review_ready (default): merge gate review_ready/awaiting_approval/completed count as satisfied. completed: strict — only 'completed' satisfies. */
-  readonly gatePolicy?: 'completed' | 'review_ready';
+  /** review_ready/ci_failed: merge gate review_ready/awaiting_approval/completed count as satisfied. completed: strict. */
+  readonly gatePolicy?: ExternalGatePolicy;
 }
 
 export interface ExternalDependencyChange {
@@ -120,7 +122,7 @@ export interface DetachedExternalDependency {
   /** Optional task selector within the upstream workflow, if the removed dependency had one. */
   readonly taskId?: string;
   readonly requiredStatus: 'completed';
-  readonly gatePolicy?: 'completed' | 'review_ready';
+  readonly gatePolicy?: ExternalGatePolicy;
   /** When the detach removed this dependency. */
   readonly detachedAt: string;
 }


### PR DESCRIPTION
## Summary

This slice is part of the current Invoker delivery stack.

It is intentionally narrow so the stack can be reviewed and reverted incrementally.

## Review Claim

This commit is safe to approve as one independently reviewable change.

## Review Lane

refactor

## Review Unit

contract

## Safety Invariant

The slice does not change work outside its committed files.

## Slice Rationale

It preserves the stack's bottom-up dependency order.

## Non-goals

No unrelated behavior is included in this review.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] Run the package tests affected by this slice.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <commit-sha>`.
- Post-revert steps: None.
- Data migration? No.

</details>
