### PR TITLE
[Continue babysit worker landing loop](1) Stop duplicate no-current-bottom blockers

### DIFF
--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -553,6 +553,8 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
         return None
     if not facts.bottom:
         first = facts.stack.prs[0]
+        if ledger.count("comment-blocked", first.number, first.head_ref_oid, "no-current-bottom") > 0:
+            return None
         return Action(
             "comment_blocked",
             first.number,

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -355,6 +355,29 @@ class PlanStackActions(PlannerTestCase):
         self.assertIn("lowest open stack PR #5885 is based on `pr/babysit-prereq-split`", actions[0].detail)
         self.assertIn("land or retarget that base", actions[0].detail)
 
+    def test_no_current_bottom_waits_after_existing_stop_for_current_head(self):
+        ledger = self._ledger()
+        ledger.record("comment-blocked", 5885, HEAD, "no-current-bottom")
+        actions = self._plan(
+            m.StackGroup(
+                "s",
+                (
+                    pr(
+                        number=5885,
+                        base_ref_name="pr/babysit-prereq-split",
+                        labels=frozenset({"admin-bypass"}),
+                    ),
+                    pr(
+                        number=5886,
+                        base_ref_name="stack/slack-routing",
+                        labels=frozenset({"admin-bypass"}),
+                    ),
+                ),
+            ),
+            ledger,
+        )
+        self.assertEqual(actions, ())
+
     def test_requeue_is_capped_after_repeated_attempts(self):
         ledger = self._ledger()
         # Two prior requeue attempts on this head+key -> the third is capped.


### PR DESCRIPTION
## Summary

The babysit planner now remembers when it has already posted a no-current-bottom blocker for the current head.

That keeps later worker ticks quiet until the PR head changes or the human-only blocker is resolved.

## Review Claim

Approve the ledger guard that suppresses repeated no-current-bottom blocker comments for the same PR head.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The slice stays inside the babysit planner and direct planner coverage; it does not requeue, relabel, merge, split, rebase, or force-push real PR branches.

## Slice Rationale

The planner rule and its focused unit coverage form one retry-suppression policy, while the shell repro lands as the next proof slice.

## Non-goals

- Does not change Mergify queue configuration.
- Does not change unrelated babysit worker repair paths.
- Does not edit live target PR branches or labels.

## Architecture

### Before

```mermaid
graph TD
    A["no current bottom on master"] --> B["planner emits comment_blocked"]
    B --> C["later tick emits comment_blocked again"]
```

### After

```mermaid
graph TD
    A["no current bottom on master"] --> B["planner checks ledger for current head"]
    B --> C["existing blocker makes planner wait"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `PYTHONDONTWRITEBYTECODE=1 bash ./loop-driver.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4c09143e7`
- Post-revert steps: Rerun `PYTHONDONTWRITEBYTECODE=1 bash ./loop-driver.sh`
- Data migration? No

</details>
