### PR TITLE
[Slack PlanDraft harness](2) Add shared planning draft actions

### DIFF
--- a/packages/planning-core/src/__tests__/planning-actions.test.ts
+++ b/packages/planning-core/src/__tests__/planning-actions.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendPlanningTurn,
+  approvePlanningDraft,
+  createPlanningSessionState,
+  runPlanToInvoker,
+} from '../planning-actions.js';
+
+const planText = [
+  'name: Shared planning actions',
+  'tasks:',
+  '  - id: implement',
+  '    description: Implement the shared actions',
+].join('\n');
+
+describe('appendPlanningTurn', () => {
+  it('appends a discussion turn when drafting is not authorized', async () => {
+    const state = createPlanningSessionState('thread-1');
+    const result = await appendPlanningTurn({
+      state,
+      userMessage: 'What would this involve?',
+      send: async () => 'Here is the scope.',
+    });
+
+    expect(result.reply).toBe('Here is the scope.');
+    expect(result.draftingAuthorized).toBe(false);
+    expect(result.draftPlanText).toBeUndefined();
+    expect(result.state.status).toBe('still_discussing');
+    expect(result.state.harnessSessionId).toBe('thread-1');
+    expect(result.state.messages).toEqual([
+      { role: 'user', content: 'What would this involve?' },
+      { role: 'assistant', content: 'Here is the scope.' },
+    ]);
+  });
+
+  it('promotes to draft_ready when drafting is authorized and a draft is extracted', async () => {
+    const state = createPlanningSessionState();
+    const result = await appendPlanningTurn({
+      state,
+      userMessage: 'Please draft the plan',
+      send: async () => 'Drafted it.',
+      extractDraftPlanText: () => planText,
+    });
+
+    expect(result.draftingAuthorized).toBe(true);
+    expect(result.draftPlanText).toBe(planText);
+    expect(result.summary).toMatchObject({ name: 'Shared planning actions', taskCount: 1 });
+    expect(result.state.status).toBe('draft_ready');
+    expect(result.state.draftPlanText).toBe(planText);
+  });
+
+  it('carries forward prior messages across turns', async () => {
+    let state = createPlanningSessionState();
+    const first = await appendPlanningTurn({
+      state,
+      userMessage: 'Hi',
+      send: async () => 'Hello, what should we build?',
+    });
+    state = first.state;
+
+    const second = await appendPlanningTurn({
+      state,
+      userMessage: 'A widget',
+      send: async () => 'Got it.',
+    });
+
+    expect(second.state.messages).toEqual([
+      { role: 'user', content: 'Hi' },
+      { role: 'assistant', content: 'Hello, what should we build?' },
+      { role: 'user', content: 'A widget' },
+      { role: 'assistant', content: 'Got it.' },
+    ]);
+  });
+
+  it('does not require draft authorization when explicitly disabled', async () => {
+    const state = createPlanningSessionState();
+    const result = await appendPlanningTurn({
+      state,
+      userMessage: 'anything',
+      send: async () => 'Drafted it.',
+      extractDraftPlanText: () => planText,
+      requireDraftAuthorization: false,
+    });
+
+    expect(result.draftingAuthorized).toBe(true);
+    expect(result.state.status).toBe('draft_ready');
+  });
+});
+
+describe('runPlanToInvoker', () => {
+  it('returns a draft_ready result when the conversion produces a valid plan', async () => {
+    const result = await runPlanToInvoker({
+      convert: async () => planText,
+    });
+
+    expect(result).toMatchObject({
+      kind: 'draft_ready',
+      planText,
+      summary: { name: 'Shared planning actions', taskCount: 1 },
+      reply: planText,
+    });
+  });
+
+  it('extracts the plan text from a wrapped output before evaluating it', async () => {
+    const wrapped = `Here you go:\n\`\`\`yaml\n${planText}\n\`\`\``;
+    const result = await runPlanToInvoker({
+      convert: async () => wrapped,
+      extractDraftPlanText: (output) => output.match(/```yaml\n([\s\S]*?)\n```/)?.[1] ?? null,
+    });
+
+    expect(result).toMatchObject({ kind: 'draft_ready', planText });
+  });
+
+  it('returns a message result when no valid plan is produced', async () => {
+    const result = await runPlanToInvoker({
+      convert: async () => 'name: incomplete',
+    });
+
+    expect(result).toEqual({ kind: 'message', reply: 'name: incomplete' });
+  });
+});
+
+describe('approvePlanningDraft', () => {
+  it('rejects when there is no draft plan text', async () => {
+    const result = await approvePlanningDraft({
+      planText: undefined,
+      loadPlan: async () => ({ planName: 'x', workflowId: 'wf-1' }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.',
+    });
+  });
+
+  it('rejects when the draft plan text cannot be summarized', async () => {
+    const result = await approvePlanningDraft({
+      planText: 'name: incomplete',
+      loadPlan: async () => ({ planName: 'x', workflowId: 'wf-1' }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.',
+    });
+  });
+
+  it('loads and returns the approved plan on success', async () => {
+    const result = await approvePlanningDraft({
+      planText,
+      loadPlan: async (text) => {
+        expect(text).toBe(planText);
+        return { planName: 'Shared planning actions', workflowId: 'wf-1', workflowIds: ['wf-1'], workflowCount: 1 };
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      planName: 'Shared planning actions',
+      workflowId: 'wf-1',
+      workflowIds: ['wf-1'],
+      workflowCount: 1,
+      summary: { name: 'Shared planning actions', taskCount: 1 },
+    });
+  });
+
+  it('surfaces errors thrown by loadPlan', async () => {
+    const result = await approvePlanningDraft({
+      planText,
+      loadPlan: async () => {
+        throw new Error('boom');
+      },
+    });
+
+    expect(result).toEqual({ ok: false, error: 'boom' });
+  });
+});

--- a/packages/planning-core/src/index.ts
+++ b/packages/planning-core/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lifecycle.js';
 export * from './plan-summary.js';
 export * from './planning-turn.js';
+export * from './planning-actions.js';

--- a/packages/planning-core/src/planning-actions.ts
+++ b/packages/planning-core/src/planning-actions.ts
@@ -1,0 +1,137 @@
+import type { PlanningMessage } from './lifecycle.js';
+import { evaluatePlanningTurn } from './planning-turn.js';
+import { summarizePlanText, type PlanSummary } from './plan-summary.js';
+
+export type PlanningSessionStatus = 'still_discussing' | 'waiting_for_answer' | 'draft_ready' | 'submitted';
+
+export interface PlanningSessionState {
+  messages: PlanningMessage[];
+  draftPlanText?: string;
+  status: PlanningSessionStatus;
+  harnessSessionId?: string;
+}
+
+export function createPlanningSessionState(harnessSessionId?: string): PlanningSessionState {
+  return { messages: [], status: 'still_discussing', harnessSessionId };
+}
+
+export interface AppendPlanningTurnInput {
+  state: PlanningSessionState;
+  userMessage: string;
+  send: (userMessage: string) => Promise<string>;
+  extractDraftPlanText?: (assistantReply: string) => string | null | undefined;
+  requireDraftAuthorization?: boolean;
+}
+
+export interface AppendPlanningTurnResult {
+  reply: string;
+  state: PlanningSessionState;
+  draftingAuthorized: boolean;
+  draftPlanText?: string;
+  summary?: PlanSummary;
+}
+
+export async function appendPlanningTurn({
+  state,
+  userMessage,
+  send,
+  extractDraftPlanText,
+  requireDraftAuthorization,
+}: AppendPlanningTurnInput): Promise<AppendPlanningTurnResult> {
+  const messagesBeforeTurn = state.messages;
+  const reply = await send(userMessage);
+  const immediateDraftPlanText = extractDraftPlanText?.(reply);
+  const turn = evaluatePlanningTurn({
+    userMessage,
+    messagesBeforeTurn,
+    assistantReply: reply,
+    immediateDraftPlanText,
+    requireDraftAuthorization,
+  });
+
+  const nextMessages: PlanningMessage[] = [
+    ...messagesBeforeTurn,
+    { role: 'user', content: userMessage },
+    { role: 'assistant', content: reply },
+  ];
+
+  if (turn.kind === 'draft_ready') {
+    return {
+      reply,
+      state: { ...state, messages: nextMessages, draftPlanText: turn.planText, status: 'draft_ready' },
+      draftingAuthorized: true,
+      draftPlanText: turn.planText,
+      summary: turn.summary,
+    };
+  }
+
+  return {
+    reply,
+    state: { ...state, messages: nextMessages, status: turn.status },
+    draftingAuthorized: turn.draftingAuthorized,
+  };
+}
+
+export interface RunPlanToInvokerInput {
+  convert: () => Promise<string>;
+  extractDraftPlanText?: (output: string) => string | null | undefined;
+}
+
+export type RunPlanToInvokerResult =
+  | { kind: 'draft_ready'; planText: string; summary: PlanSummary; reply: string }
+  | { kind: 'message'; reply: string };
+
+export async function runPlanToInvoker({
+  convert,
+  extractDraftPlanText,
+}: RunPlanToInvokerInput): Promise<RunPlanToInvokerResult> {
+  const reply = await convert();
+  const immediateDraftPlanText = extractDraftPlanText ? extractDraftPlanText(reply) : reply;
+  const turn = evaluatePlanningTurn({
+    userMessage: '',
+    messagesBeforeTurn: [],
+    assistantReply: reply,
+    immediateDraftPlanText,
+    requireDraftAuthorization: false,
+  });
+
+  if (turn.kind === 'draft_ready') {
+    return { kind: 'draft_ready', planText: turn.planText, summary: turn.summary, reply };
+  }
+  return { kind: 'message', reply };
+}
+
+export interface ApprovedPlanLoadResult {
+  planName: string;
+  workflowId: string;
+  workflowIds?: string[];
+  workflowCount?: number;
+}
+
+export interface ApprovePlanningDraftInput {
+  planText: string | null | undefined;
+  loadPlan: (planText: string) => ApprovedPlanLoadResult | Promise<ApprovedPlanLoadResult>;
+}
+
+export type ApprovePlanningDraftResult =
+  | ({ ok: true; summary: PlanSummary } & ApprovedPlanLoadResult)
+  | { ok: false; error: string };
+
+export async function approvePlanningDraft({
+  planText,
+  loadPlan,
+}: ApprovePlanningDraftInput): Promise<ApprovePlanningDraftResult> {
+  if (!planText) {
+    return { ok: false, error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.' };
+  }
+  const summary = summarizePlanText(planText);
+  if (!summary) {
+    return { ok: false, error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.' };
+  }
+  try {
+    const loaded = await loadPlan(planText);
+    return { ok: true, summary, ...loaded };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}


### PR DESCRIPTION
## Summary

Draft append, run, and approve logic was heading for duplication across surfaces.

This slice puts those helpers in planning-core with focused coverage.

## Review Claim

Approve shared planning draft actions in planning-core.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

New helpers only; existing planners are not switched yet.

## Slice Rationale

Shared API before Slack and desktop call sites migrate.

## Non-goals

No behavior change. Does not change Slack mention handling.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/planning-core && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
