### PR TITLE
[Babysit Loop](2) Landing loop fixes

### DIFF
--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -10,6 +10,13 @@ REPROS=(
   scripts/repro/repro-mergify-closed-pr-guard.sh
   scripts/repro/repro-coderabbit-pr5251-mergify-admin-requeue-yaml-alias.sh
   scripts/repro/repro-babysit-pr-body-human-split.sh
+  scripts/repro/repro-babysit-pr-body-proof-human-split.sh
+  scripts/repro/repro-babysit-pr-body-valid-noop.sh
+  scripts/repro/repro-babysit-amended-repair-push.sh
+  scripts/repro/repro-babysit-outdated-bot-thread.sh
+  scripts/repro/repro-babysit-headless-queued-comment.sh
+  scripts/repro/repro-babysit-queue-only-empty-log.sh
+  scripts/repro/repro-babysit-queue-only-missing-requeues.sh
 )
 
 # repro-mergify-stack-dogfood.sh is deliberately excluded: it's an opt-in

--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -69,6 +69,14 @@ def record_repair_outcome(
             check_name=outcome.check_name,
             queue_pr_number=pr.latest_mergify.queue_pr_number if pr.latest_mergify else 0,
         )
+    if outcome.status == "noop" and outcome.check_name == "PR Body":
+        ledger.record("repair-noop", pr.number, pr.head_ref_oid, outcome.check_name, now)
+        logger.trace(
+            "admin-bypass-repair-noop",
+            repo=repo,
+            pr_number=pr.number,
+            check_name=outcome.check_name,
+        )
 
 
 def handle_repair_outcome(

--- a/scripts/mergify_admin_requeue_gh_executor.py
+++ b/scripts/mergify_admin_requeue_gh_executor.py
@@ -70,9 +70,19 @@ class AdminBypassGhExecutor:
     def resolve_bot_threads(self, thread_id: str) -> None:
         self.gh.resolve_review_thread(thread_id)
 
+    def has_blocked_comment(self, pr: PrSnapshot, body: str) -> bool:
+        if not hasattr(self.gh, "issue_comments"):
+            return False
+        for comment in self.gh.issue_comments(self.repo, pr.number):
+            if str(comment.get("body") or "").strip() == body.strip():
+                return True
+        return False
+
     def comment_blocked(self, pr: PrSnapshot, detail: str, key: str, now: int) -> None:
         if self.ledger.count("comment-blocked", pr.number, pr.head_ref_oid, key) == 0:
-            self.gh.comment(self.repo, pr.number, f"Mergify repair stopped: {detail}")
+            body = f"Mergify repair stopped: {detail}"
+            if not self.has_blocked_comment(pr, body):
+                self.gh.comment(self.repo, pr.number, body)
             self.ledger.record("comment-blocked", pr.number, pr.head_ref_oid, key, now)
 
     def execute(self, action: Action, pr: PrSnapshot, now: int) -> None:

--- a/scripts/mergify_admin_requeue_model.py
+++ b/scripts/mergify_admin_requeue_model.py
@@ -29,6 +29,7 @@ class ReviewThread:
     id: str
     is_resolved: bool
     author_logins: tuple[str, ...]
+    is_outdated: bool = False
 
 
 @dataclass(frozen=True)
@@ -44,6 +45,13 @@ class MergifyQueueEvent:
     queue_pr_number: int = 0
     failing_check_urls: tuple[tuple[str, tuple[str, ...]], ...] = ()
     condition_states: tuple[tuple[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class RepairStopComment:
+    body: str
+    updated_at: str
+    author_login: str
 
 
 @dataclass(frozen=True)
@@ -63,6 +71,7 @@ class PrSnapshot:
     checks: Mapping[str, CheckContext]
     review_threads: tuple[ReviewThread, ...]
     latest_mergify: MergifyQueueEvent | None
+    repair_stop_comments: tuple[RepairStopComment, ...] = ()
 
 @dataclass(frozen=True)
 class StackGroup:

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -36,8 +36,18 @@ QUEUE_ONLY_REQUIRED_CHECKS = frozenset({
     "required-fast / Vitest Workspace",
     "required-fast / Submit Workflow Chain",
 })
+ACTIVE_QUEUE_STATES = frozenset({"queued", "merging"})
 
 HUMAN_BLOCKER_KINDS = frozenset({"draft", "human_review_thread", "missing_check", "closed", "human_decision"})
+REPAIR_STOP_PREFIX = "Mergify repair stopped: "
+MANUAL_SPLIT_STOP_MARKERS = (
+    "human stack split required",
+    "Split this into one Review Unit per PR.",
+    "cannot auto-split",
+    "cannot ship with tooling-policy, proof files",
+    "cannot ship with policy, proof files",
+    "cannot ship with proof files",
+)
 
 
 @dataclass(frozen=True)
@@ -79,6 +89,8 @@ def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) ->
         authors = set(thread.author_logins)
         if not authors or authors - BOT_OR_SELF_AUTHORS:
             blockers.append(Blocker(thread.id, "human_review_thread", pr.number, f"unresolved human review thread {thread.id}"))
+        elif thread.is_outdated:
+            blockers.append(Blocker(thread.id, "outdated_bot_review_thread", pr.number, f"unresolved outdated bot review thread {thread.id}"))
         else:
             blockers.append(Blocker(thread.id, "bot_review_thread", pr.number, f"unresolved bot review thread {thread.id}"))
 
@@ -88,7 +100,7 @@ def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) ->
     for name in sorted(required_checks):
         ctx = pr.checks.get(name)
         if ctx is None:
-            if pr.base_ref_name == trunk:
+            if pr.base_ref_name == trunk and not is_queue_only_required_check(name):
                 blockers.append(Blocker(name, "missing_check", pr.number, f"missing required check {name}"))
             continue
         if ctx.state == "success":
@@ -268,6 +280,24 @@ def latest_repair_invalid_blocker(pr: PrSnapshot, blocker: Blocker, ledger: Ledg
     return Blocker(blocker.key, "human_decision", pr.number, blocker.detail)
 
 
+def existing_split_stop_blocker(pr: PrSnapshot, blocker: Blocker) -> Blocker | None:
+    if blocker.kind != "failed_check":
+        return None
+    ctx = pr.checks.get(blocker.key)
+    completed_at = ctx.completed_at if ctx else ""
+    for comment in pr.repair_stop_comments:
+        body = comment.body.strip()
+        if not body.startswith(REPAIR_STOP_PREFIX):
+            continue
+        detail = body[len(REPAIR_STOP_PREFIX):].strip()
+        if not detail or not any(marker in detail for marker in MANUAL_SPLIT_STOP_MARKERS):
+            continue
+        if completed_at and comment.updated_at and comment.updated_at < completed_at:
+            continue
+        return Blocker(blocker.key, "human_decision", pr.number, detail)
+    return None
+
+
 def _assert_stack_facts_invariants(facts: StackFacts) -> None:
     assert facts.stack.prs, "stack must contain at least one PR"
     pr_numbers = tuple(pr.number for pr in facts.stack.prs)
@@ -312,12 +342,18 @@ def build_stack_facts(
         suppressed_failed_checks_by_pr[bottom.number] = suppressed_failed_checks_by_pr.get(bottom.number, ()) + (prereq_status.check_name,)
     if queue_only_noop_check and bottom:
         suppressed_failed_checks_by_pr[bottom.number] = suppressed_failed_checks_by_pr.get(bottom.number, ()) + (queue_only_noop_check,)
+    if (
+        bottom
+        and "PR Body" in required
+        and ledger.latest("repair-noop", bottom.number, bottom.head_ref_oid, "PR Body") is not None
+    ):
+        suppressed_failed_checks_by_pr[bottom.number] = suppressed_failed_checks_by_pr.get(bottom.number, ()) + ("PR Body",)
 
     blockers_by_pr: dict[int, tuple[Blocker, ...]] = {}
     for pr in stack.prs:
         effective = effective_blockers(pr, required, trunk, suppressed_failed_checks_by_pr.get(pr.number, ()))
         blockers_by_pr[pr.number] = tuple(
-            latest_repair_invalid_blocker(pr, blocker, ledger) or blocker
+            latest_repair_invalid_blocker(pr, blocker, ledger) or existing_split_stop_blocker(pr, blocker) or blocker
             for blocker in effective
         )
     facts = StackFacts(
@@ -395,6 +431,16 @@ def _has_pending_or_human_blocker(facts: StackFacts) -> bool:
     return any(blocker.kind == "pending_check" or blocker.kind in HUMAN_BLOCKER_KINDS for blocker in facts.all_blockers)
 
 
+def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
+    if not facts.bottom:
+        return _has_pending_or_human_blocker(facts)
+    return any(
+        blocker.pr_number == facts.bottom.number
+        and (blocker.kind == "pending_check" or blocker.kind in HUMAN_BLOCKER_KINDS)
+        for blocker in facts.all_blockers
+    )
+
+
 def plan_mergify_queue_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     del max_repair_attempts
     for pr in facts.stack.prs:
@@ -425,6 +471,8 @@ def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: 
 def plan_bot_thread_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     for pr in facts.stack.prs:
         for blocker in facts.blockers_by_pr[pr.number]:
+            if blocker.kind == "outdated_bot_review_thread":
+                return Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail)
             if blocker.kind != "bot_review_thread":
                 continue
             if ledger.has_different_head("repair-bot-thread", pr.number, pr.head_ref_oid, blocker.key):
@@ -462,7 +510,7 @@ def plan_merge_hold_cleanup(facts: StackFacts, ledger: Ledger) -> Action | None:
 
 
 def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts: int) -> Action | None:
-    if _has_pending_or_human_blocker(facts):
+    if _bottom_has_pending_or_human_blocker(facts):
         return None
     if any(blocker.kind == "merge_hold" for blocker in facts.all_blockers):
         return None
@@ -488,7 +536,7 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
         return Action("comment_admin_bypass_nudge", bottom.number, "admin-bypass", "missing admin-bypass label")
     if facts.upper_stack_needs_acceptance:
         return None
-    if latest and latest.head_sha == bottom.head_ref_oid and latest.state in {"queued", "merging"}:
+    if latest and latest.state in ACTIVE_QUEUE_STATES and (latest.head_sha == bottom.head_ref_oid or "queued" in bottom.labels):
         return None
     requeue_reason = "eligible-when-ready"
     requeue_key = "ready"

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -68,6 +68,37 @@ class AdminBypassRepairer:
         self.git_output(work_root, "reset", "--hard", target)
         self.git_output(work_root, "clean", "-fd")
 
+    def is_ancestor(self, work_root: Path, ancestor: str, descendant: str) -> bool:
+        if not work_root.exists():
+            return True
+        completed = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+            cwd=str(work_root),
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        return completed.returncode == 0
+
+    def normalize_repair_commit(self, work_root: Path, start_head: str, end_head: str, check_name: str) -> str:
+        if self.is_ancestor(work_root, start_head, end_head):
+            return end_head
+        diff = self.git_output(work_root, "diff", "--binary", start_head, end_head)
+        self.hard_reset_work_root(work_root, start_head)
+        if not diff.strip():
+            return start_head
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+            handle.write(diff)
+            patch_path = Path(handle.name)
+        try:
+            self.git_output(work_root, "apply", "--index", str(patch_path))
+        finally:
+            patch_path.unlink(missing_ok=True)
+        if not self.git_lines(work_root, "status", "--porcelain"):
+            return start_head
+        self.git_output(work_root, "commit", "-m", f"Repair {check_name}")
+        return self.git_output(work_root, "rev-parse", "HEAD").strip()
+
     def validate_local_pr_body(self, work_root: Path, body: str, base_branch: str) -> dict[str, object]:
         with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
             handle.write(body)
@@ -185,7 +216,7 @@ class AdminBypassRepairer:
             return False
         if not isinstance(review_units, list):
             return False
-        if "tooling-policy" not in review_units or "proof" not in review_units:
+        if len({str(unit) for unit in review_units}) < 2:
             return False
         joined = "\n".join(str(error) for error in errors)
         return (
@@ -193,6 +224,7 @@ class AdminBypassRepairer:
             or "Split this into one Review Unit per PR." in joined
             or "cannot ship with policy, proof files" in joined
             or "cannot ship with tooling-policy, proof files" in joined
+            or "cannot ship with proof files" in joined
         )
 
     def invalid_repair_errors(self, value: Mapping[str, object], pr: PrSnapshot) -> list[str]:
@@ -338,6 +370,25 @@ class AdminBypassRepairer:
             text=True,
         )
 
+    def job_log_has_evidence(self, log_path: str) -> bool:
+        if not log_path:
+            return False
+        try:
+            return bool(Path(log_path).read_text(encoding="utf-8").strip())
+        except OSError:
+            return False
+
+    def job_log_is_empty(self, log_path: str) -> bool:
+        if not log_path:
+            return False
+        path = Path(log_path)
+        if not path.exists():
+            return False
+        try:
+            return not path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return False
+
     def repair_check(self, pr: PrSnapshot, check_name: str, now: int | None = None) -> RepairOutcome:
         ctx = pr.checks.get(check_name)
         latest = pr.latest_mergify
@@ -357,6 +408,35 @@ class AdminBypassRepairer:
                 errors=(f"queue-only check {check_name} is missing a Mergify job URL",),
             )
         log_path = self.executor.download_job_log(self.repo, details_url, pr.number, check_name) if details_url else ""
