### PR TITLE
[Onboarding Step 1: CLI one-shot setup](2) Preserve branch merges without git identity config

### DIFF
--- a/packages/execution-engine/src/__tests__/branch-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/branch-utils.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import {
   computeContentHash,
   formatLifecycleTag,
@@ -30,6 +30,25 @@ function createTempRepo(): string {
 
 function gitExec(cmd: string, cwd: string): string {
   return execSync(cmd, { cwd, encoding: 'utf-8' }).trim();
+}
+
+function runBashWithoutGitIdentity(script: string, cwd?: string): string {
+  const home = mkdtempSync(join(tmpdir(), 'branch-utils-no-git-id-home-'));
+  mkdirSync(join(home, '.config'), { recursive: true });
+  try {
+    return execFileSync('bash', ['-lc', script], {
+      cwd,
+      encoding: 'utf-8',
+      env: {
+        PATH: process.env.PATH ?? '',
+        HOME: home,
+        XDG_CONFIG_HOME: join(home, '.config'),
+        GIT_CONFIG_NOSYSTEM: '1',
+      },
+    });
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -409,6 +428,31 @@ describe('bashPreserveOrReset', () => {
       expect(readFileSync(join(repoDir, 'master-update.txt'), 'utf-8')).toBe('new base');
     });
 
+    it('preserves branch with commits ahead when git identity is not configured', () => {
+      gitExec('git checkout -b invoker/no-identity', repoDir);
+      writeFileSync(join(repoDir, 'task-a.txt'), 'task work');
+      gitExec('git add -A && git commit -m "task commit"', repoDir);
+      gitExec('git checkout master', repoDir);
+
+      writeFileSync(join(repoDir, 'master-update.txt'), 'new base');
+      gitExec('git add -A && git commit -m "base update"', repoDir);
+      gitExec('git config --unset user.email', repoDir);
+      gitExec('git config --unset user.name', repoDir);
+
+      const script = bashPreserveOrReset({
+        repoDir,
+        branch: 'invoker/no-identity',
+        base: 'master',
+      });
+      const stdout = runBashWithoutGitIdentity(script, repoDir);
+      const result = parsePreserveResult(stdout);
+
+      expect(result.preserved).toBe(true);
+      expect(readFileSync(join(repoDir, 'task-a.txt'), 'utf-8')).toBe('task work');
+      expect(readFileSync(join(repoDir, 'master-update.txt'), 'utf-8')).toBe('new base');
+      expect(gitExec('git log -1 --format="%cn <%ce>"', repoDir)).toBe('Invoker Bot <invoker@local>');
+    });
+
     it('force-resets when branch exists but has 0 commits ahead', async () => {
       // Create branch at same point as master
       gitExec('git checkout -b invoker/stale', repoDir);
@@ -659,6 +703,28 @@ describe('bashMergeUpstreams', () => {
 
     expect(readFileSync(join(wtDir, 'x.txt'), 'utf-8')).toBe('x');
     expect(readFileSync(join(wtDir, 'y.txt'), 'utf-8')).toBe('y');
+  });
+
+  it('merges branches when git identity is not configured', () => {
+    gitExec('git checkout -b upstream-no-identity', repoDir);
+    writeFileSync(join(repoDir, 'upstream.txt'), 'from upstream');
+    gitExec('git add -A && git commit -m "upstream change"', repoDir);
+    gitExec('git checkout master', repoDir);
+
+    writeFileSync(join(wtDir, 'local.txt'), 'from worktree');
+    gitExec('git add -A && git commit -m "worktree change"', wtDir);
+    gitExec('git config --unset user.email', repoDir);
+    gitExec('git config --unset user.name', repoDir);
+
+    const script = bashMergeUpstreams({
+      worktreeDir: wtDir,
+      upstreamBranches: ['upstream-no-identity'],
+    });
+    runBashWithoutGitIdentity(script, wtDir);
+
+    expect(readFileSync(join(wtDir, 'local.txt'), 'utf-8')).toBe('from worktree');
+    expect(readFileSync(join(wtDir, 'upstream.txt'), 'utf-8')).toBe('from upstream');
+    expect(gitExec('git log -1 --format="%cn <%ce>"', wtDir)).toBe('Invoker Bot <invoker@local>');
   });
 
   it('resets dirty worktree state before merge to avoid false merge_conflict', async () => {

--- a/packages/execution-engine/src/branch-utils.ts
+++ b/packages/execution-engine/src/branch-utils.ts
@@ -120,6 +120,17 @@ function sanitizeAttemptShort(raw: string): string {
   return raw.toLowerCase().replace(/[^a-z0-9_-]+/g, '');
 }
 
+function bashInvokerGitIdentityFallback(repoDirVar: string): string {
+  return `if ! git -C "$${repoDirVar}" config --get user.name >/dev/null 2>&1 || ! git -C "$${repoDirVar}" config --get user.email >/dev/null 2>&1; then
+  # Fresh SSH targets may not have git user.name/user.email configured.
+  : "\${GIT_AUTHOR_NAME:=\${GIT_COMMITTER_NAME:-Invoker Bot}}"
+  : "\${GIT_AUTHOR_EMAIL:=\${GIT_COMMITTER_EMAIL:-invoker@local}}"
+  : "\${GIT_COMMITTER_NAME:=\${GIT_AUTHOR_NAME:-Invoker Bot}}"
+  : "\${GIT_COMMITTER_EMAIL:=\${GIT_AUTHOR_EMAIL:-invoker@local}}"
+  export GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
+fi`;
+}
+
 export interface PreserveOrResetOpts {
   repoDir: string;
   worktreeDir?: string;
@@ -144,6 +155,7 @@ export function bashPreserveOrReset(opts: PreserveOrResetOpts): string {
   // exists with commits ahead, and either preserves or force-creates.
   return `set -euo pipefail
 REPO_DIR=${q(repoDir)}
+${bashInvokerGitIdentityFallback('REPO_DIR')}
 BRANCH=${q(branch)}
 BASE=${q(base)}
 BASE_SHA=$(git -C "$REPO_DIR" rev-parse "$BASE")
@@ -238,6 +250,7 @@ export function bashMergeUpstreams(opts: MergeUpstreamsOpts): string {
 
   return `set -euo pipefail
 WT_DIR=${q(worktreeDir)}
+${bashInvokerGitIdentityFallback('WT_DIR')}
 # Reused worktrees can retain dirty tracked/untracked files from interrupted runs.
 # Normalize to HEAD so upstream merges are deterministic and not blocked by
 # "local changes would be overwritten by merge".


### PR DESCRIPTION
## Summary

Invoker merge helpers now supply a deterministic bot identity when no git identity is configured.

That keeps preserved branches and upstream merges working on fresh SSH targets.

## Review Claim

Branch merge helpers use a fallback committer identity only when `user.name` or `user.email` is not configured.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The fallback only exports git author and committer environment variables inside the generated merge scripts, and existing configured identities remain untouched.

## Slice Rationale

This isolates merge-helper reliability from the setup readiness slice.

## Non-goals

This does not change branch naming, upstream selection, conflict handling, or PR publication.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/branch-utils.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0fd46e7c8`
- Post-revert steps: None
- Data migration? No

</details>
