### PR TITLE
[Authoritative task-graph snapshots](2) Sync app bridge snapshots

### DIFF
--- a/packages/app/src/__tests__/ipc-read-handlers.test.ts
+++ b/packages/app/src/__tests__/ipc-read-handlers.test.ts
@@ -26,14 +26,20 @@ function expectReadContextWriteToolsAreAbsent(): void {
 
 
 describe('registerReadOnlyIpcHandlers', () => {
-  it('get-tasks returns a snapshot', async () => {
+  it('get-tasks syncs before returning a snapshot', async () => {
     const handlers = new Map<string, (...args: unknown[]) => unknown>();
     const ipcMain = {
       handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
         handlers.set(channel, handler);
       }),
     };
-    const task = makeTask('wf-1/task-1');
+    const preSyncTask = makeTask('wf-1/pre-sync-task');
+    const postSyncTask = makeTask('wf-1/post-sync-task');
+    let synced = false;
+    const syncAllFromDb = vi.fn(() => {
+      synced = true;
+    });
+    const getAllTasks = vi.fn(() => (synced ? [postSyncTask] : [preSyncTask]));
 
     registerReadOnlyIpcHandlers({
       ipcMain: ipcMain as never,
@@ -47,7 +53,8 @@ describe('registerReadOnlyIpcHandlers', () => {
         listWorkflows: vi.fn(() => [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }]),
       } as never,
       getOrchestrator: () => ({
-        getAllTasks: () => [task],
+        syncAllFromDb,
+        getAllTasks,
         getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 0, closed: 0, running: 0, pending: 1 }),
       }) as never,
       agentRegistry: {} as never,
@@ -62,10 +69,13 @@ describe('registerReadOnlyIpcHandlers', () => {
     const result = await handlers.get('invoker:get-tasks')?.({});
 
     expect(result).toEqual({
-      tasks: [task],
+      tasks: [postSyncTask],
       workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
       streamSequence: 42,
     });
+    expect(syncAllFromDb).toHaveBeenCalledTimes(1);
+    expect(getAllTasks).toHaveBeenCalledTimes(1);
+    expect(syncAllFromDb.mock.invocationCallOrder[0]).toBeLessThan(getAllTasks.mock.invocationCallOrder[0]);
   });
 
   it('get-review-gate returns the shared review gate shape', async () => {

--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -18,6 +18,7 @@ function makeDispatch(overrides: Record<string, unknown> = {}) {
   const approveTask = vi.fn(async () => ({ ok: true }));
   const deps = {
     orchestrator: {
+      syncAllFromDb: () => undefined,
       getAllTasks: () => [makeTask('wf-1/task-1')],
       getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 0, closed: 0, running: 0, pending: 1 }),
       getTask: () => null,
@@ -57,13 +58,33 @@ describe('buildWebInvokerDispatch', () => {
     ]);
   });
 
-  it('get-tasks returns the { tasks, workflows, streamSequence } snapshot', async () => {
-    const { dispatch } = makeDispatch();
-    expect(await dispatch('invoker:get-tasks', [])).toEqual({
-      tasks: [makeTask('wf-1/task-1')],
+  it('get-tasks syncs before returning the { tasks, workflows, streamSequence } snapshot', async () => {
+    const preSyncTask = makeTask('wf-1/pre-sync-task');
+    const postSyncTask = makeTask('wf-1/post-sync-task');
+    let synced = false;
+    const syncAllFromDb = vi.fn(() => {
+      synced = true;
+    });
+    const getAllTasks = vi.fn(() => (synced ? [postSyncTask] : [preSyncTask]));
+    const { dispatch } = makeDispatch({
+      orchestrator: {
+        syncAllFromDb,
+        getAllTasks,
+        getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 0, closed: 0, running: 0, pending: 1 }),
+        getTask: () => null,
+      },
+    });
+
+    const result = await dispatch('invoker:get-tasks', []);
+
+    expect(result).toEqual({
+      tasks: [postSyncTask],
       workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
       streamSequence: 7,
     });
+    expect(syncAllFromDb).toHaveBeenCalledTimes(1);
+    expect(getAllTasks).toHaveBeenCalledTimes(1);
+    expect(syncAllFromDb.mock.invocationCallOrder[0]).toBeLessThan(getAllTasks.mock.invocationCallOrder[0]);
   });
 
   it('get-execution-harnesses returns harness metadata', async () => {

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -159,7 +159,10 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     }
 
     const { tasks, workflows, streamSequence } = buildTaskGraphSnapshot({
-      orchestrator,
+      orchestrator: {
+        syncAllFromDb: () => orchestrator.syncAllFromDb(),
+        getAllTasks: () => orchestrator.getAllTasks(),
+      },
       persistence,
       getStreamSequence: getTaskDeltaStreamSequence,
     });

--- a/packages/app/src/web/task-graph-snapshot.ts
+++ b/packages/app/src/web/task-graph-snapshot.ts
@@ -17,12 +17,14 @@ export interface TaskGraphSnapshot {
 }
 
 export interface BuildTaskGraphSnapshotDeps {
-  orchestrator: Pick<Orchestrator, 'getAllTasks'>;
+  orchestrator: Pick<Orchestrator, 'syncAllFromDb' | 'getAllTasks'>;
   persistence: Pick<SQLiteAdapter, 'listWorkflows'>;
   getStreamSequence: () => number;
 }
 
 export function buildTaskGraphSnapshot(deps: BuildTaskGraphSnapshotDeps): TaskGraphSnapshot {
+  deps.orchestrator.syncAllFromDb();
+
   return {
     tasks: deps.orchestrator.getAllTasks(),
     workflows: deps.persistence.listWorkflows() as WorkflowMeta[],

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -90,7 +90,10 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       // ── Reads ─────────────────────────────────────────────
       case 'invoker:get-tasks':
         return buildTaskGraphSnapshot({
-          orchestrator,
+          orchestrator: {
+            syncAllFromDb: () => orchestrator.syncAllFromDb(),
+            getAllTasks: () => orchestrator.getAllTasks(),
+          },
           persistence,
           getStreamSequence: deps.getStreamSequence,
         });


### PR DESCRIPTION
## Summary

Renderer-facing task snapshots now route through the shared builder after a SQLite sync.

Electron IPC and web dispatch pass the sync hook into that builder, so startup snapshots include the post-sync task set.

## Review Claim

The `invoker:get-tasks` routing now builds task snapshots only after syncing from SQLite.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change stays inside the shared snapshot helper, its two transport callsites, and their focused tests; selected-workflow UI retention logic remains untouched.

## Slice Rationale

Electron and web both route through the shared snapshot builder, so reviewing both callsites together keeps the renderer-facing path cohesive.

## Non-goals

- No edits to `packages/ui/src/App.tsx`.
- No edits to `packages/ui/src/hooks/useTasks.ts`.
- No refresh-event publisher changes.

## Architecture

### Before

```mermaid
graph TD
    A["Electron get-tasks"] --> C["shared snapshot builder"]
    B["web get-tasks"] --> C
    C --> D["cached task snapshot"]
```

### After

```mermaid
graph TD
    A["Electron get-tasks"] --> C["shared snapshot builder"]
    B["web get-tasks"] --> C
    C --> D["syncAllFromDb"]
    D --> E["fresh task snapshot"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/ipc-read-handlers.test.ts -t "get-tasks"`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/web-invoker-dispatch.test.ts -t "get-tasks"`
- [x] `cd packages/ui && pnpm test -- src/__tests__/selected-workflow-graph-disappears-repro.test.tsx src/__tests__/selected-workflow-selection-steal-repro.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 72646bfe8fdeb0376ca443e2b12ef7fb215e0aa0`
- Post-revert steps: Re-run the app bridge `get-tasks` tests.
- Data migration? No

</details>
