### PR TITLE
[Slack PlanDraft harness](10) Drop pre-approval tracked-file restore guard

### DIFF
--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -24,8 +24,6 @@ import {
   captureRepoState,
   looksLikeCompletionClaim,
   repoStateUnchanged,
-  restoreTrackedChanges,
-  trackedFilesChanged,
 } from './agent-turn-verification.js';
 
 // ── Types ───────────────────────────────────────────────────
@@ -544,10 +542,6 @@ export class PlanConversation {
     const repoStateAfter = this.mode === 'agent'
       ? await captureRepoState(this.workingDir)
       : null;
-    if (this.mode === 'agent' && trackedFilesChanged(repoStateBefore, repoStateAfter)) {
-      restoreTrackedChanges(this.workingDir);
-      throw new Error('Pre-approval exploration may create repro artifacts but cannot modify tracked files.');
-    }
     if (looksLikeCompletionClaim(message) && repoStateUnchanged(repoStateBefore, repoStateAfter)) {
       message = `${message}\n\n${buildUnverifiedNotice()}`;
     }


### PR DESCRIPTION
## Summary

Pre-approval agent turns restored tracked edits and failed the turn.

This slice stops that restore/fail path so planning exploration can keep tracked changes until approve.

## Review Claim

Approve stopping the pre-approval tracked-file restore/fail path.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Scoped to PlanConversation agent-mode checks; approve still required to run plans.

## Slice Rationale

Policy tweak is separate from harness wiring so it can be reviewed alone.

## Non-goals

Does not change PlanDraft approve mechanics.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/plan-conversation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #5787