### PR TITLE
[Bugfix: planning submit-only contract](3) Refresh dogfood fixture

### DIFF
--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -63,7 +63,8 @@ Use this mode when invoked by the installed command or MCP prompt. Do not use th
 - Prefer the MCP review/submission flow when available: call `invoker_prepare_plan_review`, show its ordered steps plus `confirmationText`, then call `invoker_submit_plan` only after approval unless the review result carries `confirmationMode: auto_submit`.
 - In an Invoker source checkout, still run `bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>` before the final submission step.
 - Outside an Invoker source checkout, `invoker_prepare_plan_review` is the canonical review surface and `invoker_validate_plan` remains an optional diagnostic, not the approval gate.
-- If the request involves creating, updating, publishing, or splitting pull requests or PR stacks, first read and follow `skills/make-pr/SKILL.md` (or `skill://make-pr/SKILL.md` when available) before PR authoring or publication.
+- Plain approval stops after workflow handoff: submit the reviewed workflow plan, report the submitted workflow status, and stop. That approval does not authorize GitHub PR creation, PR updates, or `mergify stack push`.
+- Later PR publication is a separate explicit action. If the request involves creating, updating, publishing, or splitting pull requests or PR stacks, first read and follow `skills/make-pr/SKILL.md` (or `skill://make-pr/SKILL.md` when available) before PR authoring or publication.
 - If the request involves multiple review slices, first read and follow `skills/review-compression/SKILL.md` (or `skill://review-compression/SKILL.md` when available) before writing workflow YAML.
 
 ## Intended flow (do not skip steps)
@@ -104,7 +105,7 @@ Grep-only checks are Phase 1a only; behavioral claims require executed Phase 1b 
 
 **Stateful bug lifecycle matrix:** When a bug involves conversation, session, file, cache, or workflow state, Phase 1a must enumerate the transitions that can lose or reuse state. The implementation plan must verify at least one non-happy-path sequence, such as plan creation → intervening message → summary-only reply → authorization/submit. If the state type is shared by multiple surfaces, include a verification case for each affected surface or record why it is unaffected.
 
-**Invoker dogfooding rule:** When the target repo is Invoker itself (`EdbertChan/Invoker` or the upstream `Neko-Catpital-Labs/Invoker`), be explicit that GitHub PR publishing should use **Mergify Stacks** after the work is ready: keep `onFinish: pull_request` + `mergeMode: external_review`, then publish/update the resulting commit stack with `mergify stack push`. Do **not** generalize this to unrelated target repos; for example, `EdbertChan/test-playground` should keep normal PR flow unless that repo independently adopts Mergify Stacks.
+**Invoker dogfooding rule:** When the target repo is Invoker itself (`EdbertChan/Invoker` or the upstream `Neko-Catpital-Labs/Invoker`), be explicit that any later GitHub PR publishing should use **Mergify Stacks** after the work is ready: keep `onFinish: pull_request` + `mergeMode: external_review` during workflow handoff. PR publication still requires a separate explicit request; then publish/update the resulting commit stack with `mergify stack push`. Do **not** generalize this to unrelated target repos; for example, `EdbertChan/test-playground` should keep normal PR flow unless that repo independently adopts Mergify Stacks.
 
 **Review-gate artifact intent:** Plans may include optional top-level `reviewGate.artifacts` metadata to describe an ordered review PR stack. Each artifact needs a unique `id`; `required` defaults to `true` when omitted; the first artifact has no dependency; every later artifact must depend on exactly the immediately previous artifact. Do not use fixed PR-count fields or Mergify-specific fields in the plan YAML. This metadata does not affect scheduler readiness, task dependencies, or workflow `externalDependencies`.
 
@@ -172,18 +173,18 @@ If `skill-doctor.sh` fails, run individual checks to isolate the problem:
 10. `step-submit-standalone-waived` (exception path)
     Use only for verify-only plans, explicitly requested single-workflow plans, or implementation plans that satisfy the `Standalone workflow waiver:` rule.
     `./submit-plan.sh <plan-file>`
