### PR TITLE
(3) Branch tasks from explicit upstream commits

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -43,6 +43,14 @@ export interface WorkRequestInputs {
   /** Branch names from completed upstream dependencies to merge into the worktree. */
   upstreamBranches?: string[];
   /**
+   * The direct dependency branch/commit used as the starting point for the new
+   * task branch before any remaining upstream merges.
+   */
+  upstreamBase?: {
+    branch: string;
+    commitHash: string;
+  };
+  /**
    * Visible lifecycle tag (e.g. `g0.t1.aabc12345`) embedded in the branch name
    * to make every dispatch unique-by-construction across recreates and retries.
    * Replaces the legacy `salt` field that mixed lifecycle context into the

--- a/packages/execution-engine/src/__tests__/branch-chain.test.ts
+++ b/packages/execution-engine/src/__tests__/branch-chain.test.ts
@@ -302,15 +302,19 @@ describe('A→B→C branch chain', { timeout: 120_000 }, () => {
       }
     });
 
-    it('transitive history: C contains A commits', async () => {
+    it('linear chain branches directly from each parent commit history', async () => {
       const { tasks, executor } = buildChain({ a: worktreeCmd, b: worktreeCmd, c: worktreeCmd });
 
       await executeTask(executor, tasks, 'task-a');
       const hashA = execSync(`git rev-parse ${tasks[0].execution.branch}`, { cwd: tmpDir }).toString().trim();
 
       await executeTask(executor, tasks, 'task-b');
+      const hashB = execSync(`git rev-parse ${tasks[1].execution.branch}`, { cwd: tmpDir }).toString().trim();
+      expect(isAncestor(tmpDir, hashA, tasks[1].execution.branch!)).toBe(true);
+
       await executeTask(executor, tasks, 'task-c');
 
+      expect(isAncestor(tmpDir, hashB, tasks[2].execution.branch!)).toBe(true);
       expect(isAncestor(tmpDir, hashA, tasks[2].execution.branch!)).toBe(true);
     });
 

--- a/packages/execution-engine/src/__tests__/docker-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/docker-executor.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'node:events';
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { ExecutorHandle, PersistedTaskMeta } from '../executor.js';
 import { BaseExecutor } from '../base-executor.js';
-
+import { buildExperimentBranchName, computeContentHash } from '../branch-utils.js';
 // ---------------------------------------------------------------------------
 // Mock helpers
 // ---------------------------------------------------------------------------
@@ -231,6 +231,36 @@ describe('DockerExecutor', () => {
       expect.any(Object),
       expect.objectContaining({
         branchName: expect.stringMatching(/^experiment\/action-1\/g\d+\.t\d+\.a[a-z0-9_-]*-[0-9a-f]{8}$/),
+      }),
+    );
+  });
+
+  it('uses upstreamBase commit for docker branch hashing and setup base', async () => {
+    const upstreamBaseCommit = '1234567890abcdef1234567890abcdef12345678';
+    const expectedBranch = buildExperimentBranchName(
+      'action-1',
+      '',
+      computeContentHash('action-1', 'echo hello', undefined, [], upstreamBaseCommit),
+    );
+
+    await executor.start(makeRequest({
+      inputs: {
+        command: 'echo hello',
+        repoUrl: 'https://github.com/test/repo.git',
+        upstreamBase: {
+          branch: 'experiment/dep-a',
+          commitHash: upstreamBaseCommit,
+        },
+      },
+    }));
+
+    expect(setupTaskBranchSpy).toHaveBeenCalledWith(
+      '/app',
+      expect.objectContaining({ actionId: 'action-1' }),
+      expect.any(Object),
+      expect.objectContaining({
+        branchName: expectedBranch,
+        base: upstreamBaseCommit,
       }),
     );
   });

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -153,7 +153,7 @@ describe('SshExecutor pre-flight validation', () => {
       expect.any(String),
       expect.any(Object),
       expect.any(Object),
-      expect.objectContaining({ base: 'origin/master' }),
+      expect.objectContaining({ base: '0123456789abcdef0123456789abcdef01234567' }),
     );
   });
 });
@@ -412,6 +412,7 @@ branch refs/heads/experiment/test-task-oldhash
 
     const repoHash = computeRepoUrlHash('git@github.com:owner/repo.git');
     const baseHead = 'aabbccddeeff00112233445566778899aabbccdd';
+    const upstreamBaseCommit = '11223344556677889900aabbccddeeff00112233';
     const actionId = 'reuse-sandbox-test';
     const command = 'pnpm test';
     const lifecycleTag = '';
@@ -419,7 +420,7 @@ branch refs/heads/experiment/test-task-oldhash
 
     // Compute the exact branch the executor will derive from these inputs.
     // The executor uses request.inputs.prompt (not description) as the third arg.
-    const contentHash = computeContentHash(actionId, command, undefined, upstreamCommits, baseHead);
+    const contentHash = computeContentHash(actionId, command, undefined, upstreamCommits, upstreamBaseCommit);
     const experimentBranch = buildExperimentBranchName(actionId, lifecycleTag, contentHash);
     const san = experimentBranch.replace(/\//g, '-');
     const invokerHome = '/home/testuser/.invoker';
@@ -456,7 +457,15 @@ branch refs/heads/experiment/test-task-oldhash
     await ssh.start(makeRequest({
       actionType: 'command',
       actionId,
-      inputs: { command, description: 'sandbox reset test', repoUrl: 'git@github.com:owner/repo.git' },
+      inputs: {
+        command,
+        description: 'sandbox reset test',
+        repoUrl: 'git@github.com:owner/repo.git',
+        upstreamBase: {
+          branch: 'experiment/dep-parent',
+          commitHash: upstreamBaseCommit,
+        },
+      },
     }));
 
     // sandbox_reset must have been called with the right script content
@@ -464,10 +473,11 @@ branch refs/heads/experiment/test-task-oldhash
     expect(sandboxResetCall).toBeDefined();
     expect(sandboxResetCall?.script).toContain('git -C "$WT" reset --hard "$REF"');
     expect(sandboxResetCall?.script).toContain('git -C "$WT" clean -fd');
+    expect(sandboxResetCall?.script).toContain(Buffer.from(upstreamBaseCommit).toString('base64'));
 
     // mergeRequestUpstreamBranches must have been called exactly once
     expect(mergeUpstreamSpy).toHaveBeenCalledTimes(1);
-
+    expect(mergeUpstreamSpy).toHaveBeenCalledWith(expect.any(Object), exactPath, upstreamBaseCommit);
     // sandbox_reset (execRemoteCapture call) must be ordered before mergeRequestUpstreamBranches.
     // We verify this via invocationCallOrder so a future refactor cannot silently move
     // the reset after the merge without breaking this test.

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1095,6 +1095,121 @@ describe('TaskRunner', () => {
       expect(executor.collectUpstreamBranches(task)).toEqual(['experiment/wf-ext/gate-task-abc123']);
     });
   });
+  describe('WorkRequest upstreamBase', () => {
+    function createCapturingRunner(tasks: Map<string, TaskState>) {
+      let capturedRequest: WorkRequest | undefined;
+      const capturingExecutor = {
+        type: 'worktree',
+        start: async (req: WorkRequest) => {
+          capturedRequest = req;
+          return { executionId: 'exec-1', taskId: req.actionId };
+        },
+        onOutput: () => () => {},
+        onComplete: (_handle: unknown, cb: (response: WorkResponse) => void) => {
+          cb({ requestId: 'r', actionId: 'child-task', status: 'completed', outputs: { exitCode: 0 } });
+          return () => {};
+        },
+        onHeartbeat: () => () => {},
+      };
+
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: (id: string) => tasks.get(id),
+          handleWorkerResponse: vi.fn(),
+        } as any,
+        persistence: { updateTask: vi.fn() } as any,
+        executorRegistry: {
+          getDefault: () => capturingExecutor,
+          get: () => capturingExecutor,
+          getAll: () => [capturingExecutor],
+        } as any,
+        cwd: '/tmp',
+      });
+
+      return {
+        runner,
+        getCapturedRequest: () => capturedRequest,
+      };
+    }
+
+    it('uses the only completed dependency branch and commit as upstreamBase', async () => {
+      const tasks = new Map<string, TaskState>();
+      tasks.set('dep-a', makeTask({
+        id: 'dep-a',
+        status: 'completed',
+        execution: {
+          branch: 'experiment/dep-a',
+          commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        },
+      }));
+
+      const { runner, getCapturedRequest } = createCapturingRunner(tasks);
+      await runner.executeTask(makeTask({
+        id: 'child-task',
+        status: 'running',
+        dependencies: ['dep-a'],
+        config: { command: 'echo test' },
+      }));
+
+      expect(getCapturedRequest()?.inputs.upstreamBase).toEqual({
+        branch: 'experiment/dep-a',
+        commitHash: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      });
+    });
+
+    it('uses the first dependency in declared order when multiple commits exist', async () => {
+      const tasks = new Map<string, TaskState>();
+      tasks.set('dep-a', makeTask({
+        id: 'dep-a',
+        status: 'completed',
+        execution: {
+          branch: 'experiment/dep-a',
+          commit: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        },
+      }));
+      tasks.set('dep-b', makeTask({
+        id: 'dep-b',
+        status: 'completed',
+        execution: {
+          branch: 'experiment/dep-b',
+          commit: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        },
+      }));
+
+      const { runner, getCapturedRequest } = createCapturingRunner(tasks);
+      await runner.executeTask(makeTask({
+        id: 'child-task',
+        status: 'running',
+        dependencies: ['dep-b', 'dep-a'],
+        config: { command: 'echo test' },
+      }));
+
+      expect(getCapturedRequest()?.inputs.upstreamBase).toEqual({
+        branch: 'experiment/dep-b',
+        commitHash: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      });
+    });
+
+    it('leaves upstreamBase unset when only branch metadata exists', async () => {
+      const tasks = new Map<string, TaskState>();
+      tasks.set('dep-a', makeTask({
+        id: 'dep-a',
+        status: 'completed',
+        execution: { branch: 'experiment/dep-a' },
+      }));
+
+      const { runner, getCapturedRequest } = createCapturingRunner(tasks);
+      await runner.executeTask(makeTask({
+        id: 'child-task',
+        status: 'running',
+        dependencies: ['dep-a'],
+        config: { command: 'echo test' },
+      }));
+
+      expect(getCapturedRequest()?.inputs.upstreamBase).toBeUndefined();
+      expect(getCapturedRequest()?.inputs.upstreamBranches).toEqual(['experiment/dep-a']);
+    });
+  });
 
   describe('executeTask error handling', () => {
     it('sends failed WorkResponse when executor.start throws', async () => {

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -735,25 +735,58 @@ describe('WorktreeExecutor', () => {
       taskProcess.emit('close', 0, null);
     });
 
-    it('merges upstream branches into the worktree after creation', async () => {
+    it('branches from upstreamBase commit without re-merging the parent branch', async () => {
       const { taskProcess } = setupSpawnMock();
+      const pool = mockPool(executor);
+      const parentCommit = '1111111111111111111111111111111111111111';
 
       const request = makeRequest({
         inputs: {
           command: 'echo hello',
-          upstreamBranches: ['experiment/dep-1', 'experiment/dep-2'],
+          upstreamBranches: ['experiment/dep-parent'],
+          upstreamBase: {
+            branch: 'experiment/dep-parent',
+            commitHash: parentCommit,
+          },
         },
       });
       await executor.start(request);
 
-      // setupTaskBranch uses runBash for merging. Verify the merge script contains both branches.
+      expect(pool.acquireWorktree.mock.calls[0][2]).toBe(parentCommit);
+      const runBashMock = vi.mocked((BaseExecutor.prototype as any).runBash);
+      const mergeCall = runBashMock.mock.calls.find(
+        (call) => call[0].includes('Invoker: merge'),
+      );
+      expect(mergeCall).toBeUndefined();
+
+      taskProcess.emit('close', 0, null);
+    });
+
+    it('merges only the remaining parent branches after branching from upstreamBase', async () => {
+      const { taskProcess } = setupSpawnMock();
+      const pool = mockPool(executor);
+      const parentCommit = '2222222222222222222222222222222222222222';
+
+      const request = makeRequest({
+        inputs: {
+          command: 'echo hello',
+          upstreamBranches: ['experiment/dep-parent', 'experiment/dep-sibling'],
+          upstreamBase: {
+            branch: 'experiment/dep-parent',
+            commitHash: parentCommit,
+          },
+        },
+      });
+      await executor.start(request);
+
+      expect(pool.acquireWorktree.mock.calls[0][2]).toBe(parentCommit);
       const runBashMock = vi.mocked((BaseExecutor.prototype as any).runBash);
       const mergeCall = runBashMock.mock.calls.find(
         (call) => call[0].includes('Invoker: merge'),
       );
       expect(mergeCall).toBeDefined();
-      expect(mergeCall![0]).toContain('experiment/dep-1');
-      expect(mergeCall![0]).toContain('experiment/dep-2');
+      expect(mergeCall![0]).not.toContain('experiment/dep-parent');
+      expect(mergeCall![0]).toContain('experiment/dep-sibling');
 
       taskProcess.emit('close', 0, null);
     });
@@ -855,7 +888,11 @@ describe('WorktreeExecutor', () => {
       const request = makeRequest({
         inputs: {
           command: 'echo hello',
-          upstreamBranches: ['experiment/conflicting'],
+          upstreamBranches: ['experiment/dep-parent', 'experiment/conflicting'],
+          upstreamBase: {
+            branch: 'experiment/dep-parent',
+            commitHash: '3333333333333333333333333333333333333333',
+          },
         },
       });
 
@@ -894,7 +931,11 @@ describe('WorktreeExecutor', () => {
       const request = makeRequest({
         inputs: {
           command: 'echo hello',
-          upstreamBranches: ['experiment/conflicting'],
+          upstreamBranches: ['experiment/dep-parent', 'experiment/conflicting'],
+          upstreamBase: {
+            branch: 'experiment/dep-parent',
+            commitHash: '4444444444444444444444444444444444444444',
+          },
         },
       });
 
@@ -929,7 +970,11 @@ describe('WorktreeExecutor', () => {
       const request = makeRequest({
         inputs: {
           command: 'echo hello',
-          upstreamBranches: ['experiment/nonexistent-branch'],
+          upstreamBranches: ['experiment/dep-parent', 'experiment/nonexistent-branch'],
+          upstreamBase: {
+            branch: 'experiment/dep-parent',
+            commitHash: '5555555555555555555555555555555555555555',
+          },
         },
       });
 

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -662,12 +662,13 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     setupBranchExplicitBase?: string,
   ): Promise<void> {
     const upstreams = request.inputs.upstreamBranches ?? [];
-    const upstreamsToMerge = this.selectUpstreamBranchesToMerge(
-      upstreams,
-      request.inputs.baseBranch,
-      setupBranchExplicitBase,
-    );
-    const baseFromUpstream = !setupBranchExplicitBase && upstreams.length > 0;
+    const upstreamsToMerge = this.selectUpstreamBranchesToMerge({
+      upstreamBranches: upstreams,
+      requestBaseBranch: request.inputs.baseBranch,
+      upstreamBaseBranch: request.inputs.upstreamBase?.branch,
+      baseAlreadyApplied: Boolean(setupBranchExplicitBase || request.inputs.upstreamBase?.commitHash),
+    });
+    const baseFromUpstream = !setupBranchExplicitBase && !request.inputs.upstreamBase?.commitHash && upstreams.length > 0;
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} [mergeRequestUpstreamBranches] upstreamsToMerge=${JSON.stringify(upstreamsToMerge)} ` +
         `(baseFromUpstream=${baseFromUpstream}) mergeCwd=${mergeCwd}`,
@@ -709,24 +710,30 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     }
   }
 
-  private selectUpstreamBranchesToMerge(
-    upstreamBranches: string[],
-    requestBaseBranch?: string,
-    setupBranchExplicitBase?: string,
-  ): string[] {
-    const requestBase = requestBaseBranch?.trim();
+  private selectUpstreamBranchesToMerge(opts: {
+    upstreamBranches: string[];
+    requestBaseBranch?: string;
+    upstreamBaseBranch?: string;
+    baseAlreadyApplied: boolean;
+  }): string[] {
+    const requestBase = opts.requestBaseBranch?.trim();
+    const upstreamBaseBranch = opts.upstreamBaseBranch?.trim();
+    let branches = opts.upstreamBranches;
+
     // Contract: upstreamBranches may be shaped as
-    // [workflowBase, dependencyBranch, ...]. When the workflow base was already
-    // resolved and supplied explicitly, do not merge that marker again.
-    if (setupBranchExplicitBase && requestBase && upstreamBranches[0] === requestBase) {
-      return upstreamBranches.slice(1);
+    // [workflowBase, dependencyBranch, ...]. When the branch already starts from
+    // an explicit base ref/commit, do not merge that workflow-base marker again.
+    if (opts.baseAlreadyApplied && requestBase && branches[0] === requestBase) {
+      branches = branches.slice(1);
+    } else if (!opts.baseAlreadyApplied && !upstreamBaseBranch && branches.length > 0) {
+      branches = branches.slice(1);
     }
 
-    if (!setupBranchExplicitBase && upstreamBranches.length > 0) {
-      return upstreamBranches.slice(1);
+    if (!upstreamBaseBranch) {
+      return branches;
     }
 
-    return upstreamBranches;
+    return branches.filter((branch) => branch !== upstreamBaseBranch);
   }
 
   protected async setupTaskBranch(
@@ -738,9 +745,14 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     try {
       const branchName = opts?.branchName ?? `invoker/${request.actionId}`;
       const upstreams = request.inputs.upstreamBranches ?? [];
-      // When opts.base is provided, all upstreams need merging.
-      // When not provided, upstreams[0] becomes the base and the rest are merged.
-      const base = opts?.base ?? upstreams[0] ?? request.inputs.baseBranch ?? 'HEAD';
+      // When opts.base is provided, or upstreamBase is available, the branch
+      // starts from that explicit ref/commit and only the remaining upstreams
+      // are merged. Otherwise upstreams[0] becomes the base.
+      const base = opts?.base
+        ?? request.inputs.upstreamBase?.commitHash?.trim()
+        ?? upstreams[0]
+        ?? request.inputs.baseBranch
+        ?? 'HEAD';
       const mergeCwd = opts?.worktreeDir ?? cwd;
 
       traceExecution(

--- a/packages/execution-engine/src/docker-executor.ts
+++ b/packages/execution-engine/src/docker-executor.ts
@@ -381,6 +381,7 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
 
       const baseRef = request.inputs.baseBranch ?? 'HEAD';
       const baseHead = (await this.execGitSimple(['rev-parse', baseRef], CONTAINER_CWD)).trim();
+      const startupBaseHead = request.inputs.upstreamBase?.commitHash?.trim() || baseHead;
       const upstreamCommits = (request.inputs.upstreamContext ?? [])
         .map(c => c.commitHash)
         .filter((h): h is string => !!h);
@@ -389,7 +390,7 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
         request.inputs.command,
         request.inputs.prompt,
         upstreamCommits,
-        baseHead,
+        startupBaseHead,
       );
       const branchName = buildExperimentBranchName(
         request.actionId,
@@ -406,13 +407,9 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
         // Best-effort early persistence; the post-start path persists the
         // same value again.
       }
-      const baseBranch = request.inputs.upstreamBranches?.[0]
-        ?? request.inputs.baseBranch
-        ?? 'HEAD';
-
       await this.setupTaskBranch(CONTAINER_CWD, request, handle, {
         branchName,
-        base: baseBranch,
+        base: startupBaseHead,
       });
       entry.branch = handle.branch;
 

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -620,12 +620,15 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
         `[WARNING] Continuing with existing refs. Tasks may use stale commits.\n`;
       this.emitOutput(executionId, msg);
     }
+    const startupBaseHead = request.inputs.upstreamBase?.commitHash?.trim()
+      || request.inputs.baseCommit?.trim()
+      || baseHead;
     const contentHash = computeContentHash(
       request.actionId,
       request.inputs.command,
       request.inputs.prompt,
       upstreamCommits,
-      baseHead,
+      startupBaseHead,
     );
     const experimentBranch = buildExperimentBranchName(
       request.actionId,
@@ -739,23 +742,23 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
     if (skippedRemotePreserve) {
       bench('SshExecutor.startManagedWorkspace.sandboxReset.before', { remoteWt });
       await this.execRemoteCapture(
-        buildWorktreeSandboxResetScript({ worktreePath: remoteWt, toRef: resolvedBaseRef }),
+        buildWorktreeSandboxResetScript({ worktreePath: remoteWt, toRef: startupBaseHead }),
         'sandbox_reset',
       );
       bench('SshExecutor.startManagedWorkspace.sandboxReset.after', { remoteWt });
       bench('SshExecutor.startManagedWorkspace.mergeRequestUpstreamBranches.before', { remoteWt });
-      await this.mergeRequestUpstreamBranches(request, remoteWt, resolvedBaseRef);
+      await this.mergeRequestUpstreamBranches(request, remoteWt, startupBaseHead);
       bench('SshExecutor.startManagedWorkspace.mergeRequestUpstreamBranches.after', { remoteWt });
     } else {
       try {
         bench('SshExecutor.startManagedWorkspace.setupTaskBranch.before', {
           branchName: experimentBranch,
-          base: resolvedBaseRef,
+          base: startupBaseHead,
           remoteWt,
         });
         await this.setupTaskBranch(remoteClone, request, handle, {
           branchName: experimentBranch,
-          base: resolvedBaseRef,
+          base: startupBaseHead,
           worktreeDir: remoteWt,
         });
         bench('SshExecutor.startManagedWorkspace.setupTaskBranch.after', {

--- a/packages/execution-engine/src/task-runner-phase-host.ts
+++ b/packages/execution-engine/src/task-runner-phase-host.ts
@@ -28,6 +28,7 @@ export type TaskRunnerPhaseHost = Pick<
   // Prepare-phase helpers
   | 'buildUpstreamContext'
   | 'collectUpstreamBranches'
+  | 'collectUpstreamBase'
   | 'buildAlternatives'
   | 'resolveExternalDependencyTask'
   | 'shouldUseFreshWorkspace'

--- a/packages/execution-engine/src/task-runner-prepare.ts
+++ b/packages/execution-engine/src/task-runner-prepare.ts
@@ -42,6 +42,7 @@ export async function buildWorkRequest(
   bench('collectUpstreamBranches.end', {
     upstreamBranchCount: upstreamBranches.length,
   });
+  const upstreamBase = host.collectUpstreamBase(task);
   bench('buildAlternatives.start');
   const alternatives = host.buildAlternatives(task);
   bench('buildAlternatives.end', {
@@ -142,6 +143,7 @@ export async function buildWorkRequest(
       upstreamContext: upstreamContext.length > 0 ? upstreamContext : undefined,
       alternatives: alternatives.length > 0 ? alternatives : undefined,
       upstreamBranches: upstreamBranches.length > 0 ? upstreamBranches : undefined,
+      upstreamBase,
       lifecycleTag,
       baseBranch,
       baseCommit,

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1812,6 +1812,28 @@ export class TaskRunner {
 
     return branches;
   }
+  /** @internal */ collectUpstreamBase(task: TaskState): { branch: string; commitHash: string } | undefined {
+    const resolveUpstreamBase = (dep: TaskState | undefined): { branch: string; commitHash: string } | undefined => {
+      if (dep?.status !== 'completed') return undefined;
+      const branch = dep.execution.branch?.trim();
+      const commitHash = dep.execution.commit?.trim();
+      if (!branch || !commitHash) return undefined;
+      return { branch, commitHash };
+    };
+
+    for (const depId of task.dependencies) {
+      const upstreamBase = resolveUpstreamBase(this.orchestrator.getTask(depId));
+      if (upstreamBase) return upstreamBase;
+    }
+    for (const depRef of task.config.externalDependencies ?? []) {
+      const upstreamBase = resolveUpstreamBase(
+        this.resolveExternalDependencyTask(depRef.workflowId, depRef.taskId),
+      );
+      if (upstreamBase) return upstreamBase;
+    }
+
+    return undefined;
+  }
 
   /** @internal */ buildAlternatives(
     task: TaskState,

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -178,6 +178,8 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       bench('WorktreeExecutor.resolveBase.after', { baseRef, baseHead });
       log(`resolve base ${baseRef} done → ${baseHead}`);
     }
+    const startupBaseHead = request.inputs.upstreamBase?.commitHash?.trim()
+      || baseHead;
     const upstreamCommits = (request.inputs.upstreamContext ?? [])
       .map(c => c.commitHash)
       .filter((h): h is string => !!h);
@@ -186,7 +188,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       request.inputs.command,
       request.inputs.prompt,
       upstreamCommits,
-      baseHead,
+      startupBaseHead,
     );
     const branch = buildExperimentBranchName(
       request.actionId,
@@ -215,11 +217,11 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       traceExecution(
         `${RESTART_TO_BRANCH_TRACE} WorktreeExecutor.start() actionId=${request.actionId} reconciliation → acquireWorktree (skip upstream merge)`,
       );
-      bench('RepoPool.acquireWorktree.reconciliation.before', { branch, baseHead });
+      bench('RepoPool.acquireWorktree.reconciliation.before', { branch, baseHead: startupBaseHead });
       const acquired = await this.pool.acquireWorktree(
         repoUrl,
         branch,
-        baseHead,
+        startupBaseHead,
         request.actionId,
         {
           forceFresh: request.inputs.freshWorkspace === true,
@@ -283,11 +285,11 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     bench('WorktreeExecutor.reconcilePoolSlots.before');
     this.reconcilePoolSlots(repoUrl);
     bench('WorktreeExecutor.reconcilePoolSlots.after');
-    bench('RepoPool.acquireWorktree.before', { branch, baseHead });
+    bench('RepoPool.acquireWorktree.before', { branch, baseHead: startupBaseHead });
     const acquired = await this.pool.acquireWorktree(
       repoUrl,
       branch,
-      baseHead,
+      startupBaseHead,
       request.actionId,
       {
         forceFresh: request.inputs.freshWorkspace === true,
@@ -308,7 +310,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     if (poolUpstreams.length > 0) {
       try {
         bench('WorktreeExecutor.mergeRequestUpstreamBranches.before', { upstreamCount: poolUpstreams.length });
-        await this.mergeRequestUpstreamBranches(request, acquired.worktreePath, baseHead);
+        await this.mergeRequestUpstreamBranches(request, acquired.worktreePath, startupBaseHead);
         bench('WorktreeExecutor.mergeRequestUpstreamBranches.after', { upstreamCount: poolUpstreams.length });
       } catch (err: any) {
         if (err instanceof MergeConflictError) {


### PR DESCRIPTION
## Summary

This slice changes executor startup routing when one finished parent already exists.

The old startup path rebuilt from workflow base and then merged that same parent branch again, which could create fake startup conflicts.

Fan-in still works. Executors now branch from the chosen parent commit and merge only the other parent branches in order.

## Review Claim

Executor startup now branches from `upstreamBase.commitHash` and does not merge `upstreamBase.branch` again while preserving ordered fan-in merges.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only startup base selection and upstream merge filtering change; the remaining parent merges stay ordered, and tests cover worktree, SSH, Docker, and real git branch ancestry.

## Slice Rationale

The earlier slices already added the shared field and recorded its value, so this slice can focus only on executor startup routing and cross-executor parity.

## Non-goals

No merge-gate consolidation change.

No dependency-order change.

No fallback behavior removal for branch-only historical task rows.

## Architecture

### Before

```mermaid
graph TD
    A["Executor startup"] --> B["Create branch from workflow base or upstreamBranches[0]"]
    B --> C["Merge every upstream branch in order"]
```

### After

```mermaid
graph TD
    A["Executor startup"] --> B["Create branch from upstreamBase.commitHash when present"]
    B --> C["Merge only the remaining upstream branches in order"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/worktree-executor.test.ts src/__tests__/branch-chain.test.ts src/__tests__/ssh-executor.test.ts src/__tests__/docker-executor.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
