### PR TITLE
[Start Ready recreate+rebase expansion](4) Expose fresh-base headless flags

### DIFF
--- a/packages/app/src/__tests__/acknowledge-no-track-start-ready.test.ts
+++ b/packages/app/src/__tests__/acknowledge-no-track-start-ready.test.ts
@@ -1,6 +1,43 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { runHeadless } from '../headless.js';
+import { headlessStartReady } from '../headless-run-resume.js';
 import { acknowledgeNoTrackHeadlessExec } from '../ipc/gui-mutation-handlers.js';
+
+function makeTask(id: string, status: string): any {
+  return {
+    id,
+    status,
+    config: { workflowId: id.split('/')[0] },
+    execution: {},
+  };
+}
+
+function makeStartReadyDeps(tasks: any[]): any {
+  const logger = {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => logger),
+  };
+  return {
+    logger,
+    orchestrator: {
+      syncAllFromDb: vi.fn(),
+      getAllTasks: vi.fn(() => tasks),
+      getExecutableReadyTasks: vi.fn(() => []),
+      getPersistedActiveTaskIds: vi.fn(() => new Set<string>()),
+      startExecution: vi.fn(() => []),
+    },
+    persistence: {},
+    commandService: {},
+    executorRegistry: {},
+    messageBus: {},
+    repoRoot: '/fake/repo',
+    invokerConfig: {},
+  };
+}
 
 describe('acknowledgeNoTrackHeadlessExec start-ready', () => {
   it('falls through for global start-ready instead of requiring a workflow id', () => {
@@ -12,7 +49,7 @@ describe('acknowledgeNoTrackHeadlessExec start-ready', () => {
     };
     const result = acknowledgeNoTrackHeadlessExec(
       {
-        args: ['start-ready', '--recreate-failed-and-pending'],
+        args: ['start-ready', '--fresh-base-failed-and-pending'],
         noTrack: true,
       },
       undefined,
@@ -34,6 +71,77 @@ describe('acknowledgeNoTrackHeadlessExec start-ready', () => {
       expect.stringContaining('headless.exec start-ready noTrack fallthrough'),
       expect.objectContaining({ module: 'ipc-delegate' }),
     );
+  });
+
+  it('documents fresh-base start-ready flags in headless help', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    let output = '';
+
+    try {
+      await runHeadless(['--help'], {} as never);
+      output = stdout.mock.calls.map(([chunk]) => String(chunk)).join('');
+    } finally {
+      stdout.mockRestore();
+    }
+
+    expect(output).toContain('[--fresh-base-failed]');
+    expect(output).toContain('[--fresh-base-failed-and-pending]');
+    expect(output).toContain('[--fresh-base-failed-pending-and-running]');
+    expect(output).toContain('[--fresh-base-all]');
+    expect(output).toContain('Fresh-base flags recreate selected workflows from a refreshed base');
+  });
+
+  it.each([
+    [
+      '--fresh-base-failed',
+      'failed',
+      'Start ready work and recreate failed workflows from fresh base',
+      1,
+    ],
+    [
+      '--fresh-base-failed-and-pending',
+      'failed-and-pending',
+      'Start ready work and recreate failed and pending workflows from fresh base',
+      2,
+    ],
+    [
+      '--fresh-base-failed-pending-and-running',
+      'failed-pending-and-running',
+      'Start ready work and recreate failed, pending, and running workflows from fresh base',
+      3,
+    ],
+    [
+      '--fresh-base-all',
+      'all',
+      'Start ready work and recreate all workflows from fresh base (including finished)',
+      4,
+    ],
+  ])('prints explicit fresh-base preview output for %s', async (
+    flag,
+    scope,
+    label,
+    workflowCount,
+  ) => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const deps = makeStartReadyDeps([
+      makeTask('wf-failed/task-1', 'failed'),
+      makeTask('wf-pending/task-1', 'pending'),
+      makeTask('wf-running/task-1', 'running'),
+      makeTask('wf-completed/task-1', 'completed'),
+    ]);
+    let output = '';
+
+    try {
+      await headlessStartReady(['--dry-run', flag], deps);
+      output = stdout.mock.calls.map(([chunk]) => String(chunk)).join('');
+    } finally {
+      stdout.mockRestore();
+    }
+
+    expect(output).toContain(`${label}: preview`);
+    expect(output).toContain(`fresh-base scope: ${scope}`);
+    expect(output).toContain(`fresh-base workflows: ${workflowCount}`);
+    expect(output).toContain('fresh-base recreated workflows: 0');
   });
 
   it('repro: pre-fix path rejected no-track start-ready as workflow-not-resolved', () => {

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { delegationTimeoutMs, tryDelegateExec, tryDelegateRun, tryDelegateResume } from '../headless.js';
+import {
+  delegationTimeoutMs,
+  resolveDelegationTimeoutMs,
+  tryDelegateExec,
+  tryDelegateRun,
+  tryDelegateResume,
+} from '../headless.js';
 import { LocalBus } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
 import type { HeadlessTargetLookup } from '../headless-command-classification.js';
@@ -86,10 +92,26 @@ describe('headless→owner delegation', () => {
       expect(delegationTimeoutMs(['approve', 'wf-123/task-1'], targetLookup)).toBe(5_000);
     });
 
-    it('uses 60s timeout for global start-ready', () => {
-      expect(delegationTimeoutMs(['start-ready'], targetLookup)).toBe(60_000);
-      expect(delegationTimeoutMs(['start-ready', '--recreate-failed-and-pending'], targetLookup)).toBe(60_000);
-      expect(delegationTimeoutMs(['start-ready', '--recreate-all'], targetLookup)).toBe(300_000);
+    it.each([
+      ['default', []],
+      ['failed recreate', ['--recreate-failed']],
+      ['failed and pending recreate', ['--recreate-failed-and-pending']],
+      ['failed, pending, and running recreate', ['--recreate-failed-pending-and-running']],
+      ['failed fresh-base', ['--fresh-base-failed']],
+      ['failed and pending fresh-base', ['--fresh-base-failed-and-pending']],
+      ['failed, pending, and running fresh-base', ['--fresh-base-failed-pending-and-running']],
+    ])('uses 60s timeout for global start-ready %s scope', async (_label, flags) => {
+      const args = ['start-ready', ...flags];
+
+      expect(delegationTimeoutMs(args, targetLookup)).toBe(60_000);
+      await expect(resolveDelegationTimeoutMs(args)).resolves.toBe(60_000);
+    });
+
+    it('keeps the broader timeout for global start-ready recreate-all', async () => {
+      const args = ['start-ready', '--recreate-all'];
+
+      expect(delegationTimeoutMs(args, targetLookup)).toBe(300_000);
+      await expect(resolveDelegationTimeoutMs(args)).resolves.toBe(300_000);
     });
   });
 

--- a/packages/app/src/__tests__/start-ready.test.ts
+++ b/packages/app/src/__tests__/start-ready.test.ts
@@ -77,12 +77,12 @@ describe('start-ready', () => {
     });
   });
 
-  it('dry-run reports the preview without mutating work', () => {
+  it('dry-run reports the preview without mutating work', async () => {
     const ready = makeTask('wf-1/ready', 'pending');
     const recoverable = makeTask('wf-1/recoverable', 'running');
     const orchestrator = harness([ready, recoverable], [ready]);
 
-    const result = runStartReady(orchestrator, { dryRun: true });
+    const result = await runStartReady(orchestrator, { dryRun: true });
 
     expect(result.dryRun).toBe(true);
     expect(result.started).toEqual([]);
@@ -90,12 +90,12 @@ describe('start-ready', () => {
     expect(orchestrator.startExecution).not.toHaveBeenCalled();
   });
 
-  it('recovers interrupted claims and starts executable ready tasks', () => {
+  it('recovers interrupted claims and starts executable ready tasks', async () => {
     const ready = makeTask('wf-1/ready', 'pending');
     const recoverable = makeTask('wf-1/recoverable', 'running');
     const orchestrator = harness([ready, recoverable], [ready]);
 
-    const result = runStartReady(orchestrator);
+    const result = await runStartReady(orchestrator);
 
     expect(orchestrator.syncAllFromDb).toHaveBeenCalledTimes(1);
     expect(orchestrator.prepareTaskForNewAttempt).toHaveBeenCalledWith('wf-1/recoverable', 'start_ready_recovery');
@@ -103,7 +103,7 @@ describe('start-ready', () => {
     expect(result.started.map((task) => task.id)).toEqual(['wf-1/ready']);
   });
 
-  it('leaves actively executing tasks alone instead of superseding their attempts', () => {
+  it('leaves actively executing tasks alone instead of superseding their attempts', async () => {
     const ready = makeTask('wf-1/ready', 'pending');
     const live = makeTask('wf-1/live', 'running', {
       execution: { selectedAttemptId: 'attempt-live' },
@@ -111,19 +111,19 @@ describe('start-ready', () => {
     const orphaned = makeTask('wf-1/orphaned', 'running');
     const orchestrator = harness([ready, live, orphaned], [ready], ['wf-1/live']);
 
-    const result = runStartReady(orchestrator);
+    const result = await runStartReady(orchestrator);
 
     expect(orchestrator.prepareTaskForNewAttempt).not.toHaveBeenCalledWith('wf-1/live', 'start_ready_recovery');
     expect(orchestrator.prepareTaskForNewAttempt).toHaveBeenCalledWith('wf-1/orphaned', 'start_ready_recovery');
     expect(result.preview.recoverableTaskIds).toEqual(['wf-1/orphaned']);
   });
 
-  it('recreates failed workflows only when requested', () => {
+  it('recreates failed workflows only when requested', async () => {
     const failed = makeTask('wf-1/failed', 'failed');
     const pendingOnly = makeTask('wf-2/pending', 'pending');
     const orchestrator = harness([failed, pendingOnly], []);
 
-    const result = runStartReady(orchestrator, { recreateFailed: true });
+    const result = await runStartReady(orchestrator, { recreateFailed: true });
 
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
     expect(orchestrator.recreateWorkflow).not.toHaveBeenCalledWith('wf-2');
@@ -131,13 +131,13 @@ describe('start-ready', () => {
     expect(result.started.map((task) => task.id)).toEqual(['wf-1/recreated']);
   });
 
-  it('recreates failed and pending/queued workflows when requested', () => {
+  it('recreates failed and pending/queued workflows when requested', async () => {
     const failed = makeTask('wf-1/failed', 'failed');
     const pendingOnly = makeTask('wf-2/pending', 'pending');
     const queuedOnly = makeTask('wf-3/queued', 'queued' as TaskState['status']);
     const orchestrator = harness([failed, pendingOnly, queuedOnly], []);
 
-    const result = runStartReady(orchestrator, { recreateFailedAndPending: true });
+    const result = await runStartReady(orchestrator, { recreateFailedAndPending: true });
 
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-2');
@@ -145,12 +145,12 @@ describe('start-ready', () => {
     expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2', 'wf-3']);
   });
 
-  it('prefers failed-and-pending union when both recreate flags are set', () => {
+  it('prefers failed-and-pending union when both recreate flags are set', async () => {
     const failed = makeTask('wf-1/failed', 'failed');
     const pendingOnly = makeTask('wf-2/pending', 'pending');
     const orchestrator = harness([failed, pendingOnly], []);
 
-    const result = runStartReady(orchestrator, {
+    const result = await runStartReady(orchestrator, {
       recreateFailed: true,
       recreateFailedAndPending: true,
     });
@@ -158,14 +158,14 @@ describe('start-ready', () => {
     expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2']);
   });
 
-  it('recreates failed, pending/queued, and running workflows when requested', () => {
+  it('recreates failed, pending/queued, and running workflows when requested', async () => {
     const failed = makeTask('wf-1/failed', 'failed');
     const pendingOnly = makeTask('wf-2/pending', 'pending');
     const runningOnly = makeTask('wf-3/running', 'running');
     const approval = makeTask('wf-4/approval', 'awaiting_approval');
     const orchestrator = harness([failed, pendingOnly, runningOnly, approval], []);
 
-    const result = runStartReady(orchestrator, { recreateFailedPendingAndRunning: true });
+    const result = await runStartReady(orchestrator, { recreateFailedPendingAndRunning: true });
 
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-2');
@@ -174,23 +174,23 @@ describe('start-ready', () => {
     expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2', 'wf-3']);
   });
 
-  it('failed-and-pending does not recreate running-only workflows', () => {
+  it('failed-and-pending does not recreate running-only workflows', async () => {
     const runningOnly = makeTask('wf-1/running', 'running');
     const orchestrator = harness([runningOnly], []);
 
-    const result = runStartReady(orchestrator, { recreateFailedAndPending: true });
+    const result = await runStartReady(orchestrator, { recreateFailedAndPending: true });
 
     expect(orchestrator.recreateWorkflow).not.toHaveBeenCalled();
     expect(result.recreatedWorkflowIds).toEqual([]);
   });
 
-  it('prefers failed-pending-and-running union when all recreate flags are set', () => {
+  it('prefers failed-pending-and-running union when all recreate flags are set', async () => {
     const failed = makeTask('wf-1/failed', 'failed');
     const pendingOnly = makeTask('wf-2/pending', 'pending');
     const runningOnly = makeTask('wf-3/running', 'running');
     const orchestrator = harness([failed, pendingOnly, runningOnly], []);
 
-    const result = runStartReady(orchestrator, {
+    const result = await runStartReady(orchestrator, {
       recreateFailed: true,
       recreateFailedAndPending: true,
       recreateFailedPendingAndRunning: true,
@@ -199,7 +199,7 @@ describe('start-ready', () => {
     expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2', 'wf-3']);
   });
 
-  it('recreates failed, pending/queued, running, and completed workflows when recreateAll is set', () => {
+  it('recreates failed, pending/queued, running, and completed workflows when recreateAll is set', async () => {
     const failed = makeTask('wf-1/failed', 'failed');
     const pendingOnly = makeTask('wf-2/pending', 'pending');
     const runningOnly = makeTask('wf-3/running', 'running');
@@ -210,7 +210,7 @@ describe('start-ready', () => {
       [],
     );
 
-    const result = runStartReady(orchestrator, { recreateAll: true });
+    const result = await runStartReady(orchestrator, { recreateAll: true });
 
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-2');
@@ -221,16 +221,106 @@ describe('start-ready', () => {
     expect(result.preview.completedWorkflowIds).toEqual(['wf-4']);
   });
 
-  it('prefers recreateAll over narrower recreate flags', () => {
+  it('prefers recreateAll over narrower recreate flags', async () => {
     const failed = makeTask('wf-1/failed', 'failed');
     const completedOnly = makeTask('wf-2/completed', 'completed');
     const orchestrator = harness([failed, completedOnly], []);
 
-    const result = runStartReady(orchestrator, {
+    const result = await runStartReady(orchestrator, {
       recreateFailed: true,
       recreateAll: true,
     });
 
     expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-2']);
+  });
+
+  it('dry-run previews fresh-base scope selections without mutating work', async () => {
+    const failed = makeTask('wf-1/failed', 'failed');
+    const pendingOnly = makeTask('wf-2/pending', 'pending');
+    const queuedOnly = makeTask('wf-3/queued', 'queued' as TaskState['status']);
+    const runningOnly = makeTask('wf-4/running', 'running');
+    const completedOnly = makeTask('wf-5/completed', 'completed');
+    const approval = makeTask('wf-6/approval', 'awaiting_approval');
+    const orchestrator = harness(
+      [failed, pendingOnly, queuedOnly, runningOnly, completedOnly, approval],
+      [],
+    );
+
+    const result = await runStartReady(orchestrator, {
+      dryRun: true,
+      freshBaseScope: 'failed-pending-and-running',
+    });
+
+    expect(result.preview.freshBase).toEqual({
+      scope: 'failed-pending-and-running',
+      workflowIds: ['wf-1', 'wf-2', 'wf-3', 'wf-4'],
+      failedWorkflowIds: ['wf-1'],
+      pendingWorkflowIds: ['wf-2', 'wf-3'],
+      runningWorkflowIds: ['wf-4'],
+      completedWorkflowIds: [],
+    });
+    expect(result.started).toEqual([]);
+    expect(orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('routes fresh-base scopes through fresh-base recreation and reports partial outcomes', async () => {
+    const failed = makeTask('wf-1/failed', 'failed');
+    const pendingOnly = makeTask('wf-2/pending', 'pending');
+    const runningOnly = makeTask('wf-3/running', 'running');
+    const orchestrator = harness([failed, pendingOnly, runningOnly], []);
+    const freshStarted = makeTask('wf-1/fresh', 'pending');
+    const freshBaseRecreateWorkflow = vi.fn(async (workflowId: string) => {
+      if (workflowId === 'wf-2') throw new Error('base refresh failed');
+      return [freshStarted];
+    });
+
+    const result = await runStartReady(orchestrator, {
+      freshBaseScope: 'failed-and-pending',
+    }, {
+      freshBaseRecreateWorkflow,
+    });
+
+    expect(freshBaseRecreateWorkflow).toHaveBeenCalledTimes(2);
+    expect(freshBaseRecreateWorkflow).toHaveBeenNthCalledWith(1, 'wf-1');
+    expect(freshBaseRecreateWorkflow).toHaveBeenNthCalledWith(2, 'wf-2');
+    expect(orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+    expect(result.freshBaseRecreatedWorkflowIds).toEqual(['wf-1']);
+    expect(result.recreatedWorkflowIds).toEqual([]);
+    expect(result.partial).toBe(true);
+    expect(result.workflowOutcomes).toEqual([
+      {
+        ok: true,
+        workflowId: 'wf-1',
+        mode: 'fresh-base-recreate',
+        startedTaskIds: ['wf-1/fresh'],
+      },
+      {
+        ok: false,
+        workflowId: 'wf-2',
+        mode: 'fresh-base-recreate',
+        error: 'base refresh failed',
+      },
+    ]);
+    expect(result.started.map((task) => task.id)).toEqual(['wf-1/fresh']);
+  });
+
+  it('fresh-base all scope includes completed workflows', async () => {
+    const failed = makeTask('wf-1/failed', 'failed');
+    const completedOnly = makeTask('wf-2/completed', 'completed');
+    const orchestrator = harness([failed, completedOnly], []);
+    const freshBaseRecreateWorkflow = vi.fn(async (workflowId: string) => [
+      makeTask(`${workflowId}/fresh`, 'pending'),
+    ]);
+
+    const result = await runStartReady(orchestrator, {
+      freshBaseScope: 'all',
+    }, {
+      freshBaseRecreateWorkflow,
+    });
+
+    expect(result.preview.freshBase?.workflowIds).toEqual(['wf-1', 'wf-2']);
+    expect(result.preview.freshBase?.completedWorkflowIds).toEqual(['wf-2']);
+    expect(result.freshBaseRecreatedWorkflowIds).toEqual(['wf-1', 'wf-2']);
+    expect(result.partial).toBe(false);
   });
 });

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -19,6 +19,7 @@ export const DEFAULT_DELEGATION_TIMEOUT_MS = 5_000;
 export const WORKFLOW_DELEGATION_TIMEOUT_MS = 60_000;
 /** start-ready --recreate-all can recreate dozens of workflows inline on the owner. */
 export const START_READY_RECREATE_ALL_DELEGATION_TIMEOUT_MS = 300_000;
+const START_READY_RECREATE_ALL_FLAG = '--recreate-all';
 
 // ---------------------------------------------------------------------------
 // DelegationOutcome — typed result union for delegation attempts
@@ -94,6 +95,12 @@ function looksLikeWorkflowId(target: unknown): boolean {
   return /^wf-[^/]+$/.test(String(target ?? ''));
 }
 
+function startReadyDelegationTimeoutMs(args: readonly string[]): number {
+  return args.includes(START_READY_RECREATE_ALL_FLAG)
+    ? START_READY_RECREATE_ALL_DELEGATION_TIMEOUT_MS
+    : WORKFLOW_DELEGATION_TIMEOUT_MS;
+}
+
 export function delegationTimeoutMs(
   args: string[],
   targetLookup: HeadlessTargetLookup,
@@ -103,9 +110,7 @@ export function delegationTimeoutMs(
     return DEFAULT_DELEGATION_TIMEOUT_MS;
   }
   if (command === 'start-ready') {
-    return args.includes('--recreate-all')
-      ? START_READY_RECREATE_ALL_DELEGATION_TIMEOUT_MS
-      : WORKFLOW_DELEGATION_TIMEOUT_MS;
+    return startReadyDelegationTimeoutMs(args);
   }
 
   const resolvedTarget = resolveHeadlessTarget(args[1], targetLookup);
@@ -122,9 +127,7 @@ export async function resolveDelegationTimeoutMs(args: string[]): Promise<number
   }
   // start-ready is global (no workflow arg) but recreates/starts many workflows.
   if (command === 'start-ready') {
-    return args.includes('--recreate-all')
-      ? START_READY_RECREATE_ALL_DELEGATION_TIMEOUT_MS
-      : WORKFLOW_DELEGATION_TIMEOUT_MS;
+    return startReadyDelegationTimeoutMs(args);
   }
   return looksLikeWorkflowId(args[1])
     ? WORKFLOW_DELEGATION_TIMEOUT_MS

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -8,7 +8,13 @@
  * command-family modules — keeping the import graph acyclic.
  */
 
-import { makeEnvelope, type StartReadyRequest, type StartReadyResult } from '@invoker/contracts';
+import {
+  makeEnvelope,
+  type StartReadyFreshBasePreview,
+  type StartReadyFreshBaseScope,
+  type StartReadyRequest,
+  type StartReadyResult,
+} from '@invoker/contracts';
 import type { TaskState } from '@invoker/workflow-core';
 import {
   remoteFetchForPool,
@@ -62,6 +68,8 @@ type StartReadyPreviewExt = {
   failedWorkflowIds: string[];
   pendingWorkflowIds: string[];
   runningWorkflowIds: string[];
+  completedWorkflowIds?: string[];
+  freshBase?: StartReadyFreshBasePreview;
   skipped: {
     awaitingApproval: number;
     reviewReady: number;
@@ -71,6 +79,123 @@ type StartReadyPreviewExt = {
     runningTasks: number;
   };
 };
+
+const START_READY_USAGE = '--headless start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--recreate-all] [--fresh-base-failed] [--fresh-base-failed-and-pending] [--fresh-base-failed-pending-and-running] [--fresh-base-all] [--no-track]';
+
+const FRESH_BASE_MODE_LABELS: Record<StartReadyFreshBaseScope, string> = {
+  failed: 'Start ready work and recreate failed workflows from fresh base',
+  'failed-and-pending': 'Start ready work and recreate failed and pending workflows from fresh base',
+  'failed-pending-and-running': 'Start ready work and recreate failed, pending, and running workflows from fresh base',
+  all: 'Start ready work and recreate all workflows from fresh base (including finished)',
+};
+
+function includesPendingStartReadyScope(request: StartReadyRequestExt): boolean {
+  return Boolean(
+    request.recreateAll
+    || request.recreateFailedAndPending
+    || request.recreateFailedPendingAndRunning
+    || request.freshBaseScope === 'failed-and-pending'
+    || request.freshBaseScope === 'failed-pending-and-running'
+    || request.freshBaseScope === 'all',
+  );
+}
+
+function includesRunningStartReadyScope(request: StartReadyRequestExt): boolean {
+  return Boolean(
+    request.recreateAll
+    || request.recreateFailedPendingAndRunning
+    || request.freshBaseScope === 'failed-pending-and-running'
+    || request.freshBaseScope === 'all',
+  );
+}
+
+function includesCompletedStartReadyScope(request: StartReadyRequestExt): boolean {
+  return Boolean(request.recreateAll || request.freshBaseScope === 'all');
+}
+
+function unionIds(...groups: readonly (readonly string[] | undefined)[]): string[] {
+  const ids = new Set<string>();
+  for (const group of groups) {
+    for (const id of group ?? []) ids.add(id);
+  }
+  return Array.from(ids);
+}
+
+function freshBasePreviewForOutput(
+  preview: StartReadyPreviewExt,
+  scope: StartReadyFreshBaseScope,
+): StartReadyFreshBasePreview {
+  if (preview.freshBase) return preview.freshBase;
+  const pendingWorkflowIds = scope === 'failed-and-pending'
+    || scope === 'failed-pending-and-running'
+    || scope === 'all'
+    ? preview.pendingWorkflowIds
+    : [];
+  const runningWorkflowIds = scope === 'failed-pending-and-running' || scope === 'all'
+    ? preview.runningWorkflowIds
+    : [];
+  const completedWorkflowIds = scope === 'all'
+    ? preview.completedWorkflowIds ?? []
+    : [];
+  return {
+    scope,
+    workflowIds: unionIds(
+      preview.failedWorkflowIds,
+      pendingWorkflowIds,
+      runningWorkflowIds,
+      completedWorkflowIds,
+    ),
+    failedWorkflowIds: preview.failedWorkflowIds,
+    pendingWorkflowIds,
+    runningWorkflowIds,
+    completedWorkflowIds,
+  };
+}
+
+function startReadyModeLabel(request: StartReadyRequestExt): string {
+  if (request.freshBaseScope) return FRESH_BASE_MODE_LABELS[request.freshBaseScope];
+  return request.recreateAll
+    ? 'Start and recreate all (including finished)'
+    : request.recreateFailedPendingAndRunning
+      ? 'Start and recreate failed, pending, and running'
+      : request.recreateFailedAndPending
+        ? 'Start and recreate failed and pending'
+        : request.recreateFailed
+          ? 'Start and recreate failed'
+          : 'Start ready work';
+}
+
+function printFreshBasePreview(preview: StartReadyPreviewExt, scope: StartReadyFreshBaseScope): void {
+  const freshBase = freshBasePreviewForOutput(preview, scope);
+  process.stdout.write(`  fresh-base scope: ${freshBase.scope}\n`);
+  process.stdout.write(`  fresh-base workflows: ${freshBase.workflowIds.length}\n`);
+  process.stdout.write(`  fresh-base failed workflows: ${freshBase.failedWorkflowIds.length}\n`);
+  if (freshBase.scope === 'failed-and-pending'
+    || freshBase.scope === 'failed-pending-and-running'
+    || freshBase.scope === 'all') {
+    process.stdout.write(`  fresh-base pending workflows: ${freshBase.pendingWorkflowIds.length}\n`);
+  }
+  if (freshBase.scope === 'failed-pending-and-running' || freshBase.scope === 'all') {
+    process.stdout.write(`  fresh-base running workflows: ${freshBase.runningWorkflowIds.length}\n`);
+  }
+  if (freshBase.scope === 'all') {
+    process.stdout.write(`  fresh-base completed workflows: ${freshBase.completedWorkflowIds?.length ?? 0}\n`);
+  }
+}
+
+function printStartReadyOutcomeSummary(result: StartReadyResult, request: StartReadyRequestExt): void {
+  if (request.freshBaseScope || result.freshBaseRecreatedWorkflowIds !== undefined) {
+    process.stdout.write(`  fresh-base recreated workflows: ${result.freshBaseRecreatedWorkflowIds?.length ?? 0}\n`);
+  }
+  if (result.partial) {
+    process.stdout.write('  partial: yes\n');
+  }
+  if (result.workflowOutcomes?.length) {
+    const failed = result.workflowOutcomes.filter((outcome) => !outcome.ok).length;
+    const succeeded = result.workflowOutcomes.length - failed;
+    process.stdout.write(`  workflow outcomes: ${succeeded} succeeded, ${failed} failed\n`);
+  }
+}
 function createTrackedHeadlessExecutor(
   deps: HeadlessDeps,
   taskHandles: TaskHandleMap,
@@ -295,11 +420,23 @@ function parseStartReadyArgs(args: string[], inheritedNoTrack: boolean | undefin
       case '--recreate-all':
         request.recreateAll = true;
         break;
+      case '--fresh-base-failed':
+        request.freshBaseScope = 'failed';
+        break;
+      case '--fresh-base-failed-and-pending':
+        request.freshBaseScope = 'failed-and-pending';
+        break;
+      case '--fresh-base-failed-pending-and-running':
+        request.freshBaseScope = 'failed-pending-and-running';
+        break;
+      case '--fresh-base-all':
+        request.freshBaseScope = 'all';
+        break;
       case '--no-track':
         noTrack = true;
         break;
       default:
-        throw new Error(`Unknown start-ready option "${arg}". Usage: --headless start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--recreate-all] [--no-track]`);
+        throw new Error(`Unknown start-ready option "${arg}". Usage: ${START_READY_USAGE}`);
     }
   }
   return { request, noTrack };
@@ -320,33 +457,25 @@ export async function headlessStartReady(args: string[], deps: HeadlessDeps): Pr
   const runnable = result.started.filter(isDispatchableLaunch);
   const preview = result.preview;
 
-  const modeLabel = request.recreateAll
-    ? 'Start and recreate all (including finished)'
-    : request.recreateFailedPendingAndRunning
-      ? 'Start and recreate failed, pending, and running'
-      : request.recreateFailedAndPending
-        ? 'Start and recreate failed and pending'
-        : request.recreateFailed
-          ? 'Start and recreate failed'
-          : 'Start ready work';
+  const modeLabel = startReadyModeLabel(request);
   process.stdout.write(`${modeLabel}: ${result.dryRun ? 'preview' : 'submitted'}\n`);
   process.stdout.write(`  ready: ${preview.readyTaskIds.length}\n`);
   process.stdout.write(`  recoverable: ${preview.recoverableTaskIds.length}\n`);
   process.stdout.write(`  failed workflows: ${preview.failedWorkflowIds.length}\n`);
-  if (
-    request.recreateAll
-    || request.recreateFailedAndPending
-    || request.recreateFailedPendingAndRunning
-  ) {
+  if (includesPendingStartReadyScope(request)) {
     process.stdout.write(`  pending workflows: ${preview.pendingWorkflowIds.length}\n`);
   }
-  if (request.recreateAll || request.recreateFailedPendingAndRunning) {
+  if (includesRunningStartReadyScope(request)) {
     process.stdout.write(`  running workflows: ${preview.runningWorkflowIds.length}\n`);
   }
-  if (request.recreateAll) {
+  if (includesCompletedStartReadyScope(request)) {
     process.stdout.write(`  completed workflows: ${preview.completedWorkflowIds?.length ?? 0}\n`);
   }
+  if (request.freshBaseScope) {
+    printFreshBasePreview(preview, request.freshBaseScope);
+  }
   process.stdout.write(`  recreated workflows: ${result.recreatedWorkflowIds.length}\n`);
+  printStartReadyOutcomeSummary(result, request);
   process.stdout.write(`  started: ${runnable.length}\n`);
 
   if (result.dryRun || runnable.length === 0) {

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -21,6 +21,7 @@ import { startWebSurfaceForHeadless } from './web/start-web-surface.js';
 import type { TaskHandleMap } from './execution/task-runner-wiring.js';
 import {
   fixWithAgentAction,
+  recreateWorkflowFromFreshBase,
   rebaseRetry,
   rebaseRecreate,
   resolveConflictAction,
@@ -306,7 +307,14 @@ function parseStartReadyArgs(args: string[], inheritedNoTrack: boolean | undefin
 
 export async function headlessStartReady(args: string[], deps: HeadlessDeps): Promise<void> {
   const { request, noTrack } = parseStartReadyArgs(args, deps.noTrack);
-  const result = runStartReady(deps.orchestrator, request) as StartReadyResult & {
+  const result = await runStartReady(deps.orchestrator, request, {
+    freshBaseRecreateWorkflow: (workflowId) => recreateWorkflowFromFreshBase(workflowId, {
+      ...deps,
+      commandService: deps.commandService,
+      taskExecutor: createHeadlessExecutor(deps),
+      mutationTiming: deps.mutationTiming,
+    }),
+  }) as StartReadyResult & {
     preview: StartReadyPreviewExt;
   };
   const runnable = result.started.filter(isDispatchableLaunch);

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -561,8 +561,10 @@ ${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
 ${BOLD}Execute:${RESET}
   watch [<workflowId>]                                Watch workflow status until settled or Ctrl-C
   run <plan.yaml>                                     Load and execute plan
-  start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--recreate-all] [--no-track]
+  start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--recreate-all]
+              [--fresh-base-failed] [--fresh-base-failed-and-pending] [--fresh-base-failed-pending-and-running] [--fresh-base-all] [--no-track]
                                                       Start pending work that is ready to execute
+                                                      Fresh-base flags recreate selected workflows from a refreshed base
   resume <id>                                         Resume incomplete workflow
   retry <workflowId>                                  Retry workflow: rerun failed, keep completed
   retry-task <taskId>                                 Retry a single failed/stuck task

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -45,6 +45,7 @@ import {
   fixWithAgentAction,
   rebaseRecreate,
   rebaseRetry,
+  recreateWorkflowFromFreshBase,
   resolveConflictAction,
   selectFailureRecoveryRoute,
   selectExperiments as sharedSelectExperiments,
@@ -1101,8 +1102,18 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     }
   }
 
-  function executeStartReady(request: StartReadyRequest = {}): StartReadyResult {
-    const result = runStartReady(orchestrator, request);
+  async function executeStartReady(request: StartReadyRequest = {}): Promise<StartReadyResult> {
+    const result = await runStartReady(orchestrator, request, {
+      freshBaseRecreateWorkflow: (workflowId) => recreateWorkflowFromFreshBase(workflowId, {
+        logger,
+        orchestrator,
+        persistence,
+        commandService,
+        repoRoot,
+        taskExecutor: requireTaskExecutor(),
+        mutationTiming: activeMutationContext.mutationTiming,
+      }),
+    });
     if (!result.dryRun) {
       publishOrchestratorSnapshotToRenderer();
     }
@@ -1390,7 +1401,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       logger.info('resume-workflow: no workflows found', { module: 'ipc' });
       return null;
     }
-    const result = executeStartReady({});
+    const result = await executeStartReady({});
     const tasks = orchestrator.getAllTasks();
     logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${result.started.length} started`, { module: 'ipc' });
     return { workflow: workflows[0], taskCount: tasks.length, startedCount: result.started.length };

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -154,6 +154,7 @@ import {
 import {
   approveTask as sharedApproveTask,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
+  recreateWorkflowFromFreshBase as sharedRecreateWorkflowFromFreshBase,
   rejectTask as sharedRejectTask,
   selectExperiments as sharedSelectExperiments,
 } from './workflow-actions.js';
@@ -1460,7 +1461,17 @@ function startHeadlessMode(): void {
         }
         if (!workflowMutationDispatcher.has('invoker:start-ready')) {
           workflowMutationDispatcher.set('invoker:start-ready', async (requestArg: unknown) =>
-            runStartReady(orchestrator, requestArg as StartReadyRequest | undefined),
+            runStartReady(orchestrator, requestArg as StartReadyRequest | undefined, {
+              freshBaseRecreateWorkflow: (workflowId) => sharedRecreateWorkflowFromFreshBase(workflowId, {
+                logger,
+                orchestrator,
+                persistence,
+                commandService,
+                repoRoot,
+                taskExecutor: createHeadlessExecutor(headlessDeps),
+                mutationTiming: activeMutationContext?.mutationTiming,
+              }),
+            }),
           );
         }
         if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
@@ -2250,8 +2261,18 @@ startMainProcessBootstrap({
     }
   }
 
-  function executeStartReady(request: StartReadyRequest = {}): StartReadyResult {
-    const result = runStartReady(orchestrator, request);
+  async function executeStartReady(request: StartReadyRequest = {}): Promise<StartReadyResult> {
+    const result = await runStartReady(orchestrator, request, {
+      freshBaseRecreateWorkflow: (workflowId) => sharedRecreateWorkflowFromFreshBase(workflowId, {
+        logger,
+        orchestrator,
+        persistence,
+        commandService,
+        repoRoot,
+        taskExecutor: requireTaskExecutor(),
+        mutationTiming: activeMutationContext?.mutationTiming,
+      }),
+    });
     if (!result.dryRun) {
       publishOrchestratorSnapshotToRenderer();
     }

--- a/packages/app/src/start-ready.ts
+++ b/packages/app/src/start-ready.ts
@@ -1,7 +1,10 @@
 import type {
+  StartReadyFreshBasePreview,
+  StartReadyFreshBaseScope,
   StartReadyPreview,
   StartReadyRequest,
   StartReadyResult,
+  StartReadyWorkflowOutcome,
 } from '@invoker/contracts';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 
@@ -20,6 +23,10 @@ type StartReadyRequestExt = StartReadyRequest & {
   recreateFailedAndPending?: boolean;
   recreateFailedPendingAndRunning?: boolean;
 };
+
+export interface StartReadyRunOptions {
+  freshBaseRecreateWorkflow?: (workflowId: string) => Promise<TaskState[]>;
+}
 
 type StartReadyPreviewExt = StartReadyPreview & {
   pendingWorkflowIds: string[];
@@ -119,6 +126,56 @@ function workflowIdsToRecreate(
   return [];
 }
 
+function workflowIdsForFreshBaseScope(
+  scope: StartReadyFreshBaseScope,
+  preview: StartReadyPreviewExt,
+): string[] {
+  switch (scope) {
+    case 'failed':
+      return [...preview.failedWorkflowIds];
+    case 'failed-and-pending':
+      return unionWorkflowIds(preview.failedWorkflowIds, preview.pendingWorkflowIds);
+    case 'failed-pending-and-running':
+      return unionWorkflowIds(
+        preview.failedWorkflowIds,
+        preview.pendingWorkflowIds,
+        preview.runningWorkflowIds,
+      );
+    case 'all':
+      return unionWorkflowIds(
+        preview.failedWorkflowIds,
+        preview.pendingWorkflowIds,
+        preview.runningWorkflowIds,
+        preview.completedWorkflowIds,
+      );
+  }
+}
+
+function collectFreshBasePreview(
+  scope: StartReadyFreshBaseScope,
+  preview: StartReadyPreviewExt,
+): StartReadyFreshBasePreview {
+  const includePending = scope === 'failed-and-pending'
+    || scope === 'failed-pending-and-running'
+    || scope === 'all';
+  const includeRunning = scope === 'failed-pending-and-running'
+    || scope === 'all';
+  const includeCompleted = scope === 'all';
+
+  return {
+    scope,
+    workflowIds: workflowIdsForFreshBaseScope(scope, preview),
+    failedWorkflowIds: [...preview.failedWorkflowIds],
+    pendingWorkflowIds: includePending ? [...preview.pendingWorkflowIds] : [],
+    runningWorkflowIds: includeRunning ? [...preview.runningWorkflowIds] : [],
+    completedWorkflowIds: includeCompleted ? [...preview.completedWorkflowIds] : [],
+  };
+}
+
+function formatStartReadyError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 export function collectStartReadyPreview(orchestrator: StartReadyOrchestrator): StartReadyPreview {
   const tasks = orchestrator.getAllTasks();
   const readyTasks = orchestrator.getExecutableReadyTasks();
@@ -151,10 +208,25 @@ export function collectStartReadyPreview(orchestrator: StartReadyOrchestrator): 
 export function runStartReady(
   orchestrator: StartReadyOrchestrator,
   request: StartReadyRequest = {},
-): StartReadyResult {
+  options: StartReadyRunOptions = {},
+): Promise<StartReadyResult> {
+  return runStartReadyAsync(orchestrator, request, options);
+}
+
+async function runStartReadyAsync(
+  orchestrator: StartReadyOrchestrator,
+  request: StartReadyRequest = {},
+  options: StartReadyRunOptions = {},
+): Promise<StartReadyResult> {
   const extendedRequest = request as StartReadyRequestExt;
   orchestrator.syncAllFromDb();
   const preview = collectStartReadyPreview(orchestrator) as StartReadyPreviewExt;
+  const freshBasePreview = request.freshBaseScope
+    ? collectFreshBasePreview(request.freshBaseScope, preview)
+    : undefined;
+  if (freshBasePreview) {
+    preview.freshBase = freshBasePreview;
+  }
   if (request.dryRun) {
     return {
       preview,
@@ -166,9 +238,38 @@ export function runStartReady(
 
   const started: TaskState[] = [];
   const recreatedWorkflowIds: string[] = [];
-  for (const workflowId of workflowIdsToRecreate(extendedRequest, preview)) {
-    started.push(...orchestrator.recreateWorkflow(workflowId));
-    recreatedWorkflowIds.push(workflowId);
+  const freshBaseRecreatedWorkflowIds: string[] = [];
+  const workflowOutcomes: StartReadyWorkflowOutcome[] = [];
+
+  if (freshBasePreview) {
+    if (freshBasePreview.workflowIds.length > 0 && !options.freshBaseRecreateWorkflow) {
+      throw new Error('Start Ready fresh-base scope requires freshBaseRecreateWorkflow.');
+    }
+    for (const workflowId of freshBasePreview.workflowIds) {
+      try {
+        const workflowStarted = await options.freshBaseRecreateWorkflow!(workflowId);
+        started.push(...workflowStarted);
+        freshBaseRecreatedWorkflowIds.push(workflowId);
+        workflowOutcomes.push({
+          ok: true,
+          workflowId,
+          mode: 'fresh-base-recreate',
+          startedTaskIds: workflowStarted.map((task) => task.id),
+        });
+      } catch (err) {
+        workflowOutcomes.push({
+          ok: false,
+          workflowId,
+          mode: 'fresh-base-recreate',
+          error: formatStartReadyError(err),
+        });
+      }
+    }
+  } else {
+    for (const workflowId of workflowIdsToRecreate(extendedRequest, preview)) {
+      started.push(...orchestrator.recreateWorkflow(workflowId));
+      recreatedWorkflowIds.push(workflowId);
+    }
   }
 
   const recoverableTasks = collectRecoverableTasks(orchestrator);
@@ -182,6 +283,13 @@ export function runStartReady(
     preview,
     started: uniqueTasks(started),
     recreatedWorkflowIds,
+    ...(freshBasePreview
+      ? {
+          freshBaseRecreatedWorkflowIds,
+          workflowOutcomes,
+          partial: workflowOutcomes.some((outcome) => !outcome.ok),
+        }
+      : {}),
     dryRun: false,
   };
 }

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -609,12 +609,42 @@ export interface WorkflowMutationAcceptedResult {
   channel: string;
 }
 
+export type StartReadyFreshBaseScope =
+  | 'failed'
+  | 'failed-and-pending'
+  | 'failed-pending-and-running'
+  | 'all';
+
+export interface StartReadyFreshBasePreview {
+  scope: StartReadyFreshBaseScope;
+  workflowIds: string[];
+  failedWorkflowIds: string[];
+  pendingWorkflowIds: string[];
+  runningWorkflowIds: string[];
+  completedWorkflowIds?: string[];
+}
+
+export type StartReadyWorkflowOutcome =
+  | {
+      ok: true;
+      workflowId: string;
+      mode: 'recreate' | 'fresh-base-recreate';
+      startedTaskIds: string[];
+    }
+  | {
+      ok: false;
+      workflowId: string;
+      mode: 'recreate' | 'fresh-base-recreate';
+      error: string;
+    };
+
 export interface StartReadyRequest {
   recreateFailed?: boolean;
   recreateFailedAndPending?: boolean;
   recreateFailedPendingAndRunning?: boolean;
   /** Recreate failed + pending/queued + running + completed (finished) workflows. */
   recreateAll?: boolean;
+  freshBaseScope?: StartReadyFreshBaseScope;
   dryRun?: boolean;
 }
 
@@ -625,6 +655,7 @@ export interface StartReadyPreview {
   pendingWorkflowIds: string[];
   runningWorkflowIds: string[];
   completedWorkflowIds?: string[];
+  freshBase?: StartReadyFreshBasePreview;
   skipped: {
     awaitingApproval: number;
     reviewReady: number;
@@ -640,6 +671,9 @@ export interface StartReadyResult {
   preview: StartReadyPreview;
   started: TaskState[];
   recreatedWorkflowIds: string[];
+  freshBaseRecreatedWorkflowIds?: string[];
+  workflowOutcomes?: StartReadyWorkflowOutcome[];
+  partial?: boolean;
   dryRun: boolean;
 }
 


### PR DESCRIPTION
## Summary

Headless Start Ready now exposes explicit fresh-base flags and prints matching preview and outcome labels.

This gives CLI users the same scope choices as the backend before the rail menu turns them on.

## Review Claim

Expose the fresh-base Start Ready scopes on the headless surface with matching parsing, help text, and output labels.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Changes stay in headless Start Ready parsing, help, labels, and direct no-track coverage, with no rail UI edits.

## Slice Rationale

Headless parity should follow the contract and backend path, but stay separate from rail activation.

## Non-goals

- No delegation timeout classifier changes.
- No rail menu exposure.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/start-ready.test.ts src/__tests__/owner-delegation.test.ts src/__tests__/acknowledge-no-track-start-ready.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9d1db5faf80402ead5ba39ec38a7a30aca938d56`
- Post-revert steps: Re-run the focused Start Ready app regression command.
- Data migration? No

</details>
