### PR TITLE
[Safety invariant confirmation](2) Require user confirmation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@
 - **Repo rule:** See `.cursor/rules/skill-command-precedence.mdc` for the always-on summary.
 - **Benchmark direct output:** If a `/plan-to-invoker` request says `For this benchmark`, `Required output path:`, `Write the final YAML plan to`, or `Do not submit the plan`, write a complete command-only YAML plan directly to the literal required path. The first top-level keys must be `name:`, `onFinish:`, `mergeMode:`, `repoUrl:`, and `tasks:`. Do not write `version:` or `metadata:` wrappers. Do not run `git remote`, `env`, `printenv`, `set`, schema scans, validation loops, submit commands, prompt tasks, nested `steps:`, or anything that can trigger an agent/autofix. If no repo URL is provided, use `https://github.com/Neko-Catpital-Labs/Invoker.git`.
 
+- Implementation plans must include a user-confirmed `Safety invariant:` for every slice; follow `skills/review-compression/SKILL.md` and ask before finalizing.
 - Every step in a plan MUST be testable. Each implementation step must have a corresponding verification with a concrete, executable command that produces a clear pass/fail exit code (e.g. `pnpm test`, `git diff --name-only`). Do not use AI prompts for test tasks — use commands only.
 - Bug fix plans MUST follow a three-phase approach before any implementation:
   1. **Reproduce** -- Find or write a concrete reproduction case (a failing test or a command that demonstrates the bug). Report back the exact repro steps and observed vs. expected behavior. Do not proceed until the bug is reliably reproducible.

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -71,6 +71,9 @@ The unit must match the changed files. The CI validator rejects a declared unit 
 ## Safety Invariant
 
 Explain why this slice is safe to review locally.
+If the source plan or slice does not contain a user-confirmed safety invariant,
+propose one and ask the user to confirm or correct it before publishing this PR
+body.
 
 ## Slice Rationale
 

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -69,7 +69,8 @@ Use this mode when invoked by the installed command or MCP prompt. Do not use th
 
 ## Intended flow (do not skip steps)
 
-1. Discuss scope/risk with the user.
+1. Discuss scope/risk with the user; before authoring YAML, propose each
+   `Safety invariant:` and ask the user to confirm or correct it.
 2. Phase 1a static analysis.
 3. Runtime verification (Phase 1b): run the cheapest deterministic command that exercises the behavior, plus Invoker headless when applicable.
 4. Generate implementation YAML from verified facts — prefer rendering a matching formula (`skills/plan-to-invoker/formulas/`) and specializing its slots over authoring the shape from scratch.
@@ -80,7 +81,7 @@ Grep-only checks are Phase 1a only; behavioral claims require executed Phase 1b 
 
 **Deterministic validation gate:** Use `skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>` as the primary deterministic proof surface, backed by `bash scripts/test-plan-to-invoker-skill.sh` for regression coverage. Schema-only validation or ad hoc individual script checks are not sufficient as the review gate, because they can miss strict atomicity, zero-context prompt, policy coverage, and final-gate failures. Individual validator scripts remain fallback diagnostics only; they are not submission proof unless `skill-doctor.sh` has already passed or a waiver is explicitly recorded.
 
-**Review compression (required for implementation plans):** Before authoring any plan with `onFinish != none`, apply `skills/review-compression/SKILL.md`. Split by reviewer cognition, not file count: one local review claim, one review lane, one conceptual unit, one safety invariant, one slice rationale, and one architectural effect per implementation task. This applies to Invoker and non-Invoker target repos.
+**Review compression (required for implementation plans):** Before authoring any plan with `onFinish != none`, apply `skills/review-compression/SKILL.md`. Split by reviewer cognition, not file count: one local review claim, one review lane, one conceptual unit, one safety invariant, one slice rationale, and one architectural effect per implementation task. Follow its Safety Invariant Confirmation protocol before finalizing the plan. This applies to Invoker and non-Invoker target repos.
 
 **Stack-first authoring (default for implementation plans):** For any plan with `onFinish != none`, default to an authored Invoker workflow stack, not one YAML with many implementation tasks. In Invoker, one YAML file is one workflow; `tasks:` are only tasks inside that workflow. If the implementation has more than one review slice, review lane, conceptual unit, layer, implementation prompt task, package boundary, UI+non-UI boundary, or PR-worthy commit, write multiple `step-N` YAML files and submit them with `scripts/submit-workflow-chain.sh`. Later workflow templates must depend on the previous workflow's merge gate with `externalDependencies` using `workflowId: "__UPSTREAM_WORKFLOW_ID__"`, `taskId: "__merge__"`, `requiredStatus: completed`, and `gatePolicy: review_ready` unless the user explicitly asked for another gate policy.
 

--- a/skills/plan-to-invoker/references/task-patterns.md
+++ b/skills/plan-to-invoker/references/task-patterns.md
@@ -90,7 +90,9 @@ Each implementation task must include these description headings:
 - `Review claim:` the one sentence a reviewer is being asked to approve.
 - `Review lane:` exactly one of `behavior`, `refactor`, `proof`, `cleanup`,
   `policy`, or `docs`.
-- `Safety invariant:` why this slice is safe to review locally.
+- `Safety invariant:` why this slice is safe to review locally. State the
+  behavior or boundary that remains protected by this slice, then propose it to
+  the user for confirmation or correction before submitting the plan.
 - `Slice rationale:` why this slice is separate from neighboring work.
 - `Architectural effect:` what changes in control flow, data flow, ownership,
   dependency direction, or public surface.

--- a/skills/review-compression/SKILL.md
+++ b/skills/review-compression/SKILL.md
@@ -41,6 +41,14 @@ the before/after architecture and why the split is acceptable. Each slice must
 still contain one conceptual unit; validators infer mixed units from the claim,
 rationale, implementation details, and change-type entries.
 
+## Safety Invariant Confirmation
+
+Before finalizing an implementation plan, Invoker YAML, or PR stack, propose
+the `Safety invariant:` for every slice and ask the user to confirm or correct
+it. Keep the existing heading and definition: it explains why the slice is safe
+to review locally. Mechanical slices may use terse invariants, but they still
+require user confirmation.
+
 ## Ordering Rules
 
 - Evidence before change: add repros, benchmarks, or instrumentation before the


### PR DESCRIPTION
## Summary

Plan and PR skills now require users to confirm each Safety invariant before finalization.

## Review Claim

The plan-to-invoker and make-pr skills require confirmation of every Safety invariant.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This policy-only slice leaves product runtime behavior, existing validators, and benchmark direct-output exemptions unchanged.

## Slice Rationale

This follows the protocol description and isolates skill enforcement.

## Non-goals

This does not add always-on discovery guidance or a focused shell check.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-make-pr-skill.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert cf5bed737`
- Post-revert steps: None
- Data migration? No

</details>
