### PR TITLE
[Delete planning terminals — UI](1) Add Planning Terminal rail controls

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -49,6 +49,7 @@ import { InvokerTerminal, type InvokerTerminalLine, type PlanningTerminalMode } 
 import { Toaster, toast } from 'sonner';
 import { Button } from './components/primitives/index.js';
 import { ChevronDownIcon, PlayIcon } from './components/icons/index.js';
+import { Trash2 as Trash2Icon } from 'lucide-react';
 import { CommandPalette, COMMAND_PALETTE_MAX_ROWS } from './components/CommandPalette.js';
 import {
   getAttentionTaskEntries,
@@ -2729,22 +2730,103 @@ export function App() {
     workflows.size,
   ]);
 
-  const handleCreatePlanningSession = useCallback(() => {
+  const makeLocalPlanningSession = useCallback((): PlanningSessionView => {
     const index = nextPlanningSessionLocalIdRef.current;
     nextPlanningSessionLocalIdRef.current += 1;
     const now = new Date().toISOString();
     const localId = `local-planning-session-${index}`;
-    const session: PlanningSessionView = {
+    return {
       ...makeInitialPlanningSession(now),
       id: localId,
       conversationKey: localId,
       presetKey: selectedPlanningPresetKey,
     };
+  }, [selectedPlanningPresetKey]);
+
+  const removePlanningSessionsByIds = useCallback((sessionIds: string[]) => {
+    const ids = new Set(sessionIds);
+    if (ids.size === 0) return;
+
+    const previousSessions = planningSessionsRef.current;
+    const remainingSessions = previousSessions.filter((session) => !ids.has(session.id));
+    const currentActiveSessionId = activePlanningSessionIdRef.current;
+    let nextSessions = remainingSessions;
+    let nextActiveSessionId = currentActiveSessionId;
+
+    if (remainingSessions.length === 0) {
+      const session = makeLocalPlanningSession();
+      nextSessions = [session];
+      nextActiveSessionId = session.id;
+    } else if (!remainingSessions.some((session) => session.id === currentActiveSessionId)) {
+      const currentIndex = previousSessions.findIndex((session) => session.id === currentActiveSessionId);
+      const followingSession = previousSessions.slice(currentIndex + 1).find((session) => !ids.has(session.id));
+      const previousSession = previousSessions
+        .slice(0, Math.max(currentIndex, 0))
+        .reverse()
+        .find((session) => !ids.has(session.id));
+      nextActiveSessionId = (followingSession ?? previousSession ?? remainingSessions[0]).id;
+    }
+
+    planningSessionsRef.current = nextSessions;
+    activePlanningSessionIdRef.current = nextActiveSessionId;
+    setPlanningSessions(nextSessions);
+    setActivePlanningSessionId(nextActiveSessionId);
+    setReviewDraftSessionId((currentSessionId) => (
+      currentSessionId && ids.has(currentSessionId) ? null : currentSessionId
+    ));
+  }, [makeLocalPlanningSession]);
+
+  const handleDeletePlanningSession = useCallback((sessionId: string) => {
+    if (activePlanningReadOnly) return;
+    if (!sessionId.startsWith('local-')) {
+      void invoker?.planningChatDelete?.({ sessionId });
+    }
+    removePlanningSessionsByIds([sessionId]);
+    pendingPlanningStreamSessionIdsRef.current.delete(sessionId);
+    clearPlanningStreamForSessionIds([sessionId]);
+    forgetPlanningStreamAliasesForSessionIds([sessionId]);
+  }, [
+    activePlanningReadOnly,
+    clearPlanningStreamForSessionIds,
+    forgetPlanningStreamAliasesForSessionIds,
+    invoker,
+    removePlanningSessionsByIds,
+  ]);
+
+  const handleClearSubmittedPlanningSessions = useCallback(() => {
+    if (activePlanningReadOnly) return;
+    if (!planningSessionsRef.current.some((session) => session.status === 'submitted')) return;
+    const confirmed = window.confirm(
+      'Clear all submitted planning chats? This cannot be undone.',
+    );
+    if (!confirmed) return;
+
+    const submittedSessionIds = planningSessionsRef.current
+      .filter((session) => session.status === 'submitted')
+      .map((session) => session.id);
+    if (submittedSessionIds.length === 0) return;
+    void invoker?.planningChatDeleteSubmitted?.();
+    removePlanningSessionsByIds(submittedSessionIds);
+    for (const sessionId of submittedSessionIds) {
+      pendingPlanningStreamSessionIdsRef.current.delete(sessionId);
+    }
+    clearPlanningStreamForSessionIds(submittedSessionIds);
+    forgetPlanningStreamAliasesForSessionIds(submittedSessionIds);
+  }, [
+    activePlanningReadOnly,
+    clearPlanningStreamForSessionIds,
+    forgetPlanningStreamAliasesForSessionIds,
+    invoker,
+    removePlanningSessionsByIds,
+  ]);
+
+  const handleCreatePlanningSession = useCallback(() => {
+    const session = makeLocalPlanningSession();
     setPlanningSessions((prev) => [session, ...prev]);
     setActivePlanningSessionId(session.id);
     setSidebarSurface('home');
     focusKeyboardRegion('planning');
-  }, [focusKeyboardRegion, selectedPlanningPresetKey]);
+  }, [focusKeyboardRegion, makeLocalPlanningSession]);
 
   const handlePlanningModeChange = useCallback(async (mode: PlanningTerminalMode) => {
     const sourceSession = activePlanningSession;
@@ -3998,30 +4080,49 @@ export function App() {
           const selected = session.id === activePlanningSession.id;
           const preview = previewPlanningMessage(session);
           return (
-            <button
+            <div
               key={session.id}
-              type="button"
-              onClick={() => setActivePlanningSessionId(session.id)}
-              className={`flex w-full items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              data-testid={`planning-session-row-${session.id}`}
+              className="flex items-stretch"
             >
-              <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-start justify-between gap-2">
-                  <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
-                    {session.title}
+              <button
+                type="button"
+                onClick={() => setActivePlanningSessionId(session.id)}
+                className={`flex w-full min-w-0 items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              >
+                <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
+                      {session.title}
+                    </div>
+                    <span className="shrink-0 text-[11px] text-muted-foreground">
+                      {relativePlanningUpdatedAt(session.updatedAt)}
+                    </span>
                   </div>
-                  <span className="shrink-0 text-[11px] text-muted-foreground">
-                    {relativePlanningUpdatedAt(session.updatedAt)}
-                  </span>
+                  <div
+                    className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
+                    title={preview}
+                  >
+                    {preview}
+                  </div>
                 </div>
-                <div
-                  className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
-                  title={preview}
+              </button>
+              {!activePlanningReadOnly ? (
+                <button
+                  type="button"
+                  aria-label="Delete planning chat"
+                  title="Delete planning chat"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleDeletePlanningSession(session.id);
+                  }}
+                  className="flex w-9 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 >
-                  {preview}
-                </div>
-              </div>
-            </button>
+                  <Trash2Icon aria-hidden="true" className="h-3.5 w-3.5" strokeWidth={1.75} />
+                </button>
+              ) : null}
+            </div>
           );
         })}
       </div>
