### PR TITLE
[Desktop browser terminal smoke isolated](1) Isolate non-agent browser terminals

### DIFF
--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -26,7 +26,10 @@ import {
   type PtyLike,
   type PtySpawnFn,
 } from '../embedded-terminal-manager.js';
-import { resolveTaskTerminalSpec } from '../open-terminal-for-task.js';
+import {
+  resolveTaskTerminalSpec,
+  shouldAttachEmbeddedTerminalToLiveExecutor,
+} from '../open-terminal-for-task.js';
 import {
   ExecutorRegistry,
   WorktreeExecutor,
@@ -831,6 +834,82 @@ describe('GUI open-terminal embedded route', () => {
         allowRunning: true,
       });
       expect(allowed.ok).toBe(true);
+    } finally {
+      try { rmSync(wtBase, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  it('opens running command tasks as isolated shell sessions instead of attaching stdin', () => {
+    const wtBase = join(tmpdir(), `embedded-wt-${randomUUID()}`);
+    const workspacePath = join(wtBase, 'task-workspace');
+    mkdirSync(workspacePath, { recursive: true });
+    try {
+      const registry = new ExecutorRegistry();
+      registry.register('worktree', new WorktreeExecutor({
+        cacheDir: join(tmpdir(), `cache-${randomUUID()}`),
+        worktreeBaseDir: wtBase,
+      }));
+      const persistence = {
+        getTaskStatus: vi.fn(() => 'running'),
+        getRunnerKind: vi.fn(() => 'worktree'),
+        getAgentSessionId: vi.fn(() => null),
+        getContainerId: vi.fn(() => null),
+        getWorkspacePath: vi.fn(() => workspacePath),
+        getBranch: vi.fn(() => null),
+      };
+      const resolved = resolveTaskTerminalSpec({
+        taskId: 'task-cat',
+        persistence: persistence as never,
+        executorRegistry: registry,
+        repoRoot: '/repo',
+        allowRunning: true,
+      });
+      expect(resolved.ok).toBe(true);
+      if (!resolved.ok) return;
+
+      const commandChild = createFakeChild();
+      const bashSpawnFn = vi.fn(() => commandChild) as unknown as BashSpawnFn;
+      const liveExecutor = {
+        type: 'worktree',
+        onOutput: vi.fn(() => () => {}),
+        sendInput: vi.fn(),
+      };
+      const liveHandle = {
+        handle: { executionId: 'exec-cat', taskId: 'task-cat', workspacePath },
+        executor: liveExecutor as unknown as Executor,
+      };
+      const attachToLiveExecutor = shouldAttachEmbeddedTerminalToLiveExecutor(
+        resolved.meta,
+        liveHandle,
+      );
+      const mgr = new EmbeddedTerminalManager({
+        backend: createBashTerminalBackend({ spawnFn: bashSpawnFn }),
+      });
+
+      const session = mgr.openOrReuse({
+        taskId: 'task-cat',
+        spec: resolved.spec,
+        cwd: resolved.cwd,
+        attach: attachToLiveExecutor ? liveHandle : undefined,
+      });
+      const writeResult = mgr.write(session.sessionId, 'printf desktop-smoke\n');
+
+      expect(attachToLiveExecutor).toBe(false);
+      expect(session.mode).toBe('spawn');
+      expect(session.attached).toBe(false);
+      expect(bashSpawnFn).toHaveBeenCalledTimes(1);
+      expect(commandChild.__written).toEqual(['printf desktop-smoke\n']);
+      expect(liveExecutor.sendInput).not.toHaveBeenCalled();
+      expect(writeResult.ok).toBe(true);
+
+      expect(shouldAttachEmbeddedTerminalToLiveExecutor(
+        { ...resolved.meta, agentSessionId: 'agent-session-1' },
+        liveHandle,
+      )).toBe(true);
+      expect(shouldAttachEmbeddedTerminalToLiveExecutor(
+        resolved.meta,
+        { ...liveHandle, handle: { ...liveHandle.handle, agentSessionId: 'agent-session-2' } },
+      )).toBe(true);
     } finally {
       try { rmSync(wtBase, { recursive: true, force: true }); } catch { /* ignore */ }
     }

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -13,6 +13,7 @@ import {
   WorktreeExecutor,
   SshExecutor,
   type Executor,
+  type ExecutorHandle,
   type ExecutorRegistry,
   type AgentRegistry,
   type PersistedTaskMeta,
@@ -154,6 +155,13 @@ export type ResolveTaskTerminalSpecResult =
       executor: Executor;
     }
   | { ok: false; reason: string };
+
+export function shouldAttachEmbeddedTerminalToLiveExecutor(
+  meta: Pick<PersistedTaskMeta, 'agentSessionId'>,
+  liveHandle: { handle: Pick<ExecutorHandle, 'agentSessionId'>; executor: Pick<Executor, 'type'> } | undefined,
+): boolean {
+  return Boolean(liveHandle && (liveHandle.handle.agentSessionId || meta.agentSessionId));
+}
 
 export interface ResolveTaskTerminalSpecOptions {
   taskId: string;
@@ -354,12 +362,18 @@ export function openEmbeddedTerminalForTask(
   if (!resolved.ok) {
     return { opened: false, reason: resolved.reason };
   }
+  const attachToLiveExecutor = shouldAttachEmbeddedTerminalToLiveExecutor(
+    resolved.meta,
+    liveHandle,
+  );
   try {
     const session = embeddedTerminalManager.openOrReuse({
       taskId,
       spec: resolved.spec,
       cwd: resolved.cwd,
-      attach: liveHandle ? { handle: liveHandle.handle, executor: liveHandle.executor } : undefined,
+      attach: attachToLiveExecutor && liveHandle
+        ? { handle: liveHandle.handle, executor: liveHandle.executor }
+        : undefined,
     });
     return { opened: true, session };
   } catch (err) {


### PR DESCRIPTION
## Summary

Desktop browser terminals now route non-agent running tasks into isolated spawned shells.

Agent-backed tasks with session ids keep live attachment.

## Review Claim

Terminal opening routes live attachment only when an agent session exists, so non-agent running tasks get isolated spawned shells.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The gate only changes the attach/spawn decision after terminal spec resolution; cwd, task lookup, and agent-session attachment stay unchanged.

## Slice Rationale

One terminal-opening routing slice keeps the attachment decision near the embedded terminal entry point.

## Non-goals

- No renderer layout changes.
- No external terminal changes.
- No task lifecycle changes.
- No workspace resolution changes.

## Architecture

### Before

`openEmbeddedTerminalForTask()` passed any live executor handle into the embedded terminal manager.

That let non-agent running tasks receive browser-terminal input through live executor attachment.

### After

`shouldAttachEmbeddedTerminalToLiveExecutor()` allows attachment only when persisted metadata or the live handle has an agent session id.

Non-agent running tasks open spawned embedded shells, while agent-backed running tasks can still attach.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/embedded-terminal-manager.test.ts`
- [x] `node scripts/safe-stack-push.mjs`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/desktop-browser-terminal-smoke-isolated-pr-1.md --changed-files-file /tmp/desktop-browser-terminal-smoke-isolated-files.txt --diff-file /tmp/desktop-browser-terminal-smoke-isolated.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 946a22e3dc28a93639306771643cc27116985645`
- Post-revert steps: None
- Data migration? No

</details>