-    If the target repo is Invoker itself, finish the PR publication step with `mergify stack push` from the working branch after the stack of commits is ready.
+    Stop after workflow handoff unless the user separately asks for PR publication. If the target repo is Invoker itself and that later request is explicit, finish the PR publication step with `mergify stack push` from the working branch after the stack of commits is ready.
 10a. `step-submit-stacked` (single plan with upstream dependency)
      Use when the plan HAS `externalDependencies` with a concrete workflow ID (not `__UPSTREAM_WORKFLOW_ID__`).
      1. Query upstream workflow: `./run.sh --headless query workflows --output json | jq '.[] | select(.id == "<workflowId>")'`
      2. Extract the upstream workflow's `featureBranch`
      3. Rewrite baseBranch: `sed -E -i "s|^baseBranch:.*$|baseBranch: <featureBranch>|" <plan-file>`
      4. Submit: `./submit-plan.sh <plan-file>`
-     5. If the target repo is Invoker itself, publish/update the resulting PR stack with `mergify stack push` after submission-side commits are ready.
+     5. Stop after workflow handoff unless the user separately asks for PR publication. If the target repo is Invoker itself and that later request is explicit, publish/update the resulting PR stack with `mergify stack push` after submission-side commits are ready.
 10b. `step-submit-chain` (batch stacking, multiple template plans)
      Default path for implementation work with more than one review slice.
      `./scripts/submit-workflow-chain.sh [--gate-policy completed|review_ready] <plan1.yaml> <plan2.template.yaml> ...`
-     The chain script handles: template rendering, baseBranch rewrite, merge-gate injection, sequential submission. For Invoker-on-Invoker work only, publish the resulting GitHub PR stack with `mergify stack push` once the chain's commits are prepared.
+     The chain script handles: template rendering, baseBranch rewrite, merge-gate injection, sequential submission. Stop after workflow handoff unless the user separately asks for PR publication. For Invoker-on-Invoker work only, that later explicit publication action uses `mergify stack push` once the chain's commits are prepared.
      Strict default: when `--gate-policy` is omitted, chain submission enforces `taskId: "__merge__"` + `requiredStatus: completed` + `gatePolicy: review_ready` for upstream workflow dependencies.
 
 ## Runtime verification (Phase 1b)

--- a/skills/plan-to-invoker/commands/invoker-plan-to-invoker.md
+++ b/skills/plan-to-invoker/commands/invoker-plan-to-invoker.md
@@ -13,6 +13,8 @@ Convert the approved Markdown plan to `plans/invoker-handoff.yaml`.
 
 Call `invoker_prepare_plan_review` on `plans/invoker-handoff.yaml`, show the returned ordered steps and `confirmationText`, and use that review output as the only approval gate.
 
+Plain approval means workflow handoff only: stop after Invoker submission; do not publish a local branch or create, update, or publish a PR unless the user explicitly asks for PR publication.
+
 If the review result says `confirmationMode` is `require`, wait for approval before submission. If it says `auto_submit`, show the same review output and then submit immediately.
 
 Call `invoker_submit_plan` with mode `live` only after that review step, or immediately after it when `confirmationMode` is `auto_submit`.

--- a/skills/plan-to-invoker/fixtures/positive/06-invoker-dogfood-mergify-stack.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/06-invoker-dogfood-mergify-stack.yaml
@@ -1,14 +1,18 @@
-# Invoker-on-Invoker dogfood example with explicit Mergify Stacks publication.
+# Invoker-on-Invoker dogfood example with handoff-only approval and explicit later Mergify Stacks publication.
 # Source: examples.md Section 7
 
 name: "Dogfood Invoker CI docs update"
 description: |
   Updates Invoker's own contributor guidance for merge automation.
 
-  This plan still uses the normal Invoker PR gate shape: `onFinish: pull_request`
-  with `mergeMode: external_review`. Because the target repo is Invoker itself, the
-  branch publication workflow after the commits are ready should use
-  `mergify stack push` so stacked PRs stay synchronized.
+  This plan still uses the normal Invoker review gate shape:
+  `onFinish: pull_request` with `mergeMode: external_review`. Plain approval
+  means approval to hand the workflow to Invoker; it is not also GitHub PR-stack
+  publication.
+
+  Because the target repo is Invoker itself, branch publication remains a
+  separate later action after the commits are ready: `mergify stack push` keeps
+  the stacked PRs synchronized.
 onFinish: pull_request
 mergeMode: external_review
 repoUrl: git@github.com:EdbertChan/Invoker.git
