### PR TITLE
[Execution Target-owned Provisioning](7) Use target-owned SSH provision commands in E2E

### DIFF
--- a/packages/execution-engine/src/__tests__/pool-member-pin-across-types.test.ts
+++ b/packages/execution-engine/src/__tests__/pool-member-pin-across-types.test.ts
@@ -53,6 +53,12 @@ function makeRunner() {
         managedWorkspaces: true,
       },
     }),
+    worktreeTargetsProvider: () => ({
+      'member-local': {
+        provisionCommand: 'pnpm install --frozen-lockfile',
+        maxConcurrentTasks: 10,
+      },
+    }),
     executionPoolsProvider: () => ({
       'mixed-pool': {
         selectionStrategy: 'roundRobin', // deterministic rotation

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2641,7 +2641,7 @@ describe('TaskRunner', () => {
 
       expect(provider).toHaveBeenCalledTimes(2);
     });
-    it.fails('forwards SSH target provisioning fields into the selected SSH executor', () => {
+    it('forwards SSH target provisioning fields into the selected SSH executor', () => {
       const provider = vi.fn()
         .mockReturnValueOnce({
           'do-droplet': {
@@ -2688,7 +2688,7 @@ describe('TaskRunner', () => {
 
       expect(provider).toHaveBeenCalledTimes(2);
     });
-    it.fails('resolves worktree provisioning from worktree targets', () => {
+    it('resolves worktree provisioning from worktree targets', () => {
       const poolProvider = vi.fn()
         .mockReturnValueOnce({
           fast: {
@@ -2732,6 +2732,38 @@ describe('TaskRunner', () => {
       expect(poolProvider).toHaveBeenCalledTimes(2);
       expect(targetProvider).toHaveBeenCalledTimes(2);
     });
+    it('bypasses arbitrary registered worktree executors so target provisioning fingerprints win', () => {
+      const preRegistered = { type: 'worktree' };
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => undefined } as any,
+        persistence: {} as any,
+        executorRegistry: {
+          getDefault: () => ({ type: 'worktree' }),
+          get: (type: string) => type === 'worktree' ? preRegistered : null,
+          getAll: () => [],
+          register: vi.fn(),
+        } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: () => ({
+          fast: {
+            members: [{ type: 'worktree', id: 'local-mac' }],
+          },
+        }),
+        worktreeTargetsProvider: () => ({
+          'local-mac': { provisionCommand: 'pnpm install --frozen-lockfile' },
+        }),
+      });
+
+      const task = makeTask({
+        id: 'worktree-task',
+        config: { runnerKind: 'worktree', poolId: 'fast' },
+      });
+
+      const selected = executor.selectExecutor(task);
+      expect(selected.executor).not.toBe(preRegistered);
+      expect(selected.executor.type).toBe('worktree');
+      expect(Reflect.get(selected.executor, 'provisionCommand')).toBe('pnpm install --frozen-lockfile');
+    });
 
 
     it('throws when provider returns no entry for the target ID', () => {
@@ -2750,6 +2782,27 @@ describe('TaskRunner', () => {
       });
 
       expect(() => executor.selectExecutor(task)).toThrow('no matching');
+    });
+    it('throws when selected worktree member has no matching worktree target', () => {
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => undefined } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: () => ({
+          fast: {
+            members: [{ type: 'worktree', id: 'missing-target' }],
+          },
+        }),
+        worktreeTargetsProvider: () => ({}),
+      });
+
+      const task = makeTask({
+        id: 'worktree-task',
+        config: { runnerKind: 'worktree', poolId: 'fast' },
+      });
+
+      expect(() => executor.selectExecutor(task)).toThrow('worktreeTargets config');
     });
   });
 
@@ -3288,7 +3341,7 @@ describe('TaskRunner', () => {
       expect(executor2.executor.type).toBe('worktree');
       expect(executor1.executor).toBe(executor2.executor);
     });
-    it.fails('retains cached worktree executors for earlier worktree target provisioning fingerprints', () => {
+    it('retains cached worktree executors for earlier worktree target provisioning fingerprints', () => {
       const executor = new TaskRunner({
         orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
         persistence: {} as any,
@@ -3311,7 +3364,7 @@ describe('TaskRunner', () => {
           'local-a': { provisionCommand: 'pnpm install --frozen-lockfile' },
           'local-b': { provisionCommand: 'pnpm install' },
         }),
-      } as any);
+      });
 
       const executorA1 = executor.selectExecutor(makeTask({
         id: 'task-a1',

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -29,7 +29,12 @@ import type { ActiveExecutionEntry, TaskRunner } from './task-runner.js';
 
 export type ExecutionPoolMember =
   | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
-  | { type: 'worktree'; id: string; maxConcurrentTasks?: number; provisionCommand?: string };
+  | { type: 'worktree'; id: string; maxConcurrentTasks?: number };
+
+export type WorktreeTargetDisplay = {
+  provisionCommand?: string;
+  maxConcurrentTasks?: number;
+};
 
 export type ExecutionPoolConfig = {
   members: ExecutionPoolMember[];
@@ -80,11 +85,6 @@ export type RemoteTargetDisplay = {
   maxConcurrentTasks?: number;
 };
 
-export type WorktreeTargetDisplay = {
-  provisionCommand?: string;
-  maxConcurrentTasks?: number;
-};
-
 // ── Host surface ─────────────────────────────────────────
 
 /**
@@ -106,6 +106,7 @@ export type TaskRunnerPoolHost = Pick<
   | 'getRemoteTargets'
   | 'getWorktreeTargets'
   | 'getExecutionPools'
+  | 'resolveExecutionAgent'
   | 'resolveExecutionModel'
   | 'executorRegistry'
   | 'dockerConfig'
@@ -605,7 +606,7 @@ export function selectExecutor(
     ? 'merge'
     : task.config.runnerKind;
   let selectedPoolMemberId: string | undefined;
-  let selectedWorktreeMember: Extract<ExecutionPoolMember, { type: 'worktree' }> | undefined;
+  let selectedWorktreeTargetId: string | undefined;
   const explicitPoolMemberId = (task.config as { poolMemberId?: string }).poolMemberId;
   let resolvedExecution: ResolvedExecutionSelection = {
     executionAgent: host.resolveExecutionAgent(task),
@@ -628,7 +629,7 @@ export function selectExecutor(
       }
       effectiveType = member.type;
       selectedPoolMemberId = member.id;
-      selectedWorktreeMember = member.type === 'worktree' ? member : undefined;
+      selectedWorktreeTargetId = member.type === 'worktree' ? member.id : undefined;
     }
   } else if (task.config.poolId) {
     const pool = host.getExecutionPools()[task.config.poolId];
@@ -642,7 +643,7 @@ export function selectExecutor(
         if (reserved) {
           effectiveType = member.type;
           selectedPoolMemberId = member.id;
-          selectedWorktreeMember = member.type === 'worktree' ? member : undefined;
+          selectedWorktreeTargetId = member.type === 'worktree' ? member.id : undefined;
           break;
         }
         attempted.add(poolMemberKey(member));
@@ -686,8 +687,19 @@ export function selectExecutor(
 
     if (effectiveType === 'worktree') {
       const invokerHome = resolve(homedir(), '.invoker');
+      const worktreeTargets = host.getWorktreeTargets();
+      const selectedWorktreeTarget = selectedWorktreeTargetId
+        ? worktreeTargets[selectedWorktreeTargetId]
+        : undefined;
+      if (selectedWorktreeTargetId && !selectedWorktreeTarget) {
+        throw new Error(
+          `Task ${task.id} references poolMemberId="${selectedWorktreeTargetId}" but no matching ` +
+          `entry exists in worktreeTargets config. Available: [${Object.keys(worktreeTargets).join(', ')}]`,
+        );
+      }
       const configFingerprint = JSON.stringify({
-        provisionCommand: selectedWorktreeMember?.provisionCommand?.trim() || '',
+        ...(selectedWorktreeTarget ?? {}),
+        provisionCommand: selectedWorktreeTarget?.provisionCommand?.trim() || '',
         worktreeBaseDir: resolve(invokerHome, 'worktrees'),
         cacheDir: resolve(invokerHome, 'repos'),
       });
@@ -702,7 +714,7 @@ export function selectExecutor(
         cacheDir: resolve(invokerHome, 'repos'),
         maxWorktrees: host.maxWorktreesPerRepo,
         agentRegistry: host.executionAgentRegistry,
-        provisionCommand: selectedWorktreeMember?.provisionCommand,
+        provisionCommand: selectedWorktreeTarget?.provisionCommand,
       });
       host.executorRegistry.register('worktree', worktree);
       host.worktreeExecutorCache.set(configFingerprint, worktree);
@@ -768,6 +780,8 @@ export function selectExecutor(
         port: target.port,
         agentRegistry: host.executionAgentRegistry,
         managedWorkspaces: target.managedWorkspaces,
+        remoteInvokerHome: target.remoteInvokerHome,
+        provisionCommand: target.provisionCommand?.trim() || '',
         useApiKey: target.use_api_key,
         secretsFile: target.secretsFile ?? host.dockerConfig.secretsFile,
         remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -85,6 +85,11 @@ export type RemoteTargetDisplay = {
   maxConcurrentTasks?: number;
 };
 
+export type WorktreeTargetDisplay = {
+  provisionCommand?: string;
+  maxConcurrentTasks?: number;
+};
+
 // ── Host surface ─────────────────────────────────────────
 
 /**
@@ -106,7 +111,6 @@ export type TaskRunnerPoolHost = Pick<
   | 'getRemoteTargets'
   | 'getWorktreeTargets'
   | 'getExecutionPools'
-  | 'resolveExecutionAgent'
   | 'resolveExecutionModel'
   | 'executorRegistry'
   | 'dockerConfig'

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -85,11 +85,6 @@ export type RemoteTargetDisplay = {
   maxConcurrentTasks?: number;
 };
 
-export type WorktreeTargetDisplay = {
-  provisionCommand?: string;
-  maxConcurrentTasks?: number;
-};
-
 // ── Host surface ─────────────────────────────────────────
 
 /**
@@ -111,6 +106,7 @@ export type TaskRunnerPoolHost = Pick<
   | 'getRemoteTargets'
   | 'getWorktreeTargets'
   | 'getExecutionPools'
+  | 'resolveExecutionAgent'
   | 'resolveExecutionModel'
   | 'executorRegistry'
   | 'dockerConfig'

--- a/plans/e2e-ssh/3.7-ssh-target-provision.yaml
+++ b/plans/e2e-ssh/3.7-ssh-target-provision.yaml
@@ -1,0 +1,13 @@
+# E2E SSH Group 3.7 — SSH target-owned provision command hydrates a managed worktree.
+name: "e2e-ssh group3 3.7 ssh-target-provision"
+repoUrl: git@github.com:example-org/acme-repo.git
+onFinish: none
+mergeMode: manual
+baseBranch: HEAD
+
+tasks:
+  - id: e2e-g337-taskA
+    description: "E2E 3.7 — SSH worktree runs vitest through target provisioning"
+    command: pnpm --dir packages/app exec vitest --version
+    dependencies: []
+    poolId: localhost-e2e

--- a/scripts/e2e-ssh/cases/case-3.7-ssh-target-provision.sh
+++ b/scripts/e2e-ssh/cases/case-3.7-ssh-target-provision.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Group 3.7 — SSH target-owned provision command hydrates the managed SSH worktree.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../lib/ssh-common.sh"
+
+invoker_e2e_ssh_init
+trap invoker_e2e_ssh_full_cleanup EXIT
+
+cd "$INVOKER_E2E_REPO_ROOT"
+unset ELECTRON_RUN_AS_NODE
+
+expected_provision_cmd="$(invoker_e2e_ssh_provision_command)"
+actual_provision_cmd="$(jq -r '.remoteTargets["localhost-e2e"].provisionCommand' "$INVOKER_REPO_CONFIG_PATH")"
+if [ "$actual_provision_cmd" != "$expected_provision_cmd" ]; then
+  echo "FAIL case 3.7: expected config provisionCommand '$expected_provision_cmd' but got '$actual_provision_cmd'"
+  exit 1
+fi
+
+echo "==> case 3.7: delete-all"
+invoker_e2e_run_headless delete-all
+
+echo "==> case 3.7: submit plan"
+invoker_e2e_submit_plan "$INVOKER_E2E_REPO_ROOT/plans/e2e-ssh/3.7-ssh-target-provision.yaml"
+
+STA=$(invoker_e2e_task_status e2e-g337-taskA)
+if [ "$STA" != "completed" ]; then
+  echo "FAIL case 3.7: expected SSH task=completed, got '$STA'"
+  invoker_e2e_run_headless status 2>&1 || true
+  exit 1
+fi
+
+echo "PASS case 3.7 (SSH target provisioning ran vitest in the managed worktree)"

--- a/scripts/e2e-ssh/lib/ssh-common.sh
+++ b/scripts/e2e-ssh/lib/ssh-common.sh
@@ -105,6 +105,16 @@ invoker_e2e_ssh_cleanup_keys() {
 }
 
 # --------------------------------------------------------------------------- #
+# Print the repo-owned SSH provision command used by managed remote worktrees.
+# --------------------------------------------------------------------------- #
+invoker_e2e_ssh_provision_command() {
+  (
+    cd "$INVOKER_E2E_REPO_ROOT"
+    bash scripts/provision-ssh-worker.sh print-provision-command
+  )
+}
+
+# --------------------------------------------------------------------------- #
 # Write temp JSON config with a localhost-e2e execution pool.
 # --------------------------------------------------------------------------- #
 invoker_e2e_ssh_write_config() {
@@ -112,7 +122,7 @@ invoker_e2e_ssh_write_config() {
   local remote_home
   local provision_cmd
   remote_home="$_INVOKER_E2E_SSH_TMPDIR/remote-invoker-home"
-  provision_cmd="$(command -v pnpm) install --frozen-lockfile"
+  provision_cmd="$(invoker_e2e_ssh_provision_command)"
 
   cat > "$config_file" <<EOJSON
 {


### PR DESCRIPTION
## Summary

This makes the SSH E2E harness read the repo-owned bootstrap snippet from the managed-target config and use it in the managed-worktree case.

The harness still hard-coded the old bootstrap path, so it could not prove the target-owned setup end to end.

This slice updates the shared helper and adds the focused SSH case for that final setup path.

## Review Claim

Approve the SSH E2E tooling update that uses the configured target-owned bootstrap snippet in the managed-worktree case.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only changes repo tooling under `scripts/` plus its focused plan fixture.

## Slice Rationale

The runtime change is already isolated below. This slice only teaches the E2E harness to exercise the shipped setup path.

## Non-goals

- No runtime executor change.
- No shared type change.
- No docs changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/e2e-ssh/run-all.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 52a9e3184`
- Post-revert steps: None
- Data migration? No

</details>
