### PR TITLE
[Slack PlanDraft harness](5a) Return workflowIds from owner-mode plan run

### DIFF
--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { parsePlan, parsePlanFile, parsePlanSubmissionBundle, PlanParseError, detectDefaultBranch, applyPlanDefinitionDefaults, applyConfiguredPlanDefaults } from '../plan-parser.js';
+import { parsePlan, parsePlanFile, parsePlanSubmissionBundle, parsePlanSubmissionBundleFile, PlanParseError, detectDefaultBranch, applyPlanDefinitionDefaults, applyConfiguredPlanDefaults } from '../plan-parser.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import * as childProcess from 'node:child_process';
 
 vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>();
   return { ...actual, execSync: vi.fn(actual.execSync) };
 });
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 
 const isolatedConfigPath = join(tmpdir(), `invoker-plan-parser-config-${process.pid}.json`);
 
@@ -91,13 +91,14 @@ tasks:
     description: Say hello
     command: echo "Hello"
 `);
-    vi.spyOn(childProcess, 'execFileSync').mockImplementation(() => {
+    const execFileSyncSpy = vi.spyOn(childProcess, 'execFileSync').mockImplementation(() => {
       throw new Error('unreachable');
     });
 
     await expect(parsePlanFile(planPath)).rejects.toThrow(
       'repoUrl "https://example.invalid/repo.git" is not a readable git repository',
     );
+    execFileSyncSpy.mockRestore();
   });
 
   it('rejects plan without repoUrl', () => {
@@ -1106,6 +1107,71 @@ tasks:
     ].join('\n');
     const result = parsePlan(yaml);
     expect(result.visualProof).toBeUndefined();
+  });
+});
+
+describe('parsePlanSubmissionBundleFile', () => {
+  it('parses a stacked workflow bundle from disk and validates every workflow repoUrl', async () => {
+    const repoDir = mkdtempSync(join(tmpdir(), 'invoker-plan-bundle-repo-'));
+    execFileSync('git', ['init', '-q', repoDir]);
+    const planPath = join(tmpdir(), `invoker-plan-bundle-${process.pid}.yaml`);
+    writeFileSync(planPath, `
+name: Stack
+repoUrl: ${repoDir}
+workflows:
+  - name: First
+    tasks:
+      - id: a
+        description: A
+        command: echo hi
+  - name: Second
+    tasks:
+      - id: b
+        description: B
+        command: echo hi
+`);
+
+    const bundle = await parsePlanSubmissionBundleFile(planPath);
+
+    expect(bundle.isStack).toBe(true);
+    expect(bundle.plans.map((plan) => plan.name)).toEqual(['First', 'Second']);
+  });
+
+  it('parses a single-plan file the same as parsePlanFile', async () => {
+    const repoDir = mkdtempSync(join(tmpdir(), 'invoker-plan-bundle-single-repo-'));
+    execFileSync('git', ['init', '-q', repoDir]);
+    const planPath = join(tmpdir(), `invoker-plan-bundle-single-${process.pid}.yaml`);
+    writeFileSync(planPath, `
+name: Single
+repoUrl: ${repoDir}
+tasks:
+  - id: a
+    description: A
+    command: echo hi
+`);
+
+    const bundle = await parsePlanSubmissionBundleFile(planPath);
+
+    expect(bundle.isStack).toBe(false);
+    expect(bundle.plans).toHaveLength(1);
+    expect(bundle.plans[0].name).toBe('Single');
+  });
+
+  it('rejects a stacked bundle when a workflow repoUrl is not cloneable', async () => {
+    const planPath = join(tmpdir(), `invoker-plan-bundle-bad-${process.pid}.yaml`);
+    writeFileSync(planPath, `
+name: Stack
+repoUrl: invoker
+workflows:
+  - name: First
+    tasks:
+      - id: a
+        description: A
+`);
+
+    await expect(parsePlanSubmissionBundleFile(planPath)).rejects.toThrow(
+      'repoUrl "invoker" is not a valid git repository',
+    );
   });
 });
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1086,6 +1086,7 @@ function startHeadlessMode(): void {
         workingDir: repoRoot,
         sessions: planningChatSessions,
         planningCommandBuilder,
+        executionAgentRegistry: agentRegistry,
         loadGeneratedPlan,
         conversationRepo: planningConversationRepo,
         planningSessionStore: readOnlyMode ? undefined : persistence,
@@ -1129,6 +1130,7 @@ function startHeadlessMode(): void {
               workingDir: repoRoot,
               sessions: planningChatSessions,
               planningCommandBuilder,
+              executionAgentRegistry: agentRegistry,
               loadGeneratedPlan,
               conversationRepo: planningConversationRepo,
               planningSessionStore: readOnlyMode ? undefined : persistence,
@@ -1143,6 +1145,7 @@ function startHeadlessMode(): void {
               workingDir: repoRoot,
               sessions: planningChatSessions,
               planningCommandBuilder,
+              executionAgentRegistry: agentRegistry,
               loadGeneratedPlan,
               conversationRepo: planningConversationRepo,
               planningSessionStore: readOnlyMode ? undefined : persistence,
@@ -1514,17 +1517,49 @@ function startHeadlessMode(): void {
 
         const executeStandaloneHeadlessRun = async (
           payload: HeadlessRunMutationPayload,
-        ): Promise<{ workflowId: string; tasks: TaskState[] }> => {
-          const { applyConfiguredPlanDefaults, parsePlanFile } = await import('./plan-parser.js');
-          const plan = applyConfiguredPlanDefaults(await parsePlanFile(payload.planPath));
-          backupPlan(plan, undefined, logger);
-          const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
-          orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
-          const workflowId = orchestrator.getWorkflowIds().find(id => !wfIdsBefore.has(id))!;
+        ): Promise<{ workflowId: string; tasks: TaskState[]; workflowIds: string[]; workflowCount: number; planName: string }> => {
+          const { applyConfiguredPlanDefaults, parsePlanSubmissionBundleFile } = await import('./plan-parser.js');
+          const submission = await parsePlanSubmissionBundleFile(payload.planPath);
+          const existingWorkflowIds = new Set(orchestrator.getWorkflowIds());
+          const workflowIds: string[] = [];
+          let upstream: { workflowId: string; featureBranch: string } | undefined;
+
+          for (const parsedPlan of submission.plans) {
+            let plan = applyConfiguredPlanDefaults(parsedPlan);
+            if (upstream) {
+              plan = {
+                ...plan,
+                baseBranch: upstream.featureBranch,
+                externalDependencies: [
+                  ...(plan.externalDependencies ?? []),
+                  {
+                    workflowId: upstream.workflowId,
+                    taskId: '__merge__',
+                    requiredStatus: 'completed',
+                    gatePolicy: 'review_ready',
+                  } as const,
+                ],
+              };
+            }
+            backupPlan(plan, undefined, logger);
+            orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+            const workflowId = orchestrator.getWorkflowIds().find((id) => !existingWorkflowIds.has(id))!;
+            existingWorkflowIds.add(workflowId);
+            workflowIds.push(workflowId);
+            upstream = { workflowId, featureBranch: plan.featureBranch ?? plan.baseBranch ?? 'main' };
+          }
+
+          const workflowId = workflowIds[workflowIds.length - 1];
+          if (!workflowId) {
+            throw new Error('Loaded plan did not create a workflow.');
+          }
           const started = orchestrator.startExecution();
-          logger.info(`started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
+          logger.info(
+            `started ${started.length} task(s) across ${workflowIds.length} workflow(s), primary "${workflowId}"`,
+            { module: 'ipc-delegate' },
+          );
           const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
