### PR TITLE
[Bugfix: truthful planning draft readiness](2) Require draft-ready in-app approval

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -46,6 +46,8 @@ tasks:
     dependencies: [first]
     command: echo second`;
 
+const NO_DRAFT_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
+
 const VALID_PLAN_WITHOUT_CLOSING_FENCE = `Here is the plan.
 
 \`\`\`yaml
@@ -416,9 +418,9 @@ describe('planning chat', () => {
       await expect(submitPlanningChatDraft({ sessionId: session.id }, {
         sessions,
         loadGeneratedPlan,
-    })).resolves.toMatchObject({ ok: false });
-    expect(loadGeneratedPlan).not.toHaveBeenCalled();
-    expect(sessions.get(session.id)?.draftPlanText).toBeUndefined();
+      })).resolves.toEqual({ ok: false, error: NO_DRAFT_ERROR });
+      expect(loadGeneratedPlan).not.toHaveBeenCalled();
+      expect(sessions.get(session.id)?.draftPlanText).toBeUndefined();
     } finally {
       rmSync(workingDir, { recursive: true, force: true });
     }
@@ -443,7 +445,7 @@ describe('planning chat', () => {
     await expect(submitPlanningChatDraft({ sessionId: result.sessionId }, {
       sessions,
       loadGeneratedPlan,
-    })).resolves.toMatchObject({ ok: false });
+    })).resolves.toEqual({ ok: false, error: NO_DRAFT_ERROR });
     expect(loadGeneratedPlan).not.toHaveBeenCalled();
   });
 
@@ -544,6 +546,7 @@ describe('planning chat', () => {
       workflowIds: ['wf-1'],
       workflowCount: 1,
     });
+    expect(sessions.get(sent.sessionId)?.status).toBe('draft_ready');
 
     await expect(submitPlanningChatDraft({
       sessionId: sent.sessionId,
@@ -757,7 +760,59 @@ tasks:
     }, {
       sessions,
       loadGeneratedPlan: vi.fn(),
-    })).resolves.toEqual({ ok: false, error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.' });
+    })).resolves.toEqual({ ok: false, error: NO_DRAFT_ERROR });
+  });
+
+  it('rejects submit when stale draft text exists outside draft-ready state', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('stale-draft', {
+      id: 'stale-draft',
+      title: 'Stale draft',
+      presetKey: 'codex',
+      status: 'still_discussing',
+      messages: [],
+      conversation: new PlanConversation({}),
+      draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+      draftPlanText: VALID_PLAN_TEXT,
+      createdAt: '2026-07-07T00:00:00.000Z',
+      updatedAt: '2026-07-07T00:00:00.000Z',
+      nextMessageId: 1,
+    });
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(submitPlanningChatDraft({
+      sessionId: 'stale-draft',
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: NO_DRAFT_ERROR });
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
+  it('rejects submit when draft-ready state has empty draft text', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('empty-draft', {
+      id: 'empty-draft',
+      title: 'Empty draft',
+      presetKey: 'codex',
+      status: 'draft_ready',
+      messages: [],
+      conversation: new PlanConversation({}),
+      draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+      draftPlanText: '   ',
+      createdAt: '2026-07-07T00:00:00.000Z',
+      updatedAt: '2026-07-07T00:00:00.000Z',
+      nextMessageId: 1,
+    });
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(submitPlanningChatDraft({
+      sessionId: 'empty-draft',
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: NO_DRAFT_ERROR });
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
   });
 
   it('rejects submit when the draft summary cannot be read', async () => {

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -93,6 +93,8 @@ export interface InAppPlanningChatSession {
 
 export type InAppPlanningChatSessions = Map<string, InAppPlanningChatSession>;
 
+const NO_COMPLETE_PLAN_DRAFT_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
+
 export function createInAppPlanningChatSessions(): InAppPlanningChatSessions {
   return new Map();
 }
@@ -631,6 +633,9 @@ export async function submitPlanningChatDraft(
   }
   if (session.status === 'submitted') {
     return { ok: false, error: 'This planning session was already submitted.' };
+  }
+  if (session.status !== 'draft_ready' || !session.draftPlanText?.trim()) {
+    return { ok: false, error: NO_COMPLETE_PLAN_DRAFT_ERROR };
   }
   if (session.pendingSubmit) {
     return session.pendingSubmit;


### PR DESCRIPTION
## Summary

The in-app planning approval path now requires draft-ready state and non-empty draft text.

No-draft and cleared-draft sessions return the existing no-draft error before loading any plan.

## Review Claim

The in-app approval path requires draft-ready state and non-empty draft text before loading the plan.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice stays in the in-app approval handler and focused regressions. Valid draft-ready sessions still use the same approval path.

## Slice Rationale

This slice owns the backend approval precondition without changing planner reply text or terminal command dispatch.

## Non-goals

- No planner reply text changes.
- No terminal command handling changes.
- No harness or model selection changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5e15da3a6da7e1cdde819008be6ae12026dcde60`
- Post-revert steps: Rerun the focused app regression.
- Data migration? No

</details>
