### PR TITLE
[Slack PlanDraft harness](1) Add HarnessSessionDriver

### DIFF
--- a/packages/execution-engine/src/__tests__/harness-session-driver.test.ts
+++ b/packages/execution-engine/src/__tests__/harness-session-driver.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { ExecutionHarnessSessionDriver, ReplayHarnessSessionDriver } from '../harness-session-driver.js';
+import { ClaudeExecutionAgent } from '../agents/claude-execution-agent.js';
+import { CodexExecutionAgent } from '../agents/codex-execution-agent.js';
+import { OmpExecutionAgent } from '../agents/omp-execution-agent.js';
+import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions } from '../agent.js';
+
+describe('ExecutionHarnessSessionDriver', () => {
+  describe('claude', () => {
+    const driver = new ExecutionHarnessSessionDriver(new ClaudeExecutionAgent());
+
+    it('start returns a sessionId and command shape', () => {
+      const result = driver.start('Fix the bug');
+
+      expect(driver.harness).toBe('claude');
+      expect(result.command).toBe('claude');
+      expect(result.sessionId).toBeTruthy();
+      expect(result.args).toContain('--session-id');
+      expect(result.args).toContain(result.sessionId);
+      expect(result.args).toContain('-p');
+      expect(result.args).toContain('Fix the bug');
+    });
+
+    it('append resumes the session and appends the prompt', () => {
+      const result = driver.append('session-abc', 'Now add a test', { model: 'sonnet' });
+
+      expect(result.command).toBe('claude');
+      expect(result.sessionId).toBe('session-abc');
+      expect(result.args).toEqual([
+        '--resume',
+        'session-abc',
+        '--dangerously-skip-permissions',
+        '--model',
+        'sonnet',
+        '-p',
+        'Now add a test',
+      ]);
+    });
+
+    it('append omits model args when no model is given', () => {
+      const result = driver.append('session-abc', 'Now add a test');
+
+      expect(result.args).toEqual([
+        '--resume',
+        'session-abc',
+        '--dangerously-skip-permissions',
+        '-p',
+        'Now add a test',
+      ]);
+    });
+  });
+
+  describe('codex', () => {
+    const driver = new ExecutionHarnessSessionDriver(new CodexExecutionAgent());
+
+    it('append shapes argv as exec resume with the prompt trailing', () => {
+      const result = driver.append('session-xyz', 'Continue the task', { model: 'gpt-5.5' });
+
+      expect(driver.harness).toBe('codex');
+      expect(result.command).toBe('codex');
+      expect(result.sessionId).toBe('session-xyz');
+      expect(result.args).toEqual([
+        'exec',
+        'resume',
+        '--dangerously-bypass-approvals-and-sandbox',
+        'session-xyz',
+        '--model',
+        'gpt-5.5',
+        'Continue the task',
+      ]);
+    });
+  });
+
+  describe('omp', () => {
+    const driver = new ExecutionHarnessSessionDriver(new OmpExecutionAgent({ sessionDirRoot: '/tmp/omp-test-sessions' }));
+
+    it('append resumes the session directory and appends the prompt', () => {
+      const result = driver.append('session-123', 'Ship it', { model: 'chatgpt-5.4' });
+
+      expect(driver.harness).toBe('omp');
+      expect(result.command).toBe('omp');
+      expect(result.sessionId).toBe('session-123');
+      expect(result.args).toEqual([
+        '--session-dir',
+        '/tmp/omp-test-sessions/session-123',
+        '--continue',
+        '--model',
+        'chatgpt-5.4',
+        '-p',
+        'Ship it',
+      ]);
+    });
+  });
+
+  describe('unsupported harness', () => {
+    class FakeExecutionAgent implements ExecutionAgent {
+      readonly name = 'fake';
+      readonly stdinMode = 'ignore' as const;
+
+      buildCommand(fullPrompt: string, _options?: AgentCommandBuildOptions): AgentCommandSpec {
+        return { cmd: 'fake', args: [fullPrompt], sessionId: 'fake-session' };
+      }
+
+      buildResumeArgs(sessionId: string): { cmd: string; args: string[] } {
+        return { cmd: 'fake', args: ['--resume', sessionId] };
+      }
+    }
+
+    it('throws on append for a harness without append support', () => {
+      const driver = new ExecutionHarnessSessionDriver(new FakeExecutionAgent());
+
+      expect(() => driver.append('session-1', 'Do the thing')).toThrow(/does not support/);
+    });
+
+    it('throws on start when buildCommand does not return a sessionId', () => {
+      class NoSessionExecutionAgent extends FakeExecutionAgent {
+        buildCommand(fullPrompt: string): AgentCommandSpec {
+          return { cmd: 'fake', args: [fullPrompt] };
+        }
+      }
+
+      const driver = new ExecutionHarnessSessionDriver(new NoSessionExecutionAgent());
+
+      expect(() => driver.start('Do the thing')).toThrow(/did not return a session id/);
+    });
+  });
+});
+
+describe('ReplayHarnessSessionDriver', () => {
+  const buildCommand = (prompt: string, options?: { model?: string }) => ({
+    command: 'cursor-agent',
+    args: [...(options?.model ? ['--model', options.model] : []), '-p', prompt],
+  });
+
+  it('start produces a command and a fresh sessionId', () => {
+    const driver = new ReplayHarnessSessionDriver('cursor', buildCommand);
+    const result = driver.start('Fix the bug', { model: 'gpt-5.6' });
+
+    expect(driver.harness).toBe('cursor');
+    expect(result.command).toBe('cursor-agent');
+    expect(result.args).toEqual(['--model', 'gpt-5.6', '-p', 'Fix the bug']);
+    expect(result.sessionId).toBeTruthy();
+  });
+
+  it('append produces a command and mints a new sessionId rather than resuming', () => {
+    const driver = new ReplayHarnessSessionDriver('cursor', buildCommand);
+    const started = driver.start('Fix the bug');
+    const appended = driver.append(started.sessionId, 'Now add a test');
+
+    expect(appended.command).toBe('cursor-agent');
+    expect(appended.args).toEqual(['-p', 'Now add a test']);
+    expect(appended.sessionId).toBeTruthy();
+    expect(appended.sessionId).not.toBe(started.sessionId);
+  });
+});

