### PR TITLE
[Planning tmux output survives Home/Planning switches](1) Add surface-switch regression

### DIFF
--- a/packages/ui/src/__tests__/planning-terminal-tmux.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-tmux.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const xtermMock = vi.hoisted(() => {
+  type DataHandler = (data: string) => void;
+
+  const instances: MockTerminal[] = [];
+  const fitInstances: MockFitAddon[] = [];
+  const writeLog: string[] = [];
+
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    dataHandler: DataHandler | null = null;
+    loadAddon = vi.fn();
+    open = vi.fn((host: HTMLElement) => {
+      const terminalElement = document.createElement('div');
+      terminalElement.className = 'xterm';
+      terminalElement.textContent = 'mock terminal';
+      host.appendChild(terminalElement);
+    });
+    write = vi.fn((data: string) => {
+      writeLog.push(data);
+    });
+    onData = vi.fn((cb: DataHandler) => {
+      this.dataHandler = cb;
+      return { dispose: vi.fn() };
+    });
+    focus = vi.fn();
+    refresh = vi.fn();
+    dispose = vi.fn();
+
+    constructor() {
+      instances.push(this);
+    }
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+
+    constructor() {
+      fitInstances.push(this);
+    }
+  }
+
+  return {
+    Terminal: MockTerminal,
+    FitAddon: MockFitAddon,
+    instances,
+    fitInstances,
+    writeLog,
+    reset: () => {
+      instances.length = 0;
+      fitInstances.length = 0;
+      writeLog.length = 0;
+    },
+  };
+});
+
+vi.mock('xterm', () => ({ Terminal: xtermMock.Terminal }));
+vi.mock('xterm-addon-fit', () => ({ FitAddon: xtermMock.FitAddon }));
+
+const { App } = await import('../App.js');
+
+describe('planning terminal tmux', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+    xtermMock.reset();
+  });
+
+  it.fails('restores planning tmux output emitted while the planning terminal surface is hidden', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'plan-hidden-output',
+          title: 'Hidden output tmux session',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          terminalMode: 'tmux',
+          terminalSessionId: 'term-hidden-output',
+          terminalStatus: 'running',
+          terminalOutputSnapshot: 'VISIBLE_BEFORE_HIDE\n',
+          updatedAt: '2026-07-28T00:00:00.000Z',
+        }),
+        makePlanningSessionSummary({
+          id: 'plan-other-output',
+          title: 'Other tmux session',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          terminalMode: 'tmux',
+          terminalSessionId: 'rotated-terminal-id-from-event',
+          terminalStatus: 'running',
+          terminalOutputSnapshot: 'OTHER_VISIBLE\n',
+          updatedAt: '2026-07-28T00:00:00.000Z',
+        }),
+      ],
+    })) as any;
+
+    render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+
+    await waitFor(() => expect(mock.api.onTerminalOutput).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-tmux-pane')).toHaveAttribute(
+        'data-session-id',
+        'term-hidden-output',
+      );
+      expect(xtermMock.writeLog).toContain('VISIBLE_BEFORE_HIDE\n');
+    });
+
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+    await screen.findByRole('heading', { name: 'Plan graph' });
+    await waitFor(() => {
+      expect(screen.queryByTestId('invoker-terminal-tmux-pane')).not.toBeInTheDocument();
+    });
+
+    await act(async () => {
+      mock.fireTerminalOutput({
+        sessionId: 'rotated-terminal-id-from-event',
+        taskId: 'planning:plan-hidden-output',
+        kind: 'planning',
+        planningSessionId: 'plan-hidden-output',
+        data: 'HIDDEN_MATCHED_BY_PLANNING_ID\n',
+      });
+      mock.fireTerminalOutput({
+        sessionId: 'term-hidden-output',
+        taskId: 'planning:plan-hidden-output',
+        kind: 'planning',
+        data: 'HIDDEN_MATCHED_BY_TERMINAL_ID\n',
+      });
+    });
+    expect(xtermMock.writeLog.some((entry) => entry.includes('HIDDEN_MATCHED_BY_PLANNING_ID'))).toBe(false);
+    expect(xtermMock.writeLog.some((entry) => entry.includes('HIDDEN_MATCHED_BY_TERMINAL_ID'))).toBe(false);
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-tmux-pane')).toHaveAttribute(
+        'data-session-id',
+        'term-hidden-output',
+      );
+      expect(xtermMock.writeLog.some((entry) => entry.includes('HIDDEN_MATCHED_BY_PLANNING_ID\n'))).toBe(true);
+      expect(xtermMock.writeLog.some((entry) => entry.includes('HIDDEN_MATCHED_BY_TERMINAL_ID\n'))).toBe(true);
+    });
+    expect(mock.api.planningTerminalOpen).not.toHaveBeenCalled();
+
+    xtermMock.writeLog.length = 0;
+    fireEvent.click(screen.getByText('Other tmux session'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-tmux-pane')).toHaveAttribute(
+        'data-session-id',
+        'rotated-terminal-id-from-event',
+      );
+      expect(xtermMock.writeLog.join('')).toContain('OTHER_VISIBLE\n');
+    });
+    expect(xtermMock.writeLog.join('')).not.toContain('HIDDEN_MATCHED_BY_PLANNING_ID\n');
+  });
+});


### PR DESCRIPTION
## Summary

This adds focused renderer coverage for the Home and Planning switch path.

The test records the hidden-output leak as an expected failure until the behavior slice fixes it.

It covers output matched by planning id, terminal id, and a colliding terminal id from another planning session.

## Review Claim

Approve the expected-failure regression for Planning tmux output across Home/Planning switches.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds a renderer regression test marked `it.fails`, so CI stays green before the behavior fix lands.

## Slice Rationale

The regression lands before the behavior change so reviewers can see the broken contract before approving the fix.

## Non-goals

- Do not change planning terminal runtime behavior.
- Do not change task terminal behavior.
- Do not alter backend tmux session lifecycle or IPC contracts.

## Visual Proof

![Walkthrough: Planning tmux pane replays output that arrived while hidden across a Home to Planning to Home switch](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-67fbfa/planning-tmux-hidden-output-restored-walkthrough.gif)

The animation shows the Planning tmux pane remounting with hidden output restored after switching surfaces. The session-collision case is covered by the focused renderer test.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/planning-terminal-tmux.test.tsx`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/planning-tmux-pr1.md --base master`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/planning-tmux-pr1.md --require-visual-proof`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert fa60493a4`
- Post-revert steps: rerun `pnpm --filter @invoker/ui exec vitest run src/__tests__/planning-terminal-tmux.test.tsx`
- Data migration? No

</details>

## Workflow Summary

Planning tmux output survives Home/Planning switches - 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784340495515-7/implement-planning-tmux-history-sync | Keep planning tmux output snapshot in renderer state while the Planning surface is hidden, so remount restores scrollback/history | completed |
| wf-1784340495515-7/verify-planning-tmux-surface-switch-regression | Run focused UI regression test for planning tmux history across sidebar surface switches | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784340495515-7/implement-planning-tmux-history-sync - Keep planning tmux output snapshot in renderer state while the Planning surface is hidden, so remount restores scrollback/history

packages/ui/src/App.tsx | 28 +++--

### wf-1784340495515-7/verify-planning-tmux-surface-switch-regression - Run focused UI regression test for planning tmux history across sidebar surface switches

packages/ui/src/__tests__/planning-terminal-tmux.test.tsx | 177 +++++++++++++++++++++

</details>