+        if check_name == "PR Body" and self.job_log_is_empty(log_path):
+            validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
+            if validation.get("valid"):
+                self.logger.trace(
+                    "admin-bypass-pr-body-valid-noop",
+                    repo=self.repo,
+                    pr_number=pr.number,
+                    check_name=check_name,
+                    head_sha=pr.head_ref_oid,
+                    details_url=details_url,
+                    log_path=log_path,
+                )
+                return self.blocked_outcome("noop", check_name, start_head, start_head)
+        if queue_only and not self.job_log_has_evidence(log_path):
+            self.logger.trace(
+                "admin-bypass-queue-only-empty-log-noop",
+                repo=self.repo,
+                pr_number=pr.number,
+                check_name=check_name,
+                details_url=details_url,
+                log_path=log_path,
+                head_sha=pr.head_ref_oid,
+            )
+            return self.blocked_outcome(
+                "queue_only_noop",
+                check_name,
+                start_head,
+                start_head,
+            )
         queue_pr_number = latest.queue_pr_number if latest else 0
         prompt = (
             f"Fix only the failing check. Add or update a repro if the failure is reproducible. "
@@ -399,6 +479,7 @@ class AdminBypassRepairer:
                 end_head,
                 status_lines=status_lines,
             )
+        end_head = self.normalize_repair_commit(work_root, start_head, end_head, check_name)
         repair_commits = self.git_lines(work_root, "rev-list", "--reverse", f"{start_head}..{end_head}")
         validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
         if validation.get("valid"):

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -12,6 +12,7 @@ try:
     from .mergify_admin_requeue_model import (
         MergifyQueueEvent,
         PrSnapshot,
+        RepairStopComment,
         ReviewThread,
         STACK_MARKER_RE,
         StackGroup,
@@ -28,6 +29,7 @@ except ImportError:
     from mergify_admin_requeue_model import (
         MergifyQueueEvent,
         PrSnapshot,
+        RepairStopComment,
         ReviewThread,
         STACK_MARKER_RE,
         StackGroup,
@@ -106,7 +108,7 @@ class GhClient:
             "query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { "
             "pullRequest(number:$number) { number title body url isDraft state baseRefName headRefName headRefOid "
             "mergeStateStatus mergeable labels(first:50) { nodes { name } } "
-            "reviewThreads(first:100) { pageInfo { hasNextPage } nodes { id isResolved comments(first:50) { nodes { author { login } body url } } } } "
+            "reviewThreads(first:100) { pageInfo { hasNextPage } nodes { id isResolved isOutdated comments(first:50) { nodes { author { login } body url } } } } "
             "statusCheckRollup { contexts(first:100) { nodes { __typename ... on CheckRun { name conclusion status completedAt startedAt detailsUrl checkSuite { commit { oid } } } "
             "... on StatusContext { context state targetUrl commit { oid } } } } } } } }"
         )
@@ -225,6 +227,23 @@ def parse_mergify_queue_event(comment: Mapping[str, object]) -> MergifyQueueEven
     )
 
 
