### PR TITLE
[Authoritative task-graph snapshots](1) Sync owner task snapshots

### DIFF
--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -27,7 +27,7 @@ function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQuer
     getWorkerStatus: vi.fn(() => ({ generatedAt: 'now', workers: [] })),
     getWorkers: vi.fn(() => ({ generatedAt: 'workers-now', workers: [] })),
     getWorkflowStatus: vi.fn(() => ({ 'wf-1': 'running' })),
-    getTasksSnapshot: vi.fn(({ refresh }) => ({ tasks: [], workflows: [], refreshed: refresh })),
+    getTasksSnapshot: vi.fn(() => ({ tasks: [], workflows: [] })),
     getActionGraphSnapshot: vi.fn(() => ({ nodes: [] })),
     listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
     loadWorkflowBundle: vi.fn((id: string) => ({ workflow: { id }, tasks: [] })),
@@ -76,12 +76,13 @@ describe('answerOwnerReadQuery', () => {
     expect(answerOwnerReadQuery({ kind: 'action-graph' }, h)).toEqual({ nodes: [] });
   });
 
-  it('refreshes the snapshot only for task-graph-refresh', () => {
+  it('routes both task snapshot kinds to the snapshot handler', () => {
     const h = makeHandlers();
-    expect(answerOwnerReadQuery({ kind: 'tasks' }, h)).toMatchObject({ refreshed: false });
-    expect(answerOwnerReadQuery({ kind: 'task-graph-refresh' }, h)).toMatchObject({ refreshed: true });
-    expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(1, { refresh: false });
-    expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(2, { refresh: true });
+    expect(answerOwnerReadQuery({ kind: 'tasks' }, h)).toEqual({ tasks: [], workflows: [] });
+    expect(answerOwnerReadQuery({ kind: 'task-graph-refresh' }, h)).toEqual({ tasks: [], workflows: [] });
+    expect(h.getTasksSnapshot).toHaveBeenCalledTimes(2);
+    expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(1);
+    expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(2);
   });
 
   it('wraps and routes the param-bearing read kinds', () => {
@@ -218,17 +219,30 @@ describe('buildOwnerReadQueryHandlers', () => {
     expect(build().getReviewGate('missing')).toBeNull();
   });
 
-  it('getTasksSnapshot refreshes only when asked', () => {
+  it('both task snapshot entrypoints sync before reading the authoritative snapshot', () => {
     const syncAllFromDb = vi.fn();
-    const h = build({ syncAllFromDb });
-    expect(h.getTasksSnapshot({ refresh: false })).toEqual({
-      tasks: [{ id: 't' }],
-      workflows: [{ id: 'wf' }],
+    const getAllTasks = vi.fn(() => [{ id: 'fresh-task' }]);
+    const listWorkflows = vi.fn(() => [{ id: 'fresh-wf' }]);
+    const authoritative = build({ getAllTasks, syncAllFromDb }, { listWorkflows });
+
+    expect(answerOwnerReadQuery({ kind: 'tasks' }, authoritative)).toEqual({
+      tasks: [{ id: 'fresh-task' }],
+      workflows: [{ id: 'fresh-wf' }],
       streamSequence: 5,
       invokerHomeRoot: '/home',
     });
-    expect(syncAllFromDb).not.toHaveBeenCalled();
-    h.getTasksSnapshot({ refresh: true });
-    expect(syncAllFromDb).toHaveBeenCalledTimes(1);
+    expect(answerOwnerReadQuery({ kind: 'task-graph-refresh' }, authoritative)).toEqual({
+      tasks: [{ id: 'fresh-task' }],
+      workflows: [{ id: 'fresh-wf' }],
+      streamSequence: 5,
+      invokerHomeRoot: '/home',
+    });
+    expect(syncAllFromDb).toHaveBeenCalledTimes(2);
+    expect(getAllTasks).toHaveBeenCalledTimes(2);
+    expect(listWorkflows).toHaveBeenCalledTimes(2);
+    expect(syncAllFromDb.mock.invocationCallOrder[0]).toBeLessThan(getAllTasks.mock.invocationCallOrder[0]);
+    expect(syncAllFromDb.mock.invocationCallOrder[0]).toBeLessThan(listWorkflows.mock.invocationCallOrder[0]);
+    expect(syncAllFromDb.mock.invocationCallOrder[1]).toBeLessThan(getAllTasks.mock.invocationCallOrder[1]);
+    expect(syncAllFromDb.mock.invocationCallOrder[1]).toBeLessThan(listWorkflows.mock.invocationCallOrder[1]);
   });
 });

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -42,7 +42,7 @@ export interface OwnerReadQueryHandlers {
   getWorkerStatus: () => WorkerStatusSnapshot;
   getWorkers: () => WorkerStatusSnapshot;
   getWorkflowStatus: (workflowId?: string) => Record<string, unknown>;
-  getTasksSnapshot: (opts: { refresh: boolean }) => Record<string, unknown>;
+  getTasksSnapshot: () => Record<string, unknown>;
   getActionGraphSnapshot: () => Record<string, unknown>;
   listWorkflows: () => unknown[];
   loadWorkflowBundle: (workflowId: string) => Record<string, unknown>;
@@ -123,9 +123,8 @@ export function answerOwnerReadQuery(
     case 'workflow-status':
       return handlers.getWorkflowStatus(body.workflowId);
     case 'tasks':
-      return handlers.getTasksSnapshot({ refresh: false });
     case 'task-graph-refresh':
-      return handlers.getTasksSnapshot({ refresh: true });
+      return handlers.getTasksSnapshot();
     case 'action-graph':
       return handlers.getActionGraphSnapshot();
     case 'workflows':
@@ -236,8 +235,8 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     listWorkerActionHistory: (request: WorkerActionHistoryRequest) => listWorkerActionHistory(persistence, request),
     listWorkerDecisions: (request: WorkerDecisionsRequest) => listWorkerDecisions(persistence, request),
     getWorkflowStatus: (workflowId?: string) => orchestrator.getWorkflowStatus(workflowId) as unknown as Record<string, unknown>,
-    getTasksSnapshot: ({ refresh }) => {
-      if (refresh) orchestrator.syncAllFromDb();
+    getTasksSnapshot: () => {
+      orchestrator.syncAllFromDb();
       return {
         tasks: orchestrator.getAllTasks(),
         workflows: persistence.listWorkflows(),


### PR DESCRIPTION
## Summary

Owner task snapshots now route through one sync-then-read path before returning tasks and workflow metadata.

Both owner query names use that path, so detached viewers hydrate from the same fresh task set.

## Review Claim

Owner task snapshot routing now syncs from SQLite before either owner snapshot name returns data.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change stays inside `packages/app/src/owner-read-query.ts` and its directly affected tests; no UI code, mutation code, or transport callsites change here.

## Slice Rationale

Detached-viewer hydration depends on owner task snapshot routing, so this can be reviewed before the renderer bridge slice.

## Non-goals

- No app-bridge transport changes.
- No UI edits.
- No workflow-metadata shape changes.

## Architecture

### Before

```mermaid
graph TD
    A["owner tasks query"] --> B["cached task snapshot"]
    C["owner task-graph-refresh query"] --> D["syncAllFromDb"]
    D --> B
```

### After

```mermaid
graph TD
    A["owner tasks query"] --> C["syncAllFromDb"]
    B["owner task-graph-refresh query"] --> C
    C --> D["fresh task snapshot"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/owner-read-query.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e72c692c15096dce39654ed992bc5600f865b96f`
- Post-revert steps: Re-run `cd packages/app && pnpm exec vitest run src/__tests__/owner-read-query.test.ts`.
- Data migration? No

</details>
