### PR TITLE
[Planning tmux blank guarded resize fix](3) Guard planning tmux resize geometry

### DIFF
--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -14,16 +14,20 @@ vi.mock('@xyflow/react', async () => {
 
 const xtermMock = vi.hoisted(() => {
   type DataHandler = (data: string) => void;
+  type TerminalDimensions = { cols: number; rows: number };
 
   const instances: MockTerminal[] = [];
   const fitInstances: MockFitAddon[] = [];
   const writeLog: string[] = [];
+  let nextProposedDimensions: TerminalDimensions | undefined = { cols: 80, rows: 24 };
 
   class MockTerminal {
     cols = 80;
     rows = 24;
     dataHandler: DataHandler | null = null;
-    loadAddon = vi.fn();
+    loadAddon = vi.fn((addon: { activate?: (terminal: MockTerminal) => void }) => {
+      addon.activate?.(this);
+    });
     open = vi.fn((host: HTMLElement) => {
       const terminalElement = document.createElement('div');
       terminalElement.className = 'xterm';
@@ -51,7 +55,17 @@ const xtermMock = vi.hoisted(() => {
   }
 
   class MockFitAddon {
-    fit = vi.fn();
+    terminal: MockTerminal | null = null;
+    proposedDimensions = nextProposedDimensions;
+    activate = vi.fn((terminal: MockTerminal) => {
+      this.terminal = terminal;
+    });
+    proposeDimensions = vi.fn(() => this.proposedDimensions);
+    fit = vi.fn(() => {
+      if (!this.terminal || !this.proposedDimensions) return;
+      this.terminal.cols = this.proposedDimensions.cols;
+      this.terminal.rows = this.proposedDimensions.rows;
+    });
 
     constructor() {
       fitInstances.push(this);
@@ -64,10 +78,14 @@ const xtermMock = vi.hoisted(() => {
     instances,
     fitInstances,
     writeLog,
+    setNextProposedDimensions: (dimensions: TerminalDimensions | undefined) => {
+      nextProposedDimensions = dimensions;
+    },
     reset: () => {
       instances.length = 0;
       fitInstances.length = 0;
       writeLog.length = 0;
+      nextProposedDimensions = { cols: 80, rows: 24 };
     },
   };
 });
@@ -262,6 +280,34 @@ describe('Invoker terminal (component)', () => {
     };
   }
 
+  function mockElementRect(width: number, height: number) {
+    return vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: width,
+      bottom: height,
+      width,
+      height,
+      toJSON: () => ({}),
+    } as DOMRect);
+  }
+
+  async function flushPlanningTerminalFit(): Promise<void> {
+    for (let index = 0; index < 4; index += 1) {
+      await act(async () => {
+        await new Promise<void>((resolve) => {
+          if (typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(() => resolve());
+            return;
+          }
+          window.setTimeout(resolve, 0);
+        });
+      });
+    }
+  }
+
   it('does not mount planning tmux xterm or resize while inactive', async () => {
     render(<InvokerTerminal
       {...terminalProps({
@@ -279,6 +325,78 @@ describe('Invoker terminal (component)', () => {
     expect(xtermMock.fitInstances).toHaveLength(0);
     expect(mock.api.onTerminalOutput).not.toHaveBeenCalled();
     expect(mock.api.planningTerminalResize).not.toHaveBeenCalled();
+  });
+
+  it('skips planning tmux fit and resize when proposed dimensions are tiny', async () => {
+    const rectSpy = mockElementRect(640, 400);
+    xtermMock.setNextProposedDimensions({ cols: 19, rows: 4 });
+
+    try {
+      render(<InvokerTerminal
+        {...terminalProps({
+          mode: 'tmux',
+          terminalSession: makePlanningTerminalSession(),
+        })}
+      />);
+
+      await flushPlanningTerminalFit();
+
+      expect(xtermMock.fitInstances).toHaveLength(1);
+      expect(xtermMock.fitInstances[0]?.proposeDimensions).toHaveBeenCalled();
+      expect(xtermMock.fitInstances[0]?.fit).not.toHaveBeenCalled();
+      expect(mock.api.planningTerminalResize).not.toHaveBeenCalled();
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('sends planning tmux resize when proposed dimensions are sane', async () => {
+    const rectSpy = mockElementRect(640, 400);
+    xtermMock.setNextProposedDimensions({ cols: 100, rows: 30 });
+
+    try {
+      render(<InvokerTerminal
+        {...terminalProps({
+          mode: 'tmux',
+          terminalSession: makePlanningTerminalSession(),
+        })}
+      />);
+
+      await flushPlanningTerminalFit();
+
+      expect(xtermMock.fitInstances[0]?.proposeDimensions).toHaveBeenCalled();
+      expect(xtermMock.fitInstances[0]?.fit).toHaveBeenCalled();
+      expect(mock.api.planningTerminalResize).toHaveBeenCalledTimes(1);
+      expect(mock.api.planningTerminalResize).toHaveBeenCalledWith('planning-terminal-1', 100, 30);
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('suppresses duplicate planning tmux resize dimensions', async () => {
+    const rectSpy = mockElementRect(640, 400);
+    xtermMock.setNextProposedDimensions({ cols: 100, rows: 30 });
+
+    try {
+      render(<InvokerTerminal
+        {...terminalProps({
+          mode: 'tmux',
+          terminalSession: makePlanningTerminalSession(),
+        })}
+      />);
+
+      await flushPlanningTerminalFit();
+      act(() => {
+        window.dispatchEvent(new Event('focus'));
+      });
+      await flushPlanningTerminalFit();
+
+      expect(xtermMock.fitInstances[0]?.fit.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(mock.api.planningTerminalResize).toHaveBeenCalledTimes(1);
+      expect(mock.api.planningTerminalResize).toHaveBeenCalledWith('planning-terminal-1', 100, 30);
+    } finally {
+      rectSpy.mockRestore();
+    }
   });
 
   it('generates a planning reply from plain language', async () => {

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -26,6 +26,9 @@ interface PlanningPresetOptionView {
 }
 
 const TRANSCRIPT_BOTTOM_TOLERANCE_PX = 32;
+const MIN_PLANNING_TMUX_COLS = 20;
+const MIN_PLANNING_TMUX_ROWS = 5;
+const PLANNING_TMUX_FIT_SETTLE_FRAMES = 2;
 
 function isTranscriptNearBottom(element: HTMLDivElement): boolean {
   return element.scrollHeight - element.scrollTop - element.clientHeight <= TRANSCRIPT_BOTTOM_TOLERANCE_PX;
@@ -233,27 +236,91 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActi
       }
     });
 
-    const tryFit = () => {
+    let disposed = false;
+    let scheduledFitHandle: number | null = null;
+    let scheduledFitKind: 'raf' | 'timeout' | null = null;
+    let pendingFocus = false;
+    let lastSentSize: { cols: number; rows: number } | null = null;
+
+    const cancelScheduledFit = () => {
+      if (scheduledFitHandle === null) return;
+      if (scheduledFitKind === 'raf' && typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(scheduledFitHandle);
+      } else {
+        window.clearTimeout(scheduledFitHandle);
+      }
+      scheduledFitHandle = null;
+      scheduledFitKind = null;
+    };
+
+    const tryFit = (focusAfterFit: boolean): boolean => {
       try {
+        if (disposed || !host.isConnected) return false;
+        if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return false;
+        const rect = host.getBoundingClientRect();
+        if (rect.width <= 0 || rect.height <= 0) return false;
+        const proposedDimensions = fit.proposeDimensions();
+        if (
+          !proposedDimensions ||
+          proposedDimensions.cols < MIN_PLANNING_TMUX_COLS ||
+          proposedDimensions.rows < MIN_PLANNING_TMUX_ROWS
+        ) {
+          return false;
+        }
+
         fit.fit();
         if (term.rows > 0) {
           term.refresh?.(0, term.rows - 1);
         }
-        void window.invoker?.planningTerminalResize?.(session.sessionId, term.cols, term.rows);
+        const nextSize = { cols: term.cols, rows: term.rows };
+        if (!lastSentSize || lastSentSize.cols !== nextSize.cols || lastSentSize.rows !== nextSize.rows) {
+          lastSentSize = nextSize;
+          void window.invoker?.planningTerminalResize?.(session.sessionId, nextSize.cols, nextSize.rows);
+        }
+        if (focusAfterFit) term.focus();
+        return true;
       } catch {
         /* host has zero size or fit unsupported */
+        return false;
       }
     };
 
-    const raf = typeof requestAnimationFrame === 'function'
-      ? requestAnimationFrame(tryFit)
-      : null;
+    const scheduleFit = ({ focus = false }: { focus?: boolean } = {}) => {
+      if (disposed) return;
+      pendingFocus = pendingFocus || focus;
+      cancelScheduledFit();
+
+      const runAfterFrames = (remainingFrames: number) => {
+        if (typeof window.requestAnimationFrame === 'function') {
+          scheduledFitKind = 'raf';
+          scheduledFitHandle = window.requestAnimationFrame(() => {
+            scheduledFitHandle = null;
+            scheduledFitKind = null;
+            if (remainingFrames > 0) {
+              runAfterFrames(remainingFrames - 1);
+              return;
+            }
+            if (tryFit(pendingFocus)) pendingFocus = false;
+          });
+          return;
+        }
+
+        scheduledFitKind = 'timeout';
+        scheduledFitHandle = window.setTimeout(() => {
+          scheduledFitHandle = null;
+          scheduledFitKind = null;
+          if (tryFit(pendingFocus)) pendingFocus = false;
+        }, 0);
+      };
+
+      runAfterFrames(PLANNING_TMUX_FIT_SETTLE_FRAMES);
+    };
 
     let resizeObserver: ResizeObserver | null = null;
     if (typeof ResizeObserver !== 'undefined') {
       try {
         resizeObserver = new ResizeObserver(() => {
-          tryFit();
+          scheduleFit();
         });
         resizeObserver.observe(host);
       } catch {
@@ -261,10 +328,22 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActi
       }
     }
 
+    const handleVisibilityChange = () => {
+      scheduleFit();
+    };
+    const handleWindowFocus = () => {
+      scheduleFit({ focus: true });
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('focus', handleWindowFocus);
+    scheduleFit({ focus: true });
+
     return () => {
-      if (raf !== null && typeof cancelAnimationFrame === 'function') {
-        cancelAnimationFrame(raf);
-      }
+      disposed = true;
+      cancelScheduledFit();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('focus', handleWindowFocus);
       resizeObserver?.disconnect();
       inputDisposable.dispose();
       unsubscribeOutput?.();
@@ -284,23 +363,6 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActi
     if (!term || !session) return;
     seedTerminalOutputSnapshot(term, session, seededSnapshotRef);
   }, [session?.outputSnapshot, session?.sessionId, terminalActive]);
-
-  useEffect(() => {
-    if (!terminalActive) return;
-    const term = termRef.current;
-    const fit = fitRef.current;
-    if (!term || !fit || !session) return;
-    try {
-      fit.fit();
-      if (term.rows > 0) {
-        term.refresh?.(0, term.rows - 1);
-      }
-      void window.invoker?.planningTerminalResize?.(session.sessionId, term.cols, term.rows);
-      term.focus();
-    } catch {
-      /* fit failed (e.g., hidden) */
-    }
-  }, [session?.sessionId, terminalActive]);
 
   return (
     <div className="relative min-h-0 flex-1 overflow-hidden bg-black">


### PR DESCRIPTION
## Summary

Planning tmux now checks visible host geometry before mutating the PTY.

Tiny, hidden, detached, inactive, or repeated dimensions leave the current PTY size intact.

## Review Claim

Planning tmux forwards resize IPC only when the active host is visible and proposed dimensions are sane.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change is limited to planning tmux fit and resize decisions plus focused component coverage; task terminal behavior and IPC contracts stay unchanged.

## Slice Rationale

Size filtering is separate from active-view mounting so reviewers can verify the geometry rule independently.

## Non-goals

No active-view ownership change beyond consuming the previous slice, no task terminal change, and no IPC contract change.

## Architecture

### Before

Planning tmux ran `fit()` unconditionally and forwarded the resulting terminal size to `planningTerminalResize`.

### After

The renderer proposes dimensions, requires a visible host and minimum rows and columns, then forwards only new sane sizes.

## Visual Proof

![Planning tmux visible host proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-901ed5/planning-tmux-current-initial.png)

![Planning tmux zero-size host proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-901ed5/planning-tmux-current-zero-size.png)

[Planning terminal zero-size walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-901ed5/planning-tmux-current-zero-size-walkthrough.mp4)

[After-mode JSON evidence](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-901ed5/planning-tmux-current-after-artifact.json) records one sane resize payload at `108x47`, PTY samples at `47 108`, and no tiny resize payloads.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- invoker-terminal`
- [x] `bash scripts/repro/repro-planning-tmux-blank.sh after`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit for this PR>`
- Post-revert steps: None
- Data migration? No

</details>
