### PR TITLE
[Remote Sync Step 1: Sync Schema and Change Journal](1) Add data-store sync schema and journal

### DIFF
--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createAttempt } from '@invoker/workflow-core';
+import type { TaskState } from '@invoker/workflow-core';
+import type { Workflow } from '../adapter.js';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { SqliteExecutor } from '../sqlite-executor.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  readJournalSince,
+  setSyncCursor,
+} from '../sync-journal.js';
+
+describe('sync journal', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function executor(): SqliteExecutor {
+    const raw = adapter as unknown as {
+      queryOne: (sql: string, params?: unknown[]) => Record<string, unknown> | undefined;
+      queryAll: (sql: string, params?: unknown[]) => Record<string, unknown>[];
+      execRun: (sql: string, params?: unknown[]) => void;
+      db: {
+        run: (sql: string, params?: unknown[]) => void;
+        getRowsModified: () => number;
+      };
+      dirty: boolean;
+    };
+    return {
+      queryOne: (sql, params) => raw.queryOne.call(adapter, sql, params),
+      queryAll: (sql, params) => raw.queryAll.call(adapter, sql, params),
+      execRun: (sql, params) => raw.execRun.call(adapter, sql, params),
+      runTransaction: (work) => adapter.runInTransaction(work),
+      run: (sql, params) => raw.db.run(sql, params),
+      getRowsModified: () => raw.db.getRowsModified(),
+      readOnly: false,
+      markDirty: () => {
+        raw.dirty = true;
+      },
+    };
+  }
+
+  function workflow(id: string): Workflow {
+    return {
+      id,
+      name: `Workflow ${id}`,
+      status: 'pending',
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+    };
+  }
+
+  function task(id: string, workflowId: string): TaskState {
+    return {
+      id,
+      description: `Task ${id}`,
+      status: 'pending',
+      dependencies: [],
+      createdAt: new Date('2026-07-27T00:00:00.000Z'),
+      config: { workflowId },
+      execution: {},
+      taskStateVersion: 1,
+    };
+  }
+
+  it('rolls back journal appends with the mutation transaction', () => {
+    const exec = executor();
+
+    expect(() => adapter.runInTransaction(() => {
+      exec.run(
+        `INSERT INTO workflows (id, name, created_at, updated_at)
+         VALUES (?, ?, ?, ?)`,
+        [
+          'wf-rollback',
+          'Rollback',
+          '2026-07-27T00:00:00.000Z',
+          '2026-07-27T00:00:00.000Z',
+        ],
+      );
+      appendJournalEntry(exec, {
+        entityType: 'workflow',
+        entityId: 'wf-rollback',
+        op: 'upsert',
+        payload: { id: 'wf-rollback' },
+      });
+      throw new Error('rollback requested');
+    })).toThrow('rollback requested');
+
+    expect(readJournalSince(exec, 0, 10)).toEqual([]);
+    expect(adapter.loadWorkflow('wf-rollback', { includeDeleted: true })).toBeUndefined();
+  });
+
+  it('allocates strictly monotonic seq values', () => {
+    const exec = executor();
+    const seqs = [
+      appendJournalEntry(exec, {
+        entityType: 'task',
+        entityId: 'task-1',
+        op: 'upsert',
+        payload: { id: 'task-1', status: 'pending' },
+      }),
+      appendJournalEntry(exec, {
+        entityType: 'task',
+        entityId: 'task-2',
+        op: 'upsert',
+        payload: { id: 'task-2', status: 'running' },
+      }),
+      appendJournalEntry(exec, {
+        entityType: 'attempt',
+        entityId: 'attempt-1',
+        op: 'upsert',
+        payload: { id: 'attempt-1', status: 'completed' },
+      }),
+    ];
+
+    expect(seqs[1]).toBeGreaterThan(seqs[0]);
+    expect(seqs[2]).toBeGreaterThan(seqs[1]);
+    expect(readJournalSince(exec, 0, 10).map((entry) => entry.seq)).toEqual(seqs);
+  });
+
+  it('reads journal pages after the stored peer cursor', () => {
+    const exec = executor();
+    const first = appendJournalEntry(exec, {
+      entityType: 'workflow',
+      entityId: 'wf-1',
+      op: 'upsert',
+      payload: { id: 'wf-1' },
+    });
+    const second = appendJournalEntry(exec, {
+      entityType: 'workflow',
+      entityId: 'wf-2',
+      op: 'upsert',
+      payload: { id: 'wf-2' },
+    });
+    const third = appendJournalEntry(exec, {
+      entityType: 'workflow',
+      entityId: 'wf-3',
+      op: 'upsert',
+      payload: { id: 'wf-3' },
+    });
+
+    setSyncCursor(exec, {
+      peerId: 'remote-a',
+      lastSentSeq: first,
+      lastReceivedSeq: 42,
+      updatedAt: '2026-07-27T00:00:01.000Z',
+    });
+
+    const cursor = getSyncCursor(exec, 'remote-a')!;
+    expect(cursor).toMatchObject({
+      peerId: 'remote-a',
+      lastSentSeq: first,
+      lastReceivedSeq: 42,
+    });
+    expect(readJournalSince(exec, cursor.lastSentSeq, 10).map((entry) => entry.seq)).toEqual([
+      second,
+      third,
+    ]);
+
+    setSyncCursor(exec, {
+      peerId: 'remote-a',
+      lastSentSeq: third,
+      updatedAt: '2026-07-27T00:00:02.000Z',
+    });
+    expect(getSyncCursor(exec, 'remote-a')?.lastReceivedSeq).toBe(42);
+  });
+
+  it('journals task status updates and attempt creation and completion', () => {
+    const exec = executor();
+    adapter.saveWorkflow(workflow('wf-hooks'));
+    adapter.saveTask('wf-hooks', task('task-hooks', 'wf-hooks'));
+    const attempt = createAttempt('task-hooks', {
+      status: 'running',
+      createdAt: new Date('2026-07-27T00:00:03.000Z'),
+    });
+
+    adapter.saveAttempt(attempt);
+    adapter.updateTask('task-hooks', { status: 'running' });
+    adapter.updateAttempt(attempt.id, {
+      status: 'completed',
+      completedAt: new Date('2026-07-27T00:00:04.000Z'),
+    });
+
+    const entries = readJournalSince(exec, 0, 100);
+    const taskStatus = entries.find(
+      (entry) => entry.entityType === 'task'
+        && entry.entityId === 'task-hooks'
+        && (entry.payload as { status?: unknown }).status === 'running',
+    );
+    const attemptEntries = entries.filter(
+      (entry) => entry.entityType === 'attempt' && entry.entityId === attempt.id,
+    );
+
+    expect(taskStatus?.op).toBe('upsert');
+    expect(attemptEntries.map((entry) => (entry.payload as { status?: unknown }).status)).toEqual([
+      'running',
+      'completed',
+    ]);
+  });
+
+  it('excludes soft-deleted workflows from default listings but includes them on request', () => {
+    adapter.saveWorkflow(workflow('wf-soft-delete'));
+
+    adapter.deleteWorkflow('wf-soft-delete');
+
+    expect(adapter.listWorkflows()).toEqual([]);
+    expect(adapter.loadWorkflow('wf-soft-delete')).toBeUndefined();
+
+    const withDeleted = adapter.listWorkflows({ includeDeleted: true });
+    expect(withDeleted).toHaveLength(1);
+    expect(withDeleted[0]).toMatchObject({
+      id: 'wf-soft-delete',
+      name: 'Workflow wf-soft-delete',
+    });
+    expect(withDeleted[0].deletedAt).toEqual(expect.any(Number));
+    expect(adapter.loadWorkflow('wf-soft-delete', { includeDeleted: true })?.deletedAt)
+      .toEqual(expect.any(Number));
+  });
+
+  it('writes a tombstone journal entry when deleting a workflow', () => {
+    const exec = executor();
+    adapter.saveWorkflow(workflow('wf-tombstone'));
+
+    adapter.deleteWorkflow('wf-tombstone');
+
+    const tombstones = readJournalSince(exec, 0, 100).filter(
+      (entry) => entry.entityType === 'workflow'
+        && entry.entityId === 'wf-tombstone'
+        && entry.op === 'tombstone',
+    );
+
+    expect(tombstones).toHaveLength(1);
+    expect(tombstones[0].origin).toBe('home');
+    expect(tombstones[0].payload as Record<string, unknown>).toMatchObject({
+      id: 'wf-tombstone',
+      deleted_at: expect.any(Number),
+    });
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -122,10 +122,15 @@ export interface Workflow {
   /** Read-only provenance for dependencies removed by `detachWorkflow`. Never re-read by scheduling. */
   detachedExternalDependencies?: DetachedExternalDependency[];
   generation?: number;
+  deletedAt?: number;
   createdAt: string;
   updatedAt: string;
 }
 export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup'>;
+
+export interface WorkflowReadOptions {
+  includeDeleted?: boolean;
+}
 
 /**
  * Result of resolving a published PR back to its Invoker workflow via the merge
@@ -329,8 +334,8 @@ export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
-  loadWorkflow(workflowId: string): Workflow | undefined;
-  listWorkflows(): Workflow[];
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined;
+  listWorkflows(options?: WorkflowReadOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
   /** Resolve a GitHub PR number back to its Invoker workflow via the merge node. */
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined;

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -7,3 +7,4 @@ export * from './slack-session-repository.js';
 export * from './slack-plan-draft-repository.js';
 export * from './sqlite-task-repository.js';
 export * from './workflow-channel-repository.js';
+export * from './sync-journal.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -38,6 +38,7 @@ import type {
   PersistenceAdapter,
   ReviewGateLookup,
   Workflow,
+  WorkflowReadOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
   TaskEvent,
@@ -78,6 +79,7 @@ import type { SqliteExecutor } from './sqlite-executor.js';
 import * as migrations from './sqlite-migrations.js';
 import { SqliteTaskAttemptRepository } from './sqlite-task-attempt-repository.js';
 import { SqliteWorkflowRepository, type WorkflowMetadataChanges } from './sqlite-workflow-repository.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 function normalizeWorkerActionStatus(status: string): string {
   return status === 'canceled' ? 'cancelled' : status;
@@ -1050,12 +1052,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.workflowRepo.updateWorkflow(workflowId, changes);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    return this.workflowRepo.loadWorkflow(workflowId);
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined {
+    return this.workflowRepo.loadWorkflow(workflowId, options);
   }
 
-  listWorkflows(): Workflow[] {
-    return this.workflowRepo.listWorkflows();
+  listWorkflows(options?: WorkflowReadOptions): Workflow[] {
+    return this.workflowRepo.listWorkflows(options);
   }
 
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
@@ -1546,7 +1548,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   deleteWorkflow(workflowId: string): void {
+    this.ensureWritable();
+    const existing = this.queryOne('SELECT id, deleted_at FROM workflows WHERE id = ?', [workflowId]);
+    if (!existing || (existing.deleted_at !== null && existing.deleted_at !== undefined)) return;
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
+    const deletedAt = Date.now();
+    const updatedAt = new Date(deletedAt).toISOString();
     this.runTransaction(() => {
       this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
@@ -1587,7 +1594,23 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
+      this.db.run(
+        `UPDATE workflows
+            SET deleted_at = ?,
+                updated_at = ?
+          WHERE id = ?
+            AND deleted_at IS NULL`,
+        [deletedAt, updatedAt, workflowId],
+      );
+      const row = this.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+      if (row) {
+        appendJournalEntry(this.executor, {
+          entityType: 'workflow',
+          entityId: workflowId,
+          op: 'tombstone',
+          payload: row,
+        });
+      }
     });
     this.removeOutputFiles(taskIds);
   }

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -47,6 +47,7 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
     externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
     detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) as DetachedExternalDependency[] : undefined,
     generation: row.generation ?? 0,
+    deletedAt: row.deleted_at === null || row.deleted_at === undefined ? undefined : Number(row.deleted_at),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -27,6 +27,7 @@ export const SCHEMA_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       );
@@ -484,6 +485,23 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_output_spool_task_offset
         ON output_spool(task_id, offset);
 
+      CREATE TABLE IF NOT EXISTS sync_journal (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+        entity_id TEXT NOT NULL,
+        op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+        payload TEXT NOT NULL CHECK (json_valid(payload)),
+        origin TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_cursors (
+        peer_id TEXT PRIMARY KEY,
+        last_sent_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_sent_seq) = 'integer' AND last_sent_seq >= 0),
+        last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
+        updated_at TEXT NOT NULL
+      );
+
       CREATE TABLE IF NOT EXISTS terminal_sessions (
         session_id TEXT PRIMARY KEY,
         task_id TEXT NOT NULL,
@@ -562,6 +580,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE workflows ADD COLUMN external_dependency_changes TEXT',
   // detached_external_dependencies: read-only provenance for deps removed by detachWorkflow
   'ALTER TABLE workflows ADD COLUMN detached_external_dependencies TEXT',
+  'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
   // execution_agent / agent_name: interchangeable agent support
   'ALTER TABLE tasks ADD COLUMN execution_model TEXT',
   'ALTER TABLE tasks ADD COLUMN execution_agent TEXT',
@@ -622,6 +641,21 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  `CREATE TABLE IF NOT EXISTS sync_journal (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+    entity_id TEXT NOT NULL,
+    op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    origin TEXT NOT NULL,
+    created_at TEXT NOT NULL
+  )`,
+  `CREATE TABLE IF NOT EXISTS sync_cursors (
+    peer_id TEXT PRIMARY KEY,
+    last_sent_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_sent_seq) = 'integer' AND last_sent_seq >= 0),
+    last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
+    updated_at TEXT NOT NULL
+  )`,
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */
@@ -645,6 +679,7 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       )
@@ -656,12 +691,12 @@ export const WORKFLOWS_REBUILD_INSERT_DDL = `
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       FROM workflows
     `;

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -17,6 +17,7 @@ import {
 import { mapRowToTask, mapRowToAttempt } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
@@ -93,6 +94,16 @@ export class SqliteTaskAttemptRepository {
     this.exec.execRun('DELETE FROM task_crash_preservation WHERE task_id = ?', [taskId]);
   }
 
+  private hasCrashPreservationChange(changes: Partial<TaskExecution>): boolean {
+    const crashKeys = [
+      'crashPreservedAt',
+      'crashPreservedOwnerPid',
+      'crashPreservedReportPath',
+      'crashPreservedDiagnosticSummary',
+    ] as const satisfies readonly (keyof TaskExecution)[];
+    return crashKeys.some((key) => key in changes);
+  }
+
   private taskSelectColumns(alias: string): string {
     if (!this.hasCrashPreservationTable()) return `${alias}.*`;
     return `${alias}.*,
@@ -113,117 +124,120 @@ export class SqliteTaskAttemptRepository {
     assertTaskConsistent(task);
     const cfg = task.config;
     const exec = task.execution;
-    this.exec.execRun(`
-      INSERT OR REPLACE INTO tasks (
-        id, workflow_id, description, status, blocked_by, dependencies,
-        command, prompt, experiment_prompt, exit_code, error, protocol_error_code, protocol_error_message, input_prompt, external_dependencies,
-        summary, problem, approach, test_plan, repro_command, fix_prompt, fix_context,
-        branch, commit_hash, fixed_integration_sha, fixed_integration_recorded_at, fixed_integration_source, parent_task,
-        pivot, experiment_variants, is_reconciliation, selected_experiment,
-        selected_experiments, experiment_results, requires_manual_approval,
-        repo_url, feature_branch,
-        is_merge_node, auto_fix, max_fix_attempts,
-        runner_kind, pool_id, agent_session_id, workspace_path, container_id,
-        last_agent_session_id, last_agent_name,
-        action_request_id, experiments,
-        created_at, launch_phase, launch_started_at, launch_completed_at, started_at, completed_at, last_heartbeat_at,
-        utilization, pending_fix_error, fix_session_entry_status, failure_class,
-        review_url, review_id, review_status, review_provider_id, review_gate,
-        is_fixing_with_ai,
-        execution_generation,
-        selected_attempt_id,
-        pool_member_id,
-        docker_image,
-        execution_agent,
-        execution_model,
-        agent_name,
-        task_state_version
-      ) VALUES (
-        ?, ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?, ?,
-        ?, ?, ?, ?,
-        ?, ?, ?,
-        ?, ?,
-        ?, ?, ?,
-        ?, ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?, ?,
-        ?, ?,
-        ?, ?, ?, ?,
-        ?, ?,
-        ?, ?, ?, ?, ?,
-        ?,
-        ?,
-        ?,
-        ?,
-        ?,
-        ?,
-        ?,
-        ?,
-        ?
-      )
-    `, [
-      task.id, workflowId, task.description, task.status,
-      exec.blockedBy ?? null,
-      JSON.stringify(task.dependencies),
-      cfg.command ?? null, cfg.prompt ?? null, cfg.experimentPrompt ?? null,
-      exec.exitCode ?? null, exec.error ?? null, exec.protocolErrorCode ?? null, exec.protocolErrorMessage ?? null, exec.inputPrompt ?? null,
-      null,
-      cfg.summary ?? null, cfg.problem ?? null, cfg.approach ?? null,
-      cfg.testPlan ?? null, cfg.reproCommand ?? null, cfg.fixPrompt ?? null, cfg.fixContext ?? null,
-      exec.branch ?? null,
-      exec.commit ?? null,
-      exec.fixedIntegrationSha ?? null,
-      exec.fixedIntegrationRecordedAt?.toISOString() ?? null,
-      exec.fixedIntegrationSource ?? null,
-      cfg.parentTask ?? null,
-      cfg.pivot ? 1 : 0,
-      cfg.experimentVariants ? JSON.stringify(cfg.experimentVariants) : null,
-      cfg.isReconciliation ? 1 : 0,
-      exec.selectedExperiment ?? null,
-      exec.selectedExperiments ? JSON.stringify(exec.selectedExperiments) : null,
-      exec.experimentResults ? JSON.stringify(exec.experimentResults) : null,
-      cfg.requiresManualApproval ? 1 : 0,
-      null, cfg.featureBranch ?? null,
-      cfg.isMergeNode ? 1 : 0,
-      0, null,
-      cfg.runnerKind ?? null,
-      cfg.poolId ?? null,
-      exec.agentSessionId ?? null,
-      exec.workspacePath ?? null,
-      exec.containerId ?? null,
-      exec.lastAgentSessionId ?? null,
-      exec.lastAgentName ?? null,
-      exec.actionRequestId ?? null,
-      exec.experiments ? JSON.stringify(exec.experiments) : null,
-      task.createdAt.toISOString(),
-      exec.phase ?? null,
-      exec.launchStartedAt?.toISOString() ?? null,
-      exec.launchCompletedAt?.toISOString() ?? null,
-      exec.startedAt?.toISOString() ?? null,
-      exec.completedAt?.toISOString() ?? null,
-      exec.lastHeartbeatAt?.toISOString() ?? null,
-      null,
-      exec.pendingFixError ?? null,
-      exec.fixSessionEntryStatus ?? null,
-      exec.failureClass ?? null,
-      exec.reviewUrl ?? null,
-      exec.reviewId ?? null,
-      exec.reviewStatus ?? null,
-      exec.reviewProviderId ?? null,
-      exec.reviewGate ? JSON.stringify(exec.reviewGate) : null,
-      exec.isFixingWithAI ? 1 : 0,
-      exec.generation ?? 0,
-      exec.selectedAttemptId ?? null,
-      (cfg as { poolMemberId?: string }).poolMemberId ?? null,
-      cfg.dockerImage ?? null,
-      cfg.executionAgent ?? null,
-      cfg.executionModel ?? null,
-      exec.agentName ?? null,
-      task.taskStateVersion ?? 1,
-    ]);
-    this.syncCrashPreservationState(task.id, undefined, task.execution);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`
+        INSERT OR REPLACE INTO tasks (
+          id, workflow_id, description, status, blocked_by, dependencies,
+          command, prompt, experiment_prompt, exit_code, error, protocol_error_code, protocol_error_message, input_prompt, external_dependencies,
+          summary, problem, approach, test_plan, repro_command, fix_prompt, fix_context,
+          branch, commit_hash, fixed_integration_sha, fixed_integration_recorded_at, fixed_integration_source, parent_task,
+          pivot, experiment_variants, is_reconciliation, selected_experiment,
+          selected_experiments, experiment_results, requires_manual_approval,
+          repo_url, feature_branch,
+          is_merge_node, auto_fix, max_fix_attempts,
+          runner_kind, pool_id, agent_session_id, workspace_path, container_id,
+          last_agent_session_id, last_agent_name,
+          action_request_id, experiments,
+          created_at, launch_phase, launch_started_at, launch_completed_at, started_at, completed_at, last_heartbeat_at,
+          utilization, pending_fix_error, fix_session_entry_status, failure_class,
+          review_url, review_id, review_status, review_provider_id, review_gate,
+          is_fixing_with_ai,
+          execution_generation,
+          selected_attempt_id,
+          pool_member_id,
+          docker_image,
+          execution_agent,
+          execution_model,
+          agent_name,
+          task_state_version
+        ) VALUES (
+          ?, ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?,
+          ?, ?, ?, ?,
+          ?, ?, ?,
+          ?, ?,
+          ?, ?, ?,
+          ?, ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?, ?,
+          ?, ?,
+          ?, ?, ?, ?,
+          ?, ?,
+          ?, ?, ?, ?, ?,
+          ?,
+          ?,
+          ?,
+          ?,
+          ?,
+          ?,
+          ?,
+          ?,
+          ?
+        )
+      `, [
+        task.id, workflowId, task.description, task.status,
+        exec.blockedBy ?? null,
+        JSON.stringify(task.dependencies),
+        cfg.command ?? null, cfg.prompt ?? null, cfg.experimentPrompt ?? null,
+        exec.exitCode ?? null, exec.error ?? null, exec.protocolErrorCode ?? null, exec.protocolErrorMessage ?? null, exec.inputPrompt ?? null,
+        null,
+        cfg.summary ?? null, cfg.problem ?? null, cfg.approach ?? null,
+        cfg.testPlan ?? null, cfg.reproCommand ?? null, cfg.fixPrompt ?? null, cfg.fixContext ?? null,
+        exec.branch ?? null,
+        exec.commit ?? null,
+        exec.fixedIntegrationSha ?? null,
+        exec.fixedIntegrationRecordedAt?.toISOString() ?? null,
+        exec.fixedIntegrationSource ?? null,
+        cfg.parentTask ?? null,
+        cfg.pivot ? 1 : 0,
+        cfg.experimentVariants ? JSON.stringify(cfg.experimentVariants) : null,
+        cfg.isReconciliation ? 1 : 0,
+        exec.selectedExperiment ?? null,
+        exec.selectedExperiments ? JSON.stringify(exec.selectedExperiments) : null,
+        exec.experimentResults ? JSON.stringify(exec.experimentResults) : null,
+        cfg.requiresManualApproval ? 1 : 0,
+        null, cfg.featureBranch ?? null,
+        cfg.isMergeNode ? 1 : 0,
+        0, null,
+        cfg.runnerKind ?? null,
+        cfg.poolId ?? null,
+        exec.agentSessionId ?? null,
+        exec.workspacePath ?? null,
+        exec.containerId ?? null,
+        exec.lastAgentSessionId ?? null,
+        exec.lastAgentName ?? null,
+        exec.actionRequestId ?? null,
+        exec.experiments ? JSON.stringify(exec.experiments) : null,
+        task.createdAt.toISOString(),
+        exec.phase ?? null,
+        exec.launchStartedAt?.toISOString() ?? null,
+        exec.launchCompletedAt?.toISOString() ?? null,
+        exec.startedAt?.toISOString() ?? null,
+        exec.completedAt?.toISOString() ?? null,
+        exec.lastHeartbeatAt?.toISOString() ?? null,
+        null,
+        exec.pendingFixError ?? null,
+        exec.fixSessionEntryStatus ?? null,
+        exec.failureClass ?? null,
+        exec.reviewUrl ?? null,
+        exec.reviewId ?? null,
+        exec.reviewStatus ?? null,
+        exec.reviewProviderId ?? null,
+        exec.reviewGate ? JSON.stringify(exec.reviewGate) : null,
+        exec.isFixingWithAI ? 1 : 0,
+        exec.generation ?? 0,
+        exec.selectedAttemptId ?? null,
+        (cfg as { poolMemberId?: string }).poolMemberId ?? null,
+        cfg.dockerImage ?? null,
+        cfg.executionAgent ?? null,
+        cfg.executionModel ?? null,
+        exec.agentName ?? null,
+        task.taskStateVersion ?? 1,
+      ]);
+      this.syncCrashPreservationState(task.id, undefined, task.execution);
+      this.appendTaskUpsert(task.id);
+    });
   }
 
   updateTask(taskId: string, changes: TaskStateChanges): void {
@@ -298,8 +312,11 @@ export class SqliteTaskAttemptRepository {
       }
     }
 
+    const crashPreservationChanged = changes.execution
+      ? this.hasCrashPreservationChange(changes.execution)
+      : false;
+
     if (changes.execution) {
-      this.syncCrashPreservationState(taskId, beforeTask, changes.execution);
       const execution = changes.execution as Record<string, unknown>;
       const execMap: Record<string, string> = {
         blockedBy: 'blocked_by',
@@ -385,10 +402,12 @@ export class SqliteTaskAttemptRepository {
       execution: changes.execution ? { ...beforeTask.execution, ...changes.execution } : beforeTask.execution,
     });
 
-    if (setClauses.length === 0) return;
+    if (setClauses.length === 0 && !crashPreservationChanged) return;
 
-    // Atomically bump task-state version with every mutation
-    setClauses.push('task_state_version = task_state_version + 1');
+    if (setClauses.length > 0) {
+      // Atomically bump task-state version with every mutation
+      setClauses.push('task_state_version = task_state_version + 1');
+    }
 
     if (changes.execution && 'workspacePath' in changes.execution) {
       try {
@@ -409,7 +428,7 @@ export class SqliteTaskAttemptRepository {
       }
     }
 
-    values.push(taskId);
+    const statusChanged = changes.status !== undefined;
     const heartbeatOnly =
       setClauses.length === 1 && setClauses[0].trimStart().startsWith('last_heartbeat_at =');
 
@@ -417,7 +436,18 @@ export class SqliteTaskAttemptRepository {
       const cols = setClauses.map((c) => c.split(/\s*=\s*/)[0]!.trim()).join(', ');
       console.log(`[persist-sql] taskId=${taskId} columns=[${cols}]`);
     }
-    this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    this.exec.runTransaction(() => {
+      if (changes.execution) {
+        this.syncCrashPreservationState(taskId, beforeTask, changes.execution);
+      }
+      if (setClauses.length > 0) {
+        values.push(taskId);
+        this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
+        if (statusChanged) {
+          this.appendTaskUpsert(taskId);
+        }
+      }
+    });
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -460,6 +490,7 @@ export class SqliteTaskAttemptRepository {
       FROM tasks t${this.taskSelectJoin('t')}
       JOIN workflows w ON w.id = t.workflow_id
       WHERE t.status = 'completed'
+        AND w.deleted_at IS NULL
       ORDER BY t.completed_at DESC
     `);
     return rows.map((row) => ({
@@ -481,7 +512,8 @@ export class SqliteTaskAttemptRepository {
         FROM events
         GROUP BY task_id
       ) e ON e.task_id = t.id
-      WHERE COALESCE(e.event_count, 0) > 0 OR t.status != 'pending'
+      WHERE w.deleted_at IS NULL
+        AND (COALESCE(e.event_count, 0) > 0 OR t.status != 'pending')
       ORDER BY COALESCE(e.max_created_at, t.completed_at, t.started_at, t.created_at) DESC
     `);
     return rows.map((row) => {
@@ -594,40 +626,43 @@ export class SqliteTaskAttemptRepository {
   // ── Attempt CRUD ─────────────────────────────────────────
 
   saveAttempt(attempt: Attempt): void {
-    this.exec.execRun(`
-      INSERT OR REPLACE INTO attempts (
-        id, node_id, attempt_number, queue_priority, status,
-        snapshot_commit, base_branch, upstream_attempt_ids,
-        command_override, prompt_override,
-        claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
-        branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
-        supersedes_attempt_id, created_at, merge_conflict
-      ) VALUES (
-        ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?,
-        ?, ?,
-        ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?, ?,
-        ?, ?, ?
-      )
-    `, [
-      attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
-      attempt.snapshotCommit ?? null, attempt.baseBranch ?? null,
-      JSON.stringify(attempt.upstreamAttemptIds),
-      attempt.commandOverride ?? null, attempt.promptOverride ?? null,
-      attempt.claimedAt?.toISOString() ?? null,
-      attempt.startedAt?.toISOString() ?? null,
-      attempt.completedAt?.toISOString() ?? null,
-      attempt.exitCode ?? null, attempt.error ?? null,
-      attempt.lastHeartbeatAt?.toISOString() ?? null,
-      attempt.leaseExpiresAt?.toISOString() ?? null,
-      attempt.branch ?? null, attempt.commit ?? null, attempt.summary ?? null,
-      attempt.workspacePath ?? null, attempt.agentSessionId ?? null,
-      attempt.containerId ?? null,
-      attempt.supersedesAttemptId ?? null,
-      attempt.createdAt.toISOString(),
-      attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
-    ]);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`
+        INSERT OR REPLACE INTO attempts (
+          id, node_id, attempt_number, queue_priority, status,
+          snapshot_commit, base_branch, upstream_attempt_ids,
+          command_override, prompt_override,
+          claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
+          branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
+          supersedes_attempt_id, created_at, merge_conflict
+        ) VALUES (
+          ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?,
+          ?, ?,
+          ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?,
+          ?, ?, ?
+        )
+      `, [
+        attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
+        attempt.snapshotCommit ?? null, attempt.baseBranch ?? null,
+        JSON.stringify(attempt.upstreamAttemptIds),
+        attempt.commandOverride ?? null, attempt.promptOverride ?? null,
+        attempt.claimedAt?.toISOString() ?? null,
+        attempt.startedAt?.toISOString() ?? null,
+        attempt.completedAt?.toISOString() ?? null,
+        attempt.exitCode ?? null, attempt.error ?? null,
+        attempt.lastHeartbeatAt?.toISOString() ?? null,
+        attempt.leaseExpiresAt?.toISOString() ?? null,
+        attempt.branch ?? null, attempt.commit ?? null, attempt.summary ?? null,
+        attempt.workspacePath ?? null, attempt.agentSessionId ?? null,
+        attempt.containerId ?? null,
+        attempt.supersedesAttemptId ?? null,
+        attempt.createdAt.toISOString(),
+        attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
+      ]);
+      this.appendAttemptUpsert(attempt.id);
+    });
   }
 
   loadAttempts(nodeId: string): Attempt[] {
@@ -711,7 +746,15 @@ export class SqliteTaskAttemptRepository {
 
     if (setClauses.length === 0) return;
     values.push(attemptId);
-    this.exec.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    const shouldJournal =
+      changes.status !== undefined ||
+      changes.completedAt !== undefined;
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
+      if (shouldJournal) {
+        this.appendAttemptUpsert(attemptId);
+      }
+    });
   }
 
   claimAttemptForLaunch(
@@ -888,5 +931,27 @@ export class SqliteTaskAttemptRepository {
       [nodeId, selected.createdAt.toISOString(), cappedLimit],
     );
     return rows.map((row) => mapRowToAttempt(row));
+  }
+
+  private appendTaskUpsert(taskId: string): void {
+    const row = this.exec.queryOne('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (!row) return;
+    appendJournalEntry(this.exec, {
+      entityType: 'task',
+      entityId: taskId,
+      op: 'upsert',
+      payload: row,
+    });
+  }
+
+  private appendAttemptUpsert(attemptId: string): void {
+    const row = this.exec.queryOne('SELECT * FROM attempts WHERE id = ?', [attemptId]);
+    if (!row) return;
+    appendJournalEntry(this.exec, {
+      entityType: 'attempt',
+      entityId: attemptId,
+      op: 'upsert',
+      payload: row,
+    });
   }
 }

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -25,6 +25,7 @@ import {
 } from '@invoker/workflow-core';
 import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
+  WorkflowReadOptions,
   ReviewGateLookup,
   Workflow,
   WorkflowSaveInput,
@@ -32,6 +33,7 @@ import type {
 } from './adapter.js';
 import { mapRowToWorkflow, mapRowToTask } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 export type WorkflowMetadataChanges = Partial<
   Pick<
@@ -88,23 +90,27 @@ export class SqliteWorkflowRepository {
 
   saveWorkflow(workflow: WorkflowSaveInput): void {
     assertWorkflowConsistent(workflow);
-    this.exec.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `, [
-      workflow.id, workflow.name,
-      workflow.description ?? null,
-      workflow.visualProof ? 1 : 0,
-      workflow.planFile ?? null, workflow.repoUrl ?? null, workflow.intermediateRepoUrl ?? null, workflow.branch ?? null,
-      workflow.onFinish ?? null, workflow.baseBranch ?? null, null, workflow.featureBranch ?? null,
-      workflow.mergeMode ?? null,
-      workflow.reviewProvider ?? null,
-      workflow.externalDependencies ? JSON.stringify(workflow.externalDependencies) : null,
-      workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
-      workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
-      workflow.generation ?? 0,
-      workflow.createdAt, workflow.updatedAt,
-    ]);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`
+        INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, deleted_at, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `, [
+        workflow.id, workflow.name,
+        workflow.description ?? null,
+        workflow.visualProof ? 1 : 0,
+        workflow.planFile ?? null, workflow.repoUrl ?? null, workflow.intermediateRepoUrl ?? null, workflow.branch ?? null,
+        workflow.onFinish ?? null, workflow.baseBranch ?? null, null, workflow.featureBranch ?? null,
+        workflow.mergeMode ?? null,
+        workflow.reviewProvider ?? null,
+        workflow.externalDependencies ? JSON.stringify(workflow.externalDependencies) : null,
+        workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
+        workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
+        workflow.generation ?? 0,
+        workflow.deletedAt ?? null,
+        workflow.createdAt, workflow.updatedAt,
+      ]);
+      this.appendWorkflowUpsert(workflow.id);
+    });
   }
 
   updateWorkflow(workflowId: string, changes: WorkflowMetadataChanges): void {
@@ -171,19 +177,29 @@ export class SqliteWorkflowRepository {
     assertWorkflowPatchConsistent(before, after, changes);
 
     values.push(workflowId);
-    this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
+      this.appendWorkflowUpsert(workflowId);
+    });
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined {
+    const row = this.exec.queryOne(
+      `SELECT * FROM workflows
+        WHERE id = ?
+          ${options?.includeDeleted ? '' : 'AND deleted_at IS NULL'}`,
+      [workflowId],
+    );
     if (!row) return undefined;
     const rollup = this.loadWorkflowRollups([workflowId]).get(workflowId);
     return this.rowToWorkflow(row, rollup);
   }
 
