### PR TITLE
[Bugfix: main-process planner surfaces lazy-load](1) Defer planner surfaces load

### DIFF
--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -43,7 +43,6 @@ import {
   summarizePlanText,
   type PlanningMessage,
 } from '@invoker/planning-core';
-import { selectHarnessSessionDriver } from '@invoker/surfaces';
 import type { HarnessPreset, PlanConversation, PlanConversationConfig, PlanningCommandBuilder } from '@invoker/surfaces';
 import type { InvokerConfig } from './config.js';
 
@@ -119,6 +118,7 @@ interface PlannerSurfacesModule {
   DEFAULT_HARNESS_PRESET: string;
   PlanConversation: PlanConversationConstructor;
   extractYamlPlan: (output: string) => string | null;
+  selectHarnessSessionDriver: typeof import('@invoker/surfaces').selectHarnessSessionDriver;
 }
 
 async function loadPlannerSurfaces(): Promise<PlannerSurfacesModule> {
@@ -372,6 +372,7 @@ function planConversationConfig(
   preset: HarnessPreset,
   deps: Pick<InAppPlannerDeps, 'config' | 'workingDir' | 'planningCommandBuilder' | 'executionAgentRegistry' | 'conversationRepo' | 'onRawPlannerOutput'>,
   threadTs: string,
+  selectHarnessSessionDriver: PlannerSurfacesModule['selectHarnessSessionDriver'],
   options: { conversationalPlanning?: boolean } = {},
 ): PlanConversationConfig {
   return {
@@ -417,7 +418,7 @@ async function createSession(
     return { error: `Unknown planner preset "${presetKey}".` };
   }
 
-  const { PlanConversation } = await loadPlannerSurfaces();
+  const { PlanConversation, selectHarnessSessionDriver } = await loadPlannerSurfaces();
   const createdAt = new Date().toISOString();
   const id = randomUUID();
   const confirmationMode = normalizePlanningConfirmationMode(
@@ -431,7 +432,13 @@ async function createSession(
     confirmationMode,
     status: 'still_discussing',
     messages: [],
-    conversation: new PlanConversation(planConversationConfig(preset, deps, id, { conversationalPlanning: true })),
+    conversation: new PlanConversation(planConversationConfig(
+      preset,
+      deps,
+      id,
+      selectHarnessSessionDriver,
+      { conversationalPlanning: true },
+    )),
     createdAt,
     updatedAt: createdAt,
     nextMessageId: 1,
@@ -481,8 +488,13 @@ export async function planFromGoal(
   }
 
   try {
-    const { PlanConversation, extractYamlPlan } = await loadPlannerSurfaces();
-    const conversation = new PlanConversation(planConversationConfig(preset, deps, randomUUID()));
+    const { PlanConversation, extractYamlPlan, selectHarnessSessionDriver } = await loadPlannerSurfaces();
+    const conversation = new PlanConversation(planConversationConfig(
+      preset,
+      deps,
+      randomUUID(),
+      selectHarnessSessionDriver,
+    ));
     const plannerOutput = await conversation.sendMessage(goal);
     const planText = extractYamlPlan(plannerOutput);
     if (!planText) {
@@ -860,13 +872,18 @@ export async function restorePlanningChatSessions(
   // boots without surfaces/dist, so an eager load here would crash startup with no sessions.
   if (records.length === 0) return;
   const presets = await resolveHarnessPresets(deps.config);
-  const { PlanConversation } = await loadPlannerSurfaces();
+  const { PlanConversation, selectHarnessSessionDriver } = await loadPlannerSurfaces();
 
   for (const record of records) {
     const preset = presets[record.presetKey];
     if (!preset) continue;
 
-    const conversation = new PlanConversation(planConversationConfig(preset, deps, record.id));
+    const conversation = new PlanConversation(planConversationConfig(
+      preset,
+      deps,
+      record.id,
+      selectHarnessSessionDriver,
+    ));
     await conversation.init();
 
     const nextMessageId = Math.max(0, ...record.messages.map((message) => message.id)) + 1;


### PR DESCRIPTION
## Summary

Desktop app startup could crash before any planning session ran.

The cause: `packages/app/src/in-app-planner.ts` resolved `@invoker/surfaces` at module load time, even though the file already had a lazy loader for it.

`main.ts` imports this file during startup. If `@invoker/surfaces` had no usable runtime `dist` entry yet, the eager import died before logging or session restore could begin.

The fix defers the one remaining eager access, `selectHarnessSessionDriver`, behind the existing `loadPlannerSurfaces()` lazy loader. Every runtime access to the surfaces package now goes through that one boundary.

## Review Claim

The planning module no longer resolves `@invoker/surfaces` at module load, so desktop startup can reach the lazy fallback path instead of crashing first.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Session creation, restore, submit, and tmux state behavior stay unchanged except for deferring when the surfaces package is resolved. The diff only relocates an import and threads the resolved function through existing call sites; no logic changes.

## Slice Rationale

This is one behavior slice: defer the runtime load boundary in `in-app-planner.ts`. The companion verification task built a temporary bundle and reran the directly affected planner tests, but it made no file changes, so there is nothing to publish as a separate slice.

## Non-goals

No planning UX changes, no new preset behavior, no unrelated startup logging work, no proof harness authoring in this task.

## Architecture

### Before

```mermaid
graph TD
    A["main.ts imports in-app-planner.js"] --> B["module scope: import selectHarnessSessionDriver from '@invoker/surfaces'"]
    B --> C{"@invoker/surfaces has usable dist?"}
    C -->|No| D["startup crash before any planning session runs"]
    C -->|Yes| E["planner module ready"]
```

### After

```mermaid
graph TD
    A["main.ts imports in-app-planner.js"] --> E["planner module ready (no eager surfaces resolution)"]
    E --> F["createSession / restorePlanningChatSessions / planFromGoal call loadPlannerSurfaces()"]
    F --> G{"@invoker/surfaces has usable dist?"}
    G -->|No| H["that call fails; startup already logged and other paths still work"]
    G -->|Yes| I["selectHarnessSessionDriver resolved lazily"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts -t "restores draft-ready sessions and submits from persisted approved draft text|restores persisted tmux mode and planning-owned terminal state|clears submitted pending-response state during restore"` - 3 passed, 35 skipped
- [x] Temporary-bundle module-load proof: bundled `packages/app/src/in-app-planner.ts` with `tsup`, grepped the output for `require("@invoker/surfaces")` (no matches; only the lazy `import("@invoker/surfaces")` inside `loadPlannerSurfaces()` remains), then `require()`d the bundle directly and confirmed it resolves without throwing
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/bugfix-main-process-planner-surfaces-lazy-load-1.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/bugfix-main-process-planner-surfaces-lazy-load-1.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert HEAD`
- Post-revert steps: None
- Data migration? No

</details>
