### PR TITLE
[Remove deprecated merge-mode and retry paths](1) Add canonical IPC channel names

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1192,6 +1192,10 @@ export const IpcChannels = {
     request: [workflowId: string, mergeMode: string];
     response: WorkflowMutationAcceptedResult;
   },
+  'invoker:set-workflow-merge-mode': {} as {
+    request: [workflowId: string, mergeMode: string];
+    response: WorkflowMutationAcceptedResult;
+  },
   'invoker:approve-merge': {} as {
     request: [workflowId: string];
     response: WorkflowMutationAcceptedResult;


### PR DESCRIPTION
## Summary

This slice adds the canonical IPC contract keys first.

The older keys stay available for now, so later slices can adopt the new contract one surface at a time.

## Review Claim

Canonical task-rerun and merge-mode IPC contract keys exist before any caller adoption.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This slice only extends `packages/contracts/src/ipc-channels.ts`. No caller switches or runtime behavior changes here.

## Slice Rationale

The shared contract has to land before app, UI, and worker slices can adopt it without temporary aliases in their own code.

## Non-goals

- No caller migration yet.
- No deprecated contract removal yet.
- No HTTP, UI, or docs changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] pnpm --filter @invoker/contracts build

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2e34e88901b9c4cfb983fdc9d70f3436efc29d55`
- Post-revert steps: None
- Data migration? No

</details>
