### PR TITLE
Clarify Invoker headless over SQLite policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,9 @@
 
 ## SQLite Command Policy
 
-- If you are considering direct SQLite commands, use the corresponding headless command instead.
+- If you are considering direct SQLite commands, use the corresponding Invoker headless command first.
+- For normal local operations on workflows or tasks, prefer `./run.sh --headless ...` and `node scripts/headless-ipc.js ...` over SQLite reads or writes. Typical examples: `query workflows`, `query tasks`, `retry`, `retry-task`, `rebase-recreate`, `approve`, `reject`, `cancel`, and `cancel-workflow`.
+- Verify operational changes with Invoker query commands (`query workflows`, `query tasks`, `query queue`, `query audit`) instead of SQLite inspection whenever the command surface exists.
 - If no corresponding headless command exists, stop and prompt the user with a concrete plan to add that headless command functionality before proceeding.
 
 ## Testing Architecture


### PR DESCRIPTION
## Summary

This updates our repo policy so normal local workflow and task operations go through Invoker commands instead of SQLite.

The old rule was too short. It said to use a headless command when possible, but it did not spell out the normal command path or the normal verification path.

This adds the preferred Invoker commands and says to verify workflow and task changes with Invoker query commands when that surface exists.

## Review Claim

Repo guidance now clearly tells operators to prefer Invoker headless commands over SQLite for routine local workflow and task operations.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Only `CLAUDE.md` changes. No product code, persistence logic, or runtime behavior changes.

## Slice Rationale

This keeps the guidance fix isolated from product work so reviewers can approve the operator-facing rule change without re-reading unrelated runtime diffs.

## Non-goals

This does not change Invoker runtime behavior, add new headless commands, or modify tests.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `git diff -- CLAUDE.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/invoker-cli-over-sqlite-policy-pr.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
