### PR TITLE
[Bugfix: Slack repo URL classification rejects website URLs](2) Reject invalid literal repo URLs

### DIFF
--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -1134,6 +1134,28 @@ describe('lobby verb routing', () => {
     expect(say.mock.calls.map((call) => call[0].text).join('\n')).not.toContain('from the URL in your message');
   });
 
+  it('rejects an unsupported literal [repo:] URL before creating a planning session', async () => {
+    const surface = lobbySurface(true, { defaultRepoUrl: 'git@github.com:default/repo.git' });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+
+    await mentionHandler(surface)({
+      event: {
+        text: '<@BOT> [repo:https://www.onorca.dev] plan: add a /health endpoint',
+        ts: 'invalid-literal-repo',
+        user: 'U1',
+        channel: 'CLOBBY',
+      },
+      say,
+    });
+
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      text: 'Invalid repo URL "https://www.onorca.dev". Use a GitHub repo URL or a clone URL ending in .git.',
+      thread_ts: 'invalid-literal-repo',
+    }));
+    expect(planConversationConfigs).toHaveLength(0);
+  });
+
   it.each([
     ['generic website URL', 'https://www.onorca.dev'],
     ['GitHub deep link', 'https://github.com/openai/invoker/pull/123'],

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -194,6 +194,7 @@ const PRESET_TOOL_HINTS = ['cursor', 'omp', 'codex', 'claude'];
 const MESSAGE_REPO_TOKEN_RE = /<((?:https?|ssh):\/\/[^|>\s]+|git@[\w.-]+:[^|>\s]+)(?:\|[^>]+)?>|\b(?:https?:\/\/[^\s<>()\[\]{}"'|]+|ssh:\/\/[^\s<>()\[\]{}"'|]+|git@[\w.-]+:[^\s<>()\[\]{}"'|]+)/gi;
 const TRAILING_URL_PUNCTUATION = new Set(['.', ',', ';', ':', '!']);
 const GITHUB_REPO_ROOT_PATH_RE = /^\/[^/]+\/[^/]+(?:\.git)?\/?$/;
+const INVALID_LITERAL_REPO_URL_GUIDANCE = 'Use a GitHub repo URL or a clone URL ending in .git.';
 
 /** A leading bracket tag is a likely preset attempt when it names a known tool or uses the tool+model form. */
 function looksLikePreset(normalized: string): boolean {
@@ -315,27 +316,7 @@ function extractMessageRepoCandidates(text: string): string[] {
       candidate = candidate.slice(0, -1);
     }
 
-    const accepted = (() => {
-      if (/^git@[\w.-]+:.+/.test(candidate)) return candidate;
-      if (/^ssh:\/\//i.test(candidate)) return candidate;
-      if (!/^https?:\/\//i.test(candidate) || /[?#]/.test(candidate)) return undefined;
-
-      let url: URL;
-      try {
-        url = new URL(candidate);
-      } catch {
-        return undefined;
-      }
-      if (!url.host || url.username || url.password || url.search || url.hash) return undefined;
-
-      const host = url.host.toLowerCase();
-      if (host === 'github.com') {
-        return GITHUB_REPO_ROOT_PATH_RE.test(url.pathname)
-          ? candidate.replace(/\/$/, '')
-          : undefined;
-      }
-      return url.pathname.endsWith('.git') ? candidate : undefined;
-    })();
+    const accepted = normalizeSupportedRepoCandidate(candidate);
 
     if (accepted && !seen.has(accepted)) {
       seen.add(accepted);
@@ -343,6 +324,28 @@ function extractMessageRepoCandidates(text: string): string[] {
     }
   }
   return urls;
+}
+
+function normalizeSupportedRepoCandidate(candidate: string): string | undefined {
+  if (/^git@[\w.-]+:.+/.test(candidate)) return candidate;
+  if (/^ssh:\/\//i.test(candidate)) return candidate;
+  if (!/^https?:\/\//i.test(candidate) || /[?#]/.test(candidate)) return undefined;
+
+  let url: URL;
+  try {
+    url = new URL(candidate);
+  } catch {
+    return undefined;
+  }
+  if (!url.host || url.username || url.password || url.search || url.hash) return undefined;
+
+  const host = url.host.toLowerCase();
+  if (host === 'github.com') {
+    return GITHUB_REPO_ROOT_PATH_RE.test(url.pathname)
+      ? candidate.replace(/\/$/, '')
+      : undefined;
+  }
+  return url.pathname.endsWith('.git') ? candidate : undefined;
 }
 
 function repositoryIdentity(repoUrl: string): string {
@@ -1912,7 +1915,12 @@ ${text}`;
     const aliasKey = Object.keys(this.repoAliases).find((key) => key.toLowerCase() === repo.toLowerCase());
     const alias = aliasKey && this.repoAliases[aliasKey];
     if (alias) return { url: this.normalizeRepositoryUrl(alias) };
-    if (/^(git@|https?:\/\/|ssh:\/\/)/.test(repo)) return { url: this.normalizeRepositoryUrl(repo) };
+    const literalRepoUrl = repo.trim().replace(/^<([^|>]+)(?:\|[^>]+)?>$/, '$1');
+    if (/^(?:git@|https?:\/\/|ssh:\/\/)/i.test(literalRepoUrl)) {
+      const supportedRepoUrl = normalizeSupportedRepoCandidate(literalRepoUrl);
+      if (supportedRepoUrl) return { url: this.normalizeRepositoryUrl(supportedRepoUrl) };
+      return { error: `Invalid repo URL "${literalRepoUrl}". ${INVALID_LITERAL_REPO_URL_GUIDANCE}` };
+    }
     const known = Object.keys(this.repoAliases);
     const list = known.length ? known.join(', ') : '(none configured)';
     return { error: `Unknown repo "${repo}". Known aliases: ${list}. Or pass a full git URL.` };


### PR DESCRIPTION
## Summary

Slack explicit repo tags now reject unsupported full URLs before checkout.

Alias names and the configured default repo keep their existing resolution behavior.

## Review Claim

Slack literal repo resolution rejects unsupported full URLs before checkout.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

The slice stays inside `resolveRepoUrl` and its focused regressions; aliases, default repo selection, and lower clone layers remain unchanged.

## Slice Rationale

This slice covers explicit repo tags separately from automatic message URL detection.

## Non-goals

- No automatic message-text routing changes.
- No clone-layer validation.
- No startup config validation.
- No unrelated cleanup.

## Architecture

### Before

```mermaid
graph TD
    A["Literal repo tag value"] --> B["Resolved Slack repo"]
    B --> C["Checkout"]
```

### After

```mermaid
graph TD
    A["Literal repo tag value"] --> B["Alias/default resolution"]
    A --> C["Literal URL policy"]
    C --> D["Supported repo URL"]
    C --> E["Slack error response"]
    D --> F["Checkout"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && node ./scripts/vitest-run.cjs src/__tests__/slack-surface-workflows.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 892912ac8`
- Post-revert steps: Re-run the focused Slack workflow test.
- Data migration? No.

</details>

Depends-On: #5885