### PR TITLE
[Authoritative task-graph snapshots](2) Sync app bridge snapshots

### DIFF
--- a/packages/app/src/__tests__/ipc-read-handlers.test.ts
+++ b/packages/app/src/__tests__/ipc-read-handlers.test.ts
@@ -26,14 +26,25 @@ function expectReadContextWriteToolsAreAbsent(): void {
 
 
 describe('registerReadOnlyIpcHandlers', () => {
-  it('get-tasks returns a snapshot', async () => {
+  it('get-tasks syncs before returning the task snapshot', async () => {
     const handlers = new Map<string, (...args: unknown[]) => unknown>();
     const ipcMain = {
       handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
         handlers.set(channel, handler);
       }),
     };
-    const task = makeTask('wf-1/task-1');
+    const staleTask = makeTask('wf-1/stale-task');
+    const freshTask = makeTask('wf-1/fresh-task');
+    let synced = false;
+    const calls: string[] = [];
+    const syncAllFromDb = vi.fn(() => {
+      calls.push('syncAllFromDb');
+      synced = true;
+    });
+    const getAllTasks = vi.fn(() => {
+      calls.push('getAllTasks');
+      return synced ? [freshTask] : [staleTask];
+    });
 
     registerReadOnlyIpcHandlers({
       ipcMain: ipcMain as never,
@@ -47,7 +58,8 @@ describe('registerReadOnlyIpcHandlers', () => {
         listWorkflows: vi.fn(() => [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }]),
       } as never,
       getOrchestrator: () => ({
-        getAllTasks: () => [task],
+        syncAllFromDb,
+        getAllTasks,
         getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 0, closed: 0, running: 0, pending: 1 }),
       }) as never,
       agentRegistry: {} as never,
@@ -62,10 +74,13 @@ describe('registerReadOnlyIpcHandlers', () => {
     const result = await handlers.get('invoker:get-tasks')?.({});
 
     expect(result).toEqual({
-      tasks: [task],
+      tasks: [freshTask],
       workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
       streamSequence: 42,
     });
+    expect(syncAllFromDb).toHaveBeenCalledTimes(1);
+    expect(getAllTasks).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(['syncAllFromDb', 'getAllTasks']);
   });
 
   it('get-review-gate returns the shared review gate shape', async () => {

--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -18,6 +18,7 @@ function makeDispatch(overrides: Record<string, unknown> = {}) {
   const approveTask = vi.fn(async () => ({ ok: true }));
   const deps = {
     orchestrator: {
+      syncAllFromDb: () => undefined,
       getAllTasks: () => [makeTask('wf-1/task-1')],
       getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 0, closed: 0, running: 0, pending: 1 }),
       getTask: () => null,
@@ -57,13 +58,34 @@ describe('buildWebInvokerDispatch', () => {
     ]);
   });
 
-  it('get-tasks returns the { tasks, workflows, streamSequence } snapshot', async () => {
-    const { dispatch } = makeDispatch();
+  it('get-tasks syncs before returning the { tasks, workflows, streamSequence } snapshot', async () => {
+    const staleTask = makeTask('wf-1/stale-task');
+    const freshTask = makeTask('wf-1/fresh-task');
+    let synced = false;
+    const calls: string[] = [];
+    const syncAllFromDb = vi.fn(() => {
+      calls.push('syncAllFromDb');
+      synced = true;
+    });
+    const getAllTasks = vi.fn(() => {
+      calls.push('getAllTasks');
+      return synced ? [freshTask] : [staleTask];
+    });
+    const { dispatch } = makeDispatch({
+      orchestrator: {
+        syncAllFromDb,
+        getAllTasks,
+      },
+    });
+
     expect(await dispatch('invoker:get-tasks', [])).toEqual({
-      tasks: [makeTask('wf-1/task-1')],
+      tasks: [freshTask],
       workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
       streamSequence: 7,
     });
+    expect(syncAllFromDb).toHaveBeenCalledTimes(1);
+    expect(getAllTasks).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(['syncAllFromDb', 'getAllTasks']);
   });
 
   it('get-execution-harnesses returns harness metadata', async () => {

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -159,7 +159,10 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     }
 
     const { tasks, workflows, streamSequence } = buildTaskGraphSnapshot({
-      orchestrator,
+      orchestrator: {
+        syncAllFromDb: () => orchestrator.syncAllFromDb(),
+        getAllTasks: () => orchestrator.getAllTasks(),
+      },
       persistence,
       getStreamSequence: getTaskDeltaStreamSequence,
     });

--- a/packages/app/src/web/task-graph-snapshot.ts
+++ b/packages/app/src/web/task-graph-snapshot.ts
@@ -17,12 +17,13 @@ export interface TaskGraphSnapshot {
 }
 
 export interface BuildTaskGraphSnapshotDeps {
-  orchestrator: Pick<Orchestrator, 'getAllTasks'>;
+  orchestrator: Pick<Orchestrator, 'getAllTasks' | 'syncAllFromDb'>;
   persistence: Pick<SQLiteAdapter, 'listWorkflows'>;
   getStreamSequence: () => number;
 }
 
 export function buildTaskGraphSnapshot(deps: BuildTaskGraphSnapshotDeps): TaskGraphSnapshot {
+  deps.orchestrator.syncAllFromDb();
   return {
     tasks: deps.orchestrator.getAllTasks(),
     workflows: deps.persistence.listWorkflows() as WorkflowMeta[],

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -90,7 +90,10 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       // ── Reads ─────────────────────────────────────────────
       case 'invoker:get-tasks':
         return buildTaskGraphSnapshot({
-          orchestrator,
+          orchestrator: {
+            syncAllFromDb: () => orchestrator.syncAllFromDb(),
+            getAllTasks: () => orchestrator.getAllTasks(),
+          },
           persistence,
           getStreamSequence: deps.getStreamSequence,
         });


### PR DESCRIPTION
## Summary

Building on the previous slice, this one closes the same gap on the renderer-facing side.

Electron and web both build their task-graph snapshot from one shared helper. That helper could hand back tasks before the in-memory state had been synced from SQLite.

That gap is why a real workflow could open with workflow metadata present but its mini graph blank, until something else forced a later refresh.

This slice makes the shared snapshot helper sync from SQLite first, and updates both callsites that feed it.

## Review Claim

The shared `invoker:get-tasks` snapshot builder now syncs from SQLite before reading tasks, so every renderer-facing snapshot reflects the current task set, on both the Electron and web paths.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change stays inside the shared snapshot helper, its two transport callsites, and their directly affected test files; selected-workflow UI retention logic is untouched.

## Slice Rationale

Electron and web both consume the same shared builder, so their fix belongs in one review unit, kept separate from the owner-read change reviewed in the prior slice.

## Non-goals

This slice does not touch `packages/ui/src/App.tsx`, `packages/ui/src/hooks/useTasks.ts`, refresh-event publishing, or any workflow-chain or PR-body tooling.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/ipc-read-handlers.test.ts -t "get-tasks"`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/web-invoker-dispatch.test.ts -t "get-tasks"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
