### PR TITLE
[Planning terminal adverse proof harness](1) Add focused adverse repro tests

### DIFF
--- a/packages/app/src/__tests__/planning-terminal-restore-invariants.repro.test.ts
+++ b/packages/app/src/__tests__/planning-terminal-restore-invariants.repro.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { InAppPlanningSessionRecord } from '@invoker/data-store';
+import { PlanConversation } from '../../../surfaces/src/index.ts';
+import {
+  bindPlanningTerminalSessionState,
+} from '../terminal-session-ipc.js';
+import {
+  createInAppPlanningChatSessions,
+  restorePlanningChatSessions,
+  type InAppPlanningChatSession,
+} from '../in-app-planner.js';
+
+const now = '2026-07-26T00:00:00.000Z';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function planningRecord(overrides: Partial<InAppPlanningSessionRecord>): InAppPlanningSessionRecord {
+  return {
+    id: 'session-1',
+    title: 'Planning session',
+    presetKey: 'codex',
+    status: 'still_discussing',
+    messages: [],
+    pendingResponse: false,
+    createdAt: now,
+    updatedAt: now,
+    terminalMode: 'chat',
+    terminalOutputSnapshot: '',
+    ...overrides,
+  };
+}
+
+function planningSession(overrides: Partial<InAppPlanningChatSession>): InAppPlanningChatSession {
+  return {
+    id: 'session-1',
+    title: 'Planning session',
+    presetKey: 'codex',
+    status: 'still_discussing',
+    messages: [],
+    conversation: {} as InAppPlanningChatSession['conversation'],
+    createdAt: now,
+    updatedAt: now,
+    nextMessageId: 1,
+    terminalMode: 'chat',
+    terminalOutputSnapshot: '',
+    ...overrides,
+  };
+}
+
+describe('planning-terminal restore invariants repro', () => {
+  it('skips missing presets while restoring remapped/custom preset sessions with terminal state intact', async () => {
+    const init = vi.spyOn(PlanConversation.prototype, 'init').mockResolvedValue(undefined);
+    const sessions = createInAppPlanningChatSessions();
+
+    await restorePlanningChatSessions([
+      planningRecord({
+        id: 'removed-preset-chat',
+        presetKey: 'removed-preset',
+        title: 'Removed preset chat',
+      }),
+      planningRecord({
+        id: 'remapped-preset-chat',
+        presetKey: 'legacy-remapped',
+        title: 'Remapped preset chat',
+        terminalMode: 'tmux',
+        terminalSessionId: 'term-remapped',
+        terminalStatus: 'running',
+        terminalOutputSnapshot: 'restored output',
+      }),
+    ], {
+      config: {
+        slackHarnessPresets: {
+          'legacy-remapped': { tool: 'codex' },
+        },
+      },
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder: vi.fn(() => ({ command: 'planner', args: [] })),
+    });
+
+    expect(init).toHaveBeenCalledTimes(1);
+    expect(sessions.has('removed-preset-chat')).toBe(false);
+    expect(sessions.get('remapped-preset-chat')).toMatchObject({
+      id: 'remapped-preset-chat',
+      presetKey: 'legacy-remapped',
+      terminalMode: 'tmux',
+      terminalSessionId: 'term-remapped',
+      terminalStatus: 'running',
+      terminalOutputSnapshot: 'restored output',
+    });
+  });
+
+  // `it.fails`: this asserts the desired tmux restore invariant. Startup should
+  // not resurrect submitted planning tmux sessions, and chat-mode records remain
+  // chat-only even if stale terminal ids are present.
+  it.fails('does not restore submitted or chat-mode planning tmux sessions on startup', () => {
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('submitted-tmux', planningSession({
+      id: 'submitted-tmux',
+      status: 'submitted',
+      submittedWorkflowId: 'wf-submitted',
+      submittedPlanName: 'Submitted Plan',
+      terminalMode: 'tmux',
+      terminalSessionId: 'term-submitted',
+      terminalStatus: 'running',
+    }));
+    sessions.set('chat-with-stale-terminal', planningSession({
+      id: 'chat-with-stale-terminal',
+      terminalMode: 'chat',
+      terminalSessionId: 'term-chat-stale',
+      terminalStatus: 'running',
+    }));
+    sessions.set('active-tmux', planningSession({
+      id: 'active-tmux',
+      terminalMode: 'tmux',
+      terminalSessionId: 'term-active',
+      terminalStatus: 'running',
+      terminalOutputSnapshot: 'active output',
+    }));
+
+    const restoreSpawnSession = vi.fn();
+    const binding = bindPlanningTerminalSessionState({
+      embeddedTerminalManager: {
+        on: vi.fn(),
+        restoreSpawnSession,
+      } as any,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+      planningChatSessions: sessions,
+      getPlanningSessionStore: () => undefined,
+      repoRoot: '/repo',
+    });
+
+    binding.restorePersistedPlanningTerminals();
+
+    expect(restoreSpawnSession).toHaveBeenCalledTimes(1);
+    expect(restoreSpawnSession).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'term-active',
+      taskId: 'planning:active-tmux',
+      kind: 'planning',
+      planningSessionId: 'active-tmux',
+      outputSnapshot: 'active output',
+    }));
+  });
+});

