### PR TITLE
[Start Ready recreate+rebase expansion](2) Add fresh-base Start Ready execution

### DIFF
--- a/packages/app/src/__tests__/start-ready.test.ts
+++ b/packages/app/src/__tests__/start-ready.test.ts
@@ -77,12 +77,12 @@ describe('start-ready', () => {
     });
   });
 
-  it('dry-run reports the preview without mutating work', () => {
+  it('dry-run reports the preview without mutating work', async () => {
     const ready = makeTask('wf-1/ready', 'pending');
     const recoverable = makeTask('wf-1/recoverable', 'running');
     const orchestrator = harness([ready, recoverable], [ready]);
 
-    const result = runStartReady(orchestrator, { dryRun: true });
+    const result = await runStartReady(orchestrator, { dryRun: true });
 
     expect(result.dryRun).toBe(true);
     expect(result.started).toEqual([]);
@@ -90,12 +90,12 @@ describe('start-ready', () => {
     expect(orchestrator.startExecution).not.toHaveBeenCalled();
   });
 
-  it('recovers interrupted claims and starts executable ready tasks', () => {
+  it('recovers interrupted claims and starts executable ready tasks', async () => {
     const ready = makeTask('wf-1/ready', 'pending');
     const recoverable = makeTask('wf-1/recoverable', 'running');
     const orchestrator = harness([ready, recoverable], [ready]);
 
-    const result = runStartReady(orchestrator);
+    const result = await runStartReady(orchestrator);
 
     expect(orchestrator.syncAllFromDb).toHaveBeenCalledTimes(1);
     expect(orchestrator.prepareTaskForNewAttempt).toHaveBeenCalledWith('wf-1/recoverable', 'start_ready_recovery');
@@ -103,7 +103,7 @@ describe('start-ready', () => {
     expect(result.started.map((task) => task.id)).toEqual(['wf-1/ready']);
   });
 
-  it('leaves actively executing tasks alone instead of superseding their attempts', () => {
+  it('leaves actively executing tasks alone instead of superseding their attempts', async () => {
     const ready = makeTask('wf-1/ready', 'pending');
     const live = makeTask('wf-1/live', 'running', {
       execution: { selectedAttemptId: 'attempt-live' },
@@ -111,19 +111,19 @@ describe('start-ready', () => {
     const orphaned = makeTask('wf-1/orphaned', 'running');
     const orchestrator = harness([ready, live, orphaned], [ready], ['wf-1/live']);
 
-    const result = runStartReady(orchestrator);
+    const result = await runStartReady(orchestrator);
 
     expect(orchestrator.prepareTaskForNewAttempt).not.toHaveBeenCalledWith('wf-1/live', 'start_ready_recovery');
     expect(orchestrator.prepareTaskForNewAttempt).toHaveBeenCalledWith('wf-1/orphaned', 'start_ready_recovery');
     expect(result.preview.recoverableTaskIds).toEqual(['wf-1/orphaned']);
   });
 
-  it('recreates failed workflows only when requested', () => {
+  it('recreates failed workflows only when requested', async () => {
     const failed = makeTask('wf-1/failed', 'failed');
     const pendingOnly = makeTask('wf-2/pending', 'pending');
     const orchestrator = harness([failed, pendingOnly], []);
 
-    const result = runStartReady(orchestrator, { recreateFailed: true });
+    const result = await runStartReady(orchestrator, { recreateFailed: true });
 
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
     expect(orchestrator.recreateWorkflow).not.toHaveBeenCalledWith('wf-2');
@@ -131,13 +131,13 @@ describe('start-ready', () => {
     expect(result.started.map((task) => task.id)).toEqual(['wf-1/recreated']);
   });
 
-  it('recreates failed and pending/queued workflows when requested', () => {
+  it('recreates failed and pending/queued workflows when requested', async () => {
     const failed = makeTask('wf-1/failed', 'failed');
     const pendingOnly = makeTask('wf-2/pending', 'pending');
     const queuedOnly = makeTask('wf-3/queued', 'queued' as TaskState['status']);
     const orchestrator = harness([failed, pendingOnly, queuedOnly], []);
 
-    const result = runStartReady(orchestrator, { recreateFailedAndPending: true });
+    const result = await runStartReady(orchestrator, { recreateFailedAndPending: true });
 
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-2');
@@ -145,12 +145,12 @@ describe('start-ready', () => {
     expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2', 'wf-3']);
   });
 
-  it('prefers failed-and-pending union when both recreate flags are set', () => {
+  it('prefers failed-and-pending union when both recreate flags are set', async () => {
     const failed = makeTask('wf-1/failed', 'failed');
     const pendingOnly = makeTask('wf-2/pending', 'pending');
     const orchestrator = harness([failed, pendingOnly], []);
 
-    const result = runStartReady(orchestrator, {
+    const result = await runStartReady(orchestrator, {
       recreateFailed: true,
       recreateFailedAndPending: true,
     });
@@ -158,14 +158,14 @@ describe('start-ready', () => {
     expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2']);
   });
 
-  it('recreates failed, pending/queued, and running workflows when requested', () => {
+  it('recreates failed, pending/queued, and running workflows when requested', async () => {
     const failed = makeTask('wf-1/failed', 'failed');
     const pendingOnly = makeTask('wf-2/pending', 'pending');
     const runningOnly = makeTask('wf-3/running', 'running');
     const approval = makeTask('wf-4/approval', 'awaiting_approval');
     const orchestrator = harness([failed, pendingOnly, runningOnly, approval], []);
 
-    const result = runStartReady(orchestrator, { recreateFailedPendingAndRunning: true });
+    const result = await runStartReady(orchestrator, { recreateFailedPendingAndRunning: true });
 
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-2');
@@ -174,23 +174,23 @@ describe('start-ready', () => {
     expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2', 'wf-3']);
   });
 
-  it('failed-and-pending does not recreate running-only workflows', () => {
+  it('failed-and-pending does not recreate running-only workflows', async () => {
     const runningOnly = makeTask('wf-1/running', 'running');
     const orchestrator = harness([runningOnly], []);
 
-    const result = runStartReady(orchestrator, { recreateFailedAndPending: true });
+    const result = await runStartReady(orchestrator, { recreateFailedAndPending: true });
 
     expect(orchestrator.recreateWorkflow).not.toHaveBeenCalled();
     expect(result.recreatedWorkflowIds).toEqual([]);
   });
 
-  it('prefers failed-pending-and-running union when all recreate flags are set', () => {
+  it('prefers failed-pending-and-running union when all recreate flags are set', async () => {
     const failed = makeTask('wf-1/failed', 'failed');
     const pendingOnly = makeTask('wf-2/pending', 'pending');
     const runningOnly = makeTask('wf-3/running', 'running');
     const orchestrator = harness([failed, pendingOnly, runningOnly], []);
 
-    const result = runStartReady(orchestrator, {
+    const result = await runStartReady(orchestrator, {
       recreateFailed: true,
       recreateFailedAndPending: true,
       recreateFailedPendingAndRunning: true,
@@ -199,7 +199,7 @@ describe('start-ready', () => {
     expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2', 'wf-3']);
   });
 
-  it('recreates failed, pending/queued, running, and completed workflows when recreateAll is set', () => {
+  it('recreates failed, pending/queued, running, and completed workflows when recreateAll is set', async () => {
     const failed = makeTask('wf-1/failed', 'failed');
     const pendingOnly = makeTask('wf-2/pending', 'pending');
     const runningOnly = makeTask('wf-3/running', 'running');
@@ -210,7 +210,7 @@ describe('start-ready', () => {
       [],
     );
 
-    const result = runStartReady(orchestrator, { recreateAll: true });
+    const result = await runStartReady(orchestrator, { recreateAll: true });
 
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-2');
@@ -221,16 +221,106 @@ describe('start-ready', () => {
     expect(result.preview.completedWorkflowIds).toEqual(['wf-4']);
   });
 
-  it('prefers recreateAll over narrower recreate flags', () => {
+  it('prefers recreateAll over narrower recreate flags', async () => {
     const failed = makeTask('wf-1/failed', 'failed');
     const completedOnly = makeTask('wf-2/completed', 'completed');
     const orchestrator = harness([failed, completedOnly], []);
 
-    const result = runStartReady(orchestrator, {
+    const result = await runStartReady(orchestrator, {
       recreateFailed: true,
       recreateAll: true,
     });
 
     expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2']);
+  });
+
+  it('dry-run previews fresh-base scope selections without mutating work', async () => {
+    const failed = makeTask('wf-1/failed', 'failed');
+    const pendingOnly = makeTask('wf-2/pending', 'pending');
+    const queuedOnly = makeTask('wf-3/queued', 'queued' as TaskState['status']);
+    const runningOnly = makeTask('wf-4/running', 'running');
+    const completedOnly = makeTask('wf-5/completed', 'completed');
+    const approval = makeTask('wf-6/approval', 'awaiting_approval');
+    const orchestrator = harness(
+      [failed, pendingOnly, queuedOnly, runningOnly, completedOnly, approval],
+      [],
+    );
+
+    const result = await runStartReady(orchestrator, {
+      dryRun: true,
+      freshBaseScope: 'failed-pending-and-running',
+    });
+
+    expect(result.preview.freshBase).toEqual({
+      scope: 'failed-pending-and-running',
+      workflowIds: ['wf-1', 'wf-2', 'wf-3', 'wf-4'],
+      failedWorkflowIds: ['wf-1'],
+      pendingWorkflowIds: ['wf-2', 'wf-3'],
+      runningWorkflowIds: ['wf-4'],
+      completedWorkflowIds: [],
+    });
+    expect(result.started).toEqual([]);
+    expect(orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('routes fresh-base scopes through fresh-base recreation and reports partial outcomes', async () => {
+    const failed = makeTask('wf-1/failed', 'failed');
+    const pendingOnly = makeTask('wf-2/pending', 'pending');
+    const runningOnly = makeTask('wf-3/running', 'running');
+    const orchestrator = harness([failed, pendingOnly, runningOnly], []);
+    const freshStarted = makeTask('wf-1/fresh', 'pending');
+    const freshBaseRecreateWorkflow = vi.fn(async (workflowId: string) => {
+      if (workflowId === 'wf-2') throw new Error('base refresh failed');
+      return [freshStarted];
+    });
+
+    const result = await runStartReady(orchestrator, {
+      freshBaseScope: 'failed-and-pending',
+    }, {
+      freshBaseRecreateWorkflow,
+    });
+
+    expect(freshBaseRecreateWorkflow).toHaveBeenCalledTimes(2);
+    expect(freshBaseRecreateWorkflow).toHaveBeenNthCalledWith(1, 'wf-1');
+    expect(freshBaseRecreateWorkflow).toHaveBeenNthCalledWith(2, 'wf-2');
+    expect(orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+    expect(result.freshBaseRecreatedWorkflowIds).toEqual(['wf-1']);
+    expect(result.recreatedWorkflowIds).toEqual([]);
+    expect(result.partial).toBe(true);
+    expect(result.workflowOutcomes).toEqual([
+      {
+        ok: true,
+        workflowId: 'wf-1',
+        mode: 'fresh-base-recreate',
+        startedTaskIds: ['wf-1/fresh'],
+      },
+      {
+        ok: false,
+        workflowId: 'wf-2',
+        mode: 'fresh-base-recreate',
+        error: 'base refresh failed',
+      },
+    ]);
+    expect(result.started.map((task) => task.id)).toEqual(['wf-1/fresh']);
+  });
+
+  it('fresh-base all scope includes completed workflows', async () => {
+    const failed = makeTask('wf-1/failed', 'failed');
+    const completedOnly = makeTask('wf-2/completed', 'completed');
+    const orchestrator = harness([failed, completedOnly], []);
+    const freshBaseRecreateWorkflow = vi.fn(async (workflowId: string) => [
+      makeTask(`${workflowId}/fresh`, 'pending'),
+    ]);
+
+    const result = await runStartReady(orchestrator, {
+      freshBaseScope: 'all',
+    }, {
+      freshBaseRecreateWorkflow,
+    });
+
+    expect(result.preview.freshBase?.workflowIds).toEqual(['wf-1', 'wf-2']);
+    expect(result.preview.freshBase?.completedWorkflowIds).toEqual(['wf-2']);
+    expect(result.freshBaseRecreatedWorkflowIds).toEqual(['wf-1', 'wf-2']);
+    expect(result.partial).toBe(false);
   });
 });

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -21,6 +21,7 @@ import { startWebSurfaceForHeadless } from './web/start-web-surface.js';
 import type { TaskHandleMap } from './execution/task-runner-wiring.js';
 import {
   fixWithAgentAction,
+  recreateWorkflowFromFreshBase,
   rebaseRetry,
   rebaseRecreate,
   resolveConflictAction,
@@ -306,7 +307,14 @@ function parseStartReadyArgs(args: string[], inheritedNoTrack: boolean | undefin
 
 export async function headlessStartReady(args: string[], deps: HeadlessDeps): Promise<void> {
   const { request, noTrack } = parseStartReadyArgs(args, deps.noTrack);
-  const result = runStartReady(deps.orchestrator, request) as StartReadyResult & {
+  const result = await runStartReady(deps.orchestrator, request, {
+    freshBaseRecreateWorkflow: (workflowId) => recreateWorkflowFromFreshBase(workflowId, {
+      ...deps,
+      commandService: deps.commandService,
+      taskExecutor: createHeadlessExecutor(deps),
+      mutationTiming: deps.mutationTiming,
+    }),
+  }) as StartReadyResult & {
     preview: StartReadyPreviewExt;
   };
   const runnable = result.started.filter(isDispatchableLaunch);

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -45,6 +45,7 @@ import {
   fixWithAgentAction,
   rebaseRecreate,
   rebaseRetry,
+  recreateWorkflowFromFreshBase,
   resolveConflictAction,
   selectFailureRecoveryRoute,
   selectExperiments as sharedSelectExperiments,
@@ -1101,8 +1102,18 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     }
   }
 
-  function executeStartReady(request: StartReadyRequest = {}): StartReadyResult {
-    const result = runStartReady(orchestrator, request);
+  async function executeStartReady(request: StartReadyRequest = {}): Promise<StartReadyResult> {
+    const result = await runStartReady(orchestrator, request, {
+      freshBaseRecreateWorkflow: (workflowId) => recreateWorkflowFromFreshBase(workflowId, {
+        logger,
+        orchestrator,
+        persistence,
+        commandService,
+        repoRoot,
+        taskExecutor: requireTaskExecutor(),
+        mutationTiming: activeMutationContext.mutationTiming,
+      }),
+    });
     if (!result.dryRun) {
       publishOrchestratorSnapshotToRenderer();
     }
@@ -1390,7 +1401,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       logger.info('resume-workflow: no workflows found', { module: 'ipc' });
       return null;
     }
-    const result = executeStartReady({});
+    const result = await executeStartReady({});
     const tasks = orchestrator.getAllTasks();
     logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${result.started.length} started`, { module: 'ipc' });
     return { workflow: workflows[0], taskCount: tasks.length, startedCount: result.started.length };

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -154,6 +154,7 @@ import {
 import {
   approveTask as sharedApproveTask,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
+  recreateWorkflowFromFreshBase as sharedRecreateWorkflowFromFreshBase,
   rejectTask as sharedRejectTask,
   selectExperiments as sharedSelectExperiments,
 } from './workflow-actions.js';
@@ -1460,7 +1461,17 @@ function startHeadlessMode(): void {
         }
         if (!workflowMutationDispatcher.has('invoker:start-ready')) {
           workflowMutationDispatcher.set('invoker:start-ready', async (requestArg: unknown) =>
-            runStartReady(orchestrator, requestArg as StartReadyRequest | undefined),
+            runStartReady(orchestrator, requestArg as StartReadyRequest | undefined, {
+              freshBaseRecreateWorkflow: (workflowId) => sharedRecreateWorkflowFromFreshBase(workflowId, {
+                logger,
+                orchestrator,
+                persistence,
+                commandService,
+                repoRoot,
+                taskExecutor: createHeadlessExecutor(headlessDeps),
+                mutationTiming: activeMutationContext?.mutationTiming,
+              }),
+            }),
           );
         }
         if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
@@ -2250,8 +2261,18 @@ startMainProcessBootstrap({
     }
   }
 
-  function executeStartReady(request: StartReadyRequest = {}): StartReadyResult {
-    const result = runStartReady(orchestrator, request);
+  async function executeStartReady(request: StartReadyRequest = {}): Promise<StartReadyResult> {
+    const result = await runStartReady(orchestrator, request, {
+      freshBaseRecreateWorkflow: (workflowId) => sharedRecreateWorkflowFromFreshBase(workflowId, {
+        logger,
+        orchestrator,
+        persistence,
+        commandService,
+        repoRoot,
+        taskExecutor: requireTaskExecutor(),
+        mutationTiming: activeMutationContext?.mutationTiming,
+      }),
+    });
     if (!result.dryRun) {
       publishOrchestratorSnapshotToRenderer();
     }

--- a/packages/app/src/start-ready.ts
+++ b/packages/app/src/start-ready.ts
@@ -1,7 +1,10 @@
 import type {
+  StartReadyFreshBasePreview,
+  StartReadyFreshBaseScope,
   StartReadyPreview,
   StartReadyRequest,
   StartReadyResult,
+  StartReadyWorkflowOutcome,
 } from '@invoker/contracts';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 
@@ -20,6 +23,10 @@ type StartReadyRequestExt = StartReadyRequest & {
   recreateFailedAndPending?: boolean;
   recreateFailedPendingAndRunning?: boolean;
 };
+
+export interface StartReadyRunOptions {
+  freshBaseRecreateWorkflow?: (workflowId: string) => Promise<TaskState[]>;
+}
 
 type StartReadyPreviewExt = StartReadyPreview & {
   pendingWorkflowIds: string[];
@@ -119,6 +126,56 @@ function workflowIdsToRecreate(
   return [];
 }
 
+function workflowIdsForFreshBaseScope(
+  scope: StartReadyFreshBaseScope,
+  preview: StartReadyPreviewExt,
+): string[] {
+  switch (scope) {
+    case 'failed':
+      return [...preview.failedWorkflowIds];
+    case 'failed-and-pending':
+      return unionWorkflowIds(preview.failedWorkflowIds, preview.pendingWorkflowIds);
+    case 'failed-pending-and-running':
+      return unionWorkflowIds(
+        preview.failedWorkflowIds,
+        preview.pendingWorkflowIds,
+        preview.runningWorkflowIds,
+      );
+    case 'all':
+      return unionWorkflowIds(
+        preview.failedWorkflowIds,
+        preview.pendingWorkflowIds,
+        preview.runningWorkflowIds,
+        preview.completedWorkflowIds,
+      );
+  }
+}
+
+function collectFreshBasePreview(
+  scope: StartReadyFreshBaseScope,
+  preview: StartReadyPreviewExt,
+): StartReadyFreshBasePreview {
+  const includePending = scope === 'failed-and-pending'
+    || scope === 'failed-pending-and-running'
+    || scope === 'all';
+  const includeRunning = scope === 'failed-pending-and-running'
+    || scope === 'all';
+  const includeCompleted = scope === 'all';
+
+  return {
+    scope,
+    workflowIds: workflowIdsForFreshBaseScope(scope, preview),
+    failedWorkflowIds: [...preview.failedWorkflowIds],
+    pendingWorkflowIds: includePending ? [...preview.pendingWorkflowIds] : [],
+    runningWorkflowIds: includeRunning ? [...preview.runningWorkflowIds] : [],
+    completedWorkflowIds: includeCompleted ? [...preview.completedWorkflowIds] : [],
+  };
+}
+
+function formatStartReadyError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 export function collectStartReadyPreview(orchestrator: StartReadyOrchestrator): StartReadyPreview {
   const tasks = orchestrator.getAllTasks();
   const readyTasks = orchestrator.getExecutableReadyTasks();
@@ -151,10 +208,25 @@ export function collectStartReadyPreview(orchestrator: StartReadyOrchestrator): 
 export function runStartReady(
   orchestrator: StartReadyOrchestrator,
   request: StartReadyRequest = {},
-): StartReadyResult {
+  options: StartReadyRunOptions = {},
+): Promise<StartReadyResult> {
+  return runStartReadyAsync(orchestrator, request, options);
+}
+
+async function runStartReadyAsync(
+  orchestrator: StartReadyOrchestrator,
+  request: StartReadyRequest = {},
+  options: StartReadyRunOptions = {},
+): Promise<StartReadyResult> {
   const extendedRequest = request as StartReadyRequestExt;
   orchestrator.syncAllFromDb();
   const preview = collectStartReadyPreview(orchestrator) as StartReadyPreviewExt;
+  const freshBasePreview = request.freshBaseScope
+    ? collectFreshBasePreview(request.freshBaseScope, preview)
+    : undefined;
+  if (freshBasePreview) {
+    preview.freshBase = freshBasePreview;
+  }
   if (request.dryRun) {
     return {
       preview,
@@ -166,9 +238,38 @@ export function runStartReady(
 
   const started: TaskState[] = [];
   const recreatedWorkflowIds: string[] = [];
-  for (const workflowId of workflowIdsToRecreate(extendedRequest, preview)) {
-    started.push(...orchestrator.recreateWorkflow(workflowId));
-    recreatedWorkflowIds.push(workflowId);
+  const freshBaseRecreatedWorkflowIds: string[] = [];
+  const workflowOutcomes: StartReadyWorkflowOutcome[] = [];
+
+  if (freshBasePreview) {
+    if (freshBasePreview.workflowIds.length > 0 && !options.freshBaseRecreateWorkflow) {
+      throw new Error('Start Ready fresh-base scope requires freshBaseRecreateWorkflow.');
+    }
+    for (const workflowId of freshBasePreview.workflowIds) {
+      try {
+        const workflowStarted = await options.freshBaseRecreateWorkflow!(workflowId);
+        started.push(...workflowStarted);
+        freshBaseRecreatedWorkflowIds.push(workflowId);
+        workflowOutcomes.push({
+          ok: true,
+          workflowId,
+          mode: 'fresh-base-recreate',
+          startedTaskIds: workflowStarted.map((task) => task.id),
+        });
+      } catch (err) {
+        workflowOutcomes.push({
+          ok: false,
+          workflowId,
+          mode: 'fresh-base-recreate',
+          error: formatStartReadyError(err),
+        });
+      }
+    }
+  } else {
+    for (const workflowId of workflowIdsToRecreate(extendedRequest, preview)) {
+      started.push(...orchestrator.recreateWorkflow(workflowId));
+      recreatedWorkflowIds.push(workflowId);
+    }
   }
 
   const recoverableTasks = collectRecoverableTasks(orchestrator);
@@ -182,6 +283,13 @@ export function runStartReady(
     preview,
     started: uniqueTasks(started),
     recreatedWorkflowIds,
+    ...(freshBasePreview
+      ? {
+          freshBaseRecreatedWorkflowIds,
+          workflowOutcomes,
+          partial: workflowOutcomes.some((outcome) => !outcome.ok),
+        }
+      : {}),
     dryRun: false,
   };
 }

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -609,12 +609,42 @@ export interface WorkflowMutationAcceptedResult {
   channel: string;
 }
 
+export type StartReadyFreshBaseScope =
+  | 'failed'
+  | 'failed-and-pending'
+  | 'failed-pending-and-running'
+  | 'all';
+
+export interface StartReadyFreshBasePreview {
+  scope: StartReadyFreshBaseScope;
+  workflowIds: string[];
+  failedWorkflowIds: string[];
+  pendingWorkflowIds: string[];
+  runningWorkflowIds: string[];
+  completedWorkflowIds?: string[];
+}
+
+export type StartReadyWorkflowOutcome =
+  | {
+      ok: true;
+      workflowId: string;
+      mode: 'recreate' | 'fresh-base-recreate';
+      startedTaskIds: string[];
+    }
+  | {
+      ok: false;
+      workflowId: string;
+      mode: 'recreate' | 'fresh-base-recreate';
+      error: string;
+    };
+
 export interface StartReadyRequest {
   recreateFailed?: boolean;
   recreateFailedAndPending?: boolean;
   recreateFailedPendingAndRunning?: boolean;
   /** Recreate failed + pending/queued + running + completed (finished) workflows. */
   recreateAll?: boolean;
+  freshBaseScope?: StartReadyFreshBaseScope;
   dryRun?: boolean;
 }
 
@@ -625,6 +655,7 @@ export interface StartReadyPreview {
   pendingWorkflowIds: string[];
   runningWorkflowIds: string[];
   completedWorkflowIds?: string[];
+  freshBase?: StartReadyFreshBasePreview;
   skipped: {
     awaitingApproval: number;
     reviewReady: number;
@@ -640,6 +671,9 @@ export interface StartReadyResult {
   preview: StartReadyPreview;
   started: TaskState[];
   recreatedWorkflowIds: string[];
+  freshBaseRecreatedWorkflowIds?: string[];
+  workflowOutcomes?: StartReadyWorkflowOutcome[];
+  partial?: boolean;
   dryRun: boolean;
 }
 


### PR DESCRIPTION
## Summary

Start Ready can now dry-run or execute fresh-base recreation for the selected scope and keep per-workflow results.

The flow keeps going after one workflow fails, so callers see partial success instead of one opaque abort.

## Review Claim

Add the scope-aware Start Ready execution path that runs fresh-base recreation per workflow and returns partial outcomes.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Changes stay inside the Start Ready execution flow and its direct regression file, with no rail UI edits in this slice.

## Slice Rationale

Execution has to exist before later slices can expose the new scope choices on headless or rail surfaces.

## Non-goals

- No global delegation timeout classification changes.
- No rail menu exposure.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/start-ready.test.ts src/__tests__/owner-delegation.test.ts src/__tests__/acknowledge-no-track-start-ready.test.ts`

</details>

## Visual Proof

Preview state showing the fresh-base workflow counts produced by the new Start Ready execution path.

![Fresh-base Start Ready preview dialog](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-829d5e/start-ready-fresh-base-preview-dialog.png)

[Walkthrough video showing the fresh-base Start Ready preview flow](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-829d5e/walkthrough.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d01530d99b371fe79180cb9481007243bd808f93`
- Post-revert steps: Re-run the focused Start Ready app regression command.
- Data migration? No

</details>