@@ -4029,6 +4130,7 @@ export function App() {
   );
 
   const planningReadyCount = planningSessions.filter((session) => session.status === 'draft_ready').length;
+  const hasSubmittedPlanningSessions = planningSessions.some((session) => session.status === 'submitted');
   const connectedAgentLabels = (systemDiagnostics?.tools ?? [])
     .filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed)
     .map((tool) => tool.name.replace(/\s+CLI$/i, ''));
@@ -4173,6 +4275,14 @@ export function App() {
               <div className="flex items-center gap-2">
                 <Button variant="outline" size="sm" onClick={handleCreatePlanningSession}>
                   New chat
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleClearSubmittedPlanningSessions}
+                  disabled={activePlanningReadOnly || !hasSubmittedPlanningSessions}
+                >
+                  Clear submitted
                 </Button>
                 <button
                   type="button"

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -220,6 +220,8 @@ export function createMockInvoker(
       workflowId: 'wf-1',
     })),
     planningChatReset: vi.fn(async () => ({ ok: true })),
+    planningChatDelete: vi.fn(async () => ({ ok: true })),
+    planningChatDeleteSubmitted: vi.fn(async () => ({ ok: true, deletedSessionIds: [] })),
     onPlanningChatStream: vi.fn((cb: (event: InAppPlanningStreamEvent) => void) => {
       planningChatStreamCallbacks.add(cb);
       return () => { planningChatStreamCallbacks.delete(cb); };

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -57,6 +57,19 @@ describe('Invoker terminal (component)', () => {
     expectRailListScrollContract(screen.getByTestId(listTestId));
   }
 
+  async function renderPlanningTerminalWithSessions(sessions: ReturnType<typeof makePlanningSessionSummary>[]) {
+    mock.api.planningChatList = vi.fn(async () => ({ ok: true, sessions }));
+    render(<App />);
+    await openPlanningTerminal();
+    const rail = await screen.findByTestId('planning-session-list');
+    await waitFor(() => {
+      for (const session of sessions) {
+        expect(within(rail).getByText(session.title)).toBeInTheDocument();
+      }
+    });
+    return rail;
+  }
+
   it('renders an empty flush planning pane before the first message', async () => {
     render(<App />);
     await openPlanningTerminal();
@@ -271,8 +284,9 @@ describe('Invoker terminal (component)', () => {
     const secondPanel = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(secondPanel).toHaveTextContent('Drafting your plan…');
 
-    const sessionButtons = within(screen.getByTestId('planning-session-list')).getAllByRole('button');
-    fireEvent.click(sessionButtons[1]);
+    fireEvent.click(within(screen.getByTestId('planning-session-list')).getByRole('button', {
+      name: /first session request/i,
+    }));
 
     const firstPanel = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(firstPanel).toHaveTextContent('Drafting your plan…');
@@ -915,6 +929,179 @@ describe('Invoker terminal (component)', () => {
     fireEvent.click(screen.getByText('hello'));
 
     expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('I can help draft that.');
+  });
+
+  it('deletes a saved planning chat from the rail and calls the bridge with its session id', async () => {
+    const rail = await renderPlanningTerminalWithSessions([
+      makePlanningSessionSummary({
+        id: 'delete-target-chat',
+        title: 'Delete target chat',
+        status: 'still_discussing',
+        draftPlanAvailable: false,
+        draftPlanSummary: undefined,
+      }),
+      makePlanningSessionSummary({
+        id: 'keep-target-chat',
+        title: 'Keep target chat',
+        status: 'still_discussing',
+        draftPlanAvailable: false,
+        draftPlanSummary: undefined,
+      }),
+    ]);
+
+    fireEvent.click(within(screen.getByTestId('planning-session-row-delete-target-chat')).getByRole('button', {
+      name: 'Delete planning chat',
+    }));
+
+    await waitFor(() => {
+      expect(within(rail).queryByText('Delete target chat')).not.toBeInTheDocument();
+    });
+    expect(within(rail).getByText('Keep target chat')).toBeInTheDocument();
+    expect(mock.api.planningChatDelete).toHaveBeenCalledWith({ sessionId: 'delete-target-chat' });
+  });
+
+  it('deletes a local planning chat without calling the bridge delete channel', async () => {
+    render(<App />);
+    await openPlanningTerminal();
+
+    fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('2 chats');
+    });
+
+    const rail = screen.getByTestId('planning-session-list');
+    fireEvent.click(within(rail).getAllByRole('button', { name: 'Delete planning chat' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('1 chat');
+    });
+    expect(within(rail).getAllByRole('button', { name: 'Delete planning chat' })).toHaveLength(1);
+    expect(mock.api.planningChatDelete).not.toHaveBeenCalled();
+  });
+
+  it('clears submitted planning chats only after confirmation', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'idle-only-chat',
+          title: 'Idle only chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+      ],
+    }));
+    const firstRender = render(<App />);
+    await openPlanningTerminal();
+
+    expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
+
+    firstRender.unmount();
+    mock.cleanup();
+    mock = createMockInvoker();
+    mock.install();
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'idle-chat',
+          title: 'Idle chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+        makePlanningSessionSummary({
+          id: 'submitted-alpha-chat',
+          title: 'Submitted alpha chat',
+          status: 'submitted',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+        makePlanningSessionSummary({
+          id: 'submitted-beta-chat',
+          title: 'Submitted beta chat',
+          status: 'submitted',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+      ],
+    }));
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<App />);
+    await openPlanningTerminal();
+    const rail = screen.getByTestId('planning-session-list');
+    await waitFor(() => {
+      expect(within(rail).getByText('Submitted alpha chat')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear submitted' }));
+
+    await waitFor(() => {
+      expect(within(rail).queryByText('Submitted alpha chat')).not.toBeInTheDocument();
+      expect(within(rail).queryByText('Submitted beta chat')).not.toBeInTheDocument();
+    });
+    expect(within(rail).getByText('Idle chat')).toBeInTheDocument();
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(mock.api.planningChatDeleteSubmitted).toHaveBeenCalledTimes(1);
+
+    confirmSpy.mockRestore();
+  });
+
+  it('recreates a fresh empty chat after deleting the last remaining planning chat', async () => {
+    const rail = await renderPlanningTerminalWithSessions([
+      makePlanningSessionSummary({
+        id: 'last-saved-chat',
+        title: 'Last saved chat',
+        status: 'still_discussing',
+        draftPlanAvailable: false,
+        draftPlanSummary: undefined,
+      }),
+    ]);
+
+    fireEvent.click(within(screen.getByTestId('planning-session-row-last-saved-chat')).getByRole('button', {
+      name: 'Delete planning chat',
+    }));
+
+    await waitFor(() => {
+      expect(within(rail).queryByText('Last saved chat')).not.toBeInTheDocument();
+      expect(within(rail).getByText('Untitled plan')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('1 chat');
+    expect(screen.getByTestId('invoker-terminal-empty-hero')).toBeInTheDocument();
+    expect(screen.getByText('What do you want to build?')).toBeInTheDocument();
+    expect(mock.api.planningChatDelete).toHaveBeenCalledWith({ sessionId: 'last-saved-chat' });
+  });
+
+  it('hides planning chat trash buttons and disables clear submitted in read-only mode', async () => {
+    mock.cleanup();
+    mock = createMockInvoker();
+    mock.setRuntimeStatus({ ownerMode: false, readOnly: true, mode: 'read-only' });
+    mock.install();
+    const rail = await renderPlanningTerminalWithSessions([
+      makePlanningSessionSummary({
+        id: 'readonly-idle-chat',
+        title: 'Readonly idle chat',
+        status: 'still_discussing',
+        draftPlanAvailable: false,
+        draftPlanSummary: undefined,
+      }),
+      makePlanningSessionSummary({
+        id: 'readonly-submitted-chat',
+        title: 'Readonly submitted chat',
+        status: 'submitted',
+        draftPlanAvailable: false,
+        draftPlanSummary: undefined,
+      }),
+    ]);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
+    });
+    expect(within(rail).queryByRole('button', { name: 'Delete planning chat' })).not.toBeInTheDocument();
+    expect(mock.api.planningChatDeleteSubmitted).not.toHaveBeenCalled();
+    expect(mock.api.planningChatDelete).not.toHaveBeenCalled();
   });
 
   it('wraps long planning session rail titles and previews instead of clipping them to one line', async () => {


### PR DESCRIPTION
## Summary

Planning Terminal rail now offers per-row trash controls and a guarded bulk rail action.

Selection falls through to a remaining chat, and an empty local chat is recreated when the rail would otherwise have no rows.

Focused renderer checks exercise saved, local, bulk-action, last-row, read-only, and stream bookkeeping cases.

## Review Claim

Approve the Planning Terminal rail controls for individual chat trashing and guarded bulk rail clearing.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The backend IPC contract already exists on master, so this slice only changes renderer state transitions and bridge usage.

Read-only mode disables the mutation controls, and Clear submitted only targets sessions already marked submitted.

## Slice Rationale

This stays as one UI rail slice because the controls, session reselection, empty recreation, and bridge calls are one renderer interaction path.

The focused checks stay with the UI behavior because they exercise the same rail boundary and stream bookkeeping.

## Non-goals

- Do not change backend delete semantics, persistence schema, or planner submission behavior.
- Do not change workflow, task, or history deletion behavior.
- Do not clear draft, failed, or active in-progress planning chats through Clear submitted.

## Architecture

### Before

```mermaid
graph TD
    A["Planning session rail row"] --> B["Select session only"]
    C["Submitted planning chats"] --> D["Stay visible until another backend refresh"]
```

### After

```mermaid
graph TD
    A["Planning session rail row"] --> B["Select session"]
    A --> C["Trash action updates renderer state and calls delete IPC when saved"]
    D["Clear submitted button"] --> E["Confirm, call submitted-delete IPC, and reselect or recreate a chat"]
    E --> F["Stream aliases and pending stream ids are cleared"]
```

## Visual Proof

The walkthrough shows the rail with Clear submitted enabled and per-row trash buttons, then the submitted chats gone, then the final row trash action recreating an empty chat.

[Planning delete controls walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-97f6d5/planning-delete-controls-walkthrough-current.webm)

![Planning rail controls](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-97f6d5/planning-delete-controls-visible-current.png)

![Submitted chats cleared](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-97f6d5/planning-clear-submitted-result-current.png)

![Last row trash recreates empty chat](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-97f6d5/planning-row-delete-recreated-empty-current.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/ui exec vite --host 127.0.0.1 --port 5178`
- [x] `node --input-type=module <inline Playwright visual proof capture script>`
- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/invoker-terminal.test.tsx`
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/delete-planning-terminals-ui-pr.md --require-visual-proof --changed-files-file .tmp/delete-planning-terminals-ui.changed-files.txt --diff-file .tmp/delete-planning-terminals-ui.diff`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/delete-planning-terminals-ui-pr.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert HEAD` from the PR branch.
- Post-revert steps: Re-run the focused Planning Terminal UI test.
- Data migration? No.

</details>

## Workflow Summary

Delete planning terminals — UI — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784313643126-2/ui-delete-planning-chat | Add per-row trash button (instant) + header Clear submitted button (confirm) to the Planning Terminal rail with reselection, empty-recreate, read-only gating, and stream cleanup | completed |
| wf-1784313643126-2/verify-ui-planning-terminal | Verify Planning Terminal rail delete + clear-submitted UI | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784313643126-2/ui-delete-planning-chat — Add per-row trash button (instant) + header Clear submitted button (confirm) to the Planning Terminal rail with reselection, empty-recreate, read-only gating, and stream cleanup

### wf-1784313643126-2/verify-ui-planning-terminal — Verify Planning Terminal rail delete + clear-submitted UI

</details>
