### PR TITLE
[Babysit Loop](1) Add stuck-case repros

### DIFF
--- a/scripts/repro/fixtures/fake-gh/bin/gh
+++ b/scripts/repro/fixtures/fake-gh/bin/gh
@@ -199,6 +199,17 @@ def main() -> None:
             print(json.dumps({"data": {"repository": {"pullRequest": graphql_detail(pr)}}}))
             return
         if any("resolveReviewThread" in arg for arg in ARGS):
+            thread_id = ""
+            for arg in ARGS:
+                if arg.startswith("threadId="):
+                    thread_id = arg.split("=", 1)[1]
+                    break
+            if thread_id:
+                for pr in state.get("prs", []):
+                    for thread in pr.get("reviewThreads", []):
+                        if thread.get("id") == thread_id:
+                            thread["isResolved"] = True
+                            save_state(state)
             print(json.dumps({"data": {"resolveReviewThread": {"thread": {"isResolved": True}}}}))
             return
         unhandled()

--- a/scripts/repro/repro-babysit-amended-repair-push.sh
+++ b/scripts/repro/repro-babysit-amended-repair-push.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-amended-repair-push.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+WORK_PARENT="$HOME/.invoker/mergify-admin-requeue-work"
+mkdir -p "$WORK_PARENT" "$TMP/state" "$TMP/bin"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+cat > "$TMP/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+rm -f scripts/repro/proof-wrapper.sh
+git add -A
+git commit --amend --no-edit
+EOF
+chmod +x "$TMP/bin/claude"
+
+cat > "$TMP/bin/node" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$#" -ge 1 && "$1" == *"/scripts/validate-pr-body-local.mjs" ]]; then
+  cat <<'JSON'
+{"valid":true,"errors":[],"reviewLane":"behavior","reviewUnit":"routing","reviewUnits":["routing"],"scopeKinds":["product"]}
+JSON
+  exit 0
+fi
+exec /usr/bin/env node "$@"
+EOF
+chmod +x "$TMP/bin/node"
+
+REMOTE="$TMP/origin.git"
+SEED="$TMP/seed"
+WORK_ROOT="$WORK_PARENT/5806"
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+export STATE_PATH
+
+write_state() {
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+head = os.environ['ORIGINAL_HEAD']
+state = {
+    'prs': [
+        {
+            'number': 5806,
+            'title': 'Amended repair push repro',
+            'body': '## Summary\n\nAmended repair push repro.\n',
+            'url': 'https://github.com/fake/repo/pull/5806',
+            'state': 'OPEN',
+            'isDraft': False,
+            'baseRefName': 'master',
+            'headRefName': 'stack/5806',
+            'headRefOid': head,
+            'mergeStateStatus': 'UNSTABLE',
+            'mergeable': 'MERGEABLE',
+            'labels': ['admin-bypass'],
+            'reviewThreads': [],
+            'checks': {'*': 'SUCCESS', 'PR Body': 'FAILURE'},
+        }
+    ],
+    'issue_comments': {'5806': []},
+    'job_logs': {'2': 'PR body validation failed: proof wrappers are not lane-compatible\n'},
+}
+Path(os.environ['STATE_PATH']).write_text(json.dumps(state, indent=2), encoding='utf-8')
+PY
+}
+
+run_worker() {
+  python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --author fake-bot --state-file "$LEDGER_PATH" --pr 5806 2>&1
+}
+
+git clone . "$SEED" >/dev/null
+(
+  cd "$SEED"
+  git config user.email repro@example.test
+  git config user.name 'Repro Bot'
+  git checkout -B master >/dev/null
+  git init --bare "$REMOTE" >/dev/null
+  git remote add publish "$REMOTE"
+  git push publish master >/dev/null
+  git switch -c stack/5806 master >/dev/null
+  mkdir -p packages/surfaces/src/slack scripts/repro
+  printf 'planning\n' > packages/surfaces/src/slack/plan-conversation.ts
+  printf '# proof wrapper\n' > scripts/repro/proof-wrapper.sh
+  git add packages/surfaces/src/slack/plan-conversation.ts scripts/repro/proof-wrapper.sh
+  git commit -m 'mixed behavior proof wrapper' >/dev/null
+  git push publish stack/5806 >/dev/null
+)
+git --git-dir="$REMOTE" symbolic-ref HEAD refs/heads/master
+ORIGINAL_HEAD="$(git -C "$SEED" rev-parse stack/5806)"
+export ORIGINAL_HEAD
+
+git clone "$REMOTE" "$WORK_ROOT" >/dev/null
+( cd "$WORK_ROOT" && git config user.email repro@example.test && git config user.name 'Repro Bot' )
+write_state
+
+if ! out="$(run_worker)"; then
+  fail 'worker failed to push amended repair as descendant' "$out"
+fi
+printf '%s\n' "$out"
+
+REMOTE_HEAD="$(git --git-dir="$REMOTE" rev-parse refs/heads/stack/5806)"
+if [ "$REMOTE_HEAD" = "$ORIGINAL_HEAD" ]; then
+  fail 'remote branch did not advance'
+fi
+if ! git --git-dir="$REMOTE" merge-base --is-ancestor "$ORIGINAL_HEAD" "$REMOTE_HEAD"; then
+  fail 'remote repair did not descend from original head'
+fi
+if git --git-dir="$REMOTE" cat-file -e "$REMOTE_HEAD:scripts/repro/proof-wrapper.sh" 2>/dev/null; then
+  fail 'proof wrapper still exists on pushed repair'
+fi
+
+echo '[repro] passed'

