### PR TITLE
Add planning-terminal adverse proof harness

### DIFF
--- a/packages/app/src/__tests__/planning-terminal-restore-invariants.repro.test.ts
+++ b/packages/app/src/__tests__/planning-terminal-restore-invariants.repro.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { InAppPlanningSessionRecord } from '@invoker/data-store';
+import {
+  createInAppPlanningChatSessions,
+  listPlanningChatSessions,
+  restorePlanningChatSessions,
+} from '../in-app-planner.js';
+import { bindPlanningTerminalSessionState } from '../terminal-session-ipc.js';
+
+const planningCommandBuilder = vi.fn(() => ({
+  command: 'node',
+  args: ['-e', 'process.stdout.write("")'],
+}));
+
+function planningRecord(
+  overrides: Partial<InAppPlanningSessionRecord> = {},
+): InAppPlanningSessionRecord {
+  return {
+    id: 'planning-record',
+    title: 'Planning record',
+    presetKey: 'codex',
+    status: 'still_discussing',
+    messages: [
+      {
+        id: 1,
+        role: 'assistant',
+        text: 'Restored chat.',
+        createdAt: '2026-07-07T00:00:01.000Z',
+      },
+    ],
+    terminalMode: 'chat',
+    terminalOutputSnapshot: '',
+    pendingResponse: false,
+    createdAt: '2026-07-07T00:00:00.000Z',
+    updatedAt: '2026-07-07T00:00:01.000Z',
+    ...overrides,
+  };
+}
+
+function planningSession(overrides: Record<string, unknown>) {
+  return {
+    id: 'planning-session',
+    title: 'Planning session',
+    presetKey: 'codex',
+    status: 'still_discussing',
+    messages: [],
+    conversation: {} as any,
+    terminalMode: 'chat',
+    terminalOutputSnapshot: '',
+    createdAt: '2026-07-07T00:00:00.000Z',
+    updatedAt: '2026-07-07T00:00:01.000Z',
+    nextMessageId: 1,
+    ...overrides,
+  } as any;
+}
+
+describe('planning terminal restore invariant repros', () => {
+  // Desired behavior: a saved planning chat should survive config preset
+  // remapping by falling back to the current default preset instead of vanishing.
+  it.fails('restores a planning chat when its saved preset key is missing or remapped', async () => {
+    const sessions = createInAppPlanningChatSessions();
+
+    await restorePlanningChatSessions([
+      planningRecord({
+        id: 'remapped-preset-chat',
+        title: 'Remapped preset chat',
+        presetKey: 'retired+planner',
+        terminalMode: 'tmux',
+        terminalSessionId: 'term-remapped',
+        terminalStatus: 'running',
+        terminalOutputSnapshot: 'saved tmux output\n',
+      }),
+    ], {
+      config: { defaultSlackHarnessPreset: 'codex' },
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+
+    expect(listPlanningChatSessions({ sessions }).sessions).toEqual([
+      expect.objectContaining({
+        id: 'remapped-preset-chat',
+        presetKey: 'codex',
+        terminalMode: 'tmux',
+        terminalSessionId: 'term-remapped',
+        terminalStatus: 'running',
+      }),
+    ]);
+  });
+
+  // Desired behavior: startup tmux restore only revives editable tmux-mode chats.
+  // Submitted chats are read-only, and chat-mode records may only retain history.
+  it.fails('does not revive submitted or chat-mode planning tmux sessions on startup', () => {
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('submitted-tmux', planningSession({
+      id: 'submitted-tmux',
+      status: 'submitted',
+      submittedWorkflowId: 'wf-submitted',
+      submittedPlanName: 'Submitted plan',
+      terminalMode: 'tmux',
+      terminalSessionId: 'term-submitted',
+      terminalStatus: 'running',
+    }));
+    sessions.set('chat-mode-with-stale-terminal', planningSession({
+      id: 'chat-mode-with-stale-terminal',
+      terminalMode: 'chat',
+      terminalSessionId: 'term-chat-stale',
+      terminalStatus: 'running',
+    }));
+
+    const restoreSpawnSession = vi.fn();
+    const planningTerminalState = bindPlanningTerminalSessionState({
+      embeddedTerminalManager: {
+        on: vi.fn(),
+        restoreSpawnSession,
+      } as any,
+      logger: { info: vi.fn(), warn: vi.fn() },
+      planningChatSessions: sessions,
+      getPlanningSessionStore: () => undefined,
+      repoRoot: '/repo',
+    });
+
+    planningTerminalState.restorePersistedPlanningTerminals();
+
+    expect(restoreSpawnSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/__tests__/planning-terminal-preset-switch-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-preset-switch-repro.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+vi.mock('xterm', () => ({
+  Terminal: class {
+    cols = 80;
+    rows = 24;
+    loadAddon(): void {}
+    open(): void {}
+    dispose(): void {}
+    write(): void {}
+    refresh(): void {}
+    focus(): void {}
+    onData(): { dispose: () => void } {
+      return { dispose() {} };
+    }
+  },
+}));
+
+vi.mock('xterm-addon-fit', () => ({
+  FitAddon: class {
+    fit(): void {}
+  },
+}));
+
+const { App } = await import('../App.js');
+
+async function openPlanningTerminal(): Promise<void> {
+  fireEvent.click(await screen.findByTestId('sidebar-home'));
+  const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+  if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+  fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+  await waitFor(() => {
+    expect(screen.getByTestId('invoker-terminal-harness')).toBeInTheDocument();
+  });
+}
+
+describe('planning terminal preset ownership repros', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  // Desired behavior: selecting a different saved chat restores that chat's
+  // pinned preset instead of leaving the prior chat's composer preset active.
+  it.fails('restores each saved chat preset when switching between planning chats', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'codex-chat',
+          title: 'Codex plan',
+          status: 'still_discussing',
+          presetKey: 'codex',
+          messages: [
+            { id: 1, role: 'assistant', text: 'Codex chat reply.', createdAt: '2026-07-07T00:00:01.000Z' },
+          ],
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+        }),
+        makePlanningSessionSummary({
+          id: 'omp-chat',
+          title: 'OMP plan',
+          status: 'still_discussing',
+          presetKey: 'omp',
+          messages: [
+            { id: 1, role: 'assistant', text: 'OMP chat reply.', createdAt: '2026-07-07T00:00:01.000Z' },
+          ],
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+        }),
+      ],
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+    await screen.findByRole('button', { name: /OMP plan/ });
+
+    expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+    fireEvent.click(screen.getByRole('button', { name: /OMP plan/ }));
+
+    expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('omp');
+  });
+
+  it('uses the latest selected preset when tmux creates a planning chat', async () => {
+    mock.api.planningChatCreate = vi.fn(() => new Promise(() => {})) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-harness'), { target: { value: 'omp' } });
+    expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('omp');
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Tmux' }));
+
+    await waitFor(() => {
+      expect(mock.api.planningChatCreate).toHaveBeenCalledTimes(1);
+    });
+    expect(mock.api.planningChatCreate).toHaveBeenCalledWith({
+      presetKey: 'omp',
+      title: 'Untitled plan',
+    });
+  });
+});

--- a/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { InAppPlanningChatResponse } from '@invoker/contracts';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+vi.mock('xterm', () => ({
+  Terminal: class {
+    cols = 80;
+    rows = 24;
+    loadAddon(): void {}
+    open(): void {}
+    dispose(): void {}
+    write(): void {}
+    refresh(): void {}
+    focus(): void {}
+    onData(): { dispose: () => void } {
+      return { dispose() {} };
+    }
+  },
+}));
+
+vi.mock('xterm-addon-fit', () => ({
+  FitAddon: class {
+    fit(): void {}
+  },
+}));
+
+const { App } = await import('../App.js');
+
+async function openPlanningTerminal(): Promise<void> {
+  fireEvent.click(await screen.findByTestId('sidebar-home'));
+  const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+  if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+  fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+  await waitFor(() => {
+    expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+  });
+}
+
+function submitPlanningText(text: string): void {
+  fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
+  fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+}
+
+describe('planning terminal failed first-send session id repro', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  // Desired behavior: if the app bridge creates a real session before the first
+  // planner turn fails, the renderer must retain that id for the next send.
+  it.fails('reuses the real sessionId returned by a failed first send on retry', async () => {
+    const firstFailure: InAppPlanningChatResponse = {
+      ok: false,
+      sessionId: 'created-before-failure',
+      error: 'Planner failed after creating the session.',
+    };
+    const secondSuccess: InAppPlanningChatResponse = {
+      ok: true,
+      sessionId: 'created-before-failure',
+      reply: 'Retry stayed on the original planning chat.',
+      draftPlanAvailable: false,
+    };
+    mock.api.planningChatSend = vi
+      .fn()
+      .mockResolvedValueOnce(firstFailure)
+      .mockResolvedValueOnce(secondSuccess) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft the plan');
+    await screen.findByText('Planner failed after creating the session.');
+
+    submitPlanningText('retry the same plan');
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
+      sessionId: 'created-before-failure',
+      message: 'retry the same plan',
+      presetKey: 'codex',
+    });
+  });
+});

