### PR TITLE
[Continue babysit worker landing loop](1) Record babysit blocker repros

### DIFF
--- a/scripts/repro/repro-babysit-bottom-human-decision-blocks-downstream.sh
+++ b/scripts/repro/repro-babysit-bottom-human-decision-blocks-downstream.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-bottom-human-decision-blocks-downstream.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+mkdir -p "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+BOTTOM_HEAD="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+UPPER_HEAD="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+export STATE_PATH BOTTOM_HEAD UPPER_HEAD
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+bottom = os.environ['BOTTOM_HEAD']
+upper = os.environ['UPPER_HEAD']
+state = {
+    'prs': [
+        {
+            'number': 5967,
+            'title': 'Bottom human split blocker',
+            'body': '## Summary\n\nBottom needs a human split.\n',
+            'url': 'https://github.com/fake/repo/pull/5967',
+            'state': 'OPEN',
+            'isDraft': False,
+            'baseRefName': 'master',
+            'headRefName': 'stack/5967',
+            'headRefOid': bottom,
+            'mergeStateStatus': 'BLOCKED',
+            'mergeable': 'MERGEABLE',
+            'labels': ['admin-bypass', 'dequeued'],
+            'reviewThreads': [],
+            'checks': {
+                '*': 'SUCCESS',
+                'build-artifacts': 'SKIPPED',
+                'quality / TypeScript Types': 'FAILURE',
+            },
+        },
+        {
+            'number': 5968,
+            'title': 'Downstream repairable check',
+            'body': '## Summary\n\nDownstream is repairable only after the bottom lands.\n',
+            'url': 'https://github.com/fake/repo/pull/5968',
+            'state': 'OPEN',
+            'isDraft': False,
+            'baseRefName': 'stack/5967',
+            'headRefName': 'stack/5968',
+            'headRefOid': upper,
+            'mergeStateStatus': 'UNSTABLE',
+            'mergeable': 'MERGEABLE',
+            'labels': ['admin-bypass'],
+            'reviewThreads': [],
+            'checks': {
+                '*': 'SUCCESS',
+                'quality / TypeScript Types': 'FAILURE',
+            },
+        },
+    ],
+    'issue_comments': {
+        '5967': [
+            {
+                'id': 'm5967',
+                'user': {'login': 'mergify[bot]'},
+                'updated_at': '2026-07-27T03:05:07Z',
+                'html_url': 'https://github.com/fake/repo/pull/5967#m5967',
+                'body': (
+                    '-*- Mergify Payload -*-\n'
+                    '{"state":"dequeued","queue_rule_name":"admin-bypass"}\n\n'
+                    '- ❌ **Checks failed** · on draft #6067\n'
+                    f'- 🚫 **Left the queue** — `2026-07-27 03:05 UTC` · at `{bottom}`\n\n'
+                    '## Failing checks\n\n'
+                    '- [build-artifacts](https://github.com/fake/repo/actions/runs/1/job/2)\n'
+                    '- [quality / TypeScript Types](https://github.com/fake/repo/actions/runs/1/job/3)\n'
+                ),
+            },
+            {
+                'id': 'blocked5967',
+                'user': {'login': 'invoker-bot'},
+                'updated_at': '2026-07-27T03:31:00Z',
+                'html_url': 'https://github.com/fake/repo/pull/5967#blocked5967',
+                'body': 'Mergify repair stopped: PR body Review Unit "contract" cannot ship with routing files in the same PR. Split this into one Review Unit per PR.',
+            },
+        ],
+        '5968': [],
+    },
+}
+Path(os.environ['STATE_PATH']).write_text(json.dumps(state, indent=2), encoding='utf-8')
+PY
+
+python3 - <<'PY' > "$LEDGER_PATH"
+import json
+import os
+
+row = {
+    'kind': 'repair-invalid',
+    'pr': 5967,
+    'headSha': os.environ['BOTTOM_HEAD'],
+    'key': 'build-artifacts',
+    'epoch': 1785122674,
+    'meta': {
+        'errors': [
+            'PR body Review Unit "contract" cannot ship with routing files in the same PR. Split this into one Review Unit per PR.'
+        ]
+    },
+}
+print(json.dumps(row, sort_keys=True))
+PY
+
+if ! out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5967 2>&1)"; then
+  fail 'worker dry-run failed' "$out"
+fi
+printf '%s\n' "$out"
+
+! echo "$out" | grep -q 'DRY-RUN repair-check PR #5968' \
+  || fail 'worker retried downstream PR while bottom has a human-only blocker' "$out"
+! echo "$out" | grep -q 'DRY-RUN repair-check PR #5967' \
+  || fail 'worker retried the bottom human-only blocker' "$out"
+echo "$out" | grep -q '"reason": "blocked-needs-human"' \
+  || fail 'worker did not stop on the bottom human-only blocker' "$out"
+
+echo '[repro] passed'

