### PR TITLE
[Web task terminals](2) Share task terminal backend helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "clean": "pnpm -r clean",
     "setup:agent-skills": "bash scripts/setup-agent-skills.sh",
     "dev": "pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && pnpm --filter @invoker/app start",
-    "dev:hot": "concurrently \"pnpm --filter @invoker/ui dev\" \"sleep 3 && VITE_DEV_SERVER_URL=http://localhost:5173 pnpm --filter @invoker/app build && VITE_DEV_SERVER_URL=http://localhost:5173 pnpm --filter @invoker/app start\"",
+    "dev:hot": "concurrently --kill-others-on-fail \"pnpm --filter @invoker/ui exec vite --host 127.0.0.1 --port 5173 --strictPort\" \"sleep 3 && VITE_DEV_SERVER_URL=http://127.0.0.1:5173 pnpm --filter @invoker/app build && VITE_DEV_SERVER_URL=http://127.0.0.1:5173 pnpm --filter @invoker/app start\"",
     "dev:cli": "pnpm --filter @invoker/cli build && node packages/cli/dist/index.js",
     "check:required-builds": "bash scripts/required-builds.sh",
     "check:deps": "depcruise packages --config .dependency-cruiser.js",
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@mergifyio/vitest": "^0.3.0",
     "aws4": "^1.13.2",
+    "concurrently": "^10.0.4",
     "dependency-cruiser": "^17.3.10",
     "electron-builder": "^26.0.12",
     "jsdom": "^25.0.0",

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -25,31 +25,41 @@ import {
 } from '@invoker/workflow-core';
 import type { TaskStateChanges } from '@invoker/workflow-graph';
 import {
-  DockerExecutor, WorktreeExecutor, ExecutorRegistry, SshExecutor,
+  DockerExecutor,
+  WorktreeExecutor,
+  ExecutorRegistry,
+  SshExecutor,
   MergeGateExecutor,
   BaseExecutor,
   getEffectivePath,
-  type ExecutorHandle, type TerminalSpec, type PersistedTaskMeta,
+  registerBuiltinAgents as registerBuiltinAgentsStatic,
+  type Executor,
+  type ExecutorHandle,
+  type TerminalSpec,
+  type PersistedTaskMeta,
 } from '@invoker/execution-engine';
-import type { WorkResponse, WorkRequest } from '@invoker/contracts';
-vi.mock('../terminal-external-launch.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../terminal-external-launch.js')>();
-  return {
-    ...actual,
-    spawnDetachedTerminal: vi.fn(async () => ({ opened: true })),
-  };
-});
+import type * as NodeFsModule from 'node:fs';
+import type * as TerminalExternalLaunchModule from '../terminal-external-launch.js';
 import {
   buildLinuxXTerminalBashScript,
   buildMacOSOsascriptArgs,
   buildTerminalShellCommand,
   spawnDetachedTerminal,
 } from '../terminal-external-launch.js';
-import { openExternalTerminalForTask } from '../open-terminal-for-task.js';
+import { openEmbeddedTerminalForTask, openExternalTerminalForTask } from '../open-terminal-for-task.js';
+import type { EmbeddedTerminalManager } from '../embedded-terminal-manager.js';
 import * as configModule from '../config.js';
 
+vi.mock('../terminal-external-launch.js', async (importOriginal) => {
+  const actual = await importOriginal<TerminalExternalLaunchModule>();
+  return {
+    ...actual,
+    spawnDetachedTerminal: vi.fn(async () => ({ opened: true })),
+  };
+});
+
 vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs')>();
+  const actual = await importOriginal<NodeFsModule>();
   return { ...actual, existsSync: vi.fn(actual.existsSync) };
 });
 import { existsSync } from 'node:fs';