--- a/packages/ui/src/__tests__/planning-terminal-preset-switch-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-preset-switch-repro.test.tsx
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const xtermMock = vi.hoisted(() => {
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    loadAddon = vi.fn();
+    open = vi.fn((host: HTMLElement) => {
+      const terminalElement = document.createElement('div');
+      terminalElement.className = 'xterm';
+      host.appendChild(terminalElement);
+    });
+    write = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    focus = vi.fn();
+    dispose = vi.fn();
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+  }
+
+  return {
+    Terminal: MockTerminal,
+    FitAddon: MockFitAddon,
+  };
+});
+
+vi.mock('xterm', () => ({ Terminal: xtermMock.Terminal }));
+vi.mock('xterm-addon-fit', () => ({ FitAddon: xtermMock.FitAddon }));
+
+const { App } = await import('../App.js');
+
+describe('planning-terminal preset ownership repros', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  async function openPlanningTerminal() {
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+    if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+    fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toBeInTheDocument();
+    });
+  }
+
+  function submitPlanningText(text: string) {
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+  }
+
+  // `it.fails`: this asserts the desired chat ownership invariant. Switching
+  // between saved planning chats should put the composer preset back on the
+  // selected chat's persisted preset before the next send.
+  it.fails('keeps chat-to-chat preset switching owned by the selected planning session', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'claude-chat',
+          title: 'Claude chat',
+          status: 'still_discussing',
+          presetKey: 'omp+claude',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          messages: [{ id: 1, role: 'user', text: 'Use Claude', createdAt: '2026-07-26T00:00:02.000Z' }],
+          updatedAt: '2026-07-26T00:00:02.000Z',
+        }),
+        makePlanningSessionSummary({
+          id: 'codex-chat',
+          title: 'Codex chat',
+          status: 'still_discussing',
+          presetKey: 'codex',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          messages: [{ id: 1, role: 'user', text: 'Use Codex', createdAt: '2026-07-26T00:00:01.000Z' }],
+          updatedAt: '2026-07-26T00:00:01.000Z',
+        }),
+      ],
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    const selector = screen.getByTestId('invoker-terminal-harness');
+    await waitFor(() => expect(selector).toHaveValue('omp+claude'));
+
+    const sessionButtons = within(screen.getByTestId('planning-session-list')).getAllByRole('button');
+    fireEvent.click(sessionButtons.find((button) => button.textContent?.includes('Codex chat'))!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+    });
+
+    submitPlanningText('continue the codex chat');
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        sessionId: 'codex-chat',
+        message: 'continue the codex chat',
+        presetKey: 'codex',
+      });
+    });
+  });
+
+  // `it.fails`: this asserts the desired local-chat preset invariant. If a user
+  // changes the composer preset before opening tmux, the app session created for
+  // the tmux handoff should use that currently selected preset.
+  it.fails('uses a preset changed before tmux open when creating the backing planning session', async () => {
+    mock.api.planningChatCreate = vi.fn(async ({ presetKey }: { presetKey?: string }) => ({
+      ok: true,
+      session: makePlanningSessionSummary({
+        id: 'created-for-tmux',
+        title: 'Tmux handoff',
+        status: 'still_discussing',
+        presetKey: presetKey ?? 'codex',
+        draftPlanAvailable: false,
+        draftPlanSummary: undefined,
+        draftPlanText: undefined,
+      }),
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
+    fireEvent.change(screen.getByTestId('invoker-terminal-harness'), { target: { value: 'omp+claude' } });
+    fireEvent.click(screen.getByRole('tab', { name: 'Tmux' }));
+
+    await waitFor(() => {
+      expect(mock.api.planningChatCreate).toHaveBeenCalledWith({
+        presetKey: 'omp+claude',
+        title: 'Untitled plan',
+      });
+    });
+    expect(mock.api.planningTerminalOpen).toHaveBeenCalledWith('created-for-tmux');
+  });
+});

--- a/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const xtermMock = vi.hoisted(() => {
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    loadAddon = vi.fn();
+    open = vi.fn((host: HTMLElement) => {
+      const terminalElement = document.createElement('div');
+      terminalElement.className = 'xterm';
+      host.appendChild(terminalElement);
+    });
+    write = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    focus = vi.fn();
+    dispose = vi.fn();
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+  }
+
+  return {
+    Terminal: MockTerminal,
+    FitAddon: MockFitAddon,
+  };
+});
+
+vi.mock('xterm', () => ({ Terminal: xtermMock.Terminal }));
+vi.mock('xterm-addon-fit', () => ({ FitAddon: xtermMock.FitAddon }));
+
+const { App } = await import('../App.js');
+
+describe('planning-terminal failed first-send session id repro', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  async function openPlanningTerminal() {
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+    if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+    fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+    });
+  }
+
+  function submitPlanningText(text: string) {
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+  }
+
+  // `it.fails`: this asserts the desired identity-handoff invariant. A failed
+  // first send can still create a durable app session; the renderer should adopt
+  // that real id so the retry stays in the same conversation.
+  it.fails('persists the real sessionId from a failed first planner response before retrying', async () => {
+    mock.api.planningChatSend = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        sessionId: 'real-session-after-failure',
+        error: 'planner exited before replying',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        sessionId: 'real-session-after-failure',
+        reply: 'Recovered in the original failed session.',
+        draftPlanAvailable: false,
+      }) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft the first plan');
+    await screen.findByText('planner exited before replying');
+
+    submitPlanningText('retry in the same session');
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledTimes(2);
+      expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
+        sessionId: 'real-session-after-failure',
+        message: 'retry in the same session',
+        presetKey: 'codex',
+      });
+    });
+  });
+});

