### PR TITLE
[CI Fix Step 2 - file:// Repo URL Compatibility](1) Preserve proof cleanup inputs

### DIFF
--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -223,7 +223,7 @@ cleanup_proof_tmp() {
   fi
   shopt -s nullglob
   local path real
-  for path in "$tmp_root"/invoker-* "$tmp_root"/verify-exec-routing.*; do
+  for path in "$tmp_root"/invoker-e2e-* "$tmp_root"/verify-exec-routing.*; do
     [ -e "$path" ] || continue
     real="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$path")"
     if [ -n "$state_real" ] && [ "$real" = "$state_real" ]; then


### PR DESCRIPTION
## Summary

CI proof temp-file sweep now targets only Invoker E2E temp directories.

The previous broad temp sweep could touch local file URL proof inputs before proof flows used them.

This keeps the proof sweep narrow while preserving existing executor temp-file handling.

## Review Claim

Approve the CI proof temp-file sweep narrowing that preserves local file URL inputs.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only changes `scripts/run-all-tests.sh` cleanup globs in proof mode. It does not alter product runtime or suite selection.

## Slice Rationale

Keep the harness temp-file policy separate from runtime file URL handling so the policy diff can be reviewed as one line.

## Non-goals

- No product runtime changes.
- No proof manifest changes.
- No suite ordering changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/verify-executor-routing.sh`
- [x] Invoker workflow `wf-1784959452880-2/verify-file-url-repo-compatibility` reported the e2e-proof shard target passed.
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ci-fix-step-2-pr1.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/ci-fix-step-2-pr1.md --base plan/ci-fix-step-1-lockfile-freeze-gate`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 50830acf5`
- Post-revert steps: None
- Data migration? No

</details>

