### PR TITLE
[Remove deprecated merge-mode and retry paths](8) Source SSH profiles without login shells

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -1101,7 +1101,7 @@ describe('SshExecutor entry lifecycle', () => {
     vi.spyOn(ssh as any, 'mergeRequestUpstreamBranches').mockResolvedValue(undefined);
   });
 
-  it('uses a non-login shell for task payloads and sources ~/.invoker/env.sh explicitly', async () => {
+  it('uses a non-login shell for task payloads and sources remote environment explicitly', async () => {
     const request = makeRequest({
       inputs: {
         command: 'echo hello',
@@ -1121,6 +1121,9 @@ describe('SshExecutor entry lifecycle', () => {
     expect(script).toContain('export INVOKER_HOME');
     expect(script).toContain('export INVOKER_ENV_FILE');
     expect(script).toContain('. "$INVOKER_ENV_FILE"');
+    expect(script).toContain('load_remote_profile_path');
+    expect(script).toContain('"$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.profile"');
+    expect(script.indexOf('load_remote_profile_path')).toBeLessThan(script.indexOf('set -euo pipefail'));
 
     sshProcess.emit('close', 0, null);
     await new Promise((r) => setTimeout(r, 50));

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -276,7 +276,7 @@ function shellQuote(s: string): string {
 /**
  * Remote shell for agent fix/resolve commands. Keep this non-login so remote
  * dotfiles cannot trigger login-shell bash bugs or mutate execution semantics.
- * PATH comes from ~/.invoker/env.sh, sourced explicitly inside each script.
+ * Remote scripts source ~/.invoker/env.sh explicitly before running agents.
  */
 export function remoteAgentShellInvocation(): string[] {
   return ['bash', '-s'];

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -303,7 +303,21 @@ ensure_managed_pnpm_workspace
     const runPayloadSection = `echo "[SshExecutor] Running task payload..."
 `;
 
-    return `set -euo pipefail
+    return `load_remote_profile_path() {
+  local profile
+  for profile in "$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.profile"; do
+    if [ -f "$profile" ]; then
+      set +eu
+      set +o pipefail 2>/dev/null || true
+      . "$profile" || true
+      set +eu
+      set +o pipefail 2>/dev/null || true
+      break
+    fi
+  done
+}
+load_remote_profile_path
+set -euo pipefail
 ${this.remotePathNormalizeFunction()}
 ${buildSourceInvokerEnvScript(this.remoteInvokerHome, 'INVOKER_HOME')}
 STAGING_DIR="$INVOKER_HOME/runtime/ssh-executor/${stagingTokenExpression}"
@@ -365,9 +379,9 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
   }
 
   /**
-   * Remote shell for task payloads. Keep this non-login so remote dotfiles cannot
-   * trigger login-shell bash bugs or mutate execution semantics. PATH comes from
-   * ~/.invoker/env.sh, sourced explicitly inside the bootstrap script.
+   * Remote shell for task payloads. The bootstrap script sources ~/.invoker/env.sh
+   * and profile PATH fragments explicitly so PATH customizations apply without
+   * running login-shell hooks. Never forward the local host PATH.
    */
   private buildPayloadRemoteCommand(): string[] {
     return ['bash', '-s'];


### PR DESCRIPTION
## Summary

This slice sources SSH profiles in the bootstrap path.

Remote execution proof no longer depends on a login shell to source the user profile before startup.

## Review Claim

SSH task bootstrap sources profiles without requiring a login shell.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice stays in execution-engine SSH bootstrap code and its direct tests. It changes environment setup only for remote execution startup.

## Slice Rationale

The SSH bootstrap fix is separated from the channel rename slices so the remote execution assumption change is reviewed on its own.

## Non-goals

- No channel rename here.
- No app or UI surface changes.
- No docs updates.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] pnpm --filter @invoker/execution-engine test -- src/__tests__/ssh-executor.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c0b4b85ad1903c01168a3ddabaee31385e2d201f`
- Post-revert steps: None
- Data migration? No

</details>
