### PR TITLE
Persist pr_mirrors before review-gate lifecycle publish.

### DIFF
--- a/packages/app/src/__tests__/lifecycle-event-bridge.test.ts
+++ b/packages/app/src/__tests__/lifecycle-event-bridge.test.ts
@@ -265,6 +265,63 @@ describe('lifecycle event bridge', () => {
     expect(isWorkflowLifecycleEvent(events[0])).toBe(true);
   });
 
+  it('upserts pr_mirrors before publishing review-gate CI failure wakeups', () => {
+    const bus = new LocalBus();
+    const order: string[] = [];
+    bus.subscribe(Channels.WORKFLOW_LIFECYCLE, () => {
+      order.push('publish');
+    });
+    const upsertPrMirror = vi.fn((mirror) => {
+      order.push('upsert');
+      return mirror;
+    });
+    const task = makeTask({
+      id: 'wf-1/merge',
+      status: 'review_ready',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {
+        generation: 7,
+        selectedAttemptId: 'attempt-merge',
+        reviewId: '123',
+        branch: 'feature/ci-red',
+      },
+      taskStateVersion: 12,
+    });
+
+    publishReviewGateCiFailedLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'abc123',
+      headRef: 'feature/ci-red',
+      branch: 'feature/ci-red',
+      mergeState: 'clean',
+      selectedAttemptId: 'attempt-merge',
+      generation: 7,
+      failedChecks: [
+        { name: 'test-all', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/runs/1' },
+      ],
+      statusText: 'CI failed',
+    }, {
+      messageBus: bus,
+      getTask: () => task,
+      prMirrorStore: { upsertPrMirror },
+      now: () => CREATED_AT_DATE,
+    });
+
+    expect(order).toEqual(['upsert', 'publish']);
+    expect(upsertPrMirror).toHaveBeenCalledWith({
+      repo: 'owner/repo',
+      prNumber: 123,
+      headSha: 'abc123',
+      mergeState: 'clean',
+      workflowId: 'wf-1',
+      blockersJson: JSON.stringify({ kind: 'ci_failed', failedChecks: ['test-all'] }),
+      updatedAt: CREATED_AT,
+    });
+  });
+
   it('fills review-gate CI failure attempt context from persisted task state', () => {
     const bus = new LocalBus();
     const events = collectLifecycleEvents(bus);
@@ -360,6 +417,64 @@ describe('lifecycle event bridge', () => {
     });
     expectRecoveryWakeup(events[0], { reason: 'review_gate_failure' });
     expect(isWorkflowLifecycleEvent(events[0])).toBe(true);
+  });
+
+  it('upserts pr_mirrors before publishing review-gate merge conflict wakeups', () => {
+    const bus = new LocalBus();
+    const order: string[] = [];
+    bus.subscribe(Channels.WORKFLOW_LIFECYCLE, () => {
+      order.push('publish');
+    });
+    const upsertPrMirror = vi.fn((mirror) => {
+      order.push('upsert');
+      return mirror;
+    });
+    const task = makeTask({
+      id: 'wf-1/merge',
+      status: 'review_ready',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {
+        generation: 7,
+        selectedAttemptId: 'attempt-merge',
+        reviewId: 'owner/repo#123',
+        branch: 'feature/merge-conflict',
+      },
+      taskStateVersion: 12,
+    });
+
+    publishReviewGateMergeConflictLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      reviewId: 'owner/repo#123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'abc123',
+      headRef: 'feature/merge-conflict',
+      branch: 'feature/merge-conflict',
+      mergeState: 'dirty',
+      baseRef: 'main',
+      labelsJson: '["admin-bypass"]',
+      selectedAttemptId: 'attempt-merge',
+      generation: 7,
+      statusText: 'Awaiting review',
+    }, {
+      messageBus: bus,
+      getTask: () => task,
+      prMirrorStore: { upsertPrMirror },
+      now: () => CREATED_AT_DATE,
+    });
+
+    expect(order).toEqual(['upsert', 'publish']);
+    expect(upsertPrMirror).toHaveBeenCalledWith({
+      repo: 'owner/repo',
+      prNumber: 123,
+      headSha: 'abc123',
+      baseRef: 'main',
+      mergeState: 'dirty',
+      labelsJson: '["admin-bypass"]',
+      workflowId: 'wf-1',
+      blockersJson: JSON.stringify({ kind: 'merge_conflict' }),
+      updatedAt: CREATED_AT,
+    });
   });
 
   it('unsubscribes cleanly', () => {

--- a/packages/app/src/__tests__/task-runner-wiring.test.ts
+++ b/packages/app/src/__tests__/task-runner-wiring.test.ts
@@ -220,12 +220,20 @@ describe('task-runner-wiring', () => {
     await config.reviewGateCiFailurePublisher.publish({ taskId: 'merge-task' });
     expect(publishReviewGateCiFailedLifecycleEvent).toHaveBeenCalledWith(
       { taskId: 'merge-task' },
-      expect.objectContaining({ messageBus: expect.any(Object), getTask: expect.any(Function) }),
+      expect.objectContaining({
+        messageBus: expect.any(Object),
+        getTask: expect.any(Function),
+        prMirrorStore: persistence,
+      }),
     );
     await config.reviewGateMergeConflictPublisher.publish({ taskId: 'merge-task' });
     expect(publishReviewGateMergeConflictLifecycleEvent).toHaveBeenCalledWith(
       { taskId: 'merge-task' },
-      expect.objectContaining({ messageBus: expect.any(Object), getTask: expect.any(Function) }),
+      expect.objectContaining({
+        messageBus: expect.any(Object),
+        getTask: expect.any(Function),
+        prMirrorStore: persistence,
+      }),
     );
 
     const approveHook = orchestrator.setBeforeApproveHook.mock.calls[0]?.[0];

--- a/packages/app/src/execution/task-runner-wiring.ts
+++ b/packages/app/src/execution/task-runner-wiring.ts
@@ -103,6 +103,8 @@ export function rebuildTaskRunner(deps: TaskRunnerWiringDeps): TaskRunner {
         publishReviewGateCiFailedLifecycleEvent(trigger, {
           messageBus: deps.messageBus,
           getTask: (taskId) => deps.orchestrator.getTask(taskId),
+          prMirrorStore: deps.persistence,
+          logger: deps.logger,
         });
       },
     },
@@ -111,6 +113,8 @@ export function rebuildTaskRunner(deps: TaskRunnerWiringDeps): TaskRunner {
         publishReviewGateMergeConflictLifecycleEvent(trigger, {
           messageBus: deps.messageBus,
           getTask: (taskId) => deps.orchestrator.getTask(taskId),
+          prMirrorStore: deps.persistence,
+          logger: deps.logger,
         });
       },
     },

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -166,6 +166,8 @@ export function createHeadlessExecutor(
         publishReviewGateCiFailedLifecycleEvent(trigger, {
           messageBus: deps.messageBus,
           getTask: (taskId) => deps.orchestrator.getTask(taskId),
+          prMirrorStore: deps.persistence,
+          logger: deps.logger,
         });
       },
     },
@@ -174,6 +176,8 @@ export function createHeadlessExecutor(
         publishReviewGateMergeConflictLifecycleEvent(trigger, {
           messageBus: deps.messageBus,
           getTask: (taskId) => deps.orchestrator.getTask(taskId),
+          prMirrorStore: deps.persistence,
+          logger: deps.logger,
         });
       },
     },

