### PR TITLE
[CI Infra Repair Gate](1) Skip agent recovery for checkout hygiene failures

### DIFF
--- a/packages/app/src/review-gate-ci-repair-command.ts
+++ b/packages/app/src/review-gate-ci-repair-command.ts
@@ -1,5 +1,6 @@
 import type { SQLiteAdapter } from '@invoker/data-store';
 import {
+  createFailedCheckLogFetcher,
   GitHubMergeGateProvider,
   queueReviewGateCiRepair,
   type MergeGateApprovalStatus,
@@ -87,7 +88,12 @@ export async function repairReviewGateCiByPr(
   const createdAt = deps.now?.() ?? new Date().toISOString();
   const generation = mergeTask.execution.generation ?? lookup.workflowGeneration ?? 0;
   const attemptId = mergeTask.execution.selectedAttemptId ?? lookup.selectedAttemptId;
-  const result = await queueReviewGateCiRepair(deps.policy, {
+  const policy: ReviewGateCiRepairPolicyOptions = {
+    ...deps.policy,
+    fetchFailedCheckLogs: deps.policy.fetchFailedCheckLogs
+      ?? createFailedCheckLogFetcher({ cwd: deps.repoRoot }),
+  };
+  const result = await queueReviewGateCiRepair(policy, {
     eventKey: `review_gate.ci_failed|workflow:${lookup.workflowId}|task:${mergeTask.id}|scan:${prNumber}`,
     kind: 'review_gate.ci_failed',
     workflowId: lookup.workflowId,

--- a/packages/execution-engine/src/__tests__/ci-failure-infra-classifier.test.ts
+++ b/packages/execution-engine/src/__tests__/ci-failure-infra-classifier.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  classifyFailedChecks,
+  createFailedCheckLogFetcher,
+  isInfraCiFailureLog,
+  parseActionsDetailsUrl,
+} from '../ci-failure-infra-classifier.js';
+import { PR_5188_INFRA_LOG } from './fixtures/pr-5188-infra-ci-log.js';
+
+const CODE_FAILURE_LOG = `
+FAIL src/example.test.ts > does the thing
+AssertionError: expected 1 to be 2
+`;
+
+describe('parseActionsDetailsUrl', () => {
+  it('parses run and job ids from Actions details URLs', () => {
+    expect(parseActionsDetailsUrl(
+      'https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/29723090393/job/88290047107',
+    )).toEqual({ runId: '29723090393', jobId: '88290047107' });
+  });
+
+  it('parses run-only URLs', () => {
+    expect(parseActionsDetailsUrl(
+      'https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/29723090393',
+    )).toEqual({ runId: '29723090393' });
+  });
+
+  it('returns null for non-Actions URLs', () => {
+    expect(parseActionsDetailsUrl('https://example.com/checks/1')).toBeNull();
+  });
+});
+
+describe('isInfraCiFailureLog', () => {
+  it('matches PR #5188 packed-refs / EACCES checkout failure', () => {
+    expect(isInfraCiFailureLog(PR_5188_INFRA_LOG)).toBe(true);
+  });
+
+  it('rejects ordinary test failure logs', () => {
+    expect(isInfraCiFailureLog(CODE_FAILURE_LOG)).toBe(false);
+  });
+});
+
+describe('classifyFailedChecks', () => {
+  const checks = [
+    {
+      name: 'PR Body',
+      conclusion: 'FAILURE',
+      detailsUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/29723090425/job/88290047072',
+    },
+    {
+      name: 'quality / Dependency Cruise',
+      conclusion: 'FAILURE',
+      detailsUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/29723090393/job/88290047107',
+    },
+  ];
+
+  it('classifies infra when every fetched log is infra', () => {
+    const logs = new Map(checks.map((check) => [check.detailsUrl!, PR_5188_INFRA_LOG]));
+    expect(classifyFailedChecks(checks, logs)).toMatchObject({
+      classification: 'infra',
+      classifiedCheckCount: 2,
+    });
+  });
+
+  it('classifies code when any fetched log is not infra', () => {
+    const logs = new Map<string, string>([
+      [checks[0].detailsUrl!, PR_5188_INFRA_LOG],
+      [checks[1].detailsUrl!, CODE_FAILURE_LOG],
+    ]);
+    expect(classifyFailedChecks(checks, logs).classification).toBe('code');
+  });
+
+  it('classifies unknown when no logs are available', () => {
+    expect(classifyFailedChecks(checks, new Map()).classification).toBe('unknown');
+  });
+});
+
+describe('createFailedCheckLogFetcher', () => {
+  it('fetches job-scoped failed logs via gh', async () => {
+    const runGh = vi.fn(async () => PR_5188_INFRA_LOG);
+    const fetchLogs = createFailedCheckLogFetcher({ cwd: '/tmp', runGh });
+    const url = 'https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/1/job/2';
+    const logs = await fetchLogs([{ name: 'PR Body', detailsUrl: url }]);
+    expect(runGh).toHaveBeenCalledWith(['run', 'view', '--log-failed', '--job', '2'], '/tmp');
+    expect(logs.get(url)).toBe(PR_5188_INFRA_LOG);
+  });
+
+  it('fails open when gh errors', async () => {
+    const fetchLogs = createFailedCheckLogFetcher({
+      runGh: async () => {
+        throw new Error('boom');
+      },
+    });
+    const url = 'https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/1/job/2';
+    const logs = await fetchLogs([{ name: 'PR Body', detailsUrl: url }]);
+    expect(logs.size).toBe(0);
+  });
+});

--- a/packages/execution-engine/src/__tests__/fixtures/pr-5188-infra-ci-log.ts
+++ b/packages/execution-engine/src/__tests__/fixtures/pr-5188-infra-ci-log.ts
@@ -1,0 +1,7 @@
+/** Log excerpt from PR #5188 checkout failure on invoker-do2-gha-ssh. */
+export const PR_5188_INFRA_LOG = `
+##[group]Run actions/checkout@v4
+##[error]error: could not delete reference refs/heads/experiment/e2e-g336-ssh-pr: Unable to create '/home/invoker/actions-runner-do2-ssh/_work/Invoker/Invoker/.git/packed-refs.lock': Permission denied
+##[warning]Unable to prepare the existing repository. The repository will be recreated instead.
+##[error]File was unable to be removed Error: EACCES: permission denied, rmdir '/home/invoker/actions-runner-do2-ssh/_work/Invoker/Invoker/.claude/plugins'
+`;

--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -19,6 +19,12 @@ import {
   DEFAULT_PR_STATUS_WORKER_INTERVAL_MS,
   createPrStatusWorker,
 } from '../workers/pr-status-worker.js';
+import { PR_5188_INFRA_LOG } from './fixtures/pr-5188-infra-ci-log.js';
+
+const CODE_FAILURE_LOG = `
+FAIL src/example.test.ts > does the thing
+AssertionError: expected 1 to be 2
+`;
 
 
 const logger = {
@@ -313,5 +319,102 @@ describe('PR status and CI failure workers', () => {
     }, '123');
 
     expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('skips fix-with-agent for PR #5188-shaped infra checkout failures', async () => {
+    const event = makeEvent({
+      failedChecks: [
+        {
+          name: 'PR Body',
+          conclusion: 'FAILURE',
+          detailsUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/29723090425/job/88290047072',
+        },
+        {
+          name: 'quality / Dependency Cruise',
+          conclusion: 'FAILURE',
+          detailsUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/29723090393/job/88290047107',
+        },
+        {
+          name: 'quality / Release Version Sync',
+          conclusion: 'FAILURE',
+          detailsUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/29723090393/job/88290047118',
+        },
+      ],
+      reviewUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/5188',
+    });
+    const harness = makeHarness();
+    const ledgerKey = autoFixAttemptLedgerKeyFromLifecycleEvent(event);
+    const tick = createCiFailureTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 2,
+      drainEvents: () => [event],
+      fetchFailedCheckLogs: async (checks) => {
+        const logs = new Map<string, string>();
+        for (const check of checks) {
+          if (check.detailsUrl) logs.set(check.detailsUrl, PR_5188_INFRA_LOG);
+        }
+        return logs;
+      },
+    });
+
+    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
+
+    expect(harness.submit).not.toHaveBeenCalled();
+    expect(harness.attemptLedger.get(ledgerKey)).toBe(0);
+    expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toMatchObject({
+      status: 'skipped',
+      payload: expect.objectContaining({
+        reason: 'infra-failure',
+      }),
+    });
+  });
+
+  it('still queues fix-with-agent when fetched logs look like code failures', async () => {
+    const event = makeEvent({
+      failedChecks: [
+        {
+          name: 'unit',
+          conclusion: 'FAILURE',
+          detailsUrl: 'https://github.com/owner/repo/actions/runs/1/job/2',
+        },
+      ],
+    });
+    const harness = makeHarness();
+    const tick = createCiFailureTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 2,
+      drainEvents: () => [event],
+      fetchFailedCheckLogs: async () => new Map([
+        ['https://github.com/owner/repo/actions/runs/1/job/2', CODE_FAILURE_LOG],
+      ]),
+    });
+
+    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails open and queues repair when log fetch returns nothing', async () => {
+    const event = makeEvent();
+    const harness = makeHarness();
+    const tick = createCiFailureTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 2,
+      drainEvents: () => [event],
+      fetchFailedCheckLogs: async () => new Map(),
+    });
+
+    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/execution-engine/src/ci-failure-infra-classifier.ts
+++ b/packages/execution-engine/src/ci-failure-infra-classifier.ts
@@ -1,0 +1,186 @@
+import { spawn } from 'node:child_process';
+
+import type { ReviewGateFailedCheck } from './lifecycle-events.js';
+
+export type CiFailureClass = 'infra' | 'code' | 'unknown';
+
+export interface ParsedActionsDetailsUrl {
+  readonly runId: string;
+  readonly jobId?: string;
+}
+
+const ACTIONS_DETAILS_URL_RE =
+  /github\.com\/[^/]+\/[^/]+\/actions\/runs\/(\d+)(?:\/(?:attempts\/\d+\/)?jobs?\/(\d+))?/i;
+
+/** Extract run/job ids from a GitHub Actions details URL. */
+export function parseActionsDetailsUrl(detailsUrl: string | undefined): ParsedActionsDetailsUrl | null {
+  if (!detailsUrl?.trim()) return null;
+  const match = detailsUrl.match(ACTIONS_DETAILS_URL_RE);
+  if (!match) return null;
+  return {
+    runId: match[1],
+    ...(match[2] ? { jobId: match[2] } : {}),
+  };
+}
+
+/**
+ * True when failed-job log text matches self-hosted checkout / runner-hygiene
+ * failures (e.g. PR #5188 packed-refs.lock / EACCES on workspace cleanup).
+ */
+export function isInfraCiFailureLog(logText: string): boolean {
+  const text = logText.toLowerCase();
+  if (!text.trim()) return false;
+
+  const packedRefsPermission =
+    text.includes('packed-refs.lock') && text.includes('permission denied');
+  const eaccesCheckoutCleanup =
+    text.includes('eacces')
+    && text.includes('permission denied')
+    && (
+      text.includes('rmdir')
+      || text.includes('.claude/plugins')
+      || text.includes('actions/checkout')
+      || text.includes('unable to prepare the existing repository')
+    );
+  const checkoutPermissionDenied =
+    text.includes('actions/checkout')
+    && text.includes('permission denied')
+    && (
+      text.includes('packed-refs')
+      || text.includes('unable to prepare the existing repository')
+      || text.includes('file was unable to be removed')
+    );
+
+  return packedRefsPermission || eaccesCheckoutCleanup || checkoutPermissionDenied;
+}
+
+export interface ClassifyFailedChecksResult {
+  readonly classification: CiFailureClass;
+  readonly matchedSignals: readonly string[];
+  readonly classifiedCheckCount: number;
+}
+
+/**
+ * Classify a set of failed checks from their fetched logs.
+ * - infra: at least one log classified infra, and every fetched log is infra
+ * - code: any fetched log is not infra
+ * - unknown: no logs available / classifiable
+ */
+export function classifyFailedChecks(
+  checks: readonly ReviewGateFailedCheck[],
+  logsByDetailsUrl: ReadonlyMap<string, string>,
+): ClassifyFailedChecksResult {
+  const matchedSignals: string[] = [];
+  let classifiedCheckCount = 0;
+  let infraCount = 0;
+  let codeCount = 0;
+
+  for (const check of checks) {
+    const url = check.detailsUrl?.trim();
+    if (!url) continue;
+    const log = logsByDetailsUrl.get(url);
+    if (log === undefined) continue;
+    classifiedCheckCount += 1;
+    if (isInfraCiFailureLog(log)) {
+      infraCount += 1;
+      if (log.toLowerCase().includes('packed-refs.lock')) {
+        matchedSignals.push('packed-refs.lock-permission-denied');
+      }
+      if (log.toLowerCase().includes('eacces')) {
+        matchedSignals.push('eacces-permission-denied');
+      }
+      if (log.toLowerCase().includes('actions/checkout')) {
+        matchedSignals.push('actions-checkout-permission-denied');
+      }
+    } else {
+      codeCount += 1;
+    }
+  }
+
+  if (classifiedCheckCount === 0) {
+    return { classification: 'unknown', matchedSignals: [], classifiedCheckCount: 0 };
+  }
+  if (codeCount > 0) {
+    return { classification: 'code', matchedSignals: unique(matchedSignals), classifiedCheckCount };
+  }
+  if (infraCount > 0) {
+    return { classification: 'infra', matchedSignals: unique(matchedSignals), classifiedCheckCount };
+  }
+  return { classification: 'unknown', matchedSignals: [], classifiedCheckCount };
+}
+
+function unique(values: readonly string[]): string[] {
+  return [...new Set(values)];
+}
+
+export type FailedCheckLogFetcher = (
+  checks: readonly ReviewGateFailedCheck[],
+) => Promise<Map<string, string>>;
+
+export interface CreateFailedCheckLogFetcherOptions {
+  cwd?: string;
+  /** Override for tests; defaults to spawning `gh`. */
+  runGh?: (args: readonly string[], cwd: string) => Promise<string>;
+}
+
+async function defaultRunGh(args: readonly string[], cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('gh', [...args], {
+      cwd,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+    child.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(stdout);
+        return;
+      }
+      reject(new Error(`gh ${args.join(' ')} failed (code ${code}): ${stderr.trim()}`));
+    });
+  });
+}
+
+/** Build a fetcher that loads failed-step logs for Actions check details URLs. */
+export function createFailedCheckLogFetcher(
+  options: CreateFailedCheckLogFetcherOptions = {},
+): FailedCheckLogFetcher {
+  const cwd = options.cwd ?? process.cwd();
+  const runGh = options.runGh ?? defaultRunGh;
+
+  return async (checks) => {
+    const out = new Map<string, string>();
+    const seenRuns = new Map<string, string>();
+
+    for (const check of checks) {
+      const url = check.detailsUrl?.trim();
+      if (!url || out.has(url)) continue;
+      const parsed = parseActionsDetailsUrl(url);
+      if (!parsed) continue;
+
+      const cacheKey = parsed.jobId ? `job:${parsed.jobId}` : `run:${parsed.runId}`;
+      const cached = seenRuns.get(cacheKey);
+      if (cached !== undefined) {
+        out.set(url, cached);
+        continue;
+      }
+
+      try {
+        const args = parsed.jobId
+          ? ['run', 'view', '--log-failed', '--job', parsed.jobId]
+          : ['run', 'view', parsed.runId, '--log-failed'];
+        const log = await runGh(args, cwd);
+        seenRuns.set(cacheKey, log);
+        out.set(url, log);
+      } catch {
+        // Fail-open: missing logs leave the check unclassified.
+      }
+    }
+
+    return out;
+  };
+}

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -59,6 +59,7 @@ export * from './worker-lock.js';
 export * from './builtin-workers.js';
 export * from './auto-fix-recovery.js';
 export * from './review-gate-ci-repair.js';
