### PR TITLE
[Bugfix: main-process planner surfaces lazy-load](2) Preserve SSH proof bootstrap status

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -224,7 +224,9 @@ describe('SshExecutor managed workspace mode', () => {
     expect(callScript.indexOf('stop_bootstrap_heartbeat')).toBeLessThan(callScript.indexOf('"$RUNNER_PATH" "$PAYLOAD_PATH"'));
     expect(callScript).toContain('"$RUNNER_PATH" "$PAYLOAD_PATH"');
     expect(callScript).toContain('rm -rf "$STAGING_DIR"');
-    expect(callScript).toContain("trap 'cleanup_runtime \"$?\"' EXIT");
+    expect(callScript).toContain('cleanup_runtime() {');
+    expect(callScript).toContain('trap \'runtime_status="$?"; cleanup_runtime; exit "$runtime_status"\' EXIT');
+    expect(callScript).not.toContain('local status="$1"');
     expect(callAgentId).toBeUndefined();
     expect(callFinalize).toEqual({ branch: handle.branch, worktreePath: handle.workspacePath });
   });
@@ -520,6 +522,70 @@ branch refs/heads/experiment/test-task-oldhash
     expect(rmIndex).toBeGreaterThanOrEqual(0);
     expect(mkdirIndex).toBeGreaterThanOrEqual(0);
     expect(rmIndex).toBeLessThan(mkdirIndex);
+  });
+
+  it('runtime cleanup trap preserves the payload exit status without local trap variables', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+      remoteHeartbeatIntervalSeconds: 1,
+      remoteInvokerHome: '~/.invoker',
+    }) as any;
+
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return '__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=abc123def456abc123def456abc123def456abc1';
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      return '';
+    });
+    vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+
+    await ssh.start(makeRequest({
+      actionType: 'command',
+      inputs: {
+        command: 'exit 7',
+        description: 'run failing payload',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    }));
+
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+    expect(proc).toBeDefined();
+    const writeMock = (proc.stdin as any).write as ReturnType<typeof vi.fn>;
+    const bootstrapScript = writeMock.mock.calls[0]![0] as string;
+    const workspaceMatch = bootstrapScript.match(/WT=\$\(normalize_remote_path '([^']+)'\)/);
+    if (!workspaceMatch?.[1]) {
+      throw new Error('Managed SSH bootstrap did not embed a workspace path');
+    }
+    const stagingMatch = bootstrapScript.match(/STAGING_DIR="\$INVOKER_HOME\/runtime\/ssh-executor\/([^"]+)"/);
+    if (!stagingMatch?.[1]) {
+      throw new Error('Managed SSH bootstrap did not embed a staging directory');
+    }
+
+    const fakeHome = mkdtempSync(join(tmpdir(), 'ssh-runtime-cleanup-home-'));
+    try {
+      const workspacePath = workspaceMatch[1].replace(/^~(?=\/|$)/, fakeHome);
+      const stagingPath = join(fakeHome, '.invoker/runtime/ssh-executor', stagingMatch[1]);
+      mkdirSync(workspacePath, { recursive: true });
+      const childProcessModule = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+      const result = childProcessModule.spawnSync('/bin/bash', ['-lc', bootstrapScript], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: fakeHome },
+      });
+
+      expect(result.status).toBe(7);
+      expect(result.stderr).not.toContain('pop_var_context');
+      expect(existsSync(stagingPath)).toBe(false);
+      expect(bootstrapScript).not.toContain('local status="$1"');
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+      proc.emit('close', 0, null);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
   });
 
   it('persists the owning worktree path on startup failure when Git reports a branch owner', async () => {

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -257,11 +257,9 @@ STAGING_DIR="$INVOKER_HOME/runtime/ssh-executor/${stagingTokenExpression}"
 RUNNER_PATH="$STAGING_DIR/runner.sh"
 PAYLOAD_PATH="$STAGING_DIR/payload.sh"
 cleanup_runtime() {
-  local status="$1"
   trap - EXIT HUP INT TERM
   stop_bootstrap_heartbeat
   rm -rf "$STAGING_DIR" >/dev/null 2>&1 || true
-  exit "$status"
 }
 BOOTSTRAP_HEARTBEAT_PID=""
 INVOKER_HEARTBEAT_MARKER=${heartbeatMarker}
@@ -283,10 +281,10 @@ stop_bootstrap_heartbeat() {
     BOOTSTRAP_HEARTBEAT_PID=""
   fi
 }
-trap 'cleanup_runtime "$?"' EXIT
-trap 'cleanup_runtime 129' HUP
-trap 'cleanup_runtime 130' INT
-trap 'cleanup_runtime 143' TERM
+trap 'runtime_status="$?"; cleanup_runtime; exit "$runtime_status"' EXIT
+trap 'cleanup_runtime; exit 129' HUP
+trap 'cleanup_runtime; exit 130' INT
+trap 'cleanup_runtime; exit 143' TERM
 rm -rf "$STAGING_DIR" 2>/dev/null || true
 mkdir -p "$STAGING_DIR"
 chmod 700 "$STAGING_DIR"


### PR DESCRIPTION
## Summary

Managed SSH runtime teardown no longer passes exit status as a Bash trap function argument.

The teardown path still stops the heartbeat, clears the staging directory, and exits with the payload status.

A focused regression covers the `pop_var_context` failure signature hit by verification.

## Review Claim

`SshExecutor` preserves payload exit status during managed runtime teardown without using local trap variables.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change only touches generated SSH bootstrap teardown and focused SSH executor coverage; worktree setup and payload execution order stay unchanged.

## Slice Rationale

This slice keeps the SSH bootstrap repair separate from the planner runtime load change. It exists because verification exposed a distinct managed SSH trap failure.

## Non-goals

- No planner load-boundary changes in this slice.
- No SSH provisioning policy changes.
- No branch naming changes.
- No worktree reuse changes.

## Architecture

### Before

`cleanup_runtime` expected a status argument, and traps called it with `$?` before exiting.

### After

Traps capture or set status outside `cleanup_runtime`; teardown stops heartbeat, removes staging, and then exits with the preserved status.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-executor.test.ts -t "runtime cleanup trap preserves the payload exit status without local trap variables"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-commit>`
- Post-revert steps: Re-run the focused SSH executor test before depending on managed SSH proof execution.
- Data migration? No

</details>
