### PR TITLE
[Bugfix: explicit planning session continuity](1) Harden planning session contract

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -232,6 +232,7 @@ describe('planning chat', () => {
     expect(result.ok && result.sessionId).toBeTruthy();
     expect(sessions.size).toBe(1);
     const session = [...sessions.values()][0];
+    expect(session?.id).toBe(result.ok ? result.sessionId : undefined);
     expect(session?.messages).toEqual([
       expect.objectContaining({ id: 1, role: 'user', text: 'hello' }),
       expect.objectContaining({ id: 2, role: 'assistant', text: 'I can help.' }),
@@ -260,6 +261,24 @@ describe('planning chat', () => {
     expect(prompt).toContain('Talk through edge cases, corner cases, architecture, and ambiguity with the human.');
     expect(prompt).toContain('Resolve those points before producing a YAML plan.');
     expect(prompt).toContain('Draft YAML only after the human asks you to draft/proceed');
+  });
+
+  it('rejects an unknown continuation session without creating a new one', async () => {
+    const spawnPlanner = vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue('should not send');
+    const sessions = createInAppPlanningChatSessions();
+
+    await expect(sendPlanningChatMessage({
+      sessionId: 'missing-session',
+      message: 'continue planning',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    })).resolves.toEqual({ ok: false, sessionId: 'missing-session', error: 'Planning session not found.' });
+    expect(sessions.size).toBe(0);
+    expect(spawnPlanner).not.toHaveBeenCalled();
   });
 
   it('reuses an existing session and keeps its original preset', async () => {
@@ -291,6 +310,7 @@ describe('planning chat', () => {
     });
 
     expect(second).toMatchObject({ ok: true, sessionId: first.sessionId, reply: 'second' });
+    expect(sessions.size).toBe(1);
     expect(sessions.get(first.sessionId)?.presetKey).toBe('codex');
     expect(spawnPlanner).toHaveBeenCalledTimes(2);
   });

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -506,14 +506,19 @@ export async function sendPlanningChatMessage(
   },
 ): Promise<InAppPlanningChatResponse> {
   const rawRequest = request as Partial<InAppPlanningChatRequest> | null | undefined;
+  const rawSessionId = typeof rawRequest?.sessionId === 'string' ? rawRequest.sessionId : undefined;
+  const suppliedSessionId = rawSessionId !== undefined;
+  let sessionId = rawSessionId?.trim();
   const message = typeof rawRequest?.message === 'string' ? rawRequest.message.trim() : '';
   if (!message) {
-    return { ok: false, sessionId: rawRequest?.sessionId, error: 'Type a message first.' };
+    return { ok: false, sessionId, error: 'Type a message first.' };
   }
 
-  let sessionId = rawRequest?.sessionId;
   try {
-    let session = rawRequest?.sessionId ? deps.sessions.get(rawRequest.sessionId) : undefined;
+    let session = suppliedSessionId && sessionId ? deps.sessions.get(sessionId) : undefined;
+    if (suppliedSessionId && !session) {
+      return { ok: false, sessionId, error: 'Planning session not found.' };
+    }
     if (!session) {
       const created = await createSession({
         presetKey: rawRequest?.presetKey,


### PR DESCRIPTION
## Summary

Planning continuations now fail explicitly when the requested session id cannot be found.

First-turn sends still create a new planning session, and valid follow-ups keep the original preset.

## Review Claim

`sendPlanningChatMessage()` uses the fresh-chat path only when no `sessionId` was supplied.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change stays in the in-app planning bridge and its directly affected regression file; first-send creation and valid continuation reuse both remain covered.

## Slice Rationale

This backend routing slice isolates the session lookup decision before the planning terminal depends on the stricter continuation behavior.

## Non-goals

- No planning terminal renderer changes.
- No Slack planning changes.
- No harness or model selection changes.
- No unrelated cleanup.

## Architecture

### Before

`sendPlanningChatMessage()` treated an absent session and an unknown continuation id as the same request path, so both could create a new planning session.

### After

`sendPlanningChatMessage()` creates a session only for first sends. A supplied unknown id returns an explicit lost-session error.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-commit>`
- Post-revert steps: Re-run the focused in-app planner regression before depending on continuation-loss handling.
- Data migration? No

</details>
