### PR TITLE
[Bugfix: truthful planning draft readiness](3) Gate terminal confirmation command

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -114,6 +114,7 @@ const EDITABLE_SELECTOR = [
 const SYSTEM_SETUP_AUTO_OPEN_DELAY_MS = 1200;
 const RAIL_LIST_FRAME_CLASS = 'flex min-h-0 flex-1 flex-col';
 const RAIL_SCROLL_BODY_CLASS = 'min-h-0 flex-1 overflow-y-auto';
+const NO_COMPLETE_DRAFT_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
 
 function notifyMutationError(rawTitle: string, err: unknown): void {
   console.error(rawTitle, err);
@@ -861,6 +862,7 @@ export function App() {
   const draftPlanAvailable = activePlanningSession.draftPlanAvailable;
   const draftPlanSummary = activePlanningSession.draftPlanSummary;
   const draftPlanText = activePlanningSession.draftPlanText;
+  const activePlanningDraftReady = draftPlanAvailable || activePlanningSession.status === 'draft_ready';
   const activePlanningSessionBusy = activePlanningSession.busy;
   const activePlanningSessionSubmitted = activePlanningSession.status === 'submitted';
   const activePlanningMode = activePlanningSession.mode ?? 'chat';
@@ -2639,6 +2641,11 @@ export function App() {
     }
 
     if (/^submit(\s+to\s+invoker)?[.!?]*$/i.test(input)) {
+      if (!activePlanningDraftReady) {
+        setPlanningSubmitError({ title: 'Plan could not be submitted', message: NO_COMPLETE_DRAFT_ERROR });
+        appendTerminalLine(`Plan could not be submitted:\n${NO_COMPLETE_DRAFT_ERROR}`, 'system', 'error');
+        return;
+      }
       await handlePlanningSubmitDraft();
       return;
     }
@@ -2711,6 +2718,7 @@ export function App() {
   }, [
     activePlanningSessionBusy,
     activePlanningSessionId,
+    activePlanningDraftReady,
     activePlanningReadOnly,
     appendTerminalLine,
     clearPlanningStreamForSessionIds,

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -701,6 +701,34 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
+  it('does not submit or chat when the user types submit before a draft is ready', async () => {
+    mock.api.planningChatSend = vi.fn(async () => ({
+      ok: true,
+      sessionId: 'session-1',
+      reply: 'I need one more detail first.',
+      draftPlanAvailable: false,
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('help me plan the work');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('I need one more detail first.');
+    });
+
+    submitPlanningText('submit');
+
+    expect(mock.api.planningChatSubmit).not.toHaveBeenCalled();
+    expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(
+      'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.',
+    );
+    expect(mock.api.startReady).not.toHaveBeenCalled();
+    expect(mock.api.start).not.toHaveBeenCalled();
+  });
+
   it('submits a draft and starts ready work when the user types submit', async () => {
     mock.api.planningChatSend = vi.fn(async () => ({
       ok: true,


### PR DESCRIPTION
## Summary

The planning terminal now checks draft readiness before the confirmation command calls approval.

Without a ready draft, the terminal shows the deterministic no-draft error and leaves the approval API untouched.

## Review Claim

The terminal confirmation command runs the planning approval API only for an active draft-ready session.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice stays in terminal command dispatch and focused terminal regressions. Existing draft-ready command flow still reaches the same approval API.

## Slice Rationale

This slice owns terminal command dispatch without changing planner reply text or the backend approval guard.

## Non-goals

- No planner reply text changes.
- No in-app approval guard changes.
- No harness or model selection changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx`

</details>

## Visual Proof

![Planning terminal no-draft error after typed submit](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-6cc660/invoker-terminal-submit-no-draft.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d9ce20028f49d14e3a5b97bbad4562c1e5eb9977`
- Post-revert steps: Rerun the focused UI regression.
- Data migration? No

</details>
