### PR TITLE
(2) Route SSH cleanup tail through completed-task fallback

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -224,7 +224,7 @@ describe('SshExecutor managed workspace mode', () => {
     expect(callScript.indexOf('stop_bootstrap_heartbeat')).toBeLessThan(callScript.indexOf('"$RUNNER_PATH" "$PAYLOAD_PATH"'));
     expect(callScript).toContain('"$RUNNER_PATH" "$PAYLOAD_PATH"');
     expect(callScript).toContain('rm -rf "$STAGING_DIR"');
-    expect(callScript).toContain("trap 'cleanup_runtime \"$?\"' EXIT");
+    expect(callScript).toContain("trap 'cleanup_runtime' EXIT");
     expect(callAgentId).toBeUndefined();
     expect(callFinalize).toEqual({ branch: handle.branch, worktreePath: handle.workspacePath });
   });
@@ -654,6 +654,42 @@ branch refs/heads/${targetBranch}
     }
   });
 
+  it('does not call exit from the EXIT cleanup function in buildRuntimeBootstrapScript', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+    }) as any;
+
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return '__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=abc123';
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      return '';
+    });
+    vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+
+    let capturedScript = '';
+    vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
+      (_executionId: string, _request: any, handle: any, script: string) => {
+        capturedScript = script;
+        return handle;
+      },
+    );
+
+    await ssh.start(makeRequest({
+      actionType: 'command',
+      inputs: { command: 'echo hi', description: 'test', repoUrl: 'git@github.com:owner/repo.git' },
+    }));
+
+    expect(capturedScript).toContain("trap 'cleanup_runtime' EXIT");
+    expect(capturedScript).toContain("trap 'cleanup_runtime; exit 129' HUP");
+    expect(capturedScript).not.toContain('local status="$1"');
+    expect(capturedScript).not.toContain('exit "$status"');
+  });
   it('throws when managedWorkspaces=true but repoUrl is missing', async () => {
     const ssh = new SshExecutor({
       host: 'localhost',
@@ -1350,6 +1386,37 @@ describe('SshExecutor entry lifecycle', () => {
     // Let the mock process finish so heartbeat and entry state clean up.
     proc.emit('close', 0, null);
     await new Promise((r) => setTimeout(r, 50));
+  });
+  it('normalizes cleanup-tail fallback errors after a completed remote agent turn', async () => {
+    const request = makeRequest({
+      inputs: {
+        command: 'echo hello',
+        repoUrl: 'git@github.com:test/repo.git',
+      },
+    });
+
+    const handle = await ssh.start(request);
+    const sshProcess = spawnedProcesses[spawnedProcesses.length - 1];
+    const completion = new Promise<any>((resolve) => {
+      ssh.onComplete(handle, (response) => resolve(response));
+    });
+
+    (sshProcess.stdout as any).emit('data', Buffer.from([
+      '[SshExecutor] Running task payload...',
+      '{"type":"turn.completed","usage":{"input_tokens":1}}',
+      'main: line 1: pop_var_context: head of shell_variables not a function context',
+      '[SshExecutor] Recording task result and pushing branch on remote...',
+      '',
+    ].join('\n')));
+    sshProcess.emit('close', 1, null);
+
+    const response = await completion;
+    expect(response.status).toBe('failed');
+    expect(response.outputs.error).toBe(
+      'Executor cleanup failed (ssh remote finalize): bash pop_var_context after remote run completed.',
+    );
+    expect(response.outputs.error).not.toContain('[SshExecutor] Running task payload...');
+    expect(response.outputs.error).not.toContain('"type":"turn.completed"');
   });
   it.skip('managed mode skips implicit provisioning and still reaches a Flutter payload', async () => {
     const ssh2 = new SshExecutor({

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -31,7 +31,6 @@ import {
   createSshRemoteScriptError,
   parseOwnedWorktreePath,
 } from './ssh-git-exec.js';
-
 export interface SshExecutorConfig {
   host: string;
   user: string;
@@ -82,6 +81,16 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
   readonly type = 'ssh';
   private static readonly REMOTE_HEARTBEAT_MARKER = '__INVOKER_REMOTE_HEARTBEAT__';
   private static readonly DEFAULT_REMOTE_HEARTBEAT_INTERVAL_SECONDS = 30;
+  private static readonly FALLBACK_BANNER_LINES = new Set([
+    '[SshExecutor] Installing pnpm dependencies for managed worktree...',
+    '[SshExecutor] Running task payload...',
+  ]);
+  private static readonly CLEANUP_TAIL_PREFIX = 'Executor cleanup failed (ssh remote finalize):';
+  private static readonly CLEANUP_TAIL_MARKERS = [
+    'pop_var_context',
+    'Orphan function call output',
+    '[SshExecutor] Recording task result and pushing branch on remote...',
+  ] as const;
 
   private readonly host: string;
   private readonly user: string;
@@ -258,11 +267,9 @@ STAGING_DIR="$INVOKER_HOME/runtime/ssh-executor/${stagingTokenExpression}"
 RUNNER_PATH="$STAGING_DIR/runner.sh"
 PAYLOAD_PATH="$STAGING_DIR/payload.sh"
 cleanup_runtime() {
-  local status="$1"
   trap - EXIT HUP INT TERM
   stop_bootstrap_heartbeat
   rm -rf "$STAGING_DIR" >/dev/null 2>&1 || true
-  exit "$status"
 }
 BOOTSTRAP_HEARTBEAT_PID=""
 INVOKER_HEARTBEAT_MARKER=${heartbeatMarker}
@@ -284,10 +291,14 @@ stop_bootstrap_heartbeat() {
     BOOTSTRAP_HEARTBEAT_PID=""
   fi
 }
-trap 'cleanup_runtime "$?"' EXIT
-trap 'cleanup_runtime 129' HUP
-trap 'cleanup_runtime 130' INT
-trap 'cleanup_runtime 143' TERM
+# On Ubuntu bash 5.2, bash -l -s can die with:
+#   pop_var_context: head of shell_variables not a function context
+# when an EXIT trap calls a shell function that itself runs exit.
+# Keep cleanup side-effect-only and let the shell preserve its own exit status.
+trap 'cleanup_runtime' EXIT
+trap 'cleanup_runtime; exit 129' HUP
+trap 'cleanup_runtime; exit 130' INT
+trap 'cleanup_runtime; exit 143' TERM
 rm -rf "$STAGING_DIR" 2>/dev/null || true
 mkdir -p "$STAGING_DIR"
 chmod 700 "$STAGING_DIR"
@@ -1072,10 +1083,16 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
           // capture the tail of the output buffer so the UI shows what went wrong.
           if (!mappedError && exitCode !== 0 && e) {
             const allOutput = e.outputBuffer.join('');
-            const lines = allOutput.split('\n');
-            const tail = lines.slice(-50).join('\n').trim();
-            if (tail) {
-              mappedError = tail.length > 3000 ? tail.slice(-3000) : tail;
+            const sanitizedOutput = this.stripFallbackBannerPreamble(allOutput);
+            const cleanupFallbackError = this.buildCleanupFallbackError(sanitizedOutput);
+            if (cleanupFallbackError) {
+              mappedError = cleanupFallbackError;
+            } else {
+              const lines = allOutput.split('\n');
+              const tail = lines.slice(-50).join('\n').trim();
+              if (tail) {
+                mappedError = tail.length > 3000 ? tail.slice(-3000) : tail;
+              }
             }
           }
 
@@ -1142,6 +1159,49 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
 
     this.startHeartbeat(executionId, child, { emitIntervalHeartbeat: false });
     return handle;
+  }
+
+  private stripFallbackBannerPreamble(output: string): string {
+    const lines = output.split('\n');
+    let index = 0;
+    while (index < lines.length) {
+      const trimmed = lines[index]?.trim() ?? '';
+      if (!trimmed) {
+        index += 1;
+        continue;
+      }
+      if (!SshExecutor.FALLBACK_BANNER_LINES.has(trimmed)) {
+        break;
+      }
+      index += 1;
+    }
+    const stripped = lines.slice(index).join('\n').trim();
+    return stripped || output.trim();
+  }
+
+  private hasCompletedAgentTurn(output: string): boolean {
+    return output.includes('"type":"turn.completed"')
+      || (output.includes('"type":"item.completed"') && output.includes('"type":"agent_message"'));
+  }
+
+  private hasExplicitFailurePayload(output: string): boolean {
+    return output.includes('"type":"turn.failed"') || output.includes('"type":"error"');
+  }
+
+  private buildCleanupFallbackError(output: string): string | undefined {
+    if (!this.hasCompletedAgentTurn(output) || this.hasExplicitFailurePayload(output)) {
+      return undefined;
+    }
+    if (!SshExecutor.CLEANUP_TAIL_MARKERS.some((marker) => output.includes(marker))) {
+      return undefined;
+    }
+    if (output.includes('pop_var_context')) {
+      return `${SshExecutor.CLEANUP_TAIL_PREFIX} bash pop_var_context after remote run completed.`;
+    }
+    if (output.includes('Orphan function call output')) {
+      return `${SshExecutor.CLEANUP_TAIL_PREFIX} orphan function-call output after remote run completed.`;
+    }
+    return `${SshExecutor.CLEANUP_TAIL_PREFIX} remote finalize wrapper output after remote run completed.`;
   }
 
 


### PR DESCRIPTION
## Summary

This changes how the SSH executor routes trailing remote shell output after a task turn has already finished.

Finished turns now stay on the completed-task result path instead of surfacing raw wrapper noise as the final task failure text.

## Review Claim

The SSH executor now routes post-turn remote shell tail output through the completed-task fallback path, so finished turns keep one concrete final error instead of leaking wrapper noise.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice only changes the SSH executor routing path and its directly affected test file, and it is covered by the focused executor test suite plus an execution-engine build.

## Slice Rationale

The lower slice captures the shell shape in isolation. This slice only changes the executor path that routes that remote tail into the final task result.

## Non-goals

This slice does not change SSH git identity provisioning, merge publishing, or worker behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node node_modules/.pnpm/vitest@3.2.4_@types+debug@4.1.13_@types+node@25.3.3_jiti@2.6.1_jsdom@25.0.1_yaml@2.8.2/node_modules/vitest/vitest.mjs run packages/execution-engine/src/__tests__/ssh-executor.test.ts`
- [x] `pnpm --filter @invoker/execution-engine build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
