### PR TITLE
Post a human review blocker for a stuck babysit PR

### DIFF
--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -10,6 +10,7 @@ REPROS=(
   scripts/repro/repro-mergify-closed-pr-guard.sh
   scripts/repro/repro-coderabbit-pr5251-mergify-admin-requeue-yaml-alias.sh
   scripts/repro/repro-babysit-pr-body-human-split.sh
+  scripts/repro/repro-babysit-human-review-thread-block.sh
 )
 
 # repro-mergify-stack-dogfood.sh is deliberately excluded: it's an opt-in

--- a/scripts/mergify_admin_requeue_gh_executor.py
+++ b/scripts/mergify_admin_requeue_gh_executor.py
@@ -96,5 +96,7 @@ class AdminBypassGhExecutor:
             if action.key == "capped":
                 key = f"capped:{action.detail}"
                 self.comment_blocked(pr, action.detail, key, now)
+            else:
+                self.comment_blocked(pr, action.detail, action.key, now)
             return
         raise ValueError(f"unsupported executor action: {action.kind}")

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -435,7 +435,7 @@ def plan_bot_thread_repairs(facts: StackFacts, ledger: Ledger, max_repair_attemp
     return None
 
 
-def plan_hard_blockers(facts: StackFacts) -> Action | None:
+def plan_hard_blockers(facts: StackFacts, ledger: Ledger) -> Action | None:
     for pr in facts.stack.prs:
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "pending_check":
@@ -443,7 +443,9 @@ def plan_hard_blockers(facts: StackFacts) -> Action | None:
             if blocker.kind == "human_decision":
                 return None
             if blocker.kind in HUMAN_BLOCKER_KINDS:
-                return Action("comment_blocked", pr.number, blocker.key, public_blocker_kind(blocker.kind))
+                if ledger.count("comment-blocked", pr.number, pr.head_ref_oid, blocker.key) > 0:
+                    return None
+                return Action("comment_blocked", pr.number, blocker.key, blocker.detail)
     return None
 
 
@@ -518,7 +520,7 @@ def plan_actions_from_facts(
     action = plan_bot_thread_repairs(facts, ledger, max_repair_attempts)
     if action is not None:
         return (action,)
-    action = plan_hard_blockers(facts)
+    action = plan_hard_blockers(facts, ledger)
     if action is not None:
         return (action,)
     action = plan_merge_hold_cleanup(facts, ledger)

--- a/scripts/repro/repro-babysit-human-review-thread-block.sh
+++ b/scripts/repro/repro-babysit-human-review-thread-block.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-human-review-thread-block.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+mkdir -p "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+CALLS_PATH="$FAKE_GH_STATE_DIR/calls.log"
+LEDGER_PATH="$TMP/ledger.jsonl"
+export STATE_PATH
+export LEDGER_PATH
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = '931e895dd343de2646a6d9aec1b83543710a7e5e'
+state = {
+    'prs': [
+        {
+            'number': 5885,
+            'title': '[Bugfix: Slack repo URL classification rejects website URLs](1) Tighten Slack repo routing',
+            'body': '## Summary\n\nTighten Slack repo routing.\n',
+            'url': 'https://github.com/fake/repo/pull/5885',
+            'state': 'OPEN',
+            'isDraft': False,
+            'baseRefName': 'master',
+            'headRefName': 'stack/slack-routing',
+            'headRefOid': head,
+            'mergeStateStatus': 'BLOCKED',
+            'mergeable': 'MERGEABLE',
+            'labels': ['admin-bypass'],
+            'reviewThreads': [
+                {
+                    'id': 'PRRT_kwDOSFkSDM6T5EJA',
+                    'isResolved': False,
+                    'comments': {
+                        'nodes': [
+                            {
+                                'author': {'login': 'human-reviewer'},
+                                'body': 'Please address this before landing.',
+                                'url': 'https://github.com/fake/repo/pull/5885#discussion_r1',
+                            },
+                        ],
+                    },
+                },
+            ],
+            'checks': {'*': 'SUCCESS'},
+        },
+    ],
+    'issue_comments': {'5885': []},
+}
+Path(os.environ['STATE_PATH']).write_text(json.dumps(state, indent=2), encoding='utf-8')
+PY
+: > "$CALLS_PATH"
+
+run_worker() {
+  python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --author fake-bot --state-file "$LEDGER_PATH" 2>&1
+}
+
+if ! out1="$(run_worker)"; then
+  fail 'tick 1: worker failed' "$out1"
+fi
+printf '%s\n' "$out1"
+case "$out1" in
+  *'BLOCK PR #5885 unresolved human review thread PRRT_kwDOSFkSDM6T5EJA'*) ;;
+  *) fail 'tick 1: missing exact human review thread block' "$out1" ;;
+esac
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+state = json.loads(Path(os.environ['STATE_PATH']).read_text(encoding='utf-8'))
+comments = state.get('issue_comments', {}).get('5885', [])
+if len(comments) != 1:
+    raise SystemExit(f'expected exactly one blocker comment, saw {len(comments)}')
+body = comments[0].get('body', '')
+needle = 'Mergify repair stopped: unresolved human review thread PRRT_kwDOSFkSDM6T5EJA'
+if needle not in body:
+    raise SystemExit('blocker comment did not include exact review thread id')
+rows = [
+    json.loads(line)
+    for line in Path(os.environ['LEDGER_PATH']).read_text(encoding='utf-8').splitlines()
+    if line.strip()
+]
+if not any(
+    row.get('kind') == 'comment-blocked'
+    and row.get('pr') == 5885
+    and row.get('key') == 'PRRT_kwDOSFkSDM6T5EJA'
+    for row in rows
+):
+    raise SystemExit('missing comment-blocked ledger row for review thread')
+PY
+
+if ! out2="$(run_worker)"; then
+  fail 'tick 2: worker failed' "$out2"
+fi
+printf '%s\n' "$out2"
+case "$out2" in
+  *'BLOCK PR #5885'*) fail 'tick 2: worker repeated the human-only blocker comment' "$out2" ;;
+esac
+case "$out2" in
+  *'"reason": "blocked-needs-human"'*) ;;
+  *) fail 'tick 2: worker did not settle into blocked-needs-human wait state' "$out2" ;;
+esac
+
+comment_calls="$(grep -c '^gh pr comment 5885 --repo fake/repo --body Mergify repair stopped: unresolved human review thread PRRT_kwDOSFkSDM6T5EJA$' "$CALLS_PATH" || true)"
+[ "$comment_calls" = "1" ] || fail 'expected exactly one GitHub blocker comment call' "$(cat "$CALLS_PATH")"
+
+echo '[repro] passed'