--- a/scripts/repro/repro-babysit-headless-queued-comment.sh
+++ b/scripts/repro/repro-babysit-headless-queued-comment.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-headless-queued-comment.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+mkdir -p "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+export STATE_PATH
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = "1605586282a7bccef5c1ea34419a7176ca755dc1"
+state = {
+    "prs": [
+        {
+            "number": 5805,
+            "title": "Already queued with headless Mergify status",
+            "body": "## Summary\n\nQueued PR repro.\n",
+            "url": "https://github.com/fake/repo/pull/5805",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "stack/5805",
+            "headRefOid": head,
+            "mergeStateStatus": "BLOCKED",
+            "mergeable": "MERGEABLE",
+            "labels": ["admin-bypass", "queued"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS"},
+        }
+    ],
+    "issue_comments": {
+        "5805": [
+            {
+                "id": "m5805-checking",
+                "user": {"login": "mergify"},
+                "updated_at": "2026-07-26T06:11:39Z",
+                "html_url": "https://github.com/fake/repo/pull/5805#m5805-checking",
+                "body": (
+                    "<!---\n"
+                    "DO NOT EDIT\n"
+                    "-*- Mergify Payload -*-\n"
+                    '{"version":1,"state":"checking","queue_rule_name":"admin-bypass","queued_at":"2026-07-26T06:11:35Z","speculative_check_pr":5862}\n'
+                    "-*- Mergify Payload End -*-\n"
+                    "-->\n\n"
+                    "# Merge Queue Status\n\n"
+                    "- ✅ **Entered queue** — `2026-07-26 06:11 UTC` · Rule: `admin-bypass`\n"
+                    "- 🟠 **Checks running** · on draft #5862\n\n"
+                    "<details>\n<summary><strong>Waiting for</strong></summary>\n\n"
+                    "- [ ] `check-success = required-fast / Guardrails`\n\n"
+                    "</details>\n"
+                ),
+            }
+        ]
+    },
+    "job_logs": {},
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+
+if ! out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5805 2>&1)"; then
+  fail "worker dry-run failed" "$out"
+fi
+printf '%s\n' "$out"
+
+! echo "$out" | grep -q 'DRY-RUN requeue PR #5805' \
+  || fail "worker tried to requeue a PR already in Mergify queue" "$out"
+echo "$out" | grep -q '"reason": "bottom-already-queued"' \
+  || fail "worker did not wait on the active queue state" "$out"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-babysit-outdated-bot-thread.sh
+++ b/scripts/repro/repro-babysit-outdated-bot-thread.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-outdated-bot-thread.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+mkdir -p "$TMP/state" "$TMP/bin"
+export HOME="$TMP/home"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export CLAUDE_CALLED="$TMP/claude-called"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+cat > "$TMP/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "claude was called for an outdated bot review thread" > "$CLAUDE_CALLED"
+exit 42
+EOF
+chmod +x "$TMP/bin/claude"
+
+LEDGER_PATH="$TMP/ledger.jsonl"
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+export STATE_PATH
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = "1605586282a7bccef5c1ea34419a7176ca755dc1"
+state = {
+    "prs": [
+        {
+            "number": 5805,
+            "title": "Outdated CodeRabbit thread",
+            "body": "## Summary\n\nOutdated bot thread repro.\n",
+            "url": "https://github.com/fake/repo/pull/5805",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "stack/5805",
+            "headRefOid": head,
+            "mergeStateStatus": "BLOCKED",
+            "mergeable": "MERGEABLE",
+            "labels": ["admin-bypass"],
+            "reviewThreads": [
+                {
+                    "id": "thread-outdated",
+                    "isResolved": False,
+                    "isOutdated": True,
+                    "comments": {
+                        "nodes": [
+                            {
+                                "author": {"login": "coderabbitai"},
+                                "body": "Clean up a line that no longer exists.",
+                                "url": "https://github.com/fake/repo/pull/5805#discussion_r1",
+                            }
+                        ]
+                    },
+                }
+            ],
+            "checks": {"*": "SUCCESS"},
+        }
+    ],
+    "issue_comments": {"5805": []},
+    "job_logs": {},
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+
+run_worker() {
+  python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5805 2>&1
+}
+
+if ! dry_out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5805 2>&1)"; then
+  fail "dry-run failed for outdated bot thread" "$dry_out"
+fi
+printf '%s\n' "$dry_out"
+echo "$dry_out" | grep -q 'DRY-RUN resolve-bot-threads PR #5805 thread=thread-outdated' \
+  || fail "dry-run did not resolve the outdated bot thread" "$dry_out"
+! echo "$dry_out" | grep -q 'DRY-RUN repair-check PR #5805 check="thread-outdated"' \
+  || fail "dry-run tried to repair an outdated bot thread" "$dry_out"
+
+if ! out="$(run_worker)"; then
+  fail "worker failed resolving outdated bot thread" "$out"
+fi
+printf '%s\n' "$out"
+[ ! -f "$CLAUDE_CALLED" ] || fail "worker invoked Claude for outdated bot thread" "$(cat "$CLAUDE_CALLED")"
+echo "$out" | grep -q 'resolve-bot-threads PR #5805 thread=thread-outdated' \
+  || fail "worker did not execute resolve-bot-threads" "$out"
+grep -q 'resolveReviewThread' "$FAKE_GH_STATE_DIR/calls.log" \
+  || fail "worker did not call the review-thread resolve mutation" "$(cat "$FAKE_GH_STATE_DIR/calls.log")"
+! grep -q '"kind": "repair-bot-thread"' "$LEDGER_PATH" 2>/dev/null \
+  || fail "worker recorded a bot-thread repair instead of resolving stale feedback" "$(cat "$LEDGER_PATH")"
+
+if ! next_out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5805 2>&1)"; then
+  fail "dry-run failed after resolving outdated bot thread" "$next_out"
+fi
+printf '%s\n' "$next_out"
+echo "$next_out" | grep -q 'DRY-RUN requeue PR #5805' \
+  || fail "worker did not advance to requeue after resolving stale feedback" "$next_out"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-babysit-pr-body-proof-human-split.sh
+++ b/scripts/repro/repro-babysit-pr-body-proof-human-split.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
-TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-pr-body-human-split.XXXXXX")"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-pr-body-proof-human-split.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
 
 fail() {
@@ -45,7 +45,7 @@ cat > "$TMP/bin/node" <<'EOF'
 set -euo pipefail
 if [[ "$#" -ge 1 && "$1" == *"/scripts/validate-pr-body-local.mjs" ]]; then
   cat <<'JSON'
-{"valid":false,"errors":["PR body mentions multiple review units (validation-policy, routing); split into one conceptual unit per diff/task.","Review lane behavior cannot ship with policy, proof files in the same PR. Split behavior or cleanup from docs, policy, repro, and benchmark slices.","PR body Review Unit \"routing\" cannot ship with tooling-policy, proof files in the same PR. Split this into one Review Unit per PR."],"reviewLane":"behavior","reviewUnit":"routing","reviewUnits":["routing","tooling-policy","proof"],"scopeKinds":["product","policy"]}
+{"valid":false,"errors":["Review lane behavior cannot ship with proof files in the same PR. Split behavior or cleanup from docs, policy, repro, and benchmark slices.","PR body Review Unit \"routing\" cannot ship with proof files in the same PR. Split this into one Review Unit per PR."],"reviewLane":"behavior","reviewUnit":"routing","reviewUnits":["routing","proof"],"scopeKinds":["product","proof"]}
 JSON
   exit 1
 fi
@@ -57,11 +57,11 @@ BODY_PATH="$TMP/body.md"
 cat > "$BODY_PATH" <<'EOF'
 ## Summary
 
-Adds orphaned-PR repair and tighter maintenance-worker routing.
+Makes Slack planning drafts, approval buttons, and thinking placeholders recoverable.
 
 ## Review Claim
 
-Unmapped broken pull requests receive one deduplicated repair workflow.
+Slack planning state remains actionable after restarts and reconnects.
 
 ## Review Lane
 
@@ -73,23 +73,22 @@ routing
 
 ## Safety Invariant
 
-Mapped PRs remain owned by their existing workers.
+A draft remains separate from execution until its existing approval action runs.
 
 ## Slice Rationale
 
-Worker coordination ships after the orphan classifier so failed PRs have one owner.
+Recovery mechanics precede the new planning-intent entry gate.
 
 ## Non-goals
 
-- No manual stack split.
+Does not change the final workflow execution API.
 
 ## Test Plan
 
 <details>
 <summary>Test Plan</summary>
 
-- [x] `bash scripts/repro/repro-pr-orphan-repair.sh`
-
+- [x] pnpm --filter @invoker/surfaces test
 </details>
 
 ## Revert Plan
@@ -98,17 +97,16 @@ Worker coordination ships after the orphan classifier so failed PRs have one own
 <summary>Revert Plan</summary>
 
 - Safe to revert? Yes
-- Revert command: `git revert <sha>`
+- Revert command: git revert bef53b9
 - Post-revert steps: None
 - Data migration? No
-
 </details>
 EOF
 export BODY_PATH
 
 REMOTE="$TMP/origin.git"
 SEED="$TMP/seed"
-WORK_ROOT="$WORK_PARENT/5803"
+WORK_ROOT="$WORK_PARENT/5804"
 STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
 LEDGER_PATH="$TMP/ledger.jsonl"
 export STATE_PATH
@@ -124,14 +122,14 @@ head = os.environ['ORIGINAL_HEAD']
 state = {
     'prs': [
         {
-            'number': 5803,
-            'title': '[PR maintenance](14) Repair orphaned and failed pull requests',
+            'number': 5804,
+            'title': '[Slack planning](15) Make plan submission and confirmation recoverable',
             'body': body,
-            'url': 'https://github.com/fake/repo/pull/5803',
+            'url': 'https://github.com/fake/repo/pull/5804',
             'state': 'OPEN',
             'isDraft': False,
             'baseRefName': 'stack/base',
-            'headRefName': 'stack/5803',
+            'headRefName': 'stack/5804',
             'headRefOid': head,
             'mergeStateStatus': 'UNSTABLE',
             'mergeable': 'MERGEABLE',
@@ -140,7 +138,7 @@ state = {
             'checks': {'*': 'SUCCESS', 'PR Body': 'FAILURE'},
         }
     ],
-    'issue_comments': {'5803': []},
+    'issue_comments': {'5804': []},
 }
 Path(os.environ['STATE_PATH']).write_text(json.dumps(state, indent=2), encoding='utf-8')
 PY
@@ -151,23 +149,22 @@ assert_first_run_state() {
 import json
 import os
 from pathlib import Path
-ledger_path = Path(os.environ['LEDGER_PATH'])
-rows = [json.loads(line) for line in ledger_path.read_text(encoding='utf-8').splitlines() if line.strip()]
-if not any(row.get('kind') == 'repair-check' and row.get('pr') == 5803 and row.get('key') == 'PR Body' for row in rows):
-    raise SystemExit('missing repair-check ledger row for PR #5803')
-invalid = next((row for row in rows if row.get('kind') == 'repair-invalid' and row.get('pr') == 5803 and row.get('key') == 'PR Body'), None)
+rows = [json.loads(line) for line in Path(os.environ['LEDGER_PATH']).read_text(encoding='utf-8').splitlines() if line.strip()]
+invalid = next((row for row in rows if row.get('kind') == 'repair-invalid' and row.get('pr') == 5804 and row.get('key') == 'PR Body'), None)
 if invalid is None:
-    raise SystemExit('missing repair-invalid ledger row for PR #5803')
+    raise SystemExit('missing repair-invalid row for PR #5804')
 errors = (invalid.get('meta') or {}).get('errors') or []
+if not any('cannot ship with proof files' in str(item) for item in errors):
+    raise SystemExit('repair-invalid row missing proof-file split reason')
 if not any('human stack split required' in str(item) for item in errors):
     raise SystemExit('repair-invalid row missing manual split note')
 state = json.loads(Path(os.environ['STATE_PATH']).read_text(encoding='utf-8'))
-comments = state.get('issue_comments', {}).get('5803', [])
+comments = state.get('issue_comments', {}).get('5804', [])
 if len(comments) != 1:
     raise SystemExit(f'expected exactly one stop comment, saw {len(comments)}')
 body = comments[0].get('body', '')
-if 'Split this into one Review Unit per PR.' not in body:
-    raise SystemExit('stop comment missing split guidance')
+if 'cannot ship with proof files' not in body:
+    raise SystemExit('stop comment missing proof-file split reason')
 if 'human stack split required' not in body:
     raise SystemExit('stop comment missing manual split note')
 PY
@@ -179,7 +176,7 @@ import json
 import os
 from pathlib import Path
 state = json.loads(Path(os.environ['STATE_PATH']).read_text(encoding='utf-8'))
-comments = state.get('issue_comments', {}).get('5803', [])
+comments = state.get('issue_comments', {}).get('5804', [])
 expected = int(os.environ['expected'])
 actual = len(comments)
 if actual != expected:
@@ -205,16 +202,16 @@ git clone . "$SEED" >/dev/null
   git add base.txt
   git commit -m 'base branch' >/dev/null
   git push publish stack/base >/dev/null
-  git switch -c stack/5803 stack/base >/dev/null
-  mkdir -p packages/execution-engine/src/workers scripts/repro
-  printf 'route\n' > packages/execution-engine/src/workers/pr-maintenance-workers.ts
-  printf '# repro\n' > scripts/repro/repro-pr-orphan-repair.sh
-  git add packages/execution-engine/src/workers/pr-maintenance-workers.ts scripts/repro/repro-pr-orphan-repair.sh
-  git commit -m 'mixed review units' >/dev/null
-  git push publish stack/5803 >/dev/null
+  git switch -c stack/5804 stack/base >/dev/null
+  mkdir -p packages/surfaces/src/slack scripts/repro
+  printf 'planning\n' > packages/surfaces/src/slack/plan-conversation.ts
+  printf '# repro\n' > scripts/repro/repro-slack-plan-intent-confirm.sh
+  git add packages/surfaces/src/slack/plan-conversation.ts scripts/repro/repro-slack-plan-intent-confirm.sh
+  git commit -m 'mixed behavior and proof slice' >/dev/null
+  git push publish stack/5804 >/dev/null
 )
 git --git-dir="$REMOTE" symbolic-ref HEAD refs/heads/master
-ORIGINAL_HEAD="$(git -C "$SEED" rev-parse stack/5803)"
+ORIGINAL_HEAD="$(git -C "$SEED" rev-parse stack/5804)"
 export ORIGINAL_HEAD
 
 git clone "$REMOTE" "$WORK_ROOT" >/dev/null
@@ -227,30 +224,17 @@ fi
 printf '%s\n' "$out1"
 assert_first_run_state
 
+: > "$LEDGER_PATH"
 if ! out2="$(run_worker)"; then
-  fail 'tick 2: worker failed' "$out2"
+  fail 'tick 2: worker failed after ledger loss' "$out2"
 fi
 printf '%s\n' "$out2"
 case "$out2" in
-  *'repair-check PR #5803'*) fail 'tick 2: worker retried the same impossible PR Body fix' "$out2" ;;
+  *'repair-check PR #5804'*) fail 'tick 2: worker retried existing proof split stop after ledger loss' "$out2" ;;
 esac
 case "$out2" in
   *'"reason": "blocked-needs-human"'*) ;;
