### PR TITLE
[Delete planning terminals — UI](1) Add Planning Terminal rail controls

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
+import { Trash2 } from 'lucide-react';
 import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, StartReadyRequest, StartReadyResult, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus, WorkerActionSummary, WorkerLogEntry, WorkerStatusEntry } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
@@ -2729,22 +2730,82 @@ export function App() {
     workflows.size,
   ]);
 
-  const handleCreatePlanningSession = useCallback(() => {
+  const makeLocalPlanningSession = useCallback((): PlanningSessionView => {
     const index = nextPlanningSessionLocalIdRef.current;
     nextPlanningSessionLocalIdRef.current += 1;
     const now = new Date().toISOString();
     const localId = `local-planning-session-${index}`;
-    const session: PlanningSessionView = {
+    return {
       ...makeInitialPlanningSession(now),
       id: localId,
       conversationKey: localId,
       presetKey: selectedPlanningPresetKey,
     };
-    setPlanningSessions((prev) => [session, ...prev]);
+  }, [selectedPlanningPresetKey]);
+
+  const removePlanningSessions = useCallback((sessionIds: string[]) => {
+    if (sessionIds.length === 0) return;
+    const removedIds = new Set(sessionIds);
+    const currentSessions = planningSessionsRef.current;
+    let nextSessions = currentSessions.filter((session) => !removedIds.has(session.id));
+    const replacementSession = nextSessions.length === 0 ? makeLocalPlanningSession() : null;
+    if (replacementSession) {
+      nextSessions = [replacementSession];
+    }
+
+    const currentActiveSessionId = activePlanningSessionIdRef.current;
+    const currentActiveIndex = currentSessions.findIndex((session) => session.id === currentActiveSessionId);
+    const activeSessionSurvives = nextSessions.some((session) => session.id === currentActiveSessionId);
+    const nextActiveSessionId = activeSessionSurvives
+      ? currentActiveSessionId
+      : (
+          currentSessions.slice(Math.max(currentActiveIndex + 1, 0)).find((session) => !removedIds.has(session.id))?.id
+          ?? [...currentSessions.slice(0, Math.max(currentActiveIndex, 0))].reverse().find((session) => !removedIds.has(session.id))?.id
+          ?? nextSessions[0]?.id
+          ?? currentActiveSessionId
+        );
+
+    planningSessionsRef.current = nextSessions;
+    activePlanningSessionIdRef.current = nextActiveSessionId;
+    setPlanningSessions(nextSessions);
+    setActivePlanningSessionId(nextActiveSessionId);
+    clearPlanningStreamForSessionIds(sessionIds);
+    forgetPlanningStreamAliasesForSessionIds(sessionIds);
+    for (const sessionId of sessionIds) {
+      pendingPlanningStreamSessionIdsRef.current.delete(sessionId);
+    }
+  }, [clearPlanningStreamForSessionIds, forgetPlanningStreamAliasesForSessionIds, makeLocalPlanningSession]);
+
+  const handleCreatePlanningSession = useCallback(() => {
+    const session = makeLocalPlanningSession();
+    const nextSessions = [session, ...planningSessionsRef.current];
+    planningSessionsRef.current = nextSessions;
+    activePlanningSessionIdRef.current = session.id;
+    setPlanningSessions(nextSessions);
     setActivePlanningSessionId(session.id);
     setSidebarSurface('home');
     focusKeyboardRegion('planning');
-  }, [focusKeyboardRegion, selectedPlanningPresetKey]);
+  }, [focusKeyboardRegion, makeLocalPlanningSession]);
+
+  const handleDeletePlanningSession = useCallback((sessionId: string) => {
+    if (activePlanningReadOnly) return;
+    if (!sessionId.startsWith('local-')) {
+      void invoker?.planningChatDelete?.({ sessionId });
+    }
+    removePlanningSessions([sessionId]);
+  }, [activePlanningReadOnly, invoker, removePlanningSessions]);
+
+  const handleClearSubmittedPlanningSessions = useCallback(() => {
+    if (activePlanningReadOnly) return;
+    const confirmed = window.confirm('Clear all submitted planning chats? This cannot be undone.');
+    if (!confirmed) return;
+    const submittedIds = planningSessionsRef.current
+      .filter((session) => session.status === 'submitted')
+      .map((session) => session.id);
+    if (submittedIds.length === 0) return;
+    void invoker?.planningChatDeleteSubmitted?.();
+    removePlanningSessions(submittedIds);
+  }, [activePlanningReadOnly, invoker, removePlanningSessions]);
 
   const handlePlanningModeChange = useCallback(async (mode: PlanningTerminalMode) => {
     const sourceSession = activePlanningSession;
@@ -3998,30 +4059,48 @@ export function App() {
           const selected = session.id === activePlanningSession.id;
           const preview = previewPlanningMessage(session);
           return (
-            <button
+            <div
               key={session.id}
-              type="button"
-              onClick={() => setActivePlanningSessionId(session.id)}
-              className={`flex w-full items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              className="flex items-stretch"
             >
-              <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-start justify-between gap-2">
-                  <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
-                    {session.title}
+              <button
+                type="button"
+                onClick={() => setActivePlanningSessionId(session.id)}
+                className={`flex min-w-0 flex-1 w-full items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              >
+                <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
+                      {session.title}
+                    </div>
+                    <span className="shrink-0 text-[11px] text-muted-foreground">
+                      {relativePlanningUpdatedAt(session.updatedAt)}
+                    </span>
                   </div>
-                  <span className="shrink-0 text-[11px] text-muted-foreground">
-                    {relativePlanningUpdatedAt(session.updatedAt)}
-                  </span>
+                  <div
+                    className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
+                    title={preview}
+                  >
+                    {preview}
+                  </div>
                 </div>
-                <div
-                  className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
-                  title={preview}
+              </button>
+              {!activePlanningReadOnly && (
+                <button
+                  type="button"
+                  aria-label="Delete planning chat"
+                  title="Delete planning chat"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleDeletePlanningSession(session.id);
+                  }}
+                  className={`flex w-9 shrink-0 items-start justify-center px-2 py-2 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive ${selected ? 'bg-accent/40' : ''}`}
                 >
-                  {preview}
-                </div>
-              </div>
-            </button>
+                  <Trash2 className="mt-0.5 h-4 w-4" strokeWidth={1.75} aria-hidden="true" />
+                </button>
+              )}
+            </div>
           );
         })}
       </div>
