### PR TITLE
Route infra task failures away from auto-fix

### DIFF
--- a/packages/app/src/__tests__/auto-fix-gating.test.ts
+++ b/packages/app/src/__tests__/auto-fix-gating.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { shouldSkipAutoFixForError } from '../auto-fix-gating.js';
+import { shouldSkipAutoFixForError } from '../../../execution-engine/src/auto-fix-gating.js';
 
 describe('auto-fix-gating', () => {
   it('does not skip auto-fix for non-string errors', () => {
@@ -23,6 +23,15 @@ describe('auto-fix-gating', () => {
 
   it('skips auto-fix for downstream termination errors', () => {
     expect(shouldSkipAutoFixForError('Terminated: upstream task "build" was terminated')).toBe(true);
+  });
+  it.each([
+    'ERR_PNPM_OUTDATED_LOCKFILE Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with packages/planning-core/package.json',
+    'Executor startup failed (ssh): SSH remote script failed (exit=1)',
+    'Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.',
+    'SSH transport failed (exit 255): remote session terminated unexpectedly.',
+    'Executor cleanup failed (ssh remote finalize): bash pop_var_context after remote run completed.',
+  ])('skips auto-fix for known infra failures: %s', (errorText) => {
+    expect(shouldSkipAutoFixForError(errorText)).toBe(true);
   });
 
   it('does not skip auto-fix for normal failures', () => {

--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -20,7 +20,7 @@ import {
   registerAutoFixWorker,
   RECOVERY_WORKER_KIND,
   type WorkerRuntimeDependencies,
-} from '../workers/auto-fix-recovery.js';
+} from '../../../execution-engine/src/index.js';
 import type { RecoveryWorkerWakeupHint } from '../lifecycle-events.js';
 
 const attemptStateKey = ['auto', 'FixAttempts'].join('');
@@ -462,6 +462,33 @@ describe('auto-fix recovery scan submission', () => {
         owner: 'auto-fix',
         action: 'submit',
         phase: 'worker-autofix-submitted',
+      }),
+    );
+  });
+  it('skips infra-bucket failures before submitting any auto-fix intent', async () => {
+    const harness = makeRecoveryPolicyHarness(makeTask({
+      execution: {
+        error: 'Executor startup failed (ssh): SSH remote script failed (exit=1)',
+        generation: 1,
+        selectedAttemptId: 'attempt-1',
+      },
+    }));
+    const tick = createAutoFixRecoveryTick(harness.options);
+
+    await tick({
+      identity: { kind: 'recovery', instanceId: 'test' },
+      reason: 'startup',
+      tickNumber: 1,
+    });
+
+    expect(harness.submit).not.toHaveBeenCalled();
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'debug.auto-fix',
+      expect.objectContaining({
+        phase: 'worker-autofix-skip',
+        reason: 'not-eligible',
+        failureBucket: 'infra_setup',
       }),
     );
   });

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -303,6 +303,66 @@ describe('SshExecutor managed workspace mode', () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
     }
   });
+  it('managed mode runs the configured provisionCommand instead of the hard-coded pnpm install', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+      remoteHeartbeatIntervalSeconds: 1,
+      remoteInvokerHome: '~/.invoker',
+      provisionCommand: 'printf "%s\\n" custom-provision > "$HOME/provision.log"\nmkdir -p node_modules',
+    }) as any;
+
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return '__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=abc123def456abc123def456abc123def456abc1';
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      return '';
+    });
+    vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+
+    await ssh.start(makeRequest({
+      actionType: 'command',
+      inputs: {
+        command: "printf 'payload-ran\\n' > payload.out",
+        description: 'run tests',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    }));
+
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+    const writeMock = (proc.stdin as any).write as ReturnType<typeof vi.fn>;
+    const bootstrapScript = writeMock.mock.calls[0]![0] as string;
+    const workspaceMatch = bootstrapScript.match(/WT=\$\(normalize_remote_path '([^']+)'\)/);
+    if (!workspaceMatch?.[1]) {
+      throw new Error('Managed SSH bootstrap did not embed a workspace path');
+    }
+
+    const fakeHome = mkdtempSync(join(tmpdir(), 'ssh-custom-provision-home-'));
+    try {
+      const workspacePath = workspaceMatch[1].replace(/^~(?=\/|$)/, fakeHome);
+      mkdirSync(workspacePath, { recursive: true });
+      writeFileSync(join(workspacePath, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
+
+      const childProcessModule = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+      const result = childProcessModule.spawnSync('/bin/bash', ['-c', bootstrapScript], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: fakeHome, PATH: process.env.PATH ?? '' },
+      });
+
+      expect(result.status).toBe(0);
+      expect(bootstrapScript).not.toContain('pnpm install --frozen-lockfile');
+      expect(readFileSync(join(fakeHome, 'provision.log'), 'utf8')).toBe('custom-provision\n');
+      expect(existsSync(join(workspacePath, 'node_modules'))).toBe(true);
+      expect(readFileSync(join(workspacePath, 'payload.out'), 'utf8')).toBe('payload-ran\n');
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+      proc.emit('close', 0, null);
+    }
+  });
 
   it('reuses a managed SSH worktree by actionId when the old base is still compatible', async () => {
     const ssh = new SshExecutor({
@@ -1130,6 +1190,37 @@ describe('SshExecutor entry lifecycle', () => {
     expect(response.status).toBe('failed');
     expect(response.outputs.exitCode).toBe(255);
     expect(response.outputs.error).toContain('broken pipe');
+  });
+  it('normalizes cleanup-tail fallback errors after a completed remote agent turn', async () => {
+    const request = makeRequest({
+      inputs: {
+        command: 'echo hello',
+        repoUrl: 'git@github.com:test/repo.git',
+      },
+    });
+
+    const handle = await ssh.start(request);
+    const sshProcess = spawnedProcesses[spawnedProcesses.length - 1];
+    const completion = new Promise<any>((resolve) => {
+      ssh.onComplete(handle, (response) => resolve(response));
+    });
+
+    (sshProcess.stdout as any).emit('data', Buffer.from([
+      '[SshExecutor] Running task payload...',
+      '{"type":"turn.completed","usage":{"input_tokens":1}}',
+      'main: line 1: pop_var_context: head of shell_variables not a function context',
+      '[SshExecutor] Recording task result and pushing branch on remote...',
+      '',
+    ].join('\n')));
+    sshProcess.emit('close', 1, null);
+
+    const response = await completion;
+    expect(response.status).toBe('failed');
+    expect(response.outputs.error).toBe(
+      'Executor cleanup failed (ssh remote finalize): bash pop_var_context after remote run completed.',
+    );
+    expect(response.outputs.error).not.toContain('[SshExecutor] Running task payload...');
+    expect(response.outputs.error).not.toContain('"type":"turn.completed"');
   });
 
   it('uses a non-login shell for internal SSH utility scripts', async () => {

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import type { ChildProcess } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SshExecutor } from '../ssh-executor.js';
@@ -361,6 +361,94 @@ describe('SshExecutor managed workspace mode', () => {
     } finally {
       rmSync(fakeHome, { recursive: true, force: true });
       proc.emit('close', 0, null);
+    }
+  });
+  it('managed mode preserves the missing-pnpm sentinel for the default provision command', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+      remoteHeartbeatIntervalSeconds: 1,
+      remoteInvokerHome: '~/.invoker',
+    });
+    const sshPrivate = ssh as unknown as {
+      execRemoteCapture: (script: string) => Promise<string>;
+      setupTaskBranch: (...args: Array<unknown>) => Promise<void>;
+    };
+
+    vi.spyOn(sshPrivate, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return '__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=abc123def456abc123def456abc123def456abc1';
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      return '';
+    });
+    vi.spyOn(sshPrivate, 'setupTaskBranch').mockResolvedValue(undefined);
+
+    const handle = await ssh.start(makeRequest({
+      actionType: 'command',
+      inputs: {
+        command: "printf 'payload-ran\\n' > payload.out",
+        description: 'run tests',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    }));
+
+    const completion = Promise.withResolvers<void>();
+    ssh.onComplete(handle, () => {
+      completion.resolve();
+    });
+
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+    const stdin = proc.stdin;
+    if (!stdin || typeof stdin.write !== 'function') {
+      throw new Error('Managed SSH bootstrap did not expose a writable stdin');
+    }
+    const mockedWrite = stdin.write as unknown as { mock: { calls: Array<[string]> } };
+    const writeCalls = mockedWrite.mock.calls;
+    const bootstrapScript = writeCalls[0]?.[0];
+    const workspaceMatch = typeof bootstrapScript === 'string'
+      ? bootstrapScript.match(/WT=\$\(normalize_remote_path '([^']+)'\)/)
+      : undefined;
+    if (typeof bootstrapScript !== 'string' || !workspaceMatch?.[1]) {
+      throw new Error('Managed SSH bootstrap did not embed a workspace path');
+    }
+
+    const fakeHome = mkdtempSync(join(tmpdir(), 'ssh-missing-pnpm-home-'));
+    const stubBin = join(fakeHome, 'bin');
+    mkdirSync(stubBin, { recursive: true });
+
+    const childProcessModule = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+    for (const command of ['bash', 'cat', 'chmod', 'date', 'mkdir', 'rm', 'sleep']) {
+      const lookup = childProcessModule.spawnSync('/bin/bash', ['-lc', `command -v ${command}`], {
+        encoding: 'utf8',
+      });
+      expect(lookup.status).toBe(0);
+      symlinkSync(lookup.stdout.trim(), join(stubBin, command));
+    }
+
+    try {
+      const workspacePath = workspaceMatch[1].replace(/^~(?=\/|$)/, fakeHome);
+      mkdirSync(workspacePath, { recursive: true });
+      writeFileSync(join(workspacePath, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
+
+      const result = childProcessModule.spawnSync('/bin/bash', ['-c', bootstrapScript], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: fakeHome, PATH: stubBin },
+      });
+
+      expect(bootstrapScript).toContain('command -v pnpm');
+      expect(result.status).toBe(127);
+      expect(result.stderr).toContain(
+        '[SshExecutor] pnpm-lock.yaml found and node_modules missing, but pnpm is not installed.',
+      );
+      expect(result.stderr).not.toContain('pnpm: command not found');
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+      proc.emit('close', 0, null);
+      await completion.promise;
     }
   });
 

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -5,7 +5,7 @@ import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, sy
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SshExecutor } from '../ssh-executor.js';
-import type { WorkRequest } from '@invoker/contracts';
+import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { PersistedTaskMeta } from '../executor.js';
 import { createSshRemoteScriptError } from '../ssh-git-exec.js';
 import { computeRepoUrlHash } from '../git-utils.js';
