### PR TITLE
[Camera-quiet background selection](1) Stop app-driven selection changes from recentering the graph camera

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -83,6 +83,7 @@ type ModalState =
 
 type KeyboardRegion = 'workflowGraph' | 'taskGraph' | 'inspector' | 'bottomBar' | 'planning';
 type GraphKeyboardRegion = Extract<KeyboardRegion, 'workflowGraph' | 'taskGraph'>;
+type SelectionOptions = { recenter?: boolean };
 type ContextMenuCloseOptions = { restoreFocus?: boolean };
 type ContextMenuState = { x: number; y: number; taskId: string; returnFocusRegion?: GraphKeyboardRegion };
 type WorkflowContextMenuState = { x: number; y: number; workflowId: string; returnFocusRegion?: GraphKeyboardRegion };
@@ -1616,6 +1617,10 @@ export function App() {
     return command;
   }, []);
 
+  const recenterForSelection = useCallback((scope: GraphScope, target: string) => {
+    issueCameraCommand({ kind: 'centerSelection', scope, target, reason: 'select-node' });
+  }, [issueCameraCommand]);
+
   const handleWorkflowGraphViewportSnapshot = useCallback((viewport: GraphCameraViewport) => {
     workflowGraphViewportRef.current = viewport;
   }, []);
@@ -1633,7 +1638,7 @@ export function App() {
     });
   }, []);
 