@@ -4029,6 +4108,7 @@ export function App() {
   );
 
   const planningReadyCount = planningSessions.filter((session) => session.status === 'draft_ready').length;
+  const hasSubmittedPlanningSessions = planningSessions.some((session) => session.status === 'submitted');
   const connectedAgentLabels = (systemDiagnostics?.tools ?? [])
     .filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed)
     .map((tool) => tool.name.replace(/\s+CLI$/i, ''));
@@ -4162,27 +4242,38 @@ export function App() {
           </div>
         ) : (
           <>
-            <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2.5">
-              <div className="min-w-0">
-                <h2 className="text-sm font-medium text-foreground">Planning</h2>
-                <p className="mt-0.5 text-[11px] text-muted-foreground">
-                  {planningSessions.length} chat{planningSessions.length === 1 ? '' : 's'}
-                  {planningReadyCount > 0 ? ` · ${planningReadyCount} ready` : ''}
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                <Button variant="outline" size="sm" onClick={handleCreatePlanningSession}>
-                  New chat
-                </Button>
+            <div className="space-y-2 border-b border-border px-3 py-2.5">
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <h2 className="text-sm font-medium text-foreground">Planning</h2>
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">
+                    {planningSessions.length} chat{planningSessions.length === 1 ? '' : 's'}
+                    {planningReadyCount > 0 ? ` · ${planningReadyCount} ready` : ''}
+                  </p>
+                </div>
                 <button
                   type="button"
                   data-testid="planning-session-rail-toggle"
                   aria-label="Collapse planning chats"
                   onClick={() => setPlanningSessionRailCollapsed(true)}
-                  className="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-secondary"
+                  className="shrink-0 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-secondary"
                 >
                   ‹
                 </button>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" onClick={handleCreatePlanningSession} className="min-w-0 flex-1">
+                  New chat
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={activePlanningReadOnly || !hasSubmittedPlanningSessions}
+                  onClick={handleClearSubmittedPlanningSessions}
+                  className="min-w-0 flex-1"
+                >
+                  Clear submitted
+                </Button>
               </div>
             </div>
             <div className={RAIL_LIST_FRAME_CLASS}>{renderPlanningSessionList()}</div>

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -220,6 +220,8 @@ export function createMockInvoker(
       workflowId: 'wf-1',
     })),
     planningChatReset: vi.fn(async () => ({ ok: true })),
