### PR TITLE
[Authoritative task-graph snapshots](1) Sync owner task snapshots

### DIFF
--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -76,12 +76,50 @@ describe('answerOwnerReadQuery', () => {
     expect(answerOwnerReadQuery({ kind: 'action-graph' }, h)).toEqual({ nodes: [] });
   });
 
-  it('refreshes the snapshot only for task-graph-refresh', () => {
-    const h = makeHandlers();
-    expect(answerOwnerReadQuery({ kind: 'tasks' }, h)).toMatchObject({ refreshed: false });
-    expect(answerOwnerReadQuery({ kind: 'task-graph-refresh' }, h)).toMatchObject({ refreshed: true });
-    expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(1, { refresh: false });
-    expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(2, { refresh: true });
+  it('routes both task snapshot entrypoints through authoritative snapshots', () => {
+    const syncAllFromDb = vi.fn();
+    const h = buildOwnerReadQueryHandlers({
+      ownerModeLabel: 'gui',
+      getUiPerfStats: () => ({}),
+      resetUiPerfStats: () => {},
+      getStreamSequence: () => 5,
+      getWorkerStatus: () => ({ generatedAt: 'now', workers: [] }),
+      getWorkers: () => ({ generatedAt: 'workers-now', workers: [] }),
+      resolveInvokerHomeRoot: () => '/home',
+      orchestrator: {
+        getQueueStatus: () => ({ q: 1 }),
+        getWorkflowStatus: () => ({ w: 1 }),
+        getAllTasks: () => [{ id: 't' }],
+        syncAllFromDb,
+        syncFromDb: vi.fn(),
+      } as never,
+      persistence: {
+        listWorkflows: () => [{ id: 'wf' }],
+        loadWorkflow: vi.fn(),
+        loadTasks: vi.fn(),
+        loadTask: vi.fn(),
+        getEvents: vi.fn(),
+        getTaskOutput: vi.fn(),
+        getOutputChunks: vi.fn(),
+        getOutputTail: vi.fn(),
+        replayOutputFrom: vi.fn(),
+        loadAllCompletedTasks: vi.fn(),
+        loadAllHistoryTasks: vi.fn(),
+        listWorkerActions: vi.fn(),
+      } as never,
+      getActionGraphSnapshot: () => ({ ag: 1 }),
+    });
+    const expectedSnapshot = {
+      tasks: [{ id: 't' }],
+      workflows: [{ id: 'wf' }],
+      streamSequence: 5,
+      invokerHomeRoot: '/home',
+    };
+
+    expect(answerOwnerReadQuery({ kind: 'tasks' }, h)).toEqual(expectedSnapshot);
+    expect(syncAllFromDb).toHaveBeenCalledTimes(1);
+    expect(answerOwnerReadQuery({ kind: 'task-graph-refresh' }, h)).toEqual(expectedSnapshot);
+    expect(syncAllFromDb).toHaveBeenCalledTimes(2);
   });
 
   it('wraps and routes the param-bearing read kinds', () => {
@@ -218,17 +256,30 @@ describe('buildOwnerReadQueryHandlers', () => {
     expect(build().getReviewGate('missing')).toBeNull();
   });
 
-  it('getTasksSnapshot refreshes only when asked', () => {
-    const syncAllFromDb = vi.fn();
-    const h = build({ syncAllFromDb });
+  it('getTasksSnapshot syncs before every snapshot read', () => {
+    const calls: string[] = [];
+    const syncAllFromDb = vi.fn(() => {
+      calls.push('sync');
+    });
+    const getAllTasks = vi.fn(() => {
+      calls.push('tasks');
+      return [{ id: 't' }];
+    });
+    const listWorkflows = vi.fn(() => {
+      calls.push('workflows');
+      return [{ id: 'wf' }];
+    });
+    const h = build({ syncAllFromDb, getAllTasks }, { listWorkflows });
     expect(h.getTasksSnapshot({ refresh: false })).toEqual({
       tasks: [{ id: 't' }],
       workflows: [{ id: 'wf' }],
       streamSequence: 5,
       invokerHomeRoot: '/home',
     });
-    expect(syncAllFromDb).not.toHaveBeenCalled();
-    h.getTasksSnapshot({ refresh: true });
     expect(syncAllFromDb).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(['sync', 'tasks', 'workflows']);
+    h.getTasksSnapshot({ refresh: true });
+    expect(syncAllFromDb).toHaveBeenCalledTimes(2);
+    expect(calls).toEqual(['sync', 'tasks', 'workflows', 'sync', 'tasks', 'workflows']);
   });
 });

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -236,8 +236,8 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     listWorkerActionHistory: (request: WorkerActionHistoryRequest) => listWorkerActionHistory(persistence, request),
     listWorkerDecisions: (request: WorkerDecisionsRequest) => listWorkerDecisions(persistence, request),
     getWorkflowStatus: (workflowId?: string) => orchestrator.getWorkflowStatus(workflowId) as unknown as Record<string, unknown>,
-    getTasksSnapshot: ({ refresh }) => {
-      if (refresh) orchestrator.syncAllFromDb();
+    getTasksSnapshot: () => {
+      orchestrator.syncAllFromDb();
       return {
         tasks: orchestrator.getAllTasks(),
         workflows: persistence.listWorkflows(),


### PR DESCRIPTION
## Summary

Owner task snapshots can return workflow metadata with a partial task set when they read only in-process state.

This slice makes both owner snapshot entry points sync from SQLite before returning tasks, workflows, stream sequence, and the home root.

Detached viewers then hydrate from the same fresh behavior as task-graph refresh without changing UI or transport behavior.

## Review Claim

Owner task snapshot reads now sync from SQLite before responding, so plain owner task reads cannot return a pre-sync task subset.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice only touches `packages/app/src/owner-read-query.ts` and its directly affected test file. No UI code, mutation code, or transport callsites change here.

## Slice Rationale

Detached-viewer hydration depends on owner task snapshots, so this behavior change is reviewable before shared renderer bridge work.

## Non-goals

No app-bridge transport changes. No UI edits. No workflow-metadata refresh changes. No new snapshot shape fields.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/owner-read-query.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 6309e8abcc143b8ef6f1f7259152d365a020d84f`
- Post-revert steps: None
- Data migration? No

</details>
