### PR TITLE
[Remove deprecated merge-mode and retry paths](6) Move auto-fix retries to canonical transport

### DIFF
--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -160,7 +160,7 @@ describe('auto-fix recovery worker', () => {
     await runtime.stop();
   });
 
-  it('scans every failed task and submits a bare restart on the first tick when the registered worker is turned on', async () => {
+  it('scans every failed task and submits a bare retry on the first tick when the registered worker is turned on', async () => {
     const harness = makeRecoveryPolicyHarness();
     const registry = registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>());
     const definition = registry.get(AUTO_FIX_WORKER_KIND);
@@ -187,7 +187,7 @@ describe('auto-fix recovery worker', () => {
     expect(harness.submit).toHaveBeenCalledWith(
       'wf-1',
       'normal',
-      'invoker:restart-task',
+      'invoker:retry-task',
       ['wf-1/task-1'],
     );
   });
@@ -398,14 +398,14 @@ describe('auto-fix recovery candidate validation', () => {
     expect(harness.submit).toHaveBeenCalledWith(
       'wf-1',
       'normal',
-      'invoker:restart-task',
+      'invoker:retry-task',
       ['wf-1/task-1'],
     );
   });
 });
 
 describe('auto-fix recovery scan submission', () => {
-  it('submits a bare restart first, then escalates to fix-with-agent', async () => {
+  it('submits a bare retry first, then escalates to fix-with-agent', async () => {
     const harness = makeRecoveryPolicyHarness();
     const tick = createAutoFixRecoveryTick(harness.options);
 
@@ -419,7 +419,7 @@ describe('auto-fix recovery scan submission', () => {
     expect(harness.submit).toHaveBeenCalledWith(
       'wf-1',
       'normal',
-      'invoker:restart-task',
+      'invoker:retry-task',
       ['wf-1/task-1'],
     );
     expect(harness.logEvent).toHaveBeenCalledWith(
@@ -427,7 +427,7 @@ describe('auto-fix recovery scan submission', () => {
       'debug.auto-fix',
       expect.objectContaining({
         phase: 'worker-autofix-bare-retry-submitted',
-        channel: 'invoker:restart-task',
+        channel: 'invoker:retry-task',
       }),
     );
 
@@ -477,10 +477,10 @@ describe('auto-fix recovery scan submission', () => {
     harness.intents.length = 0;
     await tick({ identity: { kind: 'recovery', instanceId: 'test' }, reason: 'startup', tickNumber: 3 });
 
-    // budget=1 → exactly one automatic retry total (the bare restart counts),
+    // budget=1 → exactly one automatic retry total (the bare retry counts),
     // then the durable per-task cap exhausts.
     expect(harness.submit).toHaveBeenCalledTimes(1);
-    expect(harness.submit.mock.calls.map((call) => call[2])).toEqual(['invoker:restart-task']);
+    expect(harness.submit.mock.calls.map((call) => call[2])).toEqual(['invoker:retry-task']);
     expect(task.execution).not.toHaveProperty(attemptStateKey);
     expect(harness.logEvent).toHaveBeenCalledWith(
       'wf-1/task-1',
@@ -512,7 +512,7 @@ describe('auto-fix recovery scan submission', () => {
     // The generation bump must NOT reset the budget (incident 2026-07-12): the
     // durable per-task counter already spent its single retry, so no second one.
     expect(harness.submit).toHaveBeenCalledTimes(1);
-    expect(harness.submit.mock.calls.map((call) => call[2])).toEqual(['invoker:restart-task']);
+    expect(harness.submit.mock.calls.map((call) => call[2])).toEqual(['invoker:retry-task']);
     expect(harness.logEvent).toHaveBeenCalledWith(
       'wf-1/task-1',
       'debug.auto-fix',

--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -46,7 +46,7 @@ describe('headless auto-fix cutover', () => {
 });
 
 describe('headless worker autofix', () => {
-  it('runs a one-shot scan under the single-instance lock and enqueues a bare restart first', async () => {
+  it('runs a one-shot scan under the single-instance lock and enqueues a bare retry first', async () => {
     const task = makeTask();
     const actions = new Map<string, WorkerActionRecord>();
     const enqueueWorkflowMutationIntent = vi.fn((
@@ -99,7 +99,7 @@ describe('headless worker autofix', () => {
 
     expect(enqueueWorkflowMutationIntent).toHaveBeenCalledWith(
       'wf-1',
-      'invoker:restart-task',
+      'invoker:retry-task',
       ['wf-1/task-1'],
       'normal',
     );

--- a/packages/execution-engine/src/__tests__/auto-fix-bare-retry.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-bare-retry.test.ts
@@ -82,7 +82,7 @@ function makeHarness(task = makeFailedTask()) {
 }
 
 describe('AutoFixWorker attempt-0 bare retry', () => {
-  it('submits invoker:restart-task on the first tick and does not consume an auto-fix attempt', async () => {
+  it('submits invoker:retry-task on the first tick and does not consume an auto-fix attempt', async () => {
     const harness = makeHarness();
     const tick = createAutoFixRecoveryTick({
       store: harness.store,
@@ -99,7 +99,7 @@ describe('AutoFixWorker attempt-0 bare retry', () => {
     const [workflowId, priority, channel, args] = harness.submit.mock.calls[0]!;
     expect(workflowId).toBe('wf-1');
     expect(priority).toBe('normal');
-    expect(channel).toBe('invoker:restart-task');
+    expect(channel).toBe('invoker:retry-task');
     expect(args).toEqual(['wf-1/build']);
 
     const retryRow = harness.actions.get(`${AUTO_FIX_WORKER_KIND}:${AUTO_FIX_WORKER_KIND}:retry:wf-1/build`);
@@ -194,7 +194,7 @@ describe('AutoFixWorker attempt-0 bare retry', () => {
     });
 
     await tick({ reason: 'poll' } as never);
-    expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:restart-task');
+    expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:retry-task');
     harness.submit.mockClear();
 
     // Bare retry succeeded then failed again under a new generation/attempt.
@@ -237,7 +237,7 @@ describe('AutoFixWorker attempt-0 bare retry', () => {
     });
 
     await tick({ reason: 'poll' } as never);
-    expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:restart-task');
+    expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:retry-task');
     harness.submit.mockClear();
 
     harness.tasks.set('wf-1/build', makeFailedTask({
@@ -271,6 +271,6 @@ describe('AutoFixWorker attempt-0 bare retry', () => {
     expect(submitCalls.length).toBeGreaterThan(0);
     const payload = submitCalls[0]?.[2] as { phase?: string; details?: { channel?: string } };
     expect(payload.phase).toBe('worker-autofix-bare-retry-submitted');
-    expect(payload.details?.channel).toBe('invoker:restart-task');
+    expect(payload.details?.channel).toBe('invoker:retry-task');
   });
 });

--- a/packages/execution-engine/src/__tests__/worker-decision-ledger.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-decision-ledger.test.ts
@@ -190,7 +190,7 @@ describe('autofix decision ledger', () => {
     await tick(tickCtx);
 
     expect(submit).toHaveBeenCalledTimes(2);
-    expect(submit.mock.calls[0]?.[2]).toBe('invoker:restart-task');
+    expect(submit.mock.calls[0]?.[2]).toBe('invoker:retry-task');
     expect(submit.mock.calls[1]?.[2]).toBe('invoker:fix-with-agent');
     const autoFixWrite = upserts.find((w) => w.actionType === 'auto-fix');
     expect(autoFixWrite).toMatchObject({

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -41,7 +41,7 @@ export const RECOVERY_WORKER_KIND = 'recovery';
 
 const DEFAULT_RECOVERY_POLL_INTERVAL_MS = 60_000;
 const AUTO_FIX_COMMAND_CHANNEL = 'invoker:fix-with-agent';
-const AUTO_FIX_BARE_RETRY_CHANNEL = 'invoker:restart-task';
+const AUTO_FIX_BARE_RETRY_CHANNEL = 'invoker:retry-task';
 const AUTO_FIX_ACTION_TYPE = 'auto-fix';
 const AUTO_FIX_BARE_RETRY_ACTION_TYPE = 'auto-retry';
 
@@ -256,7 +256,7 @@ function autoFixDecisionExternalKey(candidate: AutoFixRecoveryCandidate): string
 }
 
 function autoFixBareRetryExternalKey(candidate: AutoFixRecoveryCandidate): string {
-  // Bare retry is once-per-task: after restart-task bumps generation, the next
+  // Bare retry is once-per-task: after retry-task bumps generation, the next
   // failure must escalate to fix-with-agent instead of another bare retry.
   return `${AUTO_FIX_WORKER_KIND}:retry:${candidate.taskId}`;
 }

--- a/packages/execution-engine/src/auto-fix-retry-cap.ts
+++ b/packages/execution-engine/src/auto-fix-retry-cap.ts
@@ -17,7 +17,7 @@ import { recordWorkerDecisionRow, type WorkerDecisionStore } from './worker-deci
  * This counter is stored in the durable `worker_actions` table under a key that
  * is stable across generations, attempts, and process restarts, so the total
  * number of worker-initiated retries for a task can never exceed the config.
- * Both automatic retry kinds (bare `restart-task` and `fix-with-agent`) count,
+ * Both automatic retry kinds (bare `retry-task` and `fix-with-agent`) count,
  * and every worker shares the one counter so the cap is per-task, not
  * per-worker. It is a hard cap with no automatic reset; a human who wants more
  * attempts uses the explicit `fix` command, which bypasses the worker entirely.


### PR DESCRIPTION
## Summary

This slice reroutes the first automatic recovery attempt onto the canonical task-rerun channel name.

Recovery workers still spend the same budget and escalate the same way after that first rerun.

## Review Claim

The first automatic recovery attempt for a failed task now uses the canonical task-rerun channel name, and the surrounding budget behavior stays the same.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the bare auto-fix channel label and matching expectations change; budgeting, task selection, and escalation semantics stay the same.

## Slice Rationale

This keeps recovery routing on the canonical channel before later slices trim older names elsewhere.

## Non-goals

- No change to retry-budget math.
- No change to candidate validation or scan coverage.
- No change to the later `invoker:fix-with-agent` escalation path.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/auto-fix-bare-retry.test.ts src/__tests__/worker-decision-ledger.test.ts`
- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/auto-fix-recovery.test.ts src/__tests__/headless-autofix.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
