### PR TITLE
[Bugfix: main-process planner surfaces lazy-load](1) Defer planner surfaces load

### DIFF
--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -39,7 +39,6 @@ import {
   summarizePlanText,
   type PlanningMessage,
 } from '@invoker/planning-core';
-import { selectHarnessSessionDriver } from '@invoker/surfaces';
 import type { HarnessPreset, PlanConversation, PlanConversationConfig, PlanningCommandBuilder } from '@invoker/surfaces';
 import type { InvokerConfig } from './config.js';
 
@@ -108,12 +107,20 @@ function isModuleResolutionError(error: unknown): boolean {
 }
 
 type PlanConversationConstructor = new (config: PlanConversationConfig) => PlanConversation;
+type SelectHarnessSessionDriver = (
+  preset: HarnessPreset,
+  deps: {
+    executionAgentRegistry?: Pick<AgentRegistry, 'get'>;
+    planningCommandBuilder?: PlanningCommandBuilder;
+  },
+) => PlanConversationConfig['harnessSessionDriver'];
 
 interface PlannerSurfacesModule {
   BUILTIN_HARNESS_PRESETS: Record<string, HarnessPreset>;
   DEFAULT_HARNESS_PRESET: string;
   PlanConversation: PlanConversationConstructor;
   extractYamlPlan: (output: string) => string | null;
+  selectHarnessSessionDriver: SelectHarnessSessionDriver;
 }
 
 async function loadPlannerSurfaces(): Promise<PlannerSurfacesModule> {
@@ -343,6 +350,7 @@ function planConversationConfig(
   preset: HarnessPreset,
   deps: Pick<InAppPlannerDeps, 'config' | 'workingDir' | 'planningCommandBuilder' | 'executionAgentRegistry' | 'conversationRepo' | 'onRawPlannerOutput'>,
   threadTs: string,
+  selectHarnessSessionDriver: SelectHarnessSessionDriver,
   options: { conversationalPlanning?: boolean } = {},
 ): PlanConversationConfig {
   return {
@@ -388,7 +396,7 @@ async function createSession(
     return { error: `Unknown planner preset "${presetKey}".` };
   }
 
-  const { PlanConversation } = await loadPlannerSurfaces();
+  const { PlanConversation, selectHarnessSessionDriver } = await loadPlannerSurfaces();
   const createdAt = new Date().toISOString();
   const id = randomUUID();
   const session: InAppPlanningChatSession = {
@@ -397,7 +405,7 @@ async function createSession(
     presetKey,
     status: 'still_discussing',
     messages: [],
-    conversation: new PlanConversation(planConversationConfig(preset, deps, id, { conversationalPlanning: true })),
+    conversation: new PlanConversation(planConversationConfig(preset, deps, id, selectHarnessSessionDriver, { conversationalPlanning: true })),
     createdAt,
     updatedAt: createdAt,
     nextMessageId: 1,
@@ -445,8 +453,8 @@ export async function planFromGoal(
   }
 
   try {
-    const { PlanConversation, extractYamlPlan } = await loadPlannerSurfaces();
-    const conversation = new PlanConversation(planConversationConfig(preset, deps, randomUUID()));
+    const { PlanConversation, extractYamlPlan, selectHarnessSessionDriver } = await loadPlannerSurfaces();
+    const conversation = new PlanConversation(planConversationConfig(preset, deps, randomUUID(), selectHarnessSessionDriver));
     const plannerOutput = await conversation.sendMessage(goal);
     const planText = extractYamlPlan(plannerOutput);
     if (!planText) {
@@ -769,13 +777,13 @@ export async function restorePlanningChatSessions(
   // boots without surfaces/dist, so an eager load here would crash startup with no sessions.
   if (records.length === 0) return;
   const presets = await resolveHarnessPresets(deps.config);
-  const { PlanConversation } = await loadPlannerSurfaces();
+  const { PlanConversation, selectHarnessSessionDriver } = await loadPlannerSurfaces();
 
   for (const record of records) {
     const preset = presets[record.presetKey];
     if (!preset) continue;
 
-    const conversation = new PlanConversation(planConversationConfig(preset, deps, record.id));
+    const conversation = new PlanConversation(planConversationConfig(preset, deps, record.id, selectHarnessSessionDriver));
     await conversation.init();
 
     const nextMessageId = Math.max(0, ...record.messages.map((message) => message.id)) + 1;


### PR DESCRIPTION
## Summary

The planner module no longer imports `@invoker/surfaces` while the app main process is loading.

Surfaces runtime access now goes through the existing lazy loader before planning code needs it.

This keeps startup able to reach the fallback path when surfaces has no usable runtime entry.

## Review Claim

The planning module no longer resolves `@invoker/surfaces` at module load, so desktop startup can reach the lazy fallback path instead of crashing first.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Session creation, restore, submit, and tmux state behavior stay unchanged except for deferring when the surfaces package is resolved.

## Slice Rationale

One behavior slice changes the runtime load boundary in `in-app-planner.ts` and keeps proof execution out of the product diff.

## Non-goals

No planning UX changes, no new preset behavior, no unrelated startup logging, and no proof harness changes.

## Architecture

### Before

```mermaid
graph TD
    A["main.ts imports in-app-planner.js"] --> B["in-app-planner.js resolves @invoker/surfaces during module evaluation"]
    B --> C["startup can fail before the planner lazy fallback path"]
```

### After

```mermaid
graph TD
    A["main.ts imports in-app-planner.js"] --> B["in-app-planner.js evaluates without resolving @invoker/surfaces"]
    B --> C["planner sessions resolve surfaces through loadPlannerSurfaces() only when needed"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] Temporary bundle proof and focused planner restore tests:

```bash
set -eu
mkdir -p .tmp
TMP=$(mktemp -d ./.tmp/verify-main-process-surfaces.XXXXXX)
trap 'rm -rf "$TMP"' EXIT
cat > "$TMP/tsup.config.ts" <<EOF
import { defineConfig } from "tsup";

export default defineConfig({
  entry: ["packages/app/src/in-app-planner.ts"],
  format: ["cjs"],
  platform: "node",
  bundle: true,
  splitting: false,
  sourcemap: false,
  clean: true,
  outDir: "${TMP}/out",
  external: ["@invoker/surfaces"],
  noExternal: [
    "@invoker/contracts",
    "@invoker/data-store",
    "@invoker/execution-engine",
    "@invoker/planning-core"
  ]
});
EOF
pnpm exec tsup --config "$TMP/tsup.config.ts"
node - "$TMP/out/in-app-planner.js" <<'NODE'
const fs = require("node:fs");
const bundlePath = process.argv[2];
const bundle = fs.readFileSync(bundlePath, "utf8");
if (bundle.includes('require("@invoker/surfaces")')) {
  throw new Error('bundle still contains a top-level require("@invoker/surfaces")');
}
NODE
node "$TMP/out/in-app-planner.js"
pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts -t "restores draft-ready sessions and submits from persisted approved draft text|restores persisted tmux mode and planning-owned terminal state|clears submitted pending-response state during restore"
```

- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-body-bugfix-main-process-planner-surfaces-lazy-load-1.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-body-bugfix-main-process-planner-surfaces-lazy-load-1.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a1cdda8746a0bfa1352cfc2254b2ac57dda1bc2b`
- Post-revert steps: Rerun the focused planner restore tests if the startup path changes again.
- Data migration? No

</details>
