### PR TITLE
[Onboarding Step 1: CLI one-shot setup](1) Cover setup GitHub auth checks

### DIFF
--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -550,6 +550,62 @@ describe('GitHub auth check', () => {
 });
 
 describe('setup oneshot ending', () => {
+  it('runs GitHub auth through the injected command runner', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'invoker-setup-gh-ok-'));
+    const lines: string[] = [];
+    const savedHome = process.env.HOME;
+    const calls: Array<{ command: string; args: readonly string[] }> = [];
+    try {
+      process.env.HOME = home;
+      const code = await runSetup([], {
+        print: (line) => lines.push(line),
+        prompt: async () => 'n',
+      }, {
+        isInstalled: () => true,
+        commandRunner: (command, args) => {
+          calls.push({ command, args });
+          return { status: 0, stdout: 'Logged in', stderr: '' };
+        },
+        smokePlanValidation: async () => okCheck('smoke-plan', 'Smoke plan validation', 'Parsed 1 task(s)'),
+      });
+
+      expect(code).toBe(0);
+      expect(calls).toEqual([{ command: 'gh', args: ['auth', 'status'] }]);
+      expect(lines.join('\n')).toContain('GitHub auth: gh is authenticated');
+      expect(lines.join('\n')).toContain("You're ready.");
+    } finally {
+      if (savedHome === undefined) delete process.env.HOME;
+      else process.env.HOME = savedHome;
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('surfaces injected GitHub auth failure in the final summary', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'invoker-setup-gh-fail-'));
+    const lines: string[] = [];
+    const savedHome = process.env.HOME;
+    try {
+      process.env.HOME = home;
+      const code = await runSetup([], {
+        print: (line) => lines.push(line),
+        prompt: async () => 'n',
+      }, {
+        isInstalled: () => true,
+        commandRunner: () => ({ status: 1, stdout: '', stderr: 'not logged in to any GitHub hosts' }),
+        smokePlanValidation: async () => okCheck('smoke-plan', 'Smoke plan validation', 'Parsed 1 task(s)'),
+      });
+
+      expect(code).toBe(1);
+      expect(lines.join('\n')).toContain('GitHub auth: not logged in to any GitHub hosts');
+      expect(lines.join('\n')).toContain('Fix this first: GitHub auth: not logged in to any GitHub hosts.');
+      expect(lines.join('\n')).toContain('gh auth login');
+    } finally {
+      if (savedHome === undefined) delete process.env.HOME;
+      else process.env.HOME = savedHome;
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it('selects the first error for Fix this first', () => {
     const checks: Check[] = [
       okCheck('a', 'A'),


### PR DESCRIPTION
## Summary

The onboarding test now covers the one-shot GitHub auth cases.

It proves injected runner result paths for ready and not-ready endings.

## Review Claim

The onboarding suite has focused proof for GitHub auth runner outcomes.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only changes the CLI onboarding test file; production setup behavior and user-facing output stay unchanged.

## Slice Rationale

This slice adds focused proof for already-present behavior without mixing product changes.

## Non-goals

This does not change setup output, GitHub auth behavior, Slack setup, config writes, or tool installation.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/cli exec vitest run src/__tests__/onboarding.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/onboarding-cli-one-shot-1.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/onboarding-cli-one-shot-1.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a305939ad`
- Post-revert steps: None
- Data migration? No

</details>