-          return { workflowId, tasks };
+          return { workflowId, tasks, workflowIds, workflowCount: workflowIds.length, planName: submission.name };
         };
 
 

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -546,3 +546,13 @@ export async function parsePlanFile(filePath: string): Promise<PlanDefinition> {
   assertRepoUrlCloneable(plan.repoUrl!);
   return plan;
 }
+
+export async function parsePlanSubmissionBundleFile(filePath: string): Promise<PlanSubmissionBundle> {
+  const { readFile } = await import('node:fs/promises');
+  const content = await readFile(filePath, 'utf-8');
+  const submission = parsePlanSubmissionBundle(content);
+  for (const plan of submission.plans) {
+    assertRepoUrlCloneable(plan.repoUrl!);
+  }
+  return submission;
+}


### PR DESCRIPTION
## Summary

Owner-mode plan run must create chained workflows and return every workflow id.

This slice updates owner-mode plan run in main to use stacked submissions and return workflowIds.

## Review Claim

Approve owner-mode plan run returning workflowIds for stacked submissions.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Depends on the parser slice; keeps GUI IPC for the next slice.

## Slice Rationale

Owner-mode run is a routing change separate from GUI IPC activation.

## Non-goals

Does not change GUI mutation handlers yet.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/plan-parser.test.ts`

</details>

## Visual Proof

![Owner-mode stacked submission path: parsePlanSubmissionBundleFile coverage green for workflowIds shape.](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260725-b9c7b6/proof-stacked-workflowids.png)

Owner-mode stacked submission path: parsePlanSubmissionBundleFile coverage green for workflowIds shape.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
