### PR TITLE
[Planning terminal adverse proof harness](1) Add focused adverse repro tests

### DIFF
--- a/packages/app/src/__tests__/planning-terminal-restore-invariants.repro.test.ts
+++ b/packages/app/src/__tests__/planning-terminal-restore-invariants.repro.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { IpcMain } from 'electron';
+import type { InAppPlanningSessionRecord } from '@invoker/data-store';
+import {
+  createInAppPlanningChatSessions,
+  restorePlanningChatSessions,
+  type InAppPlanningChatSession,
+} from '../in-app-planner.js';
+import {
+  bindPlanningTerminalSessionState,
+  registerPlanningTerminalSessionIpcHandlers,
+} from '../terminal-session-ipc.js';
+
+const NOW = '2026-07-26T00:00:00.000Z';
+
+const planningCommandBuilder = vi.fn(() => ({ command: 'planner', args: ['prompt'] }));
+
+function makeRecord(overrides: Partial<InAppPlanningSessionRecord>): InAppPlanningSessionRecord {
+  return {
+    id: 'planning-record',
+    title: 'Planning record',
+    presetKey: 'codex',
+    status: 'still_discussing',
+    messages: [],
+    pendingResponse: false,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function makeSession(overrides: Partial<InAppPlanningChatSession>): InAppPlanningChatSession {
+  return {
+    id: 'planning-session',
+    title: 'Planning session',
+    presetKey: 'codex',
+    status: 'still_discussing',
+    messages: [],
+    conversation: {} as InAppPlanningChatSession['conversation'],
+    createdAt: NOW,
+    updatedAt: NOW,
+    nextMessageId: 1,
+    ...overrides,
+  };
+}
+
+describe('planning terminal restore invariant repros', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // `it.fails`: this asserts the desired invariant for the behavior slice. A
+  // persisted planning chat should remain visible under the configured default
+  // when its original preset key is no longer available.
+  it.fails('keeps a restored planning chat visible when its persisted preset key is missing', async () => {
+    const sessions = createInAppPlanningChatSessions();
+
+    await restorePlanningChatSessions([
+      makeRecord({
+        id: 'missing-preset-plan',
+        title: 'Missing preset plan',
+        presetKey: 'retired+agent',
+        terminalMode: 'tmux',
+        terminalSessionId: 'term-missing-preset',
+        terminalStatus: 'running',
+      }),
+    ], {
+      config: {
+        defaultSlackHarnessPreset: 'codex',
+      },
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+
+    expect(sessions.get('missing-preset-plan')).toMatchObject({
+      id: 'missing-preset-plan',
+      presetKey: 'codex',
+      terminalMode: 'tmux',
+      terminalSessionId: 'term-missing-preset',
+      terminalStatus: 'running',
+    });
+  });
+
+  // `it.fails`: this asserts the desired invariant for the behavior slice. When
+  // a team renames a custom preset and makes the new key the default, persisted
+  // chats using the old key should restore under that configured replacement.
+  it.fails('remaps a restored planning chat from a removed custom preset key to the configured default', async () => {
+    const sessions = createInAppPlanningChatSessions();
+
+    await restorePlanningChatSessions([
+      makeRecord({
+        id: 'remapped-preset-plan',
+        title: 'Remapped preset plan',
+        presetKey: 'team-preset-before-rename',
+        terminalMode: 'tmux',
+        terminalSessionId: 'term-remapped-preset',
+        terminalStatus: 'running',
+      }),
+    ], {
+      config: {
+        defaultSlackHarnessPreset: 'team-preset-after-rename',
+        slackHarnessPresets: {
+          'team-preset-after-rename': { tool: 'codex' },
+        },
+      },
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+
+    expect(sessions.get('remapped-preset-plan')).toMatchObject({
+      id: 'remapped-preset-plan',
+      presetKey: 'team-preset-after-rename',
+      terminalMode: 'tmux',
+      terminalSessionId: 'term-remapped-preset',
+      terminalStatus: 'running',
+    });
+  });
+
+  it('restores a submitted tmux planning terminal but rejects writes after restore', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('submitted-tmux-plan', makeSession({
+      id: 'submitted-tmux-plan',
+      status: 'submitted',
+      terminalMode: 'tmux',
+      terminalSessionId: 'term-submitted',
+      terminalStatus: 'running',
+      terminalOutputSnapshot: 'submitted output\n',
+      terminalUpdatedAt: '2026-07-26T00:01:00.000Z',
+    }));
+    const embeddedTerminalManager = {
+      on: vi.fn(),
+      restoreSpawnSession: vi.fn((seed: any) => ({
+        sessionId: seed.sessionId,
+        taskId: seed.taskId,
+        kind: seed.kind,
+        planningSessionId: seed.planningSessionId,
+        status: 'running',
+        cwd: seed.cwd,
+        mode: 'spawn',
+        attached: false,
+        createdAt: seed.createdAt,
+        outputSnapshot: seed.outputSnapshot,
+      })),
+    };
+    const { restorePersistedPlanningTerminals } = bindPlanningTerminalSessionState({
+      embeddedTerminalManager: embeddedTerminalManager as any,
+      logger: { warn: vi.fn() },
+      planningChatSessions: sessions,
+      getPlanningSessionStore: () => undefined,
+      repoRoot: '/repo',
+    });
+
+    restorePersistedPlanningTerminals();
+
+    expect(embeddedTerminalManager.restoreSpawnSession).toHaveBeenCalledTimes(1);
+    expect(embeddedTerminalManager.restoreSpawnSession).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'term-submitted',
+      taskId: 'planning:submitted-tmux-plan',
+      kind: 'planning',
+      planningSessionId: 'submitted-tmux-plan',
+      spec: { cwd: '/repo' },
+      cwd: '/repo',
+      outputSnapshot: 'submitted output\n',
+    }));
+
+    const handlers = new Map<string, (...args: any[]) => Promise<unknown>>();
+    registerPlanningTerminalSessionIpcHandlers({
+      ipcMain: {
+        handle(channel: string, callback: (...args: any[]) => Promise<unknown>) {
+          handlers.set(channel, callback);
+        },
+      } as unknown as IpcMain,
+      embeddedTerminalManager: {
+        on: vi.fn(),
+        get: vi.fn(() => ({
+          sessionId: 'term-submitted',
+          taskId: 'planning:submitted-tmux-plan',
+          kind: 'planning',
+          planningSessionId: 'submitted-tmux-plan',
+          status: 'running',
+          mode: 'spawn',
+          attached: false,
+          createdAt: NOW,
+        })),
+        write: vi.fn(),
+        resize: vi.fn(),
+        close: vi.fn(),
+        list: vi.fn(() => []),
+        openOrReuse: vi.fn(),
+      } as any,
+      logger: { info: vi.fn(), warn: vi.fn() },
+      planningChatSessions: sessions,
+      getPlanningSessionStore: () => ({} as any),
+      repoRoot: '/repo',
+    });
+
+    await expect(
+      handlers.get('invoker:planning-terminal-write')?.({}, 'term-submitted', 'x'),
+    ).resolves.toEqual({ ok: false, reason: 'This planning session was already submitted.' });
+  });
+
+  it('does not restore a tmux process for a chat-mode planning session with stale terminal metadata', () => {
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('chat-mode-with-terminal-id', makeSession({
+      id: 'chat-mode-with-terminal-id',
+      terminalMode: 'chat',
+      terminalSessionId: 'term-chat-mode',
+      terminalStatus: 'running',
+    }));
+
+    const embeddedTerminalManager = {
+      on: vi.fn(),
+      restoreSpawnSession: vi.fn(),
+    };
+    const { restorePersistedPlanningTerminals } = bindPlanningTerminalSessionState({
+      embeddedTerminalManager: embeddedTerminalManager as any,
+      logger: { warn: vi.fn() },
+      planningChatSessions: sessions,
+      getPlanningSessionStore: () => undefined,
+      repoRoot: '/repo',
+    });
+
+    restorePersistedPlanningTerminals();
+
+    expect(embeddedTerminalManager.restoreSpawnSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/__tests__/planning-terminal-preset-switch-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-preset-switch-repro.test.tsx
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+vi.mock('xterm', () => ({
+  Terminal: class {
+    cols = 80;
+    rows = 24;
+    loadAddon(): void {}
+    open(): void {}
+    write(): void {}
+    focus(): void {}
+    dispose(): void {}
+    onData(): { dispose: () => void } {
+      return { dispose: () => {} };
+    }
+  },
+}));
+
+vi.mock('xterm-addon-fit', () => ({
+  FitAddon: class {
+    fit(): void {}
+  },
+}));
+
+const { App } = await import('../App.js');
+
+describe('planning terminal preset ownership repros', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  async function openPlanningTerminal() {
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+    if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+    fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+    });
+  }
+
+  function submitPlanningText(text: string) {
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+  }
+
+  // `it.fails`: this asserts the desired invariant for the behavior slice. The
+  // current renderer keeps the global preset selected when a restored chat with a
+  // different owner preset becomes active.
+  it.fails('keeps the restored chat preset selected when switching between planning chats', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'chat-codex',
+          title: 'Codex chat',
+          status: 'still_discussing',
+          presetKey: 'codex',
+          messages: [
+            { id: 1, role: 'assistant', text: 'Codex restored reply.', createdAt: '2026-07-26T00:00:01.000Z' },
+          ],
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          updatedAt: '2026-07-26T00:00:03.000Z',
+        }),
+        makePlanningSessionSummary({
+          id: 'chat-claude',
+          title: 'Claude chat',
+          status: 'still_discussing',
+          presetKey: 'omp+claude',
+          messages: [
+            { id: 1, role: 'assistant', text: 'Claude restored reply.', createdAt: '2026-07-26T00:00:02.000Z' },
+          ],
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          updatedAt: '2026-07-26T00:00:02.000Z',
+        }),
+      ],
+    }));
+    mock.api.planningChatSend = vi.fn(async (request: any) => ({
+      ok: true,
+      sessionId: request.sessionId,
+      reply: 'Continued.',
+      draftPlanAvailable: false,
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    const rail = await screen.findByTestId('planning-session-list');
+    fireEvent.click(within(rail).getByText('Claude chat'));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Claude restored reply.');
+    });
+
+    expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('omp+claude');
+    submitPlanningText('continue with saved preset');
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        sessionId: 'chat-claude',
+        message: 'continue with saved preset',
+        presetKey: 'omp+claude',
+      });
+    });
+  });
+
+  it('passes a changed local preset when opening tmux before the first chat send', async () => {
+    mock.api.planningChatCreate = vi.fn(async (request: any) => ({
+      ok: true,
+      session: makePlanningSessionSummary({
+        id: 'tmux-created-from-local',
+        title: request.title ?? 'Untitled plan',
+        status: 'still_discussing',
+        presetKey: request.presetKey ?? 'codex',
+        messages: [],
+        draftPlanAvailable: false,
+        draftPlanSummary: undefined,
+        draftPlanText: undefined,
+      }),
+    })) as any;
+    mock.api.planningTerminalOpen = vi.fn(async (planningSessionId: string) => ({
+      opened: true,
+      session: {
+        sessionId: 'tmux-created-terminal',
+        taskId: `planning:${planningSessionId}`,
+        kind: 'planning',
+        planningSessionId,
+        status: 'running',
+        cwd: '/repo',
+        mode: 'spawn',
+        attached: false,
+        createdAt: '2026-07-26T00:00:00.000Z',
+        outputSnapshot: '',
+      },
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-harness'), { target: { value: 'omp+claude' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('omp+claude');
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Tmux' }));
+
+    await waitFor(() => {
+      expect(mock.api.planningChatCreate).toHaveBeenCalledWith({
+        presetKey: 'omp+claude',
+        title: 'Untitled plan',
+      });
+      expect(mock.api.planningTerminalOpen).toHaveBeenCalledWith('tmux-created-from-local');
+    });
+    expect(await screen.findByTestId('invoker-terminal-tmux-pane')).toHaveAttribute('data-session-id', 'tmux-created-terminal');
+  });
+});

--- a/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+vi.mock('xterm', () => ({
+  Terminal: class {
+    cols = 80;
+    rows = 24;
+    loadAddon(): void {}
+    open(): void {}
+    write(): void {}
+    focus(): void {}
+    dispose(): void {}
+    onData(): { dispose: () => void } {
+      return { dispose: () => {} };
+    }
+  },
+}));
+
+vi.mock('xterm-addon-fit', () => ({
+  FitAddon: class {
+    fit(): void {}
+  },
+}));
+
+const { App } = await import('../App.js');
+
+describe('planning terminal failed first-send session id repro', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  async function openPlanningTerminal() {
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+    if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+    fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+    });
+  }
+
+  function submitPlanningText(text: string) {
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+  }
+
+  // `it.fails`: this asserts the desired invariant for the behavior slice. The
+  // current renderer drops the real session id returned with a failed first send,
+  // so retrying forks into a fresh planning conversation.
+  it.fails('persists the real session id returned by a failed first send before retrying', async () => {
+    const plannerError = 'cursor auth expired after the backend created a planner session';
+    let sendCount = 0;
+    mock.api.planningChatSend = vi.fn(async (request: any) => {
+      sendCount += 1;
+      if (sendCount === 1) {
+        return { ok: false, sessionId: 'real-session-after-fail', error: plannerError };
+      }
+      return {
+        ok: true,
+        sessionId: request.sessionId ?? 'fresh-session-after-lost-id',
+        reply: 'Recovered in a different session.',
+        draftPlanAvailable: false,
+      };
+    }) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft with expired auth');
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(plannerError);
+    });
+
+    submitPlanningText('retry after login');
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledTimes(2);
+    });
+
+    const secondRequest = vi.mocked(mock.api.planningChatSend).mock.calls[1]?.[0] as { sessionId?: string };
+    expect(secondRequest).toEqual({
+      sessionId: 'real-session-after-fail',
+      message: 'retry after login',
+      presetKey: 'codex',
+    });
+  });
+});

