### PR TITLE
Package surfaces dist for required-fast app boot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,9 @@ jobs:
       - name: Build UI and app
         run: |
           pnpm --filter @invoker/ui build
+          pnpm --filter @invoker/surfaces build
           pnpm --filter @invoker/app build
-          tar -czf app-build-dist.tgz packages/ui/dist packages/app/dist
+          tar -czf app-build-dist.tgz packages/ui/dist packages/app/dist packages/surfaces/dist
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -317,6 +318,7 @@ jobs:
               bash scripts/test-suites/required/05-delete-all-prod-db-guard.sh
               bash scripts/test-suites/required/06-large-file-guardrail.sh
               bash scripts/test-suites/required/07-invalid-config-json.sh
+              bash scripts/test-suites/required/08-build-artifact-surfaces-guard.sh
               bash scripts/test-suites/required/15-owner-boundary-policy.sh
               bash scripts/test-suites/required/50-verify-executor-routing.sh
           - name: Vitest Workspace

--- a/scripts/test-suites/required/08-build-artifact-surfaces-guard.sh
+++ b/scripts/test-suites/required/08-build-artifact-surfaces-guard.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Guardrail: the shared app-build-dist CI artifact must package packages/surfaces/dist.
+#
+# Regression: build-artifacts only tarred packages/ui/dist and packages/app/dist. The
+# built Electron app requires @invoker/surfaces at runtime (it stays external in
+# packages/app/tsup.config.ts's noExternal list), so every required-fast/ssh/e2e-proof/
+# playwright job that downloaded the artifact crashed with
+# "Cannot find module '.../@invoker/surfaces/dist/index.js'" and hung until CI timeout.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+WORKFLOW="$ROOT/.github/workflows/ci.yml"
+STEP="$(awk '/name: Build UI and app/{flag=1} flag{print} flag && /tar -czf app-build-dist.tgz/{exit}' "$WORKFLOW")"
+
+if [[ -z "$STEP" ]]; then
+  echo "FAIL: could not find the 'Build UI and app' step in $WORKFLOW" >&2
+  exit 1
+fi
+
+if ! grep -q 'pnpm --filter @invoker/surfaces build' <<<"$STEP"; then
+  echo "FAIL: build-artifacts must build @invoker/surfaces before packaging app-build-dist.tgz" >&2
+  exit 1
+fi
+
+if ! grep -q 'tar -czf app-build-dist.tgz.*packages/surfaces/dist' <<<"$STEP"; then
+  echo "FAIL: app-build-dist.tgz must include packages/surfaces/dist (required at runtime by @invoker/app)" >&2
+  exit 1
+fi
+
+echo "PASS: app-build-dist.tgz packages packages/surfaces/dist"


### PR DESCRIPTION
## Summary

Packages `@invoker/surfaces` output into the shared CI artifact so the built app can boot in required-fast jobs.

## Review Claim

The required-fast app now has the runtime files it imports during startup.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the CI artifact contents and its guard script change; runtime source behavior stays the same.

## Slice Rationale

This isolates the artifact-packaging prerequisite from the proof PR it was blocking.

## Non-goals

- No product behavior change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] bash scripts/test-suites/required/08-build-artifact-surfaces-guard.sh
</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: git revert HEAD
- Post-revert steps: None
- Data migration? No
</details>
