### PR TITLE
[Planning terminal adverse proof harness](2) Add deterministic adverse-loop runner

### DIFF
--- a/scripts/run-planning-terminal-adverse-loop.sh
+++ b/scripts/run-planning-terminal-adverse-loop.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+cd "$ROOT"
+
+pnpm --filter @invoker/ui exec vitest run \
+  src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx \
+  src/__tests__/planning-terminal-session-id-persist-repro.test.tsx \
+  src/__tests__/planning-terminal-preset-switch-repro.test.tsx
+
+pnpm --filter @invoker/app exec vitest run \
+  src/__tests__/planning-terminal-restore-invariants.repro.test.ts


### PR DESCRIPTION
## Summary

The planning-terminal adverse repro tests run as separate `vitest` invocations across two packages.

This PR adds one checked-in shell wrapper that runs all of them from the repo root.

Later behavior slices can use the same deterministic adverse matrix.

## Review Claim

The repo gains `scripts/run-planning-terminal-adverse-loop.sh`, a shell wrapper for the full planning-terminal adverse repro matrix.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice adds one shell script under `scripts/` that only invokes existing `vitest` test files added in the prior slice; it does not add, remove, or modify any test assertion or product code.

## Slice Rationale

The loop script depends on the repro tests existing first, so it lands as the next slice in the stack rather than bundled with the tests themselves.

Keeping it separate lets the tests be reviewed on their own merits before the convenience wrapper around them.

## Non-goals

No product-code changes.

No new test files or test assertions; this slice only wires the existing focused repro files behind one command.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/run-planning-terminal-adverse-loop.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
