### PR TITLE
[Start Ready recreate+rebase expansion](1) Extend Start Ready contracts

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -609,12 +609,42 @@ export interface WorkflowMutationAcceptedResult {
   channel: string;
 }
 
+export type StartReadyFreshBaseScope =
+  | 'failed'
+  | 'failed-and-pending'
+  | 'failed-pending-and-running'
+  | 'all';
+
+export interface StartReadyFreshBasePreview {
+  scope: StartReadyFreshBaseScope;
+  workflowIds: string[];
+  failedWorkflowIds: string[];
+  pendingWorkflowIds: string[];
+  runningWorkflowIds: string[];
+  completedWorkflowIds?: string[];
+}
+
+export type StartReadyWorkflowOutcome =
+  | {
+      ok: true;
+      workflowId: string;
+      mode: 'recreate' | 'fresh-base-recreate';
+      startedTaskIds: string[];
+    }
+  | {
+      ok: false;
+      workflowId: string;
+      mode: 'recreate' | 'fresh-base-recreate';
+      error: string;
+    };
+
 export interface StartReadyRequest {
   recreateFailed?: boolean;
   recreateFailedAndPending?: boolean;
   recreateFailedPendingAndRunning?: boolean;
   /** Recreate failed + pending/queued + running + completed (finished) workflows. */
   recreateAll?: boolean;
+  freshBaseScope?: StartReadyFreshBaseScope;
   dryRun?: boolean;
 }
 
@@ -625,6 +655,7 @@ export interface StartReadyPreview {
   pendingWorkflowIds: string[];
   runningWorkflowIds: string[];
   completedWorkflowIds?: string[];
+  freshBase?: StartReadyFreshBasePreview;
   skipped: {
     awaitingApproval: number;
     reviewReady: number;
@@ -640,6 +671,9 @@ export interface StartReadyResult {
   preview: StartReadyPreview;
   started: TaskState[];
   recreatedWorkflowIds: string[];
+  freshBaseRecreatedWorkflowIds?: string[];
+  workflowOutcomes?: StartReadyWorkflowOutcome[];
+  partial?: boolean;
   dryRun: boolean;
 }
 


### PR DESCRIPTION
## Summary

Start Ready now has named fields for fresh-base scope requests, preview counts, and per-workflow results.

This gives later slices one typed shape before they add new behavior.

## Review Claim

Extend the shared Start Ready contract so fresh-base scopes, preview counts, and partial outcomes are typed end to end.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Only `packages/contracts/src/ipc-channels.ts` changes, so review stays on the shared IPC shape with no execution-path edits.

## Slice Rationale

The contract lands first so later slices can consume one stable request and result shape.

## Non-goals

- No backend execution changes.
- No headless flag or rail UI changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/contracts build`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/start-ready.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ce26c03a9c28093bc1a7ace0087b85025cc257d8`
- Post-revert steps: Re-run the focused Start Ready app test because later stack slices depend on these fields.
- Data migration? No

</details>