@@ -1309,6 +1309,36 @@ describe('SshExecutor entry lifecycle', () => {
     );
     expect(response.outputs.error).not.toContain('[SshExecutor] Running task payload...');
     expect(response.outputs.error).not.toContain('"type":"turn.completed"');
+  });
+  it('normalizes managed-workspace banner-only fallback errors into a generic startup failure', async () => {
+    const request = makeRequest({
+      inputs: {
+        command: 'echo hello',
+        repoUrl: 'git@github.com:test/repo.git',
+      },
+    });
+
+    const handle = await ssh.start(request);
+    const sshProcess = spawnedProcesses[spawnedProcesses.length - 1];
+    const completion = new Promise<WorkResponse>((resolve) => {
+      ssh.onComplete(handle, (response) => resolve(response));
+    });
+    const stdout = sshProcess.stdout;
+    if (!stdout) throw new Error('Expected mock SSH process stdout');
+    stdout.emit('data', Buffer.from([
+      '[SshExecutor] Installing pnpm dependencies for managed worktree...',
+      '[SshExecutor] Running task payload...',
+      '',
+    ].join('\n')));
+    sshProcess.emit('close', 1, null);
+
+    const response = await completion;
+    expect(response.status).toBe('failed');
+    expect(response.outputs.error).toBe(
+      'Executor startup failed (ssh): remote task wrapper exited before surfacing a concrete failure.',
+    );
+    expect(response.outputs.error).not.toContain('[SshExecutor] Installing pnpm dependencies');
+    expect(response.outputs.error).not.toContain('[SshExecutor] Running task payload...');
   });
 
   it('uses a non-login shell for internal SSH utility scripts', async () => {

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2613,10 +2613,22 @@ describe('TaskRunner', () => {
     it('reads remote targets lazily from the provider on each selectExecutor call', () => {
       const provider = vi.fn()
         .mockReturnValueOnce({
-          'do-droplet': { host: '1.2.3.4', user: 'root', sshKeyPath: '/old/key' },
+          'do-droplet': {
+            host: '1.2.3.4',
+            user: 'root',
+            sshKeyPath: '/old/key',
+            remoteInvokerHome: '/old/home',
+            provisionCommand: 'old provision',
+          },
         })
         .mockReturnValueOnce({
-          'do-droplet': { host: '1.2.3.4', user: 'root', sshKeyPath: '/new/key' },
+          'do-droplet': {
+            host: '1.2.3.4',
+            user: 'root',
+            sshKeyPath: '/new/key',
+            remoteInvokerHome: '/new/home',
+            provisionCommand: 'new provision',
+          },
         });
 
       const executor = new TaskRunner({
@@ -2635,9 +2647,13 @@ describe('TaskRunner', () => {
       const executor1 = executor.selectExecutor(task);
       expect(executor1.executor.type).toBe('ssh');
       expect((executor1.executor as any).sshKeyPath).toBe('/old/key');
+      expect((executor1.executor as any).remoteInvokerHome).toBe('/old/home');
+      expect((executor1.executor as any).provisionCommand).toBe('old provision');
 
       const executor2 = executor.selectExecutor(task);
       expect((executor2.executor as any).sshKeyPath).toBe('/new/key');
+      expect((executor2.executor as any).remoteInvokerHome).toBe('/new/home');
+      expect((executor2.executor as any).provisionCommand).toBe('new provision');
 
       expect(provider).toHaveBeenCalledTimes(2);
     });

--- a/packages/execution-engine/src/auto-fix-gating.ts
+++ b/packages/execution-engine/src/auto-fix-gating.ts
@@ -1,4 +1,112 @@
-import { isLivenessFailureClass, type TaskState } from '@invoker/workflow-core';
+import {
+  isLivenessFailureClass,
+  parseMergeConflictError,
+  type TaskState,
+} from '@invoker/workflow-core';
+
+export type AutoFixFailureBucket =
+  | 'user_cancelled'
+  | 'infra_setup'
+  | 'infra_auth'
+  | 'infra_transport'
+  | 'infra_cleanup'
+  | 'git_auth'
+  | 'liveness_stall'
+  | 'merge_conflict'
+  | 'code_or_unknown';
+
+const AUTO_FIX_SKIPPED_BUCKETS = new Set<AutoFixFailureBucket>([
+  'user_cancelled',
+  'infra_setup',
+  'infra_auth',
+  'infra_transport',
+  'infra_cleanup',
+  'git_auth',
+  'liveness_stall',
+]);
+
+const USER_CANCELLED_PREFIXES = [
+  'Cancelled by user',
+  'Cancelled:',
+  'Terminated by user',
+  'Terminated:',
+] as const;
+
+const INFRA_SETUP_SNIPPETS = [
+  'err_pnpm_outdated_lockfile',
+  'err_pnpm_unsupported_engine',
+  'executor startup failed',
+  'worktree provisioning failed',
+  'no valid workspace for failed task',
+] as const;
+
+const INFRA_AUTH_SNIPPETS = [
+  'refresh token was already used',
+  '401 unauthorized',
+] as const;
+
+const INFRA_TRANSPORT_SNIPPETS = [
+  'ssh transport failed',
+  'broken pipe',
+  'remote session terminated unexpectedly',
+  'application quit',
+] as const;
+
+const INFRA_CLEANUP_SNIPPETS = [
+  'pop_var_context',
+  'orphan function call output',
+  '[sshexecutor] recording task result and pushing branch on remote...',
+] as const;
+
+function includesAny(haystack: string, needles: readonly string[]): boolean {
+  return needles.some((needle) => haystack.includes(needle));
+}
+
+function classifyAutoFixFailureText(
+  errorText: unknown,
+  failureClass?: TaskState['execution']['failureClass'],
+): AutoFixFailureBucket {
+  if (isLivenessFailureClass(failureClass)) {
+    return 'liveness_stall';
+  }
+  if (typeof errorText !== 'string') {
+    return 'code_or_unknown';
+  }
+  const text = errorText.trim();
+  if (!text) {
+    return 'code_or_unknown';
+  }
+  if (USER_CANCELLED_PREFIXES.some((prefix) => text.startsWith(prefix))) {
+    return 'user_cancelled';
+  }
+  if (parseMergeConflictError(text) || text.includes('Merge failed: CONFLICT')) {
+    return 'merge_conflict';
+  }
+
+  const lower = text.toLowerCase();
+  if (includesAny(lower, INFRA_AUTH_SNIPPETS)) {
+    return 'infra_auth';
+  }
+  if (lower.includes('remote commit or push failed (code 128): remote: invalid username or token')) {
+    return 'git_auth';
+  }
+  if (
+    text.startsWith('Executor cleanup failed (ssh remote finalize):')
+    || includesAny(lower, INFRA_CLEANUP_SNIPPETS)
+  ) {
+    return 'infra_cleanup';
+  }
+  if (includesAny(lower, INFRA_TRANSPORT_SNIPPETS)) {
+    return 'infra_transport';
+  }
+  if (
+    text === '[SshExecutor] Running task payload...'
+    || includesAny(lower, INFRA_SETUP_SNIPPETS)
+  ) {
+    return 'infra_setup';
+  }
+  return 'code_or_unknown';
+}
 
 export function normalizeAutoFixRetryBudget(raw: unknown): number {
   if (raw === Number.POSITIVE_INFINITY) {
@@ -11,15 +119,18 @@ export function normalizeAutoFixRetryBudget(raw: unknown): number {
   return budget > 0 ? budget : 0;
 }
 
+export function classifyAutoFixFailure(task: Pick<TaskState, 'execution'>): AutoFixFailureBucket {
+  return classifyAutoFixFailureText(task.execution.error, task.execution.failureClass);
+}
+
+export function shouldSkipAutoFixForTask(task: Pick<TaskState, 'execution'>): boolean {
+  return AUTO_FIX_SKIPPED_BUCKETS.has(classifyAutoFixFailure(task));
+}
 
 export function shouldSkipAutoFixForError(errorText: unknown): boolean {
-  if (typeof errorText !== 'string') {
-    return false;
-  }
-  return errorText.startsWith('Cancelled by user') || errorText.startsWith('Cancelled:')
-    || errorText.startsWith('Terminated by user') || errorText.startsWith('Terminated:');
+  return AUTO_FIX_SKIPPED_BUCKETS.has(classifyAutoFixFailureText(errorText));
 }
 
 export function isLivenessFailureTask(task: Pick<TaskState, 'execution'>): boolean {
-  return isLivenessFailureClass(task.execution.failureClass);
+  return classifyAutoFixFailure(task) === 'liveness_stall';
 }

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -20,9 +20,9 @@ import {
   type AutoFixAttemptLedger,
 } from './auto-fix-attempt-ledger.js';
 import {
+  classifyAutoFixFailure,
   normalizeAutoFixRetryBudget,
-  shouldSkipAutoFixForError,
-  isLivenessFailureTask,
+  shouldSkipAutoFixForTask,
 } from './auto-fix-gating.js';
 import {
   checkAutoFixRetryCap,
@@ -202,10 +202,7 @@ function isRuntimeAutoFixEligibleTask(task: TaskState, options: AutoFixRecoveryP
   if (task.status !== 'failed') return false;
   if (task.config.isReconciliation) return false;
   if (task.config.parentTask) return false;
-  if (shouldSkipAutoFixForError(task.execution.error)) return false;
-  // Liveness stalls (executor stopped heartbeating) are re-run by the requeue
-  // worker, not "fixed" by the AI — auto-fix would loop on a non-defect.
-  if (isLivenessFailureTask(task)) return false;
+  if (shouldSkipAutoFixForTask(task)) return false;
   const max = retryBudgetForTask(task, options);
   if (max <= 0) return false;
   return true;
@@ -435,7 +432,7 @@ function validateAutoFixCandidate(
       workerRetryBudget: retryBudgetLabel(latestRetryBudget),
       isReconciliation: Boolean(latest.config.isReconciliation),
       hasParentTask: Boolean(latest.config.parentTask),
-      skippedForError: shouldSkipAutoFixForError(latest.execution.error),
+      failureBucket: classifyAutoFixFailure(latest),
     });
     return undefined;
   }

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { accessSync, constants } from 'node:fs';
 import { normalize } from 'node:path';
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-core';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
 import { BaseExecutor, type BaseEntry } from './base-executor.js';
 import { killProcessGroup, cleanElectronEnv, SIGKILL_TIMEOUT_MS } from './process-utils.js';
@@ -30,6 +31,7 @@ import {
   createSshRemoteScriptError,
   parseOwnedWorktreePath,
 } from './ssh-git-exec.js';
+import { classifyAutoFixFailure } from './auto-fix-gating.js';
 
 export interface SshExecutorConfig {
   host: string;
@@ -55,6 +57,8 @@ export interface SshExecutorConfig {
   useApiKey?: boolean;
   /** Optional local secrets file used when useApiKey is true. */
   secretsFile?: string;
+  /** Optional remote dependency provisioning command run inside managed worktrees. */
+  provisionCommand?: string;
   /**
    * Remote workload heartbeat interval (seconds) emitted by the SSH payload wrapper.
    * Default: 30.
@@ -79,6 +83,16 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
   readonly type = 'ssh';
   private static readonly REMOTE_HEARTBEAT_MARKER = '__INVOKER_REMOTE_HEARTBEAT__';
   private static readonly DEFAULT_REMOTE_HEARTBEAT_INTERVAL_SECONDS = 30;
+  private static readonly FALLBACK_BANNER_LINES = new Set([
+    '[SshExecutor] Installing pnpm dependencies for managed worktree...',
+    '[SshExecutor] Running task payload...',
+  ]);
+  private static readonly CLEANUP_TAIL_PREFIX = 'Executor cleanup failed (ssh remote finalize):';
+  private static readonly CLEANUP_TAIL_MARKERS = [
+    'pop_var_context',
+    'Orphan function call output',
+    '[SshExecutor] Recording task result and pushing branch on remote...',
+  ] as const;
 
   private readonly host: string;
   private readonly user: string;
@@ -89,7 +103,7 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
   private readonly remoteInvokerHome: string;
   private readonly useApiKey: boolean;
   private readonly secretsFile: string | undefined;
-  private readonly remoteHeartbeatIntervalSeconds: number;
+  private readonly provisionCommand: string;
 
   constructor(config: SshExecutorConfig) {
     super();
@@ -102,6 +116,7 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
     this.remoteInvokerHome = config.remoteInvokerHome ?? '~/.invoker';
     this.useApiKey = config.useApiKey === true;
     this.secretsFile = config.secretsFile;
+    this.provisionCommand = config.provisionCommand?.trim() || 'pnpm install --frozen-lockfile';
     const configuredRemoteHeartbeatInterval = config.remoteHeartbeatIntervalSeconds;
     this.remoteHeartbeatIntervalSeconds =
       typeof configuredRemoteHeartbeatInterval === 'number'
@@ -238,12 +253,8 @@ ${content}${content.endsWith('\n') ? '' : '\n'}${delimiter}
   if [ ! -f pnpm-lock.yaml ] || [ -d node_modules ]; then
     return 0
   fi
-  if ! command -v pnpm >/dev/null 2>&1; then
-    echo "[SshExecutor] pnpm-lock.yaml found and node_modules missing, but pnpm is not installed." >&2
-    return 127
-  fi
   echo "[SshExecutor] Installing pnpm dependencies for managed worktree..."
-  pnpm install --frozen-lockfile
+  ${this.provisionCommand}
 }
 ensure_managed_pnpm_workspace
 `
@@ -885,6 +896,57 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
     }
     return 'SSH transport failed (exit 255): remote session terminated unexpectedly.';
   }
+  private classifyFallbackFailureBucket(errorText: string) {
+    return classifyAutoFixFailure({
+      execution: {
+        error: errorText,
+        failureClass: undefined,
+      },
+    } as Pick<TaskState, 'execution'>);
+  }
+
+  private stripFallbackBannerPreamble(output: string): string {
+    const lines = output.split('\n');
+    let index = 0;
+    while (index < lines.length) {
+      const trimmed = lines[index]?.trim() ?? '';
+      if (!trimmed) {
+        index += 1;
+        continue;
+      }
+      if (!SshExecutor.FALLBACK_BANNER_LINES.has(trimmed)) {
+        break;
+      }
+      index += 1;
+    }
+    const stripped = lines.slice(index).join('\n').trim();
+    return stripped || output.trim();
+  }
+
+  private hasCompletedAgentTurn(output: string): boolean {
+    return output.includes('"type":"turn.completed"')
+      || (output.includes('"type":"item.completed"') && output.includes('"type":"agent_message"'));
+  }
+
+  private hasExplicitFailurePayload(output: string): boolean {
+    return output.includes('"type":"turn.failed"') || output.includes('"type":"error"');
+  }
+
+  private buildCleanupFallbackError(output: string): string | undefined {
+    if (!this.hasCompletedAgentTurn(output) || this.hasExplicitFailurePayload(output)) {
+      return undefined;
+    }
+    if (!SshExecutor.CLEANUP_TAIL_MARKERS.some((marker) => output.includes(marker))) {
+      return undefined;
+    }
+    if (output.includes('pop_var_context')) {
+      return `${SshExecutor.CLEANUP_TAIL_PREFIX} bash pop_var_context after remote run completed.`;
+    }
+    if (output.includes('Orphan function call output')) {
+      return `${SshExecutor.CLEANUP_TAIL_PREFIX} orphan function-call output after remote run completed.`;
+    }
+    return `${SshExecutor.CLEANUP_TAIL_PREFIX} remote finalize wrapper output after remote run completed.`;
+  }
 
   /**
    * On the remote host: commit task result (same semantics as local recordTaskResult) then push branch.
@@ -1069,10 +1131,21 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
           // capture the tail of the output buffer so the UI shows what went wrong.
           if (!mappedError && exitCode !== 0 && e) {
             const allOutput = e.outputBuffer.join('');
-            const lines = allOutput.split('\n');
-            const tail = lines.slice(-50).join('\n').trim();
-            if (tail) {
-              mappedError = tail.length > 3000 ? tail.slice(-3000) : tail;
+            const sanitizedOutput = this.stripFallbackBannerPreamble(allOutput);
+            const cleanupFallbackError = this.buildCleanupFallbackError(sanitizedOutput);
+            if (cleanupFallbackError) {
+              mappedError = cleanupFallbackError;
+            } else {
+              const lines = sanitizedOutput.split('\n');
+              const tail = lines.slice(-50).join('\n').trim();
+              if (tail) {
+                const failureBucket = this.classifyFallbackFailureBucket(tail);
+                if (failureBucket === 'infra_setup' && SshExecutor.FALLBACK_BANNER_LINES.has(tail)) {
+                  mappedError = 'Executor startup failed (ssh): remote task wrapper exited before surfacing a concrete failure.';
+                } else {
+                  mappedError = tail.length > 3000 ? tail.slice(-3000) : tail;
+                }
+              }
             }
           }
 

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -82,6 +82,7 @@ interface SshEntry extends BaseEntry {
 export class SshExecutor extends BaseExecutor<SshEntry> {
   readonly type = 'ssh';
   private static readonly REMOTE_HEARTBEAT_MARKER = '__INVOKER_REMOTE_HEARTBEAT__';
+  private static readonly DEFAULT_PROVISION_COMMAND = 'pnpm install --frozen-lockfile';
   private static readonly DEFAULT_REMOTE_HEARTBEAT_INTERVAL_SECONDS = 30;
   private static readonly FALLBACK_BANNER_LINES = new Set([
     '[SshExecutor] Installing pnpm dependencies for managed worktree...',
@@ -104,6 +105,7 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
   private readonly useApiKey: boolean;
   private readonly secretsFile: string | undefined;
   private readonly provisionCommand: string;
+  private readonly usesDefaultProvisionCommand: boolean;
 
   constructor(config: SshExecutorConfig) {
     super();
@@ -116,7 +118,11 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
     this.remoteInvokerHome = config.remoteInvokerHome ?? '~/.invoker';
     this.useApiKey = config.useApiKey === true;
     this.secretsFile = config.secretsFile;
-    this.provisionCommand = config.provisionCommand?.trim() || 'pnpm install --frozen-lockfile';
+    const configuredProvisionCommand = config.provisionCommand?.trim();
+    this.provisionCommand =
+      configuredProvisionCommand || SshExecutor.DEFAULT_PROVISION_COMMAND;
+    this.usesDefaultProvisionCommand =
+      this.provisionCommand === SshExecutor.DEFAULT_PROVISION_COMMAND;
     const configuredRemoteHeartbeatInterval = config.remoteHeartbeatIntervalSeconds;
     this.remoteHeartbeatIntervalSeconds =
       typeof configuredRemoteHeartbeatInterval === 'number'
@@ -245,6 +251,13 @@ ${content}${content.endsWith('\n') ? '' : '\n'}${delimiter}
     const heartbeatMarker = this.shellQuote(SshExecutor.REMOTE_HEARTBEAT_MARKER);
     const heartbeatIntervalSeconds = this.remoteHeartbeatIntervalSeconds;
     const stagingTokenExpression = this.buildStagingDirExpression(options.executionId, options.actionId);
+    const managedWorkspaceProvisionCommand = this.usesDefaultProvisionCommand
+      ? `if ! command -v pnpm >/dev/null 2>&1; then
+  echo "[SshExecutor] pnpm-lock.yaml found and node_modules missing, but pnpm is not installed." >&2
+  return 127
+fi
+${SshExecutor.DEFAULT_PROVISION_COMMAND}`
+      : this.provisionCommand;
     const managedWorkspaceBootstrap = options.managed
       ? `ensure_managed_pnpm_workspace() {
   if [ "\${INVOKER_SKIP_MANAGED_PNPM_INSTALL:-}" = "1" ]; then
@@ -254,7 +267,7 @@ ${content}${content.endsWith('\n') ? '' : '\n'}${delimiter}
     return 0
   fi
   echo "[SshExecutor] Installing pnpm dependencies for managed worktree..."
-  ${this.provisionCommand}
+  ${managedWorkspaceProvisionCommand}
 }
 ensure_managed_pnpm_workspace
 `

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -94,6 +94,11 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
     'Orphan function call output',
     '[SshExecutor] Recording task result and pushing branch on remote...',
   ] as const;
+  private static readonly FALLBACK_WRAPPER_ONLY_LINES: Record<string, true> = {
+    '[SshExecutor] Installing pnpm dependencies for managed worktree...': true,
+    '[SshExecutor] Running task payload...': true,
+    '[SshExecutor] Recording task result and pushing branch on remote...': true,
+  };
 
   private readonly host: string;
   private readonly user: string;
@@ -935,6 +940,20 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
     const stripped = lines.slice(index).join('\n').trim();
     return stripped || output.trim();
   }
+  private buildWrapperOnlyFallbackError(output: string): string | undefined {
+    const lines = output.split('\n').map((line) => line.trim()).filter(Boolean);
+    if (lines.length === 0) {
+      return undefined;
+    }
+    const sawStartupBanner = lines.some((line) => SshExecutor.FALLBACK_BANNER_LINES.has(line));
+    if (!sawStartupBanner) {
+      return undefined;
+    }
+    if (!lines.every((line) => Boolean(SshExecutor.FALLBACK_WRAPPER_ONLY_LINES[line]))) {
+      return undefined;
+    }
+    return 'Executor startup failed (ssh): remote task wrapper exited before surfacing a concrete failure.';
+  }
 
   private hasCompletedAgentTurn(output: string): boolean {
     return output.includes('"type":"turn.completed"')
@@ -1144,20 +1163,18 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
           // capture the tail of the output buffer so the UI shows what went wrong.
           if (!mappedError && exitCode !== 0 && e) {
             const allOutput = e.outputBuffer.join('');
+            const wrapperOnlyFallbackError = this.buildWrapperOnlyFallbackError(allOutput);
             const sanitizedOutput = this.stripFallbackBannerPreamble(allOutput);
             const cleanupFallbackError = this.buildCleanupFallbackError(sanitizedOutput);
             if (cleanupFallbackError) {
               mappedError = cleanupFallbackError;
+            } else if (wrapperOnlyFallbackError) {
+              mappedError = wrapperOnlyFallbackError;
             } else {
               const lines = sanitizedOutput.split('\n');
               const tail = lines.slice(-50).join('\n').trim();
               if (tail) {
-                const failureBucket = this.classifyFallbackFailureBucket(tail);
-                if (failureBucket === 'infra_setup' && SshExecutor.FALLBACK_BANNER_LINES.has(tail)) {
-                  mappedError = 'Executor startup failed (ssh): remote task wrapper exited before surfacing a concrete failure.';
-                } else {
-                  mappedError = tail.length > 3000 ? tail.slice(-3000) : tail;
-                }
+                mappedError = tail.length > 3000 ? tail.slice(-3000) : tail;
               }
             }
           }

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -740,6 +740,8 @@ export function selectExecutor(
         port: target.port,
         agentRegistry: host.executionAgentRegistry,
         managedWorkspaces: target.managedWorkspaces,
+        remoteInvokerHome: target.remoteInvokerHome,
+        provisionCommand: target.provisionCommand,
         useApiKey: target.use_api_key,
         secretsFile: target.secretsFile ?? host.dockerConfig.secretsFile,
         remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -73,6 +73,7 @@ export type RemoteTargetDisplay = {
   port?: number;
   managedWorkspaces?: boolean;
   remoteInvokerHome?: string;
+  provisionCommand?: string;
   use_api_key?: boolean;
   secretsFile?: string;
   remoteHeartbeatIntervalSeconds?: number;

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -140,6 +140,43 @@ describe('useTasks', () => {
 
     expect(result.current.tasks.get('wf-1/task-1')?.status).toBe('running');
   });
+  it('clears pendingFixError when an updated task delta sets it to undefined', async () => {
+    const task = makeUITask({
+      id: 'wf-1/task-1',
+      workflowId: 'wf-1',
+      status: 'awaiting_approval',
+      execution: { pendingFixError: 'Approval blocked: stale failure text' },
+    });
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [task],
+      workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'awaiting_approval' }],
+    };
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(taskGraphEventHandler).toBeDefined();
+    });
+
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'delta',
+        delta: {
+          type: 'updated',
+          taskId: 'wf-1/task-1',
+          changes: {
+            execution: { pendingFixError: undefined },
+          },
+          taskStateVersion: 2,
+          previousTaskStateVersion: 1,
+        },
+        workflowRollups: [],
+      });
+      await new Promise((resolve) => setTimeout(resolve, 110));
+    });
+
+    expect(result.current.tasks.get('wf-1/task-1')?.execution.pendingFixError).toBeUndefined();
+  });
 
   it('replaces workflows when onWorkflowsChanged receives a non-empty list', async () => {
     const { result } = renderHook(() => useTasks());

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -1036,8 +1036,13 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('f2')!.execution.pendingFixError).toBe(plainTextError);
 
       await orchestrator.approve('f2');
-      expect(orchestrator.getTask('f2')!.status).toBe('completed');
-      expect(persistence.loadAttempt(fixAttemptId!)?.status).toBe('completed');
+      const approved = orchestrator.getTask('f2')!;
+      expect(approved.status).toBe('completed');
+      expect(approved.execution.pendingFixError).toBeUndefined();
+      expect(approved.execution.fixSessionEntryStatus).toBeUndefined();
+      const approvedAttempt = persistence.loadAttempt(fixAttemptId!);
+      expect(approvedAttempt?.status).toBe('completed');
+      expect(approvedAttempt?.error).toBeUndefined();
     });
   });
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1852,11 +1852,16 @@ export class Orchestrator {
 
     const changes: TaskStateChanges = {
       status: 'completed',
-      execution: { completedAt: new Date(), fixSessionEntryStatus: undefined },
+      execution: {
+        completedAt: new Date(),
+        pendingFixError: undefined,
+        fixSessionEntryStatus: undefined,
+      },
     };
     const updated = this.writeAndSync(taskId, changes);
     this.updateSelectedAttempt(taskId, {
       status: 'completed',
+      error: undefined,
       completedAt: changes.execution?.completedAt,
     });
     const delta: TaskDelta = this.buildUpdateDelta(task, updated, changes);

--- a/scripts/repro/repro-coderabbit-pr5899-default-pnpm-guard.sh
+++ b/scripts/repro/repro-coderabbit-pr5899-default-pnpm-guard.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+
+cd "$repo_root"
+
+pnpm --dir packages/execution-engine exec vitest run \
+  src/__tests__/ssh-executor.test.ts \
+  -t "managed mode preserves the missing-pnpm sentinel for the default provision command"
+
+echo "PASS: default managed-workspace provisioning preserves the missing-pnpm sentinel"

--- a/scripts/repro/repro-coderabbit-pr5899-managed-banner-fallback.sh
+++ b/scripts/repro/repro-coderabbit-pr5899-managed-banner-fallback.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+cd "$repo_root"
+
+if pnpm --dir packages/execution-engine exec vitest run \
+  src/__tests__/ssh-executor.test.ts \
+  -t "normalizes managed-workspace banner-only fallback errors into a generic startup failure"
+then
+  echo "PASS: managed-workspace banner-only fallback maps to the generic startup error"
+else
+  echo "FAIL: managed-workspace banner-only fallback leaked wrapper banners into the saved error" >&2
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr5899-remote-target-provision-command-type.sh
+++ b/scripts/repro/repro-coderabbit-pr5899-remote-target-provision-command-type.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+cd "$repo_root"
+
+type_block="$(sed -n '/export type RemoteTargetDisplay = {/,/};/p' packages/execution-engine/src/task-runner-pool.ts)"
+
+if ! printf '%s\n' "$type_block" | grep -q 'provisionCommand?: string;'; then
+  echo "FAIL: RemoteTargetDisplay is missing provisionCommand, so selectExecutor cannot read target.provisionCommand safely." >&2
+  exit 1
+fi
+
+echo "PASS: RemoteTargetDisplay includes provisionCommand for target.provisionCommand access"


### PR DESCRIPTION
## Summary

Invoker now routes remote setup and finalize failures into deterministic task errors, and approval completion clears the selected task's amber fix error state.

The lockfile task hit three routes in one lifecycle: remote setup failure, later success, then SSH finalize noise. We were surfacing those routes like one code failure.

This change gives those routes one shared classifier, keeps wrapper and shell-tail noise out of the saved task error, and clears the fix error state when approval completes.

## Review Claim

Review that remote setup and finalize failures now take one deterministic route through the executor, recovery worker, and approval completion path, so completed tasks no longer keep the amber Fix Error block.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Code failures keep their current auto-fix route, including merge conflicts. This slice only reroutes remote setup, auth, transport, and finalize failures, and approval still completes the same task.

## Slice Rationale

These edits share one task-failure lifecycle. The executor output, recovery worker decision, and approval completion path now agree on the same route instead of drifting apart.

## Non-goals

- Repair remote SSH, auth, or Git credential outages themselves.
- Change the fix approval flow beyond clearing `pendingFixError` and the selected attempt error field.
- Rework `TaskPanel` or unrelated task status surfaces.

## Architecture

### Before

```mermaid
graph TD
    A["SSH wrapper or shell-tail text becomes task.execution.error"] --> B["auto-fix recovery reparses raw text"]
    B --> C["remote setup and finalize failures follow the same route as code failures"]
    D["approve() marks task completed"] --> E["pendingFixError stays on the completed task and selected attempt"]
```

### After

```mermaid
graph TD
    A["ssh-executor normalizes setup and finalize fallback errors"] --> B["auto-fix-gating assigns one failure bucket"]
    B --> C["auto-fix-recovery logs the bucket and reroutes remote failures away from fix retries"]
    D["approve() marks task completed"] --> E["pendingFixError and fixSessionEntryStatus clear on the task and selected attempt"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 local://repro-task-status-leak.py`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/auto-fix-gating.test.ts src/__tests__/auto-fix-recovery.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-executor.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts -t "reads remote targets lazily from the provider on each selectExecutor call"`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/use-tasks.test.tsx`

</details>

## Visual Proof

Animated proof: after the approval action, the selected-task inspector switches to `completed` and the amber `Fix Error` block disappears.

![Approve flow clears the amber Fix Error block](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-524162/fix-error-approval.gif)

Before approval, the inspector shows the amber error block beside `awaiting approval`.

![Before approval the inspector still shows Fix Error](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-524162/fix-error-before.png)

After approval, the same inspector shows `completed` and no amber Fix Error block.

![After approval the amber Fix Error block is gone](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-524162/fix-error-after.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d9859b201`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added more consistent handling of automatic fixes, including clearer classification of infrastructure, cancellation, authentication, and merge-conflict failures.
  - Remote managed workspaces can now use a configured provisioning command.
  - Improved remote execution error reporting with cleaner, deterministic messages.

- **Bug Fixes**
  - Prevented automatic fixes from being attempted for ineligible infrastructure failures.
  - Approving a fix now clears stale error information from the task and fix attempt.
  - Task updates now correctly clear resolved pending-fix errors in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->