### PR TITLE
[Workflow Base Branch](1) Pin persisted workflow base branch to master

### DIFF
--- a/packages/app/e2e/base-branch-normalization.proof.spec.ts
+++ b/packages/app/e2e/base-branch-normalization.proof.spec.ts
@@ -3,7 +3,7 @@ import { test, expect, captureScreenshot, loadPlan } from './fixtures/electron-a
 const BASE_BRANCH_NORMALIZATION_PLAN = {
   name: 'Base branch normalization proof',
   repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker',
-  baseBranch: 'upstream/release',
+  baseBranch: 'release',
   onFinish: 'pull_request' as const,
   mergeMode: 'external_review' as const,
   tasks: [
@@ -16,7 +16,7 @@ const BASE_BRANCH_NORMALIZATION_PLAN = {
   ],
 };
 
-test('loadPlan preserves an explicit remote-qualified base ref', async ({ page }) => {
+test('loading a non-master plan base shows the normalized master value', async ({ page }) => {
   await loadPlan(page, BASE_BRANCH_NORMALIZATION_PLAN);
   await page.locator('.react-flow__node[data-testid$="base-branch-proof-task"]').first().waitFor({ state: 'visible', timeout: 15000 });
 
@@ -33,8 +33,8 @@ test('loadPlan preserves an explicit remote-qualified base ref', async ({ page }
   await mergeGateNode.click();
 
   await expect(page.getByTestId('workflow-inspector-title')).toBeVisible();
-  await expect(page.getByText('Base Branch', { exact: true })).toBeVisible();
-  await expect(page.getByTestId('base-branch-display')).toHaveText('upstream/release');
+  await expect(page.getByText('Base Ref')).toBeVisible();
+  await expect(page.getByTestId('base-ref-input')).toHaveValue('master');
 
-  await captureScreenshot(page, 'base-branch-upstream-release');
+  await captureScreenshot(page, 'base-branch-normalized-to-master');
 });

--- a/packages/app/src/__tests__/metadata-setter.test.ts
+++ b/packages/app/src/__tests__/metadata-setter.test.ts
@@ -68,23 +68,15 @@ describe('metadata-setter', () => {
     expect(deps.orchestrator.syncFromDb).toHaveBeenCalledWith('wf-1');
   });
 
-  it('preserves explicit workflow base refs on metadata writes', async () => {
+  it('pins workflow baseBranch metadata writes to master', async () => {
     const deps = makeDeps();
-    await setWorkflowMetadata(deps, 'wf-1', 'baseBranch', 'upstream/release');
+    await setWorkflowMetadata(deps, 'wf-1', 'baseBranch', 'release');
 
     expect(deps.persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', {
-      baseBranch: 'upstream/release',
+      baseBranch: 'master',
     });
   });
 
-  it('canonicalizes workflow base refs on metadata writes', async () => {
-    const deps = makeDeps();
-    await setWorkflowMetadata(deps, 'wf-1', 'baseBranch', 'refs/remotes/origin/release');
-
-    expect(deps.persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', {
-      baseBranch: 'origin/release',
-    });
-  });
   it('sets allowed task config metadata through serialized workflow mutation', async () => {
     const deps = makeDeps();
     await setTaskMetadata(deps, 'task-1', 'config.poolId', 'some-pool');

--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
 });
 
 describe('applyPlanDefinitionDefaults', () => {
-  it('defaults the workflow baseBranch to master when omitted', () => {
+  it('pins the workflow baseBranch to master when omitted', () => {
     const plan = applyPlanDefinitionDefaults({
       name: 'My Plan',
       repoUrl: 'git@github.com:test/repo.git',
@@ -30,7 +30,7 @@ describe('applyPlanDefinitionDefaults', () => {
     expect(plan.baseBranch).toBe('master');
   });
 
-  it('preserves an explicit workflow base ref', () => {
+  it('pins the workflow baseBranch to master even when the plan asks for another branch', () => {
     const plan = applyPlanDefinitionDefaults({
       name: 'X',
       baseBranch: 'upstream/develop',
@@ -38,30 +38,12 @@ describe('applyPlanDefinitionDefaults', () => {
       onFinish: 'merge',
       tasks: [{ id: 'a', description: 'd', command: 'echo' }],
     });
-    expect(plan.baseBranch).toBe('upstream/develop');
+    expect(plan.baseBranch).toBe('master');
     expect(plan.featureBranch).toBe('feat/x');
     expect(plan.onFinish).toBe('merge');
   });
 
-  it('normalizes git ref prefixes before saving workflow base refs', () => {
-    const plan = applyPlanDefinitionDefaults({
-      name: 'Remote PR Plan',
-      repoUrl: 'git@github.com:test/repo.git',
-      baseBranch: 'refs/remotes/upstream/release',
-      tasks: [{ id: 'a', description: 'd', command: 'echo' }],
-    });
-    expect(plan.baseBranch).toBe('upstream/release');
-
-    const localRef = applyPlanDefinitionDefaults({
-      name: 'Remote PR Plan',
-      repoUrl: 'git@github.com:test/repo.git',
-      baseBranch: 'refs/heads/release',
-      tasks: [{ id: 'a', description: 'd', command: 'echo' }],
-    });
-    expect(localRef.baseBranch).toBe('release');
-  });
-
-  it('defaults blank baseBranch values to master', () => {
+  it('pins blank baseBranch values to master too', () => {
     const empty = applyPlanDefinitionDefaults({
       name: 'Remote PR Plan',
       repoUrl: 'git@github.com:test/repo.git',
@@ -899,7 +881,7 @@ tasks:
   });
 
   describe('onFinish parsing', () => {
-    it('parses plan with onFinish: merge and preserves the explicit base ref', () => {
+    it('parses plan with onFinish: merge and still pins baseBranch to master', () => {
       const yaml = `
 name: Merge Plan
 repoUrl: git@github.com:test/repo.git
@@ -912,7 +894,7 @@ tasks:
 `;
       const plan = parsePlan(yaml);
       expect(plan.onFinish).toBe('merge');
-      expect(plan.baseBranch).toBe('upstream/develop');
+      expect(plan.baseBranch).toBe('master');
       expect(plan.featureBranch).toBe('feat/x');
     });
 
@@ -943,7 +925,10 @@ tasks:
       expect(plan.featureBranch).toBe('plan/simple-plan');
     });
 
-    it('defaults baseBranch to master when omitted', () => {
+    it('pins baseBranch to master when omitted', async () => {
+      const configMod = await import('../config.js');
+      const loadConfigSpy = vi.spyOn(configMod, 'loadConfig').mockReturnValue({});
+
       const yaml = `
 name: No Base Branch
 repoUrl: git@github.com:test/repo.git
@@ -955,9 +940,10 @@ tasks:
 `;
       const plan = parsePlan(yaml);
       expect(plan.baseBranch).toBe('master');
+      loadConfigSpy.mockRestore();
     });
 
-    it('keeps an explicit baseBranch override', () => {
+    it('ignores an explicit baseBranch override and still pins to master', () => {
       const yaml = `
 name: Explicit Base
 repoUrl: git@github.com:test/repo.git
@@ -969,7 +955,7 @@ tasks:
     description: Build the project
 `;
       const plan = parsePlan(yaml);
-      expect(plan.baseBranch).toBe('origin/release');
+      expect(plan.baseBranch).toBe('master');
     });
 
     it('rejects invalid onFinish value', () => {

--- a/packages/app/src/__tests__/workflow-base-branch-normalizer.test.ts
+++ b/packages/app/src/__tests__/workflow-base-branch-normalizer.test.ts
@@ -9,11 +9,10 @@ function makePersistence(workflows: Array<{ id: string; baseBranch?: string }>) 
 }
 
 describe('normalizePersistedWorkflowBaseBranches', () => {
-  it('fills missing refs and canonicalizes stored base refs', () => {
+  it('rewrites every non-master workflow base branch to master', () => {
     const persistence = makePersistence([
       { id: 'wf-master', baseBranch: 'master' },
-      { id: 'wf-origin-ref', baseBranch: 'refs/remotes/origin/master' },
-      { id: 'wf-local-ref', baseBranch: 'refs/heads/release' },
+      { id: 'wf-main', baseBranch: 'main' },
       { id: 'wf-empty', baseBranch: '' },
       { id: 'wf-missing' },
     ]);
@@ -21,23 +20,19 @@ describe('normalizePersistedWorkflowBaseBranches', () => {
 
     const updated = normalizePersistedWorkflowBaseBranches(persistence, logger);
 
-    expect(updated).toBe(4);
-    expect(persistence.updateWorkflow).toHaveBeenCalledTimes(4);
-    expect(persistence.updateWorkflow).toHaveBeenNthCalledWith(1, 'wf-origin-ref', { baseBranch: 'origin/master' });
-    expect(persistence.updateWorkflow).toHaveBeenNthCalledWith(2, 'wf-local-ref', { baseBranch: 'release' });
-    expect(persistence.updateWorkflow).toHaveBeenNthCalledWith(3, 'wf-empty', { baseBranch: 'master' });
-    expect(persistence.updateWorkflow).toHaveBeenNthCalledWith(4, 'wf-missing', { baseBranch: 'master' });
+    expect(updated).toBe(3);
+    expect(persistence.updateWorkflow).toHaveBeenCalledTimes(3);
+    expect(persistence.updateWorkflow).toHaveBeenNthCalledWith(1, 'wf-main', { baseBranch: 'master' });
+    expect(persistence.updateWorkflow).toHaveBeenNthCalledWith(2, 'wf-empty', { baseBranch: 'master' });
+    expect(persistence.updateWorkflow).toHaveBeenNthCalledWith(3, 'wf-missing', { baseBranch: 'master' });
     expect(logger.info).toHaveBeenCalledWith(
-      '[init] normalized 4 workflow base branch refs to canonical form',
-      { module: 'init', workflowCount: 4 },
+      '[init] normalized 3 workflow base branches to master',
+      { module: 'init', workflowCount: 3, baseBranch: 'master' },
     );
   });
 
-  it('skips logging when every workflow already has a canonical base ref', () => {
-    const persistence = makePersistence([
-      { id: 'wf-master', baseBranch: 'master' },
-      { id: 'wf-upstream', baseBranch: 'upstream/release' },
-    ]);
+  it('skips logging when every workflow already targets master', () => {
+    const persistence = makePersistence([{ id: 'wf-master', baseBranch: 'master' }]);
     const logger = { info: vi.fn() };
 
     const updated = normalizePersistedWorkflowBaseBranches(persistence, logger);

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -2169,7 +2169,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     'normal',
     async (workflowIdArg: unknown, baseBranchArg: unknown) => {
     const workflowId = String(workflowIdArg);
-    const baseBranch = normalizeWorkflowBaseBranch(String(baseBranchArg), 'master');
+    const baseBranch = normalizeWorkflowBaseBranch(String(baseBranchArg));
     logger.info(`set-merge-branch: workflow="${workflowId}" → "${baseBranch}"`, { module: 'ipc' });
     try {
       persistence.updateWorkflow(workflowId, { baseBranch });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -23,6 +23,7 @@ import {
   startMainProcessBootstrap,
 } from './bootstrap/app-bootstrap.js';
 import { createStartupWorkflowCache } from './bootstrap/startup-workflow-cache.js';
+import { normalizePersistedWorkflowBaseBranches } from './workflow-base-branch-normalizer.js';
 
 const enableTestCompositor = process.env.INVOKER_E2E_ENABLE_COMPOSITOR === '1' || Boolean(process.env.CAPTURE_MODE);
 const hideE2eWindow = process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E_HIDE_WINDOW !== '0';
@@ -761,6 +762,9 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
       );
     }
   }
+  if (!readOnly) {
+    normalizePersistedWorkflowBaseBranches(persistence, logger);
+  }
   const shellEnv = await initializeShellEnvironment();
   if (process.platform === 'darwin') {
     const suffix = shellEnv.reason ? ` (${shellEnv.reason})` : '';
@@ -1311,7 +1315,7 @@ function startHeadlessMode(): void {
           }
           case 'invoker:set-merge-branch': {
             const workflowId = String(payload.args[0]);
-            const baseBranch = normalizeWorkflowBaseBranch(String(payload.args[1]), 'master');
+            const baseBranch = normalizeWorkflowBaseBranch(String(payload.args[1]));
             persistence.updateWorkflow(workflowId, { baseBranch });
             const tasks = persistence.loadTasks(workflowId);
             const mergeTask = tasks.find((task) => task.config.isMergeNode);

--- a/packages/app/src/metadata-setter.ts
+++ b/packages/app/src/metadata-setter.ts
@@ -166,7 +166,7 @@ function validateWorkflowValue(fieldPath: string, value: unknown, raw: boolean):
     return { mergeMode: enumValue<'manual' | 'automatic' | 'external_review' | 'no_op'>(path, value, ['manual', 'automatic', 'external_review', 'no_op']) ?? undefined };
   }
   if (path === 'baseBranch') {
-    return { baseBranch: normalizeWorkflowBaseBranch(value == null ? null : String(value), 'master') };
+    return { baseBranch: normalizeWorkflowBaseBranch(value == null ? null : String(value)) };
   }
   if (path === 'externalDependencies' || path === 'externalDependencyChanges') {
     if (value !== null && !Array.isArray(value)) throw new Error(`Field "${fieldPath}" must be an array or null.`);

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -9,13 +9,14 @@ import { execFileSync, execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { parse as parseYaml } from 'yaml';
-import { normalizeWorkflowBaseBranch, type PlanDefinition } from '@invoker/workflow-core';
+import type { PlanDefinition } from '@invoker/workflow-core';
+import { normalizeWorkflowBaseBranch } from '@invoker/workflow-core';
 import { loadConfig, resolveDefaultExecutionAgent } from './config.js';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 
-/** Workflow base branches default to master, but explicit refs like upstream/main are preserved. */
+/** Workflow base branches are pinned to master, regardless of YAML/config input. */
 function resolveDefaultBaseBranch(plan: PlanDefinition): string {
-  return normalizeWorkflowBaseBranch(plan.baseBranch, 'master');
+  return normalizeWorkflowBaseBranch(plan.baseBranch);
 }
 
 /**

--- a/packages/app/src/workflow-base-branch-normalizer.ts
+++ b/packages/app/src/workflow-base-branch-normalizer.ts
@@ -1,4 +1,4 @@
-import { normalizeWorkflowBaseBranch, workflowBaseBranchNeedsMigration } from '@invoker/workflow-core';
+import { normalizeWorkflowBaseBranch, PINNED_WORKFLOW_BASE_BRANCH, workflowBaseBranchNeedsMigration } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 
 interface WorkflowBaseBranchLogger {
@@ -11,16 +11,16 @@ export function normalizePersistedWorkflowBaseBranches(
 ): number {
   let updated = 0;
   for (const workflow of persistence.listWorkflows()) {
-    if (!workflowBaseBranchNeedsMigration(workflow.baseBranch, 'master')) continue;
+    if (!workflowBaseBranchNeedsMigration(workflow.baseBranch)) continue;
     persistence.updateWorkflow(workflow.id, {
-      baseBranch: normalizeWorkflowBaseBranch(workflow.baseBranch, 'master'),
+      baseBranch: normalizeWorkflowBaseBranch(workflow.baseBranch),
     });
     updated += 1;
   }
   if (updated > 0) {
     logger?.info?.(
-      `[init] normalized ${updated} workflow base branch ref${updated === 1 ? '' : 's'} to canonical form`,
-      { module: 'init', workflowCount: updated },
+      `[init] normalized ${updated} workflow base branch${updated === 1 ? '' : 'es'} to ${PINNED_WORKFLOW_BASE_BRANCH}`,
+      { module: 'init', workflowCount: updated, baseBranch: PINNED_WORKFLOW_BASE_BRANCH },
     );
   }
   return updated;

--- a/packages/workflow-core/src/__tests__/plan-parser.test.ts
+++ b/packages/workflow-core/src/__tests__/plan-parser.test.ts
@@ -19,19 +19,20 @@ tasks:
     expect(plan.tasks.map((t) => t.id)).toEqual(['build', 'deploy']);
   });
 
-  it('preserves explicit remote-qualified base refs', () => {
+  it('pins baseBranch to master even when YAML asks for another branch', () => {
     const yaml = `
 name: Base Branch Policy
 repoUrl: git@github.com:test/repo.git
-baseBranch: upstream/release
+baseBranch: release
 tasks:
   - id: build
     description: Build it
     command: echo "build"
 `;
     const plan = parsePlan(yaml);
-    expect(plan.baseBranch).toBe('upstream/release');
+    expect(plan.baseBranch).toBe('master');
   });
+
   it('rejects plans with duplicate task ids', () => {
     const yaml = `
 name: Dup Plan

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -60,7 +60,7 @@ export interface RawPlan {
 
 
 function resolveDefaultBaseBranch(plan: PlanDefinition): string {
-  return normalizeWorkflowBaseBranch(plan.baseBranch, 'master');
+  return normalizeWorkflowBaseBranch(plan.baseBranch);
 }
 
 export function applyPlanDefinitionDefaults(plan: PlanDefinition): PlanDefinition {

--- a/packages/workflow-core/src/repo-default-branch.ts
+++ b/packages/workflow-core/src/repo-default-branch.ts
@@ -1,24 +1,15 @@
 import { execFileSync } from 'node:child_process';
 
-const HEADS_PREFIX = 'refs/heads/';
-const REMOTES_PREFIX = 'refs/remotes/';
+export const PINNED_WORKFLOW_BASE_BRANCH = 'master';
 
-export function normalizeWorkflowBaseBranch(branch?: string | null, fallback = 'master'): string {
-  const trimmed = branch?.trim() ?? '';
-  if (!trimmed) return fallback;
-  if (trimmed.startsWith(HEADS_PREFIX)) {
-    return trimmed.slice(HEADS_PREFIX.length);
-  }
-  if (trimmed.startsWith(REMOTES_PREFIX)) {
-    return trimmed.slice(REMOTES_PREFIX.length);
-  }
-  return trimmed;
+export function normalizeWorkflowBaseBranch(_branch?: string | null): string {
+  return PINNED_WORKFLOW_BASE_BRANCH;
 }
 
-export function workflowBaseBranchNeedsMigration(branch?: string | null, fallback = 'master'): boolean {
-  const trimmed = branch?.trim() ?? '';
-  return normalizeWorkflowBaseBranch(branch, fallback) !== trimmed;
+export function workflowBaseBranchNeedsMigration(branch?: string | null): boolean {
+  return (branch?.trim() ?? '') !== PINNED_WORKFLOW_BASE_BRANCH;
 }
+
 
 export function detectDefaultBranchRemote(repoUrl: string): string | undefined {
   const trimmed = repoUrl.trim();


### PR DESCRIPTION
## Summary

Workflow plan loading and persistence now pin workflow base branches to `master`.

Before this, a plan could carry another base branch like `release`, and Invoker would keep that branch in workflow metadata.

This slice makes the parser, metadata writes, and startup normalization converge on one persisted base branch.

## Review Claim

Workflow routing now persists `master` as the workflow base branch when a plan or workflow metadata tries to set another branch.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Normalization is convergent. The parser, metadata writes, and startup load all write the same final value, so workflow rows cannot keep conflicting base branches.

## Slice Rationale

The wrong-base launch starts in workflow routing state. Fix that persistence path first, then show the result in a follow-up PR.

## Non-goals

- Changing merge-gate UI copy.
- Changing merge mode behavior.
- Updating docs or changelog text.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm exec vitest run src/__tests__/plan-parser.test.ts src/__tests__/metadata-setter.test.ts src/__tests__/workflow-base-branch-normalizer.test.ts`
- [x] `pnpm exec vitest run src/__tests__/plan-parser.test.ts`
- [x] `pnpm --filter @invoker/workflow-core build && pnpm --filter @invoker/app build`
- [x] `bash scripts/ui-visual-proof.sh capture-before --spec base-branch-normalization.proof.spec.ts --output-dir /tmp/base-branch-behavior-proof`
- [x] `bash scripts/ui-visual-proof.sh capture-after --spec base-branch-normalization.proof.spec.ts --output-dir /tmp/base-branch-behavior-proof`

</details>

## Visual Proof

Before — loading a plan with `baseBranch: release` left the merge gate inspector showing `Target Branch = release`.

![](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-f8a5e7/base-branch-release-before.png)

After — the same plan now normalizes to `master` before it reaches workflow metadata, so the merge gate inspector shows `Target Branch = master`.

![](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-f8a5e7/base-branch-normalized-to-master.png)

Walkthrough video — loading the same non-master plan before and after the routing change.

Before: [base-branch-behavior-before-walkthrough.webm](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-f8a5e7/base-branch-behavior-before-walkthrough.webm)

After: [base-branch-behavior-after-walkthrough.webm](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-f8a5e7/base-branch-behavior-after-walkthrough.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert fed0e18de54f02b3ebd006a12ca3f2046dede28d`
- Post-revert steps: None.
- Data migration? No. Startup normalization only rewrites workflow metadata rows to `master`.

</details>
