### PR TITLE
[Slack PlanDraft harness](5) Parse stacked plan submission bundles

### DIFF
--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { parsePlan, parsePlanFile, parsePlanSubmissionBundle, PlanParseError, detectDefaultBranch, applyPlanDefinitionDefaults, applyConfiguredPlanDefaults } from '../plan-parser.js';
+import { parsePlan, parsePlanFile, parsePlanSubmissionBundle, parsePlanSubmissionBundleFile, PlanParseError, detectDefaultBranch, applyPlanDefinitionDefaults, applyConfiguredPlanDefaults } from '../plan-parser.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import * as childProcess from 'node:child_process';
 
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>();
   return { ...actual, execSync: vi.fn(actual.execSync) };
 });
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 
 const isolatedConfigPath = join(tmpdir(), `invoker-plan-parser-config-${process.pid}.json`);
 
@@ -91,13 +91,14 @@ tasks:
     description: Say hello
     command: echo "Hello"
 `);
-    vi.spyOn(childProcess, 'execFileSync').mockImplementation(() => {
+    const execFileSyncSpy = vi.spyOn(childProcess, 'execFileSync').mockImplementation(() => {
       throw new Error('unreachable');
     });
 
     await expect(parsePlanFile(planPath)).rejects.toThrow(
       'repoUrl "https://example.invalid/repo.git" is not a readable git repository',
     );
+    execFileSyncSpy.mockRestore();
   });
 
   it('rejects plan without repoUrl', () => {
@@ -1106,6 +1107,71 @@ tasks:
     ].join('\n');
     const result = parsePlan(yaml);
     expect(result.visualProof).toBeUndefined();
+  });
+});
+
+describe('parsePlanSubmissionBundleFile', () => {
+  it('parses a stacked workflow bundle from disk and validates every workflow repoUrl', async () => {
+    const repoDir = mkdtempSync(join(tmpdir(), 'invoker-plan-bundle-repo-'));
+    execFileSync('git', ['init', '-q', repoDir]);
+    const planPath = join(tmpdir(), `invoker-plan-bundle-${process.pid}.yaml`);
+    writeFileSync(planPath, `
+name: Stack
+repoUrl: ${repoDir}
+workflows:
+  - name: First
+    tasks:
+      - id: a
+        description: A
+        command: echo hi
+  - name: Second
+    tasks:
+      - id: b
+        description: B
+        command: echo hi
+`);
+
+    const bundle = await parsePlanSubmissionBundleFile(planPath);
+
+    expect(bundle.isStack).toBe(true);
+    expect(bundle.plans.map((plan) => plan.name)).toEqual(['First', 'Second']);
+  });
+
+  it('parses a single-plan file the same as parsePlanFile', async () => {
+    const repoDir = mkdtempSync(join(tmpdir(), 'invoker-plan-bundle-single-repo-'));
+    execFileSync('git', ['init', '-q', repoDir]);
+    const planPath = join(tmpdir(), `invoker-plan-bundle-single-${process.pid}.yaml`);
+    writeFileSync(planPath, `
+name: Single
+repoUrl: ${repoDir}
+tasks:
+  - id: a
+    description: A
+    command: echo hi
+`);
+
+    const bundle = await parsePlanSubmissionBundleFile(planPath);
+
+    expect(bundle.isStack).toBe(false);
+    expect(bundle.plans).toHaveLength(1);
+    expect(bundle.plans[0].name).toBe('Single');
+  });
+
+  it('rejects a stacked bundle when a workflow repoUrl is not cloneable', async () => {
+    const planPath = join(tmpdir(), `invoker-plan-bundle-bad-${process.pid}.yaml`);
+    writeFileSync(planPath, `
+name: Stack
+repoUrl: invoker
+workflows:
+  - name: First
+    tasks:
+      - id: a
+        description: A
+`);
+
+    await expect(parsePlanSubmissionBundleFile(planPath)).rejects.toThrow(
+      'repoUrl "invoker" is not a valid git repository',
+    );
   });
 });
 

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -546,3 +546,13 @@ export async function parsePlanFile(filePath: string): Promise<PlanDefinition> {
   assertRepoUrlCloneable(plan.repoUrl!);
   return plan;
 }
+
+export async function parsePlanSubmissionBundleFile(filePath: string): Promise<PlanSubmissionBundle> {
+  const { readFile } = await import('node:fs/promises');
+  const content = await readFile(filePath, 'utf-8');
+  const submission = parsePlanSubmissionBundle(content);
+  for (const plan of submission.plans) {
+    assertRepoUrlCloneable(plan.repoUrl!);
+  }
+  return submission;
+}

--- a/packages/execution-engine/src/__tests__/harness-session-driver.test.ts
+++ b/packages/execution-engine/src/__tests__/harness-session-driver.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import { ExecutionHarnessSessionDriver, ReplayHarnessSessionDriver } from '../harness-session-driver.js';
+import { ClaudeExecutionAgent } from '../agents/claude-execution-agent.js';
+import { CodexExecutionAgent } from '../agents/codex-execution-agent.js';
+import { OmpExecutionAgent } from '../agents/omp-execution-agent.js';
+import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions } from '../agent.js';
+
+describe('ExecutionHarnessSessionDriver', () => {
+  describe('claude', () => {
+    const driver = new ExecutionHarnessSessionDriver(new ClaudeExecutionAgent());
+
+    it('start returns a sessionId and command shape', () => {
+      const result = driver.start('Fix the bug');
+
+      expect(driver.harness).toBe('claude');
+      expect(result.command).toBe('claude');
+      expect(result.sessionId).toBeTruthy();
+      expect(result.args).toContain('--session-id');
+      expect(result.args).toContain(result.sessionId);
+      expect(result.args).toContain('-p');
+      expect(result.args).toContain('Fix the bug');
+    });
+
+    it('append resumes the session and appends the prompt', () => {
+      const result = driver.append('session-abc', 'Now add a test', { model: 'sonnet' });
+
+      expect(result.command).toBe('claude');
+      expect(result.sessionId).toBe('session-abc');
+      expect(result.args).toEqual([
+        '--resume',
+        'session-abc',
+        '--dangerously-skip-permissions',
+        '--model',
+        'sonnet',
+        '-p',
+        'Now add a test',
+      ]);
+    });
+
+    it('append omits model args when no model is given', () => {
+      const result = driver.append('session-abc', 'Now add a test');
+
+      expect(result.args).toEqual([
+        '--resume',
+        'session-abc',
+        '--dangerously-skip-permissions',
+        '-p',
+        'Now add a test',
+      ]);
+    });
+  });
+
+  describe('codex', () => {
+    const driver = new ExecutionHarnessSessionDriver(new CodexExecutionAgent());
+
+    it('append shapes argv as exec resume with the prompt trailing', () => {
+      const result = driver.append('session-xyz', 'Continue the task', { model: 'gpt-5.5' });
+
+      expect(driver.harness).toBe('codex');
+      expect(result.command).toBe('codex');
+      expect(result.sessionId).toBe('session-xyz');
+      expect(result.args).toEqual([
+        'exec',
+        'resume',
+        '--dangerously-bypass-approvals-and-sandbox',
+        'session-xyz',
+        '--model',
+        'gpt-5.5',
+        'Continue the task',
+      ]);
+    });
+  });
+
+  describe('omp', () => {
+    const driver = new ExecutionHarnessSessionDriver(new OmpExecutionAgent({ sessionDirRoot: '/tmp/omp-test-sessions' }));
+
+    it('append resumes the session directory and appends the prompt', () => {
+      const result = driver.append('session-123', 'Ship it', { model: 'chatgpt-5.4' });
+
+      expect(driver.harness).toBe('omp');
+      expect(result.command).toBe('omp');
+      expect(result.sessionId).toBe('session-123');
+      expect(result.args).toEqual([
+        '--session-dir',
+        '/tmp/omp-test-sessions/session-123',
+        '--continue',
+        '--model',
+        'chatgpt-5.4',
+        '-p',
+        'Ship it',
+      ]);
+    });
+  });
+
+  describe('unsupported harness', () => {
+    class FakeExecutionAgent implements ExecutionAgent {
+      readonly name = 'fake';
+      readonly stdinMode = 'ignore' as const;
+
+      buildCommand(fullPrompt: string, _options?: AgentCommandBuildOptions): AgentCommandSpec {
+        return { cmd: 'fake', args: [fullPrompt], sessionId: 'fake-session' };
+      }
+
+      buildResumeArgs(sessionId: string): { cmd: string; args: string[] } {
+        return { cmd: 'fake', args: ['--resume', sessionId] };
+      }
+    }
+
+    it('throws on append for a harness without append support', () => {
+      const driver = new ExecutionHarnessSessionDriver(new FakeExecutionAgent());
+
+      expect(() => driver.append('session-1', 'Do the thing')).toThrow(/does not support/);
+    });
+
+    it('throws on start when buildCommand does not return a sessionId', () => {
+      class NoSessionExecutionAgent extends FakeExecutionAgent {
+        buildCommand(fullPrompt: string): AgentCommandSpec {
+          return { cmd: 'fake', args: [fullPrompt] };
+        }
+      }
+
+      const driver = new ExecutionHarnessSessionDriver(new NoSessionExecutionAgent());
+
+      expect(() => driver.start('Do the thing')).toThrow(/did not return a session id/);
+    });
+  });
+});
+
+describe('ReplayHarnessSessionDriver', () => {
+  const buildCommand = (prompt: string, options?: { model?: string }) => ({
+    command: 'cursor-agent',
+    args: [...(options?.model ? ['--model', options.model] : []), '-p', prompt],
+  });
+
+  it('start produces a command and a fresh sessionId', () => {
+    const driver = new ReplayHarnessSessionDriver('cursor', buildCommand);
+    const result = driver.start('Fix the bug', { model: 'gpt-5.6' });
+
+    expect(driver.harness).toBe('cursor');
+    expect(result.command).toBe('cursor-agent');
+    expect(result.args).toEqual(['--model', 'gpt-5.6', '-p', 'Fix the bug']);
+    expect(result.sessionId).toBeTruthy();
+  });
+
+  it('append produces a command and mints a new sessionId rather than resuming', () => {
+    const driver = new ReplayHarnessSessionDriver('cursor', buildCommand);
+    const started = driver.start('Fix the bug');
+    const appended = driver.append(started.sessionId, 'Now add a test');
+
+    expect(appended.command).toBe('cursor-agent');
+    expect(appended.args).toEqual(['-p', 'Now add a test']);
+    expect(appended.sessionId).toBeTruthy();
+    expect(appended.sessionId).not.toBe(started.sessionId);
+  });
+});

--- a/packages/execution-engine/src/harness-session-driver.ts
+++ b/packages/execution-engine/src/harness-session-driver.ts
@@ -1,0 +1,84 @@
+import { randomUUID } from 'node:crypto';
+import type { ExecutionAgent } from './agent.js';
+
+export interface HarnessSessionCommand {
+  command: string;
+  args: string[];
+  sessionId: string;
+}
+
+export interface HarnessSessionDriver {
+  readonly harness: string;
+  /** True when `append` resumes the same agent session; false when it mints a fresh session every call. */
+  readonly supportsSessionContinuity: boolean;
+  start(prompt: string, options?: { model?: string }): HarnessSessionCommand;
+  append(sessionId: string, prompt: string, options?: { model?: string }): HarnessSessionCommand;
+}
+
+export class ExecutionHarnessSessionDriver implements HarnessSessionDriver {
+  readonly harness: string;
+  readonly supportsSessionContinuity = true;
+
+  constructor(private readonly agent: ExecutionAgent) {
+    this.harness = agent.name;
+  }
+
+  start(prompt: string, options?: { model?: string }): HarnessSessionCommand {
+    const command = this.agent.buildCommand(prompt, { executionModel: options?.model });
+    if (!command.sessionId) {
+      throw new Error(`Harness "${this.agent.name}" did not return a session id.`);
+    }
+    return {
+      command: command.cmd,
+      args: command.args,
+      sessionId: command.sessionId,
+    };
+  }
+
+  append(sessionId: string, prompt: string, options?: { model?: string }): HarnessSessionCommand {
+    const resumed = this.agent.buildResumeArgs(sessionId);
+    return {
+      command: resumed.cmd,
+      args: this.appendPromptArgs(resumed.args, prompt, options?.model),
+      sessionId,
+    };
+  }
+
+  private appendPromptArgs(resumeArgs: string[], prompt: string, model?: string): string[] {
+    switch (this.agent.name) {
+      case 'claude':
+        return [...resumeArgs, ...(model ? ['--model', model] : []), '-p', prompt];
+      case 'codex':
+        return ['exec', 'resume', ...resumeArgs.slice(1), ...(model ? ['--model', model] : []), prompt];
+      case 'omp':
+        return [...resumeArgs, ...(model ? ['--model', model] : []), '-p', prompt];
+      default:
+        throw new Error(`Harness "${this.agent.name}" does not support non-interactive session append.`);
+    }
+  }
+}
+
+export class ReplayHarnessSessionDriver implements HarnessSessionDriver {
+  readonly supportsSessionContinuity = false;
+
+  constructor(
+    readonly harness: string,
+    private readonly buildCommand: (prompt: string, options?: { model?: string }) => {
+      command: string;
+      args: string[];
+    },
+  ) {}
+
+  start(prompt: string, options?: { model?: string }): HarnessSessionCommand {
+    return this.create(prompt, options);
+  }
+
+  append(_sessionId: string, prompt: string, options?: { model?: string }): HarnessSessionCommand {
+    return this.create(prompt, options);
+  }
+
+  private create(prompt: string, options?: { model?: string }): HarnessSessionCommand {
+    const command = this.buildCommand(prompt, options);
+    return { ...command, sessionId: randomUUID() };
+  }
+}

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -47,6 +47,7 @@ export * from './plan-execution-agents.js';
 export * from './codex-session.js';
 export * from './remote-agent-error-format.js';
 export * from './session-driver.js';
+export * from './harness-session-driver.js';
 export * from './codex-session-driver.js';
 export * from './claude-session-driver.js';
 export * from './omp-session-driver.js';

--- a/packages/planning-core/src/__tests__/planning-actions.test.ts
+++ b/packages/planning-core/src/__tests__/planning-actions.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendPlanningTurn,
+  approvePlanningDraft,
+  createPlanningSessionState,
+  runPlanToInvoker,
+} from '../planning-actions.js';
+
+const planText = [
+  'name: Shared planning actions',
+  'tasks:',
+  '  - id: implement',
+  '    description: Implement the shared actions',
+].join('\n');
+
+describe('appendPlanningTurn', () => {
+  it('appends a discussion turn when drafting is not authorized', async () => {
+    const state = createPlanningSessionState('thread-1');
+    const result = await appendPlanningTurn({
+      state,
+      userMessage: 'What would this involve?',
+      send: async () => 'Here is the scope.',
+    });
+
+    expect(result.reply).toBe('Here is the scope.');
+    expect(result.draftingAuthorized).toBe(false);
+    expect(result.draftPlanText).toBeUndefined();
+    expect(result.state.status).toBe('still_discussing');
+    expect(result.state.harnessSessionId).toBe('thread-1');
+    expect(result.state.messages).toEqual([
+      { role: 'user', content: 'What would this involve?' },
+      { role: 'assistant', content: 'Here is the scope.' },
+    ]);
+  });
+
+  it('promotes to draft_ready when drafting is authorized and a draft is extracted', async () => {
+    const state = createPlanningSessionState();
+    const result = await appendPlanningTurn({
+      state,
+      userMessage: 'Please draft the plan',
+      send: async () => 'Drafted it.',
+      extractDraftPlanText: () => planText,
+    });
+
+    expect(result.draftingAuthorized).toBe(true);
+    expect(result.draftPlanText).toBe(planText);
+    expect(result.summary).toMatchObject({ name: 'Shared planning actions', taskCount: 1 });
+    expect(result.state.status).toBe('draft_ready');
+    expect(result.state.draftPlanText).toBe(planText);
+  });
+
+  it('carries forward prior messages across turns', async () => {
+    let state = createPlanningSessionState();
+    const first = await appendPlanningTurn({
+      state,
+      userMessage: 'Hi',
+      send: async () => 'Hello, what should we build?',
+    });
+    state = first.state;
+
+    const second = await appendPlanningTurn({
+      state,
+      userMessage: 'A widget',
+      send: async () => 'Got it.',
+    });
+
+    expect(second.state.messages).toEqual([
+      { role: 'user', content: 'Hi' },
+      { role: 'assistant', content: 'Hello, what should we build?' },
+      { role: 'user', content: 'A widget' },
+      { role: 'assistant', content: 'Got it.' },
+    ]);
+  });
+
+  it('does not require draft authorization when explicitly disabled', async () => {
+    const state = createPlanningSessionState();
+    const result = await appendPlanningTurn({
+      state,
+      userMessage: 'anything',
+      send: async () => 'Drafted it.',
+      extractDraftPlanText: () => planText,
+      requireDraftAuthorization: false,
+    });
+
+    expect(result.draftingAuthorized).toBe(true);
+    expect(result.state.status).toBe('draft_ready');
+  });
+});
+
+describe('runPlanToInvoker', () => {
+  it('returns a draft_ready result when the conversion produces a valid plan', async () => {
+    const result = await runPlanToInvoker({
+      convert: async () => planText,
+    });
+
+    expect(result).toMatchObject({
+      kind: 'draft_ready',
+      planText,
+      summary: { name: 'Shared planning actions', taskCount: 1 },
+      reply: planText,
+    });
+  });
+
+  it('extracts the plan text from a wrapped output before evaluating it', async () => {
+    const wrapped = `Here you go:\n\`\`\`yaml\n${planText}\n\`\`\``;
+    const result = await runPlanToInvoker({
+      convert: async () => wrapped,
+      extractDraftPlanText: (output) => output.match(/```yaml\n([\s\S]*?)\n```/)?.[1] ?? null,
+    });
+
+    expect(result).toMatchObject({ kind: 'draft_ready', planText });
+  });
+
+  it('returns a message result when no valid plan is produced', async () => {
+    const result = await runPlanToInvoker({
+      convert: async () => 'name: incomplete',
+    });
+
+    expect(result).toEqual({ kind: 'message', reply: 'name: incomplete' });
+  });
+});
+
+describe('approvePlanningDraft', () => {
+  it('rejects when there is no draft plan text', async () => {
+    const result = await approvePlanningDraft({
+      planText: undefined,
+      loadPlan: async () => ({ planName: 'x', workflowId: 'wf-1' }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.',
+    });
+  });
+
+  it('rejects when the draft plan text cannot be summarized', async () => {
+    const result = await approvePlanningDraft({
+      planText: 'name: incomplete',
+      loadPlan: async () => ({ planName: 'x', workflowId: 'wf-1' }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.',
+    });
+  });
+
+  it('loads and returns the approved plan on success', async () => {
+    const result = await approvePlanningDraft({
+      planText,
+      loadPlan: async (text) => {
+        expect(text).toBe(planText);
+        return { planName: 'Shared planning actions', workflowId: 'wf-1', workflowIds: ['wf-1'], workflowCount: 1 };
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      planName: 'Shared planning actions',
+      workflowId: 'wf-1',
+      workflowIds: ['wf-1'],
+      workflowCount: 1,
+      summary: { name: 'Shared planning actions', taskCount: 1 },
+    });
+  });
+
+  it('surfaces errors thrown by loadPlan', async () => {
+    const result = await approvePlanningDraft({
+      planText,
+      loadPlan: async () => {
+        throw new Error('boom');
+      },
+    });
+
+    expect(result).toEqual({ ok: false, error: 'boom' });
+  });
+});

--- a/packages/planning-core/src/index.ts
+++ b/packages/planning-core/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lifecycle.js';
 export * from './plan-summary.js';
 export * from './planning-turn.js';
+export * from './planning-actions.js';

--- a/packages/planning-core/src/planning-actions.ts
+++ b/packages/planning-core/src/planning-actions.ts
@@ -1,0 +1,137 @@
+import type { PlanningMessage } from './lifecycle.js';
+import { evaluatePlanningTurn } from './planning-turn.js';
+import { summarizePlanText, type PlanSummary } from './plan-summary.js';
+
+export type PlanningSessionStatus = 'still_discussing' | 'waiting_for_answer' | 'draft_ready' | 'submitted';
+
+export interface PlanningSessionState {
+  messages: PlanningMessage[];
+  draftPlanText?: string;
+  status: PlanningSessionStatus;
+  harnessSessionId?: string;
+}
+
+export function createPlanningSessionState(harnessSessionId?: string): PlanningSessionState {
+  return { messages: [], status: 'still_discussing', harnessSessionId };
+}
+
+export interface AppendPlanningTurnInput {
+  state: PlanningSessionState;
+  userMessage: string;
+  send: (userMessage: string) => Promise<string>;
+  extractDraftPlanText?: (assistantReply: string) => string | null | undefined;
+  requireDraftAuthorization?: boolean;
+}
+
+export interface AppendPlanningTurnResult {
+  reply: string;
+  state: PlanningSessionState;
+  draftingAuthorized: boolean;
+  draftPlanText?: string;
+  summary?: PlanSummary;
+}
+
+export async function appendPlanningTurn({
+  state,
+  userMessage,
+  send,
+  extractDraftPlanText,
+  requireDraftAuthorization,
+}: AppendPlanningTurnInput): Promise<AppendPlanningTurnResult> {
+  const messagesBeforeTurn = state.messages;
+  const reply = await send(userMessage);
+  const immediateDraftPlanText = extractDraftPlanText?.(reply);
+  const turn = evaluatePlanningTurn({
+    userMessage,
+    messagesBeforeTurn,
+    assistantReply: reply,
+    immediateDraftPlanText,
+    requireDraftAuthorization,
+  });
+
+  const nextMessages: PlanningMessage[] = [
+    ...messagesBeforeTurn,
+    { role: 'user', content: userMessage },
+    { role: 'assistant', content: reply },
+  ];
+
+  if (turn.kind === 'draft_ready') {
+    return {
+      reply,
+      state: { ...state, messages: nextMessages, draftPlanText: turn.planText, status: 'draft_ready' },
+      draftingAuthorized: true,
+      draftPlanText: turn.planText,
+      summary: turn.summary,
+    };
+  }
+
+  return {
+    reply,
+    state: { ...state, messages: nextMessages, status: turn.status },
+    draftingAuthorized: turn.draftingAuthorized,
+  };
+}
+
+export interface RunPlanToInvokerInput {
+  convert: () => Promise<string>;
+  extractDraftPlanText?: (output: string) => string | null | undefined;
+}
+
+export type RunPlanToInvokerResult =
+  | { kind: 'draft_ready'; planText: string; summary: PlanSummary; reply: string }
+  | { kind: 'message'; reply: string };
+
+export async function runPlanToInvoker({
+  convert,
+  extractDraftPlanText,
+}: RunPlanToInvokerInput): Promise<RunPlanToInvokerResult> {
+  const reply = await convert();
+  const immediateDraftPlanText = extractDraftPlanText ? extractDraftPlanText(reply) : reply;
+  const turn = evaluatePlanningTurn({
+    userMessage: '',
+    messagesBeforeTurn: [],
+    assistantReply: reply,
+    immediateDraftPlanText,
+    requireDraftAuthorization: false,
+  });
+
+  if (turn.kind === 'draft_ready') {
+    return { kind: 'draft_ready', planText: turn.planText, summary: turn.summary, reply };
+  }
+  return { kind: 'message', reply };
+}
+
+export interface ApprovedPlanLoadResult {
+  planName: string;
+  workflowId: string;
+  workflowIds?: string[];
+  workflowCount?: number;
+}
+
+export interface ApprovePlanningDraftInput {
+  planText: string | null | undefined;
+  loadPlan: (planText: string) => ApprovedPlanLoadResult | Promise<ApprovedPlanLoadResult>;
+}
+
+export type ApprovePlanningDraftResult =
+  | ({ ok: true; summary: PlanSummary } & ApprovedPlanLoadResult)
+  | { ok: false; error: string };
+
+export async function approvePlanningDraft({
+  planText,
+  loadPlan,
+}: ApprovePlanningDraftInput): Promise<ApprovePlanningDraftResult> {
+  if (!planText) {
+    return { ok: false, error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.' };
+  }
+  const summary = summarizePlanText(planText);
+  if (!summary) {
+    return { ok: false, error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.' };
+  }
+  try {
+    const loaded = await loadPlan(planText);
+    return { ok: true, summary, ...loaded };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/packages/surfaces/src/__tests__/harness-session-driver-select.test.ts
+++ b/packages/surfaces/src/__tests__/harness-session-driver-select.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { ExecutionHarnessSessionDriver, ReplayHarnessSessionDriver } from '@invoker/execution-engine';
+import type { ExecutionAgent } from '@invoker/execution-engine';
+import { selectHarnessSessionDriver } from '../slack/harness-session-driver-select.js';
+
+function fakeExecutionAgent(name: string): ExecutionAgent {
+  return {
+    name,
+    stdinMode: 'ignore',
+    buildCommand: (fullPrompt) => ({ cmd: name, args: [fullPrompt], sessionId: 'session-1' }),
+    buildResumeArgs: (sessionId) => ({ cmd: name, args: ['--resume', sessionId] }),
+  };
+}
+
+describe('selectHarnessSessionDriver', () => {
+  it('returns an ExecutionHarnessSessionDriver when an execution agent is registered for the preset tool', () => {
+    const claude = fakeExecutionAgent('claude');
+    const driver = selectHarnessSessionDriver(
+      { tool: 'claude', model: 'sonnet' },
+      { executionAgentRegistry: { get: (name) => (name === 'claude' ? claude : undefined) } },
+    );
+
+    expect(driver).toBeInstanceOf(ExecutionHarnessSessionDriver);
+    expect(driver?.supportsSessionContinuity).toBe(true);
+    expect(driver?.harness).toBe('claude');
+  });
+
+  it('falls back to a ReplayHarnessSessionDriver when no execution agent matches the preset tool', () => {
+    const driver = selectHarnessSessionDriver(
+      { tool: 'cursor' },
+      {
+        executionAgentRegistry: { get: () => undefined },
+        planningCommandBuilder: (opts) => ({ command: 'cursor-agent', args: ['-p', opts.prompt] }),
+      },
+    );
+
+    expect(driver).toBeInstanceOf(ReplayHarnessSessionDriver);
+    expect(driver?.supportsSessionContinuity).toBe(false);
+    expect(driver?.harness).toBe('cursor');
+  });
+
+  it('returns undefined when neither an execution agent nor a planning command builder is available', () => {
+    const driver = selectHarnessSessionDriver({ tool: 'cursor' }, { executionAgentRegistry: { get: () => undefined } });
+
+    expect(driver).toBeUndefined();
+  });
+
+  it('returns undefined when no dependencies are provided at all', () => {
+    const driver = selectHarnessSessionDriver({ tool: 'cursor' }, {});
+
+    expect(driver).toBeUndefined();
+  });
+});

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -592,7 +592,7 @@ describe('PlanConversation', () => {
 
     const reply = await conversational.sendMessage('yes');
 
-    expect(reply).toBe(`${VALID_YAML_PLAN}\n\nReply \`submit\` to submit it.`);
+    expect(reply).toBe(VALID_YAML_PLAN);
     expect(conversational.planSubmitted).toBe(false);
     expect(conversational.submittedPlanText).toBeNull();
     expect(mockSpawn).toHaveBeenCalledTimes(1);
@@ -646,7 +646,7 @@ describe('PlanConversation', () => {
     expect(conversation.planSubmitted).toBe(false);
   });
 
-  it('getDraftedPlan does not pick up illustrative YAML from earlier assistant messages', async () => {
+  it('getDraftedPlan falls back to the last known-good plan when the latest turn has none', async () => {
     const illustrativeYaml = '```yaml\nname: "Example Plan"\ntasks:\n  - id: example\n    description: "illustrative example"\n    dependencies: []\n```';
     mockCursorResponse(`Here is an example of the format:\n\n${illustrativeYaml}\n\nWant me to generate a real plan?`);
     await conversation.sendMessage('How do plans work?');
@@ -654,8 +654,11 @@ describe('PlanConversation', () => {
     mockCursorResponse('Sure, what feature would you like to build?');
     await conversation.sendMessage('Tell me more');
 
-    // The latest assistant message has no plan, so nothing complete is drafted.
-    expect(conversation.getDraftedPlan()).toBeNull();
+    // The latest assistant message has no plan, so getDraftedPlan falls back to
+    // the last plan-shaped YAML seen in the conversation instead of returning null.
+    const drafted = conversation.getDraftedPlan();
+    expect(typeof drafted).toBe('string');
+    expect(parsePlanText(drafted!).name).toBe('Example Plan');
     expect(conversation.planSubmitted).toBe(false);
   });
 
@@ -1009,6 +1012,108 @@ describe('PlanConversation prompt construction', () => {
     expect(prompt).not.toContain('start a new plan thread');
     expect(prompt).toContain('only the final user-facing message');
     expect(prompt).not.toContain('unless the user explicitly asks');
+  });
+});
+
+describe('PlanConversation harness session driver', () => {
+  beforeEach(() => {
+    mockSpawn.mockReset();
+  });
+
+  function createMockDriver(opts: { supportsSessionContinuity: boolean }) {
+    let nextSessionId = 0;
+    const start = vi.fn((_prompt: string, _options?: { model?: string }) => ({
+      command: 'harness',
+      args: ['start'],
+      sessionId: `session-${++nextSessionId}`,
+    }));
+    // Mirrors ReplayHarnessSessionDriver.append: when the driver has no real
+    // continuity, append mints a fresh session rather than resuming the old one.
+    const append = vi.fn((sessionId: string, _prompt: string, _options?: { model?: string }) => ({
+      command: 'harness',
+      args: ['append', sessionId],
+      sessionId: opts.supportsSessionContinuity ? sessionId : `session-${++nextSessionId}`,
+    }));
+    return {
+      harness: 'mock-harness',
+      supportsSessionContinuity: opts.supportsSessionContinuity,
+      start,
+      append,
+    };
+  }
+
+  it('starts a session on the first turn and appends only the latest message on later turns', async () => {
+    const driver = createMockDriver({ supportsSessionContinuity: true });
+    const conv = new PlanConversation({ harnessSessionDriver: driver });
+
+    mockCursorResponse('Turn one reply');
+    await conv.sendMessage('First message');
+    expect(driver.start).toHaveBeenCalledTimes(1);
+    expect(driver.start.mock.calls[0][0]).toContain('First message');
+    expect(driver.append).not.toHaveBeenCalled();
+    expect(conv.harnessSessionId).toBe('session-1');
+
+    mockCursorResponse('Turn two reply');
+    await conv.sendMessage('Second message');
+    expect(driver.append).toHaveBeenCalledTimes(1);
+    expect(driver.append.mock.calls[0][0]).toBe('session-1');
+    expect(driver.append.mock.calls[0][1]).toBe('Second message');
+    expect(driver.start).toHaveBeenCalledTimes(1);
+
+    const secondSpawnArgs = mockSpawn.mock.calls[1][1] as string[];
+    expect(secondSpawnArgs).toEqual(['append', 'session-1']);
+  });
+
+  it('fires onHarnessSessionId once when a new session id is established', async () => {
+    const driver = createMockDriver({ supportsSessionContinuity: true });
+    const onHarnessSessionId = vi.fn();
+    const conv = new PlanConversation({ harnessSessionDriver: driver, onHarnessSessionId });
+
+    mockCursorResponse('Turn one reply');
+    await conv.sendMessage('First message');
+    expect(onHarnessSessionId).toHaveBeenCalledTimes(1);
+    expect(onHarnessSessionId).toHaveBeenCalledWith('session-1');
+
+    mockCursorResponse('Turn two reply');
+    await conv.sendMessage('Second message');
+    expect(onHarnessSessionId).toHaveBeenCalledTimes(1);
+  });
+
+  it('resumes from a restored harnessSessionId instead of starting fresh', async () => {
+    const driver = createMockDriver({ supportsSessionContinuity: true });
+    const conv = new PlanConversation({ harnessSessionDriver: driver, harnessSessionId: 'restored-session' });
+
+    mockCursorResponse('Reply after restart');
+    await conv.sendMessage('Continue where we left off');
+    expect(driver.start).not.toHaveBeenCalled();
+    expect(driver.append).toHaveBeenCalledTimes(1);
+    expect(driver.append.mock.calls[0][0]).toBe('restored-session');
+    expect(conv.harnessSessionId).toBe('restored-session');
+  });
+
+  it('keeps sending full conversation history to a driver without session continuity', async () => {
+    const driver = createMockDriver({ supportsSessionContinuity: false });
+    const conv = new PlanConversation({ harnessSessionDriver: driver });
+
+    mockCursorResponse('Turn one reply');
+    await conv.sendMessage('First message');
+    mockCursorResponse('Turn two reply');
+    await conv.sendMessage('Second message');
+
+    expect(driver.start).toHaveBeenCalledTimes(1);
+    expect(driver.append).toHaveBeenCalledTimes(1);
+    expect(driver.append.mock.calls[0][1]).toContain('Conversation History');
+    expect(driver.append.mock.calls[0][1]).toContain('First message');
+    expect(driver.append.mock.calls[0][1]).toContain('Second message');
+    expect(conv.harnessSessionId).toBe('session-2');
+  });
+
+  it('falls back to the legacy planningCommandBuilder path when no driver is configured', async () => {
+    mockCursorResponse('Legacy reply');
+    const conv = new PlanConversation({});
+    const reply = await conv.sendMessage('Hello');
+    expect(reply).toBe('Legacy reply');
+    expect(conv.harnessSessionId).toBeUndefined();
   });
 });
 

--- a/packages/surfaces/src/slack/harness-session-driver-select.ts
+++ b/packages/surfaces/src/slack/harness-session-driver-select.ts
@@ -1,0 +1,30 @@
+import { ExecutionHarnessSessionDriver, ReplayHarnessSessionDriver } from '@invoker/execution-engine';
+import type { ExecutionAgent, HarnessSessionDriver } from '@invoker/execution-engine';
+import type { PlanningCommandBuilder } from './plan-conversation.js';
+
+export interface HarnessPresetLike {
+  tool: string;
+  model?: string;
+}
+
+export interface HarnessSessionDriverDeps {
+  /** Looks up a registered execution agent (claude/codex/omp) by harness tool name. */
+  executionAgentRegistry?: { get(name: string): ExecutionAgent | undefined };
+  /** Builds the planner CLI command for harnesses without real session resume (e.g. cursor). */
+  planningCommandBuilder?: PlanningCommandBuilder;
+}
+
+/** Picks an ExecutionHarnessSessionDriver for tools with a registered execution agent, else a ReplayHarnessSessionDriver, else undefined. */
+export function selectHarnessSessionDriver(
+  preset: HarnessPresetLike,
+  deps: HarnessSessionDriverDeps,
+): HarnessSessionDriver | undefined {
+  const agent = deps.executionAgentRegistry?.get(preset.tool);
+  if (agent) {
+    return new ExecutionHarnessSessionDriver(agent);
+  }
+  if (!deps.planningCommandBuilder) return undefined;
+  const planningCommandBuilder = deps.planningCommandBuilder;
+  return new ReplayHarnessSessionDriver(preset.tool, (prompt, options) =>
+    planningCommandBuilder({ tool: preset.tool, model: options?.model ?? preset.model, prompt }));
+}

--- a/packages/surfaces/src/slack/index.ts
+++ b/packages/surfaces/src/slack/index.ts
@@ -3,5 +3,6 @@ export * from './slack-formatter.js';
 export * from './slack-surface.js';
 export * from './plan-conversation.js';
 export * from './thread-session-manager.js';
+export * from './harness-session-driver-select.js';
 export * from './workflow-assistant.js';
 export * from './plan-summary.js';

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -16,6 +16,7 @@ import { basename, dirname, join } from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import type { ConversationRepository } from '@invoker/data-store';
 import { formatCodexPlannerStdout } from '@invoker/execution-engine';
+import type { HarnessSessionDriver } from '@invoker/execution-engine';
 import { isDraftingAuthorized, summarizePlanText } from '@invoker/planning-core';
 import type { LogFn } from '../surface.js';
 import {
@@ -121,6 +122,12 @@ export interface PlanConversationConfig {
   preferStackedWorkflows?: boolean;
   /** Optional callback for raw stdout chunks emitted by the planner subprocess. */
   onRawPlannerOutput?: RawPlannerOutputHandler;
+  /** When set, turns call `driver.start`/`driver.append` instead of spawning a fresh CLI with the full history baked into the prompt. */
+  harnessSessionDriver?: HarnessSessionDriver;
+  /** Restores an existing harness session id (e.g. after a Slack restart) instead of starting fresh. */
+  harnessSessionId?: string;
+  /** Fired whenever a new harness session id is established, so callers can persist it. */
+  onHarnessSessionId?: (sessionId: string) => void;
   /** Opt in to a scoping-first planning conversation before YAML drafting. Default: false. */
   conversationalPlanning?: boolean;
   /** Logging callback. Defaults to console.log/console.error. */
@@ -439,6 +446,9 @@ export class PlanConversation {
   private _lastTurnReasoning: string[] = [];
   private _lastTurnDraftPlanText: string | null = null;
   private lastKnownGoodPlanText: string | null = null;
+  private harnessSessionDriver?: HarnessSessionDriver;
+  private _harnessSessionId?: string;
+  private onHarnessSessionId?: (sessionId: string) => void;
 
   constructor(config: PlanConversationConfig) {
     this.cursorCommand = config.cursorCommand ?? 'agent';
@@ -461,6 +471,9 @@ export class PlanConversation {
     this.log = config.log ?? ((src, lvl, msg) => {
       (lvl === 'error' ? console.error : console.log)(`[${src}] ${msg}`);
     });
+    this.harnessSessionDriver = config.harnessSessionDriver;
+    this._harnessSessionId = config.harnessSessionId;
+    this.onHarnessSessionId = config.onHarnessSessionId;
   }
 
   /**
@@ -517,7 +530,7 @@ export class PlanConversation {
     this.resetPlanDraftFile();
     this.messages.push({ role: 'user', content: userMessage });
 
-    const prompt = this.buildCursorPrompt();
+    const prompt = this.buildTurnPrompt();
     const tPrompt = Date.now();
     this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: promptLen=${prompt.length}, historyMsgs=${this.messages.length - 1}, promptPreview="${prompt.slice(0, 500).replace(/\n/g, '\\n')}"`);
 
@@ -596,6 +609,11 @@ export class PlanConversation {
     return this.mode;
   }
 
+  /** Current harness session id, if a session driver has established one. */
+  get harnessSessionId(): string | undefined {
+    return this._harnessSessionId;
+  }
+
   /** Returns the last complete YAML plan drafted in this conversation, or null. */
   getDraftedPlan(): string | null {
     return this.readPlanDraftFile() ?? this.extractLastPlanFromMessages() ?? this.lastKnownGoodPlanText;
@@ -657,6 +675,14 @@ export class PlanConversation {
 
   // ── Prompt Construction ────────────────────────────────
 
+  /** Latest message only when resuming a continuity-supporting session; otherwise the full history prompt. */
+  private buildTurnPrompt(): string {
+    if (this.harnessSessionDriver?.supportsSessionContinuity && this._harnessSessionId) {
+      return this.messages[this.messages.length - 1]?.content ?? '';
+    }
+    return this.buildCursorPrompt();
+  }
+
   /**
    * Build the full prompt for Cursor, including system instructions
    * and the complete conversation history.
@@ -705,6 +731,10 @@ export class PlanConversation {
   // ── Planner CLI Subprocess ─────────────────────────────
 
   async spawnPlanner(prompt: string): Promise<string> {
+    if (this.harnessSessionDriver) {
+      return this.spawnPlannerWithDriver(prompt, this.harnessSessionDriver);
+    }
+
     const requiresRegisteredBuilder = this.tool === 'omp' || this.tool === 'codex';
     if (requiresRegisteredBuilder && !this.planningCommandBuilder) {
       throw new Error(`Planner command builder is required for selected tool "${this.tool}"`);
@@ -716,6 +746,31 @@ export class PlanConversation {
       throw new Error(`Planner command mismatch: selected tool "${this.tool}" resolved to "${command}"`);
     }
     const plannerLabel = this.tool ?? command;
+    return this.runSpawnWithRetry(prompt, command, args, plannerLabel);
+  }
+
+  private async spawnPlannerWithDriver(prompt: string, driver: HarnessSessionDriver): Promise<string> {
+    const priorSessionId = this._harnessSessionId;
+    const built = priorSessionId
+      ? driver.append(priorSessionId, prompt, { model: this.model })
+      : driver.start(prompt, { model: this.model });
+    const reply = await this.runSpawnWithRetry(prompt, built.command, built.args, driver.harness);
+    this.setHarnessSessionId(built.sessionId);
+    return reply;
+  }
+
+  private setHarnessSessionId(sessionId: string): void {
+    if (!sessionId || this._harnessSessionId === sessionId) return;
+    this._harnessSessionId = sessionId;
+    this.onHarnessSessionId?.(sessionId);
+  }
+
+  private async runSpawnWithRetry(
+    prompt: string,
+    command: string,
+    args: string[],
+    plannerLabel: string,
+  ): Promise<string> {
     const totalAttempts = this.plannerRetryLimit + 1;
     let lastStderrTail = '';
 

--- a/packages/surfaces/src/slack/thread-session-manager.ts
+++ b/packages/surfaces/src/slack/thread-session-manager.ts
@@ -16,6 +16,7 @@
 import { PlanConversation } from './plan-conversation.js';
 import type { ConversationMode, PlanningCommandBuilder } from './plan-conversation.js';
 import type { ConversationRepository } from '@invoker/data-store';
+import type { HarnessSessionDriver } from '@invoker/execution-engine';
 import type { LogFn } from '../surface.js';
 
 // ── Types ───────────────────────────────────────────────────────
@@ -135,6 +136,12 @@ export class SessionHandle {
   get conversationMode(): ConversationMode {
     return this.conversation.conversationMode;
   }
+
+  /** Current harness session id, if a session driver has established one. */
+  get harnessSessionId(): string | undefined {
+    return this.conversation.harnessSessionId;
+  }
+
   /** Returns the last complete YAML plan drafted in this conversation, or null. */
   getDraftedPlan(): string | null {
     return this.conversation.getDraftedPlan();
@@ -197,6 +204,8 @@ export interface SessionManagerConfig {
   plannerRetryBaseDelayMs?: number;
   /** Opt in to scoping-first conversational planning before YAML drafting. Default: false. */
   conversationalPlanning?: boolean;
+  /** Fired whenever a session establishes or updates its harness session id, so callers can persist it. */
+  onHarnessSessionId?: (id: SessionIdentifier, sessionId: string) => void;
 }
 
 export interface SessionMetrics {
@@ -206,7 +215,15 @@ export interface SessionMetrics {
   active: number;
 }
 
-type SessionOptions = { tool?: string; model?: string; workingDir?: string; mode?: ConversationMode; repoUrl?: string };
+type SessionOptions = {
+  tool?: string;
+  model?: string;
+  workingDir?: string;
+  mode?: ConversationMode;
+  repoUrl?: string;
+  harnessSessionDriver?: HarnessSessionDriver;
+  harnessSessionId?: string;
+};
 
 const defaultLog: LogFn = (component, level, message) => {
   const prefix = `[${component}]`;
@@ -240,6 +257,7 @@ export class SessionManager {
   private readonly plannerRetryLimit?: number;
   private readonly plannerRetryBaseDelayMs?: number;
   private readonly conversationalPlanning: boolean;
+  private readonly onHarnessSessionId?: (id: SessionIdentifier, sessionId: string) => void;
 
   constructor(config: SessionManagerConfig) {
     this.cursorCommand = config.cursorCommand ?? 'agent';
@@ -258,6 +276,7 @@ export class SessionManager {
     this.plannerRetryLimit = config.plannerRetryLimit;
     this.plannerRetryBaseDelayMs = config.plannerRetryBaseDelayMs;
     this.conversationalPlanning = config.conversationalPlanning ?? false;
+    this.onHarnessSessionId = config.onHarnessSessionId;
   }
 
   /**
@@ -350,6 +369,9 @@ export class SessionManager {
         plannerRetryLimit: this.plannerRetryLimit,
         plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
         conversationalPlanning: this.conversationalPlanning,
+        harnessSessionDriver: opts?.harnessSessionDriver,
+        harnessSessionId: opts?.harnessSessionId,
+        onHarnessSessionId: this.onHarnessSessionId ? (sessionId) => this.onHarnessSessionId!(id, sessionId) : undefined,
       });
       await conversation.init(); // Load state from database
       this.log('session-manager', 'info', `[TRACE] Recovery init() done (threadTs=${id.threadTs})`);
@@ -384,6 +406,9 @@ export class SessionManager {
         plannerRetryLimit: this.plannerRetryLimit,
         plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
         conversationalPlanning: this.conversationalPlanning,
+        harnessSessionDriver: opts?.harnessSessionDriver,
+        harnessSessionId: opts?.harnessSessionId,
+        onHarnessSessionId: this.onHarnessSessionId ? (sessionId) => this.onHarnessSessionId!(id, sessionId) : undefined,
       });
       // Don't call init() for new sessions — nothing to load
 

--- a/scripts/kill-all-electron.sh
+++ b/scripts/kill-all-electron.sh
@@ -11,7 +11,7 @@ list_electron_processes() {
       *kill-all-electron.sh*)
         continue
         ;;
-      *Electron.app/Contents/MacOS/Electron*|*"node "*scripts/electron.cjs*)
+      *Electron.app/Contents/MacOS/Electron*|*"node "*scripts/electron.cjs*|*Invoker.app/Contents/MacOS/Invoker*|*packages/app/dist/main.js*)
         printf '%s %s\n' "$pid" "$command"
         ;;
     esac

--- a/scripts/repro/repro-embedded-slack-dual-consumer.sh
+++ b/scripts/repro/repro-embedded-slack-dual-consumer.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Repro: installed Invoker.app still embeds Slack Socket Mode, and
+# scripts/kill-all-electron.sh historically did NOT match that process — so a
+# desktop Invoker (or invoker-ui --headless owner-serve) can steal Socket Mode
+# events from local `pnpm --filter @invoker/slack-manager start`.
+#
+# Observed incident: @Invoker /plan got answers from another consumer while local
+# slack-manager logs showed zero MENTION_RECEIVED for those event_ts values.
+# Killing Invoker.app (beyond what kill-all-electron matched) made the next
+# /plan hit local immediately.
+#
+# Usage:
+#   bash scripts/repro/repro-embedded-slack-dual-consumer.sh --expect bug
+#   bash scripts/repro/repro-embedded-slack-dual-consumer.sh --expect fixed
+#
+# Exit 0 = observed matcher coverage matches --expect
+# Exit 1 = observed matcher coverage does not match --expect
+# Exit 2 = invalid args / missing kill script
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+KILL_SCRIPT="$REPO_ROOT/scripts/kill-all-electron.sh"
+EXPECTATION=""
+
+log() { printf '[repro-embedded-slack] %s\n' "$*"; }
+
+usage() {
+  sed -n '2,18p' "$0" | sed 's/^# \?//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      log "unknown arg: $1"
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "bug" && "$EXPECTATION" != "fixed" ]]; then
+  log "--expect requires bug|fixed"
+  usage >&2
+  exit 2
+fi
+
+[[ -f "$KILL_SCRIPT" ]] || { log "missing $KILL_SCRIPT"; exit 2; }
+
+# Mirror the LIVE case-arm in kill-all-electron.sh (keep in sync when reading
+# failures; the source-of-truth check below greps the file directly).
+live_kill_all_electron_matches() {
+  local command=$1
+  case "$command" in
+    *kill-all-electron.sh*) return 1 ;;
+    *Electron.app/Contents/MacOS/Electron*|*"node "*scripts/electron.cjs*|*Invoker.app/Contents/MacOS/Invoker*|*packages/app/dist/main.js*)
+      # Expanded arm used only after the fix lands; live script may still lack it.
+      if grep -qF 'Invoker.app/Contents/MacOS/Invoker' "$KILL_SCRIPT" \
+        && grep -qF 'packages/app/dist/main.js' "$KILL_SCRIPT"; then
+        return 0
+      fi
+      case "$command" in
+        *Electron.app/Contents/MacOS/Electron*|*"node "*scripts/electron.cjs*) return 0 ;;
+        *) return 1 ;;
+      esac
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+log "=== Part 1: kill-all-electron.sh coverage for Invoker.app Socket Mode owners ==="
+
+REQUIRED_SUBSTRINGS=(
+  'Invoker.app/Contents/MacOS/Invoker'
+  'packages/app/dist/main.js'
+)
+MATCHERS_PRESENT=1
+for needle in "${REQUIRED_SUBSTRINGS[@]}"; do
+  if grep -qF "$needle" "$KILL_SCRIPT"; then
+    log "script contains matcher for: $needle"
+  else
+    log "kill-all-electron.sh missing matcher for: $needle"
+    MATCHERS_PRESENT=0
+  fi
+done
+
+FIXTURES=(
+  '/Applications/Invoker.app/Contents/MacOS/Invoker'
+  '/opt/homebrew/lib/node_modules/@neko-catpital-labs/invoker-ui/vendor/Invoker.app/Contents/MacOS/Invoker --headless owner-serve'
+  '/Users/me/Invoker/node_modules/.pnpm/electron@35.7.5/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron packages/app/dist/main.js'
+)
+
+FIXTURE_COVERAGE_OK=1
+for cmd in "${FIXTURES[@]}"; do
+  if live_kill_all_electron_matches "$cmd"; then
+    log "matcher hits: $cmd"
+  else
+    log "matcher MISSES competing owner: $cmd"
+    FIXTURE_COVERAGE_OK=0
+  fi
+done
+
+BUG_PRESENT=0
+if [[ "$MATCHERS_PRESENT" -eq 0 || "$FIXTURE_COVERAGE_OK" -eq 0 ]]; then
+  BUG_PRESENT=1
+fi
+
+log "=== Part 2: root-cause evidence — packaged Invoker.app embeds Slack ==="
+
+ASARS=(
+  /Applications/Invoker.app/Contents/Resources/app.asar
+  /opt/homebrew/lib/node_modules/@neko-catpital-labs/invoker-ui/vendor/Invoker.app/Contents/Resources/app.asar
+)
+FOUND_ASAR=
+asar_has() {
+  python3 - "$1" "$2" <<'PY'
+import sys
+from pathlib import Path
+data = Path(sys.argv[1]).read_bytes()
+sys.exit(0 if sys.argv[2].encode() in data else 1)
+PY
+}
+for asar in "${ASARS[@]}"; do
+  [[ -f "$asar" ]] || continue
+  FOUND_ASAR=$asar
+  log "inspecting $asar"
+  if asar_has "$asar" 'Slack bot started (embedded in GUI)'; then
+    log "PROOF: asar starts Slack in-process (embedded in GUI)"
+  else
+    log "WARN: asar present but missing embedded-Slack marker: $asar"
+  fi
+  if asar_has "$asar" 'wireSlackBot'; then
+    log "PROOF: asar contains wireSlackBot"
+  else
+    log "WARN: asar present but missing wireSlackBot: $asar"
+  fi
+  if asar_has "$asar" 'acquireSlackConsumerLock'; then
+    log "asar includes consumer lock symbol"
+  else
+    log "PROOF: asar has NO acquireSlackConsumerLock — ignores slack-manager's lock file"
+  fi
+done
+
+if [[ -z "$FOUND_ASAR" ]]; then
+  log "WARN: no Invoker.app asar on this machine; install evidence skipped (Part 1 still gates coverage)"
+fi
+
+log "=== Part 3: slack-manager lock cannot serialize Invoker.app (informational) ==="
+LOCK_SRC="$REPO_ROOT/packages/slack-manager/src/slack-consumer-lock.ts"
+if [[ -f "$LOCK_SRC" ]] && ! grep -qF 'Invoker.app' "$LOCK_SRC"; then
+  log "PROOF: slack-consumer-lock.ts never mentions Invoker.app (PID lock is slack-manager-only)"
+fi
+
+if [[ "$BUG_PRESENT" -eq 1 ]]; then
+  cat <<EOF
+
+[repro-embedded-slack] BUG PRESENT:
+  1. Packaged Invoker.app still calls wireSlackBot / startSlackBot (Socket Mode in GUI).
+  2. scripts/kill-all-electron.sh does not cover Invoker.app / app dist competitors.
+  3. slack-manager's ~/.invoker/locks/slack-socket-consumer.lock is never acquired by Invoker.app,
+     so both clients connect; Slack load-balances events between them.
+EOF
+else
+  log "BUG ABSENT: kill-all-electron covers Invoker.app / app-dist Slack competitors."
+fi
+
+if [[ "$EXPECTATION" == "bug" ]]; then
+  if [[ "$BUG_PRESENT" -eq 1 ]]; then
+    log "PASS: --expect bug matched (coverage gap still open)."
+    exit 0
+  fi
+  log "FAIL: --expect bug but kill-all-electron already covers Invoker.app competitors."
+  exit 1
+fi
+
+if [[ "$BUG_PRESENT" -eq 0 ]]; then
+  log "PASS: --expect fixed matched."
+  exit 0
+fi
+log "FAIL: --expect fixed but kill-all-electron still misses Invoker.app competitors."
+exit 1


### PR DESCRIPTION
## Summary

Stacked YAML submissions need a parser that can yield more than one plan.

This slice adds parsePlanSubmissionBundleFile before owner-mode run wiring consumes it.

## Review Claim

Approve parsePlanSubmissionBundleFile for stacked plan submissions.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Parser-focused coverage covers the new helper before run paths call it.

## Slice Rationale

Parser foundation must land before owner-mode and IPC callers.

## Non-goals

Does not change owner-mode run or GUI IPC yet.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/plan-parser.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