--- a/packages/ui/src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+import type { TerminalSessionDescriptor } from '@invoker/contracts';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const xtermMock = vi.hoisted(() => {
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    loadAddon = vi.fn();
+    open = vi.fn((host: HTMLElement) => {
+      const terminalElement = document.createElement('div');
+      terminalElement.className = 'xterm';
+      host.appendChild(terminalElement);
+    });
+    write = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    focus = vi.fn();
+    dispose = vi.fn();
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+  }
+
+  return {
+    Terminal: MockTerminal,
+    FitAddon: MockFitAddon,
+  };
+});
+
+vi.mock('xterm', () => ({ Terminal: xtermMock.Terminal }));
+vi.mock('xterm-addon-fit', () => ({ FitAddon: xtermMock.FitAddon }));
+
+const { App } = await import('../App.js');
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+describe('planning-terminal startup hydrate race repro', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  // `it.fails`: this asserts the desired startup invariant. The current UI has
+  // two independent planning hydrate paths, so a fast chat-list response can
+  // render a saved tmux conversation as chat before terminal hydration catches up.
+  it.fails('does not render a saved tmux planning session through a chat-only intermediate state', async () => {
+    const terminalList = deferred<TerminalSessionDescriptor[]>();
+    const restoredSession = makePlanningSessionSummary({
+      id: 'saved-tmux-plan',
+      title: 'Saved tmux plan',
+      status: 'still_discussing',
+      presetKey: 'codex',
+      draftPlanAvailable: false,
+      draftPlanSummary: undefined,
+      draftPlanText: undefined,
+      terminalMode: 'tmux',
+      terminalSessionId: 'term-saved-tmux-plan',
+      terminalStatus: 'running',
+      terminalOutputSnapshot: 'already running',
+    });
+
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [restoredSession],
+    })) as any;
+    mock.api.planningTerminalList = vi.fn(() => terminalList.promise) as any;
+
+    render(<App />);
+
+    expect(await screen.findByText('Saved tmux plan')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Tmux' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.queryByTestId('invoker-terminal-empty-hero')).not.toBeInTheDocument();
+
+    terminalList.resolve([
+      {
+        sessionId: 'term-saved-tmux-plan',
+        taskId: 'planning:saved-tmux-plan',
+        kind: 'planning',
+        planningSessionId: 'saved-tmux-plan',
+        status: 'running',
+        mode: 'spawn',
+        attached: false,
+        createdAt: '2026-07-26T00:00:00.000Z',
+        outputSnapshot: 'already running',
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-tmux-pane')).toHaveTextContent('already running');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add focused repro coverage for planning-terminal lifecycle failures.

The tests isolate delayed hydrate restore, failed first-send identity, session-owned preset selection, and restore invariants.

They do not change product behavior.

## Review Claim

The repo gains focused adverse repro tests for the planning-terminal restore, session-id, preset-switch, and tmux ownership failure classes.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice adds only focused repro tests under `packages/ui/src/__tests__/` and `packages/app/src/__tests__/`; planning-terminal product code is unchanged.

## Slice Rationale

The repro files land before the runner so reviewers can inspect each adverse case before approving the runner.

## Non-goals

No product-code changes in `packages/ui/src/App.tsx`, `packages/app/src/in-app-planner.ts`, `packages/app/src/terminal-session-ipc.ts`, or persistence adapters.

No shell runner changes in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx src/__tests__/planning-terminal-session-id-persist-repro.test.tsx src/__tests__/planning-terminal-preset-switch-repro.test.tsx`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/planning-terminal-restore-invariants.repro.test.ts`

</details>

## Visual Proof

![Focused adverse repro test output](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-1ade06/planning-terminal-adverse-repro-tests-proof.svg)

The image shows the focused adverse repro run passing in this checkout.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f47e40743341bb846151ce44c41fa19c2e0674d3`
- Post-revert steps: Re-run `bash scripts/run-planning-terminal-adverse-loop.sh` after reverting the stack tip if it remains present.
- Data migration? No

</details>
