### PR TITLE
[Preserve Graph View Across Planning Window Switches](1) Restore the workflow graph viewport on planning return

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3371,28 +3371,13 @@ export function App() {
     focusKeyboardRegion('planning');
   }, [focusKeyboardRegion]);
 
-  const navigatePlanGraph = useCallback((reason: string, options: { fit: boolean }) => {
+  const navigatePlanGraphPreservingViewport = useCallback((_reason: string) => {
     setSidebarSurface('planning');
     setInspectorManualOpen(false);
     setViewMode('dag');
     focusKeyboardRegion('workflowGraph');
-
-    if (options.fit) {
-      workflowGraphViewportRef.current = null;
-      issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason });
-      return;
-    }
-
     setCameraCommand(null);
-  }, [focusKeyboardRegion, issueCameraCommand]);
-
-  const navigatePlanGraphAndFit = useCallback((reason: string) => {
-    navigatePlanGraph(reason, { fit: true });
-  }, [navigatePlanGraph]);
-
-  const navigatePlanGraphPreservingViewport = useCallback((reason: string) => {
-    navigatePlanGraph(reason, { fit: false });
-  }, [navigatePlanGraph]);
+  }, [focusKeyboardRegion]);
 
   const handleSelectSidebarSurface = useCallback((nextSurface: SidebarSurface) => {
     setGraphActionsMenuOpen(false);
@@ -3415,18 +3400,14 @@ export function App() {
       return;
     }
     if (nextSurface === 'planning') {
-      if (sidebarSurface === 'home') {
-        navigatePlanGraphPreservingViewport('sidebar-planning');
-        return;
-      }
-      navigatePlanGraphAndFit('sidebar-planning');
+      navigatePlanGraphPreservingViewport('sidebar-planning');
       return;
     }
     setViewMode('dag');
     setSidebarSurface(nextSurface);
     setInspectorManualOpen(false);
     setStatusFilters(new Set<WorkflowStatus>());
-  }, [navigatePlanGraphAndFit, navigatePlanGraphPreservingViewport, navigatePlanningHome, sidebarSurface, viewMode]);
+  }, [navigatePlanGraphPreservingViewport, navigatePlanningHome, sidebarSurface, viewMode]);
 
   const handleDismissBrowserSurface = useCallback(() => {
     setGraphActionsMenuOpen(false);
@@ -4472,7 +4453,7 @@ export function App() {
               )}
               <button
                 type="button"
-                onClick={() => navigatePlanGraphAndFit('planning-draft-review')}
+                onClick={() => navigatePlanGraphPreservingViewport('planning-draft-review')}
                 className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
               >
                 Open graph
@@ -4506,7 +4487,7 @@ export function App() {
                 <button
                   type="button"
                   data-testid="planning-context-open-graph"
-                  onClick={() => navigatePlanGraphAndFit('planning-context')}
+                  onClick={() => navigatePlanGraphPreservingViewport('planning-context')}
                   className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
                 >
                   Open graph
@@ -4638,7 +4619,7 @@ export function App() {
             onConfirmationModeChange={handlePlanningConfirmationModeChange}
             onModeChange={(mode) => void handlePlanningModeChange(mode)}
             onExpand={() => setPlanningTerminalExpanded(true)}
-            onOpenGraph={() => navigatePlanGraphAndFit('planning-open-graph')}
+            onOpenGraph={() => navigatePlanGraphPreservingViewport('planning-open-graph')}
             onReviewDraft={() => {
               setReviewDraftSessionId(activePlanningSession.id);
               setPlanningContextCollapsed(false);
@@ -4976,7 +4957,7 @@ export function App() {
             onCloseExpanded={() => setPlanningTerminalExpanded(false)}
             onOpenGraph={() => {
               setPlanningTerminalExpanded(false);
-              navigatePlanGraphAndFit('planning-expanded-open-graph');
+              navigatePlanGraphPreservingViewport('planning-expanded-open-graph');
             }}
             onReviewDraft={() => {
               setPlanningTerminalExpanded(false);

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -17,7 +17,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import { createMockInvoker, makePlanningSessionSummary, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { WorkflowMeta } from '../types.js';
 import type { GraphCameraCommand } from '../lib/graph-camera.js';
 import * as ReactFlowModule from '@xyflow/react';
@@ -178,31 +178,40 @@ describe('Browser-surface camera (component)', () => {
     expect(fitViewMock).not.toHaveBeenCalled();
   });
 
-  it('clicking the left-nav home icon returns to the workflow graph and issues the Home fit command', async () => {
+  it('returns to the workflow graph from a browser surface by restoring the saved viewport instead of fitting', async () => {
+    const savedViewport = { x: -420, y: 96, zoom: 0.74 };
     mock.setTasks(tasks, workflows);
     render(<App />);
+
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    await screen.findByTestId('workflow-node-wf-a');
+    await settleCamera();
+    getViewportMock.mockReturnValue(savedViewport);
 
     fireEvent.click(await screen.findByTestId('sidebar-workflows'));
     await screen.findByTestId('selected-workflow-mini-dag');
     await settleCamera();
+
     fitViewMock.mockClear();
     setCenterMock.mockClear();
+    setViewportMock.mockClear();
     workflowGraphSpy.reset();
 
     fireEvent.click(screen.getByTestId('sidebar-planning'));
 
     await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
-    await waitFor(() => {
-      const matchingCommands = workflowGraphSpy.commands.filter((command): command is GraphCameraCommand => (
-        command?.kind === 'fitInitial'
-        && command.scope === 'workflow'
-        && command.reason === 'sidebar-planning'
-      ));
-      expect(matchingCommands.length).toBeGreaterThan(0);
-    });
+    await waitFor(() => expect(setViewportMock).toHaveBeenCalledWith(savedViewport, { duration: 0 }));
     await flushFrames(4);
 
-    expect(fitViewMock).toHaveBeenCalled();
+    // The selected task DAG can mount as a floating panel and run its own
+    // initial fit. The workflow graph contract is no `sidebar-planning`
+    // fitInitial command and a restored viewport.
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(workflowGraphSpy.commands.some((command) => (
+      command?.kind === 'fitInitial'
+      && command.scope === 'workflow'
+      && command.reason === 'sidebar-planning'
+    ))).toBe(false);
   });
 
   it('returns to the workflow graph from the planning-home chat rail by restoring the saved viewport instead of fitting', async () => {
@@ -239,6 +248,53 @@ describe('Browser-surface camera (component)', () => {
       command?.kind === 'fitInitial'
       && command.scope === 'workflow'
       && command.reason === 'sidebar-planning'
+    ))).toBe(false);
+  });
+
+  it('opens the workflow graph from the planning context panel by restoring the saved viewport instead of fitting', async () => {
+    const savedViewport = { x: -512, y: 188, zoom: 0.81 };
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'saved-draft-chat',
+          title: 'Saved draft chat',
+          status: 'draft_ready',
+          draftPlanAvailable: true,
+        }),
+      ],
+    })) as any;
+    mock.setTasks([], workflows);
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('Saved draft chat'));
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+    await screen.findByTestId('workflow-node-wf-a');
+    await settleCamera();
+    getViewportMock.mockReturnValue(savedViewport);
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+    await screen.findByTestId('planning-session-rail');
+    fireEvent.click(screen.getByTestId('planning-context-toggle'));
+    await screen.findByTestId('planning-context-open-graph');
+
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    setViewportMock.mockClear();
+    workflowGraphSpy.reset();
+
+    fireEvent.click(screen.getByTestId('planning-context-open-graph'));
+
+    await waitFor(() => expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument());
+    await waitFor(() => expect(setViewportMock).toHaveBeenCalledWith(savedViewport, { duration: 0 }));
+    await flushFrames(4);
+
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(workflowGraphSpy.commands.some((command) => (
+      command?.kind === 'fitInitial'
+      && command.scope === 'workflow'
+      && command.reason === 'planning-context'
     ))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Returning from planning chat, expanded chat, browser surfaces, and planning context now keeps the workflow graph viewport the user already had.

The graph entry path clears queued camera work instead of issuing a fresh workflow fit.

## Review Claim

Approve that returning from planning surfaces preserves the saved workflow graph viewport instead of issuing a fresh fit.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change stays inside planning graph entry handlers and directly affected React camera tests; task data, workflow data, and graph rendering stay unchanged.

## Slice Rationale

This slice changes the user-facing graph entry behavior. Terminal-specific coverage stays in the next PR so the behavior edit remains locally reviewable.

## Non-goals

- No task graph layout changes.
- No workflow selection changes.
- No planning chat persistence changes.
- No terminal transcript behavior changes.

## Architecture

### Before

```mermaid
graph TD
    A["Planning graph entry"] --> B["Discard saved workflow viewport"]
    B --> C["Issue fitInitial workflow camera command"]
    C --> D["WorkflowGraph refits on return"]
```

### After

```mermaid
graph TD
    A["Planning graph entry"] --> B["Keep saved workflow viewport"]
    B --> C["Clear pending camera command"]
    C --> D["WorkflowGraph restores initialViewport"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/browser-surface-camera-resnap.test.tsx src/__tests__/invoker-terminal.test.tsx src/__tests__/keyboard-controls.test.tsx`

</details>

## Visual Proof

![Workflow graph remains inspectable after returning from planning](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-0212ee/neutral-chrome-home-graph.png)

[Planning terminal return recording](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-0212ee/planning-terminal-restart.gif)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, before the proof PR or together with it.
- Revert command: `git revert 0d9137ef7`
- Post-revert steps: Rerun the focused UI tests listed above.
- Data migration? No

</details>