-  *) fail 'tick 2: worker did not surface blocked-needs-human wait state' "$out2" ;;
-esac
-assert_stop_comment_count 1
-
-: > "$LEDGER_PATH"
-if ! out3="$(run_worker)"; then
-  fail 'tick 3: worker failed after ledger loss' "$out3"
-fi
-printf '%s\n' "$out3"
-case "$out3" in
-  *'repair-check PR #5803'*) fail 'tick 3: worker retried existing split-only stop after ledger loss' "$out3" ;;
-esac
-case "$out3" in
-  *'"reason": "blocked-needs-human"'*) ;;
-  *) fail 'tick 3: worker did not keep blocked-needs-human wait state after ledger loss' "$out3" ;;
+  *) fail 'tick 2: worker did not keep blocked-needs-human wait state after ledger loss' "$out2" ;;
 esac
 assert_stop_comment_count 1
 

--- a/scripts/repro/repro-babysit-pr-body-valid-noop.sh
+++ b/scripts/repro/repro-babysit-pr-body-valid-noop.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-pr-body-valid-noop.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+WORK_PARENT="$HOME/.invoker/mergify-admin-requeue-work"
+mkdir -p "$WORK_PARENT" "$TMP/state" "$TMP/bin"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export CLAUDE_CALLED="$TMP/claude-called"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+cat > "$TMP/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "claude was called for a locally valid PR Body failure" > "$CLAUDE_CALLED"
+exit 42
+EOF
+chmod +x "$TMP/bin/claude"
+
+REMOTE="$TMP/origin.git"
+SEED="$TMP/seed"
+WORK_ROOT="$WORK_PARENT/5810"
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+export STATE_PATH
+
+write_state() {
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = os.environ['ORIGINAL_HEAD']
+body = """## Summary
+
+Routes owner build identity through the owner ping handshake.
+
+## Review Claim
+
+Owner routing refuses mismatched owners before forwarding requests.
+
+## Review Lane
+
+behavior
+
+## Review Unit
+
+routing
+
+## Safety Invariant
+
+The new field is optional and does not change the common owner response shape.
+
+## Slice Rationale
+
+This is one behavior change in the owner message-bus route.
+
+## Non-goals
+
+Does not change the rendered application UI.
+
+## Architecture
+
+### Before
+
+```mermaid
+graph TD
+    A["process pings owner"] --> B["owner answers without build identity"]
+```
+
+### After
+
+```mermaid
+graph TD
+    A["process pings owner"] --> B["owner answers with build identity"]
+```
+
+## Visual Proof
+
+Not applicable. This only changes internal owner-routing behavior.
+
+## Test Plan
+
+<details>
+<summary>Test Plan</summary>
+
+- [x] pnpm --filter @invoker/app test -- owner-build-mismatch
+
+</details>
+
+## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
+
+- Safe to revert? Yes
+- Revert command: git revert <sha>
+- Post-revert steps: None
+- Data migration? No
+
+</details>
+"""
+state = {
+    'prs': [
+        {
+            'number': 5810,
+            'title': 'Stale PR Body failure with valid local body',
+            'body': body,
+            'url': 'https://github.com/fake/repo/pull/5810',
+            'state': 'OPEN',
+            'isDraft': False,
+            'baseRefName': 'master',
+            'headRefName': 'stack/5810',
+            'headRefOid': head,
+            'mergeStateStatus': 'BLOCKED',
+            'mergeable': 'MERGEABLE',
+            'labels': ['admin-bypass'],
+            'reviewThreads': [],
+            'checks': {'*': 'SUCCESS', 'PR Body': 'FAILURE'},
+        }
+    ],
+    'issue_comments': {'5810': []},
+    'job_logs': {'2': ''},
+}
+Path(os.environ['STATE_PATH']).write_text(json.dumps(state, indent=2), encoding='utf-8')
+PY
+}
+
+run_worker() {
+  python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5810 2>&1
+}
+
+git clone . "$SEED" >/dev/null
+(
+  cd "$SEED"
+  git config user.email repro@example.test
+  git config user.name 'Repro Bot'
+  git checkout -B master >/dev/null
+  git init --bare "$REMOTE" >/dev/null
+  git remote add publish "$REMOTE"
+  git push publish master >/dev/null
+  git switch -c stack/5810 master >/dev/null
+  printf '\n// stale PR Body noop repro\n' >> packages/app/src/owner-endpoint.ts
+  git add packages/app/src/owner-endpoint.ts
+  git commit -m 'owner build route repro' >/dev/null
+  git push publish stack/5810 >/dev/null
+)
+git --git-dir="$REMOTE" symbolic-ref HEAD refs/heads/master
+ORIGINAL_HEAD="$(git -C "$SEED" rev-parse stack/5810)"
+export ORIGINAL_HEAD
+git clone "$REMOTE" "$WORK_ROOT" >/dev/null
+( cd "$WORK_ROOT" && git config user.email repro@example.test && git config user.name 'Repro Bot' )
+write_state
+
+if ! out1="$(run_worker)"; then
+  fail 'tick 1: worker failed on locally valid PR Body' "$out1"
+fi
+printf '%s\n' "$out1"
+
+[ ! -f "$CLAUDE_CALLED" ] || fail 'tick 1: worker invoked Claude for locally valid PR Body' "$(cat "$CLAUDE_CALLED")"
+echo "$out1" | grep -q 'admin-bypass-pr-body-valid-noop' || fail 'tick 1: missing PR Body valid-noop trace' "$out1"
+echo "$out1" | grep -q 'admin-bypass-repair-noop' || fail 'tick 1: missing repair-noop trace' "$out1"
+grep -q '"kind": "repair-noop".*"pr": 5810' "$LEDGER_PATH" \
+  || fail 'tick 1: repair noop was not recorded' "$(cat "$LEDGER_PATH")"
+
+if ! out2="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5810 2>&1)"; then
+  fail 'tick 2: dry-run failed after PR Body noop' "$out2"
+fi
+printf '%s\n' "$out2"
+
+! echo "$out2" | grep -q 'DRY-RUN repair-check PR #5810 check="PR Body"' \
+  || fail 'tick 2: worker retried suppressed PR Body failure' "$out2"
+echo "$out2" | grep -q 'DRY-RUN requeue PR #5810' \
+  || fail 'tick 2: worker did not advance to requeue after PR Body noop' "$out2"
+
+echo '[repro] passed'

