### PR TITLE
[Slack PlanDraft harness](9) Add PlanDraft stacked-approve and non-lobby repros

### DIFF
--- a/scripts/repro/repro-slack-non-lobby-mention.sh
+++ b/scripts/repro/repro-slack-non-lobby-mention.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repro: @Invoker hi outside the lobby / mapped workflow channel must NOT
+# refuse with "I only plan in the lobby channel…". Mentions in any channel
+# where the bot is present route to the same handleMention path.
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/invoker-slack-non-lobby-mention.XXXXXX.log")"
+trap 'rm -f "$LOG_FILE"' EXIT
+
+echo "[repro] Running Slack non-lobby mention routing regression."
+
+if ! pnpm -C "$REPO_ROOT" --filter @invoker/surfaces exec vitest run \
+  src/__tests__/slack-do1-ux-non-lobby-mention.e2e.test.ts \
+  src/__tests__/slack-surface-workflows.test.ts \
+  -t 'routes every @mention|routes a mention to planning from any channel|never refuses a mention' \
+  >"$LOG_FILE" 2>&1; then
+  status=$?
+  echo "[repro] FAIL: non-lobby @mention routing regressed."
+  cat "$LOG_FILE"
+  exit "$status"
+fi
+
+if rg -nF 'I only plan in the lobby channel (or DMs)' \
+  "$REPO_ROOT/packages/surfaces/src" \
+  "$REPO_ROOT/packages/surfaces/dist" 2>/dev/null; then
+  echo "[repro] FAIL: stale lobby-channel refusal string is still present in surfaces src/dist."
+  exit 1
+fi
+
+echo "[repro] PASS: @Invoker hi outside lobby/workflow channels is not refused."

--- a/scripts/repro/repro-slack-stacked-plan-approve.sh
+++ b/scripts/repro/repro-slack-stacked-plan-approve.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Battle-test: Slack plan-draft Approve starts every workflow in a stacked
+# YAML plan and records all resulting workflowIds on the draft, instead of
+# starting only one workflow and recording `markSubmitted(draft, [])`.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "==> slack-manager: start_plan fans a stacked run out to every workflow_created event"
+pnpm --filter @invoker/slack-manager exec vitest run src/__tests__/command-handler.test.ts
+
+echo "==> surfaces: approveSlackPlanDraft forwards every workflowId into markSubmitted"
+pnpm --filter @invoker/surfaces exec vitest run src/__tests__/slack-plan-draft-approve.test.ts
+
+echo "==> app: headless.run parses stacked workflows via parsePlanSubmissionBundleFile"
+pnpm --filter @invoker/app exec vitest run src/__tests__/plan-parser.test.ts -t parsePlanSubmissionBundleFile
+
+echo "[repro] PASS: stacked Slack plan Approve starts every workflow and records all workflowIds"


### PR DESCRIPTION
## Summary

The new Slack planning contracts need executable locks outside the package suite.

This slice adds scripts for stacked approve and non-lobby mentions.

## Review Claim

Approve PlanDraft scripts for stacked approve and non-lobby mentions.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Scripts only; no product code changes.

## Slice Rationale

Locking artifacts stay separate from the behavior slices they cover.

## Non-goals

Does not change runtime behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `test -x scripts/repro/repro-slack-stacked-plan-approve.sh && test -x scripts/repro/repro-slack-non-lobby-mention.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #5786