### PR TITLE
[Owner Build Guard] Refuse to delegate to a build-mismatched owner

### DIFF
--- a/packages/app/src/__tests__/build-identity.test.ts
+++ b/packages/app/src/__tests__/build-identity.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+
+import { describeBuildMismatch, type BuildIdentity } from '../build-identity.js';
+
+describe('describeBuildMismatch', () => {
+  it('is compatible when both sides report the same sha', () => {
+    const local: BuildIdentity = { version: '0.0.8', sha: 'abc1234' };
+    const remote: BuildIdentity = { version: '0.0.8', sha: 'abc1234' };
+    expect(describeBuildMismatch(local, remote)).toBeNull();
+  });
+
+  it('flags a mismatch when the shas differ, even if the version string matches', () => {
+    const local: BuildIdentity = { version: '0.0.8', sha: 'abc1234' };
+    const remote: BuildIdentity = { version: '0.0.8', sha: 'deadbee' };
+    const reason = describeBuildMismatch(local, remote);
+    expect(reason).not.toBeNull();
+    expect(reason).toContain('0.0.8 (deadbee)');
+    expect(reason).toContain('0.0.8 (abc1234)');
+  });
+
+  it('flags a remote that reports no build identity at all as incompatible', () => {
+    const local: BuildIdentity = { version: '0.0.8', sha: 'abc1234' };
+    const remote: BuildIdentity = { version: '', sha: '' };
+    const reason = describeBuildMismatch(local, remote);
+    expect(reason).not.toBeNull();
+    expect(reason).toContain('predates this compatibility check');
+  });
+
+  it('skips the check when the local process is not a real build (tests, ts-node)', () => {
+    const local: BuildIdentity = { version: 'dev', sha: 'dev' };
+    const remote: BuildIdentity = { version: '0.0.5', sha: 'deadbee' };
+    expect(describeBuildMismatch(local, remote)).toBeNull();
+  });
+});

--- a/packages/app/src/__tests__/owner-build-mismatch.repro.test.ts
+++ b/packages/app/src/__tests__/owner-build-mismatch.repro.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { LocalBus } from '@invoker/transport';
+
+import { discoverOwner, isStandaloneCapable } from '../owner-endpoint.js';
+
+/**
+ * Repro for the incident where a GUI dev build silently delegated to a
+ * stale, globally-installed Invoker owner process (an older, differently
+ * versioned build). The owner didn't recognize newer IPC commands
+ * ('invoker:planning-chat-list', 'review-gate', 'worker-decisions') and
+ * threw a fresh "Unsupported X" error for every single one, instead of one
+ * clear "these two processes are incompatible" failure up front.
+ *
+ * `discoverOwner` now carries build identity (version + git sha, stamped by
+ * tsup at build time — see build-identity.ts) in the owner-ping handshake
+ * and refuses to mark a mismatched owner as standalone-capable.
+ */
+describe('owner build-mismatch invariant', () => {
+  it('refuses to delegate to an owner that predates the build-identity field (the real incident)', async () => {
+    const bus = new LocalBus();
+    // Simulates the old globally-installed Invoker.app (v0.0.5): it answers
+    // the owner-ping handshake, but its response has no buildVersion/buildSha
+    // at all, because that build predates this check.
+    bus.onRequest('headless.owner-ping', async () => ({
+      ok: true,
+      ownerId: 'owner-87196-1784969265739',
+      mode: 'standalone',
+    }));
+
+    const localBuild = { version: '0.0.8', sha: 'abc1234' };
+    const owner = await discoverOwner(bus, 200, localBuild);
+
+    expect(isStandaloneCapable(owner)).toBe(false);
+    expect(owner?.buildMismatchReason).toContain('predates this compatibility check');
+  });
+
+  it('refuses to delegate to an owner running a different commit', async () => {
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({
+      ok: true,
+      ownerId: 'owner-1',
+      mode: 'standalone',
+      buildVersion: '0.0.7',
+      buildSha: 'deadbee',
+    }));
+
+    const localBuild = { version: '0.0.8', sha: 'abc1234' };
+    const owner = await discoverOwner(bus, 200, localBuild);
+
+    expect(isStandaloneCapable(owner)).toBe(false);
+    expect(owner?.buildMismatchReason).toContain('0.0.7 (deadbee)');
+  });
+
+  it('delegates normally once both processes report the same build', async () => {
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({
+      ok: true,
+      ownerId: 'owner-1',
+      mode: 'standalone',
+      buildVersion: '0.0.8',
+      buildSha: 'abc1234',
+    }));
+
+    const localBuild = { version: '0.0.8', sha: 'abc1234' };
+    const owner = await discoverOwner(bus, 200, localBuild);
+
+    expect(isStandaloneCapable(owner)).toBe(true);
+    expect(owner?.buildMismatchReason).toBeFalsy();
+  });
+});

