### PR TITLE
[Planning terminal adverse proof harness](1) Add focused adverse repro tests

### DIFF
--- a/packages/app/src/__tests__/planning-terminal-restore-invariants.repro.test.ts
+++ b/packages/app/src/__tests__/planning-terminal-restore-invariants.repro.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ConversationRepository, SQLiteAdapter, type InAppPlanningSessionRecord } from '@invoker/data-store';
+import {
+  createInAppPlanningChatSessions,
+  createPlanningCommandBuilderFromRegistry,
+  listPlanningChatSessions,
+  restorePlanningChatSessions,
+} from '../in-app-planner.js';
+import { bindPlanningTerminalSessionState } from '../terminal-session-ipc.js';
+
+const planningCommandBuilder = createPlanningCommandBuilderFromRegistry({
+  getPlanningOrThrow: vi.fn(() => ({
+    buildPlanningCommand: vi.fn(() => ({ command: 'codex', args: ['--model', 'fast', 'prompt'] })),
+  })),
+});
+
+function makePlanningRecord(
+  overrides: Partial<InAppPlanningSessionRecord> = {},
+): InAppPlanningSessionRecord {
+  return {
+    id: 'planning-restore',
+    title: 'Restored plan',
+    presetKey: 'codex',
+    status: 'still_discussing',
+    confirmationMode: 'require',
+    messages: [
+      {
+        id: 1,
+        role: 'assistant',
+        text: 'Restored reply.',
+        createdAt: '2026-07-07T00:00:01.000Z',
+      },
+    ],
+    pendingResponse: false,
+    createdAt: '2026-07-07T00:00:00.000Z',
+    updatedAt: '2026-07-07T00:00:01.000Z',
+    ...overrides,
+  };
+}
+
+describe('planning terminal restore invariants repros', () => {
+  // `it.fails`: desired behavior is that a legacy/missing preset does not make
+  // a persisted planning chat disappear. Current restore skips the whole record.
+  it.fails('remaps a missing restored preset to the configured default instead of dropping the chat', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const sessions = createInAppPlanningChatSessions();
+      await restorePlanningChatSessions([
+        makePlanningRecord({
+          id: 'legacy-preset-session',
+          presetKey: 'legacy-planner',
+        }),
+      ], {
+        config: { defaultSlackHarnessPreset: 'codex' },
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo: new ConversationRepository(adapter),
+        planningSessionStore: adapter,
+      });
+
+      expect(sessions.get('legacy-preset-session')).toMatchObject({
+        id: 'legacy-preset-session',
+        presetKey: 'codex',
+      });
+      expect(listPlanningChatSessions({ sessions }).sessions).toHaveLength(1);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('restores a remapped custom preset when the config defines that preset key', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const sessions = createInAppPlanningChatSessions();
+      await restorePlanningChatSessions([
+        makePlanningRecord({
+          id: 'custom-remapped-session',
+          presetKey: 'team-planner',
+        }),
+      ], {
+        config: {
+          slackHarnessPresets: {
+            'team-planner': { tool: 'codex', model: 'gpt-5-codex' },
+          },
+          defaultSlackHarnessPreset: 'team-planner',
+        },
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo: new ConversationRepository(adapter),
+        planningSessionStore: adapter,
+      });
+
+      expect(listPlanningChatSessions({ sessions }).sessions[0]).toMatchObject({
+        id: 'custom-remapped-session',
+        presetKey: 'team-planner',
+      });
+    } finally {
+      adapter.close();
+    }
+  });
+
+  // `it.fails`: desired behavior is that a submitted read-only chat still
+  // restores its owned tmux session even if the last selected UI mode was chat.
+  // Current restore only revives sessions whose terminalMode is already tmux.
+  it.fails('restores submitted chat-mode planning tmux sessions for read-only inspection', () => {
+    const restoreSpawnSession = vi.fn();
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('submitted-chat-mode', {
+      id: 'submitted-chat-mode',
+      title: 'Submitted plan',
+      presetKey: 'codex',
+      confirmationMode: 'require',
+      status: 'submitted',
+      messages: [],
+      conversation: {} as never,
+      submittedWorkflowId: 'wf-submitted',
+      submittedPlanName: 'Submitted plan',
+      terminalMode: 'chat',
+      terminalSessionId: 'planning-term-submitted',
+      terminalStatus: 'running',
+      terminalOutputSnapshot: 'tmux output before restart\n',
+      terminalUpdatedAt: '2026-07-07T00:00:03.000Z',
+      createdAt: '2026-07-07T00:00:00.000Z',
+      updatedAt: '2026-07-07T00:00:04.000Z',
+      nextMessageId: 1,
+    });
+
+    const binding = bindPlanningTerminalSessionState({
+      embeddedTerminalManager: {
+        on: vi.fn(),
+        restoreSpawnSession,
+      } as never,
+      logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+      planningChatSessions: sessions,
+      getPlanningSessionStore: () => undefined,
+      repoRoot: '/repo',
+    });
+
+    binding.restorePersistedPlanningTerminals();
+
+    expect(restoreSpawnSession).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'planning-term-submitted',
+      kind: 'planning',
+      planningSessionId: 'submitted-chat-mode',
+      outputSnapshot: 'tmux output before restart\n',
+    }));
+  });
+});

