### PR TITLE
[Remote Sync Step 1: Sync Schema and Change Journal](1) Add data-store sync schema and journal

### DIFF
--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createAttempt, createTaskState } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  readJournalSince,
+  setSyncCursor,
+} from '../sync-journal.js';
+
+describe('sync journal', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function db(): any {
+    return adapter as any;
+  }
+
+  function saveWorkflow(id: string): void {
+    adapter.saveWorkflow({
+      id,
+      name: `Workflow ${id}`,
+      createdAt: '2026-07-28T00:00:00.000Z',
+      updatedAt: '2026-07-28T00:00:00.000Z',
+    });
+  }
+
+  it('rolls journal appends back with the mutation transaction', () => {
+    expect(() => {
+      adapter.runInTransaction(() => {
+        saveWorkflow('wf-rollback');
+        appendJournalEntry(db(), {
+          entityType: 'workflow',
+          entityId: 'wf-rollback',
+          op: 'upsert',
+          payload: { id: 'wf-rollback' },
+        });
+        throw new Error('force rollback');
+      });
+    }).toThrow('force rollback');
+
+    expect(adapter.loadWorkflow('wf-rollback')).toBeUndefined();
+    expect(readJournalSince(db(), 0, 10)).toEqual([]);
+  });
+
+  it('allocates strictly monotonic seq values', () => {
+    const first = appendJournalEntry(db(), {
+      entityType: 'event',
+      entityId: 'event-1',
+      op: 'upsert',
+      payload: { id: 1 },
+    });
+    const second = appendJournalEntry(db(), {
+      entityType: 'event',
+      entityId: 'event-2',
+      op: 'upsert',
+      payload: { id: 2 },
+    });
+    const third = appendJournalEntry(db(), {
+      entityType: 'event',
+      entityId: 'event-3',
+      op: 'upsert',
+      payload: { id: 3 },
+    });
+
+    expect(second.seq).toBeGreaterThan(first.seq);
+    expect(third.seq).toBeGreaterThan(second.seq);
+  });
+
+  it('reads entries after a cursor and respects limit', () => {
+    const first = appendJournalEntry(db(), {
+      entityType: 'event',
+      entityId: 'event-1',
+      op: 'upsert',
+      payload: { id: 1 },
+    });
+    const second = appendJournalEntry(db(), {
+      entityType: 'event',
+      entityId: 'event-2',
+      op: 'upsert',
+      payload: { id: 2 },
+    });
+    const third = appendJournalEntry(db(), {
+      entityType: 'event',
+      entityId: 'event-3',
+      op: 'upsert',
+      payload: { id: 3 },
+    });
+
+    expect(readJournalSince(db(), first.seq, 1).map((entry) => entry.seq)).toEqual([second.seq]);
+    expect(readJournalSince(db(), first.seq, 10).map((entry) => entry.seq)).toEqual([
+      second.seq,
+      third.seq,
+    ]);
+  });
+
+  it('stores and replaces peer cursor pairs', () => {
+    expect(getSyncCursor(db(), 'peer-a')).toBeUndefined();
+
+    expect(setSyncCursor(db(), {
+      peerId: 'peer-a',
+      lastSentSeq: 12,
+      lastReceivedSeq: 34,
+      updatedAt: 1000,
+    })).toEqual({
+      peerId: 'peer-a',
+      lastSentSeq: 12,
+      lastReceivedSeq: 34,
+      updatedAt: 1000,
+    });
+
+    expect(setSyncCursor(db(), {
+      peerId: 'peer-a',
+      lastSentSeq: 56,
+      lastReceivedSeq: 78,
+      updatedAt: 2000,
+    })).toEqual({
+      peerId: 'peer-a',
+      lastSentSeq: 56,
+      lastReceivedSeq: 78,
+      updatedAt: 2000,
+    });
+  });
+
+  it('journals task status changes and attempt creation/completion', () => {
+    saveWorkflow('wf-1');
+    const task = createTaskState('task-1', 'Task 1', [], { workflowId: 'wf-1' });
+    adapter.saveTask('wf-1', task);
+
+    adapter.updateTask('task-1', { status: 'running' });
+    const attempt = createAttempt('task-1', { status: 'running' });
+    adapter.saveAttempt(attempt);
+    adapter.updateAttempt(attempt.id, {
+      status: 'completed',
+      completedAt: new Date('2026-07-28T00:01:00.000Z'),
+      exitCode: 0,
+    });
+
+    const entries = readJournalSince(db(), 0, 10);
+    expect(entries.map((entry) => [entry.entityType, entry.entityId, entry.op])).toEqual([
+      ['task', 'task-1', 'upsert'],
+      ['attempt', attempt.id, 'upsert'],
+      ['attempt', attempt.id, 'upsert'],
+    ]);
+    expect((entries[0].payload as { status?: string }).status).toBe('running');
+    expect((entries[2].payload as { status?: string }).status).toBe('completed');
+  });
+
+  it('excludes soft-deleted workflows by default but includes them when requested', () => {
+    saveWorkflow('wf-delete');
+    saveWorkflow('wf-keep');
+
+    adapter.deleteWorkflow('wf-delete');
+
+    expect(adapter.listWorkflows().map((workflow) => workflow.id)).toEqual(['wf-keep']);
+    expect(adapter.loadWorkflow('wf-delete')).toBeUndefined();
+
+    const withDeleted = adapter.listWorkflows({ includeDeleted: true });
+    expect(withDeleted.map((workflow) => workflow.id).sort()).toEqual(['wf-delete', 'wf-keep']);
+    expect(adapter.loadWorkflow('wf-delete', { includeDeleted: true })?.deletedAt).toEqual(
+      expect.any(Number),
+    );
+  });
+
+  it('writes a tombstone journal entry when a workflow is soft-deleted', () => {
+    saveWorkflow('wf-delete');
+    adapter.saveTask('wf-delete', createTaskState('task-1', 'Task 1', [], { workflowId: 'wf-delete' }));
+
+    adapter.deleteWorkflow('wf-delete');
+
+    const entries = readJournalSince(db(), 0, 10);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      entityType: 'workflow',
+      entityId: 'wf-delete',
+      op: 'tombstone',
+      origin: 'home',
+    });
+    expect(entries[0].payload).toMatchObject({
+      id: 'wf-delete',
+      deleted_at: expect.any(Number),
+    });
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -124,10 +124,15 @@ export interface Workflow {
   /** Read-only provenance for dependencies removed by `detachWorkflow`. Never re-read by scheduling. */
   detachedExternalDependencies?: DetachedExternalDependency[];
   generation?: number;
+  deletedAt?: number;
   createdAt: string;
   updatedAt: string;
 }
 export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup'>;
+
+export interface WorkflowListOptions {
+  includeDeleted?: boolean;
+}
 
 /**
  * Result of resolving a published PR back to its Invoker workflow via the merge
@@ -333,8 +338,8 @@ export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
-  loadWorkflow(workflowId: string): Workflow | undefined;
-  listWorkflows(): Workflow[];
+  loadWorkflow(workflowId: string, options?: WorkflowListOptions): Workflow | undefined;
+  listWorkflows(options?: WorkflowListOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
   /** Resolve a GitHub PR number back to its Invoker workflow via the merge node. */
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined;
@@ -343,7 +348,7 @@ export interface PersistenceAdapter {
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
   loadTasks(workflowId: string): TaskState[];
-  loadWorkflowTaskSnapshot?(): WorkflowTaskSnapshot;
+  loadWorkflowTaskSnapshot?(options?: WorkflowListOptions): WorkflowTaskSnapshot;
   /** Authoritative single-task read by ID, suitable for recovery workflows. */
   loadTask(taskId: string): TaskState | undefined;
   /** Delete one task and its task-owned rows. */

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -7,3 +7,4 @@ export * from './slack-session-repository.js';
 export * from './slack-plan-draft-repository.js';
 export * from './sqlite-task-repository.js';
 export * from './workflow-channel-repository.js';
+export * from './sync-journal.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -38,6 +38,7 @@ import type {
   PersistenceAdapter,
   ReviewGateLookup,
   Workflow,
+  WorkflowListOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
   TaskEvent,
@@ -78,6 +79,7 @@ import type { SqliteExecutor } from './sqlite-executor.js';
 import * as migrations from './sqlite-migrations.js';
 import { SqliteTaskAttemptRepository } from './sqlite-task-attempt-repository.js';
 import { SqliteWorkflowRepository, type WorkflowMetadataChanges } from './sqlite-workflow-repository.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 function normalizeWorkerActionStatus(status: string): string {
   return status === 'canceled' ? 'cancelled' : status;
@@ -1054,12 +1056,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.workflowRepo.updateWorkflow(workflowId, changes);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    return this.workflowRepo.loadWorkflow(workflowId);
+  loadWorkflow(workflowId: string, options?: WorkflowListOptions): Workflow | undefined {
+    return this.workflowRepo.loadWorkflow(workflowId, options);
   }
 
-  listWorkflows(): Workflow[] {
-    return this.workflowRepo.listWorkflows();
+  listWorkflows(options?: WorkflowListOptions): Workflow[] {
+    return this.workflowRepo.listWorkflows(options);
   }
 
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
@@ -1070,8 +1072,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return this.workflowRepo.searchWorkflowsAndTasks(query, opts);
   }
 
-  loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
-    return this.workflowRepo.loadWorkflowTaskSnapshot();
+  loadWorkflowTaskSnapshot(options?: WorkflowListOptions): WorkflowTaskSnapshot {
+    return this.workflowRepo.loadWorkflowTaskSnapshot(options);
   }
 
   getLastWorkflowTaskSnapshotStats(): Record<string, unknown> | null {
@@ -1559,6 +1561,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
   deleteWorkflow(workflowId: string): void {
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
     this.runTransaction(() => {
+      const existing = this.queryOne(
+        'SELECT deleted_at FROM workflows WHERE id = ?',
+        [workflowId],
+      ) as { deleted_at?: number | null } | undefined;
+      if (!existing || existing.deleted_at != null) return;
+
       this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM task_launch_dispatch WHERE workflow_id = ?', [workflowId]);
@@ -1598,7 +1606,23 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
+      const deletedAt = Date.now();
+      this.db.run(
+        'UPDATE workflows SET deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL',
+        [deletedAt, new Date(deletedAt).toISOString(), workflowId],
+      );
+      if (this.db.getRowsModified() === 0) return;
+      const row = this.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+      if (!row) {
+        throw new Error(`Failed to read workflow ${workflowId} after soft-delete`);
+      }
+      appendJournalEntry(this.executor, {
+        entityType: 'workflow',
+        entityId: workflowId,
+        op: 'tombstone',
+        payload: row,
+        createdAt: deletedAt,
+      });
     });
     this.removeOutputFiles(taskIds);
   }

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -47,6 +47,7 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
     externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
     detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) as DetachedExternalDependency[] : undefined,
     generation: row.generation ?? 0,
+    deletedAt: row.deleted_at == null ? undefined : Number(row.deleted_at),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -27,8 +27,28 @@ export const SCHEMA_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_journal (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+        entity_id TEXT NOT NULL,
+        op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+        payload TEXT NOT NULL CHECK (json_valid(payload)),
+        origin TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+
+      -- output is reserved for future output-spool journaling; high-volume
+      -- output_spool rows are intentionally not written to sync_journal yet.
+      CREATE TABLE IF NOT EXISTS sync_cursors (
+        peer_id TEXT PRIMARY KEY,
+        last_sent_seq INTEGER NOT NULL DEFAULT 0,
+        last_received_seq INTEGER NOT NULL DEFAULT 0,
+        updated_at INTEGER NOT NULL
       );
 
       CREATE TABLE IF NOT EXISTS tasks (
@@ -597,6 +617,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
+  'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
 ];
 
 /**
@@ -628,6 +649,8 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  "CREATE TABLE IF NOT EXISTS sync_journal (seq INTEGER PRIMARY KEY AUTOINCREMENT, entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')), entity_id TEXT NOT NULL, op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')), payload TEXT NOT NULL CHECK (json_valid(payload)), origin TEXT NOT NULL, created_at INTEGER NOT NULL)",
+  'CREATE TABLE IF NOT EXISTS sync_cursors (peer_id TEXT PRIMARY KEY, last_sent_seq INTEGER NOT NULL DEFAULT 0, last_received_seq INTEGER NOT NULL DEFAULT 0, updated_at INTEGER NOT NULL)',
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */
@@ -651,6 +674,7 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       )
@@ -662,12 +686,12 @@ export const WORKFLOWS_REBUILD_INSERT_DDL = `
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       FROM workflows
     `;

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -17,8 +17,10 @@ import {
 import { mapRowToTask, mapRowToAttempt } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
+const TERMINAL_ATTEMPT_STATUSES = new Set(['completed', 'failed']);
 
 /**
  * Adapter-side task/attempt mutators that {@link SqliteTaskAttemptRepository.failTaskAndAttempt}
@@ -227,8 +229,23 @@ export class SqliteTaskAttemptRepository {
   }
 
   updateTask(taskId: string, changes: TaskStateChanges): void {
+    if (changes.status !== undefined) {
+      this.exec.runTransaction(() => this.updateTaskInternal(taskId, changes));
+      return;
+    }
+    this.updateTaskInternal(taskId, changes);
+  }
+
+  private updateTaskInternal(taskId: string, changes: TaskStateChanges): void {
     const beforeTask = this.loadTask(taskId);
     if (!beforeTask) return;
+    const beforeStoredStatus = changes.status === undefined
+      ? undefined
+      : String(
+        this.exec.queryOne('SELECT status FROM tasks WHERE id = ?', [taskId])?.status ?? beforeTask.status,
+      );
+    const shouldJournalStatusChange =
+      changes.status !== undefined && changes.status !== beforeStoredStatus;
 
     const setClauses: string[] = [];
     const values: unknown[] = [];
@@ -418,6 +435,18 @@ export class SqliteTaskAttemptRepository {
       console.log(`[persist-sql] taskId=${taskId} columns=[${cols}]`);
     }
     this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    if (shouldJournalStatusChange) {
+      const row = this.exec.queryOne('SELECT * FROM tasks WHERE id = ?', [taskId]);
+      if (!row) {
+        throw new Error(`Failed to read task ${taskId} after status update`);
+      }
+      appendJournalEntry(this.exec, {
+        entityType: 'task',
+        entityId: taskId,
+        op: 'upsert',
+        payload: row,
+      });
+    }
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -594,6 +623,10 @@ export class SqliteTaskAttemptRepository {
   // ── Attempt CRUD ─────────────────────────────────────────
 
   saveAttempt(attempt: Attempt): void {
+    this.exec.runTransaction(() => this.saveAttemptInternal(attempt));
+  }
+
+  private saveAttemptInternal(attempt: Attempt): void {
     this.exec.execRun(`
       INSERT OR REPLACE INTO attempts (
         id, node_id, attempt_number, queue_priority, status,
@@ -628,6 +661,16 @@ export class SqliteTaskAttemptRepository {
       attempt.createdAt.toISOString(),
       attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
     ]);
+    const row = this.exec.queryOne('SELECT * FROM attempts WHERE id = ?', [attempt.id]);
+    if (!row) {
+      throw new Error(`Failed to read attempt ${attempt.id} after creation`);
+    }
+    appendJournalEntry(this.exec, {
+      entityType: 'attempt',
+      entityId: attempt.id,
+      op: 'upsert',
+      payload: row,
+    });
   }
 
   loadAttempts(nodeId: string): Attempt[] {
@@ -689,6 +732,23 @@ export class SqliteTaskAttemptRepository {
   }
 
   updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void {
+    const mayJournalCompletion =
+      (changes.status !== undefined && TERMINAL_ATTEMPT_STATUSES.has(changes.status)) ||
+      changes.completedAt !== undefined;
+    if (mayJournalCompletion) {
+      this.exec.runTransaction(() => this.updateAttemptInternal(attemptId, changes));
+      return;
+    }
+    this.updateAttemptInternal(attemptId, changes);
+  }
+
+  private updateAttemptInternal(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void {
+    const beforeRow = this.exec.queryOne(
+      'SELECT status, completed_at FROM attempts WHERE id = ?',
+      [attemptId],
+    ) as { status?: string; completed_at?: string | null } | undefined;
+    if (!beforeRow) return;
+
     const setClauses: string[] = [];
     const values: unknown[] = [];
 
@@ -712,6 +772,27 @@ export class SqliteTaskAttemptRepository {
     if (setClauses.length === 0) return;
     values.push(attemptId);
     this.exec.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    const nextStatus = changes.status ?? beforeRow.status;
+    const statusJustBecameTerminal =
+      changes.status !== undefined &&
+      TERMINAL_ATTEMPT_STATUSES.has(changes.status) &&
+      changes.status !== beforeRow.status;
+    const completedAtChanged =
+      changes.completedAt !== undefined &&
+      (changes.completedAt instanceof Date ? changes.completedAt.toISOString() : changes.completedAt ?? null) !==
+        (beforeRow.completed_at ?? null);
+    if ((statusJustBecameTerminal || completedAtChanged) && nextStatus && TERMINAL_ATTEMPT_STATUSES.has(nextStatus)) {
+      const row = this.exec.queryOne('SELECT * FROM attempts WHERE id = ?', [attemptId]);
+      if (!row) {
+        throw new Error(`Failed to read attempt ${attemptId} after completion update`);
+      }
+      appendJournalEntry(this.exec, {
+        entityType: 'attempt',
+        entityId: attemptId,
+        op: 'upsert',
+        payload: row,
+      });
+    }
   }
 
   claimAttemptForLaunch(

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -27,6 +27,7 @@ import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ReviewGateLookup,
   Workflow,
+  WorkflowListOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
 } from './adapter.js';
@@ -89,8 +90,8 @@ export class SqliteWorkflowRepository {
   saveWorkflow(workflow: WorkflowSaveInput): void {
     assertWorkflowConsistent(workflow);
     this.exec.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, deleted_at, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       workflow.id, workflow.name,
       workflow.description ?? null,
@@ -103,6 +104,7 @@ export class SqliteWorkflowRepository {
       workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
       workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
       workflow.generation ?? 0,
+      workflow.deletedAt ?? null,
       workflow.createdAt, workflow.updatedAt,
     ]);
   }
@@ -174,16 +176,19 @@ export class SqliteWorkflowRepository {
     this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+  loadWorkflow(workflowId: string, options?: WorkflowListOptions): Workflow | undefined {
+    const row = this.exec.queryOne(
+      `SELECT * FROM workflows WHERE id = ?${options?.includeDeleted ? '' : ' AND deleted_at IS NULL'}`,
+      [workflowId],
+    );
     if (!row) return undefined;
     const rollup = this.loadWorkflowRollups([workflowId]).get(workflowId);
     return this.rowToWorkflow(row, rollup);
   }
 
-  listWorkflows(): Workflow[] {
+  listWorkflows(options?: WorkflowListOptions): Workflow[] {
     const rows = this.exec.queryAll(
-      'SELECT * FROM workflows ORDER BY created_at DESC',
+      `SELECT * FROM workflows${options?.includeDeleted ? '' : ' WHERE deleted_at IS NULL'} ORDER BY created_at DESC`,
     );
     const workflowIds = rows.map((row) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
@@ -205,7 +210,9 @@ export class SqliteWorkflowRepository {
               w.base_branch AS baseBranch
          FROM tasks t
          JOIN workflows w ON w.id = t.workflow_id
-        WHERE t.is_merge_node = 1 AND (t.review_id = ? OR t.review_url LIKE ?)`,
+        WHERE w.deleted_at IS NULL
+          AND t.is_merge_node = 1
+          AND (t.review_id = ? OR t.review_url LIKE ?)`,
       [pr, `%/pull/${pr}`],
     );
     if (rows.length === 0) return undefined;
@@ -257,7 +264,8 @@ export class SqliteWorkflowRepository {
     if (type === 'workflows' || type === 'all') {
       const workflows = this.exec.queryAll(
         `SELECT id, name, description, plan_file, repo_url, branch, created_at FROM workflows 
-         WHERE name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ? 
+         WHERE deleted_at IS NULL
+           AND (name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{ id: string; name?: string | null; created_at: string }>;
@@ -323,13 +331,23 @@ export class SqliteWorkflowRepository {
     return results;
   }
 
-  loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
+  loadWorkflowTaskSnapshot(options?: WorkflowListOptions): WorkflowTaskSnapshot {
     const totalStartedAt = Date.now();
     const workflowQueryStartedAt = Date.now();
-    const workflowRows = this.exec.queryAll('SELECT * FROM workflows ORDER BY created_at DESC');
+    const workflowRows = this.exec.queryAll(
+      `SELECT * FROM workflows${options?.includeDeleted ? '' : ' WHERE deleted_at IS NULL'} ORDER BY created_at DESC`,
+    );
     const workflowMetadataQueryMs = Date.now() - workflowQueryStartedAt;
     const taskQueryStartedAt = Date.now();
-    const taskRows = this.exec.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC');
+    const taskRows = this.exec.queryAll(
+      options?.includeDeleted
+        ? 'SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC'
+        : `SELECT t.*
+             FROM tasks t
+             JOIN workflows w ON w.id = t.workflow_id
+            WHERE w.deleted_at IS NULL
+            ORDER BY t.workflow_id ASC, t.id ASC`,
+    );
     const taskQueryMs = Date.now() - taskQueryStartedAt;
     const tasksByWorkflowId = new Map<string, TaskState[]>();
     const workflowIds = workflowRows.map((row) => String(row.id));

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -1,0 +1,191 @@
+import type { SqliteExecutor } from './sqlite-executor.js';
+
+export const SYNC_ENTITY_TYPES = [
+  'workflow',
+  'task',
+  'attempt',
+  'event',
+  // Reserved for future output-spool sync. High-volume output rows are not
+  // journaled until transport/backpressure rules exist.
+  'output',
+] as const;
+
+export type SyncEntityType = (typeof SYNC_ENTITY_TYPES)[number];
+export type SyncJournalOp = 'upsert' | 'tombstone';
+
+export interface SyncJournalEntryInput {
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOp;
+  payload: unknown;
+  /** Machine id of the writer. Local owner-process writes use `home`. */
+  origin?: string;
+  /** Milliseconds since epoch. Defaults to Date.now(). */
+  createdAt?: number;
+}
+
+export interface SyncJournalEntry {
+  seq: number;
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOp;
+  payload: unknown;
+  origin: string;
+  createdAt: number;
+}
+
+export interface SyncCursor {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt: number;
+}
+
+export interface SyncCursorWrite {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  /** Milliseconds since epoch. Defaults to Date.now(). */
+  updatedAt?: number;
+}
+
+interface SyncJournalRow {
+  seq: unknown;
+  entity_type: unknown;
+  entity_id: unknown;
+  op: unknown;
+  payload: unknown;
+  origin: unknown;
+  created_at: unknown;
+}
+
+interface SyncCursorRow {
+  peer_id: unknown;
+  last_sent_seq: unknown;
+  last_received_seq: unknown;
+  updated_at: unknown;
+}
+
+function toNonNegativeInteger(value: unknown, field: string): number {
+  const n = typeof value === 'bigint' ? Number(value) : Number(value);
+  if (!Number.isSafeInteger(n) || n < 0) {
+    throw new Error(`Invalid sync ${field}: ${String(value)}`);
+  }
+  return n;
+}
+
+function stringifyPayload(payload: unknown): string {
+  const json = JSON.stringify(payload);
+  if (json === undefined) {
+    throw new Error('Sync journal payload must be JSON-serializable');
+  }
+  return json;
+}
+
+function mapJournalRow(row: SyncJournalRow): SyncJournalEntry {
+  return {
+    seq: toNonNegativeInteger(row.seq, 'journal seq'),
+    entityType: String(row.entity_type) as SyncEntityType,
+    entityId: String(row.entity_id),
+    op: String(row.op) as SyncJournalOp,
+    payload: JSON.parse(String(row.payload)),
+    origin: String(row.origin),
+    createdAt: toNonNegativeInteger(row.created_at, 'journal created_at'),
+  };
+}
+
+function mapCursorRow(row: SyncCursorRow): SyncCursor {
+  return {
+    peerId: String(row.peer_id),
+    lastSentSeq: toNonNegativeInteger(row.last_sent_seq, 'cursor last_sent_seq'),
+    lastReceivedSeq: toNonNegativeInteger(row.last_received_seq, 'cursor last_received_seq'),
+    updatedAt: toNonNegativeInteger(row.updated_at, 'cursor updated_at'),
+  };
+}
+
+export function appendJournalEntry(
+  db: SqliteExecutor,
+  entry: SyncJournalEntryInput,
+): SyncJournalEntry {
+  const createdAt = entry.createdAt ?? Date.now();
+  db.execRun(
+    `INSERT INTO sync_journal (
+        entity_type,
+        entity_id,
+        op,
+        payload,
+        origin,
+        created_at
+      ) VALUES (?, ?, ?, ?, ?, ?)`,
+    [
+      entry.entityType,
+      entry.entityId,
+      entry.op,
+      stringifyPayload(entry.payload),
+      entry.origin ?? 'home',
+      createdAt,
+    ],
+  );
+
+  const row = db.queryOne(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq = last_insert_rowid()`,
+  ) as SyncJournalRow | undefined;
+  if (!row) {
+    throw new Error('Failed to read appended sync journal row');
+  }
+  return mapJournalRow(row);
+}
+
+export function readJournalSince(
+  db: SqliteExecutor,
+  seq: number,
+  limit: number,
+): SyncJournalEntry[] {
+  const cursor = toNonNegativeInteger(seq, 'journal cursor');
+  const cappedLimit = Math.max(0, Math.trunc(limit));
+  if (cappedLimit === 0) return [];
+
+  const rows = db.queryAll(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq > ?
+      ORDER BY seq ASC
+      LIMIT ?`,
+    [cursor, cappedLimit],
+  ) as unknown as SyncJournalRow[];
+  return rows.map((row) => mapJournalRow(row));
+}
+
+export function getSyncCursor(db: SqliteExecutor, peerId: string): SyncCursor | undefined {
+  const row = db.queryOne(
+    `SELECT peer_id, last_sent_seq, last_received_seq, updated_at
+       FROM sync_cursors
+      WHERE peer_id = ?`,
+    [peerId],
+  ) as SyncCursorRow | undefined;
+  return row ? mapCursorRow(row) : undefined;
+}
+
+export function setSyncCursor(db: SqliteExecutor, cursor: SyncCursorWrite): SyncCursor {
+  const updatedAt = cursor.updatedAt ?? Date.now();
+  db.execRun(
+    `INSERT INTO sync_cursors (
+        peer_id,
+        last_sent_seq,
+        last_received_seq,
+        updated_at
+      ) VALUES (?, ?, ?, ?)
+      ON CONFLICT(peer_id) DO UPDATE SET
+        last_sent_seq = excluded.last_sent_seq,
+        last_received_seq = excluded.last_received_seq,
+        updated_at = excluded.updated_at`,
+    [cursor.peerId, cursor.lastSentSeq, cursor.lastReceivedSeq, updatedAt],
+  );
+  const saved = getSyncCursor(db, cursor.peerId);
+  if (!saved) {
+    throw new Error(`Failed to read sync cursor for peer ${cursor.peerId}`);
+  }
+  return saved;
+}


### PR DESCRIPTION
## Summary

Remote Sync Step 1: Sync Schema and Change Journal — 2 tasks completed, 0 failed, 0 closed, 0 sk&#105;pped

Adds a data-store sync schema and journal contract for later remote sync work.

Journal rows, peer cursors, and workflow tombstones are now durable SQLite records.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926077035-3/implement-sync-schema | Add sync journal, cursor, and tombstone schema to data-store | completed |
| wf-1784926077035-3/verify-sync-schema | Run data-store package tests covering the new schema and journal | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784926077035-3/implement-sync-schema — Add sync journal, cursor, and tombstone schema to data-store

### wf-1784926077035-3/verify-sync-schema — Run data-store package tests covering the new schema and journal

</details>

## Review Claim

Approve the data-store sync schema contract for journaling workflow, task, and attempt mutations with peer cursors and workflow tombstones.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Journal rows are appended inside existing SQLite transactions; a rollback removes entity rows and sync evidence together.

## Slice Rationale

Schema and local journal contract land first so later remote sync transport can consume one stable data-store contract.

## Non-goals

- No remote transport.
- No peer reconciliation.
- No UI changes.
- No output spool replication.

## Architecture

### Before

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["Entity table rows"]
    C["Workflow removal request"] --> D["Workflow row removed"]
```

### After

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["Entity table rows"]
    A --> C["sync_journal rows"]
    D["Workflow removal request"] --> E["Workflow tombstone state"]
    D --> F["sync_journal tombstone row"]
    G["Peer replication checkpoint"] --> H["sync_cursors row"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sync-journal.test.ts` (25 files, 436 tests passed)
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-bodies/remote-sync-step-1-schema-journal.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-bodies/remote-sync-step-1-schema-journal.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert HEAD`
- Post-revert steps: Rerun `pnpm --filter @invoker/data-store test -- src/__tests__/sync-journal.test.ts`.
- Data migration? Yes. Existing local databases may retain unused sync tables and the workflow tombstone column after code revert.

</details>
