### PR TITLE
Stop SSH helper shells from loading dotfiles

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -929,6 +929,24 @@ describe('SshExecutor entry lifecycle', () => {
     vi.spyOn(ssh as any, 'mergeRequestUpstreamBranches').mockResolvedValue(undefined);
   });
 
+  it('uses a login shell for task payloads so remote profile PATH applies', async () => {
+    const request = makeRequest({
+      inputs: {
+        command: 'echo hello',
+        repoUrl: 'git@github.com:test/repo.git',
+      },
+    });
+    await ssh.start(request);
+
+    const childProcessMod = await import('node:child_process');
+    const spawnMock = childProcessMod.spawn as unknown as ReturnType<typeof vi.fn>;
+    const spawnArgs = spawnMock.mock.calls[spawnMock.mock.calls.length - 1]?.[1] as string[];
+    expect(spawnArgs.slice(-3)).toEqual(['bash', '-l', '-s']);
+
+    const sshProcess = spawnedProcesses[spawnedProcesses.length - 1];
+    sshProcess.emit('close', 0, null);
+    await new Promise((r) => setTimeout(r, 50));
+  });
   it('decreases entries.size after terminal close', async () => {
     const request = makeRequest({
       inputs: {
@@ -1114,7 +1132,7 @@ describe('SshExecutor entry lifecycle', () => {
     expect(response.outputs.error).toContain('broken pipe');
   });
 
-  it('includes SSH transport timeout/keepalive options in spawned SSH args', async () => {
+  it('uses a non-login shell for internal SSH utility scripts', async () => {
     const ssh2 = new SshExecutor({
       host: 'localhost',
       user: 'testuser',
@@ -1137,6 +1155,7 @@ describe('SshExecutor entry lifecycle', () => {
       '-o', 'ServerAliveCountMax=3',
       '-o', 'BatchMode=yes',
     ]));
+    expect(firstCallArgs.slice(-2)).toEqual(['bash', '-s']);
   });
 
   it('uses configured remote heartbeat interval from SSH target config', async () => {

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -302,11 +302,20 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
   }
 
   /**
-   * Remote shell for task scripts. Use a login shell so the remote user's
+   * Remote shell for engine-managed SSH utility scripts (bootstrap, git finalize,
+   * worktree inspection). Keep this non-login so remote dotfiles cannot mutate or
+   * break deterministic helper runs.
+   */
+  private buildUtilityRemoteCommand(): string[] {
+    return ['bash', '-s'];
+  }
+
+  /**
+   * Remote shell for task payloads. Use a login shell so the remote user's
    * ~/.profile PATH (flutter, android-sdk, etc.) is applied. Never forward the
    * local host PATH — that clobbers Linux remotes with macOS Homebrew paths.
    */
-  private buildRemoteCommand(): string[] {
+  private buildPayloadRemoteCommand(): string[] {
     return ['bash', '-l', '-s'];
   }
 
@@ -321,7 +330,7 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
     });
     bench('SshExecutor.execRemoteCapture.begin');
     return new Promise((resolve, reject) => {
-      const child = spawn('ssh', [...this.buildSshArgs(), ...this.buildRemoteCommand()], {
+      const child = spawn('ssh', [...this.buildSshArgs(), ...this.buildUtilityRemoteCommand()], {
         stdio: ['pipe', 'pipe', 'pipe'],
         env: cleanElectronEnv(),
       });
@@ -922,7 +931,7 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
     return this.remoteGitRecordAndPush('publish-approved-fix', request, worktreePath, branch, 0);
   }
 
-  /** Run a bash script on the remote (fed to `bash -s` on stdin). */
+  /** Run a task bash script on the remote login shell (fed on stdin). */
   private spawnSshRemoteStdin(
     executionId: string,
     request: WorkRequest,
@@ -932,7 +941,7 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
     finalizeRemote: { worktreePath: string; branch: string } | undefined,
     effectiveAgentName?: string,
   ): ExecutorHandle {
-    const child = spawn('ssh', [...this.buildSshArgs(), ...this.buildRemoteCommand()], {
+    const child = spawn('ssh', [...this.buildSshArgs(), ...this.buildPayloadRemoteCommand()], {
       stdio: ['pipe', 'pipe', 'pipe'],
       detached: true,
       env: cleanElectronEnv(),


### PR DESCRIPTION
## Summary

Invoker no longer lets remote login dotfiles break SSH helper steps after a task already finished its real work.

Task payloads still use a login shell for remote PATH setup. Bootstrap, worktree inspection, and remote commit/push finalize now use a plain non-login shell.

The focused test now locks both shell modes in place.

## Review Claim

Approve switching engine-managed SSH helper scripts to a non-login shell while task payloads keep their login-shell PATH behavior.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the remote shell entrypoint changed. Task payload execution still uses `bash -l -s`, and helper scripts still run the same contents without remote startup side effects from user dotfiles.

## Slice Rationale

This keeps one reviewable fix around the failing SSH boundary instead of bundling it with unrelated babysit or web-surface work already in flight elsewhere.

## Non-goals

No changes to task payload PATH loading.

No changes to publish flow or worker decisions.

No UI or web-surface changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/ssh-executor.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b67972888`
- Post-revert steps: None
- Data migration? No

</details>
