### PR TITLE
[Web task terminals](4) Enable headless task terminal handles

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "clean": "pnpm -r clean",
     "setup:agent-skills": "bash scripts/setup-agent-skills.sh",
     "dev": "pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && pnpm --filter @invoker/app start",
-    "dev:hot": "concurrently \"pnpm --filter @invoker/ui dev\" \"sleep 3 && VITE_DEV_SERVER_URL=http://localhost:5173 pnpm --filter @invoker/app build && VITE_DEV_SERVER_URL=http://localhost:5173 pnpm --filter @invoker/app start\"",
+    "dev:hot": "concurrently --kill-others-on-fail \"pnpm --filter @invoker/ui exec vite --host 127.0.0.1 --port 5173 --strictPort\" \"sleep 3 && VITE_DEV_SERVER_URL=http://127.0.0.1:5173 pnpm --filter @invoker/app build && VITE_DEV_SERVER_URL=http://127.0.0.1:5173 pnpm --filter @invoker/app start\"",
     "dev:cli": "pnpm --filter @invoker/cli build && node packages/cli/dist/index.js",
     "check:required-builds": "bash scripts/required-builds.sh",
     "check:deps": "depcruise packages --config .dependency-cruiser.js",
@@ -63,6 +63,7 @@
   "devDependencies": {
     "@mergifyio/vitest": "^0.3.0",
     "aws4": "^1.13.2",
+    "concurrently": "^10.0.4",
     "dependency-cruiser": "^17.3.10",
     "electron-builder": "^26.0.12",
     "jsdom": "^25.0.0",

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -25,31 +25,41 @@ import {
 } from '@invoker/workflow-core';
 import type { TaskStateChanges } from '@invoker/workflow-graph';
 import {
-  DockerExecutor, WorktreeExecutor, ExecutorRegistry, SshExecutor,
+  DockerExecutor,
+  WorktreeExecutor,
+  ExecutorRegistry,
+  SshExecutor,
   MergeGateExecutor,
   BaseExecutor,
   getEffectivePath,
-  type ExecutorHandle, type TerminalSpec, type PersistedTaskMeta,
+  registerBuiltinAgents as registerBuiltinAgentsStatic,
+  type Executor,
+  type ExecutorHandle,
+  type TerminalSpec,
+  type PersistedTaskMeta,
 } from '@invoker/execution-engine';
-import type { WorkResponse, WorkRequest } from '@invoker/contracts';
-vi.mock('../terminal-external-launch.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../terminal-external-launch.js')>();
-  return {
-    ...actual,
-    spawnDetachedTerminal: vi.fn(async () => ({ opened: true })),
-  };
-});
+import type * as NodeFsModule from 'node:fs';
+import type * as TerminalExternalLaunchModule from '../terminal-external-launch.js';
 import {
   buildLinuxXTerminalBashScript,
   buildMacOSOsascriptArgs,
   buildTerminalShellCommand,
   spawnDetachedTerminal,
 } from '../terminal-external-launch.js';
-import { openExternalTerminalForTask } from '../open-terminal-for-task.js';
+import { openEmbeddedTerminalForTask, openExternalTerminalForTask } from '../open-terminal-for-task.js';
+import type { EmbeddedTerminalManager } from '../embedded-terminal-manager.js';
 import * as configModule from '../config.js';
 
+vi.mock('../terminal-external-launch.js', async (importOriginal) => {
+  const actual = await importOriginal<TerminalExternalLaunchModule>();
+  return {
+    ...actual,
+    spawnDetachedTerminal: vi.fn(async () => ({ opened: true })),
+  };
+});
+
 vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs')>();
+  const actual = await importOriginal<NodeFsModule>();
   return { ...actual, existsSync: vi.fn(actual.existsSync) };
 });
 import { existsSync } from 'node:fs';
