### PR TITLE
[Bugfix: planning submit-only contract](1) Tighten planning skill policy

### DIFF
--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -63,8 +63,8 @@ Use this mode when invoked by the installed command or MCP prompt. Do not use th
 - Prefer the MCP review/submission flow when available: call `invoker_prepare_plan_review`, show its ordered steps plus `confirmationText`, then call `invoker_submit_plan` only after approval unless the review result carries `confirmationMode: auto_submit`.
 - In an Invoker source checkout, still run `bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>` before the final submission step.
 - Outside an Invoker source checkout, `invoker_prepare_plan_review` is the canonical review surface and `invoker_validate_plan` remains an optional diagnostic, not the approval gate.
-- Plain approval stops after workflow handoff: submit the reviewed workflow plan, report the submitted workflow status, and stop. That approval does not authorize GitHub PR creation, PR updates, or `mergify stack push`.
-- Later PR publication is a separate explicit action. If the request involves creating, updating, publishing, or splitting pull requests or PR stacks, first read and follow `skills/make-pr/SKILL.md` (or `skill://make-pr/SKILL.md` when available) before PR authoring or publication.
+- Plain approval stops after workflow handoff: treat approval of the Markdown/YAML plan as authorization to submit the reviewed workflow plan to Invoker only, then report the submitted workflow status and stop. Stop after `invoker_submit_plan` or the documented `invoker-cli run ... --live` fallback; do not create, update, publish pull requests, or run `mergify stack push` from that approval alone.
+- Later PR publication is a separate explicit action. When the user separately asks about creating, updating, publishing, or splitting pull requests or PR stacks after workflow handoff, first read and follow `skills/make-pr/SKILL.md` (or `skill://make-pr/SKILL.md` when available) before PR authoring or publication.
 - If the request involves multiple review slices, first read and follow `skills/review-compression/SKILL.md` (or `skill://review-compression/SKILL.md` when available) before writing workflow YAML.
 
 ## Intended flow (do not skip steps)
@@ -75,7 +75,7 @@ Use this mode when invoked by the installed command or MCP prompt. Do not use th
 3. Runtime verification (Phase 1b): run the cheapest deterministic command that exercises the behavior, plus Invoker headless when applicable.
 4. Generate implementation YAML from verified facts — prefer rendering a matching formula (`skills/plan-to-invoker/formulas/`) and specializing its slots over authoring the shape from scratch.
 5. Validate with deterministic scripts.
-6. Present plan and submit on confirmation.
+6. Present plan and submit on confirmation. That confirmation authorizes workflow handoff only; later PR publication requires a separate explicit request.
 
 Grep-only checks are Phase 1a only; behavioral claims require executed Phase 1b evidence.
 


### PR DESCRIPTION
## Summary

Plain plan approval now stops at the Invoker workflow handoff.

The planning skill still documents later PR publication, but only as a separate explicit action.

## Review Claim

The plan-to-invoker policy now separates workflow handoff approval from later PR publication.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The diff only changes `skills/plan-to-invoker/SKILL.md`; runtime code and checked examples stay unchanged in this slice.

## Slice Rationale

This slice updates the main handoff policy before narrower entry, fixture, and guard changes.

## Non-goals

No installed handoff entry changes.
No dogfood fixture changes.
No checked guard changes.
No runtime code changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-plan-to-invoker-skill.sh && bash skills/plan-to-invoker/scripts/test-fixtures.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 385345db9`
- Post-revert steps: Rerun `bash scripts/test-plan-to-invoker-skill.sh && bash skills/plan-to-invoker/scripts/test-fixtures.sh`.
- Data migration? No

</details>
