### PR TITLE
[Slack PlanDraft harness](11) Document Slack PlanDraft planning flow

### DIFF
--- a/docs/slack-native-workflows.md
+++ b/docs/slack-native-workflows.md
@@ -21,6 +21,8 @@ Leading `[...]` tags select how planning runs. Order does not matter; everything
 
 The repository and harness are pinned when the thread starts. Start a new thread to use another repository or preset.
 
+When the harness preset supports it, Invoker resumes the same underlying agent session across turns and across a Slack manager restart (append-based continuity) instead of replaying the full prompt history each time.
+
 ## Local and plan modes
 
 Normal mentions outside mapped workflow channels are exploration sessions. They can answer and create repro artifacts, but tracked files are restored and the turn fails if the agent modifies them before plan approval.


### PR DESCRIPTION
## Summary

Operators need the written flow to match /plan to PlanDraft to approve.

This slice updates Slack native workflow pages for that flow.

## Review Claim

Approve the Slack PlanDraft planning documentation update.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Documentation only.

## Slice Rationale

Written flow follows the shipped behavior slices.

## Non-goals

No code changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `rg -n "PlanDraft|/plan" docs/slack-native-workflows.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #5788