### PR TITLE
[Bugfix: main-process planner surfaces lazy-load](1) Defer planner surfaces load

### DIFF
--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -43,8 +43,12 @@ import {
   summarizePlanText,
   type PlanningMessage,
 } from '@invoker/planning-core';
-import { selectHarnessSessionDriver } from '@invoker/surfaces';
-import type { HarnessPreset, PlanConversation, PlanConversationConfig, PlanningCommandBuilder } from '@invoker/surfaces';
+import type {
+  HarnessPreset,
+  PlanConversation,
+  PlanConversationConfig,
+  PlanningCommandBuilder,
+} from '@invoker/surfaces';
 import type { InvokerConfig } from './config.js';
 
 export interface LoadedGeneratedPlan {
@@ -113,12 +117,20 @@ function isModuleResolutionError(error: unknown): boolean {
 }
 
 type PlanConversationConstructor = new (config: PlanConversationConfig) => PlanConversation;
+type SelectHarnessSessionDriver = (
+  preset: HarnessPreset,
+  deps: {
+    executionAgentRegistry?: Pick<AgentRegistry, 'get'>;
+    planningCommandBuilder?: PlanningCommandBuilder;
+  },
+) => PlanConversationConfig['harnessSessionDriver'];
 
 interface PlannerSurfacesModule {
   BUILTIN_HARNESS_PRESETS: Record<string, HarnessPreset>;
   DEFAULT_HARNESS_PRESET: string;
   PlanConversation: PlanConversationConstructor;
   extractYamlPlan: (output: string) => string | null;
+  selectHarnessSessionDriver: SelectHarnessSessionDriver;
 }
 
 async function loadPlannerSurfaces(): Promise<PlannerSurfacesModule> {
@@ -372,6 +384,7 @@ function planConversationConfig(
   preset: HarnessPreset,
   deps: Pick<InAppPlannerDeps, 'config' | 'workingDir' | 'planningCommandBuilder' | 'executionAgentRegistry' | 'conversationRepo' | 'onRawPlannerOutput'>,
   threadTs: string,
+  selectHarnessSessionDriver: SelectHarnessSessionDriver,
   options: { conversationalPlanning?: boolean } = {},
 ): PlanConversationConfig {
   return {
@@ -417,7 +430,7 @@ async function createSession(
     return { error: `Unknown planner preset "${presetKey}".` };
   }
 
-  const { PlanConversation } = await loadPlannerSurfaces();
+  const { PlanConversation, selectHarnessSessionDriver } = await loadPlannerSurfaces();
   const createdAt = new Date().toISOString();
   const id = randomUUID();
   const confirmationMode = normalizePlanningConfirmationMode(
@@ -431,7 +444,9 @@ async function createSession(
     confirmationMode,
     status: 'still_discussing',
     messages: [],
-    conversation: new PlanConversation(planConversationConfig(preset, deps, id, { conversationalPlanning: true })),
+    conversation: new PlanConversation(
+      planConversationConfig(preset, deps, id, selectHarnessSessionDriver, { conversationalPlanning: true }),
+    ),
     createdAt,
     updatedAt: createdAt,
     nextMessageId: 1,
@@ -481,8 +496,10 @@ export async function planFromGoal(
   }
 
   try {
-    const { PlanConversation, extractYamlPlan } = await loadPlannerSurfaces();
-    const conversation = new PlanConversation(planConversationConfig(preset, deps, randomUUID()));
+    const { PlanConversation, extractYamlPlan, selectHarnessSessionDriver } = await loadPlannerSurfaces();
+    const conversation = new PlanConversation(
+      planConversationConfig(preset, deps, randomUUID(), selectHarnessSessionDriver),
+    );
     const plannerOutput = await conversation.sendMessage(goal);
     const planText = extractYamlPlan(plannerOutput);
     if (!planText) {
@@ -860,13 +877,15 @@ export async function restorePlanningChatSessions(
   // boots without surfaces/dist, so an eager load here would crash startup with no sessions.
   if (records.length === 0) return;
   const presets = await resolveHarnessPresets(deps.config);
-  const { PlanConversation } = await loadPlannerSurfaces();
+  const { PlanConversation, selectHarnessSessionDriver } = await loadPlannerSurfaces();
 
   for (const record of records) {
     const preset = presets[record.presetKey];
     if (!preset) continue;
 
-    const conversation = new PlanConversation(planConversationConfig(preset, deps, record.id));
+    const conversation = new PlanConversation(
+      planConversationConfig(preset, deps, record.id, selectHarnessSessionDriver),
+    );
     await conversation.init();
 
     const nextMessageId = Math.max(0, ...record.messages.map((message) => message.id)) + 1;


### PR DESCRIPTION
## Summary

Desktop startup now imports the in-app planner without resolving `@invoker/surfaces`.

The planner still loads surfaces through the existing lazy loader when a planning conversation needs those runtime exports.

## Review Claim

The in-app planner resolves surfaces only inside `loadPlannerSurfaces()`, so startup routing no longer crashes during module evaluation.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Session creation, restore, draft approval, and terminal-mode persistence keep the same code paths once surfaces are loaded; only the module-load boundary changes.

## Slice Rationale

This routing slice changes the runtime load boundary in one planner file and leaves the completed proof task as evidence, not a second review artifact.

## Non-goals

- No planning UX changes.
- No new preset behavior.
- No unrelated startup logging changes.
- No proof harness source changes.

## Architecture

### Before

```mermaid
graph TD
    A["main.ts imports in-app-planner.js"] --> B["@invoker/surfaces resolves during module evaluation"]
    B --> C["startup fails before planner fallback can run"]
```

### After

```mermaid
graph TD
    A["main.ts imports in-app-planner.js"] --> B["planner module evaluates without surfaces runtime import"]
    B --> C["planning session calls loadPlannerSurfaces()"]
    C --> D["existing package, dist, or source fallback resolves surfaces"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `ESBUILD=$(find node_modules/.pnpm -type f -path '*/node_modules/esbuild/bin/esbuild' -print | sort -V | tail -n 1); tmp=$(mktemp -d "${TMPDIR:-/tmp}/planner-surfaces-proof.XXXXXX"); node "$ESBUILD" packages/app/src/in-app-planner.ts --bundle --platform=node --format=esm --outfile="$tmp/in-app-planner.mjs" --external:@invoker/surfaces >/dev/null; node -e 'const fs=require("node:fs"); const path=process.argv[1]; const source=fs.readFileSync(path,"utf8"); if (/^import .*@invoker\/surfaces/m.test(source)) throw new Error("top-level surfaces import remained"); import(path).then(()=>console.log("planner surfaces lazy-load proof passed"));' "$tmp/in-app-planner.mjs"`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts -t "restores draft-ready sessions and submits from persisted approved draft text|restores persisted tmux mode and planning-owned terminal state|clears submitted pending-response state during restore"`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/bugfix-main-process-planner-surfaces-lazy-load-1.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/bugfix-main-process-planner-surfaces-lazy-load-1.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert HEAD`
- Post-revert steps: Rebuild or rerun the focused planner startup proof before publishing a replacement.
- Data migration? No

</details>