@@ -1044,7 +1054,7 @@ describe('SshExecutor getRestoredTerminalSpec', () => {
 
 describe('getRestoredTerminalSpec dispatches codex vs claude session resume', () => {
   // Lazy import to avoid circular dep issues at module level
-  let registerBuiltinAgents: typeof import('@invoker/execution-engine').registerBuiltinAgents;
+  let registerBuiltinAgents: typeof registerBuiltinAgentsStatic;
 
   beforeEach(async () => {
     ({ registerBuiltinAgents } = await import('@invoker/execution-engine'));
@@ -1209,7 +1219,7 @@ describe('getRestoredTerminalSpec dispatches codex vs claude session resume', ()
  * openExternalTerminalForTask does, and getRestoredTerminalSpec dispatches correctly.
  */
 describe('fix-with-agent → open-terminal produces correct agent resume command', () => {
-  let registerBuiltinAgents: typeof import('@invoker/execution-engine').registerBuiltinAgents;
+  let registerBuiltinAgents: typeof registerBuiltinAgentsStatic;
 
   beforeEach(async () => {
     ({ registerBuiltinAgents } = await import('@invoker/execution-engine'));
@@ -1647,5 +1657,46 @@ describe('openExternalTerminalForTask fail-fast workspace invariant', () => {
       expect(result.reason).not.toContain('workspace metadata is missing');
       expect(result.reason).not.toContain('requires a managed workspace');
     }
+  });
+});
+
+describe('openEmbeddedTerminalForTask', () => {
+  it('attaches running tasks without persistence metadata when a live handle exists', () => {
+    const openOrReuse = vi.fn(() => ({
+      sessionId: 'session-1',
+      taskId: 'task-1',
+      kind: 'task',
+      status: 'running',
+      mode: 'attached',
+      attached: true,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      outputSnapshot: '',
+    }));
+    const liveExecutor = { type: 'worktree' } as unknown as Executor;
+    const liveHandle = {
+      executionId: 'exec-1',
+      taskId: 'task-1',
+      workspacePath: '/tmp/task-1',
+    } as ExecutorHandle;
+
+    const result = openEmbeddedTerminalForTask({
+      taskId: 'task-1',
+      executorRegistry: new ExecutorRegistry(),
+      repoRoot: '/repo',
+      taskHandles: new Map([['task-1', { handle: liveHandle, executor: liveExecutor }]]),
+      embeddedTerminalManager: { openOrReuse } as unknown as Pick<EmbeddedTerminalManager, 'openOrReuse'>,
+    });
+
+    expect(result).toEqual({
+      opened: true,
+      session: expect.objectContaining({ sessionId: 'session-1', taskId: 'task-1', mode: 'attached' }),
+    });
+    expect(openOrReuse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: 'task-1',
+        cwd: '/tmp/task-1',
+        attach: { handle: liveHandle, executor: liveExecutor },
+      }),
+    );
   });
 });

--- a/packages/app/src/__tests__/terminal-session-persistence.test.ts
+++ b/packages/app/src/__tests__/terminal-session-persistence.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import type { IpcMain } from 'electron';
 import { EventEmitter } from 'node:events';
 import {
   EmbeddedTerminalManager,
@@ -6,17 +7,30 @@ import {
   type BashSpawnFn,
 } from '../embedded-terminal-manager.js';
 import {
+  closeTaskTerminalSession,
+  listTaskTerminalSessions,
   registerTerminalSessionIpcHandlers,
   registerTerminalSessionPersistence,
+  restorePersistedTerminalSessions,
 } from '../terminal-session-ipc.js';
+import type { SQLiteAdapter, TerminalSessionRecord } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
 import {
   createTerminalUiPerfCounters,
   createTerminalUiPerfReporter,
   createTerminalUiPerfSink,
 } from '../terminal-ui-perf.js';
 
-function createFakeChild() {
-  const ee = new EventEmitter() as any;
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: { write: Mock };
+  killed: boolean;
+  kill: Mock;
+}
+
+function createFakeChild(): FakeChild {
+  const ee = new EventEmitter() as FakeChild;
   ee.stdout = new EventEmitter();
   ee.stderr = new EventEmitter();
   ee.stdin = { write: vi.fn() };
@@ -25,6 +39,29 @@ function createFakeChild() {
   return ee;
 }
 
+function makeTerminalRow(
+  sessionId: string,
+  taskId: string,
+  overrides: Partial<TerminalSessionRecord> = {},
+): TerminalSessionRecord {
+  return {
+    sessionId,
+    taskId,
+    targetKey: `target:${sessionId}`,
+    status: 'running',
+    exitCode: undefined,
+    cwd: `/tmp/${taskId}`,
+    command: undefined,
+    args: [],
+    linuxTerminalTail: undefined,
+    mode: 'spawn',
+    attached: false,
+    outputSnapshot: '',
+    createdAt: '2026-07-26T00:00:00.000Z',
+    updatedAt: '2026-07-26T00:00:00.000Z',
+    ...overrides,
+  };
+}
 describe('registerTerminalSessionPersistence coalesce', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -51,7 +88,10 @@ describe('registerTerminalSessionPersistence coalesce', () => {
     };
     const handle = registerTerminalSessionPersistence({
       embeddedTerminalManager: mgr,
-      persistence: persistence as any,
+      persistence: persistence as Pick<
+        SQLiteAdapter,
+        'upsertTerminalSession' | 'listTerminalSessions' | 'loadTask' | 'deleteTerminalSession' | 'updateTerminalSession'
+      >,
       uiPerfStats: createTerminalUiPerfCounters(),
       terminalUiPerf: createTerminalUiPerfReporter({ throttleMs: 0 }),
       terminalUiPerfSink: createTerminalUiPerfSink(() => {}, createTerminalUiPerfCounters()),
@@ -133,16 +173,17 @@ describe('registerTerminalSessionPersistence coalesce', () => {
 
   it('keeps task terminal IPC routes isolated from planning sessions', async () => {
     const { mgr, persistence, handle } = setup(100);
-    const handlers = new Map<string, (...args: any[]) => Promise<any>>();
+    type IpcHandler = (...args: unknown[]) => Promise<unknown>;
+    const handlers = new Map<string, IpcHandler>();
     const ipcMain = {
-      handle: vi.fn((channel: string, callback: (...args: any[]) => Promise<any>) => {
+      handle(channel: string, callback: IpcHandler) {
         handlers.set(channel, callback);
-      }),
+      },
     };
     registerTerminalSessionIpcHandlers({
-      ipcMain: ipcMain as any,
+      ipcMain: ipcMain as unknown as IpcMain,
       embeddedTerminalManager: mgr,
-      persistence: persistence as any,
+      persistence: persistence as unknown as Pick<SQLiteAdapter, 'listTerminalSessions' | 'deleteTerminalSession'>,
       uiPerfStats: createTerminalUiPerfCounters(),
       terminalUiPerf: createTerminalUiPerfReporter({ throttleMs: 0 }),
       terminalUiPerfSink: createTerminalUiPerfSink(() => {}, createTerminalUiPerfCounters()),
@@ -180,5 +221,135 @@ describe('registerTerminalSessionPersistence coalesce', () => {
     });
 
     handle.dispose();
+  });
+  it('falls back to live task sessions when persisted terminal rows fail to load', () => {
+    const child = createFakeChild();
+    const mgr = new EmbeddedTerminalManager({
+      backend: createBashTerminalBackend({ spawnFn: (() => child) as unknown as BashSpawnFn }),
+    });
+    const liveTask = mgr.openOrReuse({ taskId: 'task-live', spec: {}, cwd: '/tmp/task-live' });
+
+    const sessions = listTaskTerminalSessions({
+      embeddedTerminalManager: mgr,
+      persistence: {
+        listTerminalSessions: () => {
+          throw new Error('db read failed');
+        },
+      },
+    });
+
+    expect(sessions).toEqual([
+      expect.objectContaining({
+        sessionId: liveTask.sessionId,
+        taskId: 'task-live',
+        kind: 'task',
+      }),
+    ]);
+  });
+  it('closes live task sessions even when persistence is unavailable', () => {
+    const child = createFakeChild();
+    const mgr = new EmbeddedTerminalManager({
+      backend: createBashTerminalBackend({ spawnFn: (() => child) as unknown as BashSpawnFn }),
+    });
+    const session = mgr.openOrReuse({ taskId: 'task-live', spec: {}, cwd: '/tmp/task-live' });
+
+    const result = closeTaskTerminalSession({
+      embeddedTerminalManager: mgr,
+    }, session.sessionId);
+
+    expect(result).toEqual({ ok: true });
+    expect(mgr.get(session.sessionId)).toBeUndefined();
+  });
+  it('merges persisted task sessions with live task sessions and filters planning sessions', () => {
+    const child = createFakeChild();
+    const mgr = new EmbeddedTerminalManager({
+      backend: createBashTerminalBackend({ spawnFn: (() => child) as unknown as BashSpawnFn }),
+    });
+    const liveTask = mgr.openOrReuse({ taskId: 'task-live', spec: {}, cwd: '/tmp/task-live' });
+    mgr.openOrReuse({
+      kind: 'planning',
+      taskId: 'planning:plan-1',
+      planningSessionId: 'plan-1',
+      spec: { cwd: '/repo' },
+      cwd: '/repo',
+    });
+
+    const taskPersistence: Pick<SQLiteAdapter, 'listTerminalSessions'> = {
+      listTerminalSessions: () => [
+        makeTerminalRow(liveTask.sessionId, 'task-live', {
+          outputSnapshot: 'persisted-snapshot',
+        }),
+        makeTerminalRow('persisted-only', 'task-persisted', {
+          outputSnapshot: 'persisted-only-output',
+        }),
+      ],
+    };
+    const sessions = listTaskTerminalSessions({
+      embeddedTerminalManager: mgr,
+      persistence: taskPersistence,
+    });
+
+    expect(sessions).toEqual([
+      expect.objectContaining({
+        sessionId: liveTask.sessionId,
+        taskId: 'task-live',
+        kind: 'task',
+        outputSnapshot: liveTask.outputSnapshot,
+      }),
+      expect.objectContaining({
+        sessionId: 'persisted-only',
+        taskId: 'task-persisted',
+        kind: 'task',
+        outputSnapshot: 'persisted-only-output',
+      }),
+    ]);
+  });
+
+  it('restores running spawn sessions and expires attached sessions after owner restart', () => {
+    const restoreSpawnSession = vi.fn();
+    const updateTerminalSession = vi.fn();
+
+    const embeddedTerminalManager: Pick<EmbeddedTerminalManager, 'restoreSpawnSession'> = {
+      restoreSpawnSession,
+    };
+    const persistence: Pick<
+      SQLiteAdapter,
+      'listTerminalSessions' | 'loadTask' | 'deleteTerminalSession' | 'updateTerminalSession'
+    > = {
+      listTerminalSessions: () => [
+        makeTerminalRow('spawn-running', 'task-spawn', {
+          cwd: '/tmp/task-spawn',
+          outputSnapshot: 'spawn-output',
+          mode: 'spawn',
+          attached: false,
+        }),
+        makeTerminalRow('attached-running', 'task-attached', {
+          mode: 'attached',
+          attached: true,
+          outputSnapshot: 'attached-output',
+        }),
+      ],
+      loadTask: () => ({ id: 'task' } as unknown as TaskState),
+      deleteTerminalSession: vi.fn(),
+      updateTerminalSession,
+    };
+
+    restorePersistedTerminalSessions({
+      embeddedTerminalManager,
+      persistence,
+    });
+
+    expect(restoreSpawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'spawn-running',
+        taskId: 'task-spawn',
+        cwd: '/tmp/task-spawn',
+        outputSnapshot: 'spawn-output',
+      }),
+    );
+    expect(updateTerminalSession).toHaveBeenCalledWith(
+      'attached-running',
+      expect.objectContaining({ status: 'exited' }),
+    );
   });
 });

--- a/packages/app/src/embedded-terminal-backend.ts
+++ b/packages/app/src/embedded-terminal-backend.ts
@@ -1,0 +1,35 @@
+import type {
+  EmbeddedTerminalBackendConfig,
+  InvokerConfig,
+} from './config.js';
+import { resolveEmbeddedTerminalBackendConfig } from './config.js';
+import {
+  createBashTerminalBackend,
+  createPtyTerminalBackend,
+  type EmbeddedTerminalBackend,
+} from './embedded-terminal-manager.js';
+
+export function createEmbeddedTerminalBackendFromConfig(
+  backend: EmbeddedTerminalBackendConfig,
+): EmbeddedTerminalBackend {
+  if (process.env.INVOKER_E2E_BREAK_TERMINAL_SPAWN === '1') {
+    return {
+      name: 'pty',
+      spawn() {
+        throw new Error(
+          'posix_spawnp failed. (injected by INVOKER_E2E_BREAK_TERMINAL_SPAWN)',
+        );
+      },
+    };
+  }
+  if (backend === 'bash') return createBashTerminalBackend();
+  return createPtyTerminalBackend();
+}
+
+export function createEmbeddedTerminalBackend(
+  config: InvokerConfig,
+): EmbeddedTerminalBackend {
+  return createEmbeddedTerminalBackendFromConfig(
+    resolveEmbeddedTerminalBackendConfig(config),
+  );
+}

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -2,7 +2,7 @@
  * Shared logic for opening an external OS terminal for a persisted task.
  */
 
-import type { Logger } from '@invoker/contracts';
+import type { Logger, OpenTerminalResponse } from '@invoker/contracts';
 import * as path from 'node:path';
 import { execSync } from 'node:child_process';
 import { homedir } from 'node:os';
@@ -25,6 +25,8 @@ import {
   spawnDetachedTerminal,
   type OpenTerminalResult,
 } from './terminal-external-launch.js';
+import type { EmbeddedTerminalManager } from './embedded-terminal-manager.js';
+import type { TaskHandleMap } from './execution/task-runner-wiring.js';
 import { resolveEffectiveMaxConcurrency } from './execution-capacity.js';
 
 /** Persistence methods required to resolve terminal cwd / command for a task. */
@@ -51,6 +53,16 @@ export interface OpenExternalTerminalForTaskOptions {
   repoRoot: string;
   /** Shown when task status is `running`. */
   runningTaskReason?: string;
+  logger?: Logger;
+}
+export interface OpenEmbeddedTerminalForTaskOptions {
+  taskId: string;
+  persistence?: OpenTerminalPersistence;
+  executorRegistry: ExecutorRegistry;
+  executionAgentRegistry?: AgentRegistry;
+  repoRoot: string;
+  taskHandles: Pick<TaskHandleMap, 'get'>;
+  embeddedTerminalManager: Pick<EmbeddedTerminalManager, 'openOrReuse'>;
   logger?: Logger;
 }
 
@@ -283,6 +295,80 @@ export function resolveTaskTerminalSpec(
   termLogger?.info(`effective cwd=${cwd} (repoRoot=${repoRoot})`);
 
   return { ok: true, spec, cwd, meta: repairedMeta, executor };
+}
+/**
+ * Opens or reuses an embedded task terminal session. Running tasks only attach
+ * when a live executor handle is present; otherwise the current refusal text is
+ * preserved instead of spawning a second shell.
+ */
+export function openEmbeddedTerminalForTask(
+  opts: OpenEmbeddedTerminalForTaskOptions,
+): OpenTerminalResponse {
+  const {
+    taskId,
+    persistence,
+    executorRegistry,
+    executionAgentRegistry,
+    repoRoot,
+    taskHandles,
+    embeddedTerminalManager,
+    logger,
+  } = opts;
+  logger?.info(`invoked for task="${taskId}"`, { module: 'open-terminal' });
+  const liveHandle = taskHandles.get(taskId);
+  if (!persistence) {
+    if (!liveHandle) {
+      return {
+        opened: false,
+        reason: `Task "${taskId}" terminal metadata is unavailable.`,
+      };
+    }
+    try {
+      const cwd = liveHandle.handle.workspacePath ?? repoRoot;
+      const session = embeddedTerminalManager.openOrReuse({
+        taskId,
+        spec: { cwd },
+        cwd,
+        attach: { handle: liveHandle.handle, executor: liveHandle.executor },
+      });
+      return { opened: true, session };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      logger?.warn(`terminal session attach failed for task="${taskId}": ${reason}`, {
+        module: 'open-terminal',
+      });
+      return { opened: false, reason: `Failed to start terminal session: ${reason}` };
+    }
+  }
+  const resolved = resolveTaskTerminalSpec({
+    taskId,
+    persistence,
+    executorRegistry,
+    executionAgentRegistry,
+    repoRoot,
+    logger,
+    allowRunning: Boolean(liveHandle),
+    runningTaskReason:
+      'Task is still running or being fixed with AI. View output in the terminal panel below.',
+  });
+  if (!resolved.ok) {
+    return { opened: false, reason: resolved.reason };
+  }
+  try {
+    const session = embeddedTerminalManager.openOrReuse({
+      taskId,
+      spec: resolved.spec,
+      cwd: resolved.cwd,
+      attach: liveHandle ? { handle: liveHandle.handle, executor: liveHandle.executor } : undefined,
+    });
+    return { opened: true, session };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    logger?.warn(`terminal session spawn failed for task="${taskId}": ${reason}`, {
+      module: 'open-terminal',
+    });
+    return { opened: false, reason: `Failed to start terminal session: ${reason}` };
+  }
 }
 
 /**

--- a/packages/app/src/task-terminal-adapter.ts
+++ b/packages/app/src/task-terminal-adapter.ts
@@ -1,0 +1,120 @@
+import type {
+  Logger,
+  OpenTerminalResponse,
+  TerminalSessionDescriptor,
+} from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { AgentRegistry, ExecutorRegistry } from '@invoker/execution-engine';
+import type { EmbeddedTerminalManager } from './embedded-terminal-manager.js';
+import type { TaskHandleMap } from './execution/task-runner-wiring.js';
+import {
+  openEmbeddedTerminalForTask,
+  type OpenTerminalPersistence,
+} from './open-terminal-for-task.js';
+import {
+  closeTaskTerminalSession,
+  listTaskTerminalSessions,
+  resizeTaskTerminalSession,
+  writeTaskTerminalSession,
+} from './terminal-session-ipc.js';
+import type {
+  TerminalUiPerfCounters,
+  TerminalUiPerfReporter,
+  TerminalUiPerfSink,
+} from './terminal-ui-perf.js';
+
+export interface TaskTerminalMutationResult {
+  ok: boolean;
+  reason?: string;
+}
+
+export interface TaskTerminalAdapter {
+  open(taskId: string): OpenTerminalResponse | Promise<OpenTerminalResponse>;
+  list(): TerminalSessionDescriptor[] | Promise<TerminalSessionDescriptor[]>;
+  write(
+    sessionId: string,
+    data: string,
+  ): TaskTerminalMutationResult | Promise<TaskTerminalMutationResult>;
+  resize(
+    sessionId: string,
+    cols: number,
+    rows: number,
+  ): TaskTerminalMutationResult | Promise<TaskTerminalMutationResult>;
+  close(sessionId: string): TaskTerminalMutationResult | Promise<TaskTerminalMutationResult>;
+}
+
+export interface CreateTaskTerminalAdapterDeps {
+  persistence: OpenTerminalPersistence &
+    Pick<SQLiteAdapter, 'listTerminalSessions' | 'deleteTerminalSession'>;
+  executorRegistry: ExecutorRegistry;
+  executionAgentRegistry?: AgentRegistry;
+  repoRoot: string;
+  taskHandles: Pick<TaskHandleMap, 'get'>;
+  embeddedTerminalManager: Pick<
+    EmbeddedTerminalManager,
+    'openOrReuse' | 'list' | 'get' | 'write' | 'resize' | 'close'
+  >;
+  uiPerfStats: TerminalUiPerfCounters;
+  terminalUiPerf: TerminalUiPerfReporter;
+  terminalUiPerfSink: TerminalUiPerfSink;
+  logger?: Logger;
+}
+
+export function createTaskTerminalAdapter(
+  deps: CreateTaskTerminalAdapterDeps,
+): TaskTerminalAdapter {
+  return {
+    open(taskId: string) {
+      return openEmbeddedTerminalForTask({
+        taskId,
+        persistence: deps.persistence,
+        executorRegistry: deps.executorRegistry,
+        executionAgentRegistry: deps.executionAgentRegistry,
+        repoRoot: deps.repoRoot,
+        taskHandles: deps.taskHandles,
+        embeddedTerminalManager: deps.embeddedTerminalManager,
+        logger: deps.logger,
+      });
+    },
+    list() {
+      return listTaskTerminalSessions({
+        embeddedTerminalManager: deps.embeddedTerminalManager,
+        persistence: deps.persistence,
+      });
+    },
+    write(sessionId: string, data: string) {
+      return writeTaskTerminalSession(
+        {
+          embeddedTerminalManager: deps.embeddedTerminalManager,
+          uiPerfStats: deps.uiPerfStats,
+          terminalUiPerf: deps.terminalUiPerf,
+          terminalUiPerfSink: deps.terminalUiPerfSink,
+        },
+        sessionId,
+        data,
+      );
+    },
+    resize(sessionId: string, cols: number, rows: number) {
+      return resizeTaskTerminalSession(
+        {
+          embeddedTerminalManager: deps.embeddedTerminalManager,
+          uiPerfStats: deps.uiPerfStats,
+          terminalUiPerf: deps.terminalUiPerf,
+          terminalUiPerfSink: deps.terminalUiPerfSink,
+        },
+        sessionId,
+        cols,
+        rows,
+      );
+    },
+    close(sessionId: string) {
+      return closeTaskTerminalSession(
+        {
+          embeddedTerminalManager: deps.embeddedTerminalManager,
+          persistence: deps.persistence,
+        },
+        sessionId,
+      );
+    },
+  };
+}

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -1,6 +1,6 @@
 import type { IpcMain } from 'electron';
 import type { TerminalSessionDescriptor } from '@invoker/contracts';
-import type { SQLiteAdapter } from '@invoker/data-store';
+import type { SQLiteAdapter, TerminalSessionRecord } from '@invoker/data-store';
 import type { EmbeddedTerminalManager, TerminalSessionPersistenceRecord } from './embedded-terminal-manager.js';
 import {
   timeTerminalResize,
@@ -19,7 +19,7 @@ import {
 /** Coalesce running-session snapshot upserts so PTY output does not 1:1 SQLite-write on main. */
 export const TERMINAL_SESSION_UPSERT_COALESCE_MS = 250;
 
-type TerminalSessionRow = ReturnType<SQLiteAdapter['listTerminalSessions']>[number];
+type TerminalSessionRow = TerminalSessionRecord;
 type PlanningSessionStoreGetter = () => InAppPlanningSessionStore | undefined;
 
 interface PlanningTerminalLogger {
@@ -42,6 +42,93 @@ export function terminalRowToDescriptor(row: TerminalSessionRow): TerminalSessio
     createdAt: row.createdAt,
     outputSnapshot: row.outputSnapshot,
   };
+}
+export function listTaskTerminalSessions(deps: {
+  embeddedTerminalManager: Pick<EmbeddedTerminalManager, 'list'>;
+  persistence: Pick<SQLiteAdapter, 'listTerminalSessions'>;
+}): TerminalSessionDescriptor[] {
+  let persistedRows: TerminalSessionRow[] = [];
+  try {
+    persistedRows = deps.persistence.listTerminalSessions();
+  } catch {
+    persistedRows = [];
+  }
+  const liveSessions = deps.embeddedTerminalManager
+    .list()
+    .filter((session) => session.kind !== 'planning');
+  const live = new Map(liveSessions.map((session) => [session.sessionId, session]));
+  const merged = persistedRows
+    .map((row) => live.get(row.sessionId) ?? terminalRowToDescriptor(row));
+  const persistedIds = new Set(merged.map((session) => session.sessionId));
+  for (const session of live.values()) {
+    if (!persistedIds.has(session.sessionId)) {
+      merged.push(session);
+    }
+  }
+  return merged;
+}
+
+function rejectPlanningTaskTerminalSession(
+  embeddedTerminalManager: Pick<EmbeddedTerminalManager, 'get'>,
+  sessionId: string,
+): { ok: false; reason: string } | null {
+  const session = embeddedTerminalManager.get(sessionId);
+  if (session?.kind === 'planning') {
+    return { ok: false, reason: `Session "${sessionId}" is a planning terminal session.` };
+  }
+  return null;
+}
+
+export function writeTaskTerminalSession(deps: {
+  embeddedTerminalManager: Pick<EmbeddedTerminalManager, 'get' | 'write'>;
+  uiPerfStats: TerminalUiPerfCounters;
+  terminalUiPerf: TerminalUiPerfReporter;
+  terminalUiPerfSink: TerminalUiPerfSink;
+}, sessionId: string, data: string): { ok: boolean; reason?: string } {
+  const rejected = rejectPlanningTaskTerminalSession(deps.embeddedTerminalManager, sessionId);
+  if (rejected) return rejected;
+  return timeTerminalWrite(
+    () => deps.embeddedTerminalManager.write(sessionId, data),
+    deps.uiPerfStats,
+    deps.terminalUiPerf,
+    deps.terminalUiPerfSink,
+    {
+      sessionId,
+      bytes: typeof data === 'string' ? data.length : 0,
+    },
+  );
+}
+
+export function resizeTaskTerminalSession(deps: {
+  embeddedTerminalManager: Pick<EmbeddedTerminalManager, 'get' | 'resize'>;
+  uiPerfStats: TerminalUiPerfCounters;
+  terminalUiPerf: TerminalUiPerfReporter;
+  terminalUiPerfSink: TerminalUiPerfSink;
+}, sessionId: string, cols: number, rows: number): { ok: boolean; reason?: string } {
+  const rejected = rejectPlanningTaskTerminalSession(deps.embeddedTerminalManager, sessionId);
+  if (rejected) return rejected;
+  return timeTerminalResize(
+    () => deps.embeddedTerminalManager.resize(sessionId, cols, rows),
+    deps.uiPerfStats,
+    deps.terminalUiPerf,
+    deps.terminalUiPerfSink,
+    {
+      sessionId,
+      cols,
+      rows,
+    },
+  );
+}
+
+export function closeTaskTerminalSession(deps: {
+  embeddedTerminalManager: Pick<EmbeddedTerminalManager, 'get' | 'close'>;
+  persistence?: Pick<SQLiteAdapter, 'deleteTerminalSession'>;
+}, sessionId: string): { ok: boolean; reason?: string } {
+  const rejected = rejectPlanningTaskTerminalSession(deps.embeddedTerminalManager, sessionId);
+  if (rejected) return rejected;
+  const result = deps.embeddedTerminalManager.close(sessionId);
+  deps.persistence?.deleteTerminalSession(sessionId);
+  return result.ok ? result : { ok: true };
 }
 
 export function restorePersistedTerminalSessions(deps: {
@@ -215,63 +302,47 @@ export function registerTerminalSessionIpcHandlers(deps: {
   const { ipcMain, embeddedTerminalManager, persistence, uiPerfStats, terminalUiPerf, terminalUiPerfSink } = deps;
 
   ipcMain.handle('invoker:terminal-list', async () => {
-    const liveSessions = embeddedTerminalManager
-      .list()
-      .filter((session) => session.kind !== 'planning');
-    const live = new Map(liveSessions.map((session) => [session.sessionId, session]));
-    const merged = persistence.listTerminalSessions().map((row) => live.get(row.sessionId) ?? terminalRowToDescriptor(row));
-    const persistedIds = new Set(merged.map((session) => session.sessionId));
-    for (const session of live.values()) {
-      if (!persistedIds.has(session.sessionId)) {
-        merged.push(session);
-      }
-    }
-    return merged;
+    return listTaskTerminalSessions({
+      embeddedTerminalManager,
+      persistence,
+    });
   });
 
   ipcMain.handle('invoker:terminal-write', async (_event, sessionId: string, data: string) => {
-    const session = embeddedTerminalManager.get(sessionId);
-    if (session?.kind === 'planning') {
-      return { ok: false, reason: `Session "${sessionId}" is a planning terminal session.` };
-    }
-    return timeTerminalWrite(
-      () => embeddedTerminalManager.write(sessionId, data),
-      uiPerfStats,
-      terminalUiPerf,
-      terminalUiPerfSink,
+    return writeTaskTerminalSession(
       {
-        sessionId,
-        bytes: typeof data === 'string' ? data.length : 0,
+        embeddedTerminalManager,
+        uiPerfStats,
+        terminalUiPerf,
+        terminalUiPerfSink,
       },
+      sessionId,
+      data,
     );
   });
 
   ipcMain.handle('invoker:terminal-resize', async (_event, sessionId: string, cols: number, rows: number) => {
-    const session = embeddedTerminalManager.get(sessionId);
-    if (session?.kind === 'planning') {
-      return { ok: false, reason: `Session "${sessionId}" is a planning terminal session.` };
-    }
-    return timeTerminalResize(
-      () => embeddedTerminalManager.resize(sessionId, cols, rows),
-      uiPerfStats,
-      terminalUiPerf,
-      terminalUiPerfSink,
+    return resizeTaskTerminalSession(
       {
-        sessionId,
-        cols,
-        rows,
+        embeddedTerminalManager,
+        uiPerfStats,
+        terminalUiPerf,
+        terminalUiPerfSink,
       },
+      sessionId,
+      cols,
+      rows,
     );
   });
 
   ipcMain.handle('invoker:terminal-close', async (_event, sessionId: string) => {
-    const session = embeddedTerminalManager.get(sessionId);
-    if (session?.kind === 'planning') {
-      return { ok: false, reason: `Session "${sessionId}" is a planning terminal session.` };
-    }
-    const result = embeddedTerminalManager.close(sessionId);
-    persistence.deleteTerminalSession(sessionId);
-    return result.ok ? result : { ok: true };
+    return closeTaskTerminalSession(
+      {
+        embeddedTerminalManager,
+        persistence,
+      },
+      sessionId,
+    );
   });
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       aws4:
         specifier: ^1.13.2
         version: 1.13.2
+      concurrently:
+        specifier: ^10.0.4
+        version: 10.0.4
       dependency-cruiser:
         specifier: ^17.3.10
         version: 17.3.10
@@ -2411,6 +2414,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
@@ -2462,6 +2469,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
 
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
@@ -2521,6 +2532,11 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concurrently@10.0.4:
+    resolution: {integrity: sha512-trZql+7l/0+WRAsAnEdctr4+iiOS6ZrViI6H8QWcCF9MFS/LT0dKpe8vluB1to6it+OxSI4VospFTIFMW8DJRw==}
+    engines: {node: '>=22'}
+    hasBin: true
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -2905,6 +2921,9 @@ packages:
   elkjs@0.10.2:
     resolution: {integrity: sha512-Yx3ORtbAFrXelYkAy2g0eYyVY8QG0XEmGdQXmy0eithKKjbWRfl3Xe884lfkszfBF6UKyIy4LwfcZ3AZc8oxFw==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -3149,6 +3168,10 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -4260,6 +4283,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
+    engines: {node: '>= 0.4'}
+
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
@@ -4369,6 +4396,10 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
@@ -4402,6 +4433,10 @@ packages:
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4827,6 +4862,10 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -4886,9 +4925,17 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -6717,6 +6764,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   check-error@2.1.3: {}
 
   chokidar@3.6.0:
@@ -6769,6 +6818,12 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
   clone-response@1.0.3:
     dependencies:
       mimic-response: 1.0.1
@@ -6814,6 +6869,15 @@ snapshots:
   compare-version@0.1.2: {}
 
   concat-map@0.0.1: {}
+
+  concurrently@10.0.4:
+    dependencies:
+      chalk: 5.6.2
+      rxjs: 7.8.2
+      shell-quote: 1.9.0
+      supports-color: 10.2.2
+      tree-kill: 1.2.2
+      yargs: 18.0.0
 
   confbox@0.1.8: {}
 
@@ -7286,6 +7350,8 @@ snapshots:
 
   elkjs@0.10.2: {}
 
+  emoji-regex@10.6.0: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -7592,6 +7658,8 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -8723,6 +8791,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.9.0: {}
+
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -8840,6 +8910,12 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -8879,6 +8955,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  supports-color@10.2.2: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -9376,6 +9454,12 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
@@ -9404,6 +9488,8 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
+  yargs-parser@22.0.0: {}
+
   yargs@17.7.2:
     dependencies:
       cliui: 8.0.1
@@ -9413,6 +9499,15 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   yauzl@2.10.0:
     dependencies:


### PR DESCRIPTION
## Summary

Task-terminal backend rules now use one shared helper path.

Task-terminal open and session actions lived in more than one owner entry point. That made web reuse awkward and left the running-task and restore rules harder to keep aligned.

This slice centralizes task-terminal open, session actions, and backend selection, and keeps the live-handle attach fallback when persistence metadata is missing.

## Review Claim

Task-terminal backend behavior now goes through one shared routing path with the same running-task and restore rules everywhere.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice does not expose browser terminals yet. It only unifies owner-side task-terminal behavior and adds focused coverage for the edge cases.

## Slice Rationale

The browser surface needs one owner-side terminal path before the transport layer can reuse it safely.

## Non-goals

- No browser terminal routing yet.
- No planning tmux browser support.
- No renderer behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/open-terminal.test.ts src/__tests__/terminal-session-persistence.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
