### PR TITLE
[Continue babysit worker landing loop](1) Stop capped retries and sharpen human-only blockers

### DIFF
--- a/scripts/mergify_admin_requeue_gh_executor.py
+++ b/scripts/mergify_admin_requeue_gh_executor.py
@@ -70,11 +70,17 @@ class AdminBypassGhExecutor:
     def resolve_bot_threads(self, thread_id: str) -> None:
         self.gh.resolve_review_thread(thread_id)
 
-    def has_blocked_comment(self, pr: PrSnapshot, body: str) -> bool:
+    def has_blocked_comment(self, pr: PrSnapshot | int, body_or_detail: str) -> bool:
         if not hasattr(self.gh, "issue_comments"):
             return False
-        for comment in self.gh.issue_comments(self.repo, pr.number):
-            if str(comment.get("body") or "").strip() == body.strip():
+        if isinstance(pr, PrSnapshot):
+            pr_number = pr.number
+            body = body_or_detail.strip()
+        else:
+            pr_number = pr
+            body = f"Mergify repair stopped: {body_or_detail}".strip()
+        for comment in self.gh.issue_comments(self.repo, pr_number):
+            if str(comment.get("body") or "").strip() == body:
                 return True
         return False
 
@@ -84,6 +90,14 @@ class AdminBypassGhExecutor:
             if not self.has_blocked_comment(pr, body):
                 self.gh.comment(self.repo, pr.number, body)
             self.ledger.record("comment-blocked", pr.number, pr.head_ref_oid, key, now)
+            return
+        if (
+            key == "no-current-bottom"
+            and detail != "no current bottom on master"
+            and not self.has_blocked_comment(pr.number, detail)
+        ):
+            self.gh.comment(self.repo, pr.number, f"Mergify repair stopped: {detail}")
+            self.ledger.record("comment-blocked", pr.number, pr.head_ref_oid, "no-current-bottom:exact", now)
 
     def execute(self, action: Action, pr: PrSnapshot, now: int) -> None:
         self.logger.trace("admin-bypass-action-execute", action=self.logger.action_payload(action))
@@ -103,8 +117,7 @@ class AdminBypassGhExecutor:
             self.resolve_bot_threads(action.key)
             return
         if action.kind == "comment_blocked":
-            if action.key == "capped":
-                key = f"capped:{action.detail}"
-                self.comment_blocked(pr, action.detail, key, now)
+            key = f"capped:{action.detail}" if action.key == "capped" else action.key
+            self.comment_blocked(pr, action.detail, key, now)
             return
         raise ValueError(f"unsupported executor action: {action.kind}")

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -298,6 +298,29 @@ def existing_split_stop_blocker(pr: PrSnapshot, blocker: Blocker) -> Blocker | N
     return None
 
 
+def latest_mergify_repair_invalid_blockers(
+    pr: PrSnapshot,
+    ledger: Ledger,
+    suppressed_failed_checks: Collection[str],
+) -> tuple[Blocker, ...]:
+    latest = pr.latest_mergify
+    if not latest or latest.state != "dequeued" or latest.head_sha != pr.head_ref_oid:
+        return ()
+    suppressed = set(suppressed_failed_checks)
+    blockers: list[Blocker] = []
+    for name in latest.failing_checks:
+        if name in suppressed:
+            continue
+        blocker = latest_repair_invalid_blocker(
+            pr,
+            Blocker(name, "failed_check", pr.number, f"Mergify queue check failed: {name}"),
+            ledger,
+        )
+        if blocker is not None:
+            blockers.append(blocker)
+    return tuple(blockers)
+
+
 def _assert_stack_facts_invariants(facts: StackFacts) -> None:
     assert facts.stack.prs, "stack must contain at least one PR"
     pr_numbers = tuple(pr.number for pr in facts.stack.prs)
