### PR TITLE
[Bugfix: truthful planning draft readiness](2) Require draft-ready in-app approval

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -46,6 +46,8 @@ tasks:
     dependencies: [first]
     command: echo second`;
 
+const NO_COMPLETE_DRAFT_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
+
 const VALID_PLAN_WITHOUT_CLOSING_FENCE = `Here is the plan.
 
 \`\`\`yaml
@@ -416,9 +418,9 @@ describe('planning chat', () => {
       await expect(submitPlanningChatDraft({ sessionId: session.id }, {
         sessions,
         loadGeneratedPlan,
-    })).resolves.toMatchObject({ ok: false });
-    expect(loadGeneratedPlan).not.toHaveBeenCalled();
-    expect(sessions.get(session.id)?.draftPlanText).toBeUndefined();
+      })).resolves.toEqual({ ok: false, error: NO_COMPLETE_DRAFT_ERROR });
+      expect(loadGeneratedPlan).not.toHaveBeenCalled();
+      expect(sessions.get(session.id)?.draftPlanText).toBeUndefined();
     } finally {
       rmSync(workingDir, { recursive: true, force: true });
     }
@@ -538,6 +540,7 @@ describe('planning chat', () => {
       planningCommandBuilder,
     });
     if (!sent.ok) throw new Error(sent.error);
+    expect(sessions.get(sent.sessionId)?.status).toBe('draft_ready');
     const loadGeneratedPlan = vi.fn().mockResolvedValue({
       planName: 'Mock Plan',
       workflowId: 'wf-1',
@@ -558,6 +561,7 @@ describe('planning chat', () => {
       workflowCount: 1,
     });
     expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
+    expect(sessions.get(sent.sessionId)?.status).toBe('submitted');
   });
 
   it('submits a valid final draft plan without a closing YAML fence', async () => {
@@ -741,6 +745,7 @@ tasks:
   it('rejects submit when no draft exists', async () => {
     vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue('No YAML yet.');
     const sessions = createInAppPlanningChatSessions();
+    const loadGeneratedPlan = vi.fn();
     const sent = await sendPlanningChatMessage({
       message: 'hello',
       presetKey: 'codex',
@@ -756,8 +761,67 @@ tasks:
       sessionId: sent.sessionId,
     }, {
       sessions,
-      loadGeneratedPlan: vi.fn(),
-    })).resolves.toEqual({ ok: false, error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.' });
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: NO_COMPLETE_DRAFT_ERROR });
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
+  it('rejects submit when saved draft text is not draft-ready', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('summary-only', {
+      id: 'summary-only',
+      title: 'Summary only',
+      presetKey: 'codex',
+      status: 'still_discussing',
+      messages: [],
+      conversation: new PlanConversation({}),
+      draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+      draftPlanText: VALID_PLAN_TEXT,
+      createdAt: '2026-07-07T00:00:00.000Z',
+      updatedAt: '2026-07-07T00:00:00.000Z',
+      nextMessageId: 1,
+    });
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+    } satisfies LoadedGeneratedPlan);
+
+    await expect(submitPlanningChatDraft({
+      sessionId: 'summary-only',
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: NO_COMPLETE_DRAFT_ERROR });
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
+  it('rejects submit when draft-ready state has no draft text', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('cleared-draft', {
+      id: 'cleared-draft',
+      title: 'Cleared draft',
+      presetKey: 'codex',
+      status: 'draft_ready',
+      messages: [],
+      conversation: new PlanConversation({}),
+      draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+      draftPlanText: '   ',
+      createdAt: '2026-07-07T00:00:00.000Z',
+      updatedAt: '2026-07-07T00:00:00.000Z',
+      nextMessageId: 1,
+    });
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+    } satisfies LoadedGeneratedPlan);
+
+    await expect(submitPlanningChatDraft({
+      sessionId: 'cleared-draft',
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: NO_COMPLETE_DRAFT_ERROR });
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
   });
 
   it('rejects submit when the draft summary cannot be read', async () => {
@@ -1021,6 +1085,12 @@ tasks:
       expect(sessions.get('planning-summary-restore')?.status).toBe('still_discussing');
       expect(sessions.get('planning-summary-restore')?.draftPlanSummary).toBeUndefined();
       expect(sessions.get('planning-summary-restore')?.draftPlanText).toBeUndefined();
+      const loadGeneratedPlan = vi.fn();
+      await expect(submitPlanningChatDraft({ sessionId: 'planning-summary-restore' }, {
+        sessions,
+        loadGeneratedPlan,
+      })).resolves.toEqual({ ok: false, error: NO_COMPLETE_DRAFT_ERROR });
+      expect(loadGeneratedPlan).not.toHaveBeenCalled();
     } finally {
       adapter.close();
     }

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -214,6 +214,12 @@ function hasDraftPlan(session: Pick<InAppPlanningChatSession, 'draftPlanSummary'
   return Boolean(session.draftPlanText || session.draftPlanSummary);
 }
 
+const NO_COMPLETE_DRAFT_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
+
+function noCompleteDraftResponse(): InAppPlanningSubmitResponse {
+  return { ok: false, error: NO_COMPLETE_DRAFT_ERROR };
+}
+
 function sessionToRecord(session: InAppPlanningChatSession, pendingResponse: boolean): InAppPlanningSessionRecord {
   return {
     id: session.id,
@@ -631,6 +637,9 @@ export async function submitPlanningChatDraft(
   }
   if (session.status === 'submitted') {
     return { ok: false, error: 'This planning session was already submitted.' };
+  }
+  if (session.status !== 'draft_ready' || !session.draftPlanText?.trim()) {
+    return noCompleteDraftResponse();
   }
   if (session.pendingSubmit) {
     return session.pendingSubmit;


### PR DESCRIPTION
## Summary

The in-app planning approval path now requires draft-ready state and non-empty draft text.

No-draft and cleared-draft sessions return the existing no-draft error before loading any plan.

## Review Claim

The in-app approval path requires draft-ready state and non-empty draft text before loading the plan.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice stays in the in-app approval handler and focused regressions. Valid draft-ready sessions still use the same approval path.

## Slice Rationale

This slice owns the backend approval precondition without changing planner reply text or terminal command dispatch.

## Non-goals

- No planner reply text changes.
- No terminal command handling changes.
- No harness or model selection changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0ebc71cff4ed83f1f87ce2485d7c0cb6af5fcc4d`
- Post-revert steps: Rerun the focused app regression.
- Data migration? No

</details>
