### PR TITLE
[Onboarding Step 1: CLI one-shot setup](1) Harden CLI setup readiness checks

### DIFF
--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -19,7 +19,6 @@ import {
   REQUIRED_BOT_SCOPES,
   runPlanValidationSmoke,
   slackCredsFromEnv,
-  skippedGithubAuthCheck,
   runSetup,
   setExperimentalPlannerFlag,
   upsertEnvLines,
@@ -45,7 +44,7 @@ function readySetupDeps(overrides: SetupDeps = {}): SetupDeps {
   return {
     isInstalled: () => true,
     githubAuthCheck: async () => okCheck('github-auth', 'GitHub auth', 'gh is authenticated'),
-    smokePlanValidation: async () => okCheck('smoke-plan', 'Smoke plan validation', 'Parsed 1 task(s)'),
+    smokePlanValidation: async () => okCheck('smoke-plan', 'smoke: plan validation', 'Parsed 1 task(s)'),
     ...overrides,
   };
 }
@@ -544,8 +543,23 @@ describe('GitHub auth check', () => {
     expect(check.remediation).toContain('gh auth login');
   });
 
-  it('warns and skips when gh is missing', () => {
-    expect(skippedGithubAuthCheck()).toMatchObject({ id: 'github-auth', status: 'warn' });
+  it('warns and skips when the injected runner cannot spawn gh', () => {
+    const missing = Object.assign(new Error('spawn gh ENOENT'), { code: 'ENOENT' });
+    const check = checkGithubAuth(() => {
+      throw missing;
+    });
+    expect(check).toMatchObject({ id: 'github-auth', status: 'warn' });
+    expect(check.remediation).toContain('gh auth login');
+  });
+
+  it('warns and skips when the injected runner reports gh is missing', () => {
+    const check = checkGithubAuth(() => ({
+      status: 127,
+      stdout: '',
+      stderr: 'sh: gh: command not found',
+    }));
+    expect(check).toMatchObject({ id: 'github-auth', status: 'warn' });
+    expect(check.remediation).toContain('gh auth login');
   });
 });
 
@@ -554,7 +568,7 @@ describe('setup oneshot ending', () => {
     const checks: Check[] = [
       okCheck('a', 'A'),
       errorCheck('github-auth', 'GitHub auth', 'not logged in', 'Run `gh auth login`'),
-      errorCheck('smoke-plan', 'Smoke plan validation', 'boom'),
+      errorCheck('smoke-plan', 'smoke: plan validation', 'boom'),
     ];
     expect(firstSetupFailure(checks)?.id).toBe('github-auth');
     expect(formatSetupEnding(checks)).toContain('Fix this first: GitHub auth: not logged in.');
@@ -574,14 +588,14 @@ describe('setup oneshot ending', () => {
       }, readySetupDeps({
         smokePlanValidation: async () => errorCheck(
           'smoke-plan',
-          'Smoke plan validation',
+          'smoke: plan validation',
           'parse failed',
           'Reinstall invoker-cli',
         ),
       }));
 
       expect(code).toBe(1);
-      expect(lines.join('\n')).toContain('Fix this first: Smoke plan validation: parse failed.');
+      expect(lines.join('\n')).toContain('Fix this first: smoke: plan validation: parse failed.');
       expect(lines.join('\n')).not.toContain("You're ready.");
     } finally {
       if (savedHome === undefined) delete process.env.HOME;

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -274,6 +274,7 @@ export interface CommandRunnerResult {
   status: number | null;
   stdout: string;
   stderr: string;
+  error?: unknown;
 }
 
 export type CommandRunner = (command: string, args: readonly string[]) => CommandRunnerResult;
@@ -284,6 +285,7 @@ export function defaultCommandRunner(command: string, args: readonly string[]): 
     status: result.status,
     stdout: typeof result.stdout === 'string' ? result.stdout : '',
     stderr: typeof result.stderr === 'string' ? result.stderr : '',
+    error: result.error,
   };
 }
 
@@ -299,7 +301,20 @@ export function skippedGithubAuthCheck(): PrerequisiteCheck {
 
 /** Probe `gh auth status`. Injectable `runner` keeps tests offline. */
 export function checkGithubAuth(runner: CommandRunner = defaultCommandRunner): PrerequisiteCheck {
-  const result = runner('gh', ['auth', 'status']);
+  let result: CommandRunnerResult;
+  try {
+    result = runner('gh', ['auth', 'status']);
+  } catch (error) {
+    if (isMissingCommandError(error)) return skippedGithubAuthCheck();
+    return {
+      id: 'github-auth',
+      name: 'GitHub auth',
+      status: 'error',
+      detail: formatCaughtException(error),
+      remediation: 'Run `gh auth login` and re-run `invoker-cli setup`',
+    };
+  }
+  if (commandRunnerResultIsMissing(result)) return skippedGithubAuthCheck();
   if (result.status === 0) {
     return {
       id: 'github-auth',
@@ -319,6 +334,20 @@ export function checkGithubAuth(runner: CommandRunner = defaultCommandRunner): P
   };
 }
 
+function isMissingCommandError(error: unknown): boolean {
+  const code = isJsonRecord(error) && typeof error.code === 'string' ? error.code : undefined;
+  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
+  return code === 'ENOENT'
+    || /\bENOENT\b|command not found|\bgh(?::|\b).*not found|no such file or directory/i.test(message);
+}
+
+function commandRunnerResultIsMissing(result: CommandRunnerResult): boolean {
+  if (isMissingCommandError(result.error)) return true;
+  const output = `${result.stderr}\n${result.stdout}`;
+  return (result.status === null || result.status === 127)
+    && /command not found|\bgh(?::|\b).*not found|no such file or directory|\bENOENT\b/i.test(output);
+}
+
 const SETUP_SMOKE_PLAN = `name: Setup Smoke
 description: Tiny offline plan used by invoker-cli setup.
 repoUrl: .
@@ -328,6 +357,7 @@ tasks:
     description: Validate plan parsing during setup.
     command: echo setup-smoke
 `;
+const SETUP_SMOKE_CHECK_NAME = 'smoke: plan validation';
 
 /** Parse a one-task temp plan with no network. Confirms the local plan pipeline works. */
 export async function runPlanValidationSmoke(): Promise<PrerequisiteCheck> {
@@ -339,7 +369,7 @@ export async function runPlanValidationSmoke(): Promise<PrerequisiteCheck> {
     if (!plan.tasks.length) {
       return {
         id: 'smoke-plan',
-        name: 'Smoke plan validation',
+        name: SETUP_SMOKE_CHECK_NAME,
         status: 'error',
         detail: 'Parsed plan has no tasks',
         remediation: 'Reinstall invoker-cli; plan parsing returned an empty task list',
@@ -347,14 +377,14 @@ export async function runPlanValidationSmoke(): Promise<PrerequisiteCheck> {
     }
     return {
       id: 'smoke-plan',
-      name: 'Smoke plan validation',
+      name: SETUP_SMOKE_CHECK_NAME,
       status: 'ok',
       detail: `Parsed ${plan.tasks.length} task(s) from a local smoke plan`,
     };
   } catch (error) {
     return {
       id: 'smoke-plan',
-      name: 'Smoke plan validation',
+      name: SETUP_SMOKE_CHECK_NAME,
       status: 'error',
       detail: formatCaughtException(error),
       remediation: 'Reinstall invoker-cli or report a plan-parser regression',


### PR DESCRIPTION
## Summary

Onboarding Step 1: CLI one-shot setup — 2 tasks completed, 0 failed, 0 closed

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926072929-1/implement-cli-setup-oneshot | Extend `invoker-cli setup` with a GitHub auth check, a tiny smoke task, and a single 'you're ready / fix this one thing' ending | completed |
| wf-1784926072929-1/verify-cli-setup-oneshot | Run the CLI onboarding test file | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784926072929-1/implement-cli-setup-oneshot — Extend `invoker-cli setup` with a GitHub auth check, a tiny smoke task, and a single 'you're ready / fix this one thing' ending

### wf-1784926072929-1/verify-cli-setup-oneshot — Run the CLI onboarding test file

</details>

`invoker-cli setup` now treats missing GitHub CLI runner failures as fixable warnings.

`invoker-cli setup` also keeps the smoke task label stable, so the final ending points at one actionable item.

## Review Claim

Approve the `invoker-cli setup` readiness path warning on missing GitHub CLI runner failures and keeping one ready-or-fix ending.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The slice only changes `invoker-cli setup` readiness behavior and its directly affected unit tests. It does not change persisted config writes or network setup flows.

## Slice Rationale

This is one CLI onboarding readiness path: GitHub auth, the smoke task, and the setup ending are reviewed together.

## Non-goals

This does not change the `gh auth login` remediation for real auth failures, add network smoke work, modify Slack setup, or change planner MCP setup behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/cli exec vitest run src/__tests__/onboarding.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-onboarding-cli-one-shot-pr.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/invoker-onboarding-cli-one-shot-pr.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c10b22a79517b90a41abfc5bf2ae0ff3902da56e`
- Post-revert steps: None
- Data migration? No

</details>
