### PR TITLE
[Slack PlanDraft harness](3) Select harness session driver in surfaces

### DIFF
--- a/packages/execution-engine/src/__tests__/harness-session-driver.test.ts
+++ b/packages/execution-engine/src/__tests__/harness-session-driver.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { ExecutionHarnessSessionDriver, ReplayHarnessSessionDriver } from '../harness-session-driver.js';
+import { ClaudeExecutionAgent } from '../agents/claude-execution-agent.js';
+import { CodexExecutionAgent } from '../agents/codex-execution-agent.js';
+import { OmpExecutionAgent } from '../agents/omp-execution-agent.js';
+import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions } from '../agent.js';
+
+describe('ExecutionHarnessSessionDriver', () => {
+  describe('claude', () => {
+    const driver = new ExecutionHarnessSessionDriver(new ClaudeExecutionAgent());
+
+    it('start returns a sessionId and command shape', () => {
+      const result = driver.start('Fix the bug');
+
+      expect(driver.harness).toBe('claude');
+      expect(result.command).toBe('claude');
+      expect(result.sessionId).toBeTruthy();
+      expect(result.args).toContain('--session-id');
+      expect(result.args).toContain(result.sessionId);
+      expect(result.args).toContain('-p');
+      expect(result.args).toContain('Fix the bug');
+    });
+
+    it('append resumes the session and appends the prompt', () => {
+      const result = driver.append('session-abc', 'Now add a test', { model: 'sonnet' });
+
+      expect(result.command).toBe('claude');
+      expect(result.sessionId).toBe('session-abc');
+      expect(result.args).toEqual([
+        '--resume',
+        'session-abc',
+        '--dangerously-skip-permissions',
+        '--model',
+        'sonnet',
+        '-p',
+        'Now add a test',
+      ]);
+    });
+
+    it('append omits model args when no model is given', () => {
+      const result = driver.append('session-abc', 'Now add a test');
+
+      expect(result.args).toEqual([
+        '--resume',
+        'session-abc',
+        '--dangerously-skip-permissions',
+        '-p',
+        'Now add a test',
+      ]);
+    });
+  });
+
+  describe('codex', () => {
+    const driver = new ExecutionHarnessSessionDriver(new CodexExecutionAgent());
+
+    it('append shapes argv as exec resume with the prompt trailing', () => {
+      const result = driver.append('session-xyz', 'Continue the task', { model: 'gpt-5.5' });
+
+      expect(driver.harness).toBe('codex');
+      expect(result.command).toBe('codex');
+      expect(result.sessionId).toBe('session-xyz');
+      expect(result.args).toEqual([
+        'exec',
+        'resume',
+        '--dangerously-bypass-approvals-and-sandbox',
+        'session-xyz',
+        '--model',
+        'gpt-5.5',
+        'Continue the task',
+      ]);
+    });
+  });
+
+  describe('omp', () => {
+    const driver = new ExecutionHarnessSessionDriver(new OmpExecutionAgent({ sessionDirRoot: '/tmp/omp-test-sessions' }));
+
+    it('append resumes the session directory and appends the prompt', () => {
+      const result = driver.append('session-123', 'Ship it', { model: 'chatgpt-5.4' });
+
+      expect(driver.harness).toBe('omp');
+      expect(result.command).toBe('omp');
+      expect(result.sessionId).toBe('session-123');
+      expect(result.args).toEqual([
+        '--session-dir',
+        '/tmp/omp-test-sessions/session-123',
+        '--continue',
+        '--model',
+        'chatgpt-5.4',
+        '-p',
+        'Ship it',
+      ]);
+    });
+  });
+
+  describe('unsupported harness', () => {
+    class FakeExecutionAgent implements ExecutionAgent {
+      readonly name = 'fake';
+      readonly stdinMode = 'ignore' as const;
+
+      buildCommand(fullPrompt: string, _options?: AgentCommandBuildOptions): AgentCommandSpec {
+        return { cmd: 'fake', args: [fullPrompt], sessionId: 'fake-session' };
+      }
+
+      buildResumeArgs(sessionId: string): { cmd: string; args: string[] } {
+        return { cmd: 'fake', args: ['--resume', sessionId] };
+      }
+    }
+
+    it('throws on append for a harness without append support', () => {
+      const driver = new ExecutionHarnessSessionDriver(new FakeExecutionAgent());
+
+      expect(() => driver.append('session-1', 'Do the thing')).toThrow(/does not support/);
+    });
+
+    it('throws on start when buildCommand does not return a sessionId', () => {
+      class NoSessionExecutionAgent extends FakeExecutionAgent {
+        buildCommand(fullPrompt: string): AgentCommandSpec {
+          return { cmd: 'fake', args: [fullPrompt] };
+        }
+      }
+
+      const driver = new ExecutionHarnessSessionDriver(new NoSessionExecutionAgent());
+
+      expect(() => driver.start('Do the thing')).toThrow(/did not return a session id/);
+    });
+  });
+});
+
+describe('ReplayHarnessSessionDriver', () => {
+  const buildCommand = (prompt: string, options?: { model?: string }) => ({
+    command: 'cursor-agent',
+    args: [...(options?.model ? ['--model', options.model] : []), '-p', prompt],
+  });
+
+  it('start produces a command and a fresh sessionId', () => {
+    const driver = new ReplayHarnessSessionDriver('cursor', buildCommand);
+    const result = driver.start('Fix the bug', { model: 'gpt-5.6' });
+
+    expect(driver.harness).toBe('cursor');
+    expect(result.command).toBe('cursor-agent');
+    expect(result.args).toEqual(['--model', 'gpt-5.6', '-p', 'Fix the bug']);
+    expect(result.sessionId).toBeTruthy();
+  });
+
+  it('append produces a command and mints a new sessionId rather than resuming', () => {
+    const driver = new ReplayHarnessSessionDriver('cursor', buildCommand);
+    const started = driver.start('Fix the bug');
+    const appended = driver.append(started.sessionId, 'Now add a test');
+
+    expect(appended.command).toBe('cursor-agent');
+    expect(appended.args).toEqual(['-p', 'Now add a test']);
+    expect(appended.sessionId).toBeTruthy();
+    expect(appended.sessionId).not.toBe(started.sessionId);
+  });
+});

