### PR TITLE
Lease existing review-gate repair workers.

### DIFF
--- a/packages/app/src/__tests__/pr-repair-lease-command-guard.test.ts
+++ b/packages/app/src/__tests__/pr-repair-lease-command-guard.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertActiveBabysitPrRepairLease } from '../pr-repair-lease-command-guard.js';
+
+const lease = {
+  repo: 'owner/repo',
+  prNumber: 123,
+  headSha: 'sha-1',
+  leaseId: 'lease-1',
+};
+
+describe('assertActiveBabysitPrRepairLease', () => {
+  it('rejects a missing lease before a babysit mutation executes', () => {
+    expect(() => assertActiveBabysitPrRepairLease(
+      undefined,
+      { getPrRepairLeaseById: () => undefined },
+      'repair',
+    )).toThrow('Rejected babysit repair command');
+  });
+
+  it('rejects an expired or mismatched lease', () => {
+    expect(() => assertActiveBabysitPrRepairLease(
+      lease,
+      {
+        getPrRepairLeaseById: () => ({
+          ...lease,
+          holderKind: 'ci_failed' as const,
+          acquiredAt: '2026-01-01T00:00:00.000Z',
+          expiresAt: '2026-01-01T00:00:01.000Z',
+        }),
+      },
+      'repair',
+    )).toThrow('Rejected babysit repair command');
+  });
+
+  it('accepts an active lease for the exact PR head', () => {
+    expect(() => assertActiveBabysitPrRepairLease(
+      lease,
+      {
+        getPrRepairLeaseById: () => ({
+          ...lease,
+          holderKind: 'ci_failed' as const,
+          acquiredAt: '2026-01-01T00:00:00.000Z',
+          expiresAt: '2099-01-01T00:00:00.000Z',
+        }),
+      },
+      'repair',
+    )).not.toThrow();
+  });
+});

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -27,7 +27,12 @@ import {
   remoteFetchForPool,
   registerBuiltinAgents,
 } from '@invoker/execution-engine';
