### PR TITLE
(1) Add upstream base to work request inputs

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -43,6 +43,14 @@ export interface WorkRequestInputs {
   /** Branch names from completed upstream dependencies to merge into the worktree. */
   upstreamBranches?: string[];
   /**
+   * The direct dependency branch/commit used as the starting point for the new
+   * task branch before any remaining upstream merges.
+   */
+  upstreamBase?: {
+    branch: string;
+    commitHash: string;
+  };
+  /**
    * Visible lifecycle tag (e.g. `g0.t1.aabc12345`) embedded in the branch name
    * to make every dispatch unique-by-construction across recreates and retries.
    * Replaces the legacy `salt` field that mixed lifecycle context into the


### PR DESCRIPTION
## Summary

This slice adds one optional field to `WorkRequestInputs`.

Later slices need a named place to carry one parent branch and commit together.

This slice only extends the shared type.

## Review Claim

`WorkRequestInputs` now includes an optional `upstreamBase` branch-and-commit field.

## Review Lane

refactor

## Review Unit

contract

## Safety Invariant

The new field is optional and unused in this slice, so this diff only widens the shared type surface.

## Slice Rationale

The shared type lands first so later slices can depend on one field name instead of adding ad hoc payload shape.

## Non-goals

No selection logic.

No executor logic.

Behavior unchanged.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/contracts exec tsc --noEmit -p tsconfig.json`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
