### PR TITLE
Fix file:// repoUrl routing for e2e-proof CI

### DIFF
--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -101,6 +101,27 @@ tasks:
     execFileSyncSpy.mockRestore();
   });
 
+  it('accepts a file:// checkout URL for the local workspace', async () => {
+    vi.restoreAllMocks();
+    const { pathToFileURL } = await import('node:url');
+    const repoRoot = childProcess.execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+    }).trim();
+    const planPath = join(tmpdir(), `invoker-file-url-repo-${process.pid}.yaml`);
+    writeFileSync(planPath, `
+name: File URL Repo
+repoUrl: ${pathToFileURL(repoRoot).href}
+tasks:
+  - id: greet
+    description: Say hello
+    command: echo "Hello"
+`);
+
+    const plan = await parsePlanFile(planPath);
+    expect(plan.repoUrl).toBe(pathToFileURL(repoRoot).href);
+    expect(plan.tasks).toHaveLength(1);
+  });
+
   it('rejects plan without repoUrl', () => {
     const yaml = `
 name: No Repo Plan

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -7,6 +7,7 @@
 
 import { execFileSync, execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { parse as parseYaml } from 'yaml';
 import type { PlanDefinition } from '@invoker/workflow-core';
 import { loadConfig, resolveDefaultExecutionAgent } from './config.js';
@@ -160,12 +161,21 @@ export function detectDefaultBranchRemote(repoUrl: string): string {
   return 'main';
 }
 
+function assertLocalGitRepoReadable(localPath: string): void {
+  if (!existsSync(localPath)) throw new Error('Path does not exist');
+  execFileSync('git', ['-c', 'safe.directory=*', '-C', localPath, 'rev-parse', '--git-dir'], {
+    stdio: ['ignore', 'ignore', 'ignore'],
+    timeout: 10_000,
+  });
+}
+
 export function assertRepoUrlCloneable(repoUrl: string): void {
   const trimmed = repoUrl.trim();
   const isLocalPath = trimmed.startsWith('/') || trimmed.startsWith('./') || trimmed.startsWith('../');
-  const isRemoteUrl = /^(?:git@|https?:\/\/|ssh:\/\/|file:\/\/)/.test(trimmed);
+  const isFileUrl = trimmed.startsWith('file://');
+  const isRemoteUrl = /^(?:git@|https?:\/\/|ssh:\/\/)/.test(trimmed);
 
-  if (!isLocalPath && !isRemoteUrl) {
+  if (!isLocalPath && !isFileUrl && !isRemoteUrl) {
     throw new PlanParseError(
       `repoUrl "${repoUrl}" is not a valid git repository. Use a full clone URL or a configured Slack alias.`,
     );
@@ -173,11 +183,11 @@ export function assertRepoUrlCloneable(repoUrl: string): void {
 
   try {
     if (isLocalPath) {
-      if (!existsSync(trimmed)) throw new Error('Path does not exist');
-      execFileSync('git', ['-C', trimmed, 'rev-parse', '--git-dir'], {
-        stdio: ['ignore', 'ignore', 'ignore'],
-        timeout: 10_000,
-      });
+      assertLocalGitRepoReadable(trimmed);
+      return;
+    }
+    if (isFileUrl) {
+      assertLocalGitRepoReadable(fileURLToPath(trimmed));
       return;
     }
     execFileSync('git', ['ls-remote', '--exit-code', '--', trimmed, 'HEAD'], {

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -344,6 +344,16 @@ export function parsePlanningRequest(
   };
 }
 
+function isRepoRootUrl(rawUrl: string): boolean {
+  if (/^(ssh:\/\/|git@)/.test(rawUrl)) return true;
+  try {
+    const u = new URL(rawUrl);
+    return /^\/[^/]+\/[^/]+(?:\.git|\/)?$/.test(u.pathname);
+  } catch {
+    return false;
+  }
+}
+
 function extractRepositoryUrls(text: string): string[] {
   const slackLinks = [...text.matchAll(/<((?:https?|ssh):\/\/[^|>\s]+)(?:\|[^>]+)?>/gi)];
   const withoutSlackLinks = text.replace(/<(?:(?:https?|ssh):\/\/[^>]+)>/gi, ' ');
@@ -353,7 +363,7 @@ function extractRepositoryUrls(text: string): string[] {
     ...withoutSlackLinks.matchAll(/\bssh:\/\/[^\s<>]+/gi),
     ...withoutSlackLinks.matchAll(/\bgit@[\w.-]+:[^\s<>]+/gi),
   ].map((match) => (match[1] ?? match[0]).replace(/[),.;]+$/, ''));
-  return [...new Set(candidates)];
+  return [...new Set(candidates)].filter(isRepoRootUrl);
 }
 
 function repositoryIdentity(repoUrl: string): string {


### PR DESCRIPTION
## Summary

e2e-proof shard 3 fails when plan repoUrl uses file:// because assertRepoUrlCloneable only probes remotes with git ls-remote.

Route file:// repoUrl values through local git rev-parse under safe.directory so CI workspaces remain usable for executor routing. Also keep Slack URL extraction limited to repo-root shapes.

## Review Claim

Approve routing readable local file:// git checkouts through local git rev-parse for plan repoUrl handling.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Remote http/ssh/git cloneability probes are unchanged. Only file:// and plain local paths use local rev-parse, and Slack extraction only filters non-repo-root URL shapes.

## Slice Rationale

This is the product repoUrl routing fix for e2e-proof, kept apart from SSH harness and Playwright flake budgets.

## Non-goals

- No change to remote git ls-remote probes for network URLs
- No SSH e2e harness PATH changes
- No Playwright timing changes

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/plan-parser.test.ts`
- [ ] Upstream CI e2e-proof shard 3

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert HEAD`
- Post-revert steps: None
- Data migration? No

</details>
