### PR TITLE
[Embedded Slack dual consumer](2) Kill Invoker.app Socket Mode owners

### DIFF
--- a/scripts/kill-all-electron.sh
+++ b/scripts/kill-all-electron.sh
@@ -11,7 +11,7 @@ list_electron_processes() {
       *kill-all-electron.sh*)
         continue
         ;;
-      *Electron.app/Contents/MacOS/Electron*|*"node "*scripts/electron.cjs*)
+      *Electron.app/Contents/MacOS/Electron*|*"node "*scripts/electron.cjs*|*Invoker.app/Contents/MacOS/Invoker*|*packages/app/dist/main.js*)
         printf '%s %s\n' "$pid" "$command"
         ;;
     esac


### PR DESCRIPTION
## Summary

Packaged Invoker.app still embeds Slack and never takes the slack-manager lock.

This slice widens kill-all-electron so local cutover can stop those competing owners.

## Review Claim

Approve widening kill-all-electron to match Invoker.app and app dist main.js owners.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only widens process matching in a kill helper; no Slack protocol change.

## Slice Rationale

Closes the coverage gap shown in the prior repro slice.

## Non-goals

Does not strip embedded Slack from Invoker.app itself.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-embedded-slack-dual-consumer.sh --expect fixed`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
