### PR TITLE
[Infra Failure Routing](2) Share provision-command handling across SSH and worktree

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import type { ChildProcess } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SshExecutor } from '../ssh-executor.js';
@@ -301,6 +301,154 @@ describe('SshExecutor managed workspace mode', () => {
       rmSync(fakeHome, { recursive: true, force: true });
       proc.emit('close', 0, null);
       await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  });
+  it('managed mode runs the configured provisionCommand instead of the hard-coded pnpm install', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+      remoteHeartbeatIntervalSeconds: 1,
+      remoteInvokerHome: '~/.invoker',
+      provisionCommand: 'printf "%s\\n" custom-provision > "$HOME/provision.log"\nmkdir -p node_modules',
+    }) as any;
+
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return '__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=abc123def456abc123def456abc123def456abc1';
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      return '';
+    });
+    vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+
+    await ssh.start(makeRequest({
+      actionType: 'command',
+      inputs: {
+        command: "printf 'payload-ran\\n' > payload.out",
+        description: 'run tests',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    }));
+
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+    const writeMock = (proc.stdin as any).write as ReturnType<typeof vi.fn>;
+    const bootstrapScript = writeMock.mock.calls[0]![0] as string;
+    const workspaceMatch = bootstrapScript.match(/WT=\$\(normalize_remote_path '([^']+)'\)/);
+    if (!workspaceMatch?.[1]) {
+      throw new Error('Managed SSH bootstrap did not embed a workspace path');
+    }
+
+    const fakeHome = mkdtempSync(join(tmpdir(), 'ssh-custom-provision-home-'));
+    try {
+      const workspacePath = workspaceMatch[1].replace(/^~(?=\/|$)/, fakeHome);
+      mkdirSync(workspacePath, { recursive: true });
+      writeFileSync(join(workspacePath, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
+
+      const childProcessModule = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+      const result = childProcessModule.spawnSync('/bin/bash', ['-c', bootstrapScript], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: fakeHome, PATH: process.env.PATH ?? '' },
+      });
+
+      expect(result.status).toBe(0);
+      expect(bootstrapScript).not.toContain('pnpm install --frozen-lockfile');
+      expect(readFileSync(join(fakeHome, 'provision.log'), 'utf8')).toBe('custom-provision\n');
+      expect(existsSync(join(workspacePath, 'node_modules'))).toBe(true);
+      expect(readFileSync(join(workspacePath, 'payload.out'), 'utf8')).toBe('payload-ran\n');
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+      proc.emit('close', 0, null);
+    }
+  });
+  it('managed mode preserves the missing-pnpm sentinel for the default provision command', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+      remoteHeartbeatIntervalSeconds: 1,
+      remoteInvokerHome: '~/.invoker',
+    });
+    const sshPrivate = ssh as unknown as {
+      execRemoteCapture: (script: string) => Promise<string>;
+      setupTaskBranch: (...args: Array<unknown>) => Promise<void>;
+    };
+
+    vi.spyOn(sshPrivate, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return '__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=abc123def456abc123def456abc123def456abc1';
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      return '';
+    });
+    vi.spyOn(sshPrivate, 'setupTaskBranch').mockResolvedValue(undefined);
+
+    const handle = await ssh.start(makeRequest({
+      actionType: 'command',
+      inputs: {
+        command: "printf 'payload-ran\\n' > payload.out",
+        description: 'run tests',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    }));
+
+    const completion = Promise.withResolvers<void>();
+    ssh.onComplete(handle, () => {
+      completion.resolve();
+    });
+
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+    const stdin = proc.stdin;
+    if (!stdin || typeof stdin.write !== 'function') {
+      throw new Error('Managed SSH bootstrap did not expose a writable stdin');
+    }
+    const mockedWrite = stdin.write as unknown as { mock: { calls: Array<[string]> } };
+    const writeCalls = mockedWrite.mock.calls;
+    const bootstrapScript = writeCalls[0]?.[0];
+    const workspaceMatch = typeof bootstrapScript === 'string'
+      ? bootstrapScript.match(/WT=\$\(normalize_remote_path '([^']+)'\)/)
+      : undefined;
+    if (typeof bootstrapScript !== 'string' || !workspaceMatch?.[1]) {
+      throw new Error('Managed SSH bootstrap did not embed a workspace path');
+    }
+
+    const fakeHome = mkdtempSync(join(tmpdir(), 'ssh-missing-pnpm-home-'));
+    const stubBin = join(fakeHome, 'bin');
+    mkdirSync(stubBin, { recursive: true });
+
+    const childProcessModule = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+    for (const command of ['bash', 'cat', 'chmod', 'date', 'mkdir', 'rm', 'sleep']) {
+      const lookup = childProcessModule.spawnSync('/bin/bash', ['-lc', `command -v ${command}`], {
+        encoding: 'utf8',
+      });
+      expect(lookup.status).toBe(0);
+      symlinkSync(lookup.stdout.trim(), join(stubBin, command));
+    }
+
+    try {
+      const workspacePath = workspaceMatch[1].replace(/^~(?=\/|$)/, fakeHome);
+      mkdirSync(workspacePath, { recursive: true });
+      writeFileSync(join(workspacePath, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
+
+      const result = childProcessModule.spawnSync('/bin/bash', ['-c', bootstrapScript], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: fakeHome, PATH: stubBin },
+      });
+
+      expect(bootstrapScript).toContain('command -v pnpm');
+      expect(result.status).toBe(127);
+      expect(result.stderr).toContain(
+        '[SshExecutor] pnpm-lock.yaml found and node_modules missing, but pnpm is not installed.',
+      );
+      expect(result.stderr).not.toContain('pnpm: command not found');
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+      proc.emit('close', 0, null);
+      await completion.promise;
     }
   });
 

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import type { ChildProcess } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SshExecutor } from '../ssh-executor.js';
@@ -217,11 +217,8 @@ describe('SshExecutor managed workspace mode', () => {
     expect(callScript).toContain('cat > "$RUNNER_PATH" <<');
     expect(callScript).toContain('cat > "$PAYLOAD_PATH" <<');
     expect(callScript).not.toContain('cat > "$PROVISION_PATH" <<');
-    expect(callScript).toContain('ensure_managed_pnpm_workspace');
-    expect(callScript).toContain('pnpm install --frozen-lockfile');
-    expect(callScript.indexOf('pnpm install --frozen-lockfile')).toBeLessThan(
-      callScript.indexOf('echo "[SshExecutor] Running task payload..."'),
-    );
+    expect(callScript).not.toContain('ensure_managed_pnpm_workspace');
+    expect(callScript).not.toContain('pnpm install --frozen-lockfile');
     expect(callScript).toContain('start_bootstrap_heartbeat');
     expect(callScript).toContain('stop_bootstrap_heartbeat');
     expect(callScript.indexOf('stop_bootstrap_heartbeat')).toBeLessThan(callScript.indexOf('"$RUNNER_PATH" "$PAYLOAD_PATH"'));
@@ -232,7 +229,7 @@ describe('SshExecutor managed workspace mode', () => {
     expect(callFinalize).toEqual({ branch: handle.branch, worktreePath: handle.workspacePath });
   });
 
-  it('managed mode installs pnpm dependencies when node_modules is missing before payload', async () => {
+  it('managed mode skips provisioning when provisionCommand is unset', async () => {
     const ssh = new SshExecutor({
       host: 'localhost',
       user: 'testuser',
@@ -270,32 +267,22 @@ describe('SshExecutor managed workspace mode', () => {
       throw new Error('Managed SSH bootstrap did not embed a workspace path');
     }
 
-    const fakeHome = mkdtempSync(join(tmpdir(), 'ssh-pnpm-bootstrap-home-'));
+    const fakeHome = mkdtempSync(join(tmpdir(), 'ssh-no-provision-home-'));
     try {
       const workspacePath = workspaceMatch[1].replace(/^~(?=\/|$)/, fakeHome);
-      const binDir = join(fakeHome, 'bin');
       mkdirSync(workspacePath, { recursive: true });
-      mkdirSync(binDir, { recursive: true });
       writeFileSync(join(workspacePath, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
-      const pnpmPath = join(binDir, 'pnpm');
-      writeFileSync(
-        pnpmPath,
-        '#!/usr/bin/env bash\nprintf "%s\\n" "$*" > "$HOME/pnpm-args.txt"\nprintf "%s\\n" "$PWD" > "$HOME/pnpm-cwd.txt"\nmkdir -p node_modules\n',
-      );
-      chmodSync(pnpmPath, 0o755);
 
       const childProcessModule = await vi.importActual<typeof import('node:child_process')>('node:child_process');
       const result = childProcessModule.spawnSync('/bin/bash', ['-c', bootstrapScript], {
         encoding: 'utf8',
-        env: { ...process.env, HOME: fakeHome, PATH: `${binDir}:${process.env.PATH ?? ''}` },
+        env: { ...process.env, HOME: fakeHome, PATH: process.env.PATH ?? '' },
       });
 
       expect(result.status).toBe(0);
-      expect(result.stdout).toContain('[SshExecutor] Installing pnpm dependencies for managed worktree...');
-      expect(result.stdout).toContain('[SshExecutor] Running task payload...');
-      expect(readFileSync(join(fakeHome, 'pnpm-args.txt'), 'utf8')).toBe('install --frozen-lockfile\n');
-      expect(readFileSync(join(fakeHome, 'pnpm-cwd.txt'), 'utf8')).toBe(`${workspacePath}\n`);
-      expect(existsSync(join(workspacePath, 'node_modules'))).toBe(true);
+      expect(bootstrapScript).not.toContain('ensure_managed_pnpm_workspace');
+      expect(result.stdout).not.toContain('[SshExecutor] Installing managed worktree dependencies...');
+      expect(existsSync(join(workspacePath, 'node_modules'))).toBe(false);
       expect(readFileSync(join(workspacePath, 'payload.out'), 'utf8')).toBe('payload-ran\n');
     } finally {
       rmSync(fakeHome, { recursive: true, force: true });
@@ -303,7 +290,7 @@ describe('SshExecutor managed workspace mode', () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
     }
   });
-  it('managed mode runs the configured provisionCommand instead of the hard-coded pnpm install', async () => {
+  it('managed mode runs the configured provisionCommand before payload', async () => {
     const ssh = new SshExecutor({
       host: 'localhost',
       user: 'testuser',
@@ -354,101 +341,14 @@ describe('SshExecutor managed workspace mode', () => {
       });
 
       expect(result.status).toBe(0);
-      expect(bootstrapScript).not.toContain('pnpm install --frozen-lockfile');
+      expect(bootstrapScript).toContain('ensure_managed_pnpm_workspace');
+      expect(result.stdout).toContain('[SshExecutor] Installing managed worktree dependencies...');
       expect(readFileSync(join(fakeHome, 'provision.log'), 'utf8')).toBe('custom-provision\n');
       expect(existsSync(join(workspacePath, 'node_modules'))).toBe(true);
       expect(readFileSync(join(workspacePath, 'payload.out'), 'utf8')).toBe('payload-ran\n');
     } finally {
       rmSync(fakeHome, { recursive: true, force: true });
       proc.emit('close', 0, null);
-    }
-  });
-  it('managed mode preserves the missing-pnpm sentinel for the default provision command', async () => {
-    const ssh = new SshExecutor({
-      host: 'localhost',
-      user: 'testuser',
-      sshKeyPath: '/dev/null',
-      managedWorkspaces: true,
-      remoteHeartbeatIntervalSeconds: 1,
-      remoteInvokerHome: '~/.invoker',
-    });
-    const sshPrivate = ssh as unknown as {
-      execRemoteCapture: (script: string) => Promise<string>;
-      setupTaskBranch: (...args: Array<unknown>) => Promise<void>;
-    };
-
-    vi.spyOn(sshPrivate, 'execRemoteCapture').mockImplementation(async (script: string) => {
-      if (script.includes('__INVOKER_BASE_REF__=')) {
-        return '__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=abc123def456abc123def456abc123def456abc1';
-      }
-      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
-      if (script.includes('worktree list --porcelain')) return '';
-      return '';
-    });
-    vi.spyOn(sshPrivate, 'setupTaskBranch').mockResolvedValue(undefined);
-
-    const handle = await ssh.start(makeRequest({
-      actionType: 'command',
-      inputs: {
-        command: "printf 'payload-ran\\n' > payload.out",
-        description: 'run tests',
-        repoUrl: 'git@github.com:owner/repo.git',
-      },
-    }));
-
-    const completion = Promise.withResolvers<void>();
-    ssh.onComplete(handle, () => {
-      completion.resolve();
-    });
-
-    const proc = spawnedProcesses[spawnedProcesses.length - 1];
-    const stdin = proc.stdin;
-    if (!stdin || typeof stdin.write !== 'function') {
-      throw new Error('Managed SSH bootstrap did not expose a writable stdin');
-    }
-    const mockedWrite = stdin.write as unknown as { mock: { calls: Array<[string]> } };
-    const writeCalls = mockedWrite.mock.calls;
-    const bootstrapScript = writeCalls[0]?.[0];
-    const workspaceMatch = typeof bootstrapScript === 'string'
-      ? bootstrapScript.match(/WT=\$\(normalize_remote_path '([^']+)'\)/)
-      : undefined;
-    if (typeof bootstrapScript !== 'string' || !workspaceMatch?.[1]) {
-      throw new Error('Managed SSH bootstrap did not embed a workspace path');
-    }
-
-    const fakeHome = mkdtempSync(join(tmpdir(), 'ssh-missing-pnpm-home-'));
-    const stubBin = join(fakeHome, 'bin');
-    mkdirSync(stubBin, { recursive: true });
-
-    const childProcessModule = await vi.importActual<typeof import('node:child_process')>('node:child_process');
-    for (const command of ['bash', 'cat', 'chmod', 'date', 'mkdir', 'rm', 'sleep']) {
-      const lookup = childProcessModule.spawnSync('/bin/bash', ['-lc', `command -v ${command}`], {
-        encoding: 'utf8',
-      });
-      expect(lookup.status).toBe(0);
-      symlinkSync(lookup.stdout.trim(), join(stubBin, command));
-    }
-
-    try {
-      const workspacePath = workspaceMatch[1].replace(/^~(?=\/|$)/, fakeHome);
-      mkdirSync(workspacePath, { recursive: true });
-      writeFileSync(join(workspacePath, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
-
-      const result = childProcessModule.spawnSync('/bin/bash', ['-c', bootstrapScript], {
-        encoding: 'utf8',
-        env: { ...process.env, HOME: fakeHome, PATH: stubBin },
-      });
-
-      expect(bootstrapScript).toContain('command -v pnpm');
-      expect(result.status).toBe(127);
-      expect(result.stderr).toContain(
-        '[SshExecutor] pnpm-lock.yaml found and node_modules missing, but pnpm is not installed.',
-      );
-      expect(result.stderr).not.toContain('pnpm: command not found');
-    } finally {
-      rmSync(fakeHome, { recursive: true, force: true });
-      proc.emit('close', 0, null);
-      await completion.promise;
     }
   });
 

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2641,6 +2641,71 @@ describe('TaskRunner', () => {
 
       expect(provider).toHaveBeenCalledTimes(2);
     });
+    it('reads worktree provision commands lazily from the pool provider on each selectExecutor call', () => {
+      const provider = vi.fn()
+        .mockReturnValueOnce({
+          fast: {
+            members: [{ type: 'worktree', id: 'local-mac', provisionCommand: 'old provision' }],
+          },
+        })
+        .mockReturnValueOnce({
+          fast: {
+            members: [{ type: 'worktree', id: 'local-mac', provisionCommand: 'new provision' }],
+          },
+        });
+
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => undefined } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: provider,
+      });
+
+      const task = makeTask({
+        id: 'worktree-task',
+        config: { runnerKind: 'worktree', poolId: 'fast' },
+      });
+
+      const executor1 = executor.selectExecutor(task);
+      expect(executor1.executor.type).toBe('worktree');
+      expect((executor1.executor as any).provisionCommand).toBe('old provision');
+
+      const executor2 = executor.selectExecutor(task);
+      expect((executor2.executor as any).provisionCommand).toBe('new provision');
+
+      expect(provider).toHaveBeenCalledTimes(2);
+    });
+    it('bypasses arbitrary registered worktree executors so pool provisioning fingerprints win', () => {
+      const preRegistered = { type: 'worktree' };
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => undefined } as any,
+        persistence: {} as any,
+        executorRegistry: {
+          getDefault: () => ({ type: 'worktree' }),
+          get: (type: string) => type === 'worktree' ? preRegistered : null,
+          getAll: () => [],
+          register: vi.fn(),
+        } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: () => ({
+          fast: {
+            members: [{ type: 'worktree', id: 'local-mac', provisionCommand: 'pnpm install --frozen-lockfile' }],
+          },
+        }),
+      });
+
+      const task = makeTask({
+        id: 'worktree-task',
+        config: { runnerKind: 'worktree', poolId: 'fast' },
+      });
+
+      const selected = executor.selectExecutor(task);
+      expect(selected.executor).not.toBe(preRegistered);
+      expect(selected.executor.type).toBe('worktree');
+      expect(Reflect.get(selected.executor, 'provisionCommand')).toBe('pnpm install --frozen-lockfile');
+    });
+
 
     it('throws when provider returns no entry for the target ID', () => {
       const provider = vi.fn().mockReturnValue({});
@@ -3166,7 +3231,7 @@ describe('TaskRunner', () => {
       expect(executor2.executor).not.toBe(executor3.executor);
     });
 
-    it('does not cache non-SSH executors', () => {
+    it('caches worktree executors by provisioning fingerprint', () => {
       const executor = new TaskRunner({
         orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
         persistence: {} as any,
@@ -3191,11 +3256,49 @@ describe('TaskRunner', () => {
       const executor1 = executor.selectExecutor(task1);
       const executor2 = executor.selectExecutor(task2);
 
-      // Worktree executors are created fresh each time (lazy registration creates new instances)
-      // Both should be worktree type but may be different instances
+      // Worktree executors are cached by local provisioning fingerprint.
       expect(executor1.executor.type).toBe('worktree');
       expect(executor2.executor.type).toBe('worktree');
+      expect(executor1.executor).toBe(executor2.executor);
     });
+    it('retains cached worktree executors for earlier provisioning fingerprints', () => {
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: {} as any,
+        executorRegistry: {
+          getDefault: () => ({ type: 'worktree' }),
+          get: () => null,
+          getAll: () => [],
+          register: vi.fn(),
+        } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: () => ({
+          fast: {
+            members: [{ type: 'worktree', id: 'local-a', provisionCommand: 'pnpm install --frozen-lockfile' }],
+          },
+          slow: {
+            members: [{ type: 'worktree', id: 'local-b', provisionCommand: 'pnpm install' }],
+          },
+        }),
+      });
+
+      const executorA1 = executor.selectExecutor(makeTask({
+        id: 'task-a1',
+        config: { runnerKind: 'worktree', poolId: 'fast' },
+      }));
+      const executorB = executor.selectExecutor(makeTask({
+        id: 'task-b',
+        config: { runnerKind: 'worktree', poolId: 'slow' },
+      }));
+      const executorA2 = executor.selectExecutor(makeTask({
+        id: 'task-a2',
+        config: { runnerKind: 'worktree', poolId: 'fast' },
+      }));
+
+      expect(executorA1.executor).not.toBe(executorB.executor);
+      expect(executorA1.executor).toBe(executorA2.executor);
+    });
+
 
     it('clearSshExecutorCache removes all cached SSH executors', async () => {
       const remoteTargets = {

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -24,6 +24,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { WorktreeExecutor, computeContentHash } from '../worktree-executor.js';
 import { BaseExecutor } from '../base-executor.js';
 import { registerBuiltinAgents } from '../agents/index.js';
+import { SIGKILL_TIMEOUT_MS } from '../process-utils.js';
 
 const mockedSpawn = vi.mocked(spawn);
 
@@ -338,6 +339,117 @@ describe('WorktreeExecutor', () => {
 
     taskProcess.emit('close', 0, null);
   });
+  it('runs a configured provision command before spawning the task process', async () => {
+    const { taskProcess } = setupSpawnMock();
+    const baseImpl = mockedSpawn.getMockImplementation();
+    const provisionProcess = createMockProcess();
+    mockedSpawn.mockImplementation((cmd: string, args?: readonly string[], options?: { signal?: AbortSignal }) => {
+      if (cmd === '/bin/bash' && (args as string[] | undefined)?.[1] === 'pnpm install --frozen-lockfile') {
+        return provisionProcess;
+      }
+      return baseImpl!(cmd, args, options);
+    });
+
+    const provisionedExecutor = new WorktreeExecutor({
+      cacheDir: '/fake/cache',
+      worktreeBaseDir: '/fake/worktrees',
+      provisionCommand: 'pnpm install --frozen-lockfile',
+    });
+    mockPool(provisionedExecutor);
+
+    const startPromise = provisionedExecutor.start(makeRequest());
+    await vi.waitFor(() => {
+      expect(mockedSpawn.mock.calls.find(
+        ([cmd, args]) => cmd === '/bin/bash' && (args as string[] | undefined)?.[1] === 'pnpm install --frozen-lockfile',
+      )).toBeDefined();
+    });
+
+    const provisionCall = mockedSpawn.mock.calls.find(
+      ([cmd, args]) => cmd === '/bin/bash' && (args as string[] | undefined)?.[1] === 'pnpm install --frozen-lockfile',
+    );
+    expect((provisionCall?.[2] as { cwd: string }).cwd).toMatch(/^\/fake\/worktrees\//);
+
+    provisionProcess.emit('close', 0, null);
+    await startPromise;
+
+    const taskCall = mockedSpawn.mock.calls.find(
+      ([cmd, args]) => cmd === '/bin/bash' && (args as string[] | undefined)?.[1] === 'echo hello',
+    );
+    expect(taskCall).toBeDefined();
+
+    taskProcess.emit('close', 0, null);
+  });
+  it('times out hung provision commands and terminates their process group', async () => {
+    vi.useFakeTimers();
+    const previousTimeout = process.env.INVOKER_EXECUTOR_START_TIMEOUT_MS;
+    process.env.INVOKER_EXECUTOR_START_TIMEOUT_MS = '25';
+    setupSpawnMock();
+    const baseImpl = mockedSpawn.getMockImplementation();
+    const provisionProcess = createMockProcess();
+    mockedSpawn.mockImplementation((cmd: string, args?: readonly string[], options?: { signal?: AbortSignal }) => {
+      if (cmd === '/bin/bash' && (args as string[] | undefined)?.[1] === 'pnpm install --frozen-lockfile') {
+        return provisionProcess;
+      }
+      return baseImpl!(cmd, args, options);
+    });
+
+    const provisionedExecutor = new WorktreeExecutor({
+      cacheDir: '/fake/cache',
+      worktreeBaseDir: '/fake/worktrees',
+      provisionCommand: 'pnpm install --frozen-lockfile',
+    });
+    mockPool(provisionedExecutor);
+
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation((_pid, _signal?) => true);
+    try {
+      const startPromise = provisionedExecutor.start(makeRequest());
+      const rejection = expect(startPromise).rejects.toThrow('provision command timed out after 25ms');
+      await vi.waitFor(() => {
+        expect(mockedSpawn.mock.calls.find(
+          ([cmd, args]) => cmd === '/bin/bash' && (args as string[] | undefined)?.[1] === 'pnpm install --frozen-lockfile',
+        )).toBeDefined();
+      });
+
+      await vi.advanceTimersByTimeAsync(25 + SIGKILL_TIMEOUT_MS);
+
+      await rejection;
+      expect(killSpy).toHaveBeenCalledWith(-12345, 'SIGTERM');
+      expect(killSpy).toHaveBeenCalledWith(-12345, 'SIGKILL');
+    } finally {
+      killSpy.mockRestore();
+      if (previousTimeout === undefined) {
+        delete process.env.INVOKER_EXECUTOR_START_TIMEOUT_MS;
+      } else {
+        process.env.INVOKER_EXECUTOR_START_TIMEOUT_MS = previousTimeout;
+      }
+      vi.useRealTimers();
+    }
+  });
+
+  it('retains only a bounded provisioning output tail', () => {
+    const tailingExecutor = new WorktreeExecutor({
+      cacheDir: '/fake/cache',
+      worktreeBaseDir: '/fake/worktrees',
+      provisionCommand: 'pnpm install --frozen-lockfile',
+    });
+    const appendProvisionOutputTail = Reflect.get(
+      tailingExecutor,
+      'appendProvisionOutputTail',
+    ) as (tail: string, text: string) => string;
+
+    let tail = '';
+    for (let index = 0; index < 75; index += 1) {
+      tail = appendProvisionOutputTail(tail, `line-${index}\n`);
+    }
+
+    expect(tail).not.toContain('line-0');
+    expect(tail).toContain('line-74');
+    expect(tail.trim().split('\n')).toHaveLength(50);
+
+    const oversized = appendProvisionOutputTail('', `${'x'.repeat(40_000)}\n`);
+    expect(oversized.length).toBeLessThanOrEqual(32_000);
+  });
+
 
   it('completion captures branch and commit hash in summary', async () => {
     const { taskProcess } = setupSpawnMock();

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -8,7 +8,8 @@ import type { AgentRegistry } from './agent-registry.js';
 import { assertExecutionModelSupported, DEFAULT_EXECUTION_AGENT } from './agent.js';
 import { checkStaleness } from './git-staleness-detector.js';
 import { assertNotGitConfigMutation, ensureRemoteUrl } from './git-config-mutation.js';
-import { childProcessHasExited, terminateChildProcessGroup } from './process-utils.js';
+import { childProcessHasExited, cleanElectronEnv, killProcessGroup, SIGKILL_TIMEOUT_MS, terminateChildProcessGroup } from './process-utils.js';
+import { getExecutorStartTimeoutMs } from './task-runner-launch-support.js';
 
 
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -17,6 +18,8 @@ const DEFAULT_MAX_BUFFER_CHUNKS = 1000;
 const DEFAULT_MAX_BUFFER_BYTES = 5 * 1024 * 1024; // 5MB
 /** Default cap for `git fetch` / `git push` (network-bound). Override via INVOKER_GIT_NETWORK_TIMEOUT_MS; use 0 for unbounded. */
 const DEFAULT_GIT_NETWORK_TIMEOUT_MS = 15 * 60 * 1000;
+const PROVISION_OUTPUT_TAIL_LINE_LIMIT = 50;
+const PROVISION_OUTPUT_TAIL_CHAR_LIMIT = 32_000;
 
 export interface BaseEntry {
   request: WorkRequest;
@@ -108,6 +111,8 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
   protected maxDurationMs: number;
   protected maxBufferChunks: number;
   protected maxBufferBytes: number;
+  protected provisionCommand = '';
+  private readonly localProvisioningTimeoutsMs = new Map<string, number>();
 
   constructor(
     heartbeatIntervalMs?: number,
@@ -119,6 +124,25 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     this.maxDurationMs = maxDurationMs ?? DEFAULT_MAX_DURATION_MS;
     this.maxBufferChunks = maxBufferChunks ?? DEFAULT_MAX_BUFFER_CHUNKS;
     this.maxBufferBytes = maxBufferBytes ?? DEFAULT_MAX_BUFFER_BYTES;
+  }
+  protected setProvisionCommand(command: string | undefined, fallback: string): void {
+    const trimmed = command?.trim();
+    this.provisionCommand = trimmed ? trimmed : fallback;
+  }
+
+  protected setLocalProvisioningTimeout(executionId: string, timeoutMs: number): void {
+    this.localProvisioningTimeoutsMs.set(executionId, timeoutMs);
+  }
+
+  protected appendProvisionOutputTail(tail: string, text: string): string {
+    const segments = `${tail}${text}`.split('\n');
+    const segmentLimit = segments.at(-1) === ''
+      ? PROVISION_OUTPUT_TAIL_LINE_LIMIT + 1
+      : PROVISION_OUTPUT_TAIL_LINE_LIMIT;
+    const nextTail = segments.slice(-segmentLimit).join('\n');
+    return nextTail.length <= PROVISION_OUTPUT_TAIL_CHAR_LIMIT
+      ? nextTail
+      : nextTail.slice(nextTail.length - PROVISION_OUTPUT_TAIL_CHAR_LIMIT);
   }
 
   protected createHandle(request: WorkRequest): ExecutorHandle {
@@ -199,6 +223,92 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
         this.entries.delete(executionId);
       });
     }
+  }
+  protected spawnLocalProvisioningProcess(options: {
+    command: string;
+    cwd: string;
+    executionId?: string;
+    traceLabel: string;
+    startMessage?: string;
+    failurePrefix: string;
+  }): { child: ChildProcess | null; completion: Promise<void> } {
+    const command = options.command.trim();
+    if (!command) {
+      traceExecution(`[${options.traceLabel}] skipped dir=${options.cwd}`);
+      return { child: null, completion: Promise.resolve() };
+    }
+    traceExecution(`[${options.traceLabel}] begin dir=${options.cwd}`);
+    if (options.executionId && options.startMessage) {
+      this.emitOutput(options.executionId, options.startMessage);
+    }
+    const child = spawn('/bin/bash', ['-lc', command], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      cwd: options.cwd,
+      detached: true,
+      env: cleanElectronEnv(),
+    });
+    let combinedOutputTail = '';
+    const appendOutput = (chunk: Buffer | string): void => {
+      const text = String(chunk);
+      combinedOutputTail = this.appendProvisionOutputTail(combinedOutputTail, text);
+      if (options.executionId) this.emitOutput(options.executionId, text);
+    };
+    child.stdout?.on('data', appendOutput);
+    child.stderr?.on('data', appendOutput);
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let forceKillTimeout: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
+    let timedOutMessage: string | undefined;
+    const timeoutMs = options.executionId
+      ? this.localProvisioningTimeoutsMs.get(options.executionId) ?? getExecutorStartTimeoutMs()
+      : getExecutorStartTimeoutMs();
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      clearTimeout(forceKillTimeout);
+      if (options.executionId) {
+        this.localProvisioningTimeoutsMs.delete(options.executionId);
+      }
+      fn();
+    };
+    const completion = new Promise<void>((resolve, reject) => {
+      child.on('error', (error) => {
+        finish(() => reject(new Error(`${options.failurePrefix} ${error.message}`)));
+      });
+      child.on('close', (code, signal) => {
+        finish(() => {
+          if (code === 0) {
+            traceExecution(`[${options.traceLabel}] done dir=${options.cwd}`);
+            resolve();
+            return;
+          }
+          const tail = combinedOutputTail.trim();
+          const fallback = timedOutMessage
+            ?? `provision command exited with code ${code ?? 'null'}${signal ? ` signal ${signal}` : ''}`;
+          const detail = tail ? `${fallback}\n${tail}` : fallback;
+          reject(new Error(`${options.failurePrefix} ${detail}`));
+        });
+      });
+      if (timeoutMs > 0) {
+        timeout = setTimeout(() => {
+          if (settled) return;
+          timedOutMessage = `provision command timed out after ${timeoutMs}ms`;
+          killProcessGroup(child, 'SIGTERM');
+          forceKillTimeout = setTimeout(() => {
+            if (!settled) killProcessGroup(child, 'SIGKILL');
+            finish(() => {
+              const tail = combinedOutputTail.trim();
+              const detail = tail ? `${timedOutMessage!}\n${tail}` : timedOutMessage!;
+              reject(new Error(`${options.failurePrefix} ${detail}`));
+            });
+          }, SIGKILL_TIMEOUT_MS);
+          forceKillTimeout.unref?.();
+        }, timeoutMs);
+        timeout.unref?.();
+      }
+    });
+    return { child, completion };
   }
 
   /**

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -78,6 +78,7 @@ interface SshEntry extends BaseEntry {
 export class SshExecutor extends BaseExecutor<SshEntry> {
   readonly type = 'ssh';
   private static readonly REMOTE_HEARTBEAT_MARKER = '__INVOKER_REMOTE_HEARTBEAT__';
+  private static readonly DEFAULT_PROVISION_COMMAND = 'pnpm install --frozen-lockfile';
   private static readonly DEFAULT_REMOTE_HEARTBEAT_INTERVAL_SECONDS = 30;
 
   private readonly host: string;
@@ -89,6 +90,8 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
   private readonly remoteInvokerHome: string;
   private readonly useApiKey: boolean;
   private readonly secretsFile: string | undefined;
+  private readonly provisionCommand: string;
+  private readonly usesDefaultProvisionCommand: boolean;
   private readonly remoteHeartbeatIntervalSeconds: number;
 
   constructor(config: SshExecutorConfig) {
@@ -102,6 +105,11 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
     this.remoteInvokerHome = config.remoteInvokerHome ?? '~/.invoker';
     this.useApiKey = config.useApiKey === true;
     this.secretsFile = config.secretsFile;
+    const configuredProvisionCommand = config.provisionCommand?.trim();
+    this.provisionCommand =
+      configuredProvisionCommand || SshExecutor.DEFAULT_PROVISION_COMMAND;
+    this.usesDefaultProvisionCommand =
+      this.provisionCommand === SshExecutor.DEFAULT_PROVISION_COMMAND;
     const configuredRemoteHeartbeatInterval = config.remoteHeartbeatIntervalSeconds;
     this.remoteHeartbeatIntervalSeconds =
       typeof configuredRemoteHeartbeatInterval === 'number'
@@ -230,6 +238,13 @@ ${content}${content.endsWith('\n') ? '' : '\n'}${delimiter}
     const heartbeatMarker = this.shellQuote(SshExecutor.REMOTE_HEARTBEAT_MARKER);
     const heartbeatIntervalSeconds = this.remoteHeartbeatIntervalSeconds;
     const stagingTokenExpression = this.buildStagingDirExpression(options.executionId, options.actionId);
+    const managedWorkspaceProvisionCommand = this.usesDefaultProvisionCommand
+      ? `if ! command -v pnpm >/dev/null 2>&1; then
+  echo "[SshExecutor] pnpm-lock.yaml found and node_modules missing, but pnpm is not installed." >&2
+  return 127
+fi
+${SshExecutor.DEFAULT_PROVISION_COMMAND}`
+      : this.provisionCommand;
     const managedWorkspaceBootstrap = options.managed
       ? `ensure_managed_pnpm_workspace() {
   if [ "\${INVOKER_SKIP_MANAGED_PNPM_INSTALL:-}" = "1" ]; then
@@ -243,7 +258,7 @@ ${content}${content.endsWith('\n') ? '' : '\n'}${delimiter}
     return 127
   fi
   echo "[SshExecutor] Installing pnpm dependencies for managed worktree..."
-  pnpm install --frozen-lockfile
+  ${managedWorkspaceProvisionCommand}
 }
 ensure_managed_pnpm_workspace
 `

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -51,6 +51,8 @@ export interface SshExecutorConfig {
    * Default: ~/.invoker
    */
   remoteInvokerHome?: string;
+  /** Optional dependency/bootstrap command run inside managed worktrees before the payload. */
+  provisionCommand?: string;
   /** Opt-in: export agent API keys from secretsFile into remote task shells. */
   useApiKey?: boolean;
   /** Optional local secrets file used when useApiKey is true. */
@@ -78,7 +80,6 @@ interface SshEntry extends BaseEntry {
 export class SshExecutor extends BaseExecutor<SshEntry> {
   readonly type = 'ssh';
   private static readonly REMOTE_HEARTBEAT_MARKER = '__INVOKER_REMOTE_HEARTBEAT__';
-  private static readonly DEFAULT_PROVISION_COMMAND = 'pnpm install --frozen-lockfile';
   private static readonly DEFAULT_REMOTE_HEARTBEAT_INTERVAL_SECONDS = 30;
 
   private readonly host: string;
@@ -90,7 +91,6 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
   private readonly remoteInvokerHome: string;
   private readonly useApiKey: boolean;
   private readonly secretsFile: string | undefined;
-  private readonly usesDefaultProvisionCommand: boolean;
   private readonly remoteHeartbeatIntervalSeconds: number;
 
   constructor(config: SshExecutorConfig) {
@@ -104,9 +104,7 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
     this.remoteInvokerHome = config.remoteInvokerHome ?? '~/.invoker';
     this.useApiKey = config.useApiKey === true;
     this.secretsFile = config.secretsFile;
-    this.setProvisionCommand(config.provisionCommand, SshExecutor.DEFAULT_PROVISION_COMMAND);
-    this.usesDefaultProvisionCommand =
-      this.provisionCommand === SshExecutor.DEFAULT_PROVISION_COMMAND;
+    this.setProvisionCommand(config.provisionCommand, '');
     const configuredRemoteHeartbeatInterval = config.remoteHeartbeatIntervalSeconds;
     this.remoteHeartbeatIntervalSeconds =
       typeof configuredRemoteHeartbeatInterval === 'number'
@@ -235,14 +233,7 @@ ${content}${content.endsWith('\n') ? '' : '\n'}${delimiter}
     const heartbeatMarker = this.shellQuote(SshExecutor.REMOTE_HEARTBEAT_MARKER);
     const heartbeatIntervalSeconds = this.remoteHeartbeatIntervalSeconds;
     const stagingTokenExpression = this.buildStagingDirExpression(options.executionId, options.actionId);
-    const managedWorkspaceProvisionCommand = this.usesDefaultProvisionCommand
-      ? `if ! command -v pnpm >/dev/null 2>&1; then
-  echo "[SshExecutor] pnpm-lock.yaml found and node_modules missing, but pnpm is not installed." >&2
-  return 127
-fi
-${SshExecutor.DEFAULT_PROVISION_COMMAND}`
-      : this.provisionCommand;
-    const managedWorkspaceBootstrap = options.managed
+    const managedWorkspaceBootstrap = options.managed && this.provisionCommand
       ? `ensure_managed_pnpm_workspace() {
   if [ "\${INVOKER_SKIP_MANAGED_PNPM_INSTALL:-}" = "1" ]; then
     return 0
@@ -250,12 +241,8 @@ ${SshExecutor.DEFAULT_PROVISION_COMMAND}`
   if [ ! -f pnpm-lock.yaml ] || [ -d node_modules ]; then
     return 0
   fi
-  if ! command -v pnpm >/dev/null 2>&1; then
-    echo "[SshExecutor] pnpm-lock.yaml found and node_modules missing, but pnpm is not installed." >&2
-    return 127
-  fi
-  echo "[SshExecutor] Installing pnpm dependencies for managed worktree..."
-  ${managedWorkspaceProvisionCommand}
+  echo "[SshExecutor] Installing managed worktree dependencies..."
+  ${this.provisionCommand}
 }
 ensure_managed_pnpm_workspace
 `

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -90,7 +90,6 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
   private readonly remoteInvokerHome: string;
   private readonly useApiKey: boolean;
   private readonly secretsFile: string | undefined;
-  private readonly provisionCommand: string;
   private readonly usesDefaultProvisionCommand: boolean;
   private readonly remoteHeartbeatIntervalSeconds: number;
 
@@ -105,9 +104,7 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
     this.remoteInvokerHome = config.remoteInvokerHome ?? '~/.invoker';
     this.useApiKey = config.useApiKey === true;
     this.secretsFile = config.secretsFile;
-    const configuredProvisionCommand = config.provisionCommand?.trim();
-    this.provisionCommand =
-      configuredProvisionCommand || SshExecutor.DEFAULT_PROVISION_COMMAND;
+    this.setProvisionCommand(config.provisionCommand, SshExecutor.DEFAULT_PROVISION_COMMAND);
     this.usesDefaultProvisionCommand =
       this.provisionCommand === SshExecutor.DEFAULT_PROVISION_COMMAND;
     const configuredRemoteHeartbeatInterval = config.remoteHeartbeatIntervalSeconds;

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -73,6 +73,7 @@ export type RemoteTargetDisplay = {
   port?: number;
   managedWorkspaces?: boolean;
   remoteInvokerHome?: string;
+  provisionCommand?: string;
   use_api_key?: boolean;
   secretsFile?: string;
   remoteHeartbeatIntervalSeconds?: number;

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -29,7 +29,7 @@ import type { ActiveExecutionEntry, TaskRunner } from './task-runner.js';
 
 export type ExecutionPoolMember =
   | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
-  | { type: 'worktree'; id: string; maxConcurrentTasks?: number };
+  | { type: 'worktree'; id: string; maxConcurrentTasks?: number; provisionCommand?: string };
 
 export type ExecutionPoolConfig = {
   members: ExecutionPoolMember[];
@@ -96,6 +96,7 @@ export type TaskRunnerPoolHost = Pick<
   | 'poolRoundRobinCursor'
   | 'poolMemberHealth'
   | 'sshExecutorCache'
+  | 'worktreeExecutorCache'
   | 'runnerInstanceId'
   | 'getRemoteTargets'
   | 'getExecutionPools'
@@ -599,6 +600,7 @@ export function selectExecutor(
     ? 'merge'
     : task.config.runnerKind;
   let selectedPoolMemberId: string | undefined;
+  let selectedWorktreeMember: Extract<ExecutionPoolMember, { type: 'worktree' }> | undefined;
   const explicitPoolMemberId = (task.config as { poolMemberId?: string }).poolMemberId;
   let resolvedExecution: ResolvedExecutionSelection = {
     executionAgent: host.resolveExecutionAgent(task),
@@ -621,6 +623,7 @@ export function selectExecutor(
       }
       effectiveType = member.type;
       selectedPoolMemberId = member.id;
+      selectedWorktreeMember = member.type === 'worktree' ? member : undefined;
     }
   } else if (task.config.poolId) {
     const pool = host.getExecutionPools()[task.config.poolId];
@@ -634,6 +637,7 @@ export function selectExecutor(
         if (reserved) {
           effectiveType = member.type;
           selectedPoolMemberId = member.id;
+          selectedWorktreeMember = member.type === 'worktree' ? member : undefined;
           break;
         }
         attempted.add(poolMemberKey(member));
@@ -655,7 +659,11 @@ export function selectExecutor(
 
   if (effectiveType) {
     const registered = host.executorRegistry.get(effectiveType);
-    if (registered && (effectiveType !== 'merge' || registered.type === 'merge')) {
+    if (
+      registered
+      && (effectiveType !== 'merge' || registered.type === 'merge')
+      && effectiveType !== 'worktree'
+    ) {
       traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=${effectiveType} → ${registered.type}`);
       return { executor: registered, resolvedExecution, selectedPoolMemberId };
     }
@@ -673,13 +681,26 @@ export function selectExecutor(
 
     if (effectiveType === 'worktree') {
       const invokerHome = resolve(homedir(), '.invoker');
+      const configFingerprint = JSON.stringify({
+        provisionCommand: selectedWorktreeMember?.provisionCommand?.trim() || '',
+        worktreeBaseDir: resolve(invokerHome, 'worktrees'),
+        cacheDir: resolve(invokerHome, 'repos'),
+      });
+      const cached = host.worktreeExecutorCache.get(configFingerprint);
+      if (cached) {
+        host.executorRegistry.register('worktree', cached);
+        traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=worktree → worktree (cached)`);
+        return { executor: cached, resolvedExecution, selectedPoolMemberId };
+      }
       const worktree = new WorktreeExecutor({
         worktreeBaseDir: resolve(invokerHome, 'worktrees'),
         cacheDir: resolve(invokerHome, 'repos'),
         maxWorktrees: host.maxWorktreesPerRepo,
         agentRegistry: host.executionAgentRegistry,
+        provisionCommand: selectedWorktreeMember?.provisionCommand,
       });
       host.executorRegistry.register('worktree', worktree);
+      host.worktreeExecutorCache.set(configFingerprint, worktree);
       traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=worktree → worktree (lazy registered)`);
       return { executor: worktree, resolvedExecution, selectedPoolMemberId };
     }
@@ -716,6 +737,7 @@ export function selectExecutor(
         port: target.port,
         managedWorkspaces: target.managedWorkspaces,
         remoteInvokerHome: target.remoteInvokerHome,
+        provisionCommand: target.provisionCommand?.trim() || '',
         use_api_key: target.use_api_key === true,
         secretsFile: target.secretsFile ?? host.dockerConfig.secretsFile,
         remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -188,7 +188,7 @@ export interface TaskRunnerConfig {
   executionPoolsProvider?: () => Record<string, {
     members: Array<
       | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
-      | { type: 'worktree'; id: string; maxConcurrentTasks?: number }
+      | { type: 'worktree'; id: string; maxConcurrentTasks?: number; provisionCommand?: string }
     >;
     selectionStrategy?: 'roundRobin' | 'leastLoaded';
     maxConcurrentTasksPerMember?: number;
@@ -234,6 +234,8 @@ export class TaskRunner {
   /** @internal */ readonly runnerInstanceId = randomUUID();
   /** Cache for SSH executors, keyed by poolMemberId. One instance per target for correct git locking. */
   /** @internal */ sshExecutorCache = new Map<string, SshExecutor>();
+  /** Cache for worktree executors keyed by local provisioning config fingerprint. */
+  /** @internal */ worktreeExecutorCache = new Map<string, WorktreeExecutor>();
   /** @internal */ poolRoundRobinCursor = new Map<string, number>();
   poolMemberHealth = new Map<string, PoolMemberHealth>();
   /** @internal */ readonly pendingPoolSelections = new Map<string, PoolSelection>();

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -8,6 +8,7 @@ import { BaseExecutor, MergeConflictError, type BaseEntry } from './base-executo
 import { RepoPool } from './repo-pool.js';
 import { killProcessGroup, cleanElectronEnv, resolveExecutableOnCurrentPath, SIGKILL_TIMEOUT_MS } from './process-utils.js';
 import { DEFAULT_WORKTREE_PROVISION_COMMAND } from './default-worktree-provision-command.js';
+import { getExecutorStartTimeoutMs } from './task-runner-launch-support.js';
 import {
   computeContentHash,
   buildExperimentBranchName,
@@ -28,6 +29,7 @@ import { sanitizeBranchForPath } from './git-utils.js';
 // Re-export for backward compatibility
 export { computeContentHash, buildExperimentBranchName } from './branch-utils.js';
 
+
 export interface WorktreeExecutorConfig {
   /** Directory where worktrees are created. */
   worktreeBaseDir?: string;
@@ -39,6 +41,8 @@ export interface WorktreeExecutorConfig {
   claudeCommand?: string;
   /** Agent registry for pluggable AI agents. When set, overrides claudeCommand. */
   agentRegistry?: import('./agent-registry.js').AgentRegistry;
+  /** Optional dependency/bootstrap command run before the task command in local worktrees. */
+  provisionCommand?: string;
   /** Heartbeat interval in milliseconds. Default: 30000. */
   heartbeatIntervalMs?: number;
   /** Maximum task duration in milliseconds. Default: 4 hours. */
@@ -76,11 +80,11 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
   private readonly claudeCommand: string;
   private readonly agentRegistry?: import('./agent-registry.js').AgentRegistry;
   private pool: RepoPool;
-
   constructor(config: WorktreeExecutorConfig) {
     super(config.heartbeatIntervalMs, config.maxDurationMs);
     this.claudeCommand = config.claudeCommand ?? 'claude';
     this.agentRegistry = config.agentRegistry;
+    this.setProvisionCommand(config.provisionCommand, DEFAULT_WORKTREE_PROVISION_COMMAND);
     this.worktreeBaseDir =
       config.worktreeBaseDir ?? resolve(homedir(), '.invoker', 'worktrees');
     this.pool = new RepoPool({
@@ -89,6 +93,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       worktreeBaseDir: this.worktreeBaseDir,
     });
   }
+
 
   /** Pool mirror used for this executor (rebase-and-retry / tests). */
   getRepoPool(): RepoPool {
@@ -142,6 +147,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     const executionId = handle.executionId;
     const t0 = Date.now();
     const log = (step: string) => traceExecution(`[WorktreeExecutor] start task=${request.actionId} step=${step} elapsed=${Date.now() - t0}ms`);
+    const startupDeadlineMs = Date.now() + getExecutorStartTimeoutMs();
 
     bench('RepoPool.ensureCloneThroughRepoQueue.before');
     const clonePath = await this.pool.ensureCloneThroughRepoQueue(repoUrl);
@@ -395,7 +401,11 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       branch: handle.branch,
     });
 
-    const provisioning = this.provisionWorktree(acquired.worktreePath, executionId);
+    this.setLocalProvisioningTimeout(executionId, Math.max(1, startupDeadlineMs - Date.now()));
+    const provisioning = this.provisionWorktree(
+      acquired.worktreePath,
+      executionId,
+    );
     entry.process = provisioning.child;
     try {
       await provisioning.completion;
@@ -693,8 +703,17 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     }
   }
 
-  private provisionWorktree(dir: string, _executionId?: string): { child: ChildProcess | null; completion: Promise<void> } {
-    traceExecution(`[WorktreeExecutor] provisionWorktree skipped dir=${dir}`);
-    return { child: null, completion: Promise.resolve() };
+  private provisionWorktree(
+    dir: string,
+    executionId?: string,
+  ): { child: ChildProcess | null; completion: Promise<void> } {
+    return this.spawnLocalProvisioningProcess({
+      command: this.provisionCommand,
+      cwd: dir,
+      executionId,
+      traceLabel: 'WorktreeExecutor.provisionWorktree',
+      startMessage: `[worktree] Provisioning worktree dependencies in ${dir}\n`,
+      failurePrefix: 'Worktree provisioning failed:',
+    });
   }
 }


### PR DESCRIPTION
## Summary

Provisioning is now fully opt-in for both managed SSH targets and local worktree members.

`master` still exposed `remoteTargets.*.provisionCommand`, but the SSH executor no longer read it. Worktree members also had no member-level provision hook.

This change ends the SSH built-in install step, restores explicit SSH `provisionCommand` overrides, adds optional worktree-member `provisionCommand`, and shares the local provision child-process helper in `BaseExecutor`.

## Review Claim

Review that provisioning now runs only when `provisionCommand` is explicitly configured, for both managed SSH targets and opted-in local worktree members.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Managed SSH still provisions only inside `ensure_managed_pnpm_workspace`, but now skips that step entirely when `provisionCommand` is unset. Local worktrees still do nothing unless a member sets `provisionCommand`.

## Slice Rationale

This PR only changes execution-engine provisioning routing. It closes the unused SSH config path and ends the baked-in managed-SSH install assumption.

## Non-goals

- Change the config key name.
- Add implicit provisioning for any executor.
- Broaden into app, CLI, UI, or workflow code.

## Architecture

### Before

```mermaid
graph TD
    A["config provisionCommand"] --> B["SSH target type accepts it"]
    B --> C["managed SSH bootstrap still runs a built-in pnpm install"]
    A --> D["worktree pool member has no provisionCommand field"]
    D --> E["local worktree provisioning does nothing"]
```

### After

```mermaid
graph TD
    A["config provisionCommand"] --> B["SSH executor runs only explicit provisionCommand"]
    A --> C["worktree pool member may set provisionCommand"]
    C --> D["BaseExecutor owns shared provisionCommand state"]
    D --> E["local worktree helper runs before task shell"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-executor.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/worktree-executor.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts -t "reads remote targets lazily from the provider on each selectExecutor call|reads worktree provision commands lazily from the pool provider on each selectExecutor call|caches worktree executors by provisioning fingerprint"`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Undo: `git revert 1f0d90d80 17cd38b8a 6957cb1c7`
- Follow-up: None
- Data migration? No

</details>
