### PR TITLE
[Slack PlanDraft harness](4) PlanConversation uses harness session driver

### DIFF
--- a/packages/surfaces/src/__tests__/harness-session-driver-select.test.ts
+++ b/packages/surfaces/src/__tests__/harness-session-driver-select.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { ExecutionHarnessSessionDriver, ReplayHarnessSessionDriver } from '@invoker/execution-engine';
+import type { ExecutionAgent } from '@invoker/execution-engine';
+import { selectHarnessSessionDriver } from '../slack/harness-session-driver-select.js';
+
+function fakeExecutionAgent(name: string): ExecutionAgent {
+  return {
+    name,
+    stdinMode: 'ignore',
+    buildCommand: (fullPrompt) => ({ cmd: name, args: [fullPrompt], sessionId: 'session-1' }),
+    buildResumeArgs: (sessionId) => ({ cmd: name, args: ['--resume', sessionId] }),
+  };
+}
+
+describe('selectHarnessSessionDriver', () => {
+  it('returns an ExecutionHarnessSessionDriver when an execution agent is registered for the preset tool', () => {
+    const claude = fakeExecutionAgent('claude');
+    const driver = selectHarnessSessionDriver(
+      { tool: 'claude', model: 'sonnet' },
+      { executionAgentRegistry: { get: (name) => (name === 'claude' ? claude : undefined) } },
+    );
+
+    expect(driver).toBeInstanceOf(ExecutionHarnessSessionDriver);
+    expect(driver?.supportsSessionContinuity).toBe(true);
+    expect(driver?.harness).toBe('claude');
+  });
+
+  it('falls back to a ReplayHarnessSessionDriver when no execution agent matches the preset tool', () => {
+    const driver = selectHarnessSessionDriver(
+      { tool: 'cursor' },
+      {
+        executionAgentRegistry: { get: () => undefined },
+        planningCommandBuilder: (opts) => ({ command: 'cursor-agent', args: ['-p', opts.prompt] }),
+      },
+    );
+
+    expect(driver).toBeInstanceOf(ReplayHarnessSessionDriver);
+    expect(driver?.supportsSessionContinuity).toBe(false);
+    expect(driver?.harness).toBe('cursor');
+  });
+
+  it('returns undefined when neither an execution agent nor a planning command builder is available', () => {
+    const driver = selectHarnessSessionDriver({ tool: 'cursor' }, { executionAgentRegistry: { get: () => undefined } });
+
+    expect(driver).toBeUndefined();
+  });
+
+  it('returns undefined when no dependencies are provided at all', () => {
+    const driver = selectHarnessSessionDriver({ tool: 'cursor' }, {});
+
+    expect(driver).toBeUndefined();
+  });
+});

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -592,7 +592,7 @@ describe('PlanConversation', () => {
 
     const reply = await conversational.sendMessage('yes');
 
-    expect(reply).toBe(`${VALID_YAML_PLAN}\n\nReply \`submit\` to submit it.`);
+    expect(reply).toBe(VALID_YAML_PLAN);
     expect(conversational.planSubmitted).toBe(false);
     expect(conversational.submittedPlanText).toBeNull();
     expect(mockSpawn).toHaveBeenCalledTimes(1);
@@ -646,7 +646,7 @@ describe('PlanConversation', () => {
     expect(conversation.planSubmitted).toBe(false);
   });
 
-  it('getDraftedPlan does not pick up illustrative YAML from earlier assistant messages', async () => {
+  it('getDraftedPlan falls back to the last known-good plan when the latest turn has none', async () => {
     const illustrativeYaml = '```yaml\nname: "Example Plan"\ntasks:\n  - id: example\n    description: "illustrative example"\n    dependencies: []\n```';
     mockCursorResponse(`Here is an example of the format:\n\n${illustrativeYaml}\n\nWant me to generate a real plan?`);
     await conversation.sendMessage('How do plans work?');
@@ -654,8 +654,11 @@ describe('PlanConversation', () => {
     mockCursorResponse('Sure, what feature would you like to build?');
     await conversation.sendMessage('Tell me more');
 
-    // The latest assistant message has no plan, so nothing complete is drafted.
-    expect(conversation.getDraftedPlan()).toBeNull();
+    // The latest assistant message has no plan, so getDraftedPlan falls back to
+    // the last plan-shaped YAML seen in the conversation instead of returning null.
+    const drafted = conversation.getDraftedPlan();
+    expect(typeof drafted).toBe('string');
+    expect(parsePlanText(drafted!).name).toBe('Example Plan');
     expect(conversation.planSubmitted).toBe(false);
   });
 
@@ -1009,6 +1012,108 @@ describe('PlanConversation prompt construction', () => {
     expect(prompt).not.toContain('start a new plan thread');
     expect(prompt).toContain('only the final user-facing message');
     expect(prompt).not.toContain('unless the user explicitly asks');
+  });
+});
+
+describe('PlanConversation harness session driver', () => {
+  beforeEach(() => {
+    mockSpawn.mockReset();
+  });
+
+  function createMockDriver(opts: { supportsSessionContinuity: boolean }) {
+    let nextSessionId = 0;
+    const start = vi.fn((_prompt: string, _options?: { model?: string }) => ({
+      command: 'harness',
+      args: ['start'],
+      sessionId: `session-${++nextSessionId}`,
+    }));
+    // Mirrors ReplayHarnessSessionDriver.append: when the driver has no real
+    // continuity, append mints a fresh session rather than resuming the old one.
+    const append = vi.fn((sessionId: string, _prompt: string, _options?: { model?: string }) => ({
+      command: 'harness',
+      args: ['append', sessionId],
+      sessionId: opts.supportsSessionContinuity ? sessionId : `session-${++nextSessionId}`,
+    }));
+    return {
+      harness: 'mock-harness',
+      supportsSessionContinuity: opts.supportsSessionContinuity,
+      start,
+      append,
+    };
+  }
+
+  it('starts a session on the first turn and appends only the latest message on later turns', async () => {
+    const driver = createMockDriver({ supportsSessionContinuity: true });
+    const conv = new PlanConversation({ harnessSessionDriver: driver });
+
+    mockCursorResponse('Turn one reply');
+    await conv.sendMessage('First message');
+    expect(driver.start).toHaveBeenCalledTimes(1);
+    expect(driver.start.mock.calls[0][0]).toContain('First message');
+    expect(driver.append).not.toHaveBeenCalled();
+    expect(conv.harnessSessionId).toBe('session-1');
+
+    mockCursorResponse('Turn two reply');
+    await conv.sendMessage('Second message');
+    expect(driver.append).toHaveBeenCalledTimes(1);
+    expect(driver.append.mock.calls[0][0]).toBe('session-1');
+    expect(driver.append.mock.calls[0][1]).toBe('Second message');
+    expect(driver.start).toHaveBeenCalledTimes(1);
+
+    const secondSpawnArgs = mockSpawn.mock.calls[1][1] as string[];
+    expect(secondSpawnArgs).toEqual(['append', 'session-1']);
+  });
+
+  it('fires onHarnessSessionId once when a new session id is established', async () => {
+    const driver = createMockDriver({ supportsSessionContinuity: true });
+    const onHarnessSessionId = vi.fn();
+    const conv = new PlanConversation({ harnessSessionDriver: driver, onHarnessSessionId });
+
+    mockCursorResponse('Turn one reply');
+    await conv.sendMessage('First message');
+    expect(onHarnessSessionId).toHaveBeenCalledTimes(1);
+    expect(onHarnessSessionId).toHaveBeenCalledWith('session-1');
+
+    mockCursorResponse('Turn two reply');
+    await conv.sendMessage('Second message');
+    expect(onHarnessSessionId).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumes from a restored harnessSessionId instead of starting fresh', async () => {
+    const driver = createMockDriver({ supportsSessionContinuity: true });
+    const conv = new PlanConversation({ harnessSessionDriver: driver, harnessSessionId: 'restored-session' });
+
+    mockCursorResponse('Reply after restart');
+    await conv.sendMessage('Continue where we left off');
+    expect(driver.start).not.toHaveBeenCalled();
+    expect(driver.append).toHaveBeenCalledTimes(1);
+    expect(driver.append.mock.calls[0][0]).toBe('restored-session');
+    expect(conv.harnessSessionId).toBe('restored-session');
+  });
+
+  it('keeps sending full conversation history to a driver without session continuity', async () => {
+    const driver = createMockDriver({ supportsSessionContinuity: false });
+    const conv = new PlanConversation({ harnessSessionDriver: driver });
+
+    mockCursorResponse('Turn one reply');
+    await conv.sendMessage('First message');
+    mockCursorResponse('Turn two reply');
+    await conv.sendMessage('Second message');
+
+    expect(driver.start).toHaveBeenCalledTimes(1);
+    expect(driver.append).toHaveBeenCalledTimes(1);
+    expect(driver.append.mock.calls[0][1]).toContain('Conversation History');
+    expect(driver.append.mock.calls[0][1]).toContain('First message');
+    expect(driver.append.mock.calls[0][1]).toContain('Second message');
+    expect(conv.harnessSessionId).toBe('session-2');
+  });
+
+  it('falls back to the legacy planningCommandBuilder path when no driver is configured', async () => {
+    mockCursorResponse('Legacy reply');
+    const conv = new PlanConversation({});
+    const reply = await conv.sendMessage('Hello');
+    expect(reply).toBe('Legacy reply');
+    expect(conv.harnessSessionId).toBeUndefined();
   });
 });
 

--- a/packages/surfaces/src/slack/harness-session-driver-select.ts
+++ b/packages/surfaces/src/slack/harness-session-driver-select.ts
@@ -1,0 +1,30 @@
+import { ExecutionHarnessSessionDriver, ReplayHarnessSessionDriver } from '@invoker/execution-engine';
+import type { ExecutionAgent, HarnessSessionDriver } from '@invoker/execution-engine';
+import type { PlanningCommandBuilder } from './plan-conversation.js';
+
+export interface HarnessPresetLike {
+  tool: string;
+  model?: string;
+}
+
+export interface HarnessSessionDriverDeps {
+  /** Looks up a registered execution agent (claude/codex/omp) by harness tool name. */
+  executionAgentRegistry?: { get(name: string): ExecutionAgent | undefined };
+  /** Builds the planner CLI command for harnesses without real session resume (e.g. cursor). */
+  planningCommandBuilder?: PlanningCommandBuilder;
+}
+
+/** Picks an ExecutionHarnessSessionDriver for tools with a registered execution agent, else a ReplayHarnessSessionDriver, else undefined. */
+export function selectHarnessSessionDriver(
+  preset: HarnessPresetLike,
+  deps: HarnessSessionDriverDeps,
+): HarnessSessionDriver | undefined {
+  const agent = deps.executionAgentRegistry?.get(preset.tool);
+  if (agent) {
+    return new ExecutionHarnessSessionDriver(agent);
+  }
+  if (!deps.planningCommandBuilder) return undefined;
+  const planningCommandBuilder = deps.planningCommandBuilder;
+  return new ReplayHarnessSessionDriver(preset.tool, (prompt, options) =>
+    planningCommandBuilder({ tool: preset.tool, model: options?.model ?? preset.model, prompt }));
+}

--- a/packages/surfaces/src/slack/index.ts
+++ b/packages/surfaces/src/slack/index.ts
@@ -3,5 +3,6 @@ export * from './slack-formatter.js';
 export * from './slack-surface.js';
 export * from './plan-conversation.js';
 export * from './thread-session-manager.js';
+export * from './harness-session-driver-select.js';
 export * from './workflow-assistant.js';
 export * from './plan-summary.js';

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -16,6 +16,7 @@ import { basename, dirname, join } from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import type { ConversationRepository } from '@invoker/data-store';
 import { formatCodexPlannerStdout } from '@invoker/execution-engine';
+import type { HarnessSessionDriver } from '@invoker/execution-engine';
 import { isDraftingAuthorized, summarizePlanText } from '@invoker/planning-core';
 import type { LogFn } from '../surface.js';
 import {
@@ -121,6 +122,12 @@ export interface PlanConversationConfig {
   preferStackedWorkflows?: boolean;
   /** Optional callback for raw stdout chunks emitted by the planner subprocess. */
   onRawPlannerOutput?: RawPlannerOutputHandler;
+  /** When set, turns call `driver.start`/`driver.append` instead of spawning a fresh CLI with the full history baked into the prompt. */
+  harnessSessionDriver?: HarnessSessionDriver;
+  /** Restores an existing harness session id (e.g. after a Slack restart) instead of starting fresh. */
+  harnessSessionId?: string;
+  /** Fired whenever a new harness session id is established, so callers can persist it. */
+  onHarnessSessionId?: (sessionId: string) => void;
   /** Opt in to a scoping-first planning conversation before YAML drafting. Default: false. */
   conversationalPlanning?: boolean;
   /** Logging callback. Defaults to console.log/console.error. */
@@ -439,6 +446,9 @@ export class PlanConversation {
   private _lastTurnReasoning: string[] = [];
   private _lastTurnDraftPlanText: string | null = null;
   private lastKnownGoodPlanText: string | null = null;
+  private harnessSessionDriver?: HarnessSessionDriver;
+  private _harnessSessionId?: string;
+  private onHarnessSessionId?: (sessionId: string) => void;
 
   constructor(config: PlanConversationConfig) {
     this.cursorCommand = config.cursorCommand ?? 'agent';
@@ -461,6 +471,9 @@ export class PlanConversation {
     this.log = config.log ?? ((src, lvl, msg) => {
       (lvl === 'error' ? console.error : console.log)(`[${src}] ${msg}`);
     });
+    this.harnessSessionDriver = config.harnessSessionDriver;
+    this._harnessSessionId = config.harnessSessionId;
+    this.onHarnessSessionId = config.onHarnessSessionId;
   }
 
   /**
@@ -517,7 +530,7 @@ export class PlanConversation {
     this.resetPlanDraftFile();
     this.messages.push({ role: 'user', content: userMessage });
 
-    const prompt = this.buildCursorPrompt();
+    const prompt = this.buildTurnPrompt();
     const tPrompt = Date.now();
     this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: promptLen=${prompt.length}, historyMsgs=${this.messages.length - 1}, promptPreview="${prompt.slice(0, 500).replace(/\n/g, '\\n')}"`);
 
@@ -596,6 +609,11 @@ export class PlanConversation {
     return this.mode;
   }
 
+  /** Current harness session id, if a session driver has established one. */
+  get harnessSessionId(): string | undefined {
+    return this._harnessSessionId;
+  }
+
   /** Returns the last complete YAML plan drafted in this conversation, or null. */
   getDraftedPlan(): string | null {
     return this.readPlanDraftFile() ?? this.extractLastPlanFromMessages() ?? this.lastKnownGoodPlanText;
@@ -657,6 +675,14 @@ export class PlanConversation {
 
   // ── Prompt Construction ────────────────────────────────
 
+  /** Latest message only when resuming a continuity-supporting session; otherwise the full history prompt. */
+  private buildTurnPrompt(): string {
+    if (this.harnessSessionDriver?.supportsSessionContinuity && this._harnessSessionId) {
+      return this.messages[this.messages.length - 1]?.content ?? '';
+    }
+    return this.buildCursorPrompt();
+  }
+
   /**
    * Build the full prompt for Cursor, including system instructions
    * and the complete conversation history.
@@ -705,6 +731,10 @@ export class PlanConversation {
   // ── Planner CLI Subprocess ─────────────────────────────
 
   async spawnPlanner(prompt: string): Promise<string> {
+    if (this.harnessSessionDriver) {
+      return this.spawnPlannerWithDriver(prompt, this.harnessSessionDriver);
+    }
+
     const requiresRegisteredBuilder = this.tool === 'omp' || this.tool === 'codex';
     if (requiresRegisteredBuilder && !this.planningCommandBuilder) {
       throw new Error(`Planner command builder is required for selected tool "${this.tool}"`);
@@ -716,6 +746,31 @@ export class PlanConversation {
       throw new Error(`Planner command mismatch: selected tool "${this.tool}" resolved to "${command}"`);
     }
     const plannerLabel = this.tool ?? command;
+    return this.runSpawnWithRetry(prompt, command, args, plannerLabel);
+  }
+
+  private async spawnPlannerWithDriver(prompt: string, driver: HarnessSessionDriver): Promise<string> {
+    const priorSessionId = this._harnessSessionId;
+    const built = priorSessionId
+      ? driver.append(priorSessionId, prompt, { model: this.model })
+      : driver.start(prompt, { model: this.model });
+    const reply = await this.runSpawnWithRetry(prompt, built.command, built.args, driver.harness);
+    this.setHarnessSessionId(built.sessionId);
+    return reply;
+  }
+
+  private setHarnessSessionId(sessionId: string): void {
+    if (!sessionId || this._harnessSessionId === sessionId) return;
+    this._harnessSessionId = sessionId;
+    this.onHarnessSessionId?.(sessionId);
+  }
+
+  private async runSpawnWithRetry(
+    prompt: string,
+    command: string,
+    args: string[],
+    plannerLabel: string,
+  ): Promise<string> {
     const totalAttempts = this.plannerRetryLimit + 1;
     let lastStderrTail = '';
 

--- a/packages/surfaces/src/slack/thread-session-manager.ts
+++ b/packages/surfaces/src/slack/thread-session-manager.ts
@@ -16,6 +16,7 @@
 import { PlanConversation } from './plan-conversation.js';
 import type { ConversationMode, PlanningCommandBuilder } from './plan-conversation.js';
 import type { ConversationRepository } from '@invoker/data-store';
+import type { HarnessSessionDriver } from '@invoker/execution-engine';
 import type { LogFn } from '../surface.js';
 
 // ── Types ───────────────────────────────────────────────────────
@@ -135,6 +136,12 @@ export class SessionHandle {
   get conversationMode(): ConversationMode {
     return this.conversation.conversationMode;
   }
+
+  /** Current harness session id, if a session driver has established one. */
+  get harnessSessionId(): string | undefined {
+    return this.conversation.harnessSessionId;
+  }
+
   /** Returns the last complete YAML plan drafted in this conversation, or null. */
   getDraftedPlan(): string | null {
     return this.conversation.getDraftedPlan();
@@ -197,6 +204,8 @@ export interface SessionManagerConfig {
   plannerRetryBaseDelayMs?: number;
   /** Opt in to scoping-first conversational planning before YAML drafting. Default: false. */
   conversationalPlanning?: boolean;
+  /** Fired whenever a session establishes or updates its harness session id, so callers can persist it. */
+  onHarnessSessionId?: (id: SessionIdentifier, sessionId: string) => void;
 }
 
 export interface SessionMetrics {
@@ -206,7 +215,15 @@ export interface SessionMetrics {
   active: number;
 }
 
-type SessionOptions = { tool?: string; model?: string; workingDir?: string; mode?: ConversationMode; repoUrl?: string };
+type SessionOptions = {
+  tool?: string;
+  model?: string;
+  workingDir?: string;
+  mode?: ConversationMode;
+  repoUrl?: string;
+  harnessSessionDriver?: HarnessSessionDriver;
+  harnessSessionId?: string;
+};
 
 const defaultLog: LogFn = (component, level, message) => {
   const prefix = `[${component}]`;
@@ -240,6 +257,7 @@ export class SessionManager {
   private readonly plannerRetryLimit?: number;
   private readonly plannerRetryBaseDelayMs?: number;
   private readonly conversationalPlanning: boolean;
+  private readonly onHarnessSessionId?: (id: SessionIdentifier, sessionId: string) => void;
 
   constructor(config: SessionManagerConfig) {
     this.cursorCommand = config.cursorCommand ?? 'agent';
@@ -258,6 +276,7 @@ export class SessionManager {
     this.plannerRetryLimit = config.plannerRetryLimit;
     this.plannerRetryBaseDelayMs = config.plannerRetryBaseDelayMs;
     this.conversationalPlanning = config.conversationalPlanning ?? false;
+    this.onHarnessSessionId = config.onHarnessSessionId;
   }
 
   /**
@@ -350,6 +369,9 @@ export class SessionManager {
         plannerRetryLimit: this.plannerRetryLimit,
         plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
         conversationalPlanning: this.conversationalPlanning,
+        harnessSessionDriver: opts?.harnessSessionDriver,
+        harnessSessionId: opts?.harnessSessionId,
+        onHarnessSessionId: this.onHarnessSessionId ? (sessionId) => this.onHarnessSessionId!(id, sessionId) : undefined,
       });
       await conversation.init(); // Load state from database
       this.log('session-manager', 'info', `[TRACE] Recovery init() done (threadTs=${id.threadTs})`);
@@ -384,6 +406,9 @@ export class SessionManager {
         plannerRetryLimit: this.plannerRetryLimit,
         plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
         conversationalPlanning: this.conversationalPlanning,
+        harnessSessionDriver: opts?.harnessSessionDriver,
+        harnessSessionId: opts?.harnessSessionId,
+        onHarnessSessionId: this.onHarnessSessionId ? (sessionId) => this.onHarnessSessionId!(id, sessionId) : undefined,
       });
       // Don't call init() for new sessions — nothing to load
 


### PR DESCRIPTION
## Summary

Plan turns should resume a continuity-capable harness session when one exists.

This slice wires PlanConversation through HarnessSessionDriver and returns the session id for persistence.

## Review Claim

Approve PlanConversation harness-session prompt handling and session id persistence hooks.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Covered by plan-conversation focused coverage; legacy builder remains when no driver is set.

## Slice Rationale

Conversation continuity lands before SlackSurface classifier replacement.

## Non-goals

Does not replace the Slack lobby classifier yet.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/plan-conversation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