+    planningChatDelete: vi.fn(async () => ({ ok: true })),
+    planningChatDeleteSubmitted: vi.fn(async () => ({ ok: true, deletedSessionIds: [] })),
     onPlanningChatStream: vi.fn((cb: (event: InAppPlanningStreamEvent) => void) => {
       planningChatStreamCallbacks.add(cb);
       return () => { planningChatStreamCallbacks.delete(cb); };

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -57,6 +57,43 @@ describe('Invoker terminal (component)', () => {
     expectRailListScrollContract(screen.getByTestId(listTestId));
   }
 
+  function makeRailPlanningSession(overrides: Parameters<typeof makePlanningSessionSummary>[0] = {}) {
+    return makePlanningSessionSummary({
+      status: 'still_discussing',
+      draftPlanAvailable: false,
+      draftPlanSummary: undefined,
+      messages: [],
+      ...overrides,
+    });
+  }
+
+  async function renderPlanningTerminalWithSessions(
+    sessions: ReturnType<typeof makePlanningSessionSummary>[],
+  ) {
+    mock.api.planningChatList = vi.fn(async () => ({ ok: true, sessions }));
+    render(<App />);
+    await openPlanningTerminal();
+    const list = screen.getByTestId('planning-session-list');
+    await waitFor(() => {
+      for (const session of sessions) {
+        expect(within(list).getByText(session.title)).toBeInTheDocument();
+      }
+    });
+    return list;
+  }
+
+  function planningRailRowByTitle(title: string) {
+    const list = screen.getByTestId('planning-session-list');
+    const selectionButton = within(list).getByText(title).closest('button');
+    const row = selectionButton?.parentElement;
+    if (!row) throw new Error(`Planning session row not found for ${title}`);
+    return row;
+  }
+
+  function deletePlanningRailRow(title: string) {
+    fireEvent.click(within(planningRailRowByTitle(title)).getByRole('button', { name: 'Delete planning chat' }));
+  }
+
   it('renders an empty flush planning pane before the first message', async () => {
     render(<App />);
     await openPlanningTerminal();
@@ -915,6 +952,124 @@ describe('Invoker terminal (component)', () => {
     fireEvent.click(screen.getByText('hello'));
 
     expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('I can help draft that.');
+  });
+
+  it('deletes a saved planning chat row and calls the bridge', async () => {
+    const list = await renderPlanningTerminalWithSessions([
+      makeRailPlanningSession({ id: 'keep-chat', title: 'Keep chat' }),
+      makeRailPlanningSession({ id: 'delete-chat', title: 'Delete chat' }),
+    ]);
+
+    deletePlanningRailRow('Delete chat');
+
+    await waitFor(() => {
+      expect(within(list).queryByText('Delete chat')).not.toBeInTheDocument();
+    });
+    expect(within(list).getByText('Keep chat')).toBeInTheDocument();
+    expect(mock.api.planningChatDelete).toHaveBeenCalledWith({ sessionId: 'delete-chat' });
+  });
+
+  it('deletes a local planning chat row without calling the bridge', async () => {
+    render(<App />);
+    await openPlanningTerminal();
+
+    const list = screen.getByTestId('planning-session-list');
+    fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
+
+    await waitFor(() => {
+      expect(within(list).getAllByRole('button', { name: 'Delete planning chat' })).toHaveLength(2);
+    });
+
+    fireEvent.click(within(list).getAllByRole('button', { name: 'Delete planning chat' })[0]);
+
+    await waitFor(() => {
+      expect(within(list).getAllByRole('button', { name: 'Delete planning chat' })).toHaveLength(1);
+    });
+    expect(mock.api.planningChatDelete).not.toHaveBeenCalled();
+  });
+
+  it('disables clear submitted without submitted chats and clears submitted chats after confirmation', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makeRailPlanningSession({ id: 'idle-chat', title: 'Idle chat' }),
+        makeRailPlanningSession({ id: 'draft-chat', title: 'Draft chat', status: 'draft_ready' }),
+      ],
+    }));
+
+    const firstRender = render(<App />);
+    await openPlanningTerminal();
+    expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
+    firstRender.unmount();
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    try {
+      vi.mocked(mock.api.planningChatDeleteSubmitted).mockClear();
+      mock.api.planningChatList = vi.fn(async () => ({
+        ok: true,
+        sessions: [
+          makeRailPlanningSession({ id: 'idle-chat', title: 'Idle chat' }),
+          makeRailPlanningSession({ id: 'submitted-one', title: 'Submitted one', status: 'submitted' }),
+          makeRailPlanningSession({ id: 'submitted-two', title: 'Submitted two', status: 'submitted' }),
+        ],
+      }));
+
+      render(<App />);
+      await openPlanningTerminal();
+      const list = screen.getByTestId('planning-session-list');
+      await waitFor(() => {
+        expect(within(list).getByText('Submitted one')).toBeInTheDocument();
+        expect(within(list).getByText('Submitted two')).toBeInTheDocument();
+      });
+
+      const clearSubmitted = screen.getByRole('button', { name: 'Clear submitted' });
+      expect(clearSubmitted).toBeEnabled();
+      fireEvent.click(clearSubmitted);
+
+      expect(confirmSpy).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(within(list).queryByText('Submitted one')).not.toBeInTheDocument();
+        expect(within(list).queryByText('Submitted two')).not.toBeInTheDocument();
+      });
+      expect(within(list).getByText('Idle chat')).toBeInTheDocument();
+      expect(mock.api.planningChatDeleteSubmitted).toHaveBeenCalledTimes(1);
+    } finally {
+      confirmSpy.mockRestore();
+    }
+  });
+
+  it('recreates an empty planning chat after deleting the last chat', async () => {
+    const list = await renderPlanningTerminalWithSessions([
+      makeRailPlanningSession({ id: 'only-chat', title: 'Only chat' }),
+    ]);
+
+    deletePlanningRailRow('Only chat');
+
+    await waitFor(() => {
+      expect(within(list).queryByText('Only chat')).not.toBeInTheDocument();
+      expect(within(list).getByText('Untitled plan')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('1 chat');
+    expect(screen.getByTestId('invoker-terminal-empty-hero')).toBeInTheDocument();
+    expect(screen.getByTestId('invoker-terminal-input')).toBeEnabled();
+  });
+
+  it('hides planning chat trash buttons and disables clear submitted in read-only mode', async () => {
+    mock.setRuntimeStatus({
+      ownerMode: false,
+      readOnly: true,
+      mode: 'read-only',
+    });
+    mock.install();
+    const list = await renderPlanningTerminalWithSessions([
+      makeRailPlanningSession({ id: 'submitted-chat', title: 'Submitted chat', status: 'submitted' }),
+      makeRailPlanningSession({ id: 'idle-chat', title: 'Idle chat' }),
+    ]);
+
+    await waitFor(() => {
+      expect(within(list).queryByRole('button', { name: 'Delete planning chat' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
+    });
   });
 
   it('wraps long planning session rail titles and previews instead of clipping them to one line', async () => {


### PR DESCRIPTION
## Summary

Planning chats now expose rail actions for trimming stale conversations without leaving the panel in an unusable empty state.

The header action handles finished planning chats with confirmation and owner-mode gating.

## Workflow Summary

Delete planning terminals — UI — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784313643126-2/ui-delete-planning-chat | Add per-row trash button (instant) + header Clear submitted button (confirm) to the Planning Terminal rail with reselection, empty-recreate, read-only gating, and stream cleanup | completed |
| wf-1784313643126-2/verify-ui-planning-terminal | Verify Planning Terminal rail delete + clear-submitted UI | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784313643126-2/ui-delete-planning-chat — Add per-row trash button (instant) + header Clear submitted button (confirm) to the Planning Terminal rail with reselection, empty-recreate, read-only gating, and stream cleanup

### wf-1784313643126-2/verify-ui-planning-terminal — Verify Planning Terminal rail delete + clear-submitted UI

</details>

## Review Claim

Approve the Planning Terminal rail action surface for per-chat trashing and header clearing.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The new actions are owner-mode gated, leave at least one local planning chat in the rail, and only call the planning-chat bridge methods for persisted or submitted sessions.

## Slice Rationale

This keeps the rail action surface with its reselection, empty-session fallback, and bridge calls in one reviewer-visible UI workflow.

## Non-goals

- This does not change planner response generation.
- This does not change workflow submission semantics.
- This does not change persisted planning transcript storage format.
- This does not change tmux-mode terminal rendering.

## Architecture

### Before

```mermaid
graph TD
    A["Planning rail lists sessions"] --> B["Selecting a row changes active session"]
    A --> C["No rail action exists for stale chats"]
```

### After

```mermaid
graph TD
    A["Planning rail lists sessions"] --> B["Selecting a row changes active session"]
    A --> C["Row trash action prunes one chat"]
    A --> D["Header action clears submitted chats after confirmation"]
    C --> E["Selection moves to a surviving or recreated chat"]
    D --> E
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- invoker-terminal`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/delete-planning-terminals-ui-pr.md --require-visual-proof`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/delete-planning-terminals-ui-pr.md --base master`

</details>

## Visual Proof

Planning Terminal rail walkthrough showing the row trash action, reselection, and confirmed submitted-chat clear:

[planning-terminal-delete-clear.webm](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-472b60/planning-terminal-delete-clear.webm)

Initial rail controls with the submitted-chat clear button and per-row trash action available:

![Planning Terminal rail delete controls](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-472b60/planning-terminal-delete-controls.png)

After using a row trash action, the next chat is selected and submitted-chat clear remains available:

![Planning Terminal after row trash action](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-472b60/planning-terminal-after-row-delete.png)

After confirming submitted-chat clear, only the active remaining chat stays in the rail and the clear button is disabled:

![Planning Terminal after submitted clear](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-472b60/planning-terminal-after-clear-submitted.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <published-commit-sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