--- a/packages/ui/src/__tests__/planning-terminal-preset-switch-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-preset-switch-repro.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const xtermMock = vi.hoisted(() => {
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    loadAddon = vi.fn();
+    open = vi.fn((host: HTMLElement) => {
+      const terminalElement = document.createElement('div');
+      terminalElement.className = 'xterm';
+      terminalElement.textContent = 'planning tmux';
+      host.appendChild(terminalElement);
+    });
+    write = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    focus = vi.fn();
+    dispose = vi.fn();
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+  }
+
+  return { Terminal: MockTerminal, FitAddon: MockFitAddon };
+});
+
+vi.mock('xterm', () => ({ Terminal: xtermMock.Terminal }));
+vi.mock('xterm-addon-fit', () => ({ FitAddon: xtermMock.FitAddon }));
+
+const { App } = await import('../App.js');
+
+describe('planning terminal preset ownership repros', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  async function openPlanningTerminal(): Promise<void> {
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+    if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+    fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toBeInTheDocument();
+    });
+  }
+
+  function submitPlanningText(text: string): void {
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+  }
+
+  it('uses each restored chat preset when switching chat-to-chat before send', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'chat-codex',
+          title: 'Codex chat',
+          status: 'still_discussing',
+          presetKey: 'codex',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          messages: [
+            { id: 1, role: 'assistant', text: 'Codex reply.', createdAt: '2026-07-07T00:00:01.000Z' },
+          ],
+        }),
+        makePlanningSessionSummary({
+          id: 'chat-claude',
+          title: 'Claude chat',
+          status: 'still_discussing',
+          presetKey: 'omp+claude',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          messages: [
+            { id: 1, role: 'assistant', text: 'Claude reply.', createdAt: '2026-07-07T00:00:01.000Z' },
+          ],
+        }),
+      ],
+    })) as any;
+    mock.api.planningChatSend = vi.fn(async () => ({
+      ok: true,
+      sessionId: 'chat-claude',
+      reply: 'Claude follow-up.',
+      confirmationMode: 'require',
+      draftPlanAvailable: false,
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+    fireEvent.click(await screen.findByText('Claude chat'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('omp+claude');
+    });
+
+    submitPlanningText('continue with this chat');
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        sessionId: 'chat-claude',
+        message: 'continue with this chat',
+        presetKey: 'omp+claude',
+        confirmationMode: 'require',
+      });
+    });
+  });
+
+  it('uses a preset changed on a new local chat before opening tmux', async () => {
+    mock.api.planningChatCreate = vi.fn(async () => ({
+      ok: true,
+      session: makePlanningSessionSummary({
+        id: 'created-for-tmux',
+        title: 'Untitled plan',
+        status: 'still_discussing',
+        presetKey: 'omp+claude',
+        draftPlanAvailable: false,
+        draftPlanSummary: undefined,
+        draftPlanText: undefined,
+        messages: [],
+      }),
+    })) as any;
+    mock.api.planningTerminalOpen = vi.fn(async (planningSessionId: string) => ({
+      opened: true,
+      session: {
+        sessionId: `term-${planningSessionId}`,
+        taskId: `planning:${planningSessionId}`,
+        kind: 'planning',
+        planningSessionId,
+        status: 'running',
+        mode: 'spawn',
+        attached: false,
+        createdAt: '2026-07-07T00:00:03.000Z',
+      },
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-harness'), { target: { value: 'omp+claude' } });
+    fireEvent.click(screen.getByRole('tab', { name: 'Tmux' }));
+
+    await waitFor(() => {
+      expect(mock.api.planningChatCreate).toHaveBeenCalledWith({
+        presetKey: 'omp+claude',
+        title: 'Untitled plan',
+        confirmationMode: 'require',
+      });
+    });
+    await waitFor(() => {
+      expect(mock.api.planningTerminalOpen).toHaveBeenCalledWith('created-for-tmux');
+      expect(screen.getByTestId('invoker-terminal-tmux-pane')).toHaveAttribute('data-session-id', 'term-created-for-tmux');
+    });
+  });
+});

--- a/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const xtermMock = vi.hoisted(() => {
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    loadAddon = vi.fn();
+    open = vi.fn();
+    write = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    focus = vi.fn();
+    dispose = vi.fn();
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+  }
+
+  return { Terminal: MockTerminal, FitAddon: MockFitAddon };
+});
+
+vi.mock('xterm', () => ({ Terminal: xtermMock.Terminal }));
+vi.mock('xterm-addon-fit', () => ({ FitAddon: xtermMock.FitAddon }));
+
+const { App } = await import('../App.js');
+
+describe('planning terminal failed first-send session id repro', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  async function openPlanningTerminal(): Promise<void> {
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+    if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+    fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+    });
+  }
+
+  function submitPlanningText(text: string): void {
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+  }
+
+  // `it.fails`: desired behavior is that an ok:false first send with a real
+  // sessionId still transfers the local chat to that durable id before retry.
+  // Current code keeps the local id, so the retry starts a second backend chat.
+  it.fails('retries a failed first send on the real session id returned by the bridge', async () => {
+    mock.api.planningChatSend = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        sessionId: 'real-session-created-before-failure',
+        error: 'Planner failed after creating the conversation.',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        sessionId: 'real-session-created-before-failure',
+        reply: 'Retry continued the existing conversation.',
+        confirmationMode: 'require',
+        draftPlanAvailable: false,
+      }) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('first attempt');
+    await screen.findByText('Planner failed after creating the conversation.');
+
+    submitPlanningText('retry the same chat');
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
+      sessionId: 'real-session-created-before-failure',
+      message: 'retry the same chat',
+      presetKey: 'codex',
+      confirmationMode: 'require',
+    });
+  });
+});