--- a/packages/app/src/lifecycle-event-bridge.ts
+++ b/packages/app/src/lifecycle-event-bridge.ts
@@ -1,3 +1,4 @@
+import type { PrMirrorRow } from '@invoker/data-store';
 import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
 import type { TaskDelta, TaskState, TaskStatus } from '@invoker/workflow-core';
 import {
@@ -18,10 +19,15 @@ interface LifecycleTaskMetadata {
   readonly attemptId?: string;
 }
 
+export interface PrMirrorUpsertStore {
+  upsertPrMirror(mirror: PrMirrorRow): PrMirrorRow;
+}
+
 export interface LifecycleEventBridgeOptions {
   readonly messageBus: MessageBus;
   readonly getInitialTasks?: () => readonly TaskState[];
   readonly getTask?: (taskId: string) => TaskState | undefined;
+  readonly prMirrorStore?: PrMirrorUpsertStore;
   readonly now?: () => Date;
   readonly logger?: {
     warn(message: string, details?: Record<string, unknown>): void;
@@ -42,6 +48,9 @@ export interface ReviewGateCiFailedWakeupInput {
   readonly headSha?: string;
   readonly headRef?: string;
   readonly branch?: string;
+  readonly baseRef?: string;
+  readonly mergeState?: string;
+  readonly labelsJson?: string;
   readonly selectedAttemptId?: string;
   readonly generation: number;
   readonly failedChecks: readonly ReviewGateFailedCheck[];
@@ -58,6 +67,9 @@ export interface ReviewGateMergeConflictWakeupInput {
   readonly headSha?: string;
   readonly headRef?: string;
   readonly branch?: string;
+  readonly baseRef?: string;
+  readonly mergeState?: string;
+  readonly labelsJson?: string;
   readonly selectedAttemptId?: string;
   readonly generation: number;
   readonly statusText: string;
@@ -91,7 +103,7 @@ export function startLifecycleEventBridge(options: LifecycleEventBridgeOptions):
 
 export function publishReviewGateCiFailedLifecycleEvent(
   input: ReviewGateCiFailedWakeupInput,
-  options: Pick<LifecycleEventBridgeOptions, 'messageBus' | 'getTask' | 'now'>,
+  options: Pick<LifecycleEventBridgeOptions, 'messageBus' | 'getTask' | 'prMirrorStore' | 'now' | 'logger'>,
 ): WorkflowLifecycleEvent | undefined {
   const currentTask = options.getTask?.(input.taskId);
   const status = input.status ?? currentTask?.status;
@@ -115,13 +127,18 @@ export function publishReviewGateCiFailedLifecycleEvent(
     attemptId,
     createdAt: options.now?.(),
   });
+  upsertReviewGatePrMirrorBeforePublish({
+    kind: 'ci_failed',
+    input,
+    options,
+  });
   options.messageBus.publish(Channels.WORKFLOW_LIFECYCLE, event);
   return event;
 }
 
 export function publishReviewGateMergeConflictLifecycleEvent(
   input: ReviewGateMergeConflictWakeupInput,
-  options: Pick<LifecycleEventBridgeOptions, 'messageBus' | 'getTask' | 'now'>,
+  options: Pick<LifecycleEventBridgeOptions, 'messageBus' | 'getTask' | 'prMirrorStore' | 'now' | 'logger'>,
 ): WorkflowLifecycleEvent | undefined {
   const currentTask = options.getTask?.(input.taskId);
   const status = input.status ?? currentTask?.status;
@@ -144,8 +161,68 @@ export function publishReviewGateMergeConflictLifecycleEvent(
     attemptId,
     createdAt: options.now?.(),
   });
+  upsertReviewGatePrMirrorBeforePublish({
+    kind: 'merge_conflict',
+    input,
+    options,
+  });
   options.messageBus.publish(Channels.WORKFLOW_LIFECYCLE, event);
   return event;
+}
+
+export function resolveReviewGatePrIdentity(
+  reviewUrl: string,
+  reviewId: string,
+): { repo: string; prNumber: number } | undefined {
+  const fromUrl = reviewUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/i);
+  if (fromUrl?.[1] && fromUrl[2]) {
+    return { repo: fromUrl[1], prNumber: Number(fromUrl[2]) };
+  }
+  const fromId = reviewId.match(/^([^/#]+\/[^/#]+)#(\d+)$/);
+  if (fromId?.[1] && fromId[2]) {
+    return { repo: fromId[1], prNumber: Number(fromId[2]) };
+  }
+  return undefined;
+}
+
+function upsertReviewGatePrMirrorBeforePublish(args: {
+  readonly kind: 'ci_failed' | 'merge_conflict';
+  readonly input: ReviewGateCiFailedWakeupInput | ReviewGateMergeConflictWakeupInput;
+  readonly options: Pick<LifecycleEventBridgeOptions, 'prMirrorStore' | 'now' | 'logger'>;
+}): void {
+  const store = args.options.prMirrorStore;
+  if (!store) return;
+
+  const identity = resolveReviewGatePrIdentity(args.input.reviewUrl, args.input.reviewId);
+  if (!identity || !args.input.headSha) {
+    args.options.logger?.warn('skipping pr_mirrors upsert before review-gate lifecycle publish', {
+      module: 'lifecycle-event-bridge',
+      kind: args.kind,
+      reviewId: args.input.reviewId,
+      reviewUrl: args.input.reviewUrl,
+      headSha: args.input.headSha,
+    });
+    return;
+  }
+
+  const updatedAt = (args.options.now?.() ?? new Date()).toISOString();
+  const blockers: Record<string, unknown> = { kind: args.kind };
+  if (args.kind === 'ci_failed' && 'failedChecks' in args.input) {
+    blockers.failedChecks = args.input.failedChecks.map((check) => check.name);
+  }
+
+  const mirror: PrMirrorRow = {
+    repo: identity.repo,
+    prNumber: identity.prNumber,
+    headSha: args.input.headSha,
+    ...(args.input.baseRef ? { baseRef: args.input.baseRef } : {}),
+    ...(args.input.mergeState ? { mergeState: args.input.mergeState } : {}),
+    ...(args.input.labelsJson ? { labelsJson: args.input.labelsJson } : {}),
+    workflowId: args.input.workflowId,
+    blockersJson: JSON.stringify(blockers),
+    updatedAt,
+  };
+  store.upsertPrMirror(mirror);
 }
 
 function buildEventForTaskDelta(

--- a/packages/execution-engine/src/task-runner-review-gate.ts
+++ b/packages/execution-engine/src/task-runner-review-gate.ts
@@ -49,6 +49,7 @@ export interface ReviewGateCiFailureTrigger {
   headSha?: string;
   headRef?: string;
   branch?: string;
+  mergeState?: MergeGateApprovalStatus['mergeState'];
   selectedAttemptId?: string;
   generation: number;
   failedChecks: NonNullable<MergeGateApprovalStatus['checks']>['failed'];
@@ -68,6 +69,7 @@ export interface ReviewGateMergeConflictTrigger {
   headSha?: string;
   headRef?: string;
   branch?: string;
+  mergeState?: MergeGateApprovalStatus['mergeState'];
   selectedAttemptId?: string;
   generation: number;
   statusText: string;
@@ -343,6 +345,7 @@ export async function maybePublishReviewGateCiFailure(
       headSha: status.headSha,
       headRef: status.headRef,
       branch: task.execution.branch,
+      mergeState: status.mergeState,
       selectedAttemptId: task.execution.selectedAttemptId,
       generation: task.execution.generation ?? 0,
       failedChecks: status.checks.failed,
@@ -383,6 +386,7 @@ export async function maybePublishReviewGateMergeConflict(
       headSha: status.headSha,
       headRef: status.headRef,
       branch: task.execution.branch,
+      mergeState: status.mergeState,
       selectedAttemptId: task.execution.selectedAttemptId,
       generation: task.execution.generation ?? 0,
       statusText: status.statusText,


### PR DESCRIPTION
Upsert owner-DB PR mirror rows ahead of ci_failed and merge_conflict
events so later lease/repair workers can treat persisted state as authority.

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #5818