### PR TITLE
Lease CI and conflict repair submissions

### DIFF
--- a/packages/data-store/src/__tests__/pr-mirror-lease.test.ts
+++ b/packages/data-store/src/__tests__/pr-mirror-lease.test.ts
@@ -47,7 +47,9 @@ describe('pr_mirrors and pr_repair_leases', () => {
       updatedAt: '2026-07-25T18:00:00.000Z',
     });
     expect(updated.headSha).toBe('cafebabe');
-    expect(updated.workflowId).toBeUndefined();
+    expect(updated.workflowId).toBe('wf-1');
+    expect(updated.baseRef).toBe('main');
+    expect(updated.stackId).toBe('stack-1');
     expect(adapter.getPrMirror('owner/repo', 12)?.headSha).toBe('cafebabe');
   });
 

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3744,14 +3744,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(repo, pr_number) DO UPDATE SET
         head_sha = excluded.head_sha,
-        base_ref = excluded.base_ref,
-        merge_state = excluded.merge_state,
-        labels_json = excluded.labels_json,
-        stack_id = excluded.stack_id,
-        stack_order = excluded.stack_order,
-        workflow_id = excluded.workflow_id,
-        repair_workflows_json = excluded.repair_workflows_json,
-        blockers_json = excluded.blockers_json,
+        base_ref = COALESCE(excluded.base_ref, pr_mirrors.base_ref),
+        merge_state = COALESCE(excluded.merge_state, pr_mirrors.merge_state),
+        labels_json = COALESCE(excluded.labels_json, pr_mirrors.labels_json),
+        stack_id = COALESCE(excluded.stack_id, pr_mirrors.stack_id),
+        stack_order = COALESCE(excluded.stack_order, pr_mirrors.stack_order),
+        workflow_id = COALESCE(excluded.workflow_id, pr_mirrors.workflow_id),
+        repair_workflows_json = COALESCE(excluded.repair_workflows_json, pr_mirrors.repair_workflows_json),
+        blockers_json = COALESCE(excluded.blockers_json, pr_mirrors.blockers_json),
         updated_at = excluded.updated_at`,
       [
         mirror.repo,

--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { WorkerActionRecord, WorkerActionWrite, WorkflowMutationPriority } from '@invoker/data-store';
+import type {
+  PrRepairLeaseRow,
+  WorkerActionRecord,
+  WorkerActionWrite,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
 
 import { parseFixWithAgentMutationArgs } from '../auto-fix-intents.js';
@@ -119,6 +124,8 @@ function toRecord(write: WorkerActionWrite): WorkerActionRecord {
 function makeHarness(task = makeTask()) {
   const tasks = new Map<string, TaskState>([[task.id, task]]);
   const actions = new Map<string, WorkerActionRecord>();
+  const leases = new Map<string, PrRepairLeaseRow>();
+  const leaseKey = (repo: string, prNumber: number, headSha: string) => `${repo}:${prNumber}:${headSha}`;
   const submit = vi.fn((workflowId: string, priority: WorkflowMutationPriority, channel: string, args: unknown[]) => {
     expect(workflowId).toBe('wf-1');
     expect(priority).toBe('normal');
@@ -138,6 +145,12 @@ function makeHarness(task = makeTask()) {
       return saved;
     }),
     logEvent: vi.fn(),
+    getPrRepairLease: vi.fn((repo: string, prNumber: number, headSha: string) =>
+      leases.get(leaseKey(repo, prNumber, headSha))),
+    upsertPrRepairLease: vi.fn((lease: PrRepairLeaseRow) => {
+      leases.set(leaseKey(lease.repo, lease.prNumber, lease.headSha), lease);
+      return lease;
+    }),
   };
   const attemptLedger = createAutoFixAttemptLedger();
   return { actions, store, submit, attemptLedger };
@@ -206,6 +219,12 @@ describe('PR status and CI failure workers', () => {
           selectedAttemptId: 'attempt-1',
           headSha: 'sha-1',
         },
+        prRepairLease: {
+          repo: 'owner/repo',
+          prNumber: 123,
+          headSha: 'sha-1',
+          holderKind: 'ci_failed',
+        },
       },
     });
     expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toMatchObject({
@@ -214,6 +233,36 @@ describe('PR status and CI failure workers', () => {
       status: 'queued',
       intentId: '42',
       externalKey: ciFailureActionKey(event),
+    });
+  });
+
+  it('records a skipped action and submits no CI repair when a conflict lease holds the PR', async () => {
+    const event = makeEvent();
+    const harness = makeHarness();
+    harness.store.upsertPrRepairLease({
+      repo: 'owner/repo',
+      prNumber: 123,
+      headSha: 'sha-1',
+      holderKind: 'merge_conflict',
+      leaseId: 'conflict-lease',
+      acquiredAt: '2026-07-25T00:00:00.000Z',
+      expiresAt: '2026-07-26T00:00:00.000Z',
+    });
+    const tick = createCiFailureTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 2,
+      drainEvents: () => [event],
+    });
+
+    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
+
+    expect(harness.submit).not.toHaveBeenCalled();
+    expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toMatchObject({
+      status: 'skipped',
+      payload: expect.objectContaining({ reason: 'pr-repair-lease-denied', holderKind: 'merge_conflict' }),
     });
   });
 

--- a/packages/execution-engine/src/__tests__/review-gate-merge-conflict-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/review-gate-merge-conflict-worker.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type {
+  PrRepairLeaseRow,
   WorkerActionRecord,
   WorkerActionWrite,
   WorkflowMutationIntent,
@@ -9,6 +10,8 @@ import type {
 import type { TaskState } from '@invoker/workflow-core';
 
 import type { ReviewGateMergeConflictLifecycleEvent } from '../lifecycle-events.js';
+import { createAutoFixAttemptLedger } from '../auto-fix-attempt-ledger.js';
+import { createCiFailureTick } from '../workers/ci-failure-worker.js';
 import {
   REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
   createReviewGateMergeConflictTick,
@@ -102,11 +105,14 @@ interface Harness {
     logEvent: ReturnType<typeof vi.fn>;
   };
   submit: ReturnType<typeof vi.fn>;
+  leases: Map<string, PrRepairLeaseRow>;
 }
 
 function makeHarness(task = makeTask(), intents: WorkflowMutationIntent[] = []): Harness {
   const tasks = new Map<string, TaskState>([[task.id, task]]);
   const actions = new Map<string, WorkerActionRecord>();
+  const leases = new Map<string, PrRepairLeaseRow>();
+  const leaseKey = (repo: string, prNumber: number, headSha: string) => `${repo}:${prNumber}:${headSha}`;
   const submit = vi.fn((
     workflowId: string,
     priority: WorkflowMutationPriority,
@@ -116,7 +122,14 @@ function makeHarness(task = makeTask(), intents: WorkflowMutationIntent[] = []):
     expect(workflowId).toBe('wf-1');
     expect(priority).toBe('high');
     expect(channel).toBe('invoker:rebase-recreate');
-    expect(args).toEqual(['wf-1']);
+    expect(args).toMatchObject(['wf-1', {
+      prRepairLease: {
+        repo: 'owner/repo',
+        prNumber: 123,
+        headSha: 'sha-1',
+        holderKind: 'merge_conflict',
+      },
+    }]);
     return 42;
   });
   const store = {
@@ -132,8 +145,22 @@ function makeHarness(task = makeTask(), intents: WorkflowMutationIntent[] = []):
       return saved;
     }),
     logEvent: vi.fn(),
+    getPrRepairLease: vi.fn((repo: string, prNumber: number, headSha: string) =>
+      leases.get(leaseKey(repo, prNumber, headSha))),
+    upsertPrRepairLease: vi.fn((lease: PrRepairLeaseRow) => {
+      leases.set(leaseKey(lease.repo, lease.prNumber, lease.headSha), lease);
+      return lease;
+    }),
+    deletePrRepairLeaseById: vi.fn((leaseId: string) => {
+      for (const [key, lease] of leases) {
+        if (lease.leaseId !== leaseId) continue;
+        leases.delete(key);
+        return true;
+      }
+      return false;
+    }),
   };
-  return { actions, intents, store, submit };
+  return { actions, intents, store, submit, leases };
 }
 
 function actionFor(harness: Harness, event: ReviewGateMergeConflictLifecycleEvent): WorkerActionRecord | undefined {
@@ -185,6 +212,47 @@ describe('review-gate merge-conflict worker tick', () => {
     // A later tick draining the same event again is stopped by the durable row.
     await createReviewGateMergeConflictTick({ ...options, drainEvents: () => [makeEvent()] })();
     expect(harness.submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('submits only the conflict repair when conflict and CI target the same PR', async () => {
+    const harness = makeHarness();
+    const conflictEvent = makeEvent();
+    await createReviewGateMergeConflictTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      drainEvents: () => [conflictEvent],
+    })();
+
+    const ciSubmit = vi.fn(() => 43);
+    const ciEvent = {
+      ...conflictEvent,
+      kind: 'review_gate.ci_failed',
+      eventKey: 'review_gate.ci_failed|workflow:wf-1|task:wf-1/merge',
+      failedChecks: [{ name: 'unit', conclusion: 'FAILURE' }],
+      recoveryWakeup: {
+        eventKey: 'review_gate.ci_failed|workflow:wf-1|task:wf-1/merge',
+        eventKind: 'review_gate.ci_failed',
+        workflowId: 'wf-1',
+        taskId: 'wf-1/merge',
+        generation: 2,
+        attemptId: 'attempt-1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        reason: 'review_gate_failure',
+        authoritative: false,
+      },
+    } as any;
+    await createCiFailureTick({
+      store: harness.store,
+      submitter: { submit: ciSubmit },
+      logger,
+      attemptLedger: createAutoFixAttemptLedger(),
+      defaultAutoFixRetries: 2,
+      drainEvents: () => [ciEvent],
+    })();
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    expect(ciSubmit).not.toHaveBeenCalled();
   });
 
   it('skips a stale event whose head SHA no longer matches the persisted task, without a durable row', async () => {

--- a/packages/execution-engine/src/auto-fix-intents.ts
+++ b/packages/execution-engine/src/auto-fix-intents.ts
@@ -104,6 +104,15 @@ export interface AutoFixCommandContext {
   autoFix: boolean;
   reviewGateContext?: ReviewGateCiContext;
   executionModel?: string;
+  prRepairLease?: PrRepairLeaseIntentMetadata;
+}
+
+export interface PrRepairLeaseIntentMetadata {
+  leaseId: string;
+  repo: string;
+  prNumber: number;
+  headSha?: string;
+  holderKind: string;
 }
 
 export interface ParsedHeadlessFixArgs extends AutoFixCommandContext {
@@ -168,6 +177,7 @@ export interface FixWithAgentMutationOptions {
   autoFix?: boolean;
   reviewGateContext?: ReviewGateCiContext;
   executionModel?: string;
+  prRepairLease?: PrRepairLeaseIntentMetadata;
 }
 
 export interface ParsedFixWithAgentMutationArgs {
@@ -182,11 +192,12 @@ export function buildFixWithAgentMutationArgs(
   options?: FixWithAgentMutationOptions,
 ): unknown[] {
   const args: unknown[] = [taskId, agentName];
-  if (options && (options.autoFix || options.reviewGateContext || options.executionModel)) {
+  if (options && (options.autoFix || options.reviewGateContext || options.executionModel || options.prRepairLease)) {
     args.push({
       autoFix: Boolean(options.autoFix || options.reviewGateContext),
       ...(options.reviewGateContext ? { reviewGateContext: options.reviewGateContext } : {}),
       ...(options.executionModel ? { executionModel: options.executionModel } : {}),
+      ...(options.prRepairLease ? { prRepairLease: options.prRepairLease } : {}),
     });
   }
   return args;
@@ -199,6 +210,7 @@ export function parseFixWithAgentMutationArgs(args: unknown[]): ParsedFixWithAge
   let autoFix = false;
   let reviewGateContext: ReviewGateCiContext | undefined;
   let executionModel: string | undefined;
+  let prRepairLease: PrRepairLeaseIntentMetadata | undefined;
 
   if (optionsArg && typeof optionsArg === 'object') {
     const candidate = optionsArg as Record<string, unknown>;
@@ -215,7 +227,24 @@ export function parseFixWithAgentMutationArgs(args: unknown[]): ParsedFixWithAge
     if (typeof candidate.executionModel === 'string' && candidate.executionModel.length > 0) {
       executionModel = candidate.executionModel;
     }
+    if (candidate.prRepairLease && typeof candidate.prRepairLease === 'object') {
+      const lease = candidate.prRepairLease as Record<string, unknown>;
+      if (
+        typeof lease.leaseId === 'string'
+        && typeof lease.repo === 'string'
+        && typeof lease.prNumber === 'number'
+        && typeof lease.holderKind === 'string'
+      ) {
+        prRepairLease = {
+          leaseId: lease.leaseId,
+          repo: lease.repo,
+          prNumber: lease.prNumber,
+          ...(typeof lease.headSha === 'string' ? { headSha: lease.headSha } : {}),
+          holderKind: lease.holderKind,
+        };
+      }
+    }
   }
 
-  return { taskId, agentName, context: { autoFix, reviewGateContext, executionModel } };
+  return { taskId, agentName, context: { autoFix, reviewGateContext, executionModel, prRepairLease } };
 }

--- a/packages/execution-engine/src/pr-repair-identity.ts
+++ b/packages/execution-engine/src/pr-repair-identity.ts
@@ -1,0 +1,27 @@
+export interface PrRepairIdentity {
+  repo: string;
+  prNumber: number;
+}
+
+export function resolvePrRepairIdentity(reviewUrl: string, reviewId: string): PrRepairIdentity | undefined {
+  const fromUrl = resolvePrRepairIdentityFromUrl(reviewUrl);
+  if (fromUrl) return fromUrl;
+  return resolvePrRepairIdentityFromId(reviewId);
+}
+
+function resolvePrRepairIdentityFromUrl(reviewUrl: string): PrRepairIdentity | undefined {
+  try {
+    const url = new URL(reviewUrl);
+    const match = url.pathname.match(/^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/?$/);
+    if (!match) return undefined;
+    return { repo: `${match[1]}/${match[2]}`, prNumber: Number(match[3]) };
+  } catch {
+    return undefined;
+  }
+}
+
+function resolvePrRepairIdentityFromId(reviewId: string): PrRepairIdentity | undefined {
+  const match = reviewId.match(/^([^/\s]+\/[^#\s]+)#(\d+)$/);
+  if (!match) return undefined;
+  return { repo: match[1], prNumber: Number(match[2]) };
+}

--- a/packages/execution-engine/src/pr-repair-lease.ts
+++ b/packages/execution-engine/src/pr-repair-lease.ts
@@ -18,6 +18,7 @@ export interface PrRepairLeaseStore {
   upsertPrRepairLease(lease: PrRepairLeaseRow): PrRepairLeaseRow;
   getPrRepairLeaseById(leaseId: string): PrRepairLeaseRow | undefined;
   deletePrRepairLeaseById(leaseId: string): boolean;
+  runInTransaction?<T>(work: () => T): T;
 }
 
 export type TryAcquirePrRepairLeaseResult =
@@ -46,6 +47,7 @@ function isLeaseActive(lease: PrRepairLeaseRow, nowIso: string): boolean {
 export function tryAcquirePrRepairLease(
   input: TryAcquirePrRepairLeaseInput,
 ): TryAcquirePrRepairLeaseResult {
+  const acquire = (): TryAcquirePrRepairLeaseResult => {
   const now = input.now ?? new Date();
   const nowIso = now.toISOString();
   const leaseMs = input.leaseMs ?? PR_REPAIR_LEASE_DEFAULT_MS;
@@ -95,7 +97,9 @@ export function tryAcquirePrRepairLease(
     acquiredAt: nowIso,
     expiresAt,
   });
-  return { ok: true, leaseId, preempted: false };
+    return { ok: true, leaseId, preempted: false };
+  };
+  return input.store.runInTransaction ? input.store.runInTransaction(acquire) : acquire();
 }
 
 export function releasePrRepairLease(leaseId: string, store: PrRepairLeaseStore): boolean {

--- a/packages/execution-engine/src/review-gate-ci-repair.ts
+++ b/packages/execution-engine/src/review-gate-ci-repair.ts
@@ -32,6 +32,11 @@ import {
   classifyFailedChecks,
   type FailedCheckLogFetcher,
 } from './ci-failure-infra-classifier.js';
+import {
+  tryAcquirePrRepairLease,
+  type PrRepairLeaseStore,
+} from './pr-repair-lease.js';
+import { resolvePrRepairIdentity } from './pr-repair-identity.js';
 import { recordWorkerDecisionRow } from './worker-decision-ledger.js';
 
 const CI_FAILURE_WORKER_KIND = 'ci-failure';
@@ -51,6 +56,9 @@ export interface ReviewGateCiRepairStore {
   getWorkerAction?(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
   upsertWorkerAction?(action: WorkerActionWrite): WorkerActionRecord;
   logEvent?(taskId: string, eventType: string, payload?: unknown): void;
+  getPrRepairLease?: PrRepairLeaseStore['getPrRepairLease'];
+  upsertPrRepairLease?: PrRepairLeaseStore['upsertPrRepairLease'];
+  deletePrRepairLeaseById?: PrRepairLeaseStore['deletePrRepairLeaseById'];
 }
 
 export interface ReviewGateCiRepairSubmitter {
@@ -287,6 +295,42 @@ function logCiFailureWorkerEvent(
   });
 }
 
+function acquireCiFailureLease(
+  options: ReviewGateCiRepairPolicyOptions,
+  event: ReviewGateCiFailedLifecycleEvent,
+): { available: false } | { available: true; lease?: { leaseId: string; repo: string; prNumber: number } } {
+  if (!event.headSha || !options.store.getPrRepairLease || !options.store.upsertPrRepairLease) {
+    return { available: false };
+  }
+  const identity = resolvePrRepairIdentity(event.reviewUrl, event.reviewId);
+  if (!identity) return { available: false };
+  const lease = tryAcquirePrRepairLease({
+    ...identity,
+    headSha: event.headSha,
+    kind: 'ci_failed',
+    workflowId: event.workflowId,
+    store: {
+      getPrRepairLease: options.store.getPrRepairLease,
+      upsertPrRepairLease: options.store.upsertPrRepairLease,
+      getPrRepairLeaseById: () => undefined,
+      deletePrRepairLeaseById: () => false,
+    },
+  });
+  if (!lease.ok) {
+    recordCiFailureAction(options, event, 'skipped', 'Skipped CI repair because PR repair lease is held', {
+      reason: 'pr-repair-lease-denied',
+      holderKind: lease.holderKind,
+      lease: { repo: identity.repo, prNumber: identity.prNumber, headSha: event.headSha },
+    });
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
+      reason: 'pr-repair-lease-denied',
+      holderKind: lease.holderKind,
+    });
+    return { available: true };
+  }
+  return { available: true, lease: { leaseId: lease.leaseId, ...identity } };
+}
+
 
 function buildCiFailureFixContext(event: ReviewGateCiFailedLifecycleEvent): string {
   const checks = event.failedChecks
@@ -362,6 +406,12 @@ function reconcileFinishedIntentAction(
     updatedAt: now,
     completedAt: now,
   });
+  const leaseId = payload.prRepairLease && typeof payload.prRepairLease === 'object'
+    ? (payload.prRepairLease as Record<string, unknown>).leaseId
+    : undefined;
+  if (typeof leaseId === 'string') {
+    options.store.deletePrRepairLeaseById?.(leaseId);
+  }
   logCiFailureWorkerEvent(options, event, 'worker-ci-failure-intent-reconciled', {
     intentId: existing.intentId,
     intentStatus: intent.status,
@@ -452,6 +502,11 @@ export async function queueReviewGateCiRepair(
     return { decision: 'skipped', reason: 'worker-retry-budget-exhausted' };
   }
 
+  const leaseResult = acquireCiFailureLease(options, event);
+  if (leaseResult.available && !leaseResult.lease) {
+    return { decision: 'skipped', reason: 'pr-repair-lease-denied' };
+  }
+
   const attemptDecision = options.attemptLedger.consume(
     autoFixAttemptLedgerKeyFromLifecycleEvent(event),
     workerRetryBudget,
@@ -498,6 +553,15 @@ export async function queueReviewGateCiRepair(
       fixContext: buildCiFailureFixContext(event),
     },
     executionModel,
+    ...(leaseResult.lease ? {
+      prRepairLease: {
+        leaseId: leaseResult.lease.leaseId,
+        repo: leaseResult.lease.repo,
+        prNumber: leaseResult.lease.prNumber,
+        headSha: event.headSha,
+        holderKind: 'ci_failed',
+      },
+    } : {}),
   });
   const intentId = options.submitter.submit(event.workflowId, 'normal', FIX_WITH_AGENT_CHANNEL, args);
   recordCiFailureAction(
@@ -508,6 +572,7 @@ export async function queueReviewGateCiRepair(
     {
       channel: FIX_WITH_AGENT_CHANNEL,
       workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
+      ...(leaseResult.lease ? { prRepairLease: leaseResult.lease } : {}),
     },
     intentId,
     selectedAgent,

--- a/packages/execution-engine/src/review-gate-ci-repair.ts
+++ b/packages/execution-engine/src/review-gate-ci-repair.ts
@@ -506,6 +506,7 @@ export async function queueReviewGateCiRepair(
   if (leaseResult.available && !leaseResult.lease) {
     return { decision: 'skipped', reason: 'pr-repair-lease-denied' };
   }
+  const prRepairLease = leaseResult.available ? leaseResult.lease : undefined;
 
   const attemptDecision = options.attemptLedger.consume(
     autoFixAttemptLedgerKeyFromLifecycleEvent(event),
@@ -553,11 +554,11 @@ export async function queueReviewGateCiRepair(
       fixContext: buildCiFailureFixContext(event),
     },
     executionModel,
-    ...(leaseResult.lease ? {
+    ...(prRepairLease ? {
       prRepairLease: {
-        leaseId: leaseResult.lease.leaseId,
-        repo: leaseResult.lease.repo,
-        prNumber: leaseResult.lease.prNumber,
+        leaseId: prRepairLease.leaseId,
+        repo: prRepairLease.repo,
+        prNumber: prRepairLease.prNumber,
         headSha: event.headSha,
         holderKind: 'ci_failed',
       },
@@ -572,7 +573,7 @@ export async function queueReviewGateCiRepair(
     {
       channel: FIX_WITH_AGENT_CHANNEL,
       workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
-      ...(leaseResult.lease ? { prRepairLease: leaseResult.lease } : {}),
+      ...(prRepairLease ? { prRepairLease } : {}),
     },
     intentId,
     selectedAgent,

--- a/packages/execution-engine/src/workers/review-gate-merge-conflict-worker.ts
+++ b/packages/execution-engine/src/workers/review-gate-merge-conflict-worker.ts
@@ -20,6 +20,11 @@ import type {
   WorkflowLifecycleEvent,
 } from '../lifecycle-events.js';
 import { recordWorkerDecisionRow } from '../worker-decision-ledger.js';
+import {
+  tryAcquirePrRepairLease,
+  type PrRepairLeaseStore,
+} from '../pr-repair-lease.js';
+import { resolvePrRepairIdentity } from '../pr-repair-identity.js';
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import type { WorkerRegistry } from '../worker-registry.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
@@ -47,6 +52,9 @@ export interface ReviewGateMergeConflictWorkerStore {
   getWorkerAction?(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
   upsertWorkerAction?(action: WorkerActionWrite): WorkerActionRecord;
   logEvent?(taskId: string, eventType: string, payload?: unknown): void;
+  getPrRepairLease?: PrRepairLeaseStore['getPrRepairLease'];
+  upsertPrRepairLease?: PrRepairLeaseStore['upsertPrRepairLease'];
+  deletePrRepairLeaseById?: PrRepairLeaseStore['deletePrRepairLeaseById'];
 }
 
 export interface ReviewGateMergeConflictWorkerSubmitter {
@@ -297,6 +305,48 @@ function logReviewGateMergeConflictEvent(
   });
 }
 
+function acquireMergeConflictLease(
+  options: ReviewGateMergeConflictWorkerPolicyOptions,
+  event: ReviewGateMergeConflictLifecycleEvent,
+): { available: false } | { available: true; lease?: { leaseId: string; repo: string; prNumber: number } } {
+  if (!event.headSha || !options.store.getPrRepairLease || !options.store.upsertPrRepairLease) {
+    return { available: false };
+  }
+  const identity = resolvePrRepairIdentity(event.reviewUrl, event.reviewId);
+  if (!identity) return { available: false };
+  const lease = tryAcquirePrRepairLease({
+    ...identity,
+    headSha: event.headSha,
+    kind: 'merge_conflict',
+    workflowId: event.workflowId,
+    store: {
+      getPrRepairLease: options.store.getPrRepairLease,
+      upsertPrRepairLease: options.store.upsertPrRepairLease,
+      getPrRepairLeaseById: () => undefined,
+      deletePrRepairLeaseById: () => false,
+    },
+  });
+  if (!lease.ok) {
+    recordReviewGateMergeConflictAction(
+      options,
+      event,
+      'skipped',
+      'Skipped workflow rebase-recreate because PR repair lease is held',
+      {
+        reason: 'pr-repair-lease-denied',
+        holderKind: lease.holderKind,
+        lease: { repo: identity.repo, prNumber: identity.prNumber, headSha: event.headSha },
+      },
+    );
+    logReviewGateMergeConflictEvent(options, event, 'review-gate-merge-conflict-skip', {
+      reason: 'pr-repair-lease-denied',
+      holderKind: lease.holderKind,
+    });
+    return { available: true };
+  }
+  return { available: true, lease: { leaseId: lease.leaseId, ...identity } };
+}
+
 function listOpenRecreateIntentsForEvent(
   options: ReviewGateMergeConflictWorkerPolicyOptions,
   event: ReviewGateMergeConflictLifecycleEvent,
@@ -362,6 +412,12 @@ function reconcileFinishedIntentAction(
     updatedAt: now,
     completedAt: now,
   });
+  const leaseId = payload.prRepairLease && typeof payload.prRepairLease === 'object'
+    ? (payload.prRepairLease as Record<string, unknown>).leaseId
+    : undefined;
+  if (typeof leaseId === 'string') {
+    options.store.deletePrRepairLeaseById?.(leaseId);
+  }
   logReviewGateMergeConflictEvent(options, event, 'review-gate-merge-conflict-intent-reconciled', {
     intentId: existing.intentId,
     intentStatus: intent.status,
@@ -406,13 +462,31 @@ async function handleReviewGateMergeConflictEvent(
     return;
   }
 
-  const intentId = options.submitter.submit(event.workflowId, 'high', REBASE_RECREATE_CHANNEL, [event.workflowId]);
+  const leaseResult = acquireMergeConflictLease(options, event);
+  if (leaseResult.available && !leaseResult.lease) return;
+
+  const intentArgs: unknown[] = [event.workflowId];
+  if (leaseResult.lease) {
+    intentArgs.push({
+      prRepairLease: {
+        leaseId: leaseResult.lease.leaseId,
+        repo: leaseResult.lease.repo,
+        prNumber: leaseResult.lease.prNumber,
+        headSha: event.headSha,
+        holderKind: 'merge_conflict',
+      },
+    });
+  }
+  const intentId = options.submitter.submit(event.workflowId, 'high', REBASE_RECREATE_CHANNEL, intentArgs);
   recordReviewGateMergeConflictAction(
     options,
     event,
     'queued',
     'Queued workflow rebase-recreate for review-gate merge conflict',
-    { channel: REBASE_RECREATE_CHANNEL },
+    {
+      channel: REBASE_RECREATE_CHANNEL,
+      ...(leaseResult.lease ? { prRepairLease: leaseResult.lease } : {}),
+    },
     intentId,
   );
   logReviewGateMergeConflictEvent(options, event, 'review-gate-merge-conflict-submitted', {

--- a/packages/execution-engine/src/workers/review-gate-merge-conflict-worker.ts
+++ b/packages/execution-engine/src/workers/review-gate-merge-conflict-worker.ts
@@ -464,14 +464,15 @@ async function handleReviewGateMergeConflictEvent(
 
   const leaseResult = acquireMergeConflictLease(options, event);
   if (leaseResult.available && !leaseResult.lease) return;
+  const prRepairLease = leaseResult.available ? leaseResult.lease : undefined;
 
   const intentArgs: unknown[] = [event.workflowId];
-  if (leaseResult.lease) {
+  if (prRepairLease) {
     intentArgs.push({
       prRepairLease: {
-        leaseId: leaseResult.lease.leaseId,
-        repo: leaseResult.lease.repo,
-        prNumber: leaseResult.lease.prNumber,
+        leaseId: prRepairLease.leaseId,
+        repo: prRepairLease.repo,
+        prNumber: prRepairLease.prNumber,
         headSha: event.headSha,
         holderKind: 'merge_conflict',
       },
@@ -485,7 +486,7 @@ async function handleReviewGateMergeConflictEvent(
     'Queued workflow rebase-recreate for review-gate merge conflict',
     {
       channel: REBASE_RECREATE_CHANNEL,
-      ...(leaseResult.lease ? { prRepairLease: leaseResult.lease } : {}),
+      ...(prRepairLease ? { prRepairLease } : {}),
     },
     intentId,
   );


### PR DESCRIPTION
## Summary
- acquire a durable PR-head lease before CI or conflict workers submit repair intents
- carry lease metadata through worker mutation args and release after terminal reconciliation
- record lease-denied worker actions and prove conflict blocks CI submission

## Review Claim
This makes existing mapped PR repair workers arbitration-aware without changing their executor path.

## Review Lane
behavior

## Review Unit
validation-policy

## Safety Invariant
For a shared repository, PR, and head SHA, a CI worker cannot submit while a merge-conflict lease is active.

## Slice Rationale
The two existing mutating worker paths are converted before adding new review or queue signals.

## Non-goals
- Command-route lease validation is completed in the follow-up command slice.
- No review-comment or queue-dequeue worker is added here.

## Test Plan
<details>
<summary>Test Plan</summary>

- `pnpm --filter @invoker/execution-engine test -- src/__tests__/pr-ci-workers.test.ts src/__tests__/review-gate-merge-conflict-worker.test.ts`
- Verify conflict plus CI submits only the conflict repair.
</details>

## Revert Plan
<details>
<summary>Revert Plan</summary>

Revert this PR to restore the previous CI/conflict submission behavior; Phase 0 tables remain unused by workers.
</details>

Depends on #5821.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coordination for automated pull request repairs, preventing conflicting CI-failure and merge-conflict fixes from running simultaneously.
  * Repair actions now record lease details and clean them up after completion.
  * Pull request identity can be resolved from review URLs or review IDs.
  * Added transactional support for acquiring repair coordination leases.

* **Bug Fixes**
  * Preserved existing pull request mirror metadata when updates omit those values.
  * Improved handling and reporting of skipped repair attempts when coordination is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->