### PR TITLE
[Delete planning terminals — UI](1) Add Planning Terminal rail controls

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
+import { Trash2 } from 'lucide-react';
 import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, PlanningConfirmationMode, ReviewGateQueryResponse, RuntimeStatus, StartReadyRequest, StartReadyResult, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus, WorkerActionSummary, WorkerLogEntry, WorkerStatusEntry } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
@@ -2813,23 +2814,88 @@ export function App() {
     workflows.size,
   ]);
 
-  const handleCreatePlanningSession = useCallback(() => {
+  const makeLocalPlanningSession = useCallback((): PlanningSessionView => {
     const index = nextPlanningSessionLocalIdRef.current;
     nextPlanningSessionLocalIdRef.current += 1;
     const now = new Date().toISOString();
     const localId = `local-planning-session-${index}`;
-    const session: PlanningSessionView = {
+    return {
       ...makeInitialPlanningSession(now, selectedPlanningConfirmationMode),
       id: localId,
       conversationKey: localId,
       presetKey: selectedPlanningPresetKey,
       confirmationMode: selectedPlanningConfirmationMode,
     };
-    setPlanningSessions((prev) => [session, ...prev]);
+  }, [selectedPlanningConfirmationMode, selectedPlanningPresetKey]);
+
+  const removePlanningSessionsById = useCallback((sessionIds: string[]) => {
+    const idsToRemove = new Set(sessionIds);
+    if (idsToRemove.size === 0) return;
+
+    const previousSessions = planningSessionsRef.current;
+    const remainingSessions = previousSessions.filter((session) => !idsToRemove.has(session.id));
+    let nextSessions = remainingSessions;
+    let nextActiveSessionId = activePlanningSessionIdRef.current;
+
+    if (remainingSessions.length === 0) {
+      const session = makeLocalPlanningSession();
+      nextSessions = [session];
+      nextActiveSessionId = session.id;
+    } else if (idsToRemove.has(nextActiveSessionId) || !remainingSessions.some((session) => session.id === nextActiveSessionId)) {
+      const firstRemovedIndex = previousSessions.findIndex((session) => idsToRemove.has(session.id));
+      const nextIndex = Math.min(firstRemovedIndex < 0 ? 0 : firstRemovedIndex, remainingSessions.length - 1);
+      nextActiveSessionId = remainingSessions[nextIndex]?.id ?? remainingSessions[0]!.id;
+    }
+
+    planningSessionsRef.current = nextSessions;
+    activePlanningSessionIdRef.current = nextActiveSessionId;
+    setPlanningSessions(nextSessions);
+    setActivePlanningSessionId(nextActiveSessionId);
+    setKeptPlanningDraftSessionIds((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const sessionId of idsToRemove) {
+        if (next.delete(sessionId)) changed = true;
+      }
+      return changed ? next : prev;
+    });
+    setReviewDraftSessionId((current) => (current && idsToRemove.has(current) ? null : current));
+    for (const sessionId of idsToRemove) {
+      pendingPlanningStreamSessionIdsRef.current.delete(sessionId);
+    }
+    clearPlanningStreamForSessionIds(sessionIds);
+    forgetPlanningStreamAliasesForSessionIds(sessionIds);
+  }, [clearPlanningStreamForSessionIds, forgetPlanningStreamAliasesForSessionIds, makeLocalPlanningSession]);
+
+  const handleCreatePlanningSession = useCallback(() => {
+    const session = makeLocalPlanningSession();
+    planningSessionsRef.current = [session, ...planningSessionsRef.current];
+    activePlanningSessionIdRef.current = session.id;
+    setPlanningSessions(planningSessionsRef.current);
     setActivePlanningSessionId(session.id);
     setSidebarSurface('home');
     focusKeyboardRegion('planning');
-  }, [focusKeyboardRegion, selectedPlanningConfirmationMode, selectedPlanningPresetKey]);
+  }, [focusKeyboardRegion, makeLocalPlanningSession]);
+
+  const handleDeletePlanningSession = useCallback((sessionId: string) => {
+    if (activePlanningReadOnly) return;
+    if (!sessionId.startsWith('local-')) {
+      void invoker?.planningChatDelete?.({ sessionId });
+    }
+    removePlanningSessionsById([sessionId]);
+  }, [activePlanningReadOnly, invoker, removePlanningSessionsById]);
+
+  const handleClearSubmittedPlanningSessions = useCallback(() => {
+    if (activePlanningReadOnly) return;
+    const confirmed = window.confirm('Clear all submitted planning chats?');
+    if (!confirmed) return;
+    const submittedIds = planningSessionsRef.current
+      .filter((session) => session.status === 'submitted')
+      .map((session) => session.id);
+    if (submittedIds.length === 0) return;
+    void invoker?.planningChatDeleteSubmitted?.();
+    removePlanningSessionsById(submittedIds);
+  }, [activePlanningReadOnly, invoker, removePlanningSessionsById]);
 
   const handlePlanningModeChange = useCallback(async (mode: PlanningTerminalMode) => {
     const sourceSession = activePlanningSession;
@@ -4084,30 +4150,48 @@ export function App() {
           const selected = session.id === activePlanningSession.id;
           const preview = previewPlanningMessage(session);
           return (
-            <button
+            <div
               key={session.id}
-              type="button"
-              onClick={() => setActivePlanningSessionId(session.id)}
-              className={`flex w-full items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              className="group flex items-stretch"
             >
-              <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-start justify-between gap-2">
-                  <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
-                    {session.title}
+              <button
+                type="button"
+                onClick={() => setActivePlanningSessionId(session.id)}
+                className={`flex w-full min-w-0 flex-1 items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              >
+                <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
+                      {session.title}
+                    </div>
+                    <span className="shrink-0 text-[11px] text-muted-foreground">
+                      {relativePlanningUpdatedAt(session.updatedAt)}
+                    </span>
                   </div>
-                  <span className="shrink-0 text-[11px] text-muted-foreground">
-                    {relativePlanningUpdatedAt(session.updatedAt)}
-                  </span>
+                  <div
+                    className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
+                    title={preview}
+                  >
+                    {preview}
+                  </div>
                 </div>
-                <div
-                  className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
-                  title={preview}
+              </button>
+              {!activePlanningReadOnly && (
+                <button
+                  type="button"
+                  aria-label="Delete planning chat"
+                  title="Delete planning chat"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleDeletePlanningSession(session.id);
+                  }}
+                  className={`flex w-9 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive ${selected ? 'bg-accent/40' : 'group-hover:bg-accent/20'}`}
                 >
-                  {preview}
-                </div>
-              </div>
-            </button>
+                  <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                </button>
+              )}
+            </div>
           );
         })}
       </div>
