### PR TITLE
[Planning Review Handoff](1a) Add shared planning review helpers

### DIFF
--- a/packages/planning-core/src/__tests__/planning-actions.test.ts
+++ b/packages/planning-core/src/__tests__/planning-actions.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   appendPlanningTurn,
-  approvePlanningDraft,
   createPlanningSessionState,
-  runPlanToInvoker,
 } from '../planning-actions.js';
 
 const planText = [
@@ -87,91 +85,3 @@ describe('appendPlanningTurn', () => {
   });
 });
 
-describe('runPlanToInvoker', () => {
-  it('returns a draft_ready result when the conversion produces a valid plan', async () => {
-    const result = await runPlanToInvoker({
-      convert: async () => planText,
-    });
-
-    expect(result).toMatchObject({
-      kind: 'draft_ready',
-      planText,
-      summary: { name: 'Shared planning actions', taskCount: 1 },
-      reply: planText,
-    });
-  });
-
-  it('extracts the plan text from a wrapped output before evaluating it', async () => {
-    const wrapped = `Here you go:\n\`\`\`yaml\n${planText}\n\`\`\``;
-    const result = await runPlanToInvoker({
-      convert: async () => wrapped,
-      extractDraftPlanText: (output) => output.match(/```yaml\n([\s\S]*?)\n```/)?.[1] ?? null,
-    });
-
-    expect(result).toMatchObject({ kind: 'draft_ready', planText });
-  });
-
-  it('returns a message result when no valid plan is produced', async () => {
-    const result = await runPlanToInvoker({
-      convert: async () => 'name: incomplete',
-    });
-
-    expect(result).toEqual({ kind: 'message', reply: 'name: incomplete' });
-  });
-});
-
-describe('approvePlanningDraft', () => {
-  it('rejects when there is no draft plan text', async () => {
-    const result = await approvePlanningDraft({
-      planText: undefined,
-      loadPlan: async () => ({ planName: 'x', workflowId: 'wf-1' }),
-    });
-
-    expect(result).toEqual({
-      ok: false,
-      error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.',
-    });
-  });
-
-  it('rejects when the draft plan text cannot be summarized', async () => {
-    const result = await approvePlanningDraft({
-      planText: 'name: incomplete',
-      loadPlan: async () => ({ planName: 'x', workflowId: 'wf-1' }),
-    });
-
-    expect(result).toEqual({
-      ok: false,
-      error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.',
-    });
-  });
-
-  it('loads and returns the approved plan on success', async () => {
-    const result = await approvePlanningDraft({
-      planText,
-      loadPlan: async (text) => {
-        expect(text).toBe(planText);
-        return { planName: 'Shared planning actions', workflowId: 'wf-1', workflowIds: ['wf-1'], workflowCount: 1 };
-      },
-    });
-
-    expect(result).toMatchObject({
-      ok: true,
-      planName: 'Shared planning actions',
-      workflowId: 'wf-1',
-      workflowIds: ['wf-1'],
-      workflowCount: 1,
-      summary: { name: 'Shared planning actions', taskCount: 1 },
-    });
-  });
-
-  it('surfaces errors thrown by loadPlan', async () => {
-    const result = await approvePlanningDraft({
-      planText,
-      loadPlan: async () => {
-        throw new Error('boom');
-      },
-    });
-
-    expect(result).toEqual({ ok: false, error: 'boom' });
-  });
-});

