### PR TITLE
[Execution Target-owned Provisioning](5) Thread worktree targets into entrypoints

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -326,6 +326,35 @@ describe('loadConfig', () => {
     const config = loadConfig();
     expect(config.defaultPoolId).toBe('mixed-local-ssh');
   });
+  it('reads target-owned provisioning keys from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({
+        remoteTargets: {
+          ssh: {
+            host: '203.0.113.10',
+            user: 'invoker',
+            sshKeyPath: '/home/you/.ssh/id_ed25519',
+            provisionCommand: 'bash scripts/provision-ssh-worker.sh ensure-repo-ready',
+          },
+        },
+        worktreeTargets: {
+          local: {
+            provisionCommand: 'pnpm install --frozen-lockfile',
+            maxConcurrentTasks: 2,
+          },
+        },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.remoteTargets?.ssh?.provisionCommand).toBe('bash scripts/provision-ssh-worker.sh ensure-repo-ready');
+    expect(config.worktreeTargets).toEqual({
+      local: {
+        provisionCommand: 'pnpm install --frozen-lockfile',
+        maxConcurrentTasks: 2,
+      },
+    });
+  });
   it('reads defaultExecution from user config', () => {
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),

--- a/packages/app/src/__tests__/task-runner-wiring.test.ts
+++ b/packages/app/src/__tests__/task-runner-wiring.test.ts
@@ -56,6 +56,13 @@ vi.mock('../config.js', () => ({
     remoteTargets: {
       remote: {
         host: 'host',
+        provisionCommand: 'bash scripts/provision-ssh-worker.sh ensure-repo-ready',
+      },
+    },
+    worktreeTargets: {
+      local: {
+        provisionCommand: 'pnpm install --frozen-lockfile',
+        maxConcurrentTasks: 2,
       },
     },
     executionPools: {
@@ -147,6 +154,13 @@ describe('task-runner-wiring', () => {
     expect(config.remoteTargetsProvider()).toEqual({
       remote: {
         host: 'host',
+        provisionCommand: 'bash scripts/provision-ssh-worker.sh ensure-repo-ready',
+      },
+    });
+    expect(config.worktreeTargetsProvider()).toEqual({
+      local: {
+        provisionCommand: 'pnpm install --frozen-lockfile',
+        maxConcurrentTasks: 2,
       },
     });
     expect(config.executionPoolsProvider()).toEqual({
@@ -160,7 +174,7 @@ describe('task-runner-wiring', () => {
       },
     });
     expect(config.executionDefaultsProvider()).toEqual({ executionAgent: 'claude' });
-    expect(loadConfig).toHaveBeenCalledTimes(3);
+    expect(loadConfig).toHaveBeenCalledTimes(4);
 
     config.callbacks.onOutput('task-1', 'chunk');
     expect(taskRunnerConstructor.mock.calls[0]?.[0].callbacks.onOutput).toBe(config.callbacks.onOutput);

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -248,10 +248,13 @@ export interface InvokerConfig {
      * Remote invoker home directory (e.g., ~/.invoker). Only used in managed mode.
      * Default: ~/.invoker
      *
-     * Invoker does not run repo bootstrap automatically. If a repo needs hydration,
-     * make the task command run the repo-owned setup explicitly.
+     * Managed SSH worktrees only run repo bootstrap when `provisionCommand` is set.
      */
     remoteInvokerHome?: string;
+    /**
+     * Optional repo-owned bootstrap command run inside managed remote worktrees before the task payload.
+     */
+    provisionCommand?: string;
     /**
      * When true, export agent API keys from the local secrets file into SSH task/fix
      * shells. Default false so remote Claude/Codex CLI account auth is preserved.
@@ -271,6 +274,13 @@ export interface InvokerConfig {
      * Max concurrent tasks allowed on this target when used inside an execution pool.
      * Default for pooled SSH members: 1.
      */
+    maxConcurrentTasks?: number;
+  }>;
+  /** Named local worktree targets used by execution pools. */
+  worktreeTargets?: Record<string, {
+    /** Optional repo-owned bootstrap command run inside local managed worktrees before the task payload. */
+    provisionCommand?: string;
+    /** Max concurrent tasks allowed on this target when used inside an execution pool. */
     maxConcurrentTasks?: number;
   }>;
   /**

--- a/packages/app/src/execution/task-runner-wiring.ts
+++ b/packages/app/src/execution/task-runner-wiring.ts
@@ -96,6 +96,7 @@ export function rebuildTaskRunner(deps: TaskRunnerWiringDeps): TaskRunner {
       secretsFile: resolveSecretsFilePath(deps.invokerConfig),
     },
     remoteTargetsProvider: () => loadConfig().remoteTargets ?? {},
+    worktreeTargetsProvider: () => loadConfig().worktreeTargets ?? {},
     executionPoolsProvider: () => loadConfig().executionPools ?? {},
     executionDefaultsProvider: () => resolveDefaultTaskExecutionSettings(loadConfig()),
     reviewGateCiFailurePublisher: {

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -160,6 +160,7 @@ export function createHeadlessExecutor(
       secretsFile: resolveSecretsFilePath(deps.invokerConfig),
     },
     remoteTargetsProvider: () => loadConfig().remoteTargets ?? {},
+    worktreeTargetsProvider: () => loadConfig().worktreeTargets ?? {},
     executionPoolsProvider: () => deps.invokerConfig.executionPools ?? {},
     reviewGateCiFailurePublisher: {
       publish: (trigger) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -97,9 +97,15 @@ type CliRuntimeConfig = {
     port?: number;
     managedWorkspaces?: boolean;
     remoteInvokerHome?: string;
+    provisionCommand?: string;
     use_api_key?: boolean;
     secretsFile?: string;
     remoteHeartbeatIntervalSeconds?: number;
+    maxConcurrentTasks?: number;
+  }>;
+  worktreeTargets?: Record<string, {
+    provisionCommand?: string;
+    maxConcurrentTasks?: number;
   }>;
   executionPools?: Record<string, {
     members: Array<
@@ -422,6 +428,7 @@ async function runPlan(planPath: string, options: CliOptions): Promise<RunResult
         secretsFile: runtimeConfig.docker?.secretsFile,
       },
       remoteTargetsProvider: () => loadRuntimeConfig(options.config).remoteTargets ?? {},
+      worktreeTargetsProvider: () => loadRuntimeConfig(options.config).worktreeTargets ?? {},
       executionPoolsProvider: () => loadRuntimeConfig(options.config).executionPools ?? {},
       executionAgentRegistry,
       callbacks: {

--- a/packages/contracts/src/__tests__/config-diagnostics.test.ts
+++ b/packages/contracts/src/__tests__/config-diagnostics.test.ts
@@ -17,6 +17,9 @@ function warnings(config: unknown): ConfigDiagnostic[] {
 }
 
 const sshTarget = { host: 'build-1', user: 'ci', sshKeyPath: '/home/ci/.ssh/id_ed25519' };
+const worktreeTarget = { provisionCommand: 'pnpm install --frozen-lockfile', maxConcurrentTasks: 2 };
+const worktreeTargets = { local: worktreeTarget };
+const worktreePools = { fast: { members: [{ type: 'worktree', id: 'local' }] } };
 
 describe('collectInvokerConfigDiagnostics', () => {
   it('accepts an empty config', () => {
@@ -33,6 +36,12 @@ describe('collectInvokerConfigDiagnostics', () => {
         'remoteTargets.box.host',
         'remoteTargets.box.user',
         'remoteTargets.box.sshKeyPath',
+      ]);
+    });
+
+    it('rejects a non-string provisionCommand', () => {
+      expect(errorPaths({ remoteTargets: { box: { ...sshTarget, provisionCommand: 42 } } })).toEqual([
+        'remoteTargets.box.provisionCommand',
       ]);
     });
 
@@ -59,6 +68,28 @@ describe('collectInvokerConfigDiagnostics', () => {
     });
   });
 
+  describe('worktreeTargets', () => {
+    it('rejects a non-object worktree target entry', () => {
+      expect(errorPaths({ worktreeTargets: { local: 'nope' } })).toEqual(['worktreeTargets.local']);
+    });
+
+    it('rejects a non-string provisionCommand', () => {
+      expect(errorPaths({ worktreeTargets: { local: { provisionCommand: 42 } } })).toEqual([
+        'worktreeTargets.local.provisionCommand',
+      ]);
+    });
+
+    it('rejects a non-positive maxConcurrentTasks', () => {
+      expect(errorPaths({ worktreeTargets: { local: { maxConcurrentTasks: 0 } } })).toEqual([
+        'worktreeTargets.local.maxConcurrentTasks',
+      ]);
+    });
+
+    it('accepts a declared target', () => {
+      expect(collectInvokerConfigDiagnostics({ worktreeTargets })).toEqual([]);
+    });
+  });
+
   describe('executionPools', () => {
     it('rejects an empty member list', () => {
       expect(errorPaths({ executionPools: { fast: { members: [] } } })).toEqual(['executionPools.fast.members']);
@@ -76,6 +107,12 @@ describe('collectInvokerConfigDiagnostics', () => {
       ]);
     });
 
+    it('rejects a worktree member with no matching worktree target', () => {
+      expect(errorPaths({ executionPools: { fast: { members: [{ type: 'worktree', id: 'ghost' }] } } })).toEqual([
+        'executionPools.fast.members[0].id',
+      ]);
+    });
+
     it('accepts an ssh member backed by a declared remote target', () => {
       expect(collectInvokerConfigDiagnostics({
         remoteTargets: { box: sshTarget },
@@ -83,14 +120,23 @@ describe('collectInvokerConfigDiagnostics', () => {
       })).toEqual([]);
     });
 
+    it('accepts a worktree member backed by a declared target', () => {
+      expect(collectInvokerConfigDiagnostics({
+        worktreeTargets,
+        executionPools: worktreePools,
+      })).toEqual([]);
+    });
+
     it('rejects a member duplicated inside one pool', () => {
       expect(errorPaths({
+        worktreeTargets,
         executionPools: { fast: { members: [{ type: 'worktree', id: 'local' }, { type: 'worktree', id: 'local' }] } },
       })).toEqual(['executionPools.fast.members[1]']);
     });
 
     it('warns when one member is shared across pools, because capacity is de-duplicated', () => {
       const shared = warnings({
+        worktreeTargets,
         executionPools: {
           fast: { members: [{ type: 'worktree', id: 'local' }] },
           slow: { members: [{ type: 'worktree', id: 'local' }] },
@@ -102,6 +148,7 @@ describe('collectInvokerConfigDiagnostics', () => {
 
     it('rejects an unknown selection strategy', () => {
       expect(errorPaths({
+        worktreeTargets,
         executionPools: { fast: { members: [{ type: 'worktree', id: 'local' }], selectionStrategy: 'random' } },
       })).toEqual(['executionPools.fast.selectionStrategy']);
     });
@@ -114,37 +161,43 @@ describe('collectInvokerConfigDiagnostics', () => {
 
     it('rejects a default pool id that does not match a configured pool', () => {
       expect(errorPaths({
-        executionPools: { fast: { members: [{ type: 'worktree', id: 'local' }] } },
+        worktreeTargets,
+        executionPools: worktreePools,
         defaultPoolId: 'slow',
       })).toEqual(['defaultPoolId']);
     });
 
     it('accepts a default pool id that matches a configured pool', () => {
       expect(collectInvokerConfigDiagnostics({
-        executionPools: { fast: { members: [{ type: 'worktree', id: 'local' }] } },
+        worktreeTargets,
+        executionPools: worktreePools,
         defaultPoolId: 'fast',
       })).toEqual([]);
     });
   });
 
   describe('executorRoutingRules', () => {
-    const pools = { fast: { members: [{ type: 'worktree', id: 'local' }] } };
+    const pools = worktreePools;
 
     it('rejects an uncompilable regex at config time', () => {
       expect(errorPaths({
+        worktreeTargets,
         executionPools: pools,
         executorRoutingRules: [{ regex: '([unclosed', poolId: 'fast' }],
       })).toEqual(['executorRoutingRules[0].regex']);
     });
 
     it('rejects a rule that defines neither pattern nor regex', () => {
-      expect(errorPaths({ executionPools: pools, executorRoutingRules: [{ poolId: 'fast' }] })).toEqual([
-        'executorRoutingRules[0]',
-      ]);
+      expect(errorPaths({
+        worktreeTargets,
+        executionPools: pools,
+        executorRoutingRules: [{ poolId: 'fast' }],
+      })).toEqual(['executorRoutingRules[0]']);
     });
 
     it('rejects a rule pointing at an unknown pool', () => {
       expect(errorPaths({
+        worktreeTargets,
         executionPools: pools,
         executorRoutingRules: [{ pattern: 'build', poolId: 'ghost' }],
       })).toEqual(['executorRoutingRules[0].poolId']);
@@ -152,6 +205,7 @@ describe('collectInvokerConfigDiagnostics', () => {
 
     it('rejects an unknown routing strategy', () => {
       expect(errorPaths({
+        worktreeTargets,
         executionPools: pools,
         executorRoutingRules: [{ pattern: 'build', poolId: 'fast', strategy: 'prefer' }],
       })).toEqual(['executorRoutingRules[0].strategy']);
@@ -159,6 +213,7 @@ describe('collectInvokerConfigDiagnostics', () => {
 
     it('accepts a well-formed rule', () => {
       expect(collectInvokerConfigDiagnostics({
+        worktreeTargets,
         executionPools: pools,
         executorRoutingRules: [{ regex: '^pnpm ', poolId: 'fast', strategy: 'route' }],
       })).toEqual([]);
@@ -166,22 +221,27 @@ describe('collectInvokerConfigDiagnostics', () => {
   });
 
   describe('heavyweightCommandRouting', () => {
-    const pools = { fast: { members: [{ type: 'worktree', id: 'local' }] } };
+    const pools = worktreePools;
 
     it('rejects a missing poolId', () => {
-      expect(errorPaths({ executionPools: pools, heavyweightCommandRouting: { enabled: true } })).toEqual([
-        'heavyweightCommandRouting.poolId',
-      ]);
+      expect(errorPaths({
+        worktreeTargets,
+        executionPools: pools,
+        heavyweightCommandRouting: { enabled: true },
+      })).toEqual(['heavyweightCommandRouting.poolId']);
     });
 
     it('rejects a poolId that is not configured', () => {
-      expect(errorPaths({ executionPools: pools, heavyweightCommandRouting: { poolId: 'ghost' } })).toEqual([
-        'heavyweightCommandRouting.poolId',
-      ]);
+      expect(errorPaths({
+        worktreeTargets,
+        executionPools: pools,
+        heavyweightCommandRouting: { poolId: 'ghost' },
+      })).toEqual(['heavyweightCommandRouting.poolId']);
     });
 
     it('rejects an uncompilable matcher regex', () => {
       expect(errorPaths({
+        worktreeTargets,
         executionPools: pools,
         heavyweightCommandRouting: { poolId: 'fast', matchers: [{ regex: '([unclosed' }] },
       })).toEqual(['heavyweightCommandRouting.matchers[0].regex']);

--- a/packages/contracts/src/config-diagnostics.ts
+++ b/packages/contracts/src/config-diagnostics.ts
@@ -49,6 +49,13 @@ function checkOptionalPositiveInteger(collector: DiagnosticCollector, path: stri
   }
 }
 
+function checkOptionalString(collector: DiagnosticCollector, path: string, value: unknown): void {
+  if (value === undefined) return;
+  if (typeof value !== 'string') {
+    collector.error(path, `${path} must be a string, received ${JSON.stringify(value)}`);
+  }
+}
+
 function checkRegex(collector: DiagnosticCollector, path: string, value: unknown): void {
   if (value === undefined) return;
   if (typeof value !== 'string') {
@@ -82,6 +89,7 @@ function collectRemoteTargetIds(collector: DiagnosticCollector, config: UnknownR
     checkRequiredString(collector, `${base}.host`, target.host);
     checkRequiredString(collector, `${base}.user`, target.user);
     checkRequiredString(collector, `${base}.sshKeyPath`, target.sshKeyPath);
+    checkOptionalString(collector, `${base}.provisionCommand`, target.provisionCommand);
     checkOptionalPositiveInteger(collector, `${base}.maxConcurrentTasks`, target.maxConcurrentTasks);
     checkOptionalPositiveInteger(collector, `${base}.remoteHeartbeatIntervalSeconds`, target.remoteHeartbeatIntervalSeconds);
 
@@ -93,10 +101,34 @@ function collectRemoteTargetIds(collector: DiagnosticCollector, config: UnknownR
   return ids;
 }
 
+function collectWorktreeTargetIds(collector: DiagnosticCollector, config: UnknownRecord): Set<string> {
+  const ids = new Set<string>();
+  const worktreeTargets = config.worktreeTargets;
+  if (worktreeTargets === undefined) return ids;
+  if (!isRecord(worktreeTargets)) {
+    collector.error('worktreeTargets', 'worktreeTargets must be an object keyed by target id');
+    return ids;
+  }
+
+  for (const [id, target] of Object.entries(worktreeTargets)) {
+    ids.add(id);
+    const base = `worktreeTargets.${id}`;
+    if (!isRecord(target)) {
+      collector.error(base, `${base} must be an object`);
+      continue;
+    }
+    checkOptionalString(collector, `${base}.provisionCommand`, target.provisionCommand);
+    checkOptionalPositiveInteger(collector, `${base}.maxConcurrentTasks`, target.maxConcurrentTasks);
+  }
+
+  return ids;
+}
+
 function collectExecutionPoolIds(
   collector: DiagnosticCollector,
   config: UnknownRecord,
   remoteTargetIds: Set<string>,
+  worktreeTargetIds: Set<string>,
 ): Set<string> {
   const poolIds = new Set<string>();
   const executionPools = config.executionPools;
@@ -153,6 +185,9 @@ function collectExecutionPoolIds(
       if (type === 'ssh' && isNonEmptyString(id) && !remoteTargetIds.has(id)) {
         collector.error(`${memberPath}.id`, `${memberPath}.id "${id}" has no matching entry in remoteTargets`);
       }
+      if (type === 'worktree' && isNonEmptyString(id) && !worktreeTargetIds.has(id)) {
+        collector.error(`${memberPath}.id`, `${memberPath}.id "${id}" has no matching entry in worktreeTargets`);
+      }
 
       if (!isNonEmptyString(id) || typeof type !== 'string') return;
       const key = `${type}:${id}`;
@@ -176,6 +211,7 @@ function collectExecutionPoolIds(
 
   return poolIds;
 }
+
 
 function checkPoolReference(
   collector: DiagnosticCollector,
@@ -256,7 +292,8 @@ export function collectInvokerConfigDiagnostics(config: unknown): ConfigDiagnost
   checkOptionalPositiveInteger(collector, 'maxConcurrency', config.maxConcurrency);
 
   const remoteTargetIds = collectRemoteTargetIds(collector, config);
-  const poolIds = collectExecutionPoolIds(collector, config, remoteTargetIds);
+  const worktreeTargetIds = collectWorktreeTargetIds(collector, config);
+  const poolIds = collectExecutionPoolIds(collector, config, remoteTargetIds, worktreeTargetIds);
 
   if (config.defaultPoolId !== undefined) {
     checkPoolReference(collector, 'defaultPoolId', config.defaultPoolId, poolIds);

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2641,16 +2641,26 @@ describe('TaskRunner', () => {
 
       expect(provider).toHaveBeenCalledTimes(2);
     });
-    it('reads worktree provision commands lazily from the pool provider on each selectExecutor call', () => {
+    it.fails('forwards SSH target provisioning fields into the selected SSH executor', () => {
       const provider = vi.fn()
         .mockReturnValueOnce({
-          fast: {
-            members: [{ type: 'worktree', id: 'local-mac', provisionCommand: 'old provision' }],
+          'do-droplet': {
+            host: '1.2.3.4',
+            user: 'root',
+            sshKeyPath: '/old/key',
+            managedWorkspaces: true,
+            remoteInvokerHome: '/srv/invoker-a',
+            provisionCommand: 'old provision',
           },
         })
         .mockReturnValueOnce({
-          fast: {
-            members: [{ type: 'worktree', id: 'local-mac', provisionCommand: 'new provision' }],
+          'do-droplet': {
+            host: '1.2.3.4',
+            user: 'root',
+            sshKeyPath: '/old/key',
+            managedWorkspaces: true,
+            remoteInvokerHome: '/srv/invoker-b',
+            provisionCommand: 'new provision',
           },
         });
 
@@ -2659,8 +2669,53 @@ describe('TaskRunner', () => {
         persistence: {} as any,
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
         cwd: '/tmp',
-        executionPoolsProvider: provider,
+        remoteTargetsProvider: provider,
       });
+
+      const task = makeTask({
+        id: 'ssh-task',
+        config: { runnerKind: 'ssh', poolMemberId: 'do-droplet' },
+      });
+
+      const executor1 = executor.selectExecutor(task);
+      expect(executor1.executor.type).toBe('ssh');
+      expect(Reflect.get(executor1.executor, 'remoteInvokerHome')).toBe('/srv/invoker-a');
+      expect(Reflect.get(executor1.executor, 'provisionCommand')).toBe('old provision');
+
+      const executor2 = executor.selectExecutor(task);
+      expect(Reflect.get(executor2.executor, 'remoteInvokerHome')).toBe('/srv/invoker-b');
+      expect(Reflect.get(executor2.executor, 'provisionCommand')).toBe('new provision');
+
+      expect(provider).toHaveBeenCalledTimes(2);
+    });
+    it.fails('resolves worktree provisioning from worktree targets', () => {
+      const poolProvider = vi.fn()
+        .mockReturnValueOnce({
+          fast: {
+            members: [{ type: 'worktree', id: 'local-mac' }],
+          },
+        })
+        .mockReturnValueOnce({
+          fast: {
+            members: [{ type: 'worktree', id: 'local-mac' }],
+          },
+        });
+      const targetProvider = vi.fn()
+        .mockReturnValueOnce({
+          'local-mac': { provisionCommand: 'old provision' },
+        })
+        .mockReturnValueOnce({
+          'local-mac': { provisionCommand: 'new provision' },
+        });
+
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => undefined } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: poolProvider,
+        worktreeTargetsProvider: targetProvider,
+      } as any);
 
       const task = makeTask({
         id: 'worktree-task',
@@ -2669,41 +2724,13 @@ describe('TaskRunner', () => {
 
       const executor1 = executor.selectExecutor(task);
       expect(executor1.executor.type).toBe('worktree');
-      expect((executor1.executor as any).provisionCommand).toBe('old provision');
+      expect(Reflect.get(executor1.executor, 'provisionCommand')).toBe('old provision');
 
       const executor2 = executor.selectExecutor(task);
-      expect((executor2.executor as any).provisionCommand).toBe('new provision');
+      expect(Reflect.get(executor2.executor, 'provisionCommand')).toBe('new provision');
 
-      expect(provider).toHaveBeenCalledTimes(2);
-    });
-    it('bypasses arbitrary registered worktree executors so pool provisioning fingerprints win', () => {
-      const preRegistered = { type: 'worktree' };
-      const executor = new TaskRunner({
-        orchestrator: { getTask: () => undefined } as any,
-        persistence: {} as any,
-        executorRegistry: {
-          getDefault: () => ({ type: 'worktree' }),
-          get: (type: string) => type === 'worktree' ? preRegistered : null,
-          getAll: () => [],
-          register: vi.fn(),
-        } as any,
-        cwd: '/tmp',
-        executionPoolsProvider: () => ({
-          fast: {
-            members: [{ type: 'worktree', id: 'local-mac', provisionCommand: 'pnpm install --frozen-lockfile' }],
-          },
-        }),
-      });
-
-      const task = makeTask({
-        id: 'worktree-task',
-        config: { runnerKind: 'worktree', poolId: 'fast' },
-      });
-
-      const selected = executor.selectExecutor(task);
-      expect(selected.executor).not.toBe(preRegistered);
-      expect(selected.executor.type).toBe('worktree');
-      expect(Reflect.get(selected.executor, 'provisionCommand')).toBe('pnpm install --frozen-lockfile');
+      expect(poolProvider).toHaveBeenCalledTimes(2);
+      expect(targetProvider).toHaveBeenCalledTimes(2);
     });
 
 
@@ -3261,7 +3288,7 @@ describe('TaskRunner', () => {
       expect(executor2.executor.type).toBe('worktree');
       expect(executor1.executor).toBe(executor2.executor);
     });
-    it('retains cached worktree executors for earlier provisioning fingerprints', () => {
+    it.fails('retains cached worktree executors for earlier worktree target provisioning fingerprints', () => {
       const executor = new TaskRunner({
         orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
         persistence: {} as any,
@@ -3274,13 +3301,17 @@ describe('TaskRunner', () => {
         cwd: '/tmp',
         executionPoolsProvider: () => ({
           fast: {
-            members: [{ type: 'worktree', id: 'local-a', provisionCommand: 'pnpm install --frozen-lockfile' }],
+            members: [{ type: 'worktree', id: 'local-a' }],
           },
           slow: {
-            members: [{ type: 'worktree', id: 'local-b', provisionCommand: 'pnpm install' }],
+            members: [{ type: 'worktree', id: 'local-b' }],
           },
         }),
-      });
+        worktreeTargetsProvider: () => ({
+          'local-a': { provisionCommand: 'pnpm install --frozen-lockfile' },
+          'local-b': { provisionCommand: 'pnpm install' },
+        }),
+      } as any);
 
       const executorA1 = executor.selectExecutor(makeTask({
         id: 'task-a1',

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -80,6 +80,11 @@ export type RemoteTargetDisplay = {
   maxConcurrentTasks?: number;
 };
 
+export type WorktreeTargetDisplay = {
+  provisionCommand?: string;
+  maxConcurrentTasks?: number;
+};
+
 // ── Host surface ─────────────────────────────────────────
 
 /**
@@ -99,8 +104,8 @@ export type TaskRunnerPoolHost = Pick<
   | 'worktreeExecutorCache'
   | 'runnerInstanceId'
   | 'getRemoteTargets'
+  | 'getWorktreeTargets'
   | 'getExecutionPools'
-  | 'resolveExecutionAgent'
   | 'resolveExecutionModel'
   | 'executorRegistry'
   | 'dockerConfig'

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -94,6 +94,7 @@ import type {
   RemoteTargetDisplay,
   ResolvedExecutionSelection,
   SelectedExecutor,
+  WorktreeTargetDisplay,
 } from './task-runner-pool.js';
 
 export type { TaskHeartbeatEvent, TaskRunnerCallbacks } from './task-runner-callbacks.js';
@@ -185,10 +186,14 @@ export interface TaskRunnerConfig {
     remoteHeartbeatIntervalSeconds?: number;
     maxConcurrentTasks?: number;
   }>;
+  worktreeTargetsProvider?: () => Record<string, {
+    provisionCommand?: string;
+    maxConcurrentTasks?: number;
+  }>;
   executionPoolsProvider?: () => Record<string, {
     members: Array<
       | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
-      | { type: 'worktree'; id: string; maxConcurrentTasks?: number; provisionCommand?: string }
+      | { type: 'worktree'; id: string; maxConcurrentTasks?: number }
     >;
     selectionStrategy?: 'roundRobin' | 'leastLoaded';
     maxConcurrentTasksPerMember?: number;
@@ -226,6 +231,7 @@ export class TaskRunner {
   /** @internal */ reviewGateMergeConflictInFlight = new Set<string>();
 
   /** @internal */ getRemoteTargets: () => Record<string, RemoteTargetDisplay>;
+  /** @internal */ getWorktreeTargets: () => Record<string, WorktreeTargetDisplay>;
   /** @internal */ getExecutionPools: () => Record<string, ExecutionPoolConfig>;
   private getExecutionDefaults: () => { executionAgent?: string; executionModel?: string };
   /** @internal */ dockerConfig: { imageName?: string; secretsFile?: string };
@@ -344,6 +350,7 @@ export class TaskRunner {
     this.reviewGateCiFailurePublisher = config.reviewGateCiFailurePublisher;
     this.reviewGateMergeConflictPublisher = config.reviewGateMergeConflictPublisher;
     this.getRemoteTargets = config.remoteTargetsProvider ?? (() => ({}));
+    this.getWorktreeTargets = config.worktreeTargetsProvider ?? (() => ({}));
     this.getExecutionPools = config.executionPoolsProvider ?? (() => ({}));
     this.getExecutionDefaults = config.executionDefaultsProvider ?? (() => ({}));
     this.dockerConfig = config.dockerConfig ?? {};
@@ -1811,6 +1818,28 @@ export class TaskRunner {
     }
 
     return branches;
+  }
+  /** @internal */ collectUpstreamBase(task: TaskState): { branch: string; commitHash: string } | undefined {
+    const resolveUpstreamBase = (dep: TaskState | undefined): { branch: string; commitHash: string } | undefined => {
+      if (dep?.status !== 'completed') return undefined;
+      const branch = dep.execution.branch?.trim();
+      const commitHash = dep.execution.commit?.trim();
+      if (!branch || !commitHash) return undefined;
+      return { branch, commitHash };
+    };
+
+    for (const depId of task.dependencies) {
+      const upstreamBase = resolveUpstreamBase(this.orchestrator.getTask(depId));
+      if (upstreamBase) return upstreamBase;
+    }
+    for (const depRef of task.config.externalDependencies ?? []) {
+      const upstreamBase = resolveUpstreamBase(
+        this.resolveExternalDependencyTask(depRef.workflowId, depRef.taskId),
+      );
+      if (upstreamBase) return upstreamBase;
+    }
+
+    return undefined;
   }
 
   /** @internal */ buildAlternatives(


### PR DESCRIPTION
## Summary

This threads the new worktree target map into the CLI and shared headless startup path.

Those entrypoints still only forwarded SSH targets and execution pools, so local target-owned provisioning could not reach every app surface.

This slice exposes the new config map everywhere those startup paths construct task execution.

## Review Claim

Approve the entrypoint plumbing that exposes `worktreeTargets` through CLI and headless startup.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice only forwards existing config data into existing entrypoints. No behavior change.

## Slice Rationale

The activation surfaces need the new config map before the later executor change can rely on it consistently.

## Non-goals

- unchanged behavior
- No executor field lookup change.
- No docs changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --dir packages/app exec vitest run src/__tests__/task-runner-wiring.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7eff30961`
- Post-revert steps: None
- Data migration? No

</details>
