### PR TITLE
[Bugfix: Slack repo URL classification rejects website URLs](1) Tighten Slack repo routing

### DIFF
--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -174,7 +174,7 @@ describe('parsePlanningRequest', () => {
       'cursor+claude',
     )).toMatchObject({
       presetKey: 'cursor+claude',
-      repositoryUrls: ['https://github.com/EdbertChan/notarepo/'],
+      repositoryUrls: ['https://github.com/EdbertChan/notarepo'],
     });
     expect(parsePlanningRequest(
       'plan this in git@github.com:EdbertChan/notarepo.git',
@@ -204,6 +204,15 @@ describe('extractRepoUrlFromMessage', () => {
     expect(extractRepoUrlFromMessage('repo is https://github.com/EdbertChan/notarepo.git')).toBe('https://github.com/EdbertChan/notarepo.git');
   });
 
+  it('accepts non-GitHub http URLs only when they end in .git', () => {
+    expect(extractRepoUrlFromMessage('repo is https://gitlab.com/openai/invoker')).toBeUndefined();
+    expect(extractRepoUrlFromMessage('repo is https://gitlab.com/openai/invoker.git')).toBe('https://gitlab.com/openai/invoker.git');
+  });
+
+  it('rejects generic website roots', () => {
+    expect(extractRepoUrlFromMessage('details at https://www.onorca.dev')).toBeUndefined();
+  });
+
   it('rejects credential-bearing URLs', () => {
     expect(extractRepoUrlFromMessage('https://token@github.com/openai/invoker')).toBeUndefined();
     expect(extractRepoUrlFromMessage('https://token:secret@github.com/openai/invoker.git')).toBeUndefined();
@@ -217,7 +226,7 @@ describe('extractRepoUrlFromMessage', () => {
   });
 
   it('returns the first repo-root URL when multiple are present', () => {
-    expect(extractRepoUrlFromMessage('try https://gitlab.com/first/repo then https://github.com/second/repo')).toBe('https://gitlab.com/first/repo');
+    expect(extractRepoUrlFromMessage('try https://gitlab.com/first/repo.git then https://github.com/second/repo')).toBe('https://gitlab.com/first/repo.git');
   });
 
   it('returns undefined when no repo URL is present', () => {
@@ -1125,14 +1134,18 @@ describe('lobby verb routing', () => {
     expect(say.mock.calls.map((call) => call[0].text).join('\n')).not.toContain('from the URL in your message');
   });
 
-  it('picks up any repo-shaped URL (including a deep link) as the first-message repo', async () => {
-    const surface = lobbySurface(true, { defaultRepoUrl: 'git@github.com:default/repo.git' });
+  it.each([
+    ['generic website URL', 'https://www.onorca.dev'],
+    ['GitHub deep link', 'https://github.com/openai/invoker/pull/123'],
+  ])('keeps defaultRepoUrl when the first agent message contains a %s', async (_label, url) => {
+    const defaultRepoUrl = 'git@github.com:default/repo.git';
+    const surface = lobbySurface(true, { defaultRepoUrl });
     await surface.start(async () => {});
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
 
     await mentionHandler(surface)({
       event: {
-        text: '<@BOT> plan: fix the issue at https://github.com/openai/invoker/pull/123',
+        text: `<@BOT> plan: fix the issue at ${url}`,
         ts: 't1',
         user: 'U1',
         channel: 'CLOBBY',
@@ -1140,12 +1153,9 @@ describe('lobby verb routing', () => {
       say,
     });
 
-    // `plan:` is literal agent text now (no plan-mode fork), so this uses the same
-    // repo-URL detection as every other agent message: any repo-shaped URL found in
-    // the message wins over defaultRepoUrl, deep link or not.
     expect(planConversationConfigs).toHaveLength(1);
     expect(planConversationConfigs[0].mode).toBe('agent');
-    expect(planConversationConfigs[0].repoUrl).toBe('https://github.com/openai/invoker/pull/123');
+    expect(planConversationConfigs[0].repoUrl).toBe(defaultRepoUrl);
     expect(say.mock.calls.map((call) => call[0].text).join('\n')).not.toContain('from the URL in your message');
   });
 
@@ -1286,7 +1296,7 @@ describe('lobby verb routing', () => {
     }
   });
 
-  it('accepts an equivalent non-GitHub repo URL in a thread mention', async () => {
+  it('accepts an equivalent non-GitHub .git repo URL in a thread mention', async () => {
     const boundRepo = 'git@gitlab.com:openai/invoker.git';
     const prepareRepoCheckout = vi.fn().mockResolvedValue('/checkouts/unused');
     const { adapter, surface } = await persistentLobbySurface({
@@ -1305,7 +1315,7 @@ describe('lobby verb routing', () => {
       const sameRepoSay = vi.fn().mockResolvedValue({ ts: 'b' });
       await mentionHandler(surface)({
         event: {
-          text: '<@BOT> local: continue in https://gitlab.com/openai/invoker',
+          text: '<@BOT> local: continue in https://gitlab.com/openai/invoker.git',
           thread_ts: 't1',
           ts: 't2',
           user: 'U1',
@@ -1368,7 +1378,11 @@ describe('lobby verb routing', () => {
     }
   });
 
-  it('does not rebind a follow-up deep link', async () => {
+  it.each([
+    ['generic website URL', 'https://www.onorca.dev'],
+    ['GitHub deep link', 'https://github.com/openai/new-repo/pull/123'],
+    ['non-GitHub root URL without .git', 'https://gitlab.com/openai/invoker'],
+  ])('does not rebind a follow-up %s', async (_label, url) => {
     const boundRepo = 'https://github.com/openai/invoker';
     const prepareRepoCheckout = vi.fn().mockResolvedValue('/checkouts/unused');
     const { adapter, slackSessionRepo, surface } = await persistentLobbySurface({
@@ -1384,10 +1398,10 @@ describe('lobby verb routing', () => {
         say: vi.fn().mockResolvedValue({ ts: 'a' }),
       });
 
-      const deepLinkSay = vi.fn().mockResolvedValue({ ts: 'b' });
+      const followUpSay = vi.fn().mockResolvedValue({ ts: 'b' });
       await messageHandler(surface)({
-        event: { thread_ts: 't1', ts: 't2', user: 'U1', text: 'run local: inspect https://github.com/openai/new-repo/pull/123', channel: 'CLOBBY' },
-        say: deepLinkSay,
+        event: { thread_ts: 't1', ts: 't2', user: 'U1', text: `run local: inspect ${url}`, channel: 'CLOBBY' },
+        say: followUpSay,
       });
 
       expect(prepareRepoCheckout).not.toHaveBeenCalled();
@@ -1396,7 +1410,7 @@ describe('lobby verb routing', () => {
         workingDir: '/checkouts/invoker',
       }));
       expect(planConversationConfigs).toHaveLength(1);
-      const texts = deepLinkSay.mock.calls.map((call) => call[0].text).join('\n');
+      const texts = followUpSay.mock.calls.map((call) => call[0].text).join('\n');
       expect(texts).not.toContain('switched this thread');
       expect(texts).not.toContain('previous working state');
     } finally {

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -191,8 +191,9 @@ function capTailChars(value: string, max: number): string {
 // ── Planning request parsing ─────────────────────────────────
 
 const PRESET_TOOL_HINTS = ['cursor', 'omp', 'codex', 'claude'];
-const URL_TOKEN_TERMINATORS = new Set([' ', '\t', '\n', '\r', '<', '>', '(', ')', '[', ']', '{', '}', '"', "'", '|']);
-const TRAILING_URL_PUNCTUATION = new Set(['.', ',', ';', ':', '!', '?']);
+const MESSAGE_REPO_TOKEN_RE = /<((?:https?|ssh):\/\/[^|>\s]+|git@[\w.-]+:[^|>\s]+)(?:\|[^>]+)?>|\b(?:https?:\/\/[^\s<>()\[\]{}"'|]+|ssh:\/\/[^\s<>()\[\]{}"'|]+|git@[\w.-]+:[^\s<>()\[\]{}"'|]+)/gi;
+const TRAILING_URL_PUNCTUATION = new Set(['.', ',', ';', ':', '!']);
+const GITHUB_REPO_ROOT_PATH_RE = /^\/[^/]+\/[^/]+(?:\.git)?\/?$/;
 
 /** A leading bracket tag is a likely preset attempt when it names a known tool or uses the tool+model form. */
 function looksLikePreset(normalized: string): boolean {
@@ -200,50 +201,7 @@ function looksLikePreset(normalized: string): boolean {
 }
 
 export function extractRepoUrlFromMessage(text: string): string | undefined {
-  let start = 0;
-  while (start < text.length) {
-    const httpIndex = text.indexOf('http://', start);
-    const httpsIndex = text.indexOf('https://', start);
-    const candidateStart = httpIndex === -1
-      ? httpsIndex
-      : httpsIndex === -1
-        ? httpIndex
-        : Math.min(httpIndex, httpsIndex);
-    if (candidateStart === -1) return undefined;
-    let candidateEnd = candidateStart;
-    while (candidateEnd < text.length && !URL_TOKEN_TERMINATORS.has(text[candidateEnd])) {
-      candidateEnd += 1;
-    }
-    let candidate = text.slice(candidateStart, candidateEnd);
-    while (candidate && TRAILING_URL_PUNCTUATION.has(candidate.at(-1)!)) {
-      candidate = candidate.slice(0, -1);
-    }
-    let url: URL;
-    try {
-      url = new URL(candidate);
-    } catch {
-      start = candidateEnd + 1;
-      continue;
-    }
-    if (!url.host || (url.protocol !== 'http:' && url.protocol !== 'https:')) {
-      start = candidateEnd + 1;
-      continue;
-    }
-    if (url.username || url.password) {
-      start = candidateEnd + 1;
-      continue;
-    }
-    if (url.search || url.hash) {
-      start = candidateEnd + 1;
-      continue;
-    }
-    if (!/^\/[^/]+\/[^/]+(?:\.git|\/)?$/.test(url.pathname)) {
-      start = candidateEnd + 1;
-      continue;
-    }
-    return candidate.endsWith('/') ? candidate.slice(0, -1) : candidate;
-  }
-  return undefined;
+  return extractMessageRepoCandidates(text)[0];
 }
 
 type RepoParts = {
@@ -344,26 +302,47 @@ export function parsePlanningRequest(
   };
 }
 
-function isRepoRootUrl(rawUrl: string): boolean {
-  if (/^(ssh:\/\/|git@)/.test(rawUrl)) return true;
-  try {
-    const u = new URL(rawUrl);
-    return /^\/[^/]+\/[^/]+(?:\.git|\/)?$/.test(u.pathname);
-  } catch {
-    return false;
-  }
+function extractRepositoryUrls(text: string): string[] {
+  return extractMessageRepoCandidates(text);
 }
 
-function extractRepositoryUrls(text: string): string[] {
-  const slackLinks = [...text.matchAll(/<((?:https?|ssh):\/\/[^|>\s]+)(?:\|[^>]+)?>/gi)];
-  const withoutSlackLinks = text.replace(/<(?:(?:https?|ssh):\/\/[^>]+)>/gi, ' ');
-  const candidates = [
-    ...slackLinks,
-    ...withoutSlackLinks.matchAll(/\bhttps?:\/\/[^\s<>]+/gi),
-    ...withoutSlackLinks.matchAll(/\bssh:\/\/[^\s<>]+/gi),
-    ...withoutSlackLinks.matchAll(/\bgit@[\w.-]+:[^\s<>]+/gi),
-  ].map((match) => (match[1] ?? match[0]).replace(/[),.;]+$/, ''));
-  return [...new Set(candidates)].filter(isRepoRootUrl);
+function extractMessageRepoCandidates(text: string): string[] {
+  const urls: string[] = [];
+  const seen = new Set<string>();
+  for (const match of text.matchAll(MESSAGE_REPO_TOKEN_RE)) {
+    let candidate = (match[1] ?? match[0]).trim();
+    while (candidate && TRAILING_URL_PUNCTUATION.has(candidate.at(-1)!)) {
+      candidate = candidate.slice(0, -1);
+    }
+
+    const accepted = (() => {
+      if (/^git@[\w.-]+:.+/.test(candidate)) return candidate;
+      if (/^ssh:\/\//i.test(candidate)) return candidate;
+      if (!/^https?:\/\//i.test(candidate) || /[?#]/.test(candidate)) return undefined;
+
+      let url: URL;
+      try {
+        url = new URL(candidate);
+      } catch {
+        return undefined;
+      }
+      if (!url.host || url.username || url.password || url.search || url.hash) return undefined;
+
+      const host = url.host.toLowerCase();
+      if (host === 'github.com') {
+        return GITHUB_REPO_ROOT_PATH_RE.test(url.pathname)
+          ? candidate.replace(/\/$/, '')
+          : undefined;
+      }
+      return url.pathname.endsWith('.git') ? candidate : undefined;
+    })();
+
+    if (accepted && !seen.has(accepted)) {
+      seen.add(accepted);
+      urls.push(accepted);
+    }
+  }
+  return urls;
 }
 
 function repositoryIdentity(repoUrl: string): string {


### PR DESCRIPTION
## Summary

Slack message routing now screens automatic URL candidates before binding a thread to a repo.

Website roots and GitHub deep links stay as message text, while supported clone-style repo URLs still work.

## Review Claim

Slack automatic repo routing only binds supported repo selector URLs from message text.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The slice stays inside Slack message classification and its focused regressions; checkout and repo identity code remain untouched.

## Slice Rationale

This slice covers automatic message routing separately from explicit repo tags.

## Non-goals

- No `[repo:...]` error-path changes.
- No clone-layer validation.
- No changes to `RepoPool`, host seams, or `packages/app/src/plan-parser.ts`.

## Architecture

### Before

```mermaid
graph TD
    A["Slack message text"] --> B["Any http(s) URL candidate"]
    B --> C["Thread repo binding"]
```

### After

```mermaid
graph TD
    A["Slack message text"] --> B["Slack repo URL gate"]
    B --> C["Supported repo selector"]
    B --> D["Plain message text"]
    C --> E["Thread repo binding"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && node ./scripts/vitest-run.cjs src/__tests__/slack-surface-workflows.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert db710e880`
- Post-revert steps: Re-run the focused Slack workflow test.
- Data migration? No.

</details>