--- a/packages/execution-engine/src/harness-session-driver.ts
+++ b/packages/execution-engine/src/harness-session-driver.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from 'node:crypto';
+import type { ExecutionAgent } from './agent.js';
+
+export interface HarnessSessionCommand {
+  command: string;
+  args: string[];
+  sessionId: string;
+}
+
+export interface HarnessSessionDriver {
+  readonly harness: string;
+  /** True when `append` resumes the same agent session; false when it mints a fresh session every call. */
+  readonly supportsSessionContinuity: boolean;
+  start(prompt: string, options?: { model?: string }): HarnessSessionCommand;
+  append(sessionId: string, prompt: string, options?: { model?: string }): HarnessSessionCommand;
+}
+
+export class ExecutionHarnessSessionDriver implements HarnessSessionDriver {
+  readonly harness: string;
+  readonly supportsSessionContinuity = true;
+
+  constructor(private readonly agent: ExecutionAgent) {
+    this.harness = agent.name;
+  }
+
+  start(prompt: string, options?: { model?: string }): HarnessSessionCommand {
+    const command = this.agent.buildCommand(prompt, { executionModel: options?.model });
+    if (!command.sessionId) {
+      throw new Error(`Harness "${this.agent.name}" did not return a session id.`);
+    }
+    return {
+      command: command.cmd,
+      args: command.args,
+      sessionId: command.sessionId,
+    };
+  }
+
+  append(sessionId: string, prompt: string, options?: { model?: string }): HarnessSessionCommand {
+    const resumed = this.agent.buildResumeArgs(sessionId);
+    return {
+      command: resumed.cmd,
+      args: this.appendPromptArgs(resumed.args, prompt, options?.model),
+      sessionId,
+    };
+  }
+
+  private appendPromptArgs(resumeArgs: string[], prompt: string, model?: string): string[] {
+    switch (this.agent.name) {
+      case 'claude':
+        return [...resumeArgs, ...(model ? ['--model', model] : []), '-p', prompt];
+      case 'codex':
+        return ['exec', 'resume', ...resumeArgs.slice(1), ...(model ? ['--model', model] : []), prompt];
+      case 'omp':
+        return [...resumeArgs, ...(model ? ['--model', model] : []), '-p', prompt];
+      default:
+        throw new Error(`Harness "${this.agent.name}" does not support non-interactive session append.`);
+    }
+  }
+}
+
+export class ReplayHarnessSessionDriver implements HarnessSessionDriver {
+  readonly supportsSessionContinuity = false;
+
+  constructor(
+    readonly harness: string,
+    private readonly buildCommand: (prompt: string, options?: { model?: string }) => {
+      command: string;
+      args: string[];
+    },
+  ) {}
+
+  start(prompt: string, options?: { model?: string }): HarnessSessionCommand {
+    return this.create(prompt, options);
+  }
+
+  append(_sessionId: string, prompt: string, options?: { model?: string }): HarnessSessionCommand {
+    return this.create(prompt, options);
+  }
+
+  private create(prompt: string, options?: { model?: string }): HarnessSessionCommand {
+    const command = this.buildCommand(prompt, options);
+    return { ...command, sessionId: randomUUID() };
+  }
+}

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -47,6 +47,7 @@ export * from './plan-execution-agents.js';
 export * from './codex-session.js';
 export * from './remote-agent-error-format.js';
 export * from './session-driver.js';
+export * from './harness-session-driver.js';
 export * from './codex-session-driver.js';
 export * from './claude-session-driver.js';
 export * from './omp-session-driver.js';


### PR DESCRIPTION
## Summary

Planning needs one place to choose real session resume versus full-history replay.

This slice adds HarnessSessionDriver in execution-engine with focused coverage and no surface wiring yet.

## Review Claim

Approve adding HarnessSessionDriver as dormant shared foundation.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

No callers outside focused coverage yet; planning behavior unchanged.

## Slice Rationale

Foundation before surfaces consume the driver.

## Non-goals

No behavior change. Does not wire Slack or desktop planners.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/harness-session-driver.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
