### PR TITLE
[Task Pool Reassignment UI](1) Add graph-level pool reassignment

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -34,6 +34,7 @@ import { SystemSetupModal } from './components/SystemSetupModal.js';
 import { WorkflowGraph } from './components/WorkflowGraph.js';
 import { FloatingGraphPanel } from './components/FloatingGraphPanel.js';
 import { WorkflowInspector } from './components/WorkflowInspector.js';
+import { BulkPoolReassignmentModal, type BulkPoolReassignmentResult } from './components/BulkPoolReassignmentModal.js';
 import { WorkerDetailsPanel } from './components/WorkerDetailsPanel.js';
 import { WorkerDetailControl } from './components/WorkerDetailControl.js';
 import { WorkerActivityCard } from './components/WorkerActivityCard.js';
@@ -77,7 +78,8 @@ type ModalState =
   | { type: 'input'; task: TaskState }
   | { type: 'approval'; task: TaskState; action: 'approve' | 'reject' }
   | { type: 'experiment'; task: TaskState }
-  | { type: 'replace'; task: TaskState };
+  | { type: 'replace'; task: TaskState }
+  | { type: 'bulkPoolReassignment' };
 
 type KeyboardRegion = 'workflowGraph' | 'taskGraph' | 'inspector' | 'bottomBar' | 'planning';
 type GraphKeyboardRegion = Extract<KeyboardRegion, 'workflowGraph' | 'taskGraph'>;
@@ -780,6 +782,7 @@ export function App() {
   }, [refreshTaskGraph, tasks.size, workflows.size]);
   const tasksRef = useRef(tasks);
   tasksRef.current = tasks;