+def parse_repair_stop_comment(comment: Mapping[str, object]) -> RepairStopComment | None:
+    author = comment.get("user") if isinstance(comment.get("user"), Mapping) else comment.get("author")
+    login = ""
+    if isinstance(author, Mapping):
+        login = str(author.get("login") or "")
+    elif isinstance(author, str):
+        login = author
+    body = str(comment.get("body") or "")
+    if not body.startswith("Mergify repair stopped: "):
+        return None
+    return RepairStopComment(
+        body=body,
+        updated_at=str(comment.get("updated_at") or comment.get("created_at") or comment.get("createdAt") or ""),
+        author_login=login,
+    )
+
+
 def parse_stack_metadata(comments: Sequence[Mapping[str, object]]) -> tuple[str, tuple[int, ...]] | None:
     ordered = sorted(comments, key=lambda c: str(c.get("updated_at") or c.get("created_at") or ""), reverse=True)
     for comment in ordered:
@@ -330,7 +349,12 @@ def review_threads(value: object) -> tuple[ReviewThread, ...]:
             login = author.get("login") if isinstance(author, Mapping) else None
             if login:
                 authors.append(str(login))
-        threads.append(ReviewThread(str(node.get("id") or ""), bool(node.get("isResolved")), tuple(authors)))
+        threads.append(ReviewThread(
+            str(node.get("id") or ""),
+            bool(node.get("isResolved")),
+            tuple(authors),
+            bool(node.get("isOutdated")),
+        ))
     return tuple(threads)
 
 
