### PR TITLE
[Planning Review Handoff](4) Thread planning review state through the backend

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -171,11 +171,11 @@ describe('listInAppPlanningPresets', () => {
         'custom+omp': { tool: 'omp', model: 'fast' },
       },
     })).resolves.toEqual(expect.arrayContaining([
-      { key: 'codex', label: 'Codex', tool: 'codex', model: undefined, isDefault: false },
-      { key: 'omp', label: 'OMP', tool: 'omp', model: undefined, isDefault: false },
-      { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude', isDefault: true },
-      { key: 'custom', label: 'custom', tool: 'codex', model: undefined, isDefault: false },
-      { key: 'custom+omp', label: 'custom + omp', tool: 'omp', model: 'fast', isDefault: false },
+      { key: 'codex', label: 'Codex', tool: 'codex', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },
+      { key: 'omp', label: 'OMP', tool: 'omp', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },
+      { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude', isDefault: true, defaultConfirmationMode: 'require' },
+      { key: 'custom', label: 'custom', tool: 'codex', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },
+      { key: 'custom+omp', label: 'custom + omp', tool: 'omp', model: 'fast', isDefault: false, defaultConfirmationMode: 'require' },
     ]));
   });
 });

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -10,6 +10,8 @@ import type {
   InAppPlanningDeleteRequest,
   InAppPlanningDeleteResponse,
   InAppPlanningDeleteSubmittedResponse,
+  InAppPlanningDiscardDraftRequest,
+  InAppPlanningDiscardDraftResponse,
   InAppPlanningListSessionsResponse,
   InAppPlanningPlanSummary,
   InAppPlanningResetRequest,
@@ -21,7 +23,7 @@ import type {
   InAppPlanningStreamEvent,
   InAppPlanningSubmitRequest,
   InAppPlanningSubmitResponse,
-  PlanningTerminalMode,
+  PlanningConfirmationMode,
   PlanningPresetOption,
 } from '@invoker/contracts';
 import type {
@@ -32,10 +34,11 @@ import type {
 } from '@invoker/data-store';
 import type { AgentRegistry } from '@invoker/execution-engine';
 import {
-  approvePlanningDraft,
   evaluatePlanningTurn,
   hasExplicitDraftIntent as hasCoreExplicitDraftIntent,
   isDraftingAuthorized,
+  preparePlanningReview,
+  submitPlanningReview,
   summarizePlanText,
   type PlanningMessage,
 } from '@invoker/planning-core';
@@ -71,7 +74,7 @@ export interface InAppPlanningChatSession {
   id: string;
   title: string;
   presetKey: string;
-  status: InAppPlanningSessionStatus;
+  confirmationMode: PlanningConfirmationMode;
   messages: InAppPlanningChatLine[];
   conversation: PlanConversation;
   draftPlanSummary?: InAppPlanningPlanSummary;
@@ -180,6 +183,28 @@ function titleFromMessage(message: string): string {
   if (!firstLine) return 'Untitled plan';
   return firstLine.length > 56 ? `${firstLine.slice(0, 53).trimEnd()}…` : firstLine;
 }
+function normalizePlanningConfirmationMode(
+  value: string | null | undefined,
+  fallback: PlanningConfirmationMode = 'require',
+): PlanningConfirmationMode {
+  return value === 'auto_submit' || value === 'require' ? value : fallback;
+}
+
+function resolveDefaultPlanningConfirmationMode(config: InvokerConfig): PlanningConfirmationMode {
+  return normalizePlanningConfirmationMode(config.defaultPlanningTerminalConfirmationMode, 'require');
+}
+
+function extractPlanningConfirmationOverride(message: string): {
+  message: string;
+  confirmationMode?: PlanningConfirmationMode;
+} {
+  const match = /^\[auto-submit\]\s*/i.exec(message);
+  if (!match) return { message };
+  return {
+    message: message.slice(match[0].length),
+    confirmationMode: 'auto_submit',
+  };
+}
 
 function appendSessionMessage(
   session: InAppPlanningChatSession,
@@ -220,6 +245,7 @@ function sessionToRecord(session: InAppPlanningChatSession, pendingResponse: boo
     title: session.title,
     presetKey: session.presetKey,
     status: session.status,
+    confirmationMode: session.confirmationMode ?? 'require',
     messages: session.messages,
     draftPlanSummary: session.draftPlanSummary,
     draftPlanText: session.draftPlanText,
@@ -243,6 +269,7 @@ function sessionToSummary(session: InAppPlanningChatSession): InAppPlanningSessi
     title: session.title,
     status: session.status,
     presetKey: session.presetKey,
+    confirmationMode: session.confirmationMode ?? 'require',
     messages: session.messages,
     draftPlanAvailable: hasDraftPlan(session),
     draftPlanSummary: session.draftPlanSummary,
@@ -391,10 +418,15 @@ async function createSession(
   const { PlanConversation } = await loadPlannerSurfaces();
   const createdAt = new Date().toISOString();
   const id = randomUUID();
+  const confirmationMode = normalizePlanningConfirmationMode(
+    request?.confirmationMode,
+    resolveDefaultPlanningConfirmationMode(deps.config),
+  );
   const session: InAppPlanningChatSession = {
     id,
     title: typeof request?.title === 'string' && request.title.trim() ? request.title.trim() : 'Untitled plan',
     presetKey,
+    confirmationMode,
     status: 'still_discussing',
     messages: [],
     conversation: new PlanConversation(planConversationConfig(preset, deps, id, { conversationalPlanning: true })),
@@ -412,12 +444,14 @@ async function createSession(
 export async function listInAppPlanningPresets(config: InvokerConfig): Promise<PlanningPresetOption[]> {
   const presets = await resolveHarnessPresets(config);
   const defaultPresetKey = await resolveDefaultPresetKey(config);
+  const defaultConfirmationMode = resolveDefaultPlanningConfirmationMode(config);
   return Object.entries(presets).map(([key, preset]) => ({
     key,
     label: labelForPresetKey(key),
     tool: preset.tool,
     model: preset.model,
     isDefault: key === defaultPresetKey,
+    defaultConfirmationMode,
   }));
 }
 
@@ -506,7 +540,13 @@ export async function sendPlanningChatMessage(
   },
 ): Promise<InAppPlanningChatResponse> {
   const rawRequest = request as Partial<InAppPlanningChatRequest> | null | undefined;
-  const message = typeof rawRequest?.message === 'string' ? rawRequest.message.trim() : '';
+  const rawMessage = typeof rawRequest?.message === 'string' ? rawRequest.message.trim() : '';
+  const taggedMessage = extractPlanningConfirmationOverride(rawMessage);
+  const message = taggedMessage.message.trim();
+  const requestedConfirmationMode = normalizePlanningConfirmationMode(
+    taggedMessage.confirmationMode ?? rawRequest?.confirmationMode,
+    resolveDefaultPlanningConfirmationMode(deps.config),
+  );
   if (!message) {
     return { ok: false, sessionId: rawRequest?.sessionId, error: 'Type a message first.' };
   }
@@ -518,6 +558,7 @@ export async function sendPlanningChatMessage(
       const created = await createSession({
         presetKey: rawRequest?.presetKey,
         title: titleFromMessage(message),
+        confirmationMode: requestedConfirmationMode,
       }, deps);
       if ('error' in created) {
         return { ok: false, sessionId, error: created.error };
@@ -530,6 +571,7 @@ export async function sendPlanningChatMessage(
     }
 
     const activeSession = session;
+    activeSession.confirmationMode = requestedConfirmationMode;
     const previousSend = activeSession.pendingSend ?? Promise.resolve();
     const turn = previousSend.then(async (): Promise<InAppPlanningChatResponse> => {
       clearStarterPromptIfUnused(activeSession);
@@ -575,14 +617,38 @@ export async function sendPlanningChatMessage(
             sessionId: activeSession.id,
             reply,
             reasoning,
+            confirmationMode: activeSession.confirmationMode,
             draftPlanAvailable: hasDraftPlan(activeSession),
             draftPlanSummary: activeSession.draftPlanSummary,
             draftPlanText: activeSession.draftPlanText,
           } as InAppPlanningChatResponse;
         }
 
-        activeSession.draftPlanSummary = result.summary;
-        activeSession.draftPlanText = result.planText;
+        const review = preparePlanningReview({
+          plannerOutput: reply,
+          extractDraftPlanText: () => result.planText,
+          confirmationMode: activeSession.confirmationMode,
+        });
+        if ('kind' in review) {
+          activeSession.status = hasDraftPlan(activeSession)
+            ? 'draft_ready'
+            : 'still_discussing';
+          appendSessionMessage(activeSession, 'assistant', review.reply);
+          persistPlanningSession(activeSession, deps.planningSessionStore, false);
+          return {
+            ok: true,
+            sessionId: activeSession.id,
+            reply: review.reply,
+            reasoning,
+            confirmationMode: activeSession.confirmationMode,
+            draftPlanAvailable: hasDraftPlan(activeSession),
+            draftPlanSummary: activeSession.draftPlanSummary,
+            draftPlanText: activeSession.draftPlanText,
+          } as InAppPlanningChatResponse;
+        }
+
+        activeSession.draftPlanSummary = review.summary;
+        activeSession.draftPlanText = review.planText;
         activeSession.status = 'draft_ready';
         appendSessionMessage(activeSession, 'assistant', reply);
         persistPlanningSession(activeSession, deps.planningSessionStore, false);
@@ -591,9 +657,10 @@ export async function sendPlanningChatMessage(
           sessionId: activeSession.id,
           reply,
           reasoning,
+          confirmationMode: activeSession.confirmationMode,
           draftPlanAvailable: true,
-          draftPlanSummary: result.summary,
-          draftPlanText: result.planText,
+          draftPlanSummary: review.summary,
+          draftPlanText: review.planText,
         } as InAppPlanningChatResponse;
       } catch (error) {
         persistPlanningSession(activeSession, deps.planningSessionStore, false);
@@ -638,7 +705,7 @@ export async function submitPlanningChatDraft(
 
   const submitAttempt = (async (): Promise<InAppPlanningSubmitResponse> => {
     try {
-      const approved = await approvePlanningDraft({
+      const approved = await submitPlanningReview({
         planText: session.draftPlanText,
         loadPlan: deps.loadGeneratedPlan,
       });
@@ -673,6 +740,29 @@ export async function submitPlanningChatDraft(
   })();
   session.pendingSubmit = submitAttempt;
   return submitAttempt;
+}
+
+export function discardPlanningChatDraft(
+  request: InAppPlanningDiscardDraftRequest,
+  deps: { sessions: InAppPlanningChatSessions; planningSessionStore?: InAppPlanningSessionStore },
+): InAppPlanningDiscardDraftResponse {
+  const sessionId = typeof request?.sessionId === 'string' ? request.sessionId.trim() : '';
+  const session = sessionId ? deps.sessions.get(sessionId) : undefined;
+  if (!session) {
+    return { ok: false, error: 'No planning conversation yet.' };
+  }
+  if (!hasDraftPlan(session)) {
+    return { ok: false, error: 'No saved draft to discard.' };
+  }
+  if (session.status === 'submitted') {
+    return { ok: false, error: 'This planning session was already submitted.' };
+  }
+  session.status = 'still_discussing';
+  session.draftPlanSummary = undefined;
+  session.draftPlanText = undefined;
+  appendSessionMessage(session, 'system', 'Draft discarded. Ask Invoker to draft it again.');
+  persistPlanningSession(session, deps.planningSessionStore, false);
+  return { ok: true };
 }
 
 export function resetPlanningChat(
@@ -752,7 +842,6 @@ export function updatePlanningChatTerminalState(
     session.updatedAt = terminalUpdatedAt;
     storePatch.updatedAt = terminalUpdatedAt;
   }
-
   deps.planningSessionStore?.updateInAppPlanningSession(session.id, storePatch);
   return true;
 }
@@ -783,6 +872,7 @@ export async function restorePlanningChatSessions(
       id: record.id,
       title: record.title,
       presetKey: record.presetKey,
+      confirmationMode: normalizePlanningConfirmationMode(record.confirmationMode, resolveDefaultPlanningConfirmationMode(deps.config)),
       status: record.status,
       messages: [...record.messages],
       conversation,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -60,6 +60,7 @@ import type {
   InAppPlanningCreateSessionRequest,
   InAppPlanningChatRequest,
   InAppPlanningDeleteRequest,
+  InAppPlanningDiscardDraftRequest,
   InAppPlanningResetRequest,
   InAppPlanningSubmitRequest,
   Logger,
@@ -252,6 +253,7 @@ import {
   createPlanningCommandBuilderFromRegistry,
   deletePlanningChat,
   deleteSubmittedPlanningChats,
+  discardPlanningChatDraft,
   listPlanningChatSessions,
   planFromGoal as planFromGoalInApp,
   resetPlanningChat,
@@ -1152,6 +1154,12 @@ function startHeadlessMode(): void {
             return submitPlanningChatDraft(payload.args[0] as InAppPlanningSubmitRequest, {
               sessions: planningChatSessions,
               loadGeneratedPlan,
+              planningSessionStore: readOnlyMode ? undefined : persistence,
+            });
+          }
+          case 'invoker:planning-chat-discard-draft': {
+            return discardPlanningChatDraft(payload.args[0] as InAppPlanningDiscardDraftRequest, {
+              sessions: planningChatSessions,
               planningSessionStore: readOnlyMode ? undefined : persistence,
             });
           }


### PR DESCRIPTION
## Summary

The main-process planner now carries confirmation mode and draft reuse through its saved session state.

Before this, the backend owned approval handoff directly and had no shared way to keep a cancelled draft available for a later retry.

This slice switches the backend to the shared review loader and adds the discard-draft IPC path.

## Review Claim

The Planning Terminal backend now stores confirmation mode, keeps cancelled drafts reusable, and routes approved drafts through the shared review loader.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This only changes the main-process planning state and IPC handling; the renderer UI still lands in the next slice.

## Slice Rationale

The renderer cannot show shared review semantics until the backend can persist draft text, retry approvals, and discard drafts without regenerating YAML.

## Non-goals

- Change Slack behavior.
- Change renderer controls or layout.
- Change bundled skill docs.

## Architecture

### Before

```mermaid
graph TD
    A["Planning Terminal draft exists"] --> B["Renderer calls backend-owned approval handoff"]
    B --> C["Cancelled review has no kept-draft backend state"]
```

### After

```mermaid
graph TD
    A["Planning Terminal draft exists"] --> B["Backend stores confirmationMode and draftPlanText"]
    B --> C["shared review loader owns approved-draft handoff"]
    B --> D["discardPlanningChatDraft clears the saved draft only on explicit discard"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`

</details>

## Visual Proof

Walkthrough video: the saved planning state can reopen into the later review surface instead of dropping back to an empty composer.

[Planning Terminal persisted review-state walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-92c90b/7fc8e4115c31b0863fb4b28e9bbee4ae.webm)
## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
