### PR TITLE
[Desktop browser terminal smoke](1) Treat terminal EOT as EOF

### DIFF
--- a/packages/execution-engine/src/__tests__/process-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/process-utils.test.ts
@@ -15,6 +15,7 @@ function createMockProcess(): ChildProcess & EventEmitter {
   const stderr = new EventEmitter();
   (proc as any).stdout = stdout;
   (proc as any).stderr = stderr;
+  (proc as any).stdin = { write: vi.fn(), end: vi.fn() };
   (proc as any).pid = 4321;
   proc.kill = vi.fn().mockReturnValue(true);
   return proc;
@@ -180,6 +181,28 @@ describe('childProcessHasExited', () => {
 
     expect(processUtils.childProcessHasExited(exited)).toBe(true);
     expect(processUtils.childProcessHasExited(signaled)).toBe(true);
+  });
+});
+
+describe('writeTerminalInputToChildStdin', () => {
+  it('writes ordinary terminal input to child stdin', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const child = createMockProcess();
+
+    processUtils.writeTerminalInputToChildStdin(child, 'hello\n');
+
+    expect((child.stdin as any).write).toHaveBeenCalledWith('hello\n');
+    expect((child.stdin as any).end).not.toHaveBeenCalled();
+  });
+
+  it('treats terminal EOT as EOF for pipe-backed child stdin', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const child = createMockProcess();
+
+    processUtils.writeTerminalInputToChildStdin(child, 'hello\n\x04');
+
+    expect((child.stdin as any).write).toHaveBeenCalledWith('hello\n');
+    expect((child.stdin as any).end).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -542,6 +542,20 @@ describe('WorktreeExecutor', () => {
     taskProcess.emit('close', 0, null);
   });
 
+  it('sendInput treats terminal EOT as EOF for pipe-backed command tasks', async () => {
+    const { taskProcess } = setupSpawnMock();
+
+    const request = makeRequest({ inputs: { command: 'cat' } });
+    const handle = await executor.start(request);
+
+    executor.sendInput(handle, 'hello\n\x04');
+    expect((taskProcess.stdin as any).write).toHaveBeenCalledWith('hello\n');
+    expect((taskProcess.stdin as any).end).toHaveBeenCalledTimes(1);
+
+    // Cleanup
+    taskProcess.emit('close', 0, null);
+  });
+
   it('getTerminalSpec returns worktree directory for command tasks', async () => {
     const { taskProcess } = setupSpawnMock();
 

--- a/packages/execution-engine/src/docker-executor.ts
+++ b/packages/execution-engine/src/docker-executor.ts
@@ -4,7 +4,7 @@ import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
 import { BaseExecutor, type BaseEntry } from './base-executor.js';
 import { loadSecretsFile } from './secrets-loader.js';
-import { killProcessGroup, cleanElectronEnv } from './process-utils.js';
+import { killProcessGroup, cleanElectronEnv, writeTerminalInputToChildStdin } from './process-utils.js';
 import { computeContentHash, buildExperimentBranchName } from './branch-utils.js';
 import type { AgentRegistry } from './agent-registry.js';
 import { DEFAULT_EXECUTION_AGENT } from './agent.js';
@@ -522,7 +522,7 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
   sendInput(handle: ExecutorHandle, input: string): void {
     const entry = this.entries.get(handle.executionId);
     if (!entry || entry.completed) return;
-    entry.process?.stdin?.write(input);
+    writeTerminalInputToChildStdin(entry.process, input);
   }
 
   getTerminalSpec(handle: ExecutorHandle): TerminalSpec | null {

--- a/packages/execution-engine/src/process-utils.ts
+++ b/packages/execution-engine/src/process-utils.ts
@@ -51,6 +51,23 @@ export function childProcessHasExited(child: ChildProcess): boolean {
   return child.exitCode != null || child.signalCode != null;
 }
 
+export function writeTerminalInputToChildStdin(child: ChildProcess | null | undefined, input: string): void {
+  const stdin = child?.stdin;
+  if (!stdin) return;
+
+  const eofIndex = input.indexOf('\x04');
+  if (eofIndex === -1) {
+    stdin.write(input);
+    return;
+  }
+
+  const beforeEof = input.slice(0, eofIndex);
+  if (beforeEof) {
+    stdin.write(beforeEof);
+  }
+  stdin.end();
+}
+
 export async function terminateChildProcessGroup(
   child: ChildProcess,
   isComplete: () => boolean,

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -5,7 +5,7 @@ import { normalize } from 'node:path';
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
 import { BaseExecutor, type BaseEntry } from './base-executor.js';
-import { killProcessGroup, cleanElectronEnv, SIGKILL_TIMEOUT_MS } from './process-utils.js';
+import { killProcessGroup, cleanElectronEnv, SIGKILL_TIMEOUT_MS, writeTerminalInputToChildStdin } from './process-utils.js';
 import { computeContentHash, buildExperimentBranchName } from './branch-utils.js';
 import { planManagedWorktree } from './managed-worktree-controller.js';
 import { findManagedWorktreeForBranch, abbrevRefMatchesBranch } from './worktree-discovery.js';
@@ -1145,7 +1145,7 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
   sendInput(handle: ExecutorHandle, input: string): void {
     const entry = this.entries.get(handle.executionId);
     if (!entry || entry.completed) return;
-    entry.process?.stdin?.write(input);
+    writeTerminalInputToChildStdin(entry.process, input);
   }
 
   getTerminalSpec(handle: ExecutorHandle): TerminalSpec | null {

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -6,7 +6,7 @@ import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
 import { BaseExecutor, MergeConflictError, type BaseEntry } from './base-executor.js';
 import { RepoPool } from './repo-pool.js';
-import { killProcessGroup, cleanElectronEnv, resolveExecutableOnCurrentPath, SIGKILL_TIMEOUT_MS } from './process-utils.js';
+import { killProcessGroup, cleanElectronEnv, resolveExecutableOnCurrentPath, SIGKILL_TIMEOUT_MS, writeTerminalInputToChildStdin } from './process-utils.js';
 import { DEFAULT_WORKTREE_PROVISION_COMMAND } from './default-worktree-provision-command.js';
 import {
   computeContentHash,
@@ -558,7 +558,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
   sendInput(handle: ExecutorHandle, input: string): void {
     const entry = this.entries.get(handle.executionId);
     if (!entry || entry.completed) return;
-    entry.process?.stdin?.write(input);
+    writeTerminalInputToChildStdin(entry.process, input);
   }
 
   getTerminalSpec(handle: ExecutorHandle): TerminalSpec | null {


### PR DESCRIPTION
## Summary

Terminal input now treats Ctrl-D as EOF for active task processes.

The shared executor path writes any preceding text, closes stdin, and never forwards the control byte.

Worktree, SSH, and Docker sendInput callers use the same helper.

## Review Claim

Terminal input routing now maps Ctrl-D to stdin EOF consistently across worktree, SSH, and Docker execution backends.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The slice only changes active process stdin handling. Inputs without Ctrl-D still write the original string to stdin.

## Slice Rationale

One routing slice keeps the shared EOF helper with the three executor sendInput callers that use it.

## Non-goals

- No changes to process spawning, task completion, terminal restoration, or agent resume behavior.
- No Docker, SSH, or worktree lifecycle policy changes.

## Architecture

### Before

Each executor wrote terminal input directly to child stdin, so Ctrl-D stayed in the input string for pipe-backed commands.

### After

Each executor calls `writeTerminalInputToChildStdin`, which writes text before Ctrl-D and closes child stdin on EOF.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/process-utils.test.ts src/__tests__/worktree-executor.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/dbts-pr-body-ca2ca52.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/dbts-pr-body-ca2ca52.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert afaddc15519263b1f23afadf73165247fb5012f0`
- Post-revert steps: Re-run the execution-engine focused test command.
- Data migration? No.

</details>
