### PR TITLE
[Authoritative task-graph snapshots](1) Sync owner task snapshots

### DIFF
--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -76,10 +76,12 @@ describe('answerOwnerReadQuery', () => {
     expect(answerOwnerReadQuery({ kind: 'action-graph' }, h)).toEqual({ nodes: [] });
   });
 
-  it('refreshes the snapshot only for task-graph-refresh', () => {
-    const h = makeHandlers();
-    expect(answerOwnerReadQuery({ kind: 'tasks' }, h)).toMatchObject({ refreshed: false });
-    expect(answerOwnerReadQuery({ kind: 'task-graph-refresh' }, h)).toMatchObject({ refreshed: true });
+  it('routes both task snapshot entrypoints to the snapshot handler', () => {
+    const h = makeHandlers({
+      getTasksSnapshot: vi.fn(() => ({ tasks: [{ id: 'fresh' }], workflows: [] })),
+    });
+    expect(answerOwnerReadQuery({ kind: 'tasks' }, h)).toEqual({ tasks: [{ id: 'fresh' }], workflows: [] });
+    expect(answerOwnerReadQuery({ kind: 'task-graph-refresh' }, h)).toEqual({ tasks: [{ id: 'fresh' }], workflows: [] });
     expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(1, { refresh: false });
     expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(2, { refresh: true });
   });
@@ -218,17 +220,27 @@ describe('buildOwnerReadQueryHandlers', () => {
     expect(build().getReviewGate('missing')).toBeNull();
   });
 
-  it('getTasksSnapshot refreshes only when asked', () => {
+  it('task snapshot entrypoints sync from storage before reading', () => {
     const syncAllFromDb = vi.fn();
-    const h = build({ syncAllFromDb });
-    expect(h.getTasksSnapshot({ refresh: false })).toEqual({
-      tasks: [{ id: 't' }],
-      workflows: [{ id: 'wf' }],
+    const getAllTasks = vi.fn(() => [{ id: 'fresh-t' }]);
+    const listWorkflows = vi.fn(() => [{ id: 'fresh-wf' }]);
+    const h = build({ syncAllFromDb, getAllTasks }, { listWorkflows });
+    expect(answerOwnerReadQuery({ kind: 'tasks' }, h)).toEqual({
+      tasks: [{ id: 'fresh-t' }],
+      workflows: [{ id: 'fresh-wf' }],
       streamSequence: 5,
       invokerHomeRoot: '/home',
     });
-    expect(syncAllFromDb).not.toHaveBeenCalled();
-    h.getTasksSnapshot({ refresh: true });
-    expect(syncAllFromDb).toHaveBeenCalledTimes(1);
+    expect(answerOwnerReadQuery({ kind: 'task-graph-refresh' }, h)).toEqual({
+      tasks: [{ id: 'fresh-t' }],
+      workflows: [{ id: 'fresh-wf' }],
+      streamSequence: 5,
+      invokerHomeRoot: '/home',
+    });
+    expect(syncAllFromDb).toHaveBeenCalledTimes(2);
+    expect(getAllTasks).toHaveBeenCalledTimes(2);
+    expect(listWorkflows).toHaveBeenCalledTimes(2);
+    expect(syncAllFromDb.mock.invocationCallOrder[0]).toBeLessThan(getAllTasks.mock.invocationCallOrder[0]);
+    expect(syncAllFromDb.mock.invocationCallOrder[1]).toBeLessThan(getAllTasks.mock.invocationCallOrder[1]);
   });
 });

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -236,8 +236,8 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     listWorkerActionHistory: (request: WorkerActionHistoryRequest) => listWorkerActionHistory(persistence, request),
     listWorkerDecisions: (request: WorkerDecisionsRequest) => listWorkerDecisions(persistence, request),
     getWorkflowStatus: (workflowId?: string) => orchestrator.getWorkflowStatus(workflowId) as unknown as Record<string, unknown>,
-    getTasksSnapshot: ({ refresh }) => {
-      if (refresh) orchestrator.syncAllFromDb();
+    getTasksSnapshot: () => {
+      orchestrator.syncAllFromDb();
       return {
         tasks: orchestrator.getAllTasks(),
         workflows: persistence.listWorkflows(),


### PR DESCRIPTION
## Summary

Detached task viewers read tasks through the owner's task snapshot query.

That query could return the orchestrator's in-memory task set before it had caught up with SQLite.

This slice makes both owner snapshot entrypoints sync from SQLite before returning tasks and workflows.

Every owner task snapshot now uses the same authoritative sync-then-read path.

## Review Claim

Owner task snapshot reads now use one sync-then-read path, so plain `tasks` no longer returns stale in-memory task state.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change stays inside `packages/app/src/owner-read-query.ts` and its directly affected tests; no UI code, mutation code, or transport callsites change here.

## Slice Rationale

Detached-viewer hydration depends on owner `tasks` reads, so this snapshot behavior change is a self-contained review unit before any renderer bridge work.

## Non-goals

No app-bridge transport changes, no UI edits, no workflow-metadata refresh changes, no new snapshot shape fields.

## Architecture

### Before

```mermaid
graph TD
    A["owner `tasks` read"] --> B["in-memory task snapshot"]
    C["owner `task-graph-refresh` read"] --> D["fresh database sync"]
```

### After

```mermaid
graph TD
    A["owner task snapshot read"] --> B["fresh database sync"]
    B --> C["tasks and workflows snapshot"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/owner-read-query.test.ts`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/owner-read-query.test.ts src/__tests__/ipc-read-handlers.test.ts src/__tests__/web-invoker-dispatch.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7daf29938bd36dac940e12da9afe541a7196daba`
- Post-revert steps: None
- Data migration? No

</details>
