### PR TITLE
[Authoritative task-graph snapshots](2) Sync app bridge snapshots

### DIFF
--- a/packages/app/src/__tests__/ipc-read-handlers.test.ts
+++ b/packages/app/src/__tests__/ipc-read-handlers.test.ts
@@ -26,14 +26,20 @@ function expectReadContextWriteToolsAreAbsent(): void {
 
 
 describe('registerReadOnlyIpcHandlers', () => {
-  it('get-tasks returns a snapshot', async () => {
+  it('get-tasks syncs before returning a snapshot', async () => {
     const handlers = new Map<string, (...args: unknown[]) => unknown>();
     const ipcMain = {
       handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
         handlers.set(channel, handler);
       }),
     };
-    const task = makeTask('wf-1/task-1');
+    const staleTask = makeTask('wf-1/stale-task');
+    const freshTask = makeTask('wf-1/task-1');
+    let synced = false;
+    const syncAllFromDb = vi.fn(() => {
+      synced = true;
+    });
+    const getAllTasks = vi.fn(() => (synced ? [freshTask] : [staleTask]));
 
     registerReadOnlyIpcHandlers({
       ipcMain: ipcMain as never,
@@ -47,7 +53,8 @@ describe('registerReadOnlyIpcHandlers', () => {
         listWorkflows: vi.fn(() => [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }]),
       } as never,
       getOrchestrator: () => ({
-        getAllTasks: () => [task],
+        syncAllFromDb,
+        getAllTasks,
         getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 0, closed: 0, running: 0, pending: 1 }),
       }) as never,
       agentRegistry: {} as never,
@@ -62,10 +69,13 @@ describe('registerReadOnlyIpcHandlers', () => {
     const result = await handlers.get('invoker:get-tasks')?.({});
 
     expect(result).toEqual({
-      tasks: [task],
+      tasks: [freshTask],
       workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
       streamSequence: 42,
     });
+    expect(syncAllFromDb).toHaveBeenCalledOnce();
+    expect(getAllTasks).toHaveBeenCalledOnce();
+    expect(syncAllFromDb.mock.invocationCallOrder[0]).toBeLessThan(getAllTasks.mock.invocationCallOrder[0]);
   });
 
   it('get-review-gate returns the shared review gate shape', async () => {

--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -18,6 +18,7 @@ function makeDispatch(overrides: Record<string, unknown> = {}) {
   const approveTask = vi.fn(async () => ({ ok: true }));
   const deps = {
     orchestrator: {
+      syncAllFromDb: vi.fn(),
       getAllTasks: () => [makeTask('wf-1/task-1')],
       getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 0, closed: 0, running: 0, pending: 1 }),
       getTask: () => null,
@@ -57,13 +58,31 @@ describe('buildWebInvokerDispatch', () => {
     ]);
   });
 
-  it('get-tasks returns the { tasks, workflows, streamSequence } snapshot', async () => {
-    const { dispatch } = makeDispatch();
+  it('get-tasks syncs before returning the { tasks, workflows, streamSequence } snapshot', async () => {
+    const staleTask = makeTask('wf-1/stale-task');
+    const freshTask = makeTask('wf-1/task-1');
+    let synced = false;
+    const syncAllFromDb = vi.fn(() => {
+      synced = true;
+    });
+    const getAllTasks = vi.fn(() => (synced ? [freshTask] : [staleTask]));
+    const { dispatch } = makeDispatch({
+      orchestrator: {
+        syncAllFromDb,
+        getAllTasks,
+        getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 0, closed: 0, running: 0, pending: 1 }),
+        getTask: () => null,
+      },
+    });
+
     expect(await dispatch('invoker:get-tasks', [])).toEqual({
-      tasks: [makeTask('wf-1/task-1')],
+      tasks: [freshTask],
       workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
       streamSequence: 7,
     });
+    expect(syncAllFromDb).toHaveBeenCalledOnce();
+    expect(getAllTasks).toHaveBeenCalledOnce();
+    expect(syncAllFromDb.mock.invocationCallOrder[0]).toBeLessThan(getAllTasks.mock.invocationCallOrder[0]);
   });
 
   it('get-execution-harnesses returns harness metadata', async () => {

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -159,7 +159,10 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     }
 
     const { tasks, workflows, streamSequence } = buildTaskGraphSnapshot({
-      orchestrator,
+      orchestrator: {
+        syncAllFromDb: () => orchestrator.syncAllFromDb(),
+        getAllTasks: () => orchestrator.getAllTasks(),
+      },
       persistence,
       getStreamSequence: getTaskDeltaStreamSequence,
     });

--- a/packages/app/src/web/task-graph-snapshot.ts
+++ b/packages/app/src/web/task-graph-snapshot.ts
@@ -17,12 +17,13 @@ export interface TaskGraphSnapshot {
 }
 
 export interface BuildTaskGraphSnapshotDeps {
-  orchestrator: Pick<Orchestrator, 'getAllTasks'>;
+  orchestrator: Pick<Orchestrator, 'syncAllFromDb' | 'getAllTasks'>;
   persistence: Pick<SQLiteAdapter, 'listWorkflows'>;
   getStreamSequence: () => number;
 }
 
 export function buildTaskGraphSnapshot(deps: BuildTaskGraphSnapshotDeps): TaskGraphSnapshot {
+  deps.orchestrator.syncAllFromDb();
   return {
     tasks: deps.orchestrator.getAllTasks(),
     workflows: deps.persistence.listWorkflows() as WorkflowMeta[],

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -90,7 +90,10 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       // ── Reads ─────────────────────────────────────────────
       case 'invoker:get-tasks':
         return buildTaskGraphSnapshot({
-          orchestrator,
+          orchestrator: {
+            syncAllFromDb: () => orchestrator.syncAllFromDb(),
+            getAllTasks: () => orchestrator.getAllTasks(),
+          },
           persistence,
           getStreamSequence: deps.getStreamSequence,
         });


### PR DESCRIPTION
## Summary

The shared `invoker:get-tasks` builder can pair workflow metadata with a pre-sync task subset during renderer startup.

This slice makes the builder sync from SQLite before assembling the task-graph snapshot.

Electron and web callsites now pass that sync step through the shared builder, so startup snapshots use the post-sync task set.

## Review Claim

Every plain `invoker:get-tasks` snapshot now syncs before reading tasks, so renderer startup cannot receive workflow metadata paired with a pre-sync task subset.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice only touches the shared snapshot builder, its two transport callsites, and their directly affected tests. Selected-workflow UI retention logic is unchanged.

## Slice Rationale

Electron and web consume one shared builder, so reviewing both callsites together captures the renderer-facing snapshot behavior in one pass.

## Non-goals

No edits to `packages/ui/src/App.tsx` or `packages/ui/src/hooks/useTasks.ts`. No refresh-event publisher changes. No workflow-chain or PR-body changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/ipc-read-handlers.test.ts -t "get-tasks"`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/web-invoker-dispatch.test.ts -t "get-tasks"`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/owner-read-query.test.ts src/__tests__/ipc-read-handlers.test.ts src/__tests__/web-invoker-dispatch.test.ts`
- [x] `cd packages/ui && pnpm test -- src/__tests__/selected-workflow-graph-disappears-repro.test.tsx src/__tests__/selected-workflow-selection-steal-repro.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a377a1c6e3538897f4857ba4aefa51ca8fc9f3fa`
- Post-revert steps: None
- Data migration? No

</details>
