### PR TITLE
[PR babysit] Tooling-policy repair prerequisite for #5885: UI Vitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
     name: UI Vitest
     runs-on:
       labels: Runner_Vitest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Reclaim workspace


### PR DESCRIPTION
## Summary

Worker-generated tooling-policy repair.

## Review Claim

This PR carries the worker-generated tooling-policy repair that unblocks UI Vitest on #5885.

## Review Lane

- policy

## Review Unit

- tooling-policy

## Safety Invariant

Contains only the worker-generated repair commit; the original PR branch stays proof-only.

## Slice Rationale

The repair changed tooling-policy files that a proof PR body cannot carry, so the repair must land first.

## Non-goals

- No product behavior change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] Let CI rerun UI Vitest.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the UI test workflow timeout to reduce failures caused by tests exceeding the previous time limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->