### PR TITLE
[Bugfix: truthful planning draft readiness](1) Keep planner submit text draft-backed

### DIFF
--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -54,6 +54,8 @@ tasks:
 
 Reply \`submit\` to submit it.`;
 
+const SUBMIT_LINE = 'Reply `submit` to submit it.';
+
 describe('plan draft file - activation side', () => {
   let workingDir: string;
 
@@ -101,19 +103,23 @@ describe('plan draft file - activation side', () => {
     ));
     await conversation.sendMessage('Draft it');
 
-    mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the plan. Summary: one step.'));
-    await conversation.sendMessage('What does it do?');
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(`Drafted the plan. Summary: one step.\n\n${SUBMIT_LINE}`));
+    const response = await conversation.sendMessage('What does it do?');
 
     expect(existsSync(path)).toBe(false);
+    expect(response).not.toContain(SUBMIT_LINE);
+    expect(conversation.history[conversation.history.length - 1]?.content).not.toContain(SUBMIT_LINE);
     expect(conversation.getDraftedPlan()).toBe(VALID_PLAN_YAML.trim());
   });
 
   it('does not expose a plan when a summary-only turn has no prior draft', async () => {
     const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', plannerRetryLimit: 0 });
 
-    mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the plan. Summary: one step.'));
-    await conversation.sendMessage('Draft it');
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(`Drafted the plan. Summary: one step.\n\n${SUBMIT_LINE}`));
+    const response = await conversation.sendMessage('Draft it');
 
+    expect(response).not.toContain(SUBMIT_LINE);
+    expect(conversation.history[conversation.history.length - 1]?.content).not.toContain(SUBMIT_LINE);
     expect(conversation.getDraftedPlan()).toBeNull();
   });
 
@@ -139,12 +145,14 @@ describe('plan draft file - activation side', () => {
       'Drafted the plan.\n\nReply `submit` to submit it.',
       () => writeFileSync(path, VALID_PLAN_YAML, 'utf8'),
     ));
-    await conversation.sendMessage('Create the plan');
+    const response = await conversation.sendMessage('Create the plan');
 
     expect(isConfirmation('submit')).toBe(true);
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     expect(conversation.planSubmitted).toBe(false);
     expect(conversation.submittedPlanText).toBeNull();
+    expect(response).toContain(SUBMIT_LINE);
+    expect(conversation.history[conversation.history.length - 1]?.content).toContain(SUBMIT_LINE);
 
     const draftedPlan = conversation.getDraftedPlan();
     expect(draftedPlan).not.toBeNull();
@@ -156,8 +164,10 @@ describe('plan draft file - activation side', () => {
     const conversation = new PlanConversation({ plannerRetryLimit: 0 });
 
     mockSpawn.mockReturnValueOnce(fakePlannerChild(INLINE_PLAN_RESPONSE));
-    await conversation.sendMessage('Create the plan');
+    const response = await conversation.sendMessage('Create the plan');
 
+    expect(response).toContain(SUBMIT_LINE);
+    expect(conversation.history[conversation.history.length - 1]?.content).toContain(SUBMIT_LINE);
     const draftedPlan = conversation.getDraftedPlan();
     expect(draftedPlan).not.toBeNull();
     const parsedDraft = parseYaml(draftedPlan!) as Record<string, unknown>;

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -189,6 +189,17 @@ export function isNegation(text: string): boolean {
   return NEGATION_PATTERNS.some((re) => re.test(trimmed));
 }
 
+const SUBMIT_INSTRUCTION_LINE = 'Reply `submit` to submit it.';
+
+function stripStandaloneSubmitInstruction(text: string): string {
+  return text
+    .split(/\r?\n/)
+    .filter((line) => line.trim() !== SUBMIT_INSTRUCTION_LINE)
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
 function isDraftingAuthorizedForPrompt(messages: ConversationMessage[]): boolean {
   const latest = messages[messages.length - 1];
   if (!latest || latest.role !== 'user') return false;
@@ -552,6 +563,7 @@ export class PlanConversation {
       : inlineDraft;
     this._lastTurnDraftPlanText = nextDraft;
     if (nextDraft) this.lastKnownGoodPlanText = nextDraft;
+    if (!nextDraft) message = stripStandaloneSubmitInstruction(message);
     this._lastTurnReasoning = formatted.reasoning;
     this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: responseLen=${response.length}, messageLen=${message.length}, reasoningParts=${formatted.reasoning.length}, responsePreview="${message.slice(0, 500).replace(/\n/g, '\\n')}"`);
 


### PR DESCRIPTION
## Summary

Planning replies now omit the standalone confirmation instruction when the current turn has no real draft.

Real draft turns keep the instruction, so existing ready-to-confirm conversations behave the same.

## Review Claim

Planner replies expose the confirmation instruction only when the current turn produced a real draft.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice stays in planner reply formatting and focused draft-capture regressions. Valid drafted replies keep the same ready-to-confirm behavior.

## Slice Rationale

This slice fixes the misleading saved reply at the point where draft readiness is decided.

## Non-goals

- No in-app approval guard changes.
- No terminal command handling changes.
- No harness or model selection changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/plan-draft-file-activation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c24df2637052c5dae72d2a3529b51a25271431c5`
- Post-revert steps: Rerun the focused surfaces regression.
- Data migration? No

</details>