--- a/packages/planning-core/src/__tests__/planning-review.test.ts
+++ b/packages/planning-core/src/__tests__/planning-review.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { preparePlanningReview, submitPlanningReview } from '../planning-review.js';
+
+const planText = [
+  'name: Shared planning review',
+  'tasks:',
+  '  - id: implement',
+  '    description: Implement the shared review contract',
+].join('\n');
+
+describe('preparePlanningReview', () => {
+  it('returns the canonical review draft for require mode', () => {
+    const result = preparePlanningReview({
+      plannerOutput: planText,
+      confirmationMode: 'require',
+    });
+
+    expect(result).toMatchObject({
+      planText,
+      summary: { name: 'Shared planning review', taskCount: 1 },
+      confirmationMode: 'require',
+      confirmationText: 'Approve to submit this exact YAML. Cancel keeps the draft. Discard removes it.',
+    });
+  });
+
+  it('keeps the same draft content in auto-submit mode', () => {
+    const result = preparePlanningReview({
+      plannerOutput: `Here you go:\n\`\`\`yaml\n${planText}\n\`\`\``,
+      extractDraftPlanText: (output) => output.match(/```yaml\n([\s\S]*?)\n```/)?.[1] ?? null,
+      confirmationMode: 'auto_submit',
+    });
+
+    expect(result).toMatchObject({
+      planText,
+      summary: { name: 'Shared planning review', taskCount: 1 },
+      confirmationMode: 'auto_submit',
+      confirmationText: 'Auto-submit is enabled. Submit this exact YAML now.',
+    });
+  });
+
+  it('returns the planner reply when no valid draft exists', () => {
+    const result = preparePlanningReview({
+      plannerOutput: 'name: incomplete',
+      confirmationMode: 'require',
+    });
+
+    expect(result).toEqual({ kind: 'message', reply: 'name: incomplete' });
+  });
+});
+
+describe('submitPlanningReview', () => {
+  it('rejects when there is no draft plan text', async () => {
+    const result = await submitPlanningReview({
+      planText: undefined,
+      loadPlan: async () => ({ planName: 'x', workflowId: 'wf-1' }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.',
+    });
+  });
+
+  it('rejects when the draft plan text cannot be summarized', async () => {
+    const result = await submitPlanningReview({
+      planText: 'name: incomplete',
+      loadPlan: async () => ({ planName: 'x', workflowId: 'wf-1' }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.',
+    });
+  });
+
+  it('loads and returns the approved plan on success', async () => {
+    const result = await submitPlanningReview({
+      planText,
+      loadPlan: async (text) => {
+        expect(text).toBe(planText);
+        return { planName: 'Shared planning review', workflowId: 'wf-1', workflowIds: ['wf-1'], workflowCount: 1 };
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      planName: 'Shared planning review',
+      workflowId: 'wf-1',
+      workflowIds: ['wf-1'],
+      workflowCount: 1,
+      summary: { name: 'Shared planning review', taskCount: 1 },
+    });
+  });
+
+  it('surfaces errors thrown by loadPlan', async () => {
+    const result = await submitPlanningReview({
+      planText,
+      loadPlan: async () => {
+        throw new Error('boom');
+      },
+    });
+
+    expect(result).toEqual({ ok: false, error: 'boom' });
+  });
+});

--- a/packages/planning-core/src/index.ts
+++ b/packages/planning-core/src/index.ts
@@ -1,4 +1,6 @@
 export * from './lifecycle.js';
 export * from './plan-summary.js';
 export * from './planning-turn.js';
+export * from './planning-review.js';
+export * from './planning-handoff-prompt.js';
 export * from './planning-actions.js';

--- a/packages/planning-core/src/planning-actions.ts
+++ b/packages/planning-core/src/planning-actions.ts
@@ -1,6 +1,6 @@
 import type { PlanningMessage } from './lifecycle.js';
 import { evaluatePlanningTurn } from './planning-turn.js';
-import { summarizePlanText, type PlanSummary } from './plan-summary.js';
+import { type PlanSummary } from './plan-summary.js';
 
 export type PlanningSessionStatus = 'still_discussing' | 'waiting_for_answer' | 'draft_ready' | 'submitted';
 
@@ -72,66 +72,3 @@ export async function appendPlanningTurn({
   };
 }
 
-export interface RunPlanToInvokerInput {
-  convert: () => Promise<string>;
-  extractDraftPlanText?: (output: string) => string | null | undefined;
-}
-
-export type RunPlanToInvokerResult =
-  | { kind: 'draft_ready'; planText: string; summary: PlanSummary; reply: string }
-  | { kind: 'message'; reply: string };
-
-export async function runPlanToInvoker({
-  convert,
-  extractDraftPlanText,
-}: RunPlanToInvokerInput): Promise<RunPlanToInvokerResult> {
-  const reply = await convert();
-  const immediateDraftPlanText = extractDraftPlanText ? extractDraftPlanText(reply) : reply;
-  const turn = evaluatePlanningTurn({
-    userMessage: '',
-    messagesBeforeTurn: [],
-    assistantReply: reply,
-    immediateDraftPlanText,
-    requireDraftAuthorization: false,
-  });
-
-  if (turn.kind === 'draft_ready') {
-    return { kind: 'draft_ready', planText: turn.planText, summary: turn.summary, reply };
-  }
-  return { kind: 'message', reply };
-}
-
-export interface ApprovedPlanLoadResult {
-  planName: string;
-  workflowId: string;
-  workflowIds?: string[];
-  workflowCount?: number;
-}
-
-export interface ApprovePlanningDraftInput {
-  planText: string | null | undefined;
-  loadPlan: (planText: string) => ApprovedPlanLoadResult | Promise<ApprovedPlanLoadResult>;
-}
-
-export type ApprovePlanningDraftResult =
-  | ({ ok: true; summary: PlanSummary } & ApprovedPlanLoadResult)
-  | { ok: false; error: string };
-
-export async function approvePlanningDraft({
-  planText,
-  loadPlan,
-}: ApprovePlanningDraftInput): Promise<ApprovePlanningDraftResult> {
-  if (!planText) {
-    return { ok: false, error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.' };
-  }
-  const summary = summarizePlanText(planText);
-  if (!summary) {
-    return { ok: false, error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.' };
-  }
-  try {
-    const loaded = await loadPlan(planText);
-    return { ok: true, summary, ...loaded };
-  } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : String(error) };
-  }
-}

--- a/packages/planning-core/src/planning-handoff-prompt.ts
+++ b/packages/planning-core/src/planning-handoff-prompt.ts
@@ -1,0 +1,38 @@
+import type { PlanningConfirmationMode } from './planning-review.js';
+
+export interface BuildPlanningHandoffInstructionsOptions {
+  planFilePath?: string;
+  confirmationMode?: PlanningConfirmationMode;
+  reviewInstruction?: string;
+  shortReplyInstruction?: string;
+  submissionInstruction?: string;
+}
+
+export function buildPlanningHandoffInstructions({
+  planFilePath,
+  confirmationMode = 'require',
+  reviewInstruction,
+  shortReplyInstruction,
+  submissionInstruction,
+}: BuildPlanningHandoffInstructionsOptions = {}): string {
+  const outputInstruction = planFilePath
+    ? [
+        `When the final YAML plan is ready, write the COMPLETE YAML to \`${planFilePath}\` using your file-writing tool.`,
+        shortReplyInstruction ?? 'Then reply with only a short summary. Never paste the YAML into chat.',
+      ].join(' ')
+    : 'When the final YAML plan is ready, output the COMPLETE YAML inside a ```yaml code block.';
+  const orderedStepInstruction = reviewInstruction
+    ?? 'After the YAML exists, review the exact same YAML and show its ordered steps.';
+  const confirmationInstruction = confirmationMode === 'auto_submit'
+    ? 'Auto-submit is enabled. After that review step, continue straight to the designated submission step without an extra approval pause.'
+    : 'After that review step, wait for approval before any submission step.';
+  return [
+    outputInstruction,
+    orderedStepInstruction,
+    confirmationInstruction,
+    'Do not skip the review flow by validating, submitting, or executing the plan before the exact YAML has been shown back to the user.',
+    'Before that review step completes, do not call `invoker-cli`, `invoker_submit_plan`, `invoker_validate_plan`, or `submit-plan.sh`.',
+    submissionInstruction ?? 'Only the designated review flow may submit the plan after approval.',
+    'Do not tell the user to reply `submit`; approval belongs to the review flow.',
+  ].join(' ');
+}

--- a/packages/planning-core/src/planning-review.ts
+++ b/packages/planning-core/src/planning-review.ts
@@ -1,0 +1,88 @@
+import { evaluatePlanningTurn } from './planning-turn.js';
+import { summarizePlanText, type PlanSummary } from './plan-summary.js';
+
+export type PlanningConfirmationMode = 'require' | 'auto_submit';
+
+export interface PlanningReviewDraft {
+  planText: string;
+  summary: PlanSummary;
+  confirmationMode: PlanningConfirmationMode;
+  confirmationText: string;
+}
+
+export interface PreparePlanningReviewInput {
+  plannerOutput: string;
+  extractDraftPlanText?: (output: string) => string | null | undefined;
+  confirmationMode?: PlanningConfirmationMode;
+}
+
+export type PreparePlanningReviewResult =
+  | PlanningReviewDraft
+  | { kind: 'message'; reply: string };
+
+export function preparePlanningReview({
+  plannerOutput,
+  extractDraftPlanText,
+  confirmationMode = 'require',
+}: PreparePlanningReviewInput): PreparePlanningReviewResult {
+  const immediateDraftPlanText = extractDraftPlanText ? extractDraftPlanText(plannerOutput) : plannerOutput;
+  const turn = evaluatePlanningTurn({
+    userMessage: '',
+    messagesBeforeTurn: [],
+    assistantReply: plannerOutput,
+    immediateDraftPlanText,
+    requireDraftAuthorization: false,
+  });
+
+  if (turn.kind !== 'draft_ready') {
+    return { kind: 'message', reply: plannerOutput };
+  }
+
+  return {
+    planText: turn.planText,
+    summary: turn.summary,
+    confirmationMode,
+    confirmationText: confirmationTextForMode(confirmationMode),
+  };
+}
+
+export interface PlanningReviewLoadResult {
+  planName: string;
+  workflowId: string;
+  workflowIds?: string[];
+  workflowCount?: number;
+}
+
+export interface SubmitPlanningReviewInput {
+  planText: string | null | undefined;
+  loadPlan: (planText: string) => PlanningReviewLoadResult | Promise<PlanningReviewLoadResult>;
+}
+
+export type SubmitPlanningReviewResult =
+  | ({ ok: true; summary: PlanSummary } & PlanningReviewLoadResult)
+  | { ok: false; error: string };
+
+export async function submitPlanningReview({
+  planText,
+  loadPlan,
+}: SubmitPlanningReviewInput): Promise<SubmitPlanningReviewResult> {
+  if (!planText) {
+    return { ok: false, error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.' };
+  }
+  const summary = summarizePlanText(planText);
+  if (!summary) {
+    return { ok: false, error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.' };
+  }
+  try {
+    const loaded = await loadPlan(planText);
+    return { ok: true, summary, ...loaded };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export function confirmationTextForMode(confirmationMode: PlanningConfirmationMode): string {
+  return confirmationMode === 'auto_submit'
+    ? 'Auto-submit is enabled. Submit this exact YAML now.'
+    : 'Approve to submit this exact YAML. Cancel keeps the draft. Discard removes it.';
+}


### PR DESCRIPTION
## Summary

This adds the shared planning review helpers in planning-core.

The new module turns drafted YAML into one canonical ordered-step summary and one canonical confirmation message.

Nothing in this slice changes Slack, the host adapter, or the Planning Terminal yet.

## Review Claim

Planning-core now owns YAML review parsing, ordered-step summaries, and confirmation text for drafted plans.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This is helper-layer code only; no runtime surface consumes it yet.

## Slice Rationale

The shared helpers need to exist before persistence, Slack, the host adapter, and the terminal can all consume the same review flow.

## Non-goals

- Persist confirmation mode.
- Change any runtime surface.
- Update bundled skill docs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/planning-core test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