@@ -345,6 +369,8 @@ def snapshot_from_detail(detail: Mapping[str, object], comments: Sequence[Mappin
     head = str(detail.get("headRefOid") or detail.get("head_ref_oid") or "")
     events = [event for comment in comments for event in [parse_mergify_queue_event(comment)] if event]
     events.sort(key=lambda event: event.queued_at, reverse=True)
+    stop_comments = [stop for comment in comments for stop in [parse_repair_stop_comment(comment)] if stop]
+    stop_comments.sort(key=lambda comment: comment.updated_at, reverse=True)
     return PrSnapshot(
         number=int(detail.get("number") or 0),
         title=str(detail.get("title") or ""),
@@ -361,4 +387,5 @@ def snapshot_from_detail(detail: Mapping[str, object], comments: Sequence[Mappin
         checks=latest_contexts_by_required_check(raw_contexts(detail), head, required_checks),
         review_threads=review_threads(detail.get("reviewThreads")),
         latest_mergify=events[0] if events else None,
+        repair_stop_comments=tuple(stop_comments),
     )

--- a/scripts/repro/fixtures/fake-gh/bin/gh
+++ b/scripts/repro/fixtures/fake-gh/bin/gh
@@ -199,6 +199,17 @@ def main() -> None:
             print(json.dumps({"data": {"repository": {"pullRequest": graphql_detail(pr)}}}))
             return
         if any("resolveReviewThread" in arg for arg in ARGS):
+            thread_id = ""
+            for arg in ARGS:
+                if arg.startswith("threadId="):
+                    thread_id = arg.split("=", 1)[1]
+                    break
+            if thread_id:
+                for pr in state.get("prs", []):
+                    for thread in pr.get("reviewThreads", []):
+                        if thread.get("id") == thread_id:
+                            thread["isResolved"] = True
+                            save_state(state)
             print(json.dumps({"data": {"resolveReviewThread": {"thread": {"isResolved": True}}}}))
             return
         unhandled()

--- a/scripts/repro/repro-babysit-amended-repair-push.sh
+++ b/scripts/repro/repro-babysit-amended-repair-push.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-amended-repair-push.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+WORK_PARENT="$HOME/.invoker/mergify-admin-requeue-work"
+mkdir -p "$WORK_PARENT" "$TMP/state" "$TMP/bin"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+cat > "$TMP/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+rm -f scripts/repro/proof-wrapper.sh
+git add -A
+git commit --amend --no-edit
+EOF
+chmod +x "$TMP/bin/claude"
+
+cat > "$TMP/bin/node" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$#" -ge 1 && "$1" == *"/scripts/validate-pr-body-local.mjs" ]]; then
+  cat <<'JSON'
+{"valid":true,"errors":[],"reviewLane":"behavior","reviewUnit":"routing","reviewUnits":["routing"],"scopeKinds":["product"]}
+JSON
+  exit 0
+fi
+exec /usr/bin/env node "$@"
+EOF
+chmod +x "$TMP/bin/node"
+
+REMOTE="$TMP/origin.git"
+SEED="$TMP/seed"
+WORK_ROOT="$WORK_PARENT/5806"
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+export STATE_PATH
+
+write_state() {
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+head = os.environ['ORIGINAL_HEAD']
+state = {
+    'prs': [
+        {
+            'number': 5806,
+            'title': 'Amended repair push repro',
+            'body': '## Summary\n\nAmended repair push repro.\n',
+            'url': 'https://github.com/fake/repo/pull/5806',
+            'state': 'OPEN',
+            'isDraft': False,
+            'baseRefName': 'master',
+            'headRefName': 'stack/5806',
+            'headRefOid': head,
+            'mergeStateStatus': 'UNSTABLE',
+            'mergeable': 'MERGEABLE',
+            'labels': ['admin-bypass'],
+            'reviewThreads': [],
+            'checks': {'*': 'SUCCESS', 'PR Body': 'FAILURE'},
+        }
+    ],
+    'issue_comments': {'5806': []},
+    'job_logs': {'2': 'PR body validation failed: proof wrappers are not lane-compatible\n'},
+}
+Path(os.environ['STATE_PATH']).write_text(json.dumps(state, indent=2), encoding='utf-8')
+PY
+}
+
+run_worker() {
+  python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --author fake-bot --state-file "$LEDGER_PATH" --pr 5806 2>&1
+}
+
+git clone . "$SEED" >/dev/null
+(
+  cd "$SEED"
+  git config user.email repro@example.test
+  git config user.name 'Repro Bot'
+  git checkout -B master >/dev/null
+  git init --bare "$REMOTE" >/dev/null
+  git remote add publish "$REMOTE"
+  git push publish master >/dev/null
+  git switch -c stack/5806 master >/dev/null
+  mkdir -p packages/surfaces/src/slack scripts/repro
+  printf 'planning\n' > packages/surfaces/src/slack/plan-conversation.ts
+  printf '# proof wrapper\n' > scripts/repro/proof-wrapper.sh
+  git add packages/surfaces/src/slack/plan-conversation.ts scripts/repro/proof-wrapper.sh
+  git commit -m 'mixed behavior proof wrapper' >/dev/null
+  git push publish stack/5806 >/dev/null
+)
+git --git-dir="$REMOTE" symbolic-ref HEAD refs/heads/master
+ORIGINAL_HEAD="$(git -C "$SEED" rev-parse stack/5806)"
+export ORIGINAL_HEAD
+
+git clone "$REMOTE" "$WORK_ROOT" >/dev/null
+( cd "$WORK_ROOT" && git config user.email repro@example.test && git config user.name 'Repro Bot' )
+write_state
+
+if ! out="$(run_worker)"; then
+  fail 'worker failed to push amended repair as descendant' "$out"
+fi
+printf '%s\n' "$out"
+
+REMOTE_HEAD="$(git --git-dir="$REMOTE" rev-parse refs/heads/stack/5806)"
+if [ "$REMOTE_HEAD" = "$ORIGINAL_HEAD" ]; then
+  fail 'remote branch did not advance'
+fi
+if ! git --git-dir="$REMOTE" merge-base --is-ancestor "$ORIGINAL_HEAD" "$REMOTE_HEAD"; then
+  fail 'remote repair did not descend from original head'
+fi
+if git --git-dir="$REMOTE" cat-file -e "$REMOTE_HEAD:scripts/repro/proof-wrapper.sh" 2>/dev/null; then
+  fail 'proof wrapper still exists on pushed repair'
+fi
+
+echo '[repro] passed'

--- a/scripts/repro/repro-babysit-headless-queued-comment.sh
+++ b/scripts/repro/repro-babysit-headless-queued-comment.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-headless-queued-comment.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+mkdir -p "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+export STATE_PATH
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = "1605586282a7bccef5c1ea34419a7176ca755dc1"
+state = {
+    "prs": [
+        {
+            "number": 5805,
+            "title": "Already queued with headless Mergify status",
+            "body": "## Summary\n\nQueued PR repro.\n",
+            "url": "https://github.com/fake/repo/pull/5805",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "stack/5805",
+            "headRefOid": head,
+            "mergeStateStatus": "BLOCKED",
+            "mergeable": "MERGEABLE",
+            "labels": ["admin-bypass", "queued"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS"},
+        }
+    ],
+    "issue_comments": {
+        "5805": [
+            {
+                "id": "m5805-checking",
+                "user": {"login": "mergify"},
+                "updated_at": "2026-07-26T06:11:39Z",
+                "html_url": "https://github.com/fake/repo/pull/5805#m5805-checking",
+                "body": (
+                    "<!---\n"
+                    "DO NOT EDIT\n"
+                    "-*- Mergify Payload -*-\n"
+                    '{"version":1,"state":"checking","queue_rule_name":"admin-bypass","queued_at":"2026-07-26T06:11:35Z","speculative_check_pr":5862}\n'
+                    "-*- Mergify Payload End -*-\n"
+                    "-->\n\n"
+                    "# Merge Queue Status\n\n"
+                    "- ✅ **Entered queue** — `2026-07-26 06:11 UTC` · Rule: `admin-bypass`\n"
+                    "- 🟠 **Checks running** · on draft #5862\n\n"
+                    "<details>\n<summary><strong>Waiting for</strong></summary>\n\n"
+                    "- [ ] `check-success = required-fast / Guardrails`\n\n"
+                    "</details>\n"
+                ),
+            }
+        ]
+    },
+    "job_logs": {},
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+
+if ! out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5805 2>&1)"; then
+  fail "worker dry-run failed" "$out"
+fi
+printf '%s\n' "$out"
+
+! echo "$out" | grep -q 'DRY-RUN requeue PR #5805' \
+  || fail "worker tried to requeue a PR already in Mergify queue" "$out"
+echo "$out" | grep -q '"reason": "bottom-already-queued"' \
+  || fail "worker did not wait on the active queue state" "$out"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-babysit-outdated-bot-thread.sh
+++ b/scripts/repro/repro-babysit-outdated-bot-thread.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-outdated-bot-thread.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+mkdir -p "$TMP/state" "$TMP/bin"
+export HOME="$TMP/home"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export CLAUDE_CALLED="$TMP/claude-called"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+cat > "$TMP/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "claude was called for an outdated bot review thread" > "$CLAUDE_CALLED"
+exit 42
+EOF
+chmod +x "$TMP/bin/claude"
+
+LEDGER_PATH="$TMP/ledger.jsonl"
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+export STATE_PATH
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = "1605586282a7bccef5c1ea34419a7176ca755dc1"
+state = {
+    "prs": [
+        {
+            "number": 5805,
+            "title": "Outdated CodeRabbit thread",
+            "body": "## Summary\n\nOutdated bot thread repro.\n",
+            "url": "https://github.com/fake/repo/pull/5805",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "stack/5805",
+            "headRefOid": head,
+            "mergeStateStatus": "BLOCKED",
+            "mergeable": "MERGEABLE",
+            "labels": ["admin-bypass"],
+            "reviewThreads": [
+                {
+                    "id": "thread-outdated",
+                    "isResolved": False,
+                    "isOutdated": True,
+                    "comments": {
+                        "nodes": [
+                            {
+                                "author": {"login": "coderabbitai"},
+                                "body": "Clean up a line that no longer exists.",
+                                "url": "https://github.com/fake/repo/pull/5805#discussion_r1",
+                            }
+                        ]
+                    },
+                }
+            ],
+            "checks": {"*": "SUCCESS"},
+        }
+    ],
+    "issue_comments": {"5805": []},
+    "job_logs": {},
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+
+run_worker() {
+  python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5805 2>&1
+}
+
+if ! dry_out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5805 2>&1)"; then
+  fail "dry-run failed for outdated bot thread" "$dry_out"
+fi
+printf '%s\n' "$dry_out"
+echo "$dry_out" | grep -q 'DRY-RUN resolve-bot-threads PR #5805 thread=thread-outdated' \
+  || fail "dry-run did not resolve the outdated bot thread" "$dry_out"
+! echo "$dry_out" | grep -q 'DRY-RUN repair-check PR #5805 check="thread-outdated"' \
+  || fail "dry-run tried to repair an outdated bot thread" "$dry_out"
+
+if ! out="$(run_worker)"; then
+  fail "worker failed resolving outdated bot thread" "$out"
+fi
+printf '%s\n' "$out"
+[ ! -f "$CLAUDE_CALLED" ] || fail "worker invoked Claude for outdated bot thread" "$(cat "$CLAUDE_CALLED")"
+echo "$out" | grep -q 'resolve-bot-threads PR #5805 thread=thread-outdated' \
+  || fail "worker did not execute resolve-bot-threads" "$out"
+grep -q 'resolveReviewThread' "$FAKE_GH_STATE_DIR/calls.log" \
+  || fail "worker did not call the review-thread resolve mutation" "$(cat "$FAKE_GH_STATE_DIR/calls.log")"
+! grep -q '"kind": "repair-bot-thread"' "$LEDGER_PATH" 2>/dev/null \
+  || fail "worker recorded a bot-thread repair instead of resolving stale feedback" "$(cat "$LEDGER_PATH")"
+
+if ! next_out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5805 2>&1)"; then
+  fail "dry-run failed after resolving outdated bot thread" "$next_out"
+fi
+printf '%s\n' "$next_out"
+echo "$next_out" | grep -q 'DRY-RUN requeue PR #5805' \
+  || fail "worker did not advance to requeue after resolving stale feedback" "$next_out"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-babysit-pr-body-proof-human-split.sh
+++ b/scripts/repro/repro-babysit-pr-body-proof-human-split.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
-TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-pr-body-human-split.XXXXXX")"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-pr-body-proof-human-split.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
 
 fail() {
@@ -45,7 +45,7 @@ cat > "$TMP/bin/node" <<'EOF'
 set -euo pipefail
 if [[ "$#" -ge 1 && "$1" == *"/scripts/validate-pr-body-local.mjs" ]]; then
   cat <<'JSON'
-{"valid":false,"errors":["PR body mentions multiple review units (validation-policy, routing); split into one conceptual unit per diff/task.","Review lane behavior cannot ship with policy, proof files in the same PR. Split behavior or cleanup from docs, policy, repro, and benchmark slices.","PR body Review Unit \"routing\" cannot ship with tooling-policy, proof files in the same PR. Split this into one Review Unit per PR."],"reviewLane":"behavior","reviewUnit":"routing","reviewUnits":["routing","tooling-policy","proof"],"scopeKinds":["product","policy"]}
+{"valid":false,"errors":["Review lane behavior cannot ship with proof files in the same PR. Split behavior or cleanup from docs, policy, repro, and benchmark slices.","PR body Review Unit \"routing\" cannot ship with proof files in the same PR. Split this into one Review Unit per PR."],"reviewLane":"behavior","reviewUnit":"routing","reviewUnits":["routing","proof"],"scopeKinds":["product","proof"]}
 JSON
   exit 1
 fi
@@ -57,11 +57,11 @@ BODY_PATH="$TMP/body.md"
 cat > "$BODY_PATH" <<'EOF'
 ## Summary
 
-Adds orphaned-PR repair and tighter maintenance-worker routing.
+Makes Slack planning drafts, approval buttons, and thinking placeholders recoverable.
 
 ## Review Claim
 
-Unmapped broken pull requests receive one deduplicated repair workflow.
+Slack planning state remains actionable after restarts and reconnects.
 
 ## Review Lane
 
@@ -73,23 +73,22 @@ routing
 
 ## Safety Invariant
 
-Mapped PRs remain owned by their existing workers.
+A draft remains separate from execution until its existing approval action runs.
 
 ## Slice Rationale
 
-Worker coordination ships after the orphan classifier so failed PRs have one owner.
+Recovery mechanics precede the new planning-intent entry gate.
 
 ## Non-goals
 
-- No manual stack split.
+Does not change the final workflow execution API.
 
 ## Test Plan
 
 <details>
 <summary>Test Plan</summary>
 
-- [x] `bash scripts/repro/repro-pr-orphan-repair.sh`
-
+- [x] pnpm --filter @invoker/surfaces test
 </details>
 
 ## Revert Plan
@@ -98,17 +97,16 @@ Worker coordination ships after the orphan classifier so failed PRs have one own
 <summary>Revert Plan</summary>
 
 - Safe to revert? Yes
-- Revert command: `git revert <sha>`
+- Revert command: git revert bef53b9
 - Post-revert steps: None
 - Data migration? No
-
 </details>
 EOF
 export BODY_PATH
 
 REMOTE="$TMP/origin.git"
 SEED="$TMP/seed"
-WORK_ROOT="$WORK_PARENT/5803"
+WORK_ROOT="$WORK_PARENT/5804"
 STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
 LEDGER_PATH="$TMP/ledger.jsonl"
 export STATE_PATH
@@ -124,14 +122,14 @@ head = os.environ['ORIGINAL_HEAD']
 state = {
     'prs': [
         {
-            'number': 5803,
-            'title': '[PR maintenance](14) Repair orphaned and failed pull requests',
+            'number': 5804,
+            'title': '[Slack planning](15) Make plan submission and confirmation recoverable',
             'body': body,
-            'url': 'https://github.com/fake/repo/pull/5803',
+            'url': 'https://github.com/fake/repo/pull/5804',
             'state': 'OPEN',
             'isDraft': False,
             'baseRefName': 'stack/base',
-            'headRefName': 'stack/5803',
+            'headRefName': 'stack/5804',
             'headRefOid': head,
             'mergeStateStatus': 'UNSTABLE',
             'mergeable': 'MERGEABLE',
@@ -140,7 +138,7 @@ state = {
             'checks': {'*': 'SUCCESS', 'PR Body': 'FAILURE'},
         }
     ],
-    'issue_comments': {'5803': []},
+    'issue_comments': {'5804': []},
 }
 Path(os.environ['STATE_PATH']).write_text(json.dumps(state, indent=2), encoding='utf-8')
 PY
@@ -151,23 +149,22 @@ assert_first_run_state() {
 import json
 import os
 from pathlib import Path
-ledger_path = Path(os.environ['LEDGER_PATH'])
-rows = [json.loads(line) for line in ledger_path.read_text(encoding='utf-8').splitlines() if line.strip()]
-if not any(row.get('kind') == 'repair-check' and row.get('pr') == 5803 and row.get('key') == 'PR Body' for row in rows):
-    raise SystemExit('missing repair-check ledger row for PR #5803')
-invalid = next((row for row in rows if row.get('kind') == 'repair-invalid' and row.get('pr') == 5803 and row.get('key') == 'PR Body'), None)
+rows = [json.loads(line) for line in Path(os.environ['LEDGER_PATH']).read_text(encoding='utf-8').splitlines() if line.strip()]
+invalid = next((row for row in rows if row.get('kind') == 'repair-invalid' and row.get('pr') == 5804 and row.get('key') == 'PR Body'), None)
 if invalid is None:
-    raise SystemExit('missing repair-invalid ledger row for PR #5803')
+    raise SystemExit('missing repair-invalid row for PR #5804')
 errors = (invalid.get('meta') or {}).get('errors') or []
+if not any('cannot ship with proof files' in str(item) for item in errors):
+    raise SystemExit('repair-invalid row missing proof-file split reason')
 if not any('human stack split required' in str(item) for item in errors):
     raise SystemExit('repair-invalid row missing manual split note')
 state = json.loads(Path(os.environ['STATE_PATH']).read_text(encoding='utf-8'))
-comments = state.get('issue_comments', {}).get('5803', [])
+comments = state.get('issue_comments', {}).get('5804', [])
 if len(comments) != 1:
     raise SystemExit(f'expected exactly one stop comment, saw {len(comments)}')
 body = comments[0].get('body', '')
-if 'Split this into one Review Unit per PR.' not in body:
-    raise SystemExit('stop comment missing split guidance')
+if 'cannot ship with proof files' not in body:
+    raise SystemExit('stop comment missing proof-file split reason')
 if 'human stack split required' not in body:
     raise SystemExit('stop comment missing manual split note')
 PY
@@ -179,7 +176,7 @@ import json
 import os
 from pathlib import Path
 state = json.loads(Path(os.environ['STATE_PATH']).read_text(encoding='utf-8'))
-comments = state.get('issue_comments', {}).get('5803', [])
+comments = state.get('issue_comments', {}).get('5804', [])
 expected = int(os.environ['expected'])
 actual = len(comments)
 if actual != expected:
@@ -205,16 +202,16 @@ git clone . "$SEED" >/dev/null
   git add base.txt
   git commit -m 'base branch' >/dev/null
   git push publish stack/base >/dev/null
-  git switch -c stack/5803 stack/base >/dev/null
-  mkdir -p packages/execution-engine/src/workers scripts/repro
-  printf 'route\n' > packages/execution-engine/src/workers/pr-maintenance-workers.ts
-  printf '# repro\n' > scripts/repro/repro-pr-orphan-repair.sh
-  git add packages/execution-engine/src/workers/pr-maintenance-workers.ts scripts/repro/repro-pr-orphan-repair.sh
-  git commit -m 'mixed review units' >/dev/null
-  git push publish stack/5803 >/dev/null
+  git switch -c stack/5804 stack/base >/dev/null
+  mkdir -p packages/surfaces/src/slack scripts/repro
+  printf 'planning\n' > packages/surfaces/src/slack/plan-conversation.ts
+  printf '# repro\n' > scripts/repro/repro-slack-plan-intent-confirm.sh
+  git add packages/surfaces/src/slack/plan-conversation.ts scripts/repro/repro-slack-plan-intent-confirm.sh
+  git commit -m 'mixed behavior and proof slice' >/dev/null
+  git push publish stack/5804 >/dev/null
 )
 git --git-dir="$REMOTE" symbolic-ref HEAD refs/heads/master
-ORIGINAL_HEAD="$(git -C "$SEED" rev-parse stack/5803)"
+ORIGINAL_HEAD="$(git -C "$SEED" rev-parse stack/5804)"
 export ORIGINAL_HEAD
 
 git clone "$REMOTE" "$WORK_ROOT" >/dev/null
@@ -227,30 +224,17 @@ fi
 printf '%s\n' "$out1"
 assert_first_run_state
 
+: > "$LEDGER_PATH"
 if ! out2="$(run_worker)"; then
-  fail 'tick 2: worker failed' "$out2"
+  fail 'tick 2: worker failed after ledger loss' "$out2"
 fi
 printf '%s\n' "$out2"
 case "$out2" in
-  *'repair-check PR #5803'*) fail 'tick 2: worker retried the same impossible PR Body fix' "$out2" ;;
+  *'repair-check PR #5804'*) fail 'tick 2: worker retried existing proof split stop after ledger loss' "$out2" ;;
 esac
 case "$out2" in
   *'"reason": "blocked-needs-human"'*) ;;
-  *) fail 'tick 2: worker did not surface blocked-needs-human wait state' "$out2" ;;
-esac
-assert_stop_comment_count 1
-
-: > "$LEDGER_PATH"
-if ! out3="$(run_worker)"; then
-  fail 'tick 3: worker failed after ledger loss' "$out3"
-fi
-printf '%s\n' "$out3"
-case "$out3" in
-  *'repair-check PR #5803'*) fail 'tick 3: worker retried existing split-only stop after ledger loss' "$out3" ;;
-esac
-case "$out3" in
-  *'"reason": "blocked-needs-human"'*) ;;
-  *) fail 'tick 3: worker did not keep blocked-needs-human wait state after ledger loss' "$out3" ;;
+  *) fail 'tick 2: worker did not keep blocked-needs-human wait state after ledger loss' "$out2" ;;
 esac
 assert_stop_comment_count 1
 