+  const loadedTasks = useMemo(() => [...tasks.values()], [tasks]);
   const [viewMode, setViewMode] = useState<'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph'>('dag');
   const {
     graph: actionGraph,
@@ -3176,6 +3179,75 @@ export function App() {
     [invoker, trackAcceptedMutation],
   );
 
+  const handleBulkPoolReassignment = useCallback(
+    async (sourcePoolId: string, destinationPoolId: string): Promise<BulkPoolReassignmentResult> => {
+      const result: BulkPoolReassignmentResult = {
+        moved: 0,
+        failed: 0,
+        skipped: 0,
+        skippedMerge: 0,
+        skippedAlreadyTargeted: 0,
+        attempted: 0,
+        failureDetails: [],
+      };
+      const candidates: TaskState[] = [];
+
+      for (const task of tasksRef.current.values()) {
+        if (task.config.isMergeNode) {
+          if (task.config.poolId === sourcePoolId) result.skippedMerge += 1;
+          continue;
+        }
+        if (task.config.poolId === destinationPoolId) {
+          result.skippedAlreadyTargeted += 1;
+          continue;
+        }
+        if (task.config.poolId !== sourcePoolId) continue;
+        candidates.push(task);
+      }
+
+      result.skipped = result.skippedMerge + result.skippedAlreadyTargeted;
+      result.attempted = candidates.length;
+
+      if (!invoker) {
+        result.failed = candidates.length;
+        result.failureDetails = candidates.map((task) => ({
+          taskId: task.id,
+          message: 'Invoker API is unavailable.',
+        }));
+        toast.error('Pool reassignment failed', { description: 'Invoker API is unavailable.' });
+        return result;
+      }
+
+      for (const task of candidates) {
+        try {
+          const mutationResult = await invoker.editTaskPool(task.id, destinationPoolId);
+          trackAcceptedMutation(mutationResult);
+          result.moved += 1;
+        } catch (err) {
+          result.failed += 1;
+          result.failureDetails.push({
+            taskId: task.id,
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      if (result.moved > 0) {
+        toast.success('Pool reassignment submitted', {
+          description: `${formatCount(result.moved, 'task')} moved to ${destinationPoolId}.`,
+        });
+      }
+      if (result.failed > 0) {
+        toast.error('Some pool edits failed', {
+          description: `${formatCount(result.failed, 'task')} could not be moved.`,
+        });
+      }
+
+      return result;
+    },
+    [invoker, trackAcceptedMutation],
+  );
+
   // ── Edit task execution agent ────────────────────────────
   const handleEditAgent = useCallback(
     async (taskId: string, agentName: string) => {
@@ -3459,6 +3531,17 @@ export function App() {
                 className="block w-full rounded px-3 py-2 text-left text-xs text-foreground hover:bg-secondary"
               >
                 Queue
+              </button>
+              <button
+                type="button"
+                data-testid="rail-move-tasks-between-pools"
+                onClick={() => {
+                  setGraphActionsMenuOpen(false);
+                  setModal({ type: 'bulkPoolReassignment' });
+                }}
+                className="block w-full rounded px-3 py-2 text-left text-xs text-foreground hover:bg-secondary"
+              >
+                Move Tasks Between Pools
               </button>
               <div className="my-1 border-t border-border" />
               <button
@@ -4440,6 +4523,7 @@ export function App() {
                   executionPools={executionPools}
                   executionHarnesses={executionHarnesses}
                   executionDefaults={executionDefaults}
+                  onEditPool={handleEditPool}
                   onEditAgent={handleEditAgent}
                   onEditModel={handleEditModel}
                   onEditPrompt={handleEditPrompt}
@@ -4681,6 +4765,15 @@ export function App() {
       )}
 
       {/* Modals */}
+      {modal.type === 'bulkPoolReassignment' && (
+        <BulkPoolReassignmentModal
+          executionPools={executionPools}
+          tasks={loadedTasks}
+          onConfirm={handleBulkPoolReassignment}
+          onClose={closeModal}
+        />
+      )}
+
       {modal.type === 'input' && (
         <InputModal
           task={modal.task}

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -592,14 +592,18 @@ export function makeUITask(overrides: Partial<TaskState> & {
   status?: TaskStatus;
   workflowId?: string;
   isMergeNode?: boolean;
+  poolId?: string;
   command?: string;
   prompt?: string;
 } = {}): TaskState {
   const {
     workflowId,
     isMergeNode,
+    poolId,
     command,
     prompt,
+    config,
+    execution,
     ...rest
   } = overrides;
 
@@ -612,11 +616,12 @@ export function makeUITask(overrides: Partial<TaskState> & {
     config: {
       workflowId,
       isMergeNode,
+      poolId,
       command,
       prompt,
-      ...((overrides as any).config ?? {}),
+      ...(config ?? {}),
     } as TaskConfig,
-    execution: ((overrides as any).execution ?? {}) as TaskExecution,
+    execution: (execution ?? {}) as TaskExecution,
     ...rest,
   } as TaskState;
 }

--- a/packages/ui/src/__tests__/keyboard-controls.test.tsx
+++ b/packages/ui/src/__tests__/keyboard-controls.test.tsx
@@ -117,6 +117,100 @@ describe('Side rail controls (component)', () => {
     });
   });
 
+  it('selected task inspector edits executor pool', async () => {
+    vi.mocked(mock.api.getExecutionPools).mockResolvedValue(['pool-a', 'pool-b']);
+    const pooledTasks = [
+      makeUITask({
+        id: 'wf-a/task-a',
+        description: 'Alpha Task',
+        workflowId: 'wf-a',
+        command: 'echo alpha',
+        poolId: 'pool-a',
+      }),
+    ];
+    mock.setTasks(pooledTasks, [{ id: 'wf-a', name: 'Alpha Workflow', status: 'running' }]);
+
+    render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    await screen.findByTestId('selected-workflow-mini-dag');
+    fireEvent.click(await screen.findByTestId('rf__node-wf-a/task-a'));
+
+    const select = await screen.findByTestId('executor-pool-select');
+    fireEvent.change(select, { target: { value: 'pool-b' } });
+
+    await waitFor(() => {
+      expect(mock.api.editTaskPool).toHaveBeenCalledWith('wf-a/task-a', 'pool-b');
+    });
+  });
+
+  it('bulk pool reassignment moves matching loaded tasks and continues after one failure', async () => {
+    vi.mocked(mock.api.getExecutionPools).mockResolvedValue(['pool-a', 'pool-b', 'pool-c']);
+    vi.mocked(mock.api.editTaskPool).mockImplementation(async (taskId, poolId) => {
+      if (taskId === 'wf-a/source-1') throw new Error('pool edit rejected');
+      return {
+        ok: true,
+        accepted: true,
+        intentId: 42,
+        workflowId: 'wf-a',
+        channel: 'invoker:edit-task-pool',
+      };
+    });
+    const pooledTasks = [
+      makeUITask({
+        id: 'wf-a/source-1',
+        description: 'First Source Task',
+        workflowId: 'wf-a',
+        command: 'echo source 1',
+        poolId: 'pool-a',
+      }),
+      makeUITask({
+        id: 'wf-a/source-2',
+        description: 'Second Source Task',
+        workflowId: 'wf-a',
+        command: 'echo source 2',
+        dependencies: ['wf-a/source-1'],
+        poolId: 'pool-a',
+      }),
+      makeUITask({
+        id: 'wf-a/already-targeted',
+        description: 'Already Targeted Task',
+        workflowId: 'wf-a',
+        command: 'echo target',
+        poolId: 'pool-b',
+      }),
+      makeUITask({
+        id: 'wf-a/merge',
+        description: 'Merge Task',
+        workflowId: 'wf-a',
+        isMergeNode: true,
+        poolId: 'pool-a',
+      }),
+    ];
+    mock.setTasks(pooledTasks, [{ id: 'wf-a', name: 'Alpha Workflow', status: 'running' }]);
+
+    render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    fireEvent.click(await screen.findByTestId('graph-more-button'));
+    fireEvent.click(await screen.findByTestId('rail-move-tasks-between-pools'));
+
+    await screen.findByTestId('bulk-pool-reassignment-modal');
+    await waitFor(() => expect(screen.getByTestId('bulk-pool-source-select')).toHaveValue('pool-a'));
+    await waitFor(() => expect(screen.getByTestId('bulk-pool-preview-count')).toHaveTextContent('2'));
+    expect(screen.getByTestId('bulk-pool-already-targeted-count')).toHaveTextContent('1');
+    expect(screen.getByTestId('bulk-pool-merge-skipped-count')).toHaveTextContent('1');
+
+    fireEvent.click(screen.getByTestId('bulk-pool-confirm'));
+
+    await waitFor(() => {
+      expect(mock.api.editTaskPool).toHaveBeenCalledTimes(2);
+    });
+    expect(mock.api.editTaskPool).toHaveBeenNthCalledWith(1, 'wf-a/source-1', 'pool-b');
+    expect(mock.api.editTaskPool).toHaveBeenNthCalledWith(2, 'wf-a/source-2', 'pool-b');
+    expect(await screen.findByTestId('bulk-pool-result')).toHaveTextContent('Moved 1 of 2 matching tasks');
+    expect(screen.getByTestId('bulk-pool-skipped-count')).toHaveTextContent('Skipped 2 tasks');
+    expect(screen.getByTestId('bulk-pool-skipped-count')).toHaveTextContent('Failed 1');
+  });
+
   it('cycles major keyboard regions with Tab', async () => {
     await renderKeyboardFixture(mock);
 

--- a/packages/ui/src/components/BulkPoolReassignmentModal.tsx
+++ b/packages/ui/src/components/BulkPoolReassignmentModal.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { TaskState } from '../types.js';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './primitives/index.js';
+
+export interface BulkPoolReassignmentResult {
+  moved: number;
+  failed: number;
+  skipped: number;
+  skippedMerge: number;
+  skippedAlreadyTargeted: number;
+  attempted: number;
+  failureDetails: Array<{ taskId: string; message: string }>;
+}
+
+interface BulkPoolReassignmentPreview {
+  movable: number;
+  sourceMerge: number;
+  alreadyTargeted: number;
+  loadedNonMerge: number;
+}
+
+interface BulkPoolReassignmentModalProps {
+  executionPools: string[];
+  tasks: TaskState[];
+  onConfirm: (sourcePoolId: string, destinationPoolId: string) => Promise<BulkPoolReassignmentResult>;
+  onClose: () => void;
+}
+
+function getPreview(
+  tasks: TaskState[],
+  sourcePoolId: string,
+  destinationPoolId: string,
+): BulkPoolReassignmentPreview {
+  let movable = 0;
+  let sourceMerge = 0;
+  let alreadyTargeted = 0;
+  let loadedNonMerge = 0;
+
+  for (const task of tasks) {
+    if (task.config.isMergeNode) {
+      if (task.config.poolId === sourcePoolId) sourceMerge += 1;
+      continue;
+    }
+    loadedNonMerge += 1;
+    if (task.config.poolId === destinationPoolId) alreadyTargeted += 1;
+    if (sourcePoolId && destinationPoolId && task.config.poolId === sourcePoolId && task.config.poolId !== destinationPoolId) {
+      movable += 1;
+    }
+  }
+
+  return { movable, sourceMerge, alreadyTargeted, loadedNonMerge };
+}
+
+function formatFailureDetails(result: BulkPoolReassignmentResult): string {
+  if (result.failureDetails.length === 0) return '';
+  return result.failureDetails
+    .slice(0, 3)
+    .map((failure) => `${failure.taskId}: ${failure.message}`)
+    .join('\n');
+}
+
+export function BulkPoolReassignmentModal({
+  executionPools,
+  tasks,
+  onConfirm,
+  onClose,
+}: BulkPoolReassignmentModalProps) {
+  const poolOptions = useMemo(
+    () => [...new Set(executionPools)].filter((poolId) => poolId.trim().length > 0),
+    [executionPools],
+  );
+  const [sourcePoolId, setSourcePoolId] = useState(poolOptions[0] ?? '');
+  const [destinationPoolId, setDestinationPoolId] = useState(poolOptions.find((poolId) => poolId !== sourcePoolId) ?? '');
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<BulkPoolReassignmentResult | null>(null);
+
+  useEffect(() => {
+    if (poolOptions.includes(sourcePoolId)) return;
+    setSourcePoolId(poolOptions[0] ?? '');
+  }, [poolOptions, sourcePoolId]);
+
+  const destinationOptions = useMemo(
+    () => poolOptions.filter((poolId) => poolId !== sourcePoolId),
+    [poolOptions, sourcePoolId],
+  );
+
+  useEffect(() => {
+    if (destinationOptions.includes(destinationPoolId)) return;
+    setDestinationPoolId(destinationOptions[0] ?? '');
+  }, [destinationOptions, destinationPoolId]);
+
+  const preview = useMemo(
+    () => getPreview(tasks, sourcePoolId, destinationPoolId),
+    [tasks, sourcePoolId, destinationPoolId],
+  );
+  const locked = submitting || result !== null;
+  const canSubmit = !locked && sourcePoolId.length > 0 && destinationPoolId.length > 0 && preview.movable > 0;
+
+  const handleConfirm = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    try {
+      const nextResult = await onConfirm(sourcePoolId, destinationPoolId);
+      setResult(nextResult);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="max-w-xl" data-testid="bulk-pool-reassignment-modal">
+        <DialogHeader>
+          <DialogTitle>Move Tasks Between Pools</DialogTitle>
+          <DialogDescription>
+            Reassign loaded non-merge tasks from one execution pool to another.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="grid gap-1.5 text-xs text-muted-foreground">
+              <span className="uppercase tracking-wide">Source pool</span>
+              <select
+                value={sourcePoolId}
+                onChange={(event) => {
+                  setSourcePoolId(event.target.value);
+                  setResult(null);
+                }}
+                disabled={locked || poolOptions.length === 0}
+                className="h-9 min-w-0 rounded border border-border-strong bg-muted px-2 text-sm text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                data-testid="bulk-pool-source-select"
+              >
+                {poolOptions.map((poolId) => (
+                  <option key={poolId} value={poolId}>{poolId}</option>
+                ))}
+              </select>
+            </label>
+
+            <label className="grid gap-1.5 text-xs text-muted-foreground">
+              <span className="uppercase tracking-wide">Destination pool</span>
+              <select
+                value={destinationPoolId}
+                onChange={(event) => {
+                  setDestinationPoolId(event.target.value);
+                  setResult(null);
+                }}
+                disabled={locked || destinationOptions.length === 0}
+                className="h-9 min-w-0 rounded border border-border-strong bg-muted px-2 text-sm text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                data-testid="bulk-pool-destination-select"
+              >
+                {destinationOptions.map((poolId) => (
+                  <option key={poolId} value={poolId}>{poolId}</option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <fieldset
+            className="rounded border border-border bg-secondary/70 p-3"
+            data-testid="bulk-pool-scope"
+          >
+            <legend className="px-1 text-xs uppercase tracking-wide text-muted-foreground">Apply scope</legend>
+            <label className="mt-1 flex items-start gap-2 text-sm text-foreground">
+              <input type="radio" checked readOnly className="mt-1" />
+              <span>
+                Loaded tasks in the current UI state
+                <span className="block text-xs text-muted-foreground">
+                  {preview.loadedNonMerge} non-merge tasks are eligible for pool reassignment.
+                </span>
+              </span>
+            </label>
+          </fieldset>
+
+          <div className="grid gap-2 rounded border border-border bg-muted/40 p-3 text-xs sm:grid-cols-3">
+            <div>
+              <div className="text-muted-foreground">Will move</div>
+              <div className="mt-1 text-lg font-semibold text-foreground" data-testid="bulk-pool-preview-count">
+                {preview.movable}
+              </div>
+            </div>
+            <div>
+              <div className="text-muted-foreground">Already in destination</div>
+              <div className="mt-1 text-lg font-semibold text-foreground" data-testid="bulk-pool-already-targeted-count">
+                {preview.alreadyTargeted}
+              </div>
+            </div>
+            <div>
+              <div className="text-muted-foreground">Merge nodes skipped</div>
+              <div className="mt-1 text-lg font-semibold text-foreground" data-testid="bulk-pool-merge-skipped-count">
+                {preview.sourceMerge}
+              </div>
+            </div>
+          </div>
+
+          {poolOptions.length < 2 && (
+            <p className="rounded border border-amber-700 bg-amber-950/40 p-3 text-xs text-amber-100">
+              At least two execution pools are required to move tasks.
+            </p>
+          )}
+
+          {poolOptions.length >= 2 && preview.movable === 0 && !result && (
+            <p className="rounded border border-border bg-secondary/70 p-3 text-xs text-muted-foreground">
+              No loaded non-merge tasks currently match the selected source pool.
+            </p>
+          )}
+
+          {result && (
+            <div
+              className="rounded border border-border-strong bg-card p-3 text-sm"
+              data-testid="bulk-pool-result"
+            >
+              <div className="font-medium text-foreground">
+                Moved {result.moved} of {result.attempted} matching tasks.
+              </div>
+              <div className="mt-1 text-xs text-muted-foreground" data-testid="bulk-pool-skipped-count">
+                Skipped {result.skipped} tasks ({result.skippedMerge} merge, {result.skippedAlreadyTargeted} already in destination).
+                {result.failed > 0 ? ` Failed ${result.failed}.` : ''}
+              </div>
+              {result.failed > 0 && (
+                <pre className="mt-2 max-h-24 overflow-auto whitespace-pre-wrap rounded bg-muted p-2 text-xs text-red-200">
+                  {formatFailureDetails(result)}
+                </pre>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          {result ? (
+            <Button type="button" onClick={onClose} data-testid="bulk-pool-done">
+              Done
+            </Button>
+          ) : (
+            <>
+              <Button type="button" variant="ghost" onClick={onClose} disabled={submitting} data-testid="bulk-pool-cancel">
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                onClick={() => void handleConfirm()}
+                disabled={!canSubmit}
+                data-testid="bulk-pool-confirm"
+              >
+                {submitting ? 'Moving...' : `Move ${preview.movable} Tasks`}
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary

Task Pool Reassignment UI completed implementation and focused UI verification.

The graph More menu now opens a pool reassignment modal for loaded non-merge tasks.

The modal previews the reassignment set and then applies the existing per-task pool edit.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784944597840-12/implement-pool-reassignment-ui | Add a graph-level UI flow to reassign tasks from one execution pool to another across available pools. | completed |
| wf-1784944597840-12/verify-pool-reassignment-ui | Run focused UI regression tests for menu interactions and new pool reassignment behavior. | completed (passed) |

</details>

## Review Claim

Expose one graph-level control for reassigning loaded non-merge tasks between execution pools.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This stays in the renderer activation surface and calls the existing editTaskPool IPC one task at a time; merge tasks are counted but not moved.

## Slice Rationale

The graph menu, modal, and focused component coverage are one user-visible surface; separating them would leave the control without its confirming UI or test.

## Non-goals

- No scheduler or executor capacity changes.
- No change to merge task behavior.
- No persistence migration.

## Architecture

### Before

```mermaid
graph TD
    A["Graph More menu"] --> B["Per-task pool edits only"]
```

### After

```mermaid
graph TD
    A["Graph More menu"] --> B["Bulk pool reassignment modal"]
    B --> C["editTaskPool for each loaded non-merge source task"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/keyboard-controls.test.tsx`
- [x] `pnpm --filter @invoker/ui build`
- [x] `node scripts/validate-pr-body.mjs --body-file tmp/plans/task-pool-reassignment-ui-pr.md --require-visual-proof --changed-files-file /tmp/task-pool-reassignment-ui-changed-files.txt --diff-file /tmp/task-pool-reassignment-ui.diff`
- [x] `node scripts/validate-pr-body-local.mjs --body-file tmp/plans/task-pool-reassignment-ui-pr.md --base master`

</details>

## Visual Proof

Bulk reassignment modal opened from the graph More menu, previewing 2 movable tasks, 1 already-targeted task, and 1 skipped merge node.

![Bulk pool reassignment modal](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-5d4213/task-pool-reassignment-ui-modal.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 02f8b3b2c0388768fb4167112e62601e0fc00249`
- Post-revert steps: None.
- Data migration? No.

</details>
