### PR TITLE
[Slack PlanDraft harness](6) Propagate stacked workflowIds through Slack manager

### DIFF
--- a/packages/slack-manager/src/__tests__/command-handler.test.ts
+++ b/packages/slack-manager/src/__tests__/command-handler.test.ts
@@ -16,7 +16,7 @@ function makeClient(overrides: Partial<InvokerClient> = {}): InvokerClient {
     getWorkflowStatus: vi.fn(async () => ({ total: 0, completed: 0, failed: 0, closed: 0, running: 0, pending: 0 })),
     getTaskOutput: vi.fn(async () => ''),
     exec: vi.fn(async () => {}),
-    run: vi.fn(async () => 'wf-x'),
+    run: vi.fn(async () => ({ workflowId: 'wf-x', workflowIds: ['wf-x'] })),
     launch: vi.fn(async () => true),
     withRecovery: vi.fn(async (fn: () => Promise<unknown>) => fn()) as InvokerClient['withRecovery'],
     subscribe: vi.fn(() => () => {}),
@@ -70,8 +70,8 @@ describe('createCommandHandler', () => {
   });
 
   it('start_plan → writes plan file, runs it, emits workflow_created', async () => {
-    const client = makeClient({ run: vi.fn(async () => 'wf-new') });
-    await createCommandHandler({ client, slack, plansDir, log: noop })({
+    const client = makeClient({ run: vi.fn(async () => ({ workflowId: 'wf-new', workflowIds: ['wf-new'] })) });
+    const result = await createCommandHandler({ client, slack, plansDir, log: noop })({
       type: 'start_plan',
       planText: 'name: Demo\n',
       requestedBy: 'U1',
@@ -96,6 +96,50 @@ describe('createCommandHandler', () => {
       repoUrl: 'git@example:repo.git',
       planFile: planPath,
     });
+    expect(result).toEqual({ workflowIds: ['wf-new'] });
+  });
+
+  it('start_plan → a stacked plan starts every workflow and emits workflow_created for each', async () => {
+    const client = makeClient({
+      run: vi.fn(async () => ({ workflowId: 'wf-stack-2', workflowIds: ['wf-stack-1', 'wf-stack-2'] })),
+    });
+    const result = await createCommandHandler({ client, slack, plansDir, log: noop })({
+      type: 'start_plan',
+      planText: 'name: Stack\nworkflows:\n  - name: A\n  - name: B\n',
+      requestedBy: 'U1',
+      lobbyChannel: 'C1',
+      lobbyThreadTs: '123.45',
+    });
+
+    const files = readdirSync(plansDir);
+    const planPath = path.join(plansDir, files[0]);
+    expect(slack.handleEvent).toHaveBeenCalledTimes(2);
+    expect(slack.handleEvent).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      type: 'workflow_created', workflowId: 'wf-stack-1', planFile: planPath,
+    }));
+    expect(slack.handleEvent).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      type: 'workflow_created', workflowId: 'wf-stack-2', planFile: planPath,
+    }));
+    expect(result).toEqual({ workflowIds: ['wf-stack-1', 'wf-stack-2'] });
+  });
+
+  it('start_plan → reuses cached workflowIds for a retried executionKey without re-running', async () => {
+    const client = makeClient({
+      run: vi.fn(async () => ({ workflowId: 'wf-stack-2', workflowIds: ['wf-stack-1', 'wf-stack-2'] })),
+    });
+    const handler = createCommandHandler({ client, slack, plansDir, log: noop });
+    const command = {
+      type: 'start_plan' as const,
+      planText: 'name: Stack\nworkflows:\n  - name: A\n  - name: B\n',
+      executionKey: 'key-1',
+    };
+    const first = await handler(command);
+    const second = await handler(command);
+
+    expect(client.run).toHaveBeenCalledTimes(1);
+    expect(first).toEqual({ workflowIds: ['wf-stack-1', 'wf-stack-2'] });
+    expect(second).toEqual({ workflowIds: ['wf-stack-1', 'wf-stack-2'] });
+    expect(slack.handleEvent).toHaveBeenCalledTimes(4);
   });
 
   it('rethrows a SlackCommandError when Invoker stays down so the surface can reply in-thread', async () => {

--- a/packages/slack-manager/src/command-handler.ts
+++ b/packages/slack-manager/src/command-handler.ts
@@ -28,10 +28,10 @@ export class SlackCommandError extends Error {
 }
 
 export function createCommandHandler(deps: CommandHandlerDeps): CommandHandler {
-  const startedPlans = new Map<string, string>();
-  return async (command: SurfaceCommand): Promise<void> => {
+  const startedPlans = new Map<string, string[]>();
+  return async (command: SurfaceCommand) => {
     try {
-      await deps.client.withRecovery(() => dispatch(deps, command, startedPlans));
+      return await deps.client.withRecovery(() => dispatch(deps, command, startedPlans));
     } catch (err) {
       const message = err instanceof InvokerDownError
         ? DOWN_MESSAGE
@@ -42,7 +42,11 @@ export function createCommandHandler(deps: CommandHandlerDeps): CommandHandler {
   };
 }
 
-async function dispatch(deps: CommandHandlerDeps, command: SurfaceCommand, startedPlans: Map<string, string>): Promise<void> {
+async function dispatch(
+  deps: CommandHandlerDeps,
+  command: SurfaceCommand,
+  startedPlans: Map<string, string[]>,
+): Promise<{ workflowIds?: string[] } | void> {
   const { client, slack, plansDir, log } = deps;
   switch (command.type) {
     case 'approve':
@@ -67,23 +71,25 @@ async function dispatch(deps: CommandHandlerDeps, command: SurfaceCommand, start
     }
     case 'start_plan': {
       mkdirSync(plansDir, { recursive: true });
-      const existingWorkflowId = command.executionKey ? startedPlans.get(command.executionKey) : undefined;
+      const cachedWorkflowIds = command.executionKey ? startedPlans.get(command.executionKey) : undefined;
       const planPath = path.join(plansDir, `manager-${command.executionKey ?? Date.now()}.yaml`);
-      if (!existingWorkflowId) writeFileSync(planPath, command.planText, 'utf8');
-      const workflowId = existingWorkflowId ?? await client.run(planPath);
-      if (command.executionKey) startedPlans.set(command.executionKey, workflowId);
-      log('info', `submitted plan → workflow ${workflowId}`);
-      await slack.handleEvent({
-        type: 'workflow_created',
-        workflowId,
-        requestedBy: command.requestedBy,
-        lobbyChannel: command.lobbyChannel,
-        lobbyThreadTs: command.lobbyThreadTs,
-        harnessPreset: command.harnessPreset,
-        repoUrl: command.repoUrl,
-        planFile: planPath,
-      });
-      return;
+      if (!cachedWorkflowIds) writeFileSync(planPath, command.planText, 'utf8');
+      const workflowIds = cachedWorkflowIds ?? (await client.run(planPath)).workflowIds;
+      if (command.executionKey) startedPlans.set(command.executionKey, workflowIds);
+      log('info', `submitted plan → workflow(s) ${workflowIds.join(', ')}`);
+      for (const workflowId of workflowIds) {
+        await slack.handleEvent({
+          type: 'workflow_created',
+          workflowId,
+          requestedBy: command.requestedBy,
+          lobbyChannel: command.lobbyChannel,
+          lobbyThreadTs: command.lobbyThreadTs,
+          harnessPreset: command.harnessPreset,
+          repoUrl: command.repoUrl,
+          planFile: planPath,
+        });
+      }
+      return { workflowIds };
     }
   }
 }

--- a/packages/slack-manager/src/invoker-client.ts
+++ b/packages/slack-manager/src/invoker-client.ts
@@ -63,8 +63,8 @@ export interface InvokerClient {
   getTaskOutput(taskId: string): Promise<string>;
   /** Run a delegated headless mutation (`approve`, `recreate`, `cancel-workflow`, …). Fire-and-forget. */
   exec(args: string[]): Promise<void>;
-  /** Submit a plan file; resolves to the created workflow id. */
-  run(planPath: string): Promise<string>;
+  /** Submit a plan file; resolves to the created workflow id(s). `workflowIds` covers stacked plans in submission order. */
+  run(planPath: string): Promise<{ workflowId: string; workflowIds: string[] }>;
   /** (Re)launch Invoker. Resolves true once healthy over IPC, false on timeout/throttle. */
   launch(opts?: { force?: boolean }): Promise<boolean>;
   /** Runs `fn`; on `InvokerDownError`, launches Invoker and retries once. Rethrows if still down. */
@@ -233,14 +233,17 @@ export class IpcInvokerClient implements InvokerClient {
     await this.ownerRequest('headless.exec', { args, noTrack: true, traceId: this.traceId('exec') }, EXEC_TIMEOUT_MS);
   }
 
-  async run(planPath: string): Promise<string> {
-    const res = await this.ownerRequest<{ workflowId?: string }>(
+  async run(planPath: string): Promise<{ workflowId: string; workflowIds: string[] }> {
+    const res = await this.ownerRequest<{ workflowId?: string; workflowIds?: string[] }>(
       'headless.run',
       { planPath, traceId: this.traceId('run') },
       EXEC_TIMEOUT_MS,
     );
     if (!res.workflowId) throw new Error('headless.run did not return a workflowId');
-    return res.workflowId;
+    const workflowIds = Array.isArray(res.workflowIds) && res.workflowIds.length > 0
+      ? res.workflowIds
+      : [res.workflowId];
+    return { workflowId: res.workflowId, workflowIds };
   }
 
   async withRecovery<T>(fn: () => Promise<T>): Promise<T> {

--- a/packages/surfaces/src/surface.ts
+++ b/packages/surfaces/src/surface.ts
@@ -113,7 +113,7 @@ export type LogFn = (source: string, level: string, message: string) => void;
 
 // ── Interface ──────────────────────────────────────────────
 
-export type CommandHandler = (command: SurfaceCommand) => void | Promise<void>;
+export type CommandHandler = (command: SurfaceCommand) => void | Promise<void | { workflowIds?: string[] }>;
 
 export interface Surface {
   /** Unique identifier for this surface type (e.g. 'slack', 'discord'). */


### PR DESCRIPTION
## Summary

Slack start_plan must learn about every workflow from a stacked submission.

This slice carries workflowIds through InvokerClient and fans out workflow_created events.

## Review Claim

Approve Slack manager propagation of stacked workflowIds.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Command-handler coverage covers multi-workflow fan-out.

## Slice Rationale

Uses the owner-mode return shape from the previous slice.

## Non-goals

Does not replace the Slack classifier with PlanDraft yet.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/slack-manager exec vitest run src/__tests__/command-handler.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #5793