### PR TITLE
[Repair Workflow Step 1: ci_failed gate policy](1) Prove blocked gate readiness

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -2975,6 +2975,42 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(leafId)!.execution.blockedBy).toBeUndefined();
     });
 
+    it('transitions an already-blocked ci_failed dependent to runnable when the upstream gate is awaiting_approval', () => {
+      orchestrator.loadPlan({
+        name: 'gate-prereq-ci-awaiting-approval',
+        tasks: [{ id: 'verify', description: 'Prereq task' }],
+      });
+      const prereqTaskId = sid(orchestrator, 0, 'verify');
+      const prereqWfId = prereqTaskId.split('/')[0]!;
+      const prereqMergeId = `__merge__${prereqWfId}`;
+
+      orchestrator.loadPlan({
+        name: 'gate-downstream-blocked-ci-awaiting-approval',
+        externalDependencies: [
+          { workflowId: prereqWfId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'ci_failed' },
+        ],
+        tasks: [{ id: 'leaf', description: 'leaf waits on upstream failed CI repair gate' }],
+      });
+      const leafId = sid(orchestrator, 1, 'leaf');
+
+      persistence.updateTask(prereqTaskId, { status: 'completed', execution: { completedAt: new Date() } });
+      persistence.updateTask(prereqMergeId, {
+        status: 'awaiting_approval',
+        execution: { reviewUrl: 'https://example.invalid/pull/1', reviewStatus: 'CI failed' },
+      });
+      persistence.updateTask(leafId, {
+        status: 'blocked',
+        execution: { blockedBy: `waiting on ${prereqMergeId} (running)` },
+      });
+      orchestrator.syncAllFromDb();
+
+      const started = orchestrator.autoStartExternallyUnblockedReadyTasks();
+
+      expect(started.map((t) => t.id)).toContain(leafId);
+      expect(orchestrator.getTask(leafId)!.status).toBe('running');
+      expect(orchestrator.getTask(leafId)!.execution.blockedBy).toBeUndefined();
+    });
+
     it('does NOT cancel an already-running task on the same workflow', () => {
       orchestrator.loadPlan({
         name: 'gate-prereq-running',


### PR DESCRIPTION
## Summary

Repair Workflow Step 1: ci_failed gate policy - 2 tasks completed, 0 failed, 0 closed, 0 skipped

This slice proves the blocked readiness case for the `ci_failed` external-dependency gate.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784927703552-8/implement-ci-failed-gate-policy | Add 'ci_failed' as a third external-dependency gate policy across engine, parser, and UI | completed |
| wf-1784927703552-8/verify-ci-failed-gate-policy | Run the gate-policy and parser test suites plus typecheck | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784927703552-8/implement-ci-failed-gate-policy - Add 'ci_failed' as a third external-dependency gate policy across engine, parser, and UI

- `packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`: test-only

### wf-1784927703552-8/verify-ci-failed-gate-policy - Run the gate-policy and parser test suites plus typecheck

- No source files changed.

</details>

## Review Claim

Approve the regression proof that an already-blocked `ci_failed` dependent becomes runnable when its upstream merge gate is awaiting approval.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds a workflow-core test. It does not touch runtime code, parser behavior, UI controls, or persistence writes, so it cannot alter product behavior.

## Slice Rationale

This is one proof slice because the only changed file is the regression test covering the blocked `ci_failed` dependency state. There is no paired runtime edit to bundle here.

## Non-goals

- Does not change the external-dependency gate-policy behavior.
- Does not change orchestrator runtime behavior.
- Does not change UI gate-policy controls.
- Does not change persistence storage or migrations.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-bodies/repair-ci-failed-gate-policy.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/invoker-pr-bodies/repair-ci-failed-gate-policy.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7dfae3dac12b0c2a2329baed5f321e0240f61ba1`
- Post-revert steps: Rerun the workflow-core gate tests.
- Data migration? No

</details>