--- a/scripts/repro/repro-babysit-pr-body-valid-noop.sh
+++ b/scripts/repro/repro-babysit-pr-body-valid-noop.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-pr-body-valid-noop.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+WORK_PARENT="$HOME/.invoker/mergify-admin-requeue-work"
+mkdir -p "$WORK_PARENT" "$TMP/state" "$TMP/bin"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export CLAUDE_CALLED="$TMP/claude-called"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+cat > "$TMP/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "claude was called for a locally valid PR Body failure" > "$CLAUDE_CALLED"
+exit 42
+EOF
+chmod +x "$TMP/bin/claude"
+
+REMOTE="$TMP/origin.git"
+SEED="$TMP/seed"
+WORK_ROOT="$WORK_PARENT/5810"
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+export STATE_PATH
+
+write_state() {
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = os.environ['ORIGINAL_HEAD']
+body = """## Summary
+
+Routes owner build identity through the owner ping handshake.
+
+## Review Claim
+
+Owner routing refuses mismatched owners before forwarding requests.
+
+## Review Lane
+
+behavior
+
+## Review Unit
+
+routing
+
+## Safety Invariant
+
+The new field is optional and does not change the common owner response shape.
+
+## Slice Rationale
+
+This is one behavior change in the owner message-bus route.
+
+## Non-goals
+
+Does not change the rendered application UI.
+
+## Architecture
+
+### Before
+
+```mermaid
+graph TD
+    A["process pings owner"] --> B["owner answers without build identity"]
+```
+
+### After
+
+```mermaid
+graph TD
+    A["process pings owner"] --> B["owner answers with build identity"]
+```
+
+## Visual Proof
+
+Not applicable. This only changes internal owner-routing behavior.
+
+## Test Plan
+
+<details>
+<summary>Test Plan</summary>
+
+- [x] pnpm --filter @invoker/app test -- owner-build-mismatch
+
+</details>
+
+## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
+
+- Safe to revert? Yes
+- Revert command: git revert <sha>
+- Post-revert steps: None
+- Data migration? No
+
+</details>
+"""
+state = {
+    'prs': [
+        {
+            'number': 5810,
+            'title': 'Stale PR Body failure with valid local body',
+            'body': body,
+            'url': 'https://github.com/fake/repo/pull/5810',
+            'state': 'OPEN',
+            'isDraft': False,
+            'baseRefName': 'master',
+            'headRefName': 'stack/5810',
+            'headRefOid': head,
+            'mergeStateStatus': 'BLOCKED',
+            'mergeable': 'MERGEABLE',
+            'labels': ['admin-bypass'],
+            'reviewThreads': [],
+            'checks': {'*': 'SUCCESS', 'PR Body': 'FAILURE'},
+        }
+    ],
+    'issue_comments': {'5810': []},
+    'job_logs': {'2': ''},
+}
+Path(os.environ['STATE_PATH']).write_text(json.dumps(state, indent=2), encoding='utf-8')
+PY
+}
+
+run_worker() {
+  python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5810 2>&1
+}
+
+git clone . "$SEED" >/dev/null
+(
+  cd "$SEED"
+  git config user.email repro@example.test
+  git config user.name 'Repro Bot'
+  git checkout -B master >/dev/null
+  git init --bare "$REMOTE" >/dev/null
+  git remote add publish "$REMOTE"
+  git push publish master >/dev/null
+  git switch -c stack/5810 master >/dev/null
+  printf '\n// stale PR Body noop repro\n' >> packages/app/src/owner-endpoint.ts
+  git add packages/app/src/owner-endpoint.ts
+  git commit -m 'owner build route repro' >/dev/null
+  git push publish stack/5810 >/dev/null
+)
+git --git-dir="$REMOTE" symbolic-ref HEAD refs/heads/master
+ORIGINAL_HEAD="$(git -C "$SEED" rev-parse stack/5810)"
+export ORIGINAL_HEAD
+git clone "$REMOTE" "$WORK_ROOT" >/dev/null
+( cd "$WORK_ROOT" && git config user.email repro@example.test && git config user.name 'Repro Bot' )
+write_state
+
+if ! out1="$(run_worker)"; then
+  fail 'tick 1: worker failed on locally valid PR Body' "$out1"
+fi
+printf '%s\n' "$out1"
+
+[ ! -f "$CLAUDE_CALLED" ] || fail 'tick 1: worker invoked Claude for locally valid PR Body' "$(cat "$CLAUDE_CALLED")"
+echo "$out1" | grep -q 'admin-bypass-pr-body-valid-noop' || fail 'tick 1: missing PR Body valid-noop trace' "$out1"
+echo "$out1" | grep -q 'admin-bypass-repair-noop' || fail 'tick 1: missing repair-noop trace' "$out1"
+grep -q '"kind": "repair-noop".*"pr": 5810' "$LEDGER_PATH" \
+  || fail 'tick 1: repair noop was not recorded' "$(cat "$LEDGER_PATH")"
+
+if ! out2="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5810 2>&1)"; then
+  fail 'tick 2: dry-run failed after PR Body noop' "$out2"
+fi
+printf '%s\n' "$out2"
+
+! echo "$out2" | grep -q 'DRY-RUN repair-check PR #5810 check="PR Body"' \
+  || fail 'tick 2: worker retried suppressed PR Body failure' "$out2"
+echo "$out2" | grep -q 'DRY-RUN requeue PR #5810' \
+  || fail 'tick 2: worker did not advance to requeue after PR Body noop' "$out2"
+
+echo '[repro] passed'

