### PR TITLE
[SSH Cleanup Error Surface](1) Sanitize legacy SSH cleanup task errors

### DIFF
--- a/packages/ui/src/__tests__/task-panel-error.test.tsx
+++ b/packages/ui/src/__tests__/task-panel-error.test.tsx
@@ -55,6 +55,31 @@ describe('TaskPanel error display', () => {
     expect(screen.getByText('SSH key not found')).toBeInTheDocument();
     expect(screen.getByText('Exit code: 1')).toBeInTheDocument();
   });
+  it('normalizes legacy ssh cleanup-tail blobs before rendering', () => {
+    const rawError = [
+      '{"type":"item.completed","item":{"type":"agent_message","text":"Done"}}',
+      '{"type":"turn.completed","usage":{"input_tokens":1}}',
+      'main: line 1: pop_var_context: head of shell_variables not a function context',
+      '[SshExecutor] Recording task result and pushing branch on remote...',
+    ].join('\n');
+    const task = makeTask({
+      execution: { error: rawError, exitCode: 1 },
+    });
+    render(
+      <TaskPanel
+        task={task}
+        onProvideInput={noop}
+        onApprove={noop}
+        onReject={noop}
+        onSelectExperiment={noop}
+      />,
+    );
+    expect(screen.getByText(
+      'Executor cleanup failed (ssh remote finalize): bash pop_var_context after remote run completed.',
+    )).toBeInTheDocument();
+    expect(screen.queryByText(/Recording task result and pushing branch on remote/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/"type":"turn.completed"/)).not.toBeInTheDocument();
+  });
 
   it('shows only exit code when error is undefined', () => {
     const task = makeTask({

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -754,6 +754,38 @@ describe('WorkflowInspector', () => {
       'Approval blocked: capability mismatch',
     );
   });
+  it('normalizes legacy ssh cleanup-tail blobs in the inspector error card', () => {
+    const task = makeTask({
+      status: 'failed',
+      execution: {
+        error: [
+          '{"type":"item.completed","item":{"type":"agent_message","text":"Done"}}',
+          '{"type":"turn.completed","usage":{"input_tokens":1}}',
+          'main: line 1: pop_var_context: head of shell_variables not a function context',
+          '[SshExecutor] Recording task result and pushing branch on remote...',
+        ].join('\n'),
+        exitCode: 1,
+      },
+    });
+
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={task}
+        collapsed={false}
+        advancedExpanded={false}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(
+      'Executor cleanup failed (ssh remote finalize): bash pop_var_context after remote run completed.',
+    )).toBeInTheDocument();
+    expect(screen.queryByText(/Recording task result and pushing branch on remote/)).not.toBeInTheDocument();
+  });
   it('surfaces crash-preserved inspection actions for orphaned running tasks', () => {
     const onRestartTask = vi.fn();
     const onRecreateTask = vi.fn();

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -16,10 +16,10 @@ import {
   formatStatusLabel,
   getRunningPhaseLabel,
 } from '../lib/colors.js';
+import { formatTaskExecutionErrorForDisplay } from '../lib/task-execution-error-display.js';
 import { useNow } from '../hooks/useNow.js';
 import { mergeGatePanelHeading } from '../lib/merge-gate.js';
 import { Button } from './primitives/index.js';
-
 interface TaskAuditEvent {
   eventType: string;
   payload?: string;
@@ -377,6 +377,7 @@ export function TaskPanel({
     const current = dep.gatePolicy ?? 'review_ready';
     return draft !== current;
   }).length;
+  const displayError = formatTaskExecutionErrorForDisplay(task.execution.error);
 
   const handleSaveGatePolicies = async () => {
     if (!onSetExternalGatePolicies || changedGatePolicyCount === 0) {
@@ -720,14 +721,14 @@ export function TaskPanel({
       )}
 
       {/* Error / Exit Code */}
-      {(task.execution.error || visibleWorkspaceSetupFailures.length > 0 || (task.execution.exitCode !== undefined && task.execution.exitCode !== 0)) && (
+      {(displayError || visibleWorkspaceSetupFailures.length > 0 || (task.execution.exitCode !== undefined && task.execution.exitCode !== 0)) && (
         <div className="bg-red-900/30 border border-red-700 rounded p-3">
           <h3 className="text-sm font-medium text-red-400 mb-1">Error</h3>
-          {task.execution.error && (
-            <p className="text-xs text-red-300 whitespace-pre-wrap">{task.execution.error}</p>
+          {displayError && (
+            <p className="text-xs text-red-300 whitespace-pre-wrap">{displayError}</p>
           )}
           {visibleWorkspaceSetupFailures.length > 0 && (
-            <div className={task.execution.error ? 'mt-2 space-y-2' : 'space-y-2'}>
+            <div className={displayError ? 'mt-2 space-y-2' : 'space-y-2'}>
               {visibleWorkspaceSetupFailures.map((error) => (
                 <pre
                   key={error}

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { ReviewGateArtifact, ReviewGateQueryResponse, TaskState, WorkflowMeta } from '../types.js';
 import { getEffectiveVisualStatus, getStatusColor } from '../lib/colors.js';
+import { formatTaskExecutionErrorForDisplay } from '../lib/task-execution-error-display.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
 import { subscribeVisibilityAwarePoll } from '../hooks/visibilityAwarePoll.js';
 import { mutationFailureTitle } from '../lib/mutation-failure-display.js';
@@ -453,6 +454,7 @@ export function WorkflowInspector({
   const logEntries = taskLogEvents.map(taskEventToLogEntry);
   const visibleLogEntries = logEntries
     .filter((entry) => LOG_LEVEL_RANK[entry.level] >= LOG_LEVEL_RANK[logLevelFilter]);
+  const displayError = formatTaskExecutionErrorForDisplay(task?.execution.error);
   const selectedWorkflowId = workflow?.id ?? task?.config.workflowId;
   const timelineDecisionTitle = task ? 'Worker decisions' : 'Workflow decisions';
   const timelineDecisionEmptyText = task
@@ -534,16 +536,16 @@ export function WorkflowInspector({
             )}
             {formatStatus(task?.status ?? workflow?.status)}
           </div>
-          {task?.execution.error && (
+          {displayError && (
             <div className="mt-3 border-t border-red-500/30 pt-2">
               <h3 className="text-[11px] uppercase tracking-wide text-red-300">Error</h3>
-              <p className="mt-1 text-xs text-red-300 break-words">{task.execution.error}</p>
+              <p className="mt-1 text-xs text-red-300 break-words">{displayError}</p>
               {task.execution.exitCode !== undefined && task.execution.exitCode !== 0 && (
                 <p className="mt-2 text-xs text-red-300">Exit code: {task.execution.exitCode}</p>
               )}
             </div>
           )}
-          {!task?.execution.error && task?.execution.exitCode !== undefined && task.execution.exitCode !== 0 && (
+          {!displayError && task?.execution.exitCode !== undefined && task.execution.exitCode !== 0 && (
             <p className="mt-2 text-xs text-red-300">Exit code: {task.execution.exitCode}</p>
           )}
           {task?.execution.pendingFixError && (

--- a/packages/ui/src/lib/task-execution-error-display.test.ts
+++ b/packages/ui/src/lib/task-execution-error-display.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { formatTaskExecutionErrorForDisplay } from './task-execution-error-display.js';
+
+describe('formatTaskExecutionErrorForDisplay', () => {
+  it('normalizes legacy ssh cleanup-tail blobs after a completed agent turn', () => {
+    const raw = [
+      '{"type":"item.completed","item":{"type":"agent_message","text":"done"}}',
+      '{"type":"turn.completed","usage":{"input_tokens":1}}',
+      'main: line 1: pop_var_context: head of shell_variables not a function context [SshExecutor] Recording task result and pushing branch on remote...',
+    ].join('\n');
+
+    expect(formatTaskExecutionErrorForDisplay(raw)).toBe(
+      'Executor cleanup failed (ssh remote finalize): bash pop_var_context after remote run completed.',
+    );
+  });
+
+  it('leaves unrelated errors unchanged', () => {
+    expect(formatTaskExecutionErrorForDisplay('Unit tests failed')).toBe('Unit tests failed');
+  });
+
+  it('preserves already-normalized cleanup-tail errors', () => {
+    const normalized = 'Executor cleanup failed (ssh remote finalize): bash pop_var_context after remote run completed.';
+    expect(formatTaskExecutionErrorForDisplay(normalized)).toBe(normalized);
+  });
+});

--- a/packages/ui/src/lib/task-execution-error-display.ts
+++ b/packages/ui/src/lib/task-execution-error-display.ts
@@ -1,0 +1,29 @@
+const SSH_REMOTE_FINALIZE_PREFIX = 'Executor cleanup failed (ssh remote finalize):';
+const CLEANUP_TAIL_MARKERS = [
+  'pop_var_context',
+  'Orphan function call output',
+  '[SshExecutor] Recording task result and pushing branch on remote...',
+] as const;
+
+function hasCompletedAgentTurn(error: string): boolean {
+  return error.includes('"type":"turn.completed"')
+    || (error.includes('"type":"item.completed"') && error.includes('"type":"agent_message"'));
+}
+
+function normalizeLegacySshCleanupTail(error: string): string | undefined {
+  if (error.startsWith(SSH_REMOTE_FINALIZE_PREFIX)) return error;
+  if (!hasCompletedAgentTurn(error)) return undefined;
+  if (!CLEANUP_TAIL_MARKERS.some((marker) => error.includes(marker))) return undefined;
+  if (error.includes('pop_var_context')) {
+    return `${SSH_REMOTE_FINALIZE_PREFIX} bash pop_var_context after remote run completed.`;
+  }
+  if (error.includes('Orphan function call output')) {
+    return `${SSH_REMOTE_FINALIZE_PREFIX} orphan function-call output after remote run completed.`;
+  }
+  return `${SSH_REMOTE_FINALIZE_PREFIX} remote finalize wrapper output after remote run completed.`;
+}
+
+export function formatTaskExecutionErrorForDisplay(error?: string): string | undefined {
+  if (typeof error !== 'string' || error.length === 0) return error;
+  return normalizeLegacySshCleanupTail(error) ?? error;
+}


### PR DESCRIPTION
## Summary

Task Status now shows a short legacy SSH finalize error message instead of the raw transport blob.

Some older failed tasks still store JSON event lines and wrapper noise in `execution.error`. Those error surfaces showed the whole blob, so the failure text was hard to read.

This change adds one shared formatter for those legacy SSH finalize errors and uses it in both UI error surfaces, with focused regression tests.

## Review Claim

The task panel and workflow inspector now expose legacy SSH finalize failures as one concise message instead of the raw SSH tail.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This is display-only. Persisted task errors, failure classification, and executor behavior stay unchanged.

## Slice Rationale

The bug only affects the user-facing error surfaces, so this slice stays on the activation surface and leaves persistence and executor code alone.

## Non-goals

- No database backfill.
- No executor or SSH lifecycle behavior change.
- No action-graph error-text rewrite.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/lib/task-execution-error-display.test.ts src/__tests__/task-panel-error.test.tsx src/__tests__/workflow-inspector.test.tsx`

</details>

## Visual Proof

The Task Status error card now exposes one readable SSH finalize message instead of the raw JSONL tail.

![Sanitized legacy SSH cleanup error](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-5b04d1/task-error-sanitization-after.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert fe4f3bce1a7763256be5f71217e5500d45cc6874`
- Post-revert steps: None
- Data migration? No

</details>