@@ -352,10 +375,20 @@ def build_stack_facts(
     blockers_by_pr: dict[int, tuple[Blocker, ...]] = {}
     for pr in stack.prs:
         effective = effective_blockers(pr, required, trunk, suppressed_failed_checks_by_pr.get(pr.number, ()))
-        blockers_by_pr[pr.number] = tuple(
+        blockers = [
             latest_repair_invalid_blocker(pr, blocker, ledger) or existing_split_stop_blocker(pr, blocker) or blocker
             for blocker in effective
+        ]
+        existing_keys = {blocker.key for blocker in blockers}
+        blockers.extend(
+            blocker for blocker in latest_mergify_repair_invalid_blockers(
+                pr,
+                ledger,
+                suppressed_failed_checks_by_pr.get(pr.number, ()),
+            )
+            if blocker.key not in existing_keys
         )
+        blockers_by_pr[pr.number] = tuple(blockers)
     facts = StackFacts(
         stack=stack,
         required_checks=required,
@@ -444,6 +477,8 @@ def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
 def plan_mergify_queue_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     del max_repair_attempts
     for pr in facts.stack.prs:
+        if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
+            continue
         if facts.upper_stack_needs_acceptance and facts.bottom and pr.number == facts.bottom.number:
             continue
         actions = mergify_failed_check_actions(pr, ledger, facts.suppressed_failed_checks_by_pr.get(pr.number, ()))
@@ -516,7 +551,12 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
         return None
     if not facts.bottom:
         first = facts.stack.prs[0]
-        return Action("comment_blocked", first.number, "no-current-bottom", "no current bottom on master")
+        return Action(
+            "comment_blocked",
+            first.number,
+            "no-current-bottom",
+            f"no current bottom on {facts.trunk}: lowest open stack PR #{first.number} is based on `{first.base_ref_name}`, not `{facts.trunk}`; land or retarget that base before babysitting can queue this stack",
+        )
 
     bottom = facts.bottom
     latest = bottom.latest_mergify

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -8,6 +8,12 @@ import sys
 from typing import Mapping, Sequence
 from urllib.parse import quote
 
+PR_LIST_FIELDS = (
+    "number,title,url,headRefName,headRefOid,baseRefName,state,isDraft,"
+    "labels,mergeStateStatus,mergeable,reviewDecision"
+)
+PR_CANDIDATE_FIELDS = PR_LIST_FIELDS + ",statusCheckRollup"
+
 try:
     from .mergify_admin_requeue_model import (
         MergifyQueueEvent,
@@ -58,7 +64,7 @@ class GhClient:
         args = [
             "gh", "pr", "list", "--repo", repo, "--state", "open",
             "--label", "admin-bypass", "--limit", "200", "--json",
-            "number,title,url,headRefName,headRefOid,baseRefName,state,isDraft,labels,mergeStateStatus,mergeable,reviewDecision,statusCheckRollup",
+            PR_CANDIDATE_FIELDS,
         ]
         if author:
             args[5:5] = ["--author", author]
@@ -98,7 +104,7 @@ class GhClient:
     def list_open_prs(self, repo: str) -> list[dict]:
         value = self._run_json([
             "gh", "pr", "list", "--repo", repo, "--state", "open", "--limit", "200", "--json",
-            "number,title,url,headRefName,headRefOid,baseRefName,state,isDraft,labels,mergeStateStatus,mergeable,reviewDecision,statusCheckRollup",
+            PR_LIST_FIELDS,
         ])
         return value if isinstance(value, list) else []
 

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -781,6 +781,53 @@ Failing checks
         executor.execute(action, item, 2)
         self.assertEqual(len(fake.comments), 1)
 
+    def test_human_blocker_comment_records_once(self):
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+            def issue_comments(self, repo, pr_number):
+                return [{"body": body} for _repo, _pr_number, body in self.comments]
+
+        ledger = self.ledger()
+        item = pr(2647)
+        action = Action("comment_blocked", 2647, "no-current-bottom", "no current bottom on master: lowest open stack PR #2647 is based on `feature/base`, not `master`; land or retarget that base before babysitting can queue this stack")
+        fake = FakeGh()
+        executor = self.executor(fake, ledger, "Neko-Catpital-Labs/Invoker")
+        executor.execute(action, item, 1)
+        executor.execute(action, item, 2)
+        self.assertEqual(len(fake.comments), 1)
+        self.assertIn("lowest open stack PR #2647", fake.comments[0][2])
+        self.assertEqual(ledger.count("comment-blocked", 2647, HEAD, "no-current-bottom"), 1)
+
+    def test_no_current_bottom_upgrades_legacy_generic_comment_once(self):
+        class FakeGh:
+            def __init__(self):
+                self.comments = [{
+                    "body": "Mergify repair stopped: no current bottom on master",
+                }]
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append({"body": body})
+
+            def issue_comments(self, repo, pr_number):
+                return list(self.comments)
+
+        ledger = self.ledger()
+        ledger.record("comment-blocked", 2647, HEAD, "no-current-bottom", 1)
+        item = pr(2647)
+        detail = "no current bottom on master: lowest open stack PR #2647 is based on `feature/base`, not `master`; land or retarget that base before babysitting can queue this stack"
+        action = Action("comment_blocked", 2647, "no-current-bottom", detail)
+        fake = FakeGh()
+        executor = self.executor(fake, ledger, "Neko-Catpital-Labs/Invoker")
+        executor.execute(action, item, 2)
+        executor.execute(action, item, 3)
+        self.assertEqual([comment["body"] for comment in fake.comments].count(f"Mergify repair stopped: {detail}"), 1)
+        self.assertEqual(ledger.count("comment-blocked", 2647, HEAD, "no-current-bottom:exact"), 1)
+
     def test_missing_admin_bypass_nudge_comments_once_without_label_edit(self):
         class FakeGh:
             def __init__(self):

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -333,6 +333,28 @@ class PlanStackActions(PlannerTestCase):
         actions = self._plan(m.StackGroup("s", (bottom, upper)))
         self.assertEqual((actions[0].kind, actions[0].pr_number), ("requeue", 10))
 
+    def test_no_current_bottom_blocker_names_base_branch(self):
+        actions = self._plan(
+            m.StackGroup(
+                "s",
+                (
+                    pr(
+                        number=5885,
+                        base_ref_name="pr/babysit-prereq-split",
+                        labels=frozenset({"admin-bypass"}),
+                    ),
+                    pr(
+                        number=5886,
+                        base_ref_name="stack/slack-routing",
+                        labels=frozenset({"admin-bypass"}),
+                    ),
+                ),
+            )
+        )
+        self.assertEqual((actions[0].kind, actions[0].key), ("comment_blocked", "no-current-bottom"))
+        self.assertIn("lowest open stack PR #5885 is based on `pr/babysit-prereq-split`", actions[0].detail)
+        self.assertIn("land or retarget that base", actions[0].detail)
+
     def test_requeue_is_capped_after_repeated_attempts(self):
         ledger = self._ledger()
         # Two prior requeue attempts on this head+key -> the third is capped.
@@ -515,6 +537,39 @@ class PlanStackExecution(PlannerTestCase):
             [(action.kind, action.key) for action in retry.actions],
             [("repair_check", QUEUE_ONLY_CHECK)],
         )
+
+    def test_repair_invalid_queue_failure_stops_retrying(self):
+        ledger = self._ledger()
+        ledger.record(
+            "repair-invalid",
+            5873,
+            HEAD,
+            "UI Vitest",
+            1,
+            meta={
+                "errors": [
+                    "merge-queue run failed outside the PR head: fix queue CI runner/tooling outside this PR and requeue."
+                ],
+            },
+        )
+        snapshot = pr(
+            number=5873,
+            labels=frozenset({"admin-bypass", "dequeued"}),
+            checks={"build": check("success"), "UI Vitest": check("success", "UI Vitest")},
+            latest_mergify=event(failing=("UI Vitest",)),
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            {"build"},
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={5873},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "blocked-needs-human")
+        blockers = plan.summary["prs"][0]["blockers"]
+        self.assertEqual(blockers[0]["kind"], "human_decision")
+        self.assertIn("outside the PR head", blockers[0]["detail"])
 
 
 if __name__ == "__main__":

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -276,6 +276,9 @@ class GhClientLabelEdit(unittest.TestCase):
 
         args = run_json.call_args.args[0]
         self.assertNotIn("--label", args)
+        fields = args[args.index("--json") + 1]
+        self.assertNotIn("statusCheckRollup", fields)
+        self.assertIn("headRefName", fields)
 
     def test_add_label_uses_rest_issue_labels_endpoint(self):
         client = s.GhClient()


### PR DESCRIPTION
## Summary

The babysit worker now stops retrying queue repairs once the live state already proves a human must step in.

It also rewrites the no-current-bottom blocker to name the exact off-trunk base branch.

The blocked-comment dedupe now works for every blocker key, not only capped retries.

## Review Claim

This planner slice stops repeat requeue churn after human-only blockers appear, while keeping blocker comments specific and deduped.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

This slice only changes planner and comment decisions in the babysit worker. It does not merge, queue, label, or push any real PR.

## Slice Rationale

Keep the worker policy change separate from the repro scripts so the behavior decision is reviewable on its own.

## Non-goals

- No change to the queue/merge mechanics.
- No new repro scripts.
- No manual edits to target PRs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue scripts.test_mergify_admin_requeue_plan scripts.test_mergify_admin_requeue_snapshot`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 76bcda7bc`
- Post-revert steps: None
- Data migration? No

</details>
