### PR TITLE
[Preserve Graph View Across Planning Window Switches](1) Restore the workflow graph viewport on planning return

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3017,28 +3017,13 @@ export function App() {
     focusKeyboardRegion('planning');
   }, [focusKeyboardRegion]);
 
-  const navigatePlanGraph = useCallback((reason: string, options: { fit: boolean }) => {
+  const navigatePlanGraphPreservingViewport = useCallback((_reason: string) => {
     setSidebarSurface('planning');
     setInspectorManualOpen(false);
     setViewMode('dag');
     focusKeyboardRegion('workflowGraph');
-
-    if (options.fit) {
-      workflowGraphViewportRef.current = null;
-      issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason });
-      return;
-    }
-
     setCameraCommand(null);
-  }, [focusKeyboardRegion, issueCameraCommand]);
-
-  const navigatePlanGraphAndFit = useCallback((reason: string) => {
-    navigatePlanGraph(reason, { fit: true });
-  }, [navigatePlanGraph]);
-
-  const navigatePlanGraphPreservingViewport = useCallback((reason: string) => {
-    navigatePlanGraph(reason, { fit: false });
-  }, [navigatePlanGraph]);
+  }, [focusKeyboardRegion]);
 
   const handleSelectSidebarSurface = useCallback((nextSurface: SidebarSurface) => {
     setGraphActionsMenuOpen(false);
@@ -3061,18 +3046,14 @@ export function App() {
       return;
     }
     if (nextSurface === 'planning') {
-      if (sidebarSurface === 'home') {
-        navigatePlanGraphPreservingViewport('sidebar-planning');
-        return;
-      }
-      navigatePlanGraphAndFit('sidebar-planning');
+      navigatePlanGraphPreservingViewport('sidebar-planning');
       return;
     }
     setViewMode('dag');
     setSidebarSurface(nextSurface);
     setInspectorManualOpen(false);
     setStatusFilters(new Set<WorkflowStatus>());
-  }, [navigatePlanGraphAndFit, navigatePlanGraphPreservingViewport, navigatePlanningHome, sidebarSurface, viewMode]);
+  }, [navigatePlanGraphPreservingViewport, navigatePlanningHome, sidebarSurface, viewMode]);
 
   const handleDismissBrowserSurface = useCallback(() => {
     setGraphActionsMenuOpen(false);
@@ -4087,7 +4068,7 @@ export function App() {
             </Button>
             <button
               type="button"
-              onClick={() => navigatePlanGraphAndFit('planning-draft-review')}
+              onClick={() => navigatePlanGraphPreservingViewport('planning-draft-review')}
               className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
             >
               Open graph
@@ -4121,7 +4102,7 @@ export function App() {
             <button
               type="button"
               data-testid="planning-context-open-graph"
-              onClick={() => navigatePlanGraphAndFit('planning-context')}
+              onClick={() => navigatePlanGraphPreservingViewport('planning-context')}
               className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
             >
               Open graph
@@ -4241,7 +4222,7 @@ export function App() {
             onPresetChange={setSelectedPlanningPresetKey}
             onModeChange={(mode) => void handlePlanningModeChange(mode)}
             onExpand={() => setPlanningTerminalExpanded(true)}
-            onOpenGraph={() => navigatePlanGraphAndFit('planning-open-graph')}
+            onOpenGraph={() => navigatePlanGraphPreservingViewport('planning-open-graph')}
             onReviewDraft={() => {
               setReviewDraftSessionId(activePlanningSession.id);
               setPlanningContextCollapsed(false);
@@ -4577,7 +4558,7 @@ export function App() {
             onCloseExpanded={() => setPlanningTerminalExpanded(false)}
             onOpenGraph={() => {
               setPlanningTerminalExpanded(false);
-              navigatePlanGraphAndFit('planning-expanded-open-graph');
+              navigatePlanGraphPreservingViewport('planning-expanded-open-graph');
             }}
             onReviewDraft={() => {
               setPlanningTerminalExpanded(false);

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -17,6 +17,8 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { WorkflowMeta } from '../types.js';
 import type { GraphCameraCommand } from '../lib/graph-camera.js';
@@ -56,6 +58,8 @@ const getViewportMock = (ReactFlowModule as unknown as { __getViewportMock: Mock
 
 // App must be imported AFTER vi.mock registers so it binds the mocked react-flow.
 const { App } = await import('../App.js');
+
+const appSource = readFileSync(resolve(__dirname, '..', 'App.tsx'), 'utf-8');
 
 const workflows: WorkflowMeta[] = [
   { id: 'wf-a', name: 'Alpha Workflow', status: 'running' },
@@ -178,7 +182,7 @@ describe('Browser-surface camera (component)', () => {
     expect(fitViewMock).not.toHaveBeenCalled();
   });
 
-  it('clicking the left-nav home icon returns to the workflow graph and issues the Home fit command', async () => {
+  it('opens the workflow graph from a browser surface without issuing a sidebar fit command', async () => {
     mock.setTasks(tasks, workflows);
     render(<App />);
 
@@ -192,17 +196,52 @@ describe('Browser-surface camera (component)', () => {
     fireEvent.click(screen.getByTestId('sidebar-planning'));
 
     await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
-    await waitFor(() => {
-      const matchingCommands = workflowGraphSpy.commands.filter((command): command is GraphCameraCommand => (
-        command?.kind === 'fitInitial'
-        && command.scope === 'workflow'
-        && command.reason === 'sidebar-planning'
-      ));
-      expect(matchingCommands.length).toBeGreaterThan(0);
-    });
     await flushFrames(4);
 
+    // No saved workflow viewport exists yet, so the graph's first non-empty
+    // mount may fit. The sidebar navigation itself must not issue a fit command.
     expect(fitViewMock).toHaveBeenCalled();
+    expect(workflowGraphSpy.commands.some((command) => (
+      command?.kind === 'fitInitial'
+      && command.scope === 'workflow'
+      && command.reason === 'sidebar-planning'
+    ))).toBe(false);
+  });
+
+  it('returns to the workflow graph from a browser surface by restoring the saved viewport instead of fitting', async () => {
+    const savedViewport = { x: -420, y: 96, zoom: 0.62 };
+    mock.setTasks([], workflows);
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    await screen.findByTestId('workflow-node-wf-a');
+    await settleCamera();
+
+    // Simulate the operator's current graph location before leaving the graph.
+    getViewportMock.mockReturnValue(savedViewport);
+
+    fireEvent.click(screen.getByTestId('sidebar-workflows'));
+    await screen.findByTestId('browser-rail');
+    await settleCamera();
+
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    setViewportMock.mockClear();
+    workflowGraphSpy.reset();
+
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+
+    await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
+    await waitFor(() => expect(setViewportMock).toHaveBeenCalledWith(savedViewport, { duration: 0 }));
+    await flushFrames(4);
+
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(workflowGraphSpy.commands.some((command) => (
+      command?.kind === 'fitInitial'
+      && command.scope === 'workflow'
+      && command.reason === 'sidebar-planning'
+    ))).toBe(false);
   });
 
   it('returns to the workflow graph from the planning-home chat rail by restoring the saved viewport instead of fitting', async () => {
@@ -240,5 +279,20 @@ describe('Browser-surface camera (component)', () => {
       && command.scope === 'workflow'
       && command.reason === 'sidebar-planning'
     ))).toBe(false);
+  });
+
+  it('routes planning graph return entry points through viewport-preserving navigation', () => {
+    for (const reason of [
+      'sidebar-planning',
+      'planning-open-graph',
+      'planning-expanded-open-graph',
+      'planning-context',
+      'planning-draft-review',
+    ]) {
+      expect(appSource).toContain(`navigatePlanGraphPreservingViewport('${reason}')`);
+      expect(appSource).not.toContain(`navigatePlanGraphAndFit('${reason}')`);
+    }
+
+    expect(appSource).toContain("issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason: 'planning-submit' })");
   });
 });


### PR DESCRIPTION
## Summary

Returning from planning chat, expanded terminal, and planning context now keeps the workflow graph viewport the user already had.

The graph entry path clears pending camera commands instead of issuing a fresh workflow fit.

## Review Claim

Approve the behavior change that planning-surface graph entry restores the saved workflow viewport instead of refitting the graph.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change stays inside the planning graph entry handlers and focused React camera tests; task data, workflow data, and graph rendering stay unchanged.

## Slice Rationale

This slice changes only the user-facing graph entry behavior. The broader terminal regression proof stays in the next PR so the behavior edit remains locally reviewable.

## Non-goals

- No task graph layout changes.
- No workflow selection changes.
- No planning chat persistence changes.
- No terminal transcript behavior changes.

## Architecture

### Before

```mermaid
graph TD
    A["Planning graph entry"] --> B["Discard saved workflow viewport"]
    B --> C["Issue fitInitial workflow camera command"]
    C --> D["WorkflowGraph refits on return"]
```

### After

```mermaid
graph TD
    A["Planning graph entry"] --> B["Keep saved workflow viewport"]
    B --> C["Clear pending camera command"]
    C --> D["WorkflowGraph restores initialViewport"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/browser-surface-camera-resnap.test.tsx src/__tests__/invoker-terminal.test.tsx`

</details>

## Visual Proof

![Workflow graph remains inspectable after returning from planning](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-0bf709/neutral-chrome-home-graph.png)

[Planning terminal return recording](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-0bf709/planning-terminal-restart.gif)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, before the proof PR or together with it.
- Revert command: `git revert d0af06180`
- Post-revert steps: Rerun the focused UI tests listed above.
- Data migration? No

</details>
