### PR TITLE
[Merge Gate Workspace Path](1) Add workspace path response output

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -124,6 +124,8 @@ export interface WorkResponseOutputs {
   agentName?: string;
   /** Branch the executor used — persisted at completion to close the write-once gap. */
   branch?: string;
+  /** Workspace path the executor used — persisted at completion for terminal/folder restore. */
+  workspacePath?: string;
   /** Review URL produced by merge-gate style actions. */
   reviewUrl?: string;
   /** Provider-specific review identifier produced by merge-gate style actions. */


### PR DESCRIPTION
## Summary

`WorkResponseOutputs` now includes an optional `workspacePath` field.

Merge-gate responders need this field so their launch folder can be represented in the shared response shape.

## Review Claim

Approve the `WorkResponseOutputs` contract extension for optional executor workspace paths.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The new field is optional, so existing workers and stored responses remain valid.

## Slice Rationale

This is the foundation slice so the runtime change can type-check without mixing contract review with handler code.

## Non-goals

This does not emit, parse, or persist the new field.

This does not change approval behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --dir packages/contracts exec vitest run src/__tests__/validation.test.ts`
- [x] `pnpm --filter @invoker/contracts build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5dc88a475`
- Post-revert steps: None
- Data migration? No

</details>

