### PR TITLE
[CI Fix Step 1 - Lockfile Freeze Gate](1) Complete empty Invoker review branches

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -4140,6 +4140,88 @@ console.log(JSON.stringify(out));
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
     });
 
+    it('completes an empty Invoker external_review branch without publishing a make-pr stack', async () => {
+      const mergeTask = makeTask({
+        id: '__merge__wf-1',
+        status: 'running',
+        dependencies: ['t1'],
+        config: { isMergeNode: true, workflowId: 'wf-1' },
+      });
+      const allTasks = [
+        makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),
+        mergeTask,
+      ];
+      const orchestrator = {
+        getTask: (id: string) => allTasks.find(t => t.id === id),
+        getAllTasks: () => allTasks,
+        handleWorkerResponse: vi.fn(() => []),
+        setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
+      };
+      const persistence = {
+        loadWorkflow: () => ({
+          id: 'wf-1',
+          onFinish: 'none',
+          mergeMode: 'external_review',
+          baseBranch: 'master',
+          featureBranch: 'plan/empty',
+          name: 'Empty Invoker Workflow',
+          repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+        }),
+        updateTask: vi.fn(),
+      };
+      const mergeGateProvider = {
+        createReview: vi.fn(),
+      };
+      const onComplete = vi.fn();
+      const executor = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+        callbacks: { onComplete },
+        mergeGateProvider: mergeGateProvider as any,
+      });
+
+      const gitCalls: string[][] = [];
+      (executor as any).execGitReadonly = async () => '';
+      (executor as any).execGitIn = async (args: string[], _dir: string) => {
+        gitCalls.push([...args]);
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'base-sha';
+        if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2] === 'refs/remotes/origin/master^{commit}') {
+          return 'origin-base-sha';
+        }
+        if (args[0] === 'diff' && args[1] === '--name-only') return '';
+        return '';
+      };
+      (executor as any).createMergeWorktree = vi.fn().mockResolvedValue('/tmp/mock-wt');
+      (executor as any).removeMergeWorktree = vi.fn();
+      (executor as any).publishReviewStackWithMakePrSkill = vi.fn();
+      (executor as any).authorPrBodyWithSkill = vi.fn();
+
+      await (executor as any).executeMergeNode(mergeTask);
+
+      expect(gitCalls).toContainEqual(['diff', '--name-only', 'refs/remotes/origin/master...plan/empty', '--']);
+      expect((executor as any).publishReviewStackWithMakePrSkill).not.toHaveBeenCalled();
+      expect((executor as any).authorPrBodyWithSkill).not.toHaveBeenCalled();
+      expect(mergeGateProvider.createReview).not.toHaveBeenCalled();
+      expect(orchestrator.setTaskReviewReady).not.toHaveBeenCalled();
+      expect(orchestrator.handleWorkerResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'completed',
+          outputs: expect.objectContaining({
+            exitCode: 0,
+            branch: 'plan/empty',
+          }),
+        }),
+      );
+      expect(onComplete).toHaveBeenCalledWith(
+        '__merge__wf-1',
+        expect.objectContaining({ status: 'completed' }),
+      );
+    });
+
     it('executeMergeNode anchors external_review gate worktrees on the origin-backed base branch', async () => {
       const allTasks = [
         makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -258,6 +258,44 @@ async function syncGateWorkspaceToFeatureBranch(
   await execGitInMergeSafe(host, ['checkout', featureBranch], gateWorkspacePath);
 }
 
+async function listReviewableChangedFiles(
+  host: MergeRunnerHost,
+  dir: string,
+  baseBranch: string,
+  featureBranch: string,
+): Promise<string[]> {
+  const normalizedBase = normalizeBranchForGithubCli(baseBranch);
+  let diffBaseRef = baseBranch;
+  for (const candidate of [
+    `refs/remotes/origin/${normalizedBase}`,
+    `origin/${normalizedBase}`,
+    baseBranch,
+  ]) {
+    try {
+      const resolved = (await execGitInMergeSafe(
+        host,
+        ['rev-parse', '--verify', `${candidate}^{commit}`],
+        dir,
+      )).trim();
+      if (resolved) {
+        diffBaseRef = candidate;
+        break;
+      }
+    } catch {
+      // Try the next base spelling.
+    }
+  }
+  const out = await execGitInMergeSafe(
+    host,
+    ['diff', '--name-only', `${diffBaseRef}...${featureBranch}`, '--'],
+    dir,
+  );
+  return out
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
 // ── Host interface ───────────────────────────────────────
 
 /**
@@ -847,6 +885,50 @@ export async function runMergeGateActionImpl(
           featureBranch,
         });
         await syncGateWorkspaceToFeatureBranch(host, gateWorkspacePath, featureBranch);
+
+        if (isInvokerRepoUrl(workflow?.repoUrl)) {
+          const changedFiles = await listReviewableChangedFiles(
+            host,
+            gateWorkspacePath!,
+            baseBranch,
+            featureBranch,
+          );
+          if (changedFiles.length === 0) {
+            logTaskProgress(host, task.id, 'info', 'Skipping review stack publication for empty Invoker branch', {
+              baseBranch,
+              featureBranch,
+            });
+            mergeTrace('GATE_WS_PATH_REVIEW_PUBLISH_NOOP', {
+              taskId: task.id,
+              gateWorkspacePath: gateWorkspacePath ?? null,
+              baseBranch,
+              featureBranch,
+              onFinish,
+              mergeMode,
+            });
+            response = {
+              requestId: `merge-${task.id}`,
+              actionId: task.id,
+              executionGeneration: task.execution.generation ?? 0,
+              status: 'completed',
+              outputs: { exitCode: 0, summary, branch: featureBranch },
+            };
+            return {
+              response,
+              taskChanges: {
+                config: { summary },
+                execution: {
+                  branch: featureBranch,
+                  workspacePath: gateWorkspacePath,
+                  reviewUrl: undefined,
+                  reviewId: undefined,
+                  reviewStatus: undefined,
+                  reviewGate: undefined,
+                },
+              },
+            };
+          }
+        }
 
         const expectedGeneration = task.execution.generation ?? 0;
         let fullSummary = summary;


### PR DESCRIPTION
## Summary

CI Fix Step 1 - Lockfile Freeze Gate now completes empty Invoker review branches before external publication starts.

This prevents a completed no-op workflow from entering review-ready state with no reviewable diff.

## Review Claim

The review gate publication route now completes empty Invoker branches before external publication is invoked.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The branch comparison runs after the gate workspace is synced and before publication. It only exits early when the feature branch has no changed files.

## Slice Rationale

Keep this in one review gate slice so reviewers can check the routing decision and the state update together.

## Non-goals

- No changes to review body authoring.
- No changes to non-Invoker repositories.
- No changes to lockfile content or package management.
- No UI behavior changes.

## Architecture

### Before

```mermaid
graph TD
    A["Gate workspace is synced"] --> B["Review stack publication starts"]
    B --> C["Task enters review-ready state"]
```

### After

```mermaid
graph TD
    A["Gate workspace is synced"] --> B["Changed files are checked"]
    B --> C["Review stack publication starts when files changed"]
    B --> D["Task completes when branch is empty"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- --run src/__tests__/task-runner.test.ts -t "completes an empty Invoker external_review branch without publishing a make-pr stack"`
- [ ] `pnpm --filter @invoker/execution-engine test -- --run src/__tests__/task-runner.test.ts` (fails in existing post-start lineage guard tests outside this slice)
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-ci-fix-step-1-body.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/invoker-ci-fix-step-1-body.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert HEAD`
- Post-revert steps: None
- Data migration? No

</details>
