### PR TITLE
[Review Gate CI Repair](1) Prove review-gate CI should spawn repair workflows

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { WorkerActionRecord, WorkerActionWrite, WorkflowMutationPriority } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
 
-import { parseFixWithAgentMutationArgs } from '../auto-fix-intents.js';
 import {
   autoFixAttemptLedgerKeyFromLifecycleEvent,
   createAutoFixAttemptLedger,
@@ -119,10 +118,9 @@ function toRecord(write: WorkerActionWrite): WorkerActionRecord {
 function makeHarness(task = makeTask()) {
   const tasks = new Map<string, TaskState>([[task.id, task]]);
   const actions = new Map<string, WorkerActionRecord>();
-  const submit = vi.fn((workflowId: string, priority: WorkflowMutationPriority, channel: string, args: unknown[]) => {
+  const submit = vi.fn((workflowId: string, priority: WorkflowMutationPriority, _channel: string, args: unknown[]) => {
     expect(workflowId).toBe('wf-1');
     expect(priority).toBe('normal');
-    expect(channel).toBe('invoker:fix-with-agent');
     expect(args).toBeDefined();
     return 42;
   });
@@ -166,7 +164,7 @@ describe('PR status and CI failure workers', () => {
     await worker.stop();
   });
 
-  it('queues a head-SHA guarded CI repair intent and records its dedupe action', async () => {
+  it.fails('queues a head-SHA guarded CI repair workflow intent and records its dedupe action', async () => {
     const event = makeEvent({
       failedChecks: [
         { name: 'unit', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/1' },
@@ -192,28 +190,37 @@ describe('PR status and CI failure workers', () => {
 
     expect(ciFailureActionKey(sameChecksDifferentOrder)).toBe(ciFailureActionKey(event));
     expect(harness.submit).toHaveBeenCalledTimes(1);
-    const [, , , args] = harness.submit.mock.calls[0];
-    const parsed = parseFixWithAgentMutationArgs(args);
-    expect(parsed).toMatchObject({
-      taskId: 'wf-1/merge',
+    const [, , channel, args] = harness.submit.mock.calls[0];
+    expect(channel).toBe('invoker:spawn-review-gate-ci-repair');
+    expect(args[0]).toMatchObject({
+      sourceWorkflowId: 'wf-1',
+      sourceTaskId: 'wf-1/merge',
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'sha-1',
+      headRef: 'feature/ci',
+      branch: 'feature/ci',
+      generation: 2,
+      selectedAttemptId: 'attempt-1',
+      failedChecks: [
+        { name: 'unit', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/1' },
+        { name: 'lint', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/2' },
+      ],
+      statusText: 'CI failed',
+      taskStateVersion: 10,
       agentName: 'codex',
-      context: {
-        autoFix: true,
-        executionModel: 'openai/gpt-5.2',
-        reviewGateContext: {
-          reviewId: '123',
-          generation: 2,
-          selectedAttemptId: 'attempt-1',
-          headSha: 'sha-1',
-        },
-      },
+      executionModel: 'openai/gpt-5.2',
     });
     expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toMatchObject({
       workerKind: CI_FAILURE_WORKER_KIND,
       actionType: 'fix-ci-failure',
       status: 'queued',
+      summary: 'Queued CI repair workflow',
       intentId: '42',
       externalKey: ciFailureActionKey(event),
+      payload: expect.objectContaining({
+        channel: 'invoker:spawn-review-gate-ci-repair',
+      }),
     });
   });
 


### PR DESCRIPTION
## Summary

This adds a proof-first worker test for review-gate red CI.

It records the repair-workflow expectation before the runtime change lands.

Today the worker still queues an in-place fix intent. This slice keeps CI green with `it.fails` while pinning the desired behavior.

## Review Claim

The CI-failure worker should queue a sibling repair-workflow payload, and this slice proves that expectation without changing runtime behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Tests only. Production code is unchanged.

## Slice Rationale

Evidence comes first. This isolates the proof from the runtime implementation so the next slice can focus only on behavior.

## Architectural Effect

No runtime path changes. Coverage now names the future repair-workflow payload.

## Alternative Considerations

Bundling the proof with the fix would make it harder to see whether the new behavior was intentional or incidental.

## Non-goals

- No worker behavior changes.
- No new app-side mutation.
- No command or UI text changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/pr-ci-workers.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 127d042c4`
- Post-revert steps: None.
- Data migration? No.

</details>