@@ -1044,7 +1054,7 @@ describe('SshExecutor getRestoredTerminalSpec', () => {
 
 describe('getRestoredTerminalSpec dispatches codex vs claude session resume', () => {
   // Lazy import to avoid circular dep issues at module level
-  let registerBuiltinAgents: typeof import('@invoker/execution-engine').registerBuiltinAgents;
+  let registerBuiltinAgents: typeof registerBuiltinAgentsStatic;
 
   beforeEach(async () => {
     ({ registerBuiltinAgents } = await import('@invoker/execution-engine'));
@@ -1209,7 +1219,7 @@ describe('getRestoredTerminalSpec dispatches codex vs claude session resume', ()
  * openExternalTerminalForTask does, and getRestoredTerminalSpec dispatches correctly.
  */
 describe('fix-with-agent → open-terminal produces correct agent resume command', () => {
-  let registerBuiltinAgents: typeof import('@invoker/execution-engine').registerBuiltinAgents;
+  let registerBuiltinAgents: typeof registerBuiltinAgentsStatic;
 
   beforeEach(async () => {
     ({ registerBuiltinAgents } = await import('@invoker/execution-engine'));
@@ -1647,5 +1657,46 @@ describe('openExternalTerminalForTask fail-fast workspace invariant', () => {
       expect(result.reason).not.toContain('workspace metadata is missing');
       expect(result.reason).not.toContain('requires a managed workspace');
     }
+  });
+});
+
+describe('openEmbeddedTerminalForTask', () => {
+  it('attaches running tasks without persistence metadata when a live handle exists', () => {
+    const openOrReuse = vi.fn(() => ({
+      sessionId: 'session-1',
+      taskId: 'task-1',
+      kind: 'task',
+      status: 'running',
+      mode: 'attached',
+      attached: true,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      outputSnapshot: '',
+    }));
+    const liveExecutor = { type: 'worktree' } as unknown as Executor;
+    const liveHandle = {
+      executionId: 'exec-1',
+      taskId: 'task-1',
+      workspacePath: '/tmp/task-1',
+    } as ExecutorHandle;
+
+    const result = openEmbeddedTerminalForTask({
+      taskId: 'task-1',
+      executorRegistry: new ExecutorRegistry(),
+      repoRoot: '/repo',
+      taskHandles: new Map([['task-1', { handle: liveHandle, executor: liveExecutor }]]),
+      embeddedTerminalManager: { openOrReuse } as unknown as Pick<EmbeddedTerminalManager, 'openOrReuse'>,
+    });
+
+    expect(result).toEqual({
+      opened: true,
+      session: expect.objectContaining({ sessionId: 'session-1', taskId: 'task-1', mode: 'attached' }),
+    });
+    expect(openOrReuse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: 'task-1',
+        cwd: '/tmp/task-1',
+        attach: { handle: liveHandle, executor: liveExecutor },
+      }),
+    );
   });
 });

--- a/packages/app/src/__tests__/start-web-surface.test.ts
+++ b/packages/app/src/__tests__/start-web-surface.test.ts
@@ -1,19 +1,122 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { AgentRegistry, ExecutorRegistry } from '@invoker/execution-engine';
+import type { Orchestrator } from '@invoker/workflow-core';
+
+const mocks = vi.hoisted(() => {
+  const bridgeClose = vi.fn(async () => undefined);
+  const bridgeBroadcast = vi.fn();
+  const terminalSessionDispose = vi.fn();
+  const terminalSessionFlushPending = vi.fn();
+  return {
+    bridgeClose,
+    bridgeBroadcast,
+    startWebBridge: vi.fn(() => ({
+      close: bridgeClose,
+      whenReady: Promise.resolve(4200),
+      broadcast: bridgeBroadcast,
+      port: 4200,
+    })),
+    resolveWebUiDistDir: vi.fn(() => '/tmp/ui'),
+    terminalSessionDispose,
+    terminalSessionFlushPending,
+    registerTerminalSessionPersistence: vi.fn(() => ({
+      flushPending: terminalSessionFlushPending,
+      dispose: terminalSessionDispose,
+    })),
+    createTaskTerminalAdapter: vi.fn(() => ({
+      open: vi.fn(async () => ({ opened: true })),
+      list: vi.fn(async () => []),
+      write: vi.fn(async () => ({ ok: true })),
+      resize: vi.fn(async () => ({ ok: true })),
+      close: vi.fn(async () => ({ ok: true })),
+    })),
+    createEmbeddedTerminalBackend: vi.fn(() => ({
+      name: 'bash',
+      spawn: vi.fn(),
+    })),
+  };
+});
+
+vi.mock('../web/web-bridge-server.js', () => ({
+  startWebBridge: mocks.startWebBridge,
+  resolveWebUiDistDir: mocks.resolveWebUiDistDir,
+}));
+
+vi.mock('../terminal-session-ipc.js', () => ({
+  registerTerminalSessionPersistence: mocks.registerTerminalSessionPersistence,
+}));
+
+vi.mock('../task-terminal-adapter.js', () => ({
+  createTaskTerminalAdapter: mocks.createTaskTerminalAdapter,
+}));
+
+vi.mock('../embedded-terminal-backend.js', () => ({
+  createEmbeddedTerminalBackend: mocks.createEmbeddedTerminalBackend,
+}));
+
 import {
   resolveWebToken,
   resolveWebHost,
   resolveWebPort,
   startHeadlessWebSurface,
+  type StartHeadlessWebSurfaceDeps,
 } from '../web/start-web-surface.js';
 
 const ENV_KEYS = ['INVOKER_WEB_TOKEN', 'INVOKER_WEB_HOST', 'INVOKER_WEB_PORT'] as const;
 const saved: Record<string, string | undefined> = {};
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+function makeDeps(
+  overrides: Partial<StartHeadlessWebSurfaceDeps> = {},
+): StartHeadlessWebSurfaceDeps {
+  return {
+    logger: makeLogger(),
+    orchestrator: {
+      syncAllFromDb: vi.fn(),
+      getAllTasks: vi.fn(() => []),
+    } as unknown as Orchestrator,
+    persistence: {
+      listWorkflows: vi.fn(() => []),
+      getActivityLogs: vi.fn(() => []),
+      writeActivityLog: vi.fn(),
+      listTerminalSessions: vi.fn(() => []),
+      loadTask: vi.fn(() => undefined),
+      deleteTerminalSession: vi.fn(),
+      updateTerminalSession: vi.fn(),
+      upsertTerminalSession: vi.fn(),
+    } as unknown as SQLiteAdapter,
+    messageBus: {
+      subscribe: vi.fn(() => vi.fn()),
+    } as unknown as StartHeadlessWebSurfaceDeps['messageBus'],
+    agentRegistry: {} as AgentRegistry,
+    mutations: {} as StartHeadlessWebSurfaceDeps['mutations'],
+    deleteWorkflow: vi.fn(async () => undefined),
+    detachWorkflow: vi.fn(async () => undefined),
+    loadConfig: () => ({}),
+    config: {},
+    appRootDir: '/tmp/app',
+    ...overrides,
+  };
+}
 
 beforeEach(() => {
   for (const key of ENV_KEYS) {
     saved[key] = process.env[key];
     delete process.env[key];
   }
+  mocks.bridgeClose.mockClear();
+  mocks.bridgeBroadcast.mockClear();
+  mocks.startWebBridge.mockClear();
+  mocks.resolveWebUiDistDir.mockClear();
+  mocks.terminalSessionDispose.mockClear();
+  mocks.terminalSessionFlushPending.mockClear();
+  mocks.registerTerminalSessionPersistence.mockClear();
+  mocks.createTaskTerminalAdapter.mockClear();
+  mocks.createEmbeddedTerminalBackend.mockClear();
 });
 
 afterEach(() => {
@@ -44,26 +147,72 @@ describe('web surface configuration resolution', () => {
   });
 });
 
-describe('startHeadlessWebSurface token gate', () => {
+describe('startHeadlessWebSurface', () => {
   it('returns null and starts no server when no token is configured', () => {
-    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
-    const subscribe = vi.fn();
-    const result = startHeadlessWebSurface({
-      logger: logger as never,
-      orchestrator: {} as never,
-      persistence: {} as never,
-      messageBus: { subscribe } as never,
-      agentRegistry: {} as never,
-      mutations: {} as never,
-      deleteWorkflow: vi.fn(),
-      detachWorkflow: vi.fn(),
-      loadConfig: () => ({}),
-      config: {},
-      appRootDir: '/tmp',
-    });
+    const deps = makeDeps();
+
+    const result = startHeadlessWebSurface(deps);
+
     expect(result).toBeNull();
-    // No token => no task.delta subscription, no server wiring.
-    expect(subscribe).not.toHaveBeenCalled();
-    expect(logger.info).toHaveBeenCalled();
+    expect(deps.messageBus.subscribe).not.toHaveBeenCalled();
+    expect(deps.logger.info).toHaveBeenCalled();
+    expect(mocks.startWebBridge).not.toHaveBeenCalled();
+  });
+
+  it('keeps browser task terminals disabled when terminal deps are absent', async () => {
+    const deps = makeDeps({ config: { webToken: 'secret' } });
+
+    const result = startHeadlessWebSurface(deps);
+
+    expect(result).not.toBeNull();
+    expect(mocks.createTaskTerminalAdapter).not.toHaveBeenCalled();
+    expect(mocks.registerTerminalSessionPersistence).not.toHaveBeenCalled();
+    expect(mocks.startWebBridge).toHaveBeenCalledWith(
+      expect.objectContaining({ terminalEvents: undefined }),
+    );
+
+    const dispatch = mocks.startWebBridge.mock.calls[0]?.[0].dispatch as (
+      channel: string,
+      args: unknown[],
+    ) => Promise<unknown>;
+    await expect(dispatch('invoker:open-terminal', ['task-1'])).resolves.toEqual({
+      opened: false,
+      reason: 'Terminals are not available in the web UI',
+    });
+    await expect(dispatch('invoker:terminal-list', [])).resolves.toEqual([]);
+
+    await result?.close();
+  });
+
+  it('wires task terminal support and disposes persistence on close when terminal deps are supplied', async () => {
+    const taskHandles = new Map();
+    const deps = makeDeps({
+      config: { webToken: 'secret' },
+      repoRoot: '/repo',
+      executorRegistry: {} as ExecutorRegistry,
+      taskHandles,
+    });
+
+    const result = startHeadlessWebSurface(deps);
+
+    expect(result).not.toBeNull();
+    expect(mocks.createEmbeddedTerminalBackend).toHaveBeenCalledWith(deps.config);
+    expect(mocks.registerTerminalSessionPersistence).toHaveBeenCalledTimes(1);
+    expect(mocks.createTaskTerminalAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        persistence: deps.persistence,
+        executorRegistry: deps.executorRegistry,
+        repoRoot: '/repo',
+        taskHandles,
+      }),
+    );
+    expect(mocks.startWebBridge).toHaveBeenCalledWith(
+      expect.objectContaining({ terminalEvents: expect.any(Object) }),
+    );
+
+    await result?.close();
+
+    expect(mocks.terminalSessionDispose).toHaveBeenCalledTimes(1);
+    expect(mocks.bridgeClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/__tests__/terminal-session-persistence.test.ts
+++ b/packages/app/src/__tests__/terminal-session-persistence.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import type { IpcMain } from 'electron';
 import { EventEmitter } from 'node:events';
 import {
   EmbeddedTerminalManager,
@@ -6,17 +7,30 @@ import {
   type BashSpawnFn,
 } from '../embedded-terminal-manager.js';
 import {
+  closeTaskTerminalSession,
+  listTaskTerminalSessions,
   registerTerminalSessionIpcHandlers,
   registerTerminalSessionPersistence,
+  restorePersistedTerminalSessions,
 } from '../terminal-session-ipc.js';
+import type { SQLiteAdapter, TerminalSessionRecord } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
 import {
   createTerminalUiPerfCounters,
   createTerminalUiPerfReporter,
   createTerminalUiPerfSink,
 } from '../terminal-ui-perf.js';
 
-function createFakeChild() {
-  const ee = new EventEmitter() as any;
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: { write: Mock };
+  killed: boolean;
+  kill: Mock;
+}
+
+function createFakeChild(): FakeChild {
+  const ee = new EventEmitter() as FakeChild;
   ee.stdout = new EventEmitter();
   ee.stderr = new EventEmitter();
   ee.stdin = { write: vi.fn() };
@@ -25,6 +39,29 @@ function createFakeChild() {
   return ee;
 }
 
+function makeTerminalRow(
+  sessionId: string,
+  taskId: string,
+  overrides: Partial<TerminalSessionRecord> = {},
+): TerminalSessionRecord {
+  return {
+    sessionId,
+    taskId,
+    targetKey: `target:${sessionId}`,
+    status: 'running',
+    exitCode: undefined,
+    cwd: `/tmp/${taskId}`,
+    command: undefined,
+    args: [],
+    linuxTerminalTail: undefined,
+    mode: 'spawn',
+    attached: false,
+    outputSnapshot: '',
+    createdAt: '2026-07-26T00:00:00.000Z',
+    updatedAt: '2026-07-26T00:00:00.000Z',
+    ...overrides,
+  };
+}
 describe('registerTerminalSessionPersistence coalesce', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -51,7 +88,10 @@ describe('registerTerminalSessionPersistence coalesce', () => {
     };
     const handle = registerTerminalSessionPersistence({
       embeddedTerminalManager: mgr,
-      persistence: persistence as any,
+      persistence: persistence as Pick<
+        SQLiteAdapter,
+        'upsertTerminalSession' | 'listTerminalSessions' | 'loadTask' | 'deleteTerminalSession' | 'updateTerminalSession'
+      >,
       uiPerfStats: createTerminalUiPerfCounters(),
       terminalUiPerf: createTerminalUiPerfReporter({ throttleMs: 0 }),
       terminalUiPerfSink: createTerminalUiPerfSink(() => {}, createTerminalUiPerfCounters()),
@@ -133,16 +173,17 @@ describe('registerTerminalSessionPersistence coalesce', () => {
 
   it('keeps task terminal IPC routes isolated from planning sessions', async () => {
     const { mgr, persistence, handle } = setup(100);
-    const handlers = new Map<string, (...args: any[]) => Promise<any>>();
+    type IpcHandler = (...args: unknown[]) => Promise<unknown>;
+    const handlers = new Map<string, IpcHandler>();
     const ipcMain = {
-      handle: vi.fn((channel: string, callback: (...args: any[]) => Promise<any>) => {
+      handle(channel: string, callback: IpcHandler) {
         handlers.set(channel, callback);
-      }),
+      },
     };
     registerTerminalSessionIpcHandlers({
-      ipcMain: ipcMain as any,
+      ipcMain: ipcMain as unknown as IpcMain,
       embeddedTerminalManager: mgr,
-      persistence: persistence as any,
+      persistence: persistence as unknown as Pick<SQLiteAdapter, 'listTerminalSessions' | 'deleteTerminalSession'>,
       uiPerfStats: createTerminalUiPerfCounters(),
       terminalUiPerf: createTerminalUiPerfReporter({ throttleMs: 0 }),
       terminalUiPerfSink: createTerminalUiPerfSink(() => {}, createTerminalUiPerfCounters()),
@@ -180,5 +221,135 @@ describe('registerTerminalSessionPersistence coalesce', () => {
     });
 
     handle.dispose();
+  });
+  it('falls back to live task sessions when persisted terminal rows fail to load', () => {
+    const child = createFakeChild();
+    const mgr = new EmbeddedTerminalManager({
+      backend: createBashTerminalBackend({ spawnFn: (() => child) as unknown as BashSpawnFn }),
+    });
+    const liveTask = mgr.openOrReuse({ taskId: 'task-live', spec: {}, cwd: '/tmp/task-live' });
+
+    const sessions = listTaskTerminalSessions({
+      embeddedTerminalManager: mgr,
+      persistence: {
+        listTerminalSessions: () => {
+          throw new Error('db read failed');
+        },
+      },
+    });
+
+    expect(sessions).toEqual([
+      expect.objectContaining({
+        sessionId: liveTask.sessionId,
+        taskId: 'task-live',
+        kind: 'task',
+      }),
+    ]);
+  });
+  it('closes live task sessions even when persistence is unavailable', () => {
+    const child = createFakeChild();
+    const mgr = new EmbeddedTerminalManager({
+      backend: createBashTerminalBackend({ spawnFn: (() => child) as unknown as BashSpawnFn }),
+    });
+    const session = mgr.openOrReuse({ taskId: 'task-live', spec: {}, cwd: '/tmp/task-live' });
+
+    const result = closeTaskTerminalSession({
+      embeddedTerminalManager: mgr,
+    }, session.sessionId);
+
+    expect(result).toEqual({ ok: true });
+    expect(mgr.get(session.sessionId)).toBeUndefined();
+  });
+  it('merges persisted task sessions with live task sessions and filters planning sessions', () => {
+    const child = createFakeChild();
+    const mgr = new EmbeddedTerminalManager({
+      backend: createBashTerminalBackend({ spawnFn: (() => child) as unknown as BashSpawnFn }),
+    });
+    const liveTask = mgr.openOrReuse({ taskId: 'task-live', spec: {}, cwd: '/tmp/task-live' });
+    mgr.openOrReuse({
+      kind: 'planning',
+      taskId: 'planning:plan-1',
+      planningSessionId: 'plan-1',
+      spec: { cwd: '/repo' },
+      cwd: '/repo',
+    });
+
+    const taskPersistence: Pick<SQLiteAdapter, 'listTerminalSessions'> = {
+      listTerminalSessions: () => [
+        makeTerminalRow(liveTask.sessionId, 'task-live', {
+          outputSnapshot: 'persisted-snapshot',
+        }),
+        makeTerminalRow('persisted-only', 'task-persisted', {
+          outputSnapshot: 'persisted-only-output',
+        }),
+      ],
+    };
+    const sessions = listTaskTerminalSessions({
+      embeddedTerminalManager: mgr,
+      persistence: taskPersistence,
+    });
+
+    expect(sessions).toEqual([
+      expect.objectContaining({
+        sessionId: liveTask.sessionId,
+        taskId: 'task-live',
+        kind: 'task',
+        outputSnapshot: liveTask.outputSnapshot,
+      }),
+      expect.objectContaining({
+        sessionId: 'persisted-only',
+        taskId: 'task-persisted',
+        kind: 'task',
+        outputSnapshot: 'persisted-only-output',
+      }),
+    ]);
+  });
+
+  it('restores running spawn sessions and expires attached sessions after owner restart', () => {
+    const restoreSpawnSession = vi.fn();
+    const updateTerminalSession = vi.fn();
+
+    const embeddedTerminalManager: Pick<EmbeddedTerminalManager, 'restoreSpawnSession'> = {
+      restoreSpawnSession,
+    };
+    const persistence: Pick<
+      SQLiteAdapter,
+      'listTerminalSessions' | 'loadTask' | 'deleteTerminalSession' | 'updateTerminalSession'
+    > = {
+      listTerminalSessions: () => [
+        makeTerminalRow('spawn-running', 'task-spawn', {
+          cwd: '/tmp/task-spawn',
+          outputSnapshot: 'spawn-output',
+          mode: 'spawn',
+          attached: false,
+        }),
+        makeTerminalRow('attached-running', 'task-attached', {
+          mode: 'attached',
+          attached: true,
+          outputSnapshot: 'attached-output',
+        }),
+      ],
+      loadTask: () => ({ id: 'task' } as unknown as TaskState),
+      deleteTerminalSession: vi.fn(),
+      updateTerminalSession,
+    };
+
+    restorePersistedTerminalSessions({
+      embeddedTerminalManager,
+      persistence,
+    });
+
+    expect(restoreSpawnSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'spawn-running',
+        taskId: 'task-spawn',
+        cwd: '/tmp/task-spawn',
+        outputSnapshot: 'spawn-output',
+      }),
+    );
+    expect(updateTerminalSession).toHaveBeenCalledWith(
+      'attached-running',
+      expect.objectContaining({ status: 'exited' }),
+    );
   });
 });

--- a/packages/app/src/__tests__/web-bridge-server.test.ts
+++ b/packages/app/src/__tests__/web-bridge-server.test.ts
@@ -25,6 +25,30 @@ function makeBus() {
     },
   };
 }
+function makeTerminalEvents() {
+  let outputListener: ((payload: unknown) => void) | null = null;
+  let exitListener: ((payload: unknown) => void) | null = null;
+  return {
+    onOutput(cb: (payload: unknown) => void) {
+      outputListener = cb;
+      return () => {
+        outputListener = null;
+      };
+    },
+    onExit(cb: (payload: unknown) => void) {
+      exitListener = cb;
+      return () => {
+        exitListener = null;
+      };
+    },
+    emitOutput(payload: unknown) {
+      outputListener?.(payload);
+    },
+    emitExit(payload: unknown) {
+      exitListener?.(payload);
+    },
+  };
+}
 
 interface RequestResult {
   status: number;
@@ -58,7 +82,10 @@ function request(
 
 let bridge: WebBridge | null = null;
 
-async function startBridge(dispatch = vi.fn(async () => ({ ok: true }))) {
+async function startBridge(
+  dispatch = vi.fn(async () => ({ ok: true })),
+  options: { terminalEvents?: { onOutput(cb: (payload: unknown) => void): () => void; onExit(cb: (payload: unknown) => void): () => void } } = {},
+) {
   const bus = makeBus();
   bridge = startWebBridge({
     dispatch: dispatch as never,
@@ -68,6 +95,7 @@ async function startBridge(dispatch = vi.fn(async () => ({ ok: true }))) {
     token: TOKEN,
     host: '127.0.0.1',
     port: 0,
+    terminalEvents: options.terminalEvents as never,
   });
   const port = await bridge.whenReady;
   return { port, bus, dispatch };
@@ -196,6 +224,42 @@ describe('startWebBridge', () => {
     expect(received).toContain('event: invoker:task-graph-event');
     expect(received).toContain('event: invoker:task-output');
     expect(received).toContain('"taskId":"wf-1/task-1"');
+  });
+  it('streams terminal output and exit events over /events', async () => {
+    const terminalEvents = makeTerminalEvents();
+    const { port } = await startBridge(undefined, { terminalEvents });
+    const { promise, resolve } = Promise.withResolvers<string>();
+    const req = http.request(
+      { host: '127.0.0.1', port, path: '/events', headers: { cookie: `invoker_web=${TOKEN}` } },
+      (res) => {
+        expect(res.statusCode).toBe(200);
+        let buffer = '';
+        res.on('data', (c) => {
+          buffer += (c as Buffer).toString('utf8');
+          if (
+            buffer.includes('event: invoker:terminal-output')
+            && buffer.includes('event: invoker:terminal-exit')
+          ) {
+            req.destroy();
+            resolve(buffer);
+          }
+        });
+      },
+    );
+    req.on('error', () => { /* destroyed after resolve */ });
+    req.end();
+
+    await new Promise((r) => setTimeout(r, 50));
+    terminalEvents.emitOutput({ sessionId: 'session-1', taskId: 'task-1', chunk: 'hello' });
+    terminalEvents.emitExit({ sessionId: 'session-1', taskId: 'task-1', exitCode: 0 });
+
+    const received = await Promise.race([
+      promise,
+      new Promise<string>((_, rej) => setTimeout(() => rej(new Error('terminal SSE timeout')), 2000)),
+    ]);
+    expect(received).toContain('event: invoker:terminal-output');
+    expect(received).toContain('event: invoker:terminal-exit');
+    expect(received).toContain('"sessionId":"session-1"');
   });
 });
 

--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { buildWebInvokerDispatch } from '../web/web-invoker-dispatch.js';
+import type { InvokerConfig } from '../config.js';
 
 function makeTask(id: string) {
   return {
@@ -35,6 +36,18 @@ function makeDispatch(overrides: Record<string, unknown> = {}) {
   };
   return { dispatch: buildWebInvokerDispatch(deps as never), approveTask };
 }
+function makeTaskTerminalAdapter() {
+  return {
+    open: vi.fn(async (taskId: string) => ({
+      opened: true,
+      session: { sessionId: `session-${taskId}`, taskId, kind: 'task', status: 'running' },
+    })),
+    list: vi.fn(async () => [{ sessionId: 'session-1', taskId: 'task-1', kind: 'task', status: 'running' }]),
+    write: vi.fn(async (sessionId: string, data: string) => ({ ok: true, sessionId, bytes: data.length })),
+    resize: vi.fn(async (sessionId: string, cols: number, rows: number) => ({ ok: true, sessionId, cols, rows })),
+    close: vi.fn(async (sessionId: string) => ({ ok: true, sessionId })),
+  };
+}
 
 describe('buildWebInvokerDispatch', () => {
   it('list-workflows returns the persisted workflows', async () => {
@@ -65,12 +78,13 @@ describe('buildWebInvokerDispatch', () => {
 
   it('get-planning-presets returns configured planning presets', async () => {
     const { dispatch } = makeDispatch({
-      loadConfig: () => ({
-        defaultSlackHarnessPreset: 'omp+claude',
-        slackHarnessPresets: {
-          custom: { tool: 'codex' },
-        },
-      } as any),
+      loadConfig: () =>
+        ({
+          defaultSlackHarnessPreset: 'omp+claude',
+          slackHarnessPresets: {
+            custom: { tool: 'codex' },
+          },
+        } as unknown as InvokerConfig),
     });
     expect(await dispatch('invoker:get-planning-presets', [])).toEqual(expect.arrayContaining([
       { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude', isDefault: true },
@@ -80,7 +94,8 @@ describe('buildWebInvokerDispatch', () => {
 
   it('get-execution-defaults returns configured task execution defaults', async () => {
     const { dispatch } = makeDispatch({
-      loadConfig: () => ({ defaultExecutionAgent: 'omp', defaultExecutionModel: 'chatgpt-5.4' } as any),
+      loadConfig: () =>
+        ({ defaultExecutionAgent: 'omp', defaultExecutionModel: 'chatgpt-5.4' } as unknown as InvokerConfig),
     });
     expect(await dispatch('invoker:get-execution-defaults', [])).toEqual({
       executionAgent: 'omp',
@@ -137,11 +152,68 @@ describe('buildWebInvokerDispatch', () => {
     expect(approveTask).toHaveBeenCalledWith('wf/x');
   });
 
-  it('open-terminal degrades gracefully instead of rejecting', async () => {
+  it('open-terminal degrades gracefully when task terminal support is absent', async () => {
     const { dispatch } = makeDispatch();
     expect(await dispatch('invoker:open-terminal', ['t'])).toEqual({
       opened: false,
       reason: expect.any(String),
+    });
+  });
+
+  it('routes task terminal channels through the injected adapter', async () => {
+    const taskTerminals = makeTaskTerminalAdapter();
+    const { dispatch } = makeDispatch({ taskTerminals });
+
+    await expect(dispatch('invoker:open-terminal', ['task-1'])).resolves.toEqual({
+      opened: true,
+      session: expect.objectContaining({ sessionId: 'session-task-1', taskId: 'task-1' }),
+    });
+    await expect(dispatch('invoker:terminal-list', [])).resolves.toEqual([
+      expect.objectContaining({ sessionId: 'session-1', taskId: 'task-1' }),
+    ]);
+    await expect(dispatch('invoker:terminal-write', ['session-1', 'echo hi'])).resolves.toEqual({
+      ok: true,
+      sessionId: 'session-1',
+      bytes: 7,
+    });
+    await expect(dispatch('invoker:terminal-resize', ['session-1', 120, 40])).resolves.toEqual({
+      ok: true,
+      sessionId: 'session-1',
+      cols: 120,
+      rows: 40,
+    });
+    await expect(dispatch('invoker:terminal-close', ['session-1'])).resolves.toEqual({
+      ok: true,
+      sessionId: 'session-1',
+    });
+
+    expect(taskTerminals.open).toHaveBeenCalledWith('task-1');
+    expect(taskTerminals.list).toHaveBeenCalledWith();
+    expect(taskTerminals.write).toHaveBeenCalledWith('session-1', 'echo hi');
+    expect(taskTerminals.resize).toHaveBeenCalledWith('session-1', 120, 40);
+    expect(taskTerminals.close).toHaveBeenCalledWith('session-1');
+  });
+
+  it('keeps planning terminal routes degraded on the web surface', async () => {
+    const taskTerminals = makeTaskTerminalAdapter();
+    const { dispatch } = makeDispatch({ taskTerminals });
+
+    await expect(dispatch('invoker:planning-terminal-open', ['plan-1'])).resolves.toEqual({
+      opened: false,
+      reason: 'Planning terminals are not available in the web UI',
+    });
+    await expect(dispatch('invoker:planning-terminal-list', [])).resolves.toEqual([]);
+    await expect(dispatch('invoker:planning-terminal-write', ['session-1', 'x'])).resolves.toEqual({
+      ok: false,
+      reason: 'unsupported',
+    });
+    await expect(dispatch('invoker:planning-terminal-resize', ['session-1', 80, 24])).resolves.toEqual({
+      ok: false,
+      reason: 'unsupported',
+    });
+    await expect(dispatch('invoker:planning-terminal-close', ['session-1'])).resolves.toEqual({
+      ok: false,
+      reason: 'unsupported',
     });
   });
 

--- a/packages/app/src/embedded-terminal-backend.ts
+++ b/packages/app/src/embedded-terminal-backend.ts
@@ -1,0 +1,35 @@
+import type {
+  EmbeddedTerminalBackendConfig,
+  InvokerConfig,
+} from './config.js';
+import { resolveEmbeddedTerminalBackendConfig } from './config.js';
+import {
+  createBashTerminalBackend,
+  createPtyTerminalBackend,
+  type EmbeddedTerminalBackend,
+} from './embedded-terminal-manager.js';
+
+export function createEmbeddedTerminalBackendFromConfig(
+  backend: EmbeddedTerminalBackendConfig,
+): EmbeddedTerminalBackend {
+  if (process.env.INVOKER_E2E_BREAK_TERMINAL_SPAWN === '1') {
+    return {
+      name: 'pty',
+      spawn() {
+        throw new Error(
+          'posix_spawnp failed. (injected by INVOKER_E2E_BREAK_TERMINAL_SPAWN)',
+        );
+      },
+    };
+  }
+  if (backend === 'bash') return createBashTerminalBackend();
+  return createPtyTerminalBackend();
+}
+
+export function createEmbeddedTerminalBackend(
+  config: InvokerConfig,
+): EmbeddedTerminalBackend {
+  return createEmbeddedTerminalBackendFromConfig(
+    resolveEmbeddedTerminalBackendConfig(config),
+  );
+}

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -8,7 +8,7 @@
  * command-family modules — keeping the import graph acyclic.
  */
 
-import { makeEnvelope, type StartReadyRequest } from '@invoker/contracts';
+import { makeEnvelope, type StartReadyRequest, type StartReadyResult } from '@invoker/contracts';
 import type { TaskState } from '@invoker/workflow-core';
 import {
   remoteFetchForPool,
@@ -18,6 +18,7 @@ import {
 import { backupPlan } from './plan-backup.js';
 import { startApiServer } from './api-server.js';
 import { startWebSurfaceForHeadless } from './web/start-web-surface.js';
+import type { TaskHandleMap } from './execution/task-runner-wiring.js';
 import {
   fixWithAgentAction,
   rebaseRetry,
@@ -69,6 +70,25 @@ type StartReadyPreviewExt = {
     runningTasks: number;
   };
 };
+function createTrackedHeadlessExecutor(
+  deps: HeadlessDeps,
+  taskHandles: TaskHandleMap,
+) {
+  return createHeadlessExecutor(
+    {
+      ...deps,
+      ownerTaskRunnerProvider: undefined,
+    },
+    {
+      onSpawned: (taskId, handle, executor) => {
+        taskHandles.set(taskId, { handle, executor });
+      },
+      onComplete: (taskId) => {
+        taskHandles.delete(taskId);
+      },
+    },
+  );
+}
 
 export async function headlessWatch(workflowId: string | undefined, deps: HeadlessDeps): Promise<void> {
   const workflows = deps.persistence.listWorkflows();
@@ -114,7 +134,8 @@ export async function headlessRun(
   process.stdout.write(`${BOLD}Loading plan: ${plan.name}${RESET}\n`);
   process.stdout.write(`Tasks: ${plan.tasks.length}\n\n`);
 
-  const taskExecutor = createHeadlessExecutor(deps);
+  const taskHandles: TaskHandleMap = new Map();
+  const taskExecutor = createTrackedHeadlessExecutor(deps, taskHandles);
   wireHeadlessApproveHook(deps, taskExecutor);
 
   const apiServerDeps = buildHeadlessApiServerDeps(deps, taskExecutor);
@@ -125,7 +146,15 @@ export async function headlessRun(
     executorRegistry: deps.executorRegistry,
     ...apiServerDeps,
   });
-  const webSurface = startWebSurfaceForHeadless(deps, apiServerDeps);
+  const webSurface = startWebSurfaceForHeadless(
+    {
+      ...deps,
+      repoRoot: deps.repoRoot,
+      executorRegistry: deps.executorRegistry,
+      taskHandles,
+    },
+    apiServerDeps,
+  );
 
   const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
   orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
@@ -180,7 +209,8 @@ export async function headlessResume(
 
   process.stdout.write(`${BOLD}Resuming workflow: ${workflowId}${RESET}\n\n`);
 
-  const taskExecutor = createHeadlessExecutor(deps);
+  const taskHandles: TaskHandleMap = new Map();
+  const taskExecutor = createTrackedHeadlessExecutor(deps, taskHandles);
   wireHeadlessApproveHook(deps, taskExecutor);
 
   const apiServerDeps = buildHeadlessApiServerDeps(deps, taskExecutor);
@@ -191,7 +221,15 @@ export async function headlessResume(
     executorRegistry: deps.executorRegistry,
     ...apiServerDeps,
   });
-  const webSurface = startWebSurfaceForHeadless(deps, apiServerDeps);
+  const webSurface = startWebSurfaceForHeadless(
+    {
+      ...deps,
+      repoRoot: deps.repoRoot,
+      executorRegistry: deps.executorRegistry,
+      taskHandles,
+    },
+    apiServerDeps,
+  );
 
   orchestrator.syncFromDb(workflowId);
   const allStarted = orchestrator.startExecution();
@@ -268,7 +306,7 @@ function parseStartReadyArgs(args: string[], inheritedNoTrack: boolean | undefin
 
 export async function headlessStartReady(args: string[], deps: HeadlessDeps): Promise<void> {
   const { request, noTrack } = parseStartReadyArgs(args, deps.noTrack);
-  const result = runStartReady(deps.orchestrator, request) as ReturnType<typeof runStartReady> & {
+  const result = runStartReady(deps.orchestrator, request) as StartReadyResult & {
     preview: StartReadyPreviewExt;
   };
   const runnable = result.started.filter(isDispatchableLaunch);

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -104,9 +104,7 @@ import {
   loadConfig,
   resolveAutoFixExecutionModel,
   resolveConfigFileState,
-  resolveEmbeddedTerminalBackendConfig,
   resolvePrMaintenanceWorkerConfig,
-  type EmbeddedTerminalBackendConfig,
   type InvokerConfig,
 } from './config.js';
 import {
@@ -145,6 +143,7 @@ import {
   wireHeadlessApproveHook,
   type HeadlessDeps,
 } from './headless.js';
+import { buildHeadlessApiServerDeps } from './headless-shared.js';
 import { parseReviewGatePrNumber, repairReviewGateCiByPr } from './review-gate-ci-repair-command.js';
 import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
 import {
@@ -158,13 +157,9 @@ import {
   selectExperiments as sharedSelectExperiments,
 } from './workflow-actions.js';
 import { execSync } from 'node:child_process';
-import { resolveTaskTerminalSpec } from './open-terminal-for-task.js';
-import {
-  createBashTerminalBackend,
-  createPtyTerminalBackend,
-  EmbeddedTerminalManager,
-  type EmbeddedTerminalBackend,
-} from './embedded-terminal-manager.js';
+import { createTaskTerminalAdapter } from './task-terminal-adapter.js';
+import { EmbeddedTerminalManager } from './embedded-terminal-manager.js';
+import { createEmbeddedTerminalBackend } from './embedded-terminal-backend.js';
 import { collectSystemDiagnostics } from './system-diagnostics.js';
 import { installBundledSkills, resolveBundledSkillsStatus } from './bundled-skills.js';
 import {
@@ -188,6 +183,7 @@ import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.j
 import {
   dispatchStartedTasksWithGlobalTopup,
 } from './global-topup.js';
+import type { WebBridgeTerminalEvents } from './web/web-bridge-server.js';
 import { preserveCrashedInFlightTasks } from './crash-preserved-tasks.js';
 
 
@@ -210,7 +206,7 @@ import { startSurfaceEventRelay } from './surface-event-relay.js';
 import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
 import { buildWebInvokerDispatch } from './web/web-invoker-dispatch.js';
 import { startWebBridge, resolveWebUiDistDir, type WebBridge } from './web/web-bridge-server.js';
-import { resolveWebToken, resolveWebHost, resolveWebPort } from './web/start-web-surface.js';
+import { resolveWebToken, resolveWebHost, resolveWebPort, startWebSurfaceForHeadless } from './web/start-web-surface.js';
 import {
   createGuiMutationRegistrars,
   registerBootstrapStateIpc,
@@ -275,9 +271,8 @@ import {
   registerMainWindowActivateHandler,
   registerMainWindowSecondInstanceHandler,
 } from './window/window-lifecycle.js';
-import { createRendererTaskFeed } from './window/renderer-task-feed.js';
+import { createRendererTaskFeed, type RendererTaskFeed } from './window/renderer-task-feed.js';
 import { tryAcquireGuiInstanceLock, type GuiInstanceLock } from './gui-instance-lock.js';
-import { currentBuildIdentity } from './build-identity.js';
 import { logProcessError } from './process-error-handling.js';
 
 
@@ -350,6 +345,9 @@ function createRegisteredWorkerRegistry(): WorkerRegistry<WorkerRuntimeDependenc
   const registry = registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>());
   return registerExternalWorkersFromConfig(invokerConfig.externalWorkers, registry);
 }
+
+declare const __BUILD_SHA__: string | undefined;
+declare const __BUILD_VERSION__: string | undefined;
 
 // ── Detect headless mode ─────────────────────────────────────
 
@@ -448,7 +446,8 @@ const appProcessStartedAt = Date.now();
 
 let logger: Logger = new FileAndDbLogger({ module: 'main' });
 let guiInstanceLock: GuiInstanceLock | null = null;
-const { version: buildVersion, sha: buildSha } = currentBuildIdentity();
+const buildSha = typeof __BUILD_SHA__ !== 'undefined' ? __BUILD_SHA__ : 'dev';
+const buildVersion = typeof __BUILD_VERSION__ !== 'undefined' ? __BUILD_VERSION__ : 'dev';
 logger.info(`Invoker ${buildVersion} (${buildSha})`, { module: 'startup' });
 
 const headlessExecMutationContext: HeadlessExecMutationContext = {
@@ -494,9 +493,6 @@ async function discoverStandaloneOwnerForGui(waitMs: number): Promise<boolean> {
       if (isStandaloneCapable(owner)) {
         logger.info(`daemon owner ready ownerId=${owner.ownerId}`, { module: 'init' });
         return true;
-      }
-      if (owner?.buildMismatchReason) {
-        logger.warn(`daemon owner ${owner.ownerId} incompatible: ${owner.buildMismatchReason}`, { module: 'init' });
       }
       ownerBus.disconnect();
       ownerBus = new IpcBus(undefined, { allowServe: false });
@@ -938,6 +934,7 @@ function startHeadlessMode(): void {
     let workerRuntimeController: WorkerRuntimeController | null = null;
     let lifecycleEventBridge: LifecycleEventBridge | null = null;
     let standaloneLaunchDispatcherController: StandaloneLaunchDispatcherController | null = null;
+    let headlessWebBridge: WebBridge | null = null;
     try {
       // Standalone mode: initialize services and run headless
       await initServices({
@@ -1593,8 +1590,6 @@ function startHeadlessMode(): void {
             ok: true,
             ownerId: workflowMutationOwnerId,
             mode: 'standalone',
-            buildVersion,
-            buildSha,
           };
         });
         messageBus.onRequest('headless.query', async (req: unknown) =>
@@ -1711,6 +1706,24 @@ function startHeadlessMode(): void {
           );
         }
         workerRuntimeController.startAutoStartedWorkers();
+        if (command === 'owner-serve') {
+          const ownerServeTaskExecutor = createStandaloneTaskExecutor();
+          const apiServerDeps = buildHeadlessApiServerDeps(headlessDeps, ownerServeTaskExecutor);
+          headlessWebBridge = startWebSurfaceForHeadless(
+            {
+              logger,
+              orchestrator,
+              persistence,
+              messageBus,
+              executionAgentRegistry: agentRegistry,
+              invokerConfig,
+              repoRoot,
+              executorRegistry,
+              appRootDir: __dirname,
+            },
+            apiServerDeps,
+          );
+        }
 
         // Owner discovery and exec handlers must exist before dispatch polling starts.
         if (!readOnlyMode) {
@@ -1736,6 +1749,7 @@ function startHeadlessMode(): void {
       process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
       exitCode = 1;
     } finally {
+      await headlessWebBridge?.close();
       standaloneLaunchDispatcherController?.stop();
       lifecycleEventBridge?.stop();
       await workerRuntimeController?.stopAll();
@@ -1803,24 +1817,6 @@ startMainProcessBootstrap({
 // GUI MODE
 // ══════════════════════════════════════════════════════════════
 
-function createEmbeddedTerminalBackendFromConfig(
-  backend: EmbeddedTerminalBackendConfig,
-): EmbeddedTerminalBackend {
-  // E2E fault injection: reproduce node-pty's synchronous spawn throw (e.g.
-  // a spawn-helper binary without its exec bit) without mutating the shared
-  // node_modules that parallel tests rely on.
-  if (process.env.INVOKER_E2E_BREAK_TERMINAL_SPAWN === '1') {
-    return {
-      name: 'pty',
-      spawn() {
-        throw new Error('posix_spawnp failed. (injected by INVOKER_E2E_BREAK_TERMINAL_SPAWN)');
-      },
-    };
-  }
-  if (backend === 'bash') return createBashTerminalBackend();
-  return createPtyTerminalBackend();
-}
-
   function setupGuiMode(): void {
   const agentRegistry = registerBuiltinAgents();
   const planningChatSessions = createInAppPlanningChatSessions();
@@ -1833,7 +1829,7 @@ function createEmbeddedTerminalBackendFromConfig(
   let ownerMode = true;
   const taskHandles: TaskHandleMap = new Map();
   const embeddedTerminalManager = new EmbeddedTerminalManager({
-    backend: createEmbeddedTerminalBackendFromConfig(resolveEmbeddedTerminalBackendConfig(invokerConfig)),
+    backend: createEmbeddedTerminalBackend(invokerConfig),
   });
 
   embeddedTerminalManager.on('output', (payload) => {
@@ -1856,7 +1852,7 @@ function createEmbeddedTerminalBackendFromConfig(
   const guiMutationHandlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
   let dbPollInterval: { stop(): void } | null = null;
   let uiPerfLogInterval: { stop(): void } | null = null;
-  let rendererTaskFeed: ReturnType<typeof createRendererTaskFeed> | null = null;
+  let rendererTaskFeed: RendererTaskFeed | null = null;
   let guiMutationTaskActions: GuiMutationTaskActions | null = null;
   let terminalSessionPersistenceHandle: TerminalSessionPersistenceHandle | null = null;
   const deferredWorkflowLaunches = new Map<string, {
@@ -1906,6 +1902,32 @@ function createEmbeddedTerminalBackendFromConfig(
     },
     uiPerfStats,
   );
+  const taskTerminals = createTaskTerminalAdapter({
+    persistence,
+    executorRegistry,
+    executionAgentRegistry: agentRegistry,
+    repoRoot,
+    taskHandles,
+    embeddedTerminalManager,
+    uiPerfStats,
+    terminalUiPerf,
+    terminalUiPerfSink,
+    logger,
+  });
+  const terminalEvents: WebBridgeTerminalEvents = {
+    onOutput(cb) {
+      embeddedTerminalManager.on('output', cb);
+      return () => {
+        embeddedTerminalManager.off('output', cb);
+      };
+    },
+    onExit(cb) {
+      embeddedTerminalManager.on('exit', cb);
+      return () => {
+        embeddedTerminalManager.off('exit', cb);
+      };
+    },
+  };
   const startupMarks = new Map<string, number>();
   const startupPhaseDetails: Array<Record<string, unknown>> = [];
   const recordStartupMark = (phase: string, extra?: Record<string, unknown>): void => {
@@ -1973,7 +1995,7 @@ function createEmbeddedTerminalBackendFromConfig(
     ts: new Date().toISOString(),
   });
 
-  const requireRendererTaskFeed = (): ReturnType<typeof createRendererTaskFeed> => {
+  const requireRendererTaskFeed = (): RendererTaskFeed => {
     if (!rendererTaskFeed) throw new Error('Renderer task feed is unavailable');
     return rendererTaskFeed;
   };
@@ -2300,6 +2322,7 @@ function createEmbeddedTerminalBackendFromConfig(
             persistence,
             autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
           }),
+          taskTerminals,
           getSystemDiagnostics: () => collectSystemDiagnostics({
             appVersion: app.getVersion(),
             isPackaged: app.isPackaged,
@@ -2320,6 +2343,7 @@ function createEmbeddedTerminalBackendFromConfig(
           token: webToken,
           host: resolveWebHost(invokerConfig),
           port: resolveWebPort(invokerConfig),
+          terminalEvents,
         });
       } else {
         logger.info('Web surface disabled — set INVOKER_WEB_TOKEN (or config.webToken) to enable it', { module: 'web-bridge' });
@@ -2403,11 +2427,7 @@ function createEmbeddedTerminalBackendFromConfig(
         const owner = await discoverOwner(messageBus, 1500);
         if (!isStandaloneCapable(owner)) {
           process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
-          if (owner?.buildMismatchReason) {
-            process.stderr.write(`${RED}Detached viewer fallback refused: ${owner.buildMismatchReason}\n${RESET}`);
-          } else {
-            process.stderr.write(`${RED}Detached viewer fallback requires a reachable owner, but no owner answered IPC.\n${RESET}`);
-          }
+          process.stderr.write(`${RED}Detached viewer fallback requires a reachable owner, but no owner answered IPC.\n${RESET}`);
           app.quit();
           return;
         }
@@ -2597,8 +2617,6 @@ function createEmbeddedTerminalBackendFromConfig(
         ok: true,
         ownerId: workflowMutationOwnerId,
         mode: 'gui',
-        buildVersion,
-        buildSha,
       }));
       messageBus.onRequest('headless.query', async (req: unknown) =>
         answerOwnerHeadlessQuery(req, buildOwnerReadQueryHandlers({
@@ -2948,40 +2966,7 @@ function createEmbeddedTerminalBackendFromConfig(
     });
 
     ipcMain.handle('invoker:open-terminal', async (_event, taskId: string) => {
-      logger.info(`invoked for task="${taskId}"`, { module: 'open-terminal' });
-      const liveHandle = taskHandles.get(taskId);
-      const resolved = resolveTaskTerminalSpec({
-        taskId,
-        persistence,
-        executorRegistry,
-        executionAgentRegistry: agentRegistry,
-        repoRoot,
-        logger,
-        // If a live executor handle exists we can safely attach instead of
-        // refusing — embedded mode is designed for this case.
-        allowRunning: Boolean(liveHandle),
-        runningTaskReason:
-          'Task is still running or being fixed with AI. View output in the terminal panel below.',
-      });
-      if (!resolved.ok) {
-        return { opened: false, reason: resolved.reason };
-      }
-      try {
-        const session = embeddedTerminalManager.openOrReuse({
-          taskId,
-          spec: resolved.spec,
-          cwd: resolved.cwd,
-          attach: liveHandle ? { handle: liveHandle.handle, executor: liveHandle.executor } : undefined,
-        });
-        return { opened: true, session };
-      } catch (err) {
-        // A backend spawn failure (e.g. node-pty's spawn-helper missing its
-        // exec bit) must surface as a visible refusal, not a rejected IPC
-        // promise the renderer drops silently.
-        const reason = err instanceof Error ? err.message : String(err);
-        logger.warn(`terminal session spawn failed for task="${taskId}": ${reason}`, { module: 'open-terminal' });
-        return { opened: false, reason: `Failed to start terminal session: ${reason}` };
-      }
+      return taskTerminals.open(taskId);
     });
 
     registerPlanningTerminalSessionIpcHandlers({

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -2,7 +2,7 @@
  * Shared logic for opening an external OS terminal for a persisted task.
  */
 
-import type { Logger } from '@invoker/contracts';
+import type { Logger, OpenTerminalResponse } from '@invoker/contracts';
 import * as path from 'node:path';
 import { execSync } from 'node:child_process';
 import { homedir } from 'node:os';
@@ -25,6 +25,8 @@ import {
   spawnDetachedTerminal,
   type OpenTerminalResult,
 } from './terminal-external-launch.js';
+import type { EmbeddedTerminalManager } from './embedded-terminal-manager.js';
+import type { TaskHandleMap } from './execution/task-runner-wiring.js';
 import { resolveEffectiveMaxConcurrency } from './execution-capacity.js';
 
 /** Persistence methods required to resolve terminal cwd / command for a task. */
@@ -51,6 +53,16 @@ export interface OpenExternalTerminalForTaskOptions {
   repoRoot: string;
   /** Shown when task status is `running`. */
   runningTaskReason?: string;
+  logger?: Logger;
+}
+export interface OpenEmbeddedTerminalForTaskOptions {
+  taskId: string;
+  persistence?: OpenTerminalPersistence;
+  executorRegistry: ExecutorRegistry;
+  executionAgentRegistry?: AgentRegistry;
+  repoRoot: string;
+  taskHandles: Pick<TaskHandleMap, 'get'>;
+  embeddedTerminalManager: Pick<EmbeddedTerminalManager, 'openOrReuse'>;
   logger?: Logger;
 }
 
@@ -283,6 +295,80 @@ export function resolveTaskTerminalSpec(
   termLogger?.info(`effective cwd=${cwd} (repoRoot=${repoRoot})`);
 
   return { ok: true, spec, cwd, meta: repairedMeta, executor };
+}
+/**
+ * Opens or reuses an embedded task terminal session. Running tasks only attach
+ * when a live executor handle is present; otherwise the current refusal text is
+ * preserved instead of spawning a second shell.
+ */
+export function openEmbeddedTerminalForTask(
+  opts: OpenEmbeddedTerminalForTaskOptions,
+): OpenTerminalResponse {
+  const {
+    taskId,
+    persistence,
+    executorRegistry,
+    executionAgentRegistry,
+    repoRoot,
+    taskHandles,
+    embeddedTerminalManager,
+    logger,
+  } = opts;
+  logger?.info(`invoked for task="${taskId}"`, { module: 'open-terminal' });
+  const liveHandle = taskHandles.get(taskId);
+  if (!persistence) {
+    if (!liveHandle) {
+      return {
+        opened: false,
+        reason: `Task "${taskId}" terminal metadata is unavailable.`,
+      };
+    }
+    try {
+      const cwd = liveHandle.handle.workspacePath ?? repoRoot;
+      const session = embeddedTerminalManager.openOrReuse({
+        taskId,
+        spec: { cwd },
+        cwd,
+        attach: { handle: liveHandle.handle, executor: liveHandle.executor },
+      });
+      return { opened: true, session };
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      logger?.warn(`terminal session attach failed for task="${taskId}": ${reason}`, {
+        module: 'open-terminal',
+      });
+      return { opened: false, reason: `Failed to start terminal session: ${reason}` };
+    }
+  }
+  const resolved = resolveTaskTerminalSpec({
+    taskId,
+    persistence,
+    executorRegistry,
+    executionAgentRegistry,
+    repoRoot,
+    logger,
+    allowRunning: Boolean(liveHandle),
+    runningTaskReason:
+      'Task is still running or being fixed with AI. View output in the terminal panel below.',
+  });
+  if (!resolved.ok) {
+    return { opened: false, reason: resolved.reason };
+  }
+  try {
+    const session = embeddedTerminalManager.openOrReuse({
+      taskId,
+      spec: resolved.spec,
+      cwd: resolved.cwd,
+      attach: liveHandle ? { handle: liveHandle.handle, executor: liveHandle.executor } : undefined,
+    });
+    return { opened: true, session };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    logger?.warn(`terminal session spawn failed for task="${taskId}": ${reason}`, {
+      module: 'open-terminal',
+    });
+    return { opened: false, reason: `Failed to start terminal session: ${reason}` };
+  }
 }
 
 /**

--- a/packages/app/src/task-terminal-adapter.ts
+++ b/packages/app/src/task-terminal-adapter.ts
@@ -1,0 +1,120 @@
+import type {
+  Logger,
+  OpenTerminalResponse,
+  TerminalSessionDescriptor,
+} from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { AgentRegistry, ExecutorRegistry } from '@invoker/execution-engine';
+import type { EmbeddedTerminalManager } from './embedded-terminal-manager.js';
+import type { TaskHandleMap } from './execution/task-runner-wiring.js';
+import {
+  openEmbeddedTerminalForTask,
+  type OpenTerminalPersistence,
+} from './open-terminal-for-task.js';
+import {
+  closeTaskTerminalSession,
+  listTaskTerminalSessions,
+  resizeTaskTerminalSession,
+  writeTaskTerminalSession,
+} from './terminal-session-ipc.js';
+import type {
+  TerminalUiPerfCounters,
+  TerminalUiPerfReporter,
+  TerminalUiPerfSink,
+} from './terminal-ui-perf.js';
+
+export interface TaskTerminalMutationResult {
+  ok: boolean;
+  reason?: string;
+}
+
+export interface TaskTerminalAdapter {
+  open(taskId: string): OpenTerminalResponse | Promise<OpenTerminalResponse>;
+  list(): TerminalSessionDescriptor[] | Promise<TerminalSessionDescriptor[]>;
+  write(
+    sessionId: string,
+    data: string,
+  ): TaskTerminalMutationResult | Promise<TaskTerminalMutationResult>;
+  resize(
+    sessionId: string,
+    cols: number,
+    rows: number,
+  ): TaskTerminalMutationResult | Promise<TaskTerminalMutationResult>;
+  close(sessionId: string): TaskTerminalMutationResult | Promise<TaskTerminalMutationResult>;
+}
+
+export interface CreateTaskTerminalAdapterDeps {
+  persistence: OpenTerminalPersistence &
+    Pick<SQLiteAdapter, 'listTerminalSessions' | 'deleteTerminalSession'>;
+  executorRegistry: ExecutorRegistry;
+  executionAgentRegistry?: AgentRegistry;
+  repoRoot: string;
+  taskHandles: Pick<TaskHandleMap, 'get'>;
+  embeddedTerminalManager: Pick<
+    EmbeddedTerminalManager,
+    'openOrReuse' | 'list' | 'get' | 'write' | 'resize' | 'close'
+  >;
+  uiPerfStats: TerminalUiPerfCounters;
+  terminalUiPerf: TerminalUiPerfReporter;
+  terminalUiPerfSink: TerminalUiPerfSink;
+  logger?: Logger;
+}
+
+export function createTaskTerminalAdapter(
+  deps: CreateTaskTerminalAdapterDeps,
+): TaskTerminalAdapter {
+  return {
+    open(taskId: string) {
+      return openEmbeddedTerminalForTask({
+        taskId,
+        persistence: deps.persistence,
+        executorRegistry: deps.executorRegistry,
+        executionAgentRegistry: deps.executionAgentRegistry,
+        repoRoot: deps.repoRoot,
+        taskHandles: deps.taskHandles,
+        embeddedTerminalManager: deps.embeddedTerminalManager,
+        logger: deps.logger,
+      });
+    },
+    list() {
+      return listTaskTerminalSessions({
+        embeddedTerminalManager: deps.embeddedTerminalManager,
+        persistence: deps.persistence,
+      });
+    },
+    write(sessionId: string, data: string) {
+      return writeTaskTerminalSession(
+        {
+          embeddedTerminalManager: deps.embeddedTerminalManager,
+          uiPerfStats: deps.uiPerfStats,
+          terminalUiPerf: deps.terminalUiPerf,
+          terminalUiPerfSink: deps.terminalUiPerfSink,
+        },
+        sessionId,
+        data,
+      );
+    },
+    resize(sessionId: string, cols: number, rows: number) {
+      return resizeTaskTerminalSession(
+        {
+          embeddedTerminalManager: deps.embeddedTerminalManager,
+          uiPerfStats: deps.uiPerfStats,
+          terminalUiPerf: deps.terminalUiPerf,
+          terminalUiPerfSink: deps.terminalUiPerfSink,
+        },
+        sessionId,
+        cols,
+        rows,
+      );
+    },
+    close(sessionId: string) {
+      return closeTaskTerminalSession(
+        {
+          embeddedTerminalManager: deps.embeddedTerminalManager,
+          persistence: deps.persistence,
+        },
+        sessionId,
+      );
+    },
+  };
+}

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -1,6 +1,6 @@
 import type { IpcMain } from 'electron';
 import type { TerminalSessionDescriptor } from '@invoker/contracts';
-import type { SQLiteAdapter } from '@invoker/data-store';
+import type { SQLiteAdapter, TerminalSessionRecord } from '@invoker/data-store';
 import type { EmbeddedTerminalManager, TerminalSessionPersistenceRecord } from './embedded-terminal-manager.js';
 import {
   timeTerminalResize,
@@ -19,7 +19,7 @@ import {
 /** Coalesce running-session snapshot upserts so PTY output does not 1:1 SQLite-write on main. */
 export const TERMINAL_SESSION_UPSERT_COALESCE_MS = 250;
 
-type TerminalSessionRow = ReturnType<SQLiteAdapter['listTerminalSessions']>[number];
+type TerminalSessionRow = TerminalSessionRecord;
 type PlanningSessionStoreGetter = () => InAppPlanningSessionStore | undefined;
 
 interface PlanningTerminalLogger {
@@ -42,6 +42,93 @@ export function terminalRowToDescriptor(row: TerminalSessionRow): TerminalSessio
     createdAt: row.createdAt,
     outputSnapshot: row.outputSnapshot,
   };
+}
+export function listTaskTerminalSessions(deps: {
+  embeddedTerminalManager: Pick<EmbeddedTerminalManager, 'list'>;
+  persistence: Pick<SQLiteAdapter, 'listTerminalSessions'>;
+}): TerminalSessionDescriptor[] {
+  let persistedRows: TerminalSessionRow[] = [];
+  try {
+    persistedRows = deps.persistence.listTerminalSessions();
+  } catch {
+    persistedRows = [];
+  }
+  const liveSessions = deps.embeddedTerminalManager
+    .list()
+    .filter((session) => session.kind !== 'planning');
+  const live = new Map(liveSessions.map((session) => [session.sessionId, session]));
+  const merged = persistedRows
+    .map((row) => live.get(row.sessionId) ?? terminalRowToDescriptor(row));
+  const persistedIds = new Set(merged.map((session) => session.sessionId));
+  for (const session of live.values()) {
+    if (!persistedIds.has(session.sessionId)) {
+      merged.push(session);
+    }
+  }
+  return merged;
+}
+
+function rejectPlanningTaskTerminalSession(
+  embeddedTerminalManager: Pick<EmbeddedTerminalManager, 'get'>,
+  sessionId: string,
+): { ok: false; reason: string } | null {
+  const session = embeddedTerminalManager.get(sessionId);
+  if (session?.kind === 'planning') {
+    return { ok: false, reason: `Session "${sessionId}" is a planning terminal session.` };
+  }
+  return null;
+}
+
+export function writeTaskTerminalSession(deps: {
+  embeddedTerminalManager: Pick<EmbeddedTerminalManager, 'get' | 'write'>;
+  uiPerfStats: TerminalUiPerfCounters;
+  terminalUiPerf: TerminalUiPerfReporter;
+  terminalUiPerfSink: TerminalUiPerfSink;
+}, sessionId: string, data: string): { ok: boolean; reason?: string } {
+  const rejected = rejectPlanningTaskTerminalSession(deps.embeddedTerminalManager, sessionId);
+  if (rejected) return rejected;
+  return timeTerminalWrite(
+    () => deps.embeddedTerminalManager.write(sessionId, data),
+    deps.uiPerfStats,
+    deps.terminalUiPerf,
+    deps.terminalUiPerfSink,
+    {
+      sessionId,
+      bytes: typeof data === 'string' ? data.length : 0,
+    },
+  );
+}
+
+export function resizeTaskTerminalSession(deps: {
+  embeddedTerminalManager: Pick<EmbeddedTerminalManager, 'get' | 'resize'>;
+  uiPerfStats: TerminalUiPerfCounters;
+  terminalUiPerf: TerminalUiPerfReporter;
+  terminalUiPerfSink: TerminalUiPerfSink;
+}, sessionId: string, cols: number, rows: number): { ok: boolean; reason?: string } {
+  const rejected = rejectPlanningTaskTerminalSession(deps.embeddedTerminalManager, sessionId);
+  if (rejected) return rejected;
+  return timeTerminalResize(
+    () => deps.embeddedTerminalManager.resize(sessionId, cols, rows),
+    deps.uiPerfStats,
+    deps.terminalUiPerf,
+    deps.terminalUiPerfSink,
+    {
+      sessionId,
+      cols,
+      rows,
+    },
+  );
+}
+
+export function closeTaskTerminalSession(deps: {
+  embeddedTerminalManager: Pick<EmbeddedTerminalManager, 'get' | 'close'>;
+  persistence?: Pick<SQLiteAdapter, 'deleteTerminalSession'>;
+}, sessionId: string): { ok: boolean; reason?: string } {
+  const rejected = rejectPlanningTaskTerminalSession(deps.embeddedTerminalManager, sessionId);
+  if (rejected) return rejected;
+  const result = deps.embeddedTerminalManager.close(sessionId);
+  deps.persistence?.deleteTerminalSession(sessionId);
+  return result.ok ? result : { ok: true };
 }
 
 export function restorePersistedTerminalSessions(deps: {
@@ -215,63 +302,47 @@ export function registerTerminalSessionIpcHandlers(deps: {
   const { ipcMain, embeddedTerminalManager, persistence, uiPerfStats, terminalUiPerf, terminalUiPerfSink } = deps;
 
   ipcMain.handle('invoker:terminal-list', async () => {
-    const liveSessions = embeddedTerminalManager
-      .list()
-      .filter((session) => session.kind !== 'planning');
-    const live = new Map(liveSessions.map((session) => [session.sessionId, session]));
-    const merged = persistence.listTerminalSessions().map((row) => live.get(row.sessionId) ?? terminalRowToDescriptor(row));
-    const persistedIds = new Set(merged.map((session) => session.sessionId));
-    for (const session of live.values()) {
-      if (!persistedIds.has(session.sessionId)) {
-        merged.push(session);
-      }
-    }
-    return merged;
+    return listTaskTerminalSessions({
+      embeddedTerminalManager,
+      persistence,
+    });
   });
 
   ipcMain.handle('invoker:terminal-write', async (_event, sessionId: string, data: string) => {
-    const session = embeddedTerminalManager.get(sessionId);
-    if (session?.kind === 'planning') {
-      return { ok: false, reason: `Session "${sessionId}" is a planning terminal session.` };
-    }
-    return timeTerminalWrite(
-      () => embeddedTerminalManager.write(sessionId, data),
-      uiPerfStats,
-      terminalUiPerf,
-      terminalUiPerfSink,
+    return writeTaskTerminalSession(
       {
-        sessionId,
-        bytes: typeof data === 'string' ? data.length : 0,
+        embeddedTerminalManager,
+        uiPerfStats,
+        terminalUiPerf,
+        terminalUiPerfSink,
       },
+      sessionId,
+      data,
     );
   });
 
   ipcMain.handle('invoker:terminal-resize', async (_event, sessionId: string, cols: number, rows: number) => {
-    const session = embeddedTerminalManager.get(sessionId);
-    if (session?.kind === 'planning') {
-      return { ok: false, reason: `Session "${sessionId}" is a planning terminal session.` };
-    }
-    return timeTerminalResize(
-      () => embeddedTerminalManager.resize(sessionId, cols, rows),
-      uiPerfStats,
-      terminalUiPerf,
-      terminalUiPerfSink,
+    return resizeTaskTerminalSession(
       {
-        sessionId,
-        cols,
-        rows,
+        embeddedTerminalManager,
+        uiPerfStats,
+        terminalUiPerf,
+        terminalUiPerfSink,
       },
+      sessionId,
+      cols,
+      rows,
     );
   });
 
   ipcMain.handle('invoker:terminal-close', async (_event, sessionId: string) => {
-    const session = embeddedTerminalManager.get(sessionId);
-    if (session?.kind === 'planning') {
-      return { ok: false, reason: `Session "${sessionId}" is a planning terminal session.` };
-    }
-    const result = embeddedTerminalManager.close(sessionId);
-    persistence.deleteTerminalSession(sessionId);
-    return result.ok ? result : { ok: true };
+    return closeTaskTerminalSession(
+      {
+        embeddedTerminalManager,
+        persistence,
+      },
+      sessionId,
+    );
   });
 }
 

--- a/packages/app/src/web/start-web-surface.ts
+++ b/packages/app/src/web/start-web-surface.ts
@@ -19,17 +19,45 @@ import type {
 } from '@invoker/contracts';
 import { Channels, type MessageBus } from '@invoker/transport';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import { createWorkerRegistry, registerBuiltinAgents, registerBuiltinWorkers, type AgentRegistry, type WorkerRuntimeDependencies } from '@invoker/execution-engine';
+import {
+  createWorkerRegistry,
+  registerBuiltinAgents,
+  registerBuiltinWorkers,
+  type AgentRegistry,
+  type ExecutorRegistry,
+  type WorkerRuntimeDependencies,
+} from '@invoker/execution-engine';
 import type { Orchestrator, TaskDelta } from '@invoker/workflow-core';
 import { loadConfig, type InvokerConfig } from '../config.js';
 import type { ApiMutationFacade } from '../api-server.js';
+import { createEmbeddedTerminalBackend } from '../embedded-terminal-backend.js';
+import { EmbeddedTerminalManager } from '../embedded-terminal-manager.js';
+import type { TaskHandleMap } from '../execution/task-runner-wiring.js';
+import { registerExternalWorkersFromConfig } from '../external-worker-loader.js';
+import {
+  createTaskTerminalAdapter,
+  type TaskTerminalAdapter,
+} from '../task-terminal-adapter.js';
 import { createTaskGraphEventPublisher } from '../task-graph-event-publisher.js';
 import { createTaskDeltaStreamSequence } from '../task-delta-stream-sequence.js';
+import {
+  createTerminalUiPerfCounters,
+  createTerminalUiPerfReporter,
+  createTerminalUiPerfSink,
+} from '../terminal-ui-perf.js';
+import {
+  registerTerminalSessionPersistence,
+  type TerminalSessionPersistenceHandle,
+} from '../terminal-session-ipc.js';
 import { WorkflowRollupProjection } from '../workflow-rollup-projection.js';
-import { buildWebInvokerDispatch } from './web-invoker-dispatch.js';
-import { registerExternalWorkersFromConfig } from '../external-worker-loader.js';
 import { autoStartedOwnerWorkerKindsForConfig, createLocalWorkerStatusSnapshot } from '../worker-control.js';
-import { startWebBridge, resolveWebUiDistDir, type WebBridge } from './web-bridge-server.js';
+import { buildWebInvokerDispatch } from './web-invoker-dispatch.js';
+import {
+  startWebBridge,
+  resolveWebUiDistDir,
+  type WebBridge,
+  type WebBridgeTerminalEvents,
+} from './web-bridge-server.js';
 
 const DEFAULT_WEB_HOST = '127.0.0.1';
 const DEFAULT_WEB_PORT = 4200;
@@ -61,6 +89,9 @@ export interface StartHeadlessWebSurfaceDeps {
   detachWorkflow: (workflowId: string, upstreamWorkflowId: string) => Promise<void>;
   loadConfig: () => InvokerConfig;
   config: InvokerConfig;
+  repoRoot?: string;
+  executorRegistry?: ExecutorRegistry;
+  taskHandles?: TaskHandleMap;
   /** Main process dist directory (`__dirname` of main.js) used to locate the built UI. */
   appRootDir: string;
   getBundledSkillsStatus?: () => BundledSkillsStatus;
@@ -80,6 +111,55 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
   const port = resolveWebPort(deps.config);
   const uiDistDir = resolveWebUiDistDir(deps.appRootDir);
 
+  let terminalSessionPersistenceHandle: TerminalSessionPersistenceHandle | null = null;
+  let taskTerminals: TaskTerminalAdapter | undefined;
+  let terminalEvents: WebBridgeTerminalEvents | undefined;
+  if (deps.repoRoot && deps.executorRegistry && deps.taskHandles) {
+    const embeddedTerminalManager = new EmbeddedTerminalManager({
+      backend: createEmbeddedTerminalBackend(deps.config),
+    });
+    const terminalUiPerfStats = createTerminalUiPerfCounters();
+    const terminalUiPerf = createTerminalUiPerfReporter();
+    const terminalUiPerfSink = createTerminalUiPerfSink(
+      (source, level, message) => {
+        deps.persistence.writeActivityLog(source, level, message);
+      },
+      terminalUiPerfStats,
+    );
+    terminalSessionPersistenceHandle = registerTerminalSessionPersistence({
+      embeddedTerminalManager,
+      persistence: deps.persistence,
+      uiPerfStats: terminalUiPerfStats,
+      terminalUiPerf,
+      terminalUiPerfSink,
+    });
+    taskTerminals = createTaskTerminalAdapter({
+      persistence: deps.persistence,
+      executorRegistry: deps.executorRegistry,
+      executionAgentRegistry: deps.agentRegistry,
+      repoRoot: deps.repoRoot,
+      taskHandles: deps.taskHandles,
+      embeddedTerminalManager,
+      uiPerfStats: terminalUiPerfStats,
+      terminalUiPerf,
+      terminalUiPerfSink,
+      logger: deps.logger,
+    });
+    terminalEvents = {
+      onOutput(cb) {
+        embeddedTerminalManager.on('output', cb);
+        return () => {
+          embeddedTerminalManager.off('output', cb);
+        };
+      },
+      onExit(cb) {
+        embeddedTerminalManager.on('exit', cb);
+        return () => {
+          embeddedTerminalManager.off('exit', cb);
+        };
+      },
+    };
+  }
   const streamSeq = createTaskDeltaStreamSequence();
   const projection = new WorkflowRollupProjection();
   let bridge: WebBridge | null = null;
@@ -129,6 +209,7 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
       persistence: deps.persistence,
       autoStartKinds: autoStartedOwnerWorkerKindsForConfig(deps.config),
     }),
+    taskTerminals,
     logger: deps.logger,
   });
 
@@ -141,6 +222,7 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
     token,
     host,
     port,
+    terminalEvents,
   });
 
   const originalClose = bridge.close;
@@ -152,6 +234,7 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
     },
     close: async (): Promise<void> => {
       unsubscribe?.();
+      terminalSessionPersistenceHandle?.dispose();
       await originalClose();
     },
   };
@@ -165,6 +248,9 @@ export interface HeadlessWebSurfaceHost {
   messageBus: MessageBus;
   executionAgentRegistry?: AgentRegistry;
   invokerConfig: InvokerConfig;
+  repoRoot?: string;
+  executorRegistry?: ExecutorRegistry;
+  taskHandles?: TaskHandleMap;
   appRootDir?: string;
   getBundledSkillsStatus?: () => BundledSkillsStatus;
 }
@@ -193,6 +279,9 @@ export function startWebSurfaceForHeadless(
     detachWorkflow: apiServerDeps.detachWorkflow,
     loadConfig,
     config: host.invokerConfig,
+    repoRoot: host.repoRoot,
+    executorRegistry: host.executorRegistry,
+    taskHandles: host.taskHandles,
     appRootDir: host.appRootDir ?? __dirname,
     getBundledSkillsStatus: host.getBundledSkillsStatus,
   });

--- a/packages/app/src/web/web-bridge-server.ts
+++ b/packages/app/src/web/web-bridge-server.ts
@@ -21,7 +21,7 @@ import { brotliCompressSync, gzipSync } from 'node:zlib';
 import { createReadStream, existsSync, statSync } from 'node:fs';
 import { join, normalize, sep, extname } from 'node:path';
 import { timingSafeEqual } from 'node:crypto';
-import type { Logger } from '@invoker/contracts';
+import type { Logger, TerminalExitEvent, TerminalOutputEvent } from '@invoker/contracts';
 import { Channels, type MessageBus } from '@invoker/transport';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WebInvokerDispatch } from './web-invoker-dispatch.js';
@@ -44,6 +44,11 @@ export interface WebBridgeDeps {
   token: string;
   host: string;
   port: number;
+  terminalEvents?: WebBridgeTerminalEvents;
+}
+export interface WebBridgeTerminalEvents {
+  onOutput(cb: (payload: TerminalOutputEvent) => void): () => void;
+  onExit(cb: (payload: TerminalExitEvent) => void): () => void;
 }
 
 export interface WebBridge {
@@ -220,7 +225,8 @@ export function startWebBridge(deps: WebBridgeDeps): WebBridge {
         sendJson(res, 200, { ok: false, error: { message: 'request failed', code } }, req);
         return;
       }
-      logger?.warn(`web invoke failed for ${parsed.channel}`, {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      logger?.warn(`web invoke failed for ${parsed.channel}: ${errorMessage}`, {
         module: 'web-bridge',
       });
       sendJson(res, 200, { ok: false, error: { message: 'internal server error' } }, req);
@@ -310,6 +316,12 @@ export function startWebBridge(deps: WebBridgeDeps): WebBridge {
     broadcast('invoker:task-output', payload);
   });
 
+  const unsubscribeTerminalOutput = deps.terminalEvents?.onOutput((payload) => {
+    broadcast('invoker:terminal-output', payload);
+  });
+  const unsubscribeTerminalExit = deps.terminalEvents?.onExit((payload) => {
+    broadcast('invoker:terminal-exit', payload);
+  });
   let activityWatermark = 0;
   const activityTimer = setInterval(() => {
     try {
@@ -357,6 +369,8 @@ export function startWebBridge(deps: WebBridgeDeps): WebBridge {
     clearInterval(workflowsTimer);
     clearInterval(pingTimer);
     unsubscribeOutput?.();
+    unsubscribeTerminalOutput?.();
+    unsubscribeTerminalExit?.();
     for (const client of clients) client.end();
     clients.clear();
     const { promise, resolve } = Promise.withResolvers<void>();

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -31,6 +31,7 @@ import { buildCurrentActionGraphSnapshot } from '../action-graph-snapshot.js';
 import { collectSystemDiagnostics } from '../system-diagnostics.js';
 import { resolveAgentSession } from '../headless-query-list.js';
 import { buildTaskGraphSnapshot } from './task-graph-snapshot.js';
+import type { TaskTerminalAdapter } from '../task-terminal-adapter.js';
 
 export interface WebInvokerDispatchDeps {
   orchestrator: Orchestrator;
@@ -49,6 +50,7 @@ export interface WebInvokerDispatchDeps {
   getBundledSkillsStatus?: () => BundledSkillsStatus;
   checkPrStatuses?: () => void | Promise<void>;
   getWorkers?: () => WorkerStatusSnapshot;
+  taskTerminals?: TaskTerminalAdapter;
   logger?: Logger;
 }
 
@@ -236,15 +238,36 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       case 'invoker:delete-workflow':
         return deps.deleteWorkflow(String(args[0]));
 
-      // ── Terminals: no pty over HTTP — degrade gracefully ──
+      // ── Task terminals: supported when the owner wires an adapter ──
       case 'invoker:open-terminal':
-        return { opened: false, reason: 'Terminals are not available in the web UI' };
+        if (!deps.taskTerminals) {
+          return { opened: false, reason: 'Terminals are not available in the web UI' };
+        }
+        return deps.taskTerminals.open(String(args[0]));
       case 'invoker:terminal-list':
-        return [];
+        if (!deps.taskTerminals) {
+          return [];
+        }
+        return deps.taskTerminals.list();
       case 'invoker:terminal-write':
+        if (!deps.taskTerminals) {
+          return { ok: false, reason: 'unsupported' };
+        }
+        return deps.taskTerminals.write(String(args[0]), String(args[1] ?? ''));
       case 'invoker:terminal-resize':
+        if (!deps.taskTerminals) {
+          return { ok: false, reason: 'unsupported' };
+        }
+        return deps.taskTerminals.resize(
+          String(args[0]),
+          Number(args[1]),
+          Number(args[2]),
+        );
       case 'invoker:terminal-close':
-        return { ok: false, reason: 'unsupported' };
+        if (!deps.taskTerminals) {
+          return { ok: false, reason: 'unsupported' };
+        }
+        return deps.taskTerminals.close(String(args[0]));
       case 'invoker:planning-terminal-open':
         return { opened: false, reason: 'Planning terminals are not available in the web UI' };
       case 'invoker:planning-terminal-list':

--- a/packages/ui/src/web/__tests__/web-invoker-client.test.ts
+++ b/packages/ui/src/web/__tests__/web-invoker-client.test.ts
@@ -85,6 +85,15 @@ describe('installWebInvoker', () => {
     es.fire('invoker:planning-chat-stream', payload);
     expect(cb).toHaveBeenCalledWith(payload);
   });
+  it('onTerminalOutput receives terminal SSE payloads through the generic event source path', () => {
+    installWebInvoker({});
+    const cb = vi.fn();
+    window.invoker.onTerminalOutput(cb as never);
+    const es = FakeEventSource.instances[0];
+    const payload = { sessionId: 'session-1', taskId: 'task-1', chunk: 'browser-output' };
+    es.fire('invoker:terminal-output', payload);
+    expect(cb).toHaveBeenCalledWith(payload);
+  });
 
   it('approve POSTs the approve channel with args', async () => {
     fetchResult = undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       aws4:
         specifier: ^1.13.2
         version: 1.13.2
+      concurrently:
+        specifier: ^10.0.4
+        version: 10.0.4
       dependency-cruiser:
         specifier: ^17.3.10
         version: 17.3.10
@@ -2411,6 +2414,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
@@ -2462,6 +2469,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
 
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
@@ -2521,6 +2532,11 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concurrently@10.0.4:
+    resolution: {integrity: sha512-trZql+7l/0+WRAsAnEdctr4+iiOS6ZrViI6H8QWcCF9MFS/LT0dKpe8vluB1to6it+OxSI4VospFTIFMW8DJRw==}
+    engines: {node: '>=22'}
+    hasBin: true
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -2905,6 +2921,9 @@ packages:
   elkjs@0.10.2:
     resolution: {integrity: sha512-Yx3ORtbAFrXelYkAy2g0eYyVY8QG0XEmGdQXmy0eithKKjbWRfl3Xe884lfkszfBF6UKyIy4LwfcZ3AZc8oxFw==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -3149,6 +3168,10 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -4260,6 +4283,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
+    engines: {node: '>= 0.4'}
+
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
@@ -4369,6 +4396,10 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
@@ -4402,6 +4433,10 @@ packages:
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4827,6 +4862,10 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -4886,9 +4925,17 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -6717,6 +6764,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   check-error@2.1.3: {}
 
   chokidar@3.6.0:
@@ -6769,6 +6818,12 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
   clone-response@1.0.3:
     dependencies:
       mimic-response: 1.0.1
@@ -6814,6 +6869,15 @@ snapshots:
   compare-version@0.1.2: {}
 
   concat-map@0.0.1: {}
+
+  concurrently@10.0.4:
+    dependencies:
+      chalk: 5.6.2
+      rxjs: 7.8.2
+      shell-quote: 1.9.0
+      supports-color: 10.2.2
+      tree-kill: 1.2.2
+      yargs: 18.0.0
 
   confbox@0.1.8: {}
 
@@ -7286,6 +7350,8 @@ snapshots:
 
   elkjs@0.10.2: {}
 
+  emoji-regex@10.6.0: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -7592,6 +7658,8 @@ snapshots:
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -8723,6 +8791,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.9.0: {}
+
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -8840,6 +8910,12 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -8879,6 +8955,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  supports-color@10.2.2: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -9376,6 +9454,12 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
@@ -9404,6 +9488,8 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
+  yargs-parser@22.0.0: {}
+
   yargs@17.7.2:
     dependencies:
       cliui: 8.0.1
@@ -9413,6 +9499,15 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   yauzl@2.10.0:
     dependencies:


### PR DESCRIPTION
## Summary

Headless owners now keep the live task handles that browser terminals need.

The headless browser path already had the terminal bridge.

Headless run and resume did not retain the live task handles that attached terminals use, so browser terminals could not join running tasks.

This slice records live handles during headless run and resume so the existing browser-terminal path can attach to active tasks.

## Review Claim

Headless owners now keep the live task handles needed for browser task terminals to attach to running work.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice only changes headless owner startup state. The browser-terminal support path is already in place from the earlier slice.

## Slice Rationale

The headless browser path needs one extra owner input: live task handles. Landing that enablement last keeps the earlier browser reuse review local.

## Non-goals

- No local-owner request changes.
- No planning terminal browser support.
- No renderer changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `./run.sh --headless run local://browser-terminal-smoke.yaml`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: Restart any headless owner process.
- Data migration? No.

</details>
