### PR TITLE
[Planning Review Handoff](5) Align planning terminal review flow

### DIFF
--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -7,6 +7,7 @@ import type {
   InAppPlanRequest,
   InAppPlanningChatRequest,
   InAppPlanningCreateSessionRequest,
+  InAppPlanningDiscardDraftRequest,
   InAppPlanningResetRequest,
   InAppPlanningSetTerminalModeRequest,
   InAppPlanningStreamEvent,
@@ -83,6 +84,7 @@ import {
   sendPlanningChatMessage,
   setPlanningChatTerminalMode,
   submitPlanningChatDraft,
+  discardPlanningChatDraft,
 } from '../in-app-planner.js';
 import { seedMainProcessHitchFixture } from '../main-process-hitch-fixture.js';
 import { seedStressFixture, type StressFixtureOptions } from '../stress-fixture.js';
@@ -1278,6 +1280,12 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
         logLabel: 'planning-chat-submit',
       }),
       planningSessionStore: ownerMode ? persistence : undefined,
+    });
+  });
+  registerGuiMutationHandler('invoker:planning-chat-discard-draft', async (request: unknown) => {
+    return discardPlanningChatDraft(request as InAppPlanningDiscardDraftRequest, {
+      sessions: planningChatSessions,
+      planningSessionStore: readOnlyMode ? undefined : persistence,
     });
   });
   registerGuiMutationHandler('invoker:planning-chat-reset', async (request: unknown) => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
-import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, StartReadyRequest, StartReadyResult, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
+import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, PlanningConfirmationMode, ReviewGateQueryResponse, RuntimeStatus, StartReadyRequest, StartReadyResult, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus, WorkerActionSummary, WorkerLogEntry, WorkerStatusEntry } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
 import { reportUiNavigation } from './lib/report-ui-navigation.js';
@@ -179,12 +179,16 @@ type PlanningStreamState = {
   status: 'streaming' | 'failed';
 };
 
-function makeInitialPlanningSession(now: string = new Date().toISOString()): PlanningSessionView {
+function makeInitialPlanningSession(
+  now: string = new Date().toISOString(),
+  confirmationMode: PlanningConfirmationMode = 'require',
+): PlanningSessionView {
   return {
     id: 'local-planning-session-1',
     title: 'Untitled plan',
     status: 'still_discussing',
     presetKey: '',
+    confirmationMode,
     messages: [],
     input: '',
     draftPlanAvailable: false,
@@ -844,8 +848,10 @@ export function App() {
   const nextPlanningSessionLocalIdRef = useRef(2);
   const nextTerminalLineIdRef = useRef(1);
   const [planningStreamBySessionId, setPlanningStreamBySessionId] = useState<Record<string, PlanningStreamState>>({});
-  const [planningPresetOptions, setPlanningPresetOptions] = useState<Array<{ key: string; label: string; isDefault?: boolean }>>([]);
+  const [planningPresetOptions, setPlanningPresetOptions] = useState<Array<{ key: string; label: string; isDefault?: boolean; defaultConfirmationMode?: PlanningConfirmationMode }>>([]);
   const [selectedPlanningPresetKey, setSelectedPlanningPresetKey] = useState('');
+  const [selectedPlanningConfirmationMode, setSelectedPlanningConfirmationMode] = useState<PlanningConfirmationMode>('require');
+  const [keptPlanningDraftSessionIds, setKeptPlanningDraftSessionIds] = useState<Set<string>>(new Set());
   const [planningSubmitError, setPlanningSubmitError] = useState<{ title: string; message: string } | null>(null);
   const [planningTerminalExpanded, setPlanningTerminalExpanded] = useState(false);
   const [reviewDraftSessionId, setReviewDraftSessionId] = useState<string | null>(null);
@@ -996,17 +1002,31 @@ export function App() {
     window.invoker?.getPlanningPresets?.()
       .then((options) => {
         const resolved = Array.isArray(options) && options.length > 0
-          ? options.map((option) => ({ key: option.key, label: option.label, isDefault: option.isDefault }))
-          : [{ key: 'codex', label: 'Codex', isDefault: true }];
+          ? options.map((option) => ({
+              key: option.key,
+              label: option.label,
+              isDefault: option.isDefault,
+              defaultConfirmationMode: option.defaultConfirmationMode,
+            }))
+          : [{ key: 'codex', label: 'Codex', isDefault: true, defaultConfirmationMode: 'require' as const }];
         setPlanningPresetOptions(resolved);
         setSelectedPlanningPresetKey(resolved.find((option) => option.isDefault)?.key ?? resolved[0]?.key ?? 'codex');
+        setSelectedPlanningConfirmationMode(resolved.find((option) => option.isDefault)?.defaultConfirmationMode ?? resolved[0]?.defaultConfirmationMode ?? 'require');
       })
       .catch(() => {
-        setPlanningPresetOptions([{ key: 'codex', label: 'Codex', isDefault: true }]);
+        setPlanningPresetOptions([{ key: 'codex', label: 'Codex', isDefault: true, defaultConfirmationMode: 'require' }]);
         setSelectedPlanningPresetKey('codex');
-    });
+        setSelectedPlanningConfirmationMode('require');
+      });
     refreshSystemDiagnostics();
   }, [refreshSystemDiagnostics]);
+
+  useEffect(() => {
+    if (activePlanningSession.presetKey) {
+      setSelectedPlanningPresetKey(activePlanningSession.presetKey);
+    }
+    setSelectedPlanningConfirmationMode(activePlanningSession.confirmationMode ?? 'require');
+  }, [activePlanningSession.id, activePlanningSession.presetKey, activePlanningSession.confirmationMode]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1021,13 +1041,12 @@ export function App() {
           && first.messages.every((line) => line.role === 'system');
         if (!onlyInitialPlaceholder) return;
         const restored = response.sessions.map(planningSessionSummaryToView);
-        const maxLineId = restored.reduce((max, session) => (
-          Math.max(max, ...session.messages.map((line) => line.id))
-        ), 1);
+        const maxLineId = Math.max(1, ...restored.flatMap((session) => session.messages.map((message) => message.id)));
         nextTerminalLineIdRef.current = Math.max(nextTerminalLineIdRef.current, maxLineId + 1);
         setPlanningSessions(restored);
         setActivePlanningSessionId(restored[0]?.id ?? 'local-planning-session-1');
         setSelectedPlanningPresetKey((current) => current || restored[0]?.presetKey || current);
+        setSelectedPlanningConfirmationMode(restored[0]?.confirmationMode ?? 'require');
       })
       .catch(() => {});
     return () => {
@@ -2524,6 +2543,15 @@ export function App() {
       setStartReadyBusy(false);
     }
   }, [invoker]);
