### PR TITLE
[Merge Gate Workspace Path](2) Persist merge gate workspace paths

### DIFF
--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -870,7 +870,7 @@ export async function runMergeGateActionImpl(
           actionId: task.id,
           executionGeneration: task.execution.generation ?? 0,
           status: 'review_ready',
-          outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined },
+          outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined, workspacePath: gateWorkspacePath },
         };
         return {
           response,
@@ -977,6 +977,7 @@ export async function runMergeGateActionImpl(
             exitCode: 0,
             summary,
             branch: featureBranch,
+            workspacePath: gateWorkspacePath,
             reviewUrl,
             reviewId,
             reviewStatus,
@@ -1003,7 +1004,7 @@ export async function runMergeGateActionImpl(
         actionId: task.id,
         executionGeneration: task.execution.generation ?? 0,
         status: 'completed',
-        outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined },
+        outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined, workspacePath: gateWorkspacePath },
       };
     } catch (err) {
       logTaskProgress(host, task.id, 'error', 'Merge gate failed', {
@@ -1042,7 +1043,7 @@ export async function runMergeGateActionImpl(
         actionId: task.id,
         executionGeneration: task.execution.generation ?? 0,
         status: 'review_ready',
-        outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined },
+        outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined, workspacePath: gateWorkspacePath },
       };
       return {
         response,
@@ -1057,7 +1058,7 @@ export async function runMergeGateActionImpl(
       actionId: task.id,
       executionGeneration: task.execution.generation ?? 0,
       status: 'completed',
-      outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined },
+      outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined, workspacePath: gateWorkspacePath },
     };
   }
 

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -428,6 +428,7 @@ describe('Orchestrator', () => {
           exitCode: 0,
           summary: 'ready',
           branch: 'feature/review-ready',
+          workspacePath: '/tmp/review-ready-gate',
           reviewUrl: 'https://github.com/owner/repo/pull/1',
           reviewId: 'owner/repo#1',
           reviewStatus: 'Awaiting review',
@@ -438,6 +439,7 @@ describe('Orchestrator', () => {
       expect(task.status).toBe('review_ready');
       expect(task.config.summary).toBe('ready');
       expect(task.execution.branch).toBe('feature/review-ready');
+      expect(task.execution.workspacePath).toBe('/tmp/review-ready-gate');
       expect(task.execution.reviewUrl).toBe('https://github.com/owner/repo/pull/1');
       expect(task.execution.reviewId).toBe('owner/repo#1');
       expect(task.execution.reviewStatus).toBe('Awaiting review');

--- a/packages/workflow-core/src/__tests__/response-handler.test.ts
+++ b/packages/workflow-core/src/__tests__/response-handler.test.ts
@@ -111,12 +111,14 @@ describe('ResponseHandler (pure parser)', () => {
           outputs: {
             exitCode: 0,
             reviewGate,
+            workspacePath: '/tmp/gate-workspace',
           },
         }),
       );
       expect('type' in result).toBe(true);
       if (!('type' in result)) return;
       expect(result.type).toBe('review_ready');
+      expect(result.workspacePath).toBe('/tmp/gate-workspace');
       expect(result.reviewGate).toEqual(reviewGate);
     });
   });

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -275,6 +275,7 @@ export function handleReviewReadyImpl(
     execution: {
       exitCode: parsed.exitCode,
       branch: parsed.branch,
+      workspacePath: parsed.workspacePath,
       reviewUrl: parsed.reviewUrl,
       reviewId: parsed.reviewId,
       reviewStatus: parsed.reviewStatus,

--- a/packages/workflow-core/src/response-handler.ts
+++ b/packages/workflow-core/src/response-handler.ts
@@ -38,6 +38,7 @@ export type ParsedResponse =
       agentSessionId?: string;
       agentName?: string;
       branch?: string;
+      workspacePath?: string;
       reviewUrl?: string;
       reviewId?: string;
       reviewStatus?: string;
@@ -49,6 +50,7 @@ export type ParsedResponse =
       exitCode: number;
       summary?: string;
       branch?: string;
+      workspacePath?: string;
       reviewUrl?: string;
       reviewId?: string;
       reviewStatus?: string;
@@ -104,6 +106,7 @@ export class ResponseHandler {
           agentSessionId: outputs.agentSessionId,
           agentName: outputs.agentName,
           branch: outputs.branch,
+          workspacePath: outputs.workspacePath,
           reviewUrl: outputs.reviewUrl,
           reviewId: outputs.reviewId,
           reviewStatus: outputs.reviewStatus,
@@ -117,6 +120,7 @@ export class ResponseHandler {
           exitCode: outputs.exitCode ?? 0,
           summary: outputs.summary,
           branch: outputs.branch,
+          workspacePath: outputs.workspacePath,
           reviewUrl: outputs.reviewUrl,
           reviewId: outputs.reviewId,
           reviewStatus: outputs.reviewStatus,


### PR DESCRIPTION
## Summary

Merge-gate responses now include the gate workspace path when they report `review_ready` or `completed`.

The response parser carries that value into the orchestrator transition.

The review-ready transition saves it on task execution, so terminal restore no longer depends on side metadata writes.

## Review Claim

Approve carrying merge-gate workspace paths through the normal worker response route.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only an optional `workspacePath` value is copied when present; review metadata and approval semantics are unchanged.

## Slice Rationale

This slice stays separate from the output-field slice so runtime routing can be reviewed independently.

## Non-goals

This does not change whether open review artifacts block gate approval.

This does not change terminal-opening policy when a task has no workspace path.

## Architecture

### Before

```mermaid
graph TD
    A["Merge gate creates workspace"]
    B["Side metadata write may save workspacePath"]
    C["Worker response omits workspacePath"]
    D["review_ready transition cannot save workspacePath from response"]
    A --> B
    A --> C
    C --> D
```

### After

```mermaid
graph TD
    A["Merge gate creates workspace"]
    B["Worker response includes workspacePath"]
    C["Response parser preserves workspacePath"]
    D["review_ready transition saves workspacePath"]
    A --> B
    B --> C
    C --> D
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/response-handler.test.ts src/__tests__/orchestrator.test.ts -t "review_ready|review ready|merge gate review metadata"`
- [x] `pnpm --dir packages/execution-engine exec vitest run src/__tests__/merge-gate-executor.test.ts`
- [x] `pnpm --filter @invoker/workflow-core build`
- [x] `pnpm --filter @invoker/execution-engine build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7aa8ef28f`
- Post-revert steps: None
- Data migration? No

</details>
