### PR TITLE
[Remove deprecated merge-mode and retry paths](4) Reject removed aliases before startup

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -88,6 +88,19 @@ describe('headless-client', () => {
     }
   });
 
+  it('rejects removed top-level aliases before booting Electron', async () => {
+    const runElectronHeadless = vi.fn(async () => 23);
+
+    await expect(runHeadlessClientCommand(['set-merge-mode', 'wf-123', 'manual'], {
+      messageBus: new LocalBus(),
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      refreshMessageBus: vi.fn(async () => new LocalBus()),
+      runElectronHeadless,
+    })).rejects.toThrow('Unknown command: set-merge-mode');
+
+    expect(runElectronHeadless).not.toHaveBeenCalled();
+  });
+
   it('refreshes to a reachable standalone owner for read-only queries without bootstrapping', async () => {
     process.env.INVOKER_HEADLESS_STANDALONE = '1';
     const firstBus = new LocalBus();

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -70,8 +70,8 @@ export function isHeadlessHelpCommand(command: string | undefined): boolean {
   return command === undefined || command === '--help' || command === '-h';
 }
 
-export function isRemovedHeadlessCommandAlias(_command: string | undefined): boolean {
-  return false;
+export function isRemovedHeadlessCommandAlias(command: string | undefined): boolean {
+  return command === 'set-merge-mode';
 }
 
 export function isMutatingSetSubcommand(subcommand: string | undefined): boolean {


### PR DESCRIPTION
## Summary

This slice makes the deprecated `set-merge-mode` headless command report as unknown in the command registry.

The check happens before Electron startup, so bad invocations do not reach the owner path.

## Review Claim

The headless command registry treats `set-merge-mode` as unknown before Electron fallback can run.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the headless command registry and its client test change; owner execution stays unchanged.

## Slice Rationale

This activation-surface change follows the argv rename and keeps alias handling separate from deeper owner behavior.

## Non-goals

- No new command names.
- No workflow-core lifecycle changes.
- No docs updates.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] pnpm --filter @invoker/app exec vitest run src/__tests__/headless-client.test.ts

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1ceec9aca20d3256cfba8f784637232a56f5349d`
- Post-revert steps: None
- Data migration? No

</details>
