### PR TITLE
[Bugfix: truthful planning draft readiness](1) Keep planner submit text draft-backed

### DIFF
--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -39,6 +39,7 @@ tasks:
     prompt: "Do the work"
     dependencies: []
 `;
+const SUBMIT_REPLY_LINE = 'Reply `submit` to submit it.';
 
 const INLINE_PLAN_RESPONSE = `Here is the plan:
 
@@ -52,7 +53,7 @@ tasks:
     dependencies: []
 \`\`\`
 
-Reply \`submit\` to submit it.`;
+${SUBMIT_REPLY_LINE}`;
 
 describe('plan draft file - activation side', () => {
   let workingDir: string;
@@ -92,15 +93,17 @@ describe('plan draft file - activation side', () => {
     if (!path) throw new Error('expected a plan draft path');
 
     mockSpawn.mockReturnValueOnce(fakePlannerChild(
-      'Drafted the plan.\n\nReply `submit` to submit it.',
+      `Drafted the plan.\n\n${SUBMIT_REPLY_LINE}`,
       () => writeFileSync(path, VALID_PLAN_YAML, 'utf8'),
     ));
     await conversation.sendMessage('Draft it');
 
-    mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the plan. Summary: one step.'));
-    await conversation.sendMessage('What does it do?');
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(`Drafted the plan. Summary: one step.\n\n${SUBMIT_REPLY_LINE}`));
+    const reply = await conversation.sendMessage('What does it do?');
 
     expect(existsSync(path)).toBe(false);
+    expect(reply).not.toContain(SUBMIT_REPLY_LINE);
+    expect(conversation.history.at(-1)?.content).not.toContain(SUBMIT_REPLY_LINE);
     expect(conversation.getDraftedPlan()).toBe(VALID_PLAN_YAML.trim());
   });
 
@@ -110,6 +113,17 @@ describe('plan draft file - activation side', () => {
     mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the plan. Summary: one step.'));
     await conversation.sendMessage('Draft it');
 
+    expect(conversation.getDraftedPlan()).toBeNull();
+  });
+
+  it('strips the standalone submit instruction when the current turn produced no draft', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', plannerRetryLimit: 0 });
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(`Drafted the plan.\n\n${SUBMIT_REPLY_LINE}`));
+    const reply = await conversation.sendMessage('Draft it');
+
+    expect(reply).toBe('Drafted the plan.');
+    expect(conversation.history.at(-1)?.content).toBe('Drafted the plan.');
     expect(conversation.getDraftedPlan()).toBeNull();
   });
 
@@ -130,13 +144,14 @@ describe('plan draft file - activation side', () => {
     if (!path) throw new Error('expected a plan draft path');
 
     mockSpawn.mockReturnValueOnce(fakePlannerChild(
-      'Drafted the plan.\n\nReply `submit` to submit it.',
+      `Drafted the plan.\n\n${SUBMIT_REPLY_LINE}`,
       () => writeFileSync(path, VALID_PLAN_YAML, 'utf8'),
     ));
-    await conversation.sendMessage('Create the plan');
+    const reply = await conversation.sendMessage('Create the plan');
 
     expect(isConfirmation('submit')).toBe(true);
     expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(reply).toContain(SUBMIT_REPLY_LINE);
     expect(conversation.planSubmitted).toBe(false);
     expect(conversation.submittedPlanText).toBeNull();
 

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -53,6 +53,7 @@ export function defaultPlanningCommand(
 }
 
 const EMPTY_PLANNER_STDERR_TAIL_LIMIT = 500;
+const SUBMIT_REPLY_INSTRUCTION_LINE = 'Reply `submit` to submit it.';
 
 export const DEFAULT_PLANNER_RETRY_LIMIT = 2;
 export const DEFAULT_PLANNER_RETRY_BASE_DELAY_MS = 500;
@@ -88,6 +89,16 @@ class RetryableEmptyPlannerOutputError extends Error {
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function stripStandaloneSubmitReplyInstruction(text: string): string {
+  const lines = text.split('\n');
+  if (!lines.some((line) => line.trim() === SUBMIT_REPLY_INSTRUCTION_LINE)) return text;
+  return lines
+    .filter((line) => line.trim() !== SUBMIT_REPLY_INSTRUCTION_LINE)
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd();
 }
 
 export interface PlanConversationConfig {
@@ -546,6 +557,9 @@ export class PlanConversation {
     const nextDraft = fileDraft && summarizePlanText(fileDraft)
       ? fileDraft
       : inlineDraft;
+    if (!nextDraft) {
+      message = stripStandaloneSubmitReplyInstruction(message);
+    }
     this._lastTurnDraftPlanText = nextDraft;
     if (nextDraft) this.lastKnownGoodPlanText = nextDraft;
     this._lastTurnReasoning = formatted.reasoning;


### PR DESCRIPTION
## Summary

The planning reply now omits the standalone confirmation line when the current turn did not produce a draft.

The ready path keeps the same instruction when `nextDraft` exists, so real draft replies stay actionable.

## Review Claim

The planner only shows the confirmation instruction when the current turn produced a real draft.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change stays in planner reply formatting and the matching regression file; valid drafted replies keep the same ready-to-submit behavior.

## Slice Rationale

One reply-text slice fixes the misleading instruction at the point where the assistant message is stored.

## Non-goals

- No backend submit guards.
- No terminal command changes.
- No harness or model-switch work.
- No unrelated cleanup.

## Architecture

### Before

Assistant text could retain the standalone `submit` instruction even when draft extraction returned no current-turn draft.

### After

Assistant text derives that instruction from the same `nextDraft` decision that marks the session ready.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/plan-draft-file-activation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4030726f3`
- Post-revert steps: Rerun the focused surfaces regression.
- Data migration? No

</details>
