### PR TITLE
Add PR review and queue lifecycle signals

### DIFF
--- a/packages/app/src/lifecycle-events.ts
+++ b/packages/app/src/lifecycle-events.ts
@@ -13,6 +13,8 @@ import {
   type ReviewGateFailedCheck,
   type ReviewGateCiFailedLifecycleEvent,
   type ReviewGateMergeConflictLifecycleEvent,
+  type PrQueueDequeuedLifecycleEvent,
+  type PrReviewCommentLifecycleEvent,
   type WorkflowWakeupLifecycleEvent,
   type RecoveryWorkerWakeupHint,
   type RecoveryWorkerWakeupReason,
@@ -32,6 +34,8 @@ export {
   type ReviewGateFailedCheck,
   type ReviewGateCiFailedLifecycleEvent,
   type ReviewGateMergeConflictLifecycleEvent,
+  type PrQueueDequeuedLifecycleEvent,
+  type PrReviewCommentLifecycleEvent,
   type WorkflowWakeupLifecycleEvent,
   type RecoveryWorkerWakeupHint,
   type RecoveryWorkerWakeupReason,
@@ -394,6 +398,13 @@ export function isWorkflowLifecycleEvent(value: unknown): value is WorkflowLifec
         && typeof value.reviewId === 'string'
         && typeof value.reviewUrl === 'string'
         && typeof value.statusText === 'string';
+    case 'pr.review_comment':
+      return typeof value.repo === 'string'
+        && typeof value.prNumber === 'number'
+        && typeof value.commentId === 'string';
+    case 'pr.queue_dequeued':
+      return typeof value.repo === 'string'
+        && typeof value.prNumber === 'number';
     case 'workflow.wakeup':
       return value.reason === 'startup_reconcile'
         || value.reason === 'stalled_workflow_recovery'

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -19,6 +19,10 @@ import {
   PR_CONFLICT_REBASE_WORKER_KIND,
 } from '../workers/pr-maintenance-workers.js';
 import { PR_STATUS_WORKER_KIND } from '../workers/pr-status-worker.js';
+import {
+  PR_QUEUE_DEQUEUED_WORKER_KIND,
+  PR_REVIEW_COMMENT_WORKER_KIND,
+} from '../workers/pr-lifecycle-signal-workers.js';
 import { PR_SUMMARY_REFRESH_WORKER_KIND } from '../workers/pr-summary-refresh-worker.js';
 import { DISK_HEADROOM_WORKER_KIND } from '../workers/disk-headroom-worker.js';
 import { REQUEUE_WORKER_KIND } from '../workers/requeue-worker.js';
@@ -78,6 +82,8 @@ describe('worker registry', () => {
       PR_SUMMARY_REFRESH_WORKER_KIND,
       CI_FAILURE_WORKER_KIND,
       REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
+      PR_REVIEW_COMMENT_WORKER_KIND,
+      PR_QUEUE_DEQUEUED_WORKER_KIND,
       DISK_HEADROOM_WORKER_KIND,
       AUTO_APPROVE_WORKER_KIND,
       CODERABBIT_ADDRESS_WORKER_KIND,
@@ -93,6 +99,8 @@ describe('worker registry', () => {
     expect(registry.get(PR_SUMMARY_REFRESH_WORKER_KIND)).toBeDefined();
     expect(registry.get(CI_FAILURE_WORKER_KIND)).toBeDefined();
     expect(registry.get(REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND)).toBeDefined();
+    expect(registry.get(PR_REVIEW_COMMENT_WORKER_KIND)).toBeDefined();
+    expect(registry.get(PR_QUEUE_DEQUEUED_WORKER_KIND)).toBeDefined();
     expect(registry.get(DISK_HEADROOM_WORKER_KIND)).toBeDefined();
     expect(registry.get(AUTO_APPROVE_WORKER_KIND)).toBeDefined();
     expect(registry.get(CODERABBIT_ADDRESS_WORKER_KIND)).toBeDefined();

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -8,6 +8,7 @@ import { registerDiskHeadroomWorker } from './workers/disk-headroom-worker.js';
 import { registerPrMaintenanceWorkers } from './workers/pr-maintenance-workers.js';
 import { registerPrSummaryRefreshWorker } from './workers/pr-summary-refresh-worker.js';
 import { registerPrStatusWorker } from './workers/pr-status-worker.js';
+import { registerPrLifecycleSignalWorkers } from './workers/pr-lifecycle-signal-workers.js';
 import { registerRequeueWorker } from './workers/requeue-worker.js';
 import { registerReviewGateMergeConflictWorker } from './workers/review-gate-merge-conflict-worker.js';
 import { registerWorkflowResumeWorker } from './workers/workflow-resume-worker.js';
@@ -23,6 +24,7 @@ export function registerBuiltinWorkers(
   registerPrSummaryRefreshWorker(registry);
   registerCiFailureWorker(registry);
   registerReviewGateMergeConflictWorker(registry);
+  registerPrLifecycleSignalWorkers(registry);
   registerDiskHeadroomWorker(registry);
   registerAutoApproveWorker(registry);
   registerPrMaintenanceWorkers(registry);

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -69,6 +69,7 @@ export * from './workers/disk-headroom-monitor.js';
 export * from './workers/disk-headroom-reclaim.js';
 export * from './workers/disk-headroom.js';
 export * from './workers/pr-maintenance-workers.js';
+export * from './workers/pr-lifecycle-signal-workers.js';
 export * from './workers/review-gate-merge-conflict-worker.js';
 export * from './workers/e2e-autofix-worker.js';
 export * from './workers/requeue-worker.js';

--- a/packages/execution-engine/src/lifecycle-events.ts
+++ b/packages/execution-engine/src/lifecycle-events.ts
@@ -20,6 +20,8 @@ export const WORKFLOW_LIFECYCLE_EVENT_KINDS = [
   'task.removed',
   'review_gate.ci_failed',
   'review_gate.merge_conflict',
+  'pr.review_comment',
+  'pr.queue_dequeued',
   'workflow.wakeup',
 ] as const;
 
@@ -104,6 +106,25 @@ export interface ReviewGateMergeConflictLifecycleEvent extends WorkflowLifecycle
   readonly statusText: string;
 }
 
+export interface PrReviewCommentLifecycleEvent extends WorkflowLifecycleEventBase {
+  readonly kind: 'pr.review_comment';
+  readonly repo: string;
+  readonly prNumber: number;
+  readonly headSha?: string;
+  readonly commentId: string;
+  readonly commentUrl?: string;
+  readonly author?: string;
+}
+
+export interface PrQueueDequeuedLifecycleEvent extends WorkflowLifecycleEventBase {
+  readonly kind: 'pr.queue_dequeued';
+  readonly repo: string;
+  readonly prNumber: number;
+  readonly headSha?: string;
+  readonly queueRule?: string;
+  readonly reason?: string;
+}
+
 export interface WorkflowWakeupLifecycleEvent extends WorkflowLifecycleEventBase {
   readonly kind: 'workflow.wakeup';
   readonly reason: WorkflowWakeupReason;
@@ -114,6 +135,8 @@ export type WorkflowLifecycleEvent =
   | TaskLifecycleEvent
   | ReviewGateCiFailedLifecycleEvent
   | ReviewGateMergeConflictLifecycleEvent
+  | PrReviewCommentLifecycleEvent
+  | PrQueueDequeuedLifecycleEvent
   | WorkflowWakeupLifecycleEvent;
 
 export type WorkflowWakeupReason =

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -29,6 +29,10 @@ import type {
   WorkflowResumeWorkerSubmitter,
 } from './workers/workflow-resume-worker.js';
 import type { PrSummaryRefreshWorkerStore } from './workers/pr-summary-refresh-worker.js';
+import type {
+  PrLifecycleSignalWorkerStore,
+  PrLifecycleSignalWorkerSubmitter,
+} from './workers/pr-lifecycle-signal-workers.js';
 
 /** Dependencies injected into a built-in worker factory when its runtime is built. */
 export interface WorkerRuntimeDependencies {
@@ -38,6 +42,7 @@ export interface WorkerRuntimeDependencies {
     & ReviewGateCiRepairStore
     & AutoApproveWorkerStore
     & ReviewGateMergeConflictWorkerStore
+    & PrLifecycleSignalWorkerStore
     & WorkflowResumeWorkerStore
     & PrSummaryRefreshWorkerStore;
   /** Action-output channel used to submit follow-up mutation intents. */
@@ -47,6 +52,7 @@ export interface WorkerRuntimeDependencies {
     & RequeueWorkerSubmitter
     & AutoApproveWorkerSubmitter
     & ReviewGateMergeConflictWorkerSubmitter
+    & PrLifecycleSignalWorkerSubmitter
     & WorkflowResumeWorkerSubmitter;
   /** Operator logger. */
   logger: Logger;

--- a/packages/execution-engine/src/workers/pr-lifecycle-signal-workers.ts
+++ b/packages/execution-engine/src/workers/pr-lifecycle-signal-workers.ts
@@ -1,0 +1,271 @@
+import type { Logger } from '@invoker/contracts';
+import type {
+  PrMirrorRow,
+  PrRepairLeaseRow,
+  WorkerActionRecord,
+  WorkerActionWrite,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
+import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
+
+import type {
+  PrQueueDequeuedLifecycleEvent,
+  PrReviewCommentLifecycleEvent,
+  WorkflowLifecycleEvent,
+} from '../lifecycle-events.js';
+import { tryAcquirePrRepairLease, type RepairKind } from '../pr-repair-lease.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const PR_REVIEW_COMMENT_WORKER_KIND = 'pr-review-comment';
+export const PR_QUEUE_DEQUEUED_WORKER_KIND = 'pr-queue-dequeued';
+export const PR_REVIEW_COMMENT_REPAIR_CHANNEL = 'invoker:repair-review-comments';
+export const PR_QUEUE_DEQUEUED_REPAIR_CHANNEL = 'invoker:repair-queue-dequeue';
+const DEFAULT_INTERVAL_MS = 60_000;
+
+type PrLifecycleSignalEvent = PrReviewCommentLifecycleEvent | PrQueueDequeuedLifecycleEvent;
+
+export interface PrLifecycleSignalWorkerStore {
+  getPrMirror?(repo: string, prNumber: number): PrMirrorRow | undefined;
+  getPrRepairLease?(repo: string, prNumber: number, headSha: string): PrRepairLeaseRow | undefined;
+  upsertPrRepairLease?(lease: PrRepairLeaseRow): PrRepairLeaseRow;
+  getWorkerAction?(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
+  upsertWorkerAction?(action: WorkerActionWrite): WorkerActionRecord;
+  logEvent?(taskId: string, eventType: string, payload?: unknown): void;
+}
+
+export interface PrLifecycleSignalWorkerSubmitter {
+  submit(
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: typeof PR_REVIEW_COMMENT_REPAIR_CHANNEL | typeof PR_QUEUE_DEQUEUED_REPAIR_CHANNEL,
+    args: unknown[],
+    options?: { deferDrain?: boolean },
+  ): number;
+}
+
+export interface PrLifecycleSignalWorkerPolicyOptions {
+  store: PrLifecycleSignalWorkerStore;
+  submitter: PrLifecycleSignalWorkerSubmitter;
+  logger: Logger;
+  drainEvents?: () => PrLifecycleSignalEvent[];
+}
+
+export interface PrLifecycleSignalWorkerOptions {
+  logger: Logger;
+  instanceId?: string;
+  intervalMs?: number;
+  installSignalHandlers?: boolean;
+  tickOnStart?: boolean;
+  messageBus?: MessageBus;
+  signals?: Omit<PrLifecycleSignalWorkerPolicyOptions, 'logger' | 'drainEvents'>;
+  onTick?: WorkerTick;
+}
+
+type SignalDefinition = {
+  kind: typeof PR_REVIEW_COMMENT_WORKER_KIND | typeof PR_QUEUE_DEQUEUED_WORKER_KIND;
+  eventKind: PrLifecycleSignalEvent['kind'];
+  leaseKind: RepairKind;
+  channel: typeof PR_REVIEW_COMMENT_REPAIR_CHANNEL | typeof PR_QUEUE_DEQUEUED_REPAIR_CHANNEL;
+  actionType: string;
+  summary: string;
+};
+
+const REVIEW_COMMENT: SignalDefinition = {
+  kind: PR_REVIEW_COMMENT_WORKER_KIND,
+  eventKind: 'pr.review_comment',
+  leaseKind: 'review_comments',
+  channel: PR_REVIEW_COMMENT_REPAIR_CHANNEL,
+  actionType: 'repair-pr-review-comments',
+  summary: 'Queued PR review-comment repair intent',
+};
+
+const QUEUE_DEQUEUED: SignalDefinition = {
+  kind: PR_QUEUE_DEQUEUED_WORKER_KIND,
+  eventKind: 'pr.queue_dequeued',
+  leaseKind: 'queue_dequeued',
+  channel: PR_QUEUE_DEQUEUED_REPAIR_CHANNEL,
+  actionType: 'repair-pr-queue-dequeue',
+  summary: 'Queued PR queue-dequeue repair intent',
+};
+
+export function registerPrLifecycleSignalWorkers(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  for (const definition of [REVIEW_COMMENT, QUEUE_DEQUEUED]) {
+    registry.register({
+      kind: definition.kind,
+      note: `Records ${definition.eventKind} wakeups and submits a deferred PR repair intent.`,
+      factory: (deps) => createPrLifecycleSignalWorker(definition, {
+        logger: deps.logger,
+        messageBus: deps.messageBus,
+        signals: { store: deps.store, submitter: deps.submitter },
+      }),
+    });
+  }
+  return registry;
+}
+
+export function prLifecycleSignalActionKey(event: PrLifecycleSignalEvent): string {
+  if (event.kind === 'pr.review_comment') {
+    return `${event.kind}:${event.repo}:${event.prNumber}:${event.commentId}`;
+  }
+  return `${event.kind}:${event.repo}:${event.prNumber}:${event.headSha ?? 'no-head'}:${event.eventKey}`;
+}
+
+function record(
+  options: PrLifecycleSignalWorkerPolicyOptions,
+  definition: SignalDefinition,
+  event: PrLifecycleSignalEvent,
+  status: 'queued' | 'skipped',
+  summary: string,
+  payload: Record<string, unknown>,
+  intentId?: number,
+): void {
+  const key = prLifecycleSignalActionKey(event);
+  const existing = options.store.getWorkerAction?.(definition.kind, key);
+  const now = new Date().toISOString();
+  options.store.upsertWorkerAction?.({
+    id: existing?.id ?? `${definition.kind}:${key}`,
+    workerKind: definition.kind,
+    actionType: definition.actionType,
+    workflowId: event.workflowId,
+    ...(event.taskId ? { taskId: event.taskId } : {}),
+    subjectType: 'review',
+    subjectId: `${event.repo}#${event.prNumber}`,
+    externalKey: key,
+    status,
+    attemptCount: status === 'queued' ? (existing?.attemptCount ?? 0) + 1 : (existing?.attemptCount ?? 0),
+    ...(intentId !== undefined ? { intentId: String(intentId) } : {}),
+    summary,
+    payload,
+    updatedAt: now,
+    ...(status === 'skipped' ? { completedAt: now } : {}),
+  });
+}
+
+function handleSignal(
+  options: PrLifecycleSignalWorkerPolicyOptions,
+  definition: SignalDefinition,
+  event: PrLifecycleSignalEvent,
+): void {
+  const key = prLifecycleSignalActionKey(event);
+  const existing = options.store.getWorkerAction?.(definition.kind, key);
+  if (existing?.status === 'queued' || existing?.status === 'completed') return;
+
+  const mirror = options.store.getPrMirror?.(event.repo, event.prNumber);
+  const common = { eventKey: event.eventKey, repo: event.repo, prNumber: event.prNumber };
+  if (!mirror) {
+    record(options, definition, event, 'skipped', 'Skipped PR repair: mirror is missing', { ...common, reason: 'mirror-missing' });
+    return;
+  }
+  if (event.headSha && mirror.headSha !== event.headSha) {
+    record(options, definition, event, 'skipped', 'Skipped PR repair: mirror head changed', {
+      ...common, reason: 'mirror-head-changed', eventHeadSha: event.headSha, mirrorHeadSha: mirror.headSha,
+    });
+    return;
+  }
+  if (!options.store.getPrRepairLease || !options.store.upsertPrRepairLease) {
+    record(options, definition, event, 'skipped', 'Skipped PR repair: lease store is unavailable', { ...common, reason: 'lease-store-unavailable' });
+    return;
+  }
+  const lease = tryAcquirePrRepairLease({
+    repo: mirror.repo,
+    prNumber: mirror.prNumber,
+    headSha: mirror.headSha,
+    kind: definition.leaseKind,
+    workflowId: event.workflowId,
+    store: {
+      getPrRepairLease: options.store.getPrRepairLease,
+      upsertPrRepairLease: options.store.upsertPrRepairLease,
+      getPrRepairLeaseById: () => undefined,
+      deletePrRepairLeaseById: () => false,
+    },
+  });
+  if (!lease.ok) {
+    record(options, definition, event, 'skipped', 'Skipped PR repair: lease is held', {
+      ...common, reason: 'pr-repair-lease-denied', holderKind: lease.holderKind,
+    });
+    return;
+  }
+  const intentId = options.submitter.submit(event.workflowId, 'normal', definition.channel, [{
+    repo: mirror.repo,
+    prNumber: mirror.prNumber,
+    headSha: mirror.headSha,
+    leaseId: lease.leaseId,
+    holderKind: definition.leaseKind,
+    eventKey: event.eventKey,
+  }]);
+  record(options, definition, event, 'queued', definition.summary, {
+    ...common, channel: definition.channel, prRepairLease: { leaseId: lease.leaseId, holderKind: definition.leaseKind },
+  }, intentId);
+}
+
+export function createPrLifecycleSignalTick(
+  definition: SignalDefinition,
+  options: PrLifecycleSignalWorkerPolicyOptions,
+): WorkerTick {
+  return async () => {
+    const seen = new Set<string>();
+    for (const event of options.drainEvents?.() ?? []) {
+      if (event.kind !== definition.eventKind) continue;
+      const key = prLifecycleSignalActionKey(event);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      handleSignal(options, definition, event);
+    }
+  };
+}
+
+export function createPrReviewCommentTick(options: PrLifecycleSignalWorkerPolicyOptions): WorkerTick {
+  return createPrLifecycleSignalTick(REVIEW_COMMENT, options);
+}
+
+export function createPrQueueDequeuedTick(options: PrLifecycleSignalWorkerPolicyOptions): WorkerTick {
+  return createPrLifecycleSignalTick(QUEUE_DEQUEUED, options);
+}
+
+export function createPrLifecycleSignalWorker(
+  definition: SignalDefinition,
+  options: PrLifecycleSignalWorkerOptions,
+): WorkerRuntime {
+  const pending: PrLifecycleSignalEvent[] = [];
+  let unsubscribe: Unsubscribe | undefined;
+  const runtime = createWorkerRuntime({
+    kind: definition.kind,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick: options.onTick ?? (options.signals
+      ? createPrLifecycleSignalTick(definition, { ...options.signals, logger: options.logger, drainEvents: () => pending.splice(0) })
+      : (() => {})),
+  });
+  if (!options.messageBus || !options.signals || options.onTick) return runtime;
+  return {
+    ...runtime,
+    start: () => {
+      unsubscribe ??= options.messageBus!.subscribe<WorkflowLifecycleEvent>(Channels.WORKFLOW_LIFECYCLE, (event) => {
+        if (event.kind !== definition.eventKind) return;
+        pending.push(event);
+        runtime.wake('wake');
+      });
+      runtime.start();
+    },
+    stop: async () => {
+      unsubscribe?.();
+      unsubscribe = undefined;
+      await runtime.stop();
+    },
+  };
+}
+
+export function createPrReviewCommentWorker(options: PrLifecycleSignalWorkerOptions): WorkerRuntime {
+  return createPrLifecycleSignalWorker(REVIEW_COMMENT, options);
+}
+
+export function createPrQueueDequeuedWorker(options: PrLifecycleSignalWorkerOptions): WorkerRuntime {
+  return createPrLifecycleSignalWorker(QUEUE_DEQUEUED, options);
+}

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -226,7 +226,10 @@ def parse_stack_metadata(comments: Sequence[Mapping[str, object]]) -> tuple[str,
         numbers = payload.get("pull_numbers_bottom_to_top") or payload.get("pullNumbersBottomToTop") or payload.get("prs") or payload.get("pulls")
         if stack_id and isinstance(numbers, Sequence) and not isinstance(numbers, (str, bytes)):
             try:
-                return stack_id, tuple(int(n) for n in numbers)
+                return stack_id, tuple(
+                    int(n["number"]) if isinstance(n, Mapping) else int(n)
+                    for n in numbers
+                )
             except (TypeError, ValueError):
                 continue
     return None

--- a/scripts/repro/fixtures/mergify-stack-pulls.json
+++ b/scripts/repro/fixtures/mergify-stack-pulls.json
@@ -1,0 +1,3 @@
+{
+  "body": "<!-- mergify-stack-data: {\"stack_id\":\"mergify-stack\",\"pulls\":[{\"number\":10},{\"number\":11},{\"number\":12}]} -->"
+}

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -13,6 +13,7 @@ Run:  python3 scripts/test_mergify_admin_requeue_snapshot.py
 
 from __future__ import annotations
 
+import json
 import sys
 import unittest
 from unittest import mock
@@ -92,6 +93,11 @@ class ParseStackMetadata(unittest.TestCase):
 
     def test_no_marker_returns_none(self):
         self.assertIsNone(s.parse_stack_metadata([{"body": "nothing here"}]))
+
+    def test_parses_mergify_pulls_marker_objects_in_order(self):
+        fixture = Path(__file__).resolve().parent / "repro/fixtures/mergify-stack-pulls.json"
+        comment = json.loads(fixture.read_text())
+        self.assertEqual(s.parse_stack_metadata([comment]), ("mergify-stack", (10, 11, 12)))
 
 
 class LabelsFromNodes(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add lifecycle event vocabulary and registered submit-only workers for review comments and queue dequeues
- persist lease-aware worker actions instead of executing local git work
- parse modern Mergify stack markers containing `pulls: [{number: ...}]`

## Review Claim
This introduces the signal and worker surfaces required for the next command implementation slice.

## Review Lane
behavior

## Review Unit
routing

## Safety Invariant
New PR signal workers read a persisted mirror, acquire a repair lease, then submit an intent; they never create a checkout or invoke omp.

## Slice Rationale
Signal vocabulary and safe worker routing land independently from command execution bodies.

## Non-goals
- Do not execute review or queue repair in this slice.
- Do not remove legacy cron scripts yet.

## Test Plan
<details>
<summary>Test Plan</summary>

- `pnpm --filter @invoker/execution-engine test -- src/__tests__/worker-registry.test.ts`
- `python3 -m unittest scripts/test_mergify_admin_requeue_snapshot.py`
- `pnpm --filter @invoker/execution-engine build`
</details>

## Revert Plan
<details>
<summary>Revert Plan</summary>

Revert this PR to unregister the new workers and restore legacy stack-marker parsing.
</details>

Depends on #5822.