### PR TITLE
[Bugfix: explicit planning session continuity](1) Harden planning session contract

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -376,6 +376,29 @@ describe('planning chat', () => {
     expect(spawnPlanner).toHaveBeenCalledTimes(2);
   });
 
+  it('rejects an unknown continuation session without creating a new chat', async () => {
+    const spawnPlanner = vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue('new chat');
+    const sessions = createInAppPlanningChatSessions();
+
+    await expect(sendPlanningChatMessage({
+      sessionId: 'missing-session',
+      message: 'continue planning',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    })).resolves.toEqual({
+      ok: false,
+      sessionId: 'missing-session',
+      error: 'Planning session "missing-session" was not found.',
+    });
+
+    expect(sessions.size).toBe(0);
+    expect(spawnPlanner).not.toHaveBeenCalled();
+  });
+
   it('returns the raw draft reply and keeps a draft plan summary for valid YAML', async () => {
     vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
     const sessions = createInAppPlanningChatSessions();

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -699,9 +699,21 @@ export async function sendPlanningChatMessage(
     return { ok: false, sessionId: rawRequest?.sessionId, error: 'Type a message first.' };
   }
 
-  let sessionId = rawRequest?.sessionId;
+  const suppliedSessionId = typeof rawRequest?.sessionId === 'string'
+    ? rawRequest.sessionId
+    : undefined;
+  let sessionId = suppliedSessionId;
   try {
-    let session = rawRequest?.sessionId ? deps.sessions.get(rawRequest.sessionId) : undefined;
+    let session = suppliedSessionId === undefined
+      ? undefined
+      : deps.sessions.get(suppliedSessionId);
+    if (suppliedSessionId !== undefined && !session) {
+      return {
+        ok: false,
+        sessionId: suppliedSessionId,
+        error: `Planning session "${suppliedSessionId}" was not found.`,
+      };
+    }
     if (!session) {
       const created = await createSession({
         presetKey: rawRequest?.presetKey,


### PR DESCRIPTION
## Summary

The in-app planner now separates deliberate new-chat creation from continuation lookup failure.

Requests without `sessionId` still create a planning session.

Requests with an unknown non-empty `sessionId` now return a deterministic lost-session error.

This prevents follow-up sends from silently entering a brand-new planner conversation when the continuation id is gone.

## Review Claim

`sendPlanningChatMessage()` uses the fresh-chat path only when no non-empty `sessionId` was supplied, and unknown non-empty ids return an error without creating a session.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change stays in the in-app planning bridge and its focused regression file; valid first-send creation and valid continuation reuse both remain covered.

## Slice Rationale

This slice isolates the request routing branch that previously treated absent ids and unknown continuation ids as the same case.

## Non-goals

No UI request-building changes.

No Slack planning changes.

No harness or model-selection changes.

No unrelated cleanup.

## Architecture

### Before

`sendPlanningChatMessage()` created a planning session whenever the session lookup returned no session.

That made an unknown continuation id indistinguishable from an intentional first send.

### After

Requests without `sessionId` still create a new planning session.

Requests with an unknown non-empty `sessionId` return a deterministic continuation-lost error and never enter the fresh-chat path.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8f3f02307`
- Post-revert steps: Rerun `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`
- Data migration? No

</details>
