### PR TITLE
[Remote Sync Step 1: Sync Schema and Change Journal](1) Add data-store sync schema and journal

### DIFF
--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createTaskState } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { WorkflowSaveInput } from '../adapter.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  readJournalSince,
+  setSyncCursor,
+} from '../sync-journal.js';
+
+type JournalDb =
+  Parameters<typeof appendJournalEntry>[0] &
+  Parameters<typeof readJournalSince>[0] &
+  Parameters<typeof getSyncCursor>[0] &
+  Parameters<typeof setSyncCursor>[0];
+
+describe('sync journal', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function db(): JournalDb {
+    return adapter as unknown as JournalDb;
+  }
+
+  function workflow(
+    id: string,
+    name = id,
+    createdAt = '2026-07-01T00:00:00.000Z',
+  ): WorkflowSaveInput {
+    return {
+      id,
+      name,
+      createdAt,
+      updatedAt: createdAt,
+    };
+  }
+
+  function saveWorkflowAndTask(workflowId = 'wf-1', taskId = 'task-1'): void {
+    adapter.saveWorkflow(workflow(workflowId));
+    adapter.saveTask(
+      workflowId,
+      createTaskState(taskId, `Task ${taskId}`, [], { workflowId }),
+    );
+  }
+
+  it('rolls back journal rows with the mutation transaction', () => {
+    saveWorkflowAndTask();
+
+    expect(() =>
+      adapter.runInTransaction(() => {
+        adapter.updateTask('task-1', { status: 'running' });
+        throw new Error('rollback sentinel');
+      }),
+    ).toThrow(/rollback sentinel/);
+
+    expect(adapter.loadTask('task-1')?.status).toBe('pending');
+    expect(readJournalSince(db(), 0, 10)).toEqual([]);
+  });
+
+  it('allocates strictly monotonic journal seq values', () => {
+    appendJournalEntry(db(), {
+      entityType: 'task',
+      entityId: 'task-1',
+      op: 'upsert',
+      payload: { id: 'task-1', status: 'running' },
+    });
+    appendJournalEntry(db(), {
+      entityType: 'attempt',
+      entityId: 'attempt-1',
+      op: 'upsert',
+      payload: { id: 'attempt-1', status: 'completed' },
+    });
+    appendJournalEntry(db(), {
+      entityType: 'event',
+      entityId: 'event-1',
+      op: 'upsert',
+      payload: { id: 1, event_type: 'task.completed' },
+    });
+
+    const rows = readJournalSince(db(), 0, 10);
+    expect(rows).toHaveLength(3);
+    expect(rows[1].seq).toBeGreaterThan(rows[0].seq);
+    expect(rows[2].seq).toBeGreaterThan(rows[1].seq);
+  });
+
+  it('reads journal rows after the supplied cursor', () => {
+    for (const id of ['one', 'two', 'three']) {
+      appendJournalEntry(db(), {
+        entityType: 'task',
+        entityId: id,
+        op: 'upsert',
+        payload: { id },
+      });
+    }
+
+    const allRows = readJournalSince(db(), 0, 10);
+    const afterSecond = readJournalSince(db(), allRows[1].seq, 10);
+
+    expect(afterSecond.map((row) => row.entityId)).toEqual(['three']);
+  });
+
+  it('sets and gets remote peer cursors', () => {
+    setSyncCursor(db(), {
+      peerId: 'remote-laptop',
+      lastSentSeq: 12,
+      lastReceivedSeq: 8,
+      updatedAt: '2026-07-01T00:00:01.000Z',
+    });
+
+    expect(getSyncCursor(db(), 'remote-laptop')).toEqual({
+      peerId: 'remote-laptop',
+      lastSentSeq: 12,
+      lastReceivedSeq: 8,
+      updatedAt: '2026-07-01T00:00:01.000Z',
+    });
+  });
+
+  it('excludes soft-deleted workflows by default but can include them', () => {
+    adapter.saveWorkflow(workflow('deleted-wf', 'Deleted'));
+    adapter.saveWorkflow(workflow('live-wf', 'Live', '2026-07-01T00:01:00.000Z'));
+
+    adapter.deleteWorkflow('deleted-wf');
+
+    expect(adapter.listWorkflows().map((wf) => wf.id)).toEqual(['live-wf']);
+    const withDeleted = adapter.listWorkflows({ includeDeleted: true });
+    expect(withDeleted.map((wf) => wf.id)).toEqual(['live-wf', 'deleted-wf']);
+    expect(withDeleted.find((wf) => wf.id === 'deleted-wf')?.deletedAt).toEqual(expect.any(Number));
+  });
+
+  it('writes a tombstone journal entry when a workflow is deleted', () => {
+    adapter.saveWorkflow(workflow('wf-delete'));
+
+    adapter.deleteWorkflow('wf-delete');
+
+    const [entry] = readJournalSince(db(), 0, 10);
+    expect(entry).toMatchObject({
+      entityType: 'workflow',
+      entityId: 'wf-delete',
+      op: 'tombstone',
+      origin: 'home',
+    });
+    expect(entry.payload).toMatchObject({
+      id: 'wf-delete',
+      deleted_at: expect.any(Number),
+    });
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -122,10 +122,15 @@ export interface Workflow {
   /** Read-only provenance for dependencies removed by `detachWorkflow`. Never re-read by scheduling. */
   detachedExternalDependencies?: DetachedExternalDependency[];
   generation?: number;
+  deletedAt?: number;
   createdAt: string;
   updatedAt: string;
 }
 export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup'>;
+
+export interface WorkflowListOptions {
+  includeDeleted?: boolean;
+}
 
 /**
  * Result of resolving a published PR back to its Invoker workflow via the merge
@@ -330,7 +335,7 @@ export interface PersistenceAdapter {
   saveWorkflow(workflow: WorkflowSaveInput): void;
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
   loadWorkflow(workflowId: string): Workflow | undefined;
-  listWorkflows(): Workflow[];
+  listWorkflows(options?: WorkflowListOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
   /** Resolve a GitHub PR number back to its Invoker workflow via the merge node. */
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined;
@@ -339,7 +344,7 @@ export interface PersistenceAdapter {
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
   loadTasks(workflowId: string): TaskState[];
-  loadWorkflowTaskSnapshot?(): WorkflowTaskSnapshot;
+  loadWorkflowTaskSnapshot?(options?: WorkflowListOptions): WorkflowTaskSnapshot;
   /** Authoritative single-task read by ID, suitable for recovery workflows. */
   loadTask(taskId: string): TaskState | undefined;
   /** Delete one task and its task-owned rows. */

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -7,3 +7,4 @@ export * from './slack-session-repository.js';
 export * from './slack-plan-draft-repository.js';
 export * from './sqlite-task-repository.js';
 export * from './workflow-channel-repository.js';
+export * from './sync-journal.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -57,6 +57,7 @@ import type {
   TerminalSessionRecord,
   InAppPlanningSessionPatch,
   InAppPlanningSessionRecord,
+  WorkflowListOptions,
 } from './adapter.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
 import { SCHEMA_DDL } from './sqlite-schema.js';
@@ -78,6 +79,7 @@ import type { SqliteExecutor } from './sqlite-executor.js';
 import * as migrations from './sqlite-migrations.js';
 import { SqliteTaskAttemptRepository } from './sqlite-task-attempt-repository.js';
 import { SqliteWorkflowRepository, type WorkflowMetadataChanges } from './sqlite-workflow-repository.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 function normalizeWorkerActionStatus(status: string): string {
   return status === 'canceled' ? 'cancelled' : status;
@@ -1054,8 +1056,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return this.workflowRepo.loadWorkflow(workflowId);
   }
 
-  listWorkflows(): Workflow[] {
-    return this.workflowRepo.listWorkflows();
+  listWorkflows(options?: WorkflowListOptions): Workflow[] {
+    return this.workflowRepo.listWorkflows(options);
   }
 
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
@@ -1066,8 +1068,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return this.workflowRepo.searchWorkflowsAndTasks(query, opts);
   }
 
-  loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
-    return this.workflowRepo.loadWorkflowTaskSnapshot();
+  loadWorkflowTaskSnapshot(options?: WorkflowListOptions): WorkflowTaskSnapshot {
+    return this.workflowRepo.loadWorkflowTaskSnapshot(options);
   }
 
   getLastWorkflowTaskSnapshotStats(): Record<string, unknown> | null {
@@ -1546,7 +1548,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   deleteWorkflow(workflowId: string): void {
+    const workflow = this.queryOne('SELECT * FROM workflows WHERE id = ? AND deleted_at IS NULL', [workflowId]);
+    if (!workflow) return;
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
+    const deletedAt = Date.now();
+    const updatedAt = new Date(deletedAt).toISOString();
     this.runTransaction(() => {
       this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
@@ -1587,7 +1593,16 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
+      this.db.run('UPDATE workflows SET deleted_at = ?, updated_at = ? WHERE id = ?', [deletedAt, updatedAt, workflowId]);
+      const payload = this.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+      if (payload) {
+        appendJournalEntry(this.executor, {
+          entityType: 'workflow',
+          entityId: workflowId,
+          op: 'tombstone',
+          payload,
+        });
+      }
     });
     this.removeOutputFiles(taskIds);
   }

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -47,6 +47,7 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
     externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
     detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) as DetachedExternalDependency[] : undefined,
     generation: row.generation ?? 0,
+    deletedAt: row.deleted_at ?? undefined,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -27,6 +27,7 @@ export const SCHEMA_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       );
@@ -508,6 +509,23 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_terminal_sessions_status_updated
         ON terminal_sessions(status, updated_at);
 
+      CREATE TABLE IF NOT EXISTS sync_journal (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+        entity_id TEXT NOT NULL,
+        op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+        payload TEXT NOT NULL CHECK (json_valid(payload)),
+        origin TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_cursors (
+        peer_id TEXT PRIMARY KEY,
+        last_sent_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_sent_seq) = 'integer' AND last_sent_seq >= 0),
+        last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
     `;
 
 /** Idempotent `ALTER TABLE ... ADD COLUMN` migrations for older databases. */
@@ -591,6 +609,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
+  'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
 ];
 
 /**
@@ -622,6 +641,21 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  `CREATE TABLE IF NOT EXISTS sync_journal (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+    entity_id TEXT NOT NULL,
+    op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    origin TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`,
+  `CREATE TABLE IF NOT EXISTS sync_cursors (
+    peer_id TEXT PRIMARY KEY,
+    last_sent_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_sent_seq) = 'integer' AND last_sent_seq >= 0),
+    last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`,
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */
@@ -645,6 +679,7 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       )
@@ -656,12 +691,12 @@ export const WORKFLOWS_REBUILD_INSERT_DDL = `
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       FROM workflows
     `;

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -17,6 +17,7 @@ import {
 import { mapRowToTask, mapRowToAttempt } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
@@ -299,7 +300,6 @@ export class SqliteTaskAttemptRepository {
     }
 
     if (changes.execution) {
-      this.syncCrashPreservationState(taskId, beforeTask, changes.execution);
       const execution = changes.execution as Record<string, unknown>;
       const execMap: Record<string, string> = {
         blockedBy: 'blocked_by',
@@ -385,7 +385,14 @@ export class SqliteTaskAttemptRepository {
       execution: changes.execution ? { ...beforeTask.execution, ...changes.execution } : beforeTask.execution,
     });
 
-    if (setClauses.length === 0) return;
+    if (setClauses.length === 0) {
+      if (changes.execution) {
+        this.exec.runTransaction(() => {
+          this.syncCrashPreservationState(taskId, beforeTask, changes.execution ?? {});
+        });
+      }
+      return;
+    }
 
     // Atomically bump task-state version with every mutation
     setClauses.push('task_state_version = task_state_version + 1');
@@ -417,7 +424,24 @@ export class SqliteTaskAttemptRepository {
       const cols = setClauses.map((c) => c.split(/\s*=\s*/)[0]!.trim()).join(', ');
       console.log(`[persist-sql] taskId=${taskId} columns=[${cols}]`);
     }
-    this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    const shouldJournalStatusChange = changes.status !== undefined && changes.status !== beforeTask.status;
+    this.exec.runTransaction(() => {
+      if (changes.execution) {
+        this.syncCrashPreservationState(taskId, beforeTask, changes.execution);
+      }
+      this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
+      if (shouldJournalStatusChange) {
+        const payload = this.exec.queryOne('SELECT * FROM tasks WHERE id = ?', [taskId]);
+        if (payload) {
+          appendJournalEntry(this.exec, {
+            entityType: 'task',
+            entityId: taskId,
+            op: 'upsert',
+            payload,
+          });
+        }
+      }
+    });
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -460,6 +484,7 @@ export class SqliteTaskAttemptRepository {
       FROM tasks t${this.taskSelectJoin('t')}
       JOIN workflows w ON w.id = t.workflow_id
       WHERE t.status = 'completed'
+        AND w.deleted_at IS NULL
       ORDER BY t.completed_at DESC
     `);
     return rows.map((row) => ({
@@ -481,7 +506,8 @@ export class SqliteTaskAttemptRepository {
         FROM events
         GROUP BY task_id
       ) e ON e.task_id = t.id
-      WHERE COALESCE(e.event_count, 0) > 0 OR t.status != 'pending'
+      WHERE w.deleted_at IS NULL
+        AND (COALESCE(e.event_count, 0) > 0 OR t.status != 'pending')
       ORDER BY COALESCE(e.max_created_at, t.completed_at, t.started_at, t.created_at) DESC
     `);
     return rows.map((row) => {
@@ -594,40 +620,51 @@ export class SqliteTaskAttemptRepository {
   // ── Attempt CRUD ─────────────────────────────────────────
 
   saveAttempt(attempt: Attempt): void {
-    this.exec.execRun(`
-      INSERT OR REPLACE INTO attempts (
-        id, node_id, attempt_number, queue_priority, status,
-        snapshot_commit, base_branch, upstream_attempt_ids,
-        command_override, prompt_override,
-        claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
-        branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
-        supersedes_attempt_id, created_at, merge_conflict
-      ) VALUES (
-        ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?,
-        ?, ?,
-        ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?, ?,
-        ?, ?, ?
-      )
-    `, [
-      attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
-      attempt.snapshotCommit ?? null, attempt.baseBranch ?? null,
-      JSON.stringify(attempt.upstreamAttemptIds),
-      attempt.commandOverride ?? null, attempt.promptOverride ?? null,
-      attempt.claimedAt?.toISOString() ?? null,
-      attempt.startedAt?.toISOString() ?? null,
-      attempt.completedAt?.toISOString() ?? null,
-      attempt.exitCode ?? null, attempt.error ?? null,
-      attempt.lastHeartbeatAt?.toISOString() ?? null,
-      attempt.leaseExpiresAt?.toISOString() ?? null,
-      attempt.branch ?? null, attempt.commit ?? null, attempt.summary ?? null,
-      attempt.workspacePath ?? null, attempt.agentSessionId ?? null,
-      attempt.containerId ?? null,
-      attempt.supersedesAttemptId ?? null,
-      attempt.createdAt.toISOString(),
-      attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
-    ]);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`
+        INSERT OR REPLACE INTO attempts (
+          id, node_id, attempt_number, queue_priority, status,
+          snapshot_commit, base_branch, upstream_attempt_ids,
+          command_override, prompt_override,
+          claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
+          branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
+          supersedes_attempt_id, created_at, merge_conflict
+        ) VALUES (
+          ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?,
+          ?, ?,
+          ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?,
+          ?, ?, ?
+        )
+      `, [
+        attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
+        attempt.snapshotCommit ?? null, attempt.baseBranch ?? null,
+        JSON.stringify(attempt.upstreamAttemptIds),
+        attempt.commandOverride ?? null, attempt.promptOverride ?? null,
+        attempt.claimedAt?.toISOString() ?? null,
+        attempt.startedAt?.toISOString() ?? null,
+        attempt.completedAt?.toISOString() ?? null,
+        attempt.exitCode ?? null, attempt.error ?? null,
+        attempt.lastHeartbeatAt?.toISOString() ?? null,
+        attempt.leaseExpiresAt?.toISOString() ?? null,
+        attempt.branch ?? null, attempt.commit ?? null, attempt.summary ?? null,
+        attempt.workspacePath ?? null, attempt.agentSessionId ?? null,
+        attempt.containerId ?? null,
+        attempt.supersedesAttemptId ?? null,
+        attempt.createdAt.toISOString(),
+        attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
+      ]);
+      const payload = this.exec.queryOne('SELECT * FROM attempts WHERE id = ?', [attempt.id]);
+      if (payload) {
+        appendJournalEntry(this.exec, {
+          entityType: 'attempt',
+          entityId: attempt.id,
+          op: 'upsert',
+          payload,
+        });
+      }
+    });
   }
 
   loadAttempts(nodeId: string): Attempt[] {
@@ -689,6 +726,9 @@ export class SqliteTaskAttemptRepository {
   }
 
   updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void {
+    const beforeAttempt = this.loadAttempt(attemptId);
+    if (!beforeAttempt) return;
+
     const setClauses: string[] = [];
     const values: unknown[] = [];
 
@@ -711,7 +751,25 @@ export class SqliteTaskAttemptRepository {
 
     if (setClauses.length === 0) return;
     values.push(attemptId);
-    this.exec.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    const shouldJournalCompletion =
+      changes.completedAt !== undefined ||
+      (changes.status !== undefined &&
+        changes.status !== beforeAttempt.status &&
+        (changes.status === 'completed' || changes.status === 'failed'));
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
+      if (shouldJournalCompletion) {
+        const payload = this.exec.queryOne('SELECT * FROM attempts WHERE id = ?', [attemptId]);
+        if (payload) {
+          appendJournalEntry(this.exec, {
+            entityType: 'attempt',
+            entityId: attemptId,
+            op: 'upsert',
+            payload,
+          });
+        }
+      }
+    });
   }
 
   claimAttemptForLaunch(

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -27,6 +27,7 @@ import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ReviewGateLookup,
   Workflow,
+  WorkflowListOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
 } from './adapter.js';
@@ -175,15 +176,16 @@ export class SqliteWorkflowRepository {
   }
 
   loadWorkflow(workflowId: string): Workflow | undefined {
-    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ? AND deleted_at IS NULL', [workflowId]);
     if (!row) return undefined;
     const rollup = this.loadWorkflowRollups([workflowId]).get(workflowId);
     return this.rowToWorkflow(row, rollup);
   }
 
-  listWorkflows(): Workflow[] {
+  listWorkflows(options?: WorkflowListOptions): Workflow[] {
+    const where = options?.includeDeleted ? '' : 'WHERE deleted_at IS NULL';
     const rows = this.exec.queryAll(
-      'SELECT * FROM workflows ORDER BY created_at DESC',
+      `SELECT * FROM workflows ${where} ORDER BY created_at DESC`,
     );
     const workflowIds = rows.map((row) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
@@ -205,7 +207,9 @@ export class SqliteWorkflowRepository {
               w.base_branch AS baseBranch
          FROM tasks t
          JOIN workflows w ON w.id = t.workflow_id
-        WHERE t.is_merge_node = 1 AND (t.review_id = ? OR t.review_url LIKE ?)`,
+        WHERE w.deleted_at IS NULL
+          AND t.is_merge_node = 1
+          AND (t.review_id = ? OR t.review_url LIKE ?)`,
       [pr, `%/pull/${pr}`],
     );
     if (rows.length === 0) return undefined;
@@ -257,7 +261,8 @@ export class SqliteWorkflowRepository {
     if (type === 'workflows' || type === 'all') {
       const workflows = this.exec.queryAll(
         `SELECT id, name, description, plan_file, repo_url, branch, created_at FROM workflows 
-         WHERE name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ? 
+         WHERE deleted_at IS NULL
+           AND (name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{ id: string; name?: string | null; created_at: string }>;
@@ -281,8 +286,11 @@ export class SqliteWorkflowRepository {
     
     if (type === 'tasks' || type === 'all') {
       const tasks = this.exec.queryAll(
-        `SELECT id, workflow_id, description, command, prompt, summary, problem, approach, test_plan, repro_command, status, created_at FROM tasks 
-         WHERE description LIKE ? OR command LIKE ? OR prompt LIKE ? OR summary LIKE ? OR problem LIKE ? OR approach LIKE ? OR test_plan LIKE ? OR repro_command LIKE ? 
+        `SELECT t.id, t.workflow_id, t.description, t.command, t.prompt, t.summary, t.problem, t.approach, t.test_plan, t.repro_command, t.status, t.created_at
+         FROM tasks t
+         JOIN workflows w ON w.id = t.workflow_id
+         WHERE w.deleted_at IS NULL
+           AND (t.description LIKE ? OR t.command LIKE ? OR t.prompt LIKE ? OR t.summary LIKE ? OR t.problem LIKE ? OR t.approach LIKE ? OR t.test_plan LIKE ? OR t.repro_command LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{
@@ -298,7 +306,7 @@ export class SqliteWorkflowRepository {
       if (workflowIds.length > 0) {
         const placeholders = workflowIds.map(() => '?').join(',');
         const workflowRows = this.exec.queryAll(
-          `SELECT id, name FROM workflows WHERE id IN (${placeholders})`,
+          `SELECT id, name FROM workflows WHERE deleted_at IS NULL AND id IN (${placeholders})`,
           workflowIds
         ) as Array<{ id: string; name?: string | null }>;
         for (const wf of workflowRows) {
@@ -323,13 +331,20 @@ export class SqliteWorkflowRepository {
     return results;
   }
 
-  loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
+  loadWorkflowTaskSnapshot(options?: WorkflowListOptions): WorkflowTaskSnapshot {
     const totalStartedAt = Date.now();
     const workflowQueryStartedAt = Date.now();
-    const workflowRows = this.exec.queryAll('SELECT * FROM workflows ORDER BY created_at DESC');
+    const workflowWhere = options?.includeDeleted ? '' : 'WHERE deleted_at IS NULL';
+    const workflowRows = this.exec.queryAll(`SELECT * FROM workflows ${workflowWhere} ORDER BY created_at DESC`);
     const workflowMetadataQueryMs = Date.now() - workflowQueryStartedAt;
     const taskQueryStartedAt = Date.now();
-    const taskRows = this.exec.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC');
+    const taskRows = this.exec.queryAll(options?.includeDeleted
+      ? 'SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC'
+      : `SELECT t.*
+           FROM tasks t
+           JOIN workflows w ON w.id = t.workflow_id
+          WHERE w.deleted_at IS NULL
+          ORDER BY t.workflow_id ASC, t.id ASC`);
     const taskQueryMs = Date.now() - taskQueryStartedAt;
     const tasksByWorkflowId = new Map<string, TaskState[]>();
     const workflowIds = workflowRows.map((row) => String(row.id));

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -1,0 +1,147 @@
+import type { SqliteExecutor } from './sqlite-executor.js';
+
+export const SYNC_JOURNAL_ENTITY_TYPES = [
+  'workflow',
+  'task',
+  'attempt',
+  'event',
+  // Reserved for output sync metadata. High-volume output spool rows are not
+  // journaled until the transport/compaction design exists.
+  'output',
+] as const;
+
+export type SyncJournalEntityType = (typeof SYNC_JOURNAL_ENTITY_TYPES)[number];
+export type SyncJournalOperation = 'upsert' | 'tombstone';
+
+export interface SyncJournalEntryInput {
+  entityType: SyncJournalEntityType;
+  entityId: string;
+  op: SyncJournalOperation;
+  payload: unknown;
+  origin?: string;
+  createdAt?: string;
+}
+
+export interface SyncJournalEntry {
+  seq: number;
+  entityType: SyncJournalEntityType;
+  entityId: string;
+  op: SyncJournalOperation;
+  payload: unknown;
+  origin: string;
+  createdAt: string;
+}
+
+export interface SyncCursor {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt: string;
+}
+
+export interface SyncCursorInput {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt?: string;
+}
+
+type SyncJournalDb = Pick<SqliteExecutor, 'execRun' | 'queryAll' | 'queryOne'>;
+
+export function appendJournalEntry(db: SyncJournalDb, entry: SyncJournalEntryInput): void {
+  const payloadJson = JSON.stringify(entry.payload);
+  if (payloadJson === undefined) {
+    throw new Error('sync journal payload must be JSON-serializable');
+  }
+  db.execRun(
+    `INSERT INTO sync_journal (
+      entity_type,
+      entity_id,
+      op,
+      payload,
+      origin,
+      created_at
+    ) VALUES (?, ?, ?, ?, ?, ?)`,
+    [
+      entry.entityType,
+      entry.entityId,
+      entry.op,
+      payloadJson,
+      entry.origin ?? 'home',
+      entry.createdAt ?? new Date().toISOString(),
+    ],
+  );
+}
+
+export function readJournalSince(
+  db: Pick<SqliteExecutor, 'queryAll'>,
+  seq: number,
+  limit: number,
+): SyncJournalEntry[] {
+  const boundedLimit = Math.max(0, Math.trunc(limit));
+  if (boundedLimit === 0) return [];
+  const rows = db.queryAll(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq > ?
+      ORDER BY seq ASC
+      LIMIT ?`,
+    [Math.max(0, Math.trunc(seq)), boundedLimit],
+  );
+  return rows.map(mapJournalRow);
+}
+
+export function getSyncCursor(
+  db: Pick<SqliteExecutor, 'queryOne'>,
+  peerId: string,
+): SyncCursor | undefined {
+  const row = db.queryOne(
+    `SELECT peer_id, last_sent_seq, last_received_seq, updated_at
+       FROM sync_cursors
+      WHERE peer_id = ?`,
+    [peerId],
+  );
+  return row ? mapCursorRow(row) : undefined;
+}
+
+export function setSyncCursor(db: Pick<SqliteExecutor, 'execRun'>, cursor: SyncCursorInput): void {
+  db.execRun(
+    `INSERT INTO sync_cursors (
+      peer_id,
+      last_sent_seq,
+      last_received_seq,
+      updated_at
+    ) VALUES (?, ?, ?, ?)
+    ON CONFLICT(peer_id) DO UPDATE SET
+      last_sent_seq = excluded.last_sent_seq,
+      last_received_seq = excluded.last_received_seq,
+      updated_at = excluded.updated_at`,
+    [
+      cursor.peerId,
+      cursor.lastSentSeq,
+      cursor.lastReceivedSeq,
+      cursor.updatedAt ?? new Date().toISOString(),
+    ],
+  );
+}
+
+function mapJournalRow(row: Record<string, unknown>): SyncJournalEntry {
+  return {
+    seq: Number(row.seq),
+    entityType: String(row.entity_type) as SyncJournalEntityType,
+    entityId: String(row.entity_id),
+    op: String(row.op) as SyncJournalOperation,
+    payload: JSON.parse(String(row.payload)),
+    origin: String(row.origin),
+    createdAt: String(row.created_at),
+  };
+}
+
+function mapCursorRow(row: Record<string, unknown>): SyncCursor {
+  return {
+    peerId: String(row.peer_id),
+    lastSentSeq: Number(row.last_sent_seq),
+    lastReceivedSeq: Number(row.last_received_seq),
+    updatedAt: String(row.updated_at),
+  };
+}


### PR DESCRIPTION
## Summary

Remote sync gets a first durable SQLite contract for replaying local state changes.

The data store now records sync journal entries, peer cursors, and workflow tombstones alongside the mutations that create them.

Tombstoned workflows stay hidden from normal reads while their sync record remains available for replay.

## Review Claim

The data-store sync schema and journal helpers safely capture task, attempt, and workflow tombstone changes in SQLite.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The change stays inside the data-store persistence layer, keeps default workflow reads excluding deleted rows, and writes journal rows in the same SQLite transaction as their source mutation.

## Slice Rationale

Remote sync needs the durable schema, cursors, and tombstone records before any transport or remote replay path can consume them.

## Non-goals

- No remote transport is added.
- No sync replay or conflict resolution is added.
- No UI, API, or executor behavior is changed.

## Architecture

### Before

```mermaid
graph TD
    A["SQLite task, attempt, and workflow mutations"] --> B["Current data-store tables only"]
    C["Workflow delete"] --> D["Hard-delete workflow row and task-owned rows"]
```

### After

```mermaid
graph TD
    A["SQLite task, attempt, and workflow mutations"] --> B["Current data-store tables"]
    A --> C["sync_journal rows with monotonic seq"]
    D["Workflow delete"] --> E["deleted_at tombstone row"]
    D --> F["sync_journal tombstone entry"]
    G["Remote peer progress"] --> H["sync_cursors"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sync-journal.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, before remote sync transport depends on these tables.
- Revert command: `git revert <sha>`
- Post-revert steps: Remove any local sync_journal and sync_cursors tables from development databases if needed.
- Data migration? Yes, this adds SQLite tables and a nullable workflows.deleted_at column.

</details>
