### PR TITLE
[PR babysit prerequisite split](6) Handle queue-only admin-bypass dequeues

### DIFF
--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -452,6 +452,7 @@ Failing checks
         stack = StackGroup("s", (pr(2606, labels={"admin-bypass"}, checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}),))
         actions = plan_stack_actions(stack, REQUIRED, ledger, 2)
         self.assertEqual(actions, ())
+
     def test_queue_only_repair_uses_mergify_job_log_and_returns_noop(self):
         stderr = io.StringIO()
         latest = MergifyQueueEvent(


### PR DESCRIPTION
## Summary

This teaches the babysit worker to recover when Mergify dequeues the bottom PR because a queue-only check failed.

Before this change, that path could leave an admin-bypass or dequeued PR stuck instead of moving it back toward landing.

This slice restores the bottom label when needed, records the one follow-up requeue, and keeps the queue-only repair flow covered in tests.

## Review Claim

Queue-only dequeues now move the current admin-bypass PR back toward landing instead of leaving it stuck.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change stays inside the babysit scripts, keeps the action executor surface explicit, and pins the new queue-only path with worker tests and the fake-GitHub repro.

## Slice Rationale

The proof slice lands first so this slice can focus on the recovery behavior itself. The later planner cleanup slice then rewrites structure without changing this path.

## Non-goals

- No UI change.
- No new repair strategy outside queue-only dequeues.
- No planner cleanup beyond what the recovery path needs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue_plan`
- [x] `python3 -m unittest scripts.test_mergify_admin_requeue`
- [x] `bash scripts/repro/repro-babysit-queue-only-check.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2c654e856`
- Post-revert steps: None
- Data migration? No

</details>
