### PR TITLE
[Bugfix: main-process planner surfaces lazy-load](1) Defer planner surfaces load

### DIFF
--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -39,7 +39,6 @@ import {
   summarizePlanText,
   type PlanningMessage,
 } from '@invoker/planning-core';
-import { selectHarnessSessionDriver } from '@invoker/surfaces';
 import type { HarnessPreset, PlanConversation, PlanConversationConfig, PlanningCommandBuilder } from '@invoker/surfaces';
 import type { InvokerConfig } from './config.js';
 
@@ -114,6 +113,13 @@ interface PlannerSurfacesModule {
   DEFAULT_HARNESS_PRESET: string;
   PlanConversation: PlanConversationConstructor;
   extractYamlPlan: (output: string) => string | null;
+  selectHarnessSessionDriver: (
+    preset: HarnessPreset,
+    deps: {
+      executionAgentRegistry?: Pick<AgentRegistry, 'get'>;
+      planningCommandBuilder?: PlanningCommandBuilder;
+    },
+  ) => PlanConversationConfig['harnessSessionDriver'];
 }
 
 async function loadPlannerSurfaces(): Promise<PlannerSurfacesModule> {
@@ -343,6 +349,7 @@ function planConversationConfig(
   preset: HarnessPreset,
   deps: Pick<InAppPlannerDeps, 'config' | 'workingDir' | 'planningCommandBuilder' | 'executionAgentRegistry' | 'conversationRepo' | 'onRawPlannerOutput'>,
   threadTs: string,
+  selectHarnessSessionDriver: PlannerSurfacesModule['selectHarnessSessionDriver'],
   options: { conversationalPlanning?: boolean } = {},
 ): PlanConversationConfig {
   return {
@@ -388,7 +395,7 @@ async function createSession(
     return { error: `Unknown planner preset "${presetKey}".` };
   }
 
-  const { PlanConversation } = await loadPlannerSurfaces();
+  const { PlanConversation, selectHarnessSessionDriver } = await loadPlannerSurfaces();
   const createdAt = new Date().toISOString();
   const id = randomUUID();
   const session: InAppPlanningChatSession = {
@@ -397,7 +404,13 @@ async function createSession(
     presetKey,
     status: 'still_discussing',
     messages: [],
-    conversation: new PlanConversation(planConversationConfig(preset, deps, id, { conversationalPlanning: true })),
+    conversation: new PlanConversation(planConversationConfig(
+      preset,
+      deps,
+      id,
+      selectHarnessSessionDriver,
+      { conversationalPlanning: true },
+    )),
     createdAt,
     updatedAt: createdAt,
     nextMessageId: 1,
@@ -445,8 +458,13 @@ export async function planFromGoal(
   }
 
   try {
-    const { PlanConversation, extractYamlPlan } = await loadPlannerSurfaces();
-    const conversation = new PlanConversation(planConversationConfig(preset, deps, randomUUID()));
+    const { PlanConversation, extractYamlPlan, selectHarnessSessionDriver } = await loadPlannerSurfaces();
+    const conversation = new PlanConversation(planConversationConfig(
+      preset,
+      deps,
+      randomUUID(),
+      selectHarnessSessionDriver,
+    ));
     const plannerOutput = await conversation.sendMessage(goal);
     const planText = extractYamlPlan(plannerOutput);
     if (!planText) {
@@ -769,13 +787,18 @@ export async function restorePlanningChatSessions(
   // boots without surfaces/dist, so an eager load here would crash startup with no sessions.
   if (records.length === 0) return;
   const presets = await resolveHarnessPresets(deps.config);
-  const { PlanConversation } = await loadPlannerSurfaces();
+  const { PlanConversation, selectHarnessSessionDriver } = await loadPlannerSurfaces();
 
   for (const record of records) {
     const preset = presets[record.presetKey];
     if (!preset) continue;
 
-    const conversation = new PlanConversation(planConversationConfig(preset, deps, record.id));
+    const conversation = new PlanConversation(planConversationConfig(
+      preset,
+      deps,
+      record.id,
+      selectHarnessSessionDriver,
+    ));
     await conversation.init();
 
     const nextMessageId = Math.max(0, ...record.messages.map((message) => message.id)) + 1;


### PR DESCRIPTION
## Summary

Desktop startup can now import the in-app planner without resolving `@invoker/surfaces`.

The planner still resolves presets, conversations, YAML extraction, and harness drivers through the existing lazy loader.

This keeps the crash fix at the runtime load boundary.

## Review Claim

`packages/app/src/in-app-planner.ts` no longer resolves `@invoker/surfaces` during module evaluation.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Session creation, restore, submit, and tmux state behavior stay unchanged except for deferring when the surfaces package is resolved.

## Slice Rationale

This slice changes only the runtime load boundary in `in-app-planner.ts`; SSH bootstrap repair and proof execution stay in the next slice.

## Non-goals

- No planning UX changes.
- No new preset behavior.
- No startup logging changes.
- No proof harness authoring.

## Architecture

### Before

The main process imported `in-app-planner.js`, and that module immediately resolved `@invoker/surfaces` for `selectHarnessSessionDriver`.

### After

The module keeps only type imports at load time. Runtime surfaces exports are resolved by `loadPlannerSurfaces()` when planning work actually needs them.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/planner-proof.XXXXXX"); pnpm --filter @invoker/app exec tsup src/in-app-planner.ts --format esm --platform node --external @invoker/surfaces --out-dir "$tmpdir" --silent; if grep -q 'require("@invoker/surfaces")' "$tmpdir/in-app-planner.mjs" 2>/dev/null; then echo 'eager require remains' >&2; exit 1; fi; node -e "import(process.argv[1]).then(() => console.log('import ok'))" "$tmpdir/in-app-planner.mjs"`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts -t "restores draft-ready sessions and submits from persisted approved draft text|restores persisted tmux mode and planning-owned terminal state|clears submitted pending-response state during restore"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-commit>`
- Post-revert steps: Re-run the focused planner restore tests before release if this is reverted.
- Data migration? No

</details>