--- a/scripts/repro/repro-mergify-admin-requeue.sh
+++ b/scripts/repro/repro-mergify-admin-requeue.sh
@@ -129,7 +129,7 @@ case "$out" in
   *) echo "[repro] missing repair line" >&2; exit 1 ;;
 esac
 case "$out" in
-  *"BLOCK PR #2607 human-review-thread"*) ;;
+  *"BLOCK PR #2607 unresolved human review thread thread-human"*) ;;
   *) echo "[repro] missing human block line" >&2; exit 1 ;;
 esac
 

--- a/scripts/repro/repro-mergify-closed-pr-guard.sh
+++ b/scripts/repro/repro-mergify-closed-pr-guard.sh
@@ -82,7 +82,7 @@ out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo Neko-Cat
 printf '%s\n' "$out"
 
 case "$out" in
-  *"BLOCK PR #2999 closed"*) ;;
+  *"BLOCK PR #2999 state=CLOSED"*) ;;
   *) echo "[repro] missing closed block line" >&2; exit 1 ;;
 esac
 case "$out" in

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -223,7 +223,7 @@ Failing checks
         self.assertEqual([(a.kind, a.pr_number) for a in actions], [("repair_check", 2605)])
         thread_stack = StackGroup("s", (pr(2604, head="stack/a", latest=mergify()), pr(2605, base="stack/a", threads=(ReviewThread("t1", False, ("alice",)),))))
         actions = plan_stack_actions(thread_stack, REQUIRED, self.ledger(), 1)
-        self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2605, "human-review-thread")])
+        self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2605, "unresolved human review thread t1")])
     def test_unaccepted_upper_failed_check_repairs_upper_before_bottom(self):
         failed = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
         stack = StackGroup(
@@ -301,7 +301,7 @@ Failing checks
     def test_human_review_thread_blocks(self):
         stack = StackGroup("s", (pr(2607, threads=(ReviewThread("t1", False, ("alice",)),), latest=mergify()),))
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
-        self.assertEqual([(a.kind, a.detail) for a in actions], [("comment_blocked", "human-review-thread")])
+        self.assertEqual([(a.kind, a.detail) for a in actions], [("comment_blocked", "unresolved human review thread t1")])
 
     def test_bot_thread_repairs_then_resolves(self):
         stack = StackGroup("s", (pr(2608, threads=(ReviewThread("tbot", False, ("coderabbitai[bot]",)),), latest=mergify()),))
@@ -735,6 +735,31 @@ Failing checks
         executor.execute(action, item, 2)
         self.assertEqual(len(fake.comments), 1)
 
+    def test_human_block_comment_records_once_then_waits(self):
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+        ledger = self.ledger()
+        item = pr(5885, threads=(ReviewThread("PRRT_kwDOSFkSDM6T5EJA", False, ("reviewer",)),), latest=mergify())
+        stack = StackGroup("s", (item,))
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 1)
+        self.assertEqual(
+            [(a.kind, a.key, a.detail) for a in actions],
+            [("comment_blocked", "PRRT_kwDOSFkSDM6T5EJA", "unresolved human review thread PRRT_kwDOSFkSDM6T5EJA")],
+        )
+        fake = FakeGh()
+        executor = self.executor(fake, ledger, "Neko-Catpital-Labs/Invoker")
+        executor.execute(actions[0], item, 1)
+        executor.execute(actions[0], item, 2)
+        self.assertEqual(len(fake.comments), 1)
+        self.assertIn("unresolved human review thread PRRT_kwDOSFkSDM6T5EJA", fake.comments[0][2])
+        self.assertEqual(ledger.count("comment-blocked", 5885, HEAD, "PRRT_kwDOSFkSDM6T5EJA"), 1)
+        self.assertEqual(plan_stack_actions(stack, REQUIRED, ledger, 3), ())
+
     def test_missing_admin_bypass_nudge_comments_once_without_label_edit(self):
         class FakeGh:
             def __init__(self):
@@ -825,7 +850,7 @@ The merge conditions cannot be satisfied due to failing checks
     def test_closed_pr_never_requeues_even_when_manually_requested(self):
         stack = StackGroup("s", (pr(2999, state="CLOSED", latest=mergify()),))
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
-        self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2999, "closed")])
+        self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2999, "state=CLOSED")])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Continue the babysit worker loop against the live admin-bypass /
dequeued PR set: extend the human-only blocker path to cover
non-capped blocker kinds and dedupe repeated posts.