### PR TITLE
[Planning Review Handoff](4) Wire planning review UI, MCP adapter, and discard-draft IPC

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -171,11 +171,11 @@ describe('listInAppPlanningPresets', () => {
         'custom+omp': { tool: 'omp', model: 'fast' },
       },
     })).resolves.toEqual(expect.arrayContaining([
-      { key: 'codex', label: 'Codex', tool: 'codex', model: undefined, isDefault: false },
-      { key: 'omp', label: 'OMP', tool: 'omp', model: undefined, isDefault: false },
-      { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude', isDefault: true },
-      { key: 'custom', label: 'custom', tool: 'codex', model: undefined, isDefault: false },
-      { key: 'custom+omp', label: 'custom + omp', tool: 'omp', model: 'fast', isDefault: false },
+      { key: 'codex', label: 'Codex', tool: 'codex', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },
+      { key: 'omp', label: 'OMP', tool: 'omp', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },
+      { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude', isDefault: true, defaultConfirmationMode: 'require' },
+      { key: 'custom', label: 'custom', tool: 'codex', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },
+      { key: 'custom+omp', label: 'custom + omp', tool: 'omp', model: 'fast', isDefault: false, defaultConfirmationMode: 'require' },
     ]));
   });
 });

--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -87,8 +87,8 @@ describe('buildWebInvokerDispatch', () => {
         } as unknown as InvokerConfig),
     });
     expect(await dispatch('invoker:get-planning-presets', [])).toEqual(expect.arrayContaining([
-      { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude', isDefault: true },
-      { key: 'custom', label: 'custom', tool: 'codex', model: undefined, isDefault: false },
+      { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude', isDefault: true, defaultConfirmationMode: 'require' },
+      { key: 'custom', label: 'custom', tool: 'codex', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },
     ]));
   });
 

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -9,6 +9,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { resolveInvokerConfigPath } from '@invoker/contracts';
+import type { PlanningConfirmationMode } from '@invoker/contracts';
 import { validateInvokerConfig } from './config-validation.js';
 import type { PrMaintenanceWorkerConfig } from '@invoker/execution-engine';
 
