### PR TITLE
[Continue babysit worker landing loop](2) Verify the babysit worker loop locally

### DIFF
--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -17,6 +17,9 @@ REPROS=(
   scripts/repro/repro-babysit-headless-queued-comment.sh
   scripts/repro/repro-babysit-queue-only-empty-log.sh
   scripts/repro/repro-babysit-queue-only-missing-requeues.sh
+  scripts/repro/repro-babysit-targeted-scan-light.sh
+  scripts/repro/repro-babysit-queue-repair-invalid-stop.sh
+  scripts/repro/repro-babysit-no-current-bottom-comment.sh
 )
 
 # repro-mergify-stack-dogfood.sh is deliberately excluded: it's an opt-in

--- a/scripts/repro/repro-babysit-no-current-bottom-comment.sh
+++ b/scripts/repro/repro-babysit-no-current-bottom-comment.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-no-current-bottom-comment.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1"
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----"
+    echo "$2"
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+mkdir -p "$HOME" "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+export STATE_PATH LEDGER_PATH
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+state = {
+    "prs": [
+        {
+            "number": 5885,
+            "title": "Tighten Slack repo routing",
+            "body": "## Summary\n\nNo current bottom repro.\n",
+            "url": "https://github.com/fake/repo/pull/5885",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "pr/babysit-prereq-split",
+            "headRefName": "stack/slack-routing-1",
+            "headRefOid": "1111111111111111111111111111111111111111",
+            "mergeStateStatus": "CLEAN",
+            "mergeable": "MERGEABLE",
+            "labels": ["admin-bypass"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS"},
+        },
+        {
+            "number": 5886,
+            "title": "Reject invalid literal repo URLs",
+            "body": "## Summary\n\nUpper stack member.\n",
+            "url": "https://github.com/fake/repo/pull/5886",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "stack/slack-routing-1",
+            "headRefName": "stack/slack-routing-2",
+            "headRefOid": "2222222222222222222222222222222222222222",
+            "mergeStateStatus": "CLEAN",
+            "mergeable": "MERGEABLE",
+            "labels": ["admin-bypass"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS"},
+        },
+    ],
+    "issue_comments": {"5885": [], "5886": []},
+    "job_logs": {},
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+: > "$LEDGER_PATH"
+
+run_worker() {
+  python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5886 2>&1
+}
+
+if ! out1="$(run_worker)"; then
+  fail 'tick 1: worker failed' "$out1"
+fi
+if ! out2="$(run_worker)"; then
+  fail 'tick 2: worker failed' "$out2"
+fi
+
+python3 - <<'PY' || fail 'expected one exact no-current-bottom comment' "$(cat "$STATE_PATH")"
+import json
+import os
+from pathlib import Path
+
+state = json.loads(Path(os.environ["STATE_PATH"]).read_text(encoding="utf-8"))
+comments = state.get("issue_comments", {}).get("5885", [])
+if len(comments) != 1:
+    raise SystemExit(f"expected 1 comment on #5885, saw {len(comments)}")
+body = comments[0].get("body", "")
+expected = "lowest open stack PR #5885 is based on `pr/babysit-prereq-split`, not `master`; land or retarget that base before babysitting can queue this stack"
+if expected not in body:
+    raise SystemExit(body)
+if state.get("issue_comments", {}).get("5886"):
+    raise SystemExit("upper PR received the blocker comment")
+PY
+
+python3 - <<'PY' || fail 'expected one no-current-bottom ledger row' "$(cat "$LEDGER_PATH")"
+import json
+import os
+from pathlib import Path
+
+rows = [
+    json.loads(line)
+    for line in Path(os.environ["LEDGER_PATH"]).read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+matches = [
+    row for row in rows
+    if row.get("kind") == "comment-blocked"
+    and row.get("key") == "no-current-bottom"
+    and int(row.get("pr", 0)) == 5885
+]
+if len(matches) != 1:
+    raise SystemExit(f"expected 1 matching row, saw {len(matches)}")
+PY
+echo "$out1$out2" | grep -q 'no current bottom on master' || fail 'worker output did not name the blocker' "$out1$out2"
+
+echo '[repro] passed'

--- a/scripts/repro/repro-babysit-queue-repair-invalid-stop.sh
+++ b/scripts/repro/repro-babysit-queue-repair-invalid-stop.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-queue-repair-invalid-stop.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1"
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----"
+    echo "$2"
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+mkdir -p "$HOME" "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+HEAD="5a71947f46f2190a5a53bf2e4ff6e44688cc6aa2"
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+EXACT_REASON='merge-queue run failed outside the PR head: `required-fast / Vitest Workspace`: `scripts/test-land-stack-skill.sh: line 24: rg: command not found`; `required-fast / Vitest Workspace`: `playwright install-deps chromium` tried to use sudo without a password. Current PR head `UI Vitest` is green; fix queue CI runner/tooling outside this PR and requeue.'
+export HEAD STATE_PATH LEDGER_PATH EXACT_REASON
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = os.environ["HEAD"]
+reason = os.environ["EXACT_REASON"]
+state = {
+    "prs": [
+        {
+            "number": 5873,
+            "title": "Route owner-serve through web surface startup",
+            "body": "## Summary\n\nQueue repair-invalid repro.\n",
+            "url": "https://github.com/fake/repo/pull/5873",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "pr/owner-serve-web-surface",
+            "headRefOid": head,
+            "mergeStateStatus": "BLOCKED",
+            "mergeable": "MERGEABLE",
+            "labels": ["admin-bypass", "dequeued"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS", "UI Vitest": "SUCCESS"},
+        }
+    ],
+    "issue_comments": {
+        "5873": [
+            {
+                "id": "5083062006",
+                "user": {"login": "mergify[bot]"},
+                "updated_at": "2026-07-26T10:30:00Z",
+                "html_url": "https://github.com/fake/repo/pull/5873#issuecomment-5083062006",
+                "body": (
+                    "-*- Mergify Payload -*-\n"
+                    "{\"state\":\"dequeued\",\"queue_rule_name\":\"admin-bypass\"}\n\n"
+                    f"- Left the queue at `{head}`\n\n"
+                    "## Waiting for\n\n"
+                    "- UI Vitest\n\n"
+                    "## Failing checks\n\n"
+                    "- [UI Vitest](https://github.com/fake/repo/actions/runs/1/job/2)\n"
+                ),
+            }
+        ]
+    },
+    "job_logs": {"2": "merge queue failed elsewhere\n"},
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+rows = [
+    {
+        "epoch": 1785062162,
+        "headSha": head,
+        "key": "UI Vitest",
+        "kind": "repair-invalid",
+        "meta": {"errors": [reason]},
+        "pr": 5873,
+    },
+    {
+        "epoch": 1785062162,
+        "headSha": head,
+        "key": f"repair-invalid:UI Vitest:{head}",
+        "kind": "comment-blocked",
+        "pr": 5873,
+    },
+]
+Path(os.environ["LEDGER_PATH"]).write_text(
+    "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+    encoding="utf-8",
+)
+PY
+
+if ! out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5873 2>&1)"; then
+  fail 'targeted worker dry-run failed' "$out"
+fi
+
+! echo "$out" | grep -q 'repair-check PR #5873' || fail 'repair-invalid queue failure retried repair' "$out"
+! echo "$out" | grep -q 'requeue PR #5873' || fail 'repair-invalid queue failure was blindly requeued' "$out"
+echo "$out" | grep -q 'blocked-needs-human' || fail 'repair-invalid queue failure did not become terminal human blocker' "$out"
+echo "$out" | grep -q 'fix queue CI runner/tooling outside this PR and requeue' || fail 'exact human-only reason was not preserved' "$out"
+
+echo '[repro] passed'

--- a/scripts/repro/repro-babysit-targeted-scan-light.sh
+++ b/scripts/repro/repro-babysit-targeted-scan-light.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-targeted-scan-light.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1"
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----"
+    echo "$2"
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+mkdir -p "$HOME" "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+HEAD="5a71947f46f2190a5a53bf2e4ff6e44688cc6aa2"
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+CALLS_PATH="$FAKE_GH_STATE_DIR/calls.log"
+LEDGER_PATH="$TMP/ledger.jsonl"
+export HEAD STATE_PATH
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = os.environ["HEAD"]
+state = {
+    "prs": [
+        {
+            "number": 5873,
+            "title": "Route owner-serve through web surface startup",
+            "body": "## Summary\n\nTargeted scan repro.\n",
+            "url": "https://github.com/fake/repo/pull/5873",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "pr/owner-serve-web-surface",
+            "headRefOid": head,
+            "mergeStateStatus": "CLEAN",
+            "mergeable": "MERGEABLE",
+            "labels": ["admin-bypass"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS"},
+        }
+    ],
+    "issue_comments": {"5873": []},
+    "job_logs": {},
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+: > "$CALLS_PATH"
+
+if ! out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5873 2>&1)"; then
+  fail 'targeted worker dry-run failed' "$out"
+fi
+
+echo "$out" | grep -q 'DRY-RUN requeue PR #5873' || fail 'targeted run did not reach a worker decision' "$out"
+if grep '^gh pr list ' "$CALLS_PATH" | grep -q 'statusCheckRollup'; then
+  fail 'targeted scan used heavy all-open statusCheckRollup list' "$(cat "$CALLS_PATH")"
+fi
+grep '^gh api graphql ' "$CALLS_PATH" | grep -q 'number=5873' || fail 'targeted run did not fetch the requested PR detail' "$(cat "$CALLS_PATH")"
+
+echo '[repro] passed'


### PR DESCRIPTION
## Summary

This slice adds three deterministic babysit-worker repro scripts and runs them from battle-loop.

They pin down three babysit-worker paths that previously had no single local check.

That keeps the local proof for this loop in one place instead of re-deriving it by hand.

## Review Claim

These scripts make the babysit-worker loop locally reproducible from battle-loop.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds local repro coverage and battle-loop registration. It does not change production babysit-worker behavior.

## Slice Rationale

Keep the local proof harness separate from the worker behavior change so reviewers can inspect the evidence by itself.

## Non-goals

- No production worker edits.
- No change to queue or merge behavior.
- No manual edits to target PRs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-babysit-queue-repair-invalid-stop.sh` (fails on plain `master`; passes with #5953)
- [ ] `bash scripts/repro/repro-babysit-no-current-bottom-comment.sh` (blocked behind #5953)
- [ ] `bash scripts/repro/repro-babysit-targeted-scan-light.sh` (blocked behind #5953)
- [ ] `bash ./loop-driver.sh --skip-battle` (blocked behind #5953)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 596ed7186`
- Post-revert steps: None
- Data migration? No

</details>