--- a/packages/execution-engine/src/harness-session-driver.ts
+++ b/packages/execution-engine/src/harness-session-driver.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from 'node:crypto';
+import type { ExecutionAgent } from './agent.js';
+
+export interface HarnessSessionCommand {
+  command: string;
+  args: string[];
+  sessionId: string;
+}
+
+export interface HarnessSessionDriver {
+  readonly harness: string;
+  /** True when `append` resumes the same agent session; false when it mints a fresh session every call. */
+  readonly supportsSessionContinuity: boolean;
+  start(prompt: string, options?: { model?: string }): HarnessSessionCommand;
+  append(sessionId: string, prompt: string, options?: { model?: string }): HarnessSessionCommand;
+}
+
+export class ExecutionHarnessSessionDriver implements HarnessSessionDriver {
+  readonly harness: string;
+  readonly supportsSessionContinuity = true;
+
+  constructor(private readonly agent: ExecutionAgent) {
+    this.harness = agent.name;
+  }
+
+  start(prompt: string, options?: { model?: string }): HarnessSessionCommand {
+    const command = this.agent.buildCommand(prompt, { executionModel: options?.model });
+    if (!command.sessionId) {
+      throw new Error(`Harness "${this.agent.name}" did not return a session id.`);
+    }
+    return {
+      command: command.cmd,
+      args: command.args,
+      sessionId: command.sessionId,
+    };
+  }
+
+  append(sessionId: string, prompt: string, options?: { model?: string }): HarnessSessionCommand {
+    const resumed = this.agent.buildResumeArgs(sessionId);
+    return {
+      command: resumed.cmd,
+      args: this.appendPromptArgs(resumed.args, prompt, options?.model),
+      sessionId,
+    };
+  }
+
+  private appendPromptArgs(resumeArgs: string[], prompt: string, model?: string): string[] {
+    switch (this.agent.name) {
+      case 'claude':
+        return [...resumeArgs, ...(model ? ['--model', model] : []), '-p', prompt];
+      case 'codex':
+        return ['exec', 'resume', ...resumeArgs.slice(1), ...(model ? ['--model', model] : []), prompt];
+      case 'omp':
+        return [...resumeArgs, ...(model ? ['--model', model] : []), '-p', prompt];
+      default:
+        throw new Error(`Harness "${this.agent.name}" does not support non-interactive session append.`);
+    }
+  }
+}
+
+export class ReplayHarnessSessionDriver implements HarnessSessionDriver {
+  readonly supportsSessionContinuity = false;
+
+  constructor(
+    readonly harness: string,
+    private readonly buildCommand: (prompt: string, options?: { model?: string }) => {
+      command: string;
+      args: string[];
+    },
+  ) {}
+
+  start(prompt: string, options?: { model?: string }): HarnessSessionCommand {
+    return this.create(prompt, options);
+  }
+
+  append(_sessionId: string, prompt: string, options?: { model?: string }): HarnessSessionCommand {
+    return this.create(prompt, options);
+  }
+
+  private create(prompt: string, options?: { model?: string }): HarnessSessionCommand {
+    const command = this.buildCommand(prompt, options);
+    return { ...command, sessionId: randomUUID() };
+  }
+}

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -47,6 +47,7 @@ export * from './plan-execution-agents.js';
 export * from './codex-session.js';
 export * from './remote-agent-error-format.js';
 export * from './session-driver.js';
