### PR TITLE
[Remove deprecated merge-mode and retry paths](2) Reject removed aliases in the owner entrypoint

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -128,6 +128,10 @@ import {
   isHeadlessReadOnlyCommand,
   resolveHeadlessTargetWorkflowId,
 } from './headless-command-classification.js';
+import {
+  isHeadlessHelpCommand,
+  isRemovedHeadlessCommandAlias,
+} from './headless-command-registry.js';
 import { backupPlan } from './plan-backup.js';
 import { startApiServer, type ApiServer } from './api-server.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
@@ -143,6 +147,7 @@ import {
   wireHeadlessApproveHook,
   type HeadlessDeps,
 } from './headless.js';
+import { printHeadlessUsage } from './headless-usage.js';
 import { buildHeadlessApiServerDeps } from './headless-shared.js';
 import { parseReviewGatePrNumber, repairReviewGateCiByPr } from './review-gate-ci-repair-command.js';
 import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
@@ -858,6 +863,18 @@ function startHeadlessMode(): void {
     const mutatingMode = isHeadlessMutatingCommand(cliArgs);
     const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1' || command === 'owner-serve';
     const ownsHeadlessShutdown = standaloneMode && !readOnlyMode && command === 'owner-serve';
+
+    if (isHeadlessHelpCommand(command)) {
+      printHeadlessUsage();
+      process.exit(0);
+      return;
+    }
+
+    if (isRemovedHeadlessCommandAlias(command)) {
+      process.stderr.write(`${RED}Error:${RESET} Unknown command: ${command}. Run with --help for usage.\n`);
+      process.exit(1);
+      return;
+    }
 
     // Try delegation for mutating commands first (owner mode).
     // In standalone mode we skip delegation and run locally.


### PR DESCRIPTION
## Summary

This slice adds the same single startup gate to the owner entrypoint argv flow.

Direct owner-mode startup now routes help and stops legacy alias tokens before startup continues.

## Review Claim

Direct owner-mode startup now stops legacy alias tokens before any delegation or runtime setup begins.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Valid owner startup, delegation, standalone mode, and normal startup still follow the same path after this early gate.

## Slice Rationale

Slice 1 closes the client wrapper. This closes the raw owner entrypoint so the same startup routing applies everywhere.

## Non-goals

- No dispatcher refactor.
- No GUI or web transport changes.
- No mutation semantics changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-client.test.ts src/__tests__/headless-delegation.test.ts`

</details>

## Visual Proof

Owner entrypoint proof: direct `dist/main.js --headless set-merge-mode ...` exits with `Unknown command: set-merge-mode` before startup continues.

![Visual proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-159e87/slice2-owner-entrypoint-before-startup.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
