### PR TITLE
[Bugfix: truthful planning draft readiness](3) Gate terminal confirmation command

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -86,6 +86,7 @@ type GraphKeyboardRegion = Extract<KeyboardRegion, 'workflowGraph' | 'taskGraph'
 type ContextMenuCloseOptions = { restoreFocus?: boolean };
 type ContextMenuState = { x: number; y: number; taskId: string; returnFocusRegion?: GraphKeyboardRegion };
 type WorkflowContextMenuState = { x: number; y: number; workflowId: string; returnFocusRegion?: GraphKeyboardRegion };
+const NO_COMPLETE_PLAN_DRAFTED_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
 const KEYBOARD_REGION_ORDER: readonly KeyboardRegion[] = ['planning', 'workflowGraph', 'taskGraph', 'inspector', 'bottomBar'];
 const GRAPH_KEYBOARD_REGION_ORDER: readonly KeyboardRegion[] = ['workflowGraph', 'taskGraph', 'inspector', 'bottomBar'];
 const SIDEBAR_NAV_ITEM_SELECTOR = '[data-sidebar-nav-item]';
@@ -2874,6 +2875,11 @@ export function App() {
     }
 
     if (/^submit(\s+to\s+invoker)?[.!?]*$/i.test(input)) {
+      if (!draftPlanAvailable && activePlanningSession.status !== 'draft_ready') {
+        setPlanningSubmitError({ title: 'Plan could not be submitted', message: NO_COMPLETE_PLAN_DRAFTED_ERROR });
+        appendTerminalLine(`Plan could not be submitted:\n${NO_COMPLETE_PLAN_DRAFTED_ERROR}`, 'system', 'error');
+        return;
+      }
       await handlePlanningSubmitDraft();
       return;
     }

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -703,6 +703,29 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
+  it('does not submit or send typed submit before a draft is ready', async () => {
+    const noDraftError = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('talk through the plan');
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        message: 'talk through the plan',
+        presetKey: 'codex',
+        confirmationMode: 'require',
+      });
+    });
+
+    submitPlanningText('submit');
+
+    expect(mock.api.planningChatSubmit).not.toHaveBeenCalled();
+    expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(noDraftError);
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+  });
+
   it('submits a draft and starts ready work when the user types submit', async () => {
     mock.api.planningChatSend = vi.fn(async () => ({
       ok: true,
@@ -710,6 +733,7 @@ describe('Invoker terminal (component)', () => {
       reply: 'Here is the plan.',
       draftPlanAvailable: true,
       draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First', 'Second'] },
+      draftPlanText: 'name: Mock Plan\ntasks:\n  - id: first\n    description: First\n',
     })) as any;
     render(<App />);
     await openPlanningTerminal();


### PR DESCRIPTION
## Summary

The terminal command now checks active draft readiness before calling the planning approval handler.

No-draft confirmation attempts show a deterministic terminal error while real drafts keep the same approval path.

## Review Claim

The typed confirmation command only invokes planning approval when the active session is draft-ready.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change stays in terminal command routing and the matching regression file; the existing draft-ready submit path keeps the same call flow.

## Slice Rationale

One command-surface slice fixes the user-visible branch without touching reply text or backend approval.

## Non-goals

- No reply-text changes.
- No backend approval changes.
- No harness or model-switch work.
- No unrelated cleanup.

## Architecture

### Before

The typed confirmation branch called planning approval before checking whether the active session had a current draft.

### After

The typed confirmation branch checks `draftPlanAvailable` or `status === 'draft_ready'` before calling planning approval.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx`

</details>

## Visual Proof

![Terminal no-draft error proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-38cbef/terminal-submit-guard-20260727.svg)

The no-draft command state displays the deterministic terminal error and the focused component regression verifies that approval is not called.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1f7294128`
- Post-revert steps: Rerun the focused terminal regression.
- Data migration? No

</details>
