### PR TITLE
[Bugfix: truthful planning draft readiness](2) Require draft-ready in-app approval

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -46,6 +46,8 @@ tasks:
     dependencies: [first]
     command: echo second`;
 
+const NO_DRAFT_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
+
 const VALID_PLAN_WITHOUT_CLOSING_FENCE = `Here is the plan.
 
 \`\`\`yaml
@@ -416,9 +418,9 @@ describe('planning chat', () => {
       await expect(submitPlanningChatDraft({ sessionId: session.id }, {
         sessions,
         loadGeneratedPlan,
-    })).resolves.toMatchObject({ ok: false });
-    expect(loadGeneratedPlan).not.toHaveBeenCalled();
-    expect(sessions.get(session.id)?.draftPlanText).toBeUndefined();
+      })).resolves.toEqual({ ok: false, error: NO_DRAFT_ERROR });
+      expect(loadGeneratedPlan).not.toHaveBeenCalled();
+      expect(sessions.get(session.id)?.draftPlanText).toBeUndefined();
     } finally {
       rmSync(workingDir, { recursive: true, force: true });
     }
@@ -538,6 +540,7 @@ describe('planning chat', () => {
       planningCommandBuilder,
     });
     if (!sent.ok) throw new Error(sent.error);
+    expect(sessions.get(sent.sessionId)?.status).toBe('draft_ready');
     const loadGeneratedPlan = vi.fn().mockResolvedValue({
       planName: 'Mock Plan',
       workflowId: 'wf-1',
@@ -558,6 +561,7 @@ describe('planning chat', () => {
       workflowCount: 1,
     });
     expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
+    expect(sessions.get(sent.sessionId)?.status).toBe('submitted');
   });
 
   it('submits a valid final draft plan without a closing YAML fence', async () => {
@@ -752,12 +756,67 @@ tasks:
     });
     if (!sent.ok) throw new Error(sent.error);
 
+    const loadGeneratedPlan = vi.fn();
+
     await expect(submitPlanningChatDraft({
       sessionId: sent.sessionId,
     }, {
       sessions,
-      loadGeneratedPlan: vi.fn(),
-    })).resolves.toEqual({ ok: false, error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.' });
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: NO_DRAFT_ERROR });
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
+  it('rejects submit when draft text exists without draft-ready status', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('not-ready-draft', {
+      id: 'not-ready-draft',
+      title: 'Not ready draft',
+      presetKey: 'codex',
+      status: 'still_discussing',
+      messages: [],
+      conversation: new PlanConversation({}),
+      draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+      draftPlanText: VALID_PLAN_TEXT,
+      createdAt: '2026-07-07T00:00:00.000Z',
+      updatedAt: '2026-07-07T00:00:00.000Z',
+      nextMessageId: 1,
+    });
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(submitPlanningChatDraft({
+      sessionId: 'not-ready-draft',
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: NO_DRAFT_ERROR });
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
+  it('rejects submit when a draft-ready session has empty draft text', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('empty-draft', {
+      id: 'empty-draft',
+      title: 'Empty draft',
+      presetKey: 'codex',
+      status: 'draft_ready',
+      messages: [],
+      conversation: new PlanConversation({}),
+      draftPlanSummary: { name: 'Empty Draft', taskCount: 1, steps: ['Empty task'] },
+      draftPlanText: '   ',
+      createdAt: '2026-07-07T00:00:00.000Z',
+      updatedAt: '2026-07-07T00:00:00.000Z',
+      nextMessageId: 1,
+    });
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(submitPlanningChatDraft({
+      sessionId: 'empty-draft',
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: NO_DRAFT_ERROR });
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
   });
 
   it('rejects submit when the draft summary cannot be read', async () => {

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -98,6 +98,8 @@ export interface InAppPlanningChatSession {
 
 export type InAppPlanningChatSessions = Map<string, InAppPlanningChatSession>;
 
+const NO_COMPLETE_PLAN_DRAFTED_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
+
 export function createInAppPlanningChatSessions(): InAppPlanningChatSessions {
   return new Map();
 }
@@ -701,6 +703,12 @@ export async function submitPlanningChatDraft(
   if (session.status === 'submitted') {
     return { ok: false, error: 'This planning session was already submitted.' };
   }
+  const approvedDraftPlanText = session.status === 'draft_ready' && session.draftPlanText?.trim()
+    ? session.draftPlanText
+    : undefined;
+  if (!approvedDraftPlanText) {
+    return { ok: false, error: NO_COMPLETE_PLAN_DRAFTED_ERROR };
+  }
   if (session.pendingSubmit) {
     return session.pendingSubmit;
   }
@@ -708,7 +716,7 @@ export async function submitPlanningChatDraft(
   const submitAttempt = (async (): Promise<InAppPlanningSubmitResponse> => {
     try {
       const approved = await submitPlanningReview({
-        planText: session.draftPlanText,
+        planText: approvedDraftPlanText,
         loadPlan: deps.loadGeneratedPlan,
       });
       if (!approved.ok) {


### PR DESCRIPTION
## Summary

In-app planning approval now checks the session state before loading the draft for approval.

Cleared or summary-only sessions return the existing no-draft error instead of reaching the late failure path.

## Review Claim

`submitPlanningChatDraft()` only approves sessions that are `draft_ready` and have non-empty `draftPlanText`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change stays in the in-app submit handler and the matching regression file; valid draft-ready sessions still submit through the same approval path.

## Slice Rationale

One precondition slice fixes the app-side contract without changing reply text or renderer behavior.

## Non-goals

- No reply-text changes.
- No terminal command changes.
- No harness or model-switch work.
- No unrelated cleanup.

## Architecture

### Before

The in-app approval path could reach plan approval with an empty `draftPlanText` value.

### After

The in-app approval path requires `status === 'draft_ready'` and non-empty draft text before approval.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 88f341a16`
- Post-revert steps: Rerun the focused in-app planner regression.
- Data migration? No

</details>
