### PR TITLE
[Authoritative task-graph snapshots](2) Sync app bridge snapshots

### DIFF
--- a/packages/app/src/__tests__/ipc-read-handlers.test.ts
+++ b/packages/app/src/__tests__/ipc-read-handlers.test.ts
@@ -26,14 +26,25 @@ function expectReadContextWriteToolsAreAbsent(): void {
 
 
 describe('registerReadOnlyIpcHandlers', () => {
-  it('get-tasks returns a snapshot', async () => {
+  it('get-tasks returns a post-sync snapshot', async () => {
     const handlers = new Map<string, (...args: unknown[]) => unknown>();
     const ipcMain = {
       handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
         handlers.set(channel, handler);
       }),
     };
-    const task = makeTask('wf-1/task-1');
+    const staleTask = makeTask('wf-1/stale-task');
+    const syncedTask = makeTask('wf-1/task-1');
+    const orchestratorCalls: string[] = [];
+    let hasSynced = false;
+    const syncAllFromDb = vi.fn(() => {
+      orchestratorCalls.push('syncAllFromDb');
+      hasSynced = true;
+    });
+    const getAllTasks = vi.fn(() => {
+      orchestratorCalls.push('getAllTasks');
+      return hasSynced ? [syncedTask] : [staleTask];
+    });
 
     registerReadOnlyIpcHandlers({
       ipcMain: ipcMain as never,
@@ -47,7 +58,8 @@ describe('registerReadOnlyIpcHandlers', () => {
         listWorkflows: vi.fn(() => [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }]),
       } as never,
       getOrchestrator: () => ({
-        getAllTasks: () => [task],
+        getAllTasks,
+        syncAllFromDb,
         getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 0, closed: 0, running: 0, pending: 1 }),
       }) as never,
       agentRegistry: {} as never,
@@ -62,10 +74,12 @@ describe('registerReadOnlyIpcHandlers', () => {
     const result = await handlers.get('invoker:get-tasks')?.({});
 
     expect(result).toEqual({
-      tasks: [task],
+      tasks: [syncedTask],
       workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
       streamSequence: 42,
     });
+    expect(orchestratorCalls).toEqual(['syncAllFromDb', 'getAllTasks']);
+    expect(syncAllFromDb).toHaveBeenCalledTimes(1);
   });
 
   it('get-review-gate returns the shared review gate shape', async () => {

--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -19,6 +19,7 @@ function makeDispatch(overrides: Record<string, unknown> = {}) {
   const deps = {
     orchestrator: {
       getAllTasks: () => [makeTask('wf-1/task-1')],
+      syncAllFromDb: vi.fn(),
       getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 0, closed: 0, running: 0, pending: 1 }),
       getTask: () => null,
     },
@@ -57,13 +58,35 @@ describe('buildWebInvokerDispatch', () => {
     ]);
   });
 
-  it('get-tasks returns the { tasks, workflows, streamSequence } snapshot', async () => {
-    const { dispatch } = makeDispatch();
+  it('get-tasks returns the post-sync { tasks, workflows, streamSequence } snapshot', async () => {
+    const staleTask = makeTask('wf-1/stale-task');
+    const syncedTask = makeTask('wf-1/task-1');
+    const orchestratorCalls: string[] = [];
+    let hasSynced = false;
+    const syncAllFromDb = vi.fn(() => {
+      orchestratorCalls.push('syncAllFromDb');
+      hasSynced = true;
+    });
+    const getAllTasks = vi.fn(() => {
+      orchestratorCalls.push('getAllTasks');
+      return hasSynced ? [syncedTask] : [staleTask];
+    });
+    const { dispatch } = makeDispatch({
+      orchestrator: {
+        getAllTasks,
+        syncAllFromDb,
+        getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 0, closed: 0, running: 0, pending: 1 }),
+        getTask: () => null,
+      },
+    });
+
     expect(await dispatch('invoker:get-tasks', [])).toEqual({
-      tasks: [makeTask('wf-1/task-1')],
+      tasks: [syncedTask],
       workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
       streamSequence: 7,
     });
+    expect(orchestratorCalls).toEqual(['syncAllFromDb', 'getAllTasks']);
+    expect(syncAllFromDb).toHaveBeenCalledTimes(1);
   });
 
   it('get-execution-harnesses returns harness metadata', async () => {

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -159,7 +159,10 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     }
 
     const { tasks, workflows, streamSequence } = buildTaskGraphSnapshot({
-      orchestrator,
+      orchestrator: {
+        getAllTasks: () => orchestrator.getAllTasks(),
+        syncAllFromDb: () => orchestrator.syncAllFromDb(),
+      },
       persistence,
       getStreamSequence: getTaskDeltaStreamSequence,
     });

--- a/packages/app/src/web/task-graph-snapshot.ts
+++ b/packages/app/src/web/task-graph-snapshot.ts
@@ -17,12 +17,13 @@ export interface TaskGraphSnapshot {
 }
 
 export interface BuildTaskGraphSnapshotDeps {
-  orchestrator: Pick<Orchestrator, 'getAllTasks'>;
+  orchestrator: Pick<Orchestrator, 'getAllTasks' | 'syncAllFromDb'>;
   persistence: Pick<SQLiteAdapter, 'listWorkflows'>;
   getStreamSequence: () => number;
 }
 
 export function buildTaskGraphSnapshot(deps: BuildTaskGraphSnapshotDeps): TaskGraphSnapshot {
+  deps.orchestrator.syncAllFromDb();
   return {
     tasks: deps.orchestrator.getAllTasks(),
     workflows: deps.persistence.listWorkflows() as WorkflowMeta[],

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -90,7 +90,10 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       // ── Reads ─────────────────────────────────────────────
       case 'invoker:get-tasks':
         return buildTaskGraphSnapshot({
-          orchestrator,
+          orchestrator: {
+            getAllTasks: () => orchestrator.getAllTasks(),
+            syncAllFromDb: () => orchestrator.syncAllFromDb(),
+          },
           persistence,
           getStreamSequence: deps.getStreamSequence,
         });


### PR DESCRIPTION
Renderer-facing get-tasks snapshots now sync before building shared task graph data.

Depends-On: #5915