### PR TITLE
[Remote Sync Step 1: Sync Schema and Change Journal](1) Add data-store sync schema and journal

### DIFF
--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { WorkflowSaveInput } from '../adapter.js';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  readJournalSince,
+  setSyncCursor,
+  type SyncJournalDatabase,
+} from '../sync-journal.js';
+
+describe('sync journal', () => {
+  let adapter: SQLiteAdapter | undefined;
+
+  afterEach(() => {
+    adapter?.close();
+    adapter = undefined;
+  });
+
+  async function createAdapter(): Promise<SQLiteAdapter> {
+    adapter = await SQLiteAdapter.create(':memory:');
+    return adapter;
+  }
+
+  function journalDb(db: SQLiteAdapter): SyncJournalDatabase {
+    return (db as unknown as { executor: SyncJournalDatabase }).executor;
+  }
+
+  function workflow(id: string): WorkflowSaveInput {
+    return {
+      id,
+      name: `Workflow ${id}`,
+      createdAt: '2026-07-26T00:00:00.000Z',
+      updatedAt: '2026-07-26T00:00:00.000Z',
+    };
+  }
+
+  it('rolls back journal appends with the enclosing mutation transaction', async () => {
+    const db = await createAdapter();
+    const syncDb = journalDb(db);
+
+    expect(() => {
+      db.runInTransaction(() => {
+        db.saveWorkflow(workflow('wf-rollback'));
+        const row = syncDb.queryOne('SELECT * FROM workflows WHERE id = ?', ['wf-rollback']);
+        appendJournalEntry(syncDb, {
+          entityType: 'workflow',
+          entityId: 'wf-rollback',
+          op: 'upsert',
+          payload: row,
+        });
+        throw new Error('rollback requested');
+      });
+    }).toThrow('rollback requested');
+
+    expect(db.loadWorkflow('wf-rollback', { includeDeleted: true })).toBeUndefined();
+    expect(readJournalSince(syncDb, 0, 10)).toEqual([]);
+  });
+
+  it('assigns strictly monotonic seq values', async () => {
+    const db = await createAdapter();
+    const syncDb = journalDb(db);
+
+    const first = appendJournalEntry(syncDb, {
+      entityType: 'workflow',
+      entityId: 'wf-1',
+      op: 'upsert',
+      payload: { id: 'wf-1' },
+    });
+    const second = appendJournalEntry(syncDb, {
+      entityType: 'task',
+      entityId: 'task-1',
+      op: 'upsert',
+      payload: { id: 'task-1' },
+    });
+    const third = appendJournalEntry(syncDb, {
+      entityType: 'attempt',
+      entityId: 'attempt-1',
+      op: 'upsert',
+      payload: { id: 'attempt-1' },
+    });
+
+    expect(second.seq).toBeGreaterThan(first.seq);
+    expect(third.seq).toBeGreaterThan(second.seq);
+    expect(readJournalSince(syncDb, 0, 10).map((entry) => entry.seq)).toEqual([
+      first.seq,
+      second.seq,
+      third.seq,
+    ]);
+  });
+
+  it('reads journal entries after the supplied cursor', async () => {
+    const db = await createAdapter();
+    const syncDb = journalDb(db);
+
+    appendJournalEntry(syncDb, {
+      entityType: 'workflow',
+      entityId: 'wf-before',
+      op: 'upsert',
+      payload: { id: 'wf-before' },
+    });
+    const cursorEntry = appendJournalEntry(syncDb, {
+      entityType: 'task',
+      entityId: 'task-cursor',
+      op: 'upsert',
+      payload: { id: 'task-cursor' },
+    });
+    const afterCursor = appendJournalEntry(syncDb, {
+      entityType: 'attempt',
+      entityId: 'attempt-after',
+      op: 'upsert',
+      payload: { id: 'attempt-after' },
+    });
+
+    const cursor = setSyncCursor(syncDb, 'peer-a', {
+      lastSentSeq: cursorEntry.seq,
+      lastReceivedSeq: 7,
+    });
+
+    expect(getSyncCursor(syncDb, 'peer-a')).toMatchObject({
+      peerId: 'peer-a',
+      lastSentSeq: cursorEntry.seq,
+      lastReceivedSeq: 7,
+    });
+    expect(readJournalSince(syncDb, cursor.lastSentSeq, 10).map((entry) => entry.seq)).toEqual([
+      afterCursor.seq,
+    ]);
+  });
+
+  it('excludes soft-deleted workflows by default and reads them with includeDeleted', async () => {
+    const db = await createAdapter();
+
+    db.saveWorkflow(workflow('wf-soft-delete'));
+    db.deleteWorkflow('wf-soft-delete');
+
+    expect(db.listWorkflows()).toEqual([]);
+    expect(db.loadWorkflow('wf-soft-delete')).toBeUndefined();
+
+    const [deleted] = db.listWorkflows({ includeDeleted: true });
+    expect(deleted.id).toBe('wf-soft-delete');
+    expect(deleted.deletedAt).toEqual(expect.any(Number));
+    expect(db.loadWorkflow('wf-soft-delete', { includeDeleted: true })?.deletedAt)
+      .toEqual(expect.any(Number));
+  });
+
+  it('writes a workflow tombstone journal entry on delete', async () => {
+    const db = await createAdapter();
+    const syncDb = journalDb(db);
+
+    db.saveWorkflow(workflow('wf-tombstone'));
+    db.deleteWorkflow('wf-tombstone');
+
+    const entries = readJournalSince(syncDb, 0, 10);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      entityType: 'workflow',
+      entityId: 'wf-tombstone',
+      op: 'tombstone',
+      origin: 'home',
+    });
+    expect(entries[0].payload).toMatchObject({
+      id: 'wf-tombstone',
+      deleted_at: expect.any(Number),
+    });
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -124,8 +124,17 @@ export interface Workflow {
   generation?: number;
   createdAt: string;
   updatedAt: string;
+  deletedAt?: number;
 }
 export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup'>;
+
+export interface WorkflowReadOptions {
+  includeDeleted?: boolean;
+}
+
+export interface WorkflowListOptions {
+  includeDeleted?: boolean;
+}
 
 /**
  * Result of resolving a published PR back to its Invoker workflow via the merge
@@ -329,8 +338,8 @@ export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
-  loadWorkflow(workflowId: string): Workflow | undefined;
-  listWorkflows(): Workflow[];
+  loadWorkflow(workflowId: string, opts?: WorkflowReadOptions): Workflow | undefined;
+  listWorkflows(opts?: WorkflowListOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
   /** Resolve a GitHub PR number back to its Invoker workflow via the merge node. */
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined;

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -7,3 +7,4 @@ export * from './slack-session-repository.js';
 export * from './slack-plan-draft-repository.js';
 export * from './sqlite-task-repository.js';
 export * from './workflow-channel-repository.js';
+export * from './sync-journal.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -38,6 +38,8 @@ import type {
   PersistenceAdapter,
   ReviewGateLookup,
   Workflow,
+  WorkflowListOptions,
+  WorkflowReadOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
   TaskEvent,
@@ -78,6 +80,7 @@ import type { SqliteExecutor } from './sqlite-executor.js';
 import * as migrations from './sqlite-migrations.js';
 import { SqliteTaskAttemptRepository } from './sqlite-task-attempt-repository.js';
 import { SqliteWorkflowRepository, type WorkflowMetadataChanges } from './sqlite-workflow-repository.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 function normalizeWorkerActionStatus(status: string): string {
   return status === 'canceled' ? 'cancelled' : status;
@@ -1050,12 +1053,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.workflowRepo.updateWorkflow(workflowId, changes);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    return this.workflowRepo.loadWorkflow(workflowId);
+  loadWorkflow(workflowId: string, opts?: WorkflowReadOptions): Workflow | undefined {
+    return this.workflowRepo.loadWorkflow(workflowId, opts);
   }
 
-  listWorkflows(): Workflow[] {
-    return this.workflowRepo.listWorkflows();
+  listWorkflows(opts?: WorkflowListOptions): Workflow[] {
+    return this.workflowRepo.listWorkflows(opts);
   }
 
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
@@ -1081,6 +1084,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   updateTask(taskId: string, changes: TaskStateChanges): void {
+    if (changes.status !== undefined) {
+      this.runTransaction(() => {
+        this.taskAttemptRepo.updateTask(taskId, changes);
+      });
+      return;
+    }
     this.taskAttemptRepo.updateTask(taskId, changes);
   }
 
@@ -1546,6 +1555,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   deleteWorkflow(workflowId: string): void {
+    const workflowRow = this.queryOne(
+      'SELECT * FROM workflows WHERE id = ? AND deleted_at IS NULL',
+      [workflowId],
+    );
+    if (!workflowRow) return;
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
     this.runTransaction(() => {
       this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
@@ -1587,7 +1601,22 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
+      const deletedAt = Date.now();
+      const updatedAt = new Date(deletedAt).toISOString();
+      this.db.run(
+        'UPDATE workflows SET deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL',
+        [deletedAt, updatedAt, workflowId],
+      );
+      const tombstoneRow = this.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+      if (!tombstoneRow) {
+        throw new Error(`Cannot journal workflow "${workflowId}": row not found after soft-delete`);
+      }
+      appendJournalEntry(this.executor, {
+        entityType: 'workflow',
+        entityId: workflowId,
+        op: 'tombstone',
+        payload: tombstoneRow,
+      });
     });
     this.removeOutputFiles(taskIds);
   }
@@ -2615,7 +2644,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Attempts ────────────────────────────────────────────
 
   saveAttempt(attempt: Attempt): void {
-    this.taskAttemptRepo.saveAttempt(attempt);
+    this.runTransaction(() => {
+      this.taskAttemptRepo.saveAttempt(attempt);
+    });
   }
 
   loadAttempts(nodeId: string): Attempt[] {
@@ -2639,6 +2670,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void {
+    if (changes.status !== undefined) {
+      this.runTransaction(() => {
+        this.taskAttemptRepo.updateAttempt(attemptId, changes);
+      });
+      return;
+    }
     this.taskAttemptRepo.updateAttempt(attemptId, changes);
   }
 

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -49,6 +49,7 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
     generation: row.generation ?? 0,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+    deletedAt: row.deleted_at == null ? undefined : Number(row.deleted_at),
   };
 }
 

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -28,7 +28,25 @@ export const SCHEMA_DDL = `
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
         created_at TEXT DEFAULT (datetime('now')),
-        updated_at TEXT DEFAULT (datetime('now'))
+        updated_at TEXT DEFAULT (datetime('now')),
+        deleted_at INTEGER
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_journal (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+        entity_id TEXT NOT NULL,
+        op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+        payload TEXT NOT NULL CHECK (json_valid(payload)),
+        origin TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_cursors (
+        peer_id TEXT PRIMARY KEY,
+        last_sent_seq INTEGER NOT NULL DEFAULT 0,
+        last_received_seq INTEGER NOT NULL DEFAULT 0,
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
       );
 
       CREATE TABLE IF NOT EXISTS tasks (
@@ -591,6 +609,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
+  'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
 ];
 
 /**
@@ -622,6 +641,21 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  `CREATE TABLE IF NOT EXISTS sync_journal (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+    entity_id TEXT NOT NULL,
+    op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    origin TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`,
+  `CREATE TABLE IF NOT EXISTS sync_cursors (
+    peer_id TEXT PRIMARY KEY,
+    last_sent_seq INTEGER NOT NULL DEFAULT 0,
+    last_received_seq INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`,
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */
@@ -646,7 +680,8 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
         created_at TEXT DEFAULT (datetime('now')),
-        updated_at TEXT DEFAULT (datetime('now'))
+        updated_at TEXT DEFAULT (datetime('now')),
+        deleted_at INTEGER
       )
     `;
 
@@ -656,12 +691,12 @@ export const WORKFLOWS_REBUILD_INSERT_DDL = `
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, created_at, updated_at, deleted_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, created_at, updated_at, deleted_at
       FROM workflows
     `;

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -17,6 +17,7 @@ import {
 import { mapRowToTask, mapRowToAttempt } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
@@ -43,6 +44,23 @@ export class SqliteTaskAttemptRepository {
   ) {}
 
   private hasCrashPreservationTableCache: boolean | null = null;
+
+  private appendEntityJournalEntry(
+    entityType: 'task' | 'attempt',
+    table: 'tasks' | 'attempts',
+    entityId: string,
+  ): void {
+    const row = this.exec.queryOne(`SELECT * FROM ${table} WHERE id = ?`, [entityId]);
+    if (!row) {
+      throw new Error(`Cannot journal ${entityType} "${entityId}": row not found after mutation`);
+    }
+    appendJournalEntry(this.exec, {
+      entityType,
+      entityId,
+      op: 'upsert',
+      payload: row,
+    });
+  }
 
   private hasCrashPreservationTable(): boolean {
     if (this.hasCrashPreservationTableCache !== null) return this.hasCrashPreservationTableCache;
@@ -229,6 +247,8 @@ export class SqliteTaskAttemptRepository {
   updateTask(taskId: string, changes: TaskStateChanges): void {
     const beforeTask = this.loadTask(taskId);
     if (!beforeTask) return;
+    const shouldJournalStatusChange =
+      changes.status !== undefined && changes.status !== beforeTask.status;
 
     const setClauses: string[] = [];
     const values: unknown[] = [];
@@ -418,6 +438,9 @@ export class SqliteTaskAttemptRepository {
       console.log(`[persist-sql] taskId=${taskId} columns=[${cols}]`);
     }
     this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    if (shouldJournalStatusChange) {
+      this.appendEntityJournalEntry('task', 'tasks', taskId);
+    }
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -459,7 +482,8 @@ export class SqliteTaskAttemptRepository {
              w.name AS workflow_name
       FROM tasks t${this.taskSelectJoin('t')}
       JOIN workflows w ON w.id = t.workflow_id
-      WHERE t.status = 'completed'
+      WHERE w.deleted_at IS NULL
+        AND t.status = 'completed'
       ORDER BY t.completed_at DESC
     `);
     return rows.map((row) => ({
@@ -481,7 +505,8 @@ export class SqliteTaskAttemptRepository {
         FROM events
         GROUP BY task_id
       ) e ON e.task_id = t.id
-      WHERE COALESCE(e.event_count, 0) > 0 OR t.status != 'pending'
+      WHERE w.deleted_at IS NULL
+        AND (COALESCE(e.event_count, 0) > 0 OR t.status != 'pending')
       ORDER BY COALESCE(e.max_created_at, t.completed_at, t.started_at, t.created_at) DESC
     `);
     return rows.map((row) => {
@@ -628,6 +653,7 @@ export class SqliteTaskAttemptRepository {
       attempt.createdAt.toISOString(),
       attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
     ]);
+    this.appendEntityJournalEntry('attempt', 'attempts', attempt.id);
   }
 
   loadAttempts(nodeId: string): Attempt[] {
@@ -689,6 +715,10 @@ export class SqliteTaskAttemptRepository {
   }
 
   updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void {
+    const beforeAttempt = this.loadAttempt(attemptId);
+    if (!beforeAttempt) return;
+    const shouldJournalStatusChange =
+      changes.status !== undefined && changes.status !== beforeAttempt.status;
     const setClauses: string[] = [];
     const values: unknown[] = [];
 
@@ -712,6 +742,9 @@ export class SqliteTaskAttemptRepository {
     if (setClauses.length === 0) return;
     values.push(attemptId);
     this.exec.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    if (shouldJournalStatusChange) {
+      this.appendEntityJournalEntry('attempt', 'attempts', attemptId);
+    }
   }
 
   claimAttemptForLaunch(

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -27,6 +27,8 @@ import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ReviewGateLookup,
   Workflow,
+  WorkflowListOptions,
+  WorkflowReadOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
 } from './adapter.js';
@@ -89,8 +91,8 @@ export class SqliteWorkflowRepository {
   saveWorkflow(workflow: WorkflowSaveInput): void {
     assertWorkflowConsistent(workflow);
     this.exec.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at, deleted_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       workflow.id, workflow.name,
       workflow.description ?? null,
@@ -104,6 +106,7 @@ export class SqliteWorkflowRepository {
       workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
       workflow.generation ?? 0,
       workflow.createdAt, workflow.updatedAt,
+      workflow.deletedAt ?? null,
     ]);
   }
 
@@ -174,16 +177,23 @@ export class SqliteWorkflowRepository {
     this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+  loadWorkflow(workflowId: string, opts?: WorkflowReadOptions): Workflow | undefined {
+    const row = this.exec.queryOne(
+      `SELECT * FROM workflows
+       WHERE id = ?
+         ${opts?.includeDeleted === true ? '' : 'AND deleted_at IS NULL'}`,
+      [workflowId],
+    );
     if (!row) return undefined;
     const rollup = this.loadWorkflowRollups([workflowId]).get(workflowId);
     return this.rowToWorkflow(row, rollup);
   }
 
-  listWorkflows(): Workflow[] {
+  listWorkflows(opts?: WorkflowListOptions): Workflow[] {
     const rows = this.exec.queryAll(
-      'SELECT * FROM workflows ORDER BY created_at DESC',
+      `SELECT * FROM workflows
+       ${opts?.includeDeleted === true ? '' : 'WHERE deleted_at IS NULL'}
+       ORDER BY created_at DESC`,
     );
     const workflowIds = rows.map((row) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
@@ -205,7 +215,9 @@ export class SqliteWorkflowRepository {
               w.base_branch AS baseBranch
          FROM tasks t
          JOIN workflows w ON w.id = t.workflow_id
-        WHERE t.is_merge_node = 1 AND (t.review_id = ? OR t.review_url LIKE ?)`,
+        WHERE w.deleted_at IS NULL
+          AND t.is_merge_node = 1
+          AND (t.review_id = ? OR t.review_url LIKE ?)`,
       [pr, `%/pull/${pr}`],
     );
     if (rows.length === 0) return undefined;
@@ -257,7 +269,8 @@ export class SqliteWorkflowRepository {
     if (type === 'workflows' || type === 'all') {
       const workflows = this.exec.queryAll(
         `SELECT id, name, description, plan_file, repo_url, branch, created_at FROM workflows 
-         WHERE name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ? 
+         WHERE deleted_at IS NULL
+           AND (name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{ id: string; name?: string | null; created_at: string }>;
@@ -281,8 +294,11 @@ export class SqliteWorkflowRepository {
     
     if (type === 'tasks' || type === 'all') {
       const tasks = this.exec.queryAll(
-        `SELECT id, workflow_id, description, command, prompt, summary, problem, approach, test_plan, repro_command, status, created_at FROM tasks 
-         WHERE description LIKE ? OR command LIKE ? OR prompt LIKE ? OR summary LIKE ? OR problem LIKE ? OR approach LIKE ? OR test_plan LIKE ? OR repro_command LIKE ? 
+        `SELECT t.id, t.workflow_id, t.description, t.command, t.prompt, t.summary, t.problem, t.approach, t.test_plan, t.repro_command, t.status, t.created_at
+         FROM tasks t
+         JOIN workflows w ON w.id = t.workflow_id
+         WHERE w.deleted_at IS NULL
+           AND (t.description LIKE ? OR t.command LIKE ? OR t.prompt LIKE ? OR t.summary LIKE ? OR t.problem LIKE ? OR t.approach LIKE ? OR t.test_plan LIKE ? OR t.repro_command LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{
@@ -298,7 +314,9 @@ export class SqliteWorkflowRepository {
       if (workflowIds.length > 0) {
         const placeholders = workflowIds.map(() => '?').join(',');
         const workflowRows = this.exec.queryAll(
-          `SELECT id, name FROM workflows WHERE id IN (${placeholders})`,
+          `SELECT id, name FROM workflows
+           WHERE deleted_at IS NULL
+             AND id IN (${placeholders})`,
           workflowIds
         ) as Array<{ id: string; name?: string | null }>;
         for (const wf of workflowRows) {
@@ -326,10 +344,18 @@ export class SqliteWorkflowRepository {
   loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
     const totalStartedAt = Date.now();
     const workflowQueryStartedAt = Date.now();
-    const workflowRows = this.exec.queryAll('SELECT * FROM workflows ORDER BY created_at DESC');
+    const workflowRows = this.exec.queryAll(
+      'SELECT * FROM workflows WHERE deleted_at IS NULL ORDER BY created_at DESC',
+    );
     const workflowMetadataQueryMs = Date.now() - workflowQueryStartedAt;
     const taskQueryStartedAt = Date.now();
-    const taskRows = this.exec.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC');
+    const taskRows = this.exec.queryAll(
+      `SELECT t.*
+       FROM tasks t
+       JOIN workflows w ON w.id = t.workflow_id
+       WHERE w.deleted_at IS NULL
+       ORDER BY t.workflow_id ASC, t.id ASC`,
+    );
     const taskQueryMs = Date.now() - taskQueryStartedAt;
     const tasksByWorkflowId = new Map<string, TaskState[]>();
     const workflowIds = workflowRows.map((row) => String(row.id));

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -1,0 +1,171 @@
+import type { SqliteExecutor } from './sqlite-executor.js';
+
+// `output` is reserved for future output-spool sync. The adapter deliberately
+// does not journal high-volume output rows yet.
+export type SyncEntityType = 'workflow' | 'task' | 'attempt' | 'event' | 'output';
+export type SyncJournalOp = 'upsert' | 'tombstone';
+
+export interface SyncJournalEntryInput {
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOp;
+  payload: unknown;
+  origin?: string;
+  createdAt?: string;
+}
+
+export interface SyncJournalEntry {
+  seq: number;
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOp;
+  payload: unknown;
+  origin: string;
+  createdAt: string;
+}
+
+export interface SyncCursor {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt: string;
+}
+
+export interface SyncCursorWrite {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt?: string;
+}
+
+export type SyncJournalDatabase = Pick<SqliteExecutor, 'execRun' | 'queryOne' | 'queryAll'>;
+
+const LOCAL_JOURNAL_ORIGIN = 'home';
+
+function encodePayload(payload: unknown): string {
+  return JSON.stringify(payload ?? null);
+}
+
+function mapJournalRow(row: Record<string, unknown>): SyncJournalEntry {
+  return {
+    seq: Number(row.seq),
+    entityType: row.entity_type as SyncEntityType,
+    entityId: String(row.entity_id),
+    op: row.op as SyncJournalOp,
+    payload: JSON.parse(String(row.payload)),
+    origin: String(row.origin),
+    createdAt: String(row.created_at),
+  };
+}
+
+function mapCursorRow(row: Record<string, unknown>): SyncCursor {
+  return {
+    peerId: String(row.peer_id),
+    lastSentSeq: Number(row.last_sent_seq ?? 0),
+    lastReceivedSeq: Number(row.last_received_seq ?? 0),
+    updatedAt: String(row.updated_at),
+  };
+}
+
+export function appendJournalEntry(
+  db: SyncJournalDatabase,
+  entry: SyncJournalEntryInput,
+): SyncJournalEntry {
+  db.execRun(
+    `INSERT INTO sync_journal (
+       entity_type,
+       entity_id,
+       op,
+       payload,
+       origin,
+       created_at
+     ) VALUES (?, ?, ?, ?, ?, ?)`,
+    [
+      entry.entityType,
+      entry.entityId,
+      entry.op,
+      encodePayload(entry.payload),
+      entry.origin ?? LOCAL_JOURNAL_ORIGIN,
+      entry.createdAt ?? new Date().toISOString(),
+    ],
+  );
+  const row = db.queryOne('SELECT * FROM sync_journal WHERE seq = last_insert_rowid()');
+  if (!row) {
+    throw new Error('sync_journal insert did not return a row');
+  }
+  return mapJournalRow(row);
+}
+
+export function readJournalSince(
+  db: SyncJournalDatabase,
+  seq: number,
+  limit: number,
+): SyncJournalEntry[] {
+  const safeSeq = Math.max(0, Math.trunc(seq));
+  const safeLimit = Math.max(0, Math.trunc(limit));
+  if (safeLimit === 0) return [];
+  const rows = db.queryAll(
+    `SELECT * FROM sync_journal
+      WHERE seq > ?
+      ORDER BY seq ASC
+      LIMIT ?`,
+    [safeSeq, safeLimit],
+  );
+  return rows.map((row) => mapJournalRow(row));
+}
+
+export function getSyncCursor(
+  db: SyncJournalDatabase,
+  peerId: string,
+): SyncCursor | undefined {
+  const row = db.queryOne('SELECT * FROM sync_cursors WHERE peer_id = ?', [peerId]);
+  return row ? mapCursorRow(row) : undefined;
+}
+
+export function setSyncCursor(db: SyncJournalDatabase, cursor: SyncCursorWrite): SyncCursor;
+export function setSyncCursor(
+  db: SyncJournalDatabase,
+  peerId: string,
+  cursor: Omit<SyncCursorWrite, 'peerId'>,
+): SyncCursor;
+export function setSyncCursor(
+  db: SyncJournalDatabase,
+  peerOrCursor: string | SyncCursorWrite,
+  cursor?: Omit<SyncCursorWrite, 'peerId'>,
+): SyncCursor {
+  const next: SyncCursorWrite = typeof peerOrCursor === 'string'
+    ? {
+        peerId: peerOrCursor,
+        lastSentSeq: cursor?.lastSentSeq ?? 0,
+        lastReceivedSeq: cursor?.lastReceivedSeq ?? 0,
+        updatedAt: cursor?.updatedAt,
+      }
+    : peerOrCursor;
+  if (!next.peerId) {
+    throw new Error('sync cursor peerId is required');
+  }
+  const updatedAt = next.updatedAt ?? new Date().toISOString();
+  db.execRun(
+    `INSERT INTO sync_cursors (
+       peer_id,
+       last_sent_seq,
+       last_received_seq,
+       updated_at
+     ) VALUES (?, ?, ?, ?)
+     ON CONFLICT(peer_id) DO UPDATE SET
+       last_sent_seq = excluded.last_sent_seq,
+       last_received_seq = excluded.last_received_seq,
+       updated_at = excluded.updated_at`,
+    [
+      next.peerId,
+      Math.max(0, Math.trunc(next.lastSentSeq)),
+      Math.max(0, Math.trunc(next.lastReceivedSeq)),
+      updatedAt,
+    ],
+  );
+  const saved = getSyncCursor(db, next.peerId);
+  if (!saved) {
+    throw new Error(`sync cursor "${next.peerId}" was not saved`);
+  }
+  return saved;
+}


### PR DESCRIPTION
## Summary

Remote Sync Step 1 adds the data-store schema needed to journal syncable workflow state.

The new journal records sync entries, peer cursors, and tombstones while preserving existing workflow and task persistence.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926077035-3/implement-sync-schema | Add sync journal, cursor, and tombstone schema to data-store | completed |
| wf-1784926077035-3/verify-sync-schema | Run data-store package tests covering the new schema and journal | completed (passed) |

</details>

## Review Claim

Approve the data-store sync contract that adds journal entries, peer cursors, and tombstones to workflow persistence.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This slice is confined to data-store schema, journal helpers, and directly affected persistence tests; no sync transport or remote execution path is activated.

## Slice Rationale

Schema and local journaling land first so later remote-sync transport can consume one stable data-store contract.

## Non-goals

- No remote-sync transport.
- No peer protocol.
- No output spool sync.
- No UI changes.

## Architecture

### Before

```mermaid
graph TD
    A["SQLite persistence tables"] --> B["Workflow and task rows"]
```

### After

```mermaid
graph TD
    A["SQLite persistence tables"] --> B["Workflow and task rows"]
    A --> C["sync_journal entries"]
    A --> D["sync_cursors per peer"]
    B --> E["tombstone rows for removed workflows"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sync-journal.test.ts` (25 files, 434 tests passed locally; `wf-1784926077035-3/verify-sync-schema` also passed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert e16e48dd300fb84b19e1519c2989a7fa9db70026`
- Post-revert steps: Rerun the data-store focused test.
- Data migration? No production migration has shipped yet.

</details>

