### PR TITLE
[Remove deprecated merge-mode and retry paths](3) Add canonical IPC channels

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1038,6 +1038,10 @@ export const IpcChannels = {
     request: [taskId: string];
     response: WorkflowMutationAcceptedResult;
   },
+  'invoker:retry-task': {} as {
+    request: [taskId: string];
+    response: WorkflowMutationAcceptedResult;
+  },
   'invoker:cancel-task': {} as {
     request: [taskId: string];
     response: WorkflowMutationAcceptedResult;
@@ -1125,6 +1129,10 @@ export const IpcChannels = {
     response: WorkflowMutationAcceptedResult;
   },
   'invoker:set-merge-mode': {} as {
+    request: [workflowId: string, mergeMode: string];
+    response: WorkflowMutationAcceptedResult;
+  },
+  'invoker:set-workflow-merge-mode': {} as {
     request: [workflowId: string, mergeMode: string];
     response: WorkflowMutationAcceptedResult;
   },


### PR DESCRIPTION
## Summary

This slice extends the shared IPC contract with canonical channel keys for task rerun and workflow merge-mode updates.

Payload shapes stay the same; only the typed contract keys grow.

## Review Claim

The contracts package now declares typed canonical IPC keys for task rerun and workflow merge-mode mutation.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Request and response payload shapes stay the same; only the declared contract keys expand.

## Slice Rationale

The shared contract has to exist before downstream callsites can migrate cleanly.

## Non-goals

- No callsite rewrites.
- No runtime handler changes.
- No legacy channel removal yet.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/contracts test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
