### PR TITLE
[Desktop browser terminal smoke](1) Treat terminal EOT as EOF

### DIFF
--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -542,6 +542,22 @@ describe('WorktreeExecutor', () => {
     taskProcess.emit('close', 0, null);
   });
 
+  it('sendInput maps terminal Ctrl-D to stdin EOF for command processes', async () => {
+    const { taskProcess } = setupSpawnMock();
+
+    const request = makeRequest({ inputs: { command: 'cat' } });
+    const handle = await executor.start(request);
+
+    executor.sendInput(handle, 'hello\n\x04');
+
+    expect((taskProcess.stdin as any).write).toHaveBeenCalledWith('hello\n');
+    expect((taskProcess.stdin as any).write).not.toHaveBeenCalledWith('\x04');
+    expect((taskProcess.stdin as any).end).toHaveBeenCalledTimes(1);
+
+    // Cleanup
+    taskProcess.emit('close', 0, null);
+  });
+
   it('getTerminalSpec returns worktree directory for command tasks', async () => {
     const { taskProcess } = setupSpawnMock();
 

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -1156,6 +1156,22 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     await terminateChildProcessGroup(entry.process, () => entry.completed);
   }
 
+  protected writeProcessInput(entry: TEntry | undefined, input: string): void {
+    if (!entry || entry.completed) return;
+    const stdin = entry.process?.stdin;
+    if (!stdin) return;
+
+    const eofIndex = input.indexOf('\x04');
+    if (eofIndex === -1) {
+      stdin.write(input);
+      return;
+    }
+
+    const beforeEof = input.slice(0, eofIndex);
+    if (beforeEof) stdin.write(beforeEof);
+    stdin.end();
+  }
+
   // Abstract methods that subclasses must implement
   abstract start(request: WorkRequest): Promise<ExecutorHandle>;
   abstract sendInput(handle: ExecutorHandle, input: string): void;

--- a/packages/execution-engine/src/docker-executor.ts
+++ b/packages/execution-engine/src/docker-executor.ts
@@ -521,8 +521,7 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
 
   sendInput(handle: ExecutorHandle, input: string): void {
     const entry = this.entries.get(handle.executionId);
-    if (!entry || entry.completed) return;
-    entry.process?.stdin?.write(input);
+    this.writeProcessInput(entry, input);
   }
 
   getTerminalSpec(handle: ExecutorHandle): TerminalSpec | null {

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -1144,8 +1144,7 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
 
   sendInput(handle: ExecutorHandle, input: string): void {
     const entry = this.entries.get(handle.executionId);
-    if (!entry || entry.completed) return;
-    entry.process?.stdin?.write(input);
+    this.writeProcessInput(entry, input);
   }
 
   getTerminalSpec(handle: ExecutorHandle): TerminalSpec | null {

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -557,8 +557,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
 
   sendInput(handle: ExecutorHandle, input: string): void {
     const entry = this.entries.get(handle.executionId);
-    if (!entry || entry.completed) return;
-    entry.process?.stdin?.write(input);
+    this.writeProcessInput(entry, input);
   }
 
   getTerminalSpec(handle: ExecutorHandle): TerminalSpec | null {


### PR DESCRIPTION
## Summary

Terminal input now treats Ctrl-D as EOF for active task processes.

The shared executor path writes any preceding text, closes stdin, and never forwards the control byte.

Worktree coverage verifies the browser terminal smoke path with a `cat` process.

## Review Claim

Terminal input routing now maps Ctrl-D to stdin EOF consistently across worktree, SSH, and Docker execution backends.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The slice only changes active process stdin handling and adds a focused worktree regression; process start, completion, terminal specs, and workspace lifecycle stay unchanged.

## Slice Rationale

One routing slice keeps the shared EOF helper with the three executor sendInput callers that use it.

## Non-goals

- No changes to process spawning, task completion, terminal restoration, or agent resume behavior.
- No Docker, SSH, or worktree lifecycle policy changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/worktree-executor.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 30f9d4e1116729f0e204d3d7d613b685b0153b1f`
- Post-revert steps: Rerun `pnpm --filter @invoker/execution-engine test -- src/__tests__/worktree-executor.test.ts`.
- Data migration? No.

</details>
