### PR TITLE
[Bugfix: explicit planning session continuity](2) Guard UI planning continuation

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -116,6 +116,7 @@ const SYSTEM_SETUP_AUTO_OPEN_DELAY_MS = 1200;
 const RAIL_LIST_FRAME_CLASS = 'flex min-h-0 flex-1 flex-col';
 const RAIL_SCROLL_BODY_CLASS = 'min-h-0 flex-1 overflow-y-auto';
 const PLANNING_TERMINAL_OUTPUT_SNAPSHOT_CHARS = 64 * 1024;
+const PLANNING_CONTINUATION_LOST_MESSAGE = 'This planning chat lost its server session. Start a new chat to continue planning.';
 
 function appendPlanningTerminalSnapshot(snapshot: string | undefined, data: string): string {
   const next = `${snapshot ?? ''}${data}`;
@@ -2941,6 +2942,12 @@ export function App() {
       return;
     }
 
+    if (!planningSessionId && activePlanningSession.messages.length > 0) {
+      setPlanningSubmitError({ title: 'Planner could not respond', message: PLANNING_CONTINUATION_LOST_MESSAGE });
+      appendTerminalLine(PLANNING_CONTINUATION_LOST_MESSAGE, 'system', 'error');
+      return;
+    }
+
     const request = {
       message: input,
       presetKey: selectedPlanningPresetKey || undefined,
@@ -3005,6 +3012,17 @@ export function App() {
         pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
         if (result.sessionId) pendingPlanningStreamSessionIdsRef.current.delete(result.sessionId);
         appendTerminalLine(result.error, 'system', 'error');
+        if (result.sessionId) {
+          const failedSessionId = result.sessionId;
+          setPlanningSessions((prev) => prev.map((session) => (
+            session.id === previousSessionId
+              ? { ...session, id: failedSessionId }
+              : session
+          )));
+          setActivePlanningSessionId((currentSessionId) => (
+            currentSessionId === previousSessionId ? failedSessionId : currentSessionId
+          ));
+        }
         setPlanningSubmitError({ title: 'Planner could not respond', message: result.error });
       }
     } catch (err) {
@@ -3030,6 +3048,7 @@ export function App() {
     keepPlanningStreamFailureForSessionIds,
     invoker,
     activePlanningSession.draftPlanAvailable,
+    activePlanningSession.messages.length,
     activePlanningSession.status,
     planningInput,
     planningSessionId,

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -992,6 +992,39 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
+  it('shows a lost-session error instead of starting a fresh chat for local transcript continuation', async () => {
+    mock.api.planningChatSend = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        error: 'planner failed before creating a server session',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        sessionId: 'session-2',
+        reply: 'What do you want to build?',
+        draftPlanAvailable: false,
+      }) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft a plan that fails before a session exists');
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('planner failed before creating a server session');
+    });
+
+    submitPlanningText('continue without losing context');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(
+        'This planning chat lost its server session. Start a new chat to continue planning.',
+      );
+    });
+    expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('invoker-terminal-transcript')).not.toHaveTextContent('What do you want to build?');
+  });
+
   it('passes the selected planning preset', async () => {
     render(<App />);
     await openPlanningTerminal();

--- a/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
@@ -38,10 +38,10 @@ describe('planning terminal failed first send session id persist repro', () => {
     fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
   }
 
-  // Expected-failing proof: the first failing send may still create a real
-  // persisted session in the app process. The renderer must keep that id for
+  // Regression proof: the first failing send may still create a real
+  // persisted session in the app process. The renderer keeps that id for
   // the retry instead of sending a second "new chat" request.
-  it.fails('persists a real session id returned by a failed first send before retrying', async () => {
+  it('persists a real session id returned by a failed first send before retrying', async () => {
     mock.api.planningChatSend = vi
       .fn()
       .mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

Follow-up planning sends now keep using the materialized server session id.

If a visible transcript still has only a local placeholder id, the terminal writes a recovery error before IPC.

That keeps the transcript from silently re-entering the fresh planner path.

## Review Claim

The planning terminal either sends the real server `sessionId` for follow-up turns or shows an explicit recovery error; it never silently falls back to a fresh planner conversation.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change stays in the planning terminal renderer and its focused test file; first-turn placeholder behavior and valid continuation behavior both stay covered.

## Slice Rationale

This renderer slice fixes the user-visible continuation path without changing backend policy or unrelated terminal behavior.

## Non-goals

No backend contract changes.

No Slack planning changes.

No harness or model-selection changes.

No unrelated cleanup.

## Architecture

### Before

A transcripted local planning placeholder could continue without a server session id.

That allowed the renderer to send a follow-up as a fresh first turn.

### After

The renderer stops transcripted local placeholders before IPC.

It appends a clear recovery error to the same visible transcript instead of accepting a fresh planner reply.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test src/__tests__/invoker-terminal.test.tsx`

</details>

## Visual Proof

![Planning terminal lost-session transcript](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-cc3b78/planning-continuation-lost-current-20260727.png)

The capture shows the same planning transcript with the explicit missing-session error after a follow-up send. The scripted run recorded one backend send, so no fresh planner reply ran.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1500bd226`
- Post-revert steps: Rerun `pnpm --filter @invoker/ui test src/__tests__/invoker-terminal.test.tsx`
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved planning-session recovery when a response fails or a session is unexpectedly lost.
  * Displays a clear error message and preserves transcript continuity during retry attempts.
  * Correctly reuses the latest planning session identifier after failed responses.

* **Tests**
  * Added coverage for lost-session recovery and verified that failed planning responses do not duplicate transcript content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