--- a/scripts/repro/repro-babysit-queue-only-empty-log.sh
+++ b/scripts/repro/repro-babysit-queue-only-empty-log.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-queue-only-empty-log.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+WORK_PARENT="$HOME/.invoker/mergify-admin-requeue-work"
+mkdir -p "$WORK_PARENT" "$TMP/state" "$TMP/bin"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export CLAUDE_CALLED="$TMP/claude-called"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+cat > "$TMP/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "claude was called for an empty queue-only log" > "$CLAUDE_CALLED"
+exit 42
+EOF
+chmod +x "$TMP/bin/claude"
+
+REMOTE="$TMP/origin.git"
+SEED="$TMP/seed"
+WORK_ROOT="$WORK_PARENT/5810"
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+export STATE_PATH
+
+write_state() {
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = os.environ['ORIGINAL_HEAD']
+state = {
+    'prs': [
+        {
+            'number': 5810,
+            'title': 'Queue-only guardrails empty log',
+            'body': '## Summary\n\nQueue-only repro with an empty Guardrails log.\n',
+            'url': 'https://github.com/fake/repo/pull/5810',
+            'state': 'OPEN',
+            'isDraft': False,
+            'baseRefName': 'master',
+            'headRefName': 'stack/5810',
+            'headRefOid': head,
+            'mergeStateStatus': 'BLOCKED',
+            'mergeable': 'MERGEABLE',
+            'labels': ['dequeued'],
+            'reviewThreads': [],
+            'checks': {
+                '*': 'SUCCESS',
+                'PR Body': 'FAILURE',
+                'required-fast / Guardrails': None,
+            },
+        }
+    ],
+    'issue_comments': {
+        '5810': [
+            {
+                'id': 'm5810',
+                'user': {'login': 'mergify[bot]'},
+                'updated_at': '2026-07-20T00:00:00Z',
+                'html_url': 'https://github.com/fake/repo/pull/5810#m5810',
+                'body': (
+                    '-*- Mergify Payload -*-\n'
+                    '{"state":"dequeued","queue_rule_name":"admin-bypass"}\n\n'
+                    '- ❌ **Checks failed** · on draft #5816\n'
+                    f'- 🚫 **Left the queue** — `2026-07-20 00:00 UTC` · at `{head}`\n\n'
+                    '## Failing checks\n\n'
+                    '- [required-fast / Guardrails](https://github.com/fake/repo/actions/runs/1/job/2)\n'
+                ),
+            }
+        ]
+    },
+    'job_logs': {
+        '2': '',
+    },
+}
+Path(os.environ['STATE_PATH']).write_text(json.dumps(state, indent=2), encoding='utf-8')
+PY
+}
+
+run_worker() {
+  python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5810 2>&1
+}
+
+git clone . "$SEED" >/dev/null
+(
+  cd "$SEED"
+  git config user.email repro@example.test
+  git config user.name 'Repro Bot'
+  git checkout -B master >/dev/null
+  git init --bare "$REMOTE" >/dev/null
+  git remote add publish "$REMOTE"
+  git push publish master >/dev/null
+  git switch -c stack/5810 master >/dev/null
+  echo queue-only-empty-log > queue-only-empty-log.txt
+  git add queue-only-empty-log.txt
+  git commit -m 'queue only empty log slice' >/dev/null
+  git push publish stack/5810 >/dev/null
+)
+git --git-dir="$REMOTE" symbolic-ref HEAD refs/heads/master
+ORIGINAL_HEAD="$(git -C "$SEED" rev-parse stack/5810)"
+export ORIGINAL_HEAD
+git clone "$REMOTE" "$WORK_ROOT" >/dev/null
+( cd "$WORK_ROOT" && git config user.email repro@example.test && git config user.name 'Repro Bot' )
+write_state
+
+if ! out1="$(run_worker)"; then
+  fail 'tick 1: worker failed on empty queue-only log' "$out1"
+fi
+printf '%s\n' "$out1"
+
+[ ! -f "$CLAUDE_CALLED" ] || fail 'tick 1: worker invoked Claude for empty queue-only log' "$(cat "$CLAUDE_CALLED")"
+echo "$out1" | grep -q 'admin-bypass-queue-only-empty-log-noop' || fail 'tick 1: missing empty-log noop trace' "$out1"
+echo "$out1" | grep -q 'admin-bypass-queue-only-noop' || fail 'tick 1: missing queue-only noop trace' "$out1"
+
+if ! grep -q '"kind": "queue-only-noop".*"pr": 5810' "$LEDGER_PATH"; then
+  fail 'tick 1: queue-only noop was not recorded' "$(cat "$LEDGER_PATH")"
+fi
+
+if ! out2="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5810 2>&1)"; then
+  fail 'tick 2: dry-run failed after empty queue-only noop' "$out2"
+fi
+printf '%s\n' "$out2"
+
+! echo "$out2" | grep -q 'DRY-RUN repair-check PR #5810 check="required-fast / Guardrails"' \
+  || fail 'tick 2: worker retried suppressed queue-only Guardrails failure' "$out2"
+echo "$out2" | grep -q 'DRY-RUN repair-check PR #5810 check="PR Body"' \
+  || fail 'tick 2: worker did not move on to the remaining PR-head blocker' "$out2"
+
+echo '[repro] passed'