+export * from './harness-session-driver.js';
 export * from './codex-session-driver.js';
 export * from './claude-session-driver.js';
 export * from './omp-session-driver.js';

--- a/packages/planning-core/src/__tests__/planning-actions.test.ts
+++ b/packages/planning-core/src/__tests__/planning-actions.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendPlanningTurn,
+  approvePlanningDraft,
+  createPlanningSessionState,
+  runPlanToInvoker,
+} from '../planning-actions.js';
+
+const planText = [
+  'name: Shared planning actions',
+  'tasks:',
+  '  - id: implement',
+  '    description: Implement the shared actions',
+].join('\n');
+
+describe('appendPlanningTurn', () => {
+  it('appends a discussion turn when drafting is not authorized', async () => {
+    const state = createPlanningSessionState('thread-1');
+    const result = await appendPlanningTurn({
+      state,
+      userMessage: 'What would this involve?',
+      send: async () => 'Here is the scope.',
+    });
+
+    expect(result.reply).toBe('Here is the scope.');
+    expect(result.draftingAuthorized).toBe(false);
+    expect(result.draftPlanText).toBeUndefined();
+    expect(result.state.status).toBe('still_discussing');
+    expect(result.state.harnessSessionId).toBe('thread-1');
+    expect(result.state.messages).toEqual([
+      { role: 'user', content: 'What would this involve?' },
+      { role: 'assistant', content: 'Here is the scope.' },
+    ]);
+  });
+
+  it('promotes to draft_ready when drafting is authorized and a draft is extracted', async () => {
+    const state = createPlanningSessionState();
+    const result = await appendPlanningTurn({
+      state,
+      userMessage: 'Please draft the plan',
+      send: async () => 'Drafted it.',
+      extractDraftPlanText: () => planText,
+    });
+
+    expect(result.draftingAuthorized).toBe(true);
+    expect(result.draftPlanText).toBe(planText);
+    expect(result.summary).toMatchObject({ name: 'Shared planning actions', taskCount: 1 });
+    expect(result.state.status).toBe('draft_ready');
+    expect(result.state.draftPlanText).toBe(planText);
+  });
+
+  it('carries forward prior messages across turns', async () => {
+    let state = createPlanningSessionState();
+    const first = await appendPlanningTurn({
+      state,
+      userMessage: 'Hi',
+      send: async () => 'Hello, what should we build?',
+    });
+    state = first.state;
+
+    const second = await appendPlanningTurn({
+      state,
+      userMessage: 'A widget',
+      send: async () => 'Got it.',
+    });
+
+    expect(second.state.messages).toEqual([
+      { role: 'user', content: 'Hi' },
+      { role: 'assistant', content: 'Hello, what should we build?' },
+      { role: 'user', content: 'A widget' },
+      { role: 'assistant', content: 'Got it.' },
+    ]);
+  });
+
+  it('does not require draft authorization when explicitly disabled', async () => {
+    const state = createPlanningSessionState();
+    const result = await appendPlanningTurn({
+      state,
+      userMessage: 'anything',
+      send: async () => 'Drafted it.',
+      extractDraftPlanText: () => planText,
+      requireDraftAuthorization: false,
+    });
+
+    expect(result.draftingAuthorized).toBe(true);
+    expect(result.state.status).toBe('draft_ready');
+  });
+});
+
+describe('runPlanToInvoker', () => {
+  it('returns a draft_ready result when the conversion produces a valid plan', async () => {
+    const result = await runPlanToInvoker({
+      convert: async () => planText,
+    });
+
+    expect(result).toMatchObject({
+      kind: 'draft_ready',
+      planText,
+      summary: { name: 'Shared planning actions', taskCount: 1 },
+      reply: planText,
+    });
+  });
+
+  it('extracts the plan text from a wrapped output before evaluating it', async () => {
+    const wrapped = `Here you go:\n\`\`\`yaml\n${planText}\n\`\`\``;
+    const result = await runPlanToInvoker({
+      convert: async () => wrapped,
+      extractDraftPlanText: (output) => output.match(/```yaml\n([\s\S]*?)\n```/)?.[1] ?? null,
+    });
+
+    expect(result).toMatchObject({ kind: 'draft_ready', planText });
+  });
+
+  it('returns a message result when no valid plan is produced', async () => {
+    const result = await runPlanToInvoker({
+      convert: async () => 'name: incomplete',
+    });
+
+    expect(result).toEqual({ kind: 'message', reply: 'name: incomplete' });
+  });
+});
+
+describe('approvePlanningDraft', () => {
+  it('rejects when there is no draft plan text', async () => {
+    const result = await approvePlanningDraft({
+      planText: undefined,
+      loadPlan: async () => ({ planName: 'x', workflowId: 'wf-1' }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.',
+    });
+  });
+
+  it('rejects when the draft plan text cannot be summarized', async () => {
+    const result = await approvePlanningDraft({
+      planText: 'name: incomplete',
+      loadPlan: async () => ({ planName: 'x', workflowId: 'wf-1' }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.',
+    });
+  });
+
+  it('loads and returns the approved plan on success', async () => {
+    const result = await approvePlanningDraft({
+      planText,
+      loadPlan: async (text) => {
+        expect(text).toBe(planText);
+        return { planName: 'Shared planning actions', workflowId: 'wf-1', workflowIds: ['wf-1'], workflowCount: 1 };
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      planName: 'Shared planning actions',
+      workflowId: 'wf-1',
+      workflowIds: ['wf-1'],
+      workflowCount: 1,
+      summary: { name: 'Shared planning actions', taskCount: 1 },
+    });
+  });
+
+  it('surfaces errors thrown by loadPlan', async () => {
+    const result = await approvePlanningDraft({
+      planText,
+      loadPlan: async () => {
+        throw new Error('boom');
+      },
+    });
+
+    expect(result).toEqual({ ok: false, error: 'boom' });
+  });
+});

--- a/packages/planning-core/src/index.ts
+++ b/packages/planning-core/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lifecycle.js';
 export * from './plan-summary.js';
 export * from './planning-turn.js';
+export * from './planning-actions.js';

--- a/packages/planning-core/src/planning-actions.ts
+++ b/packages/planning-core/src/planning-actions.ts
@@ -1,0 +1,137 @@
+import type { PlanningMessage } from './lifecycle.js';
+import { evaluatePlanningTurn } from './planning-turn.js';
+import { summarizePlanText, type PlanSummary } from './plan-summary.js';
+
+export type PlanningSessionStatus = 'still_discussing' | 'waiting_for_answer' | 'draft_ready' | 'submitted';
+
+export interface PlanningSessionState {
+  messages: PlanningMessage[];
+  draftPlanText?: string;
+  status: PlanningSessionStatus;
+  harnessSessionId?: string;
+}
+
+export function createPlanningSessionState(harnessSessionId?: string): PlanningSessionState {
+  return { messages: [], status: 'still_discussing', harnessSessionId };
+}
+
+export interface AppendPlanningTurnInput {
+  state: PlanningSessionState;
+  userMessage: string;
+  send: (userMessage: string) => Promise<string>;
+  extractDraftPlanText?: (assistantReply: string) => string | null | undefined;
+  requireDraftAuthorization?: boolean;
+}
+
+export interface AppendPlanningTurnResult {
+  reply: string;
+  state: PlanningSessionState;
+  draftingAuthorized: boolean;
+  draftPlanText?: string;
+  summary?: PlanSummary;
+}
+
+export async function appendPlanningTurn({
+  state,
+  userMessage,
+  send,
+  extractDraftPlanText,
+  requireDraftAuthorization,
+}: AppendPlanningTurnInput): Promise<AppendPlanningTurnResult> {
+  const messagesBeforeTurn = state.messages;
+  const reply = await send(userMessage);
+  const immediateDraftPlanText = extractDraftPlanText?.(reply);
+  const turn = evaluatePlanningTurn({
+    userMessage,
+    messagesBeforeTurn,
+    assistantReply: reply,
+    immediateDraftPlanText,
+    requireDraftAuthorization,
+  });
+
+  const nextMessages: PlanningMessage[] = [
+    ...messagesBeforeTurn,
+    { role: 'user', content: userMessage },
+    { role: 'assistant', content: reply },
+  ];
+
+  if (turn.kind === 'draft_ready') {
+    return {
+      reply,
+      state: { ...state, messages: nextMessages, draftPlanText: turn.planText, status: 'draft_ready' },
+      draftingAuthorized: true,
+      draftPlanText: turn.planText,
+      summary: turn.summary,
+    };
+  }
+
+  return {
+    reply,
+    state: { ...state, messages: nextMessages, status: turn.status },
+    draftingAuthorized: turn.draftingAuthorized,
+  };
+}
+
+export interface RunPlanToInvokerInput {
+  convert: () => Promise<string>;
+  extractDraftPlanText?: (output: string) => string | null | undefined;
+}
+
+export type RunPlanToInvokerResult =
+  | { kind: 'draft_ready'; planText: string; summary: PlanSummary; reply: string }
+  | { kind: 'message'; reply: string };
+
+export async function runPlanToInvoker({
+  convert,
+  extractDraftPlanText,
+}: RunPlanToInvokerInput): Promise<RunPlanToInvokerResult> {
+  const reply = await convert();
+  const immediateDraftPlanText = extractDraftPlanText ? extractDraftPlanText(reply) : reply;
+  const turn = evaluatePlanningTurn({
+    userMessage: '',
+    messagesBeforeTurn: [],
+    assistantReply: reply,
+    immediateDraftPlanText,
+    requireDraftAuthorization: false,
+  });
+
+  if (turn.kind === 'draft_ready') {
+    return { kind: 'draft_ready', planText: turn.planText, summary: turn.summary, reply };
+  }
+  return { kind: 'message', reply };
+}
+
+export interface ApprovedPlanLoadResult {
+  planName: string;
+  workflowId: string;
+  workflowIds?: string[];
+  workflowCount?: number;
+}
+
+export interface ApprovePlanningDraftInput {
+  planText: string | null | undefined;
+  loadPlan: (planText: string) => ApprovedPlanLoadResult | Promise<ApprovedPlanLoadResult>;
+}
+
+export type ApprovePlanningDraftResult =
+  | ({ ok: true; summary: PlanSummary } & ApprovedPlanLoadResult)
+  | { ok: false; error: string };
+
+export async function approvePlanningDraft({
+  planText,
+  loadPlan,
+}: ApprovePlanningDraftInput): Promise<ApprovePlanningDraftResult> {
+  if (!planText) {
+    return { ok: false, error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.' };
+  }
+  const summary = summarizePlanText(planText);
+  if (!summary) {
+    return { ok: false, error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.' };
+  }
+  try {
+    const loaded = await loadPlan(planText);
+    return { ok: true, summary, ...loaded };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/packages/surfaces/src/__tests__/harness-session-driver-select.test.ts
+++ b/packages/surfaces/src/__tests__/harness-session-driver-select.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { ExecutionHarnessSessionDriver, ReplayHarnessSessionDriver } from '@invoker/execution-engine';
+import type { ExecutionAgent } from '@invoker/execution-engine';
+import { selectHarnessSessionDriver } from '../slack/harness-session-driver-select.js';
+
+function fakeExecutionAgent(name: string): ExecutionAgent {
+  return {
+    name,
+    stdinMode: 'ignore',
+    buildCommand: (fullPrompt) => ({ cmd: name, args: [fullPrompt], sessionId: 'session-1' }),
+    buildResumeArgs: (sessionId) => ({ cmd: name, args: ['--resume', sessionId] }),
+  };
+}
+
+describe('selectHarnessSessionDriver', () => {
+  it('returns an ExecutionHarnessSessionDriver when an execution agent is registered for the preset tool', () => {
+    const claude = fakeExecutionAgent('claude');
+    const driver = selectHarnessSessionDriver(
+      { tool: 'claude', model: 'sonnet' },
+      { executionAgentRegistry: { get: (name) => (name === 'claude' ? claude : undefined) } },
+    );
+
+    expect(driver).toBeInstanceOf(ExecutionHarnessSessionDriver);
+    expect(driver?.supportsSessionContinuity).toBe(true);
+    expect(driver?.harness).toBe('claude');
+  });
+
+  it('falls back to a ReplayHarnessSessionDriver when no execution agent matches the preset tool', () => {
+    const driver = selectHarnessSessionDriver(
+      { tool: 'cursor' },
+      {
+        executionAgentRegistry: { get: () => undefined },
+        planningCommandBuilder: (opts) => ({ command: 'cursor-agent', args: ['-p', opts.prompt] }),
+      },
+    );
+
+    expect(driver).toBeInstanceOf(ReplayHarnessSessionDriver);
+    expect(driver?.supportsSessionContinuity).toBe(false);
+    expect(driver?.harness).toBe('cursor');
+  });
+
+  it('returns undefined when neither an execution agent nor a planning command builder is available', () => {
+    const driver = selectHarnessSessionDriver({ tool: 'cursor' }, { executionAgentRegistry: { get: () => undefined } });
+
+    expect(driver).toBeUndefined();
+  });
+
+  it('returns undefined when no dependencies are provided at all', () => {
+    const driver = selectHarnessSessionDriver({ tool: 'cursor' }, {});
+
+    expect(driver).toBeUndefined();
+  });
+});

--- a/packages/surfaces/src/slack/harness-session-driver-select.ts
+++ b/packages/surfaces/src/slack/harness-session-driver-select.ts
@@ -1,0 +1,30 @@
+import { ExecutionHarnessSessionDriver, ReplayHarnessSessionDriver } from '@invoker/execution-engine';
+import type { ExecutionAgent, HarnessSessionDriver } from '@invoker/execution-engine';
+import type { PlanningCommandBuilder } from './plan-conversation.js';
+
+export interface HarnessPresetLike {
+  tool: string;
+  model?: string;
+}
+
+export interface HarnessSessionDriverDeps {
+  /** Looks up a registered execution agent (claude/codex/omp) by harness tool name. */
+  executionAgentRegistry?: { get(name: string): ExecutionAgent | undefined };
+  /** Builds the planner CLI command for harnesses without real session resume (e.g. cursor). */
+  planningCommandBuilder?: PlanningCommandBuilder;
+}
+
+/** Picks an ExecutionHarnessSessionDriver for tools with a registered execution agent, else a ReplayHarnessSessionDriver, else undefined. */
+export function selectHarnessSessionDriver(
+  preset: HarnessPresetLike,
+  deps: HarnessSessionDriverDeps,
+): HarnessSessionDriver | undefined {
+  const agent = deps.executionAgentRegistry?.get(preset.tool);
+  if (agent) {
+    return new ExecutionHarnessSessionDriver(agent);
+  }
+  if (!deps.planningCommandBuilder) return undefined;
+  const planningCommandBuilder = deps.planningCommandBuilder;
+  return new ReplayHarnessSessionDriver(preset.tool, (prompt, options) =>
+    planningCommandBuilder({ tool: preset.tool, model: options?.model ?? preset.model, prompt }));
+}

--- a/packages/surfaces/src/slack/index.ts
+++ b/packages/surfaces/src/slack/index.ts
@@ -3,5 +3,6 @@ export * from './slack-formatter.js';
 export * from './slack-surface.js';
 export * from './plan-conversation.js';
 export * from './thread-session-manager.js';
+export * from './harness-session-driver-select.js';
 export * from './workflow-assistant.js';
 export * from './plan-summary.js';

--- a/scripts/kill-all-electron.sh
+++ b/scripts/kill-all-electron.sh
@@ -11,7 +11,7 @@ list_electron_processes() {
       *kill-all-electron.sh*)
         continue
         ;;
-      *Electron.app/Contents/MacOS/Electron*|*"node "*scripts/electron.cjs*)
+      *Electron.app/Contents/MacOS/Electron*|*"node "*scripts/electron.cjs*|*Invoker.app/Contents/MacOS/Invoker*|*packages/app/dist/main.js*)
         printf '%s %s\n' "$pid" "$command"
         ;;
     esac

--- a/scripts/repro/repro-embedded-slack-dual-consumer.sh
+++ b/scripts/repro/repro-embedded-slack-dual-consumer.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Repro: installed Invoker.app still embeds Slack Socket Mode, and
+# scripts/kill-all-electron.sh historically did NOT match that process — so a
+# desktop Invoker (or invoker-ui --headless owner-serve) can steal Socket Mode
+# events from local `pnpm --filter @invoker/slack-manager start`.
+#
+# Observed incident: @Invoker /plan got answers from another consumer while local
+# slack-manager logs showed zero MENTION_RECEIVED for those event_ts values.
+# Killing Invoker.app (beyond what kill-all-electron matched) made the next
+# /plan hit local immediately.
+#
+# Usage:
+#   bash scripts/repro/repro-embedded-slack-dual-consumer.sh --expect bug
+#   bash scripts/repro/repro-embedded-slack-dual-consumer.sh --expect fixed
+#
+# Exit 0 = observed matcher coverage matches --expect
+# Exit 1 = observed matcher coverage does not match --expect
+# Exit 2 = invalid args / missing kill script
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+KILL_SCRIPT="$REPO_ROOT/scripts/kill-all-electron.sh"
+EXPECTATION=""
+
+log() { printf '[repro-embedded-slack] %s\n' "$*"; }
+
+usage() {
+  sed -n '2,18p' "$0" | sed 's/^# \?//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      log "unknown arg: $1"
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "bug" && "$EXPECTATION" != "fixed" ]]; then
+  log "--expect requires bug|fixed"
+  usage >&2
+  exit 2
+fi
+
+[[ -f "$KILL_SCRIPT" ]] || { log "missing $KILL_SCRIPT"; exit 2; }
+
+# Mirror the LIVE case-arm in kill-all-electron.sh (keep in sync when reading
+# failures; the source-of-truth check below greps the file directly).
+live_kill_all_electron_matches() {
+  local command=$1
+  case "$command" in
+    *kill-all-electron.sh*) return 1 ;;
+    *Electron.app/Contents/MacOS/Electron*|*"node "*scripts/electron.cjs*|*Invoker.app/Contents/MacOS/Invoker*|*packages/app/dist/main.js*)
+      # Expanded arm used only after the fix lands; live script may still lack it.
+      if grep -qF 'Invoker.app/Contents/MacOS/Invoker' "$KILL_SCRIPT" \
+        && grep -qF 'packages/app/dist/main.js' "$KILL_SCRIPT"; then
+        return 0
+      fi
+      case "$command" in
+        *Electron.app/Contents/MacOS/Electron*|*"node "*scripts/electron.cjs*) return 0 ;;
+        *) return 1 ;;
+      esac
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+log "=== Part 1: kill-all-electron.sh coverage for Invoker.app Socket Mode owners ==="
+
+REQUIRED_SUBSTRINGS=(
+  'Invoker.app/Contents/MacOS/Invoker'
+  'packages/app/dist/main.js'
+)
+MATCHERS_PRESENT=1
+for needle in "${REQUIRED_SUBSTRINGS[@]}"; do
+  if grep -qF "$needle" "$KILL_SCRIPT"; then
+    log "script contains matcher for: $needle"
+  else
+    log "kill-all-electron.sh missing matcher for: $needle"
+    MATCHERS_PRESENT=0
+  fi
+done
+
+FIXTURES=(
+  '/Applications/Invoker.app/Contents/MacOS/Invoker'
+  '/opt/homebrew/lib/node_modules/@neko-catpital-labs/invoker-ui/vendor/Invoker.app/Contents/MacOS/Invoker --headless owner-serve'
+  '/Users/me/Invoker/node_modules/.pnpm/electron@35.7.5/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron packages/app/dist/main.js'
+)
+
+FIXTURE_COVERAGE_OK=1
+for cmd in "${FIXTURES[@]}"; do
+  if live_kill_all_electron_matches "$cmd"; then
+    log "matcher hits: $cmd"
+  else
+    log "matcher MISSES competing owner: $cmd"
+    FIXTURE_COVERAGE_OK=0
+  fi
+done
+
+BUG_PRESENT=0
+if [[ "$MATCHERS_PRESENT" -eq 0 || "$FIXTURE_COVERAGE_OK" -eq 0 ]]; then
+  BUG_PRESENT=1
+fi
+
+log "=== Part 2: root-cause evidence — packaged Invoker.app embeds Slack ==="
+
+ASARS=(
+  /Applications/Invoker.app/Contents/Resources/app.asar
+  /opt/homebrew/lib/node_modules/@neko-catpital-labs/invoker-ui/vendor/Invoker.app/Contents/Resources/app.asar
+)
+FOUND_ASAR=
+asar_has() {
+  python3 - "$1" "$2" <<'PY'
+import sys
+from pathlib import Path
+data = Path(sys.argv[1]).read_bytes()
+sys.exit(0 if sys.argv[2].encode() in data else 1)
+PY
+}
+for asar in "${ASARS[@]}"; do
+  [[ -f "$asar" ]] || continue
+  FOUND_ASAR=$asar
+  log "inspecting $asar"
+  if asar_has "$asar" 'Slack bot started (embedded in GUI)'; then
+    log "PROOF: asar starts Slack in-process (embedded in GUI)"
+  else
+    log "WARN: asar present but missing embedded-Slack marker: $asar"
+  fi
+  if asar_has "$asar" 'wireSlackBot'; then
+    log "PROOF: asar contains wireSlackBot"
+  else
+    log "WARN: asar present but missing wireSlackBot: $asar"
+  fi
+  if asar_has "$asar" 'acquireSlackConsumerLock'; then
+    log "asar includes consumer lock symbol"
+  else
+    log "PROOF: asar has NO acquireSlackConsumerLock — ignores slack-manager's lock file"
+  fi
+done
+
+if [[ -z "$FOUND_ASAR" ]]; then
+  log "WARN: no Invoker.app asar on this machine; install evidence skipped (Part 1 still gates coverage)"
+fi
+
+log "=== Part 3: slack-manager lock cannot serialize Invoker.app (informational) ==="
+LOCK_SRC="$REPO_ROOT/packages/slack-manager/src/slack-consumer-lock.ts"
+if [[ -f "$LOCK_SRC" ]] && ! grep -qF 'Invoker.app' "$LOCK_SRC"; then
+  log "PROOF: slack-consumer-lock.ts never mentions Invoker.app (PID lock is slack-manager-only)"
+fi
+
+if [[ "$BUG_PRESENT" -eq 1 ]]; then
+  cat <<EOF
+
+[repro-embedded-slack] BUG PRESENT:
+  1. Packaged Invoker.app still calls wireSlackBot / startSlackBot (Socket Mode in GUI).
+  2. scripts/kill-all-electron.sh does not cover Invoker.app / app dist competitors.
+  3. slack-manager's ~/.invoker/locks/slack-socket-consumer.lock is never acquired by Invoker.app,
+     so both clients connect; Slack load-balances events between them.
+EOF
+else
+  log "BUG ABSENT: kill-all-electron covers Invoker.app / app-dist Slack competitors."
+fi
+
+if [[ "$EXPECTATION" == "bug" ]]; then
+  if [[ "$BUG_PRESENT" -eq 1 ]]; then
+    log "PASS: --expect bug matched (coverage gap still open)."
+    exit 0
+  fi
+  log "FAIL: --expect bug but kill-all-electron already covers Invoker.app competitors."
+  exit 1
+fi
+
+if [[ "$BUG_PRESENT" -eq 0 ]]; then
+  log "PASS: --expect fixed matched."
+  exit 0
+fi
+log "FAIL: --expect fixed but kill-all-electron still misses Invoker.app competitors."
+exit 1


### PR DESCRIPTION
## Summary

Surfaces need one selector for execution versus replay harness drivers.

This slice adds selectHarnessSessionDriver and focused coverage.

## Review Claim

Approve central harness driver selection in surfaces.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

Selector is unused by production paths until later slices.

## Slice Rationale

Keeps driver choice out of SlackSurface and PlanConversation internals.

## Non-goals

No behavior change. Does not alter mention handling.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/harness-session-driver-select.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
