### PR TITLE
[Bugfix: planning submit-only contract](2) Tighten handoff entry wording

### DIFF
--- a/skills/plan-to-invoker/commands/invoker-plan-to-invoker.md
+++ b/skills/plan-to-invoker/commands/invoker-plan-to-invoker.md
@@ -4,6 +4,7 @@ argument-hint: "help me plan <change>"
 ---
 
 Use this host's native planning mode when the host supports entering it from this command. If the host cannot be switched by this command, do a read-only planning pass and do not edit product code before the plan is approved.
+Plain approval stops after workflow handoff: submit the approved workflow and do not publish local branches, create PRs, or update PR stacks unless the user explicitly asks for PR publication.
 If the request involves creating, updating, publishing, or splitting pull requests or PR stacks, first read and follow `skill://make-pr/SKILL.md` before PR authoring or publication. If it involves multiple review slices, first read and follow `skill://review-compression/SKILL.md` before writing workflow YAML.
 
 


### PR DESCRIPTION
## Summary

Plain approval now reads as handoff only in the installed entry.

Local PR branch publication is named as a separate explicit request.

## Review Claim

The installed handoff entry now presents plain approval as workflow handoff only.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

The diff only changes `skills/plan-to-invoker/commands/invoker-plan-to-invoker.md`; runtime code and checked guards stay unchanged in this slice.

## Slice Rationale

This entry wording slice keeps the user-facing handoff text aligned without bundling the main policy or fixture updates.

## Non-goals

No planning skill changes.
No dogfood fixture changes.
No checked guard changes.
No runtime code changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-plan-to-invoker-skill.sh && bash skills/plan-to-invoker/scripts/test-fixtures.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1e3920638`
- Post-revert steps: Rerun `bash scripts/test-plan-to-invoker-skill.sh && bash skills/plan-to-invoker/scripts/test-fixtures.sh`.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that plain approval ends after workflow handoff.
  - Specified that publishing branches, creating pull requests, or updating pull request stacks requires explicit user approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->