### PR TITLE
[Safety invariant confirmation](1) Document the protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@
 - **Repo rule:** See `.cursor/rules/skill-command-precedence.mdc` for the always-on summary.
 - **Benchmark direct output:** If a `/plan-to-invoker` request says `For this benchmark`, `Required output path:`, `Write the final YAML plan to`, or `Do not submit the plan`, write a complete command-only YAML plan directly to the literal required path. The first top-level keys must be `name:`, `onFinish:`, `mergeMode:`, `repoUrl:`, and `tasks:`. Do not write `version:` or `metadata:` wrappers. Do not run `git remote`, `env`, `printenv`, `set`, schema scans, validation loops, submit commands, prompt tasks, nested `steps:`, or anything that can trigger an agent/autofix. If no repo URL is provided, use `https://github.com/Neko-Catpital-Labs/Invoker.git`.
 
+- Implementation plans must include a user-confirmed `Safety invariant:` for every slice; follow `skills/review-compression/SKILL.md` and ask before finalizing.
 - Every step in a plan MUST be testable. Each implementation step must have a corresponding verification with a concrete, executable command that produces a clear pass/fail exit code (e.g. `pnpm test`, `git diff --name-only`). Do not use AI prompts for test tasks — use commands only.
 - Bug fix plans MUST follow a three-phase approach before any implementation:
   1. **Reproduce** -- Find or write a concrete reproduction case (a failing test or a command that demonstrates the bug). Report back the exact repro steps and observed vs. expected behavior. Do not proceed until the bug is reliably reproducible.

--- a/skills/plan-to-invoker/references/task-patterns.md
+++ b/skills/plan-to-invoker/references/task-patterns.md
@@ -90,7 +90,9 @@ Each implementation task must include these description headings:
 - `Review claim:` the one sentence a reviewer is being asked to approve.
 - `Review lane:` exactly one of `behavior`, `refactor`, `proof`, `cleanup`,
   `policy`, or `docs`.
-- `Safety invariant:` why this slice is safe to review locally.
+- `Safety invariant:` why this slice is safe to review locally. State the
+  behavior or boundary that remains protected by this slice, then propose it to
+  the user for confirmation or correction before submitting the plan.
 - `Slice rationale:` why this slice is separate from neighboring work.
 - `Architectural effect:` what changes in control flow, data flow, ownership,
   dependency direction, or public surface.

--- a/skills/review-compression/SKILL.md
+++ b/skills/review-compression/SKILL.md
@@ -41,6 +41,14 @@ the before/after architecture and why the split is acceptable. Each slice must
 still contain one conceptual unit; validators infer mixed units from the claim,
 rationale, implementation details, and change-type entries.
 
+## Safety Invariant Confirmation
+
+Before finalizing an implementation plan, Invoker YAML, or PR stack, propose
+the `Safety invariant:` for every slice and ask the user to confirm or correct
+it. Keep the existing heading and definition: it explains why the slice is safe
+to review locally. Mechanical slices may use terse invariants, but they still
+require user confirmation.
+
 ## Ordering Rules
 
 - Evidence before change: add repros, benchmarks, or instrumentation before the


### PR DESCRIPTION
## Summary

Planning guidance now defines the Safety Invariant Confirmation protocol.

## Review Claim

The documentation establishes one user-confirmed Safety invariant for every implementation slice.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This documentation-only slice leaves all executable behavior and benchmark direct-output behavior unchanged.

## Slice Rationale

Documenting the protocol first gives later enforcement a stable reference.

## Non-goals

This does not add always-on enforcement or a shell check.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-plan-to-invoker-skill.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a866f96ff`
- Post-revert steps: None
- Data migration? No

</details>
