### PR TITLE
Use trusted base for local PR body validation

### DIFF
--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -277,7 +277,11 @@ export function classifyReviewUnitsForPath(filePath) {
   if (path.startsWith('packages/app/e2e/visual-proof/')) return ['activation-surface'];
   if (/(benchmark|performance)/.test(lowerPath)) return ['proof'];
   if (/visual-proof/.test(lowerPath) && path.includes('/e2e/')) return ['proof'];
-  if (path === 'skills/make-pr/SKILL.md' || path === 'skills/plan-to-invoker/SKILL.md') return ['tooling-policy'];
+  if (
+    path === 'skills/make-pr/SKILL.md'
+    || path === 'skills/plan-to-invoker/SKILL.md'
+    || path === 'skills/land-stack/SKILL.md'
+  ) return ['tooling-policy'];
   if (path.startsWith('docs/') || path.startsWith('skills/') || path.endsWith('.md')) return ['docs'];
   if (path.startsWith('.github/')) return ['tooling-policy'];
   if (

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 import { spawnSync } from 'node:child_process';
 import { getPrAtomicityBlockers, getPrBodyWarnings, getReviewMetadata, validatePrBody, validatePrScope } from './validate-pr-body.mjs';
 
@@ -15,6 +16,8 @@ function assert(condition, message) {
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, '..');
+const require = createRequire(import.meta.url);
+const runtimeNodeModules = require.resolve('jsdom/package.json').split('/node_modules/')[0] + '/node_modules';
 
 function runValidatorCli(bodyFile) {
   return spawnSync(process.execPath, ['scripts/validate-pr-body.mjs', '--body-file', bodyFile], {
@@ -1037,10 +1040,13 @@ try {
   };
   const sourceFile = join(localWrapperTmp, 'packages', 'app', 'src', 'refresh-route.ts');
   const bodyPath = join(localWrapperTmp, 'body.md');
+  const reviewUnitRulesPath = join(localWrapperTmp, 'scripts', 'review-unit-rules.mjs');
 
   runGit(['init', '--initial-branch=master']);
   runGit(['config', 'user.email', 'pr-body-test@example.test']);
   runGit(['config', 'user.name', 'PR Body Test']);
+  cpSync(join(repoRoot, 'scripts'), join(localWrapperTmp, 'scripts'), { recursive: true });
+  symlinkSync(runtimeNodeModules, join(localWrapperTmp, 'node_modules'), 'dir');
   mkdirSync(dirname(sourceFile), { recursive: true });
   writeFileSync(sourceFile, 'export const refreshRoute = 1;\n');
   runGit(['add', '.']);
@@ -1082,6 +1088,31 @@ try {
   assert(
     reviewUnitLocalWrapper.stderr.includes('Review Unit "contract" cannot ship with routing files'),
     'local wrapper should report the CI review-unit file mismatch',
+  );
+
+  runGit(['switch', '-c', 'trusted-base-classifier', 'master']);
+  const sentinelPath = join(localWrapperTmp, 'scripts', 'sentinel.mjs');
+  writeFileSync(bodyPath, validMinimal.replace('- behavior', '- policy').replace('- routing', '- tooling-policy'));
+  writeFileSync(sentinelPath, 'export const sentinel = true;\n');
+  const headReviewRules = readFileSync(reviewUnitRulesPath, 'utf8').replace(
+    "if (path.startsWith('scripts/')) return ['tooling-policy'];",
+    "if (path === 'scripts/sentinel.mjs') return ['docs'];\n  if (path.startsWith('scripts/')) return ['tooling-policy'];",
+  );
+  assert(headReviewRules.includes("if (path === 'scripts/sentinel.mjs') return ['docs'];"), 'test must change the head-only classifier');
+  writeFileSync(
+    reviewUnitRulesPath,
+    headReviewRules,
+  );
+  runGit(['add', 'scripts/review-unit-rules.mjs', 'scripts/sentinel.mjs']);
+  runGit(['commit', '-m', 'change head-only review classification']);
+  const trustedBaseLocalWrapper = spawnSync(
+    process.execPath,
+    [join(repoRoot, 'scripts', 'validate-pr-body-local.mjs'), '--body-file', bodyPath, '--base', 'master'],
+    { cwd: localWrapperTmp, encoding: 'utf8' },
+  );
+  assert(
+    trustedBaseLocalWrapper.status === 0,
+    `local wrapper should use the trusted base classifier, not the head classifier: ${trustedBaseLocalWrapper.stderr}`,
   );
 } finally {
   rmSync(localWrapperTmp, { recursive: true, force: true });

--- a/scripts/test-review-unit-classification.mjs
+++ b/scripts/test-review-unit-classification.mjs
@@ -9,8 +9,8 @@ import {
 const rootPackage = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
 assert.match(
   rootPackage.scripts.test,
-  /node scripts\/test-review-unit-classification\.mjs && bash scripts\/workspace-test\.sh/,
-  'root test must add review-unit classification before the existing workspace test contract',
+  /node scripts\/test-review-unit-classification\.mjs && (?:node scripts\/test-create-pr-stack-workflow\.mjs && )?bash scripts\/workspace-test\.sh/,
+  'root test must run review-unit classification before the workspace test contract',
 );
 
 const neutralManifests = [
@@ -37,6 +37,7 @@ const stillToolingPolicy = [
   '.github/workflows/ci.yml',
   'skills/make-pr/SKILL.md',
   'skills/plan-to-invoker/SKILL.md',
+  'skills/land-stack/SKILL.md',
 ];
 for (const path of stillToolingPolicy) {
   assert.deepEqual(

--- a/scripts/validate-pr-body-local.mjs
+++ b/scripts/validate-pr-body-local.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-import { execFileSync } from 'node:child_process';
-import { readFileSync, realpathSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join, parse } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { getPrBodyWarnings, validatePrBody } from './validate-pr-body.mjs';
 
 const DEFAULT_BASE_BRANCH = 'master';
 const DEFAULT_BASE_REMOTE = process.env.INVOKER_PARENT_REMOTE || 'origin';
@@ -58,6 +58,97 @@ function gitText(args) {
   }
 }
 
+function parseValidatorMessages(output, heading) {
+  const lines = String(output).split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim() === heading);
+  if (start === -1) return [];
+  return lines
+    .slice(start + 1)
+    .filter((line) => line.startsWith('- '))
+    .map((line) => line.slice(2));
+}
+
+function findNodeModules(repoRoot) {
+  let current = repoRoot;
+  while (true) {
+    const nodeModules = join(current, 'node_modules');
+    if (existsSync(nodeModules)) return nodeModules;
+    const parent = dirname(current);
+    if (parent === current || parent === parse(current).root) return '';
+    current = parent;
+  }
+}
+
+function runTrustedBaseValidator({ repoRoot, baseRef, body, changedFiles, diffText }) {
+  const tempRoot = join(repoRoot, '.tmp');
+  mkdirSync(tempRoot, { recursive: true });
+  const validatorWorktree = mkdtempSync(join(tempRoot, 'pr-body-validator-base-'));
+  const inputsDir = mkdtempSync(join(tempRoot, 'pr-body-validator-inputs-'));
+  const bodyPath = join(inputsDir, 'pr-body.md');
+  const changedFilesPath = join(inputsDir, 'changed-files.txt');
+  const diffPath = join(inputsDir, 'pr.diff');
+  let worktreeAdded = false;
+
+  try {
+    execFileSync('git', ['worktree', 'add', '--detach', validatorWorktree, baseRef], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    worktreeAdded = true;
+    const nodeModules = findNodeModules(repoRoot);
+    const validatorNodeModules = join(validatorWorktree, 'node_modules');
+    if (nodeModules && !existsSync(validatorNodeModules)) {
+      symlinkSync(nodeModules, validatorNodeModules, 'dir');
+    }
+    writeFileSync(bodyPath, body);
+    writeFileSync(changedFilesPath, `${changedFiles.join('\n')}\n`);
+    writeFileSync(diffPath, diffText);
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(validatorWorktree, 'scripts', 'validate-pr-body.mjs'),
+        '--body-file',
+        bodyPath,
+        '--changed-files-file',
+        changedFilesPath,
+        '--diff-file',
+        diffPath,
+      ],
+      { cwd: validatorWorktree, encoding: 'utf8' },
+    );
+    if (result.error) throw result.error;
+
+    const stdout = String(result.stdout ?? '');
+    const stderr = String(result.stderr ?? '');
+    if (result.status === 0) {
+      return {
+        errors: [],
+        warnings: parseValidatorMessages(stdout, 'PR body validation warnings:'),
+      };
+    }
+
+    const errors = parseValidatorMessages(stderr, 'PR body validation failed:');
+    if (errors.length > 0) return { errors, warnings: [] };
+
+    throw new Error(`Trusted-base PR body validator failed: ${stderr || stdout}`);
+  } finally {
+    try {
+      if (worktreeAdded) {
+        execFileSync('git', ['worktree', 'remove', '--force', validatorWorktree], {
+          cwd: repoRoot,
+          encoding: 'utf8',
+          stdio: 'pipe',
+        });
+      }
+    } finally {
+      rmSync(validatorWorktree, { recursive: true, force: true });
+      rmSync(inputsDir, { recursive: true, force: true });
+    }
+  }
+}
+
 export function isUiImpactingPath(filePath) {
   const path = filePath.replace(/\\/g, '/');
   return path.startsWith('packages/ui/')
@@ -69,6 +160,7 @@ export function isUiImpactingPath(filePath) {
 
 export async function validateLocalPrBody({ body, baseBranch = DEFAULT_BASE_BRANCH, baseRemote = DEFAULT_BASE_REMOTE }) {
   const baseRef = `${baseRemote}/${baseBranch}`;
+  const repoRoot = process.cwd();
   gitText(['fetch', '--quiet', baseRemote, baseBranch]);
   const changedFiles = gitText(['diff', '--name-only', `${baseRef}...HEAD`])
     .split('\n')
@@ -82,11 +174,15 @@ export async function validateLocalPrBody({ body, baseBranch = DEFAULT_BASE_BRAN
     `${baseRef}...HEAD`,
     '--',
   ]);
-  const requiresVisualProof = changedFiles.some(isUiImpactingPath);
-  const errors = await validatePrBody(body, { changedFiles, diffText, requiresVisualProof });
-  const warnings = getPrBodyWarnings(body, { changedFiles, diffText });
+  const { errors, warnings } = runTrustedBaseValidator({
+    repoRoot,
+    baseRef,
+    body,
+    changedFiles,
+    diffText,
+  });
 
-  return { changedFiles, diffText, errors, warnings, requiresVisualProof };
+  return { changedFiles, diffText, errors, warnings, requiresVisualProof: false };
 }
 
 async function main() {


### PR DESCRIPTION
## Summary

Local PR checks now run the validator from the selected parent revision.

The landing skill is recognized as tooling policy before its policy text changes.

## Review Claim

Local PR body validation uses the same trusted validator revision as `pull_request_target`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The PR diff remains local, while only the parent revision supplies validation rules.

## Slice Rationale

This foundation lands before the landing-confirmation policy that relies on its classifier.

## Non-goals

This slice does not change PR metadata, merge queue behavior, or application runtime behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-validator.mjs`
- [x] `node scripts/test-review-unit-classification.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`.
- Post-revert steps: None.
- Data migration? No.

</details>