--- a/scripts/repro/repro-babysit-headless-queued-comment.sh
+++ b/scripts/repro/repro-babysit-headless-queued-comment.sh
@@ -57,7 +57,7 @@ state = {
             "mergeable": "MERGEABLE",
             "labels": ["admin-bypass", "queued"],
             "reviewThreads": [],
-            "checks": {"*": "SUCCESS"},
+            "checks": {"*": "SUCCESS", "PR Body": "FAILURE"},
         }
     ],
     "issue_comments": {
@@ -96,6 +96,8 @@ printf '%s\n' "$out"
 
 ! echo "$out" | grep -q 'DRY-RUN requeue PR #5805' \
   || fail "worker tried to requeue a PR already in Mergify queue" "$out"
+! echo "$out" | grep -q 'DRY-RUN repair-check PR #5805 check="PR Body"' \
+  || fail "worker tried to repair a PR already in Mergify queue" "$out"
 echo "$out" | grep -q '"reason": "bottom-already-queued"' \
   || fail "worker did not wait on the active queue state" "$out"
 

--- a/scripts/repro/repro-babysit-no-current-bottom-comment.sh
+++ b/scripts/repro/repro-babysit-no-current-bottom-comment.sh
@@ -93,6 +93,8 @@ fi
 if ! out2="$(run_worker)"; then
   fail 'tick 2: worker failed' "$out2"
 fi
+! echo "$out2" | grep -q 'BLOCK PR #5885 no current bottom on master' \
+  || fail 'tick 2: worker retried no-current-bottom blocker' "$out2"
 
 python3 - <<'PY' || fail 'expected one exact no-current-bottom comment' "$(cat "$STATE_PATH")"
 import json

--- a/scripts/repro/repro-babysit-queue-only-skipped-check.sh
+++ b/scripts/repro/repro-babysit-queue-only-skipped-check.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-queue-only-skipped-check.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+WORK_PARENT="$HOME/.invoker/mergify-admin-requeue-work"
+mkdir -p "$WORK_PARENT" "$TMP/state" "$TMP/bin"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export CLAUDE_CALLED="$TMP/claude-called"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+cat > "$TMP/bin/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "claude was called for a skipped queue-only PR-head check" > "$CLAUDE_CALLED"
+exit 42
+EOF
+chmod +x "$TMP/bin/claude"
+
+REMOTE="$TMP/origin.git"
+SEED="$TMP/seed"
+WORK_ROOT="$WORK_PARENT/5967"
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+export STATE_PATH
+
+write_state() {
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = os.environ['ORIGINAL_HEAD']
+state = {
+    'prs': [
+        {
+            'number': 5967,
+            'title': 'Queue-only build artifact skipped on PR head',
+            'body': '## Summary\n\nQueue-only build-artifacts repro with a real PR-head failure.\n',
+            'url': 'https://github.com/fake/repo/pull/5967',
+            'state': 'OPEN',
+            'isDraft': False,
+            'baseRefName': 'master',
+            'headRefName': 'stack/5967',
+            'headRefOid': head,
+            'mergeStateStatus': 'BLOCKED',
+            'mergeable': 'MERGEABLE',
+            'labels': ['admin-bypass', 'dequeued'],
+            'reviewThreads': [],
+            'checks': {
+                '*': 'SUCCESS',
+                'build-artifacts': 'SKIPPED',
+                'PR Body': 'FAILURE',
+            },
+        }
+    ],
+    'issue_comments': {
+        '5967': [
+            {
+                'id': 'm5967',
+                'user': {'login': 'mergify[bot]'},
+                'updated_at': '2026-07-26T21:13:00Z',
+                'html_url': 'https://github.com/fake/repo/pull/5967#m5967',
+                'body': (
+                    '-*- Mergify Payload -*-\n'
+                    '{"state":"dequeued","queue_rule_name":"admin-bypass"}\n\n'
+                    '- ❌ **Checks failed** · on draft #5968\n'
+                    f'- 🚫 **Left the queue** — `2026-07-26 21:13 UTC` · at `{head}`\n\n'
+                    '## Failing checks\n\n'
+                    '- [build-artifacts](https://github.com/fake/repo/actions/runs/1/job/2)\n'
+                ),
+            }
+        ]
+    },
+    'job_logs': {
+        '2': '',
+    },
+}
+Path(os.environ['STATE_PATH']).write_text(json.dumps(state, indent=2), encoding='utf-8')
+PY
+}
+
+run_worker() {
+  python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5967 2>&1
+}
+
+git clone . "$SEED" >/dev/null
+(
+  cd "$SEED"
+  git config user.email repro@example.test
+  git config user.name 'Repro Bot'
+  git checkout -B master >/dev/null
+  git init --bare "$REMOTE" >/dev/null
+  git remote add publish "$REMOTE"
+  git push publish master >/dev/null
+  git switch -c stack/5967 master >/dev/null
+  echo queue-only-skipped-check > queue-only-skipped-check.txt
+  git add queue-only-skipped-check.txt
+  git commit -m 'queue only skipped check slice' >/dev/null
+  git push publish stack/5967 >/dev/null
+)
+git --git-dir="$REMOTE" symbolic-ref HEAD refs/heads/master
+ORIGINAL_HEAD="$(git -C "$SEED" rev-parse stack/5967)"
+export ORIGINAL_HEAD
+git clone "$REMOTE" "$WORK_ROOT" >/dev/null
+( cd "$WORK_ROOT" && git config user.email repro@example.test && git config user.name 'Repro Bot' )
+write_state
+
+if ! out1="$(run_worker)"; then
+  fail 'tick 1: worker failed on skipped queue-only check' "$out1"
+fi
+printf '%s\n' "$out1"
+
+[ ! -f "$CLAUDE_CALLED" ] || fail 'tick 1: worker invoked Claude for skipped queue-only check' "$(cat "$CLAUDE_CALLED")"
+echo "$out1" | grep -q 'admin-bypass-queue-only-empty-log-noop' || fail 'tick 1: missing empty-log noop trace' "$out1"
+echo "$out1" | grep -q 'admin-bypass-queue-only-noop' || fail 'tick 1: missing queue-only noop trace' "$out1"
+
+if ! grep -q '"kind": "queue-only-noop"' "$LEDGER_PATH" \
+  || ! grep -q '"key": "build-artifacts"' "$LEDGER_PATH" \
+  || ! grep -q '"pr": 5967' "$LEDGER_PATH"; then
+  fail 'tick 1: build-artifacts queue-only noop was not recorded' "$(cat "$LEDGER_PATH")"
+fi
+
+if ! out2="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5967 2>&1)"; then
+  fail 'tick 2: dry-run failed after skipped queue-only noop' "$out2"
+fi
+printf '%s\n' "$out2"
+
+! echo "$out2" | grep -q 'DRY-RUN repair-check PR #5967 check="build-artifacts"' \
+  || fail 'tick 2: worker retried suppressed queue-only build-artifacts failure' "$out2"
+echo "$out2" | grep -q 'DRY-RUN repair-check PR #5967 check="PR Body"' \
+  || fail 'tick 2: worker did not move on to the remaining PR-head blocker' "$out2"
+
+echo '[repro] passed'

--- a/scripts/repro/repro-babysit-upper-stack-needs-acceptance.sh
+++ b/scripts/repro/repro-babysit-upper-stack-needs-acceptance.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-upper-stack-needs-acceptance.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+mkdir -p "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+CALLS_PATH="$FAKE_GH_STATE_DIR/calls.log"
+LEDGER_PATH="$TMP/ledger.jsonl"
+BOTTOM_HEAD="d3620377b5b7b91690a68beee56130cf53c261c1"
+UPPER_HEAD="a404cc402eb77d43f3779f3594c1ee604f7ec090"
+export STATE_PATH BOTTOM_HEAD UPPER_HEAD
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+bottom = os.environ['BOTTOM_HEAD']
+upper = os.environ['UPPER_HEAD']
+state = {
+    'prs': [
+        {
+            'number': 4362,
+            'title': 'Route daemon GUI-only actions',
+            'body': '## Summary\n\nBottom PR is otherwise green.\n',
+            'url': 'https://github.com/fake/repo/pull/4362',
+            'state': 'OPEN',
+            'isDraft': False,
+            'baseRefName': 'master',
+            'headRefName': 'stack/off-main-ui-mutations-routing',
+            'headRefOid': bottom,
+            'mergeStateStatus': 'BLOCKED',
+            'mergeable': 'MERGEABLE',
+            'labels': ['admin-bypass', 'dequeued'],
+            'reviewThreads': [],
+            'checks': {
+                '*': 'SUCCESS',
+                'required-fast / Guardrails': None,
+            },
+        },
+        {
+            'number': 4363,
+            'title': 'Prefer daemon owner in auto mode',
+            'body': '## Summary\n\nUpper PR has not been accepted into admin-bypass.\n',
+            'url': 'https://github.com/fake/repo/pull/4363',
+            'state': 'OPEN',
+            'isDraft': False,
+            'baseRefName': 'stack/off-main-ui-mutations-routing',
+            'headRefName': 'stack/off-main-ui-mutations-daemon-default',
+            'headRefOid': upper,
+            'mergeStateStatus': 'CLEAN',
+            'mergeable': 'MERGEABLE',
+            'labels': [],
+            'reviewThreads': [],
+            'checks': {'*': 'SUCCESS'},
+        },
+    ],
+    'issue_comments': {
+        '4362': [
+            {
+                'id': 'm4362',
+                'user': {'login': 'mergify[bot]'},
+                'updated_at': '2026-07-27T03:02:55Z',
+                'html_url': 'https://github.com/fake/repo/pull/4362#m4362',
+                'body': (
+                    '-*- Mergify Payload -*-\n'
+                    '{"state":"dequeued","queue_rule_name":"admin-bypass"}\n\n'
+                    '- ❌ **Checks failed** · on draft #6065\n'
+                    f'- 🚫 **Left the queue** — `2026-07-27 03:02 UTC` · at `{bottom}`\n\n'
+                    '## Failing checks\n\n'
+                    '- [required-fast / Guardrails](https://github.com/fake/repo/actions/runs/1/job/2)\n'
+                ),
+            }
+        ],
+        '4363': [],
+    },
+}
+Path(os.environ['STATE_PATH']).write_text(json.dumps(state, indent=2), encoding='utf-8')
+PY
+
+run_worker() {
+  python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 4362 2>&1
+}
+
+: > "$CALLS_PATH"
+if ! out1="$(run_worker)"; then
+  fail 'tick 1: worker failed' "$out1"
+fi
+printf '%s\n' "$out1"
+
+echo "$out1" | grep -q 'BLOCK PR #4362 upper stack member(s) #4363 (`stack/off-main-ui-mutations-daemon-default`) are open above #4362 without `admin-bypass`' \
+  || fail 'tick 1: worker did not print exact upper-stack blocker' "$out1"
+comment_calls="$(grep -c '^gh pr comment 4362 ' "$CALLS_PATH" || true)"
+[ "$comment_calls" = "1" ] || fail 'tick 1: expected one blocker comment' "$(cat "$CALLS_PATH")"
+if ! grep -q '"kind": "comment-blocked"' "$LEDGER_PATH" \
+  || ! grep -q '"key": "upper-stack-needs-acceptance"' "$LEDGER_PATH" \
+  || ! grep -q '"pr": 4362' "$LEDGER_PATH"; then
+  fail 'tick 1: blocker ledger row missing' "$(cat "$LEDGER_PATH")"
+fi
+
+: > "$CALLS_PATH"
+if ! out2="$(run_worker)"; then
+  fail 'tick 2: worker failed' "$out2"
+fi
+printf '%s\n' "$out2"
+
+! echo "$out2" | grep -q 'BLOCK PR #4362' \
+  || fail 'tick 2: worker repeated upper-stack blocker' "$out2"
+! echo "$out2" | grep -q '@mergifyio queue' \
+  || fail 'tick 2: worker tried to queue while upper stack needs acceptance' "$out2"
+comment_calls="$(grep -c '^gh pr comment 4362 ' "$CALLS_PATH" || true)"
+[ "$comment_calls" = "0" ] || fail 'tick 2: expected no repeated blocker comment' "$(cat "$CALLS_PATH")"
+echo "$out2" | grep -q '"reason": "upper-stack-needs-acceptance"' \
+  || fail 'tick 2: worker did not settle into upper-stack wait' "$out2"
+
+echo '[repro] passed'


### PR DESCRIPTION
## Summary

This records the live babysit blocker cases that were driving the landing loop.

The repro scripts cover queue-only checks, no-current-bottom stops, upper-stack acceptance, and downstream human-decision blockers.

They give reviewers deterministic evidence before the worker policy changes land.

## Review Claim

The babysit loop now has deterministic repro coverage for the blocker classes seen in the live admin-bypass and dequeued PR set.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds or updates repro scripts; it does not change worker decision code or touch live PR state.

## Slice Rationale

The evidence lands first so the following worker-policy slice can be reviewed against concrete, repeatable cases.

## Non-goals

This slice does not change queue repair behavior, labels, merges, rebases, stack splits, or live PR branches.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash ./loop-driver.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5814f8997`
- Post-revert steps: Rerun `bash ./loop-driver.sh` before keeping the worker-policy slice.
- Data migration? No

</details>