@@ -70,6 +71,12 @@ export interface PrMaintenanceConfig {
 
 export interface InvokerConfig {
   defaultBranch?: string;
+  /**
+   * Default review/confirmation mode for in-app planning terminal sessions.
+   * 'require' asks before submitting a generated plan; 'auto_submit' submits
+   * automatically. Unset falls back to 'require'.
+   */
+  defaultPlanningTerminalConfirmationMode?: PlanningConfirmationMode;
   /**
    * Web surface (browser mirror of the desktop app) shared-secret token.
    * When set (or via INVOKER_WEB_TOKEN), the owner process serves the UI at

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -10,6 +10,8 @@ import type {
   InAppPlanningDeleteRequest,
   InAppPlanningDeleteResponse,
   InAppPlanningDeleteSubmittedResponse,
+  InAppPlanningDiscardDraftRequest,
+  InAppPlanningDiscardDraftResponse,
   InAppPlanningListSessionsResponse,
   InAppPlanningPlanSummary,
   InAppPlanningResetRequest,
@@ -21,6 +23,7 @@ import type {
   InAppPlanningStreamEvent,
   InAppPlanningSubmitRequest,
   InAppPlanningSubmitResponse,
+  PlanningConfirmationMode,
   PlanningTerminalMode,
   PlanningPresetOption,
 } from '@invoker/contracts';
@@ -32,10 +35,11 @@ import type {
 } from '@invoker/data-store';
 import type { AgentRegistry } from '@invoker/execution-engine';
 import {
-  approvePlanningDraft,
   evaluatePlanningTurn,
   hasExplicitDraftIntent as hasCoreExplicitDraftIntent,
   isDraftingAuthorized,
+  preparePlanningReview,
+  submitPlanningReview,
   summarizePlanText,
   type PlanningMessage,
 } from '@invoker/planning-core';
@@ -71,6 +75,7 @@ export interface InAppPlanningChatSession {
   id: string;
   title: string;
   presetKey: string;
+  confirmationMode: PlanningConfirmationMode;
   status: InAppPlanningSessionStatus;
   messages: InAppPlanningChatLine[];
   conversation: PlanConversation;
@@ -180,6 +185,28 @@ function titleFromMessage(message: string): string {
   if (!firstLine) return 'Untitled plan';
   return firstLine.length > 56 ? `${firstLine.slice(0, 53).trimEnd()}…` : firstLine;
 }
+function normalizePlanningConfirmationMode(
+  value: string | null | undefined,
+  fallback: PlanningConfirmationMode = 'require',
+): PlanningConfirmationMode {
+  return value === 'auto_submit' || value === 'require' ? value : fallback;
+}
+
+function resolveDefaultPlanningConfirmationMode(config: InvokerConfig): PlanningConfirmationMode {
+  return normalizePlanningConfirmationMode(config.defaultPlanningTerminalConfirmationMode, 'require');
+}
+
+function extractPlanningConfirmationOverride(message: string): {
+  message: string;
+  confirmationMode?: PlanningConfirmationMode;
+} {
+  const match = /^\[auto-submit\]\s*/i.exec(message);
+  if (!match) return { message };
+  return {
+    message: message.slice(match[0].length),
+    confirmationMode: 'auto_submit',
+  };
+}
 
 function appendSessionMessage(
   session: InAppPlanningChatSession,
@@ -220,6 +247,7 @@ function sessionToRecord(session: InAppPlanningChatSession, pendingResponse: boo
     title: session.title,
     presetKey: session.presetKey,
     status: session.status,
+    confirmationMode: session.confirmationMode ?? 'require',
     messages: session.messages,
     draftPlanSummary: session.draftPlanSummary,
     draftPlanText: session.draftPlanText,
@@ -243,6 +271,7 @@ function sessionToSummary(session: InAppPlanningChatSession): InAppPlanningSessi
     title: session.title,
     status: session.status,
     presetKey: session.presetKey,
+    confirmationMode: session.confirmationMode ?? 'require',
     messages: session.messages,
     draftPlanAvailable: hasDraftPlan(session),
     draftPlanSummary: session.draftPlanSummary,
@@ -391,10 +420,15 @@ async function createSession(
   const { PlanConversation } = await loadPlannerSurfaces();
   const createdAt = new Date().toISOString();
   const id = randomUUID();
+  const confirmationMode = normalizePlanningConfirmationMode(
+    request?.confirmationMode,
+    resolveDefaultPlanningConfirmationMode(deps.config),
+  );
   const session: InAppPlanningChatSession = {
     id,
     title: typeof request?.title === 'string' && request.title.trim() ? request.title.trim() : 'Untitled plan',
     presetKey,
+    confirmationMode,
     status: 'still_discussing',
     messages: [],
     conversation: new PlanConversation(planConversationConfig(preset, deps, id, { conversationalPlanning: true })),
@@ -412,12 +446,14 @@ async function createSession(
 export async function listInAppPlanningPresets(config: InvokerConfig): Promise<PlanningPresetOption[]> {
   const presets = await resolveHarnessPresets(config);
   const defaultPresetKey = await resolveDefaultPresetKey(config);
+  const defaultConfirmationMode = resolveDefaultPlanningConfirmationMode(config);
   return Object.entries(presets).map(([key, preset]) => ({
     key,
     label: labelForPresetKey(key),
     tool: preset.tool,
     model: preset.model,
     isDefault: key === defaultPresetKey,
+    defaultConfirmationMode,
   }));
 }
 
@@ -506,7 +542,13 @@ export async function sendPlanningChatMessage(
   },
 ): Promise<InAppPlanningChatResponse> {
   const rawRequest = request as Partial<InAppPlanningChatRequest> | null | undefined;
-  const message = typeof rawRequest?.message === 'string' ? rawRequest.message.trim() : '';
+  const rawMessage = typeof rawRequest?.message === 'string' ? rawRequest.message.trim() : '';
+  const taggedMessage = extractPlanningConfirmationOverride(rawMessage);
+  const message = taggedMessage.message.trim();
+  const requestedConfirmationMode = normalizePlanningConfirmationMode(
+    taggedMessage.confirmationMode ?? rawRequest?.confirmationMode,
+    resolveDefaultPlanningConfirmationMode(deps.config),
+  );
   if (!message) {
     return { ok: false, sessionId: rawRequest?.sessionId, error: 'Type a message first.' };
   }
@@ -518,6 +560,7 @@ export async function sendPlanningChatMessage(
       const created = await createSession({
         presetKey: rawRequest?.presetKey,
         title: titleFromMessage(message),
+        confirmationMode: requestedConfirmationMode,
       }, deps);
       if ('error' in created) {
         return { ok: false, sessionId, error: created.error };
@@ -530,6 +573,7 @@ export async function sendPlanningChatMessage(
     }
 
     const activeSession = session;
+    activeSession.confirmationMode = requestedConfirmationMode;
     const previousSend = activeSession.pendingSend ?? Promise.resolve();
     const turn = previousSend.then(async (): Promise<InAppPlanningChatResponse> => {
       clearStarterPromptIfUnused(activeSession);
@@ -575,14 +619,38 @@ export async function sendPlanningChatMessage(
             sessionId: activeSession.id,
             reply,
             reasoning,
+            confirmationMode: activeSession.confirmationMode,
             draftPlanAvailable: hasDraftPlan(activeSession),
             draftPlanSummary: activeSession.draftPlanSummary,
             draftPlanText: activeSession.draftPlanText,
           } as InAppPlanningChatResponse;
         }
 
-        activeSession.draftPlanSummary = result.summary;
-        activeSession.draftPlanText = result.planText;
+        const review = preparePlanningReview({
+          plannerOutput: reply,
+          extractDraftPlanText: () => result.planText,
+          confirmationMode: activeSession.confirmationMode,
+        });
+        if ('kind' in review) {
+          activeSession.status = hasDraftPlan(activeSession)
+            ? 'draft_ready'
+            : 'still_discussing';
+          appendSessionMessage(activeSession, 'assistant', review.reply);
+          persistPlanningSession(activeSession, deps.planningSessionStore, false);
+          return {
+            ok: true,
+            sessionId: activeSession.id,
+            reply: review.reply,
+            reasoning,
+            confirmationMode: activeSession.confirmationMode,
+            draftPlanAvailable: hasDraftPlan(activeSession),
+            draftPlanSummary: activeSession.draftPlanSummary,
+            draftPlanText: activeSession.draftPlanText,
+          } as InAppPlanningChatResponse;
+        }
+
+        activeSession.draftPlanSummary = review.summary;
+        activeSession.draftPlanText = review.planText;
         activeSession.status = 'draft_ready';
         appendSessionMessage(activeSession, 'assistant', reply);
         persistPlanningSession(activeSession, deps.planningSessionStore, false);
@@ -591,9 +659,10 @@ export async function sendPlanningChatMessage(
           sessionId: activeSession.id,
           reply,
           reasoning,
+          confirmationMode: activeSession.confirmationMode,
           draftPlanAvailable: true,
-          draftPlanSummary: result.summary,
-          draftPlanText: result.planText,
+          draftPlanSummary: review.summary,
+          draftPlanText: review.planText,
         } as InAppPlanningChatResponse;
       } catch (error) {
         persistPlanningSession(activeSession, deps.planningSessionStore, false);
@@ -638,7 +707,7 @@ export async function submitPlanningChatDraft(
 
   const submitAttempt = (async (): Promise<InAppPlanningSubmitResponse> => {
     try {
-      const approved = await approvePlanningDraft({
+      const approved = await submitPlanningReview({
         planText: session.draftPlanText,
         loadPlan: deps.loadGeneratedPlan,
       });
@@ -673,6 +742,29 @@ export async function submitPlanningChatDraft(
   })();
   session.pendingSubmit = submitAttempt;
   return submitAttempt;
+}
+
+export function discardPlanningChatDraft(
+  request: InAppPlanningDiscardDraftRequest,
+  deps: { sessions: InAppPlanningChatSessions; planningSessionStore?: InAppPlanningSessionStore },
+): InAppPlanningDiscardDraftResponse {
+  const sessionId = typeof request?.sessionId === 'string' ? request.sessionId.trim() : '';
+  const session = sessionId ? deps.sessions.get(sessionId) : undefined;
+  if (!session) {
+    return { ok: false, error: 'No planning conversation yet.' };
+  }
+  if (!hasDraftPlan(session)) {
+    return { ok: false, error: 'No saved draft to discard.' };
+  }
+  if (session.status === 'submitted') {
+    return { ok: false, error: 'This planning session was already submitted.' };
+  }
+  session.status = 'still_discussing';
+  session.draftPlanSummary = undefined;
+  session.draftPlanText = undefined;
+  appendSessionMessage(session, 'system', 'Draft discarded. Ask Invoker to draft it again.');
+  persistPlanningSession(session, deps.planningSessionStore, false);
+  return { ok: true };
 }
 
 export function resetPlanningChat(
@@ -752,7 +844,6 @@ export function updatePlanningChatTerminalState(
     session.updatedAt = terminalUpdatedAt;
     storePatch.updatedAt = terminalUpdatedAt;
   }
-
   deps.planningSessionStore?.updateInAppPlanningSession(session.id, storePatch);
   return true;
 }
@@ -783,6 +874,7 @@ export async function restorePlanningChatSessions(
       id: record.id,
       title: record.title,
       presetKey: record.presetKey,
+      confirmationMode: normalizePlanningConfirmationMode(record.confirmationMode, resolveDefaultPlanningConfirmationMode(deps.config)),
       status: record.status,
       messages: [...record.messages],
       conversation,

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -7,6 +7,7 @@ import type {
   InAppPlanRequest,
   InAppPlanningChatRequest,
   InAppPlanningCreateSessionRequest,
+  InAppPlanningDiscardDraftRequest,
   InAppPlanningResetRequest,
   InAppPlanningSetTerminalModeRequest,
   InAppPlanningStreamEvent,
@@ -83,6 +84,7 @@ import {
   sendPlanningChatMessage,
   setPlanningChatTerminalMode,
   submitPlanningChatDraft,
+  discardPlanningChatDraft,
 } from '../in-app-planner.js';
 import { seedMainProcessHitchFixture } from '../main-process-hitch-fixture.js';
 import { seedStressFixture, type StressFixtureOptions } from '../stress-fixture.js';
@@ -1277,6 +1279,12 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
         preserveTaskHandles: true,
         logLabel: 'planning-chat-submit',
       }),
+      planningSessionStore: ownerMode ? persistence : undefined,
+    });
+  });
+  registerGuiMutationHandler('invoker:planning-chat-discard-draft', async (request: unknown) => {
+    return discardPlanningChatDraft(request as InAppPlanningDiscardDraftRequest, {
+      sessions: planningChatSessions,
       planningSessionStore: ownerMode ? persistence : undefined,
     });
   });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -60,6 +60,7 @@ import type {
   InAppPlanningCreateSessionRequest,
   InAppPlanningChatRequest,
   InAppPlanningDeleteRequest,
+  InAppPlanningDiscardDraftRequest,
   InAppPlanningResetRequest,
   InAppPlanningSubmitRequest,
   Logger,
@@ -252,6 +253,7 @@ import {
   createPlanningCommandBuilderFromRegistry,
   deletePlanningChat,
   deleteSubmittedPlanningChats,
+  discardPlanningChatDraft,
   listPlanningChatSessions,
   planFromGoal as planFromGoalInApp,
   resetPlanningChat,
@@ -1152,6 +1154,12 @@ function startHeadlessMode(): void {
             return submitPlanningChatDraft(payload.args[0] as InAppPlanningSubmitRequest, {
               sessions: planningChatSessions,
               loadGeneratedPlan,
+              planningSessionStore: readOnlyMode ? undefined : persistence,
+            });
+          }
+          case 'invoker:planning-chat-discard-draft': {
+            return discardPlanningChatDraft(payload.args[0] as InAppPlanningDiscardDraftRequest, {
+              sessions: planningChatSessions,
               planningSessionStore: readOnlyMode ? undefined : persistence,
             });
           }

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -7,7 +7,7 @@ import { LocalBus } from '@invoker/transport';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { main } from '../index.js';
-import { HANDOFF_PROMPT_DESCRIPTION, handoffPrompt, resolveCliInvocation, submitPlanForMcp, validatePlanForMcp, type McpCliRunner } from '../mcp-server.js';
+import { HANDOFF_PROMPT_DESCRIPTION, handoffPrompt, preparePlanReviewForMcp, resolveCliInvocation, submitPlanForMcp, validatePlanForMcp, type McpCliRunner } from '../mcp-server.js';
 
 const repoRoot = resolve(__dirname, '../../../..');
 const cliPath = resolve(repoRoot, 'packages/cli/dist/index.js');
@@ -345,6 +345,39 @@ tasks:
     expect(prompt).toContain('multiple review slices');
     expect(prompt).toContain('skill://review-compression/SKILL.md');
     expect(prompt).toContain('before writing workflow YAML');
+  });
+  it('tells MCP handoff users to keep review and approval ahead of submission', () => {
+    const prompt = handoffPrompt('ship this change');
+
+    expect(prompt).toContain('show the returned ordered steps and confirmation text to the user');
+    expect(prompt).toContain('wait for approval before any submission step');
+    expect(prompt).toContain('Do not tell the user to reply `submit`');
+    expect(prompt).toContain('If `invoker_prepare_plan_review` returns `confirmationMode: "require"`');
+  });
+  it('prepares a canonical MCP review from a YAML file', async () => {
+    const result = await preparePlanReviewForMcp(fixturePlan);
+
+    expect(result).toMatchObject({
+      planText: expect.any(String),
+      summary: { name: 'Hello World CLI', taskCount: 1, taskGroups: [{ workflow: null, tasks: ['Print hello from the standalone CLI.'] }] },
+      confirmationMode: 'require',
+      confirmationText: 'Approve to submit this exact YAML. Cancel keeps the draft. Discard removes it.',
+    });
+  });
+
+  it('tells MCP handoff users to call invoker_prepare_plan_review before approval', () => {
+    const prompt = handoffPrompt('ship this change');
+
+    expect(prompt).toContain('Call `invoker_prepare_plan_review` on that exact YAML file');
+    expect(prompt).toContain('show the returned ordered steps and confirmation text to the user');
+  });
+
+  it('documents the auto-submit branch in the MCP handoff prompt', () => {
+    const prompt = handoffPrompt('ship this change');
+
+    expect(prompt).toContain('If `invoker_prepare_plan_review` returns `confirmationMode: "require"`');
+    expect(prompt).toContain('If it returns `confirmationMode: "auto_submit"`');
+    expect(prompt).toContain('call `invoker_submit_plan` immediately');
   });
 
   it('describes PR skill triggers in the MCP prompt metadata', () => {

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -1,8 +1,12 @@
+import { readFile } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
 import { resolve } from 'node:path';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { PlanningConfirmationMode, PlanningReviewDraft } from '../../planning-core/src/planning-review.js';
+import { buildPlanningHandoffInstructions } from '../../planning-core/src/planning-handoff-prompt.js';
+import { preparePlanningReview } from '../../planning-core/src/planning-review.js';
 import { parsePlanFile } from '@invoker/workflow-core';
 import { z } from 'zod';
 
@@ -12,7 +16,7 @@ export interface McpCliRunner {
   run(args: string[], options?: { cwd?: string }): Promise<{ exitCode: number; stdout: string; stderr: string }>;
 }
 
-export const HANDOFF_PROMPT_DESCRIPTION = 'Plan a requested change, trigger PR skills for PR/stack work, convert it to Invoker YAML, validate it, and submit it live.';
+export const HANDOFF_PROMPT_DESCRIPTION = 'Plan a requested change, trigger PR skills for PR/stack work, convert it to Invoker YAML, review the canonical ordered steps, and submit it live.';
 
 type SubmitSuccess = { ok: true; workflowId: string; stdout: string };
 type SubmitFailure = { ok: false; exitCode: number; stdout: string; stderr: string; error?: string };
@@ -91,6 +95,21 @@ export async function validatePlanForMcp(
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
 }
+export async function preparePlanReviewForMcp(
+  planPath: string,
+  confirmationMode: PlanningConfirmationMode = 'require',
+): Promise<PlanningReviewDraft | { ok: false; error: string }> {
+  try {
+    const planText = await readFile(resolve(planPath), 'utf8');
+    const review = preparePlanningReview({ plannerOutput: planText, confirmationMode });
+    if ('kind' in review && review.kind === 'message') {
+      return { ok: false, error: 'I could not read that Invoker YAML plan. Regenerate the YAML, then try the review step again.' };
+    }
+    return review;
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
 
 export async function submitPlanForMcp(
   planPath: string,
@@ -128,6 +147,12 @@ function formatSubmitFailure(result: SubmitFailure): string {
 }
 
 export function handoffPrompt(request: string): string {
+  const handoffInstructions = buildPlanningHandoffInstructions({
+    planFilePath: 'plans/invoker-handoff.yaml',
+    reviewInstruction: 'Call `invoker_prepare_plan_review` on that exact YAML file, then show the returned ordered steps and confirmation text to the user.',
+    shortReplyInstruction: 'Then keep the chat reply focused on the review summary and approval state. Never paste the YAML into chat.',
+    submissionInstruction: 'If `invoker_prepare_plan_review` returns `confirmationMode: "require"`, wait for approval before `invoker_submit_plan`. If it returns `confirmationMode: "auto_submit"`, show the same review output and then call `invoker_submit_plan` immediately. Use mode `live` so the workflow appears in the running Invoker app.',
+  });
   return [
     `User request: ${request}`,
     '',
@@ -136,9 +161,8 @@ export function handoffPrompt(request: string): string {
     'If the request involves multiple review slices, first read and follow skill://review-compression/SKILL.md before writing workflow YAML.',
     'Write the planning artifact to plans/invoker-handoff.md.',
     'Convert the approved Markdown plan to plans/invoker-handoff.yaml.',
-    'Validate with invoker_validate_plan before submitting.',
-    'Submit with invoker_submit_plan using mode "live" so the workflow appears in the running Invoker app.',
-    'If MCP tools are not available but invoker-cli is on PATH, run invoker-cli run plans/invoker-handoff.yaml --live instead.',
+    handoffInstructions,
+    'If MCP tools are unavailable but `invoker-cli` is on PATH, mirror the same flow with `invoker-cli run plans/invoker-handoff.yaml --live` only after the approval step that `invoker_prepare_plan_review` would have gated.',
   ].join('\n');
 }
 
@@ -165,6 +189,33 @@ export async function runMcpServer(options: { runner?: McpCliRunner; cliPath?: s
           {
             type: 'text',
             text: `Valid Invoker plan: ${result.name} (${result.taskCount} tasks).`,
+          },
+        ],
+      };
+    },
+  );
+  server.registerTool(
+    'invoker_prepare_plan_review',
+    {
+      description: 'Prepare the canonical ordered-step review for an existing Invoker YAML plan.',
+      inputSchema: {
+        planPath: z.string(),
+        confirmationMode: z.enum(['require', 'auto_submit']).optional(),
+      },
+    },
+    async ({ planPath, confirmationMode }) => {
+      const result = await preparePlanReviewForMcp(planPath, confirmationMode ?? 'require');
+      if ('ok' in result && result.ok === false) {
+        return {
+          content: [{ type: 'text', text: `Could not prepare Invoker plan review: ${result.error}` }],
+          isError: true,
+        };
+      }
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(result, null, 2),
           },
         ],
       };

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -436,12 +436,14 @@ export type InAppPlanResponse =
       error: string;
     };
 
+export type PlanningConfirmationMode = 'require' | 'auto_submit';
 export interface PlanningPresetOption {
   key: string;
   label: string;
   tool: string;
   model?: string;
   isDefault: boolean;
+  defaultConfirmationMode?: PlanningConfirmationMode;
 }
 
 export interface InAppPlanningPlanSummaryTaskGroup {
@@ -477,6 +479,7 @@ export interface InAppPlanningSessionSummary {
   title: string;
   status: InAppPlanningSessionStatus;
   presetKey: string;
+  confirmationMode?: PlanningConfirmationMode;
   messages: InAppPlanningChatLine[];
   draftPlanAvailable: boolean;
   draftPlanSummary?: InAppPlanningPlanSummary;
@@ -496,6 +499,7 @@ export interface InAppPlanningSessionSummary {
 export interface InAppPlanningCreateSessionRequest {
   presetKey?: string;
   title?: string;
+  confirmationMode?: PlanningConfirmationMode;
 }
 
 export type InAppPlanningCreateSessionResponse =
@@ -522,6 +526,7 @@ export interface InAppPlanningChatRequest {
   sessionId?: string;
   message: string;
   presetKey?: string;
+  confirmationMode?: PlanningConfirmationMode;
 }
 
 export type InAppPlanningChatResponse =
@@ -529,6 +534,7 @@ export type InAppPlanningChatResponse =
       ok: true;
       sessionId: string;
       reply: string;
+      confirmationMode?: PlanningConfirmationMode;
       draftPlanAvailable: boolean;
       draftPlanSummary?: InAppPlanningPlanSummary;
       draftPlanText?: string;
@@ -561,6 +567,13 @@ export interface InAppPlanningResetRequest {
 }
 
 export type InAppPlanningResetResponse = { ok: true };
+export interface InAppPlanningDiscardDraftRequest {
+  sessionId: string;
+}
+
+export type InAppPlanningDiscardDraftResponse =
+  | { ok: true }
+  | { ok: false; error: string };
 
 export interface InAppPlanningSetTerminalModeRequest {
   sessionId: string;
@@ -880,6 +893,10 @@ export const IpcChannels = {
   'invoker:planning-chat-submit': {} as {
     request: [request: InAppPlanningSubmitRequest];
     response: InAppPlanningSubmitResponse;
+  },
+  'invoker:planning-chat-discard-draft': {} as {
+    request: [request: InAppPlanningDiscardDraftRequest];
+    response: InAppPlanningDiscardDraftResponse;
   },
   'invoker:planning-chat-reset': {} as {
     request: [request: InAppPlanningResetRequest];

--- a/packages/data-store/src/__tests__/slack-session-repository.test.ts
+++ b/packages/data-store/src/__tests__/slack-session-repository.test.ts
@@ -27,6 +27,7 @@ describe('SlackSessionRepository', () => {
       workingDir: '/tmp/repo',
       requestedBy: 'U123',
       lobbyChannelId: 'C456',
+      confirmationMode: 'require' as const,
     };
 
     repo.saveLaunchContext(context);
@@ -46,6 +47,7 @@ describe('SlackSessionRepository', () => {
       workingDir: '/tmp/repo',
       requestedBy: 'U123',
       lobbyChannelId: 'C456',
+      confirmationMode: 'require' as const,
     };
     try {
       const writer = await SQLiteAdapter.create(databasePath, { ownerCapability: true });

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -72,6 +72,7 @@ describe('SQLiteAdapter', () => {
       title: `Planning ${id}`,
       presetKey: 'codex',
       status: 'draft_ready',
+      confirmationMode: 'require',
       messages: [
         {
           id: 1,
@@ -462,6 +463,7 @@ describe('SQLiteAdapter', () => {
         'title',
         'preset_key',
         'status',
+        'confirmation_mode',
         'draft_plan_summary_json',
         'draft_plan_text',
         'submitted_workflow_id',

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -6,7 +6,7 @@
  */
 
 import type { TaskState, TaskStateChanges, PlanDefinition, Attempt, WorkflowDerivedStatus, WorkflowRollup, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency } from '@invoker/workflow-core';
-import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
+import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, PlanningConfirmationMode, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
 
 
@@ -40,6 +40,7 @@ export interface SlackLaunchContext {
   workingDir: string;
   requestedBy: string;
   lobbyChannelId: string;
+  confirmationMode: PlanningConfirmationMode;
   harnessSessionId?: string;
 }
 
@@ -67,6 +68,7 @@ export interface SlackPlanDraft {
   harnessPreset: string;
   workingDir: string;
   requestedBy: string;
+  confirmationMode: PlanningConfirmationMode;
   createdAt: string;
   decidedAt?: string;
   decidedBy?: string;
@@ -290,6 +292,7 @@ export interface InAppPlanningSessionRecord {
   title: string;
   presetKey: string;
   status: InAppPlanningSessionStatus;
+  confirmationMode: PlanningConfirmationMode;
   messages: InAppPlanningChatLine[];
   draftPlanSummary?: InAppPlanningPlanSummary;
   draftPlanText?: string;
@@ -310,6 +313,7 @@ export type InAppPlanningSessionPatch = Partial<Pick<
   InAppPlanningSessionRecord,
   | 'title'
   | 'status'
+  | 'confirmationMode'
   | 'messages'
   | 'draftPlanSummary'
   | 'draftPlanText'

--- a/packages/data-store/src/slack-plan-draft-repository.ts
+++ b/packages/data-store/src/slack-plan-draft-repository.ts
@@ -10,6 +10,7 @@ export interface CreateSlackPlanDraft {
   harnessPreset: string;
   workingDir: string;
   requestedBy: string;
+  confirmationMode: SlackPlanDraft['confirmationMode'];
 }
 
 export class SlackPlanDraftRepository {
@@ -33,6 +34,7 @@ export class SlackPlanDraftRepository {
       harnessPreset: input.harnessPreset,
       workingDir: input.workingDir,
       requestedBy: input.requestedBy,
+      confirmationMode: input.confirmationMode,
       createdAt: now,
     };
     this.adapter.saveSlackPlanDraft(draft);

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -31,7 +31,7 @@ import type {
   DetachedExternalDependency,
 } from '@invoker/workflow-core';
 import { DISPATCH_LEASE_MS } from '@invoker/contracts';
-import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
+import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, PlanningConfirmationMode, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ExecutionResourceLeaseReleaseRow,
   LaunchDispatchInvalidationRow,
@@ -526,6 +526,7 @@ type InAppPlanningSessionRow = {
   title?: unknown;
   preset_key?: unknown;
   status?: unknown;
+  confirmation_mode?: unknown;
   draft_plan_summary_json?: unknown;
   draft_plan_text?: unknown;
   submitted_workflow_id?: unknown;
@@ -577,6 +578,9 @@ function isPlanningTerminalStatus(value: unknown): value is 'running' | 'exited'
 
 function isInAppPlanningMessageRole(value: unknown): value is InAppPlanningChatLine['role'] {
   return value === 'user' || value === 'assistant' || value === 'system';
+}
+function isPlanningConfirmationMode(value: unknown): value is PlanningConfirmationMode {
+  return value === 'require' || value === 'auto_submit';
 }
 
 function isInAppPlanningMessageTone(value: unknown): value is InAppPlanningChatLine['tone'] {
@@ -1210,6 +1214,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
           title,
           preset_key,
           status,
+          confirmation_mode,
           draft_plan_summary_json,
           draft_plan_text,
           submitted_workflow_id,
@@ -1223,11 +1228,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
           pending_response,
           created_at,
           updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(session_id) DO UPDATE SET
           title = excluded.title,
           preset_key = excluded.preset_key,
           status = excluded.status,
+          confirmation_mode = excluded.confirmation_mode,
           draft_plan_summary_json = excluded.draft_plan_summary_json,
           draft_plan_text = excluded.draft_plan_text,
           submitted_workflow_id = excluded.submitted_workflow_id,
@@ -1246,6 +1252,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
           record.title,
           record.presetKey,
           record.status,
+          record.confirmationMode ?? 'require',
           record.draftPlanSummary ? JSON.stringify(record.draftPlanSummary) : null,
           record.draftPlanText ?? null,
           record.submittedWorkflowId ?? null,
@@ -1294,6 +1301,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
       if (Object.hasOwn(patch, 'status')) {
         setClauses.push('status = ?');
         values.push(patch.status ?? null);
+      }
+      if (Object.hasOwn(patch, 'confirmationMode')) {
+        setClauses.push('confirmation_mode = ?');
+        values.push(patch.confirmationMode ?? 'require');
       }
       if (Object.hasOwn(patch, 'draftPlanSummary')) {
         setClauses.push('draft_plan_summary_json = ?');
@@ -2148,8 +2159,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
   saveSlackLaunchContext(context: SlackLaunchContext): void {
     this.execRun(`
       INSERT OR REPLACE INTO slack_launch_contexts
-        (thread_ts, repo_url, harness_preset, working_dir, requested_by, lobby_channel_id, harness_session_id)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
+        (thread_ts, repo_url, harness_preset, working_dir, requested_by, lobby_channel_id, confirmation_mode, harness_session_id)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       context.threadTs,
       context.repoUrl,
@@ -2157,6 +2168,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       context.workingDir,
       context.requestedBy,
       context.lobbyChannelId,
+      context.confirmationMode ?? 'require',
       context.harnessSessionId ?? null,
     ]);
   }
@@ -2174,6 +2186,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       workingDir: row.working_dir as string,
       requestedBy: row.requested_by as string,
       lobbyChannelId: row.lobby_channel_id as string,
+      confirmationMode: isPlanningConfirmationMode(row.confirmation_mode) ? row.confirmation_mode : 'require',
       harnessSessionId: typeof row.harness_session_id === 'string' ? row.harness_session_id : undefined,
     };
   }
@@ -2186,8 +2199,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.execRun(`
       INSERT OR REPLACE INTO slack_plan_drafts
         (draft_id, version, channel_id, thread_ts, message_ts, slack_file_id, plan_text, content_hash, summary_json,
-         status, repo_url, harness_preset, working_dir, requested_by, created_at, decided_at, decided_by, execution_key, workflow_ids_json)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         status, repo_url, harness_preset, working_dir, requested_by, confirmation_mode, created_at, decided_at, decided_by, execution_key, workflow_ids_json)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       draft.draftId,
       draft.version,
@@ -2203,6 +2216,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       draft.harnessPreset,
       draft.workingDir,
       draft.requestedBy,
+      draft.confirmationMode ?? 'require',
       draft.createdAt,
       draft.decidedAt ?? null,
       draft.decidedBy ?? null,
@@ -2310,6 +2324,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       harnessPreset: row.harness_preset as string,
       workingDir: row.working_dir as string,
       requestedBy: row.requested_by as string,
+      confirmationMode: isPlanningConfirmationMode(row.confirmation_mode) ? row.confirmation_mode : 'require',
       createdAt: row.created_at as string,
       decidedAt: typeof row.decided_at === 'string' ? row.decided_at : undefined,
       decidedBy: typeof row.decided_by === 'string' ? row.decided_by : undefined,
@@ -2774,12 +2789,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
           message.role,
           message.text,
           message.tone ?? null,
-          message.createdAt ?? fallbackCreatedAt,
+          message.createdAt || fallbackCreatedAt,
         ],
       );
     }
   }
-
 
   private mapInAppPlanningSessionRow(row: InAppPlanningSessionRow): InAppPlanningSessionRecord | undefined {
     try {
@@ -2788,7 +2802,15 @@ export class SQLiteAdapter implements PersistenceAdapter {
       const presetKey = typeof row.preset_key === 'string' ? row.preset_key : '';
       const createdAt = typeof row.created_at === 'string' ? row.created_at : '';
       const updatedAt = typeof row.updated_at === 'string' ? row.updated_at : '';
-      if (!id || !title || !presetKey || !createdAt || !updatedAt || !isInAppPlanningSessionStatus(row.status)) {
+      if (
+        !id
+        || !title
+        || !presetKey
+        || !createdAt
+        || !updatedAt
+        || !isInAppPlanningSessionStatus(row.status)
+        || !isPlanningConfirmationMode(row.confirmation_mode)
+      ) {
         return undefined;
       }
       const terminalMode = row.terminal_mode === undefined || row.terminal_mode === null
@@ -2842,6 +2864,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         title,
         presetKey,
         status: row.status,
+        confirmationMode: row.confirmation_mode,
         messages,
         ...(draftPlanSummary ? { draftPlanSummary } : {}),
         ...(typeof row.draft_plan_text === 'string' ? { draftPlanText: row.draft_plan_text } : {}),

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -191,6 +191,7 @@ export const SCHEMA_DDL = `
         working_dir TEXT NOT NULL,
         requested_by TEXT NOT NULL,
         lobby_channel_id TEXT NOT NULL,
+        confirmation_mode TEXT NOT NULL DEFAULT 'require' CHECK (confirmation_mode IN ('require', 'auto_submit')),
         harness_session_id TEXT
       );
 
@@ -209,6 +210,7 @@ export const SCHEMA_DDL = `
         harness_preset TEXT NOT NULL,
         working_dir TEXT NOT NULL,
         requested_by TEXT NOT NULL,
+        confirmation_mode TEXT NOT NULL DEFAULT 'require' CHECK (confirmation_mode IN ('require', 'auto_submit')),
         created_at TEXT NOT NULL,
         decided_at TEXT,
         decided_by TEXT,
@@ -239,6 +241,7 @@ export const SCHEMA_DDL = `
         title TEXT NOT NULL,
         preset_key TEXT NOT NULL,
         status TEXT NOT NULL CHECK (status IN ('still_discussing', 'waiting_for_answer', 'draft_ready', 'submitted')),
+        confirmation_mode TEXT NOT NULL DEFAULT 'require' CHECK (confirmation_mode IN ('require', 'auto_submit')),
         draft_plan_summary_json TEXT CHECK (draft_plan_summary_json IS NULL OR json_valid(draft_plan_summary_json)),
         draft_plan_text TEXT,
         submitted_workflow_id TEXT,
@@ -515,9 +518,11 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE workflow_channels ADD COLUMN progress_card_ts TEXT',
   "ALTER TABLE conversations ADD COLUMN mode TEXT DEFAULT 'plan'",
   'ALTER TABLE slack_launch_contexts ADD COLUMN harness_session_id TEXT',
+  "ALTER TABLE slack_launch_contexts ADD COLUMN confirmation_mode TEXT NOT NULL DEFAULT 'require' CHECK (confirmation_mode IN ('require', 'auto_submit'))",
   'ALTER TABLE slack_plan_drafts ADD COLUMN slack_file_id TEXT',
   'ALTER TABLE slack_plan_drafts ADD COLUMN execution_key TEXT',
   'ALTER TABLE slack_plan_drafts ADD COLUMN workflow_ids_json TEXT',
+  "ALTER TABLE slack_plan_drafts ADD COLUMN confirmation_mode TEXT NOT NULL DEFAULT 'require' CHECK (confirmation_mode IN ('require', 'auto_submit'))",
   'ALTER TABLE tasks ADD COLUMN claude_session_id TEXT',
   'ALTER TABLE tasks ADD COLUMN workspace_path TEXT',
   'ALTER TABLE tasks ADD COLUMN container_id TEXT',
@@ -585,6 +590,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE attempts ADD COLUMN lease_expires_at TEXT',
   'ALTER TABLE tasks ADD COLUMN task_state_version INTEGER NOT NULL DEFAULT 1',
   'ALTER TABLE in_app_planning_sessions ADD COLUMN draft_plan_text TEXT',
+  "ALTER TABLE in_app_planning_sessions ADD COLUMN confirmation_mode TEXT NOT NULL DEFAULT 'require' CHECK (confirmation_mode IN ('require', 'auto_submit'))",
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_mode TEXT NOT NULL DEFAULT 'chat' CHECK (terminal_mode IN ('chat', 'tmux'))",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_session_id TEXT',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_status TEXT CHECK (terminal_status IS NULL OR terminal_status IN ('running', 'exited'))",

--- a/packages/planning-core/src/__tests__/planning-actions.test.ts
+++ b/packages/planning-core/src/__tests__/planning-actions.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   appendPlanningTurn,
-  approvePlanningDraft,
   createPlanningSessionState,
-  runPlanToInvoker,
 } from '../planning-actions.js';
 
 const planText = [
@@ -87,91 +85,3 @@ describe('appendPlanningTurn', () => {
   });
 });
 
-describe('runPlanToInvoker', () => {
-  it('returns a draft_ready result when the conversion produces a valid plan', async () => {
-    const result = await runPlanToInvoker({
-      convert: async () => planText,
-    });
-
-    expect(result).toMatchObject({
-      kind: 'draft_ready',
-      planText,
-      summary: { name: 'Shared planning actions', taskCount: 1 },
-      reply: planText,
-    });
-  });
-
-  it('extracts the plan text from a wrapped output before evaluating it', async () => {
-    const wrapped = `Here you go:\n\`\`\`yaml\n${planText}\n\`\`\``;
-    const result = await runPlanToInvoker({
-      convert: async () => wrapped,
-      extractDraftPlanText: (output) => output.match(/```yaml\n([\s\S]*?)\n```/)?.[1] ?? null,
-    });
-
-    expect(result).toMatchObject({ kind: 'draft_ready', planText });
-  });
-
-  it('returns a message result when no valid plan is produced', async () => {
-    const result = await runPlanToInvoker({
-      convert: async () => 'name: incomplete',
-    });
-
-    expect(result).toEqual({ kind: 'message', reply: 'name: incomplete' });
-  });
-});
-
-describe('approvePlanningDraft', () => {
-  it('rejects when there is no draft plan text', async () => {
-    const result = await approvePlanningDraft({
-      planText: undefined,
-      loadPlan: async () => ({ planName: 'x', workflowId: 'wf-1' }),
-    });
-
-    expect(result).toEqual({
-      ok: false,
-      error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.',
-    });
-  });
-
-  it('rejects when the draft plan text cannot be summarized', async () => {
-    const result = await approvePlanningDraft({
-      planText: 'name: incomplete',
-      loadPlan: async () => ({ planName: 'x', workflowId: 'wf-1' }),
-    });
-
-    expect(result).toEqual({
-      ok: false,
-      error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.',
-    });
-  });
-
-  it('loads and returns the approved plan on success', async () => {
-    const result = await approvePlanningDraft({
-      planText,
-      loadPlan: async (text) => {
-        expect(text).toBe(planText);
-        return { planName: 'Shared planning actions', workflowId: 'wf-1', workflowIds: ['wf-1'], workflowCount: 1 };
-      },
-    });
-
-    expect(result).toMatchObject({
-      ok: true,
-      planName: 'Shared planning actions',
-      workflowId: 'wf-1',
-      workflowIds: ['wf-1'],
-      workflowCount: 1,
-      summary: { name: 'Shared planning actions', taskCount: 1 },
-    });
-  });
-
-  it('surfaces errors thrown by loadPlan', async () => {
-    const result = await approvePlanningDraft({
-      planText,
-      loadPlan: async () => {
-        throw new Error('boom');
-      },
-    });
-
-    expect(result).toEqual({ ok: false, error: 'boom' });
-  });
-});

--- a/packages/planning-core/src/__tests__/planning-review.test.ts
+++ b/packages/planning-core/src/__tests__/planning-review.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { preparePlanningReview, submitPlanningReview } from '../planning-review.js';
+
+const planText = [
+  'name: Shared planning review',
+  'tasks:',
+  '  - id: implement',
+  '    description: Implement the shared review contract',
+].join('\n');
+
+describe('preparePlanningReview', () => {
+  it('returns the canonical review draft for require mode', () => {
+    const result = preparePlanningReview({
+      plannerOutput: planText,
+      confirmationMode: 'require',
+    });
+
+    expect(result).toMatchObject({
+      planText,
+      summary: { name: 'Shared planning review', taskCount: 1 },
+      confirmationMode: 'require',
+      confirmationText: 'Approve to submit this exact YAML. Cancel keeps the draft. Discard removes it.',
+    });
+  });
+
+  it('keeps the same draft content in auto-submit mode', () => {
+    const result = preparePlanningReview({
+      plannerOutput: `Here you go:\n\`\`\`yaml\n${planText}\n\`\`\``,
+      extractDraftPlanText: (output) => output.match(/```yaml\n([\s\S]*?)\n```/)?.[1] ?? null,
+      confirmationMode: 'auto_submit',
+    });
+
+    expect(result).toMatchObject({
+      planText,
+      summary: { name: 'Shared planning review', taskCount: 1 },
+      confirmationMode: 'auto_submit',
+      confirmationText: 'Auto-submit is enabled. Submit this exact YAML now.',
+    });
+  });
+
+  it('returns the planner reply when no valid draft exists', () => {
+    const result = preparePlanningReview({
+      plannerOutput: 'name: incomplete',
+      confirmationMode: 'require',
+    });
+
+    expect(result).toEqual({ kind: 'message', reply: 'name: incomplete' });
+  });
+});
+
+describe('submitPlanningReview', () => {
+  it('rejects when there is no draft plan text', async () => {
+    const result = await submitPlanningReview({
+      planText: undefined,
+      loadPlan: async () => ({ planName: 'x', workflowId: 'wf-1' }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.',
+    });
+  });
+
+  it('rejects when the draft plan text cannot be summarized', async () => {
+    const result = await submitPlanningReview({
+      planText: 'name: incomplete',
+      loadPlan: async () => ({ planName: 'x', workflowId: 'wf-1' }),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.',
+    });
+  });
+
+  it('loads and returns the approved plan on success', async () => {
+    const result = await submitPlanningReview({
+      planText,
+      loadPlan: async (text) => {
+        expect(text).toBe(planText);
+        return { planName: 'Shared planning review', workflowId: 'wf-1', workflowIds: ['wf-1'], workflowCount: 1 };
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      planName: 'Shared planning review',
+      workflowId: 'wf-1',
+      workflowIds: ['wf-1'],
+      workflowCount: 1,
+      summary: { name: 'Shared planning review', taskCount: 1 },
+    });
+  });
+
+  it('surfaces errors thrown by loadPlan', async () => {
+    const result = await submitPlanningReview({
+      planText,
+      loadPlan: async () => {
+        throw new Error('boom');
+      },
+    });
+
+    expect(result).toEqual({ ok: false, error: 'boom' });
+  });
+});

--- a/packages/planning-core/src/index.ts
+++ b/packages/planning-core/src/index.ts
@@ -1,4 +1,6 @@
 export * from './lifecycle.js';
 export * from './plan-summary.js';
 export * from './planning-turn.js';
+export * from './planning-review.js';
+export * from './planning-handoff-prompt.js';
 export * from './planning-actions.js';

--- a/packages/planning-core/src/planning-actions.ts
+++ b/packages/planning-core/src/planning-actions.ts
@@ -1,6 +1,6 @@
 import type { PlanningMessage } from './lifecycle.js';
 import { evaluatePlanningTurn } from './planning-turn.js';
-import { summarizePlanText, type PlanSummary } from './plan-summary.js';
+import { type PlanSummary } from './plan-summary.js';
 
 export type PlanningSessionStatus = 'still_discussing' | 'waiting_for_answer' | 'draft_ready' | 'submitted';
 
@@ -72,66 +72,3 @@ export async function appendPlanningTurn({
   };
 }
 
-export interface RunPlanToInvokerInput {
-  convert: () => Promise<string>;
-  extractDraftPlanText?: (output: string) => string | null | undefined;
-}
-
-export type RunPlanToInvokerResult =
-  | { kind: 'draft_ready'; planText: string; summary: PlanSummary; reply: string }
-  | { kind: 'message'; reply: string };
-
-export async function runPlanToInvoker({
-  convert,
-  extractDraftPlanText,
-}: RunPlanToInvokerInput): Promise<RunPlanToInvokerResult> {
-  const reply = await convert();
-  const immediateDraftPlanText = extractDraftPlanText ? extractDraftPlanText(reply) : reply;
-  const turn = evaluatePlanningTurn({
-    userMessage: '',
-    messagesBeforeTurn: [],
-    assistantReply: reply,
-    immediateDraftPlanText,
-    requireDraftAuthorization: false,
-  });
-
-  if (turn.kind === 'draft_ready') {
-    return { kind: 'draft_ready', planText: turn.planText, summary: turn.summary, reply };
-  }
-  return { kind: 'message', reply };
-}
-
-export interface ApprovedPlanLoadResult {
-  planName: string;
-  workflowId: string;
-  workflowIds?: string[];
-  workflowCount?: number;
-}
-
-export interface ApprovePlanningDraftInput {
-  planText: string | null | undefined;
-  loadPlan: (planText: string) => ApprovedPlanLoadResult | Promise<ApprovedPlanLoadResult>;
-}
-
-export type ApprovePlanningDraftResult =
-  | ({ ok: true; summary: PlanSummary } & ApprovedPlanLoadResult)
-  | { ok: false; error: string };
-
-export async function approvePlanningDraft({
-  planText,
-  loadPlan,
-}: ApprovePlanningDraftInput): Promise<ApprovePlanningDraftResult> {
-  if (!planText) {
-    return { ok: false, error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.' };
-  }
-  const summary = summarizePlanText(planText);
-  if (!summary) {
-    return { ok: false, error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.' };
-  }
-  try {
-    const loaded = await loadPlan(planText);
-    return { ok: true, summary, ...loaded };
-  } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : String(error) };
-  }
-}

--- a/packages/planning-core/src/planning-handoff-prompt.ts
+++ b/packages/planning-core/src/planning-handoff-prompt.ts
@@ -1,0 +1,38 @@
+import type { PlanningConfirmationMode } from './planning-review.js';
+
+export interface BuildPlanningHandoffInstructionsOptions {
+  planFilePath?: string;
+  confirmationMode?: PlanningConfirmationMode;
+  reviewInstruction?: string;
+  shortReplyInstruction?: string;
+  submissionInstruction?: string;
+}
+
+export function buildPlanningHandoffInstructions({
+  planFilePath,
+  confirmationMode = 'require',
+  reviewInstruction,
+  shortReplyInstruction,
+  submissionInstruction,
+}: BuildPlanningHandoffInstructionsOptions = {}): string {
+  const outputInstruction = planFilePath
+    ? [
+        `When the final YAML plan is ready, write the COMPLETE YAML to \`${planFilePath}\` using your file-writing tool.`,
+        shortReplyInstruction ?? 'Then reply with only a short summary. Never paste the YAML into chat.',
+      ].join(' ')
+    : 'When the final YAML plan is ready, output the COMPLETE YAML inside a ```yaml code block.';
+  const orderedStepInstruction = reviewInstruction
+    ?? 'After the YAML exists, review the exact same YAML and show its ordered steps.';
+  const confirmationInstruction = confirmationMode === 'auto_submit'
+    ? 'Auto-submit is enabled. After that review step, continue straight to the designated submission step without an extra approval pause.'
+    : 'After that review step, wait for approval before any submission step.';
+  return [
+    outputInstruction,
+    orderedStepInstruction,
+    confirmationInstruction,
+    'Do not skip the review flow by validating, submitting, or executing the plan before the exact YAML has been shown back to the user.',
+    'Before that review step completes, do not call `invoker-cli`, `invoker_submit_plan`, `invoker_validate_plan`, or `submit-plan.sh`.',
+    submissionInstruction ?? 'Only the designated review flow may submit the plan after approval.',
+    'Do not tell the user to reply `submit`; approval belongs to the review flow.',
+  ].join(' ');
+}

--- a/packages/planning-core/src/planning-review.ts
+++ b/packages/planning-core/src/planning-review.ts
@@ -1,0 +1,88 @@
+import { evaluatePlanningTurn } from './planning-turn.js';
+import { summarizePlanText, type PlanSummary } from './plan-summary.js';
+
+export type PlanningConfirmationMode = 'require' | 'auto_submit';
+
+export interface PlanningReviewDraft {
+  planText: string;
+  summary: PlanSummary;
+  confirmationMode: PlanningConfirmationMode;
+  confirmationText: string;
+}
+
+export interface PreparePlanningReviewInput {
+  plannerOutput: string;
+  extractDraftPlanText?: (output: string) => string | null | undefined;
+  confirmationMode?: PlanningConfirmationMode;
+}
+
+export type PreparePlanningReviewResult =
+  | PlanningReviewDraft
+  | { kind: 'message'; reply: string };
+
+export function preparePlanningReview({
+  plannerOutput,
+  extractDraftPlanText,
+  confirmationMode = 'require',
+}: PreparePlanningReviewInput): PreparePlanningReviewResult {
+  const immediateDraftPlanText = extractDraftPlanText ? extractDraftPlanText(plannerOutput) : plannerOutput;
+  const turn = evaluatePlanningTurn({
+    userMessage: '',
+    messagesBeforeTurn: [],
+    assistantReply: plannerOutput,
+    immediateDraftPlanText,
+    requireDraftAuthorization: false,
+  });
+
+  if (turn.kind !== 'draft_ready') {
+    return { kind: 'message', reply: plannerOutput };
+  }
+
+  return {
+    planText: turn.planText,
+    summary: turn.summary,
+    confirmationMode,
+    confirmationText: confirmationTextForMode(confirmationMode),
+  };
+}
+
+export interface PlanningReviewLoadResult {
+  planName: string;
+  workflowId: string;
+  workflowIds?: string[];
+  workflowCount?: number;
+}
+
+export interface SubmitPlanningReviewInput {
+  planText: string | null | undefined;
+  loadPlan: (planText: string) => PlanningReviewLoadResult | Promise<PlanningReviewLoadResult>;
+}
+
+export type SubmitPlanningReviewResult =
+  | ({ ok: true; summary: PlanSummary } & PlanningReviewLoadResult)
+  | { ok: false; error: string };
+
+export async function submitPlanningReview({
+  planText,
+  loadPlan,
+}: SubmitPlanningReviewInput): Promise<SubmitPlanningReviewResult> {
+  if (!planText) {
+    return { ok: false, error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.' };
+  }
+  const summary = summarizePlanText(planText);
+  if (!summary) {
+    return { ok: false, error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.' };
+  }
+  try {
+    const loaded = await loadPlan(planText);
+    return { ok: true, summary, ...loaded };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export function confirmationTextForMode(confirmationMode: PlanningConfirmationMode): string {
+  return confirmationMode === 'auto_submit'
+    ? 'Auto-submit is enabled. Submit this exact YAML now.'
+    : 'Approve to submit this exact YAML. Cancel keeps the draft. Discard removes it.';
+}

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -600,7 +600,8 @@ describe('PlanConversation', () => {
     expect(prompt).toContain('The user has explicitly approved drafting');
     expect(prompt).toContain('name: "Plan Name"');
     expect(prompt).toContain('Generate a YAML task plan');
-    expect(prompt).toContain('Reply `submit` to submit it.');
+    expect(prompt).not.toContain('Reply `submit` to submit it.');
+    expect(prompt).toContain('Do not tell the user to reply `submit`');
   });
 
   it('submittedPlanText is null before confirmation', async () => {
@@ -918,16 +919,15 @@ describe('PlanConversation prompt construction', () => {
     expect(prompt).not.toContain('repoUrl: "git@github.com:user/repo.git"');
   });
 
-  it('requires the submit instruction as a standalone post-plan summary line', () => {
+  it('routes post-yaml approval through the Slack review flow', () => {
     const conv = new PlanConversation({});
     (conv as any).messages.push({ role: 'user', content: 'Build a feature' });
     const prompt = conv.buildCursorPrompt();
-    const submitLine = 'Reply `submit` to submit it.';
 
-    expect(prompt.split('\n').filter((line) => line === submitLine)).toHaveLength(1);
-    expect(prompt.match(/Reply `submit` to submit it\./g)).toHaveLength(1);
-    expect(prompt).toContain('short post-plan summary');
-    expect(prompt).toContain('Do NOT place that line inline in a sentence.');
+    expect(prompt).not.toContain('Reply `submit` to submit it.');
+    expect(prompt).toContain('Slack orchestrator reads that exact YAML');
+    expect(prompt).toContain('wait for approval before any submission step');
+    expect(prompt).toContain('Do not tell the user to reply `submit`');
   });
 
   it('keeps existing plan delivery, stack, and merge mode guidance', () => {
@@ -937,7 +937,7 @@ describe('PlanConversation prompt construction', () => {
 
     expect(prompt).toContain('mergeMode: external_review');
     expect(prompt).toContain('Prefer small reviewable slices');
-    expect(prompt).toContain('The Slack orchestrator validates and executes the plan after the user replies `submit` and approves it.');
+    expect(prompt).toContain('Only the Slack orchestrator may submit the plan after approval from its review flow.');
   });
 
   it('delegates Slack plan submission to the orchestrator', () => {
@@ -945,13 +945,12 @@ describe('PlanConversation prompt construction', () => {
     (conv as any).messages.push({ role: 'user', content: 'Build a feature' });
     const prompt = conv.buildCursorPrompt();
 
-    expect(prompt).toContain('Do NOT invoke `invoker-cli` (with any flags)');
+    expect(prompt).toContain('`invoker-cli`');
     expect(prompt).toContain('`invoker_submit_plan`');
     expect(prompt).toContain('`invoker_validate_plan`');
     expect(prompt).toContain('`submit-plan.sh`');
     expect(prompt).toContain('Harness handoff mode');
-    expect(prompt).toContain('This rule overrides that skill\'s handoff instructions in this Slack thread');
-    expect(prompt).toContain('remind them to reply with `submit`; never run it yourself');
+    expect(prompt).toContain('This rule overrides the plan-to-invoker skill\'s Harness handoff mode in this Slack thread');
   });
 
   it('system prompt requires discovered verification commands for target repos', () => {
@@ -972,8 +971,8 @@ describe('PlanConversation prompt construction', () => {
     // The canonical GitHub review gate must be named explicitly for reviewable plans.
     expect(prompt).toContain('mergeMode: external_review');
     expect(prompt).toContain('GitHub-backed review gate');
-    // Manual remains the verification-only default; automatic still documented.
-    expect(prompt).toContain('"manual" (default)');
+    // Pull-request plans now default to external_review; manual stays available for verification-only plans.
+    expect(prompt).toContain('default for pull_request plans');
     expect(prompt).toContain('"automatic"');
   });
 

--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -73,12 +73,8 @@ describe('plan draft file - activation side', () => {
 
     expect(path).not.toBeNull();
     expect(prompt).toContain(String(path));
-    // The delivery rule is hoisted to the top, before the YAML schema examples.
-    const deliveryIndex = prompt.indexOf('HOW TO DELIVER THE PLAN');
-    const firstSchemaIndex = prompt.indexOf('```yaml');
-    expect(deliveryIndex).toBeGreaterThanOrEqual(0);
-    expect(deliveryIndex).toBeLessThan(firstSchemaIndex);
-    expect(prompt).toContain('NEVER paste the YAML plan into your chat reply');
+    expect(prompt).toContain(`write the COMPLETE YAML to \`${String(path)}\``);
+    expect(prompt).toContain('Then reply in chat with only a one-or-two-sentence summary. Never paste the YAML into chat.');
     expect(prompt).not.toContain('output the plan inside a ```yaml code block');
   });
 
@@ -87,7 +83,7 @@ describe('plan draft file - activation side', () => {
     const prompt = conversation.buildCursorPrompt();
 
     expect(conversation.planDraftFilePath()).toBeNull();
-    expect(prompt).toContain('output the plan inside a ```yaml code block');
+    expect(prompt).toContain('When the final YAML plan is ready, output the COMPLETE YAML inside a ```yaml code block.');
   });
 
   it('keeps the last valid plan after a later turn clears its draft file', async () => {
@@ -117,17 +113,15 @@ describe('plan draft file - activation side', () => {
     expect(conversation.getDraftedPlan()).toBeNull();
   });
 
-  it('requires the exact submit line as a standalone post-plan instruction', () => {
+  it('routes approval through the review flow instead of a submit reply', () => {
     const conversation = new PlanConversation({});
     (conversation as any).messages.push({ role: 'user', content: 'Draft a plan' });
 
     const prompt = conversation.buildCursorPrompt();
-    const submitLine = 'Reply `submit` to submit it.';
-    const lines = prompt.split('\n');
 
-    expect(lines.filter((line) => line === submitLine)).toHaveLength(1);
-    expect(prompt.match(/Reply `submit` to submit it\./g)).toHaveLength(1);
-    expect(prompt).toContain('Do NOT place that line inline in a sentence.');
+    expect(prompt).not.toContain('Reply `submit` to submit it.');
+    expect(prompt).toContain('wait for approval before any submission step');
+    expect(prompt).toContain('Do not tell the user to reply `submit`');
   });
 
   it('exposes the latest draft for the submit handler without marking it submitted', async () => {
@@ -172,8 +166,8 @@ describe('plan draft-file activation prompt policy', () => {
     expect(prompt).toContain('Generate a YAML task plan');
     expect(prompt).toContain('repoUrl: "git@github.com:test/repo.git"');
     expect(prompt).toContain('name: "Plan Name"');
-    expect(prompt).toContain('When ready, output the plan inside a ```yaml code block');
-    expect(prompt).toContain('After generating a plan, include a short post-plan summary');
+    expect(prompt).toContain('When the final YAML plan is ready, output the COMPLETE YAML inside a ```yaml code block.');
+    expect(prompt).toContain('Slack orchestrator reads that exact YAML');
   });
 
   it('keeps YAML and draft-file mechanics unavailable before conversational authorization', () => {
@@ -202,8 +196,8 @@ describe('plan draft-file activation prompt policy', () => {
     expect(prompt).toContain('The user has explicitly approved drafting');
     expect(prompt).toContain('baseBranch: develop');
     expect(prompt).toContain('name: "Plan Name"');
-    expect(prompt).toContain('When ready, output the plan inside a ```yaml code block');
-    expect(prompt).toContain('After generating a plan, include a short post-plan summary');
+    expect(prompt).toContain('When the final YAML plan is ready, output the COMPLETE YAML inside a ```yaml code block.');
+    expect(prompt).toContain('Slack orchestrator reads that exact YAML');
     expect(prompt).toContain('Every implementation task MUST have a corresponding test task');
   });
 });

--- a/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
@@ -301,13 +301,34 @@ describe('Slack plan submission restart repro contracts', () => {
 
     expect(sharedSlack.client.chat.update).toHaveBeenCalledWith(expect.objectContaining({
       channel: 'C_LOBBY',
-      ts: 'draft-msg-ts',
-      text: 'Plan review cancelled.',
-      blocks: [],
+      ts: 'plan-turn-reply',
+      text: 'Proof plan\n• Exercise the submission flow\nPlan not submitted. Draft kept.',
+      blocks: expect.any(Array),
     }));
     expect(respond).not.toHaveBeenCalled();
-    expect(slackPlanDrafts.get(draft!.draftId, draft!.version)?.status).toBe('rejected');
+    expect(slackPlanDrafts.get(draft!.draftId, draft!.version)?.status).toBe('ready');
     expect(commands).not.toContainEqual(expect.objectContaining({ type: 'start_plan' }));
+  });
+  it('auto-submits a plan draft when the thread is tagged [auto-submit]', async () => {
+    const commands: SurfaceCommand[] = [];
+    const slack = surface(commands);
+    await start(slack, commands);
+    mockSpawn.mockImplementationOnce(() => processWith('ok'));
+    await mention(slack, '[auto-submit] build this draft', 'thread-auto-start');
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await mention(slack, '/plan', 'plan-turn-auto', 'thread-auto-start');
+
+    expect(commands).toContainEqual(expect.objectContaining({
+      type: 'start_plan',
+      planText: expect.stringContaining('name: Proof plan'),
+      lobbyThreadTs: 'thread-auto-start',
+    }));
+    expect(sharedSlack.client.chat.update).toHaveBeenCalledWith(expect.objectContaining({
+      channel: 'C_LOBBY',
+      ts: 'plan-turn-auto-reply',
+      text: 'Starting plan execution…',
+      blocks: [],
+    }));
   });
 
   it('restores repo, preset, and harness session context for a /plan draft after a SlackSurface restart', async () => {

--- a/packages/surfaces/src/__tests__/slack-surface.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface.test.ts
@@ -100,9 +100,18 @@ describe('SlackSurface', () => {
     it('registers action handlers for approve, reject, select, input', async () => {
       await surface.start(async () => {});
       const app = surface.getApp() as any;
-      // 8 action registrations: approve:, reject:, select:, input:, plan_draft_approve,
-      // plan_draft_cancel, lobby_confirm (op/restart only), lobby_cancel
-      expect(app.action).toHaveBeenCalledTimes(8);
+      const actionPatterns = app._actionHandlers.map((handler: MockHandler) => String(handler.pattern));
+      expect(actionPatterns).toEqual(expect.arrayContaining([
+        '/^approve:/',
+        '/^reject:/',
+        '/^select:/',
+        '/^input:/',
+        'plan_draft_approve',
+        'plan_draft_cancel',
+        'plan_draft_discard',
+        'lobby_confirm',
+        'lobby_cancel',
+      ]));
     });
 
     it('registers app_mention and message event handlers', async () => {
@@ -131,6 +140,7 @@ describe('SlackSurface', () => {
         instanceId: 'do1-proof',
         log,
       });
+      mockSendMessage.mockResolvedValue('hello');
       await surface.start(async () => {});
       const app = surface.getApp() as any;
       const mention = app._eventHandlers.find((handler: MockHandler) => handler.pattern === 'app_mention').handler;
@@ -141,7 +151,7 @@ describe('SlackSurface', () => {
       });
 
       expect(log).toHaveBeenCalledWith('slack', 'info', expect.stringContaining('[MENTION_RECEIVED] instance=do1-proof event_ts=event-1'));
-      expect(log).toHaveBeenCalledWith('slack', 'info', expect.stringContaining('[MENTION_ROUTE] instance=do1-proof event_ts=event-1 workflow=none'));
+      expect(log).toHaveBeenCalledWith('slack', 'info', expect.stringContaining('[MENTION_ROUTE] instance=do1-proof event_ts=event-1 route=planning'));
     });
   });
 

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -17,7 +17,7 @@ import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import type { ConversationRepository } from '@invoker/data-store';
 import { formatCodexPlannerStdout } from '@invoker/execution-engine';
 import type { HarnessSessionDriver } from '@invoker/execution-engine';
-import { isDraftingAuthorized, summarizePlanText } from '@invoker/planning-core';
+import { buildPlanningHandoffInstructions, isDraftingAuthorized, summarizePlanText } from '@invoker/planning-core';
 import type { LogFn } from '../surface.js';
 import {
   buildUnverifiedNotice,
@@ -270,25 +270,25 @@ function buildDirectPlanSystemPrompt(
   const stackedWorkflowSection = preferStackedWorkflows
     ? `\n${buildStackedWorkflowPrompt(repoUrlLine, defaultBranch)}\n`
     : '';
-  const outputInstruction = planFilePath
-    ? `This is the delivery rule stated at the top. Write the COMPLETE YAML plan to the file at \`${planFilePath}\`, and reply in chat with only a one-or-two-sentence summary. Never paste the YAML into chat.`
-    : 'When ready, output the plan inside a \`\`\`yaml code block.';
-  const deliveryDirective = planFilePath
-    ? `HOW TO DELIVER THE PLAN (read first): write the COMPLETE YAML plan to the file at \`${planFilePath}\` using your file-writing tool, then reply in chat with ONLY a short summary — one or two sentences. NEVER paste the YAML plan into your chat reply; Invoker reads it from the file and shows the user a per-task summary. Every YAML block below is the format for that file, not for your chat reply. A pasted plan gets cut off at your output limit, which is the exact problem the file avoids.\n\n`
-    : '';
+  const handoffInstructions = buildPlanningHandoffInstructions({
+    planFilePath,
+    reviewInstruction: 'After the YAML exists, the Slack orchestrator reads that exact YAML, renders the ordered steps in its review card, and owns the approval flow.',
+    shortReplyInstruction: 'Then reply in chat with only a one-or-two-sentence summary. Never paste the YAML into chat.',
+    submissionInstruction: 'Only the Slack orchestrator may submit the plan after approval from its review flow. This rule overrides the plan-to-invoker skill\'s Harness handoff mode in this Slack thread.',
+  });
   const repoUrlDirective = repoUrl
     ? ''
     : 'NO REPO CONFIGURED (read first): this thread has no target repository configured — not via a `[repo:]` tag and not via a default. Before drafting any YAML, ask the user which repository this plan targets (a `[repo:<alias>]` tag, or a full git clone URL) and wait for their reply. Never invent, guess, or copy the `repoUrl` placeholder shown below literally into a plan.\n\n';
   return `You are an assistant for the Invoker orchestrator. The user explicitly requested an Invoker plan.
 
-${repoUrlDirective}${deliveryDirective}Generate a YAML task plan as described below. Answer simple follow-up questions directly only when they are about the plan being drafted.
+${repoUrlDirective}Generate a YAML task plan as described below. Answer simple follow-up questions directly only when they are about the plan being drafted.
 
 A plan has this structure:
 \`\`\`yaml
 name: "Plan Name"
 ${repoUrlLine}
 onFinish: pull_request  # "pull_request" (default), "merge", or "none"
-mergeMode: external_review  # "external_review" = GitHub-backed review gate for reviewable implementation work; "manual" (default) = verification-only, no review; "automatic" = merge without review
+mergeMode: external_review  # default for pull_request plans; "manual" = verification-only, no review; "automatic" = merge without review
 baseBranch: ${defaultBranch}        # base git branch
 featureBranch: plan/my-feature  # auto-generated from plan name if omitted
 tasks:
@@ -325,13 +325,9 @@ Rules:
    - If Invoker config auto-routes heavyweight commands, keep discovered test/build commands as normal command tasks unless the task must name a specific remote target
    - NEVER invent test file names. Verify the test file exists before referencing it in a command.
 7. Use meaningful task IDs (kebab-case).
-8. ${outputInstruction}
+8. ${handoffInstructions}
 9. Always include \`dependencies\` (even if empty array).
-10. After generating a plan, include a short post-plan summary that tells the user they can confirm execution. The confirmation instruction MUST be exactly this standalone line:
-Reply \`submit\` to submit it.
-Do NOT place that line inline in a sentence.
-11. NEVER submit, validate, or execute this plan yourself. Do NOT invoke \`invoker-cli\` (with any flags), \`invoker_submit_plan\`, \`invoker_validate_plan\`, \`submit-plan.sh\`, or the \`plan-to-invoker\` skill's Harness handoff mode. This rule overrides that skill's handoff instructions in this Slack thread. The Slack orchestrator validates and executes the plan after the user replies \`submit\` and approves it. If the user instead says \`execute\`, \`run it\`, \`yes\`, or \`go\` before submitting, remind them to reply with \`submit\`; never run it yourself.
-12. Choose \`mergeMode\` deliberately. For reviewable implementation plans, set \`mergeMode: external_review\` so changes land through the canonical GitHub-backed review gate. Keep \`mergeMode: manual\` (the default) for verification-only plans that should not open a review, and use \`mergeMode: automatic\` only when the user explicitly wants changes merged without review.`;
+10. Choose \`mergeMode\` deliberately. \`pull_request\` plans default to \`mergeMode: external_review\` so changes land through the canonical GitHub-backed review gate. Use \`mergeMode: manual\` for verification-only plans that should not open a review, and use \`mergeMode: automatic\` only when the user explicitly wants changes merged without review.`;
 }
 
 function buildConversationalPlanSystemPrompt(

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -14,9 +14,10 @@ import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 import {
   formatPlanSummaryLines,
   formatSlackPlanBrief,
-  runPlanToInvoker,
+  preparePlanningReview,
   summarizePlanText,
   type PlanSummary,
+  type PlanningConfirmationMode,
 } from '@invoker/planning-core';
 import type { Surface, CommandHandler, SurfaceCommand, SurfaceEvent, LogFn, WorkflowOp, WorkflowOpResult, WorkflowOpProgress } from '../surface.js';
 import { parseSlackCommand } from './slack-commands.js';
@@ -118,6 +119,8 @@ export interface SlackSurfaceConfig {
   repoAliases?: Record<string, string>;
   /** Repo URL used when the message carries no `[repo:]` tag. */
   defaultRepoUrl?: string;
+  /** Default Slack plan review mode. Default: 'require'. */
+  defaultPlanningConfirmationMode?: PlanningConfirmationMode;
   /** Persisted workflow↔channel mapping for routing + channel creation. */
   workflowChannelRepo?: WorkflowChannelRepository;
   /** Gathers a workflow's planning convo + task transcripts for the in-channel assistant. */
@@ -154,6 +157,7 @@ interface PlanningContext {
   workingDir?: string;
   requestedBy?: string;
   lobbyChannel?: string;
+  confirmationMode: PlanningConfirmationMode;
   harnessSessionId?: string;
 }
 
@@ -258,12 +262,14 @@ export function parsePlanningRequest(
   repo?: string;
   repositoryUrls?: string[];
   hasExplicitPreset?: boolean;
+  confirmationMode?: PlanningConfirmationMode;
   text: string;
   unknownPreset?: string;
 } {
   let rest = text.replace(/<@[^>]+>/g, '').trim();
   let presetKey = defaultPresetKey;
   let repo: string | undefined;
+  let confirmationMode: PlanningConfirmationMode | undefined;
   let unknownPreset: string | undefined;
   let hasExplicitPreset = false;
   const keyset = new Set(presetKeys.map((k) => k.toLowerCase()));
@@ -279,6 +285,11 @@ export function parsePlanningRequest(
       continue;
     }
     const normalized = raw.toLowerCase().replace(/\s+/g, '').replace(/^plain/, '');
+    if (normalized === 'auto-submit' || normalized === 'autosubmit') {
+      confirmationMode = 'auto_submit';
+      rest = rest.slice(m[0].length);
+      continue;
+    }
     if (keyset.has(normalized)) {
       presetKey = normalized;
       hasExplicitPreset = true;
@@ -299,6 +310,7 @@ export function parsePlanningRequest(
     text: rest.trim(),
     ...(repositoryUrls.length > 0 ? { repositoryUrls } : {}),
     ...(hasExplicitPreset ? { hasExplicitPreset } : {}),
+    ...(confirmationMode ? { confirmationMode } : {}),
     ...(unknownPreset ? { unknownPreset } : {}),
   };
 }
@@ -503,6 +515,7 @@ export class SlackSurface implements Surface {
   private planningContexts = new Map<string, PlanningContext>();
   /** Maps thread_ts → an action awaiting yes/no (or button) confirmation. */
   private pendingConfirms = new Map<string, PendingConfirm>();
+  private defaultPlanningConfirmationMode: PlanningConfirmationMode;
 
   // ── Slack-native workflow extensions ──────────────────────
   private lobbyChannelId: string;
@@ -549,10 +562,11 @@ export class SlackSurface implements Surface {
     this.lobbyChannelId = config.lobbyChannelId ?? config.channelId;
     this.planningCommandBuilder = config.planningCommandBuilder;
     this.prepareRepoCheckout = config.prepareRepoCheckout;
-    this.harnessPresets = config.harnessPresets ?? BUILTIN_HARNESS_PRESETS;
+    this.harnessPresets = { ...BUILTIN_HARNESS_PRESETS, ...(config.harnessPresets ?? {}) };
     this.defaultHarnessPreset = config.defaultHarnessPreset ?? DEFAULT_HARNESS_PRESET;
     this.repoAliases = config.repoAliases ?? {};
     this.defaultRepoUrl = config.defaultRepoUrl ?? config.repoUrl;
+    this.defaultPlanningConfirmationMode = config.defaultPlanningConfirmationMode ?? 'require';
     this.workflowChannelRepo = config.workflowChannelRepo;
     this.gatherWorkflowContext = config.gatherWorkflowContext;
     this.runWorkflowOp = config.runWorkflowOp;
@@ -812,6 +826,11 @@ export class SlackSurface implements Surface {
       if (action.type !== 'button' || !action.value) return;
       await this.approveSlackPlanDraft(action.value, body, respond);
     });
+    this.app.action('plan_draft_discard', async ({ action, body, ack, respond }) => {
+      await ack();
+      if (action.type !== 'button' || !action.value) return;
+      await this.discardSlackPlanDraft(action.value, body, respond);
+    });
 
     this.app.action('plan_draft_cancel', async ({ action, body, ack, respond }) => {
       await ack();
@@ -969,6 +988,7 @@ export class SlackSurface implements Surface {
         workingDir: this.workingDir,
         requestedBy: event.user,
         lobbyChannel: channel,
+        confirmationMode: parsed.confirmationMode ?? this.defaultPlanningConfirmationMode,
       };
       await this.stagePlanIntentConfirm(threadTs, channel, {
         kind: 'plan_intent',
@@ -1036,14 +1056,18 @@ export class SlackSurface implements Surface {
           return;
         }
       }
+      const effectiveConfirmationMode = parsed.confirmationMode
+        ?? storedContext?.confirmationMode
+        ?? this.defaultPlanningConfirmationMode;
       const context = storedContext
-        ? storedContext
+        ? { ...storedContext, confirmationMode: effectiveConfirmationMode }
         : {
             repoUrl: routeRepoUrl,
             presetKey: parsed.presetKey,
             workingDir: this.workingDir,
             requestedBy: event.user,
             lobbyChannel: channel,
+            confirmationMode: effectiveConfirmationMode,
           };
       const contextPreset = this.resolveHarnessPreset(context.presetKey);
       let workingDir = context.workingDir ?? this.workingDir;
@@ -1096,14 +1120,17 @@ export class SlackSurface implements Surface {
       await say({ text: 'Start a conversation in this thread before asking me to create a plan.', thread_ts: threadTs });
       return;
     }
-    const result = await runPlanToInvoker({
-      convert: () => conversation.runPlanConversion(),
+    const plannerOutput = await conversation.runPlanConversion();
+    const review = preparePlanningReview({
+      plannerOutput,
       extractDraftPlanText: () => conversation.lastTurnDraftPlanText,
+      confirmationMode: this.loadPlanningContext(threadTs)?.confirmationMode ?? this.defaultPlanningConfirmationMode,
     });
-    if (result.kind === 'message') {
-      await this.sayWithRateLimitRetry(say, { text: result.reply, thread_ts: threadTs });
+    if ('kind' in review) {
+      await this.sayWithRateLimitRetry(say, { text: review.reply, thread_ts: threadTs });
       return;
     }
+    const draftReview = review;
     const context = this.loadPlanningContext(threadTs);
     if (!context?.repoUrl || !context.workingDir) {
       await this.sayWithRateLimitRetry(say, {
@@ -1115,14 +1142,22 @@ export class SlackSurface implements Surface {
     const draft = this.slackPlanDraftRepo.create({
       channelId: channel,
       threadTs,
-      planText: result.planText,
-      summaryJson: JSON.stringify(result.summary),
+      planText: draftReview.planText,
+      summaryJson: JSON.stringify(draftReview.summary),
       repoUrl: context.repoUrl,
       harnessPreset: context.presetKey,
       workingDir: context.workingDir,
       requestedBy: context.requestedBy ?? userId,
+      confirmationMode: draftReview.confirmationMode,
     });
-    await this.postSlackPlanDraft(draft, result.summary, say);
+    await this.postSlackPlanDraft(draft, draftReview.summary, say);
+    if (draftReview.confirmationMode === 'auto_submit') {
+      try {
+        await this.submitSlackPlanDraft(this.slackPlanDraftRepo.get(draft.draftId, draft.version) ?? draft, { userId });
+      } catch (error) {
+        this.log('slack', 'error', `Auto-submit failed for draft ${draft.draftId}:${draft.version}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
   }
 
   /** Post the immediate "received it" acknowledgment and track it for in-place replacement. */
@@ -1250,30 +1285,37 @@ export class SlackSurface implements Surface {
     };
   }
 
-  private async approveSlackPlanDraft(value: string, body: unknown, respond?: RespondFn): Promise<void> {
-    const key = this.parseDraftAction(value);
-    const context = this.draftActionContext(body);
-    const draft = key && this.slackPlanDraftRepo?.get(key.draftId, key.version);
-    if (!draft || !context.channel || !context.threadTs
-      || draft.channelId !== context.channel || draft.threadTs !== context.threadTs) {
-      await respond?.({ text: 'This plan review is no longer available.', replace_original: true });
-      return;
-    }
+  private parseSlackDraftSummary(draft: SlackPlanDraft): PlanSummary {
+    const parsed = JSON.parse(draft.summaryJson) as PlanSummary;
+    return parsed;
+  }
+
+  private async replacePlanDraftMessage(draft: SlackPlanDraft, text: string, blocks: unknown[]): Promise<void> {
+    if (!draft.messageTs) return;
+    await this.app.client.chat.update({
+      channel: draft.channelId,
+      ts: draft.messageTs,
+      text,
+      blocks: blocks as never,
+    });
+  }
+
+  private async submitSlackPlanDraft(
+    draft: SlackPlanDraft,
+    context: { userId?: string },
+  ): Promise<void> {
     if (draft.status !== 'ready') {
-      await respond?.({ text: `This plan review is ${draft.status}.`, replace_original: true });
-      return;
+      throw new Error(`This plan review is ${draft.status}.`);
     }
     if (!draft.messageTs || !draft.slackFileId
       || createHash('sha256').update(draft.planText).digest('hex') !== draft.contentHash) {
-      await respond?.({ text: 'This plan review failed its integrity check and cannot be approved.', replace_original: true });
-      return;
+      throw new Error('This plan review failed its integrity check and cannot be approved.');
     }
     const executionKey = this.slackPlanDraftRepo?.claim(draft);
     if (!executionKey) {
-      await respond?.({ text: 'This plan is already being submitted.', replace_original: true });
-      return;
+      throw new Error('This plan is already being submitted.');
     }
-    await this.replaceConfirmationMessage(body, respond, 'Starting plan execution…');
+    await this.replacePlanDraftMessage(draft, 'Starting plan execution…', []);
     try {
       const result = await this.onCommand?.({
         type: 'start_plan',
@@ -1288,11 +1330,28 @@ export class SlackSurface implements Surface {
       this.slackPlanDraftRepo?.markSubmitted(draft, result?.workflowIds ?? []);
     } catch (error) {
       this.slackPlanDraftRepo?.markFailed(draft, context.userId ?? 'unknown');
-      await this.replaceConfirmationMessage(
-        body,
-        respond,
+      await this.replacePlanDraftMessage(
+        draft,
         `Plan execution failed: ${error instanceof Error ? error.message : String(error)}`,
+        [],
       );
+      throw error;
+    }
+  }
+
+  private async approveSlackPlanDraft(value: string, body: unknown, respond?: RespondFn): Promise<void> {
+    const key = this.parseDraftAction(value);
+    const context = this.draftActionContext(body);
+    const draft = key && this.slackPlanDraftRepo?.get(key.draftId, key.version);
+    if (!draft || !context.channel || !context.threadTs
+      || draft.channelId !== context.channel || draft.threadTs !== context.threadTs) {
+      await respond?.({ text: 'This plan review is no longer available.', replace_original: true });
+      return;
+    }
+    try {
+      await this.submitSlackPlanDraft(draft, context);
+    } catch (error) {
+      await respond?.({ text: error instanceof Error ? error.message : String(error), replace_original: true });
     }
   }
 
@@ -1309,17 +1368,39 @@ export class SlackSurface implements Surface {
       await respond?.({ text: `This plan review is ${draft.status}.`, replace_original: true });
       return;
     }
-    this.slackPlanDraftRepo?.decide(draft, 'rejected', context.userId ?? 'unknown');
-    await this.replaceConfirmationMessage(body, respond, 'Plan review cancelled.');
+    const summary = this.parseSlackDraftSummary(draft);
+    await this.replacePlanDraftMessage(
+      draft,
+      `${summary.name}\n${formatPlanSummaryLines(summary).join('\n')}\nPlan not submitted. Draft kept.`,
+      this.planDraftBlocks(summary, draft, 'kept'),
+    );
   }
 
-  private planDraftBlocks(summary: PlanSummary, draft: SlackPlanDraft, ready: boolean): unknown[] {
+  private async discardSlackPlanDraft(value: string, body: unknown, respond?: RespondFn): Promise<void> {
+    const key = this.parseDraftAction(value);
+    const context = this.draftActionContext(body);
+    const draft = key && this.slackPlanDraftRepo?.get(key.draftId, key.version);
+    if (!draft || !context.channel || !context.threadTs
+      || draft.channelId !== context.channel || draft.threadTs !== context.threadTs) {
+      await respond?.({ text: 'This plan review is no longer available.', replace_original: true });
+      return;
+    }
+    if (draft.status !== 'ready') {
+      await respond?.({ text: `This plan review is ${draft.status}.`, replace_original: true });
+      return;
+    }
+    this.slackPlanDraftRepo?.decide(draft, 'rejected', context.userId ?? 'unknown');
+    await this.replacePlanDraftMessage(draft, 'Plan draft discarded.', []);
+  }
+
+  private planDraftBlocks(
+    summary: PlanSummary,
+    draft: SlackPlanDraft,
+    state: 'plain' | 'ready' | 'kept',
+  ): unknown[] {
     const text = [`*${summary.name}*`, ...formatPlanSummaryLines(summary)].join('\n');
-    return [
-      { type: 'section', text: { type: 'mrkdwn', text } },
-      ...(ready ? [{
-        type: 'actions',
-        elements: [
+    const actionButtons = state === 'ready'
+      ? [
           {
             type: 'button',
             action_id: 'plan_draft_approve',
@@ -1333,7 +1414,29 @@ export class SlackSurface implements Surface {
             text: { type: 'plain_text', text: 'Cancel' },
             value: `${draft.draftId}:${draft.version}`,
           },
-        ],
+        ]
+      : state === 'kept'
+        ? [
+            {
+              type: 'button',
+              action_id: 'plan_draft_approve',
+              style: 'primary',
+              text: { type: 'plain_text', text: 'Approve' },
+              value: `${draft.draftId}:${draft.version}`,
+            },
+            {
+              type: 'button',
+              action_id: 'plan_draft_discard',
+              text: { type: 'plain_text', text: 'Discard draft' },
+              value: `${draft.draftId}:${draft.version}`,
+            },
+          ]
+        : [];
+    return [
+      { type: 'section', text: { type: 'mrkdwn', text } },
+      ...(actionButtons.length > 0 ? [{
+        type: 'actions',
+        elements: actionButtons,
       }] : []),
     ];
   }
@@ -1347,7 +1450,7 @@ export class SlackSurface implements Surface {
     const posted = await this.sayWithRateLimitRetry(say, {
       text: `${summary.name}\n${formatPlanSummaryLines(summary).join('\n')}\nPreparing YAML attachment…`,
       thread_ts: draft.threadTs,
-      blocks: this.planDraftBlocks(summary, draft, false),
+      blocks: this.planDraftBlocks(summary, draft, 'plain'),
     });
     if (!posted?.ts) throw new Error('Slack did not return a timestamp for the plan review message.');
     this.slackPlanDraftRepo.bindMessage(draft, posted.ts);
@@ -1365,12 +1468,11 @@ export class SlackSurface implements Surface {
       if (!fileId) throw new Error('Slack did not return an uploaded YAML file id.');
       this.slackPlanDraftRepo.bindAttachment(draft, fileId);
       this.slackPlanDraftRepo.markReady(draft);
-      await this.app.client.chat.update({
-        channel: draft.channelId,
-        ts: posted.ts,
-        text: `${summary.name}\n${formatPlanSummaryLines(summary).join('\n')}`,
-        blocks: this.planDraftBlocks(summary, draft, true) as never,
-      });
+      await this.replacePlanDraftMessage(
+        this.slackPlanDraftRepo.get(draft.draftId, draft.version) ?? draft,
+        `${summary.name}\n${formatPlanSummaryLines(summary).join('\n')}`,
+        this.planDraftBlocks(summary, draft, 'ready'),
+      );
     } catch (error) {
       await this.app.client.chat.update({
         channel: draft.channelId,
@@ -1634,6 +1736,7 @@ export class SlackSurface implements Surface {
       workingDir: persisted.workingDir || undefined,
       requestedBy: persisted.requestedBy || undefined,
       lobbyChannel: persisted.lobbyChannelId || undefined,
+      confirmationMode: persisted.confirmationMode,
       harnessSessionId: persisted.harnessSessionId || undefined,
     };
     this.planningContexts.set(threadTs, context);
@@ -1661,6 +1764,7 @@ export class SlackSurface implements Surface {
       harnessSessionId: context.harnessSessionId,
       requestedBy: context.requestedBy ?? '',
       lobbyChannelId: context.lobbyChannel ?? '',
+      confirmationMode: context.confirmationMode,
     });
   }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
-import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, StartReadyRequest, StartReadyResult, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
+import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, PlanningConfirmationMode, ReviewGateQueryResponse, RuntimeStatus, StartReadyRequest, StartReadyResult, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus, WorkerActionSummary, WorkerLogEntry, WorkerStatusEntry } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
 import { reportUiNavigation } from './lib/report-ui-navigation.js';
@@ -179,12 +179,16 @@ type PlanningStreamState = {
   status: 'streaming' | 'failed';
 };
 
-function makeInitialPlanningSession(now: string = new Date().toISOString()): PlanningSessionView {
+function makeInitialPlanningSession(
+  now: string = new Date().toISOString(),
+  confirmationMode: PlanningConfirmationMode = 'require',
+): PlanningSessionView {
   return {
     id: 'local-planning-session-1',
     title: 'Untitled plan',
     status: 'still_discussing',
     presetKey: '',
+    confirmationMode,
     messages: [],
     input: '',
     draftPlanAvailable: false,
@@ -844,8 +848,10 @@ export function App() {
   const nextPlanningSessionLocalIdRef = useRef(2);
   const nextTerminalLineIdRef = useRef(1);
   const [planningStreamBySessionId, setPlanningStreamBySessionId] = useState<Record<string, PlanningStreamState>>({});
-  const [planningPresetOptions, setPlanningPresetOptions] = useState<Array<{ key: string; label: string; isDefault?: boolean }>>([]);
+  const [planningPresetOptions, setPlanningPresetOptions] = useState<Array<{ key: string; label: string; isDefault?: boolean; defaultConfirmationMode?: PlanningConfirmationMode }>>([]);
   const [selectedPlanningPresetKey, setSelectedPlanningPresetKey] = useState('');
+  const [selectedPlanningConfirmationMode, setSelectedPlanningConfirmationMode] = useState<PlanningConfirmationMode>('require');
+  const [keptPlanningDraftSessionIds, setKeptPlanningDraftSessionIds] = useState<Set<string>>(new Set());
   const [planningSubmitError, setPlanningSubmitError] = useState<{ title: string; message: string } | null>(null);
   const [planningTerminalExpanded, setPlanningTerminalExpanded] = useState(false);
   const [reviewDraftSessionId, setReviewDraftSessionId] = useState<string | null>(null);
@@ -996,17 +1002,31 @@ export function App() {
     window.invoker?.getPlanningPresets?.()
       .then((options) => {
         const resolved = Array.isArray(options) && options.length > 0
-          ? options.map((option) => ({ key: option.key, label: option.label, isDefault: option.isDefault }))
-          : [{ key: 'codex', label: 'Codex', isDefault: true }];
+          ? options.map((option) => ({
+              key: option.key,
+              label: option.label,
+              isDefault: option.isDefault,
+              defaultConfirmationMode: option.defaultConfirmationMode,
+            }))
+          : [{ key: 'codex', label: 'Codex', isDefault: true, defaultConfirmationMode: 'require' as const }];
         setPlanningPresetOptions(resolved);
         setSelectedPlanningPresetKey(resolved.find((option) => option.isDefault)?.key ?? resolved[0]?.key ?? 'codex');
+        setSelectedPlanningConfirmationMode(resolved.find((option) => option.isDefault)?.defaultConfirmationMode ?? resolved[0]?.defaultConfirmationMode ?? 'require');
       })
       .catch(() => {
-        setPlanningPresetOptions([{ key: 'codex', label: 'Codex', isDefault: true }]);
+        setPlanningPresetOptions([{ key: 'codex', label: 'Codex', isDefault: true, defaultConfirmationMode: 'require' }]);
         setSelectedPlanningPresetKey('codex');
-    });
+        setSelectedPlanningConfirmationMode('require');
+      });
     refreshSystemDiagnostics();
   }, [refreshSystemDiagnostics]);
+
+  useEffect(() => {
+    if (activePlanningSession.presetKey) {
+      setSelectedPlanningPresetKey(activePlanningSession.presetKey);
+    }
+    setSelectedPlanningConfirmationMode(activePlanningSession.confirmationMode ?? 'require');
+  }, [activePlanningSession.id, activePlanningSession.presetKey, activePlanningSession.confirmationMode]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1021,13 +1041,12 @@ export function App() {
           && first.messages.every((line) => line.role === 'system');
         if (!onlyInitialPlaceholder) return;
         const restored = response.sessions.map(planningSessionSummaryToView);
-        const maxLineId = restored.reduce((max, session) => (
-          Math.max(max, ...session.messages.map((line) => line.id))
-        ), 1);
+        const maxLineId = Math.max(1, ...restored.flatMap((session) => session.messages.map((message) => message.id)));
         nextTerminalLineIdRef.current = Math.max(nextTerminalLineIdRef.current, maxLineId + 1);
         setPlanningSessions(restored);
         setActivePlanningSessionId(restored[0]?.id ?? 'local-planning-session-1');
         setSelectedPlanningPresetKey((current) => current || restored[0]?.presetKey || current);
+        setSelectedPlanningConfirmationMode(restored[0]?.confirmationMode ?? 'require');
       })
       .catch(() => {});
     return () => {
@@ -2524,6 +2543,15 @@ export function App() {
       setStartReadyBusy(false);
     }
   }, [invoker]);
+  const handlePlanningPresetChange = useCallback((presetKey: string) => {
+    setSelectedPlanningPresetKey(presetKey);
+    updatePlanningSessionById(activePlanningSessionId, (session) => ({ ...session, presetKey }));
+  }, [activePlanningSessionId, updatePlanningSessionById]);
+
+  const handlePlanningConfirmationModeChange = useCallback((confirmationMode: PlanningConfirmationMode) => {
+    setSelectedPlanningConfirmationMode(confirmationMode);
+    updatePlanningSessionById(activePlanningSessionId, (session) => ({ ...session, confirmationMode }));
+  }, [activePlanningSessionId, updatePlanningSessionById]);
 
   const handleConfirmStartAndRecreateFailed = useCallback(async () => {
     const result = await handleStartReadyAction(
@@ -2536,11 +2564,11 @@ export function App() {
     if (result) setStartReadyPreview(null);
   }, [handleStartReadyAction, startReadyPreviewMode]);
 
-  const handlePlanningSubmitDraft = useCallback(async () => {
+  const handlePlanningSubmitDraft = useCallback(async (targetSessionId: string | null = planningSessionId) => {
     if (activePlanningReadOnly) {
       return;
     }
-    if (!planningSessionId) {
+    if (!targetSessionId) {
       setPlanningSubmitError({ title: 'Plan could not be submitted', message: 'No planning conversation yet.' });
       appendTerminalLine('Plan could not be submitted:\nNo planning conversation yet.', 'system', 'error');
       return;
@@ -2550,21 +2578,26 @@ export function App() {
       appendTerminalLine('Plan could not be submitted:\nPlanner is not available.', 'system', 'error');
       return;
     }
-    updatePlanningSessionById(planningSessionId, (session) => ({ ...session, busy: true }));
+    updatePlanningSessionById(targetSessionId, (session) => ({ ...session, busy: true }));
     try {
-      const result = await invoker.planningChatSubmit({ sessionId: planningSessionId });
+      const result = await invoker.planningChatSubmit({ sessionId: targetSessionId });
       if (result.ok) {
         setPlanningSubmitError(null);
         setHasLoadedPlan(true);
         setWorkflowSelectionDismissed(false);
         setGraphActionsMenuOpen(false);
+        setKeptPlanningDraftSessionIds((prev) => {
+          const next = new Set(prev);
+          next.delete(targetSessionId);
+          return next;
+        });
         setReviewDraftSessionId(null);
         setPlanName(result.planName);
         setSelectedWorkflowId(result.workflowId);
         setSidebarSurface('home');
         setViewMode('dag');
         issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason: 'planning-submit' });
-        updatePlanningSessionById(planningSessionId, (session) => ({
+        updatePlanningSessionById(targetSessionId, (session) => ({
           ...session,
           busy: false,
           status: 'submitted',
@@ -2591,17 +2624,51 @@ export function App() {
           'success',
         );
       } else {
-        updatePlanningSessionById(planningSessionId, (session) => ({ ...session, busy: false }));
+        updatePlanningSessionById(targetSessionId, (session) => ({ ...session, busy: false }));
         setPlanningSubmitError({ title: 'Plan could not be submitted', message: result.error });
         appendTerminalLine(`Plan could not be submitted:\n${result.error}`, 'system', 'error');
       }
     } catch (err) {
-      updatePlanningSessionById(planningSessionId, (session) => ({ ...session, busy: false }));
+      updatePlanningSessionById(targetSessionId, (session) => ({ ...session, busy: false }));
       const message = err instanceof Error ? err.message : 'Failed to submit the plan.';
       setPlanningSubmitError({ title: 'Plan could not be submitted', message });
       appendTerminalLine(`Plan could not be submitted:\n${message}`, 'system', 'error');
     }
   }, [activePlanningReadOnly, appendTerminalLine, handleStartReadyAction, invoker, issueCameraCommand, planningSessionId, refreshTaskGraph, updatePlanningSessionById]);
+  const handlePlanningCancelReview = useCallback(() => {
+    appendTerminalLine('Submission cancelled. Draft kept.', 'system');
+    setKeptPlanningDraftSessionIds((prev) => new Set(prev).add(activePlanningSessionId));
+    setReviewDraftSessionId(null);
+  }, [activePlanningSessionId, appendTerminalLine]);
+
+  const handlePlanningDiscardDraft = useCallback(async () => {
+    const targetSessionId = planningSessionId;
+    if (!targetSessionId) return;
+    if (!invoker?.planningChatDiscardDraft) {
+      setPlanningSubmitError({ title: 'Draft could not be discarded', message: 'Planner is not available.' });
+      return;
+    }
+    const result = await invoker.planningChatDiscardDraft({ sessionId: targetSessionId });
+    if (!result.ok) {
+      setPlanningSubmitError({ title: 'Draft could not be discarded', message: result.error });
+      appendTerminalLine(result.error, 'system', 'error');
+      return;
+    }
+    setKeptPlanningDraftSessionIds((prev) => {
+      const next = new Set(prev);
+      next.delete(targetSessionId);
+      return next;
+    });
+    setReviewDraftSessionId(null);
+    updatePlanningSessionById(targetSessionId, (session) => ({
+      ...session,
+      status: 'still_discussing',
+      draftPlanAvailable: false,
+      draftPlanSummary: undefined,
+      draftPlanText: undefined,
+      updatedAt: new Date().toISOString(),
+    }));
+  }, [appendTerminalLine, invoker, planningSessionId, updatePlanningSessionById]);
 
   const handlePlanningSubmit = useCallback(async () => {
     const input = planningInput.trim();
@@ -2648,17 +2715,18 @@ export function App() {
       return;
     }
 
+    const request = {
+      message: input,
+      presetKey: selectedPlanningPresetKey || undefined,
+      confirmationMode: selectedPlanningConfirmationMode,
+      ...(planningSessionId ? { sessionId: planningSessionId } : {}),
+    };
     const previousSessionId = activePlanningSessionId;
     pendingPlanningStreamSessionIdsRef.current.add(previousSessionId);
     clearPlanningStreamForSessionIds([previousSessionId, planningSessionId]);
     forgetPlanningStreamAliasesForSessionIds([previousSessionId, planningSessionId]);
     updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: true }));
     try {
-      const request = {
-        message: input,
-        presetKey: selectedPlanningPresetKey || undefined,
-        ...(planningSessionId ? { sessionId: planningSessionId } : {}),
-      };
       const result = await invoker.planningChatSend(request);
       if (result.ok) {
         const updatedAt = new Date().toISOString();
@@ -2673,6 +2741,8 @@ export function App() {
             title: session.title === 'Untitled plan'
               ? (input.length > 56 ? `${input.slice(0, 53).trimEnd()}…` : input)
               : session.title,
+            presetKey: request.presetKey ?? session.presetKey,
+            confirmationMode: result.confirmationMode ?? session.confirmationMode ?? 'require',
             status: result.draftPlanAvailable ? 'draft_ready' : result.reply.includes('?') ? 'waiting_for_answer' : 'still_discussing',
             messages: [...session.messages, { id: replyLineId, text: result.reply, role: 'assistant', ...((result as { reasoning?: string }).reasoning ? { reasoning: (result as { reasoning?: string }).reasoning } : {}) }],
             draftPlanAvailable: result.draftPlanAvailable,
@@ -2689,6 +2759,19 @@ export function App() {
         pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
         pendingPlanningStreamSessionIdsRef.current.delete(result.sessionId);
         setHasLoadedPlan(false);
+        setKeptPlanningDraftSessionIds((prev) => {
+          const next = new Set(prev);
+          next.delete(previousSessionId);
+          next.delete(result.sessionId);
+          return next;
+        });
+        if (result.draftPlanAvailable) {
+          setReviewDraftSessionId(result.sessionId);
+          setPlanningContextCollapsed(false);
+          if ((result.confirmationMode ?? 'require') === 'auto_submit') {
+            void handlePlanningSubmitDraft(result.sessionId);
+          }
+        }
       } else {
         updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: false }));
         keepPlanningStreamFailureForSessionIds([previousSessionId, result.sessionId], result.error);
@@ -2722,6 +2805,7 @@ export function App() {
     invoker,
     planningInput,
     planningSessionId,
+    selectedPlanningConfirmationMode,
     selectedPlanningPresetKey,
     setPlanningInput,
     tasks.size,
@@ -2735,16 +2819,17 @@ export function App() {
     const now = new Date().toISOString();
     const localId = `local-planning-session-${index}`;
     const session: PlanningSessionView = {
-      ...makeInitialPlanningSession(now),
+      ...makeInitialPlanningSession(now, selectedPlanningConfirmationMode),
       id: localId,
       conversationKey: localId,
       presetKey: selectedPlanningPresetKey,
+      confirmationMode: selectedPlanningConfirmationMode,
     };
     setPlanningSessions((prev) => [session, ...prev]);
     setActivePlanningSessionId(session.id);
     setSidebarSurface('home');
     focusKeyboardRegion('planning');
-  }, [focusKeyboardRegion, selectedPlanningPresetKey]);
+  }, [focusKeyboardRegion, selectedPlanningConfirmationMode, selectedPlanningPresetKey]);
 
   const handlePlanningModeChange = useCallback(async (mode: PlanningTerminalMode) => {
     const sourceSession = activePlanningSession;
@@ -2792,6 +2877,7 @@ export function App() {
         const result = await invoker.planningChatCreate({
           presetKey: sourceSession.presetKey || selectedPlanningPresetKey || undefined,
           title: sourceSession.title,
+          confirmationMode: sourceSession.confirmationMode ?? selectedPlanningConfirmationMode,
         });
         if (!result.ok) {
           updatePlanningSessionById(sourceSession.id, (session) => ({
@@ -4038,99 +4124,123 @@ export function App() {
     const draftTaskGroups = draftPlanSummary?.taskGroups ?? (
       draftPlanSummary ? [{ workflow: null, tasks: draftPlanSummary.steps }] : []
     );
+    const keptDraft = keptPlanningDraftSessionIds.has(activePlanningSession.id);
     return (
       <aside
-      data-testid="planning-context-panel"
-      className={`${planningContextCollapsed ? 'w-16' : 'w-72'} shrink-0 border-l border-border bg-card/60 transition-all duration-150`}
-    >
-      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2.5">
+        data-testid="planning-context-panel"
+        className={`${planningContextCollapsed ? 'w-16' : 'w-72'} shrink-0 border-l border-border bg-card/60 transition-all duration-150`}
+      >
+        <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2.5">
+          {!planningContextCollapsed && (
+            <h2 className="text-sm font-semibold text-foreground">{reviewingDraft ? 'Review draft' : 'Current plan'}</h2>
+          )}
+          <button
+            type="button"
+            data-testid="planning-context-toggle"
+            aria-label={planningContextCollapsed ? 'Expand current plan' : 'Collapse current plan'}
+            onClick={() => setPlanningContextCollapsed((value) => !value)}
+            className="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-secondary"
+          >
+            {planningContextCollapsed ? '›' : '‹'}
+          </button>
+        </div>
         {!planningContextCollapsed && (
-          <h2 className="text-sm font-semibold text-foreground">{reviewingDraft ? 'Review draft' : 'Current plan'}</h2>
+          reviewingDraft ? (
+            <div className="space-y-4 p-4 text-sm">
+              {draftTaskGroups.map((group, groupIndex) => (
+                <section key={`${group.workflow ?? 'plan'}-${groupIndex}`} data-testid="draft-task-group">
+                  {group.workflow && <h3 className="text-xs font-medium text-foreground">{group.workflow}</h3>}
+                  <ul className={group.workflow ? 'mt-2 space-y-1.5' : 'space-y-1.5'}>
+                    {group.tasks.map((task, taskIndex) => (
+                      <li key={`${task}-${taskIndex}`} data-testid="draft-step-summary" className="text-xs leading-5 text-muted-foreground">
+                        {task}
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+              {draftPlanText && (
+                <pre data-testid="draft-raw-yaml" className="max-h-56 overflow-auto rounded-md border border-border bg-background p-3 text-[11px] leading-5 text-muted-foreground">
+                  {draftPlanText}
+                </pre>
+              )}
+              {activePlanningSession.confirmationMode === 'require' && (
+                <div className="grid gap-2">
+                  <Button
+                    type="button"
+                    data-testid="planning-create-workflow"
+                    onClick={() => void handlePlanningSubmitDraft()}
+                    className="w-full"
+                  >
+                    Create workflow
+                  </Button>
+                  {keptDraft ? (
+                    <button
+                      type="button"
+                      data-testid="planning-discard-draft"
+                      onClick={() => void handlePlanningDiscardDraft()}
+                      className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
+                    >
+                      Discard draft
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      data-testid="planning-cancel-review"
+                      onClick={handlePlanningCancelReview}
+                      className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
+                    >
+                      Cancel
+                    </button>
+                  )}
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={() => navigatePlanGraphAndFit('planning-draft-review')}
+                className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
+              >
+                Open graph
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-4 p-4 text-sm">
+              <div>
+                <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Goal</div>
+                <p className="mt-1 text-foreground">
+                  {activePlanningSession.title === 'Untitled plan'
+                    ? 'Describe a goal in the chat to begin drafting.'
+                    : activePlanningSession.title}
+                </p>
+              </div>
+              {draftPlanSummary && (
+                <div>
+                  <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Draft</div>
+                  <p className="mt-1 text-foreground">
+                    {draftPlanSummary.name} · {draftPlanSummary.taskCount} task{draftPlanSummary.taskCount === 1 ? '' : 's'}
+                  </p>
+                </div>
+              )}
+              {activePlanningSession.submittedPlanName && (
+                <div>
+                  <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Submitted</div>
+                  <p className="mt-1 text-foreground">{activePlanningSession.submittedPlanName}</p>
+                </div>
+              )}
+              {(draftPlanAvailable || activePlanningSession.status === 'submitted') && (
+                <button
+                  type="button"
+                  data-testid="planning-context-open-graph"
+                  onClick={() => navigatePlanGraphAndFit('planning-context')}
+                  className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
+                >
+                  Open graph
+                </button>
+              )}
+            </div>
+          )
         )}
-        <button
-          type="button"
-          data-testid="planning-context-toggle"
-          aria-label={planningContextCollapsed ? 'Expand current plan' : 'Collapse current plan'}
-          onClick={() => setPlanningContextCollapsed((value) => !value)}
-          className="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:bg-secondary"
-        >
-          {planningContextCollapsed ? '›' : '‹'}
-        </button>
-      </div>
-      {!planningContextCollapsed && (
-        reviewingDraft ? (
-          <div className="space-y-4 p-4 text-sm">
-            {draftTaskGroups.map((group, groupIndex) => (
-              <section key={`${group.workflow ?? 'plan'}-${groupIndex}`} data-testid="draft-task-group">
-                {group.workflow && <h3 className="text-xs font-medium text-foreground">{group.workflow}</h3>}
-                <ul className={group.workflow ? 'mt-2 space-y-1.5' : 'space-y-1.5'}>
-                  {group.tasks.map((task, taskIndex) => (
-                    <li key={`${task}-${taskIndex}`} data-testid="draft-step-summary" className="text-xs leading-5 text-muted-foreground">
-                      {task}
-                    </li>
-                  ))}
-                </ul>
-              </section>
-            ))}
-            {draftPlanText && (
-              <pre data-testid="draft-raw-yaml" className="max-h-56 overflow-auto rounded-md border border-border bg-background p-3 text-[11px] leading-5 text-muted-foreground">
-                {draftPlanText}
-              </pre>
-            )}
-            <Button
-              type="button"
-              data-testid="planning-create-workflow"
-              onClick={() => void handlePlanningSubmitDraft()}
-              className="w-full"
-            >
-              Create workflow
-            </Button>
-            <button
-              type="button"
-              onClick={() => navigatePlanGraphAndFit('planning-draft-review')}
-              className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
-            >
-              Open graph
-            </button>
-          </div>
-        ) : (
-          <div className="space-y-4 p-4 text-sm">
-          <div>
-            <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Goal</div>
-            <p className="mt-1 text-foreground">
-              {activePlanningSession.title === 'Untitled plan'
-                ? 'Describe a goal in the chat to begin drafting.'
-                : activePlanningSession.title}
-            </p>
-          </div>
-          {draftPlanSummary && (
-            <div>
-              <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Draft</div>
-              <p className="mt-1 text-foreground">
-                {draftPlanSummary.name} · {draftPlanSummary.taskCount} task{draftPlanSummary.taskCount === 1 ? '' : 's'}
-              </p>
-            </div>
-          )}
-          {activePlanningSession.submittedPlanName && (
-            <div>
-              <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Submitted</div>
-              <p className="mt-1 text-foreground">{activePlanningSession.submittedPlanName}</p>
-            </div>
-          )}
-          {(draftPlanAvailable || activePlanningSession.status === 'submitted') && (
-            <button
-              type="button"
-              data-testid="planning-context-open-graph"
-              onClick={() => navigatePlanGraphAndFit('planning-context')}
-              className="w-full rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary"
-            >
-              Open graph
-            </button>
-          )}
-          </div>
-        )
-      )}
-    </aside>
+      </aside>
     );
   };
 
@@ -4227,6 +4337,7 @@ export function App() {
             value={planningInput}
             selectedPresetKey={selectedPlanningPresetKey}
             presetOptions={planningPresetOptions}
+            selectedConfirmationMode={selectedPlanningConfirmationMode}
             draftPlanAvailable={draftPlanAvailable}
             draftPlanSummary={draftPlanSummary}
             planningStream={activePlanningStream}
@@ -4238,7 +4349,8 @@ export function App() {
             submittedPlanName={activePlanningSession.submittedPlanName}
             onValueChange={setPlanningInput}
             onSubmit={() => void handlePlanningSubmit()}
-            onPresetChange={setSelectedPlanningPresetKey}
+            onPresetChange={handlePlanningPresetChange}
+            onConfirmationModeChange={handlePlanningConfirmationModeChange}
             onModeChange={(mode) => void handlePlanningModeChange(mode)}
             onExpand={() => setPlanningTerminalExpanded(true)}
             onOpenGraph={() => navigatePlanGraphAndFit('planning-open-graph')}
@@ -4559,6 +4671,7 @@ export function App() {
             value={planningInput}
             selectedPresetKey={selectedPlanningPresetKey}
             presetOptions={planningPresetOptions}
+            selectedConfirmationMode={selectedPlanningConfirmationMode}
             draftPlanAvailable={draftPlanAvailable}
             draftPlanSummary={draftPlanSummary}
             planningStream={activePlanningStream}
@@ -4571,7 +4684,8 @@ export function App() {
             onValueChange={setPlanningInput}
             readOnly={activePlanningReadOnly}
             onSubmit={() => void handlePlanningSubmit()}
-            onPresetChange={setSelectedPlanningPresetKey}
+            onPresetChange={handlePlanningPresetChange}
+            onConfirmationModeChange={handlePlanningConfirmationModeChange}
             onModeChange={(mode) => void handlePlanningModeChange(mode)}
             onExpand={() => setPlanningTerminalExpanded(true)}
             onCloseExpanded={() => setPlanningTerminalExpanded(false)}

--- a/packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx
@@ -51,7 +51,7 @@ describe('CodeRabbit PR #3050 — Enter-to-submit ignores IME composition', () =
     // A subsequent plain Enter (composition finished) submits normally.
     fireEvent.keyDown(input, { key: 'Enter' });
     await waitFor(() => {
-      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'こんにちは', presetKey: 'codex' });
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'こんにちは', presetKey: 'codex', confirmationMode: 'require' });
     });
   });
 });

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -81,6 +81,7 @@ export function makePlanningSessionSummary(
     title: 'Saved planning chat',
     status: 'draft_ready',
     presetKey: 'codex',
+    confirmationMode: 'require',
     messages: [
       {
         id: 1,
@@ -201,6 +202,7 @@ export function createMockInvoker(
         title: 'Untitled plan',
         status: 'still_discussing',
         presetKey: 'codex',
+        confirmationMode: 'require',
         messages: [],
         draftPlanAvailable: false,
         createdAt: '2026-01-01T00:00:00.000Z',
@@ -212,6 +214,7 @@ export function createMockInvoker(
       ok: true,
       sessionId: 'session-1',
       reply: 'I can help draft that.',
+      confirmationMode: 'require',
       draftPlanAvailable: false,
     })),
     planningChatSubmit: vi.fn(async () => ({
@@ -219,6 +222,7 @@ export function createMockInvoker(
       planName: 'Mock Plan',
       workflowId: 'wf-1',
     })),
+    planningChatDiscardDraft: vi.fn(async () => ({ ok: true })),
     planningChatReset: vi.fn(async () => ({ ok: true })),
     onPlanningChatStream: vi.fn((cb: (event: InAppPlanningStreamEvent) => void) => {
       planningChatStreamCallbacks.add(cb);
@@ -243,9 +247,9 @@ export function createMockInvoker(
     planningTerminalResize: vi.fn(async () => ({ ok: true })),
     planningTerminalClose: vi.fn(async () => ({ ok: true })),
     getPlanningPresets: vi.fn(async () => [
-      { key: 'codex', label: 'Codex', tool: 'codex', isDefault: true },
-      { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude', isDefault: false },
-      { key: 'omp', label: 'OMP', tool: 'omp', isDefault: false },
+      { key: 'codex', label: 'Codex', tool: 'codex', isDefault: true, defaultConfirmationMode: 'require' },
+      { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude', isDefault: false, defaultConfirmationMode: 'require' },
+      { key: 'omp', label: 'OMP', tool: 'omp', isDefault: false, defaultConfirmationMode: 'require' },
     ]),
     start: vi.fn(async () => taskSnapshot),
     stop: vi.fn(async () => {}),

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -152,7 +152,7 @@ describe('Invoker terminal (component)', () => {
     submitPlanningText('hello');
 
     await waitFor(() => {
-      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'hello', presetKey: 'codex' });
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'hello', presetKey: 'codex', confirmationMode: 'require' });
       expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('I can help draft that.');
     });
     expect(screen.queryByText(/Unknown command/)).not.toBeInTheDocument();
@@ -334,7 +334,7 @@ describe('Invoker terminal (component)', () => {
     fireEvent.keyDown(input, { key: 'Enter' });
 
     await waitFor(() => {
-      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'hello', presetKey: 'codex' });
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'hello', presetKey: 'codex', confirmationMode: 'require' });
     });
   });
 
@@ -606,6 +606,7 @@ describe('Invoker terminal (component)', () => {
         sessionId: 'saved-pressure-chat',
         message: 'continue the restored session',
         presetKey: 'codex',
+        confirmationMode: 'require',
       });
     });
   });
@@ -685,6 +686,7 @@ describe('Invoker terminal (component)', () => {
         sessionId: 'session-1',
         message: 'make the plan more detailed',
         presetKey: 'codex',
+        confirmationMode: 'require',
       });
     });
   });
@@ -697,7 +699,7 @@ describe('Invoker terminal (component)', () => {
     submitPlanningText('draft a plan');
 
     await waitFor(() => {
-      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'draft a plan', presetKey: 'omp+claude' });
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'draft a plan', presetKey: 'omp+claude', confirmationMode: 'require' });
     });
   });
 

--- a/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
@@ -49,6 +49,7 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
       ok: true,
       sessionId: 'session-1',
       reply: 'Here is the plan.',
+      confirmationMode: 'require',
       draftPlanAvailable: true,
       draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First', 'Second'] },
     };
@@ -91,6 +92,7 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
       expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
         message: 'draft the next plan',
         presetKey: 'codex',
+        confirmationMode: 'require',
       });
     });
 
@@ -155,6 +157,64 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
 
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'draft-1' });
+    });
+  });
+  it('keeps the same draft after cancel and exposes discard on reopen', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [makePlanningSessionSummary({
+        id: 'draft-keep',
+        draftPlanSummary: {
+          name: 'Kept draft',
+          taskCount: 2,
+          steps: ['Add API endpoint', 'Verify API endpoint'],
+          taskGroups: [{ workflow: 'Backend workflow', tasks: ['Add API endpoint', 'Verify API endpoint'] }],
+        },
+        draftPlanText: 'name: Kept draft\ntasks:\n  - id: keep\n    description: Add API endpoint\n',
+      })],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    fireEvent.click(await screen.findByTestId('invoker-terminal-review-draft'));
+    fireEvent.click(await screen.findByTestId('planning-cancel-review'));
+
+    expect(await screen.findByText('Submission cancelled. Draft kept.')).toBeInTheDocument();
+    expect(screen.getByTestId('invoker-terminal-review-draft')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('invoker-terminal-review-draft'));
+    expect(await screen.findByTestId('planning-discard-draft')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('planning-discard-draft'));
+
+    await waitFor(() => {
+      expect(mock.api.planningChatDiscardDraft).toHaveBeenCalledWith({ sessionId: 'draft-keep' });
+    });
+  });
+
+  it('auto-submits after rendering a draft when review mode is auto-submit', async () => {
+    mock.api.planningChatSend = vi.fn(async () => ({
+      ok: true,
+      sessionId: 'session-auto',
+      reply: 'Here is the auto-submit plan.',
+      confirmationMode: 'auto_submit',
+      draftPlanAvailable: true,
+      draftPlanSummary: { name: 'Auto submit plan', taskCount: 1, steps: ['Ship it'] },
+      draftPlanText: 'name: Auto submit plan\ntasks:\n  - id: ship\n    description: Ship it\n',
+    })) as any;
+    mock.api.planningChatSubmit = vi.fn(async () => ({
+      ok: true,
+      planName: 'Auto submit plan',
+      workflowId: 'wf-auto',
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft and submit');
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-auto' });
     });
   });
 });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useStat
 import { Terminal as XTermTerminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import type { TerminalSessionDescriptor } from '@invoker/contracts';
+import type { PlanningConfirmationMode } from '@invoker/contracts';
 import { SendIcon } from './icons/index.js';
 
 export interface InvokerTerminalLine {
@@ -48,6 +49,7 @@ interface InvokerTerminalProps {
   value: string;
   selectedPresetKey: string;
   presetOptions: PlanningPresetOptionView[];
+  selectedConfirmationMode: PlanningConfirmationMode;
   draftPlanAvailable: boolean;
   draftPlanSummary?: {
     name: string;
@@ -65,6 +67,7 @@ interface InvokerTerminalProps {
   onValueChange: (value: string) => void;
   onSubmit: () => void;
   onPresetChange: (presetKey: string) => void;
+  onConfirmationModeChange: (confirmationMode: PlanningConfirmationMode) => void;
   onModeChange?: (mode: PlanningTerminalMode) => void;
   onExpand: () => void;
   onCloseExpanded?: () => void;
@@ -326,6 +329,7 @@ export function InvokerTerminal({
   value,
   selectedPresetKey,
   presetOptions,
+  selectedConfirmationMode,
   draftPlanAvailable,
   draftPlanSummary,
   planningStream,
@@ -338,6 +342,7 @@ export function InvokerTerminal({
   onValueChange,
   onSubmit,
   onPresetChange,
+  onConfirmationModeChange,
   onModeChange,
   onExpand,
   onCloseExpanded,
@@ -727,20 +732,35 @@ export function InvokerTerminal({
                     Options
                   </button>
                   {showComposerOptions && (
-                    <label className="ml-3 text-xs text-muted-foreground">
-                      Agent
-                      <select
-                        data-testid="invoker-terminal-harness"
-                        value={selectedPresetKey}
-                        onChange={(event) => onPresetChange(event.target.value)}
-                        disabled={readOnly}
-                        className="ml-2 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none hover:border-border-strong focus:border-ring"
-                      >
-                        {presetOptions.map((option) => (
-                          <option key={option.key} value={option.key}>{option.label}</option>
-                        ))}
-                      </select>
-                    </label>
+                    <div className="ml-3 flex flex-wrap items-center gap-3">
+                      <label className="text-xs text-muted-foreground">
+                        Agent
+                        <select
+                          data-testid="invoker-terminal-harness"
+                          value={selectedPresetKey}
+                          onChange={(event) => onPresetChange(event.target.value)}
+                          disabled={readOnly}
+                          className="ml-2 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none hover:border-border-strong focus:border-ring"
+                        >
+                          {presetOptions.map((option) => (
+                            <option key={option.key} value={option.key}>{option.label}</option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="text-xs text-muted-foreground">
+                        Review
+                        <select
+                          data-testid="invoker-terminal-confirmation-mode"
+                          value={selectedConfirmationMode}
+                          onChange={(event) => onConfirmationModeChange(event.target.value as PlanningConfirmationMode)}
+                          disabled={readOnly}
+                          className="ml-2 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none hover:border-border-strong focus:border-ring"
+                        >
+                          <option value="require">Ask first</option>
+                          <option value="auto_submit">Auto-submit</option>
+                        </select>
+                      </label>
+                    </div>
                   )}
                 </div>
                 <button


### PR DESCRIPTION
## Summary

Wires the planning review handoff into the UI, the MCP adapter, and the discard-draft IPC.

The planning terminal gains a review-mode selector, the MCP server exposes the plan review adapter, and the discard-draft IPC is handled.

## Review Claim

Approve the planning review activation surfaces.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

UI Vitest passes whole-suite and the change type-checks.

## Slice Rationale

Surface wiring lands after the core handoff it depends on.

## Non-goals

- No planning-core or persistence changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] pnpm --filter @invoker/ui test

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