--- a/packages/ui/src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { InAppPlanningListSessionsResponse } from '@invoker/contracts';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+vi.mock('xterm', () => ({
+  Terminal: class {
+    cols = 80;
+    rows = 24;
+    loadAddon(): void {}
+    open(): void {}
+    dispose(): void {}
+    write(): void {}
+    refresh(): void {}
+    focus(): void {}
+    onData(): { dispose: () => void } {
+      return { dispose() {} };
+    }
+  },
+}));
+
+vi.mock('xterm-addon-fit', () => ({
+  FitAddon: class {
+    fit(): void {}
+  },
+}));
+
+const { App } = await import('../App.js');
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function openPlanningTerminal(): Promise<void> {
+  fireEvent.click(await screen.findByTestId('sidebar-home'));
+  const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+  if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+  fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+  await waitFor(() => {
+    expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+  });
+}
+
+function submitPlanningText(text: string): void {
+  fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
+  fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+}
+
+describe('planning terminal startup hydrate race repro', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  // Desired behavior: a late startup restore must not replace an active local
+  // planning turn that already received its real server session id.
+  it.fails('keeps the active first turn when delayed startup hydrate returns saved sessions', async () => {
+    const listCalls: Array<Deferred<InAppPlanningListSessionsResponse>> = [];
+    mock.api.planningChatList = vi.fn(() => {
+      const call = deferred<InAppPlanningListSessionsResponse>();
+      listCalls.push(call);
+      return call.promise;
+    }) as any;
+    mock.api.planningChatSend = vi.fn(async () => ({
+      ok: true,
+      sessionId: 'fresh-session',
+      reply: 'Fresh reply after late hydrate.',
+      draftPlanAvailable: false,
+    })) as any;
+
+    render(<App />);
+    await waitFor(() => expect(mock.api.planningChatList).toHaveBeenCalledTimes(2));
+    await openPlanningTerminal();
+
+    submitPlanningText('draft the fresh plan');
+    await screen.findByText('Fresh reply after late hydrate.');
+
+    const staleRestore: InAppPlanningListSessionsResponse = {
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'stale-restored-session',
+          title: 'Stale restored plan',
+          messages: [
+            {
+              id: 1,
+              role: 'assistant',
+              text: 'Stale restored answer from startup hydrate.',
+              createdAt: '2026-07-07T00:00:01.000Z',
+            },
+          ],
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+        }),
+      ],
+    };
+
+    await act(async () => {
+      for (const call of listCalls) call.resolve(staleRestore);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const transcript = screen.getByTestId('invoker-terminal-transcript');
+    expect(transcript).toHaveTextContent('Fresh reply after late hydrate.');
+    expect(transcript).not.toHaveTextContent('Stale restored answer from startup hydrate.');
+  });
+});

--- a/scripts/repro/run-planning-terminal-adverse-loop.sh
+++ b/scripts/repro/run-planning-terminal-adverse-loop.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+pnpm --filter @invoker/ui exec vitest run \
+  src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx \
+  src/__tests__/planning-terminal-session-id-persist-repro.test.tsx \
+  src/__tests__/planning-terminal-preset-switch-repro.test.tsx
+
+pnpm --filter @invoker/app exec vitest run \
+  src/__tests__/planning-terminal-restore-invariants.repro.test.ts


### PR DESCRIPTION
Add a deterministic planning-terminal adverse-loop runner and focused
repro tests for the known lifecycle failures (startup hydrate race,
session-id persistence, preset switching, and tmux restore
invariants), plus a proof command that runs the full matrix.