### PR TITLE
[Bugfix: truthful planning draft readiness](1) Keep planner submit text draft-backed

### DIFF
--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -17,6 +17,7 @@ vi.mock('node:child_process', async (importOriginal) => {
 });
 
 const mockSpawn = vi.mocked(child_process.spawn);
+const SUBMIT_LINE = 'Reply `submit` to submit it.';
 
 function fakePlannerChild(stdout: string, beforeClose?: () => void): any {
   const proc = new EventEmitter() as any;
@@ -52,7 +53,7 @@ tasks:
     dependencies: []
 \`\`\`
 
-Reply \`submit\` to submit it.`;
+${SUBMIT_LINE}`;
 
 describe('plan draft file - activation side', () => {
   let workingDir: string;
@@ -101,20 +102,24 @@ describe('plan draft file - activation side', () => {
     ));
     await conversation.sendMessage('Draft it');
 
-    mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the plan. Summary: one step.'));
-    await conversation.sendMessage('What does it do?');
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(`Drafted the plan. Summary: one step.\n\n${SUBMIT_LINE}`));
+    const reply = await conversation.sendMessage('What does it do?');
 
     expect(existsSync(path)).toBe(false);
     expect(conversation.getDraftedPlan()).toBe(VALID_PLAN_YAML.trim());
+    expect(reply).not.toContain(SUBMIT_LINE);
+    expect(conversation.history.at(-1)?.content).not.toContain(SUBMIT_LINE);
   });
 
   it('does not expose a plan when a summary-only turn has no prior draft', async () => {
     const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', plannerRetryLimit: 0 });
 
-    mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the plan. Summary: one step.'));
-    await conversation.sendMessage('Draft it');
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(`Drafted the plan. Summary: one step.\n\n${SUBMIT_LINE}`));
+    const reply = await conversation.sendMessage('Draft it');
 
     expect(conversation.getDraftedPlan()).toBeNull();
+    expect(reply).not.toContain(SUBMIT_LINE);
+    expect(conversation.history.at(-1)?.content).not.toContain(SUBMIT_LINE);
   });
 
   it('requires the exact submit line as a standalone post-plan instruction', () => {
@@ -122,10 +127,9 @@ describe('plan draft file - activation side', () => {
     (conversation as any).messages.push({ role: 'user', content: 'Draft a plan' });
 
     const prompt = conversation.buildCursorPrompt();
-    const submitLine = 'Reply `submit` to submit it.';
     const lines = prompt.split('\n');
 
-    expect(lines.filter((line) => line === submitLine)).toHaveLength(1);
+    expect(lines.filter((line) => line === SUBMIT_LINE)).toHaveLength(1);
     expect(prompt.match(/Reply `submit` to submit it\./g)).toHaveLength(1);
     expect(prompt).toContain('Do NOT place that line inline in a sentence.');
   });
@@ -139,8 +143,9 @@ describe('plan draft file - activation side', () => {
       'Drafted the plan.\n\nReply `submit` to submit it.',
       () => writeFileSync(path, VALID_PLAN_YAML, 'utf8'),
     ));
-    await conversation.sendMessage('Create the plan');
+    const reply = await conversation.sendMessage('Create the plan');
 
+    expect(reply).toContain(SUBMIT_LINE);
     expect(isConfirmation('submit')).toBe(true);
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     expect(conversation.planSubmitted).toBe(false);

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -53,9 +53,18 @@ export function defaultPlanningCommand(
 }
 
 const EMPTY_PLANNER_STDERR_TAIL_LIMIT = 500;
+const SUBMIT_INSTRUCTION_LINE = 'Reply `submit` to submit it.';
 
 export const DEFAULT_PLANNER_RETRY_LIMIT = 2;
 export const DEFAULT_PLANNER_RETRY_BASE_DELAY_MS = 500;
+
+function removeStandaloneSubmitInstruction(text: string): string {
+  return text
+    .split('\n')
+    .filter((line) => line.trim() !== SUBMIT_INSTRUCTION_LINE)
+    .join('\n')
+    .trimEnd();
+}
 
 // Shared with slack-surface.ts so both planner spawn paths surface the same
 // actionable error when the CLI exits 0 but writes nothing to stdout. The
@@ -550,6 +559,9 @@ export class PlanConversation {
     const nextDraft = fileDraft && summarizePlanText(fileDraft)
       ? fileDraft
       : inlineDraft;
+    if (!nextDraft) {
+      message = removeStandaloneSubmitInstruction(message);
+    }
     this._lastTurnDraftPlanText = nextDraft;
     if (nextDraft) this.lastKnownGoodPlanText = nextDraft;
     this._lastTurnReasoning = formatted.reasoning;


### PR DESCRIPTION
## Summary

Planning replies now omit the standalone confirmation instruction when the current turn has no real draft.

Real draft turns keep the instruction, so existing ready-to-confirm conversations behave the same.

## Review Claim

Planner replies expose the confirmation instruction only when the current turn produced a real draft.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice stays in planner reply formatting and focused draft-capture regressions. Valid drafted replies keep the same ready-to-confirm behavior.

## Slice Rationale

This slice fixes the misleading saved reply at the point where draft readiness is decided.

## Non-goals

- No in-app approval guard changes.
- No terminal command handling changes.
- No harness or model selection changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/plan-draft-file-activation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b2de80c8bd4cc1aaaad2f7468a6306d5d295a692`
- Post-revert steps: Rerun the focused surfaces regression.
- Data migration? No

</details>
