### PR TITLE
[Continue babysit worker landing loop](2) Continue babysit worker landing loop

### DIFF
--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -13,10 +13,13 @@ REPROS=(
   scripts/repro/repro-babysit-human-review-thread-block.sh
   scripts/repro/repro-babysit-pr-body-proof-human-split.sh
   scripts/repro/repro-babysit-pr-body-valid-noop.sh
+  scripts/repro/repro-babysit-bottom-human-decision-blocks-downstream.sh
   scripts/repro/repro-babysit-amended-repair-push.sh
   scripts/repro/repro-babysit-outdated-bot-thread.sh
+  scripts/repro/repro-babysit-upper-stack-needs-acceptance.sh
   scripts/repro/repro-babysit-headless-queued-comment.sh
   scripts/repro/repro-babysit-queue-only-empty-log.sh
+  scripts/repro/repro-babysit-queue-only-skipped-check.sh
   scripts/repro/repro-babysit-queue-only-missing-requeues.sh
   scripts/repro/repro-babysit-targeted-scan-light.sh
   scripts/repro/repro-babysit-queue-repair-invalid-stop.sh

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -32,6 +32,7 @@ except ImportError:
 TRUNK = "master"
 
 QUEUE_ONLY_REQUIRED_CHECKS = frozenset({
+    "build-artifacts",
     "required-fast / Guardrails",
     "required-fast / Vitest Workspace",
     "required-fast / Submit Workflow Chain",
@@ -180,10 +181,26 @@ def current_bottom_pr(stack: StackGroup, trunk: str) -> PrSnapshot | None:
     return None
 
 
+def unaccepted_upper_prs(stack: StackGroup, bottom: PrSnapshot | None) -> tuple[PrSnapshot, ...]:
+    if not bottom:
+        return ()
+    return tuple(
+        pr for pr in stack.prs
+        if pr.state == "OPEN" and pr.number != bottom.number and "admin-bypass" not in pr.labels
+    )
+
+
 def stack_has_unaccepted_upper_pr(stack: StackGroup, bottom: PrSnapshot | None) -> bool:
-    return bool(bottom) and any(
-        pr.state == "OPEN" and pr.number != bottom.number and "admin-bypass" not in pr.labels
-        for pr in stack.prs
+    return bool(unaccepted_upper_prs(stack, bottom))
+
+
+def upper_stack_acceptance_detail(facts: StackFacts) -> str:
+    assert facts.bottom is not None, "upper stack acceptance requires a current bottom"
+    upper = unaccepted_upper_prs(facts.stack, facts.bottom)
+    members = ", ".join(f"#{pr.number} (`{pr.head_ref_name}`)" for pr in upper)
+    return (
+        f"upper stack member(s) {members} are open above #{facts.bottom.number} without `admin-bypass`; "
+        "accept them into the admin-bypass stack, land them, close them, or retarget them before babysitting can queue this stack"
     )
 
 
@@ -447,7 +464,7 @@ def summarize_stack(facts: StackFacts) -> dict[str, object]:
 def wait_reason_for_facts(facts: StackFacts) -> str:
     if facts.upper_stack_needs_acceptance:
         return "upper-stack-needs-acceptance"
-    if facts.bottom and facts.bottom.latest_mergify and facts.bottom.latest_mergify.state in {"queued", "merging"}:
+    if bottom_has_active_queue(facts):
         return "bottom-already-queued"
     for pr in facts.stack.prs:
         blocker_kinds = {blocker.kind for blocker in facts.blockers_by_pr[pr.number]}
@@ -458,6 +475,14 @@ def wait_reason_for_facts(facts: StackFacts) -> str:
         if HUMAN_BLOCKER_KINDS & blocker_kinds:
             return "blocked-needs-human"
     return "no-action"
+
+
+def bottom_has_active_queue(facts: StackFacts) -> bool:
+    bottom = facts.bottom
+    if not bottom or not bottom.latest_mergify:
+        return False
+    latest = bottom.latest_mergify
+    return latest.state in ACTIVE_QUEUE_STATES and (latest.head_sha == bottom.head_ref_oid or "queued" in bottom.labels)
 
 
 def _has_pending_or_human_blocker(facts: StackFacts) -> bool:
@@ -474,10 +499,19 @@ def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
     )
 
 
+def _has_human_decision_at_or_below(facts: StackFacts, pr_number: int) -> bool:
+    for pr in facts.stack.prs:
+        if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
+            return True
+        if pr.number == pr_number:
+            return False
+    return False
+
+
 def plan_mergify_queue_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     del max_repair_attempts
     for pr in facts.stack.prs:
-        if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
+        if _has_human_decision_at_or_below(facts, pr.number):
             continue
         if facts.upper_stack_needs_acceptance and facts.bottom and pr.number == facts.bottom.number:
             continue
@@ -489,6 +523,8 @@ def plan_mergify_queue_repairs(facts: StackFacts, ledger: Ledger, max_repair_att
 
 def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     for pr in facts.stack.prs:
+        if _has_human_decision_at_or_below(facts, pr.number):
+            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "conflict":
                 key = f"conflict:{pr.number}"
@@ -505,6 +541,8 @@ def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: 
 
 def plan_bot_thread_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     for pr in facts.stack.prs:
+        if _has_human_decision_at_or_below(facts, pr.number):
+            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "outdated_bot_review_thread":
                 return Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail)
@@ -553,10 +591,13 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
         return None
     if not facts.bottom:
         first = facts.stack.prs[0]
+        key = "no-current-bottom"
+        if ledger.count("comment-blocked", first.number, first.head_ref_oid, key) > 0:
+            return None
         return Action(
             "comment_blocked",
             first.number,
-            "no-current-bottom",
+            key,
             f"no current bottom on {facts.trunk}: lowest open stack PR #{first.number} is based on `{first.base_ref_name}`, not `{facts.trunk}`; land or retarget that base before babysitting can queue this stack",
         )
 
@@ -577,7 +618,10 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
             )
         return Action("comment_admin_bypass_nudge", bottom.number, "admin-bypass", "missing admin-bypass label")
     if facts.upper_stack_needs_acceptance:
-        return None
+        key = "upper-stack-needs-acceptance"
+        if ledger.count("comment-blocked", bottom.number, bottom.head_ref_oid, key) > 0:
+            return None
+        return Action("comment_blocked", bottom.number, key, upper_stack_acceptance_detail(facts))
     if latest and latest.state in ACTIVE_QUEUE_STATES and (latest.head_sha == bottom.head_ref_oid or "queued" in bottom.labels):
         return None
     requeue_reason = "eligible-when-ready"
@@ -599,6 +643,8 @@ def plan_actions_from_facts(
     max_requeue_attempts: int,
     max_repair_attempts: int,
 ) -> tuple[Action, ...]:
+    if bottom_has_active_queue(facts):
+        return ()
     action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts)
     if action is not None:
         return (action,)

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -392,9 +392,12 @@ class AdminBypassRepairer:
     def repair_check(self, pr: PrSnapshot, check_name: str, now: int | None = None) -> RepairOutcome:
         ctx = pr.checks.get(check_name)
         latest = pr.latest_mergify
-        queue_only = ctx is None and is_queue_only_required_check(check_name)
+        queue_only = is_queue_only_required_check(check_name) and (ctx is None or ctx.state == "skipped")
         mergify_urls = mergify_check_urls(latest, check_name)
-        details_url = (ctx.details_url if ctx and ctx.details_url else "") or (mergify_urls[0] if mergify_urls else "")
+        if queue_only and mergify_urls:
+            details_url = mergify_urls[0]
+        else:
+            details_url = (ctx.details_url if ctx and ctx.details_url else "") or (mergify_urls[0] if mergify_urls else "")
         work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
         work_root.parent.mkdir(parents=True, exist_ok=True)
         checkout_pr_head(self.repo, pr, work_root)

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -236,7 +236,8 @@ Failing checks
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 2605, "PR Body")])
 