-  const selectWorkflowById = useCallback((workflowId: string) => {
+  const selectWorkflowById = useCallback((workflowId: string, options: SelectionOptions = {}) => {
     armSuppressDagSurfaceDismiss();
     setWorkflowSelectionDismissed(false);
     setSelectedWorkflowId(workflowId);
@@ -1641,9 +1646,12 @@ export function App() {
     setContextMenu(null);
     setWorkflowContextMenu(null);
     focusKeyboardRegion('workflowGraph');
-  }, [armSuppressDagSurfaceDismiss, focusKeyboardRegion]);
+    if (options.recenter ?? true) {
+      recenterForSelection('workflow', workflowId);
+    }
+  }, [armSuppressDagSurfaceDismiss, focusKeyboardRegion, recenterForSelection]);
 
-  const selectTaskById = useCallback((taskId: string) => {
+  const selectTaskById = useCallback((taskId: string, options: SelectionOptions = {}) => {
     const task = tasksRef.current.get(taskId);
     if (!task) return;
     setSelectedTaskId(task.id);
@@ -1656,19 +1664,26 @@ export function App() {
     setContextMenu(null);
     setWorkflowContextMenu(null);
     focusKeyboardRegion('taskGraph');
-  }, [focusKeyboardRegion]);
+    if (options.recenter ?? true) {
+      recenterForSelection('task', task.id);
+    }
+  }, [focusKeyboardRegion, recenterForSelection]);
 
   useEffect(() => {
     const unsubscribe = window.invoker?.onWorkflowMutationFailed?.((event) => {
       const failedTaskId = event.taskId;
       if (failedTaskId) {
         setMutationFailuresByTaskId((prev) => new Map(prev).set(failedTaskId, event));
+        const task = tasksRef.current.get(failedTaskId);
+        if (task) {
+          selectTaskById(task.id, { recenter: false });
+        }
         return;
       }
       notifyMutationError('Mutation failed', event.message);
     });
     return () => { unsubscribe?.(); };
-  }, []);
+  }, [selectTaskById]);
 
   const selectRelativeNode = useCallback((direction: 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight') => {
     const inTaskGraph = keyboardRegion === 'taskGraph';
@@ -2015,7 +2030,8 @@ export function App() {
     setSelectedTaskId(null);
     setContextMenu(null);
     setWorkflowContextMenu(null);
-  }, [armSuppressDagSurfaceDismiss]);
+    recenterForSelection('workflow', workflowId);
+  }, [armSuppressDagSurfaceDismiss, recenterForSelection]);
 
   const handleWorkflowContextMenu = useCallback((event: React.MouseEvent<Element>, workflowId: string) => {
     event.preventDefault();
@@ -2042,7 +2058,7 @@ export function App() {
       if (activeWorkflowId !== null && !selectedWorkflowVanished) {
         return;
       }
-      selectWorkflowById(workflowEntries[0].workflow.id);
+      selectWorkflowById(workflowEntries[0].workflow.id, { recenter: false });
       return;
     }
 
@@ -2058,7 +2074,7 @@ export function App() {
       if (attentionEntries.some((entry) => entry.task.id === selectedTaskId)) {
         return;
       }
-      selectTaskById(attentionEntries[0].task.id);
+      selectTaskById(attentionEntries[0].task.id, { recenter: false });
       return;
     }
 

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -7,7 +7,8 @@
  * task delta. Each tick therefore re-issued fitInitial + centerSelection and
  * yanked the viewport back to the selection while the user was panning the graph.
  * The effect now keys off stable surface-entry signals, so live updates and
- * selection changes while already on the surface issue no camera command.
+ * app-driven selection changes while already on the surface issue no camera
+ * command. User-initiated selection still recenters by default.
  *
  * The effect is shared by every non-home browser surface (its guard only excludes
  * `home`), so this drives the Workflows surface — the jsdom harness cannot render
@@ -16,7 +17,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { WorkflowMeta } from '../types.js';
 import type { GraphCameraCommand } from '../lib/graph-camera.js';
@@ -114,6 +115,7 @@ describe('Browser-surface camera (component)', () => {
   });
 
   afterEach(() => {
+    cleanup();
     mock.cleanup();
   });
 
@@ -156,7 +158,7 @@ describe('Browser-surface camera (component)', () => {
     expect(fitViewMock).not.toHaveBeenCalled();
   }, 20000);
 
-  it('does not re-center or re-fit when the selected task changes while already on a browser surface', async () => {
+  it('user-initiated task selection recenters without re-fitting while already on a browser surface', async () => {
     mock.setTasks(tasks, workflows);
     render(<App />);
 
@@ -167,7 +169,95 @@ describe('Browser-surface camera (component)', () => {
     fitViewMock.mockClear();
     setCenterMock.mockClear();
 
-    fireEvent.click(screen.getByTestId('rf__node-wf-a/two'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('rf__node-wf-a/two'));
+      await flushFrames(2);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Task Two');
+    });
+    await settleCamera();
+
+    expect(setCenterMock).toHaveBeenCalled();
+    expect(fitViewMock).not.toHaveBeenCalled();
+  });
+
+  it('a background auto-select reshuffle changes selection but issues no camera command', async () => {
+    const attentionTasks = [
+      makeUITask({
+        id: 'wf-a/attention-one',
+        description: 'Attention One',
+        workflowId: 'wf-a',
+        status: 'awaiting_approval',
+        command: 'echo one',
+        taskStateVersion: 1,
+      }),
+      makeUITask({
+        id: 'wf-a/attention-two',
+        description: 'Attention Two',
+        workflowId: 'wf-a',
+        status: 'needs_input',
+        command: 'echo two',
+        dependencies: ['wf-a/attention-one'],
+        taskStateVersion: 1,
+      }),
+    ];
+    mock.setTasks(attentionTasks, workflows);
+    render(<App />);
+
+    fireEvent.click(screen.getByTestId('sidebar-attention'));
+    await screen.findByTestId('selected-workflow-mini-dag');
+    fireEvent.click(await screen.findByRole('button', { name: /Attention Two/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Attention Two');
+    });
+    await settleCamera();
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+
+    act(() => {
+      mock.fireDelta({
+        type: 'updated',
+        taskId: 'wf-a/attention-two',
+        changes: { status: 'completed' },
+        taskStateVersion: 2,
+        previousTaskStateVersion: 1,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Attention One');
+    });
+    await flushFrames(6);
+
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(fitViewMock).not.toHaveBeenCalled();
+  });
+
+  it('a workflow-mutation-failed event selects the failed task but issues no camera command', async () => {
+    mock.setTasks(tasks, workflows);
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId('sidebar-workflows'));
+    await screen.findByTestId('selected-workflow-mini-dag');
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Alpha Workflow');
+    });
+    await settleCamera();
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+
+    act(() => {
+      mock.fireWorkflowMutationFailed({
+        intentId: 72,
+        workflowId: 'wf-a',
+        channel: 'invoker:approve',
+        taskId: 'wf-a/two',
+        message: 'approve failed',
+        failedAt: '2026-07-27T00:00:00.000Z',
+      });
+    });
 
     await waitFor(() => {
       expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Task Two');


### PR DESCRIPTION
Camera-quiet background selection — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784181997868-1/quiet-background-camera | Stop app-driven selection changes from recentering the graph camera | completed |
| wf-1784181997868-1/verify-camera-quiet | Run the browser-surface camera regression suite | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784181997868-1/quiet-background-camera — Stop app-driven selection changes from recentering the graph camera

### wf-1784181997868-1/verify-camera-quiet — Run the browser-surface camera regression suite

</details>

## Summary

The graph camera now treats app-driven selection as quiet.

User clicks and Home navigation still issue deliberate camera commands.

Focused component coverage locks background auto-select and mutation-failure focus against camera movement.

## Review Claim

Approve that app-driven workflow and task selection changes no longer recenter or refit the browser-surface graph, while explicit user navigation still can move the camera.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change stays in UI selection and camera coordination plus direct component regression coverage. It does not alter selected task data, graph topology, or task execution.

## Slice Rationale

This slice keeps the camera behavior change and regression coverage together because they define one selection-camera boundary.

The verification-only task has no file diff, so it is represented in the test plan rather than as an empty PR.

## Non-goals

- Does not change graph layout, node positions, or zoom math.
- Does not change task execution, workflow mutation payloads, or inspector content.
- Does not add worktree, SSH, or clone provisioning changes.

## Architecture

### Before

Selection state changes also acted like camera commands. Background auto-selection or mutation-failure focus could recenter the browser-surface graph.

### After

Selection helpers distinguish user navigation from quiet app-driven selection. Browser-surface auto-fit stays idle for quiet selection, while explicit navigation still moves the camera.

## Visual Proof

![Browser-surface graph context for the camera regression](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-0cbf7d/dag-after-selection.png)

Camera quietness is an inspectable motion invariant, not a static layout change. The focused regression test is the primary proof: it verifies background selection issues no `setCenter` or `fitView` call, while user navigation still moves the camera.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/browser-surface-camera-resnap.test.tsx`
- [x] Invoker workflow task `wf-1784181997868-1/verify-camera-quiet` completed with the browser-surface camera regression suite passing.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 29a70c59843df994fd93855a752e3f83974a79a0`
- Post-revert steps: None. Reverting restores the previous selection-driven camera recenter behavior.
- Data migration? No

</details>