+export * from './ci-failure-infra-classifier.js';
 export * from './workers/pr-status-worker.js';
 export * from './workers/pr-summary-refresh-worker.js';
 export * from './workers/ci-failure-worker.js';

--- a/packages/execution-engine/src/review-gate-ci-repair.ts
+++ b/packages/execution-engine/src/review-gate-ci-repair.ts
@@ -28,6 +28,10 @@ import type {
   ReviewGateCiFailedLifecycleEvent,
   ReviewGateFailedCheck,
 } from './lifecycle-events.js';
+import {
+  classifyFailedChecks,
+  type FailedCheckLogFetcher,
+} from './ci-failure-infra-classifier.js';
 import { recordWorkerDecisionRow } from './worker-decision-ledger.js';
 
 const CI_FAILURE_WORKER_KIND = 'ci-failure';
@@ -68,6 +72,8 @@ export interface ReviewGateCiRepairPolicyOptions {
   getAutoFixExecutionModel?: () => string | undefined;
   attemptLedger: AutoFixAttemptLedger;
   getRetryBudget?: (task: TaskState) => number;
+  /** Optional failed-check log fetcher used to skip non-fixable infra failures. */
+  fetchFailedCheckLogs?: FailedCheckLogFetcher;
 }
 
 export function ciFailureChecksHash(failedChecks: readonly ReviewGateFailedCheck[]): string {
@@ -399,6 +405,37 @@ export async function queueReviewGateCiRepair(
   if (stale.stale) {
     logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', { reason: stale.reason, ...stale.details });
     return { decision: 'skipped', reason: stale.reason };
+  }
+
+  if (options.fetchFailedCheckLogs) {
+    let logsByDetailsUrl = new Map<string, string>();
+    try {
+      logsByDetailsUrl = await options.fetchFailedCheckLogs(event.failedChecks);
+    } catch (error) {
+      logCiFailureWorkerEvent(options, event, 'worker-ci-failure-infra-classify-error', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    const classified = classifyFailedChecks(event.failedChecks, logsByDetailsUrl);
+    if (classified.classification === 'infra') {
+      recordCiFailureAction(
+        options,
+        event,
+        'skipped',
+        'Skipped CI repair because failure looks like runner/infra',
+        {
+          reason: 'infra-failure',
+          matchedSignals: [...classified.matchedSignals],
+          classifiedCheckCount: classified.classifiedCheckCount,
+        },
+      );
+      logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
+        reason: 'infra-failure',
+        matchedSignals: [...classified.matchedSignals],
+        classifiedCheckCount: classified.classifiedCheckCount,
+      });
+      return { decision: 'skipped', reason: 'infra-failure' };
+    }
   }
 
   const workerRetryBudget = retryBudgetForTask(task, options);

--- a/packages/execution-engine/src/workers/ci-failure-worker.ts
+++ b/packages/execution-engine/src/workers/ci-failure-worker.ts
@@ -5,6 +5,7 @@ import {
   createAutoFixAttemptLedger,
   type AutoFixAttemptLedger,
 } from '../auto-fix-attempt-ledger.js';
+import { createFailedCheckLogFetcher } from '../ci-failure-infra-classifier.js';
 import type {
   ReviewGateCiFailedLifecycleEvent,
   WorkflowLifecycleEvent,
@@ -62,6 +63,9 @@ export function registerCiFailureWorker(
           getAutoFixAgent: deps.autoFix?.getAutoFixAgent,
           attemptLedger: deps.autoFix?.attemptLedger,
           getAutoFixExecutionModel: deps.autoFix?.getAutoFixExecutionModel,
+          fetchFailedCheckLogs: createFailedCheckLogFetcher({
+            cwd: deps.prMaintenance?.repoRoot,
+          }),
         },
       }),
   });