-import type { AgentRegistry, WorkerRegistry, WorkerRuntimeDependencies } from '@invoker/execution-engine';
+import type {
+  AgentRegistry,
+  PrRepairLeaseContext,
+  WorkerRegistry,
+  WorkerRuntimeDependencies,
+} from '@invoker/execution-engine';
 import {
   DEFAULT_SLACK_HARNESS_PRESETS,
   loadConfig,
@@ -68,6 +73,7 @@ import {
   parseFixWithAgentMutationArgs,
   type ReviewGateCiContext,
 } from '../auto-fix-intents.js';
+import { assertActiveBabysitPrRepairLease } from '../pr-repair-lease-command-guard.js';
 import { persistShutdownDiagnostic } from '../shutdown-diagnostic.js';
 import { buildCurrentActionGraphSnapshot } from '../action-graph-snapshot.js';
 import { registerReadOnlyIpcHandlers } from '../ipc-read-handlers.js';
@@ -2049,43 +2055,49 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     'invoker:rebase-recreate',
     (targetArg: unknown) => workflowIdForTargetArg(targetArg),
     'high',
-    async (targetArg: unknown) => {
-    const target = String(targetArg);
-    const workflowId = workflowIdForTargetArg(targetArg);
-    if (!workflowId) {
-      throw new Error(`Could not resolve workflow for rebase-recreate target "${target}"`);
-    }
-    cancelDeferredWorkflowLaunch(workflowId, 'ipc.rebase-recreate');
-    logger.info(`rebase-recreate: "${target}"`, { module: 'ipc' });
-    try {
-      await preemptWorkflowBeforeMutation(workflowId, {
-        preemptWorkflowExecution,
-        logger,
-        context: 'ipc.rebase-recreate',
-        mutationTiming: activeMutationContext?.mutationTiming,
-      });
-      const started = await rebaseRecreate(target, {
-        logger,
-        orchestrator,
-        persistence,
-        commandService,
-        repoRoot,
-        taskExecutor: requireTaskExecutor(),
-        mutationTiming: activeMutationContext?.mutationTiming,
-      });
-      await dispatchStartedTasksWithGlobalTopup({
-        orchestrator,
-        taskExecutor: requireTaskExecutor(),
-        logger,
-        context: 'ipc.rebase-recreate',
-        started,
-        scopedWorkflowId: workflowId,
-        mutationTiming: activeMutationContext?.mutationTiming,
-      });
-    } catch (err) {
-      logger.error(`rebase-recreate failed: ${err}`, { module: 'ipc' });
-      throw err;
-    }
+    async (targetArg: unknown, optionsArg?: unknown) => {
+      const prRepairLease = optionsArg && typeof optionsArg === 'object'
+        ? (optionsArg as { prRepairLease?: PrRepairLeaseContext }).prRepairLease
+        : undefined;
+      if (optionsArg !== undefined) {
+        assertActiveBabysitPrRepairLease(prRepairLease, persistence, 'rebase-recreate');
+      }
+      const target = String(targetArg);
+      const workflowId = workflowIdForTargetArg(targetArg);
+      if (!workflowId) {
+        throw new Error(`Could not resolve workflow for rebase-recreate target "${target}"`);
+      }
+      cancelDeferredWorkflowLaunch(workflowId, 'ipc.rebase-recreate');
+      logger.info(`rebase-recreate: "${target}"`, { module: 'ipc' });
+      try {
+        await preemptWorkflowBeforeMutation(workflowId, {
+          preemptWorkflowExecution,
+          logger,
+          context: 'ipc.rebase-recreate',
+          mutationTiming: activeMutationContext?.mutationTiming,
+        });
+        const started = await rebaseRecreate(target, {
+          logger,
+          orchestrator,
+          persistence,
+          commandService,
+          repoRoot,
+          taskExecutor: requireTaskExecutor(),
+          mutationTiming: activeMutationContext?.mutationTiming,
+        });
+        await dispatchStartedTasksWithGlobalTopup({
+          orchestrator,
+          taskExecutor: requireTaskExecutor(),
+          logger,
+          context: 'ipc.rebase-recreate',
+          started,
+          scopedWorkflowId: workflowId,
+          mutationTiming: activeMutationContext?.mutationTiming,
+        });
+      } catch (err) {
+        logger.error(`rebase-recreate failed: ${err}`, { module: 'ipc' });
+        throw err;
+      }
     },
   );
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -195,6 +195,7 @@ import {
   buildHeadlessFixArgs,
   parseFixWithAgentMutationArgs,
 } from './auto-fix-intents.js';
+import { assertActiveBabysitPrRepairLease } from './pr-repair-lease-command-guard.js';
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { answerOwnerHeadlessQuery, buildOwnerReadQueryHandlers } from './owner-read-query.js';
@@ -1461,6 +1462,9 @@ function startHeadlessMode(): void {
         if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
           workflowMutationDispatcher.set('invoker:fix-with-agent', async (...fixArgs: unknown[]) => {
             const { taskId, agentName, context } = parseFixWithAgentMutationArgs(fixArgs);
+            if (context.reviewGateContext) {
+              assertActiveBabysitPrRepairLease(context.prRepairLease, persistence, 'repair');
+            }
             const args = buildHeadlessFixArgs(taskId, agentName, context);
             await runHeadless(args, {
               ...headlessDeps,

--- a/packages/app/src/pr-repair-lease-command-guard.ts
+++ b/packages/app/src/pr-repair-lease-command-guard.ts
@@ -1,0 +1,17 @@
+import type { SQLiteAdapter } from '@invoker/data-store';
+import {
+  hasActivePrRepairLease,
+  type PrRepairLeaseContext,
+} from '@invoker/execution-engine';
+
+export function assertActiveBabysitPrRepairLease(
+  lease: PrRepairLeaseContext | undefined,
+  persistence: Pick<SQLiteAdapter, 'getPrRepairLeaseById'>,
+  command: string,
+): void {
+  if (!hasActivePrRepairLease(lease, persistence)) {
+    throw new Error(
+      `Rejected babysit ${command} command because its PR repair lease is missing, expired, or does not match the PR head.`,
+    );
+  }
+}

--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { WorkerActionRecord, WorkerActionWrite, WorkflowMutationPriority } from '@invoker/data-store';
+import type {
+  PrRepairLeaseRow,
+  WorkerActionRecord,
+  WorkerActionWrite,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
 
 import { parseFixWithAgentMutationArgs } from '../auto-fix-intents.js';
@@ -119,6 +124,7 @@ function toRecord(write: WorkerActionWrite): WorkerActionRecord {
 function makeHarness(task = makeTask()) {
   const tasks = new Map<string, TaskState>([[task.id, task]]);
   const actions = new Map<string, WorkerActionRecord>();
+  const leases = new Map<string, PrRepairLeaseRow>();
   const submit = vi.fn((workflowId: string, priority: WorkflowMutationPriority, channel: string, args: unknown[]) => {
     expect(workflowId).toBe('wf-1');
     expect(priority).toBe('normal');
@@ -137,10 +143,24 @@ function makeHarness(task = makeTask()) {
       actions.set(`${write.workerKind}:${write.externalKey}`, saved);
       return saved;
     }),
+    getPrRepairLease: vi.fn((repo: string, prNumber: number, headSha: string) =>
+      leases.get(`${repo}:${prNumber}:${headSha}`)),
+    upsertPrRepairLease: vi.fn((lease: PrRepairLeaseRow) => {
+      leases.set(`${lease.repo}:${lease.prNumber}:${lease.headSha}`, lease);
+      return lease;
+    }),
+    getPrRepairLeaseById: vi.fn((leaseId: string) =>
+      Array.from(leases.values()).find((lease) => lease.leaseId === leaseId)),
+    deletePrRepairLeaseById: vi.fn((leaseId: string) => {
+      const entry = Array.from(leases.entries()).find(([, lease]) => lease.leaseId === leaseId);
+      if (!entry) return false;
+      leases.delete(entry[0]);
+      return true;
+    }),
     logEvent: vi.fn(),
   };
   const attemptLedger = createAutoFixAttemptLedger();
-  return { actions, store, submit, attemptLedger };
+  return { actions, leases, store, submit, attemptLedger };
 }
 
 describe('PR status and CI failure workers', () => {
@@ -206,6 +226,11 @@ describe('PR status and CI failure workers', () => {
           selectedAttemptId: 'attempt-1',
           headSha: 'sha-1',
         },
+        prRepairLease: expect.objectContaining({
+          repo: 'owner/repo',
+          prNumber: 123,
+          headSha: 'sha-1',
+        }),
       },
     });
     expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toMatchObject({
@@ -214,6 +239,35 @@ describe('PR status and CI failure workers', () => {
       status: 'queued',
       intentId: '42',
       externalKey: ciFailureActionKey(event),
+    });
+  });
+
+  it('skips CI repair when a merge-conflict repair owns the same PR head lease', async () => {
+    const event = makeEvent();
+    const harness = makeHarness();
+    harness.leases.set('owner/repo:123:sha-1', {
+      repo: 'owner/repo',
+      prNumber: 123,
+      headSha: 'sha-1',
+      holderKind: 'merge_conflict',
+      leaseId: 'lease-conflict',
+      acquiredAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2099-01-01T01:00:00.000Z',
+    });
+
+    await createCiFailureTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 2,
+      drainEvents: () => [event],
+    })({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
+
+    expect(harness.submit).not.toHaveBeenCalled();
+    expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toMatchObject({
+      status: 'skipped',
+      payload: expect.objectContaining({ reason: 'lease-held', holderKind: 'merge_conflict' }),
     });
   });
 

--- a/packages/execution-engine/src/__tests__/review-gate-merge-conflict-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/review-gate-merge-conflict-worker.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type {
+  PrRepairLeaseRow,
   WorkerActionRecord,
   WorkerActionWrite,
   WorkflowMutationIntent,
@@ -92,6 +93,7 @@ function toRecord(write: WorkerActionWrite): WorkerActionRecord {
 
 interface Harness {
   actions: Map<string, WorkerActionRecord>;
+  leases: Map<string, PrRepairLeaseRow>;
   intents: WorkflowMutationIntent[];
   store: {
     loadTasks: ReturnType<typeof vi.fn>;
@@ -99,6 +101,10 @@ interface Harness {
     listWorkflowMutationIntents: ReturnType<typeof vi.fn>;
     getWorkerAction: ReturnType<typeof vi.fn>;
     upsertWorkerAction: ReturnType<typeof vi.fn>;
+    getPrRepairLease: ReturnType<typeof vi.fn>;
+    upsertPrRepairLease: ReturnType<typeof vi.fn>;
+    getPrRepairLeaseById: ReturnType<typeof vi.fn>;
+    deletePrRepairLeaseById: ReturnType<typeof vi.fn>;
     logEvent: ReturnType<typeof vi.fn>;
   };
   submit: ReturnType<typeof vi.fn>;
@@ -107,6 +113,7 @@ interface Harness {
 function makeHarness(task = makeTask(), intents: WorkflowMutationIntent[] = []): Harness {
   const tasks = new Map<string, TaskState>([[task.id, task]]);
   const actions = new Map<string, WorkerActionRecord>();
+  const leases = new Map<string, PrRepairLeaseRow>();
   const submit = vi.fn((
     workflowId: string,
     priority: WorkflowMutationPriority,
@@ -116,7 +123,16 @@ function makeHarness(task = makeTask(), intents: WorkflowMutationIntent[] = []):
     expect(workflowId).toBe('wf-1');
     expect(priority).toBe('high');
     expect(channel).toBe('invoker:rebase-recreate');
-    expect(args).toEqual(['wf-1']);
+    expect(args).toEqual([
+      'wf-1',
+      {
+        prRepairLease: expect.objectContaining({
+          repo: 'owner/repo',
+          prNumber: 123,
+          headSha: 'sha-1',
+        }),
+      },
+    ]);
     return 42;
   });
   const store = {
@@ -131,9 +147,23 @@ function makeHarness(task = makeTask(), intents: WorkflowMutationIntent[] = []):
       actions.set(`${write.workerKind}:${write.externalKey}`, saved);
       return saved;
     }),
+    getPrRepairLease: vi.fn((repo: string, prNumber: number, headSha: string) =>
+      leases.get(`${repo}:${prNumber}:${headSha}`)),
+    upsertPrRepairLease: vi.fn((lease: PrRepairLeaseRow) => {
+      leases.set(`${lease.repo}:${lease.prNumber}:${lease.headSha}`, lease);
+      return lease;
+    }),
+    getPrRepairLeaseById: vi.fn((leaseId: string) =>
+      Array.from(leases.values()).find((lease) => lease.leaseId === leaseId)),
+    deletePrRepairLeaseById: vi.fn((leaseId: string) => {
+      const entry = Array.from(leases.entries()).find(([, lease]) => lease.leaseId === leaseId);
+      if (!entry) return false;
+      leases.delete(entry[0]);
+      return true;
+    }),
     logEvent: vi.fn(),
   };
-  return { actions, intents, store, submit };
+  return { actions, intents, leases, store, submit };
 }
 
 function actionFor(harness: Harness, event: ReviewGateMergeConflictLifecycleEvent): WorkerActionRecord | undefined {

--- a/packages/execution-engine/src/auto-fix-intents.ts
+++ b/packages/execution-engine/src/auto-fix-intents.ts
@@ -1,4 +1,5 @@
 import type { WorkflowMutationIntent } from '@invoker/data-store';
+import type { PrRepairLeaseContext } from './pr-repair-lease.js';
 
 
 type HeadlessExecPayload = {
@@ -104,6 +105,7 @@ export interface AutoFixCommandContext {
   autoFix: boolean;
   reviewGateContext?: ReviewGateCiContext;
   executionModel?: string;
+  prRepairLease?: PrRepairLeaseContext;
 }
 
 export interface ParsedHeadlessFixArgs extends AutoFixCommandContext {
@@ -117,6 +119,7 @@ export function parseHeadlessFixArgs(args: readonly string[]): ParsedHeadlessFix
   let agentName: string | undefined;
   let autoFix = false;
   let reviewGateContext: ReviewGateCiContext | undefined;
+  let prRepairLease: PrRepairLeaseContext | undefined;
 
   for (let i = 0; i < rest.length; i += 1) {
     const token = rest[i];
@@ -168,6 +171,7 @@ export interface FixWithAgentMutationOptions {
   autoFix?: boolean;
   reviewGateContext?: ReviewGateCiContext;
   executionModel?: string;
+  prRepairLease?: PrRepairLeaseContext;
 }
 
 export interface ParsedFixWithAgentMutationArgs {
@@ -182,11 +186,12 @@ export function buildFixWithAgentMutationArgs(
   options?: FixWithAgentMutationOptions,
 ): unknown[] {
   const args: unknown[] = [taskId, agentName];
-  if (options && (options.autoFix || options.reviewGateContext || options.executionModel)) {
+  if (options && (options.autoFix || options.reviewGateContext || options.executionModel || options.prRepairLease)) {
     args.push({
       autoFix: Boolean(options.autoFix || options.reviewGateContext),
       ...(options.reviewGateContext ? { reviewGateContext: options.reviewGateContext } : {}),
       ...(options.executionModel ? { executionModel: options.executionModel } : {}),
+      ...(options.prRepairLease ? { prRepairLease: options.prRepairLease } : {}),
     });
   }
   return args;
@@ -199,6 +204,7 @@ export function parseFixWithAgentMutationArgs(args: unknown[]): ParsedFixWithAge
   let autoFix = false;
   let reviewGateContext: ReviewGateCiContext | undefined;
   let executionModel: string | undefined;
+  let prRepairLease: PrRepairLeaseContext | undefined;
 
   if (optionsArg && typeof optionsArg === 'object') {
     const candidate = optionsArg as Record<string, unknown>;
@@ -215,7 +221,18 @@ export function parseFixWithAgentMutationArgs(args: unknown[]): ParsedFixWithAge
     if (typeof candidate.executionModel === 'string' && candidate.executionModel.length > 0) {
       executionModel = candidate.executionModel;
     }
+    const lease = candidate.prRepairLease;
+    if (
+      lease
+      && typeof lease === 'object'
+      && typeof (lease as Record<string, unknown>).repo === 'string'
+      && typeof (lease as Record<string, unknown>).prNumber === 'number'
+      && typeof (lease as Record<string, unknown>).headSha === 'string'
+      && typeof (lease as Record<string, unknown>).leaseId === 'string'
+    ) {
+      prRepairLease = lease as PrRepairLeaseContext;
+    }
   }
 
-  return { taskId, agentName, context: { autoFix, reviewGateContext, executionModel } };
+  return { taskId, agentName, context: { autoFix, reviewGateContext, executionModel, prRepairLease } };
 }

--- a/packages/execution-engine/src/pr-repair-lease.ts
+++ b/packages/execution-engine/src/pr-repair-lease.ts
@@ -20,6 +20,13 @@ export interface PrRepairLeaseStore {
   deletePrRepairLeaseById(leaseId: string): boolean;
 }
 
+export interface PrRepairLeaseContext {
+  repo: string;
+  prNumber: number;
+  headSha: string;
+  leaseId: string;
+}
+
 export type TryAcquirePrRepairLeaseResult =
   | { ok: true; leaseId: string; preempted: false }
   | { ok: true; leaseId: string; preempted: true; previousHolderKind: RepairKind }
@@ -41,6 +48,37 @@ export interface TryAcquirePrRepairLeaseInput {
 function isLeaseActive(lease: PrRepairLeaseRow, nowIso: string): boolean {
   if (lease.expiresAt == null) return true;
   return lease.expiresAt > nowIso;
+}
+
+export function resolveReviewGatePrRepairIdentity(
+  reviewUrl: string,
+  reviewId: string,
+): Omit<PrRepairLeaseContext, 'headSha' | 'leaseId'> | undefined {
+  const fromUrl = reviewUrl.match(/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/i);
+  if (fromUrl?.[1] && fromUrl[2]) {
+    return { repo: fromUrl[1], prNumber: Number(fromUrl[2]) };
+  }
+  const fromId = reviewId.match(/^([^/#]+\/[^/#]+)#(\d+)$/);
+  if (fromId?.[1] && fromId[2]) {
+    return { repo: fromId[1], prNumber: Number(fromId[2]) };
+  }
+  return undefined;
+}
+
+export function hasActivePrRepairLease(
+  context: PrRepairLeaseContext | undefined,
+  store: Pick<PrRepairLeaseStore, 'getPrRepairLeaseById'>,
+  now: Date = new Date(),
+): boolean {
+  if (!context) return false;
+  const lease = store.getPrRepairLeaseById(context.leaseId);
+  return Boolean(
+    lease
+    && lease.repo === context.repo
+    && lease.prNumber === context.prNumber
+    && lease.headSha === context.headSha
+    && isLeaseActive(lease, now.toISOString()),
+  );
 }
 
 export function tryAcquirePrRepairLease(

--- a/packages/execution-engine/src/review-gate-ci-repair.ts
+++ b/packages/execution-engine/src/review-gate-ci-repair.ts
@@ -32,6 +32,12 @@ import {
   classifyFailedChecks,
   type FailedCheckLogFetcher,
 } from './ci-failure-infra-classifier.js';
+import {
+  releasePrRepairLease,
+  resolveReviewGatePrRepairIdentity,
+  tryAcquirePrRepairLease,
+  type PrRepairLeaseStore,
+} from './pr-repair-lease.js';
 import { recordWorkerDecisionRow } from './worker-decision-ledger.js';
 
 const CI_FAILURE_WORKER_KIND = 'ci-failure';
@@ -41,7 +47,7 @@ const NO_HEAD_SHA = 'no-head';
 
 type CiFailureActionStatus = WorkerActionStatus;
 
-export interface ReviewGateCiRepairStore {
+export interface ReviewGateCiRepairStore extends PrRepairLeaseStore {
   loadTasks(workflowId: string): TaskState[];
   loadTask?(taskId: string): TaskState | undefined;
   listWorkflowMutationIntents?(
@@ -362,6 +368,10 @@ function reconcileFinishedIntentAction(
     updatedAt: now,
     completedAt: now,
   });
+  const leaseId = payload.prRepairLeaseId;
+  if (typeof leaseId === 'string') {
+    releasePrRepairLease(leaseId, options.store);
+  }
   logCiFailureWorkerEvent(options, event, 'worker-ci-failure-intent-reconciled', {
     intentId: existing.intentId,
     intentStatus: intent.status,
@@ -452,11 +462,41 @@ export async function queueReviewGateCiRepair(
     return { decision: 'skipped', reason: 'worker-retry-budget-exhausted' };
   }
 
+  const identity = resolveReviewGatePrRepairIdentity(event.reviewUrl, event.reviewId);
+  if (!identity || !event.headSha) {
+    recordCiFailureAction(options, event, 'skipped', 'Skipped CI repair because PR lease identity is unavailable', {
+      reason: 'lease-identity-missing',
+    });
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
+      reason: 'lease-identity-missing',
+    });
+    return { decision: 'skipped', reason: 'lease-identity-missing' };
+  }
+  const lease = tryAcquirePrRepairLease({
+    ...identity,
+    headSha: event.headSha,
+    kind: 'ci_failed',
+    store: options.store,
+    workflowId: event.workflowId,
+  });
+  if (!lease.ok) {
+    recordCiFailureAction(options, event, 'skipped', 'Skipped CI repair because a higher-priority repair holds the lease', {
+      reason: 'lease-held',
+      holderKind: lease.holderKind,
+    });
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
+      reason: 'lease-held',
+      holderKind: lease.holderKind,
+    });
+    return { decision: 'skipped', reason: 'lease-held' };
+  }
+
   const attemptDecision = options.attemptLedger.consume(
     autoFixAttemptLedgerKeyFromLifecycleEvent(event),
     workerRetryBudget,
   );
   if (!attemptDecision.allowed) {
+    releasePrRepairLease(lease.leaseId, options.store);
     const summary = attemptDecision.reason === 'worker-retry-budget-disabled'
       ? 'Skipped CI repair because retry budget is disabled'
       : 'Skipped CI repair because retry budget is exhausted';
@@ -498,8 +538,19 @@ export async function queueReviewGateCiRepair(
       fixContext: buildCiFailureFixContext(event),
     },
     executionModel,
+    prRepairLease: {
+      ...identity,
+      headSha: event.headSha,
+      leaseId: lease.leaseId,
+    },
   });
-  const intentId = options.submitter.submit(event.workflowId, 'normal', FIX_WITH_AGENT_CHANNEL, args);
+  let intentId: number;
+  try {
+    intentId = options.submitter.submit(event.workflowId, 'normal', FIX_WITH_AGENT_CHANNEL, args);
+  } catch (error) {
+    releasePrRepairLease(lease.leaseId, options.store);
+    throw error;
+  }
   recordCiFailureAction(
     options,
     event,
@@ -508,6 +559,7 @@ export async function queueReviewGateCiRepair(
     {
       channel: FIX_WITH_AGENT_CHANNEL,
       workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
+      prRepairLeaseId: lease.leaseId,
     },
     intentId,
     selectedAgent,

--- a/packages/execution-engine/src/workers/review-gate-merge-conflict-worker.ts
+++ b/packages/execution-engine/src/workers/review-gate-merge-conflict-worker.ts
@@ -19,6 +19,12 @@ import type {
   ReviewGateMergeConflictLifecycleEvent,
   WorkflowLifecycleEvent,
 } from '../lifecycle-events.js';
+import {
+  releasePrRepairLease,
+  resolveReviewGatePrRepairIdentity,
+  tryAcquirePrRepairLease,
+  type PrRepairLeaseStore,
+} from '../pr-repair-lease.js';
 import { recordWorkerDecisionRow } from '../worker-decision-ledger.js';
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import type { WorkerRegistry } from '../worker-registry.js';
@@ -37,7 +43,7 @@ type HeadlessExecPayload = {
   args?: unknown[];
 };
 
-export interface ReviewGateMergeConflictWorkerStore {
+export interface ReviewGateMergeConflictWorkerStore extends PrRepairLeaseStore {
   loadTasks(workflowId: string): TaskState[];
   loadTask?(taskId: string): TaskState | undefined;
   listWorkflowMutationIntents?(
@@ -362,6 +368,10 @@ function reconcileFinishedIntentAction(
     updatedAt: now,
     completedAt: now,
   });
+  const leaseId = payload.prRepairLeaseId;
+  if (typeof leaseId === 'string') {
+    releasePrRepairLease(leaseId, options.store);
+  }
   logReviewGateMergeConflictEvent(options, event, 'review-gate-merge-conflict-intent-reconciled', {
     intentId: existing.intentId,
     intentStatus: intent.status,
@@ -406,13 +416,57 @@ async function handleReviewGateMergeConflictEvent(
     return;
   }
 
-  const intentId = options.submitter.submit(event.workflowId, 'high', REBASE_RECREATE_CHANNEL, [event.workflowId]);
+  const identity = resolveReviewGatePrRepairIdentity(event.reviewUrl, event.reviewId);
+  if (!identity || !event.headSha) {
+    recordReviewGateMergeConflictAction(options, event, 'skipped', 'Skipped merge-conflict repair because PR lease identity is unavailable', {
+      reason: 'lease-identity-missing',
+    });
+    logReviewGateMergeConflictEvent(options, event, 'review-gate-merge-conflict-skip', {
+      reason: 'lease-identity-missing',
+    });
+    return;
+  }
+  const lease = tryAcquirePrRepairLease({
+    ...identity,
+    headSha: event.headSha,
+    kind: 'merge_conflict',
+    store: options.store,
+    workflowId: event.workflowId,
+  });
+  if (!lease.ok) {
+    recordReviewGateMergeConflictAction(options, event, 'skipped', 'Skipped merge-conflict repair because a higher-priority repair holds the lease', {
+      reason: 'lease-held',
+      holderKind: lease.holderKind,
+    });
+    logReviewGateMergeConflictEvent(options, event, 'review-gate-merge-conflict-skip', {
+      reason: 'lease-held',
+      holderKind: lease.holderKind,
+    });
+    return;
+  }
+
+  let intentId: number;
+  try {
+    intentId = options.submitter.submit(event.workflowId, 'high', REBASE_RECREATE_CHANNEL, [
+      event.workflowId,
+      {
+        prRepairLease: {
+          ...identity,
+          headSha: event.headSha,
+          leaseId: lease.leaseId,
+        },
+      },
+    ]);
+  } catch (error) {
+    releasePrRepairLease(lease.leaseId, options.store);
+    throw error;
+  }
   recordReviewGateMergeConflictAction(
     options,
     event,
     'queued',
     'Queued workflow rebase-recreate for review-gate merge conflict',
-    { channel: REBASE_RECREATE_CHANNEL },
+    { channel: REBASE_RECREATE_CHANNEL, prRepairLeaseId: lease.leaseId },
     intentId,
   );
   logReviewGateMergeConflictEvent(options, event, 'review-gate-merge-conflict-submitted', {


### PR DESCRIPTION
Acquire precedence leases before CI and merge-conflict workers submit
mutations, validate them at the app command boundary, and release them
when mutation intents terminate.

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #5824