--- a/scripts/repro/repro-babysit-queue-only-missing-requeues.sh
+++ b/scripts/repro/repro-babysit-queue-only-missing-requeues.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-queue-only-missing-requeues.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+mkdir -p "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+CURRENT_HEAD="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+OLD_QUEUE_HEAD="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+export STATE_PATH CURRENT_HEAD OLD_QUEUE_HEAD
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+head = os.environ['CURRENT_HEAD']
+old = os.environ['OLD_QUEUE_HEAD']
+state = {
+    'prs': [
+        {
+            'number': 5801,
+            'title': 'Queue-only missing check requeue',
+            'body': '## Summary\n\nQueue-only missing checks are merge-queue checks.\n',
+            'url': 'https://github.com/fake/repo/pull/5801',
+            'state': 'OPEN',
+            'isDraft': False,
+            'baseRefName': 'master',
+            'headRefName': 'stack/5801',
+            'headRefOid': head,
+            'mergeStateStatus': 'BLOCKED',
+            'mergeable': 'MERGEABLE',
+            'labels': ['admin-bypass'],
+            'reviewThreads': [],
+            'checks': {
+                '*': 'SUCCESS',
+                'required-fast / Guardrails': None,
+                'required-fast / Submit Workflow Chain': None,
+                'required-fast / Vitest Workspace': None,
+            },
+        },
+        {
+            'number': 5803,
+            'title': 'Upper human-only split blocker',
+            'body': '## Summary\n\nUpper PR needs a human split.\n',
+            'url': 'https://github.com/fake/repo/pull/5803',
+            'state': 'OPEN',
+            'isDraft': False,
+            'baseRefName': 'stack/5801',
+            'headRefName': 'stack/5803',
+            'headRefOid': 'cccccccccccccccccccccccccccccccccccccccc',
+            'mergeStateStatus': 'UNSTABLE',
+            'mergeable': 'MERGEABLE',
+            'labels': ['admin-bypass'],
+            'reviewThreads': [],
+            'checks': {'*': 'SUCCESS', 'PR Body': 'FAILURE'},
+        }
+    ],
+    'issue_comments': {
+        '5801': [
+            {
+                'id': 'm5801-old',
+                'user': {'login': 'mergify[bot]'},
+                'updated_at': '2026-07-20T00:00:00Z',
+                'html_url': 'https://github.com/fake/repo/pull/5801#m5801-old',
+                'body': (
+                    '-*- Mergify Payload -*-\n'
+                    '{"state":"dequeued","queue_rule_name":"admin-bypass"}\n\n'
+                    f'- 🚫 **Left the queue** — `2026-07-20 00:00 UTC` · at `{old}`\n\n'
+                    '## Reason\n\nThe pull request conflicts with the base branch\n'
+                ),
+            }
+        ],
+        '5803': [
+            {
+                'id': 'stop-5803',
+                'user': {'login': 'EdbertChan'},
+                'updated_at': '2026-07-20T00:01:00Z',
+                'html_url': 'https://github.com/fake/repo/pull/5803#stop-5803',
+                'body': 'Mergify repair stopped: worker cannot auto-split this PR on a non-trunk base; human stack split required',
+            }
+        ],
+    },
+}
+Path(os.environ['STATE_PATH']).write_text(json.dumps(state, indent=2), encoding='utf-8')
+PY
+
+if ! out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5801 2>&1)"; then
+  fail 'worker dry-run failed' "$out"
+fi
+printf '%s\n' "$out"
+
+case "$out" in
+  *'BLOCK PR #5801 missing-check'*) fail 'worker blocked on queue-only missing check' "$out" ;;
+esac
+case "$out" in
+  *'DRY-RUN requeue PR #5801'*) ;;
+  *) fail 'worker did not requeue clean bottom PR with only queue-only checks missing' "$out" ;;
+esac
+
+echo '[repro] passed'

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -312,6 +312,11 @@ Failing checks
         actions = plan_stack_actions(stack, REQUIRED, ledger, 2)
         self.assertEqual([(a.kind, a.key) for a in actions], [("resolve_bot_threads", "tbot")])
 
+    def test_outdated_bot_thread_resolves_without_repair(self):
+        stack = StackGroup("s", (pr(2608, threads=(ReviewThread("tbot", False, ("coderabbitai[bot]",), True),), latest=mergify()),))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.key) for a in actions], [("resolve_bot_threads", "tbot")])
+
     def test_conflict_uses_claude_repair_cap(self):
         stack = StackGroup("s", (pr(2609, merge_state="DIRTY", latest=mergify()),))
         ledger = self.ledger()
@@ -471,16 +476,57 @@ Failing checks
         git_rev_parse = iter([HEAD, HEAD])
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
-                with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                    with mock.patch.object(repairer, "git_lines", return_value=()):
-                        with mock.patch.object(repairer, "run_claude_repair") as repair:
-                            with redirect_stderr(stderr):
-                                result = repairer.repair_check(item, "required-fast / Guardrails")
+                with mock.patch.object(repairer, "job_log_has_evidence", return_value=True):
+                    with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
+                        with mock.patch.object(repairer, "git_lines", return_value=()):
+                            with mock.patch.object(repairer, "run_claude_repair") as repair:
+                                with redirect_stderr(stderr):
+                                    result = repairer.repair_check(item, "required-fast / Guardrails")
         checkout.assert_called_once()
         repair.assert_called_once()
         self.assertEqual(result.status, "queue_only_noop")
         self.assertIn("Queue draft PR: #5854", repair.call_args.args[1])
         self.assertIn("Job log path: /tmp/guardrails.log", repair.call_args.args[1])
