### PR TITLE
[Onboarding Step 2: app first-run setup](1) Make Slack opt-in and link first workflow tutorial

### DIFF
--- a/packages/ui/src/__tests__/system-setup-cli.test.tsx
+++ b/packages/ui/src/__tests__/system-setup-cli.test.tsx
@@ -251,7 +251,7 @@ describe('SystemSetupModal — Invoker CLI section', () => {
     fireEvent.click(screen.getByRole('button', { name: /System check details/ }));
     expect(screen.getByText('Enable Cursor CLI')).toBeInTheDocument();
   });
-  it('reviews selected setup items before running Slack checked by default', () => {
+  it('reviews selected setup items before running with Slack unchecked by default', () => {
     const onRunSetup = vi.fn();
     render(
       <SystemSetupModal
@@ -261,27 +261,21 @@ describe('SystemSetupModal — Invoker CLI section', () => {
       />,
     );
 
-    expect(screen.getByRole('checkbox', { name: /Set up Slack integration/ })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Install or update invoker-cli/ })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Install Invoker helpers/ })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Install missing tools/ })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /Set up Slack integration/ })).not.toBeChecked();
     expect(screen.queryByText(/Next: add Bot token/)).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Set it up for me' }));
     expect(screen.getByText('Review setup plan')).toBeInTheDocument();
-    expect(screen.getByText(/Next: add Bot token/)).toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText(/Bot token/), { target: { value: 'xoxb-token' } });
-    fireEvent.change(screen.getByLabelText(/App token/), { target: { value: 'xapp-token' } });
-    fireEvent.change(screen.getByLabelText(/Signing secret/), { target: { value: 'secret' } });
-    fireEvent.change(screen.getByLabelText(/Lobby channel ID/), { target: { value: 'C123' } });
+    expect(screen.queryByText(/Next: add Bot token/)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Approve and run setup' }));
     expect(onRunSetup).toHaveBeenCalledWith({
       updateCli: true,
       installHelpers: true,
       fixTools: true,
-      slack: {
-        botToken: 'xoxb-token',
-        appToken: 'xapp-token',
-        signingSecret: 'secret',
-        channelId: 'C123',
-      },
+      slack: false,
     });
   });
 
