### PR TITLE
[Remote Sync Step 1: Sync Schema and Change Journal](1) Add data-store sync schema and journal

### DIFF
--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createAttempt, type TaskState } from '@invoker/workflow-core';
+import type { WorkflowSaveInput } from '../adapter.js';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { SqliteExecutor } from '../sqlite-executor.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  readJournalSince,
+  setSyncCursor,
+} from '../sync-journal.js';
+
+describe('sync journal', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function exec(): SqliteExecutor {
+    return (adapter as unknown as { executor: SqliteExecutor }).executor;
+  }
+
+  function workflow(id = 'wf-1'): WorkflowSaveInput {
+    return {
+      id,
+      name: `Workflow ${id}`,
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+    };
+  }
+
+  function task(id = 'task-1'): TaskState {
+    return {
+      id,
+      description: `Task ${id}`,
+      status: 'pending',
+      dependencies: [],
+      createdAt: new Date('2026-07-27T00:00:00.000Z'),
+      config: {},
+      execution: {},
+      taskStateVersion: 1,
+    };
+  }
+
+  it('fails loudly and rolls back the mutation when journal append fails', () => {
+    const db = (adapter as unknown as { db: { run: (sql: string, params?: unknown[]) => void } }).db;
+    const originalRun = db.run.bind(db);
+    db.run = (sql: string, params?: unknown[]) => {
+      if (sql.includes('INSERT INTO sync_journal')) {
+        throw new Error('simulated journal failure');
+      }
+      return originalRun(sql, params);
+    };
+
+    try {
+      expect(() => adapter.saveWorkflow(workflow())).toThrow('simulated journal failure');
+    } finally {
+      db.run = originalRun;
+    }
+
+    expect(adapter.listWorkflows({ includeDeleted: true })).toEqual([]);
+    expect(readJournalSince(exec(), 0, 10)).toEqual([]);
+  });
+
+  it('rolls back journal rows with their enclosing transaction', () => {
+    expect(() => adapter.runInTransaction(() => {
+      adapter.saveWorkflow(workflow());
+      throw new Error('rollback');
+    })).toThrow('rollback');
+
+    expect(adapter.listWorkflows({ includeDeleted: true })).toEqual([]);
+    expect(readJournalSince(exec(), 0, 10)).toEqual([]);
+  });
+
+  it('assigns strictly monotonic seq values across journaled mutations', () => {
+    adapter.saveWorkflow(workflow());
+    adapter.saveTask('wf-1', task());
+    adapter.updateTask('task-1', { status: 'running' });
+    const attempt = createAttempt('task-1', { status: 'running' });
+    adapter.saveAttempt(attempt);
+    adapter.updateAttempt(attempt.id, {
+      status: 'completed',
+      completedAt: new Date('2026-07-27T00:05:00.000Z'),
+      exitCode: 0,
+    });
+
+    const seqs = readJournalSince(exec(), 0, 20).map((entry) => entry.seq);
+    expect(seqs).toHaveLength(5);
+    expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+    for (let i = 1; i < seqs.length; i += 1) {
+      expect(seqs[i]).toBeGreaterThan(seqs[i - 1]);
+    }
+  });
+
+  it('reads journal rows after the stored cursor', () => {
+    const first = appendJournalEntry(exec(), {
+      entityType: 'workflow',
+      entityId: 'wf-1',
+      op: 'upsert',
+      payload: { id: 'wf-1' },
+      createdAt: 1,
+    });
+    const second = appendJournalEntry(exec(), {
+      entityType: 'task',
+      entityId: 'task-1',
+      op: 'upsert',
+      payload: { id: 'task-1' },
+      createdAt: 2,
+    });
+    const third = appendJournalEntry(exec(), {
+      entityType: 'attempt',
+      entityId: 'attempt-1',
+      op: 'upsert',
+      payload: { id: 'attempt-1' },
+      createdAt: 3,
+    });
+
+    setSyncCursor(exec(), {
+      peerId: 'peer-a',
+      lastSentSeq: second,
+      lastReceivedSeq: first,
+      updatedAt: 4,
+    });
+
+    const cursor = getSyncCursor(exec(), 'peer-a');
+    expect(cursor).toMatchObject({ peerId: 'peer-a', lastSentSeq: second, lastReceivedSeq: first });
+    expect(readJournalSince(exec(), cursor!.lastSentSeq, 10).map((entry) => entry.seq)).toEqual([third]);
+  });
+
+  it('excludes soft-deleted workflows by default but includes them when requested', () => {
+    adapter.saveWorkflow(workflow());
+    adapter.deleteWorkflow('wf-1');
+
+    expect(adapter.loadWorkflow('wf-1')).toBeUndefined();
+    expect(adapter.listWorkflows()).toEqual([]);
+
+    const deleted = adapter.loadWorkflow('wf-1', { includeDeleted: true });
+    expect(deleted?.id).toBe('wf-1');
+    expect(deleted?.deletedAt).toEqual(expect.any(Number));
+    expect(adapter.listWorkflows({ includeDeleted: true }).map((wf) => wf.id)).toEqual(['wf-1']);
+  });
+
+  it('writes a workflow tombstone journal entry on delete', () => {
+    adapter.saveWorkflow(workflow());
+    adapter.deleteWorkflow('wf-1');
+
+    const tombstone = readJournalSince(exec(), 0, 10).find((entry) => entry.op === 'tombstone');
+    expect(tombstone).toMatchObject({
+      entityType: 'workflow',
+      entityId: 'wf-1',
+      origin: 'home',
+    });
+    expect(tombstone?.payload).toMatchObject({
+      id: 'wf-1',
+      deleted_at: expect.any(Number),
+    });
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -126,8 +126,12 @@ export interface Workflow {
   generation?: number;
   createdAt: string;
   updatedAt: string;
+  deletedAt?: number;
 }
 export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup'>;
+export interface WorkflowListOptions {
+  includeDeleted?: boolean;
+}
 
 /**
  * Result of resolving a published PR back to its Invoker workflow via the merge
@@ -333,8 +337,8 @@ export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
-  loadWorkflow(workflowId: string): Workflow | undefined;
-  listWorkflows(): Workflow[];
+  loadWorkflow(workflowId: string, opts?: WorkflowListOptions): Workflow | undefined;
+  listWorkflows(opts?: WorkflowListOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
   /** Resolve a GitHub PR number back to its Invoker workflow via the merge node. */
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined;
@@ -343,7 +347,7 @@ export interface PersistenceAdapter {
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
   loadTasks(workflowId: string): TaskState[];
-  loadWorkflowTaskSnapshot?(): WorkflowTaskSnapshot;
+  loadWorkflowTaskSnapshot?(opts?: WorkflowListOptions): WorkflowTaskSnapshot;
   /** Authoritative single-task read by ID, suitable for recovery workflows. */
   loadTask(taskId: string): TaskState | undefined;
   /** Delete one task and its task-owned rows. */

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -7,3 +7,4 @@ export * from './slack-session-repository.js';
 export * from './slack-plan-draft-repository.js';
 export * from './sqlite-task-repository.js';
 export * from './workflow-channel-repository.js';
+export * from './sync-journal.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -53,6 +53,7 @@ import type {
   WorkerActionRecord,
   WorkerActionWrite,
   WorkerDesiredStateRecord,
+  WorkflowListOptions,
   TerminalSessionPatch,
   TerminalSessionRecord,
   InAppPlanningSessionPatch,
@@ -78,6 +79,7 @@ import type { SqliteExecutor } from './sqlite-executor.js';
 import * as migrations from './sqlite-migrations.js';
 import { SqliteTaskAttemptRepository } from './sqlite-task-attempt-repository.js';
 import { SqliteWorkflowRepository, type WorkflowMetadataChanges } from './sqlite-workflow-repository.js';
+import { appendJournalEntry, type SyncEntityType, type SyncJournalOperation } from './sync-journal.js';
 
 function normalizeWorkerActionStatus(status: string): string {
   return status === 'canceled' ? 'cancelled' : status;
@@ -951,6 +953,40 @@ export class SQLiteAdapter implements PersistenceAdapter {
     };
   }
 
+  private loadSyncJournalPayload(
+    entityType: Exclude<SyncEntityType, 'output'>,
+    entityId: string,
+  ): Record<string, unknown> | undefined {
+    switch (entityType) {
+      case 'workflow':
+        return this.queryOne('SELECT * FROM workflows WHERE id = ?', [entityId]);
+      case 'task':
+        return this.queryOne('SELECT * FROM tasks WHERE id = ?', [entityId]);
+      case 'attempt':
+        return this.queryOne('SELECT * FROM attempts WHERE id = ?', [entityId]);
+      case 'event':
+        return this.queryOne('SELECT * FROM events WHERE id = ?', [entityId]);
+    }
+  }
+
+  private appendRowJournalEntry(
+    entityType: Exclude<SyncEntityType, 'output'>,
+    entityId: string,
+    op: SyncJournalOperation,
+  ): void {
+    const payload = this.loadSyncJournalPayload(entityType, entityId);
+    if (!payload) {
+      throw new Error(`Cannot append sync journal entry for missing ${entityType} "${entityId}"`);
+    }
+    appendJournalEntry(this.executor, {
+      entityType,
+      entityId,
+      op,
+      payload,
+      origin: 'home',
+    });
+  }
+
   runCompatibilityMigration(): {
     migratedFixingWithAiStatuses: number;
     normalizedMergeModes: number;
@@ -1047,19 +1083,28 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Workflows ─────────────────────────────────────────
 
   saveWorkflow(workflow: WorkflowSaveInput): void {
-    this.workflowRepo.saveWorkflow(workflow);
+    this.runTransaction(() => {
+      this.workflowRepo.saveWorkflow(workflow);
+      this.appendRowJournalEntry('workflow', workflow.id, 'upsert');
+    });
   }
 
   updateWorkflow(workflowId: string, changes: WorkflowMetadataChanges): void {
-    this.workflowRepo.updateWorkflow(workflowId, changes);
+    if (!this.queryOne('SELECT 1 FROM workflows WHERE id = ? AND deleted_at IS NULL', [workflowId])) {
+      return;
+    }
+    this.runTransaction(() => {
+      this.workflowRepo.updateWorkflow(workflowId, changes);
+      this.appendRowJournalEntry('workflow', workflowId, 'upsert');
+    });
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    return this.workflowRepo.loadWorkflow(workflowId);
+  loadWorkflow(workflowId: string, opts?: WorkflowListOptions): Workflow | undefined {
+    return this.workflowRepo.loadWorkflow(workflowId, opts);
   }
 
-  listWorkflows(): Workflow[] {
-    return this.workflowRepo.listWorkflows();
+  listWorkflows(opts?: WorkflowListOptions): Workflow[] {
+    return this.workflowRepo.listWorkflows(opts);
   }
 
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
@@ -1070,8 +1115,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return this.workflowRepo.searchWorkflowsAndTasks(query, opts);
   }
 
-  loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
-    return this.workflowRepo.loadWorkflowTaskSnapshot();
+  loadWorkflowTaskSnapshot(opts?: WorkflowListOptions): WorkflowTaskSnapshot {
+    return this.workflowRepo.loadWorkflowTaskSnapshot(opts);
   }
 
   getLastWorkflowTaskSnapshotStats(): Record<string, unknown> | null {
@@ -1081,11 +1126,24 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Tasks ─────────────────────────────────────────────
 
   saveTask(workflowId: string, task: TaskState): void {
-    this.taskAttemptRepo.saveTask(workflowId, task);
+    this.runTransaction(() => {
+      this.taskAttemptRepo.saveTask(workflowId, task);
+      this.appendRowJournalEntry('task', task.id, 'upsert');
+    });
   }
 
   updateTask(taskId: string, changes: TaskStateChanges): void {
-    this.taskAttemptRepo.updateTask(taskId, changes);
+    if (changes.status === undefined) {
+      this.taskAttemptRepo.updateTask(taskId, changes);
+      return;
+    }
+    if (!this.queryOne('SELECT 1 FROM tasks WHERE id = ?', [taskId])) {
+      return;
+    }
+    this.runTransaction(() => {
+      this.taskAttemptRepo.updateTask(taskId, changes);
+      this.appendRowJournalEntry('task', taskId, 'upsert');
+    });
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -1558,6 +1616,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   deleteWorkflow(workflowId: string): void {
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
+    let removedTasks = false;
     this.runTransaction(() => {
       this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
@@ -1598,18 +1657,37 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
+      removedTasks = taskIds.length > 0;
+      const deletedAt = Date.now();
+      this.db.run(
+        `UPDATE workflows
+            SET deleted_at = ?,
+                updated_at = ?
+          WHERE id = ?
+            AND deleted_at IS NULL`,
+        [deletedAt, new Date(deletedAt).toISOString(), workflowId],
+      );
+      if (this.db.getRowsModified() > 0) {
+        this.appendRowJournalEntry('workflow', workflowId, 'tombstone');
+      }
     });
-    this.removeOutputFiles(taskIds);
+    if (removedTasks) this.removeOutputFiles(taskIds);
   }
 
   // ── Events ────────────────────────────────────────────
 
   logEvent(taskId: string, eventType: string, payload?: unknown): void {
-    this.execRun(`
-      INSERT INTO events (task_id, event_type, payload)
-      VALUES (?, ?, ?)
-    `, [taskId, eventType, payload ? JSON.stringify(payload) : null]);
+    this.runTransaction(() => {
+      this.execRun(`
+        INSERT INTO events (task_id, event_type, payload)
+        VALUES (?, ?, ?)
+      `, [taskId, eventType, payload ? JSON.stringify(payload) : null]);
+      const row = this.queryOne('SELECT last_insert_rowid() AS id') as { id?: number | bigint } | undefined;
+      if (row?.id === undefined) {
+        throw new Error('Could not resolve inserted event id for sync journal');
+      }
+      this.appendRowJournalEntry('event', String(row.id), 'upsert');
+    });
   }
 
   getEvents(taskId: string): TaskEvent[];
@@ -2630,7 +2708,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Attempts ────────────────────────────────────────────
 
   saveAttempt(attempt: Attempt): void {
-    this.taskAttemptRepo.saveAttempt(attempt);
+    this.runTransaction(() => {
+      this.taskAttemptRepo.saveAttempt(attempt);
+      this.appendRowJournalEntry('attempt', attempt.id, 'upsert');
+    });
   }
 
   loadAttempts(nodeId: string): Attempt[] {
@@ -2654,7 +2735,21 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void {
-    this.taskAttemptRepo.updateAttempt(attemptId, changes);
+    const shouldJournal =
+      changes.status === 'completed' ||
+      changes.status === 'failed' ||
+      Object.hasOwn(changes, 'completedAt');
+    if (!shouldJournal) {
+      this.taskAttemptRepo.updateAttempt(attemptId, changes);
+      return;
+    }
+    if (!this.queryOne('SELECT 1 FROM attempts WHERE id = ?', [attemptId])) {
+      return;
+    }
+    this.runTransaction(() => {
+      this.taskAttemptRepo.updateAttempt(attemptId, changes);
+      this.appendRowJournalEntry('attempt', attemptId, 'upsert');
+    });
   }
 
   claimAttemptForLaunch(

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -49,6 +49,7 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
     generation: row.generation ?? 0,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+    deletedAt: row.deleted_at === null || row.deleted_at === undefined ? undefined : Number(row.deleted_at),
   };
 }
 

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -28,7 +28,25 @@ export const SCHEMA_DDL = `
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
         created_at TEXT DEFAULT (datetime('now')),
-        updated_at TEXT DEFAULT (datetime('now'))
+        updated_at TEXT DEFAULT (datetime('now')),
+        deleted_at INTEGER
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_journal (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+        entity_id TEXT NOT NULL,
+        op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+        payload TEXT NOT NULL CHECK (json_valid(payload)),
+        origin TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_cursors (
+        peer_id TEXT PRIMARY KEY,
+        last_sent_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_sent_seq) = 'integer' AND last_sent_seq >= 0),
+        last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
+        updated_at INTEGER NOT NULL
       );
 
       CREATE TABLE IF NOT EXISTS tasks (
@@ -597,6 +615,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
+  'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
 ];
 
 /**
@@ -628,6 +647,21 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  `CREATE TABLE IF NOT EXISTS sync_journal (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+    entity_id TEXT NOT NULL,
+    op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    origin TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+  )`,
+  `CREATE TABLE IF NOT EXISTS sync_cursors (
+    peer_id TEXT PRIMARY KEY,
+    last_sent_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_sent_seq) = 'integer' AND last_sent_seq >= 0),
+    last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
+    updated_at INTEGER NOT NULL
+  )`,
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */
@@ -652,7 +686,8 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
         created_at TEXT DEFAULT (datetime('now')),
-        updated_at TEXT DEFAULT (datetime('now'))
+        updated_at TEXT DEFAULT (datetime('now')),
+        deleted_at INTEGER
       )
     `;
 
@@ -662,12 +697,12 @@ export const WORKFLOWS_REBUILD_INSERT_DDL = `
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, created_at, updated_at, deleted_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, created_at, updated_at, deleted_at
       FROM workflows
     `;

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -27,6 +27,7 @@ import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ReviewGateLookup,
   Workflow,
+  WorkflowListOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
 } from './adapter.js';
@@ -174,16 +175,23 @@ export class SqliteWorkflowRepository {
     this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+  loadWorkflow(workflowId: string, opts?: WorkflowListOptions): Workflow | undefined {
+    const row = this.exec.queryOne(
+      opts?.includeDeleted
+        ? 'SELECT * FROM workflows WHERE id = ?'
+        : 'SELECT * FROM workflows WHERE id = ? AND deleted_at IS NULL',
+      [workflowId],
+    );
     if (!row) return undefined;
     const rollup = this.loadWorkflowRollups([workflowId]).get(workflowId);
     return this.rowToWorkflow(row, rollup);
   }
 
-  listWorkflows(): Workflow[] {
+  listWorkflows(opts?: WorkflowListOptions): Workflow[] {
     const rows = this.exec.queryAll(
-      'SELECT * FROM workflows ORDER BY created_at DESC',
+      opts?.includeDeleted
+        ? 'SELECT * FROM workflows ORDER BY created_at DESC'
+        : 'SELECT * FROM workflows WHERE deleted_at IS NULL ORDER BY created_at DESC',
     );
     const workflowIds = rows.map((row) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
@@ -205,7 +213,9 @@ export class SqliteWorkflowRepository {
               w.base_branch AS baseBranch
          FROM tasks t
          JOIN workflows w ON w.id = t.workflow_id
-        WHERE t.is_merge_node = 1 AND (t.review_id = ? OR t.review_url LIKE ?)`,
+        WHERE w.deleted_at IS NULL
+          AND t.is_merge_node = 1
+          AND (t.review_id = ? OR t.review_url LIKE ?)`,
       [pr, `%/pull/${pr}`],
     );
     if (rows.length === 0) return undefined;
@@ -257,7 +267,8 @@ export class SqliteWorkflowRepository {
     if (type === 'workflows' || type === 'all') {
       const workflows = this.exec.queryAll(
         `SELECT id, name, description, plan_file, repo_url, branch, created_at FROM workflows 
-         WHERE name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ? 
+         WHERE deleted_at IS NULL
+           AND (name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{ id: string; name?: string | null; created_at: string }>;
@@ -299,7 +310,7 @@ export class SqliteWorkflowRepository {
         const placeholders = workflowIds.map(() => '?').join(',');
         const workflowRows = this.exec.queryAll(
           `SELECT id, name FROM workflows WHERE id IN (${placeholders})`,
-          workflowIds
+          workflowIds,
         ) as Array<{ id: string; name?: string | null }>;
         for (const wf of workflowRows) {
           workflowNameMap.set(wf.id, wf.name || 'Unnamed workflow');
@@ -323,16 +334,27 @@ export class SqliteWorkflowRepository {
     return results;
   }
 
-  loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
+  loadWorkflowTaskSnapshot(opts?: WorkflowListOptions): WorkflowTaskSnapshot {
     const totalStartedAt = Date.now();
     const workflowQueryStartedAt = Date.now();
-    const workflowRows = this.exec.queryAll('SELECT * FROM workflows ORDER BY created_at DESC');
+    const workflowRows = this.exec.queryAll(
+      opts?.includeDeleted
+        ? 'SELECT * FROM workflows ORDER BY created_at DESC'
+        : 'SELECT * FROM workflows WHERE deleted_at IS NULL ORDER BY created_at DESC',
+    );
     const workflowMetadataQueryMs = Date.now() - workflowQueryStartedAt;
     const taskQueryStartedAt = Date.now();
-    const taskRows = this.exec.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC');
+    const workflowIds = workflowRows.map((row) => String(row.id));
+    const taskRows = workflowIds.length > 0
+      ? this.exec.queryAll(
+        `SELECT * FROM tasks
+         WHERE workflow_id IN (${workflowIds.map(() => '?').join(', ')})
+         ORDER BY workflow_id ASC, id ASC`,
+        workflowIds,
+      )
+      : [];
     const taskQueryMs = Date.now() - taskQueryStartedAt;
     const tasksByWorkflowId = new Map<string, TaskState[]>();
-    const workflowIds = workflowRows.map((row) => String(row.id));
     const rollupStartedAt = Date.now();
     const rollups = this.computeWorkflowRollupsFromRows(workflowIds, taskRows);
     const rollupComputationMs = Date.now() - rollupStartedAt;

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -1,0 +1,143 @@
+import type { SqliteExecutor } from './sqlite-executor.js';
+
+// `output` is reserved for a future low-volume output summary/spool checkpoint
+// journal entry. Raw output-spool rows are intentionally not journaled yet.
+export const SYNC_ENTITY_TYPES = ['workflow', 'task', 'attempt', 'event', 'output'] as const;
+
+export type SyncEntityType = typeof SYNC_ENTITY_TYPES[number];
+export type SyncJournalOperation = 'upsert' | 'tombstone';
+
+export interface SyncJournalEntryInput {
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOperation;
+  payload: unknown;
+  origin?: string;
+  createdAt?: number;
+}
+
+export interface SyncJournalEntry {
+  seq: number;
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOperation;
+  payload: unknown;
+  origin: string;
+  createdAt: number;
+}
+
+export interface SyncCursor {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt: number;
+}
+
+export interface SyncCursorInput {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt?: number;
+}
+
+function toNonNegativeInteger(value: number, label: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function parsePayload(payload: unknown, seq: number): unknown {
+  try {
+    return JSON.parse(String(payload));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Invalid sync journal payload for seq ${seq}: ${message}`);
+  }
+}
+
+export function appendJournalEntry(db: SqliteExecutor, entry: SyncJournalEntryInput): number {
+  const createdAt = entry.createdAt ?? Date.now();
+  toNonNegativeInteger(createdAt, 'createdAt');
+  const origin = entry.origin ?? 'home';
+  const payload = JSON.stringify(entry.payload);
+  if (payload === undefined) {
+    throw new Error('payload must be JSON-serializable');
+  }
+  db.execRun(
+    `INSERT INTO sync_journal (entity_type, entity_id, op, payload, origin, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [entry.entityType, entry.entityId, entry.op, payload, origin, createdAt],
+  );
+  const row = db.queryOne('SELECT last_insert_rowid() AS seq') as { seq?: number | bigint } | undefined;
+  return Number(row?.seq ?? 0);
+}
+
+export function readJournalSince(
+  db: SqliteExecutor,
+  seq: number,
+  limit: number,
+): SyncJournalEntry[] {
+  const cursor = toNonNegativeInteger(seq, 'seq');
+  const cappedLimit = toNonNegativeInteger(limit, 'limit');
+  if (cappedLimit === 0) return [];
+
+  const rows = db.queryAll(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq > ?
+      ORDER BY seq ASC
+      LIMIT ?`,
+    [cursor, cappedLimit],
+  );
+
+  return rows.map((row) => {
+    const rowSeq = Number(row.seq);
+    return {
+      seq: rowSeq,
+      entityType: String(row.entity_type) as SyncEntityType,
+      entityId: String(row.entity_id),
+      op: String(row.op) as SyncJournalOperation,
+      payload: parsePayload(row.payload, rowSeq),
+      origin: String(row.origin),
+      createdAt: Number(row.created_at),
+    };
+  });
+}
+
+export function getSyncCursor(db: SqliteExecutor, peerId: string): SyncCursor | undefined {
+  const row = db.queryOne(
+    `SELECT peer_id, last_sent_seq, last_received_seq, updated_at
+       FROM sync_cursors
+      WHERE peer_id = ?`,
+    [peerId],
+  );
+  if (!row) return undefined;
+  return {
+    peerId: String(row.peer_id),
+    lastSentSeq: Number(row.last_sent_seq),
+    lastReceivedSeq: Number(row.last_received_seq),
+    updatedAt: Number(row.updated_at),
+  };
+}
+
+export function setSyncCursor(db: SqliteExecutor, cursor: SyncCursorInput): SyncCursor {
+  const lastSentSeq = toNonNegativeInteger(cursor.lastSentSeq, 'lastSentSeq');
+  const lastReceivedSeq = toNonNegativeInteger(cursor.lastReceivedSeq, 'lastReceivedSeq');
+  const updatedAt = toNonNegativeInteger(cursor.updatedAt ?? Date.now(), 'updatedAt');
+  db.execRun(
+    `INSERT INTO sync_cursors (peer_id, last_sent_seq, last_received_seq, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(peer_id) DO UPDATE SET
+       last_sent_seq = excluded.last_sent_seq,
+       last_received_seq = excluded.last_received_seq,
+       updated_at = excluded.updated_at`,
+    [cursor.peerId, lastSentSeq, lastReceivedSeq, updatedAt],
+  );
+  return {
+    peerId: cursor.peerId,
+    lastSentSeq,
+    lastReceivedSeq,
+    updatedAt,
+  };
+}


### PR DESCRIPTION
## Summary

Remote Sync Step 1 adds the data-store schema needed to journal syncable workflow state.

Journal rows, peer cursors, and workflow tombstones now share the SQLite persistence contract.

## Workflow Summary

Remote Sync Step 1: Sync Schema and Change Journal — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926077035-3/implement-sync-schema | Add sync journal, cursor, and tombstone schema to data-store | completed |
| wf-1784926077035-3/verify-sync-schema | Run data-store package tests covering the new schema and journal | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784926077035-3/implement-sync-schema — Add sync journal, cursor, and tombstone schema to data-store

packages/data-store/src/__tests__/sync-journal.test.ts
packages/data-store/src/adapter.ts
packages/data-store/src/index.ts
packages/data-store/src/sqlite-adapter.ts
packages/data-store/src/sqlite-row-mappers.ts
packages/data-store/src/sqlite-schema.ts
packages/data-store/src/sqlite-workflow-repository.ts
packages/data-store/src/sync-journal.ts

### wf-1784926077035-3/verify-sync-schema — Run data-store package tests covering the new schema and journal

No file changes; verification ran against the implement slice.

</details>

## Review Claim

Approve the data-store sync schema contract for journal entries, peer cursors, workflow tombstones, and local journal writes.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This slice is confined to data-store schema, journal helpers, persistence adapter paths, and directly affected persistence tests; no sync transport or remote execution path is activated.

## Slice Rationale

Schema and local journaling land first so later remote sync transport can consume one stable data-store contract.

## Non-goals

- No remote sync transport.
- No peer protocol.
- No merge logic.
- No output spool journaling.
- No UI changes.

## Architecture

### Before

```mermaid
graph TD
    A["SQLite persistence tables"] --> B["Workflow, task, and attempt rows"]
    C["Remote sync peers"] --> D["No durable cursor contract"]
```

### After

```mermaid
graph TD
    A["SQLite persistence tables"] --> B["Workflow, task, and attempt rows"]
    A --> C["sync_journal entries"]
    A --> D["sync_cursors per peer"]
    B --> E["workflow tombstones represented by deleted_at rows"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sync-journal.test.ts` (25 files, 435 tests passed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b0974a1eaab0a2d636d49696bf25a04634ddb9b6`
- Post-revert steps: Rerun the data-store focused test.
- Data migration? No production migration has shipped yet.

</details>
