### PR TITLE
(1) Fix SSH runtime shell bootstrap

### DIFF
--- a/packages/execution-engine/src/__tests__/conflict-resolver.test.ts
+++ b/packages/execution-engine/src/__tests__/conflict-resolver.test.ts
@@ -785,7 +785,7 @@ describe('conflict-resolver fail-fast workspace invariant', () => {
 });
 
 describe('remoteAgentShellInvocation', () => {
-  it('uses a remote login shell so ~/.profile PATH (flutter, agents) applies', () => {
-    expect(remoteAgentShellInvocation()).toEqual(['bash', '-l', '-s']);
+  it('uses a non-login shell because remote scripts source ~/.invoker/env.sh explicitly', () => {
+    expect(remoteAgentShellInvocation()).toEqual(['bash', '-s']);
   });
 });

--- a/packages/execution-engine/src/__tests__/fix-prompt-transport.test.ts
+++ b/packages/execution-engine/src/__tests__/fix-prompt-transport.test.ts
@@ -154,8 +154,9 @@ describe('fix prompt transport for oversized prompts', () => {
     expect(bootstrapPrompt).toContain('The full task instructions are in this file:');
     expect(bootstrapPrompt).toContain('/tmp/invoker-agent-prompt-');
     expect(stdinScript).toContain('PROMPT_FILE=');
-    expect(stdinScript).toContain('base64 -d > "$PROMPT_FILE"');
-    expect(stdinScript).toContain("trap 'rm -f \"$PROMPT_FILE\"' EXIT");
+    expect(stdinScript).toContain('INVOKER_ENV_FILE="$INVOKER_RUNTIME_HOME/env.sh"');
+    expect(stdinScript).toContain('invoker_base64_decode > "$PROMPT_FILE"');
+    expect(stdinScript).toContain('cleanup_remote_fix() {');
   });
 
   it('passes resolved executionModel into local OMP fix commands', async () => {
@@ -226,7 +227,9 @@ describe('fix prompt transport for oversized prompts', () => {
       'small prompt',
       { executionModel: 'anthropic/claude-opus-4' },
     );
-    expect(stdinScript).toContain('eval "$(echo "');
+    expect(stdinScript).toContain('AGENT_CMD_FILE=$(mktemp)');
+    expect(stdinScript).toContain('bash "$AGENT_CMD_FILE"');
+    expect(stdinScript).not.toContain('eval "$(echo ');
   });
 });
 

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -977,7 +977,7 @@ describe('SshExecutor entry lifecycle', () => {
     vi.spyOn(ssh as any, 'mergeRequestUpstreamBranches').mockResolvedValue(undefined);
   });
 
-  it('uses a login shell for task payloads so remote profile PATH applies', async () => {
+  it('uses a non-login shell for task payloads and sources ~/.invoker/env.sh explicitly', async () => {
     const request = makeRequest({
       inputs: {
         command: 'echo hello',
@@ -989,9 +989,13 @@ describe('SshExecutor entry lifecycle', () => {
     const childProcessMod = await import('node:child_process');
     const spawnMock = childProcessMod.spawn as unknown as ReturnType<typeof vi.fn>;
     const spawnArgs = spawnMock.mock.calls[spawnMock.mock.calls.length - 1]?.[1] as string[];
-    expect(spawnArgs.slice(-3)).toEqual(['bash', '-l', '-s']);
-
+    expect(spawnArgs.slice(-2)).toEqual(['bash', '-s']);
     const sshProcess = spawnedProcesses[spawnedProcesses.length - 1];
+    const writeMock = (sshProcess.stdin as any).write as ReturnType<typeof vi.fn>;
+    const script = writeMock.mock.calls[0]![0] as string;
+    expect(script).toContain('INVOKER_ENV_FILE="$INVOKER_HOME/env.sh"');
+    expect(script).toContain('. "$INVOKER_ENV_FILE"');
+
     sshProcess.emit('close', 0, null);
     await new Promise((r) => setTimeout(r, 50));
   });
@@ -1323,7 +1327,7 @@ describe('SshExecutor entry lifecycle', () => {
     // the remote, avoiding the old buggy `WT="~/.invoker/..."` literal (which
     // bash would NOT expand) and avoiding base64 runtime delivery.
     expect(script).not.toContain('base64 -d');
-    expect(script).toContain("INVOKER_HOME=$(normalize_remote_path '~/.invoker')");
+    expect(script).toContain("INVOKER_HOME='~/.invoker'");
     expect(script).toContain('WT=$(normalize_remote_path \'~/.invoker/worktrees/');
     expect(script).toContain(`if [[ "$path" == '~' ]]; then`);
     expect(script).not.toContain('WT="~/.invoker/');
@@ -1503,7 +1507,7 @@ describe('SshExecutor entry lifecycle', () => {
     const script = writeMock.mock.calls[0]![0] as string;
 
     expect(script).not.toContain('base64 -d');
-    expect(script).toContain("INVOKER_HOME=$(normalize_remote_path '/opt/invoker')");
+    expect(script).toContain("INVOKER_HOME='/opt/invoker'");
     expect(script).toContain('STAGING_DIR="$INVOKER_HOME/runtime/ssh-executor/');
     expect(script).toContain('WT=$(normalize_remote_path \'/opt/invoker/worktrees/');
     expect(script).toContain('RUNNER_PATH="$STAGING_DIR/runner.sh"');

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -92,10 +92,10 @@ describe('buildMirrorCloneScript', () => {
     });
 
     expect(script).toContain('set -euo pipefail');
-    expect(script).toContain('REPO=$(echo');
-    expect(script).toContain('base64 -d)');
+    expect(script).toContain('invoker_base64_decode() {');
+    expect(script).toContain("REPO=$(printf '%s'");
     expect(script).toContain('H="abc123def456"');
-    expect(script).toContain('INVOKER_HOME=$(echo');
+    expect(script).toContain("INVOKER_HOME=$(printf '%s'");
     expect(script).toContain('CLONE="$INVOKER_HOME/repos/$H"');
     expect(script).toContain('if [ ! -d "$CLONE/.git" ]; then git clone "$REPO" "$CLONE"; fi');
     expect(script).toContain('if ! git -C "$CLONE" fetch --all --prune; then');
@@ -140,8 +140,8 @@ describe('buildMirrorCloneScript', () => {
     // Should not contain the raw malicious string
     expect(script).not.toContain(maliciousUrl);
     // Should contain base64 encoded version
-    expect(script).toContain('REPO=$(echo');
-    expect(script).toContain('base64 -d)');
+    expect(script).toContain("REPO=$(printf '%s'");
+    expect(script).toContain('invoker_base64_decode');
   });
 
   it('fetches branch repo refs without mutating shared mirror remotes', () => {
@@ -152,7 +152,7 @@ describe('buildMirrorCloneScript', () => {
       baseRef: 'main',
     });
 
-    expect(script).toContain('BRANCH_REPO=$(echo');
+    expect(script).toContain("BRANCH_REPO=$(printf '%s'");
     expect(script).not.toContain('remote set-url invoker-branches');
     expect(script).not.toContain('remote add invoker-branches');
     expect(script).toContain('git -C "$CLONE" fetch "$BRANCH_REPO" \'+refs/heads/*:refs/remotes/invoker-branches/*\' --prune');
@@ -241,7 +241,7 @@ describe('buildWorktreeListScript', () => {
     const script = buildWorktreeListScript({ repoHash: 'xyz789' });
     expect(script).toContain('set -euo pipefail');
     expect(script).toContain('H="xyz789"');
-    expect(script).toContain('INVOKER_HOME=$(echo');
+    expect(script).toContain("INVOKER_HOME=$(printf '%s'");
     expect(script).toContain('CLONE="$INVOKER_HOME/repos/$H"');
     expect(script).toContain('git -C "$CLONE" worktree list --porcelain');
   });
@@ -316,9 +316,9 @@ describe('buildWorktreeSandboxResetScript', () => {
     });
 
     expect(script).toContain('set -euo pipefail');
-    expect(script).toContain('WT=$(echo');
-    expect(script).toContain('REF=$(echo');
-    expect(script).toContain('base64 -d)');
+    expect(script).toContain("WT=$(printf '%s'");
+    expect(script).toContain("REF=$(printf '%s'");
+    expect(script).toContain('invoker_base64_decode');
     expect(script).toContain('git -C "$WT" reset --hard "$REF"');
     expect(script).toContain('git -C "$WT" clean -fd');
     expect(script).not.toContain('clean -fdx');
@@ -437,9 +437,9 @@ describe('buildWorktreeRenameBranchScript', () => {
       toBranch: 'experiment/task-new',
     });
 
-    expect(script).toContain('WT=$(echo');
-    expect(script).toContain('FROM=$(echo');
-    expect(script).toContain('TO=$(echo');
+    expect(script).toContain("WT=$(printf '%s'");
+    expect(script).toContain("FROM=$(printf '%s'");
+    expect(script).toContain("TO=$(printf '%s'");
     expect(script).toContain('git -C "$WT" branch -m "$FROM" "$TO"');
     expect(script).toContain('git -C "$WT" rev-parse --abbrev-ref HEAD');
   });
@@ -457,8 +457,8 @@ describe('buildRecordAndPushScript', () => {
     });
 
     expect(script).toContain('set -euo pipefail');
-    expect(script).toContain('WT=$(echo');
-    expect(script).toContain('base64 -d)');
+    expect(script).toContain("WT=$(printf '%s'");
+    expect(script).toContain('invoker_base64_decode');
     expect(script).not.toContain('git config user.name');
     expect(script).not.toContain('git config user.email');
     expect(script).toContain('GIT_AUTHOR_NAME="$GIT_NAME"');

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -20,6 +20,7 @@ import { buildWorktreeListScript, createSshRemoteScriptError } from './ssh-git-e
 import { buildSshConnectionArgs } from './ssh-transport-options.js';
 import { findManagedWorktreeForBranch } from './worktree-discovery.js';
 import { buildRemoteAgentEnvExports } from './remote-agent-env.js';
+import { buildPortableBase64DecodeFunction, buildSourceInvokerEnvScript } from './remote-shell-fragments.js';
 import {
   buildAgentPromptFileBootstrap,
   materializeLocalAgentPrompt,
@@ -273,12 +274,12 @@ function shellQuote(s: string): string {
 }
 
 /**
- * Remote shell for agent fix/resolve commands. Use a login shell so the remote
- * user's ~/.profile PATH is applied (same as SshExecutor task payloads). Do not
- * forward the local host PATH — that clobbers Linux remotes with macOS paths.
+ * Remote shell for agent fix/resolve commands. Keep this non-login so remote
+ * dotfiles cannot trigger login-shell bash bugs or mutate execution semantics.
+ * PATH comes from ~/.invoker/env.sh, sourced explicitly inside each script.
  */
 export function remoteAgentShellInvocation(): string[] {
-  return ['bash', '-l', '-s'];
+  return ['bash', '-s'];
 }
 
 /**
@@ -381,17 +382,28 @@ async function resolveConflictRemote(
   const envExports = buildRemoteAgentEnvExports(target.secretsFile, target.use_api_key === true);
 
   const script = `set -euo pipefail
+${buildPortableBase64DecodeFunction()}
+${buildSourceInvokerEnvScript(target.remoteInvokerHome)}
 WT="${remoteCwd}"
 if [[ "$WT" == '~' ]]; then WT="$HOME"; elif [[ "\${WT:0:2}" == '~/' ]]; then WT="$HOME/\${WT:2}"; fi
 cd "$WT"
 ${envExports}
+AGENT_CMD_FILE=""
+cleanup_remote_agent() {
+  if [ -n "$AGENT_CMD_FILE" ]; then
+    rm -f "$AGENT_CMD_FILE"
+  fi
+}
+trap cleanup_remote_agent EXIT
 git checkout "${taskBranch}"
-MERGE_MSG=$(echo "${mergeMsgB64}" | base64 -d)
+MERGE_MSG=$(printf '%s' ${shellQuote(mergeMsgB64)} | invoker_base64_decode)
 if git merge --no-edit -m "$MERGE_MSG" "${conflictInfo.failedBranch}" 2>/dev/null; then
   echo "[resolveConflict] Merge succeeded without conflict on retry"
 else
   echo "[resolveConflict] Conflict reproduced, spawning agent to resolve..."
-  eval "$(echo "${agentCmdB64}" | base64 -d)"
+  AGENT_CMD_FILE=$(mktemp)
+  printf '%s' ${shellQuote(agentCmdB64)} | invoker_base64_decode > "$AGENT_CMD_FILE"
+  bash "$AGENT_CMD_FILE"
 fi
 `;
 
@@ -669,19 +681,32 @@ export function spawnRemoteAgentFixImpl(
   const promptWrite = promptTransport.remotePromptFilePath && promptTransport.promptB64
     ? [
         `PROMPT_FILE=${shellQuote(promptTransport.remotePromptFilePath)}`,
-        `printf '%s' ${shellQuote(promptTransport.promptB64)} | base64 -d > "$PROMPT_FILE"`,
-        `trap 'rm -f "$PROMPT_FILE"' EXIT`,
+        `printf '%s' ${shellQuote(promptTransport.promptB64)} | invoker_base64_decode > "$PROMPT_FILE"`,
       ].join('\n') + '\n'
     : '';
   const envExports = buildRemoteAgentEnvExports(target.secretsFile, target.use_api_key === true);
 
   const script = `set -euo pipefail
+${buildPortableBase64DecodeFunction()}
+${buildSourceInvokerEnvScript(target.remoteInvokerHome)}
 WT="${remoteCwd}"
 if [[ "$WT" == '~' ]]; then WT="$HOME"; elif [[ "\${WT:0:2}" == '~/' ]]; then WT="$HOME/\${WT:2}"; fi
 cd "$WT"
 ${envExports}
-${promptWrite}
-eval "$(echo "${agentCmdB64}" | base64 -d)"
+PROMPT_FILE=""
+AGENT_CMD_FILE=""
+cleanup_remote_fix() {
+  if [ -n "$PROMPT_FILE" ]; then
+    rm -f "$PROMPT_FILE"
+  fi
+  if [ -n "$AGENT_CMD_FILE" ]; then
+    rm -f "$AGENT_CMD_FILE"
+  fi
+}
+trap cleanup_remote_fix EXIT
+${promptWrite}AGENT_CMD_FILE=$(mktemp)
+printf '%s' ${shellQuote(agentCmdB64)} | invoker_base64_decode > "$AGENT_CMD_FILE"
+bash "$AGENT_CMD_FILE"
 `;
 
   const sshArgs = [

--- a/packages/execution-engine/src/remote-shell-fragments.ts
+++ b/packages/execution-engine/src/remote-shell-fragments.ts
@@ -1,0 +1,25 @@
+
+export function buildPortableBase64DecodeFunction(functionName = 'invoker_base64_decode'): string {
+  return `${functionName}() {
+  if base64 --decode </dev/null >/dev/null 2>&1; then
+    base64 --decode
+  elif base64 -d </dev/null >/dev/null 2>&1; then
+    base64 -d
+  else
+    base64 -D
+  fi
+}`;
+}
+
+export function buildSourceInvokerEnvScript(remoteInvokerHome = '~/.invoker', varName = 'INVOKER_RUNTIME_HOME'): string {
+  return `${varName}='${remoteInvokerHome.replace(/'/g, `'\\''`)}'
+if [[ "$${varName}" == '~' ]]; then
+  ${varName}="$HOME"
+elif [[ "\${${varName}:0:2}" == '~/' ]]; then
+  ${varName}="$HOME/\${${varName}:2}"
+fi
+INVOKER_ENV_FILE="$${varName}/env.sh"
+if [ -f "$INVOKER_ENV_FILE" ]; then
+  . "$INVOKER_ENV_FILE"
+fi`;
+}

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -16,6 +16,7 @@ import { isWorkspaceCleanupEnabled } from './workspace-cleanup-policy.js';
 import { buildSshConnectionArgs } from './ssh-transport-options.js';
 import { createExecutionBench } from './execution-bench.js';
 import { buildRemoteAgentEnvExports } from './remote-agent-env.js';
+import { buildSourceInvokerEnvScript } from './remote-shell-fragments.js';
 import {
   shellPosixSingleQuote as sshGitShellQuote,
   sshInteractiveCdFragment,
@@ -252,7 +253,7 @@ ensure_managed_pnpm_workspace
 
     return `set -euo pipefail
 ${this.remotePathNormalizeFunction()}
-INVOKER_HOME=$(normalize_remote_path ${this.shellQuote(this.remoteInvokerHome)})
+${buildSourceInvokerEnvScript(this.remoteInvokerHome, 'INVOKER_HOME')}
 STAGING_DIR="$INVOKER_HOME/runtime/ssh-executor/${stagingTokenExpression}"
 RUNNER_PATH="$STAGING_DIR/runner.sh"
 PAYLOAD_PATH="$STAGING_DIR/payload.sh"
@@ -310,12 +311,12 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
   }
 
   /**
-   * Remote shell for task payloads. Use a login shell so the remote user's
-   * ~/.profile PATH (flutter, android-sdk, etc.) is applied. Never forward the
-   * local host PATH — that clobbers Linux remotes with macOS Homebrew paths.
+   * Remote shell for task payloads. Keep this non-login so remote dotfiles cannot
+   * trigger login-shell bash bugs or mutate execution semantics. PATH comes from
+   * ~/.invoker/env.sh, sourced explicitly inside the bootstrap script.
    */
   private buildPayloadRemoteCommand(): string[] {
-    return ['bash', '-l', '-s'];
+    return ['bash', '-s'];
   }
 
   private async execRemoteCapture(script: string, phase?: string): Promise<string> {
@@ -930,7 +931,7 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
     return this.remoteGitRecordAndPush('publish-approved-fix', request, worktreePath, branch, 0);
   }
 
-  /** Run a task bash script on the remote login shell (fed on stdin). */
+  /** Run a task bash script on the remote bash stdin transport. */
   private spawnSshRemoteStdin(
     executionId: string,
     request: WorkRequest,

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -6,6 +6,7 @@
  */
 
 import { spawn, type ChildProcess } from 'node:child_process';
+import { buildPortableBase64DecodeFunction } from './remote-shell-fragments.js';
 
 export interface SshRemoteErrorMetadata {
   exitCode?: number;
@@ -64,7 +65,7 @@ export function base64Encode(s: string): string {
 
 /**
  * Bash fragment to expand leading ~ in a variable after base64 decode.
- * After `WT=$(echo … | base64 -d)`, this ensures `cd "$WT"` works with tilde paths.
+ * After `WT=$(printf '%s' … | invoker_base64_decode)`, this ensures `cd "$WT"` works with tilde paths.
  *
  * NOTE: Do NOT use `case ~/*)` — bash tilde-expands case patterns, so `~/*` becomes
  * `/root/*` and never matches literal `~/.invoker/…`.
@@ -130,11 +131,12 @@ export function buildMirrorCloneScript(opts: GitMirrorCloneOpts): string {
   const homeB64 = base64Encode(invokerHome);
 
   return `set -euo pipefail
-REPO=$(echo ${repoB64} | base64 -d)
-BRANCH_REPO=$(echo ${branchRepoB64} | base64 -d)
-BASE=$(echo ${baseB64} | base64 -d)
+${buildPortableBase64DecodeFunction()}
+REPO=$(printf '%s' ${shellPosixSingleQuote(repoB64)} | invoker_base64_decode)
+BRANCH_REPO=$(printf '%s' ${shellPosixSingleQuote(branchRepoB64)} | invoker_base64_decode)
+BASE=$(printf '%s' ${shellPosixSingleQuote(baseB64)} | invoker_base64_decode)
 H="${repoHash}"
-INVOKER_HOME=$(echo ${homeB64} | base64 -d)
+INVOKER_HOME=$(printf '%s' ${shellPosixSingleQuote(homeB64)} | invoker_base64_decode)
 if [[ "$INVOKER_HOME" == '~' ]]; then
   INVOKER_HOME="$HOME"
 elif [[ "\${INVOKER_HOME:0:2}" == '~/' ]]; then
@@ -168,19 +170,19 @@ if [ "$BASE" = "HEAD" ] && [ -n "$ORIGIN_HEAD" ] && git -C "$CLONE" rev-parse --
 elif git -C "$CLONE" rev-parse --verify "origin/$BASE^{commit}" >/dev/null 2>&1; then
   RESOLVED_BASE="origin/$BASE"
 elif git -C "$CLONE" rev-parse --verify "$RESOLVED_BASE^{commit}" >/dev/null 2>&1; then
-  :
+  RESOLVED_BASE="$BASE"
 else
-  if [ -n "$ORIGIN_HEAD" ] && git -C "$CLONE" rev-parse --verify "$ORIGIN_HEAD^{commit}" >/dev/null 2>&1; then
-    RESOLVED_BASE="$ORIGIN_HEAD"
+  FALLBACK="\${ORIGIN_HEAD:-origin/master}"
+  if git -C "$CLONE" rev-parse --verify "$FALLBACK^{commit}" >/dev/null 2>&1; then
+    RESOLVED_BASE="$FALLBACK"
     printf "__INVOKER_BASE_WARNING__=Requested base '%s' not found; falling back to '%s'.\\n" "$BASE" "$RESOLVED_BASE"
   else
-    echo "Requested base '$BASE' does not exist and origin/HEAD is unavailable." >&2
+    echo "ERROR: base ref '$BASE' not found and fallback '$FALLBACK' also missing" >&2
     exit 128
   fi
 fi
-BASE_HEAD=$(git -C "$CLONE" rev-parse "$RESOLVED_BASE")
 printf "__INVOKER_BASE_REF__=%s\\n" "$RESOLVED_BASE"
-printf "__INVOKER_BASE_HEAD__=%s\\n" "$BASE_HEAD"
+printf "__INVOKER_BASE_HEAD__=%s\\n" "$(git -C "$CLONE" rev-parse "$RESOLVED_BASE^{commit}")"
 `;
 }
 
@@ -231,8 +233,9 @@ export function buildWorktreeListScript(opts: GitWorktreeListOpts): string {
   const homeB64 = base64Encode(invokerHome);
 
   return `set -euo pipefail
+${buildPortableBase64DecodeFunction()}
 H="${repoHash}"
-INVOKER_HOME=$(echo ${homeB64} | base64 -d)
+INVOKER_HOME=$(printf '%s' ${shellPosixSingleQuote(homeB64)} | invoker_base64_decode)
 if [[ "$INVOKER_HOME" == '~' ]]; then
   INVOKER_HOME="$HOME"
 elif [[ "\${INVOKER_HOME:0:2}" == '~/' ]]; then
@@ -264,6 +267,7 @@ export interface GitWorktreeCleanupOpts {
 export function buildWorktreeCleanupScript(opts: GitWorktreeCleanupOpts): string {
   const worktreesB64 = base64Encode(`${opts.worktreePaths.join('\n')}\n`);
   return `set -euo pipefail
+${buildPortableBase64DecodeFunction()}
 CLONE="${opts.remoteClone}"
 ${bashNormalizeTildePath('CLONE')}
 WORKTREES_B64="${worktreesB64}"
@@ -278,7 +282,7 @@ while IFS= read -r WT; do
     rm -rf "$WT"
     git -C "$CLONE" worktree prune 2>/dev/null || true
   fi
-done < <(echo "$WORKTREES_B64" | base64 -d)
+done < <(printf '%s' "$WORKTREES_B64" | invoker_base64_decode)
 `;
 }
 
@@ -307,8 +311,9 @@ export function buildWorktreeSandboxResetScript(opts: GitWorktreeSandboxResetOpt
   const wtB64 = base64Encode(opts.worktreePath);
   const refB64 = base64Encode(opts.toRef);
   return `set -euo pipefail
-WT=$(echo ${wtB64} | base64 -d)
-REF=$(echo ${refB64} | base64 -d)
+${buildPortableBase64DecodeFunction()}
+WT=$(printf '%s' ${shellPosixSingleQuote(wtB64)} | invoker_base64_decode)
+REF=$(printf '%s' ${shellPosixSingleQuote(refB64)} | invoker_base64_decode)
 ${bashNormalizeTildePath('WT')}
 git -C "$WT" reset --hard "$REF"
 git -C "$WT" clean -fd
@@ -326,9 +331,10 @@ export function buildWorktreeRenameBranchScript(opts: GitWorktreeRenameBranchOpt
   const fromB64 = base64Encode(opts.fromBranch);
   const toB64 = base64Encode(opts.toBranch);
   return `set -euo pipefail
-WT=$(echo ${wtB64} | base64 -d)
-FROM=$(echo ${fromB64} | base64 -d)
-TO=$(echo ${toB64} | base64 -d)
+${buildPortableBase64DecodeFunction()}
+WT=$(printf '%s' ${shellPosixSingleQuote(wtB64)} | invoker_base64_decode)
+FROM=$(printf '%s' ${shellPosixSingleQuote(fromB64)} | invoker_base64_decode)
+TO=$(printf '%s' ${shellPosixSingleQuote(toB64)} | invoker_base64_decode)
 ${bashNormalizeTildePath('WT')}
 git -C "$WT" branch -m "$FROM" "$TO"
 git -C "$WT" rev-parse --abbrev-ref HEAD
@@ -362,24 +368,25 @@ export function buildRecordAndPushScript(opts: GitRecordAndPushOpts): string {
   const pushRemoteUrlB = base64Encode(opts.pushRemoteUrl ?? '');
 
   return `set -euo pipefail
-WT=$(echo ${wtB} | base64 -d)
+${buildPortableBase64DecodeFunction()}
+WT=$(printf '%s' ${shellPosixSingleQuote(wtB)} | invoker_base64_decode)
 ${bashNormalizeTildePath()}
 cd "$WT"
 git add -A
 M=$(mktemp)
 trap 'rm -f "$M"' EXIT
-GIT_NAME=$(echo ${userNameB} | base64 -d)
-GIT_EMAIL=$(echo ${userEmailB} | base64 -d)
+GIT_NAME=$(printf '%s' ${shellPosixSingleQuote(userNameB)} | invoker_base64_decode)
+GIT_EMAIL=$(printf '%s' ${shellPosixSingleQuote(userEmailB)} | invoker_base64_decode)
 if git diff --cached --quiet; then
-  echo ${emB} | base64 -d > "$M"
+  printf '%s' ${shellPosixSingleQuote(emB)} | invoker_base64_decode > "$M"
   GIT_AUTHOR_NAME="$GIT_NAME" GIT_AUTHOR_EMAIL="$GIT_EMAIL" GIT_COMMITTER_NAME="$GIT_NAME" GIT_COMMITTER_EMAIL="$GIT_EMAIL" git commit --allow-empty -F "$M"
 else
-  echo ${chB} | base64 -d > "$M"
+  printf '%s' ${shellPosixSingleQuote(chB)} | invoker_base64_decode > "$M"
   GIT_AUTHOR_NAME="$GIT_NAME" GIT_AUTHOR_EMAIL="$GIT_EMAIL" GIT_COMMITTER_NAME="$GIT_NAME" GIT_COMMITTER_EMAIL="$GIT_EMAIL" git commit -F "$M"
 fi
 HASH=$(git rev-parse HEAD)
-BR=$(echo ${brB} | base64 -d)
-PUSH_URL=$(echo ${pushRemoteUrlB} | base64 -d)
+BR=$(printf '%s' ${shellPosixSingleQuote(brB)} | invoker_base64_decode)
+PUSH_URL=$(printf '%s' ${shellPosixSingleQuote(pushRemoteUrlB)} | invoker_base64_decode)
 if [ -n "$PUSH_URL" ]; then
   git push "$PUSH_URL" "$BR:refs/heads/$BR"
 else


### PR DESCRIPTION
## Summary

SSH task shells no longer depend on remote login dotfiles. They source `~/.invoker/env.sh` directly and run under non-login `bash -s`.

The old login-shell path could hit Bash's `pop_var_context` bug after a task had already finished. Invoker then marked good SSH runs as failed and the auto-fix worker kept retrying them.

This also replaces remote `eval` with temp-script execution and swaps in a GNU/BSD-compatible base64 decoder so the generated remote shell works on both Linux and macOS.

## Review Claim

SSH execution and remote fix shells now bootstrap deterministically across Linux and macOS without spurious post-success failures.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the SSH shell bootstrap changed: task payload commands, git finalize behavior, and agent CLI arguments stay the same. Focused execution-engine tests cover the generated scripts end to end.

## Slice Rationale

The login-shell failure, the remote `eval` path, and the GNU/BSD base64 difference all sit in the same execution-engine shell seam. Keeping them together fixes the shipped SSH runtime path in one slice.

## Non-goals

- Changing task payload contents.
- Changing agent/model selection.
- Changing remote git finalize semantics.

## Architecture

### Before

```mermaid
graph TD
    A["ssh -> bash -l -s"] --> B["user dotfiles decide PATH and shell side effects"]
    B --> C["runner/payload scripts or eval-decoded remote agent command"]
```

### After

```mermaid
graph TD
    A["ssh -> bash -s"] --> B["script sources ~/.invoker/env.sh explicitly"]
    B --> C["runner/payload scripts or temp-file remote agent command"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/ssh-executor.test.ts src/__tests__/ssh-git-exec.test.ts src/__tests__/conflict-resolver.test.ts src/__tests__/fix-prompt-transport.test.ts src/__tests__/remote-fix-process-output.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7aad8fe95`
- Post-revert steps: None
- Data migration? No

</details>
