### PR TITLE
[Planning terminal adverse proof harness](2) Add deterministic adverse-loop runner

### DIFF
--- a/scripts/run-planning-terminal-adverse-loop.sh
+++ b/scripts/run-planning-terminal-adverse-loop.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+pnpm --filter @invoker/ui exec vitest run \
+  src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx \
+  src/__tests__/planning-terminal-session-id-persist-repro.test.tsx \
+  src/__tests__/planning-terminal-preset-switch-repro.test.tsx
+
+pnpm --filter @invoker/app exec vitest run \
+  src/__tests__/planning-terminal-restore-invariants.repro.test.ts


### PR DESCRIPTION
## Summary

Add a repo-root adverse-loop script for the planning-terminal proof matrix.

The script runs only the focused UI and app repro files added below it in the stack.

## Review Claim

The repo gains a deterministic runner that executes the focused planning-terminal adverse repro matrix.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice touches only `scripts/run-planning-terminal-adverse-loop.sh`; product code and repro test logic are unchanged.

## Slice Rationale

The runner lands after the repro files so reviewers can first inspect the adverse cases and then review the wrapper command.

## Non-goals

No product-code changes.

No new repro scenarios beyond the focused files added in the previous slice.

No broader workspace suite wiring.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/run-planning-terminal-adverse-loop.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5c60912f69c1c5e3fa7fd5391b36e199c686403e`
- Post-revert steps: Run the focused UI and app vitest commands directly if the repro tests remain in the stack.
- Data migration? No

</details>