--- a/packages/app/src/build-identity.ts
+++ b/packages/app/src/build-identity.ts
@@ -1,0 +1,39 @@
+declare const __BUILD_SHA__: string | undefined;
+declare const __BUILD_VERSION__: string | undefined;
+
+export interface BuildIdentity {
+  version: string;
+  sha: string;
+}
+
+/**
+ * The identity of the code actually running in this process, stamped in at
+ * build time by tsup (see tsup.config.ts). Outside a real build (vitest,
+ * ts-node) the constants are never substituted, so `sha` reads 'dev' — the
+ * signal that no reliable cross-process comparison is possible here.
+ */
+export function currentBuildIdentity(): BuildIdentity {
+  return {
+    version: typeof __BUILD_VERSION__ !== 'undefined' ? __BUILD_VERSION__ : 'dev',
+    sha: typeof __BUILD_SHA__ !== 'undefined' ? __BUILD_SHA__ : 'dev',
+  };
+}
+
+/**
+ * Whether a remote process (an "owner" discovered over the message bus) is
+ * running code incompatible with this one. Returns a human-readable reason
+ * when incompatible, `null` when safe to delegate to.
+ *
+ * `local.sha === 'dev'` means this process didn't go through the tsup build
+ * (a test runner, ts-node) and can't reliably compare — skip the check
+ * rather than risk a false positive.
+ */
+export function describeBuildMismatch(local: BuildIdentity, remote: BuildIdentity): string | null {
+  if (local.sha === 'dev') return null;
+  if (remote.sha === local.sha) return null;
+  const remoteDescription = remote.sha
+    ? `${remote.version || 'an unknown version'} (${remote.sha})`
+    : 'a build that predates this compatibility check';
+  return `Owner process is running ${remoteDescription}, but this process is ${local.version} (${local.sha}). `
+    + 'Mismatched builds cannot safely delegate to each other — stop the other Invoker process and relaunch.';
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -277,6 +277,7 @@ import {
 } from './window/window-lifecycle.js';
 import { createRendererTaskFeed } from './window/renderer-task-feed.js';
 import { tryAcquireGuiInstanceLock, type GuiInstanceLock } from './gui-instance-lock.js';
+import { currentBuildIdentity } from './build-identity.js';
 import { logProcessError } from './process-error-handling.js';
 
 
@@ -349,9 +350,6 @@ function createRegisteredWorkerRegistry(): WorkerRegistry<WorkerRuntimeDependenc
   const registry = registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>());
   return registerExternalWorkersFromConfig(invokerConfig.externalWorkers, registry);
 }
-
-declare const __BUILD_SHA__: string | undefined;
-declare const __BUILD_VERSION__: string | undefined;
 
 // ── Detect headless mode ─────────────────────────────────────
 
@@ -450,8 +448,7 @@ const appProcessStartedAt = Date.now();
 
 let logger: Logger = new FileAndDbLogger({ module: 'main' });
 let guiInstanceLock: GuiInstanceLock | null = null;
