### PR TITLE
[Remote Sync Step 1: Sync Schema and Change Journal](1) Add data-store sync schema and journal

### DIFF
--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createAttempt, type TaskState } from '@invoker/workflow-core';
+import type { Workflow } from '../adapter.js';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { SqliteExecutor } from '../sqlite-executor.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  readJournalSince,
+  setSyncCursor,
+} from '../sync-journal.js';
+
+describe('sync journal', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function exec(): SqliteExecutor {
+    return (adapter as any).executor as SqliteExecutor;
+  }
+
+  function workflow(id: string): Workflow {
+    return {
+      id,
+      name: `Workflow ${id}`,
+      status: 'pending',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+  }
+
+  function task(id: string): TaskState {
+    return {
+      id,
+      description: `Task ${id}`,
+      status: 'pending',
+      dependencies: [],
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      config: {},
+      execution: {},
+      taskStateVersion: 1,
+    };
+  }
+
+  it('rolls back journal appends with the enclosing mutation transaction', () => {
+    adapter.saveWorkflow(workflow('wf-rollback'));
+    adapter.saveTask('wf-rollback', task('task-rollback'));
+    const beforeSeqs = readJournalSince(exec(), 0, 100).map((entry) => entry.seq);
+
+    expect(() => {
+      adapter.runInTransaction(() => {
+        adapter.updateTask('task-rollback', { status: 'running' });
+        throw new Error('simulated rollback');
+      });
+    }).toThrow('simulated rollback');
+
+    expect(adapter.loadTask('task-rollback')?.status).toBe('pending');
+    expect(readJournalSince(exec(), 0, 100).map((entry) => entry.seq)).toEqual(beforeSeqs);
+  });
+
+  it('allocates strictly monotonic seq values and reads entries after the supplied cursor', () => {
+    const firstSeq = appendJournalEntry(exec(), {
+      entityType: 'event',
+      entityId: 'event-1',
+      op: 'upsert',
+      payload: { id: 1 },
+      createdAt: 1000,
+    });
+    const secondSeq = appendJournalEntry(exec(), {
+      entityType: 'event',
+      entityId: 'event-2',
+      op: 'upsert',
+      payload: { id: 2 },
+      createdAt: 1001,
+    });
+
+    expect(secondSeq).toBeGreaterThan(firstSeq);
+    expect(readJournalSince(exec(), firstSeq, 10).map((entry) => entry.seq)).toEqual([secondSeq]);
+    expect(readJournalSince(exec(), secondSeq, 10)).toEqual([]);
+
+    expect(getSyncCursor(exec(), 'peer-a')).toBeUndefined();
+    setSyncCursor(exec(), {
+      peerId: 'peer-a',
+      lastSentSeq: firstSeq,
+      lastReceivedSeq: secondSeq,
+      updatedAt: 2000,
+    });
+    expect(getSyncCursor(exec(), 'peer-a')).toEqual({
+      peerId: 'peer-a',
+      lastSentSeq: firstSeq,
+      lastReceivedSeq: secondSeq,
+      updatedAt: 2000,
+    });
+  });
+
+  it('journals attempt creation and completion snapshots', () => {
+    adapter.saveWorkflow(workflow('wf-attempt'));
+    adapter.saveTask('wf-attempt', task('task-attempt'));
+
+    const attempt = createAttempt('task-attempt', { status: 'pending' });
+    adapter.saveAttempt(attempt);
+    adapter.updateAttempt(attempt.id, {
+      status: 'completed',
+      completedAt: new Date('2026-01-01T00:01:00.000Z'),
+      exitCode: 0,
+    });
+
+    const attemptEntries = readJournalSince(exec(), 0, 100)
+      .filter((entry) => entry.entityType === 'attempt' && entry.entityId === attempt.id);
+    expect(attemptEntries.map((entry) => entry.op)).toEqual(['upsert', 'upsert']);
+    expect((attemptEntries[0]!.payload as { status?: string }).status).toBe('pending');
+    expect((attemptEntries[1]!.payload as { status?: string }).status).toBe('completed');
+    expect(attemptEntries[1]!.seq).toBeGreaterThan(attemptEntries[0]!.seq);
+  });
+
+  it('excludes soft-deleted workflows by default and journals a tombstone on delete', () => {
+    adapter.saveWorkflow(workflow('wf-soft-delete'));
+    adapter.saveTask('wf-soft-delete', task('task-soft-delete'));
+
+    adapter.deleteWorkflow('wf-soft-delete');
+
+    expect(adapter.listWorkflows()).toEqual([]);
+    expect(adapter.loadWorkflow('wf-soft-delete')).toBeUndefined();
+    expect(adapter.loadTasks('wf-soft-delete')).toEqual([]);
+
+    const deleted = adapter.listWorkflows({ includeDeleted: true });
+    expect(deleted).toHaveLength(1);
+    expect(deleted[0]!.id).toBe('wf-soft-delete');
+    expect(deleted[0]!.deletedAt).toEqual(expect.any(Number));
+    expect(adapter.loadWorkflow('wf-soft-delete', { includeDeleted: true })?.deletedAt)
+      .toBe(deleted[0]!.deletedAt);
+
+    const tombstone = readJournalSince(exec(), 0, 100)
+      .find((entry) =>
+        entry.entityType === 'workflow'
+        && entry.entityId === 'wf-soft-delete'
+        && entry.op === 'tombstone');
+    expect(tombstone).toBeDefined();
+    expect(tombstone!.origin).toBe('home');
+    expect((tombstone!.payload as { id?: string; deleted_at?: number }).id).toBe('wf-soft-delete');
+    expect((tombstone!.payload as { deleted_at?: number }).deleted_at).toBe(deleted[0]!.deletedAt);
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -124,10 +124,15 @@ export interface Workflow {
   /** Read-only provenance for dependencies removed by `detachWorkflow`. Never re-read by scheduling. */
   detachedExternalDependencies?: DetachedExternalDependency[];
   generation?: number;
+  deletedAt?: number;
   createdAt: string;
   updatedAt: string;
 }
 export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup'>;
+
+export interface WorkflowReadOptions {
+  includeDeleted?: boolean;
+}
 
 /**
  * Result of resolving a published PR back to its Invoker workflow via the merge
@@ -333,8 +338,8 @@ export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
-  loadWorkflow(workflowId: string): Workflow | undefined;
-  listWorkflows(): Workflow[];
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined;
+  listWorkflows(options?: WorkflowReadOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
   /** Resolve a GitHub PR number back to its Invoker workflow via the merge node. */
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined;
@@ -343,7 +348,7 @@ export interface PersistenceAdapter {
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
   loadTasks(workflowId: string): TaskState[];
-  loadWorkflowTaskSnapshot?(): WorkflowTaskSnapshot;
+  loadWorkflowTaskSnapshot?(options?: WorkflowReadOptions): WorkflowTaskSnapshot;
   /** Authoritative single-task read by ID, suitable for recovery workflows. */
   loadTask(taskId: string): TaskState | undefined;
   /** Delete one task and its task-owned rows. */

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -1,6 +1,7 @@
 export * from './adapter.js';
 export * from './attempt-read-models.js';
 export * from './sqlite-adapter.js';
+export * from './sync-journal.js';
 export * from './slow-query-aggregator.js';
 export * from './conversation-repository.js';
 export * from './slack-session-repository.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -38,6 +38,7 @@ import type {
   PersistenceAdapter,
   ReviewGateLookup,
   Workflow,
+  WorkflowReadOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
   TaskEvent,
@@ -78,6 +79,7 @@ import type { SqliteExecutor } from './sqlite-executor.js';
 import * as migrations from './sqlite-migrations.js';
 import { SqliteTaskAttemptRepository } from './sqlite-task-attempt-repository.js';
 import { SqliteWorkflowRepository, type WorkflowMetadataChanges } from './sqlite-workflow-repository.js';
+import { appendJournalEntry, type SyncEntityType, type SyncJournalOperation } from './sync-journal.js';
 
 function normalizeWorkerActionStatus(status: string): string {
   return status === 'canceled' ? 'cancelled' : status;
@@ -951,6 +953,25 @@ export class SQLiteAdapter implements PersistenceAdapter {
     };
   }
 
+  private appendJournalSnapshot(
+    entityType: SyncEntityType,
+    entityId: string,
+    op: SyncJournalOperation,
+    tableName: 'workflows' | 'tasks' | 'attempts',
+    idColumn: 'id' = 'id',
+  ): void {
+    const row = this.queryOne(`SELECT * FROM ${tableName} WHERE ${idColumn} = ?`, [entityId]);
+    if (!row) {
+      throw new Error(`Cannot journal ${op} for missing ${entityType} "${entityId}"`);
+    }
+    appendJournalEntry(this.executor, {
+      entityType,
+      entityId,
+      op,
+      payload: row,
+    });
+  }
+
   runCompatibilityMigration(): {
     migratedFixingWithAiStatuses: number;
     normalizedMergeModes: number;
@@ -1047,19 +1068,26 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Workflows ─────────────────────────────────────────
 
   saveWorkflow(workflow: WorkflowSaveInput): void {
-    this.workflowRepo.saveWorkflow(workflow);
+    this.runTransaction(() => {
+      this.workflowRepo.saveWorkflow(workflow);
+      this.appendJournalSnapshot('workflow', workflow.id, 'upsert', 'workflows');
+    });
   }
 
   updateWorkflow(workflowId: string, changes: WorkflowMetadataChanges): void {
-    this.workflowRepo.updateWorkflow(workflowId, changes);
+    this.runTransaction(() => {
+      if (!this.workflowRepo.loadWorkflow(workflowId)) return;
+      this.workflowRepo.updateWorkflow(workflowId, changes);
+      this.appendJournalSnapshot('workflow', workflowId, 'upsert', 'workflows');
+    });
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    return this.workflowRepo.loadWorkflow(workflowId);
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined {
+    return this.workflowRepo.loadWorkflow(workflowId, options);
   }
 
-  listWorkflows(): Workflow[] {
-    return this.workflowRepo.listWorkflows();
+  listWorkflows(options?: WorkflowReadOptions): Workflow[] {
+    return this.workflowRepo.listWorkflows(options);
   }
 
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
@@ -1070,8 +1098,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return this.workflowRepo.searchWorkflowsAndTasks(query, opts);
   }
 
-  loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
-    return this.workflowRepo.loadWorkflowTaskSnapshot();
+  loadWorkflowTaskSnapshot(options?: WorkflowReadOptions): WorkflowTaskSnapshot {
+    return this.workflowRepo.loadWorkflowTaskSnapshot(options);
   }
 
   getLastWorkflowTaskSnapshotStats(): Record<string, unknown> | null {
@@ -1081,11 +1109,20 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Tasks ─────────────────────────────────────────────
 
   saveTask(workflowId: string, task: TaskState): void {
-    this.taskAttemptRepo.saveTask(workflowId, task);
+    this.runTransaction(() => {
+      this.taskAttemptRepo.saveTask(workflowId, task);
+      this.appendJournalSnapshot('task', task.id, 'upsert', 'tasks');
+    });
   }
 
   updateTask(taskId: string, changes: TaskStateChanges): void {
-    this.taskAttemptRepo.updateTask(taskId, changes);
+    this.runTransaction(() => {
+      const shouldJournal = changes.status !== undefined && this.taskAttemptRepo.loadTask(taskId) !== undefined;
+      this.taskAttemptRepo.updateTask(taskId, changes);
+      if (shouldJournal) {
+        this.appendJournalSnapshot('task', taskId, 'upsert', 'tasks');
+      }
+    });
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -1557,7 +1594,15 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   deleteWorkflow(workflowId: string): void {
+    const existing = this.queryOne(
+      'SELECT id, deleted_at FROM workflows WHERE id = ?',
+      [workflowId],
+    );
+    if (!existing || (existing.deleted_at !== null && existing.deleted_at !== undefined)) return;
+
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
+    const deletedAt = Date.now();
+    const updatedAt = new Date(deletedAt).toISOString();
     this.runTransaction(() => {
       this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
@@ -1598,7 +1643,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
+      this.db.run(
+        'UPDATE workflows SET deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL',
+        [deletedAt, updatedAt, workflowId],
+      );
+      this.appendJournalSnapshot('workflow', workflowId, 'tombstone', 'workflows');
     });
     this.removeOutputFiles(taskIds);
   }
@@ -2630,7 +2679,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Attempts ────────────────────────────────────────────
 
   saveAttempt(attempt: Attempt): void {
-    this.taskAttemptRepo.saveAttempt(attempt);
+    this.runTransaction(() => {
+      this.taskAttemptRepo.saveAttempt(attempt);
+      this.appendJournalSnapshot('attempt', attempt.id, 'upsert', 'attempts');
+    });
   }
 
   loadAttempts(nodeId: string): Attempt[] {
@@ -2654,7 +2706,15 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void {
-    this.taskAttemptRepo.updateAttempt(attemptId, changes);
+    this.runTransaction(() => {
+      const shouldJournal =
+        (changes.status !== undefined || changes.completedAt !== undefined)
+        && this.taskAttemptRepo.loadAttempt(attemptId) !== undefined;
+      this.taskAttemptRepo.updateAttempt(attemptId, changes);
+      if (shouldJournal) {
+        this.appendJournalSnapshot('attempt', attemptId, 'upsert', 'attempts');
+      }
+    });
   }
 
   claimAttemptForLaunch(

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -47,6 +47,7 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
     externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
     detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) as DetachedExternalDependency[] : undefined,
     generation: row.generation ?? 0,
+    deletedAt: row.deleted_at === null || row.deleted_at === undefined ? undefined : Number(row.deleted_at),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -27,8 +27,26 @@ export const SCHEMA_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_journal (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+        entity_id TEXT NOT NULL,
+        op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+        payload TEXT NOT NULL CHECK (json_valid(payload)),
+        origin TEXT NOT NULL DEFAULT 'home',
+        created_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_cursors (
+        peer_id TEXT PRIMARY KEY,
+        last_sent_seq INTEGER NOT NULL DEFAULT 0,
+        last_received_seq INTEGER NOT NULL DEFAULT 0,
+        updated_at INTEGER NOT NULL
       );
 
       CREATE TABLE IF NOT EXISTS tasks (
@@ -597,6 +615,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
+  'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
 ];
 
 /**
@@ -628,6 +647,21 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  `CREATE TABLE IF NOT EXISTS sync_journal (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+    entity_id TEXT NOT NULL,
+    op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    origin TEXT NOT NULL DEFAULT 'home',
+    created_at INTEGER NOT NULL
+  )`,
+  `CREATE TABLE IF NOT EXISTS sync_cursors (
+    peer_id TEXT PRIMARY KEY,
+    last_sent_seq INTEGER NOT NULL DEFAULT 0,
+    last_received_seq INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER NOT NULL
+  )`,
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */
@@ -651,6 +685,7 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       )
@@ -662,12 +697,12 @@ export const WORKFLOWS_REBUILD_INSERT_DDL = `
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       FROM workflows
     `;

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -459,7 +459,8 @@ export class SqliteTaskAttemptRepository {
              w.name AS workflow_name
       FROM tasks t${this.taskSelectJoin('t')}
       JOIN workflows w ON w.id = t.workflow_id
-      WHERE t.status = 'completed'
+      WHERE w.deleted_at IS NULL
+        AND t.status = 'completed'
       ORDER BY t.completed_at DESC
     `);
     return rows.map((row) => ({
@@ -481,7 +482,8 @@ export class SqliteTaskAttemptRepository {
         FROM events
         GROUP BY task_id
       ) e ON e.task_id = t.id
-      WHERE COALESCE(e.event_count, 0) > 0 OR t.status != 'pending'
+      WHERE w.deleted_at IS NULL
+        AND (COALESCE(e.event_count, 0) > 0 OR t.status != 'pending')
       ORDER BY COALESCE(e.max_created_at, t.completed_at, t.started_at, t.created_at) DESC
     `);
     return rows.map((row) => {

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -27,6 +27,7 @@ import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ReviewGateLookup,
   Workflow,
+  WorkflowReadOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
 } from './adapter.js';
@@ -174,16 +175,19 @@ export class SqliteWorkflowRepository {
     this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+  loadWorkflow(workflowId: string, options: WorkflowReadOptions = {}): Workflow | undefined {
+    const row = this.exec.queryOne(
+      `SELECT * FROM workflows WHERE id = ?${options.includeDeleted ? '' : ' AND deleted_at IS NULL'}`,
+      [workflowId],
+    );
     if (!row) return undefined;
     const rollup = this.loadWorkflowRollups([workflowId]).get(workflowId);
     return this.rowToWorkflow(row, rollup);
   }
 
-  listWorkflows(): Workflow[] {
+  listWorkflows(options: WorkflowReadOptions = {}): Workflow[] {
     const rows = this.exec.queryAll(
-      'SELECT * FROM workflows ORDER BY created_at DESC',
+      `SELECT * FROM workflows${options.includeDeleted ? '' : ' WHERE deleted_at IS NULL'} ORDER BY created_at DESC`,
     );
     const workflowIds = rows.map((row) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
@@ -205,7 +209,9 @@ export class SqliteWorkflowRepository {
               w.base_branch AS baseBranch
          FROM tasks t
          JOIN workflows w ON w.id = t.workflow_id
-        WHERE t.is_merge_node = 1 AND (t.review_id = ? OR t.review_url LIKE ?)`,
+        WHERE w.deleted_at IS NULL
+          AND t.is_merge_node = 1
+          AND (t.review_id = ? OR t.review_url LIKE ?)`,
       [pr, `%/pull/${pr}`],
     );
     if (rows.length === 0) return undefined;
@@ -257,7 +263,8 @@ export class SqliteWorkflowRepository {
     if (type === 'workflows' || type === 'all') {
       const workflows = this.exec.queryAll(
         `SELECT id, name, description, plan_file, repo_url, branch, created_at FROM workflows 
-         WHERE name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ? 
+         WHERE deleted_at IS NULL
+           AND (name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{ id: string; name?: string | null; created_at: string }>;
@@ -281,8 +288,11 @@ export class SqliteWorkflowRepository {
     
     if (type === 'tasks' || type === 'all') {
       const tasks = this.exec.queryAll(
-        `SELECT id, workflow_id, description, command, prompt, summary, problem, approach, test_plan, repro_command, status, created_at FROM tasks 
-         WHERE description LIKE ? OR command LIKE ? OR prompt LIKE ? OR summary LIKE ? OR problem LIKE ? OR approach LIKE ? OR test_plan LIKE ? OR repro_command LIKE ? 
+        `SELECT t.id, t.workflow_id, t.description, t.command, t.prompt, t.summary, t.problem, t.approach, t.test_plan, t.repro_command, t.status, t.created_at
+         FROM tasks t
+         JOIN workflows w ON w.id = t.workflow_id
+         WHERE w.deleted_at IS NULL
+           AND (t.description LIKE ? OR t.command LIKE ? OR t.prompt LIKE ? OR t.summary LIKE ? OR t.problem LIKE ? OR t.approach LIKE ? OR t.test_plan LIKE ? OR t.repro_command LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{
@@ -298,7 +308,7 @@ export class SqliteWorkflowRepository {
       if (workflowIds.length > 0) {
         const placeholders = workflowIds.map(() => '?').join(',');
         const workflowRows = this.exec.queryAll(
-          `SELECT id, name FROM workflows WHERE id IN (${placeholders})`,
+          `SELECT id, name FROM workflows WHERE deleted_at IS NULL AND id IN (${placeholders})`,
           workflowIds
         ) as Array<{ id: string; name?: string | null }>;
         for (const wf of workflowRows) {
@@ -323,13 +333,23 @@ export class SqliteWorkflowRepository {
     return results;
   }
 
-  loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
+  loadWorkflowTaskSnapshot(options: WorkflowReadOptions = {}): WorkflowTaskSnapshot {
     const totalStartedAt = Date.now();
     const workflowQueryStartedAt = Date.now();
-    const workflowRows = this.exec.queryAll('SELECT * FROM workflows ORDER BY created_at DESC');
+    const workflowRows = this.exec.queryAll(
+      `SELECT * FROM workflows${options.includeDeleted ? '' : ' WHERE deleted_at IS NULL'} ORDER BY created_at DESC`,
+    );
     const workflowMetadataQueryMs = Date.now() - workflowQueryStartedAt;
     const taskQueryStartedAt = Date.now();
-    const taskRows = this.exec.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC');
+    const taskRows = options.includeDeleted
+      ? this.exec.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC')
+      : this.exec.queryAll(
+        `SELECT t.*
+         FROM tasks t
+         JOIN workflows w ON w.id = t.workflow_id
+         WHERE w.deleted_at IS NULL
+         ORDER BY t.workflow_id ASC, t.id ASC`,
+      );
     const taskQueryMs = Date.now() - taskQueryStartedAt;
     const tasksByWorkflowId = new Map<string, TaskState[]>();
     const workflowIds = workflowRows.map((row) => String(row.id));

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -1,0 +1,183 @@
+import type { SqliteExecutor } from './sqlite-executor.js';
+
+export type SyncEntityType = 'workflow' | 'task' | 'attempt' | 'event' | 'output';
+export type SyncJournalOperation = 'upsert' | 'tombstone';
+
+export interface SyncJournalEntry {
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOperation;
+  payload: unknown;
+  origin?: string;
+  createdAt?: number;
+}
+
+export interface SyncJournalRow {
+  seq: number;
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOperation;
+  payload: unknown;
+  origin: string;
+  createdAt: number;
+}
+
+export interface SyncCursor {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt: number;
+}
+
+export interface SyncCursorInput {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt?: number;
+}
+
+const ENTITY_TYPES = new Set<SyncEntityType>([
+  'workflow',
+  'task',
+  'attempt',
+  'event',
+  // Reserved for future output-spool sync; adapter output writes are not
+  // journaled yet because they are high-volume.
+  'output',
+]);
+
+const OPS = new Set<SyncJournalOperation>(['upsert', 'tombstone']);
+
+function assertEntityType(value: SyncEntityType): void {
+  if (!ENTITY_TYPES.has(value)) {
+    throw new Error(`Invalid sync journal entity_type "${String(value)}"`);
+  }
+}
+
+function assertOp(value: SyncJournalOperation): void {
+  if (!OPS.has(value)) {
+    throw new Error(`Invalid sync journal op "${String(value)}"`);
+  }
+}
+
+function assertNonEmptyString(label: string, value: string): void {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+}
+
+function assertNonNegativeInteger(label: string, value: number): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative safe integer`);
+  }
+}
+
+function payloadToJson(payload: unknown): string {
+  const json = JSON.stringify(payload);
+  if (json === undefined) {
+    throw new Error('sync journal payload must be JSON-serializable');
+  }
+  return json;
+}
+
+function parsePayload(raw: unknown, seq: unknown): unknown {
+  try {
+    return JSON.parse(String(raw));
+  } catch (err) {
+    throw new Error(
+      `Invalid sync journal payload JSON at seq ${String(seq)}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+export function appendJournalEntry(db: SqliteExecutor, entry: SyncJournalEntry): number {
+  assertEntityType(entry.entityType);
+  assertOp(entry.op);
+  assertNonEmptyString('sync journal entityId', entry.entityId);
+  const origin = entry.origin ?? 'home';
+  assertNonEmptyString('sync journal origin', origin);
+  const createdAt = entry.createdAt ?? Date.now();
+  assertNonNegativeInteger('sync journal createdAt', createdAt);
+  const payloadJson = payloadToJson(entry.payload);
+
+  db.execRun(
+    `INSERT INTO sync_journal (entity_type, entity_id, op, payload, origin, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [entry.entityType, entry.entityId, entry.op, payloadJson, origin, createdAt],
+  );
+
+  const row = db.queryOne('SELECT last_insert_rowid() AS seq') as { seq?: number | bigint } | undefined;
+  const seq = Number(row?.seq ?? 0);
+  if (!Number.isSafeInteger(seq) || seq <= 0) {
+    throw new Error('Could not resolve sync journal seq after insert');
+  }
+  return seq;
+}
+
+export function readJournalSince(db: SqliteExecutor, seq: number, limit: number): SyncJournalRow[] {
+  assertNonNegativeInteger('sync journal seq', Math.trunc(seq));
+  const pageLimit = Math.trunc(limit);
+  if (pageLimit <= 0) return [];
+  assertNonNegativeInteger('sync journal limit', pageLimit);
+
+  const rows = db.queryAll(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq > ?
+      ORDER BY seq ASC
+      LIMIT ?`,
+    [Math.trunc(seq), pageLimit],
+  );
+
+  return rows.map((row) => ({
+    seq: Number(row.seq ?? 0),
+    entityType: row.entity_type as SyncEntityType,
+    entityId: String(row.entity_id),
+    op: row.op as SyncJournalOperation,
+    payload: parsePayload(row.payload, row.seq),
+    origin: String(row.origin ?? 'home'),
+    createdAt: Number(row.created_at ?? 0),
+  }));
+}
+
+export function getSyncCursor(db: SqliteExecutor, peerId: string): SyncCursor | undefined {
+  assertNonEmptyString('sync cursor peerId', peerId);
+  const row = db.queryOne(
+    `SELECT peer_id, last_sent_seq, last_received_seq, updated_at
+       FROM sync_cursors
+      WHERE peer_id = ?`,
+    [peerId],
+  );
+  if (!row) return undefined;
+  return {
+    peerId: String(row.peer_id),
+    lastSentSeq: Number(row.last_sent_seq ?? 0),
+    lastReceivedSeq: Number(row.last_received_seq ?? 0),
+    updatedAt: Number(row.updated_at ?? 0),
+  };
+}
+
+export function setSyncCursor(db: SqliteExecutor, cursor: SyncCursorInput): SyncCursor {
+  assertNonEmptyString('sync cursor peerId', cursor.peerId);
+  assertNonNegativeInteger('sync cursor lastSentSeq', cursor.lastSentSeq);
+  assertNonNegativeInteger('sync cursor lastReceivedSeq', cursor.lastReceivedSeq);
+  const updatedAt = cursor.updatedAt ?? Date.now();
+  assertNonNegativeInteger('sync cursor updatedAt', updatedAt);
+
+  db.execRun(
+    `INSERT INTO sync_cursors (peer_id, last_sent_seq, last_received_seq, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(peer_id) DO UPDATE SET
+       last_sent_seq = excluded.last_sent_seq,
+       last_received_seq = excluded.last_received_seq,
+       updated_at = excluded.updated_at`,
+    [cursor.peerId, cursor.lastSentSeq, cursor.lastReceivedSeq, updatedAt],
+  );
+
+  return {
+    peerId: cursor.peerId,
+    lastSentSeq: cursor.lastSentSeq,
+    lastReceivedSeq: cursor.lastReceivedSeq,
+    updatedAt,
+  };
+}


### PR DESCRIPTION
## Summary

Remote Sync Step 1 adds the data-store replication contract for journal entries, peer cursors, and workflow tombstones.

## Review Claim

Approve the data-store sync contract: journal entries, peer cursors, and workflow tombstones are persisted with existing SQLite mutations.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This slice stays inside data-store schema, adapter, repository, and focused data-store tests.

## Slice Rationale

Remote sync needs this durable local contract before later replay, transport, or conflict-resolution work can depend on it.

## Non-goals

- No remote transport.
- No sync replay worker.
- No conflict resolution.
- No UI changes.

## Architecture

### Before

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["entity tables only"]
    C["Remote sync peers"] --> D["no durable cursor contract"]
```

### After

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["entity tables"]
    A --> C["sync_journal rows in the same transaction"]
    D["Remote sync peers"] --> E["sync_cursors records last sent and received sequence"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sync-journal.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9376972ae`
- Post-revert steps: None
- Data migration? No production migration has shipped yet.

</details>

## Workflow Summary

Remote Sync Step 1: Sync Schema and Change Journal — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926077035-3/implement-sync-schema | Add sync journal, cursor, and tombstone schema to data-store | completed |
| wf-1784926077035-3/verify-sync-schema | Run data-store package tests covering the new schema and journal | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784926077035-3/implement-sync-schema — Add sync journal, cursor, and tombstone schema to data-store

### wf-1784926077035-3/verify-sync-schema — Run data-store package tests covering the new schema and journal

</details>
