### PR TITLE
[Repair Workflow Step 2: spawn-repair-workflow command](3) Route standalone repair spawn execution

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -94,12 +94,15 @@ import {
   E2E_AUTOFIX_WORKER_KIND,
   registerBuiltinAgents,
   registerBuiltinWorkers,
+  parseSpawnRepairWorkflowMutationArgs,
   parseRequeueMutationArgs,
   parseRequeueEscalateMutationArgs,
   parseReviewGateCiRepairWorkflowMutationArgs,
   parseReviewGateStackCiRepairWorkflowMutationArgs,
   fetchOpenStackPrs,
   reconcileTerminalWorkerActionsOnStartup,
+  SPAWN_REPAIR_WORKFLOW_CHANNEL,
+  submitRepairWorkflowFromCiFailure,
   type AgentRegistry,
   type WorkerRegistry,
   type WorkerRuntimeDependencies,
@@ -1544,6 +1547,32 @@ function startHeadlessMode(): void {
             });
           });
         }
+        if (!workflowMutationDispatcher.has(SPAWN_REPAIR_WORKFLOW_CHANNEL)) {
+          workflowMutationDispatcher.set(SPAWN_REPAIR_WORKFLOW_CHANNEL, async (payloadArg: unknown) => {
+            const payload = parseSpawnRepairWorkflowMutationArgs([payloadArg]);
+            const result = submitRepairWorkflowFromCiFailure({
+              store: persistence,
+              orchestrator,
+              logger,
+              allowGraphMutation: invokerConfig.allowGraphMutation,
+              defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
+              getAutoFixAgent: () => invokerConfig.autoFixAgent,
+              getAutoFixExecutionModel: () => resolveAutoFixExecutionModel(invokerConfig),
+            }, payload);
+            if (result.decision === 'spawned' && result.workflowId) {
+              await dispatchStartedTasksWithGlobalTopup({
+                orchestrator,
+                taskExecutor: createStandaloneTaskExecutor(),
+                logger,
+                context: 'standalone.spawn-repair-workflow',
+                started: result.started,
+                scopedWorkflowId: result.workflowId,
+                mutationTiming: activeMutationContext?.mutationTiming,
+              });
+            }
+            return result;
+          });
+        }
         if (!workflowMutationDispatcher.has('invoker:requeue')) {
           workflowMutationDispatcher.set('invoker:requeue', async (...requeueArgs: unknown[]) => {
             const { taskId } = parseRequeueMutationArgs(requeueArgs);
@@ -2351,6 +2380,12 @@ startMainProcessBootstrap({
     setTimeout(() => {
       if (!ownerMode) return;
 
+      const repairSpawnFacadeDefaults = {
+        allowGraphMutation: invokerConfig.allowGraphMutation,
+        defaultAutoFixRetries: resolveAutoFixRetries(invokerConfig),
+        getAutoFixAgent: () => invokerConfig.autoFixAgent,
+        getAutoFixExecutionModel: () => resolveAutoFixExecutionModel(invokerConfig),
+      };
       const webMutations = new WorkflowMutationFacade({
         logger,
         orchestrator,
@@ -2358,6 +2393,7 @@ startMainProcessBootstrap({
         commandService,
         taskExecutor: requireTaskExecutor(),
         autoApproveAIFixes: resolveAutoApproveAIFixes(invokerConfig),
+        ...repairSpawnFacadeDefaults,
         killRunningTask,
       });
       apiServer = startApiServer({


### PR DESCRIPTION
## Summary

This slice wires standalone owner execution to call the repair workflow spawn helper when the mutation dispatcher receives the channel.

It also keeps facade repair defaults shared between owner startup surfaces.

## Review Claim

Approve the standalone owner routing for repair workflow spawn requests.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice only adds standalone owner handling for the new channel. Existing mutation channels keep their current handlers.

## Slice Rationale

Keep `main.ts` separate because that file owns startup routing; the next slice handles the owner entrypoints.

## Non-goals

- Does not add the IPC or web entrypoint calls.
- Does not change the repair workflow plan builder.
- Does not change existing startup channels.

## Workflow Context

Repair Workflow Step 2: spawn-repair-workflow command - 2 tasks completed, 0 failed, 0 closed, 0 skipped.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784927703568-9/implement-spawn-repair-workflow | Build the repair-workflow spec builder and the explicit invoker:spawn-repair-workflow command with dedupe and spawn cap | completed |
| wf-1784927703568-9/verify-spawn-repair-workflow | Run the new repair-workflow spawn tests plus typecheck | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784927703568-9/implement-spawn-repair-workflow - Build the repair-workflow spec builder and the explicit invoker:spawn-repair-workflow command with dedupe and spawn cap

### wf-1784927703568-9/verify-spawn-repair-workflow - Run the new repair-workflow spawn tests plus typecheck

</details>

## Visual Proof

![Standalone repair spawn dispatcher proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-abdc3d/repair-step2-standalone-proof.svg)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-mutation-facade.test.ts src/__tests__/web-invoker-dispatch.test.ts src/__tests__/gui-mutation-translation.test.ts`
- [x] `pnpm run check:types`
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-bodies/repair-step2-3-standalone.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-bodies/repair-step2-3-standalone.md --base stack/EdbertChan/stack-source/repair-workflow-step-2-spawn-command-v2/repair-workflow-step-2-spawn-repair-workflow-cmd--e6c253fd`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a0788dc4b281d25951e0bc5f571bac0a3efc0314`
- Post-revert steps: Rerun app spawn routing tests and typecheck.
- Data migration? No

</details>

Depends-On: #6098
