### PR TITLE
[Repair Workflow Step 1: ci_failed gate policy](1) Repair blocked gate wakeups

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -273,12 +273,12 @@ class InMemoryBus implements OrchestratorMessageBus {
   }
 }
 
-const consoleLogger: Logger = {
-  debug: (msg, fields) => console.debug(msg, fields),
-  info: (msg, fields) => console.log(msg, fields),
-  warn: (msg, fields) => console.warn(msg, fields),
-  error: (msg, fields) => console.error(msg, fields),
-  child: () => consoleLogger,
+const testLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => testLogger,
 };
 
 // ── Helpers ─────────────────────────────────────────────────
@@ -316,7 +316,7 @@ describe('Orchestrator', () => {
       persistence,
       messageBus: bus,
       maxConcurrency: 3,
-      logger: consoleLogger,
+      logger: testLogger,
       resolveRepoDefaultBranch: () => repoDefaultBranch,
     });
   });
@@ -1802,7 +1802,7 @@ describe('Orchestrator', () => {
         persistence,
         messageBus: bus,
         maxConcurrency: 3,
-        logger: consoleLogger,
+        logger: testLogger,
         resolveRepoDefaultBranch: () => {
           throw new Error('repo default unavailable');
         },
@@ -2222,7 +2222,7 @@ describe('Orchestrator', () => {
       const launchingOrchestrator = new Orchestrator({
         persistence,
         messageBus: bus,
-        logger: consoleLogger,
+        logger: testLogger,
         maxConcurrency: 3,
         deferRunningUntilLaunch: true,
       });
@@ -2365,7 +2365,7 @@ describe('Orchestrator', () => {
       const parkOrchestrator = new Orchestrator({
         persistence,
         messageBus: bus,
-        logger: consoleLogger,
+        logger: testLogger,
         maxConcurrency: 3,
         deferRunningUntilLaunch: true,
         launchDeferralBackoffMs: 60_000,
@@ -2400,7 +2400,7 @@ describe('Orchestrator', () => {
       const parkOrchestrator = new Orchestrator({
         persistence,
         messageBus: bus,
-        logger: consoleLogger,
+        logger: testLogger,
         maxConcurrency: 3,
         deferRunningUntilLaunch: true,
         launchDeferralBackoffMs: 60_000,
@@ -2430,7 +2430,7 @@ describe('Orchestrator', () => {
       const parkOrchestrator = new Orchestrator({
         persistence,
         messageBus: bus,
-        logger: consoleLogger,
+        logger: testLogger,
         maxConcurrency: 3,
         launchDeferralBackoffMs: 600_000,
       });
@@ -2464,7 +2464,7 @@ describe('Orchestrator', () => {
       const parkOrchestrator = new Orchestrator({
         persistence,
         messageBus: bus,
-        logger: consoleLogger,
+        logger: testLogger,
         maxConcurrency: 3,
         launchDeferralBackoffMs: 600_000,
       });
@@ -2497,7 +2497,7 @@ describe('Orchestrator', () => {
       const parkOrchestrator = new Orchestrator({
         persistence,
         messageBus: bus,
-        logger: consoleLogger,
+        logger: testLogger,
         maxConcurrency: 3,
         deferRunningUntilLaunch: true,
         launchDeferralBackoffMs: 0,
@@ -2960,6 +2960,42 @@ describe('Orchestrator', () => {
       persistence.updateTask(prereqTaskId, { status: 'completed', execution: { completedAt: new Date() } });
       persistence.updateTask(prereqMergeId, {
         status: 'review_ready',
+        execution: { reviewUrl: 'https://example.invalid/pull/1', reviewStatus: 'CI failed' },
+      });
+      persistence.updateTask(leafId, {
+        status: 'blocked',
+        execution: { blockedBy: `waiting on ${prereqMergeId} (running)` },
+      });
+      orchestrator.syncAllFromDb();
+
+      const started = orchestrator.autoStartExternallyUnblockedReadyTasks();
+
+      expect(started.map((t) => t.id)).toContain(leafId);
+      expect(orchestrator.getTask(leafId)!.status).toBe('running');
+      expect(orchestrator.getTask(leafId)!.execution.blockedBy).toBeUndefined();
+    });
+
+    it('transitions an already-blocked ci_failed dependent to runnable when the upstream gate is awaiting_approval', () => {
+      orchestrator.loadPlan({
+        name: 'gate-prereq-ci-awaiting-approval',
+        tasks: [{ id: 'verify', description: 'Prereq task' }],
+      });
+      const prereqTaskId = sid(orchestrator, 0, 'verify');
+      const prereqWfId = prereqTaskId.split('/')[0]!;
+      const prereqMergeId = `__merge__${prereqWfId}`;
+
+      orchestrator.loadPlan({
+        name: 'gate-downstream-blocked-ci-awaiting-approval',
+        externalDependencies: [
+          { workflowId: prereqWfId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'ci_failed' },
+        ],
+        tasks: [{ id: 'leaf', description: 'leaf waits on upstream failed CI approval gate' }],
+      });
+      const leafId = sid(orchestrator, 1, 'leaf');
+
+      persistence.updateTask(prereqTaskId, { status: 'completed', execution: { completedAt: new Date() } });
+      persistence.updateTask(prereqMergeId, {
+        status: 'awaiting_approval',
         execution: { reviewUrl: 'https://example.invalid/pull/1', reviewStatus: 'CI failed' },
       });
       persistence.updateTask(leafId, {

--- a/packages/workflow-core/src/state-machine.ts
+++ b/packages/workflow-core/src/state-machine.ts
@@ -50,15 +50,6 @@ export class TaskStateMachine {
     const ready: string[] = [];
 
     for (const task of this.graph.getAllNodes()) {
-      // Log merge nodes specifically to trace why they're skipped/included
-      if (task.config?.isMergeNode) {
-        const depStatuses = task.dependencies.map(depId => {
-          const dep = this.graph.getNode(depId);
-          return `${depId}=${dep?.status ?? 'NOT_FOUND'}`;
-        });
-        console.log(`[state-machine] findNewlyReadyTasks(${completedTaskId}): merge node "${task.id}" status=${task.status} deps=[${depStatuses.join(', ')}] hasDep=${task.dependencies.includes(completedTaskId)}`);
-      }
-
       if (task.status !== 'pending' && task.status !== 'blocked') continue;
       if (!task.dependencies.includes(completedTaskId)) continue;
 


### PR DESCRIPTION
## Summary

`ci_failed` stack dependents now have regression coverage for the approval-shaped failed-CI gate.

The branch also quiets readiness tracing so the focused gate-policy suite stays readable.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784927703552-8/implement-ci-failed-gate-policy | Add 'ci_failed' as a third external-dependency gate policy across engine, parser, and UI | completed |
| wf-1784927703552-8/verify-ci-failed-gate-policy | Run the gate-policy and parser test suites plus typecheck | completed (passed) |

</details>

## Review Claim

Approve the `ci_failed` gate-policy repair coverage and the quiet readiness query path that keeps the regression suite usable.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The runtime readiness decision remains local to the task graph, and the added case exercises only in-memory orchestrator state.

## Slice Rationale

This is the remaining repair slice for Step 1: it keeps the gate-policy assertion with the readiness path that produced noisy traces during verification.

## Non-goals

- Does not change review artifact publication.
- Does not change parser syntax.
- Does not change UI rendering.
- Does not change merge queue policy.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core test -- orchestrator-gates-and-workflow-admin.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <published-sha>`
- Post-revert steps: Re-run the workflow-core gate-policy suite.
- Data migration? No

</details>
