### PR TITLE
[Bugfix: explicit planning session continuity](2) Guard UI planning continuation

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -248,6 +248,7 @@ function relativePlanningUpdatedAt(value: string): string {
 }
 const PLANNING_TYPING_LAG_METRIC = 'planning_typing_lag_baseline';
 const PLANNING_TYPING_SCENARIO = 'many-chats-many-messages-typing';
+const PLANNING_CONTINUATION_LOST_MESSAGE = 'This planning chat lost its session. Start a new chat to continue planning.';
 
 interface PlanningTypingTelemetryState {
   tasks: Map<string, TaskState>;
@@ -856,6 +857,7 @@ export function App() {
   const activePlanningStream = planningStreamBySessionId[activePlanningSession.id] ?? null;
   const activePlanningConversationKey = activePlanningSession.conversationKey;
   const terminalLines = activePlanningSession.messages;
+  const activePlanningTranscriptLength = terminalLines.length;
   const planningInput = activePlanningSession.input;
   const planningSessionId = activePlanningSession.id.startsWith('local-') ? null : activePlanningSession.id;
   const draftPlanAvailable = activePlanningSession.draftPlanAvailable;
@@ -2649,6 +2651,12 @@ export function App() {
     }
 
     const previousSessionId = activePlanningSessionId;
+    if (!planningSessionId && activePlanningTranscriptLength > 0) {
+      appendTerminalLine(PLANNING_CONTINUATION_LOST_MESSAGE, 'system', 'error');
+      setPlanningSubmitError({ title: 'Planning chat lost its session', message: PLANNING_CONTINUATION_LOST_MESSAGE });
+      return;
+    }
+
     pendingPlanningStreamSessionIdsRef.current.add(previousSessionId);
     clearPlanningStreamForSessionIds([previousSessionId, planningSessionId]);
     forgetPlanningStreamAliasesForSessionIds([previousSessionId, planningSessionId]);
@@ -2690,12 +2698,30 @@ export function App() {
         pendingPlanningStreamSessionIdsRef.current.delete(result.sessionId);
         setHasLoadedPlan(false);
       } else {
-        updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: false }));
+        const errorLineId = nextTerminalLineIdRef.current;
+        nextTerminalLineIdRef.current += 1;
+        const failedSessionId = result.sessionId ?? previousSessionId;
+        const updatedAt = new Date().toISOString();
+        setPlanningSessions((prev) => prev.map((session) => {
+          if (session.id !== previousSessionId) return session;
+          return {
+            ...session,
+            id: failedSessionId,
+            busy: false,
+            messages: [...session.messages, { id: errorLineId, text: result.error, role: 'system', tone: 'error' }],
+            updatedAt,
+          };
+        }));
+        if (result.sessionId) {
+          const materializedSessionId = result.sessionId;
+          setActivePlanningSessionId((currentSessionId) => (
+            currentSessionId === previousSessionId ? materializedSessionId : currentSessionId
+          ));
+        }
         keepPlanningStreamFailureForSessionIds([previousSessionId, result.sessionId], result.error);
         forgetPlanningStreamAliasesForSessionIds([previousSessionId, result.sessionId]);
         pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
         if (result.sessionId) pendingPlanningStreamSessionIdsRef.current.delete(result.sessionId);
-        appendTerminalLine(result.error, 'system', 'error');
         setPlanningSubmitError({ title: 'Planner could not respond', message: result.error });
       }
     } catch (err) {
@@ -2711,6 +2737,7 @@ export function App() {
   }, [
     activePlanningSessionBusy,
     activePlanningSessionId,
+    activePlanningTranscriptLength,
     activePlanningReadOnly,
     appendTerminalLine,
     clearPlanningStreamForSessionIds,

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -689,6 +689,30 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
+  it('shows an explicit error instead of restarting when a local transcript has no server session', async () => {
+    mock.api.planningChatSend = vi.fn(async () => ({
+      ok: false,
+      error: 'planner failed before creating a session',
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft a plan');
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'draft a plan', presetKey: 'codex' });
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('planner failed before creating a session');
+    });
+
+    submitPlanningText('continue anyway');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('This planning chat lost its session. Start a new chat to continue planning.');
+    });
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('continue anyway');
+    expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1);
+  });
+
   it('passes the selected planning preset', async () => {
     render(<App />);
     await openPlanningTerminal();

--- a/packages/ui/src/test-setup.ts
+++ b/packages/ui/src/test-setup.ts
@@ -16,7 +16,33 @@ if (typeof Element !== 'undefined' && typeof Element.prototype.scrollIntoView !=
   Element.prototype.scrollIntoView = function noopScrollIntoView(): void {};
 }
 
-if (typeof window !== 'undefined' && !window.localStorage) {
+if (typeof HTMLCanvasElement !== 'undefined') {
+  const canvasContext = {
+    fillStyle: '#000000',
+    globalCompositeOperation: 'source-over',
+    clearRect: () => {},
+    createLinearGradient: () => ({
+      addColorStop: () => {},
+    }),
+    fillRect: () => {},
+    getImageData: () => ({
+      data: new Uint8ClampedArray([0, 0, 0, 255]),
+    }),
+    measureText: (text: string) => ({
+      width: text.length * 8,
+    }),
+  } as unknown as CanvasRenderingContext2D;
+
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value: function getContext(contextId: string): RenderingContext | null {
+      return contextId === '2d' ? canvasContext : null;
+    },
+  });
+}
+
+if (typeof window !== 'undefined') {
+  const localStorageDescriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
   const store: Record<string, string> = {};
   const storage: Storage = {
     getItem: (key) => (key in store ? store[key] : null),
@@ -34,10 +60,12 @@ if (typeof window !== 'undefined' && !window.localStorage) {
       return Object.keys(store).length;
     },
   };
-  Object.defineProperty(window, 'localStorage', {
-    configurable: true,
-    value: storage,
-  });
+  if (!localStorageDescriptor || typeof localStorageDescriptor.get === 'function' || !localStorageDescriptor.value) {
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: storage,
+    });
+  }
 }
 
 // jsdom defaults to 1024px; pin a wide viewport so App auto-collapse matches desktop


### PR DESCRIPTION
## Summary

The planning terminal now keeps follow-up sends tied to the real server session id.

Transcripted chats that lost that id show a recovery error instead of starting over.

## Review Claim

The planning terminal either sends the real server `sessionId` for follow-up turns or shows an explicit recovery error.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change stays in the planning terminal renderer, its focused regression file, and shared UI test setup; first-turn placeholder behavior and continuation behavior stay covered.

## Slice Rationale

This UI activation slice keeps terminal continuation behavior separate from the backend session contract.

## Non-goals

- No backend contract changes.
- No Slack planning changes.
- No harness or model selection changes.
- No unrelated terminal cleanup.

## Architecture

### Before

The terminal could continue a transcripted local placeholder without a materialized server id, which let the next send start over.

### After

The terminal omits `sessionId` only for deliberate first sends. Transcripted local placeholders stop with a recovery message before sending.

## Visual Proof

Planning Terminal proof shows the chat surface preserved during the planning-session recovery path.

![Planning terminal continuation proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-130d0b/planning-terminal-restart.gif)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-commit>`
- Post-revert steps: Re-run the focused planning terminal regression before depending on continuation-loss handling.
- Data migration? No

</details>