@@ -17,22 +21,139 @@ featureBranch: docs/dogfood-mergify-stack
 
 tasks:
   - id: update-dogfood-guidance
-    description: "Clarify when Invoker-on-Invoker changes should use Mergify Stacks"
-    prompt: |
-      Update the Invoker skills and examples so they are explicit about the
-      repo-specific dogfood rule:
-
-      1. When the target repo is Invoker itself, keep `mergeMode: external_review`
-         and publish/update the resulting commit stack with `mergify stack push`.
-      2. When the target repo is an external repo, keep normal PR flow unless
-         that repo independently uses Mergify Stacks.
-
+    description: |
+      Review claim:
+      - Refresh the dogfood docs so plain approval is handoff-only and later PR publication is separate.
+      Review lane:
+      - docs
+      Safety invariant:
+      - The update stays in plan-to-invoker skill docs and the positive dogfood example.
+      Slice rationale:
+      - The docs wording is one conceptual fixture and guidance update.
+      Architectural effect:
+      - Invoker-on-Invoker guidance keeps the review gate separate from later publication.
+      Goal:
+      - Clarify when Invoker-on-Invoker changes should use Mergify Stacks.
+      Motivation:
+      - Keep the dogfood example aligned with the handoff-only approval boundary.
+      Alternative considerations:
+      - Option A (chosen): document the separate later publication action in the dogfood guidance.
+      - Option B: leave Mergify publication implied by approval, which keeps the old ambiguity.
+      Implementation details:
+      - Edit the plan-to-invoker skill guidance and examples to separate handoff approval from later Mergify publication.
+      Non-goals:
+      - Do not generalize Mergify guidance to external repositories.
+      Layer: docs
+      Feature state: active
+      Files:
+      - skills/plan-to-invoker/SKILL.md
+      - skills/plan-to-invoker/references/examples.md
+      - skills/plan-to-invoker/fixtures/positive/06-invoker-dogfood-mergify-stack.yaml
+      Change types:
+      - skills/plan-to-invoker/SKILL.md: modify
+      - skills/plan-to-invoker/references/examples.md: modify
+      - skills/plan-to-invoker/fixtures/positive/06-invoker-dogfood-mergify-stack.yaml: modify
       Acceptance criteria:
-      - Relevant skills mention the Invoker-only scope.
+      - Relevant skill docs mention the Invoker-only scope.
       - Examples include an Invoker positive case and an external-repo counterexample.
+      - The Invoker positive case separates plain approval from later Mergify stack publication.
+    prompt: |
+      Review claim:
+      - Refresh the dogfood docs so plain approval is handoff-only and later PR publication is separate.
+      Review lane:
+      - docs
+      Safety invariant:
+      - Keep the update inside skills/plan-to-invoker/SKILL.md, skills/plan-to-invoker/references/examples.md, and skills/plan-to-invoker/fixtures/positive/06-invoker-dogfood-mergify-stack.yaml.
+      Slice rationale:
+      - The docs wording is one conceptual fixture and guidance update.
+      Architectural effect:
+      - Invoker-on-Invoker guidance keeps the review gate separate from later publication.
+      Goal:
+      - Clarify when Invoker-on-Invoker changes should use Mergify Stacks.
+      Motivation:
+      - Keep the dogfood example aligned with the handoff-only approval boundary.
+      Alternative considerations:
+      - Option A (chosen): document the separate later publication action in the dogfood guidance.
+      - Option B: leave Mergify publication implied by approval, which keeps the old ambiguity.
+      Implementation details:
+      - Assume no prior context. Update the Invoker skills and examples so they are explicit about the repo-specific dogfood boundary:
+      1. Plain approval approves the handoff to Invoker only; it must not be described as publishing or updating GitHub PRs.
+      2. When the target repo is Invoker itself, keep `onFinish: pull_request` with `mergeMode: external_review`.
+      3. After Invoker has prepared the resulting commit stack, publish/update that PR stack as a separate explicit action with `mergify stack push`.
+      4. When the target repo is an external repo, keep normal PR flow unless
+         that repo independently uses Mergify Stacks.
+      Non-goals:
+      - Do not generalize Mergify guidance to external repositories.
+      Files:
+      - skills/plan-to-invoker/SKILL.md
+      - skills/plan-to-invoker/references/examples.md
+      - skills/plan-to-invoker/fixtures/positive/06-invoker-dogfood-mergify-stack.yaml
+      Change types:
+      - skills/plan-to-invoker/SKILL.md: modify
+      - skills/plan-to-invoker/references/examples.md: modify
+      - skills/plan-to-invoker/fixtures/positive/06-invoker-dogfood-mergify-stack.yaml: modify
+      Acceptance criteria:
+      - Relevant skill docs mention the Invoker-only scope.
+      - Examples include an Invoker positive case and an external-repo counterexample.
+      - The Invoker positive case separates plain approval from later Mergify stack publication.
+      - Pass condition: bash skills/plan-to-invoker/scripts/test-fixtures.sh exits 0.
     dependencies: []
 
   - id: verify-skill-fixtures
