### PR TITLE
[Planning Review Handoff](1b) Persist planning review confirmation state

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -436,12 +436,14 @@ export type InAppPlanResponse =
       error: string;
     };
 
+export type PlanningConfirmationMode = 'require' | 'auto_submit';
 export interface PlanningPresetOption {
   key: string;
   label: string;
   tool: string;
   model?: string;
   isDefault: boolean;
+  defaultConfirmationMode?: PlanningConfirmationMode;
 }
 
 export interface InAppPlanningPlanSummaryTaskGroup {
@@ -477,6 +479,7 @@ export interface InAppPlanningSessionSummary {
   title: string;
   status: InAppPlanningSessionStatus;
   presetKey: string;
+  confirmationMode: PlanningConfirmationMode;
   messages: InAppPlanningChatLine[];
   draftPlanAvailable: boolean;
   draftPlanSummary?: InAppPlanningPlanSummary;
@@ -496,6 +499,7 @@ export interface InAppPlanningSessionSummary {
 export interface InAppPlanningCreateSessionRequest {
   presetKey?: string;
   title?: string;
+  confirmationMode?: PlanningConfirmationMode;
 }
 
 export type InAppPlanningCreateSessionResponse =
@@ -522,6 +526,7 @@ export interface InAppPlanningChatRequest {
   sessionId?: string;
   message: string;
   presetKey?: string;
+  confirmationMode?: PlanningConfirmationMode;
 }
 
 export type InAppPlanningChatResponse =
@@ -529,6 +534,7 @@ export type InAppPlanningChatResponse =
       ok: true;
       sessionId: string;
       reply: string;
+      confirmationMode: PlanningConfirmationMode;
       draftPlanAvailable: boolean;
       draftPlanSummary?: InAppPlanningPlanSummary;
       draftPlanText?: string;
@@ -561,6 +567,13 @@ export interface InAppPlanningResetRequest {
 }
 
 export type InAppPlanningResetResponse = { ok: true };
+export interface InAppPlanningDiscardDraftRequest {
+  sessionId: string;
+}
+
+export type InAppPlanningDiscardDraftResponse =
+  | { ok: true }
+  | { ok: false; error: string };
 
 export interface InAppPlanningSetTerminalModeRequest {
   sessionId: string;
@@ -880,6 +893,10 @@ export const IpcChannels = {
   'invoker:planning-chat-submit': {} as {
     request: [request: InAppPlanningSubmitRequest];
     response: InAppPlanningSubmitResponse;
+  },
+  'invoker:planning-chat-discard-draft': {} as {
+    request: [request: InAppPlanningDiscardDraftRequest];
+    response: InAppPlanningDiscardDraftResponse;
   },
   'invoker:planning-chat-reset': {} as {
     request: [request: InAppPlanningResetRequest];

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -6,7 +6,7 @@
  */
 
 import type { TaskState, TaskStateChanges, PlanDefinition, Attempt, WorkflowDerivedStatus, WorkflowRollup, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency } from '@invoker/workflow-core';
-import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
+import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, PlanningConfirmationMode, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
 
 
@@ -40,6 +40,7 @@ export interface SlackLaunchContext {
   workingDir: string;
   requestedBy: string;
   lobbyChannelId: string;
+  confirmationMode: PlanningConfirmationMode;
   harnessSessionId?: string;
 }
 
@@ -67,6 +68,7 @@ export interface SlackPlanDraft {
   harnessPreset: string;
   workingDir: string;
   requestedBy: string;
+  confirmationMode: PlanningConfirmationMode;
   createdAt: string;
   decidedAt?: string;
   decidedBy?: string;
@@ -290,6 +292,7 @@ export interface InAppPlanningSessionRecord {
   title: string;
   presetKey: string;
   status: InAppPlanningSessionStatus;
+  confirmationMode: PlanningConfirmationMode;
   messages: InAppPlanningChatLine[];
   draftPlanSummary?: InAppPlanningPlanSummary;
   draftPlanText?: string;
@@ -310,6 +313,7 @@ export type InAppPlanningSessionPatch = Partial<Pick<
   InAppPlanningSessionRecord,
   | 'title'
   | 'status'
+  | 'confirmationMode'
   | 'messages'
   | 'draftPlanSummary'
   | 'draftPlanText'

--- a/packages/data-store/src/slack-plan-draft-repository.ts
+++ b/packages/data-store/src/slack-plan-draft-repository.ts
@@ -10,6 +10,7 @@ export interface CreateSlackPlanDraft {
   harnessPreset: string;
   workingDir: string;
   requestedBy: string;
+  confirmationMode: SlackPlanDraft['confirmationMode'];
 }
 
 export class SlackPlanDraftRepository {
@@ -33,6 +34,7 @@ export class SlackPlanDraftRepository {
       harnessPreset: input.harnessPreset,
       workingDir: input.workingDir,
       requestedBy: input.requestedBy,
+      confirmationMode: input.confirmationMode,
       createdAt: now,
     };
     this.adapter.saveSlackPlanDraft(draft);

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -31,7 +31,7 @@ import type {
   DetachedExternalDependency,
 } from '@invoker/workflow-core';
 import { DISPATCH_LEASE_MS } from '@invoker/contracts';
-import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
+import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, PlanningConfirmationMode, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ExecutionResourceLeaseReleaseRow,
   LaunchDispatchInvalidationRow,
@@ -526,6 +526,7 @@ type InAppPlanningSessionRow = {
   title?: unknown;
   preset_key?: unknown;
   status?: unknown;
+  confirmation_mode?: unknown;
   draft_plan_summary_json?: unknown;
   draft_plan_text?: unknown;
   submitted_workflow_id?: unknown;
@@ -577,6 +578,9 @@ function isPlanningTerminalStatus(value: unknown): value is 'running' | 'exited'
 
 function isInAppPlanningMessageRole(value: unknown): value is InAppPlanningChatLine['role'] {
   return value === 'user' || value === 'assistant' || value === 'system';
+}
+function isPlanningConfirmationMode(value: unknown): value is PlanningConfirmationMode {
+  return value === 'require' || value === 'auto_submit';
 }
 
 function isInAppPlanningMessageTone(value: unknown): value is InAppPlanningChatLine['tone'] {
@@ -1210,6 +1214,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
           title,
           preset_key,
           status,
+          confirmation_mode,
           draft_plan_summary_json,
           draft_plan_text,
           submitted_workflow_id,
@@ -1223,11 +1228,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
           pending_response,
           created_at,
           updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(session_id) DO UPDATE SET
           title = excluded.title,
           preset_key = excluded.preset_key,
           status = excluded.status,
+          confirmation_mode = excluded.confirmation_mode,
           draft_plan_summary_json = excluded.draft_plan_summary_json,
           draft_plan_text = excluded.draft_plan_text,
           submitted_workflow_id = excluded.submitted_workflow_id,
@@ -1246,6 +1252,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
           record.title,
           record.presetKey,
           record.status,
+          record.confirmationMode ?? 'require',
           record.draftPlanSummary ? JSON.stringify(record.draftPlanSummary) : null,
           record.draftPlanText ?? null,
           record.submittedWorkflowId ?? null,
@@ -1294,6 +1301,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
       if (Object.hasOwn(patch, 'status')) {
         setClauses.push('status = ?');
         values.push(patch.status ?? null);
+      }
+      if (Object.hasOwn(patch, 'confirmationMode')) {
+        setClauses.push('confirmation_mode = ?');
+        values.push(patch.confirmationMode ?? 'require');
       }
       if (Object.hasOwn(patch, 'draftPlanSummary')) {
         setClauses.push('draft_plan_summary_json = ?');
@@ -2148,8 +2159,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
   saveSlackLaunchContext(context: SlackLaunchContext): void {
     this.execRun(`
       INSERT OR REPLACE INTO slack_launch_contexts
-        (thread_ts, repo_url, harness_preset, working_dir, requested_by, lobby_channel_id, harness_session_id)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
+        (thread_ts, repo_url, harness_preset, working_dir, requested_by, lobby_channel_id, confirmation_mode, harness_session_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       context.threadTs,
       context.repoUrl,
@@ -2157,6 +2168,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       context.workingDir,
       context.requestedBy,
       context.lobbyChannelId,
+      context.confirmationMode ?? 'require',
       context.harnessSessionId ?? null,
     ]);
   }
@@ -2174,6 +2186,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       workingDir: row.working_dir as string,
       requestedBy: row.requested_by as string,
       lobbyChannelId: row.lobby_channel_id as string,
+      confirmationMode: isPlanningConfirmationMode(row.confirmation_mode) ? row.confirmation_mode : 'require',
       harnessSessionId: typeof row.harness_session_id === 'string' ? row.harness_session_id : undefined,
     };
   }
@@ -2186,8 +2199,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.execRun(`
       INSERT OR REPLACE INTO slack_plan_drafts
         (draft_id, version, channel_id, thread_ts, message_ts, slack_file_id, plan_text, content_hash, summary_json,
-         status, repo_url, harness_preset, working_dir, requested_by, created_at, decided_at, decided_by, execution_key, workflow_ids_json)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         status, repo_url, harness_preset, working_dir, requested_by, confirmation_mode, created_at, decided_at, decided_by, execution_key, workflow_ids_json)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       draft.draftId,
       draft.version,
@@ -2203,6 +2216,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       draft.harnessPreset,
       draft.workingDir,
       draft.requestedBy,
+      draft.confirmationMode ?? 'require',
       draft.createdAt,
       draft.decidedAt ?? null,
       draft.decidedBy ?? null,
@@ -2310,10 +2324,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
       harnessPreset: row.harness_preset as string,
       workingDir: row.working_dir as string,
       requestedBy: row.requested_by as string,
+      confirmationMode: isPlanningConfirmationMode(row.confirmation_mode) ? row.confirmation_mode : 'require',
       createdAt: row.created_at as string,
       decidedAt: typeof row.decided_at === 'string' ? row.decided_at : undefined,
       decidedBy: typeof row.decided_by === 'string' ? row.decided_by : undefined,
-      executionKey: typeof row.execution_key === 'string' ? row.execution_key : undefined,
       workflowIdsJson: typeof row.workflow_ids_json === 'string' ? row.workflow_ids_json : undefined,
     };
   }
@@ -2774,12 +2788,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
           message.role,
           message.text,
           message.tone ?? null,
-          message.createdAt ?? fallbackCreatedAt,
+          message.createdAt || fallbackCreatedAt,
         ],
       );
     }
   }
-
 
   private mapInAppPlanningSessionRow(row: InAppPlanningSessionRow): InAppPlanningSessionRecord | undefined {
     try {
@@ -2788,7 +2801,15 @@ export class SQLiteAdapter implements PersistenceAdapter {
       const presetKey = typeof row.preset_key === 'string' ? row.preset_key : '';
       const createdAt = typeof row.created_at === 'string' ? row.created_at : '';
       const updatedAt = typeof row.updated_at === 'string' ? row.updated_at : '';
-      if (!id || !title || !presetKey || !createdAt || !updatedAt || !isInAppPlanningSessionStatus(row.status)) {
+      if (
+        !id
+        || !title
+        || !presetKey
+        || !createdAt
+        || !updatedAt
+        || !isInAppPlanningSessionStatus(row.status)
+        || !isPlanningConfirmationMode(row.confirmation_mode)
+      ) {
         return undefined;
       }
       const terminalMode = row.terminal_mode === undefined || row.terminal_mode === null
@@ -2842,6 +2863,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         title,
         presetKey,
         status: row.status,
+        confirmationMode: row.confirmation_mode,
         messages,
         ...(draftPlanSummary ? { draftPlanSummary } : {}),
         ...(typeof row.draft_plan_text === 'string' ? { draftPlanText: row.draft_plan_text } : {}),

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -191,6 +191,7 @@ export const SCHEMA_DDL = `
         working_dir TEXT NOT NULL,
         requested_by TEXT NOT NULL,
         lobby_channel_id TEXT NOT NULL,
+        confirmation_mode TEXT NOT NULL DEFAULT 'require' CHECK (confirmation_mode IN ('require', 'auto_submit')),
         harness_session_id TEXT
       );
 
@@ -209,6 +210,7 @@ export const SCHEMA_DDL = `
         harness_preset TEXT NOT NULL,
         working_dir TEXT NOT NULL,
         requested_by TEXT NOT NULL,
+        confirmation_mode TEXT NOT NULL DEFAULT 'require' CHECK (confirmation_mode IN ('require', 'auto_submit')),
         created_at TEXT NOT NULL,
         decided_at TEXT,
         decided_by TEXT,
@@ -239,6 +241,7 @@ export const SCHEMA_DDL = `
         title TEXT NOT NULL,
         preset_key TEXT NOT NULL,
         status TEXT NOT NULL CHECK (status IN ('still_discussing', 'waiting_for_answer', 'draft_ready', 'submitted')),
+        confirmation_mode TEXT NOT NULL DEFAULT 'require' CHECK (confirmation_mode IN ('require', 'auto_submit')),
         draft_plan_summary_json TEXT CHECK (draft_plan_summary_json IS NULL OR json_valid(draft_plan_summary_json)),
         draft_plan_text TEXT,
         submitted_workflow_id TEXT,
@@ -515,9 +518,11 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE workflow_channels ADD COLUMN progress_card_ts TEXT',
   "ALTER TABLE conversations ADD COLUMN mode TEXT DEFAULT 'plan'",
   'ALTER TABLE slack_launch_contexts ADD COLUMN harness_session_id TEXT',
+  "ALTER TABLE slack_launch_contexts ADD COLUMN confirmation_mode TEXT NOT NULL DEFAULT 'require' CHECK (confirmation_mode IN ('require', 'auto_submit'))",
   'ALTER TABLE slack_plan_drafts ADD COLUMN slack_file_id TEXT',
   'ALTER TABLE slack_plan_drafts ADD COLUMN execution_key TEXT',
   'ALTER TABLE slack_plan_drafts ADD COLUMN workflow_ids_json TEXT',
+  "ALTER TABLE slack_plan_drafts ADD COLUMN confirmation_mode TEXT NOT NULL DEFAULT 'require' CHECK (confirmation_mode IN ('require', 'auto_submit'))",
   'ALTER TABLE tasks ADD COLUMN claude_session_id TEXT',
   'ALTER TABLE tasks ADD COLUMN workspace_path TEXT',
   'ALTER TABLE tasks ADD COLUMN container_id TEXT',
@@ -585,6 +590,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE attempts ADD COLUMN lease_expires_at TEXT',
   'ALTER TABLE tasks ADD COLUMN task_state_version INTEGER NOT NULL DEFAULT 1',
   'ALTER TABLE in_app_planning_sessions ADD COLUMN draft_plan_text TEXT',
+  "ALTER TABLE in_app_planning_sessions ADD COLUMN confirmation_mode TEXT NOT NULL DEFAULT 'require' CHECK (confirmation_mode IN ('require', 'auto_submit'))",
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_mode TEXT NOT NULL DEFAULT 'chat' CHECK (terminal_mode IN ('chat', 'tmux'))",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_session_id TEXT',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_status TEXT CHECK (terminal_status IS NULL OR terminal_status IN ('running', 'exited'))",


### PR DESCRIPTION
## Summary

This persists the shared planning review state.

Saved planning sessions and Slack draft metadata now carry confirmation mode and the exact drafted YAML text.

That gives later slices one stable place to reopen and reuse the same draft.

## Review Claim

Planning review confirmation mode and drafted YAML text now persist across Slack and Planning Terminal state records.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This only changes shared state shapes and persistence records; no user-facing behavior changes land in this slice.

## Slice Rationale

The later slices need one stable saved draft record before they can keep a cancelled draft or reopen the same YAML.

## Non-goals

- Change Slack draft-card behavior.
- Change host review tooling.
- Change the Planning Terminal layout.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
