### PR TITLE
[Remote Sync Step 1: Sync Schema and Change Journal](2) Pass SSH provision settings into selected executors

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2641,6 +2641,35 @@ describe('TaskRunner', () => {
 
       expect(provider).toHaveBeenCalledTimes(2);
     });
+
+    it('passes SSH target provisioning settings into the selected executor', () => {
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => undefined } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({
+          'do-droplet': {
+            host: '1.2.3.4',
+            user: 'root',
+            sshKeyPath: '/key',
+            managedWorkspaces: true,
+            remoteInvokerHome: '~/.custom-invoker',
+            provisionCommand: 'pnpm install --frozen-lockfile',
+          },
+        }),
+      });
+
+      const selected = executor.selectExecutor(makeTask({
+        id: 'ssh-task',
+        config: { runnerKind: 'ssh', poolMemberId: 'do-droplet' },
+      }));
+
+      expect(selected.executor.type).toBe('ssh');
+      expect(Reflect.get(selected.executor, 'remoteInvokerHome')).toBe('~/.custom-invoker');
+      expect(Reflect.get(selected.executor, 'provisionCommand')).toBe('pnpm install --frozen-lockfile');
+    });
+
     it('reads worktree provision commands lazily from the pool provider on each selectExecutor call', () => {
       const provider = vi.fn()
         .mockReturnValueOnce({

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -763,6 +763,8 @@ export function selectExecutor(
         port: target.port,
         agentRegistry: host.executionAgentRegistry,
         managedWorkspaces: target.managedWorkspaces,
+        remoteInvokerHome: target.remoteInvokerHome,
+        provisionCommand: target.provisionCommand,
         useApiKey: target.use_api_key,
         secretsFile: target.secretsFile ?? host.dockerConfig.secretsFile,
         remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,


### PR DESCRIPTION
## Summary

Remote Sync Step 1 also preserves the SSH provisioning knobs needed by remote verification tasks.

Selected SSH executors now receive remoteInvokerHome and provisionCommand from the remote target record.

## Review Claim

Approve the executor routing handoff that carries explicit SSH provisioning settings into the selected executor.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice only threads two existing remote-target fields into SSH executor construction and covers that selection path with one focused test.

## Slice Rationale

This stays separate from the lower data-store slice because executor selection has a different reviewer surface.

## Non-goals

- No data-store behavior changes.
- No worktree executor changes.
- No remote target config key changes.

## Architecture

### Before

```mermaid
graph TD
    A["remoteTargets entry"] --> B["TaskRunner.selectExecutor"]
    B --> C["SshExecutor without remoteInvokerHome or provisionCommand"]
```

### After

```mermaid
graph TD
    A["remoteTargets entry"] --> B["TaskRunner.selectExecutor"]
    B --> C["SshExecutor receives remoteInvokerHome and provisionCommand"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts -t "passes SSH target provisioning settings into the selected executor"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert aec376928`
- Post-revert steps: None
- Data migration? No

</details>