-    description: "Run the plan-to-invoker fixture tests"
+    description: |
+      Review claim:
+      - Run focused fixture validation for the dogfood guidance update.
+      Review lane:
+      - proof
+      Safety invariant:
+      - This command only validates checked-in plan-to-invoker fixtures.
+      Slice rationale:
+      - Fixture proof stays separate from the docs update.
+      Architectural effect:
+      - No architecture change; the proof validates fixture compatibility.
+      Goal:
+      - Run the plan-to-invoker fixture tests.
+      Motivation:
+      - Ensure the refreshed dogfood fixture remains a valid positive example.
+      Alternative considerations:
+      - Option A (chosen): run the existing fixture test script.
+      - Option B: rely on manual YAML inspection only.
+      Implementation details:
+      - Execute the fixture test script from the repository root.
+      Non-goals:
+      - Do not modify source files during verification.
+      Layer exception: allowed
+      - Proof depends on the docs fixture slice so validation runs after the example update.
+      Layer: e2e_regression
+      Feature state: active
     command: "bash skills/plan-to-invoker/scripts/test-fixtures.sh"
     dependencies: [update-dogfood-guidance]
+
+  - id: publish-invoker-pr-stack
+    description: |
+      Review claim:
+      - Publish the prepared Invoker PR stack with Mergify as a separate later action.
+      Review lane:
+      - docs
+      Safety invariant:
+      - This task runs only after fixture proof and requires its own manual approval.
+      Slice rationale:
+      - Later publication is visible as its own action instead of being folded into plain approval.
+      Architectural effect:
+      - The workflow example preserves the handoff-only approval boundary.
+      Goal:
+      - Publish or update the prepared Invoker PR stack after the commits are ready.
+      Motivation:
+      - Keep Invoker-on-Invoker stacked PRs synchronized without teaching that approval publishes them.
+      Alternative considerations:
+      - Option A (chosen): make `mergify stack push` a separate manually approved publication task.
+      - Option B: mention Mergify only in the approval wording, which keeps publication ambiguous.
+      Implementation details:
+      - Run `mergify stack push` from the working branch after Invoker has prepared the commit stack.
+      Non-goals:
+      - Do not run Mergify for external target repositories.
+      Layer: docs
+      Feature state: active
+    command: "mergify stack push"
+    requiresManualApproval: true
+    dependencies: [verify-skill-fixtures]


### PR DESCRIPTION
## Summary

The checked-in dogfood fixture is the canonical example agents and readers copy from.

It previously folded `mergify stack push` into the same step as plain approval and handoff.

This slice updates the fixture so PR publication is its own later task, separate from approval and handoff.

## Review Claim

The positive dogfood fixture keeps later PR publication as a separate explicit action instead of part of plain approval.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

The change stays in the positive fixture only; runtime code stays untouched.

## Slice Rationale

One fixture slice keeps the checked-in example aligned with the handoff-only boundary.

## Non-goals

No planning-skill edits here, no handoff-entry edits here, no handoff-check edits here, no runtime code changes, no unrelated docs cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-plan-to-invoker-skill.sh && bash skills/plan-to-invoker/scripts/test-fixtures.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #6046

