### PR TITLE
[Execution Target-owned Provisioning](6) Resolve provisioning from execution targets

### DIFF
--- a/packages/execution-engine/src/__tests__/pool-member-pin-across-types.test.ts
+++ b/packages/execution-engine/src/__tests__/pool-member-pin-across-types.test.ts
@@ -53,6 +53,12 @@ function makeRunner() {
         managedWorkspaces: true,
       },
     }),
+    worktreeTargetsProvider: () => ({
+      'member-local': {
+        provisionCommand: 'pnpm install --frozen-lockfile',
+        maxConcurrentTasks: 10,
+      },
+    }),
     executionPoolsProvider: () => ({
       'mixed-pool': {
         selectionStrategy: 'roundRobin', // deterministic rotation

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2641,7 +2641,7 @@ describe('TaskRunner', () => {
 
       expect(provider).toHaveBeenCalledTimes(2);
     });
-    it.fails('forwards SSH target provisioning fields into the selected SSH executor', () => {
+    it('forwards SSH target provisioning fields into the selected SSH executor', () => {
       const provider = vi.fn()
         .mockReturnValueOnce({
           'do-droplet': {
@@ -2688,7 +2688,7 @@ describe('TaskRunner', () => {
 
       expect(provider).toHaveBeenCalledTimes(2);
     });
-    it.fails('resolves worktree provisioning from worktree targets', () => {
+    it('resolves worktree provisioning from worktree targets', () => {
       const poolProvider = vi.fn()
         .mockReturnValueOnce({
           fast: {
@@ -2732,6 +2732,38 @@ describe('TaskRunner', () => {
       expect(poolProvider).toHaveBeenCalledTimes(2);
       expect(targetProvider).toHaveBeenCalledTimes(2);
     });
+    it('bypasses arbitrary registered worktree executors so target provisioning fingerprints win', () => {
+      const preRegistered = { type: 'worktree' };
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => undefined } as any,
+        persistence: {} as any,
+        executorRegistry: {
+          getDefault: () => ({ type: 'worktree' }),
+          get: (type: string) => type === 'worktree' ? preRegistered : null,
+          getAll: () => [],
+          register: vi.fn(),
+        } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: () => ({
+          fast: {
+            members: [{ type: 'worktree', id: 'local-mac' }],
+          },
+        }),
+        worktreeTargetsProvider: () => ({
+          'local-mac': { provisionCommand: 'pnpm install --frozen-lockfile' },
+        }),
+      });
+
+      const task = makeTask({
+        id: 'worktree-task',
+        config: { runnerKind: 'worktree', poolId: 'fast' },
+      });
+
+      const selected = executor.selectExecutor(task);
+      expect(selected.executor).not.toBe(preRegistered);
+      expect(selected.executor.type).toBe('worktree');
+      expect(Reflect.get(selected.executor, 'provisionCommand')).toBe('pnpm install --frozen-lockfile');
+    });
 
 
     it('throws when provider returns no entry for the target ID', () => {
@@ -2750,6 +2782,27 @@ describe('TaskRunner', () => {
       });
 
       expect(() => executor.selectExecutor(task)).toThrow('no matching');
+    });
+    it('throws when selected worktree member has no matching worktree target', () => {
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => undefined } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: () => ({
+          fast: {
+            members: [{ type: 'worktree', id: 'missing-target' }],
+          },
+        }),
+        worktreeTargetsProvider: () => ({}),
+      });
+
+      const task = makeTask({
+        id: 'worktree-task',
+        config: { runnerKind: 'worktree', poolId: 'fast' },
+      });
+
+      expect(() => executor.selectExecutor(task)).toThrow('worktreeTargets config');
     });
   });
 
@@ -3288,7 +3341,7 @@ describe('TaskRunner', () => {
       expect(executor2.executor.type).toBe('worktree');
       expect(executor1.executor).toBe(executor2.executor);
     });
-    it.fails('retains cached worktree executors for earlier worktree target provisioning fingerprints', () => {
+    it('retains cached worktree executors for earlier worktree target provisioning fingerprints', () => {
       const executor = new TaskRunner({
         orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
         persistence: {} as any,
@@ -3311,7 +3364,7 @@ describe('TaskRunner', () => {
           'local-a': { provisionCommand: 'pnpm install --frozen-lockfile' },
           'local-b': { provisionCommand: 'pnpm install' },
         }),
-      } as any);
+      });
 
       const executorA1 = executor.selectExecutor(makeTask({
         id: 'task-a1',

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -29,7 +29,12 @@ import type { ActiveExecutionEntry, TaskRunner } from './task-runner.js';
 
 export type ExecutionPoolMember =
   | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
-  | { type: 'worktree'; id: string; maxConcurrentTasks?: number; provisionCommand?: string };
+  | { type: 'worktree'; id: string; maxConcurrentTasks?: number };
+
+export type WorktreeTargetDisplay = {
+  provisionCommand?: string;
+  maxConcurrentTasks?: number;
+};
 
 export type ExecutionPoolConfig = {
   members: ExecutionPoolMember[];
@@ -80,11 +85,6 @@ export type RemoteTargetDisplay = {
   maxConcurrentTasks?: number;
 };
 
-export type WorktreeTargetDisplay = {
-  provisionCommand?: string;
-  maxConcurrentTasks?: number;
-};
-
 // ── Host surface ─────────────────────────────────────────
 
 /**
@@ -106,6 +106,7 @@ export type TaskRunnerPoolHost = Pick<
   | 'getRemoteTargets'
   | 'getWorktreeTargets'
   | 'getExecutionPools'
+  | 'resolveExecutionAgent'
   | 'resolveExecutionModel'
   | 'executorRegistry'
   | 'dockerConfig'
@@ -605,7 +606,7 @@ export function selectExecutor(
     ? 'merge'
     : task.config.runnerKind;
   let selectedPoolMemberId: string | undefined;
-  let selectedWorktreeMember: Extract<ExecutionPoolMember, { type: 'worktree' }> | undefined;
+  let selectedWorktreeTargetId: string | undefined;
   const explicitPoolMemberId = (task.config as { poolMemberId?: string }).poolMemberId;
   let resolvedExecution: ResolvedExecutionSelection = {
     executionAgent: host.resolveExecutionAgent(task),
@@ -628,7 +629,7 @@ export function selectExecutor(
       }
       effectiveType = member.type;
       selectedPoolMemberId = member.id;
-      selectedWorktreeMember = member.type === 'worktree' ? member : undefined;
+      selectedWorktreeTargetId = member.type === 'worktree' ? member.id : undefined;
     }
   } else if (task.config.poolId) {
     const pool = host.getExecutionPools()[task.config.poolId];
@@ -642,7 +643,7 @@ export function selectExecutor(
         if (reserved) {
           effectiveType = member.type;
           selectedPoolMemberId = member.id;
-          selectedWorktreeMember = member.type === 'worktree' ? member : undefined;
+          selectedWorktreeTargetId = member.type === 'worktree' ? member.id : undefined;
           break;
         }
         attempted.add(poolMemberKey(member));
@@ -686,8 +687,19 @@ export function selectExecutor(
 
     if (effectiveType === 'worktree') {
       const invokerHome = resolve(homedir(), '.invoker');
+      const worktreeTargets = host.getWorktreeTargets();
+      const selectedWorktreeTarget = selectedWorktreeTargetId
+        ? worktreeTargets[selectedWorktreeTargetId]
+        : undefined;
+      if (selectedWorktreeTargetId && !selectedWorktreeTarget) {
+        throw new Error(
+          `Task ${task.id} references poolMemberId="${selectedWorktreeTargetId}" but no matching ` +
+          `entry exists in worktreeTargets config. Available: [${Object.keys(worktreeTargets).join(', ')}]`,
+        );
+      }
       const configFingerprint = JSON.stringify({
-        provisionCommand: selectedWorktreeMember?.provisionCommand?.trim() || '',
+        ...(selectedWorktreeTarget ?? {}),
+        provisionCommand: selectedWorktreeTarget?.provisionCommand?.trim() || '',
         worktreeBaseDir: resolve(invokerHome, 'worktrees'),
         cacheDir: resolve(invokerHome, 'repos'),
       });
@@ -702,7 +714,7 @@ export function selectExecutor(
         cacheDir: resolve(invokerHome, 'repos'),
         maxWorktrees: host.maxWorktreesPerRepo,
         agentRegistry: host.executionAgentRegistry,
-        provisionCommand: selectedWorktreeMember?.provisionCommand,
+        provisionCommand: selectedWorktreeTarget?.provisionCommand,
       });
       host.executorRegistry.register('worktree', worktree);
       host.worktreeExecutorCache.set(configFingerprint, worktree);
@@ -768,6 +780,8 @@ export function selectExecutor(
         port: target.port,
         agentRegistry: host.executionAgentRegistry,
         managedWorkspaces: target.managedWorkspaces,
+        remoteInvokerHome: target.remoteInvokerHome,
+        provisionCommand: target.provisionCommand?.trim() || '',
         useApiKey: target.use_api_key,
         secretsFile: target.secretsFile ?? host.dockerConfig.secretsFile,
         remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,


### PR DESCRIPTION
## Summary

This switches provisioning lookup to concrete execution targets instead of pool member payloads.

SSH selection used to drop `remoteInvokerHome` and `provisionCommand`, and local pooled worktrees still pulled provisioning from the pool member record.

Selected executors now resolve those fields from the target maps, and worktree target misses fail loudly.

## Review Claim

Approve the routing change that resolves provisioning from executor targets and forwards SSH target bootstrap fields into the selected executor.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The routing model stays stable: direct SSH `poolId`, default no-pool local worktrees, and persisted `poolMemberId` pinning all remain intact while provisioning ownership moves to targets.

## Slice Rationale

This is the single runtime behavior slice, kept separate from the earlier provider seams and the later tooling/docs updates.

## Non-goals

- No public docs changes.
- No SSH E2E harness changes.
- No new routing modes.

## Architecture

### Before

```mermaid
graph TD
    A["executionPools member"] --> B["worktree provisionCommand lookup"]
    C["remoteTargets entry"] --> D["TaskRunner.selectExecutor"]
    D --> E["SshExecutor without target bootstrap fields"]
```

### After

```mermaid
graph TD
    A["worktreeTargets entry"] --> B["worktree provisionCommand lookup"]
    C["remoteTargets entry"] --> D["TaskRunner.selectExecutor"]
    D --> E["SshExecutor with remoteInvokerHome and provisionCommand"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --dir packages/execution-engine exec vitest run src/__tests__/pool-member-pin-across-types.test.ts`
- [x] `pnpm --dir packages/execution-engine exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts -t "forwards SSH target provisioning fields|resolves worktree provisioning from worktree targets|bypasses arbitrary registered worktree executors|selected worktree member has no matching worktree target|retains cached worktree executors for earlier worktree target provisioning fingerprints"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 687356af5`
- Post-revert steps: None
- Data migration? No

</details>