@@ -4115,6 +4199,7 @@ export function App() {
   );
 
   const planningReadyCount = planningSessions.filter((session) => session.status === 'draft_ready').length;
+  const hasSubmittedPlanningSessions = planningSessions.some((session) => session.status === 'submitted');
   const connectedAgentLabels = (systemDiagnostics?.tools ?? [])
     .filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed)
     .map((tool) => tool.name.replace(/\s+CLI$/i, ''));
@@ -4283,6 +4368,14 @@ export function App() {
               <div className="flex items-center gap-2">
                 <Button variant="outline" size="sm" onClick={handleCreatePlanningSession}>
                   New chat
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={activePlanningReadOnly || !hasSubmittedPlanningSessions}
+                  onClick={handleClearSubmittedPlanningSessions}
+                >
+                  Clear submitted
                 </Button>
                 <button
                   type="button"

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -224,6 +224,8 @@ export function createMockInvoker(
     })),
     planningChatDiscardDraft: vi.fn(async () => ({ ok: true })),
     planningChatReset: vi.fn(async () => ({ ok: true })),
+    planningChatDelete: vi.fn(async () => ({ ok: true })),
+    planningChatDeleteSubmitted: vi.fn(async () => ({ ok: true, deletedSessionIds: [] })),
     onPlanningChatStream: vi.fn((cb: (event: InAppPlanningStreamEvent) => void) => {
       planningChatStreamCallbacks.add(cb);
       return () => { planningChatStreamCallbacks.delete(cb); };

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -27,6 +27,7 @@ describe('Invoker terminal (component)', () => {
 
   afterEach(() => {
     mock.cleanup();
+    vi.restoreAllMocks();
   });
 
   async function openPlanningTerminal() {
@@ -271,8 +272,8 @@ describe('Invoker terminal (component)', () => {
     const secondPanel = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(secondPanel).toHaveTextContent('Drafting your plan…');
 
-    const sessionButtons = within(screen.getByTestId('planning-session-list')).getAllByRole('button');
-    fireEvent.click(sessionButtons[1]);
+    const sessionButton = within(screen.getByTestId('planning-session-list')).getByRole('button', { name: /first session request/ });
+    fireEvent.click(sessionButton);
 
     const firstPanel = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(firstPanel).toHaveTextContent('Drafting your plan…');
@@ -917,6 +918,182 @@ describe('Invoker terminal (component)', () => {
     fireEvent.click(screen.getByText('hello'));
 
     expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('I can help draft that.');
+  });
+
+  it('deletes a saved planning chat from the rail', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'delete-saved-chat',
+          title: 'Delete saved chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+        makePlanningSessionSummary({
+          id: 'keep-saved-chat',
+          title: 'Keep saved chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    const rail = screen.getByTestId('planning-session-list');
+    await waitFor(() => expect(rail).toHaveTextContent('Delete saved chat'));
+
+    fireEvent.click(within(rail).getAllByRole('button', { name: 'Delete planning chat' })[0]);
+
+    expect(mock.api.planningChatDelete).toHaveBeenCalledWith({ sessionId: 'delete-saved-chat' });
+    await waitFor(() => expect(rail).not.toHaveTextContent('Delete saved chat'));
+    expect(rail).toHaveTextContent('Keep saved chat');
+  });
+
+  it('deletes a local planning chat without calling the backend', async () => {
+    render(<App />);
+    await openPlanningTerminal();
+
+    fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
+    await waitFor(() => expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('2 chats'));
+
+    fireEvent.click(within(screen.getByTestId('planning-session-list')).getAllByRole('button', { name: 'Delete planning chat' })[0]);
+
+    expect(mock.api.planningChatDelete).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('1 chat'));
+  });
+
+  it('clears submitted planning chats after confirmation', async () => {
+    const { unmount } = render(<App />);
+    await openPlanningTerminal();
+
+    expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
+
+    unmount();
+    mock.cleanup();
+    mock = createMockInvoker();
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'active-chat',
+          title: 'Active chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+        makePlanningSessionSummary({
+          id: 'submitted-chat-one',
+          title: 'Submitted chat one',
+          status: 'submitted',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          submittedPlanName: 'Submitted one',
+        }),
+        makePlanningSessionSummary({
+          id: 'submitted-chat-two',
+          title: 'Submitted chat two',
+          status: 'submitted',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          submittedPlanName: 'Submitted two',
+        }),
+        makePlanningSessionSummary({
+          id: 'waiting-chat',
+          title: 'Waiting chat',
+          status: 'waiting_for_answer',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+      ],
+    }));
+    mock.install();
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<App />);
+    await openPlanningTerminal();
+
+    const rail = screen.getByTestId('planning-session-list');
+    await waitFor(() => expect(rail).toHaveTextContent('Submitted chat one'));
+
+    const clearSubmitted = screen.getByRole('button', { name: 'Clear submitted' });
+    expect(clearSubmitted).toBeEnabled();
+    fireEvent.click(clearSubmitted);
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(mock.api.planningChatDeleteSubmitted).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(rail).not.toHaveTextContent('Submitted chat one'));
+    expect(rail).not.toHaveTextContent('Submitted chat two');
+    expect(rail).toHaveTextContent('Active chat');
+    expect(rail).toHaveTextContent('Waiting chat');
+    confirmSpy.mockRestore();
+  });
+
+  it('recreates a fresh empty planning chat when deleting the last one', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'only-saved-chat',
+          title: 'Only saved chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    const rail = screen.getByTestId('planning-session-list');
+    await waitFor(() => expect(rail).toHaveTextContent('Only saved chat'));
+
+    fireEvent.click(within(rail).getByRole('button', { name: 'Delete planning chat' }));
+
+    expect(mock.api.planningChatDelete).toHaveBeenCalledWith({ sessionId: 'only-saved-chat' });
+    await waitFor(() => expect(rail).not.toHaveTextContent('Only saved chat'));
+    expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('1 chat');
+    expect(rail).toHaveTextContent('Untitled plan');
+    expect(screen.getByTestId('invoker-terminal-empty-hero')).toBeInTheDocument();
+    expect(screen.getByTestId('invoker-terminal-input')).toBeEnabled();
+  });
+
+  it('hides planning chat delete buttons and disables clear submitted in read-only mode', async () => {
+    mock.cleanup();
+    mock = createMockInvoker();
+    mock.setRuntimeStatus({ ownerMode: false, readOnly: true, mode: 'read-only' });
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'readonly-active-chat',
+          title: 'Read-only active chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+        makePlanningSessionSummary({
+          id: 'readonly-submitted-chat',
+          title: 'Read-only submitted chat',
+          status: 'submitted',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+      ],
+    }));
+    mock.install();
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    await waitFor(() => expect(screen.getByTestId('planning-session-list')).toHaveTextContent('Read-only submitted chat'));
+    expect(within(screen.getByTestId('planning-session-list')).queryAllByRole('button', { name: 'Delete planning chat' })).toHaveLength(0);
+    expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
   });
 
   it('wraps long planning session rail titles and previews instead of clipping them to one line', async () => {


### PR DESCRIPTION
## Summary

Planning chats now expose rail actions for trimming stale conversations without leaving the panel in an unusable empty state.

The header action handles finished planning chats with confirmation and owner-mode gating.

## Workflow Summary

Delete planning terminals — UI — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784313643126-2/ui-delete-planning-chat | Add per-row trash button (instant) + header Clear submitted button (confirm) to the Planning Terminal rail with reselection, empty-recreate, read-only gating, and stream cleanup | completed |
| wf-1784313643126-2/verify-ui-planning-terminal | Verify Planning Terminal rail delete + clear-submitted UI | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784313643126-2/ui-delete-planning-chat — Add per-row trash button (instant) + header Clear submitted button (confirm) to the Planning Terminal rail with reselection, empty-recreate, read-only gating, and stream cleanup

### wf-1784313643126-2/verify-ui-planning-terminal — Verify Planning Terminal rail delete + clear-submitted UI

</details>

## Review Claim

Approve the Planning Terminal rail action surface for per-chat trashing and header clearing.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The new actions are owner-mode gated, leave at least one local planning chat in the rail, and only call the planning-chat bridge methods for persisted or submitted sessions.

## Slice Rationale

This keeps the rail action surface with its reselection, empty-session fallback, and bridge calls in one reviewer-visible UI workflow.

## Non-goals

- This does not change planner response generation.
- This does not change workflow submission semantics.
- This does not change persisted planning transcript storage format.
- This does not change tmux-mode terminal rendering.

## Architecture

### Before

```mermaid
graph TD
    A["Planning rail lists sessions"] --> B["Selecting a row changes active session"]
    A --> C["No rail action exists for stale chats"]
```

### After

```mermaid
graph TD
    A["Planning rail lists sessions"] --> B["Selecting a row changes active session"]
    A --> C["Row trash action prunes one chat"]
    A --> D["Header action clears submitted chats after confirmation"]
    C --> E["Selection moves to a surviving or recreated chat"]
    D --> E
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- invoker-terminal`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-bodies/delete-planning-terminals-ui-pr.md --require-visual-proof`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/invoker-pr-bodies/delete-planning-terminals-ui-pr.md --base master`

</details>

## Visual Proof

Planning Terminal rail walkthrough showing the row trash action, reselection, and confirmed submitted-chat clear:

[planning-terminal-delete-clear.webm](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-e7e773/planning-terminal-delete-clear.webm)

Initial rail controls with the submitted-chat clear button and per-row trash action available:

![Planning Terminal rail delete controls](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-e7e773/planning-terminal-delete-controls.png)

After using a row trash action, the next chat is selected and submitted-chat clear remains available:

![Planning Terminal after row trash action](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-e7e773/planning-terminal-after-row-delete.png)

After confirming submitted-chat clear, only the active remaining chat stays in the rail and the clear button is disabled:

![Planning Terminal after submitted clear](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-e7e773/planning-terminal-after-clear-submitted.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <published-commit-sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