### PR DESCRIPTION
## Summary

Review-gate CI repair treated runner checkout hygiene failures as agent work.

That wasted recovery attempts on permission errors such as `packed-refs.lock` and workspace `EACCES`.

The shared repair gate now inspects failed-job logs and records an infra decision instead of launching an agent.

## Review Claim

The review-gate CI repair gate declines agent recovery when failed-job logs show runner checkout hygiene errors.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Missing or unrecognized logs keep the current recovery path. Infra decisions do not spend the recovery attempt budget.

## Slice Rationale

The live worker and PR CI maintenance path share one repair gate, so the gate is the single place for this decision.

## Non-goals

Do not add automatic workflow reruns or runner cleanup.

Do not change failed-task recovery outside review-gate CI repair.

Do not change Slack or other surfaces.

## Architecture

### Before

```mermaid
flowchart TD
  failed["review_gate.ci_failed"] --> queue["queueReviewGateCiRepair"]
  queue --> agent["agent recovery"]
```

### After

```mermaid
flowchart TD
  failed["review_gate.ci_failed"] --> queue["queueReviewGateCiRepair"]
  queue --> logs["inspect failed-job logs"]
  logs --> decide{"infra only?"}
  decide -->|"yes"| stop["record infra decision"]
  decide -->|"no or unknown"| agent["agent recovery"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/pr-ci-workers.test.ts src/__tests__/ci-failure-infra-classifier.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert fb8993d0b
- Post-revert steps: None
- Data migration? No

</details>