-  listWorkflows(): Workflow[] {
+  listWorkflows(options?: WorkflowReadOptions): Workflow[] {
     const rows = this.exec.queryAll(
-      'SELECT * FROM workflows ORDER BY created_at DESC',
+      `SELECT * FROM workflows
+        ${options?.includeDeleted ? '' : 'WHERE deleted_at IS NULL'}
+        ORDER BY created_at DESC`,
     );
     const workflowIds = rows.map((row) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
@@ -203,9 +219,11 @@ export class SqliteWorkflowRepository {
               t.status AS mergeTaskStatus,
               w.generation AS workflowGeneration,
               w.base_branch AS baseBranch
-         FROM tasks t
-         JOIN workflows w ON w.id = t.workflow_id
-        WHERE t.is_merge_node = 1 AND (t.review_id = ? OR t.review_url LIKE ?)`,
+       FROM tasks t
+       JOIN workflows w ON w.id = t.workflow_id
+        WHERE w.deleted_at IS NULL
+          AND t.is_merge_node = 1
+          AND (t.review_id = ? OR t.review_url LIKE ?)`,
       [pr, `%/pull/${pr}`],
     );
     if (rows.length === 0) return undefined;
@@ -257,7 +275,8 @@ export class SqliteWorkflowRepository {
     if (type === 'workflows' || type === 'all') {
       const workflows = this.exec.queryAll(
         `SELECT id, name, description, plan_file, repo_url, branch, created_at FROM workflows 
-         WHERE name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ? 
+         WHERE deleted_at IS NULL
+           AND (name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{ id: string; name?: string | null; created_at: string }>;
@@ -282,7 +301,12 @@ export class SqliteWorkflowRepository {
     if (type === 'tasks' || type === 'all') {
       const tasks = this.exec.queryAll(
         `SELECT id, workflow_id, description, command, prompt, summary, problem, approach, test_plan, repro_command, status, created_at FROM tasks 
-         WHERE description LIKE ? OR command LIKE ? OR prompt LIKE ? OR summary LIKE ? OR problem LIKE ? OR approach LIKE ? OR test_plan LIKE ? OR repro_command LIKE ? 
+         WHERE EXISTS (
+           SELECT 1 FROM workflows w
+           WHERE w.id = tasks.workflow_id
+             AND w.deleted_at IS NULL
+         )
+           AND (description LIKE ? OR command LIKE ? OR prompt LIKE ? OR summary LIKE ? OR problem LIKE ? OR approach LIKE ? OR test_plan LIKE ? OR repro_command LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{
@@ -298,7 +322,7 @@ export class SqliteWorkflowRepository {
       if (workflowIds.length > 0) {
         const placeholders = workflowIds.map(() => '?').join(',');
         const workflowRows = this.exec.queryAll(
-          `SELECT id, name FROM workflows WHERE id IN (${placeholders})`,
+          `SELECT id, name FROM workflows WHERE deleted_at IS NULL AND id IN (${placeholders})`,
           workflowIds
         ) as Array<{ id: string; name?: string | null }>;
         for (const wf of workflowRows) {
@@ -326,10 +350,17 @@ export class SqliteWorkflowRepository {
   loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
     const totalStartedAt = Date.now();
     const workflowQueryStartedAt = Date.now();
-    const workflowRows = this.exec.queryAll('SELECT * FROM workflows ORDER BY created_at DESC');
+    const workflowRows = this.exec.queryAll(
+      'SELECT * FROM workflows WHERE deleted_at IS NULL ORDER BY created_at DESC',
+    );
     const workflowMetadataQueryMs = Date.now() - workflowQueryStartedAt;
     const taskQueryStartedAt = Date.now();
-    const taskRows = this.exec.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC');
+    const taskRows = this.exec.queryAll(
+      `SELECT t.* FROM tasks t
+       JOIN workflows w ON w.id = t.workflow_id
+      WHERE w.deleted_at IS NULL
+      ORDER BY t.workflow_id ASC, t.id ASC`,
+    );
     const taskQueryMs = Date.now() - taskQueryStartedAt;
     const tasksByWorkflowId = new Map<string, TaskState[]>();
     const workflowIds = workflowRows.map((row) => String(row.id));
@@ -465,5 +496,16 @@ export class SqliteWorkflowRepository {
 
   private rowToWorkflow(row: Record<string, unknown>, rollup?: WorkflowRollup): Workflow {
     return mapRowToWorkflow(row, rollup);
+  }
+
+  private appendWorkflowUpsert(workflowId: string): void {
+    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+    if (!row) return;
+    appendJournalEntry(this.exec, {
+      entityType: 'workflow',
+      entityId: workflowId,
+      op: 'upsert',
+      payload: row,
+    });
   }
 }

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -1,0 +1,178 @@
+import type { SqliteExecutor } from './sqlite-executor.js';
+
+export type SyncJournalEntityType =
+  | 'workflow'
+  | 'task'
+  | 'attempt'
+  | 'event'
+  // Reserved for future output-spool sync. Adapter output writes are not journaled yet.
+  | 'output';
+
+export type SyncJournalOperation = 'upsert' | 'tombstone';
+
+export interface SyncJournalAppendEntry {
+  entityType: SyncJournalEntityType;
+  entityId: string;
+  op: SyncJournalOperation;
+  payload: unknown;
+  origin?: string;
+  createdAt?: string;
+}
+
+export interface SyncJournalEntry {
+  seq: number;
+  entityType: SyncJournalEntityType;
+  entityId: string;
+  op: SyncJournalOperation;
+  payload: unknown;
+  origin: string;
+  createdAt: string;
+}
+
+export interface SyncCursor {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt: string;
+}
+
+export interface SyncCursorPatch {
+  peerId: string;
+  lastSentSeq?: number;
+  lastReceivedSeq?: number;
+  updatedAt?: string;
+}
+
+const ENTITY_TYPES = new Set<SyncJournalEntityType>([
+  'workflow',
+  'task',
+  'attempt',
+  'event',
+  'output',
+]);
+
+const OPERATIONS = new Set<SyncJournalOperation>(['upsert', 'tombstone']);
+
+function assertEntityType(value: SyncJournalEntityType): void {
+  if (!ENTITY_TYPES.has(value)) {
+    throw new Error(`Invalid sync journal entity_type: ${String(value)}`);
+  }
+}
+
+function assertOperation(value: SyncJournalOperation): void {
+  if (!OPERATIONS.has(value)) {
+    throw new Error(`Invalid sync journal op: ${String(value)}`);
+  }
+}
+
+function normalizeSeq(value: number, name: string): number {
+  const seq = Math.trunc(value);
+  if (!Number.isFinite(seq) || seq < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return seq;
+}
+
+function mapJournalRow(row: Record<string, unknown>): SyncJournalEntry {
+  return {
+    seq: Number(row.seq),
+    entityType: String(row.entity_type) as SyncJournalEntityType,
+    entityId: String(row.entity_id),
+    op: String(row.op) as SyncJournalOperation,
+    payload: JSON.parse(String(row.payload)),
+    origin: String(row.origin),
+    createdAt: String(row.created_at),
+  };
+}
+
+function mapCursorRow(row: Record<string, unknown>): SyncCursor {
+  return {
+    peerId: String(row.peer_id),
+    lastSentSeq: Number(row.last_sent_seq ?? 0),
+    lastReceivedSeq: Number(row.last_received_seq ?? 0),
+    updatedAt: String(row.updated_at),
+  };
+}
+
+export function appendJournalEntry(db: SqliteExecutor, entry: SyncJournalAppendEntry): number {
+  assertEntityType(entry.entityType);
+  assertOperation(entry.op);
+  const origin = entry.origin ?? 'home';
+  if (!origin.trim()) {
+    throw new Error('sync journal origin must be non-empty');
+  }
+  const createdAt = entry.createdAt ?? new Date().toISOString();
+
+  db.execRun(
+    `INSERT INTO sync_journal (entity_type, entity_id, op, payload, origin, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [
+      entry.entityType,
+      entry.entityId,
+      entry.op,
+      JSON.stringify(entry.payload),
+      origin,
+      createdAt,
+    ],
+  );
+
+  const row = db.queryOne('SELECT last_insert_rowid() AS seq');
+  return Number(row?.seq ?? 0);
+}
+
+export function readJournalSince(
+  db: SqliteExecutor,
+  seq: number,
+  limit: number,
+): SyncJournalEntry[] {
+  const cursor = normalizeSeq(seq, 'seq');
+  const pageLimit = Math.trunc(limit);
+  if (!Number.isFinite(pageLimit) || pageLimit <= 0) return [];
+
+  const rows = db.queryAll(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq > ?
+      ORDER BY seq ASC
+      LIMIT ?`,
+    [cursor, pageLimit],
+  );
+  return rows.map((row) => mapJournalRow(row));
+}
+
+export function getSyncCursor(db: SqliteExecutor, peerId: string): SyncCursor | undefined {
+  const row = db.queryOne(
+    `SELECT peer_id, last_sent_seq, last_received_seq, updated_at
+       FROM sync_cursors
+      WHERE peer_id = ?`,
+    [peerId],
+  );
+  return row ? mapCursorRow(row) : undefined;
+}
+
+export function setSyncCursor(db: SqliteExecutor, cursor: SyncCursorPatch): SyncCursor {
+  const previous = getSyncCursor(db, cursor.peerId);
+  const lastSentSeq = normalizeSeq(cursor.lastSentSeq ?? previous?.lastSentSeq ?? 0, 'lastSentSeq');
+  const lastReceivedSeq = normalizeSeq(
+    cursor.lastReceivedSeq ?? previous?.lastReceivedSeq ?? 0,
+    'lastReceivedSeq',
+  );
+  const updatedAt = cursor.updatedAt ?? new Date().toISOString();
+
+  db.execRun(
+    `INSERT INTO sync_cursors (peer_id, last_sent_seq, last_received_seq, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(peer_id) DO UPDATE SET
+       last_sent_seq = excluded.last_sent_seq,
+       last_received_seq = excluded.last_received_seq,
+       updated_at = excluded.updated_at`,
+    [cursor.peerId, lastSentSeq, lastReceivedSeq, updatedAt],
+  );
+
+  return {
+    peerId: cursor.peerId,
+    lastSentSeq,
+    lastReceivedSeq,
+    updatedAt,
+  };
+}


### PR DESCRIPTION
## Summary

Remote Sync Step 1 adds the data-store schema needed to journal syncable workflow state.

Journal rows, peer cursors, and workflow tombstones now share the SQLite persistence contract.

## Workflow Summary

Remote Sync Step 1: Sync Schema and Change Journal — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926077035-3/implement-sync-schema | Add sync journal, cursor, and tombstone schema to data-store | completed |
| wf-1784926077035-3/verify-sync-schema | Run data-store package tests covering the new schema and journal | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784926077035-3/implement-sync-schema — Add sync journal, cursor, and tombstone schema to data-store

packages/data-store/src/__tests__/sync-journal.test.ts
packages/data-store/src/adapter.ts
packages/data-store/src/index.ts
packages/data-store/src/sqlite-adapter.ts
packages/data-store/src/sqlite-row-mappers.ts
packages/data-store/src/sqlite-schema.ts
packages/data-store/src/sqlite-task-attempt-repository.ts
packages/data-store/src/sqlite-workflow-repository.ts
packages/data-store/src/sync-journal.ts

### wf-1784926077035-3/verify-sync-schema — Run data-store package tests covering the new schema and journal

No file changes; verification ran against the implement slice.

</details>

## Review Claim

Approve the data-store sync schema contract for journal entries, peer cursors, workflow tombstones, and task/attempt journal writes.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This slice is confined to data-store schema, journal helpers, and directly affected persistence tests; no sync transport or remote execution path is activated.

## Slice Rationale

Schema and local journaling land first so later remote sync transport can consume one stable data-store contract.

## Non-goals

- No remote sync transport.
- No peer protocol.
- No merge logic.
- No output spool journaling.
- No UI changes.

## Architecture

### Before

```mermaid
graph TD
    A["SQLite persistence tables"] --> B["Workflow, task, and attempt rows"]
    C["Remote sync peers"] --> D["No durable cursor contract"]
```

### After

```mermaid
graph TD
    A["SQLite persistence tables"] --> B["Workflow, task, and attempt rows"]
    A --> C["sync_journal entries"]
    A --> D["sync_cursors per peer"]
    B --> E["workflow tombstones represented by deleted_at rows"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sync-journal.test.ts` (25 files, 435 tests passed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 777693eeacd69bc1e23edde8d8e2d91c1b1c58e6`
- Post-revert steps: Rerun the data-store focused test.
- Data migration? No production migration has shipped yet.

</details>