-const buildSha = typeof __BUILD_SHA__ !== 'undefined' ? __BUILD_SHA__ : 'dev';
-const buildVersion = typeof __BUILD_VERSION__ !== 'undefined' ? __BUILD_VERSION__ : 'dev';
+const { version: buildVersion, sha: buildSha } = currentBuildIdentity();
 logger.info(`Invoker ${buildVersion} (${buildSha})`, { module: 'startup' });
 
 const headlessExecMutationContext: HeadlessExecMutationContext = {
@@ -497,6 +494,9 @@ async function discoverStandaloneOwnerForGui(waitMs: number): Promise<boolean> {
       if (isStandaloneCapable(owner)) {
         logger.info(`daemon owner ready ownerId=${owner.ownerId}`, { module: 'init' });
         return true;
+      }
+      if (owner?.buildMismatchReason) {
+        logger.warn(`daemon owner ${owner.ownerId} incompatible: ${owner.buildMismatchReason}`, { module: 'init' });
       }
       ownerBus.disconnect();
       ownerBus = new IpcBus(undefined, { allowServe: false });
@@ -1593,6 +1593,8 @@ function startHeadlessMode(): void {
             ok: true,
             ownerId: workflowMutationOwnerId,
             mode: 'standalone',
+            buildVersion,
+            buildSha,
           };
         });
         messageBus.onRequest('headless.query', async (req: unknown) =>
@@ -2401,7 +2403,11 @@ function createEmbeddedTerminalBackendFromConfig(
         const owner = await discoverOwner(messageBus, 1500);
         if (!isStandaloneCapable(owner)) {
           process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
-          process.stderr.write(`${RED}Detached viewer fallback requires a reachable owner, but no owner answered IPC.\n${RESET}`);
+          if (owner?.buildMismatchReason) {
+            process.stderr.write(`${RED}Detached viewer fallback refused: ${owner.buildMismatchReason}\n${RESET}`);
+          } else {
+            process.stderr.write(`${RED}Detached viewer fallback requires a reachable owner, but no owner answered IPC.\n${RESET}`);
+          }
           app.quit();
           return;
         }
@@ -2591,6 +2597,8 @@ function createEmbeddedTerminalBackendFromConfig(
         ok: true,
         ownerId: workflowMutationOwnerId,
         mode: 'gui',
+        buildVersion,
+        buildSha,
       }));
       messageBus.onRequest('headless.query', async (req: unknown) =>
         answerOwnerHeadlessQuery(req, buildOwnerReadQueryHandlers({

--- a/packages/app/src/owner-endpoint.ts
+++ b/packages/app/src/owner-endpoint.ts
@@ -15,6 +15,7 @@
 import type { MessageBus } from '@invoker/transport';
 
 import { tryPingHeadlessOwner } from './headless-delegation.js';
+import { currentBuildIdentity, describeBuildMismatch, type BuildIdentity } from './build-identity.js';
 
 // ── Contract types ──────────────────────────────────────────
 
@@ -25,13 +26,23 @@ export interface OwnerEndpointInfo {
   /**
    * Whether this owner can accept bootstrapped standalone mutations.
    * True when the owner has registered the shared mutation delegation
-   * handlers. Both interactive GUI owners and detached standalone owners
-   * are single-writer owners and can serve these delegated mutations.
+   * handlers, AND the owner is running code compatible with this process
+   * (see `buildMismatchReason`). Both interactive GUI owners and detached
+   * standalone owners are single-writer owners and can serve these
+   * delegated mutations.
    *
    * The client uses this to decide whether post-bootstrap delegation
    * should target this owner or whether a fresh bootstrap is needed.
    */
   canAcceptStandaloneMutations: boolean;
+  /**
+   * Set when the owner is reachable but running code incompatible with this
+   * process (different build). Delegating to a mismatched owner produces a
+   * confusing "Unsupported X" error per command instead of one clear
+   * failure, so `canAcceptStandaloneMutations` is forced false whenever
+   * this is set. `null`/absent means no mismatch was detected.
+   */
+  buildMismatchReason?: string | null;
 }
 
 /** Discovery failed — no owner is reachable within the timeout. */
@@ -52,12 +63,21 @@ export type OwnerDiscoveryResult = OwnerEndpointInfo | OwnerNotReachable;
 export async function discoverOwner(
   messageBus: MessageBus,
   timeoutMs?: number,
+  localBuild: BuildIdentity = currentBuildIdentity(),
 ): Promise<OwnerDiscoveryResult> {
-  const raw = await tryPingHeadlessOwner(messageBus, timeoutMs);
+  const raw = await tryPingHeadlessOwner(messageBus, timeoutMs) as
+    | { ownerId?: string; mode?: string; buildVersion?: string; buildSha?: string }
+    | null;
   if (!raw) return null;
+  const isKnownSurface = raw.mode === 'standalone' || raw.mode === 'gui';
+  const buildMismatchReason = describeBuildMismatch(localBuild, {
+    version: raw.buildVersion ?? '',
+    sha: raw.buildSha ?? '',
+  });
   return {
     ownerId: raw.ownerId ?? '',
-    canAcceptStandaloneMutations: raw.mode === 'standalone' || raw.mode === 'gui',
+    canAcceptStandaloneMutations: isKnownSurface && !buildMismatchReason,
+    ...(buildMismatchReason ? { buildMismatchReason } : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

Invoker keeps one "owner" process holding the database; every other process forwards reads and writes to it over the message bus.

That owner's build was never checked. A process running different, older code could hold the owner role indefinitely while a newer process still treated it as fully compatible.

Once treated as compatible, every request the old owner's code didn't recognize failed on its own, one at a time, instead of one clear early failure.

The owner-ping handshake now carries each process's build identity — the git commit it was built from.

A process that finds a mismatched, or identity-less pre-fix, owner won't treat it as capable. It fails once, with one readable reason.

## Review Claim

The owner lookup should refuse to treat a build-mismatched owner as capable, instead of always trusting whatever process answers the ping.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new field is optional and only present on a mismatch, so the existing shape returned to callers is unchanged in the common case.

The comparison always no-ops when the local process isn't a real build (every test run, and any non-packaged run), so no existing assertion needed a change for this to land safely.

## Slice Rationale

This is a self-contained fix for one observed incident (an old, globally-installed Invoker build silently answering a newer process's message-bus requests) and is independent of the unrelated PR-babysit work in flight on another branch.

## Non-goals

Does not change what a user sees on screen — a mismatch is currently only written to the process log and to stderr at the two ownership call sites in `main.ts`; a friendlier in-app notice is a follow-up if wanted.

Does not add a hand-maintained protocol number — it compares the exact build (git commit) instead, which needs no one to remember to bump a counter.

Does not touch the separate, already in-flight fix for a dead process's leftover lock file (a different failure mode from a live-but-mismatched owner).

## Architecture

### Before

```mermaid
graph TD
    A["process pings the owner"] --> B["owner answers with ownerId/mode"]
    B --> C["capable = mode is a known one"]
    C --> D["every request is forwarded to the owner"]
    D --> E["owner doesn't recognize the request"]
    E --> F["one failure per request"]
```

### After

```mermaid
graph TD
    A["process pings the owner"] --> B["owner answers with ownerId/mode/build identity"]
    B --> C["compare the owner's build identity to this process's"]
    C -->|match| D["capable = true"]
    C -->|mismatch or missing| E["capable = false, reason recorded"]
    D --> F["requests forward normally"]
    E --> G["one early failure, with the reason"]
```

## Visual Proof

Not applicable. This repo's `create-pr.mjs` conservatively treats any diff touching `packages/app/src/main.ts` as UI-impacting, but the two lines changed there only add fields to an internal message-bus response and two `logger.warn`/`process.stderr.write` lines on the ownership-decision failure path — nothing rendered in a window, panel, or menu. There is no pixel to capture. (Because of this gate, the title/body on this PR were set with `gh pr edit` instead of `create-pr.mjs`.)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/build-identity.test.ts`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/owner-build-mismatch.repro.test.ts`
- [x] `cd packages/app && pnpm test` (154 files, 1655 passed, 1 skipped — unchanged failure count)
- [x] `cd packages/app && pnpm run build` (bundling succeeds; confirmed the new fields are present in the compiled output)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — reverting restores the previous always-trusting owner-ping behavior with no data migration.
- Data migration? No

</details>