-    def test_unaccepted_upper_without_blockers_waits_instead_of_requeueing_bottom(self):
+    def test_unaccepted_upper_without_blockers_posts_once_instead_of_requeueing_bottom(self):
+        ledger = self.ledger()
         stack = StackGroup(
             "s",
             (
@@ -244,7 +245,11 @@ Failing checks
                 pr(2605, base="stack/a", labels={"dequeued"}),
             ),
         )
-        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 1)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("comment_blocked", 2604, "upper-stack-needs-acceptance")])
+        self.assertIn("#2605 (`stack/2605`)", actions[0].detail)
+        ledger.record("comment-blocked", 2604, HEAD, "upper-stack-needs-acceptance", 1)
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 2)
         self.assertEqual(actions, ())
 
     def test_missing_admin_bypass_label_on_current_bottom_nudges_human_first(self):
@@ -513,6 +518,39 @@ Failing checks
         repair.assert_not_called()
         self.assertEqual(result.status, "queue_only_noop")
 
+    def test_queue_only_skipped_pr_head_check_uses_mergify_log_without_claude(self):
+        queue_url = "https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/10/job/20"
+        skipped_url = "https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/11/job/21"
+        latest = MergifyQueueEvent(
+            "m5967",
+            "dequeued",
+            "admin-bypass",
+            "2026-07-26T21:13:00Z",
+            HEAD,
+            (),
+            ("build-artifacts",),
+            "https://github.com/Neko-Catpital-Labs/Invoker/pull/5967#issuecomment-1",
+            5968,
+            (("build-artifacts", (queue_url,)),),
+        )
+        item = pr(
+            5967,
+            labels={"admin-bypass", "dequeued"},
+            checks={"build-artifacts": CheckContext("build-artifacts", "skipped", skipped_url, HEAD, "2026-07-26T21:12:53Z")},
+            latest=latest,
+        )
+        repairer = self.repairer(object(), self.ledger())
+        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
+            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/build-artifacts.log") as download:
+                with mock.patch.object(repairer, "job_log_has_evidence", return_value=False):
+                    with mock.patch.object(repairer, "git_output", return_value=HEAD):
+                        with mock.patch.object(repairer, "run_claude_repair") as repair:
+                            result = repairer.repair_check(item, "build-artifacts")
+        checkout.assert_called_once()
+        download.assert_called_once_with("owner/repo", queue_url, 5967, "build-artifacts")
+        repair.assert_not_called()
+        self.assertEqual(result.status, "queue_only_noop")
+
     def test_pr_body_valid_local_repair_returns_noop_without_claude(self):
         item = pr(5810, checks={"PR Body": check("PR Body", "failure")}, body=PROOF_BODY)
         repairer = self.repairer(object(), self.ledger())
