### PR TITLE
[Planning terminal adverse proof harness](2) Add deterministic adverse-loop runner

### DIFF
--- a/scripts/run-planning-terminal-adverse-loop.sh
+++ b/scripts/run-planning-terminal-adverse-loop.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+pnpm --filter @invoker/ui exec vitest run \
+  src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx \
+  src/__tests__/planning-terminal-session-id-persist-repro.test.tsx \
+  src/__tests__/planning-terminal-preset-switch-repro.test.tsx
+
+pnpm --filter @invoker/app exec vitest run \
+  src/__tests__/planning-terminal-restore-invariants.repro.test.ts


### PR DESCRIPTION
## Summary

Add one checked-in shell runner for the focused planning-terminal adverse test matrix.

The runner keeps later fixes pointed at the same renderer and app repro files.

## Review Claim

The repo gains a deterministic planning-terminal adverse-loop runner that executes only the focused repro surface.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice adds only a script wrapper around already committed focused test files.

## Slice Rationale

The runner stays separate from the repro files because repo policy treats checked-in scripts as tooling policy.

## Non-goals

No product-code changes.

No changes to the focused repro test assertions.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/run-planning-terminal-adverse-loop.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
