### PR TITLE
[Remove deprecated merge-mode and retry paths](4) Move web dispatch to canonical IPC names

### DIFF
--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -192,7 +192,7 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return mutations.rejectTask(String(args[0]), args[1] === undefined ? undefined : String(args[1]));
       case 'invoker:provide-input':
         return mutations.provideInput(String(args[0]), String(args[1]));
-      case 'invoker:restart-task':
+      case 'invoker:retry-task':
         return mutations.retryTask(String(args[0]));
       case 'invoker:recreate-task':
         return mutations.recreateTask(String(args[0]));
@@ -231,7 +231,7 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         );
       case 'invoker:resolve-conflict':
         return mutations.resolveConflict(String(args[0]), args[1] === undefined ? undefined : String(args[1]));
-      case 'invoker:set-merge-mode':
+      case 'invoker:set-workflow-merge-mode':
         return mutations.setWorkflowMergeMode(String(args[0]), String(args[1]));
       case 'invoker:detach-workflow':
         return deps.detachWorkflow(String(args[0]), String(args[1]));


### PR DESCRIPTION
## Summary

This slice rewires the web dispatch table to the canonical IPC keys.

The web surface still calls the same mutation methods, but the dispatch map now follows the new key names.

## Review Claim

Web-surface mutation dispatch now accepts the canonical task-rerun and workflow merge-mode IPC keys.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The underlying mutation methods and argument coercion stay unchanged; only the dispatch keys change.

## Slice Rationale

This isolates the web dispatch rename before the broader desktop bridge migration.

## Non-goals

- No IPC contract edits.
- No GUI mutation handler changes.
- No UI component changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/web-invoker-dispatch.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
