### PR TITLE
[Planning tmux blank guarded resize fix](2) Gate active planning tmux view

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4705,6 +4705,7 @@ export function App() {
             terminalSession={activePlanningTerminalSession}
             terminalBusy={activePlanningTerminalBusy}
             terminalError={activePlanningTerminalError}
+            terminalActive={!planningTerminalExpanded}
             submittedPlanName={activePlanningSession.submittedPlanName}
             onValueChange={setPlanningInput}
             onSubmit={() => void handlePlanningSubmit()}
@@ -5039,6 +5040,7 @@ export function App() {
             terminalSession={activePlanningTerminalSession}
             terminalBusy={activePlanningTerminalBusy}
             terminalError={activePlanningTerminalError}
+            terminalActive
             submittedPlanName={activePlanningSession.submittedPlanName}
             onValueChange={setPlanningInput}
             readOnly={activePlanningReadOnly}

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -3,6 +3,7 @@ import { act, render, screen, fireEvent, waitFor, within } from '@testing-librar
 import { vi } from 'vitest';
 import { useState } from 'react';
 import { createMockInvoker, makePlanningSessionSummary, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import type { TerminalSessionDescriptor } from '@invoker/contracts';
 import type { TaskState, WorkflowMeta } from '../types.js';
 
 vi.mock('@xyflow/react', async () => {
@@ -84,6 +85,7 @@ describe('Invoker terminal (component)', () => {
   let mock: MockInvoker;
 
   beforeEach(() => {
+    xtermMock.reset();
     mock = createMockInvoker();
     mock.install();
   });
@@ -243,6 +245,41 @@ describe('Invoker terminal (component)', () => {
       ...overrides,
     };
   }
+
+  function makePlanningTerminalSession(
+    overrides: Partial<TerminalSessionDescriptor> = {},
+  ): TerminalSessionDescriptor {
+    return {
+      sessionId: 'planning-terminal-1',
+      taskId: 'planning:chat-1',
+      kind: 'planning',
+      planningSessionId: 'chat-1',
+      status: 'running',
+      mode: 'spawn',
+      attached: false,
+      createdAt: '2026-07-07T00:00:01.000Z',
+      ...overrides,
+    };
+  }
+
+  it('does not mount planning tmux xterm or resize while inactive', async () => {
+    render(<InvokerTerminal
+      {...terminalProps({
+        mode: 'tmux',
+        terminalSession: makePlanningTerminalSession(),
+        terminalActive: false,
+      })}
+    />);
+
+    await act(async () => {});
+
+    expect(screen.getByTestId('invoker-terminal-tmux-pane')).toHaveAttribute('data-session-id', 'planning-terminal-1');
+    expect(screen.queryByText('mock terminal')).not.toBeInTheDocument();
+    expect(xtermMock.instances).toHaveLength(0);
+    expect(xtermMock.fitInstances).toHaveLength(0);
+    expect(mock.api.onTerminalOutput).not.toHaveBeenCalled();
+    expect(mock.api.planningTerminalResize).not.toHaveBeenCalled();
+  });
 
   it('generates a planning reply from plain language', async () => {
     render(<App />);

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -64,6 +64,7 @@ interface InvokerTerminalProps {
   terminalSession?: TerminalSessionDescriptor | null;
   terminalBusy?: boolean;
   terminalError?: string | null;
+  terminalActive?: boolean;
   onValueChange: (value: string) => void;
   onSubmit: () => void;
   onPresetChange: (presetKey: string) => void;
@@ -182,9 +183,10 @@ interface PlanningTmuxPaneProps {
   busy: boolean;
   error?: string | null;
   readOnly?: boolean;
+  terminalActive?: boolean;
 }
 
-function PlanningTmuxPane({ session, busy, error, readOnly = false }: PlanningTmuxPaneProps): JSX.Element {
+function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActive = true }: PlanningTmuxPaneProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<XTermTerminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
@@ -192,7 +194,7 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false }: PlanningTm
 
   useEffect(() => {
     const host = containerRef.current;
-    if (!host || !session) return;
+    if (!terminalActive || !host || !session) return;
 
     let term: XTermTerminal;
     let fit: FitAddon;
@@ -274,15 +276,17 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false }: PlanningTm
       termRef.current = null;
       fitRef.current = null;
     };
-  }, [readOnly, session?.sessionId]);
+  }, [readOnly, session?.sessionId, terminalActive]);
 
   useEffect(() => {
+    if (!terminalActive) return;
     const term = termRef.current;
     if (!term || !session) return;
     seedTerminalOutputSnapshot(term, session, seededSnapshotRef);
-  }, [session?.outputSnapshot, session?.sessionId]);
+  }, [session?.outputSnapshot, session?.sessionId, terminalActive]);
 
   useEffect(() => {
+    if (!terminalActive) return;
     const term = termRef.current;
     const fit = fitRef.current;
     if (!term || !fit || !session) return;
@@ -296,7 +300,7 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false }: PlanningTm
     } catch {
       /* fit failed (e.g., hidden) */
     }
-  }, [session?.sessionId]);
+  }, [session?.sessionId, terminalActive]);
 
   return (
     <div className="relative min-h-0 flex-1 overflow-hidden bg-black">
@@ -349,6 +353,7 @@ export function InvokerTerminal({
   terminalSession = null,
   terminalBusy = false,
   terminalError = null,
+  terminalActive = true,
   onValueChange,
   onSubmit,
   onPresetChange,
@@ -623,7 +628,13 @@ export function InvokerTerminal({
       </div>
 
       {mode === 'tmux' ? (
-        <PlanningTmuxPane session={terminalSession} busy={terminalBusy} error={terminalError} readOnly={readOnly} />
+        <PlanningTmuxPane
+          session={terminalSession}
+          busy={terminalBusy}
+          error={terminalError}
+          readOnly={readOnly}
+          terminalActive={terminalActive}
+        />
       ) : (
         <>
           <div


### PR DESCRIPTION
## Summary

Render only the visible planning tmux pane.

The inactive view no longer mounts xterm or sends planning terminal resize IPC.

## Review Claim

A planning tmux session has at most one mounted renderer-side xterm instance across normal and expanded planning views.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change is limited to planning tmux activation and focused component coverage; task terminals and IPC contracts stay unchanged.

## Slice Rationale

Active-view mounting is separate from geometry filtering so reviewers can inspect one mounted-instance rule.

## Non-goals

No size geometry guard beyond active-view mounting, no task terminal change, and no IPC contract change.

## Architecture

### Before

Normal and expanded planning views could both render a tmux pane for the same persistent PTY.

### After

`terminalActive` allows only the current planning view to mount the tmux pane and own xterm lifecycle.

## Visual Proof

![Planning tmux active pane proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-2dcb9e/planning-tmux-current-initial.png)

[Planning terminal zero-size walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-2dcb9e/planning-tmux-current-zero-size-walkthrough.mp4)

The screenshot anchors the focused after-mode proof on the live tmux pane. Component coverage verifies inactive views do not mount xterm.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- invoker-terminal`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit for this PR>`
- Post-revert steps: None
- Data migration? No

</details>