--- a/scripts/repro/repro-babysit-queue-only-empty-log.sh
+++ b/scripts/repro/repro-babysit-queue-only-empty-log.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-queue-only-empty-log.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+WORK_PARENT="$HOME/.invoker/mergify-admin-requeue-work"
+mkdir -p "$WORK_PARENT" "$TMP/state" "$TMP/bin"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export CLAUDE_CALLED="$TMP/claude-called"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+cat > "$TMP/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "claude was called for an empty queue-only log" > "$CLAUDE_CALLED"
+exit 42
+EOF
+chmod +x "$TMP/bin/claude"
+
+REMOTE="$TMP/origin.git"
+SEED="$TMP/seed"
+WORK_ROOT="$WORK_PARENT/5810"
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+export STATE_PATH
+
+write_state() {
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = os.environ['ORIGINAL_HEAD']
+state = {
+    'prs': [
+        {
+            'number': 5810,
+            'title': 'Queue-only guardrails empty log',
+            'body': '## Summary\n\nQueue-only repro with an empty Guardrails log.\n',
+            'url': 'https://github.com/fake/repo/pull/5810',
+            'state': 'OPEN',
+            'isDraft': False,
+            'baseRefName': 'master',
+            'headRefName': 'stack/5810',
+            'headRefOid': head,
+            'mergeStateStatus': 'BLOCKED',
+            'mergeable': 'MERGEABLE',
+            'labels': ['dequeued'],
+            'reviewThreads': [],
+            'checks': {
+                '*': 'SUCCESS',
+                'PR Body': 'FAILURE',
+                'required-fast / Guardrails': None,
+            },
+        }
+    ],
+    'issue_comments': {
+        '5810': [
+            {
+                'id': 'm5810',
+                'user': {'login': 'mergify[bot]'},
+                'updated_at': '2026-07-20T00:00:00Z',
+                'html_url': 'https://github.com/fake/repo/pull/5810#m5810',
+                'body': (
+                    '-*- Mergify Payload -*-\n'
+                    '{"state":"dequeued","queue_rule_name":"admin-bypass"}\n\n'
+                    '- ❌ **Checks failed** · on draft #5816\n'
+                    f'- 🚫 **Left the queue** — `2026-07-20 00:00 UTC` · at `{head}`\n\n'
+                    '## Failing checks\n\n'
+                    '- [required-fast / Guardrails](https://github.com/fake/repo/actions/runs/1/job/2)\n'
+                ),
+            }
+        ]
+    },
+    'job_logs': {
+        '2': '',
+    },
+}
+Path(os.environ['STATE_PATH']).write_text(json.dumps(state, indent=2), encoding='utf-8')
+PY
+}
+
+run_worker() {
+  python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5810 2>&1
+}
+
+git clone . "$SEED" >/dev/null
+(
+  cd "$SEED"
+  git config user.email repro@example.test
+  git config user.name 'Repro Bot'
+  git checkout -B master >/dev/null
+  git init --bare "$REMOTE" >/dev/null
+  git remote add publish "$REMOTE"
+  git push publish master >/dev/null
+  git switch -c stack/5810 master >/dev/null
+  echo queue-only-empty-log > queue-only-empty-log.txt
+  git add queue-only-empty-log.txt
+  git commit -m 'queue only empty log slice' >/dev/null
+  git push publish stack/5810 >/dev/null
+)
+git --git-dir="$REMOTE" symbolic-ref HEAD refs/heads/master
+ORIGINAL_HEAD="$(git -C "$SEED" rev-parse stack/5810)"
+export ORIGINAL_HEAD
+git clone "$REMOTE" "$WORK_ROOT" >/dev/null
+( cd "$WORK_ROOT" && git config user.email repro@example.test && git config user.name 'Repro Bot' )
+write_state
+
+if ! out1="$(run_worker)"; then
+  fail 'tick 1: worker failed on empty queue-only log' "$out1"
+fi
+printf '%s\n' "$out1"
+
+[ ! -f "$CLAUDE_CALLED" ] || fail 'tick 1: worker invoked Claude for empty queue-only log' "$(cat "$CLAUDE_CALLED")"
+echo "$out1" | grep -q 'admin-bypass-queue-only-empty-log-noop' || fail 'tick 1: missing empty-log noop trace' "$out1"
+echo "$out1" | grep -q 'admin-bypass-queue-only-noop' || fail 'tick 1: missing queue-only noop trace' "$out1"
+
+if ! grep -q '"kind": "queue-only-noop".*"pr": 5810' "$LEDGER_PATH"; then
+  fail 'tick 1: queue-only noop was not recorded' "$(cat "$LEDGER_PATH")"
+fi
+
+if ! out2="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5810 2>&1)"; then
+  fail 'tick 2: dry-run failed after empty queue-only noop' "$out2"
+fi
+printf '%s\n' "$out2"
+
+! echo "$out2" | grep -q 'DRY-RUN repair-check PR #5810 check="required-fast / Guardrails"' \
+  || fail 'tick 2: worker retried suppressed queue-only Guardrails failure' "$out2"
+echo "$out2" | grep -q 'DRY-RUN repair-check PR #5810 check="PR Body"' \
+  || fail 'tick 2: worker did not move on to the remaining PR-head blocker' "$out2"
+
+echo '[repro] passed'

