### PR TITLE
[Authoritative task-graph snapshots](1) Sync owner task snapshots

### DIFF
--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -27,7 +27,7 @@ function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQuer
     getWorkerStatus: vi.fn(() => ({ generatedAt: 'now', workers: [] })),
     getWorkers: vi.fn(() => ({ generatedAt: 'workers-now', workers: [] })),
     getWorkflowStatus: vi.fn(() => ({ 'wf-1': 'running' })),
-    getTasksSnapshot: vi.fn(({ refresh }) => ({ tasks: [], workflows: [], refreshed: refresh })),
+    getTasksSnapshot: vi.fn(() => ({ tasks: [], workflows: [], synced: true })),
     getActionGraphSnapshot: vi.fn(() => ({ nodes: [] })),
     listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
     loadWorkflowBundle: vi.fn((id: string) => ({ workflow: { id }, tasks: [] })),
@@ -76,12 +76,11 @@ describe('answerOwnerReadQuery', () => {
     expect(answerOwnerReadQuery({ kind: 'action-graph' }, h)).toEqual({ nodes: [] });
   });
 
-  it('refreshes the snapshot only for task-graph-refresh', () => {
+  it('routes both task snapshot kinds to the authoritative snapshot handler', () => {
     const h = makeHandlers();
-    expect(answerOwnerReadQuery({ kind: 'tasks' }, h)).toMatchObject({ refreshed: false });
-    expect(answerOwnerReadQuery({ kind: 'task-graph-refresh' }, h)).toMatchObject({ refreshed: true });
-    expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(1, { refresh: false });
-    expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(2, { refresh: true });
+    expect(answerOwnerReadQuery({ kind: 'tasks' }, h)).toMatchObject({ synced: true });
+    expect(answerOwnerReadQuery({ kind: 'task-graph-refresh' }, h)).toMatchObject({ synced: true });
+    expect(h.getTasksSnapshot).toHaveBeenCalledTimes(2);
   });
 
   it('wraps and routes the param-bearing read kinds', () => {
@@ -170,7 +169,11 @@ describe('buildOwnerReadQueryHandlers', () => {
       },
     };
   }
-  function build(orch: Record<string, unknown> = {}, persist: Record<string, unknown> = {}) {
+  function build(
+    orch: Record<string, unknown> = {},
+    persist: Record<string, unknown> = {},
+    deps: Record<string, unknown> = {},
+  ) {
     const f = fakes();
     return buildOwnerReadQueryHandlers({
       ownerModeLabel: 'gui',
@@ -183,6 +186,7 @@ describe('buildOwnerReadQueryHandlers', () => {
       orchestrator: { ...f.orchestrator, ...orch } as never,
       persistence: { ...f.persistence, ...persist } as never,
       getActionGraphSnapshot: () => ({ ag: 1 }),
+      ...deps,
     });
   }
 
@@ -218,17 +222,28 @@ describe('buildOwnerReadQueryHandlers', () => {
     expect(build().getReviewGate('missing')).toBeNull();
   });
 
-  it('getTasksSnapshot refreshes only when asked', () => {
+  it.each(['tasks', 'task-graph-refresh'] as const)('%s syncs before returning the owner task snapshot', (kind) => {
     const syncAllFromDb = vi.fn();
-    const h = build({ syncAllFromDb });
-    expect(h.getTasksSnapshot({ refresh: false })).toEqual({
+    const getAllTasks = vi.fn(() => [{ id: 't' }]);
+    const listWorkflows = vi.fn(() => [{ id: 'wf' }]);
+    const getStreamSequence = vi.fn(() => 5);
+    const resolveInvokerHomeRoot = vi.fn(() => '/home');
+    const h = build(
+      { syncAllFromDb, getAllTasks },
+      { listWorkflows },
+      { getStreamSequence, resolveInvokerHomeRoot },
+    );
+    expect(answerOwnerReadQuery({ kind }, h)).toEqual({
       tasks: [{ id: 't' }],
       workflows: [{ id: 'wf' }],
       streamSequence: 5,
       invokerHomeRoot: '/home',
     });
-    expect(syncAllFromDb).not.toHaveBeenCalled();
-    h.getTasksSnapshot({ refresh: true });
     expect(syncAllFromDb).toHaveBeenCalledTimes(1);
+    const syncOrder = syncAllFromDb.mock.invocationCallOrder[0];
+    expect(syncOrder).toBeLessThan(getAllTasks.mock.invocationCallOrder[0]);
+    expect(syncOrder).toBeLessThan(listWorkflows.mock.invocationCallOrder[0]);
+    expect(syncOrder).toBeLessThan(getStreamSequence.mock.invocationCallOrder[0]);
+    expect(syncOrder).toBeLessThan(resolveInvokerHomeRoot.mock.invocationCallOrder[0]);
   });
 });

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -42,7 +42,7 @@ export interface OwnerReadQueryHandlers {
   getWorkerStatus: () => WorkerStatusSnapshot;
   getWorkers: () => WorkerStatusSnapshot;
   getWorkflowStatus: (workflowId?: string) => Record<string, unknown>;
-  getTasksSnapshot: (opts: { refresh: boolean }) => Record<string, unknown>;
+  getTasksSnapshot: () => Record<string, unknown>;
   getActionGraphSnapshot: () => Record<string, unknown>;
   listWorkflows: () => unknown[];
   loadWorkflowBundle: (workflowId: string) => Record<string, unknown>;
@@ -123,9 +123,8 @@ export function answerOwnerReadQuery(
     case 'workflow-status':
       return handlers.getWorkflowStatus(body.workflowId);
     case 'tasks':
-      return handlers.getTasksSnapshot({ refresh: false });
     case 'task-graph-refresh':
-      return handlers.getTasksSnapshot({ refresh: true });
+      return handlers.getTasksSnapshot();
     case 'action-graph':
       return handlers.getActionGraphSnapshot();
     case 'workflows':
@@ -236,8 +235,8 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     listWorkerActionHistory: (request: WorkerActionHistoryRequest) => listWorkerActionHistory(persistence, request),
     listWorkerDecisions: (request: WorkerDecisionsRequest) => listWorkerDecisions(persistence, request),
     getWorkflowStatus: (workflowId?: string) => orchestrator.getWorkflowStatus(workflowId) as unknown as Record<string, unknown>,
-    getTasksSnapshot: ({ refresh }) => {
-      if (refresh) orchestrator.syncAllFromDb();
+    getTasksSnapshot: () => {
+      orchestrator.syncAllFromDb();
       return {
         tasks: orchestrator.getAllTasks(),
         workflows: persistence.listWorkflows(),


### PR DESCRIPTION
## Summary

Owner task snapshots now sync from SQLite before returning tasks and workflow metadata.

That makes plain `tasks` and `task-graph-refresh` share one fresh owner snapshot behavior.

## Review Claim

Owner task snapshot requests now use one sync-then-return path, so plain `tasks` cannot return outdated in-memory task state.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The slice only changes the owner read-query handler and its focused tests; renderer bridge, UI, mutation, and transport code stay unchanged.

## Slice Rationale

Detached-viewer hydration depends on owner `tasks` snapshots, so this owner-only request path lands before renderer bridge behavior changes.

## Non-goals

No renderer bridge changes.

No selected-workflow UI retention logic changes.

No workflow metadata shape changes.

No mutation path changes.

## Architecture

### Before

`tasks` could return the owner in-memory task set without first syncing from SQLite.

`task-graph-refresh` could force a database sync before returning similar snapshot data.

### After

Both owner snapshot requests call the same snapshot handler, and that handler syncs before returning tasks and workflows.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/owner-read-query.test.ts`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/owner-read-query.test.ts src/__tests__/ipc-read-handlers.test.ts src/__tests__/web-invoker-dispatch.test.ts`
- [x] `cd packages/ui && pnpm test -- src/__tests__/selected-workflow-graph-disappears-repro.test.tsx src/__tests__/selected-workflow-selection-steal-repro.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert da10acdcc`
- Post-revert steps: Re-run the focused app snapshot tests.
- Data migration? No

</details>
