### PR TITLE
[Onboarding Step 1: CLI one-shot setup](1) Add setup readiness checks

### DIFF
--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -19,7 +19,6 @@ import {
   REQUIRED_BOT_SCOPES,
   runPlanValidationSmoke,
   slackCredsFromEnv,
-  skippedGithubAuthCheck,
   runSetup,
   setExperimentalPlannerFlag,
   upsertEnvLines,
@@ -544,8 +543,22 @@ describe('GitHub auth check', () => {
     expect(check.remediation).toContain('gh auth login');
   });
 
-  it('warns and skips when gh is missing', () => {
-    expect(skippedGithubAuthCheck()).toMatchObject({ id: 'github-auth', status: 'warn' });
+  it('warns and skips when the injected runner cannot find gh', () => {
+    const error = Object.assign(new Error('spawn gh ENOENT'), { code: 'ENOENT' });
+    const check = checkGithubAuth(() => { throw error; });
+    expect(check).toMatchObject({ id: 'github-auth', status: 'warn' });
+    expect(check.detail).toContain('skipped auth check');
+    expect(check.remediation).toContain('gh auth login');
+  });
+
+  it('warns and skips when gh spawn returns no status', () => {
+    const check = checkGithubAuth(() => ({ status: null, stdout: '', stderr: '' }));
+    expect(check).toMatchObject({ id: 'github-auth', status: 'warn' });
+  });
+
+  it('warns and skips when a shell runner reports gh as command-not-found', () => {
+    const check = checkGithubAuth(() => ({ status: 127, stdout: '', stderr: 'gh: command not found' }));
+    expect(check).toMatchObject({ id: 'github-auth', status: 'warn' });
   });
 });
 

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -274,6 +274,7 @@ export interface CommandRunnerResult {
   status: number | null;
   stdout: string;
   stderr: string;
+  error?: unknown;
 }
 
 export type CommandRunner = (command: string, args: readonly string[]) => CommandRunnerResult;
@@ -284,6 +285,7 @@ export function defaultCommandRunner(command: string, args: readonly string[]): 
     status: result.status,
     stdout: typeof result.stdout === 'string' ? result.stdout : '',
     stderr: typeof result.stderr === 'string' ? result.stderr : '',
+    error: result.error,
   };
 }
 
@@ -297,9 +299,35 @@ export function skippedGithubAuthCheck(): PrerequisiteCheck {
   };
 }
 
+function isMissingCommandError(error: unknown): boolean {
+  if (!error) return false;
+  const code = typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code)
+    : '';
+  const message = formatCaughtException(error).toLowerCase();
+  return code === 'ENOENT' || message.includes('enoent') || message.includes('not found');
+}
+
+function firstOutputLine(result: Pick<CommandRunnerResult, 'stdout' | 'stderr'>, fallback: string): string {
+  return (result.stderr || result.stdout || fallback).trim().split('\n')[0] || fallback;
+}
+
 /** Probe `gh auth status`. Injectable `runner` keeps tests offline. */
 export function checkGithubAuth(runner: CommandRunner = defaultCommandRunner): PrerequisiteCheck {
-  const result = runner('gh', ['auth', 'status']);
+  let result: CommandRunnerResult;
+  try {
+    result = runner('gh', ['auth', 'status']);
+  } catch (error) {
+    return isMissingCommandError(error)
+      ? skippedGithubAuthCheck()
+      : {
+        id: 'github-auth',
+        name: 'GitHub auth',
+        status: 'error',
+        detail: formatCaughtException(error),
+        remediation: 'Run `gh auth status` to inspect the GitHub CLI failure',
+      };
+  }
   if (result.status === 0) {
     return {
       id: 'github-auth',
@@ -308,8 +336,13 @@ export function checkGithubAuth(runner: CommandRunner = defaultCommandRunner): P
       detail: 'gh is authenticated',
     };
   }
-  const detail = (result.stderr || result.stdout || 'gh auth status failed').trim().split('\n')[0]
-    || 'gh auth status failed';
+  if (isMissingCommandError(result.error) || isMissingCommandError(firstOutputLine(result, ''))) {
+    return skippedGithubAuthCheck();
+  }
+  if (result.status === null && result.stdout.trim() === '' && result.stderr.trim() === '') {
+    return skippedGithubAuthCheck();
+  }
+  const detail = firstOutputLine(result, 'gh auth status failed');
   return {
     id: 'github-auth',
     name: 'GitHub auth',


### PR DESCRIPTION
## Summary

`invoker-cli setup` now finishes with concrete readiness evidence.

The setup path checks GitHub auth, parses a tiny offline plan, and ends with either "You're ready." or one fix-first item.

## Review Claim

`invoker-cli setup` now performs the onboarding readiness checks needed for a one-shot setup result.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The new checks are appended to the existing setup flow and use injectable runners, so tests cover success, failure, and missing `gh` without network access.

## Slice Rationale

The CLI setup experience is one review unit; merge-helper identity hardening belongs in the next slice.

## Non-goals

This does not change Slack token validation, planner MCP installation, or runtime workflow execution.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/cli exec vitest run src/__tests__/onboarding.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ef4d6ec51`
- Post-revert steps: None
- Data migration? No

</details>