--- a/packages/ui/src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { InAppPlanningListSessionsResponse } from '@invoker/contracts';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const xtermMock = vi.hoisted(() => {
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    loadAddon = vi.fn();
+    open = vi.fn();
+    write = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    focus = vi.fn();
+    dispose = vi.fn();
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+  }
+
+  return { Terminal: MockTerminal, FitAddon: MockFitAddon };
+});
+
+vi.mock('xterm', () => ({ Terminal: xtermMock.Terminal }));
+vi.mock('xterm-addon-fit', () => ({ FitAddon: xtermMock.FitAddon }));
+
+const { App } = await import('../App.js');
+
+describe('planning terminal startup hydrate race repro', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  async function openPlanningTerminal(): Promise<void> {
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+    if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+    fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+    });
+  }
+
+  function submitPlanningText(text: string): void {
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+  }
+
+  // `it.fails`: desired behavior is that stale startup hydrate responses cannot
+  // replace a user-started chat. Current code still has a second hydrate path
+  // that can overwrite the active local send after it adopts a real session id.
+  it.fails('keeps the active first-send chat when stale startup hydration resolves later', async () => {
+    const hydrateResolvers: Array<(value: InAppPlanningListSessionsResponse) => void> = [];
+    mock.api.planningChatList = vi.fn(() => new Promise<InAppPlanningListSessionsResponse>((resolve) => {
+      hydrateResolvers.push(resolve);
+    })) as any;
+    mock.api.planningTerminalList = vi.fn(async () => []) as any;
+    mock.api.planningChatSend = vi.fn(async () => ({
+      ok: true,
+      sessionId: 'live-session-from-first-send',
+      reply: 'Live reply from the first send.',
+      confirmationMode: 'require',
+      draftPlanAvailable: false,
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+    await waitFor(() => {
+      expect(mock.api.planningChatList).toHaveBeenCalledTimes(2);
+    });
+
+    submitPlanningText('start while restore is pending');
+    await screen.findByText('Live reply from the first send.');
+
+    const staleHydrate: InAppPlanningListSessionsResponse = {
+      ok: true,
+      sessions: [makePlanningSessionSummary({
+        id: 'stale-restored-session',
+        title: 'Stale restored session',
+        status: 'still_discussing',
+        draftPlanAvailable: false,
+        draftPlanSummary: undefined,
+        draftPlanText: undefined,
+        messages: [
+          {
+            id: 1,
+            role: 'assistant',
+            text: 'Stale restored reply.',
+            createdAt: '2026-07-07T00:00:02.000Z',
+          },
+        ],
+      })],
+    };
+
+    await act(async () => {
+      for (const resolve of hydrateResolvers) resolve(staleHydrate);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Live reply from the first send.');
+    expect(screen.getByTestId('invoker-terminal-transcript')).not.toHaveTextContent('Stale restored reply.');
+    expect(screen.getByText('start while restore is pending')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Planning-terminal lifecycle bugs need a deterministic proof surface before product behavior changes.

These focused repros cover delayed hydrate restore, failed first-send identity, per-chat preset selection, and tmux restore cases.

Each adverse expectation is isolated in a focused renderer or app test.

This PR adds test files only. It does not change product code.

## Review Claim

The repo gains focused adverse repro tests for the planning-terminal restore, session-id, preset-switch, and tmux restore failure classes.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice adds only test files under `packages/ui/src/__tests__/` and `packages/app/src/__tests__/`; no planning-terminal product file is touched.

## Slice Rationale

Landing the repro tests first lets a reviewer inspect each adverse case before the wrapper slice.

The loop runner depends on these files existing, so it stays in the next PR.

## Root Cause Inputs

Verified in this checkout:
- `packages/ui/src/App.tsx:1047-1067` can overwrite a live local planning chat with late restore data.
- `packages/ui/src/App.tsx:2648-2696` drops `result.sessionId` on the failed first-send path.
- `packages/ui/src/App.tsx:844-845`, `:2654-2657`, and `:3914-3922` keep harness selection global instead of session-scoped.
- `packages/app/src/in-app-planner.ts:217-236`, `:342-369`, and `:774-776` restore planner identity from preset lookup only.
- `packages/app/src/in-app-planner.ts:648-660`, `:687-708`, and `packages/app/src/terminal-session-ipc.ts:428-455` leave tmux ownership metadata alive when the chat is back in `chat` mode or already submitted.

## Non-goals

No product-code changes in `packages/ui/src/App.tsx`, `packages/app/src/in-app-planner.ts`, `packages/app/src/terminal-session-ipc.ts`, or persistence adapters.

No loop-runner script in this slice.

## Visual Proof

![planning-terminal adverse repro matrix passing](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-41137f/planning-terminal-adverse-proof-harness-run.svg)

This image is command-output proof from `bash scripts/run-planning-terminal-adverse-loop.sh` on this publication branch.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/run-planning-terminal-adverse-loop.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run `bash scripts/run-planning-terminal-adverse-loop.sh` after reverting the stack tip if it remains present.
- Data migration? No

</details>