+
+    def test_queue_only_repair_empty_job_log_returns_noop_without_claude(self):
+        latest = MergifyQueueEvent(
+            "m5811",
+            "dequeued",
+            "admin-bypass",
+            "2026-07-03T06:13:00Z",
+            HEAD,
+            (),
+            ("required-fast / Guardrails",),
+            "https://github.com/Neko-Catpital-Labs/Invoker/pull/5811#issuecomment-1",
+            5854,
+            (("required-fast / Guardrails", ("https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/1/job/2",)),),
+        )
+        item = pr(5811, labels={"dequeued"}, checks={}, latest=latest)
+        repairer = self.repairer(object(), self.ledger())
+        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
+            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
+                with mock.patch.object(repairer, "job_log_has_evidence", return_value=False):
+                    with mock.patch.object(repairer, "git_output", return_value=HEAD):
+                        with mock.patch.object(repairer, "run_claude_repair") as repair:
+                            result = repairer.repair_check(item, "required-fast / Guardrails")
+        checkout.assert_called_once()
+        repair.assert_not_called()
+        self.assertEqual(result.status, "queue_only_noop")
+
+    def test_pr_body_valid_local_repair_returns_noop_without_claude(self):
+        item = pr(5810, checks={"PR Body": check("PR Body", "failure")}, body=PROOF_BODY)
+        repairer = self.repairer(object(), self.ledger())
+        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
+            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log") as download:
+                with mock.patch.object(repairer, "job_log_is_empty", return_value=True):
+                    with mock.patch.object(repairer, "git_output", return_value=HEAD):
+                        with mock.patch.object(repairer, "validate_current_pr_body", return_value={"valid": True}):
+                            with mock.patch.object(repairer, "run_claude_repair") as repair:
+                                result = repairer.repair_check(item, "PR Body")
+        checkout.assert_called_once()
+        download.assert_called_once()
+        repair.assert_not_called()
+        self.assertEqual(result.status, "noop")
     def test_run_cycle_logs_selected_bottom_repair_context(self):
         args = requeue.parse_args(["--once", "--dry-run", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
         stack = StackGroup("s", (pr(2606, checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}, latest=mergify()),))

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -108,14 +108,27 @@ class ClassifyPr(unittest.TestCase):
     def test_human_vs_bot_review_threads(self):
         human = pr(review_threads=(m.ReviewThread("t", False, ("alice",)),))
         bot = pr(review_threads=(m.ReviewThread("t", False, ("coderabbitai[bot]",)),))
+        outdated = pr(review_threads=(m.ReviewThread("t", False, ("coderabbitai[bot]",), True),))
         self.assertIn("human_review_thread", self._kinds(human))
         self.assertIn("bot_review_thread", self._kinds(bot))
+        self.assertIn("outdated_bot_review_thread", self._kinds(outdated))
 
     def test_merge_hold_label(self):
         self.assertIn("merge_hold", self._kinds(pr(labels=frozenset({"merge-hold"}))))
 
 
 class EffectiveBlockers(unittest.TestCase):
+    def test_queue_only_missing_check_is_not_pr_head_blocker(self):
+        snapshot = pr(checks={})
+        kinds = {
+            b.kind for b in p.effective_blockers(
+                snapshot,
+                {QUEUE_ONLY_CHECK},
+                trunk="master",
+            )
+        }
+        self.assertNotIn("missing_check", kinds)
+
     def test_mergify_success_condition_clears_missing_check(self):
         # classify_pr flags "build" as missing, but the current Mergify event
         # says that condition passed -> the loader-derived blocker is dropped.
@@ -215,6 +228,35 @@ class BuildStackFacts(PlannerTestCase):
         self.assertEqual(facts.suppressed_failed_checks_by_pr, {10: (QUEUE_ONLY_CHECK,)})
         self.assertEqual(facts.blockers_by_pr[10], ())
 
+    def test_pr_body_noop_suppresses_stale_failed_check_on_bottom(self):
+        ledger = self._ledger()
+        ledger.record("queue-only-noop", 10, HEAD, QUEUE_ONLY_CHECK, 1)
+        ledger.record("repair-noop", 10, HEAD, "PR Body", 2)
+        facts, _ = self._facts(
+            m.StackGroup(
+                "s",
+                (
+                    pr(
+                        number=10,
+                        labels=frozenset({"dequeued"}),
+                        checks={"PR Body": check("failure", "PR Body")},
+                        latest_mergify=event(
+                            state="dequeued",
+                            comment_id="cm10",
+                            failing=(QUEUE_ONLY_CHECK,),
+                        ),
+                    ),
+                ),
+            ),
+            required_checks={"PR Body", QUEUE_ONLY_CHECK},
+            ledger=ledger,
+            open_pr_numbers={10},
+        )
+        self.assertEqual(facts.suppressed_failed_checks_by_pr, {10: (QUEUE_ONLY_CHECK, "PR Body")})
+        self.assertEqual(facts.blockers_by_pr[10], ())
+        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        self.assertEqual([(action.kind, action.key) for action in actions], [("restore_admin_bypass_label", QUEUE_ONLY_CHECK)])
+
     def test_detects_bottom_and_unaccepted_upper(self):
         facts, _ledger = self._facts(
             m.StackGroup(
@@ -263,10 +305,33 @@ class PlanStackActions(PlannerTestCase):
         actions = self._plan(snapshot)
         self.assertEqual((actions[0].kind, actions[0].detail), ("requeue", "eligible-after-dequeue"))
 
+    def test_queued_label_with_headless_active_queue_event_waits(self):
+        snapshot = pr(labels=frozenset({"admin-bypass", "queued"}), latest_mergify=event(state="queued", head=""))
+        actions = self._plan(snapshot)
+        self.assertEqual(actions, ())
+
     def test_clean_bottom_queues_without_prior_dequeue(self):
         snapshot = pr(labels=frozenset({"admin-bypass"}))
         actions = self._plan(snapshot)
         self.assertEqual((actions[0].kind, actions[0].detail), ("requeue", "eligible-when-ready"))
+
+    def test_upper_human_decision_does_not_block_clean_bottom_requeue(self):
+        bottom = pr(number=10, head_ref_name="stack/bottom", labels=frozenset({"admin-bypass"}))
+        upper = pr(
+            number=11,
+            base_ref_name="stack/bottom",
+            labels=frozenset({"admin-bypass"}),
+            checks={"build": check("failure")},
+            repair_stop_comments=(
+                m.RepairStopComment(
+                    "Mergify repair stopped: worker cannot auto-split this PR on a non-trunk base; human stack split required",
+                    "2026-07-20T00:00:00Z",
+                    "EdbertChan",
+                ),
+            ),
+        )
+        actions = self._plan(m.StackGroup("s", (bottom, upper)))
+        self.assertEqual((actions[0].kind, actions[0].pr_number), ("requeue", 10))
 
     def test_requeue_is_capped_after_repeated_attempts(self):
         ledger = self._ledger()

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -115,13 +115,14 @@ class ReviewThreadsParsing(unittest.TestCase):
             "pageInfo": {"hasNextPage": False},
             "nodes": [
                 {"id": "t1", "isResolved": False,
+                 "isOutdated": True,
                  "comments": {"nodes": [{"author": {"login": "coderabbitai[bot]"}}]}},
                 {"id": "t2", "isResolved": True, "comments": {"nodes": []}},
             ],
         }
         self.assertEqual(
             s.review_threads(value),
-            (m.ReviewThread("t1", False, ("coderabbitai[bot]",)),
+            (m.ReviewThread("t1", False, ("coderabbitai[bot]",), True),
              m.ReviewThread("t2", True, ())),
         )
 


### PR DESCRIPTION
## Summary

This slice wires the babysit worker to act on the new stuck-PR repro cases.

It restores `admin-bypass` after queue-only dequeues, resolves old bot threads, and turns queue-log or PR Body noops into exact worker actions or exact human blockers.

## Review Claim

The babysit worker keeps moving real `admin-bypass` / `dequeued` PRs forward, and it stops once with an exact human-only reason when it cannot act safely.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The worker acts only through its own repair, comment, and queue paths for the targeted PR set. It does not manually requeue, relabel, merge, split, rebase, or force-push the real target PR branches.

## Slice Rationale

The repro artifacts live in the earlier proof slice. This slice is only the worker-side follow-through that consumes those cases and keeps the live babysit loop moving.

## Non-goals

- No new repro fixtures.
- No queue-rule changes outside the worker.
- No unrelated refactors.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts/test_mergify_admin_requeue.py scripts/test_mergify_admin_requeue_model.py scripts/test_mergify_admin_requeue_plan.py scripts/test_mergify_admin_requeue_snapshot.py`
- [x] `bash scripts/test-suites/required/12-mergify-admin-requeue.sh`
- [x] `bash ./loop-driver.sh`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/pr5948-body.md --base stack/EdbertChan/babysit-loop-proof-clean--4013cbb12`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 06718a311`
- Post-revert steps: None
- Data migration? No

</details>
