### PR TITLE
[Planning Terminal Tmux Blank Repro](2) Restore managed worktree hydration

### DIFF
--- a/packages/execution-engine/src/__tests__/default-worktree-provision-command.test.ts
+++ b/packages/execution-engine/src/__tests__/default-worktree-provision-command.test.ts
@@ -1,9 +1,103 @@
-import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import { DEFAULT_WORKTREE_PROVISION_COMMAND } from '../default-worktree-provision-command.js';
 
+let tmpDirs: string[] = [];
+
+function makeTmpDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'invoker-worktree-provision-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function runProvision(cwd: string, env: NodeJS.ProcessEnv = {}) {
+  return spawnSync('/bin/bash', ['-c', DEFAULT_WORKTREE_PROVISION_COMMAND], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+}
+
+function writeFakePnpm(binDir: string): void {
+  mkdirSync(binDir, { recursive: true });
+  const pnpmPath = join(binDir, 'pnpm');
+  writeFileSync(
+    pnpmPath,
+    [
+      '#!/usr/bin/env bash',
+      'printf "%s\\n" "$@" > "$PWD/pnpm-args.txt"',
+      'mkdir -p "$PWD/node_modules"',
+      '',
+    ].join('\n'),
+  );
+  chmodSync(pnpmPath, 0o755);
+}
+
 describe('DEFAULT_WORKTREE_PROVISION_COMMAND', () => {
-  it('is empty so managed worktrees never auto-provision repos', () => {
-    expect(DEFAULT_WORKTREE_PROVISION_COMMAND).toBe('');
-    expect(DEFAULT_WORKTREE_PROVISION_COMMAND.trim()).toBe('');
+  afterEach(() => {
+    for (const dir of tmpDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tmpDirs = [];
+  });
+
+  it('installs pnpm dependencies when a lockfile exists and node_modules is missing', () => {
+    const workspace = makeTmpDir();
+    const binDir = join(workspace, 'bin');
+    writeFakePnpm(binDir);
+    writeFileSync(join(workspace, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
+
+    const result = runProvision(workspace, {
+      PATH: `${binDir}:/usr/bin:/bin`,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Installing pnpm dependencies');
+    expect(readFileSync(join(workspace, 'pnpm-args.txt'), 'utf8')).toBe(
+      'install\n--frozen-lockfile\n',
+    );
+    expect(existsSync(join(workspace, 'node_modules'))).toBe(true);
+  });
+
+  it('skips installation when explicitly disabled', () => {
+    const workspace = makeTmpDir();
+    const binDir = join(workspace, 'bin');
+    writeFakePnpm(binDir);
+    writeFileSync(join(workspace, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
+
+    const result = runProvision(workspace, {
+      INVOKER_SKIP_MANAGED_PNPM_INSTALL: '1',
+      PATH: `${binDir}:/usr/bin:/bin`,
+    });
+
+    expect(result.status).toBe(0);
+    expect(existsSync(join(workspace, 'pnpm-args.txt'))).toBe(false);
+    expect(existsSync(join(workspace, 'node_modules'))).toBe(false);
+  });
+
+  it('skips installation when node_modules already exists', () => {
+    const workspace = makeTmpDir();
+    const binDir = join(workspace, 'bin');
+    writeFakePnpm(binDir);
+    writeFileSync(join(workspace, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
+    mkdirSync(join(workspace, 'node_modules'));
+
+    const result = runProvision(workspace, {
+      PATH: `${binDir}:/usr/bin:/bin`,
+    });
+
+    expect(result.status).toBe(0);
+    expect(existsSync(join(workspace, 'pnpm-args.txt'))).toBe(false);
   });
 });

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -102,6 +102,19 @@ function createMockProcess(): ChildProcess & EventEmitter {
   return proc;
 }
 
+function isProvisionSpawn(cmd: string, args?: readonly string[]): boolean {
+  return cmd === '/bin/bash'
+    && args?.[0] === '-c'
+    && typeof args[1] === 'string'
+    && args[1].includes('pnpm install --frozen-lockfile');
+}
+
+function findPayloadSpawnCall() {
+  return mockedSpawn.mock.calls.find(
+    ([cmd, args]) => cmd !== 'git' && !isProvisionSpawn(cmd, args as readonly string[] | undefined),
+  );
+}
+
 /**
  * Sets up mockedSpawn to handle both git commands and task commands.
  *
@@ -109,9 +122,11 @@ function createMockProcess(): ChildProcess & EventEmitter {
  */
 function setupSpawnMock(): {
   gitProcesses: Array<ChildProcess & EventEmitter>;
+  provisionProcesses: Array<ChildProcess & EventEmitter>;
   taskProcess: ChildProcess & EventEmitter;
 } {
   const gitProcesses: Array<ChildProcess & EventEmitter> = [];
+  const provisionProcesses: Array<ChildProcess & EventEmitter> = [];
   const taskProcess = createMockProcess();
   let taskProcessReturned = false;
 
@@ -155,6 +170,15 @@ function setupSpawnMock(): {
       return gitProc as any;
     }
 
+    if (isProvisionSpawn(cmd, args)) {
+      const provisionProc = createMockProcess();
+      provisionProcesses.push(provisionProc);
+      Promise.resolve().then(() => {
+        provisionProc.emit('close', 0, null);
+      });
+      return provisionProc as any;
+    }
+
     // For non-git commands (task execution), return the task process
     if (!taskProcessReturned) {
       taskProcessReturned = true;
@@ -166,7 +190,7 @@ function setupSpawnMock(): {
     return extra as any;
   });
 
-  return { gitProcesses, taskProcess };
+  return { gitProcesses, provisionProcesses, taskProcess };
 }
 
 async function waitForCondition(predicate: () => boolean, timeoutMs = 500): Promise<void> {
@@ -308,8 +332,8 @@ describe('WorktreeExecutor', () => {
     const request = makeRequest({ inputs: { command: 'make test' } });
     await executor.start(request);
 
-    // Find the task spawn call (non-git)
-    const taskCall = mockedSpawn.mock.calls.find(([cmd]) => cmd !== 'git');
+    // Find the payload spawn call, excluding the bootstrap provision step.
+    const taskCall = findPayloadSpawnCall();
     expect(taskCall).toBeDefined();
 
     const options = taskCall![2] as { cwd: string };
@@ -321,19 +345,21 @@ describe('WorktreeExecutor', () => {
     taskProcess.emit('close', 0, null);
   });
 
-  it('does not run implicit provisioning before spawning the task process', async () => {
+  it('runs managed pnpm provisioning before spawning the task process', async () => {
     const { taskProcess } = setupSpawnMock();
 
     const request = makeRequest();
     await executor.start(request);
 
     const bootstrapCall = mockedSpawn.mock.calls.find(
-      ([cmd, args]) => cmd === '/bin/bash' && (args as string[])?.[1]?.includes('pnpm install'),
+      ([cmd, args]) => isProvisionSpawn(cmd, args as readonly string[] | undefined),
     );
-    expect(bootstrapCall).toBeUndefined();
-    const taskCall = mockedSpawn.mock.calls.find(([cmd]) => cmd !== 'git');
+    expect(bootstrapCall).toBeDefined();
+    const taskCall = findPayloadSpawnCall();
     expect(taskCall).toBeDefined();
-
+    expect(mockedSpawn.mock.calls.indexOf(bootstrapCall!)).toBeLessThan(
+      mockedSpawn.mock.calls.indexOf(taskCall!),
+    );
 
 
     taskProcess.emit('close', 0, null);
@@ -426,6 +452,14 @@ describe('WorktreeExecutor', () => {
           gitProc.emit('close', 0, null);
         });
         return gitProc as any;
+      }
+
+      if (isProvisionSpawn(cmd, args)) {
+        const provisionProc = createMockProcess();
+        Promise.resolve().then(() => {
+          provisionProc.emit('close', 0, null);
+        });
+        return provisionProc as any;
       }
 
       const tp = createMockProcess();
@@ -871,7 +905,7 @@ describe('WorktreeExecutor', () => {
       const handle = await claudeExecutor.start(request);
 
       // Verify the command is the claude command, not /bin/bash echo
-      const taskCall = mockedSpawn.mock.calls.find(([cmd]) => cmd !== 'git');
+      const taskCall = findPayloadSpawnCall();
       expect(taskCall).toBeDefined();
       expect(taskCall![0]).toBe('/bin/echo');
 
@@ -910,7 +944,7 @@ describe('WorktreeExecutor', () => {
       });
       await claudeExecutor.start(request);
 
-      const taskCall = mockedSpawn.mock.calls.find(([cmd]) => cmd !== 'git');
+      const taskCall = findPayloadSpawnCall();
       const args = taskCall![1] as string[];
       const promptArg = args[args.indexOf('-p') + 1];
       expect(promptArg).toContain('Upstream task: dep-1');
@@ -1037,9 +1071,7 @@ describe('WorktreeExecutor', () => {
       });
       await claudeExecutor.start(request);
 
-      const taskCall = mockedSpawn.mock.calls.find(
-        (call) => call[0] !== 'git',
-      );
+      const taskCall = findPayloadSpawnCall();
       const options = taskCall![2] as { stdio: any[] };
       expect(options.stdio[0]).toBe('ignore');
 

--- a/packages/execution-engine/src/default-worktree-provision-command.ts
+++ b/packages/execution-engine/src/default-worktree-provision-command.ts
@@ -1,5 +1,18 @@
-/**
- * Managed worktrees no longer run any implicit dependency/bootstrap setup.
- * Repos must do their own hydration inside the task command or a repo-owned wrapper.
- */
-export const DEFAULT_WORKTREE_PROVISION_COMMAND = '';
+export const DEFAULT_WORKTREE_PROVISION_COMMAND = `set -euo pipefail
+
+if [ "\${INVOKER_SKIP_MANAGED_PNPM_INSTALL:-}" = "1" ]; then
+  exit 0
+fi
+
+if [ ! -f pnpm-lock.yaml ] || [ -d node_modules ]; then
+  exit 0
+fi
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "[WorktreeExecutor] pnpm-lock.yaml found and node_modules missing, but pnpm is not installed." >&2
+  exit 127
+fi
+
+echo "[WorktreeExecutor] Installing pnpm dependencies for managed worktree..."
+pnpm install --frozen-lockfile
+`;

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -693,8 +693,54 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     }
   }
 
-  private provisionWorktree(dir: string, _executionId?: string): { child: ChildProcess | null; completion: Promise<void> } {
-    traceExecution(`[WorktreeExecutor] provisionWorktree skipped dir=${dir}`);
-    return { child: null, completion: Promise.resolve() };
+  private provisionWorktree(dir: string, executionId?: string): { child: ChildProcess | null; completion: Promise<void> } {
+    const command = DEFAULT_WORKTREE_PROVISION_COMMAND.trim();
+    if (!command) {
+      traceExecution(`[WorktreeExecutor] provisionWorktree skipped dir=${dir}`);
+      return { child: null, completion: Promise.resolve() };
+    }
+
+    traceExecution(`[WorktreeExecutor] provisionWorktree begin dir=${dir}`);
+    const child = spawn('/bin/bash', ['-c', command], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      cwd: dir,
+      detached: true,
+      env: cleanElectronEnv(),
+    });
+
+    if (executionId) {
+      child.stdout?.on('data', (chunk: Buffer) => {
+        this.emitOutput(executionId, chunk.toString());
+      });
+      child.stderr?.on('data', (chunk: Buffer) => {
+        this.emitOutput(executionId, chunk.toString());
+      });
+    }
+
+    const completion = new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const finish = (fn: () => void) => {
+        if (settled) return;
+        settled = true;
+        fn();
+      };
+
+      child.on('error', (err) => {
+        traceExecution(`[WorktreeExecutor] provisionWorktree spawn error dir=${dir}: ${err.message}`);
+        finish(() => reject(new Error(`Worktree provisioning failed to spawn: ${err.message}`)));
+      });
+      child.on('close', (code, signal) => {
+        if (code === 0) {
+          traceExecution(`[WorktreeExecutor] provisionWorktree done dir=${dir}`);
+          finish(resolve);
+          return;
+        }
+        const reason = signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`;
+        traceExecution(`[WorktreeExecutor] provisionWorktree failed dir=${dir}: ${reason}`);
+        finish(() => reject(new Error(`Worktree provisioning failed with ${reason}`)));
+      });
+    });
+
+    return { child, completion };
   }
 }


### PR DESCRIPTION
## Summary

Local managed worktrees now run conditional pnpm hydration before task payloads.

Fresh pnpm repos install from the lockfile only when dependencies are missing, with an opt-out for managed worktree provisioning.

## Review Claim

Local managed worktrees hydrate pnpm dependencies before payloads run.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The bootstrap is conditional: it exits when disabled, when no pnpm lockfile exists, or when node_modules already exists.

## Slice Rationale

This behavior slice follows the repro proof and keeps dependency hydration separate from the e2e defect contract.

## Non-goals

- No tmux rendering fix.
- No SSH provisioning change.
- No package manager support beyond pnpm lockfile worktrees.

## Architecture

### Before

```mermaid
graph TD
    A["Worktree acquired"] --> B["Payload starts"]
```

### After

```mermaid
graph TD
    A["Worktree acquired"] --> B["Conditional pnpm hydration"]
    B --> C["Payload starts"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- worktree-executor.test.ts default-worktree-provision-command.test.ts`
- [x] `pnpm --filter @invoker/execution-engine build`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && pnpm --filter @invoker/app test:e2e -- planning-terminal-tmux-blank-repro.spec.ts` (exits 0; tmux tests skipped locally because `tmux` is unavailable)
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-planning-tmux-blank-repro-pr2.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 54a24dd4831bfe158ce23c0e90f48c35f51cb93f`
- Post-revert steps: None
- Data migration? No

</details>
