### PR TITLE
[Authoritative task-graph snapshots](1) Sync owner task snapshots

### DIFF
--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -27,7 +27,12 @@ function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQuer
     getWorkerStatus: vi.fn(() => ({ generatedAt: 'now', workers: [] })),
     getWorkers: vi.fn(() => ({ generatedAt: 'workers-now', workers: [] })),
     getWorkflowStatus: vi.fn(() => ({ 'wf-1': 'running' })),
-    getTasksSnapshot: vi.fn(({ refresh }) => ({ tasks: [], workflows: [], refreshed: refresh })),
+    getTasksSnapshot: vi.fn(() => ({
+      tasks: [],
+      workflows: [],
+      streamSequence: 5,
+      invokerHomeRoot: '/home',
+    })),
     getActionGraphSnapshot: vi.fn(() => ({ nodes: [] })),
     listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
     loadWorkflowBundle: vi.fn((id: string) => ({ workflow: { id }, tasks: [] })),
@@ -76,12 +81,17 @@ describe('answerOwnerReadQuery', () => {
     expect(answerOwnerReadQuery({ kind: 'action-graph' }, h)).toEqual({ nodes: [] });
   });
 
-  it('refreshes the snapshot only for task-graph-refresh', () => {
+  it('routes both owner task snapshot entrypoints to the snapshot handler', () => {
     const h = makeHandlers();
-    expect(answerOwnerReadQuery({ kind: 'tasks' }, h)).toMatchObject({ refreshed: false });
-    expect(answerOwnerReadQuery({ kind: 'task-graph-refresh' }, h)).toMatchObject({ refreshed: true });
-    expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(1, { refresh: false });
-    expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(2, { refresh: true });
+    const expected = {
+      tasks: [],
+      workflows: [],
+      streamSequence: 5,
+      invokerHomeRoot: '/home',
+    };
+    expect(answerOwnerReadQuery({ kind: 'tasks' }, h)).toEqual(expected);
+    expect(answerOwnerReadQuery({ kind: 'task-graph-refresh' }, h)).toEqual(expected);
+    expect(vi.mocked(h.getTasksSnapshot).mock.calls).toEqual([[], []]);
   });
 
   it('wraps and routes the param-bearing read kinds', () => {
@@ -218,17 +228,29 @@ describe('buildOwnerReadQueryHandlers', () => {
     expect(build().getReviewGate('missing')).toBeNull();
   });
 
-  it('getTasksSnapshot refreshes only when asked', () => {
-    const syncAllFromDb = vi.fn();
-    const h = build({ syncAllFromDb });
-    expect(h.getTasksSnapshot({ refresh: false })).toEqual({
+  it('tasks and task-graph-refresh both sync before reading the owner snapshot', () => {
+    const calls: string[] = [];
+    const syncAllFromDb = vi.fn(() => {
+      calls.push('sync');
+    });
+    const getAllTasks = vi.fn(() => {
+      calls.push('tasks');
+      return [{ id: 't' }];
+    });
+    const listWorkflows = vi.fn(() => {
+      calls.push('workflows');
+      return [{ id: 'wf' }];
+    });
+    const h = build({ syncAllFromDb, getAllTasks }, { listWorkflows });
+    const expected = {
       tasks: [{ id: 't' }],
       workflows: [{ id: 'wf' }],
       streamSequence: 5,
       invokerHomeRoot: '/home',
-    });
-    expect(syncAllFromDb).not.toHaveBeenCalled();
-    h.getTasksSnapshot({ refresh: true });
-    expect(syncAllFromDb).toHaveBeenCalledTimes(1);
+    };
+    expect(answerOwnerReadQuery({ kind: 'tasks' }, h)).toEqual(expected);
+    expect(answerOwnerReadQuery({ kind: 'task-graph-refresh' }, h)).toEqual(expected);
+    expect(syncAllFromDb).toHaveBeenCalledTimes(2);
+    expect(calls).toEqual(['sync', 'tasks', 'workflows', 'sync', 'tasks', 'workflows']);
   });
 });

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -42,7 +42,7 @@ export interface OwnerReadQueryHandlers {
   getWorkerStatus: () => WorkerStatusSnapshot;
   getWorkers: () => WorkerStatusSnapshot;
   getWorkflowStatus: (workflowId?: string) => Record<string, unknown>;
-  getTasksSnapshot: (opts: { refresh: boolean }) => Record<string, unknown>;
+  getTasksSnapshot: () => Record<string, unknown>;
   getActionGraphSnapshot: () => Record<string, unknown>;
   listWorkflows: () => unknown[];
   loadWorkflowBundle: (workflowId: string) => Record<string, unknown>;
@@ -123,9 +123,9 @@ export function answerOwnerReadQuery(
     case 'workflow-status':
       return handlers.getWorkflowStatus(body.workflowId);
     case 'tasks':
-      return handlers.getTasksSnapshot({ refresh: false });
+      return handlers.getTasksSnapshot();
     case 'task-graph-refresh':
-      return handlers.getTasksSnapshot({ refresh: true });
+      return handlers.getTasksSnapshot();
     case 'action-graph':
       return handlers.getActionGraphSnapshot();
     case 'workflows':
@@ -236,8 +236,8 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     listWorkerActionHistory: (request: WorkerActionHistoryRequest) => listWorkerActionHistory(persistence, request),
     listWorkerDecisions: (request: WorkerDecisionsRequest) => listWorkerDecisions(persistence, request),
     getWorkflowStatus: (workflowId?: string) => orchestrator.getWorkflowStatus(workflowId) as unknown as Record<string, unknown>,
-    getTasksSnapshot: ({ refresh }) => {
-      if (refresh) orchestrator.syncAllFromDb();
+    getTasksSnapshot: () => {
+      orchestrator.syncAllFromDb();
       return {
         tasks: orchestrator.getAllTasks(),
         workflows: persistence.listWorkflows(),


### PR DESCRIPTION
## Summary

A detached workflow viewer can open and show a workflow with no mini graph at all, even though the workflow is real and has tasks running.

The cause sits upstream of the viewer. The owner-side task read could hand back an in-memory task set that had not been synced from SQLite first.

This slice makes the owner task read always sync from the database before it answers, for both of its two entry points, so callers never see a partial task set.

## Review Claim

Owner task reads now sync from SQLite before answering, so a plain `tasks` read can no longer return a stale, partial task set.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change stays inside `packages/app/src/owner-read-query.ts` and its directly affected test file; no UI code, mutation code, or transport callsites change here.

## Slice Rationale

Detached-viewer hydration depends on this owner read, so making it authoritative is a self-contained review unit before any renderer bridge work in the next slice.

## Non-goals

This slice does not touch app-bridge transport code, UI components, workflow-metadata refresh behavior, or the shape of the returned snapshot.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/owner-read-query.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
