### PR TITLE
[Continue babysit worker landing loop](2) Assert no-current-bottom replay in repro

### DIFF
--- a/scripts/repro/repro-babysit-no-current-bottom-comment.sh
+++ b/scripts/repro/repro-babysit-no-current-bottom-comment.sh
@@ -93,6 +93,9 @@ fi
 if ! out2="$(run_worker)"; then
   fail 'tick 2: worker failed' "$out2"
 fi
+case "$out2" in
+  *"BLOCK PR #5885"*) fail 'tick 2: worker retried existing no-current-bottom blocker' "$out2" ;;
+esac
 
 python3 - <<'PY' || fail 'expected one exact no-current-bottom comment' "$(cat "$STATE_PATH")"
 import json


### PR DESCRIPTION
## Summary

The no-current-bottom repro now watches the second worker tick.

It fails if the worker posts `BLOCK PR #5885` again for the same head.

## Review Claim

Approve the repro assertion that protects no-current-bottom blocker comments from replaying on a second worker tick.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The slice changes only the focused repro script; it does not change worker runtime decisions or live PR state.

## Slice Rationale

The repro is isolated after the planner guard so the shell proof stays green while documenting the final behavior.

## Non-goals

- Does not change planner logic.
- Does not change queue commands or Mergify configuration.
- Does not touch live target PR branches, labels, or reviews.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `PYTHONDONTWRITEBYTECODE=1 bash ./loop-driver.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 40963f8b3`
- Post-revert steps: Rerun `PYTHONDONTWRITEBYTECODE=1 bash ./loop-driver.sh`
- Data migration? No

</details>
