### PR TITLE
[Preserve Graph View Across Planning Window Switches](2) Add viewport switch regression proof

### DIFF
--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -16,10 +16,10 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import { createMockInvoker, makePlanningSessionSummary, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { WorkflowMeta } from '../types.js';
 import type { GraphCameraCommand } from '../lib/graph-camera.js';
 import * as ReactFlowModule from '@xyflow/react';
@@ -99,6 +99,27 @@ async function settleCamera(): Promise<void> {
       prev = total;
     }
   }
+}
+
+function restoreSubmittedPlanningSession(
+  mock: MockInvoker,
+  overrides: Parameters<typeof makePlanningSessionSummary>[0] = {},
+) {
+  mock.api.planningChatList = vi.fn(async () => ({
+    ok: true,
+    sessions: [
+      makePlanningSessionSummary({
+        id: 'submitted-planning-session',
+        title: 'Submitted planning session',
+        status: 'submitted',
+        draftPlanAvailable: false,
+        draftPlanSummary: undefined,
+        submittedWorkflowId: 'wf-a',
+        submittedPlanName: 'Stable Viewport Plan',
+        ...overrides,
+      }),
+    ],
+  }));
 }
 
 describe('Browser-surface camera (component)', () => {
@@ -278,6 +299,83 @@ describe('Browser-surface camera (component)', () => {
       command?.kind === 'fitInitial'
       && command.scope === 'workflow'
       && command.reason === 'sidebar-planning'
+    ))).toBe(false);
+  });
+
+  it('returns to the workflow graph from a submitted planning chat by restoring the saved viewport instead of fitting', async () => {
+    const savedViewport = { x: -380, y: 112, zoom: 0.7 };
+    mock.setTasks([], workflows);
+    restoreSubmittedPlanningSession(mock);
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    await screen.findByTestId('workflow-node-wf-a');
+    await settleCamera();
+
+    getViewportMock.mockReturnValue(savedViewport);
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-submitted-bar')).toHaveTextContent('Stable Viewport Plan');
+    });
+
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    setViewportMock.mockClear();
+    workflowGraphSpy.reset();
+
+    fireEvent.click(screen.getByTestId('invoker-terminal-open-graph'));
+
+    await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
+    await waitFor(() => expect(setViewportMock).toHaveBeenCalledWith(savedViewport, { duration: 0 }));
+    await flushFrames(4);
+
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(workflowGraphSpy.commands.some((command) => (
+      command?.kind === 'fitInitial'
+      && command.scope === 'workflow'
+      && command.reason === 'planning-open-graph'
+    ))).toBe(false);
+  });
+
+  it('returns to the workflow graph from expanded planning chat by restoring the saved viewport instead of fitting', async () => {
+    const savedViewport = { x: -512, y: 84, zoom: 0.58 };
+    mock.setTasks([], workflows);
+    restoreSubmittedPlanningSession(mock, { id: 'expanded-submitted-planning-session' });
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    await screen.findByTestId('workflow-node-wf-a');
+    await settleCamera();
+
+    getViewportMock.mockReturnValue(savedViewport);
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-submitted-bar')).toHaveTextContent('Stable Viewport Plan');
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Expand planning chat' }));
+
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    setViewportMock.mockClear();
+    workflowGraphSpy.reset();
+
+    const expandedTerminal = screen.getByTestId('invoker-terminal-expanded');
+    fireEvent.click(within(expandedTerminal).getByTestId('invoker-terminal-open-graph'));
+
+    await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
+    await waitFor(() => expect(setViewportMock).toHaveBeenCalledWith(savedViewport, { duration: 0 }));
+    await flushFrames(4);
+
+    expect(screen.queryByTestId('invoker-terminal-expanded')).not.toBeInTheDocument();
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(workflowGraphSpy.commands.some((command) => (
+      command?.kind === 'fitInitial'
+      && command.scope === 'workflow'
+      && command.reason === 'planning-expanded-open-graph'
     ))).toBe(false);
   });
 

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -882,6 +882,43 @@ describe('Invoker terminal (component)', () => {
     expect(screen.getAllByText(/submitted/i).length).toBeGreaterThan(0);
   });
 
+  it('opens the Plan graph from a submitted planning terminal session', async () => {
+    const submittedWorkflow: WorkflowMeta = {
+      id: 'submitted-wf',
+      name: 'Submitted Workflow',
+      status: 'running',
+    };
+    mock.setTasks([], [submittedWorkflow]);
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'submitted-terminal-session',
+          title: 'Submitted terminal session',
+          status: 'submitted',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          submittedWorkflowId: submittedWorkflow.id,
+          submittedPlanName: 'Submitted Terminal Plan',
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-submitted-bar')).toHaveTextContent('Submitted Terminal Plan');
+    });
+
+    fireEvent.click(screen.getByTestId('invoker-terminal-open-graph'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sidebar-planning')).toHaveAttribute('aria-current', 'page');
+    });
+    expect(await screen.findByTestId('workflow-node-submitted-wf')).toBeInTheDocument();
+  });
+
   it('opens the expanded planning chat and Escape closes it without clearing transcript', async () => {
     render(<App />);
     await openPlanningTerminal();


### PR DESCRIPTION
## Summary

The terminal test suite now covers submitted planning graph entry with a saved workflow viewport.

The new assertion proves that terminal graph entry restores the viewport and does not issue a fit command.

## Review Claim

Approve the regression proof that submitted planning terminal graph entry preserves the saved workflow viewport.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes only focused UI regression coverage; product code and runtime behavior are unchanged here.

## Slice Rationale

This proof follows the behavior slice so the test-only expansion can be reviewed as the evidence for the planning terminal path.

## Non-goals

- No product code changes.
- No planning terminal UI copy changes.
- No task graph rendering changes.
- No broader UI suite reshaping.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/browser-surface-camera-resnap.test.tsx src/__tests__/invoker-terminal.test.tsx`

</details>

## Visual Proof

[Planning terminal return recording](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-374381/planning-terminal-restart.gif)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, this removes only the added proof coverage.
- Revert command: `git revert 487e6aed6`
- Post-revert steps: Rerun the focused UI tests listed above.
- Data migration? No

</details>
