### PR TITLE
[Visual Proof Background Capture](1) Keep capture window off-screen by default

### DIFF
--- a/packages/app/src/__tests__/window-lifecycle.test.ts
+++ b/packages/app/src/__tests__/window-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createMainWindow,
   registerMainWindowActivateHandler,
@@ -41,6 +41,9 @@ vi.mock('electron', () => ({
     openExternal: vi.fn(),
   },
 }));
+const savedCaptureMode = process.env.CAPTURE_MODE;
+const savedVisualProofShowUi = process.env.INVOKER_VISUAL_PROOF_SHOW_UI;
+
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -48,6 +51,22 @@ beforeEach(() => {
   electronMock.fakeWindow.isDestroyed.mockReturnValue(false);
   electronMock.fakeWindow.loadURL.mockResolvedValue(undefined);
   electronMock.fakeWindow.loadFile.mockResolvedValue(undefined);
+  delete process.env.CAPTURE_MODE;
+  delete process.env.INVOKER_VISUAL_PROOF_SHOW_UI;
+});
+
+afterAll(() => {
+  if (savedCaptureMode === undefined) {
+    delete process.env.CAPTURE_MODE;
+  } else {
+    process.env.CAPTURE_MODE = savedCaptureMode;
+  }
+
+  if (savedVisualProofShowUi === undefined) {
+    delete process.env.INVOKER_VISUAL_PROOF_SHOW_UI;
+  } else {
+    process.env.INVOKER_VISUAL_PROOF_SHOW_UI = savedVisualProofShowUi;
+  }
 });
 
 describe('window-lifecycle', () => {
@@ -119,6 +138,80 @@ describe('window-lifecycle', () => {
   });
 
   it('maps and focuses e2e compositor windows', () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() };
+    const recordStartupMark = vi.fn();
+    const setUiInteractive = vi.fn();
+    const startDeferredStartupWork = vi.fn();
+
+    createMainWindow({
+      appRootDir: '/tmp/app',
+      invokerConfig: {},
+      logger,
+      hideE2eWindow: true,
+      enableTestCompositor: true,
+      recordStartupMark,
+      setUiInteractive,
+      startDeferredStartupWork,
+      setMainWindow: vi.fn(),
+    });
+
+    const options = electronMock.BrowserWindow.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(options.show).toBe(false);
+    expect(options.skipTaskbar).toBe(true);
+    expect(options.x).toBeUndefined();
+    expect(options.y).toBeUndefined();
+
+    const readyHandler = electronMock.fakeWindow.once.mock.calls.find(([eventName]) => eventName === 'ready-to-show')?.[1];
+    expect(readyHandler).toBeDefined();
+    readyHandler?.();
+
+    expect(electronMock.fakeWindow.show).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.showInactive).not.toHaveBeenCalled();
+    expect(electronMock.fakeWindow.focus).toHaveBeenCalledTimes(1);
+    expect(setUiInteractive).toHaveBeenCalledWith(true);
+    expect(startDeferredStartupWork).toHaveBeenCalledTimes(1);
+    expect(recordStartupMark).toHaveBeenCalledWith('window.show');
+  });
+  it('keeps visual proof compositor windows off-screen and unfocused by default', () => {
+    process.env.CAPTURE_MODE = 'before';
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() };
+    const recordStartupMark = vi.fn();
+    const setUiInteractive = vi.fn();
+    const startDeferredStartupWork = vi.fn();
+
+    createMainWindow({
+      appRootDir: '/tmp/app',
+      invokerConfig: {},
+      logger,
+      hideE2eWindow: true,
+      enableTestCompositor: true,
+      recordStartupMark,
+      setUiInteractive,
+      startDeferredStartupWork,
+      setMainWindow: vi.fn(),
+    });
+
+    const options = electronMock.BrowserWindow.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(options.show).toBe(false);
+    expect(options.skipTaskbar).toBe(true);
+    expect(options.x).toBe(-32000);
+    expect(options.y).toBe(-32000);
+
+    const readyHandler = electronMock.fakeWindow.once.mock.calls.find(([eventName]) => eventName === 'ready-to-show')?.[1];
+    expect(readyHandler).toBeDefined();
+    readyHandler?.();
+
+    expect(electronMock.fakeWindow.show).not.toHaveBeenCalled();
+    expect(electronMock.fakeWindow.showInactive).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.focus).not.toHaveBeenCalled();
+    expect(setUiInteractive).toHaveBeenCalledWith(true);
+    expect(startDeferredStartupWork).toHaveBeenCalledTimes(1);
+    expect(recordStartupMark).toHaveBeenCalledWith('window.hidden-ready');
+  });
+
+  it('shows visual proof compositor windows when explicitly requested', () => {
+    process.env.CAPTURE_MODE = 'before';
+    process.env.INVOKER_VISUAL_PROOF_SHOW_UI = '1';
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() };
     const recordStartupMark = vi.fn();
     const setUiInteractive = vi.fn();

--- a/packages/app/src/window/window-lifecycle.ts
+++ b/packages/app/src/window/window-lifecycle.ts
@@ -53,7 +53,12 @@ export function createMainWindow(deps: MainWindowLifecycleDeps): BrowserWindow {
   deps.recordStartupMark('createWindow.begin');
   const iconPath = path.join(deps.appRootDir, 'assets', 'icons', 'png', '256x256.png');
   const icon = nativeImage.createFromPath(iconPath);
-  const keepE2eWindowHidden = deps.hideE2eWindow && !deps.enableTestCompositor;
+  const captureMode = process.env.CAPTURE_MODE;
+  // Visual proof capture should stay off-screen unless a maintainer explicitly
+  // opts into watching it with INVOKER_VISUAL_PROOF_SHOW_UI=1.
+  const showVisualProofWindow = captureMode !== undefined && process.env.INVOKER_VISUAL_PROOF_SHOW_UI === '1';
+  const keepE2eWindowHidden = deps.hideE2eWindow
+    && (!deps.enableTestCompositor || (captureMode !== undefined && !showVisualProofWindow));
   const mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
@@ -134,7 +139,9 @@ export function createMainWindow(deps: MainWindowLifecycleDeps): BrowserWindow {
       showTriggered = true;
       deps.logger.info(keepE2eWindowHidden ? 'main window ready while hidden' : 'main window show()', { module: 'window' });
       deps.recordStartupMark(keepE2eWindowHidden ? 'window.hidden-ready' : 'window.show');
-      if (!keepE2eWindowHidden) {
+      if (keepE2eWindowHidden && deps.enableTestCompositor) {
+        mainWindow.showInactive();
+      } else if (!keepE2eWindowHidden) {
         mainWindow.show();
         mainWindow.focus();
       }


### PR DESCRIPTION
## Summary

Visual proof capture now stays in the background by default.

The old capture path always mapped and focused the Electron window, so proof runs could jump in front of your work.

Now CAPTURE_MODE keeps the window off-screen and inactive unless a maintainer sets `INVOKER_VISUAL_PROOF_SHOW_UI=1`.

## Review Claim

Visual proof capture no longer steals desktop focus unless someone explicitly opts into a visible window.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the CAPTURE_MODE window-launch branch changes. Normal app launches still show and focus the window, and the regression test covers default-hidden and opt-in-visible visual proof behavior.

## Slice Rationale

The runtime branch and its regression tests need to land together. Splitting them would either hide the new contract or ship the behavior without proof.

## Non-goals

No change to normal app launches.

No change to the screenshot set or proof artifact format.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/window-lifecycle.test.ts`
- [x] `CAPTURE_MODE=before CAPTURE_VIDEO=1 INVOKER_VISUAL_PROOF_SHOW_UI=0 pnpm --filter @invoker/app exec playwright test e2e/visual-proof.spec.ts --grep "empty state"`

</details>

## Visual Proof

Focused proof: `packages/app/src/__tests__/window-lifecycle.test.ts` now asserts that visual proof launches stay off-screen and call `showInactive()` by default, then switch back to `show()` + `focus()` only when `INVOKER_VISUAL_PROOF_SHOW_UI=1` is set.

A screenshot cannot show desktop focus directly, so the image below only proves the hidden capture path still renders the normal empty-state frame.

![Hidden visual-proof capture still renders the empty-state frame](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-91b377/visual-proof-background-empty-state.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