@@ -545,19 +583,21 @@ Failing checks
         self.assertIn('"failed_check"', log)
         self.assertIn('"pr_number": 2606', log)
 
-    def test_run_cycle_logs_wait_reason_for_unaccepted_upper_stack(self):
+    def test_run_cycle_posts_blocker_for_unaccepted_upper_stack(self):
         args = requeue.parse_args(["--once", "--dry-run", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
         stack = StackGroup("s", (pr(2604, head="stack/a", latest=mergify()), pr(2605, base="stack/a", labels={"dequeued"})))
         stderr = io.StringIO()
+        stdout = io.StringIO()
         with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
             with mock.patch.object(exec_impl, "GhClient", return_value=object()):
                 with mock.patch.object(AdminBypassStackLoader, "load", return_value=(stack,)):
-                    with redirect_stderr(stderr):
+                    with redirect_stdout(stdout), redirect_stderr(stderr):
                         should_poll = exec_impl.run_cycle(args)
-        self.assertTrue(should_poll)
+        self.assertFalse(should_poll)
+        self.assertIn("BLOCK PR #2604 upper stack member(s) #2605", stdout.getvalue())
         log = stderr.getvalue()
-        self.assertIn('"event": "admin-bypass-stack-wait"', log)
-        self.assertIn('"reason": "upper-stack-needs-acceptance"', log)
+        self.assertIn('"event": "admin-bypass-stack-actions"', log)
+        self.assertIn('"kind": "comment_blocked"', log)
         self.assertIn('"upper_stack_needs_acceptance": true', log)
 
     def test_repair_check_splits_tooling_policy_prerequisite(self):

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -25,6 +25,7 @@ import mergify_admin_requeue_plan as p
 HEAD = "a" * 40
 REQUIRED = {"build"}
 QUEUE_ONLY_CHECK = "required-fast / Guardrails"
+QUEUE_ONLY_SKIPPED_CHECK = "build-artifacts"
 
 
 def check(state, name="build"):
@@ -124,6 +125,17 @@ class EffectiveBlockers(unittest.TestCase):
             b.kind for b in p.effective_blockers(
                 snapshot,
                 {QUEUE_ONLY_CHECK},
+                trunk="master",
+            )
+        }
+        self.assertNotIn("missing_check", kinds)
+
+    def test_build_artifacts_missing_check_is_not_pr_head_blocker(self):
+        snapshot = pr(checks={})
+        kinds = {
+            b.kind for b in p.effective_blockers(
+                snapshot,
+                {QUEUE_ONLY_SKIPPED_CHECK},
                 trunk="master",
             )
         }
@@ -310,6 +322,15 @@ class PlanStackActions(PlannerTestCase):
         actions = self._plan(snapshot)
         self.assertEqual(actions, ())
 
+    def test_queued_label_with_headless_active_queue_failed_check_waits(self):
+        snapshot = pr(
+            labels=frozenset({"admin-bypass", "queued"}),
+            latest_mergify=event(state="queued", head=""),
+            checks={"build": check("failure")},
+        )
+        actions = self._plan(snapshot)
+        self.assertEqual(actions, ())
+
     def test_clean_bottom_queues_without_prior_dequeue(self):
         snapshot = pr(labels=frozenset({"admin-bypass"}))
         actions = self._plan(snapshot)
@@ -333,6 +354,24 @@ class PlanStackActions(PlannerTestCase):
         actions = self._plan(m.StackGroup("s", (bottom, upper)))
         self.assertEqual((actions[0].kind, actions[0].pr_number), ("requeue", 10))
 
+    def test_lower_human_decision_blocks_downstream_repairs(self):
+        ledger = self._ledger()
+        ledger.record("repair-invalid", 10, HEAD, "build", 1, meta={"errors": ["human split required"]})
+        bottom = pr(
+            number=10,
+            head_ref_name="stack/bottom",
+            labels=frozenset({"admin-bypass", "dequeued"}),
+            checks={"build": check("failure")},
+        )
+        upper = pr(
+            number=11,
+            base_ref_name="stack/bottom",
+            labels=frozenset({"admin-bypass"}),
+            checks={"build": check("failure")},
+        )
+        actions = self._plan(m.StackGroup("s", (bottom, upper)), ledger)
+        self.assertEqual(actions, ())
+
     def test_no_current_bottom_blocker_names_base_branch(self):
         actions = self._plan(
             m.StackGroup(
@@ -354,6 +393,29 @@ class PlanStackActions(PlannerTestCase):
         self.assertEqual((actions[0].kind, actions[0].key), ("comment_blocked", "no-current-bottom"))
         self.assertIn("lowest open stack PR #5885 is based on `pr/babysit-prereq-split`", actions[0].detail)
         self.assertIn("land or retarget that base", actions[0].detail)
+
+    def test_no_current_bottom_comment_waits_after_ledger_row(self):
+        ledger = self._ledger()
+        ledger.record("comment-blocked", 5885, HEAD, "no-current-bottom", 1)
+        actions = self._plan(
+            m.StackGroup(
+                "s",
+                (
+                    pr(
+                        number=5885,
+                        base_ref_name="pr/babysit-prereq-split",
+                        labels=frozenset({"admin-bypass"}),
+                    ),
+                    pr(
+                        number=5886,
+                        base_ref_name="stack/slack-routing",
+                        labels=frozenset({"admin-bypass"}),
+                    ),
+                ),
+            ),
+            ledger,
+        )
+        self.assertEqual(actions, ())
 
     def test_requeue_is_capped_after_repeated_attempts(self):
         ledger = self._ledger()


### PR DESCRIPTION
## Summary

This updates the babysit worker path so capped attempts no longer hide specific blocker reasons.

The planner handles queue-only checks, active-queue waits, upper-stack acceptance, no-current-bottom, and downstream human blockers as separate outcomes.

The worker posts exact human-only reasons once and keeps worker-owned fixes actionable.

## Review Claim

The babysit worker now reports specific Mergify queue outcomes instead of falling back to a generic capped-attempt blocker.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The worker actions remain scoped to target PRs; this does not manually requeue, relabel, merge, split, rebase, or force-push live PR branches.

## Slice Rationale

This policy change follows the repro slice, so the worker behavior can be reviewed against deterministic blocker coverage.

## Non-goals

No manual real-PR cleanup, unrelated refactors, metadata-only PR edits, or queue-rule changes outside what the worker needs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash ./loop-driver.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3114282d7`
- Post-revert steps: Keep or revert the preceding repro slice depending on whether the cases are still useful.
- Data migration? No

</details>
