### PR TITLE
[Remote Sync Step 1: Sync Schema and Change Journal](1) Add data-store sync schema and journal

### DIFF
--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createAttempt, createTaskState } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { SqliteExecutor } from '../sqlite-executor.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  readJournalSince,
+  setSyncCursor,
+} from '../sync-journal.js';
+
+describe('sync journal', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    adapter.saveWorkflow({
+      id: 'wf-sync',
+      name: 'Sync workflow',
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+    });
+    adapter.saveTask('wf-sync', createTaskState('task-sync', 'Sync task', [], { workflowId: 'wf-sync' }));
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function exec(): SqliteExecutor {
+    return (adapter as unknown as { executor: SqliteExecutor }).executor;
+  }
+
+  it('rolls back appended journal rows with the enclosing mutation transaction', () => {
+    expect(() => exec().runTransaction(() => {
+      exec().execRun("UPDATE tasks SET status = 'running' WHERE id = ?", ['task-sync']);
+      const payload = exec().queryOne('SELECT * FROM tasks WHERE id = ?', ['task-sync']);
+      appendJournalEntry(exec(), {
+        entityType: 'task',
+        entityId: 'task-sync',
+        op: 'upsert',
+        payload,
+      });
+      throw new Error('rollback sync mutation');
+    })).toThrow('rollback sync mutation');
+
+    expect(adapter.loadTask('task-sync')?.status).toBe('pending');
+    expect(readJournalSince(exec(), 0, 10)).toEqual([]);
+  });
+
+  it('allocates strictly monotonic seq values for adapter mutation hooks', () => {
+    adapter.updateTask('task-sync', { status: 'running' });
+    const attempt = createAttempt('task-sync', { status: 'running' });
+    adapter.saveAttempt(attempt);
+    adapter.updateAttempt(attempt.id, {
+      status: 'completed',
+      completedAt: new Date('2026-07-27T00:01:00.000Z'),
+      exitCode: 0,
+    });
+
+    const entries = adapter.readJournalSince(0, 20);
+    expect(entries.length).toBeGreaterThanOrEqual(3);
+    for (let index = 1; index < entries.length; index += 1) {
+      expect(entries[index].seq).toBeGreaterThan(entries[index - 1].seq);
+    }
+  });
+
+  it('reads journal entries strictly after the supplied cursor and persists peer cursors', () => {
+    adapter.updateTask('task-sync', { status: 'running' });
+    const attempt = createAttempt('task-sync', { status: 'running' });
+    adapter.saveAttempt(attempt);
+    adapter.updateAttempt(attempt.id, {
+      status: 'failed',
+      completedAt: new Date('2026-07-27T00:01:00.000Z'),
+      error: 'failed',
+    });
+
+    const entries = adapter.readJournalSince(0, 20);
+    const cursor = setSyncCursor(exec(), {
+      peerId: 'peer-a',
+      lastSentSeq: entries[1].seq,
+      lastReceivedSeq: 4,
+      updatedAt: 12345,
+    });
+
+    expect(getSyncCursor(exec(), 'peer-a')).toEqual(cursor);
+    expect(adapter.readJournalSince(cursor.lastSentSeq, 20).map((entry) => entry.seq))
+      .toEqual(entries.slice(2).map((entry) => entry.seq));
+  });
+
+  it('excludes soft-deleted workflows by default and includes them when requested', () => {
+    adapter.deleteWorkflow('wf-sync');
+
+    expect(adapter.listWorkflows()).toEqual([]);
+    expect(adapter.loadWorkflow('wf-sync')).toBeUndefined();
+    expect(adapter.loadTasks('wf-sync')).toEqual([]);
+
+    const deleted = adapter.listWorkflows({ includeDeleted: true });
+    expect(deleted).toHaveLength(1);
+    expect(deleted[0]).toMatchObject({ id: 'wf-sync', name: 'Sync workflow' });
+    expect(deleted[0].deletedAt).toEqual(expect.any(Number));
+    expect(adapter.loadWorkflow('wf-sync', { includeDeleted: true })?.deletedAt)
+      .toBe(deleted[0].deletedAt);
+  });
+
+  it('writes a workflow tombstone journal entry on workflow delete', () => {
+    adapter.deleteWorkflow('wf-sync');
+
+    const [tombstone] = adapter.readJournalSince(0, 20)
+      .filter((entry) => entry.entityType === 'workflow' && entry.op === 'tombstone');
+    expect(tombstone).toBeDefined();
+    expect(tombstone.entityId).toBe('wf-sync');
+    expect(tombstone.origin).toBe('home');
+    expect(tombstone.payload).toMatchObject({
+      id: 'wf-sync',
+      deleted_at: expect.any(Number),
+    });
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -122,10 +122,15 @@ export interface Workflow {
   /** Read-only provenance for dependencies removed by `detachWorkflow`. Never re-read by scheduling. */
   detachedExternalDependencies?: DetachedExternalDependency[];
   generation?: number;
+  deletedAt?: number;
   createdAt: string;
   updatedAt: string;
 }
 export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup'>;
+
+export interface WorkflowReadOptions {
+  includeDeleted?: boolean;
+}
 
 /**
  * Result of resolving a published PR back to its Invoker workflow via the merge
@@ -329,8 +334,8 @@ export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
-  loadWorkflow(workflowId: string): Workflow | undefined;
-  listWorkflows(): Workflow[];
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined;
+  listWorkflows(options?: WorkflowReadOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
   /** Resolve a GitHub PR number back to its Invoker workflow via the merge node. */
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined;

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -1,6 +1,7 @@
 export * from './adapter.js';
 export * from './attempt-read-models.js';
 export * from './sqlite-adapter.js';
+export * from './sync-journal.js';
 export * from './slow-query-aggregator.js';
 export * from './conversation-repository.js';
 export * from './slack-session-repository.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -53,6 +53,7 @@ import type {
   WorkerActionRecord,
   WorkerActionWrite,
   WorkerDesiredStateRecord,
+  WorkflowReadOptions,
   TerminalSessionPatch,
   TerminalSessionRecord,
   InAppPlanningSessionPatch,
@@ -78,6 +79,17 @@ import type { SqliteExecutor } from './sqlite-executor.js';
 import * as migrations from './sqlite-migrations.js';
 import { SqliteTaskAttemptRepository } from './sqlite-task-attempt-repository.js';
 import { SqliteWorkflowRepository, type WorkflowMetadataChanges } from './sqlite-workflow-repository.js';
+import {
+  appendJournalEntry,
+  readJournalSince,
+  getSyncCursor,
+  setSyncCursor,
+  type SyncCursor,
+  type SyncCursorInput,
+  type SyncEntityType,
+  type SyncJournalEntry,
+  type SyncJournalOp,
+} from './sync-journal.js';
 
 function normalizeWorkerActionStatus(status: string): string {
   return status === 'canceled' ? 'cancelled' : status;
@@ -947,6 +959,54 @@ export class SQLiteAdapter implements PersistenceAdapter {
     };
   }
 
+  private appendJournalForSnapshot(
+    entityType: SyncEntityType,
+    entityId: string,
+    op: SyncJournalOp = 'upsert',
+  ): SyncJournalEntry | undefined {
+    const payload = this.loadJournalPayloadSnapshot(entityType, entityId);
+    if (!payload) return undefined;
+    return appendJournalEntry(this.executor, { entityType, entityId, op, payload });
+  }
+
+  private loadJournalPayloadSnapshot(
+    entityType: SyncEntityType,
+    entityId: string,
+  ): Record<string, unknown> | undefined {
+    switch (entityType) {
+      case 'workflow':
+        return this.queryOne('SELECT * FROM workflows WHERE id = ?', [entityId]);
+      case 'task':
+        return this.queryOne('SELECT * FROM tasks WHERE id = ?', [entityId]);
+      case 'attempt':
+        return this.queryOne('SELECT * FROM attempts WHERE id = ?', [entityId]);
+      case 'event':
+        return this.queryOne('SELECT * FROM events WHERE id = ?', [entityId]);
+      case 'output':
+        return undefined;
+    }
+  }
+
+  private shouldJournalAttemptUpdate(
+    changes: Partial<Pick<Attempt, 'status' | 'completedAt'>>,
+  ): boolean {
+    return changes.completedAt !== undefined
+      || changes.status === 'completed'
+      || changes.status === 'failed';
+  }
+
+  readJournalSince(seq: number, limit: number): SyncJournalEntry[] {
+    return readJournalSince(this.executor, seq, limit);
+  }
+
+  getSyncCursor(peerId: string): SyncCursor | undefined {
+    return getSyncCursor(this.executor, peerId);
+  }
+
+  setSyncCursor(cursor: SyncCursorInput): SyncCursor {
+    return setSyncCursor(this.executor, cursor);
+  }
+
   runCompatibilityMigration(): {
     migratedFixingWithAiStatuses: number;
     normalizedMergeModes: number;
@@ -1050,12 +1110,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.workflowRepo.updateWorkflow(workflowId, changes);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    return this.workflowRepo.loadWorkflow(workflowId);
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined {
+    return this.workflowRepo.loadWorkflow(workflowId, options);
   }
 
-  listWorkflows(): Workflow[] {
-    return this.workflowRepo.listWorkflows();
+  listWorkflows(options?: WorkflowReadOptions): Workflow[] {
+    return this.workflowRepo.listWorkflows(options);
   }
 
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
@@ -1081,7 +1141,31 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   updateTask(taskId: string, changes: TaskStateChanges): void {
-    this.taskAttemptRepo.updateTask(taskId, changes);
+    const shouldJournalTask = changes.status !== undefined;
+    if (!shouldJournalTask) {
+      this.taskAttemptRepo.updateTask(taskId, changes);
+      return;
+    }
+
+    this.runTransaction(() => {
+      const beforeTask = this.taskAttemptRepo.loadTask(taskId);
+      const workflowId = beforeTask?.config.workflowId;
+      const beforeWorkflowStatus = workflowId
+        ? this.workflowRepo.loadWorkflow(workflowId, { includeDeleted: true })?.status
+        : undefined;
+
+      this.taskAttemptRepo.updateTask(taskId, changes);
+
+      const afterTask = this.taskAttemptRepo.loadTask(taskId);
+      if (!afterTask) return;
+      this.appendJournalForSnapshot('task', taskId);
+
+      if (!workflowId || beforeWorkflowStatus === undefined) return;
+      const afterWorkflow = this.workflowRepo.loadWorkflow(workflowId, { includeDeleted: true });
+      if (afterWorkflow && afterWorkflow.status !== beforeWorkflowStatus) {
+        this.appendJournalForSnapshot('workflow', workflowId);
+      }
+    });
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -1548,6 +1632,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
   deleteWorkflow(workflowId: string): void {
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
     this.runTransaction(() => {
+      const existing = this.queryOne(
+        'SELECT id FROM workflows WHERE id = ? AND deleted_at IS NULL',
+        [workflowId],
+      );
+      if (!existing) return;
+
       this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM task_launch_dispatch WHERE workflow_id = ?', [workflowId]);
@@ -1587,7 +1677,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
+      const deletedAt = Date.now();
+      this.db.run(
+        'UPDATE workflows SET deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL',
+        [deletedAt, new Date(deletedAt).toISOString(), workflowId],
+      );
+      if (this.db.getRowsModified() > 0) {
+        this.appendJournalForSnapshot('workflow', workflowId, 'tombstone');
+      }
     });
     this.removeOutputFiles(taskIds);
   }
@@ -2615,7 +2712,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Attempts ────────────────────────────────────────────
 
   saveAttempt(attempt: Attempt): void {
-    this.taskAttemptRepo.saveAttempt(attempt);
+    this.runTransaction(() => {
+      this.taskAttemptRepo.saveAttempt(attempt);
+      this.appendJournalForSnapshot('attempt', attempt.id);
+    });
   }
 
   loadAttempts(nodeId: string): Attempt[] {
@@ -2639,7 +2739,15 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void {
-    this.taskAttemptRepo.updateAttempt(attemptId, changes);
+    const shouldJournal = this.shouldJournalAttemptUpdate(changes);
+    if (!shouldJournal) {
+      this.taskAttemptRepo.updateAttempt(attemptId, changes);
+      return;
+    }
+    this.runTransaction(() => {
+      this.taskAttemptRepo.updateAttempt(attemptId, changes);
+      this.appendJournalForSnapshot('attempt', attemptId);
+    });
   }
 
   claimAttemptForLaunch(

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -47,6 +47,7 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
     externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
     detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) as DetachedExternalDependency[] : undefined,
     generation: row.generation ?? 0,
+    deletedAt: row.deleted_at === null || row.deleted_at === undefined ? undefined : Number(row.deleted_at),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -27,6 +27,7 @@ export const SCHEMA_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       );
@@ -508,6 +509,26 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_terminal_sessions_status_updated
         ON terminal_sessions(status, updated_at);
 
+      CREATE TABLE IF NOT EXISTS sync_journal (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+        entity_id TEXT NOT NULL,
+        op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+        payload TEXT NOT NULL CHECK (json_valid(payload)),
+        origin TEXT NOT NULL DEFAULT 'home',
+        created_at INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_sync_journal_entity
+        ON sync_journal(entity_type, entity_id, seq);
+
+      CREATE TABLE IF NOT EXISTS sync_cursors (
+        peer_id TEXT PRIMARY KEY,
+        last_sent_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_sent_seq) = 'integer' AND last_sent_seq >= 0),
+        last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
+        updated_at INTEGER NOT NULL
+      );
+
     `;
 
 /** Idempotent `ALTER TABLE ... ADD COLUMN` migrations for older databases. */
@@ -591,6 +612,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
+  'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
 ];
 
 /**
@@ -622,6 +644,22 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  `CREATE TABLE IF NOT EXISTS sync_journal (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+    entity_id TEXT NOT NULL,
+    op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    origin TEXT NOT NULL DEFAULT 'home',
+    created_at INTEGER NOT NULL
+  )`,
+  'CREATE INDEX IF NOT EXISTS idx_sync_journal_entity ON sync_journal(entity_type, entity_id, seq)',
+  `CREATE TABLE IF NOT EXISTS sync_cursors (
+    peer_id TEXT PRIMARY KEY,
+    last_sent_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_sent_seq) = 'integer' AND last_sent_seq >= 0),
+    last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
+    updated_at INTEGER NOT NULL
+  )`,
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */
@@ -645,6 +683,7 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       )
@@ -656,12 +695,12 @@ export const WORKFLOWS_REBUILD_INSERT_DDL = `
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       FROM workflows
     `;

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -27,6 +27,7 @@ import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ReviewGateLookup,
   Workflow,
+  WorkflowReadOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
 } from './adapter.js';
@@ -89,8 +90,8 @@ export class SqliteWorkflowRepository {
   saveWorkflow(workflow: WorkflowSaveInput): void {
     assertWorkflowConsistent(workflow);
     this.exec.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, deleted_at, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       workflow.id, workflow.name,
       workflow.description ?? null,
@@ -103,6 +104,7 @@ export class SqliteWorkflowRepository {
       workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
       workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
       workflow.generation ?? 0,
+      null,
       workflow.createdAt, workflow.updatedAt,
     ]);
   }
@@ -174,16 +176,23 @@ export class SqliteWorkflowRepository {
     this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined {
+    const row = this.exec.queryOne(
+      options?.includeDeleted
+        ? 'SELECT * FROM workflows WHERE id = ?'
+        : 'SELECT * FROM workflows WHERE id = ? AND deleted_at IS NULL',
+      [workflowId],
+    );
     if (!row) return undefined;
     const rollup = this.loadWorkflowRollups([workflowId]).get(workflowId);
     return this.rowToWorkflow(row, rollup);
   }
 
-  listWorkflows(): Workflow[] {
+  listWorkflows(options?: WorkflowReadOptions): Workflow[] {
     const rows = this.exec.queryAll(
-      'SELECT * FROM workflows ORDER BY created_at DESC',
+      options?.includeDeleted
+        ? 'SELECT * FROM workflows ORDER BY created_at DESC'
+        : 'SELECT * FROM workflows WHERE deleted_at IS NULL ORDER BY created_at DESC',
     );
     const workflowIds = rows.map((row) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
@@ -205,7 +214,9 @@ export class SqliteWorkflowRepository {
               w.base_branch AS baseBranch
          FROM tasks t
          JOIN workflows w ON w.id = t.workflow_id
-        WHERE t.is_merge_node = 1 AND (t.review_id = ? OR t.review_url LIKE ?)`,
+        WHERE w.deleted_at IS NULL
+          AND t.is_merge_node = 1
+          AND (t.review_id = ? OR t.review_url LIKE ?)`,
       [pr, `%/pull/${pr}`],
     );
     if (rows.length === 0) return undefined;
@@ -257,7 +268,8 @@ export class SqliteWorkflowRepository {
     if (type === 'workflows' || type === 'all') {
       const workflows = this.exec.queryAll(
         `SELECT id, name, description, plan_file, repo_url, branch, created_at FROM workflows 
-         WHERE name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ? 
+         WHERE deleted_at IS NULL
+           AND (name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{ id: string; name?: string | null; created_at: string }>;
@@ -298,7 +310,7 @@ export class SqliteWorkflowRepository {
       if (workflowIds.length > 0) {
         const placeholders = workflowIds.map(() => '?').join(',');
         const workflowRows = this.exec.queryAll(
-          `SELECT id, name FROM workflows WHERE id IN (${placeholders})`,
+          `SELECT id, name FROM workflows WHERE deleted_at IS NULL AND id IN (${placeholders})`,
           workflowIds
         ) as Array<{ id: string; name?: string | null }>;
         for (const wf of workflowRows) {
@@ -326,7 +338,7 @@ export class SqliteWorkflowRepository {
   loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
     const totalStartedAt = Date.now();
     const workflowQueryStartedAt = Date.now();
-    const workflowRows = this.exec.queryAll('SELECT * FROM workflows ORDER BY created_at DESC');
+    const workflowRows = this.exec.queryAll('SELECT * FROM workflows WHERE deleted_at IS NULL ORDER BY created_at DESC');
     const workflowMetadataQueryMs = Date.now() - workflowQueryStartedAt;
     const taskQueryStartedAt = Date.now();
     const taskRows = this.exec.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC');

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -1,0 +1,119 @@
+import type { SqliteExecutor } from './sqlite-executor.js';
+
+export const SYNC_ENTITY_TYPES = [
+  'workflow',
+  'task',
+  'attempt',
+  'event',
+  // Reserved for future output-spool snapshots; adapter output rows are not journaled yet.
+  'output',
+] as const;
+
+export type SyncEntityType = typeof SYNC_ENTITY_TYPES[number];
+export type SyncJournalOp = 'upsert' | 'tombstone';
+
+export interface SyncJournalEntryInput {
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOp;
+  payload: unknown;
+  origin?: string;
+  createdAt?: number;
+}
+
+export interface SyncJournalEntry {
+  seq: number;
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOp;
+  payload: unknown;
+  origin: string;
+  createdAt: number;
+}
+
+export interface SyncCursor {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt: number;
+}
+
+export interface SyncCursorInput {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt?: number;
+}
+
+export function appendJournalEntry(db: SqliteExecutor, entry: SyncJournalEntryInput): SyncJournalEntry {
+  const origin = entry.origin ?? 'home';
+  const createdAt = entry.createdAt ?? Date.now();
+  const payload = JSON.stringify(entry.payload);
+  db.execRun(
+    `INSERT INTO sync_journal (entity_type, entity_id, op, payload, origin, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [entry.entityType, entry.entityId, entry.op, payload, origin, createdAt],
+  );
+  const row = db.queryOne('SELECT * FROM sync_journal WHERE seq = last_insert_rowid()');
+  if (!row) {
+    throw new Error('Failed to read appended sync journal entry');
+  }
+  return mapJournalRow(row);
+}
+
+export function readJournalSince(db: SqliteExecutor, seq: number, limit: number): SyncJournalEntry[] {
+  const boundedLimit = Math.max(0, Math.trunc(limit));
+  if (boundedLimit === 0) return [];
+  const rows = db.queryAll(
+    `SELECT * FROM sync_journal
+     WHERE seq > ?
+     ORDER BY seq ASC
+     LIMIT ?`,
+    [Math.max(0, Math.trunc(seq)), boundedLimit],
+  );
+  return rows.map((row) => mapJournalRow(row));
+}
+
+export function getSyncCursor(db: SqliteExecutor, peerId: string): SyncCursor | undefined {
+  const row = db.queryOne('SELECT * FROM sync_cursors WHERE peer_id = ?', [peerId]);
+  return row ? mapCursorRow(row) : undefined;
+}
+
+export function setSyncCursor(db: SqliteExecutor, cursor: SyncCursorInput): SyncCursor {
+  const updatedAt = cursor.updatedAt ?? Date.now();
+  db.execRun(
+    `INSERT INTO sync_cursors (peer_id, last_sent_seq, last_received_seq, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(peer_id) DO UPDATE SET
+       last_sent_seq = excluded.last_sent_seq,
+       last_received_seq = excluded.last_received_seq,
+       updated_at = excluded.updated_at`,
+    [cursor.peerId, cursor.lastSentSeq, cursor.lastReceivedSeq, updatedAt],
+  );
+  const row = db.queryOne('SELECT * FROM sync_cursors WHERE peer_id = ?', [cursor.peerId]);
+  if (!row) {
+    throw new Error(`Failed to read sync cursor for peer "${cursor.peerId}"`);
+  }
+  return mapCursorRow(row);
+}
+
+function mapJournalRow(row: Record<string, unknown>): SyncJournalEntry {
+  return {
+    seq: Number(row.seq),
+    entityType: row.entity_type as SyncEntityType,
+    entityId: String(row.entity_id),
+    op: row.op as SyncJournalOp,
+    payload: JSON.parse(String(row.payload)),
+    origin: String(row.origin),
+    createdAt: Number(row.created_at),
+  };
+}
+
+function mapCursorRow(row: Record<string, unknown>): SyncCursor {
+  return {
+    peerId: String(row.peer_id),
+    lastSentSeq: Number(row.last_sent_seq),
+    lastReceivedSeq: Number(row.last_received_seq),
+    updatedAt: Number(row.updated_at),
+  };
+}


### PR DESCRIPTION
## Summary

Remote Sync Step 1 adds the data-store schema needed to journal syncable workflow state.

Journal rows, peer cursors, and workflow tombstones now share the SQLite persistence contract.

## Workflow Summary

Remote Sync Step 1: Sync Schema and Change Journal — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926077035-3/implement-sync-schema | Add sync journal, cursor, and tombstone schema to data-store | completed |
| wf-1784926077035-3/verify-sync-schema | Run data-store package tests covering the new schema and journal | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784926077035-3/implement-sync-schema — Add sync journal, cursor, and tombstone schema to data-store

packages/data-store/src/__tests__/sync-journal.test.ts
packages/data-store/src/adapter.ts
packages/data-store/src/index.ts
packages/data-store/src/sqlite-adapter.ts
packages/data-store/src/sqlite-row-mappers.ts
packages/data-store/src/sqlite-schema.ts
packages/data-store/src/sqlite-workflow-repository.ts
packages/data-store/src/sync-journal.ts

### wf-1784926077035-3/verify-sync-schema — Run data-store package tests covering the new schema and journal

No file changes; verification ran against the implement slice.

</details>

## Review Claim

Approve the data-store sync schema contract for journal entries, peer cursors, and workflow tombstones.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This slice is confined to data-store schema, journal helpers, and directly affected persistence tests; no sync transport or remote execution path is activated.

## Slice Rationale

Schema and local journaling land first so later remote sync transport can consume one stable data-store contract.

## Non-goals

- No remote sync transport.
- No peer protocol.
- No output spool sync.
- No UI changes.

## Architecture

### Before

```mermaid
graph TD
    A["SQLite persistence tables"] --> B["Workflow and task rows"]
    C["Remote sync peers"] --> D["No durable cursor contract"]
```

### After

```mermaid
graph TD
    A["SQLite persistence tables"] --> B["Workflow and task rows"]
    A --> C["sync_journal entries"]
    A --> D["sync_cursors per peer"]
    B --> E["workflow_tombstones represented by deleted_at rows"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sync-journal.test.ts` (25 files, 434 tests passed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 14d1ad272ec460d3e3be4341bfb903f7ff379d94`
- Post-revert steps: Rerun the data-store focused test.
- Data migration? No production migration has shipped yet.

</details>
