### PR TITLE
[Delete planning terminals — UI](1) Add Planning Terminal rail controls

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
+import { Trash2 } from 'lucide-react';
 import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, StartReadyRequest, StartReadyResult, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus, WorkerActionSummary, WorkerLogEntry, WorkerStatusEntry } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
@@ -2729,22 +2730,82 @@ export function App() {
     workflows.size,
   ]);
 
-  const handleCreatePlanningSession = useCallback(() => {
+  const makeLocalPlanningSession = useCallback((): PlanningSessionView => {
     const index = nextPlanningSessionLocalIdRef.current;
     nextPlanningSessionLocalIdRef.current += 1;
     const now = new Date().toISOString();
     const localId = `local-planning-session-${index}`;
-    const session: PlanningSessionView = {
+    return {
       ...makeInitialPlanningSession(now),
       id: localId,
       conversationKey: localId,
       presetKey: selectedPlanningPresetKey,
     };
+  }, [selectedPlanningPresetKey]);
+
+  const removePlanningSessionsAndReselect = useCallback((sessionIds: string[]) => {
+    const ids = new Set(sessionIds);
+    if (ids.size === 0) return;
+
+    const currentSessions = planningSessionsRef.current;
+    const firstDeletedIndex = currentSessions.findIndex((session) => ids.has(session.id));
+    const remainingSessions = currentSessions.filter((session) => !ids.has(session.id));
+    if (remainingSessions.length === currentSessions.length) return;
+
+    const nextSessions = remainingSessions.length > 0 ? remainingSessions : [makeLocalPlanningSession()];
+    const currentActiveSessionId = activePlanningSessionIdRef.current;
+    const activeSessionStillPresent = nextSessions.some((session) => session.id === currentActiveSessionId);
+    const shouldReselect = ids.has(currentActiveSessionId) || !activeSessionStillPresent;
+    const nextActiveSessionId = shouldReselect
+      ? nextSessions[Math.min(Math.max(firstDeletedIndex, 0), nextSessions.length - 1)]?.id ?? nextSessions[0].id
+      : currentActiveSessionId;
+
+    planningSessionsRef.current = nextSessions;
+    activePlanningSessionIdRef.current = nextActiveSessionId;
+    setPlanningSessions(nextSessions);
+    setActivePlanningSessionId(nextActiveSessionId);
+  }, [makeLocalPlanningSession]);
+
+  const forgetDeletedPlanningSessionStreams = useCallback((sessionIds: string[]) => {
+    clearPlanningStreamForSessionIds(sessionIds);
+    forgetPlanningStreamAliasesForSessionIds(sessionIds);
+    for (const sessionId of sessionIds) {
+      pendingPlanningStreamSessionIdsRef.current.delete(sessionId);
+    }
+  }, [clearPlanningStreamForSessionIds, forgetPlanningStreamAliasesForSessionIds]);
+
+  const handleCreatePlanningSession = useCallback(() => {
+    const session = makeLocalPlanningSession();
+    planningSessionsRef.current = [session, ...planningSessionsRef.current];
+    activePlanningSessionIdRef.current = session.id;
     setPlanningSessions((prev) => [session, ...prev]);
     setActivePlanningSessionId(session.id);
     setSidebarSurface('home');
     focusKeyboardRegion('planning');
-  }, [focusKeyboardRegion, selectedPlanningPresetKey]);
+  }, [focusKeyboardRegion, makeLocalPlanningSession]);
+
+  const handleDeletePlanningSession = useCallback((sessionId: string) => {
+    if (activePlanningReadOnly) return;
+    if (!sessionId.startsWith('local-')) {
+      void invoker?.planningChatDelete?.({ sessionId });
+    }
+    removePlanningSessionsAndReselect([sessionId]);
+    forgetDeletedPlanningSessionStreams([sessionId]);
+  }, [activePlanningReadOnly, forgetDeletedPlanningSessionStreams, invoker, removePlanningSessionsAndReselect]);
+
+  const handleClearSubmittedPlanningSessions = useCallback(() => {
+    if (activePlanningReadOnly) return;
+    const submittedIds = planningSessionsRef.current
+      .filter((session) => session.status === 'submitted')
+      .map((session) => session.id);
+    if (submittedIds.length === 0) return;
+    const confirmed = window.confirm('Clear all submitted planning chats? This cannot be undone.');
+    if (!confirmed) return;
+
+    void invoker?.planningChatDeleteSubmitted?.();
+    removePlanningSessionsAndReselect(submittedIds);
+    forgetDeletedPlanningSessionStreams(submittedIds);
+  }, [activePlanningReadOnly, forgetDeletedPlanningSessionStreams, invoker, removePlanningSessionsAndReselect]);
 
   const handlePlanningModeChange = useCallback(async (mode: PlanningTerminalMode) => {
     const sourceSession = activePlanningSession;
@@ -3998,30 +4059,48 @@ export function App() {
           const selected = session.id === activePlanningSession.id;
           const preview = previewPlanningMessage(session);
           return (
-            <button
+            <div
               key={session.id}
-              type="button"
-              onClick={() => setActivePlanningSessionId(session.id)}
-              className={`flex w-full items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              className="group flex items-stretch"
             >
-              <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-start justify-between gap-2">
-                  <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
-                    {session.title}
+              <button
+                type="button"
+                data-testid="planning-session-select"
+                onClick={() => setActivePlanningSessionId(session.id)}
+                className={`flex w-full min-w-0 flex-1 items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              >
+                <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
+                      {session.title}
+                    </div>
+                    <span className="shrink-0 text-[11px] text-muted-foreground">
+                      {relativePlanningUpdatedAt(session.updatedAt)}
+                    </span>
                   </div>
-                  <span className="shrink-0 text-[11px] text-muted-foreground">
-                    {relativePlanningUpdatedAt(session.updatedAt)}
-                  </span>
+                  <div
+                    className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
+                    title={preview}
+                  >
+                    {preview}
+                  </div>
                 </div>
-                <div
-                  className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
-                  title={preview}
+              </button>
+              {!activePlanningReadOnly && (
+                <button
+                  type="button"
+                  aria-label={`Delete planning chat ${session.title}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleDeletePlanningSession(session.id);
+                  }}
+                  className={`flex w-8 shrink-0 items-start justify-center border-l border-border px-2 py-2 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${selected ? 'bg-accent/40' : 'hover:bg-accent/20'}`}
                 >
-                  {preview}
-                </div>
-              </div>
-            </button>
+                  <Trash2 aria-hidden="true" className="mt-0.5 h-3.5 w-3.5" strokeWidth={1.75} />
+                </button>
+              )}
+            </div>
           );
         })}
       </div>
@@ -4029,6 +4108,7 @@ export function App() {
   );
 
   const planningReadyCount = planningSessions.filter((session) => session.status === 'draft_ready').length;
+  const hasSubmittedPlanningSessions = planningSessions.some((session) => session.status === 'submitted');
   const connectedAgentLabels = (systemDiagnostics?.tools ?? [])
     .filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed)
     .map((tool) => tool.name.replace(/\s+CLI$/i, ''));
@@ -4173,6 +4253,14 @@ export function App() {
               <div className="flex items-center gap-2">
                 <Button variant="outline" size="sm" onClick={handleCreatePlanningSession}>
                   New chat
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={activePlanningReadOnly || !hasSubmittedPlanningSessions}
+                  onClick={handleClearSubmittedPlanningSessions}
+                >
+                  Clear submitted
                 </Button>
                 <button
                   type="button"

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -220,6 +220,8 @@ export function createMockInvoker(
       workflowId: 'wf-1',
     })),
     planningChatReset: vi.fn(async () => ({ ok: true })),
+    planningChatDelete: vi.fn(async () => ({ ok: true })),
+    planningChatDeleteSubmitted: vi.fn(async () => ({ ok: true, deletedSessionIds: [] })),
     onPlanningChatStream: vi.fn((cb: (event: InAppPlanningStreamEvent) => void) => {
       planningChatStreamCallbacks.add(cb);
       return () => { planningChatStreamCallbacks.delete(cb); };

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -27,6 +27,7 @@ describe('Invoker terminal (component)', () => {
 
   afterEach(() => {
     mock.cleanup();
+    vi.restoreAllMocks();
   });
 
   async function openPlanningTerminal() {
@@ -47,6 +48,16 @@ describe('Invoker terminal (component)', () => {
   function expectRailListScrollContract(list: HTMLElement) {
     expect(list).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto');
     expect(list.parentElement).toHaveClass('flex', 'min-h-0', 'flex-1', 'flex-col');
+  }
+
+  function planningRail() {
+    return screen.getByTestId('planning-session-list');
+  }
+
+  async function waitForPlanningRailTitle(title: string) {
+    await waitFor(() => {
+      expect(within(planningRail()).getByText(title)).toBeInTheDocument();
+    });
   }
 
   async function expectSurfaceRailList(surface: 'home' | 'workflows' | 'attention', listTestId: string) {
@@ -271,7 +282,7 @@ describe('Invoker terminal (component)', () => {
     const secondPanel = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(secondPanel).toHaveTextContent('Drafting your plan…');
 
-    const sessionButtons = within(screen.getByTestId('planning-session-list')).getAllByRole('button');
+    const sessionButtons = within(screen.getByTestId('planning-session-list')).getAllByTestId('planning-session-select');
     fireEvent.click(sessionButtons[1]);
 
     const firstPanel = await screen.findByTestId('invoker-terminal-planner-stream');
@@ -915,6 +926,198 @@ describe('Invoker terminal (component)', () => {
     fireEvent.click(screen.getByText('hello'));
 
     expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('I can help draft that.');
+  });
+
+  it('deletes an individual persisted planning chat from the rail', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'delete-target',
+          title: 'Delete target chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+        }),
+        makePlanningSessionSummary({
+          id: 'keep-chat',
+          title: 'Keep chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+    await waitForPlanningRailTitle('Delete target chat');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete planning chat Delete target chat' }));
+
+    await waitFor(() => {
+      expect(within(planningRail()).queryByText('Delete target chat')).not.toBeInTheDocument();
+    });
+    expect(within(planningRail()).getByText('Keep chat')).toBeInTheDocument();
+    expect(mock.api.planningChatDelete).toHaveBeenCalledWith({ sessionId: 'delete-target' });
+  });
+
+  it('deletes a local planning chat without calling the persisted delete bridge', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'persisted-chat',
+          title: 'Persisted chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+    await waitForPlanningRailTitle('Persisted chat');
+
+    fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
+    await waitForPlanningRailTitle('Untitled plan');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete planning chat Untitled plan' }));
+
+    await waitFor(() => {
+      expect(within(planningRail()).queryByText('Untitled plan')).not.toBeInTheDocument();
+    });
+    expect(within(planningRail()).getByText('Persisted chat')).toBeInTheDocument();
+    expect(mock.api.planningChatDelete).not.toHaveBeenCalled();
+  });
+
+  it('clears submitted planning chats after confirmation', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'active-chat',
+          title: 'Active chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+        }),
+      ],
+    }));
+
+    const { unmount } = render(<App />);
+    await openPlanningTerminal();
+    await waitForPlanningRailTitle('Active chat');
+    expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
+    unmount();
+    mock.cleanup();
+
+    mock = createMockInvoker();
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'discussion-chat',
+          title: 'Discussion chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+        }),
+        makePlanningSessionSummary({
+          id: 'submitted-one',
+          title: 'Submitted one',
+          status: 'submitted',
+          draftPlanAvailable: false,
+        }),
+        makePlanningSessionSummary({
+          id: 'submitted-two',
+          title: 'Submitted two',
+          status: 'submitted',
+          draftPlanAvailable: false,
+        }),
+        makePlanningSessionSummary({
+          id: 'draft-chat',
+          title: 'Draft chat',
+          status: 'draft_ready',
+          draftPlanAvailable: true,
+        }),
+      ],
+    }));
+    mock.install();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<App />);
+    await openPlanningTerminal();
+    await waitForPlanningRailTitle('Submitted one');
+    const clearSubmitted = screen.getByRole('button', { name: 'Clear submitted' });
+    await waitFor(() => expect(clearSubmitted).toBeEnabled());
+
+    fireEvent.click(clearSubmitted);
+
+    await waitFor(() => {
+      expect(within(planningRail()).queryByText('Submitted one')).not.toBeInTheDocument();
+      expect(within(planningRail()).queryByText('Submitted two')).not.toBeInTheDocument();
+    });
+    expect(within(planningRail()).getByText('Discussion chat')).toBeInTheDocument();
+    expect(within(planningRail()).getByText('Draft chat')).toBeInTheDocument();
+    expect(confirmSpy).toHaveBeenCalledWith('Clear all submitted planning chats? This cannot be undone.');
+    expect(mock.api.planningChatDeleteSubmitted).toHaveBeenCalledTimes(1);
+    confirmSpy.mockRestore();
+  });
+
+  it('recreates an empty planning chat after deleting the last remaining chat', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'only-chat',
+          title: 'Only chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+    await waitForPlanningRailTitle('Only chat');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete planning chat Only chat' }));
+
+    await waitFor(() => {
+      expect(within(planningRail()).queryByText('Only chat')).not.toBeInTheDocument();
+      expect(within(planningRail()).getByText('Untitled plan')).toBeInTheDocument();
+    });
+    expect(screen.getByText('What do you want to build?')).toBeInTheDocument();
+    expect(screen.getByTestId('invoker-terminal-empty-hero')).toBeInTheDocument();
+    expect(mock.api.planningChatDelete).toHaveBeenCalledWith({ sessionId: 'only-chat' });
+  });
+
+  it('hides planning chat trash controls and disables submitted clearing in read-only mode', async () => {
+    mock.cleanup();
+    mock = createMockInvoker();
+    mock.setRuntimeStatus({ ownerMode: false, readOnly: true, mode: 'read-only' });
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'readonly-chat',
+          title: 'Read-only chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+        }),
+        makePlanningSessionSummary({
+          id: 'readonly-submitted',
+          title: 'Read-only submitted',
+          status: 'submitted',
+          draftPlanAvailable: false,
+        }),
+      ],
+    }));
+    mock.install();
+
+    render(<App />);
+    await openPlanningTerminal();
+    await waitForPlanningRailTitle('Read-only submitted');
+
+    expect(screen.queryByRole('button', { name: /Delete planning chat/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
   });
 
   it('wraps long planning session rail titles and previews instead of clipping them to one line', async () => {


### PR DESCRIPTION
## Summary

Planning chats now expose rail actions for trimming stale conversations without leaving the panel in an unusable empty state.

The header action handles finished planning chats with confirmation and owner-mode gating.

## Workflow Summary

Delete planning terminals — UI — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784313643126-2/ui-delete-planning-chat | Add per-row trash button (instant) + header Clear submitted button (confirm) to the Planning Terminal rail with reselection, empty-recreate, read-only gating, and stream cleanup | completed |
| wf-1784313643126-2/verify-ui-planning-terminal | Verify Planning Terminal rail delete + clear-submitted UI | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784313643126-2/ui-delete-planning-chat — Add per-row trash button (instant) + header Clear submitted button (confirm) to the Planning Terminal rail with reselection, empty-recreate, read-only gating, and stream cleanup

### wf-1784313643126-2/verify-ui-planning-terminal — Verify Planning Terminal rail delete + clear-submitted UI

</details>

## Review Claim

Approve the Planning Terminal rail action surface for per-chat trashing and header clearing.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The new actions are owner-mode gated, leave at least one local planning chat in the rail, and only call the planning-chat bridge methods for persisted or submitted sessions.

## Slice Rationale

This keeps the rail action surface with its reselection, empty-session fallback, and bridge calls in one reviewer-visible UI workflow.

## Non-goals

- This does not change planner response generation.
- This does not change workflow submission semantics.
- This does not change persisted planning transcript storage format.
- This does not change tmux-mode terminal rendering.

## Architecture

### Before

```mermaid
graph TD
    A["Planning rail lists sessions"] --> B["Selecting a row changes active session"]
    A --> C["No rail action exists for stale chats"]
```

### After

```mermaid
graph TD
    A["Planning rail lists sessions"] --> B["Selecting a row changes active session"]
    A --> C["Row trash action prunes one chat"]
    A --> D["Header action clears submitted chats after confirmation"]
    C --> E["Selection moves to a surviving or recreated chat"]
    D --> E
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- invoker-terminal`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/delete-planning-terminals-ui-pr.md --require-visual-proof`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/delete-planning-terminals-ui-pr.md --base master`

</details>

## Visual Proof

Planning Terminal rail walkthrough showing the row trash action, reselection, and confirmed submitted-chat clear:

[planning-terminal-delete-clear.webm](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-472b60/planning-terminal-delete-clear.webm)

Initial rail controls with the submitted-chat clear button and per-row trash action available:

![Planning Terminal rail delete controls](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-472b60/planning-terminal-delete-controls.png)

After using a row trash action, the next chat is selected and submitted-chat clear remains available:

![Planning Terminal after row trash action](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-472b60/planning-terminal-after-row-delete.png)

After confirming submitted-chat clear, only the active remaining chat stays in the rail and the clear button is disabled:

![Planning Terminal after submitted clear](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-472b60/planning-terminal-after-clear-submitted.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <published-commit-sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
