### PR TITLE
[Planning Review Handoff](3) Add MCP plan review adapter

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -7,7 +7,7 @@ import { LocalBus } from '@invoker/transport';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { main } from '../index.js';
-import { HANDOFF_PROMPT_DESCRIPTION, handoffPrompt, resolveCliInvocation, submitPlanForMcp, validatePlanForMcp, type McpCliRunner } from '../mcp-server.js';
+import { HANDOFF_PROMPT_DESCRIPTION, handoffPrompt, preparePlanReviewForMcp, resolveCliInvocation, submitPlanForMcp, validatePlanForMcp, type McpCliRunner } from '../mcp-server.js';
 
 const repoRoot = resolve(__dirname, '../../../..');
 const cliPath = resolve(repoRoot, 'packages/cli/dist/index.js');
@@ -345,6 +345,39 @@ tasks:
     expect(prompt).toContain('multiple review slices');
     expect(prompt).toContain('skill://review-compression/SKILL.md');
     expect(prompt).toContain('before writing workflow YAML');
+  });
+  it('tells MCP handoff users to keep review and approval ahead of submission', () => {
+    const prompt = handoffPrompt('ship this change');
+
+    expect(prompt).toContain('show the returned ordered steps and confirmation text to the user');
+    expect(prompt).toContain('wait for approval before any submission step');
+    expect(prompt).toContain('Do not tell the user to reply `submit`');
+    expect(prompt).toContain('If `invoker_prepare_plan_review` returns `confirmationMode: "require"`');
+  });
+  it('prepares a canonical MCP review from a YAML file', async () => {
+    const result = await preparePlanReviewForMcp(fixturePlan);
+
+    expect(result).toMatchObject({
+      planText: expect.any(String),
+      summary: { name: 'Hello World CLI', taskCount: 1, taskGroups: [{ workflow: null, tasks: ['Print hello from the standalone CLI.'] }] },
+      confirmationMode: 'require',
+      confirmationText: 'Approve to submit this exact YAML. Cancel keeps the draft. Discard removes it.',
+    });
+  });
+
+  it('tells MCP handoff users to call invoker_prepare_plan_review before approval', () => {
+    const prompt = handoffPrompt('ship this change');
+
+    expect(prompt).toContain('Call `invoker_prepare_plan_review` on that exact YAML file');
+    expect(prompt).toContain('show the returned ordered steps and confirmation text to the user');
+  });
+
+  it('documents the auto-submit branch in the MCP handoff prompt', () => {
+    const prompt = handoffPrompt('ship this change');
+
+    expect(prompt).toContain('If `invoker_prepare_plan_review` returns `confirmationMode: "require"`');
+    expect(prompt).toContain('If it returns `confirmationMode: "auto_submit"`');
+    expect(prompt).toContain('call `invoker_submit_plan` immediately');
   });
 
   it('describes PR skill triggers in the MCP prompt metadata', () => {

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -1,8 +1,12 @@
+import { readFile } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
 import { resolve } from 'node:path';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { PlanningConfirmationMode, PlanningReviewDraft } from '../../planning-core/src/planning-review.js';
+import { buildPlanningHandoffInstructions } from '../../planning-core/src/planning-handoff-prompt.js';
+import { preparePlanningReview } from '../../planning-core/src/planning-review.js';
 import { parsePlanFile } from '@invoker/workflow-core';
 import { z } from 'zod';
 
@@ -12,7 +16,7 @@ export interface McpCliRunner {
   run(args: string[], options?: { cwd?: string }): Promise<{ exitCode: number; stdout: string; stderr: string }>;
 }
 
-export const HANDOFF_PROMPT_DESCRIPTION = 'Plan a requested change, trigger PR skills for PR/stack work, convert it to Invoker YAML, validate it, and submit it live.';
+export const HANDOFF_PROMPT_DESCRIPTION = 'Plan a requested change, trigger PR skills for PR/stack work, convert it to Invoker YAML, review the canonical ordered steps, and submit it live.';
 
 type SubmitSuccess = { ok: true; workflowId: string; stdout: string };
 type SubmitFailure = { ok: false; exitCode: number; stdout: string; stderr: string; error?: string };
@@ -91,6 +95,21 @@ export async function validatePlanForMcp(
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
 }
+export async function preparePlanReviewForMcp(
+  planPath: string,
+  confirmationMode: PlanningConfirmationMode = 'require',
+): Promise<PlanningReviewDraft | { ok: false; error: string }> {
+  try {
+    const planText = await readFile(resolve(planPath), 'utf8');
+    const review = preparePlanningReview({ plannerOutput: planText, confirmationMode });
+    if ('kind' in review && review.kind === 'message') {
+      return { ok: false, error: 'I could not read that Invoker YAML plan. Regenerate the YAML, then try the review step again.' };
+    }
+    return review;
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
 
 export async function submitPlanForMcp(
   planPath: string,
@@ -128,6 +147,12 @@ function formatSubmitFailure(result: SubmitFailure): string {
 }
 
 export function handoffPrompt(request: string): string {
+  const handoffInstructions = buildPlanningHandoffInstructions({
+    planFilePath: 'plans/invoker-handoff.yaml',
+    reviewInstruction: 'Call `invoker_prepare_plan_review` on that exact YAML file, then show the returned ordered steps and confirmation text to the user.',
+    shortReplyInstruction: 'Then keep the chat reply focused on the review summary and approval state. Never paste the YAML into chat.',
+    submissionInstruction: 'If `invoker_prepare_plan_review` returns `confirmationMode: "require"`, wait for approval before `invoker_submit_plan`. If it returns `confirmationMode: "auto_submit"`, show the same review output and then call `invoker_submit_plan` immediately. Use mode `live` so the workflow appears in the running Invoker app.',
+  });
   return [
     `User request: ${request}`,
     '',
@@ -136,9 +161,8 @@ export function handoffPrompt(request: string): string {
     'If the request involves multiple review slices, first read and follow skill://review-compression/SKILL.md before writing workflow YAML.',
     'Write the planning artifact to plans/invoker-handoff.md.',
     'Convert the approved Markdown plan to plans/invoker-handoff.yaml.',
-    'Validate with invoker_validate_plan before submitting.',
-    'Submit with invoker_submit_plan using mode "live" so the workflow appears in the running Invoker app.',
-    'If MCP tools are not available but invoker-cli is on PATH, run invoker-cli run plans/invoker-handoff.yaml --live instead.',
+    handoffInstructions,
+    'If MCP tools are unavailable but `invoker-cli` is on PATH, mirror the same flow with `invoker-cli run plans/invoker-handoff.yaml --live` only after the approval step that `invoker_prepare_plan_review` would have gated.',
   ].join('\n');
 }
 
@@ -165,6 +189,33 @@ export async function runMcpServer(options: { runner?: McpCliRunner; cliPath?: s
           {
             type: 'text',
             text: `Valid Invoker plan: ${result.name} (${result.taskCount} tasks).`,
+          },
+        ],
+      };
+    },
+  );
+  server.registerTool(
+    'invoker_prepare_plan_review',
+    {
+      description: 'Prepare the canonical ordered-step review for an existing Invoker YAML plan.',
+      inputSchema: {
+        planPath: z.string(),
+        confirmationMode: z.enum(['require', 'auto_submit']).optional(),
+      },
+    },
+    async ({ planPath, confirmationMode }) => {
+      const result = await preparePlanReviewForMcp(planPath, confirmationMode ?? 'require');
+      if ('ok' in result && result.ok === false) {
+        return {
+          content: [{ type: 'text', text: `Could not prepare Invoker plan review: ${result.error}` }],
+          isError: true,
+        };
+      }
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(result, null, 2),
           },
         ],
       };


### PR DESCRIPTION
## Summary

The host handoff now has a first-party review step.

Before this, the MCP prompt told the host to generate YAML and then improvise the review and approval flow in prompt text.

This slice adds `invoker_prepare_plan_review` so the host can show the canonical ordered steps and confirmation text before submission.

## Review Claim

The MCP handoff now uses a real review tool instead of duplicating YAML summary and approval rules in prompt text.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This only changes the host-facing MCP surface and prompt flow; Slack and the terminal keep their own runtime paths.

## Slice Rationale

The shared planning review logic only helps the host once the MCP server exposes it as a concrete tool.

## Non-goals

- Change Slack buttons.
- Change the Planning Terminal backend.
- Update bundled skill files.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/planning-core build && pnpm --filter @invoker/cli build && pnpm --filter @invoker/cli exec vitest run src/__tests__/cli.test.ts`
- [x] `pnpm --filter @invoker/cli exec vitest run src/__tests__/cli.test.ts -t "runs the hello-world fixture with an isolated db dir"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
