### PR TITLE
[Bugfix: truthful planning draft readiness](3) Gate terminal confirmation command

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -114,6 +114,7 @@ const EDITABLE_SELECTOR = [
 const SYSTEM_SETUP_AUTO_OPEN_DELAY_MS = 1200;
 const RAIL_LIST_FRAME_CLASS = 'flex min-h-0 flex-1 flex-col';
 const RAIL_SCROLL_BODY_CLASS = 'min-h-0 flex-1 overflow-y-auto';
+const NO_COMPLETE_PLAN_DRAFT_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
 
 function notifyMutationError(rawTitle: string, err: unknown): void {
   console.error(rawTitle, err);
@@ -859,6 +860,7 @@ export function App() {
   const planningInput = activePlanningSession.input;
   const planningSessionId = activePlanningSession.id.startsWith('local-') ? null : activePlanningSession.id;
   const draftPlanAvailable = activePlanningSession.draftPlanAvailable;
+  const activePlanningDraftReady = draftPlanAvailable || activePlanningSession.status === 'draft_ready';
   const draftPlanSummary = activePlanningSession.draftPlanSummary;
   const draftPlanText = activePlanningSession.draftPlanText;
   const activePlanningSessionBusy = activePlanningSession.busy;
@@ -2639,6 +2641,11 @@ export function App() {
     }
 
     if (/^submit(\s+to\s+invoker)?[.!?]*$/i.test(input)) {
+      if (!activePlanningDraftReady) {
+        setPlanningSubmitError({ title: 'Plan could not be submitted', message: NO_COMPLETE_PLAN_DRAFT_ERROR });
+        appendTerminalLine(`Plan could not be submitted:\n${NO_COMPLETE_PLAN_DRAFT_ERROR}`, 'system', 'error');
+        return;
+      }
       await handlePlanningSubmitDraft();
       return;
     }
@@ -2710,6 +2717,7 @@ export function App() {
     }
   }, [
     activePlanningSessionBusy,
+    activePlanningDraftReady,
     activePlanningSessionId,
     activePlanningReadOnly,
     appendTerminalLine,

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -16,6 +16,7 @@ const { App } = await import('../App.js');
 const { InvokerTerminal } = await import('../components/InvokerTerminal.js');
 
 const COMPONENT_INPUT_HANDLER_BUDGET_MS = 16;
+const NO_COMPLETE_PLAN_DRAFT_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
 
 describe('Invoker terminal (component)', () => {
   let mock: MockInvoker;
@@ -701,6 +702,43 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
+  it('does not submit or chat when the user types submit before a draft is ready', async () => {
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('hello');
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'hello', presetKey: 'codex' });
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('I can help draft that.');
+    });
+
+    submitPlanningText('submit');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(
+        NO_COMPLETE_PLAN_DRAFT_ERROR,
+      );
+    });
+    expect(mock.api.planningChatSubmit).not.toHaveBeenCalled();
+    expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1);
+    expect(mock.api.startReady).not.toHaveBeenCalled();
+  });
+
+  it('shows the no-draft error when the user starts by typing submit', async () => {
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('submit');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(NO_COMPLETE_PLAN_DRAFT_ERROR);
+    });
+    expect(mock.api.planningChatSubmit).not.toHaveBeenCalled();
+    expect(mock.api.planningChatSend).not.toHaveBeenCalled();
+    expect(mock.api.startReady).not.toHaveBeenCalled();
+  });
+
   it('submits a draft and starts ready work when the user types submit', async () => {
     mock.api.planningChatSend = vi.fn(async () => ({
       ok: true,
@@ -708,6 +746,7 @@ describe('Invoker terminal (component)', () => {
       reply: 'Here is the plan.',
       draftPlanAvailable: true,
       draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First', 'Second'] },
+      draftPlanText: 'name: Mock Plan\ntasks:\n  - id: first\n    description: First\n',
     })) as any;
     render(<App />);
     await openPlanningTerminal();
@@ -734,6 +773,35 @@ describe('Invoker terminal (component)', () => {
     expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Submit to Invoker' })).not.toBeInTheDocument();
     expect(mock.api.start).not.toHaveBeenCalled();
+  });
+
+  it('submits a restored status-ready draft when the user types submit', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'status-ready-chat',
+          title: 'Status ready chat',
+          status: 'draft_ready',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    await waitFor(() => {
+      expect(screen.getByText('Draft ready')).toBeInTheDocument();
+    });
+
+    submitPlanningText('submit');
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'status-ready-chat' });
+      expect(mock.api.startReady).toHaveBeenCalledWith({});
+    });
   });
 
   it('shows stacked workflow counts before creating the workflow', async () => {

--- a/packages/ui/src/test-setup.ts
+++ b/packages/ui/src/test-setup.ts
@@ -16,6 +16,33 @@ if (typeof Element !== 'undefined' && typeof Element.prototype.scrollIntoView !=
   Element.prototype.scrollIntoView = function noopScrollIntoView(): void {};
 }
 
+if (typeof HTMLCanvasElement !== 'undefined') {
+  Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+    configurable: true,
+    value(contextId: string) {
+      if (contextId !== '2d') return null;
+
+      let fillStyle: string | CanvasGradient | CanvasPattern = '#000000';
+      return {
+        globalCompositeOperation: 'source-over',
+        get fillStyle() {
+          return fillStyle;
+        },
+        set fillStyle(value: string | CanvasGradient | CanvasPattern) {
+          fillStyle = value;
+        },
+        createLinearGradient: () => ({
+          addColorStop: () => {},
+        }),
+        fillRect: () => {},
+        getImageData: () => ({
+          data: new Uint8ClampedArray([0, 0, 0, 255]),
+        }),
+      } as unknown as CanvasRenderingContext2D;
+    },
+  });
+}
+
 if (typeof window !== 'undefined' && !window.localStorage) {
   const store: Record<string, string> = {};
   const storage: Storage = {


### PR DESCRIPTION
## Summary

The planning terminal now checks draft readiness before the confirmation command calls approval.

Without a ready draft, the terminal shows the deterministic no-draft error and leaves the approval API untouched.

## Review Claim

The terminal confirmation command runs the planning approval API only for an active draft-ready session.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice stays in terminal command dispatch and focused terminal regressions. Existing draft-ready command flow still reaches the same approval API.

## Slice Rationale

This slice owns terminal command dispatch without changing planner reply text or the backend approval guard.

## Non-goals

- No planner reply text changes.
- No in-app approval guard changes.
- No harness or model selection changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx`

</details>

## Visual Proof

![Planning terminal no-draft error after typed submit](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-6cc660/invoker-terminal-submit-no-draft.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a245ff85e29e40a09b2f62fbe2a81cd078a9255a`
- Post-revert steps: Rerun the focused UI regression.
- Data migration? No

</details>
