### PR TITLE
[PR Publication Guardrails](1) Reject stale stacked publication shapes

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -619,6 +619,59 @@ function assertCleanPrBase(baseBranch) {
     ].join('\n'),
   );
 }
+function assertStackHeadForStackedBase(baseBranch, currentBranch, mergifyState) {
+  if (!isStackedPrContext(baseBranch, mergifyState)) return;
+  if (!baseBranch.startsWith('stack/')) return;
+  if (currentBranch.startsWith('stack/')) return;
+  const baseRef = TRUNK_BRANCHES.has(baseBranch) ? 'origin/master' : 'origin/<live-stack-base>';
+  throw new Error(
+    [
+      'Refusing to create/update PR: stacked publication requires a stack/ head branch.',
+      `Current branch: ${currentBranch}`,
+      `Requested base: ${baseBranch}`,
+      '',
+      'Recovery:',
+      `  git switch -c stack/<name> ${baseRef}`,
+      '  git cherry-pick <commit> [<commit> ...]',
+      '  publish through the supported stack flow in docs/pr-branching-workflow.md',
+    ].join('\n'),
+  );
+}
+
+function assertOpenHelperBasePr(nwo, baseBranch, dryRun) {
+  if (!baseBranch.startsWith('pr/')) return;
+  if (dryRun) return;
+
+  const prs = listPullRequestsForHead(nwo, baseBranch);
+  if (prs.length === 0) return;
+  if (prs.length > 1) {
+    const choices = prs.map((pr) => `  - #${pr.number}: ${pr.html_url}`).join('\n');
+    throw new Error(
+      [
+        `Found multiple PRs for base branch "${baseBranch}" in ${nwo}.`,
+        'Refusing to guess. Resolve the duplicate helper-base PRs first.',
+        choices,
+      ].join('\n'),
+    );
+  }
+
+  const [pr] = prs;
+  if (pr.state === 'OPEN') return;
+
+  const helperState = pr.merged_at ? 'merged helper PR' : 'closed helper PR';
+  throw new Error(
+    [
+      `Refusing to create/update PR: base branch "${baseBranch}" belongs to a stale helper PR.`,
+      `Found ${helperState} #${pr.number}: ${pr.html_url}`,
+      '',
+      'Recovery:',
+      '  git switch -c stack/<name> origin/<live-stack-base>',
+      '  git cherry-pick <commit> [<commit> ...]',
+      '  publish through the supported stack flow in docs/pr-branching-workflow.md',
+    ].join('\n'),
+  );
+}
+
 
 function getBranchMergeRef(branch) {
   return gitTextOrEmpty(['config', '--get', `branch.${branch}.merge`]);
@@ -789,6 +842,15 @@ async function main() {
 
   assertCleanPrBase(args.base);
 
+  const currentBranch = getCurrentBranch();
+  const mergifyState = getMergifyBranchState(currentBranch);
+  assertStackHeadForStackedBase(args.base, currentBranch, mergifyState);
+  let nwo = '';
+  if (args.base.startsWith('pr/')) {
+    nwo = args.dryRun ? 'OWNER/REPO' : getRepoNwo();
+    assertOpenHelperBasePr(nwo, args.base, args.dryRun);
+  }
+
   let body = '';
   if (args.bodyFile) {
     body = readFileSync(args.bodyFile, 'utf-8');
@@ -808,8 +870,6 @@ async function main() {
   printPrBodyWarnings(body, changedFiles, diffText);
   body = await injectImages(body, args.dryRun);
 
-  const currentBranch = getCurrentBranch();
-  const mergifyState = getMergifyBranchState(currentBranch);
   const requestedUpdatePath = Boolean(args.update || args.updateExisting);
   if (mergifyState.managed && !requestedUpdatePath) {
     throw new Error(
@@ -831,12 +891,13 @@ async function main() {
     assertValidStackPrTitle(args.title);
   }
 
-  const nwo = args.dryRun ? 'OWNER/REPO' : getRepoNwo();
+  if (!nwo) {
+    nwo = args.dryRun ? 'OWNER/REPO' : getRepoNwo();
+  }
   let updatePrNumber = args.update;
   if (args.updateExisting) {
     updatePrNumber = resolveExistingPrNumber(nwo, currentBranch, args.dryRun);
   }
-
   if (!(mergifyState.managed && requestedUpdatePath)) {
     gitPush(args.dryRun);
   }

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -357,6 +357,92 @@ function testStaleBaseDetection() {
     rmSync(harness.root, { recursive: true, force: true });
   }
 }
+function testStaleMergedHelperBaseRejectsPublication() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    gitQuiet(work, 'branch', 'pr/previous', 'origin/master');
+    gitQuiet(work, 'push', 'origin', 'pr/previous');
+    createTrackedBranch(work, 'feature/on-stale-helper', 'origin/pr/previous');
+    commitFile(work, 'feature.txt', 'feature\n', 'feature change');
+
+    const result = runCreatePr(work, harness, ['--title', 'test title', '--base', 'pr/previous', '--body-file', 'pr-body.md'], {
+      GH_API_PULLS_JSON: JSON.stringify([
+        {
+          number: 86,
+          state: 'closed',
+          merged_at: '2026-07-26T07:32:31Z',
+          html_url: 'https://example.com/pull/86',
+          head: { ref: 'pr/previous', repo: { full_name: 'owner/repo' } },
+        },
+      ]),
+    });
+
+    assert(result.status === 1, `stale merged helper base should fail\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert(
+      result.stderr.includes('Refusing to create/update PR: base branch "pr/previous" belongs to a stale helper PR.'),
+      `stale helper base error should explain the stale helper branch\nstderr:\n${result.stderr}`,
+    );
+    assert(result.stderr.includes('merged helper PR #86'), `stale helper base error should name the merged helper PR\nstderr:\n${result.stderr}`);
+    assert(result.stderr.includes('git switch -c stack/<name> origin/<live-stack-base>'), 'stale helper base error should include stack rebuild command');
+    assert(result.stderr.includes('git cherry-pick <commit> [<commit> ...]'), 'stale helper base error should include cherry-pick recovery');
+    expectNoPush(harness, 'stale merged helper base');
+    const ghCalls = readGhCalls(harness.ghLog);
+    assert(ghCalls.some((call) => call.route.includes('/pulls?')), 'stale helper base rejection should look up helper-base PRs');
+    assert(
+      !ghCalls.some((call) => /\/pulls(?:\/[0-9]+)?$/.test(call.route)),
+      `stale helper base rejection should fail before PR mutation\n${JSON.stringify(ghCalls, null, 2)}`,
+    );
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testDuplicateHelperBasePrsRejectPublication() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    gitQuiet(work, 'branch', 'pr/previous', 'origin/master');
+    gitQuiet(work, 'push', 'origin', 'pr/previous');
+    createTrackedBranch(work, 'feature/on-stale-helper', 'origin/pr/previous');
+    commitFile(work, 'feature.txt', 'feature\n', 'feature change');
+
+    const result = runCreatePr(work, harness, ['--title', 'test title', '--base', 'pr/previous', '--body-file', 'pr-body.md'], {
+      GH_API_PULLS_JSON: JSON.stringify([
+        {
+          number: 86,
+          state: 'open',
+          html_url: 'https://example.com/pull/86',
+          head: { ref: 'pr/previous', repo: { full_name: 'owner/repo' } },
+        },
+        {
+          number: 87,
+          state: 'closed',
+          html_url: 'https://example.com/pull/87',
+          head: { ref: 'pr/previous', repo: { full_name: 'owner/repo' } },
+        },
+      ]),
+    });
+
+    assert(result.status === 1, `duplicate helper-base PRs should fail\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert(
+      result.stderr.includes('Found multiple PRs for base branch "pr/previous"'),
+      `duplicate helper-base error should name the helper base\nstderr:\n${result.stderr}`,
+    );
+    assert(result.stderr.includes('Refusing to guess. Resolve the duplicate helper-base PRs first.'), 'duplicate helper-base error should refuse to guess');
+    assert(result.stderr.includes('#86: https://example.com/pull/86'), 'duplicate helper-base error should list PR #86');
+    assert(result.stderr.includes('#87: https://example.com/pull/87'), 'duplicate helper-base error should list PR #87');
+    expectNoPush(harness, 'duplicate helper-base PRs');
+    const ghCalls = readGhCalls(harness.ghLog);
+    assert(
+      !ghCalls.some((call) => /\/pulls(?:\/[0-9]+)?$/.test(call.route)),
+      `duplicate helper-base rejection should fail before PR mutation\n${JSON.stringify(ghCalls, null, 2)}`,
+    );
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
 
 function testNoFileChangesBlockPrCreation() {
   const harness = createHarness();
@@ -854,13 +940,15 @@ Keep entrypoint behavior separate from routing internals.
 function testStackedDiffTitleRequiredForNonTrunkBase() {
   const harness = createHarness();
   try {
+    const branch = 'stack/stacked-diff';
     const { work } = createRepo(harness);
-    gitQuiet(work, 'branch', 'pr/previous', 'origin/master');
-    gitQuiet(work, 'push', 'origin', 'pr/previous');
-    createTrackedBranch(work, 'pr/stacked-diff', 'origin/pr/previous');
+    gitQuiet(work, 'branch', 'stack/previous', 'origin/master');
+    gitQuiet(work, 'push', 'origin', 'stack/previous');
+    createTrackedBranch(work, branch, 'origin/stack/previous');
     commitFile(work, 'stacked.txt', 'stacked\n', 'stacked diff');
+    gitQuiet(work, 'push', '-u', 'origin', branch);
 
-    const result = runCreatePr(work, harness, ['--title', 'plain title', '--base', 'pr/previous', '--body-file', 'pr-body.md']);
+    const result = runCreatePr(work, harness, ['--title', 'plain title', '--base', 'stack/previous', '--body-file', 'pr-body.md', '--update-existing']);
 
     assert(result.status === 1, 'stacked diff PR should reject a plain title');
     assert(result.stderr.includes('Stack PR titles must start with a shared idea'), 'stacked diff title error should explain format');
@@ -870,6 +958,36 @@ function testStackedDiffTitleRequiredForNonTrunkBase() {
     rmSync(harness.root, { recursive: true, force: true });
   }
 }
+
+function testStackedBaseRequiresStackHead() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    gitQuiet(work, 'branch', 'stack/previous', 'origin/master');
+    gitQuiet(work, 'push', 'origin', 'stack/previous');
+    createTrackedBranch(work, 'pr/stacked-diff', 'origin/stack/previous');
+    commitFile(work, 'stacked.txt', 'stacked\n', 'stacked diff');
+
+    const result = runCreatePr(work, harness, stackTitleArgs('stack/previous'));
+
+    assert(result.status === 1, `stacked base should require a stack head branch\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert(
+      result.stderr.includes('Refusing to create/update PR: stacked publication requires a stack/ head branch.'),
+      `stacked head guard should explain the stack branch requirement\nstderr:\n${result.stderr}`,
+    );
+    assert(result.stderr.includes('Current branch: pr/stacked-diff'), 'stacked head guard should name the current branch');
+    assert(result.stderr.includes('Requested base: stack/previous'), 'stacked head guard should name the requested base');
+    expectNoPush(harness, 'stacked base requires stack head');
+    const ghCalls = readGhCalls(harness.ghLog);
+    assert(
+      !ghCalls.some((call) => /\/pulls(?:\/[0-9]+)?$/.test(call.route)),
+      `stacked head guard should fail before PR mutation\n${JSON.stringify(ghCalls, null, 2)}`,
+    );
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
 
 function testDiffAtomicityBlocksMixedDiff() {
   const harness = createHarness();
@@ -966,6 +1084,8 @@ function testHelpMentionsStackUpdateFlow() {
 
 const tests = [
   testStaleBaseDetection,
+  testStaleMergedHelperBaseRejectsPublication,
+  testDuplicateHelperBasePrsRejectPublication,
   testNoFileChangesBlockPrCreation,
   testEmptyCommitAloneBlocksPrCreation,
   testEmptyCommitMixedWithRealChangeBlocksPrCreation,
@@ -978,6 +1098,7 @@ const tests = [
   testCurrentBranchPrLookupFailure,
   testNonStackedUnrelatedAreasStayWarnings,
   testStackedDiffTitleRequiredForNonTrunkBase,
+  testStackedBaseRequiresStackHead,
   testDiffAtomicityBlocksMixedDiff,
   testCreatePrDryRunMatchesCiBodyValidation,
   testDiffComputationFailureBlocksPrCreation,


### PR DESCRIPTION
## Summary

This blocks two malformed stack publication paths before `create-pr` reads bodies, computes diffs, pushes branches, or edits GitHub PRs.

Stacked bases now require a `stack/` head branch. `pr/...` helper bases now must still belong to exactly one open helper PR.

The stack workflow harness now covers the live-stack title path, stale merged helpers, and duplicate helper PRs so the guard fails before push or PR mutation.

## Review Claim

`create-pr` refuses stale helper bases and non-`stack/` heads before any publication side effect.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the PR publication guard and its dedicated stack-workflow harness change. The new paths stop before `git push` or PR POST/PATCH, and `land-stack` stays unchanged.

## Slice Rationale

Keep the guard and harness together because the tests pin the exact refusal text and the fail-before-publish order.

## Non-goals

- Do not change `scripts/land-stack.mjs`.
- Do not add GitHub API requirements to dry-run mode.
- Do not change PR body validation or diff-atomicity rules outside these early publication refusals.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-create-pr-stack-workflow.mjs`
- [x] `node scripts/test-land-stack.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 80b55141a`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent publishing stacked changes from incompatible branch names.
  * Blocked updates targeting merged or closed helper pull requests.
  * Prevented publishing when multiple matching helper pull requests create ambiguity.
  * Added clearer error messages identifying invalid, stale, or ambiguous configurations.
  * Invalid requests now fail before any branch push or pull request creation/update occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->