### PR TITLE
Add PR mirror and repair-lease persistence for babysit priority.

### DIFF
--- a/packages/data-store/src/__tests__/pr-mirror-lease.test.ts
+++ b/packages/data-store/src/__tests__/pr-mirror-lease.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+describe('pr_mirrors and pr_repair_leases', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  it('creates pr_mirrors and pr_repair_leases tables on fresh databases', () => {
+    const tables = ((adapter as any).db.exec(
+      `SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('pr_mirrors', 'pr_repair_leases') ORDER BY name`,
+    ) as Array<{ values: unknown[][] }>)[0]?.values ?? [];
+    expect(tables.map((row) => String(row[0]))).toEqual(['pr_mirrors', 'pr_repair_leases']);
+  });
+
+  it('upserts and reads pr mirrors', () => {
+    const saved = adapter.upsertPrMirror({
+      repo: 'owner/repo',
+      prNumber: 12,
+      headSha: 'deadbeef',
+      baseRef: 'main',
+      mergeState: 'BLOCKED',
+      labelsJson: '["stack"]',
+      stackId: 'stack-1',
+      stackOrder: 0,
+      workflowId: 'wf-1',
+      repairWorkflowsJson: '{"fix_ci":"wf-fix"}',
+      blockersJson: '{"conflict":true}',
+      updatedAt: '2026-07-25T17:00:00.000Z',
+    });
+
+    expect(saved.repo).toBe('owner/repo');
+    expect(saved.prNumber).toBe(12);
+    expect(saved.workflowId).toBe('wf-1');
+
+    const updated = adapter.upsertPrMirror({
+      repo: 'owner/repo',
+      prNumber: 12,
+      headSha: 'cafebabe',
+      updatedAt: '2026-07-25T18:00:00.000Z',
+    });
+    expect(updated.headSha).toBe('cafebabe');
+    expect(updated.workflowId).toBeUndefined();
+    expect(adapter.getPrMirror('owner/repo', 12)?.headSha).toBe('cafebabe');
+  });
+
+  it('supports pr repair lease CRUD keyed by repo/pr/head', () => {
+    const lease = adapter.upsertPrRepairLease({
+      repo: 'owner/repo',
+      prNumber: 12,
+      headSha: 'deadbeef',
+      holderKind: 'ci_failed',
+      leaseId: 'lease-1',
+      commandId: 'cmd-1',
+      workflowId: 'wf-1',
+      acquiredAt: '2026-07-25T17:00:00.000Z',
+      expiresAt: '2026-07-25T17:30:00.000Z',
+    });
+    expect(lease.leaseId).toBe('lease-1');
+    expect(adapter.getPrRepairLease('owner/repo', 12, 'deadbeef')?.holderKind).toBe('ci_failed');
+    expect(adapter.getPrRepairLeaseById('lease-1')?.commandId).toBe('cmd-1');
+
+    adapter.upsertPrRepairLease({
+      repo: 'owner/repo',
+      prNumber: 12,
+      headSha: 'deadbeef',
+      holderKind: 'merge_conflict',
+      leaseId: 'lease-2',
+      acquiredAt: '2026-07-25T17:05:00.000Z',
+    });
+    expect(adapter.getPrRepairLeaseById('lease-1')).toBeUndefined();
+    expect(adapter.getPrRepairLease('owner/repo', 12, 'deadbeef')?.leaseId).toBe('lease-2');
+
+    expect(adapter.deletePrRepairLeaseById('lease-2')).toBe(true);
+    expect(adapter.getPrRepairLease('owner/repo', 12, 'deadbeef')).toBeUndefined();
+  });
+
+  it('keeps distinct lease rows for different head shas', () => {
+    adapter.upsertPrRepairLease({
+      repo: 'owner/repo',
+      prNumber: 12,
+      headSha: 'head-a',
+      holderKind: 'ci_failed',
+      leaseId: 'lease-a',
+      acquiredAt: '2026-07-25T17:00:00.000Z',
+    });
+    adapter.upsertPrRepairLease({
+      repo: 'owner/repo',
+      prNumber: 12,
+      headSha: 'head-b',
+      holderKind: 'review_comments',
+      leaseId: 'lease-b',
+      acquiredAt: '2026-07-25T17:00:00.000Z',
+    });
+
+    expect(adapter.getPrRepairLease('owner/repo', 12, 'head-a')?.leaseId).toBe('lease-a');
+    expect(adapter.getPrRepairLease('owner/repo', 12, 'head-b')?.leaseId).toBe('lease-b');
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -184,6 +184,39 @@ export interface ExecutionResourceLeaseReleaseRow {
   taskId?: string;
 }
 
+export type PrRepairHolderKind =
+  | 'merge_conflict'
+  | 'ci_failed'
+  | 'review_comments'
+  | 'queue_dequeued';
+
+export interface PrMirrorRow {
+  repo: string;
+  prNumber: number;
+  headSha: string;
+  baseRef?: string;
+  mergeState?: string;
+  labelsJson?: string;
+  stackId?: string;
+  stackOrder?: number;
+  workflowId?: string;
+  repairWorkflowsJson?: string;
+  blockersJson?: string;
+  updatedAt: string;
+}
+
+export interface PrRepairLeaseRow {
+  repo: string;
+  prNumber: number;
+  headSha: string;
+  holderKind: PrRepairHolderKind;
+  leaseId: string;
+  commandId?: string;
+  workflowId?: string;
+  acquiredAt: string;
+  expiresAt?: string;
+}
+
 export type WorkerActionStatus =
   | 'queued'
   | 'pending'

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -57,6 +57,9 @@ import type {
   TerminalSessionRecord,
   InAppPlanningSessionPatch,
   InAppPlanningSessionRecord,
+  PrMirrorRow,
+  PrRepairLeaseRow,
+  PrRepairHolderKind,
 } from './adapter.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
 import { SCHEMA_DDL } from './sqlite-schema.js';
@@ -3731,6 +3734,154 @@ export class SQLiteAdapter implements PersistenceAdapter {
        WHERE id = ?`,
       [new Date().toISOString(), error, id],
     );
+  }
+
+  upsertPrMirror(mirror: PrMirrorRow): PrMirrorRow {
+    this.execRun(
+      `INSERT INTO pr_mirrors (
+        repo, pr_number, head_sha, base_ref, merge_state, labels_json,
+        stack_id, stack_order, workflow_id, repair_workflows_json, blockers_json, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(repo, pr_number) DO UPDATE SET
+        head_sha = excluded.head_sha,
+        base_ref = excluded.base_ref,
+        merge_state = excluded.merge_state,
+        labels_json = excluded.labels_json,
+        stack_id = excluded.stack_id,
+        stack_order = excluded.stack_order,
+        workflow_id = excluded.workflow_id,
+        repair_workflows_json = excluded.repair_workflows_json,
+        blockers_json = excluded.blockers_json,
+        updated_at = excluded.updated_at`,
+      [
+        mirror.repo,
+        mirror.prNumber,
+        mirror.headSha,
+        mirror.baseRef ?? null,
+        mirror.mergeState ?? null,
+        mirror.labelsJson ?? null,
+        mirror.stackId ?? null,
+        mirror.stackOrder ?? null,
+        mirror.workflowId ?? null,
+        mirror.repairWorkflowsJson ?? null,
+        mirror.blockersJson ?? null,
+        mirror.updatedAt,
+      ],
+    );
+    const saved = this.getPrMirror(mirror.repo, mirror.prNumber);
+    if (!saved) {
+      throw new Error(`Failed to persist pr_mirror ${mirror.repo}#${mirror.prNumber}`);
+    }
+    return saved;
+  }
+
+  getPrMirror(repo: string, prNumber: number): PrMirrorRow | undefined {
+    const row = this.queryOne(
+      'SELECT * FROM pr_mirrors WHERE repo = ? AND pr_number = ?',
+      [repo, prNumber],
+    );
+    return row ? this.rowToPrMirror(row) : undefined;
+  }
+
+  deletePrMirror(repo: string, prNumber: number): void {
+    this.execRun(
+      'DELETE FROM pr_mirrors WHERE repo = ? AND pr_number = ?',
+      [repo, prNumber],
+    );
+  }
+
+  upsertPrRepairLease(lease: PrRepairLeaseRow): PrRepairLeaseRow {
+    this.execRun(
+      `INSERT INTO pr_repair_leases (
+        repo, pr_number, head_sha, holder_kind, lease_id,
+        command_id, workflow_id, acquired_at, expires_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(repo, pr_number, head_sha) DO UPDATE SET
+        holder_kind = excluded.holder_kind,
+        lease_id = excluded.lease_id,
+        command_id = excluded.command_id,
+        workflow_id = excluded.workflow_id,
+        acquired_at = excluded.acquired_at,
+        expires_at = excluded.expires_at`,
+      [
+        lease.repo,
+        lease.prNumber,
+        lease.headSha,
+        lease.holderKind,
+        lease.leaseId,
+        lease.commandId ?? null,
+        lease.workflowId ?? null,
+        lease.acquiredAt,
+        lease.expiresAt ?? null,
+      ],
+    );
+    const saved = this.getPrRepairLease(lease.repo, lease.prNumber, lease.headSha);
+    if (!saved) {
+      throw new Error(
+        `Failed to persist pr_repair_lease ${lease.repo}#${lease.prNumber}@${lease.headSha}`,
+      );
+    }
+    return saved;
+  }
+
+  getPrRepairLease(repo: string, prNumber: number, headSha: string): PrRepairLeaseRow | undefined {
+    const row = this.queryOne(
+      'SELECT * FROM pr_repair_leases WHERE repo = ? AND pr_number = ? AND head_sha = ?',
+      [repo, prNumber, headSha],
+    );
+    return row ? this.rowToPrRepairLease(row) : undefined;
+  }
+
+  getPrRepairLeaseById(leaseId: string): PrRepairLeaseRow | undefined {
+    const row = this.queryOne(
+      'SELECT * FROM pr_repair_leases WHERE lease_id = ?',
+      [leaseId],
+    );
+    return row ? this.rowToPrRepairLease(row) : undefined;
+  }
+
+  deletePrRepairLease(repo: string, prNumber: number, headSha: string): void {
+    this.execRun(
+      'DELETE FROM pr_repair_leases WHERE repo = ? AND pr_number = ? AND head_sha = ?',
+      [repo, prNumber, headSha],
+    );
+  }
+
+  deletePrRepairLeaseById(leaseId: string): boolean {
+    this.execRun('DELETE FROM pr_repair_leases WHERE lease_id = ?', [leaseId]);
+    return ((this.db.getRowsModified?.() ?? 0) as number) > 0;
+  }
+
+  private rowToPrMirror(row: Record<string, unknown>): PrMirrorRow {
+    return {
+      repo: String(row.repo),
+      prNumber: Number(row.pr_number),
+      headSha: String(row.head_sha),
+      baseRef: row.base_ref != null ? String(row.base_ref) : undefined,
+      mergeState: row.merge_state != null ? String(row.merge_state) : undefined,
+      labelsJson: row.labels_json != null ? String(row.labels_json) : undefined,
+      stackId: row.stack_id != null ? String(row.stack_id) : undefined,
+      stackOrder: row.stack_order != null ? Number(row.stack_order) : undefined,
+      workflowId: row.workflow_id != null ? String(row.workflow_id) : undefined,
+      repairWorkflowsJson:
+        row.repair_workflows_json != null ? String(row.repair_workflows_json) : undefined,
+      blockersJson: row.blockers_json != null ? String(row.blockers_json) : undefined,
+      updatedAt: String(row.updated_at),
+    };
+  }
+
+  private rowToPrRepairLease(row: Record<string, unknown>): PrRepairLeaseRow {
+    return {
+      repo: String(row.repo),
+      prNumber: Number(row.pr_number),
+      headSha: String(row.head_sha),
+      holderKind: String(row.holder_kind) as PrRepairHolderKind,
+      leaseId: String(row.lease_id),
+      commandId: row.command_id != null ? String(row.command_id) : undefined,
+      workflowId: row.workflow_id != null ? String(row.workflow_id) : undefined,
+      acquiredAt: String(row.acquired_at),
+      expiresAt: row.expires_at != null ? String(row.expires_at) : undefined,
+    };
   }
 
   private rowToWorkflowMutationIntent(row: Record<string, unknown>): WorkflowMutationIntent {

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -508,6 +508,44 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_terminal_sessions_status_updated
         ON terminal_sessions(status, updated_at);
 
+      CREATE TABLE IF NOT EXISTS pr_mirrors (
+        repo TEXT NOT NULL,
+        pr_number INTEGER NOT NULL,
+        head_sha TEXT NOT NULL,
+        base_ref TEXT,
+        merge_state TEXT,
+        labels_json TEXT CHECK (labels_json IS NULL OR json_valid(labels_json)),
+        stack_id TEXT,
+        stack_order INTEGER,
+        workflow_id TEXT,
+        repair_workflows_json TEXT CHECK (repair_workflows_json IS NULL OR json_valid(repair_workflows_json)),
+        blockers_json TEXT CHECK (blockers_json IS NULL OR json_valid(blockers_json)),
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (repo, pr_number)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_pr_mirrors_workflow_id
+        ON pr_mirrors(workflow_id);
+
+      CREATE TABLE IF NOT EXISTS pr_repair_leases (
+        repo TEXT NOT NULL,
+        pr_number INTEGER NOT NULL,
+        head_sha TEXT NOT NULL,
+        holder_kind TEXT NOT NULL,
+        lease_id TEXT NOT NULL UNIQUE,
+        command_id TEXT,
+        workflow_id TEXT,
+        acquired_at TEXT NOT NULL,
+        expires_at TEXT,
+        PRIMARY KEY (repo, pr_number, head_sha)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_pr_repair_leases_lease_id
+        ON pr_repair_leases(lease_id);
+
+      CREATE INDEX IF NOT EXISTS idx_pr_repair_leases_expires_at
+        ON pr_repair_leases(expires_at);
+
     `;
 
 /** Idempotent `ALTER TABLE ... ADD COLUMN` migrations for older databases. */
@@ -622,6 +660,36 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  `CREATE TABLE IF NOT EXISTS pr_mirrors (
+    repo TEXT NOT NULL,
+    pr_number INTEGER NOT NULL,
+    head_sha TEXT NOT NULL,
+    base_ref TEXT,
+    merge_state TEXT,
+    labels_json TEXT CHECK (labels_json IS NULL OR json_valid(labels_json)),
+    stack_id TEXT,
+    stack_order INTEGER,
+    workflow_id TEXT,
+    repair_workflows_json TEXT CHECK (repair_workflows_json IS NULL OR json_valid(repair_workflows_json)),
+    blockers_json TEXT CHECK (blockers_json IS NULL OR json_valid(blockers_json)),
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (repo, pr_number)
+  )`,
+  'CREATE INDEX IF NOT EXISTS idx_pr_mirrors_workflow_id ON pr_mirrors(workflow_id)',
+  `CREATE TABLE IF NOT EXISTS pr_repair_leases (
+    repo TEXT NOT NULL,
+    pr_number INTEGER NOT NULL,
+    head_sha TEXT NOT NULL,
+    holder_kind TEXT NOT NULL,
+    lease_id TEXT NOT NULL UNIQUE,
+    command_id TEXT,
+    workflow_id TEXT,
+    acquired_at TEXT NOT NULL,
+    expires_at TEXT,
+    PRIMARY KEY (repo, pr_number, head_sha)
+  )`,
+  'CREATE INDEX IF NOT EXISTS idx_pr_repair_leases_lease_id ON pr_repair_leases(lease_id)',
+  'CREATE INDEX IF NOT EXISTS idx_pr_repair_leases_expires_at ON pr_repair_leases(expires_at)',
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */

--- a/packages/execution-engine/src/__tests__/pr-repair-lease.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-repair-lease.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PrRepairLeaseRow } from '@invoker/data-store';
+
+import {
+  getPrRepairLease,
+  releasePrRepairLease,
+  REPAIR_KIND_RANK,
+  tryAcquirePrRepairLease,
+  type PrRepairLeaseStore,
+  type RepairKind,
+} from '../pr-repair-lease.js';
+
+function createMemoryStore(): PrRepairLeaseStore {
+  const byKey = new Map<string, PrRepairLeaseRow>();
+  const byId = new Map<string, PrRepairLeaseRow>();
+  const keyOf = (repo: string, prNumber: number, headSha: string) =>
+    `${repo}\0${prNumber}\0${headSha}`;
+
+  return {
+    getPrRepairLease(repo, prNumber, headSha) {
+      return byKey.get(keyOf(repo, prNumber, headSha));
+    },
+    upsertPrRepairLease(lease) {
+      const prev = byKey.get(keyOf(lease.repo, lease.prNumber, lease.headSha));
+      if (prev) byId.delete(prev.leaseId);
+      byKey.set(keyOf(lease.repo, lease.prNumber, lease.headSha), lease);
+      byId.set(lease.leaseId, lease);
+      return lease;
+    },
+    getPrRepairLeaseById(leaseId) {
+      return byId.get(leaseId);
+    },
+    deletePrRepairLeaseById(leaseId) {
+      const existing = byId.get(leaseId);
+      if (!existing) return false;
+      byId.delete(leaseId);
+      byKey.delete(keyOf(existing.repo, existing.prNumber, existing.headSha));
+      return true;
+    },
+  };
+}
+
+describe('REPAIR_KIND_RANK', () => {
+  it('orders conflict above ci above review above queue', () => {
+    expect(REPAIR_KIND_RANK.merge_conflict).toBeLessThan(REPAIR_KIND_RANK.ci_failed);
+    expect(REPAIR_KIND_RANK.ci_failed).toBeLessThan(REPAIR_KIND_RANK.review_comments);
+    expect(REPAIR_KIND_RANK.review_comments).toBeLessThan(REPAIR_KIND_RANK.queue_dequeued);
+  });
+});
+
+describe('tryAcquirePrRepairLease', () => {
+  const repo = 'owner/repo';
+  const prNumber = 42;
+  const headSha = 'abc123';
+  const now = new Date('2026-07-25T17:00:00.000Z');
+
+  function acquire(store: PrRepairLeaseStore, kind: RepairKind, leaseId: string) {
+    return tryAcquirePrRepairLease({
+      repo,
+      prNumber,
+      headSha,
+      kind,
+      store,
+      now,
+      createLeaseId: () => leaseId,
+    });
+  }
+
+  it('grants when empty', () => {
+    const store = createMemoryStore();
+    const result = acquire(store, 'ci_failed', 'lease-ci-1');
+    expect(result).toEqual({ ok: true, leaseId: 'lease-ci-1', preempted: false });
+    expect(getPrRepairLease(repo, prNumber, headSha, store)?.holderKind).toBe('ci_failed');
+  });
+
+  it('lets conflict beat ci', () => {
+    const store = createMemoryStore();
+    expect(acquire(store, 'ci_failed', 'lease-ci').ok).toBe(true);
+
+    const conflict = acquire(store, 'merge_conflict', 'lease-conflict');
+    expect(conflict).toEqual({
+      ok: true,
+      leaseId: 'lease-conflict',
+      preempted: true,
+      previousHolderKind: 'ci_failed',
+    });
+    expect(getPrRepairLease(repo, prNumber, headSha, store)?.leaseId).toBe('lease-conflict');
+  });
+
+  it('denies ci while conflict holds', () => {
+    const store = createMemoryStore();
+    expect(acquire(store, 'merge_conflict', 'lease-conflict').ok).toBe(true);
+
+    const denied = acquire(store, 'ci_failed', 'lease-ci');
+    expect(denied).toEqual({
+      ok: false,
+      holderKind: 'merge_conflict',
+      reason: 'held_by_higher_or_equal_priority',
+    });
+  });
+
+  it('allows ci after conflict releases', () => {
+    const store = createMemoryStore();
+    const conflict = acquire(store, 'merge_conflict', 'lease-conflict');
+    expect(conflict.ok).toBe(true);
+    if (!conflict.ok) throw new Error('expected grant');
+
+    expect(releasePrRepairLease(conflict.leaseId, store)).toBe(true);
+    expect(getPrRepairLease(repo, prNumber, headSha, store)).toBeUndefined();
+
+    const ci = acquire(store, 'ci_failed', 'lease-ci');
+    expect(ci).toEqual({ ok: true, leaseId: 'lease-ci', preempted: false });
+  });
+
+  it('preempts from review to conflict', () => {
+    const store = createMemoryStore();
+    expect(acquire(store, 'review_comments', 'lease-review').ok).toBe(true);
+
+    const conflict = acquire(store, 'merge_conflict', 'lease-conflict');
+    expect(conflict).toEqual({
+      ok: true,
+      leaseId: 'lease-conflict',
+      preempted: true,
+      previousHolderKind: 'review_comments',
+    });
+  });
+
+  it('denies equal priority re-acquire', () => {
+    const store = createMemoryStore();
+    expect(acquire(store, 'ci_failed', 'lease-ci-1').ok).toBe(true);
+    expect(acquire(store, 'ci_failed', 'lease-ci-2')).toEqual({
+      ok: false,
+      holderKind: 'ci_failed',
+      reason: 'held_by_higher_or_equal_priority',
+    });
+  });
+
+  it('treats different headSha as a separate lease row', () => {
+    const store = createMemoryStore();
+    expect(
+      tryAcquirePrRepairLease({
+        repo,
+        prNumber,
+        headSha: 'head-a',
+        kind: 'ci_failed',
+        store,
+        now,
+        createLeaseId: () => 'lease-a',
+      }).ok,
+    ).toBe(true);
+
+    const otherHead = tryAcquirePrRepairLease({
+      repo,
+      prNumber,
+      headSha: 'head-b',
+      kind: 'review_comments',
+      store,
+      now,
+      createLeaseId: () => 'lease-b',
+    });
+    expect(otherHead).toEqual({ ok: true, leaseId: 'lease-b', preempted: false });
+    expect(getPrRepairLease(repo, prNumber, 'head-a', store)?.leaseId).toBe('lease-a');
+    expect(getPrRepairLease(repo, prNumber, 'head-b', store)?.leaseId).toBe('lease-b');
+  });
+
+  it('treats expired leases as empty', () => {
+    const store = createMemoryStore();
+    const past = new Date('2026-07-25T16:00:00.000Z');
+    expect(
+      tryAcquirePrRepairLease({
+        repo,
+        prNumber,
+        headSha,
+        kind: 'review_comments',
+        store,
+        now: past,
+        leaseMs: 1,
+        createLeaseId: () => 'lease-expired',
+      }).ok,
+    ).toBe(true);
+
+    const next = tryAcquirePrRepairLease({
+      repo,
+      prNumber,
+      headSha,
+      kind: 'ci_failed',
+      store,
+      now,
+      createLeaseId: () => 'lease-fresh',
+    });
+    expect(next).toEqual({ ok: true, leaseId: 'lease-fresh', preempted: false });
+  });
+});

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -80,4 +80,5 @@ export * from './auto-fix-attempt-ledger.js';
 export * from './worker-decision-ledger.js';
 export * from './auto-fix-intents.js';
 export * from './lifecycle-events.js';
+export * from './pr-repair-lease.js';
 export * from './external-worker.js';

--- a/packages/execution-engine/src/pr-repair-lease.ts
+++ b/packages/execution-engine/src/pr-repair-lease.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from 'node:crypto';
+
+import type { PrRepairHolderKind, PrRepairLeaseRow } from '@invoker/data-store';
+
+export type RepairKind = PrRepairHolderKind;
+
+export const REPAIR_KIND_RANK: Readonly<Record<RepairKind, number>> = {
+  merge_conflict: 0,
+  ci_failed: 1,
+  review_comments: 2,
+  queue_dequeued: 3,
+};
+
+export const PR_REPAIR_LEASE_DEFAULT_MS = 30 * 60 * 1000;
+
+export interface PrRepairLeaseStore {
+  getPrRepairLease(repo: string, prNumber: number, headSha: string): PrRepairLeaseRow | undefined;
+  upsertPrRepairLease(lease: PrRepairLeaseRow): PrRepairLeaseRow;
+  getPrRepairLeaseById(leaseId: string): PrRepairLeaseRow | undefined;
+  deletePrRepairLeaseById(leaseId: string): boolean;
+}
+
+export type TryAcquirePrRepairLeaseResult =
+  | { ok: true; leaseId: string; preempted: false }
+  | { ok: true; leaseId: string; preempted: true; previousHolderKind: RepairKind }
+  | { ok: false; holderKind: RepairKind; reason: 'held_by_higher_or_equal_priority' };
+
+export interface TryAcquirePrRepairLeaseInput {
+  repo: string;
+  prNumber: number;
+  headSha: string;
+  kind: RepairKind;
+  store: PrRepairLeaseStore;
+  now?: Date;
+  leaseMs?: number;
+  commandId?: string;
+  workflowId?: string;
+  createLeaseId?: () => string;
+}
+
+function isLeaseActive(lease: PrRepairLeaseRow, nowIso: string): boolean {
+  if (lease.expiresAt == null) return true;
+  return lease.expiresAt > nowIso;
+}
+
+export function tryAcquirePrRepairLease(
+  input: TryAcquirePrRepairLeaseInput,
+): TryAcquirePrRepairLeaseResult {
+  const now = input.now ?? new Date();
+  const nowIso = now.toISOString();
+  const leaseMs = input.leaseMs ?? PR_REPAIR_LEASE_DEFAULT_MS;
+  const expiresAt = new Date(now.getTime() + leaseMs).toISOString();
+  const existing = input.store.getPrRepairLease(input.repo, input.prNumber, input.headSha);
+
+  if (existing && isLeaseActive(existing, nowIso)) {
+    const holderRank = REPAIR_KIND_RANK[existing.holderKind];
+    const requesterRank = REPAIR_KIND_RANK[input.kind];
+    if (requesterRank >= holderRank) {
+      return {
+        ok: false,
+        holderKind: existing.holderKind,
+        reason: 'held_by_higher_or_equal_priority',
+      };
+    }
+
+    const leaseId = (input.createLeaseId ?? randomUUID)();
+    input.store.upsertPrRepairLease({
+      repo: input.repo,
+      prNumber: input.prNumber,
+      headSha: input.headSha,
+      holderKind: input.kind,
+      leaseId,
+      commandId: input.commandId,
+      workflowId: input.workflowId,
+      acquiredAt: nowIso,
+      expiresAt,
+    });
+    return {
+      ok: true,
+      leaseId,
+      preempted: true,
+      previousHolderKind: existing.holderKind,
+    };
+  }
+
+  const leaseId = (input.createLeaseId ?? randomUUID)();
+  input.store.upsertPrRepairLease({
+    repo: input.repo,
+    prNumber: input.prNumber,
+    headSha: input.headSha,
+    holderKind: input.kind,
+    leaseId,
+    commandId: input.commandId,
+    workflowId: input.workflowId,
+    acquiredAt: nowIso,
+    expiresAt,
+  });
+  return { ok: true, leaseId, preempted: false };
+}
+
+export function releasePrRepairLease(leaseId: string, store: PrRepairLeaseStore): boolean {
+  return store.deletePrRepairLeaseById(leaseId);
+}
+
+export function getPrRepairLease(
+  repo: string,
+  prNumber: number,
+  headSha: string,
+  store: PrRepairLeaseStore,
+): PrRepairLeaseRow | undefined {
+  return store.getPrRepairLease(repo, prNumber, headSha);
+}


### PR DESCRIPTION
## Summary
- Add owner SQLite `pr_mirrors` and `pr_repair_leases` tables with adapter CRUD.
- Add `tryAcquirePrRepairLease` with precedence `merge_conflict > ci_failed > review_comments > queue_dequeued` (preempt lower holders; 30m TTL).
- Phase 0 only: no worker wiring yet. Foundation for submit-only PR babysit repairs and live admin-bypass landing campaign.

## Test plan
- [x] `cd packages/data-store && pnpm test`
- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/pr-repair-lease.test.ts`
- [ ] Follow-on phases wire leases into CI/conflict workers; acceptance remains all open `admin-bypass` PRs landing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistence for pull request mirrors and repair leases.
  * Added priority-based repair lease acquisition, preemption, expiration, and release handling.
  * Repair requests are coordinated by pull request revision, with higher-priority issues able to replace lower-priority leases.

* **Bug Fixes**
  * Ensured lease records remain distinct across pull request revisions and are correctly replaced or removed.

* **Tests**
  * Added coverage for mirror persistence, lease lifecycle behavior, priority ordering, preemption, and expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->