### PR TITLE
[Remove deprecated merge-mode and retry paths](2) Remove legacy app command aliases

### DIFF
--- a/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
+++ b/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
@@ -1156,7 +1156,7 @@ const MANUAL_MERGE_ONFINISH_NONE_PLAN: PlanDefinition = {
 
 // ── Flow 9c: UI external_review merge mode ───────────────────
 
-describe('Flow 9c: set-merge-mode external_review', () => {
+describe('Flow 9c: workflow merge mode external_review', () => {
   const mockMergeGate: MergeGateProvider = {
     name: 'mock',
     createReview: async () => ({

--- a/packages/app/src/__tests__/gui-mutation-translation.test.ts
+++ b/packages/app/src/__tests__/gui-mutation-translation.test.ts
@@ -50,7 +50,7 @@ function getPerformDetachWorkflowSource(): string {
 
 function getSetMergeBranchSource(): string {
   const start = guiMutationHandlersSource.lastIndexOf("'invoker:set-merge-branch'");
-  const end = guiMutationHandlersSource.indexOf("'invoker:set-merge-mode'", start);
+  const end = guiMutationHandlersSource.indexOf("'invoker:set-workflow-merge-mode'", start);
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
   return guiMutationHandlersSource.slice(start, end);

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -66,6 +66,28 @@ describe('headless-client', () => {
     expect(args.slice(mainIndex + 1)).toEqual(['--headless', 'query', 'workflows']);
   });
 
+  it('prints help locally without booting Electron or delegating', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const runElectronHeadless = vi.fn(async () => 23);
+    try {
+      const exitCode = await runHeadlessClientCommand(['--help'], {
+        messageBus: new LocalBus(),
+        ensureStandaloneOwner: vi.fn(async () => {}),
+        refreshMessageBus: vi.fn(async () => new LocalBus()),
+        runElectronHeadless,
+      });
+
+      const output = stdout.mock.calls.map(([chunk]) => String(chunk)).join('');
+      expect(exitCode).toBe(0);
+      expect(runElectronHeadless).not.toHaveBeenCalled();
+      expect(output).toContain('retry-task <taskId>');
+      expect(output).not.toContain('Deprecated');
+      expect(output).not.toContain('set-merge-mode');
+    } finally {
+      stdout.mockRestore();
+    }
+  });
+
   it('refreshes to a reachable standalone owner for read-only queries without bootstrapping', async () => {
     process.env.INVOKER_HEADLESS_STANDALONE = '1';
     const firstBus = new LocalBus();

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -169,6 +169,12 @@ describe('headless delegation enforcement', () => {
       ).rejects.toThrow('Unknown command: list');
     });
 
+    it('rejects removed restart alias', async () => {
+      await expect(
+        runHeadless(['restart', 'wf-1/task-1'], mockDeps),
+      ).rejects.toThrow('Unknown command: restart');
+    });
+
     it('allows query workflow for a single workflow', async () => {
       mockDeps.persistence.loadWorkflow = vi.fn(() => ({
         id: 'wf-1',

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -13,6 +13,7 @@ import {
 
 import { resolveInvokerHomeRoot } from './delete-all-snapshot.js';
 import { isHeadlessMutatingCommand } from './headless-command-classification.js';
+import { isHeadlessHelpCommand, isRemovedHeadlessCommandAlias } from './headless-command-registry.js';
 import {
   resolveDelegationTimeoutMs,
   tryDelegateExec,
@@ -44,10 +45,6 @@ import {
   tryAcknowledgeNoTrackTaskMutationWithoutDb,
   tryAcknowledgeNoTrackTaskMutationWithoutOwner,
 } from './headless-no-track-fallback.js';
-import {
-  isHeadlessHelpCommand,
-  isRemovedHeadlessCommandAlias,
-} from './headless-command-registry.js';
 import { printHeadlessUsage } from './headless-usage.js';
 
 const RED = '\x1b[31m';

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1001,7 +1001,7 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:set-merge-branch':
         return { channel: 'headless.gui-mutation', request: payload };
-      case 'invoker:set-merge-mode':
+      case 'invoker:set-workflow-merge-mode':
         return { channel: 'headless.exec', request: { args: ['set', 'merge-mode', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:approve-merge': {
         const workflowId = String(arg0);
@@ -2273,13 +2273,13 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   });
 
   registerTaskScopedGuiMutationHandler(
-    'invoker:set-merge-mode',
+    'invoker:set-workflow-merge-mode',
     (workflowIdArg: unknown) => String(workflowIdArg),
     'normal',
     async (workflowIdArg: unknown, mergeModeArg: unknown) => {
     const workflowId = String(workflowIdArg);
     const mergeMode = String(mergeModeArg);
-    logger.info(`set-merge-mode: workflow="${workflowId}" → "${mergeMode}"`, { module: 'ipc' });
+    logger.info(`set workflow merge mode: workflow="${workflowId}" -> "${mergeMode}"`, { module: 'ipc' });
     try {
       await setWorkflowMergeMode(workflowId, mergeMode, {
         orchestrator,
@@ -2287,12 +2287,12 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
         taskExecutor: requireTaskExecutor(),
       });
     } catch (err) {
-      logger.error(`set-merge-mode failed: ${err}`, { module: 'ipc' });
+      logger.error(`set workflow merge mode failed: ${err}`, { module: 'ipc' });
       throw err;
     }
     const workflows = persistence.listWorkflows();
     rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
-    requestWorkflowMetadataPublish('set-merge-mode');
+    requestWorkflowMetadataPublish('set-workflow-merge-mode');
   });
 
   registerWorkflowScopedGuiMutationHandler(

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -763,7 +763,7 @@ export async function selectExperiments(
  *
  * This wrapper deliberately stays a thin async delegate to keep the
  * public surface (`(workflowId, mergeMode, deps)` returning `void`)
- * backward compatible for IPC handlers (`invoker:set-merge-mode`),
+ * compatible with workflow-scoped IPC handlers,
  * the api-server (`POST /api/workflows/:id/merge-mode`), and Slack
  * surfaces. The merge-task-id translation (`workflowId → mergeNodeId`)
  * happens here because callers speak workflow ids; the orchestrator


### PR DESCRIPTION
## Summary

This slice retires legacy app-side aliases.

The Electron IPC bridge and headless CLI now use the canonical task-rerun and merge-mode names, and the focused app checks point at those names directly.

The web-transport counterpart of this rename ships separately in a dependent PR, because it lives in a different file bucket.

## Review Claim

Legacy app aliases stop resolving while the canonical Electron IPC and headless surface keeps working.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice stays in the headless parser, help, and Electron IPC mutation-handler surface. It trims compatibility code only and does not change deeper workflow semantics. The web-transport dispatch counterpart is out of scope here.

## Slice Rationale

The user-facing surface should collapse before later engine slices rename lower-level channel keys, so every caller above the core uses one vocabulary. The web dispatch counterpart ships in its own dependent PR so this PR stays a single review unit.

## Non-goals

- No web-dispatch channel change here (see the dependent PR).
- No UI bridge rename here.
- No workflow-core lifecycle changes here.
- No contract deletion yet.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test -- src/__tests__/bridge-orchestrator-executor.test.ts src/__tests__/gui-mutation-translation.test.ts src/__tests__/headless-client.test.ts src/__tests__/headless-delegation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c698ef0af37dd550e7767a622fd081841403cd0a`
- Post-revert steps: None
- Data migration? No

</details>