--- a/scripts/repro/repro-babysit-queue-only-missing-requeues.sh
+++ b/scripts/repro/repro-babysit-queue-only-missing-requeues.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-queue-only-missing-requeues.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+mkdir -p "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+CURRENT_HEAD="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+OLD_QUEUE_HEAD="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+export STATE_PATH CURRENT_HEAD OLD_QUEUE_HEAD
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+head = os.environ['CURRENT_HEAD']
+old = os.environ['OLD_QUEUE_HEAD']
+state = {
+    'prs': [
+        {
+            'number': 5801,
+            'title': 'Queue-only missing check requeue',
+            'body': '## Summary\n\nQueue-only missing checks are merge-queue checks.\n',
+            'url': 'https://github.com/fake/repo/pull/5801',
+            'state': 'OPEN',
+            'isDraft': False,
+            'baseRefName': 'master',
+            'headRefName': 'stack/5801',
+            'headRefOid': head,
+            'mergeStateStatus': 'BLOCKED',
+            'mergeable': 'MERGEABLE',
+            'labels': ['admin-bypass'],
+            'reviewThreads': [],
+            'checks': {
+                '*': 'SUCCESS',
+                'required-fast / Guardrails': None,
+                'required-fast / Submit Workflow Chain': None,
+                'required-fast / Vitest Workspace': None,
+            },
+        },
+        {
+            'number': 5803,
+            'title': 'Upper human-only split blocker',
+            'body': '## Summary\n\nUpper PR needs a human split.\n',
+            'url': 'https://github.com/fake/repo/pull/5803',
+            'state': 'OPEN',
+            'isDraft': False,
+            'baseRefName': 'stack/5801',
+            'headRefName': 'stack/5803',
+            'headRefOid': 'cccccccccccccccccccccccccccccccccccccccc',
+            'mergeStateStatus': 'UNSTABLE',
+            'mergeable': 'MERGEABLE',
+            'labels': ['admin-bypass'],
+            'reviewThreads': [],
+            'checks': {'*': 'SUCCESS', 'PR Body': 'FAILURE'},
+        }
+    ],
+    'issue_comments': {
+        '5801': [
+            {
+                'id': 'm5801-old',
+                'user': {'login': 'mergify[bot]'},
+                'updated_at': '2026-07-20T00:00:00Z',
+                'html_url': 'https://github.com/fake/repo/pull/5801#m5801-old',
+                'body': (
+                    '-*- Mergify Payload -*-\n'
+                    '{"state":"dequeued","queue_rule_name":"admin-bypass"}\n\n'
+                    f'- 🚫 **Left the queue** — `2026-07-20 00:00 UTC` · at `{old}`\n\n'
+                    '## Reason\n\nThe pull request conflicts with the base branch\n'
+                ),
+            }
+        ],
+        '5803': [
+            {
+                'id': 'stop-5803',
+                'user': {'login': 'EdbertChan'},
+                'updated_at': '2026-07-20T00:01:00Z',
+                'html_url': 'https://github.com/fake/repo/pull/5803#stop-5803',
+                'body': 'Mergify repair stopped: worker cannot auto-split this PR on a non-trunk base; human stack split required',
+            }
+        ],
+    },
+}
+Path(os.environ['STATE_PATH']).write_text(json.dumps(state, indent=2), encoding='utf-8')
+PY
+
+if ! out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5801 2>&1)"; then
+  fail 'worker dry-run failed' "$out"
+fi
+printf '%s\n' "$out"
+
+case "$out" in
+  *'BLOCK PR #5801 missing-check'*) fail 'worker blocked on queue-only missing check' "$out" ;;
+esac
+case "$out" in
+  *'DRY-RUN requeue PR #5801'*) ;;
+  *) fail 'worker did not requeue clean bottom PR with only queue-only checks missing' "$out" ;;
+esac
+
+echo '[repro] passed'