@@ -295,6 +289,7 @@ describe('SystemSetupModal — Invoker CLI section', () => {
       />,
     );
 
+    fireEvent.click(screen.getByRole('checkbox', { name: /Set up Slack integration/ }));
     fireEvent.click(screen.getByRole('button', { name: 'Set it up for me' }));
     expect(screen.getByText('Slack waits for Bot token. The rest can run now.')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Approve and run setup' }));
@@ -318,5 +313,23 @@ describe('SystemSetupModal — Invoker CLI section', () => {
 
     expect(screen.getByText('Setup completed')).toBeInTheDocument();
     expect(screen.getByText(/Git: git found/)).toBeInTheDocument();
+  });
+
+  it('renders the first agent workflow tutorial link on the finish step', () => {
+    render(
+      <SystemSetupModal
+        diagnostics={makeDiagnostics({ supported: true, bundledVersion: '0.0.3', upToDate: true })}
+        setupResult={{ ok: true, steps: [{ id: 'tools', name: 'Install missing tools', ok: true, output: 'ok  Git: git found' }] }}
+        onRunSetup={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    const tutorialLink = screen.getByRole('link', { name: 'Open the First Agent Workflow Tutorial' });
+    expect(tutorialLink).toHaveAttribute(
+      'href',
+      'https://github.com/Neko-Catpital-Labs/Invoker/blob/main/docs/tutorial-first-agent-workflow.md',
+    );
+    expect(tutorialLink).toHaveAttribute('target', '_blank');
   });
 });

--- a/packages/ui/src/components/SystemSetupModal.tsx
+++ b/packages/ui/src/components/SystemSetupModal.tsx
@@ -62,6 +62,8 @@ const setupStepLabels: Record<'choose' | 'review' | 'finish', string> = {
 
 type SlackFieldId = 'botToken' | 'appToken' | 'signingSecret' | 'channelId';
 
+const firstAgentWorkflowTutorialUrl = 'https://github.com/Neko-Catpital-Labs/Invoker/blob/main/docs/tutorial-first-agent-workflow.md';
+
 const slackSetupFields: Array<{
   id: SlackFieldId;
   label: string;
@@ -122,7 +124,7 @@ export function SystemSetupModal({
     updateCli: true,
     installHelpers: true,
     fixTools: true,
-    slack: true,
+    slack: false,
   });
   const [slackFields, setSlackFields] = useState<Record<SlackFieldId, string>>({
     botToken: '',
@@ -216,7 +218,7 @@ export function SystemSetupModal({
     {
       checkId: 'slack',
       title: 'Set up Slack integration',
-      detail: 'Add Slack app values here; Slack is on by default.',
+      detail: 'Optional: opt in to Slack by adding app values here.',
       status: slackFieldsComplete ? 'Ready to run' : 'Needs fields',
     },
   ];
@@ -359,7 +361,19 @@ export function SystemSetupModal({
               )}
               {setupResult && (
                 <div className={`rounded border px-3 py-2 text-sm ${setupResult.ok ? 'border-green-700/50 bg-green-950/30 text-green-100' : 'border-red-700/50 bg-red-950/30 text-red-100'}`}>
-                  <div className="font-medium">{setupResult.ok ? 'Setup completed' : 'Setup completed with failures'}</div>
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="font-medium">{setupResult.ok ? 'Setup completed' : 'Setup completed with failures'}</div>
+                    {currentSetupStep === 'finish' && (
+                      <a
+                        href={firstAgentWorkflowTutorialUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="rounded bg-green-800/70 px-3 py-1.5 text-xs font-medium text-green-50 hover:bg-green-700"
+                      >
+                        Open the First Agent Workflow Tutorial
+                      </a>
+                    )}
+                  </div>
                   <div className="mt-2 space-y-2">
                     {setupResult.steps.map((step) => (
                       <div key={step.id} className="rounded bg-card/50 px-2 py-2">


### PR DESCRIPTION
## Summary

Onboarding Step 2: app first-run setup — 2 tasks completed, 0 failed, 0 closed, 0 skipped (no skipped tasks)

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926072945-2/implement-app-first-run | Make Slack opt-in in the System Setup modal and deep-link the First Agent Workflow tutorial after setup finishes | completed |
| wf-1784926072945-2/verify-app-first-run | Run the System Setup modal test file | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784926072945-2/implement-app-first-run — Make Slack opt-in in the System Setup modal and deep-link the First Agent Workflow tutorial after setup finishes

### wf-1784926072945-2/verify-app-first-run — Run the System Setup modal test file

</details>

Slack setup is now opt-in during app first-run setup.

Completed setup now links directly to the First Agent Workflow tutorial.

## Review Claim

Approve the System Setup modal behavior that leaves Slack unselected by default and surfaces the first workflow tutorial after setup completes.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The slice only changes System Setup modal state and direct component coverage; CLI setup execution remains behind the existing request shape.

## Slice Rationale

This is one first-run activation change: choose the default setup path, then hand the user to the next tutorial from the finish state.

## Non-goals

- Does not change the CLI setup command implementation.
- Does not collect Slack credentials unless Slack is selected.
- Does not change the tutorial document.

## Architecture

### Before

```mermaid
graph TD
    A["System Setup opens"] --> B["Slack selected by default"]
    B --> C["Review asks for Slack fields"]
    D["Setup finishes"] --> E["Setup result only"]
```

### After

```mermaid
graph TD
    A["System Setup opens"] --> B["Slack unselected by default"]
    B --> C["Local setup can run without Slack fields"]
    D["Setup finishes"] --> E["Setup result includes tutorial link"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- --run src/__tests__/system-setup-cli.test.tsx`
- [x] `bash scripts/ui-visual-proof.sh capture-after --spec system-setup-app-first-run-pr-proof.spec.ts --output-dir /tmp/onboarding-app-first-run-proof`

</details>

## Visual Proof

Slack is unchecked on the setup chooser while the local setup items remain selected.

![Slack opt-in setup chooser](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-ab60de/app-first-run-slack-opt-in.png)

The finish step shows the First Agent Workflow Tutorial handoff link after setup completes.

![First agent workflow tutorial link](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-ab60de/app-first-run-tutorial-link.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d91f16469`
- Post-revert steps: None
- Data migration? No

</details>