--- a/packages/ui/src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { InAppPlanningListSessionsResponse, TerminalSessionDescriptor } from '@invoker/contracts';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+vi.mock('xterm', () => ({
+  Terminal: class {
+    cols = 80;
+    rows = 24;
+    loadAddon(): void {}
+    open(): void {}
+    write(): void {}
+    focus(): void {}
+    dispose(): void {}
+    onData(): { dispose: () => void } {
+      return { dispose: () => {} };
+    }
+  },
+}));
+
+vi.mock('xterm-addon-fit', () => ({
+  FitAddon: class {
+    fit(): void {}
+  },
+}));
+
+const { App } = await import('../App.js');
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+describe('planning terminal startup hydrate race repro', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  it('keeps the terminal-aware restore when the chat-only startup hydrate resolves last', async () => {
+    const legacyChatOnlyHydrate = deferred<InAppPlanningListSessionsResponse>();
+    const terminalAwareHydrate = deferred<InAppPlanningListSessionsResponse>();
+    const restoredSession = makePlanningSessionSummary({
+      id: 'startup-plan-1',
+      title: 'Restored tmux plan',
+      status: 'still_discussing',
+      draftPlanAvailable: false,
+      draftPlanSummary: undefined,
+      draftPlanText: undefined,
+      terminalMode: 'tmux',
+      terminalSessionId: 'persisted-terminal-from-summary',
+      terminalStatus: 'running',
+      terminalOutputSnapshot: 'summary snapshot\n',
+    });
+    const liveTerminal: TerminalSessionDescriptor = {
+      sessionId: 'live-terminal-startup',
+      taskId: 'planning:startup-plan-1',
+      kind: 'planning',
+      planningSessionId: 'startup-plan-1',
+      status: 'running',
+      cwd: '/repo',
+      mode: 'spawn',
+      attached: false,
+      createdAt: '2026-07-26T00:00:00.000Z',
+      outputSnapshot: 'live tmux snapshot\n',
+    };
+
+    mock.api.planningChatList = vi
+      .fn()
+      .mockImplementationOnce(() => legacyChatOnlyHydrate.promise)
+      .mockImplementationOnce(() => terminalAwareHydrate.promise) as any;
+    mock.api.planningTerminalList = vi.fn(async () => [liveTerminal]) as any;
+
+    render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+
+    await waitFor(() => {
+      expect(mock.api.planningChatList).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      terminalAwareHydrate.resolve({ ok: true, sessions: [restoredSession] });
+      await terminalAwareHydrate.promise;
+    });
+
+    const tmuxPane = await screen.findByTestId('invoker-terminal-tmux-pane');
+    expect(tmuxPane).toHaveAttribute('data-session-id', 'live-terminal-startup');
+    expect(screen.getByRole('tab', { name: 'Tmux' })).toHaveAttribute('aria-selected', 'true');
+
+    await act(async () => {
+      legacyChatOnlyHydrate.resolve({ ok: true, sessions: [restoredSession] });
+      await legacyChatOnlyHydrate.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Tmux' })).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByTestId('invoker-terminal-tmux-pane')).toHaveAttribute('data-session-id', 'live-terminal-startup');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add focused planning-terminal repro tests for the lifecycle cases that later fixes must satisfy.

The tests cover late hydrate, first-send session identity, preset changes, preset lookup, and tmux metadata cases.

## Review Claim

The repo gains focused planning-terminal adverse repro tests without changing product behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice adds only focused test files; planning terminal product code stays unchanged.

## Slice Rationale

The adverse scenarios need reviewable proof before later behavior slices make them pass.

## Non-goals

No product-code changes in `packages/ui/src/App.tsx`, `packages/app/src/in-app-planner.ts`, `packages/app/src/terminal-session-ipc.ts`, or persistence adapters.

No reusable runner script changes in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx src/__tests__/planning-terminal-session-id-persist-repro.test.tsx src/__tests__/planning-terminal-preset-switch-repro.test.tsx`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/planning-terminal-restore-invariants.repro.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