### PR DESCRIPTION
## Summary

This slice adds repro scripts for the stuck babysit cases.

It captures queue-only dequeues, old bot threads, empty queue logs, amended-repair ancestry, and multi-unit PR Body dead ends in one repeatable fixture set.

## Review Claim

The babysit stack now has explicit repro artifacts for the edge cases covered by the follow-up fix slice.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice adds proof files only. It does not change worker behavior.

## Slice Rationale

The edge cases need concrete repro artifacts before the follow-up fix slice is reviewed. Keeping the artifacts separate makes the later behavior diff smaller.

## Non-goals

- No worker logic changes.
- No live PR mutations.
- No battle-loop wiring.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash -n scripts/repro/repro-babysit-amended-repair-push.sh scripts/repro/repro-babysit-headless-queued-comment.sh scripts/repro/repro-babysit-outdated-bot-thread.sh scripts/repro/repro-babysit-pr-body-human-split.sh scripts/repro/repro-babysit-pr-body-proof-human-split.sh scripts/repro/repro-babysit-pr-body-valid-noop.sh scripts/repro/repro-babysit-queue-only-empty-log.sh scripts/repro/repro-babysit-queue-only-missing-requeues.sh`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/pr5947-body.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0a6d5a3b6`
- Post-revert steps: None
- Data migration? No

</details>
