### PR TITLE
Add PR review and queue lifecycle workers.

### DIFF
--- a/packages/app/src/lifecycle-event-bridge.ts
+++ b/packages/app/src/lifecycle-event-bridge.ts
@@ -4,6 +4,8 @@ import type { TaskDelta, TaskState, TaskStatus } from '@invoker/workflow-core';
 import {
   buildReviewGateCiFailedLifecycleEvent,
   buildReviewGateMergeConflictLifecycleEvent,
+  buildPrQueueDequeuedLifecycleEvent,
+  buildPrReviewCommentsLifecycleEvent,
   buildTaskCreatedLifecycleEvent,
   buildTaskRemovedLifecycleEvent,
   buildTaskUpdatedLifecycleEvent,
@@ -73,6 +75,30 @@ export interface ReviewGateMergeConflictWakeupInput {
   readonly selectedAttemptId?: string;
   readonly generation: number;
   readonly statusText: string;
+}
+
+export interface PrReviewCommentsWakeupInput {
+  readonly repo: string;
+  readonly prNumber: number;
+  readonly headSha: string;
+  readonly commentMarker: string;
+  readonly commentUrls: readonly string[];
+  readonly workflowId?: string;
+  readonly baseRef?: string;
+  readonly labelsJson?: string;
+}
+
+export interface PrQueueDequeuedWakeupInput {
+  readonly repo: string;
+  readonly prNumber: number;
+  readonly headSha: string;
+  readonly dequeueCommentId: string;
+  readonly failedChecks: readonly string[];
+  readonly workflowId?: string;
+  readonly stackId?: string;
+  readonly stackOrder?: number;
+  readonly baseRef?: string;
+  readonly labelsJson?: string;
 }
 
 export function startLifecycleEventBridge(options: LifecycleEventBridgeOptions): LifecycleEventBridge {
@@ -170,6 +196,46 @@ export function publishReviewGateMergeConflictLifecycleEvent(
   return event;
 }
 
+export function publishPrReviewCommentsLifecycleEvent(
+  input: PrReviewCommentsWakeupInput,
+  options: Pick<LifecycleEventBridgeOptions, 'messageBus' | 'prMirrorStore' | 'now'>,
+): WorkflowLifecycleEvent {
+  const event = buildPrReviewCommentsLifecycleEvent({
+    ...input,
+    createdAt: options.now?.(),
+  });
+  upsertPrMirrorBeforePublish(input, {
+    blockersJson: JSON.stringify({
+      kind: 'review_comments',
+      commentMarker: input.commentMarker,
+      commentUrls: input.commentUrls,
+    }),
+    options,
+  });
+  options.messageBus.publish(Channels.WORKFLOW_LIFECYCLE, event);
+  return event;
+}
+
+export function publishPrQueueDequeuedLifecycleEvent(
+  input: PrQueueDequeuedWakeupInput,
+  options: Pick<LifecycleEventBridgeOptions, 'messageBus' | 'prMirrorStore' | 'now'>,
+): WorkflowLifecycleEvent {
+  const event = buildPrQueueDequeuedLifecycleEvent({
+    ...input,
+    createdAt: options.now?.(),
+  });
+  upsertPrMirrorBeforePublish(input, {
+    blockersJson: JSON.stringify({
+      kind: 'queue_dequeued',
+      dequeueCommentId: input.dequeueCommentId,
+      failedChecks: input.failedChecks,
+    }),
+    options,
+  });
+  options.messageBus.publish(Channels.WORKFLOW_LIFECYCLE, event);
+  return event;
+}
+
 export function resolveReviewGatePrIdentity(
   reviewUrl: string,
   reviewId: string,
@@ -223,6 +289,29 @@ function upsertReviewGatePrMirrorBeforePublish(args: {
     updatedAt,
   };
   store.upsertPrMirror(mirror);
+}
+
+function upsertPrMirrorBeforePublish(
+  input: PrReviewCommentsWakeupInput | PrQueueDequeuedWakeupInput,
+  args: {
+    readonly blockersJson: string;
+    readonly options: Pick<LifecycleEventBridgeOptions, 'prMirrorStore' | 'now'>;
+  },
+): void {
+  const store = args.options.prMirrorStore;
+  if (!store) return;
+  store.upsertPrMirror({
+    repo: input.repo,
+    prNumber: input.prNumber,
+    headSha: input.headSha,
+    ...(input.baseRef ? { baseRef: input.baseRef } : {}),
+    ...(input.labelsJson ? { labelsJson: input.labelsJson } : {}),
+    ...(input.workflowId ? { workflowId: input.workflowId } : {}),
+    ...('stackId' in input && input.stackId ? { stackId: input.stackId } : {}),
+    ...('stackOrder' in input && input.stackOrder !== undefined ? { stackOrder: input.stackOrder } : {}),
+    blockersJson: args.blockersJson,
+    updatedAt: (args.options.now?.() ?? new Date()).toISOString(),
+  });
 }
 
 function buildEventForTaskDelta(

--- a/packages/app/src/lifecycle-events.ts
+++ b/packages/app/src/lifecycle-events.ts
@@ -13,6 +13,8 @@ import {
   type ReviewGateFailedCheck,
   type ReviewGateCiFailedLifecycleEvent,
   type ReviewGateMergeConflictLifecycleEvent,
+  type PrQueueDequeuedLifecycleEvent,
+  type PrReviewCommentsLifecycleEvent,
   type WorkflowWakeupLifecycleEvent,
   type RecoveryWorkerWakeupHint,
   type RecoveryWorkerWakeupReason,
@@ -32,6 +34,8 @@ export {
   type ReviewGateFailedCheck,
   type ReviewGateCiFailedLifecycleEvent,
   type ReviewGateMergeConflictLifecycleEvent,
+  type PrQueueDequeuedLifecycleEvent,
+  type PrReviewCommentsLifecycleEvent,
   type WorkflowWakeupLifecycleEvent,
   type RecoveryWorkerWakeupHint,
   type RecoveryWorkerWakeupReason,
@@ -84,6 +88,28 @@ export interface ReviewGateMergeConflictLifecycleEventInput extends LifecycleBui
   readonly headRef?: string;
   readonly branch?: string;
   readonly statusText: string;
+}
+
+export interface PrReviewCommentsLifecycleEventInput {
+  readonly repo: string;
+  readonly prNumber: number;
+  readonly headSha: string;
+  readonly commentMarker: string;
+  readonly commentUrls: readonly string[];
+  readonly workflowId?: string;
+  readonly createdAt?: Date;
+}
+
+export interface PrQueueDequeuedLifecycleEventInput {
+  readonly repo: string;
+  readonly prNumber: number;
+  readonly headSha: string;
+  readonly dequeueCommentId: string;
+  readonly failedChecks: readonly string[];
+  readonly stackId?: string;
+  readonly stackOrder?: number;
+  readonly workflowId?: string;
+  readonly createdAt?: Date;
 }
 
 export interface WorkflowWakeupLifecycleEventInput {
@@ -288,6 +314,40 @@ export function buildReviewGateMergeConflictLifecycleEvent(
   };
 }
 
+export function buildPrReviewCommentsLifecycleEvent(
+  input: PrReviewCommentsLifecycleEventInput,
+): PrReviewCommentsLifecycleEvent {
+  return {
+    eventKey: `pr.review_comments|repo:${input.repo}|pr:${input.prNumber}|head:${input.headSha}|marker:${input.commentMarker}`,
+    kind: 'pr.review_comments',
+    repo: input.repo,
+    prNumber: input.prNumber,
+    headSha: input.headSha,
+    commentMarker: input.commentMarker,
+    commentUrls: [...input.commentUrls],
+    ...(input.workflowId ? { workflowId: input.workflowId } : {}),
+    createdAt: lifecycleCreatedAt(input.createdAt),
+  };
+}
+
+export function buildPrQueueDequeuedLifecycleEvent(
+  input: PrQueueDequeuedLifecycleEventInput,
+): PrQueueDequeuedLifecycleEvent {
+  return {
+    eventKey: `pr.queue_dequeued|repo:${input.repo}|pr:${input.prNumber}|head:${input.headSha}|comment:${input.dequeueCommentId}`,
+    kind: 'pr.queue_dequeued',
+    repo: input.repo,
+    prNumber: input.prNumber,
+    headSha: input.headSha,
+    dequeueCommentId: input.dequeueCommentId,
+    failedChecks: [...input.failedChecks],
+    ...(input.stackId ? { stackId: input.stackId } : {}),
+    ...(input.stackOrder !== undefined ? { stackOrder: input.stackOrder } : {}),
+    ...(input.workflowId ? { workflowId: input.workflowId } : {}),
+    createdAt: lifecycleCreatedAt(input.createdAt),
+  };
+}
+
 export function buildWorkflowWakeupLifecycleEvent(
   input: WorkflowWakeupLifecycleEventInput,
 ): WorkflowWakeupLifecycleEvent {
@@ -360,6 +420,24 @@ export function isWorkflowLifecycleEvent(value: unknown): value is WorkflowLifec
   if (!isRecord(value)) return false;
   if (typeof value.eventKey !== 'string') return false;
   if (!isWorkflowLifecycleEventKind(value.kind)) return false;
+  if (value.kind === 'pr.review_comments') {
+    return typeof value.repo === 'string'
+      && typeof value.prNumber === 'number'
+      && typeof value.headSha === 'string'
+      && typeof value.commentMarker === 'string'
+      && Array.isArray(value.commentUrls)
+      && typeof value.createdAt === 'string'
+      && isCanonicalUtcIsoTimestamp(value.createdAt);
+  }
+  if (value.kind === 'pr.queue_dequeued') {
+    return typeof value.repo === 'string'
+      && typeof value.prNumber === 'number'
+      && typeof value.headSha === 'string'
+      && typeof value.dequeueCommentId === 'string'
+      && Array.isArray(value.failedChecks)
+      && typeof value.createdAt === 'string'
+      && isCanonicalUtcIsoTimestamp(value.createdAt);
+  }
   if (typeof value.workflowId !== 'string') return false;
   if (typeof value.createdAt !== 'string') return false;
   if (!isCanonicalUtcIsoTimestamp(value.createdAt)) return false;

--- a/packages/execution-engine/src/__tests__/pr-submit-only-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-submit-only-workers.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PrRepairLeaseRow, WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store';
+
+import type {
+  PrQueueDequeuedLifecycleEvent,
+  PrReviewCommentsLifecycleEvent,
+} from '../lifecycle-events.js';
+import {
+  createPrQueueLandTick,
+  PR_QUEUE_LAND_WORKER_KIND,
+  prQueueLandActionKey,
+} from '../workers/pr-queue-land-worker.js';
+import {
+  createReviewCommentsTick,
+  REVIEW_COMMENTS_WORKER_KIND,
+  reviewCommentsActionKey,
+} from '../workers/review-comments-worker.js';
+
+const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn() };
+
+function createStore() {
+  const actions = new Map<string, WorkerActionRecord>();
+  const leases = new Map<string, PrRepairLeaseRow>();
+  return {
+    actions,
+    leases,
+    store: {
+      getWorkerAction: vi.fn((workerKind: string, externalKey: string) => actions.get(`${workerKind}:${externalKey}`)),
+      upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+        const now = '2026-01-01T00:00:00.000Z';
+        const record: WorkerActionRecord = {
+          ...write,
+          attemptCount: write.attemptCount ?? 0,
+          createdAt: now,
+          updatedAt: now,
+        };
+        actions.set(`${write.workerKind}:${write.externalKey}`, record);
+        return record;
+      }),
+      getPrRepairLease: vi.fn((repo: string, prNumber: number, headSha: string) => leases.get(`${repo}:${prNumber}:${headSha}`)),
+      upsertPrRepairLease: vi.fn((lease: PrRepairLeaseRow) => {
+        leases.set(`${lease.repo}:${lease.prNumber}:${lease.headSha}`, lease);
+        return lease;
+      }),
+      getPrRepairLeaseById: vi.fn((leaseId: string) => Array.from(leases.values()).find((lease) => lease.leaseId === leaseId)),
+      deletePrRepairLeaseById: vi.fn((leaseId: string) => {
+        const entry = Array.from(leases.entries()).find(([, lease]) => lease.leaseId === leaseId);
+        if (!entry) return false;
+        leases.delete(entry[0]);
+        return true;
+      }),
+    },
+  };
+}
+
+const reviewEvent: PrReviewCommentsLifecycleEvent = {
+  eventKey: 'review-1',
+  kind: 'pr.review_comments',
+  repo: 'owner/repo',
+  prNumber: 12,
+  headSha: 'abc',
+  commentMarker: 'comment-1',
+  commentUrls: ['https://github.com/owner/repo/pull/12#discussion_r1'],
+  workflowId: 'wf-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+const queueEvent: PrQueueDequeuedLifecycleEvent = {
+  eventKey: 'queue-1',
+  kind: 'pr.queue_dequeued',
+  repo: 'owner/repo',
+  prNumber: 12,
+  headSha: 'abc',
+  dequeueCommentId: '900',
+  failedChecks: ['CI'],
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('submit-only PR lifecycle workers', () => {
+  it('deduplicates review comments, records command-not-ready, and releases its lease', async () => {
+    const harness = createStore();
+    const tick = createReviewCommentsTick({ store: harness.store, logger, drainEvents: () => [reviewEvent, reviewEvent] });
+
+    await tick({ identity: { kind: REVIEW_COMMENTS_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
+
+    expect(harness.store.upsertPrRepairLease).toHaveBeenCalledWith(expect.objectContaining({ holderKind: 'review_comments' }));
+    expect(harness.actions.get(`${REVIEW_COMMENTS_WORKER_KIND}:${reviewCommentsActionKey(reviewEvent)}`)).toMatchObject({
+      status: 'skipped',
+      workflowId: 'wf-1',
+      payload: expect.objectContaining({ reason: 'command-not-ready' }),
+    });
+    expect(harness.leases).toEqual(new Map());
+  });
+
+  it('records a command-not-ready queue action without a workflow or command submission', async () => {
+    const harness = createStore();
+    const tick = createPrQueueLandTick({ store: harness.store, logger, drainEvents: () => [queueEvent] });
+
+    await tick({ identity: { kind: PR_QUEUE_LAND_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
+
+    expect(harness.store.upsertPrRepairLease).toHaveBeenCalledWith(expect.objectContaining({ holderKind: 'queue_dequeued' }));
+    const action = harness.actions.get(`${PR_QUEUE_LAND_WORKER_KIND}:${prQueueLandActionKey(queueEvent)}`);
+    expect(action).toMatchObject({
+      status: 'skipped',
+      payload: expect.objectContaining({ reason: 'command-not-ready', failedChecks: ['CI'] }),
+    });
+    expect(action?.workflowId).toBeUndefined();
+    expect(harness.leases).toEqual(new Map());
+  });
+});

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -20,8 +20,10 @@ import {
 } from '../workers/pr-maintenance-workers.js';
 import { PR_STATUS_WORKER_KIND } from '../workers/pr-status-worker.js';
 import { PR_SUMMARY_REFRESH_WORKER_KIND } from '../workers/pr-summary-refresh-worker.js';
+import { PR_QUEUE_LAND_WORKER_KIND } from '../workers/pr-queue-land-worker.js';
 import { DISK_HEADROOM_WORKER_KIND } from '../workers/disk-headroom-worker.js';
 import { REQUEUE_WORKER_KIND } from '../workers/requeue-worker.js';
+import { REVIEW_COMMENTS_WORKER_KIND } from '../workers/review-comments-worker.js';
 import { REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND } from '../workers/review-gate-merge-conflict-worker.js';
 import { WORKFLOW_RESUME_WORKER_KIND } from '../workers/workflow-resume-worker.js';
 import { E2E_AUTOFIX_WORKER_KIND } from '../workers/e2e-autofix-worker.js';
@@ -78,6 +80,8 @@ describe('worker registry', () => {
       PR_SUMMARY_REFRESH_WORKER_KIND,
       CI_FAILURE_WORKER_KIND,
       REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND,
+      REVIEW_COMMENTS_WORKER_KIND,
+      PR_QUEUE_LAND_WORKER_KIND,
       DISK_HEADROOM_WORKER_KIND,
       AUTO_APPROVE_WORKER_KIND,
       CODERABBIT_ADDRESS_WORKER_KIND,
@@ -93,6 +97,8 @@ describe('worker registry', () => {
     expect(registry.get(PR_SUMMARY_REFRESH_WORKER_KIND)).toBeDefined();
     expect(registry.get(CI_FAILURE_WORKER_KIND)).toBeDefined();
     expect(registry.get(REVIEW_GATE_MERGE_CONFLICT_WORKER_KIND)).toBeDefined();
+    expect(registry.get(REVIEW_COMMENTS_WORKER_KIND)).toBeDefined();
+    expect(registry.get(PR_QUEUE_LAND_WORKER_KIND)).toBeDefined();
     expect(registry.get(DISK_HEADROOM_WORKER_KIND)).toBeDefined();
     expect(registry.get(AUTO_APPROVE_WORKER_KIND)).toBeDefined();
     expect(registry.get(CODERABBIT_ADDRESS_WORKER_KIND)).toBeDefined();
@@ -134,5 +140,9 @@ describe('worker registry', () => {
       .toBe(PR_CI_FAILURE_SCAN_WORKER_KIND);
     expect(registry.get(PR_ADMIN_BYPASS_LAND_WORKER_KIND)?.factory(deps()).identity.kind)
       .toBe(PR_ADMIN_BYPASS_LAND_WORKER_KIND);
+    expect(registry.get(REVIEW_COMMENTS_WORKER_KIND)?.factory(deps()).identity.kind)
+      .toBe(REVIEW_COMMENTS_WORKER_KIND);
+    expect(registry.get(PR_QUEUE_LAND_WORKER_KIND)?.factory(deps()).identity.kind)
+      .toBe(PR_QUEUE_LAND_WORKER_KIND);
   });
 });

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -625,6 +625,7 @@ export function createRecoveryWorker(options: RecoveryWorkerOptions): WorkerRunt
       lifecycleUnsubscribe = options.messageBus?.subscribe<WorkflowLifecycleEvent>(
         Channels.WORKFLOW_LIFECYCLE,
         (event) => {
+          if (!('recoveryWakeup' in event)) return;
           pendingWakeups.push(event.recoveryWakeup);
           runtime.wake('wake');
         },

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -8,7 +8,9 @@ import { registerDiskHeadroomWorker } from './workers/disk-headroom-worker.js';
 import { registerPrMaintenanceWorkers } from './workers/pr-maintenance-workers.js';
 import { registerPrSummaryRefreshWorker } from './workers/pr-summary-refresh-worker.js';
 import { registerPrStatusWorker } from './workers/pr-status-worker.js';
+import { registerPrQueueLandWorker } from './workers/pr-queue-land-worker.js';
 import { registerRequeueWorker } from './workers/requeue-worker.js';
+import { registerReviewCommentsWorker } from './workers/review-comments-worker.js';
 import { registerReviewGateMergeConflictWorker } from './workers/review-gate-merge-conflict-worker.js';
 import { registerWorkflowResumeWorker } from './workers/workflow-resume-worker.js';
 
@@ -23,6 +25,8 @@ export function registerBuiltinWorkers(
   registerPrSummaryRefreshWorker(registry);
   registerCiFailureWorker(registry);
   registerReviewGateMergeConflictWorker(registry);
+  registerReviewCommentsWorker(registry);
+  registerPrQueueLandWorker(registry);
   registerDiskHeadroomWorker(registry);
   registerAutoApproveWorker(registry);
   registerPrMaintenanceWorkers(registry);

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -70,6 +70,8 @@ export * from './workers/disk-headroom-reclaim.js';
 export * from './workers/disk-headroom.js';
 export * from './workers/pr-maintenance-workers.js';
 export * from './workers/review-gate-merge-conflict-worker.js';
+export * from './workers/review-comments-worker.js';
+export * from './workers/pr-queue-land-worker.js';
 export * from './workers/e2e-autofix-worker.js';
 export * from './workers/requeue-worker.js';
 export * from './workers/workflow-resume-worker.js';

--- a/packages/execution-engine/src/lifecycle-events.ts
+++ b/packages/execution-engine/src/lifecycle-events.ts
@@ -20,6 +20,8 @@ export const WORKFLOW_LIFECYCLE_EVENT_KINDS = [
   'task.removed',
   'review_gate.ci_failed',
   'review_gate.merge_conflict',
+  'pr.review_comments',
+  'pr.queue_dequeued',
   'workflow.wakeup',
 ] as const;
 
@@ -104,6 +106,32 @@ export interface ReviewGateMergeConflictLifecycleEvent extends WorkflowLifecycle
   readonly statusText: string;
 }
 
+export interface PrReviewCommentsLifecycleEvent {
+  readonly eventKey: string;
+  readonly kind: 'pr.review_comments';
+  readonly repo: string;
+  readonly prNumber: number;
+  readonly headSha: string;
+  readonly commentMarker: string;
+  readonly commentUrls: readonly string[];
+  readonly workflowId?: string;
+  readonly createdAt: string;
+}
+
+export interface PrQueueDequeuedLifecycleEvent {
+  readonly eventKey: string;
+  readonly kind: 'pr.queue_dequeued';
+  readonly repo: string;
+  readonly prNumber: number;
+  readonly headSha: string;
+  readonly dequeueCommentId: string;
+  readonly failedChecks: readonly string[];
+  readonly stackId?: string;
+  readonly stackOrder?: number;
+  readonly workflowId?: string;
+  readonly createdAt: string;
+}
+
 export interface WorkflowWakeupLifecycleEvent extends WorkflowLifecycleEventBase {
   readonly kind: 'workflow.wakeup';
   readonly reason: WorkflowWakeupReason;
@@ -114,6 +142,8 @@ export type WorkflowLifecycleEvent =
   | TaskLifecycleEvent
   | ReviewGateCiFailedLifecycleEvent
   | ReviewGateMergeConflictLifecycleEvent
+  | PrReviewCommentsLifecycleEvent
+  | PrQueueDequeuedLifecycleEvent
   | WorkflowWakeupLifecycleEvent;
 
 export type WorkflowWakeupReason =

--- a/packages/execution-engine/src/workers/auto-approve-worker.ts
+++ b/packages/execution-engine/src/workers/auto-approve-worker.ts
@@ -485,6 +485,7 @@ export function createAutoApproveWorker(options: AutoApproveWorkerOptions): Work
         Channels.WORKFLOW_LIFECYCLE,
         (event) => {
           if (!isAwaitingApprovalEvent(event)) return;
+          if (!('recoveryWakeup' in event)) return;
           pendingWakeups.push(event.recoveryWakeup);
           runtime.wake('wake');
         },

--- a/packages/execution-engine/src/workers/pr-queue-land-worker.ts
+++ b/packages/execution-engine/src/workers/pr-queue-land-worker.ts
@@ -1,0 +1,171 @@
+import type { Logger } from '@invoker/contracts';
+import type { WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store';
+import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
+
+import type { PrQueueDequeuedLifecycleEvent, WorkflowLifecycleEvent } from '../lifecycle-events.js';
+import { releasePrRepairLease, tryAcquirePrRepairLease, type PrRepairLeaseStore } from '../pr-repair-lease.js';
+import { recordWorkerDecisionRow } from '../worker-decision-ledger.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const PR_QUEUE_LAND_WORKER_KIND = 'pr-queue-land';
+export const DEFAULT_PR_QUEUE_LAND_WORKER_INTERVAL_MS = 60_000;
+const PR_QUEUE_LAND_ACTION_TYPE = 'land-dequeued-pr';
+
+export interface PrQueueLandWorkerStore extends PrRepairLeaseStore {
+  getWorkerAction?(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
+  upsertWorkerAction?(action: WorkerActionWrite): WorkerActionRecord;
+}
+
+export interface PrQueueLandWorkerPolicyOptions {
+  store: PrQueueLandWorkerStore;
+  logger: Logger;
+  drainEvents?: () => PrQueueDequeuedLifecycleEvent[];
+}
+
+export interface PrQueueLandWorkerOptions {
+  logger: Logger;
+  instanceId?: string;
+  intervalMs?: number;
+  installSignalHandlers?: boolean;
+  prQueueLand?: Omit<PrQueueLandWorkerPolicyOptions, 'logger' | 'drainEvents'>;
+  tickOnStart?: boolean;
+  messageBus?: MessageBus;
+  onTick?: WorkerTick;
+}
+
+export function prQueueLandActionKey(event: Pick<
+  PrQueueDequeuedLifecycleEvent,
+  'repo' | 'prNumber' | 'headSha' | 'dequeueCommentId'
+>): string {
+  return [PR_QUEUE_LAND_WORKER_KIND, event.repo, event.prNumber, event.headSha, event.dequeueCommentId].join(':');
+}
+
+export function registerPrQueueLandWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: PR_QUEUE_LAND_WORKER_KIND,
+    note: 'Records dequeued PR land events until a command handler is available.',
+    source: 'built-in',
+    factory: (deps) => createPrQueueLandWorker({
+      logger: deps.logger,
+      messageBus: deps.messageBus,
+      prQueueLand: { store: deps.store },
+    }),
+  });
+  return registry;
+}
+
+function handlePrQueueLandEvent(
+  options: PrQueueLandWorkerPolicyOptions,
+  event: PrQueueDequeuedLifecycleEvent,
+): void {
+  const externalKey = prQueueLandActionKey(event);
+  if (options.store.getWorkerAction?.(PR_QUEUE_LAND_WORKER_KIND, externalKey)) return;
+
+  const lease = tryAcquirePrRepairLease({
+    repo: event.repo,
+    prNumber: event.prNumber,
+    headSha: event.headSha,
+    kind: 'queue_dequeued',
+    store: options.store,
+    workflowId: event.workflowId,
+  });
+  if (!lease.ok) {
+    recordWorkerDecisionRow(options.store, {
+      workerKind: PR_QUEUE_LAND_WORKER_KIND,
+      actionType: PR_QUEUE_LAND_ACTION_TYPE,
+      externalKey,
+      subjectType: 'pull_request',
+      subjectId: `${event.repo}#${event.prNumber}`,
+      workflowId: event.workflowId,
+      status: 'skipped',
+      summary: 'Skipped dequeued PR landing because a PR repair lease is held',
+      reason: 'lease-held',
+      payload: { headSha: event.headSha, holderKind: lease.holderKind, failedChecks: event.failedChecks },
+    });
+    return;
+  }
+
+  try {
+    recordWorkerDecisionRow(options.store, {
+      workerKind: PR_QUEUE_LAND_WORKER_KIND,
+      actionType: PR_QUEUE_LAND_ACTION_TYPE,
+      externalKey,
+      subjectType: 'pull_request',
+      subjectId: `${event.repo}#${event.prNumber}`,
+      workflowId: event.workflowId,
+      status: 'skipped',
+      summary: 'Skipped dequeued PR landing because its command is not ready',
+      reason: 'command-not-ready',
+      payload: {
+        headSha: event.headSha,
+        failedChecks: event.failedChecks,
+        stackId: event.stackId,
+        stackOrder: event.stackOrder,
+        prRepairLeaseId: lease.leaseId,
+      },
+    });
+  } finally {
+    releasePrRepairLease(lease.leaseId, options.store);
+  }
+}
+
+export function createPrQueueLandTick(options: PrQueueLandWorkerPolicyOptions): WorkerTick {
+  return async () => {
+    const seen = new Set<string>();
+    for (const event of options.drainEvents?.() ?? []) {
+      const externalKey = prQueueLandActionKey(event);
+      if (seen.has(externalKey)) continue;
+      seen.add(externalKey);
+      handlePrQueueLandEvent(options, event);
+    }
+  };
+}
+
+function isPrQueueDequeuedEvent(event: WorkflowLifecycleEvent): event is PrQueueDequeuedLifecycleEvent {
+  return event.kind === 'pr.queue_dequeued';
+}
+
+export function createPrQueueLandWorker(options: PrQueueLandWorkerOptions): WorkerRuntime {
+  const pendingEvents: PrQueueDequeuedLifecycleEvent[] = [];
+  let lifecycleUnsubscribe: Unsubscribe | undefined;
+  const onTick = options.onTick ?? (options.prQueueLand
+    ? createPrQueueLandTick({ ...options.prQueueLand, logger: options.logger, drainEvents: () => pendingEvents.splice(0) })
+    : (() => {}));
+  const runtime = createWorkerRuntime({
+    kind: PR_QUEUE_LAND_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_PR_QUEUE_LAND_WORKER_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick,
+  });
+  if (!options.messageBus || !options.prQueueLand || options.onTick) return runtime;
+
+  return {
+    identity: runtime.identity,
+    start: () => {
+      lifecycleUnsubscribe ??= options.messageBus!.subscribe<WorkflowLifecycleEvent>(
+        Channels.WORKFLOW_LIFECYCLE,
+        (event) => {
+          if (!isPrQueueDequeuedEvent(event)) return;
+          pendingEvents.push(event);
+          runtime.wake('wake');
+        },
+      );
+      runtime.start();
+    },
+    wake: runtime.wake,
+    tick: runtime.tick,
+    stop: async () => {
+      lifecycleUnsubscribe?.();
+      lifecycleUnsubscribe = undefined;
+      await runtime.stop();
+    },
+    isRunning: runtime.isRunning,
+  };
+}

--- a/packages/execution-engine/src/workers/requeue-worker.ts
+++ b/packages/execution-engine/src/workers/requeue-worker.ts
@@ -264,6 +264,7 @@ export function createRequeueWorker(options: RequeueWorkerOptions): WorkerRuntim
       lifecycleUnsubscribe = options.messageBus?.subscribe<WorkflowLifecycleEvent>(
         Channels.WORKFLOW_LIFECYCLE,
         (event) => {
+          if (!('recoveryWakeup' in event)) return;
           pendingWakeups.push(event.recoveryWakeup);
           runtime.wake('wake');
         },

--- a/packages/execution-engine/src/workers/review-comments-worker.ts
+++ b/packages/execution-engine/src/workers/review-comments-worker.ts
@@ -1,0 +1,165 @@
+import type { Logger } from '@invoker/contracts';
+import type { WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store';
+import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
+
+import type { PrReviewCommentsLifecycleEvent, WorkflowLifecycleEvent } from '../lifecycle-events.js';
+import { releasePrRepairLease, tryAcquirePrRepairLease, type PrRepairLeaseStore } from '../pr-repair-lease.js';
+import { recordWorkerDecisionRow } from '../worker-decision-ledger.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const REVIEW_COMMENTS_WORKER_KIND = 'review-comments';
+export const DEFAULT_REVIEW_COMMENTS_WORKER_INTERVAL_MS = 60_000;
+const REVIEW_COMMENTS_ACTION_TYPE = 'address-review-comments';
+
+export interface ReviewCommentsWorkerStore extends PrRepairLeaseStore {
+  getWorkerAction?(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
+  upsertWorkerAction?(action: WorkerActionWrite): WorkerActionRecord;
+}
+
+export interface ReviewCommentsWorkerPolicyOptions {
+  store: ReviewCommentsWorkerStore;
+  logger: Logger;
+  drainEvents?: () => PrReviewCommentsLifecycleEvent[];
+}
+
+export interface ReviewCommentsWorkerOptions {
+  logger: Logger;
+  instanceId?: string;
+  intervalMs?: number;
+  installSignalHandlers?: boolean;
+  reviewComments?: Omit<ReviewCommentsWorkerPolicyOptions, 'logger' | 'drainEvents'>;
+  tickOnStart?: boolean;
+  messageBus?: MessageBus;
+  onTick?: WorkerTick;
+}
+
+export function reviewCommentsActionKey(event: Pick<
+  PrReviewCommentsLifecycleEvent,
+  'repo' | 'prNumber' | 'headSha' | 'commentMarker'
+>): string {
+  return [REVIEW_COMMENTS_WORKER_KIND, event.repo, event.prNumber, event.headSha, event.commentMarker].join(':');
+}
+
+export function registerReviewCommentsWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: REVIEW_COMMENTS_WORKER_KIND,
+    note: 'Records review-comment repair events until a command handler is available.',
+    source: 'built-in',
+    factory: (deps) => createReviewCommentsWorker({
+      logger: deps.logger,
+      messageBus: deps.messageBus,
+      reviewComments: { store: deps.store },
+    }),
+  });
+  return registry;
+}
+
+function handleReviewCommentsEvent(
+  options: ReviewCommentsWorkerPolicyOptions,
+  event: PrReviewCommentsLifecycleEvent,
+): void {
+  const externalKey = reviewCommentsActionKey(event);
+  if (options.store.getWorkerAction?.(REVIEW_COMMENTS_WORKER_KIND, externalKey)) return;
+
+  const lease = tryAcquirePrRepairLease({
+    repo: event.repo,
+    prNumber: event.prNumber,
+    headSha: event.headSha,
+    kind: 'review_comments',
+    store: options.store,
+    workflowId: event.workflowId,
+  });
+  if (!lease.ok) {
+    recordWorkerDecisionRow(options.store, {
+      workerKind: REVIEW_COMMENTS_WORKER_KIND,
+      actionType: REVIEW_COMMENTS_ACTION_TYPE,
+      externalKey,
+      subjectType: 'pull_request',
+      subjectId: `${event.repo}#${event.prNumber}`,
+      workflowId: event.workflowId,
+      status: 'skipped',
+      summary: 'Skipped review-comment repair because a PR repair lease is held',
+      reason: 'lease-held',
+      payload: { headSha: event.headSha, holderKind: lease.holderKind, commentUrls: event.commentUrls },
+    });
+    return;
+  }
+
+  try {
+    recordWorkerDecisionRow(options.store, {
+      workerKind: REVIEW_COMMENTS_WORKER_KIND,
+      actionType: REVIEW_COMMENTS_ACTION_TYPE,
+      externalKey,
+      subjectType: 'pull_request',
+      subjectId: `${event.repo}#${event.prNumber}`,
+      workflowId: event.workflowId,
+      status: 'skipped',
+      summary: 'Skipped review-comment repair because its command is not ready',
+      reason: 'command-not-ready',
+      payload: { headSha: event.headSha, commentUrls: event.commentUrls, prRepairLeaseId: lease.leaseId },
+    });
+  } finally {
+    releasePrRepairLease(lease.leaseId, options.store);
+  }
+}
+
+export function createReviewCommentsTick(options: ReviewCommentsWorkerPolicyOptions): WorkerTick {
+  return async () => {
+    const seen = new Set<string>();
+    for (const event of options.drainEvents?.() ?? []) {
+      const externalKey = reviewCommentsActionKey(event);
+      if (seen.has(externalKey)) continue;
+      seen.add(externalKey);
+      handleReviewCommentsEvent(options, event);
+    }
+  };
+}
+
+function isReviewCommentsEvent(event: WorkflowLifecycleEvent): event is PrReviewCommentsLifecycleEvent {
+  return event.kind === 'pr.review_comments';
+}
+
+export function createReviewCommentsWorker(options: ReviewCommentsWorkerOptions): WorkerRuntime {
+  const pendingEvents: PrReviewCommentsLifecycleEvent[] = [];
+  let lifecycleUnsubscribe: Unsubscribe | undefined;
+  const onTick = options.onTick ?? (options.reviewComments
+    ? createReviewCommentsTick({ ...options.reviewComments, logger: options.logger, drainEvents: () => pendingEvents.splice(0) })
+    : (() => {}));
+  const runtime = createWorkerRuntime({
+    kind: REVIEW_COMMENTS_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_REVIEW_COMMENTS_WORKER_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick,
+  });
+  if (!options.messageBus || !options.reviewComments || options.onTick) return runtime;
+
+  return {
+    identity: runtime.identity,
+    start: () => {
+      lifecycleUnsubscribe ??= options.messageBus!.subscribe<WorkflowLifecycleEvent>(
+        Channels.WORKFLOW_LIFECYCLE,
+        (event) => {
+          if (!isReviewCommentsEvent(event)) return;
+          pendingEvents.push(event);
+          runtime.wake('wake');
+        },
+      );
+      runtime.start();
+    },
+    wake: runtime.wake,
+    tick: runtime.tick,
+    stop: async () => {
+      lifecycleUnsubscribe?.();
+      lifecycleUnsubscribe = undefined;
+      await runtime.stop();
+    },
+    isRunning: runtime.isRunning,
+  };
+}

--- a/packages/execution-engine/src/workers/workflow-resume-worker.ts
+++ b/packages/execution-engine/src/workers/workflow-resume-worker.ts
@@ -196,6 +196,7 @@ export function createWorkflowResumeWorker(options: WorkflowResumeWorkerOptions)
       lifecycleUnsubscribe = options.messageBus?.subscribe<WorkflowLifecycleEvent>(
         Channels.WORKFLOW_LIFECYCLE,
         (event) => {
+          if (!('recoveryWakeup' in event)) return;
           pendingWakeups.push(event.recoveryWakeup);
           runtime.wake('wake');
         },

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -226,7 +226,10 @@ def parse_stack_metadata(comments: Sequence[Mapping[str, object]]) -> tuple[str,
         numbers = payload.get("pull_numbers_bottom_to_top") or payload.get("pullNumbersBottomToTop") or payload.get("prs") or payload.get("pulls")
         if stack_id and isinstance(numbers, Sequence) and not isinstance(numbers, (str, bytes)):
             try:
-                return stack_id, tuple(int(n) for n in numbers)
+                return stack_id, tuple(
+                    int(n.get("number") if isinstance(n, Mapping) else n)
+                    for n in numbers
+                )
             except (TypeError, ValueError):
                 continue
     return None

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -90,6 +90,12 @@ class ParseStackMetadata(unittest.TestCase):
                "body": '<!-- mergify-stack-data: {"stack_id":"new","pull_numbers_bottom_to_top":[10,11,12]} -->'}
         self.assertEqual(s.parse_stack_metadata([old, new]), ("new", (10, 11, 12)))
 
+    def test_accepts_modern_pull_object_marker(self):
+        comment = {
+            "body": '<!-- mergify-stack-data: {"stack_id":"stack-1","pulls":[{"number":10},{"number":11}]} -->',
+        }
+        self.assertEqual(s.parse_stack_metadata([comment]), ("stack-1", (10, 11)))
+
     def test_no_marker_returns_none(self):
         self.assertIsNone(s.parse_stack_metadata([{"body": "nothing here"}]))
 


### PR DESCRIPTION
Publish PR-scoped lifecycle events after mirroring state, add submit-only
workers that acquire/release repair leases until Phase 4 commands exist,
and parse modern Mergify stack markers.

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #5833