### PR TITLE
[Planning Review Handoff](7) Update plan-to-invoker command docs

### DIFF
--- a/skills/plan-to-invoker/commands/invoker-plan-to-invoker.md
+++ b/skills/plan-to-invoker/commands/invoker-plan-to-invoker.md
@@ -11,8 +11,10 @@ Write the planning artifact to `plans/invoker-handoff.md`.
 
 Convert the approved Markdown plan to `plans/invoker-handoff.yaml`.
 
-Validate with `invoker_validate_plan` before submitting.
+Call `invoker_prepare_plan_review` on `plans/invoker-handoff.yaml`, show the returned ordered steps and `confirmationText`, and use that review output as the only approval gate.
 
-Submit with `invoker_submit_plan` using mode `live` so the workflow appears in the running Invoker app.
+If the review result says `confirmationMode` is `require`, wait for approval before submission. If it says `auto_submit`, show the same review output and then submit immediately.
 
-If MCP tools are not available but `invoker-cli` is on PATH, run `invoker-cli run plans/invoker-handoff.yaml --live` instead.
+Call `invoker_submit_plan` with mode `live` only after that review step, or immediately after it when `confirmationMode` is `auto_submit`.
+
+If MCP tools are not available but `invoker-cli` is on PATH, mirror the same flow with `invoker-cli run plans/invoker-handoff.yaml --live` only after the review/approval step.


### PR DESCRIPTION
## Summary

The installed handoff markdown now matches the current host review order.

It now says to write Markdown, convert it to YAML, review the generated YAML, and pause for approval when required.

This keeps the shipped handoff text aligned with the behavior already landed below it.

## Review Claim

The installed handoff markdown now documents the current host review order for plan handoff.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This is markdown-only wording; no shipped code changes in this slice.

## Slice Rationale

The docs land last so they describe the final shipped order instead of an intermediate one.

## Non-goals

- Change any shipped code.
- Change bundled skill files.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] Not run (docs-only).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
