### PR TITLE
(2) Thread upstream base through task runner requests

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -43,6 +43,14 @@ export interface WorkRequestInputs {
   /** Branch names from completed upstream dependencies to merge into the worktree. */
   upstreamBranches?: string[];
   /**
+   * The direct dependency branch/commit used as the starting point for the new
+   * task branch before any remaining upstream merges.
+   */
+  upstreamBase?: {
+    branch: string;
+    commitHash: string;
+  };
+  /**
    * Visible lifecycle tag (e.g. `g0.t1.aabc12345`) embedded in the branch name
    * to make every dispatch unique-by-construction across recreates and retries.
    * Replaces the legacy `salt` field that mixed lifecycle context into the

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1095,6 +1095,121 @@ describe('TaskRunner', () => {
       expect(executor.collectUpstreamBranches(task)).toEqual(['experiment/wf-ext/gate-task-abc123']);
     });
   });
+  describe('WorkRequest upstreamBase', () => {
+    function createCapturingRunner(tasks: Map<string, TaskState>) {
+      let capturedRequest: WorkRequest | undefined;
+      const capturingExecutor = {
+        type: 'worktree',
+        start: async (req: WorkRequest) => {
+          capturedRequest = req;
+          return { executionId: 'exec-1', taskId: req.actionId };
+        },
+        onOutput: () => () => {},
+        onComplete: (_handle: unknown, cb: (response: WorkResponse) => void) => {
+          cb({ requestId: 'r', actionId: 'child-task', status: 'completed', outputs: { exitCode: 0 } });
+          return () => {};
+        },
+        onHeartbeat: () => () => {},
+      };
+
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: (id: string) => tasks.get(id),
+          handleWorkerResponse: vi.fn(),
+        } as any,
+        persistence: { updateTask: vi.fn() } as any,
+        executorRegistry: {
+          getDefault: () => capturingExecutor,
+          get: () => capturingExecutor,
+          getAll: () => [capturingExecutor],
+        } as any,
+        cwd: '/tmp',
+      });
+
+      return {
+        runner,
+        getCapturedRequest: () => capturedRequest,
+      };
+    }
+
+    it('uses the only completed dependency branch and commit as upstreamBase', async () => {
+      const tasks = new Map<string, TaskState>();
+      tasks.set('dep-a', makeTask({
+        id: 'dep-a',
+        status: 'completed',
+        execution: {
+          branch: 'experiment/dep-a',
+          commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        },
+      }));
+
+      const { runner, getCapturedRequest } = createCapturingRunner(tasks);
+      await runner.executeTask(makeTask({
+        id: 'child-task',
+        status: 'running',
+        dependencies: ['dep-a'],
+        config: { command: 'echo test' },
+      }));
+
+      expect(getCapturedRequest()?.inputs.upstreamBase).toEqual({
+        branch: 'experiment/dep-a',
+        commitHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      });
+    });
+
+    it('uses the first dependency in declared order when multiple commits exist', async () => {
+      const tasks = new Map<string, TaskState>();
+      tasks.set('dep-a', makeTask({
+        id: 'dep-a',
+        status: 'completed',
+        execution: {
+          branch: 'experiment/dep-a',
+          commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        },
+      }));
+      tasks.set('dep-b', makeTask({
+        id: 'dep-b',
+        status: 'completed',
+        execution: {
+          branch: 'experiment/dep-b',
+          commit: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        },
+      }));
+
+      const { runner, getCapturedRequest } = createCapturingRunner(tasks);
+      await runner.executeTask(makeTask({
+        id: 'child-task',
+        status: 'running',
+        dependencies: ['dep-b', 'dep-a'],
+        config: { command: 'echo test' },
+      }));
+
+      expect(getCapturedRequest()?.inputs.upstreamBase).toEqual({
+        branch: 'experiment/dep-b',
+        commitHash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      });
+    });
+
+    it('leaves upstreamBase unset when only branch metadata exists', async () => {
+      const tasks = new Map<string, TaskState>();
+      tasks.set('dep-a', makeTask({
+        id: 'dep-a',
+        status: 'completed',
+        execution: { branch: 'experiment/dep-a' },
+      }));
+
+      const { runner, getCapturedRequest } = createCapturingRunner(tasks);
+      await runner.executeTask(makeTask({
+        id: 'child-task',
+        status: 'running',
+        dependencies: ['dep-a'],
+        config: { command: 'echo test' },
+      }));
+
+      expect(getCapturedRequest()?.inputs.upstreamBase).toBeUndefined();
+      expect(getCapturedRequest()?.inputs.upstreamBranches).toEqual(['experiment/dep-a']);
+    });
+  });
 
   describe('executeTask error handling', () => {
     it('sends failed WorkResponse when executor.start throws', async () => {

--- a/packages/execution-engine/src/task-runner-phase-host.ts
+++ b/packages/execution-engine/src/task-runner-phase-host.ts
@@ -28,6 +28,7 @@ export type TaskRunnerPhaseHost = Pick<
   // Prepare-phase helpers
   | 'buildUpstreamContext'
   | 'collectUpstreamBranches'
+  | 'collectUpstreamBase'
   | 'buildAlternatives'
   | 'resolveExternalDependencyTask'
   | 'shouldUseFreshWorkspace'

--- a/packages/execution-engine/src/task-runner-prepare.ts
+++ b/packages/execution-engine/src/task-runner-prepare.ts
@@ -42,6 +42,7 @@ export async function buildWorkRequest(
   bench('collectUpstreamBranches.end', {
     upstreamBranchCount: upstreamBranches.length,
   });
+  const upstreamBase = host.collectUpstreamBase(task);
   bench('buildAlternatives.start');
   const alternatives = host.buildAlternatives(task);
   bench('buildAlternatives.end', {
@@ -142,6 +143,7 @@ export async function buildWorkRequest(
       upstreamContext: upstreamContext.length > 0 ? upstreamContext : undefined,
       alternatives: alternatives.length > 0 ? alternatives : undefined,
       upstreamBranches: upstreamBranches.length > 0 ? upstreamBranches : undefined,
+      upstreamBase,
       lifecycleTag,
       baseBranch,
       baseCommit,

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1812,6 +1812,28 @@ export class TaskRunner {
 
     return branches;
   }
+  /** @internal */ collectUpstreamBase(task: TaskState): { branch: string; commitHash: string } | undefined {
+    const resolveUpstreamBase = (dep: TaskState | undefined): { branch: string; commitHash: string } | undefined => {
+      if (dep?.status !== 'completed') return undefined;
+      const branch = dep.execution.branch?.trim();
+      const commitHash = dep.execution.commit?.trim();
+      if (!branch || !commitHash) return undefined;
+      return { branch, commitHash };
+    };
+
+    for (const depId of task.dependencies) {
+      const upstreamBase = resolveUpstreamBase(this.orchestrator.getTask(depId));
+      if (upstreamBase) return upstreamBase;
+    }
+    for (const depRef of task.config.externalDependencies ?? []) {
+      const upstreamBase = resolveUpstreamBase(
+        this.resolveExternalDependencyTask(depRef.workflowId, depRef.taskId),
+      );
+      if (upstreamBase) return upstreamBase;
+    }
+
+    return undefined;
+  }
 
   /** @internal */ buildAlternatives(
     task: TaskState,


### PR DESCRIPTION
## Summary

This slice adds one explicit upstream base to task dispatch routing.

The recreate bug needs one chosen parent branch and commit instead of only a flat set of upstream branch names.

Executors still ignore that field here. This slice only records it on the work request before dispatch.

## Review Claim

Task-runner now records one completed parent branch and commit in `inputs.upstreamBase` before executor dispatch.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

Executors still ignore `upstreamBase` in this slice, so task startup behavior stays unchanged while tests lock the new request shape.

## Slice Rationale

The dispatch-routing slice lands before the executor slice so startup code can consume one already-recorded parent commit.

## Non-goals

No executor startup behavior change.

No merge-order change.

Behavior unchanged.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts -t "WorkRequest upstreamBase"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