+  const handlePlanningPresetChange = useCallback((presetKey: string) => {
+    setSelectedPlanningPresetKey(presetKey);
+    updatePlanningSessionById(activePlanningSessionId, (session) => ({ ...session, presetKey }));
+  }, [activePlanningSessionId, updatePlanningSessionById]);
+
+  const handlePlanningConfirmationModeChange = useCallback((confirmationMode: PlanningConfirmationMode) => {
+    setSelectedPlanningConfirmationMode(confirmationMode);
+    updatePlanningSessionById(activePlanningSessionId, (session) => ({ ...session, confirmationMode }));
+  }, [activePlanningSessionId, updatePlanningSessionById]);
 
   const handleConfirmStartAndRecreateFailed = useCallback(async () => {
     const result = await handleStartReadyAction(
@@ -2536,11 +2564,11 @@ export function App() {
     if (result) setStartReadyPreview(null);
   }, [handleStartReadyAction, startReadyPreviewMode]);
 
-  const handlePlanningSubmitDraft = useCallback(async () => {
+  const handlePlanningSubmitDraft = useCallback(async (targetSessionId: string | null = planningSessionId) => {
     if (activePlanningReadOnly) {
       return;
     }
-    if (!planningSessionId) {
+    if (!targetSessionId) {
       setPlanningSubmitError({ title: 'Plan could not be submitted', message: 'No planning conversation yet.' });
       appendTerminalLine('Plan could not be submitted:\nNo planning conversation yet.', 'system', 'error');
       return;
@@ -2550,21 +2578,26 @@ export function App() {
       appendTerminalLine('Plan could not be submitted:\nPlanner is not available.', 'system', 'error');
       return;
     }
-    updatePlanningSessionById(planningSessionId, (session) => ({ ...session, busy: true }));
+    updatePlanningSessionById(targetSessionId, (session) => ({ ...session, busy: true }));
     try {
-      const result = await invoker.planningChatSubmit({ sessionId: planningSessionId });
+      const result = await invoker.planningChatSubmit({ sessionId: targetSessionId });
       if (result.ok) {
         setPlanningSubmitError(null);
         setHasLoadedPlan(true);
         setWorkflowSelectionDismissed(false);
         setGraphActionsMenuOpen(false);
+        setKeptPlanningDraftSessionIds((prev) => {
+          const next = new Set(prev);
+          next.delete(targetSessionId);
+          return next;
+        });
         setReviewDraftSessionId(null);
         setPlanName(result.planName);
         setSelectedWorkflowId(result.workflowId);
         setSidebarSurface('home');
         setViewMode('dag');
         issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason: 'planning-submit' });
-        updatePlanningSessionById(planningSessionId, (session) => ({
+        updatePlanningSessionById(targetSessionId, (session) => ({
           ...session,
           busy: false,
           status: 'submitted',
@@ -2591,17 +2624,51 @@ export function App() {
           'success',
         );
       } else {
-        updatePlanningSessionById(planningSessionId, (session) => ({ ...session, busy: false }));
+        updatePlanningSessionById(targetSessionId, (session) => ({ ...session, busy: false }));
         setPlanningSubmitError({ title: 'Plan could not be submitted', message: result.error });
         appendTerminalLine(`Plan could not be submitted:\n${result.error}`, 'system', 'error');
       }
     } catch (err) {
-      updatePlanningSessionById(planningSessionId, (session) => ({ ...session, busy: false }));
+      updatePlanningSessionById(targetSessionId, (session) => ({ ...session, busy: false }));
       const message = err instanceof Error ? err.message : 'Failed to submit the plan.';
       setPlanningSubmitError({ title: 'Plan could not be submitted', message });
       appendTerminalLine(`Plan could not be submitted:\n${message}`, 'system', 'error');
     }
   }, [activePlanningReadOnly, appendTerminalLine, handleStartReadyAction, invoker, issueCameraCommand, planningSessionId, refreshTaskGraph, updatePlanningSessionById]);
+  const handlePlanningCancelReview = useCallback(() => {
+    appendTerminalLine('Submission cancelled. Draft kept.', 'system');
+    setKeptPlanningDraftSessionIds((prev) => new Set(prev).add(activePlanningSessionId));
+    setReviewDraftSessionId(null);
+  }, [activePlanningSessionId, appendTerminalLine]);
+
+  const handlePlanningDiscardDraft = useCallback(async () => {
+    const targetSessionId = planningSessionId;
+    if (!targetSessionId) return;
+    if (!invoker?.planningChatDiscardDraft) {
+      setPlanningSubmitError({ title: 'Draft could not be discarded', message: 'Planner is not available.' });
+      return;
+    }
+    const result = await invoker.planningChatDiscardDraft({ sessionId: targetSessionId });
+    if (!result.ok) {
+      setPlanningSubmitError({ title: 'Draft could not be discarded', message: result.error });
+      appendTerminalLine(result.error, 'system', 'error');
+      return;
+    }
+    setKeptPlanningDraftSessionIds((prev) => {
+      const next = new Set(prev);
+      next.delete(targetSessionId);
+      return next;
+    });
+    setReviewDraftSessionId(null);
+    updatePlanningSessionById(targetSessionId, (session) => ({
+      ...session,
+      status: 'still_discussing',
+      draftPlanAvailable: false,
+      draftPlanSummary: undefined,
+      draftPlanText: undefined,
+      updatedAt: new Date().toISOString(),
+    }));
+  }, [appendTerminalLine, invoker, planningSessionId, updatePlanningSessionById]);
 
   const handlePlanningSubmit = useCallback(async () => {
     const input = planningInput.trim();
@@ -2648,17 +2715,18 @@ export function App() {
       return;
     }
 
+    const request = {
+      message: input,
+      presetKey: selectedPlanningPresetKey || undefined,
+      confirmationMode: selectedPlanningConfirmationMode,
+      ...(planningSessionId ? { sessionId: planningSessionId } : {}),
+    };
     const previousSessionId = activePlanningSessionId;
     pendingPlanningStreamSessionIdsRef.current.add(previousSessionId);
     clearPlanningStreamForSessionIds([previousSessionId, planningSessionId]);
     forgetPlanningStreamAliasesForSessionIds([previousSessionId, planningSessionId]);
     updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: true }));
     try {
-      const request = {
-        message: input,
-        presetKey: selectedPlanningPresetKey || undefined,
-        ...(planningSessionId ? { sessionId: planningSessionId } : {}),
-      };
       const result = await invoker.planningChatSend(request);
       if (result.ok) {
         const updatedAt = new Date().toISOString();
@@ -2673,6 +2741,8 @@ export function App() {
             title: session.title === 'Untitled plan'
               ? (input.length > 56 ? `${input.slice(0, 53).trimEnd()}…` : input)
               : session.title,
+            presetKey: request.presetKey ?? session.presetKey,
+            confirmationMode: result.confirmationMode ?? session.confirmationMode ?? 'require',
             status: result.draftPlanAvailable ? 'draft_ready' : result.reply.includes('?') ? 'waiting_for_answer' : 'still_discussing',
             messages: [...session.messages, { id: replyLineId, text: result.reply, role: 'assistant', ...((result as { reasoning?: string }).reasoning ? { reasoning: (result as { reasoning?: string }).reasoning } : {}) }],
             draftPlanAvailable: result.draftPlanAvailable,
@@ -2689,6 +2759,19 @@ export function App() {
         pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
         pendingPlanningStreamSessionIdsRef.current.delete(result.sessionId);
         setHasLoadedPlan(false);
+        setKeptPlanningDraftSessionIds((prev) => {
+          const next = new Set(prev);
+          next.delete(previousSessionId);
+          next.delete(result.sessionId);
+          return next;
+        });
+        if (result.draftPlanAvailable) {
+          setReviewDraftSessionId(result.sessionId);
+          setPlanningContextCollapsed(false);
+          if ((result.confirmationMode ?? 'require') === 'auto_submit') {
+            void handlePlanningSubmitDraft(result.sessionId);
+          }
+        }
       } else {
         updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: false }));
         keepPlanningStreamFailureForSessionIds([previousSessionId, result.sessionId], result.error);
@@ -2722,6 +2805,7 @@ export function App() {
     invoker,
     planningInput,
     planningSessionId,
+    selectedPlanningConfirmationMode,
     selectedPlanningPresetKey,
     setPlanningInput,
     tasks.size,
@@ -2735,16 +2819,17 @@ export function App() {
     const now = new Date().toISOString();
     const localId = `local-planning-session-${index}`;
     const session: PlanningSessionView = {
-      ...makeInitialPlanningSession(now),
+      ...makeInitialPlanningSession(now, selectedPlanningConfirmationMode),
       id: localId,
       conversationKey: localId,
       presetKey: selectedPlanningPresetKey,
+      confirmationMode: selectedPlanningConfirmationMode,
     };
     setPlanningSessions((prev) => [session, ...prev]);
     setActivePlanningSessionId(session.id);
     setSidebarSurface('home');
     focusKeyboardRegion('planning');
-  }, [focusKeyboardRegion, selectedPlanningPresetKey]);
+  }, [focusKeyboardRegion, selectedPlanningConfirmationMode, selectedPlanningPresetKey]);
 
   const handlePlanningModeChange = useCallback(async (mode: PlanningTerminalMode) => {
     const sourceSession = activePlanningSession;
@@ -2792,6 +2877,7 @@ export function App() {
         const result = await invoker.planningChatCreate({
           presetKey: sourceSession.presetKey || selectedPlanningPresetKey || undefined,
           title: sourceSession.title,
+          confirmationMode: sourceSession.confirmationMode ?? selectedPlanningConfirmationMode,
         });
         if (!result.ok) {
           updatePlanningSessionById(sourceSession.id, (session) => ({
@@ -4038,99 +4124,123 @@ export function App() {
     const draftTaskGroups = draftPlanSummary?.taskGroups ?? (
       draftPlanSummary ? [{ workflow: null, tasks: draftPlanSummary.steps }] : []
     );
+    const keptDraft = keptPlanningDraftSessionIds.has(activePlanningSession.id);
     return (
       <aside
-      data-testid="planning-context-panel"
-      className={`${planningContextCollapsed ? 'w-16' : 'w-72'} shrink-0 border-l border-border bg-card/60 transition-all duration-150`}
-    >
-      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2.5">
+        data-testid="planning-context-panel"
+        className={`${planningContextCollapsed ? 'w-16' : 'w-72'} shrink-0 border-l border-border bg-card/60 transition-all duration-150`}
+      >
+        <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2.5">
+          {!planningContextCollapsed && (
+            <h2 className="text-sm font-semibold text-foreground">{reviewingDraft ? 'Review draft' : 'Current plan'}</h2>
+          )}
+          <button
+            type="button"
+            data-testid="planning-context-toggle"
+            aria-label={planningContextCollapsed ? 'Expand current plan' : 'Collapse current plan'}
+            onClick={() => setPlanningContextCollapsed((value) => !value)}
+            className="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-secondary"
+          >
+            {planningContextCollapsed ? '›' : '‹'}
+          </button>
+        </div>
         {!planningContextCollapsed && (
-          <h2 className="text-sm font-semibold text-foreground">{reviewingDraft ? 'Review draft' : 'Current plan'}</h2>
+          reviewingDraft ? (
+            <div className="space-y-4 p-4 text-sm">
+              {draftTaskGroups.map((group, groupIndex) => (
+                <section key={`${group.workflow ?? 'plan'}-${groupIndex}`} data-testid="draft-task-group">
+                  {group.workflow && <h3 className="text-xs font-medium text-foreground">{group.workflow}</h3>}
+                  <ul className={group.workflow ? 'mt-2 space-y-1.5' : 'space-y-1.5'}>
+                    {group.tasks.map((task, taskIndex) => (
+                      <li key={`${task}-${taskIndex}`} data-testid="draft-step-summary" className="text-xs leading-5 text-muted-foreground">
+                        {task}
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+              {draftPlanText && (
+                <pre data-testid="draft-raw-yaml" className="max-h-56 overflow-auto rounded-md border border-border bg-background p-3 text-[11px] leading-5 text-muted-foreground">
+                  {draftPlanText}
+                </pre>
+              )}
+              {activePlanningSession.confirmationMode === 'require' && (
+                <div className="grid gap-2">
+                  <Button
+                    type="button"
+                    data-testid="planning-create-workflow"
+                    onClick={() => void handlePlanningSubmitDraft()}
+                    className="w-full"
+                  >
+                    Create workflow
+                  </Button>
+                  {keptDraft ? (
+                    <button
+                      type="button"
+                      data-testid="planning-discard-draft"
+                      onClick={() => void handlePlanningDiscardDraft()}
+                      className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
+                    >
+                      Discard draft
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      data-testid="planning-cancel-review"
+                      onClick={handlePlanningCancelReview}
+                      className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
+                    >
+                      Cancel
+                    </button>
+                  )}
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={() => navigatePlanGraphAndFit('planning-draft-review')}
+                className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
+              >
+                Open graph
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-4 p-4 text-sm">
+              <div>
+                <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Goal</div>
+                <p className="mt-1 text-foreground">
+                  {activePlanningSession.title === 'Untitled plan'
+                    ? 'Describe a goal in the chat to begin drafting.'
+                    : activePlanningSession.title}
+                </p>
+              </div>
+              {draftPlanSummary && (
+                <div>
+                  <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Draft</div>
+                  <p className="mt-1 text-foreground">
+                    {draftPlanSummary.name} · {draftPlanSummary.taskCount} task{draftPlanSummary.taskCount === 1 ? '' : 's'}
+                  </p>
+                </div>
+              )}
+              {activePlanningSession.submittedPlanName && (
+                <div>
+                  <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Submitted</div>
+                  <p className="mt-1 text-foreground">{activePlanningSession.submittedPlanName}</p>
+                </div>
+              )}
+              {(draftPlanAvailable || activePlanningSession.status === 'submitted') && (
+                <button
+                  type="button"
+                  data-testid="planning-context-open-graph"
+                  onClick={() => navigatePlanGraphAndFit('planning-context')}
+                  className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
+                >
+                  Open graph
+                </button>
+              )}
+            </div>
+          )
         )}
-        <button
-          type="button"
-          data-testid="planning-context-toggle"
-          aria-label={planningContextCollapsed ? 'Expand current plan' : 'Collapse current plan'}
-          onClick={() => setPlanningContextCollapsed((value) => !value)}
-          className="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-secondary"
-        >
-          {planningContextCollapsed ? '›' : '‹'}
-        </button>
-      </div>
-      {!planningContextCollapsed && (
-        reviewingDraft ? (
-          <div className="space-y-4 p-4 text-sm">
-            {draftTaskGroups.map((group, groupIndex) => (
-              <section key={`${group.workflow ?? 'plan'}-${groupIndex}`} data-testid="draft-task-group">
-                {group.workflow && <h3 className="text-xs font-medium text-foreground">{group.workflow}</h3>}
-                <ul className={group.workflow ? 'mt-2 space-y-1.5' : 'space-y-1.5'}>
-                  {group.tasks.map((task, taskIndex) => (
-                    <li key={`${task}-${taskIndex}`} data-testid="draft-step-summary" className="text-xs leading-5 text-muted-foreground">
-                      {task}
-                    </li>
-                  ))}
-                </ul>
-              </section>
-            ))}
-            {draftPlanText && (
-              <pre data-testid="draft-raw-yaml" className="max-h-56 overflow-auto rounded-md border border-border bg-background p-3 text-[11px] leading-5 text-muted-foreground">
-                {draftPlanText}
-              </pre>
-            )}
-            <Button
-              type="button"
-              data-testid="planning-create-workflow"
-              onClick={() => void handlePlanningSubmitDraft()}
-              className="w-full"
-            >
-              Create workflow
-            </Button>
-            <button
-              type="button"
-              onClick={() => navigatePlanGraphAndFit('planning-draft-review')}
-              className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
-            >
-              Open graph
-            </button>
-          </div>
-        ) : (
-          <div className="space-y-4 p-4 text-sm">
-          <div>
-            <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Goal</div>
-            <p className="mt-1 text-foreground">
-              {activePlanningSession.title === 'Untitled plan'
-                ? 'Describe a goal in the chat to begin drafting.'
-                : activePlanningSession.title}
-            </p>
-          </div>
-          {draftPlanSummary && (
-            <div>
-              <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Draft</div>
-              <p className="mt-1 text-foreground">
-                {draftPlanSummary.name} · {draftPlanSummary.taskCount} task{draftPlanSummary.taskCount === 1 ? '' : 's'}
-              </p>
-            </div>
-          )}
-          {activePlanningSession.submittedPlanName && (
-            <div>
-              <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Submitted</div>
-              <p className="mt-1 text-foreground">{activePlanningSession.submittedPlanName}</p>
-            </div>
-          )}
-          {(draftPlanAvailable || activePlanningSession.status === 'submitted') && (
-            <button
-              type="button"
-              data-testid="planning-context-open-graph"
-              onClick={() => navigatePlanGraphAndFit('planning-context')}
-              className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
-            >
-              Open graph
-            </button>
-          )}
-          </div>
-        )
-      )}
-    </aside>
+      </aside>
     );
   };
 
@@ -4227,6 +4337,7 @@ export function App() {
             value={planningInput}
             selectedPresetKey={selectedPlanningPresetKey}
             presetOptions={planningPresetOptions}
+            selectedConfirmationMode={selectedPlanningConfirmationMode}
             draftPlanAvailable={draftPlanAvailable}
             draftPlanSummary={draftPlanSummary}
             planningStream={activePlanningStream}
@@ -4238,7 +4349,8 @@ export function App() {
             submittedPlanName={activePlanningSession.submittedPlanName}
             onValueChange={setPlanningInput}
             onSubmit={() => void handlePlanningSubmit()}
-            onPresetChange={setSelectedPlanningPresetKey}
+            onPresetChange={handlePlanningPresetChange}
+            onConfirmationModeChange={handlePlanningConfirmationModeChange}
             onModeChange={(mode) => void handlePlanningModeChange(mode)}
             onExpand={() => setPlanningTerminalExpanded(true)}
             onOpenGraph={() => navigatePlanGraphAndFit('planning-open-graph')}
@@ -4559,6 +4671,7 @@ export function App() {
             value={planningInput}
             selectedPresetKey={selectedPlanningPresetKey}
             presetOptions={planningPresetOptions}
+            selectedConfirmationMode={selectedPlanningConfirmationMode}
             draftPlanAvailable={draftPlanAvailable}
             draftPlanSummary={draftPlanSummary}
             planningStream={activePlanningStream}
@@ -4571,7 +4684,8 @@ export function App() {
             onValueChange={setPlanningInput}
             readOnly={activePlanningReadOnly}
             onSubmit={() => void handlePlanningSubmit()}
-            onPresetChange={setSelectedPlanningPresetKey}
+            onPresetChange={handlePlanningPresetChange}
+            onConfirmationModeChange={handlePlanningConfirmationModeChange}
             onModeChange={(mode) => void handlePlanningModeChange(mode)}
             onExpand={() => setPlanningTerminalExpanded(true)}
             onCloseExpanded={() => setPlanningTerminalExpanded(false)}

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -81,6 +81,7 @@ export function makePlanningSessionSummary(
     title: 'Saved planning chat',
     status: 'draft_ready',
     presetKey: 'codex',
+    confirmationMode: 'require',
     messages: [
       {
         id: 1,
@@ -201,6 +202,7 @@ export function createMockInvoker(
         title: 'Untitled plan',
         status: 'still_discussing',
         presetKey: 'codex',
+        confirmationMode: 'require',
         messages: [],
         draftPlanAvailable: false,
         createdAt: '2026-01-01T00:00:00.000Z',
@@ -212,6 +214,7 @@ export function createMockInvoker(
       ok: true,
       sessionId: 'session-1',
       reply: 'I can help draft that.',
+      confirmationMode: 'require',
       draftPlanAvailable: false,
     })),
     planningChatSubmit: vi.fn(async () => ({
@@ -219,6 +222,7 @@ export function createMockInvoker(
       planName: 'Mock Plan',
       workflowId: 'wf-1',
     })),
+    planningChatDiscardDraft: vi.fn(async () => ({ ok: true })),
     planningChatReset: vi.fn(async () => ({ ok: true })),
     onPlanningChatStream: vi.fn((cb: (event: InAppPlanningStreamEvent) => void) => {
       planningChatStreamCallbacks.add(cb);
@@ -243,9 +247,9 @@ export function createMockInvoker(
     planningTerminalResize: vi.fn(async () => ({ ok: true })),
     planningTerminalClose: vi.fn(async () => ({ ok: true })),
     getPlanningPresets: vi.fn(async () => [
-      { key: 'codex', label: 'Codex', tool: 'codex', isDefault: true },
-      { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude', isDefault: false },
-      { key: 'omp', label: 'OMP', tool: 'omp', isDefault: false },
+      { key: 'codex', label: 'Codex', tool: 'codex', isDefault: true, defaultConfirmationMode: 'require' },
+      { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude', isDefault: false, defaultConfirmationMode: 'require' },
+      { key: 'omp', label: 'OMP', tool: 'omp', isDefault: false, defaultConfirmationMode: 'require' },
     ]),
     start: vi.fn(async () => taskSnapshot),
     stop: vi.fn(async () => {}),

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -152,7 +152,7 @@ describe('Invoker terminal (component)', () => {
     submitPlanningText('hello');
 
     await waitFor(() => {
-      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'hello', presetKey: 'codex' });
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'hello', presetKey: 'codex', confirmationMode: 'require' });
       expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('I can help draft that.');
     });
     expect(screen.queryByText(/Unknown command/)).not.toBeInTheDocument();
@@ -334,7 +334,7 @@ describe('Invoker terminal (component)', () => {
     fireEvent.keyDown(input, { key: 'Enter' });
 
     await waitFor(() => {
-      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'hello', presetKey: 'codex' });
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'hello', presetKey: 'codex', confirmationMode: 'require' });
     });
   });
 
@@ -606,6 +606,7 @@ describe('Invoker terminal (component)', () => {
         sessionId: 'saved-pressure-chat',
         message: 'continue the restored session',
         presetKey: 'codex',
+        confirmationMode: 'require',
       });
     });
   });
@@ -685,6 +686,7 @@ describe('Invoker terminal (component)', () => {
         sessionId: 'session-1',
         message: 'make the plan more detailed',
         presetKey: 'codex',
+        confirmationMode: 'require',
       });
     });
   });
@@ -697,7 +699,7 @@ describe('Invoker terminal (component)', () => {
     submitPlanningText('draft a plan');
 
     await waitFor(() => {
-      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'draft a plan', presetKey: 'omp+claude' });
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'draft a plan', presetKey: 'omp+claude', confirmationMode: 'require' });
     });
   });
 

--- a/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
@@ -49,6 +49,7 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
       ok: true,
       sessionId: 'session-1',
       reply: 'Here is the plan.',
+      confirmationMode: 'require',
       draftPlanAvailable: true,
       draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First', 'Second'] },
     };
@@ -91,6 +92,7 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
       expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
         message: 'draft the next plan',
         presetKey: 'codex',
+        confirmationMode: 'require',
       });
     });
 
@@ -155,6 +157,64 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
 
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'draft-1' });
+    });
+  });
+  it('keeps the same draft after cancel and exposes discard on reopen', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [makePlanningSessionSummary({
+        id: 'draft-keep',
+        draftPlanSummary: {
+          name: 'Kept draft',
+          taskCount: 2,
+          steps: ['Add API endpoint', 'Verify API endpoint'],
+          taskGroups: [{ workflow: 'Backend workflow', tasks: ['Add API endpoint', 'Verify API endpoint'] }],
+        },
+        draftPlanText: 'name: Kept draft\ntasks:\n  - id: keep\n    description: Add API endpoint\n',
+      })],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    fireEvent.click(await screen.findByTestId('invoker-terminal-review-draft'));
+    fireEvent.click(await screen.findByTestId('planning-cancel-review'));
+
+    expect(await screen.findByText('Submission cancelled. Draft kept.')).toBeInTheDocument();
+    expect(screen.getByTestId('invoker-terminal-review-draft')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('invoker-terminal-review-draft'));
+    expect(await screen.findByTestId('planning-discard-draft')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('planning-discard-draft'));
+
+    await waitFor(() => {
+      expect(mock.api.planningChatDiscardDraft).toHaveBeenCalledWith({ sessionId: 'draft-keep' });
+    });
+  });
+
+  it('auto-submits after rendering a draft when review mode is auto-submit', async () => {
+    mock.api.planningChatSend = vi.fn(async () => ({
+      ok: true,
+      sessionId: 'session-auto',
+      reply: 'Here is the auto-submit plan.',
+      confirmationMode: 'auto_submit',
+      draftPlanAvailable: true,
+      draftPlanSummary: { name: 'Auto submit plan', taskCount: 1, steps: ['Ship it'] },
+      draftPlanText: 'name: Auto submit plan\ntasks:\n  - id: ship\n    description: Ship it\n',
+    })) as any;
+    mock.api.planningChatSubmit = vi.fn(async () => ({
+      ok: true,
+      planName: 'Auto submit plan',
+      workflowId: 'wf-auto',
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft and submit');
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-auto' });
     });
   });
 });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useStat
 import { Terminal as XTermTerminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import type { TerminalSessionDescriptor } from '@invoker/contracts';
+import type { PlanningConfirmationMode } from '@invoker/contracts';
 import { SendIcon } from './icons/index.js';
 
 export interface InvokerTerminalLine {
@@ -48,6 +49,7 @@ interface InvokerTerminalProps {
   value: string;
   selectedPresetKey: string;
   presetOptions: PlanningPresetOptionView[];
+  selectedConfirmationMode: PlanningConfirmationMode;
   draftPlanAvailable: boolean;
   draftPlanSummary?: {
     name: string;
@@ -65,6 +67,7 @@ interface InvokerTerminalProps {
   onValueChange: (value: string) => void;
   onSubmit: () => void;
   onPresetChange: (presetKey: string) => void;
+  onConfirmationModeChange: (confirmationMode: PlanningConfirmationMode) => void;
   onModeChange?: (mode: PlanningTerminalMode) => void;
   onExpand: () => void;
   onCloseExpanded?: () => void;
@@ -326,6 +329,7 @@ export function InvokerTerminal({
   value,
   selectedPresetKey,
   presetOptions,
+  selectedConfirmationMode,
   draftPlanAvailable,
   draftPlanSummary,
   planningStream,
@@ -338,6 +342,7 @@ export function InvokerTerminal({
   onValueChange,
   onSubmit,
   onPresetChange,
+  onConfirmationModeChange,
   onModeChange,
   onExpand,
   onCloseExpanded,
@@ -727,20 +732,35 @@ export function InvokerTerminal({
                     Options
                   </button>
                   {showComposerOptions && (
-                    <label className="ml-3 text-xs text-muted-foreground">
-                      Agent
-                      <select
-                        data-testid="invoker-terminal-harness"
-                        value={selectedPresetKey}
-                        onChange={(event) => onPresetChange(event.target.value)}
-                        disabled={readOnly}
-                        className="ml-2 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none hover:border-border-strong focus:border-ring"
-                      >
-                        {presetOptions.map((option) => (
-                          <option key={option.key} value={option.key}>{option.label}</option>
-                        ))}
-                      </select>
-                    </label>
+                    <div className="ml-3 flex flex-wrap items-center gap-3">
+                      <label className="text-xs text-muted-foreground">
+                        Agent
+                        <select
+                          data-testid="invoker-terminal-harness"
+                          value={selectedPresetKey}
+                          onChange={(event) => onPresetChange(event.target.value)}
+                          disabled={readOnly}
+                          className="ml-2 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none hover:border-border-strong focus:border-ring"
+                        >
+                          {presetOptions.map((option) => (
+                            <option key={option.key} value={option.key}>{option.label}</option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="text-xs text-muted-foreground">
+                        Review
+                        <select
+                          data-testid="invoker-terminal-confirmation-mode"
+                          value={selectedConfirmationMode}
+                          onChange={(event) => onConfirmationModeChange(event.target.value as PlanningConfirmationMode)}
+                          disabled={readOnly}
+                          className="ml-2 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none hover:border-border-strong focus:border-ring"
+                        >
+                          <option value="require">Ask first</option>
+                          <option value="auto_submit">Auto-submit</option>
+                        </select>
+                      </label>
+                    </div>
                   )}
                 </div>
                 <button


### PR DESCRIPTION
## Summary

The Planning Terminal now shows the review mode in its own composer controls.

Users can see the review mode next to the agent selector, keep a cancelled draft, reopen the same YAML, and discard it only when they choose to.

Auto-submit sessions still render the same draft summary first, then continue without a second click.

## Review Claim

The Planning Terminal renderer now shows the review controls and kept-draft behavior without regenerating the drafted YAML.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This changes the renderer and GUI mutation surface only after the backend already knows how to persist, hand off, cancel, and discard the same draft.

## Slice Rationale

The user-facing review pane is the last behavior step because it depends on the earlier backend persistence slices.

## Non-goals

- Change Slack cards.
- Change host MCP prompts.
- Change bundled skill docs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx`

</details>

## Visual Proof

Planning Terminal before: the composer only shows the agent picker.

![Planning Terminal before review mode selector](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-a8ccfd/planning-terminal-before.png)

Planning Terminal after: the composer options now show `Review` next to `Agent`, and the current-plan sidebar stays visible after the plan runs.

![Planning Terminal after review mode selector](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-a8ccfd/planning-terminal-after.png)
Walkthrough video: the Planning Terminal shows the review controls and current-plan sidebar after the draft runs.

[Planning Terminal review walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-92c90b/7fc8e4115c31b0863fb4b28e9bbee4ae.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
