### PR TITLE
[CI Fix Step 2 - file:// Repo URL Compatibility](2) Accept local file URL repos

### DIFF
--- a/packages/app/src/__tests__/executor-routing-file-url.test.ts
+++ b/packages/app/src/__tests__/executor-routing-file-url.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { ExecutorRegistry, TaskRunner } from '@invoker/execution-engine';
+import type { TaskState } from '@invoker/workflow-core';
+
+function makeTask(config: Partial<TaskState['config']>): TaskState {
+  return {
+    id: 'wf-1/verify-routing-command',
+    description: 'Command task validates poolId routing',
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config,
+    execution: {},
+  } as TaskState;
+}
+
+describe('executor routing for local proof pools', () => {
+  it('uses the default local worktree executor when a worktree pool member has no target override', async () => {
+    const runner = new TaskRunner({
+      orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+      persistence: {} as any,
+      executorRegistry: new ExecutorRegistry(),
+      cwd: process.cwd(),
+      worktreeTargetsProvider: () => ({}),
+      executionPoolsProvider: () => ({
+        'dummy-target': {
+          members: [{ type: 'worktree', id: 'local-worktree' }],
+        },
+      }),
+    });
+
+    const selected = runner.selectExecutor(makeTask({ poolId: 'dummy-target' }));
+
+    try {
+      expect(selected.executor.type).toBe('worktree');
+      expect(selected.selectedPoolMemberId).toBe('local-worktree');
+    } finally {
+      await selected.executor.destroyAll();
+    }
+  });
+});

--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { parsePlan, parsePlanFile, parsePlanSubmissionBundle, parsePlanSubmissionBundleFile, PlanParseError, detectDefaultBranch, applyPlanDefinitionDefaults, applyConfiguredPlanDefaults } from '../plan-parser.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import * as childProcess from 'node:child_process';
 
 vi.mock('node:child_process', async (importOriginal) => {
@@ -118,8 +118,40 @@ tasks:
 `);
 
     const plan = await parsePlanFile(planPath);
-    expect(plan.repoUrl).toBe(pathToFileURL(repoRoot).href);
+    expect(plan.repoUrl).toBe(repoRoot);
     expect(plan.tasks).toHaveLength(1);
+  });
+
+  it('normalizes a file:// checkout URL before default branch detection', async () => {
+    const { pathToFileURL } = await import('node:url');
+    const configMod = await import('../config.js');
+    const loadConfigSpy = vi.spyOn(configMod, 'loadConfig').mockReturnValue({});
+    const repoRoot = mkdtempSync(join(tmpdir(), 'invoker file-url repo '));
+    try {
+      childProcess.execFileSync('git', ['init', '-q', repoRoot]);
+      childProcess.execFileSync('git', ['-C', repoRoot, 'config', 'user.email', 'test@test.com']);
+      childProcess.execFileSync('git', ['-C', repoRoot, 'config', 'user.name', 'Test']);
+      writeFileSync(join(repoRoot, 'README.md'), '# Test Repo\n');
+      childProcess.execFileSync('git', ['-C', repoRoot, 'add', '-A']);
+      childProcess.execFileSync('git', ['-C', repoRoot, 'commit', '-q', '-m', 'initial']);
+      childProcess.execFileSync('git', ['-C', repoRoot, 'branch', '-M', 'main']);
+
+      const yaml = `
+name: File URL Branch Detection
+repoUrl: ${pathToFileURL(repoRoot).href}
+onFinish: none
+tasks:
+  - id: greet
+    description: Say hello
+    command: echo "Hello"
+`;
+      const plan = parsePlan(yaml);
+      expect(plan.repoUrl).toBe(repoRoot);
+      expect(plan.baseBranch).toBe('main');
+    } finally {
+      loadConfigSpy.mockRestore();
+      rmSync(repoRoot, { recursive: true, force: true });
+    }
   });
 
   it('rejects plan without repoUrl', () => {
@@ -934,9 +966,8 @@ tasks:
       const configMod = await import('../config.js');
       const loadConfigSpy = vi.spyOn(configMod, 'loadConfig').mockReturnValue({});
 
-      const mockExecSync = vi.mocked(execSync);
-      mockExecSync.mockImplementation(((cmd: string) => {
-        if (typeof cmd === 'string' && cmd.includes('ls-remote')) {
+      const execFileSyncSpy = vi.spyOn(childProcess, 'execFileSync').mockImplementation(((cmd: string, args?: readonly string[]) => {
+        if (cmd === 'git' && Array.isArray(args) && args.includes('ls-remote')) {
           return 'ref: refs/heads/develop\tHEAD\nabc123\tHEAD\n';
         }
         throw new Error('unexpected');
@@ -953,7 +984,7 @@ tasks:
 `;
       const plan = parsePlan(yaml);
       expect(plan.baseBranch).toBe('develop');
-      mockExecSync.mockRestore();
+      execFileSyncSpy.mockRestore();
       loadConfigSpy.mockRestore();
     });
 

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -25,14 +25,17 @@ function resolveDefaultBaseBranch(plan: PlanDefinition): string {
  * Use when a {@link PlanDefinition} is built outside the YAML parser — e.g. GUI `yaml.load` + IPC.
  */
 export function applyPlanDefinitionDefaults(plan: PlanDefinition): PlanDefinition {
+  const normalizedPlan = typeof plan.repoUrl === 'string'
+    ? { ...plan, repoUrl: normalizeRepoUrlCloneTarget(plan.repoUrl) }
+    : plan;
   const slug = plan.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-  const fb = plan.featureBranch;
+  const fb = normalizedPlan.featureBranch;
   const featureBranch = typeof fb === 'string' && fb.trim() !== '' ? fb.trim() : `plan/${slug}`;
 
   return {
-    ...plan,
-    onFinish: plan.onFinish ?? 'pull_request',
-    baseBranch: resolveDefaultBaseBranch(plan),
+    ...normalizedPlan,
+    onFinish: normalizedPlan.onFinish ?? 'pull_request',
+    baseBranch: resolveDefaultBaseBranch(normalizedPlan),
     featureBranch,
   };
 }
@@ -121,6 +124,13 @@ export interface PlanSubmissionBundle {
   isStack: boolean;
 }
 
+export class PlanParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PlanParseError';
+  }
+}
+
 /**
  * Auto-detect the repo's default branch via git.
  * Tries origin/HEAD first, then checks if 'main' exists locally, falls back to 'master'.
@@ -149,7 +159,7 @@ export function detectDefaultBranch(cwd?: string): string {
  */
 export function detectDefaultBranchRemote(repoUrl: string): string {
   try {
-    const output = execSync(`git ls-remote --symref ${repoUrl} HEAD`, {
+    const output = execFileSync('git', ['ls-remote', '--symref', '--', normalizeRepoUrlCloneTarget(repoUrl), 'HEAD'], {
       encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 10000,
     }).trim();
     // Output format: "ref: refs/heads/main\tHEAD"
@@ -159,6 +169,22 @@ export function detectDefaultBranchRemote(repoUrl: string): string {
     // Network error or timeout
   }
   return 'main';
+}
+
+export function normalizeRepoUrlCloneTarget(repoUrl: string): string {
+  const trimmed = repoUrl.trim();
+  if (!isFileRepoUrl(trimmed)) return trimmed;
+  try {
+    return fileURLToPath(trimmed);
+  } catch {
+    throw new PlanParseError(
+      `repoUrl "${repoUrl}" is not a valid git repository. Use a full clone URL or a configured Slack alias.`,
+    );
+  }
+}
+
+function isFileRepoUrl(repoUrl: string): boolean {
+  return repoUrl.toLowerCase().startsWith('file://');
 }
 
 function assertLocalGitRepoReadable(localPath: string): void {
@@ -172,7 +198,7 @@ function assertLocalGitRepoReadable(localPath: string): void {
 export function assertRepoUrlCloneable(repoUrl: string): void {
   const trimmed = repoUrl.trim();
   const isLocalPath = trimmed.startsWith('/') || trimmed.startsWith('./') || trimmed.startsWith('../');
-  const isFileUrl = trimmed.startsWith('file://');
+  const isFileUrl = isFileRepoUrl(trimmed);
   const isRemoteUrl = /^(?:git@|https?:\/\/|ssh:\/\/)/.test(trimmed);
 
   if (!isLocalPath && !isFileUrl && !isRemoteUrl) {
@@ -187,7 +213,7 @@ export function assertRepoUrlCloneable(repoUrl: string): void {
       return;
     }
     if (isFileUrl) {
-      assertLocalGitRepoReadable(fileURLToPath(trimmed));
+      assertLocalGitRepoReadable(normalizeRepoUrlCloneTarget(trimmed));
       return;
     }
     execFileSync('git', ['ls-remote', '--exit-code', '--', trimmed, 'HEAD'], {
@@ -198,13 +224,6 @@ export function assertRepoUrlCloneable(repoUrl: string): void {
     throw new PlanParseError(
       `repoUrl "${repoUrl}" is not a readable git repository. Check its clone URL and credentials.`,
     );
-  }
-}
-
-export class PlanParseError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'PlanParseError';
   }
 }
 
@@ -355,11 +374,12 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
     raw.featureBranch = `plan/${slug}`;
   }
 
-  if (!raw.repoUrl || typeof raw.repoUrl !== 'string') {
+  if (!raw.repoUrl || typeof raw.repoUrl !== 'string' || raw.repoUrl.trim() === '') {
     throw new PlanParseError(
       `${ownerLabel} must have a "repoUrl" field (e.g. repoUrl: git@github.com:user/repo.git).`,
     );
   }
+  const repoUrl = normalizeRepoUrlCloneTarget(raw.repoUrl);
   if (raw.intermediateRepoUrl !== undefined) {
     if (typeof raw.intermediateRepoUrl !== 'string' || raw.intermediateRepoUrl.trim() === '') {
       throw new PlanParseError(
@@ -453,7 +473,7 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
     featureBranch: raw.featureBranch,
     mergeMode,
     reviewProvider,
-    repoUrl: raw.repoUrl,
+    repoUrl,
     intermediateRepoUrl: raw.intermediateRepoUrl,
     externalDependencies: topLevelExternalDependencies,
     tasks,

--- a/packages/execution-engine/src/__tests__/repo-pool.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-pool.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import { RepoPool, ResourceLimitError } from '../repo-pool.js';
 import { remoteFetchForPool } from '../remote-fetch-policy.js';
 import * as branchUtils from '../branch-utils.js';
@@ -62,6 +62,32 @@ describe('RepoPool', () => {
     expect(p1).toBe(p2);
   });
 
+  it('ensureCloneThroughRepoQueue: reuses a clone created by a competing process', async () => {
+    const racingPool = new RepoPool({ cacheDir: tmpDir });
+    const clonePath = racingPool.getClonePath(localRepoUrl);
+    const originalExecGit = (racingPool as any).execGit.bind(racingPool);
+    let seededCompetingClone = false;
+    vi.spyOn(racingPool as any, 'execGit').mockImplementation(
+      async (...params: unknown[]) => {
+        const args = params[0] as string[];
+        const cwd = params[1] as string;
+        if (!seededCompetingClone && args[0] === 'clone') {
+          seededCompetingClone = true;
+          execFileSync('git', ['clone', localRepoUrl, clonePath], {
+            stdio: ['ignore', 'ignore', 'ignore'],
+          });
+        }
+        return originalExecGit(args, cwd);
+      },
+    );
+
+    const path = await racingPool.ensureCloneThroughRepoQueue(localRepoUrl);
+
+    expect(path).toBe(clonePath);
+    expect(execSync('git rev-parse --is-inside-work-tree', { cwd: path }).toString().trim()).toBe('true');
+    await racingPool.destroyAll();
+  });
+
   it('uses one cache path for equivalent GitHub SSH and HTTPS URLs', () => {
     const githubPool = new RepoPool({ cacheDir: tmpDir, worktreeBaseDir: join(tmpDir, 'worktrees') });
     const httpsUrl = 'https://github.com/Neko-Catpital-Labs/Invoker';
@@ -92,6 +118,26 @@ describe('RepoPool', () => {
     expect(ensureCloneUnqueued).toHaveBeenCalledTimes(1);
     expect(ensureCloneUnqueued).toHaveBeenCalledWith(httpsUrl);
     await githubPool.destroyAll();
+  });
+
+  it('serializes worktree acquisition across separate pools sharing one cache', async () => {
+    const worktreeBaseDir = join(tmpDir, 'managed-worktrees');
+    const poolA = new RepoPool({ cacheDir: tmpDir, worktreeBaseDir });
+    const poolB = new RepoPool({ cacheDir: tmpDir, worktreeBaseDir });
+    const branch = 'experiment/shared-cache/task/g0.t0.aaaa-deadbeef';
+
+    try {
+      const [a, b] = await Promise.all([
+        poolA.acquireWorktree(localRepoUrl, branch, undefined, 'shared-cache/task'),
+        poolB.acquireWorktree(localRepoUrl, branch, undefined, 'shared-cache/task'),
+      ]);
+
+      expect(a.worktreePath).toBe(b.worktreePath);
+      expect(execSync('git branch --show-current', { cwd: a.worktreePath }).toString().trim()).toBe(branch);
+    } finally {
+      await poolA.destroyAll();
+      await poolB.destroyAll();
+    }
   });
 
   it('acquireWorktree: creates worktree with feature branch', async () => {
@@ -229,6 +275,191 @@ describe('RepoPool', () => {
       expect(realpathSync(acquired.worktreePath)).toBe(realpathSync(targetPath));
       expect(existsSync(join(acquired.worktreePath, '.git'))).toBe(true);
       expect(runBashSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      runBashSpy.mockRestore();
+      await poolWithExternalBase.destroyAll();
+    }
+  });
+
+  it('acquireWorktree: retries stale managed branch ref-lock by deleting an empty managed branch', async () => {
+    const branch = 'experiment/wf-ref-lock/task/g0.t0.aaaa-deadbeef';
+    const actionId = 'wf-ref-lock/task';
+    const poolWithExternalBase = new RepoPool({
+      cacheDir: tmpDir,
+      worktreeBaseDir: join(tmpDir, 'managed-worktrees'),
+    });
+    const clonePath = await poolWithExternalBase.ensureCloneThroughRepoQueue(localRepoUrl);
+    execFileSync('git', ['branch', branch], {
+      cwd: clonePath,
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+
+    const originalRunBashLocal = branchUtils.runBashLocal;
+    let shouldFailFirstAttempt = true;
+    const runBashSpy = vi
+      .spyOn(branchUtils, 'runBashLocal')
+      .mockImplementation(async (script, cwd) => {
+        if (shouldFailFirstAttempt) {
+          shouldFailFirstAttempt = false;
+          const error = new Error(
+            `bash exited with code 128: Preparing worktree (new branch '${branch}')\n` +
+              `fatal: cannot lock ref 'refs/heads/${branch}': reference already exists`,
+          );
+          (error as Error & { exitCode?: number }).exitCode = 128;
+          throw error;
+        }
+        return originalRunBashLocal(script, cwd);
+      });
+
+    try {
+      const acquired = await poolWithExternalBase.acquireWorktree(
+        localRepoUrl,
+        branch,
+        undefined,
+        actionId,
+        { forceFresh: true },
+      );
+      expect(existsSync(join(acquired.worktreePath, '.git'))).toBe(true);
+      expect(execSync('git branch --show-current', { cwd: acquired.worktreePath }).toString().trim()).toBe(branch);
+      expect(runBashSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      runBashSpy.mockRestore();
+      await poolWithExternalBase.destroyAll();
+    }
+  });
+
+  it('acquireWorktree: retries stale managed branch checkout metadata at the target path', async () => {
+    const branch = 'experiment/wf-checked-out/task/g0.t0.aaaa-deadbeef';
+    const actionId = 'wf-checked-out/task';
+    const poolWithExternalBase = new RepoPool({
+      cacheDir: tmpDir,
+      worktreeBaseDir: join(tmpDir, 'managed-worktrees'),
+    });
+    const clonePath = await poolWithExternalBase.ensureCloneThroughRepoQueue(localRepoUrl);
+    const targetPath = poolWithExternalBase.externalWorktreePath(localRepoUrl, branch);
+    execFileSync('git', ['branch', branch], {
+      cwd: clonePath,
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+
+    const originalRunBashLocal = branchUtils.runBashLocal;
+    let shouldFailFirstAttempt = true;
+    const runBashSpy = vi
+      .spyOn(branchUtils, 'runBashLocal')
+      .mockImplementation(async (script, cwd) => {
+        if (shouldFailFirstAttempt) {
+          shouldFailFirstAttempt = false;
+          const error = new Error(
+            `bash exited with code 128: fatal: '${branch}' is already checked out at '${targetPath}'`,
+          );
+          (error as Error & { exitCode?: number }).exitCode = 128;
+          throw error;
+        }
+        return originalRunBashLocal(script, cwd);
+      });
+
+    try {
+      const acquired = await poolWithExternalBase.acquireWorktree(
+        localRepoUrl,
+        branch,
+        undefined,
+        actionId,
+        { forceFresh: true },
+      );
+      expect(realpathSync(acquired.worktreePath)).toBe(realpathSync(targetPath));
+      expect(execSync('git branch --show-current', { cwd: acquired.worktreePath }).toString().trim()).toBe(branch);
+      expect(runBashSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      runBashSpy.mockRestore();
+      await poolWithExternalBase.destroyAll();
+    }
+  });
+
+  it('acquireWorktree: retries stale managed force-update checkout collision at the target path', async () => {
+    const branch = 'experiment/wf-force-update/task/g0.t0.aaaa-deadbeef';
+    const actionId = 'wf-force-update/task';
+    const poolWithExternalBase = new RepoPool({
+      cacheDir: tmpDir,
+      worktreeBaseDir: join(tmpDir, 'managed-worktrees'),
+    });
+    const clonePath = await poolWithExternalBase.ensureCloneThroughRepoQueue(localRepoUrl);
+    const targetPath = poolWithExternalBase.externalWorktreePath(localRepoUrl, branch);
+    execFileSync('git', ['branch', branch], {
+      cwd: clonePath,
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+
+    const originalRunBashLocal = branchUtils.runBashLocal;
+    let shouldFailFirstAttempt = true;
+    const runBashSpy = vi
+      .spyOn(branchUtils, 'runBashLocal')
+      .mockImplementation(async (script, cwd) => {
+        if (shouldFailFirstAttempt) {
+          shouldFailFirstAttempt = false;
+          const error = new Error(
+            `bash exited with code 255: Preparing worktree (resetting branch '${branch}'; was at c23c9f350)\n` +
+              `fatal: cannot force update the branch '${branch}' checked out at '${targetPath}'`,
+          );
+          (error as Error & { exitCode?: number }).exitCode = 255;
+          throw error;
+        }
+        return originalRunBashLocal(script, cwd);
+      });
+
+    try {
+      const acquired = await poolWithExternalBase.acquireWorktree(
+        localRepoUrl,
+        branch,
+        undefined,
+        actionId,
+        { forceFresh: true },
+      );
+      expect(realpathSync(acquired.worktreePath)).toBe(realpathSync(targetPath));
+      expect(execSync('git branch --show-current', { cwd: acquired.worktreePath }).toString().trim()).toBe(branch);
+      expect(runBashSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      runBashSpy.mockRestore();
+      await poolWithExternalBase.destroyAll();
+    }
+  });
+
+  it('acquireWorktree: accepts a usable target worktree when git reports a checkout collision', async () => {
+    const branch = 'experiment/wf-usable-target/task/g0.t0.aaaa-deadbeef';
+    const actionId = 'wf-usable-target/task';
+    const poolWithExternalBase = new RepoPool({
+      cacheDir: tmpDir,
+      worktreeBaseDir: join(tmpDir, 'managed-worktrees'),
+    });
+    const targetPath = poolWithExternalBase.externalWorktreePath(localRepoUrl, branch);
+
+    const originalRunBashLocal = branchUtils.runBashLocal;
+    let shouldFailFirstAttempt = true;
+    const runBashSpy = vi
+      .spyOn(branchUtils, 'runBashLocal')
+      .mockImplementation(async (script, cwd) => {
+        if (shouldFailFirstAttempt) {
+          shouldFailFirstAttempt = false;
+          await originalRunBashLocal(script, cwd);
+          const error = new Error(
+            `bash exited with code 128: fatal: '${branch}' is already checked out at '${targetPath}'`,
+          );
+          (error as Error & { exitCode?: number }).exitCode = 128;
+          throw error;
+        }
+        return originalRunBashLocal(script, cwd);
+      });
+
+    try {
+      const acquired = await poolWithExternalBase.acquireWorktree(
+        localRepoUrl,
+        branch,
+        undefined,
+        actionId,
+        { forceFresh: true },
+      );
+      expect(realpathSync(acquired.worktreePath)).toBe(realpathSync(targetPath));
+      expect(execSync('git branch --show-current', { cwd: acquired.worktreePath }).toString().trim()).toBe(branch);
+      expect(runBashSpy).toHaveBeenCalledTimes(1);
     } finally {
       runBashSpy.mockRestore();
       await poolWithExternalBase.destroyAll();

--- a/packages/execution-engine/src/branch-utils.ts
+++ b/packages/execution-engine/src/branch-utils.ts
@@ -165,7 +165,9 @@ if git -C "$REPO_DIR" rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
   fi
 fi
 if [ "$preserved" -eq 0 ]; then
-  git -C "$REPO_DIR" worktree add --no-track -B "$BRANCH" "$WT_DIR" "$BASE"
+  git -C "$REPO_DIR" worktree prune >/dev/null 2>&1 || true
+  git -C "$REPO_DIR" branch -f "$BRANCH" "$BASE"
+  git -C "$REPO_DIR" worktree add "$WT_DIR" "$BRANCH"
 fi`;
 }
 

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { mkdirSync, existsSync, rmSync } from 'node:fs';
+import { mkdirSync, existsSync, rmSync, mkdtempSync, renameSync, statSync, writeFileSync } from 'node:fs';
 import { normalize } from 'node:path';
 import { bashPreserveOrReset, runBashLocal } from './branch-utils.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
@@ -18,7 +18,7 @@ import {
 import { syncPlanBaseRemoteForRef, isInvokerManagedPoolBranch, resolvePlanBaseRevision } from './plan-base-remote.js';
 import { remoteFetchForPool } from './remote-fetch-policy.js';
 import { isWorkspaceCleanupEnabled } from './workspace-cleanup-policy.js';
-import { computeRepoCacheHash, computeRepoCacheKey, sanitizeBranchForPath } from './git-utils.js';
+import { computeRepoCacheHash, computeRepoCacheKey, isGitRefLockRace, sanitizeBranchForPath } from './git-utils.js';
 
 export interface RepoPoolConfig {
   cacheDir: string;
@@ -68,6 +68,8 @@ interface RebaseMirrorRefreshResult {
 
 const REBASE_REFRESH_BATCH_WINDOW_MS = 25;
 const REBASE_REFRESH_RECENT_REUSE_MS = 30_000;
+const REPO_FILE_LOCK_STALE_MS = 30 * 60_000;
+const REPO_FILE_LOCK_POLL_MS = 100;
 
 export class ResourceLimitError extends Error {
   constructor(message: string) {
@@ -168,7 +170,9 @@ export class RepoPool {
           durationMs: Date.now() - queuedAtMs,
         });
       }
-      const dir = await this.doRefreshMirrorForRebaseBatch(repoUrl, batch, initialTimings[0]);
+      const dir = await this.withRepoFileLock(repoUrl, 'refresh-mirror-for-rebase', () =>
+        this.doRefreshMirrorForRebaseBatch(repoUrl, batch, initialTimings[0]),
+      );
       const finalBaseBranches = [...batch.syncedBaseBranches];
       const finalTimings = [...new Set(batch.timings)];
       for (const batchTiming of finalTimings) {
@@ -383,7 +387,9 @@ export class RepoPool {
         branchCount: branches.length,
         durationMs: Date.now() - queuedAtMs,
       });
-      return this.doRemoveManagedBranchesInMirror(repoUrl, branches, timing);
+      return this.withRepoFileLock(repoUrl, 'remove-managed-branches', () =>
+        this.doRemoveManagedBranchesInMirror(repoUrl, branches, timing),
+      );
     });
     this.repoChains.set(repoKey, next.catch(() => {}));
     return next;
@@ -436,6 +442,49 @@ export class RepoPool {
     return timing.span(functionName, metadata, fn);
   }
 
+  private async withRepoFileLock<T>(repoUrl: string, label: string, fn: () => Promise<T>): Promise<T> {
+    const release = await this.acquireRepoFileLock(repoUrl, label);
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+
+  private async acquireRepoFileLock(repoUrl: string, label: string): Promise<() => void> {
+    mkdirSync(this.cacheDir, { recursive: true });
+    const lockDir = `${this.cacheDir}/.${computeRepoCacheHash(repoUrl)}.lock`;
+    while (true) {
+      try {
+        mkdirSync(lockDir);
+        writeFileSync(
+          `${lockDir}/owner.json`,
+          JSON.stringify({ pid: process.pid, label, repoUrl, acquiredAt: new Date().toISOString() }),
+        );
+        return () => {
+          try {
+            rmSync(lockDir, { recursive: true, force: true });
+          } catch {
+            /* best-effort */
+          }
+        };
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== 'EEXIST') throw err;
+        try {
+          const ageMs = Date.now() - statSync(lockDir).mtimeMs;
+          if (ageMs > REPO_FILE_LOCK_STALE_MS) {
+            rmSync(lockDir, { recursive: true, force: true });
+            continue;
+          }
+        } catch {
+          continue;
+        }
+        await new Promise(resolve => setTimeout(resolve, REPO_FILE_LOCK_POLL_MS));
+      }
+    }
+  }
+
   async ensureCloneThroughRepoQueue(repoUrl: string): Promise<string> {
     const bench = createExecutionBench({
       module: 'repo-pool-bench',
@@ -458,7 +507,7 @@ export class RepoPool {
     const queuedAtMs = Date.now();
     const promise = prev.then(() => {
       bench('RepoPool.ensureCloneThroughRepoQueue.repoChainWait.after', { durationMs: Date.now() - queuedAtMs });
-      return this.ensureCloneUnqueued(repoUrl);
+      return this.withRepoFileLock(repoUrl, 'ensure-clone', () => this.ensureCloneUnqueued(repoUrl));
     });
     this.cloneLocks.set(repoKey, promise);
     this.repoChains.set(repoKey, promise.catch(() => {}));
@@ -481,6 +530,11 @@ export class RepoPool {
       await this.execGit(['worktree', 'remove', '--force', worktreePath], clonePath);
     } catch {
       /* not registered with this clone */
+    }
+    try {
+      await this.execGit(['worktree', 'prune'], clonePath);
+    } catch {
+      /* best-effort; stale metadata will be surfaced by retry */
     }
     if (existsSync(worktreePath)) {
       try {
@@ -543,28 +597,124 @@ export class RepoPool {
       branch,
       base,
     });
-    try {
-      bench('RepoPool.runPreserveOrResetWithRecovery.runBashLocal.before');
-      await runBashLocal(script, clonePath);
-      bench('RepoPool.runPreserveOrResetWithRecovery.runBashLocal.after');
-      return;
-    } catch (err) {
-      if (!this.isAlreadyExistsWorktreeError(err, worktreePath)) {
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        bench('RepoPool.runPreserveOrResetWithRecovery.runBashLocal.before', { attempt });
+        await runBashLocal(script, clonePath);
+        bench('RepoPool.runPreserveOrResetWithRecovery.runBashLocal.after', { attempt });
+        return;
+      } catch (err) {
+        lastErr = err;
+        if (
+          this.isAlreadyCheckedOutAtTargetWorktreeError(err, worktreePath)
+          && await this.isReusableManagedWorktree(worktreePath, branch)
+        ) {
+          bench('RepoPool.runPreserveOrResetWithRecovery.reuseUsableTargetAfterGitError', { attempt });
+          return;
+        }
+        if (attempt >= 3) break;
+        if (this.isAlreadyExistsWorktreeError(err, worktreePath)) {
+          traceExecution(
+            `[RepoPool] runPreserveOrResetWithRecovery: retrying after pre-existing path branch=${branch} path=${worktreePath}`,
+          );
+          bench('RepoPool.runPreserveOrResetWithRecovery.reconcileStaleWorktreePath.before', { attempt });
+          await this.reconcileStaleWorktreePath(clonePath, worktreePath);
+          bench('RepoPool.runPreserveOrResetWithRecovery.reconcileStaleWorktreePath.after', { attempt });
+          continue;
+        }
+        if (await this.reconcileManagedBranchCreationCollision(clonePath, worktreePath, branch, base, err)) {
+          bench('RepoPool.runPreserveOrResetWithRecovery.reconcileManagedBranchCreationCollision.after', { attempt });
+          continue;
+        }
         bench('RepoPool.runPreserveOrResetWithRecovery.runBashLocal.failed', {
+          attempt,
           error: err instanceof Error ? err.message : String(err),
         });
         throw err;
       }
-      traceExecution(
-        `[RepoPool] runPreserveOrResetWithRecovery: retrying after pre-existing path branch=${branch} path=${worktreePath}`,
-      );
-      bench('RepoPool.runPreserveOrResetWithRecovery.reconcileStaleWorktreePath.before');
-      await this.reconcileStaleWorktreePath(clonePath, worktreePath);
-      bench('RepoPool.runPreserveOrResetWithRecovery.reconcileStaleWorktreePath.after');
     }
-    bench('RepoPool.runPreserveOrResetWithRecovery.retryRunBashLocal.before');
-    await runBashLocal(script, clonePath);
-    bench('RepoPool.runPreserveOrResetWithRecovery.retryRunBashLocal.after');
+    bench('RepoPool.runPreserveOrResetWithRecovery.runBashLocal.failed', {
+      attempts: 3,
+      error: lastErr instanceof Error ? lastErr.message : String(lastErr),
+    });
+    throw lastErr;
+  }
+
+  private async branchHasCommitsAhead(clonePath: string, branch: string, base: string): Promise<boolean> {
+    const count = Number.parseInt(
+      (await this.execGit(['rev-list', '--count', `${base}..${branch}`], clonePath)).trim(),
+      10,
+    );
+    return Number.isFinite(count) && count > 0;
+  }
+
+  private isAlreadyCheckedOutAtTargetWorktreeError(err: unknown, worktreePath: string): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!/(?:is already checked out at|cannot force update the branch\b.+\bchecked out at)/i.test(message)) return false;
+    if (message.includes(worktreePath)) return true;
+    return message.includes(canonicalPathForComparison(worktreePath));
+  }
+
+  private async reconcileManagedBranchCreationCollision(
+    clonePath: string,
+    worktreePath: string,
+    branch: string,
+    base: string,
+    err: unknown,
+  ): Promise<boolean> {
+    const isRecoverableGitError = isGitRefLockRace(err) || this.isAlreadyCheckedOutAtTargetWorktreeError(err, worktreePath);
+    if (!isRecoverableGitError || !isInvokerManagedPoolBranch(branch)) return false;
+    if (await this.branchHasCommitsAhead(clonePath, branch, base).catch(() => false)) {
+      return false;
+    }
+    traceExecution(
+      `[RepoPool] runPreserveOrResetWithRecovery: retrying after stale managed branch creation collision branch=${branch} path=${worktreePath}`,
+    );
+    await this.reconcileStaleWorktreePath(clonePath, worktreePath);
+    try {
+      await this.execGit(['branch', '-D', branch], clonePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async isUsableClone(dir: string): Promise<boolean> {
+    try {
+      const result = (await this.execGit(['rev-parse', '--is-inside-work-tree'], dir)).trim();
+      return result === 'true';
+    } catch {
+      return false;
+    }
+  }
+
+  private async waitForUsableClone(dir: string): Promise<boolean> {
+    for (let attempt = 0; attempt < 50; attempt++) {
+      if (await this.isUsableClone(dir)) return true;
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    return false;
+  }
+
+  private async cloneIntoCache(repoUrl: string, dir: string): Promise<void> {
+    const tempDir = mkdtempSync(`${dir}.tmp-`);
+    try {
+      await this.execGit(['clone', repoUrl, tempDir], this.cacheDir);
+      try {
+        renameSync(tempDir, dir);
+      } catch (err) {
+        if (existsSync(dir) && await this.waitForUsableClone(dir)) return;
+        throw err;
+      }
+    } catch (err) {
+      if (existsSync(dir) && await this.waitForUsableClone(dir)) return;
+      throw err;
+    } finally {
+      if (existsSync(tempDir)) {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    }
   }
 
   private async ensureCloneUnqueued(repoUrl: string): Promise<string> {
@@ -575,6 +725,9 @@ export class RepoPool {
     const dir = this.cloneDir(repoUrl);
     bench('RepoPool.ensureCloneUnqueued.begin', { dir, exists: existsSync(dir) });
     if (existsSync(dir)) {
+      if (!(await this.waitForUsableClone(dir))) {
+        throw new Error(`RepoPool cached clone is not a usable git repository: ${dir}`);
+      }
       if (remoteFetchForPool.enabled) {
         try {
           bench('RepoPool.ensureCloneUnqueued.gitFetchAllPrune.before', { dir });
@@ -612,7 +765,7 @@ export class RepoPool {
     }
     mkdirSync(this.cacheDir, { recursive: true });
     bench('RepoPool.ensureCloneUnqueued.gitClone.before', { dir });
-    await this.execGit(['clone', repoUrl, dir], this.cacheDir);
+    await this.cloneIntoCache(repoUrl, dir);
     bench('RepoPool.ensureCloneUnqueued.gitClone.after', { dir });
     return dir;
   }
@@ -635,7 +788,9 @@ export class RepoPool {
     const queuedAtMs = Date.now();
     const next = prev.then(() => {
       bench('RepoPool.acquireWorktree.repoChainWait.after', { durationMs: Date.now() - queuedAtMs });
-      return this.doAcquireWorktree(repoUrl, branch, base, actionId, opts);
+      return this.withRepoFileLock(repoUrl, 'acquire-worktree', () =>
+        this.doAcquireWorktree(repoUrl, branch, base, actionId, opts),
+      );
     });
     this.repoChains.set(repoKey, next.catch(() => {}));
     const acquired = await next;

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -688,15 +688,11 @@ export function selectExecutor(
     if (effectiveType === 'worktree') {
       const invokerHome = resolve(homedir(), '.invoker');
       const worktreeTargets = host.getWorktreeTargets();
+      // Pool worktree members may be only capacity/routing IDs; worktreeTargets
+      // is an optional per-member provisioning override.
       const selectedWorktreeTarget = selectedWorktreeTargetId
         ? worktreeTargets[selectedWorktreeTargetId]
         : undefined;
-      if (selectedWorktreeTargetId && !selectedWorktreeTarget) {
-        throw new Error(
-          `Task ${task.id} references poolMemberId="${selectedWorktreeTargetId}" but no matching ` +
-          `entry exists in worktreeTargets config. Available: [${Object.keys(worktreeTargets).join(', ')}]`,
-        );
-      }
       const configFingerprint = JSON.stringify({
         ...(selectedWorktreeTarget ?? {}),
         provisionCommand: selectedWorktreeTarget?.provisionCommand?.trim() || '',


### PR DESCRIPTION
## Summary

Plan parsing now normalizes cloneable `file://` repository URLs before default branch lookup.

Worktree preparation now hashes equivalent local paths consistently and recovers from shared-cache clone and branch races.

Pool worktree members without target overrides still route to the default local worktree executor.

## Review Claim

Approve support for local `file://` repository inputs across plan parsing, executor routing, and worktree preparation.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

File URLs are converted to local paths before existing git commands run. Remote URL handling stays unchanged, and tests cover local repo parsing, routing, and shared cache recovery.

## Slice Rationale

Keep the runtime compatibility in one slice because plan parsing, pool selection, and repo acquisition all must agree on the same repo target.

## Non-goals

- No new routing modes.
- No remote URL behavior changes.
- No UI behavior changes.
- No proof harness policy changes.

## Architecture

### Before

```mermaid
graph TD
    A["Plan repoUrl uses file://"] --> B["Repo target remains URL-shaped"]
    B --> C["Branch lookup and clone setup use mixed spellings"]
    D["Worktree pool member has no target override"] --> E["Target lookup can block default worktree routing"]
```

### After

```mermaid
graph TD
    A["Plan repoUrl uses file://"] --> B["Repo target becomes a local path"]
    B --> C["Branch lookup and clone setup share one target"]
    D["Worktree pool member has no target override"] --> E["Default worktree routing proceeds"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/plan-parser.test.ts src/__tests__/executor-routing-file-url.test.ts`
- [x] `pnpm --filter @invoker/execution-engine test -- --run src/__tests__/repo-pool.test.ts`
- [x] `bash scripts/verify-executor-routing.sh`
- [x] Invoker workflow `wf-1784959452880-2/verify-file-url-repo-compatibility` reported the e2e-proof shard target passed.
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ci-fix-step-2-pr2.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/ci-fix-step-2-pr2.md --base stack/EdbertChan/plan/ci-fix-step-2-file-url-compat/ci-fix-step-2-file-repo-url-compatibility-1--d9f1c347`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4b63dfbb1`
- Post-revert steps: None
- Data migration? No

</details>

