### PR TITLE
[Review Gate CI Repair](2) Spawn sibling repair workflows for review-gate CI

### DIFF
--- a/packages/app/src/__tests__/review-gate-ci-repair-command.test.ts
+++ b/packages/app/src/__tests__/review-gate-ci-repair-command.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { ReviewGateLookup } from '@invoker/data-store';
-import { createAutoFixAttemptLedger, type MergeGateApprovalStatus } from '@invoker/execution-engine';
-import type { TaskState } from '@invoker/workflow-core';
+import type { ReviewGateLookup, WorkflowMutationPriority } from '@invoker/data-store';
+import {
+  createAutoFixAttemptLedger,
+  parseReviewGateCiRepairWorkflowMutationArgs,
+  SPAWN_REVIEW_GATE_CI_REPAIR_CHANNEL,
+  type MergeGateApprovalStatus,
+} from '@invoker/execution-engine';
 
 import { repairReviewGateCiByPr } from '../review-gate-ci-repair-command.js';
 
@@ -103,8 +107,8 @@ describe('repairReviewGateCiByPr', () => {
     expect(checkApproval).not.toHaveBeenCalled();
   });
 
-  it('queues a CI repair when the mapped PR is red', async () => {
-    const submit = vi.fn(() => 42);
+  it('queues a CI repair workflow when the mapped PR is red', async () => {
+    const submit = vi.fn((_workflowId: string, _priority: WorkflowMutationPriority, _channel: string, _args: unknown[]) => 42);
     const checkApproval = vi.fn(async () => makeCheckStatus());
     const result = await repairReviewGateCiByPr('123', {
       persistence: {
@@ -131,9 +135,23 @@ describe('repairReviewGateCiByPr', () => {
 
     expect(checkApproval).toHaveBeenCalledWith({ identifier: '123', cwd: '/repo' });
     expect(submit).toHaveBeenCalledTimes(1);
+    const [workflowId, priority, channel, args] = submit.mock.calls[0];
+    expect(workflowId).toBe('wf-1');
+    expect(priority).toBe('normal');
+    expect(channel).toBe(SPAWN_REVIEW_GATE_CI_REPAIR_CHANNEL);
+    expect(parseReviewGateCiRepairWorkflowMutationArgs(args)).toMatchObject({
+      sourceWorkflowId: 'wf-1',
+      sourceTaskId: 'wf-1/merge',
+      reviewId: '123',
+      branch: 'feature/ci',
+      headSha: 'sha-1',
+      headRef: 'feature/ci',
+      statusText: 'CI failed',
+    });
     expect(result).toMatchObject({
       status: 'queued',
       reason: 'queued',
+      message: 'Queued CI repair workflow for PR 123 on wf-1/merge.',
       prNumber: '123',
       workflowId: 'wf-1',
       taskId: 'wf-1/merge',

--- a/packages/app/src/__tests__/review-gate-ci-repair-workflow.test.ts
+++ b/packages/app/src/__tests__/review-gate-ci-repair-workflow.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestHarness, type TestHarness } from '@invoker/test-kit';
+import type { ReviewGateCiRepairWorkflowMutationArgs } from '@invoker/execution-engine';
+import type { PlanDefinition } from '@invoker/workflow-core';
+
+import { spawnReviewGateCiRepairWorkflow } from '../review-gate-ci-repair-workflow.js';
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+const SOURCE_PLAN: PlanDefinition = {
+  name: 'Source review gate workflow',
+  onFinish: 'none',
+  mergeMode: 'manual',
+  baseBranch: 'main',
+  featureBranch: 'feature/review-gate-ci',
+  repoUrl: 'memory://repo.git',
+  intermediateRepoUrl: 'memory://intermediate.git',
+  tasks: [
+    { id: 'A', description: 'Task A', command: 'echo a' },
+  ],
+};
+
+async function driveSourceGateToReviewReady(
+  h: TestHarness,
+  plan: PlanDefinition = SOURCE_PLAN,
+): Promise<{ workflowId: string; mergeId: string }> {
+  h.loadAndStart(plan);
+  h.completeTask('A');
+  const mergeTask = h.getAllTasks().find((task) => task.config.isMergeNode);
+  expect(mergeTask).toBeDefined();
+  await h.executor.executeTasks([mergeTask!]);
+  expect(h.getTask(mergeTask!.id)?.status).toBe('review_ready');
+
+  const gate = h.getTask(mergeTask!.id)!;
+  const generation = gate.execution.generation ?? 0;
+  h.persistence.updateTask(mergeTask!.id, {
+    execution: {
+      reviewId: '123',
+      branch: 'feature/review-gate-ci',
+      reviewGate: {
+        activeGeneration: generation,
+        completion: gate.execution.reviewGate?.completion ?? { required: 'all', status: 'approved' },
+        artifacts: [{
+          id: 'pr-123',
+          providerId: '123',
+          provider: 'github',
+          required: true,
+          status: 'open',
+          generation,
+          headSha: 'sha-1',
+        }],
+      },
+    },
+  });
+  h.orchestrator.getWorkflowStatus();
+  return { workflowId: gate.config.workflowId!, mergeId: mergeTask!.id };
+}
+
+function makeArgs(h: TestHarness, mergeId: string, workflowId: string): ReviewGateCiRepairWorkflowMutationArgs {
+  const gate = h.getTask(mergeId)!;
+  return {
+    sourceWorkflowId: workflowId,
+    sourceTaskId: mergeId,
+    reviewId: '123',
+    reviewUrl: 'https://github.com/owner/repo/pull/123',
+    headSha: 'sha-1',
+    headRef: 'feature/review-gate-ci',
+    branch: 'feature/review-gate-ci',
+    generation: gate.execution.generation ?? 0,
+    selectedAttemptId: gate.execution.selectedAttemptId,
+    failedChecks: [
+      { name: 'unit', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/1' },
+      { name: 'lint', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/2' },
+    ],
+    statusText: 'CI failed',
+    taskStateVersion: gate.taskStateVersion,
+    agentName: 'codex',
+    executionModel: 'openai/gpt-5.2',
+  };
+}
+
+describe('spawnReviewGateCiRepairWorkflow', () => {
+  let h: TestHarness;
+
+  beforeEach(() => {
+    h = createTestHarness();
+  });
+
+  it('spawns one repair workflow and leaves the source merge gate untouched', async () => {
+    const { workflowId: sourceWorkflowId, mergeId } = await driveSourceGateToReviewReady(h);
+    const args = makeArgs(h, mergeId, sourceWorkflowId);
+    const sourceBefore = h.getTask(mergeId)!;
+    const workflowIdsBefore = new Set(h.persistence.listWorkflows().map((workflow) => workflow.id));
+
+    const result = await spawnReviewGateCiRepairWorkflow(args, {
+      orchestrator: h.orchestrator,
+      persistence: h.persistence,
+      logger,
+    });
+
+    expect(result.workflowId).not.toBe(sourceWorkflowId);
+    expect(result.taskId).toBe(`${result.workflowId}/repair`);
+    expect(result.started.map((task) => task.id)).toEqual([`${result.workflowId}/repair`]);
+
+    const spawnedWorkflowIds = h.persistence
+      .listWorkflows()
+      .map((workflow) => workflow.id)
+      .filter((workflowId) => !workflowIdsBefore.has(workflowId));
+    expect(spawnedWorkflowIds).toEqual([result.workflowId]);
+
+    const spawnedWorkflow = h.persistence.loadWorkflow(result.workflowId);
+    expect(spawnedWorkflow).toMatchObject({
+      id: result.workflowId,
+      name: 'repair-review-gate-ci-123-sha-1',
+      onFinish: 'none',
+      baseBranch: 'main',
+      repoUrl: 'memory://repo.git',
+      intermediateRepoUrl: 'memory://intermediate.git',
+    });
+
+    const spawnedTasks = h.persistence.loadTasks(result.workflowId);
+    const repairTasks = spawnedTasks.filter((task) => !task.config.isMergeNode);
+    expect(repairTasks).toHaveLength(1);
+    expect(repairTasks[0]).toMatchObject({
+      id: `${result.workflowId}/repair`,
+      description: 'Repair PR #123: CI failed',
+      status: 'running',
+      config: {
+        prompt: expect.stringContaining('git fetch origin feature/review-gate-ci && git checkout feature/review-gate-ci'),
+        executionAgent: 'codex',
+        executionModel: 'openai/gpt-5.2',
+      },
+    });
+
+    const sourceAfter = h.getTask(mergeId)!;
+    expect(sourceAfter.status).toBe('review_ready');
+    expect(sourceAfter.taskStateVersion).toBe(sourceBefore.taskStateVersion);
+    expect(sourceAfter.execution.generation).toBe(sourceBefore.execution.generation);
+    expect(sourceAfter.execution.selectedAttemptId).toBe(sourceBefore.execution.selectedAttemptId);
+  });
+
+  it('rejects stale lineage without creating a workflow', async () => {
+    const { workflowId: sourceWorkflowId, mergeId } = await driveSourceGateToReviewReady(h);
+    const args = makeArgs(h, mergeId, sourceWorkflowId);
+    const workflowIdsBefore = h.persistence.listWorkflows().map((workflow) => workflow.id);
+
+    h.persistence.updateTask(mergeId, {
+      execution: { generation: (args.generation ?? 0) + 1 },
+    });
+    h.orchestrator.getWorkflowStatus();
+
+    await expect(spawnReviewGateCiRepairWorkflow(args, {
+      orchestrator: h.orchestrator,
+      persistence: h.persistence,
+      logger,
+    })).rejects.toThrow('Review-gate CI repair workflow is stale: generation changed');
+
+    expect(h.persistence.listWorkflows().map((workflow) => workflow.id)).toEqual(workflowIdsBefore);
+  });
+
+  it('throws explicit branch and base-branch errors', async () => {
+    const branchHarness = createTestHarness();
+    const noBranchPlan: PlanDefinition = {
+      ...SOURCE_PLAN,
+      featureBranch: undefined,
+    };
+    const { workflowId: branchWorkflowId, mergeId: branchMergeId } = await driveSourceGateToReviewReady(
+      branchHarness,
+      noBranchPlan,
+    );
+    const branchArgs = makeArgs(branchHarness, branchMergeId, branchWorkflowId);
+    const workflowIdsBefore = branchHarness.persistence.listWorkflows().map((workflow) => workflow.id);
+
+    branchHarness.persistence.updateTask(branchMergeId, {
+      execution: {
+        branch: undefined,
+        reviewGate: {
+          activeGeneration: branchArgs.generation,
+          completion: { required: 'all', status: 'approved' },
+          artifacts: [{
+            id: 'pr-123',
+            providerId: '123',
+            provider: 'github',
+            required: true,
+            status: 'open',
+            generation: branchArgs.generation,
+          }],
+        },
+      },
+    });
+    branchHarness.orchestrator.getWorkflowStatus();
+
+    await expect(spawnReviewGateCiRepairWorkflow({
+      ...branchArgs,
+      branch: undefined,
+      headSha: undefined,
+    }, {
+      orchestrator: branchHarness.orchestrator,
+      persistence: branchHarness.persistence,
+      logger,
+    })).rejects.toThrow('Review-gate CI repair requires a branch to checkout.');
+
+    const baseHarness = createTestHarness();
+    const noBasePlan: PlanDefinition = {
+      ...SOURCE_PLAN,
+      baseBranch: undefined,
+    };
+    const { workflowId: baseWorkflowId, mergeId: baseMergeId } = await driveSourceGateToReviewReady(
+      baseHarness,
+      noBasePlan,
+    );
+    const baseArgs = makeArgs(baseHarness, baseMergeId, baseWorkflowId);
+
+    await expect(spawnReviewGateCiRepairWorkflow(baseArgs, {
+      orchestrator: baseHarness.orchestrator,
+      persistence: baseHarness.persistence,
+      logger,
+    })).rejects.toThrow('Review-gate CI repair requires source workflow baseBranch.');
+
+    expect(branchHarness.persistence.listWorkflows().map((workflow) => workflow.id)).toEqual(workflowIdsBefore);
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -94,6 +94,7 @@ import {
   registerBuiltinWorkers,
   parseRequeueMutationArgs,
   parseRequeueEscalateMutationArgs,
+  parseReviewGateCiRepairWorkflowMutationArgs,
   reconcileTerminalWorkerActionsOnStartup,
   resetAutoFixBudgetForTasks,
   type AgentRegistry,
@@ -155,7 +156,6 @@ import {
 import {
   approveTask as sharedApproveTask,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
-  recreateWorkflowFromFreshBase as sharedRecreateWorkflowFromFreshBase,
   rejectTask as sharedRejectTask,
   selectExperiments as sharedSelectExperiments,
 } from './workflow-actions.js';
@@ -194,6 +194,7 @@ import {
   buildHeadlessFixArgs,
   parseFixWithAgentMutationArgs,
 } from './auto-fix-intents.js';
+import { spawnReviewGateCiRepairWorkflow } from './review-gate-ci-repair-workflow.js';
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { answerOwnerHeadlessQuery, buildOwnerReadQueryHandlers } from './owner-read-query.js';
@@ -1468,17 +1469,7 @@ function startHeadlessMode(): void {
         }
         if (!workflowMutationDispatcher.has('invoker:start-ready')) {
           workflowMutationDispatcher.set('invoker:start-ready', async (requestArg: unknown) =>
-            runStartReady(orchestrator, requestArg as StartReadyRequest | undefined, {
-              freshBaseRecreateWorkflow: (workflowId) => sharedRecreateWorkflowFromFreshBase(workflowId, {
-                logger,
-                orchestrator,
-                persistence,
-                commandService,
-                repoRoot,
-                taskExecutor: createHeadlessExecutor(headlessDeps),
-                mutationTiming: activeMutationContext?.mutationTiming,
-              }),
-            }),
+            runStartReady(orchestrator, requestArg as StartReadyRequest | undefined),
           );
         }
         if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
@@ -1493,6 +1484,17 @@ function startHeadlessMode(): void {
               mutationTiming: activeMutationContext?.mutationTiming,
             });
             return { ok: true };
+          });
+        }
+        if (!workflowMutationDispatcher.has('invoker:spawn-review-gate-ci-repair')) {
+          workflowMutationDispatcher.set('invoker:spawn-review-gate-ci-repair', async (...repairArgs: unknown[]) => {
+            const args = parseReviewGateCiRepairWorkflowMutationArgs(repairArgs);
+            return spawnReviewGateCiRepairWorkflow(args, {
+              orchestrator,
+              persistence,
+              logger,
+              allowGraphMutation: invokerConfig.allowGraphMutation,
+            });
           });
         }
         if (!workflowMutationDispatcher.has('invoker:requeue')) {
@@ -2268,18 +2270,8 @@ startMainProcessBootstrap({
     }
   }
 
-  async function executeStartReady(request: StartReadyRequest = {}): Promise<StartReadyResult> {
-    const result = await runStartReady(orchestrator, request, {
-      freshBaseRecreateWorkflow: (workflowId) => sharedRecreateWorkflowFromFreshBase(workflowId, {
-        logger,
-        orchestrator,
-        persistence,
-        commandService,
-        repoRoot,
-        taskExecutor: requireTaskExecutor(),
-        mutationTiming: activeMutationContext?.mutationTiming,
-      }),
-    });
+  function executeStartReady(request: StartReadyRequest = {}): StartReadyResult {
+    const result = runStartReady(orchestrator, request);
     if (!result.dryRun) {
       publishOrchestratorSnapshotToRenderer();
     }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -96,7 +96,6 @@ import {
   parseRequeueEscalateMutationArgs,
   parseReviewGateCiRepairWorkflowMutationArgs,
   reconcileTerminalWorkerActionsOnStartup,
-  resetAutoFixBudgetForTasks,
   type AgentRegistry,
   type WorkerRegistry,
   type WorkerRuntimeDependencies,
@@ -156,6 +155,7 @@ import {
 import {
   approveTask as sharedApproveTask,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
+  recreateWorkflowFromFreshBase as sharedRecreateWorkflowFromFreshBase,
   rejectTask as sharedRejectTask,
   selectExperiments as sharedSelectExperiments,
 } from './workflow-actions.js';
@@ -813,9 +813,6 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     defaultPoolId: invokerConfig.defaultPoolId,
     availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
     deferRunningUntilLaunch: true,
-    onRecreateTasksReset: (taskIds) => {
-      resetAutoFixBudgetForTasks(persistence, taskIds);
-    },
   });
   commandService = new CommandService(
     orchestrator,
@@ -1113,9 +1110,6 @@ function startHeadlessMode(): void {
               defaultPoolId: invokerConfig.defaultPoolId,
               availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
               deferRunningUntilLaunch: true,
-              onRecreateTasksReset: (taskIds) => {
-                resetAutoFixBudgetForTasks(persistence, taskIds);
-              },
             });
             commandService = new CommandService(
               orchestrator,
@@ -1469,7 +1463,17 @@ function startHeadlessMode(): void {
         }
         if (!workflowMutationDispatcher.has('invoker:start-ready')) {
           workflowMutationDispatcher.set('invoker:start-ready', async (requestArg: unknown) =>
-            runStartReady(orchestrator, requestArg as StartReadyRequest | undefined),
+            runStartReady(orchestrator, requestArg as StartReadyRequest | undefined, {
+              freshBaseRecreateWorkflow: (workflowId) => sharedRecreateWorkflowFromFreshBase(workflowId, {
+                logger,
+                orchestrator,
+                persistence,
+                commandService,
+                repoRoot,
+                taskExecutor: createHeadlessExecutor(headlessDeps),
+                mutationTiming: activeMutationContext?.mutationTiming,
+              }),
+            }),
           );
         }
         if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
@@ -2270,8 +2274,18 @@ startMainProcessBootstrap({
     }
   }
 
-  function executeStartReady(request: StartReadyRequest = {}): StartReadyResult {
-    const result = runStartReady(orchestrator, request);
+  async function executeStartReady(request: StartReadyRequest = {}): Promise<StartReadyResult> {
+    const result = await runStartReady(orchestrator, request, {
+      freshBaseRecreateWorkflow: (workflowId) => sharedRecreateWorkflowFromFreshBase(workflowId, {
+        logger,
+        orchestrator,
+        persistence,
+        commandService,
+        repoRoot,
+        taskExecutor: requireTaskExecutor(),
+        mutationTiming: activeMutationContext?.mutationTiming,
+      }),
+    });
     if (!result.dryRun) {
       publishOrchestratorSnapshotToRenderer();
     }

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -5,6 +5,7 @@ import {
   type WorkflowMutationPriority,
 } from '@invoker/data-store';
 import type { Logger, WorkflowMutationFailedEvent } from '@invoker/contracts';
+import { parseReviewGateCiRepairWorkflowMutationArgs } from '@invoker/execution-engine';
 import { resolveHeadlessTarget } from './headless-command-classification.js';
 import { createWorkflowMutationTiming, type WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import {
@@ -593,6 +594,9 @@ export class PersistedWorkflowMutationCoordinator {
   private resolveIntentFailureTaskId(intent: WorkflowMutationIntent): string | undefined {
     if (intent.channel === 'headless.exec') {
       return this.resolveHeadlessIntentFailureTaskId(intent.args);
+    }
+    if (intent.channel === 'invoker:spawn-review-gate-ci-repair') {
+      return parseReviewGateCiRepairWorkflowMutationArgs(intent.args).sourceTaskId;
     }
     if (TARGET_RESOLVED_MUTATION_CHANNELS.has(intent.channel)) {
       return this.resolveTaskTarget(intent.args[0]);

--- a/packages/app/src/review-gate-ci-repair-command.ts
+++ b/packages/app/src/review-gate-ci-repair-command.ts
@@ -128,7 +128,7 @@ export async function repairReviewGateCiByPr(
     ? {
       status: 'queued',
       reason: result.reason,
-      message: `Queued CI repair for PR ${prNumber} on ${mergeTask.id}.`,
+      message: `Queued CI repair workflow for PR ${prNumber} on ${mergeTask.id}.`,
       prNumber,
       workflowId: lookup.workflowId,
       taskId: mergeTask.id,

--- a/packages/app/src/review-gate-ci-repair-workflow.ts
+++ b/packages/app/src/review-gate-ci-repair-workflow.ts
@@ -1,0 +1,200 @@
+import type { Logger } from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { ReviewGateCiRepairWorkflowMutationArgs } from '@invoker/execution-engine';
+import type { Orchestrator, PlanDefinition, TaskState } from '@invoker/workflow-core';
+
+import { backupPlan } from './plan-backup.js';
+
+export interface SpawnReviewGateCiRepairWorkflowDeps {
+  orchestrator: Pick<Orchestrator, 'getWorkflowIds' | 'loadPlan' | 'startExecution'>;
+  persistence: Pick<SQLiteAdapter, 'listWorkflows' | 'loadTasks' | 'loadWorkflow'> & {
+    loadTask?: (taskId: string) => TaskState | undefined;
+  };
+  logger?: Logger;
+  allowGraphMutation?: boolean;
+}
+
+export interface SpawnReviewGateCiRepairWorkflowResult {
+  workflowId: string;
+  taskId: string;
+  started: TaskState[];
+}
+
+function currentReviewGateLineage(task: TaskState, reviewId: string): {
+  reviewId?: string;
+  generation: number;
+  selectedAttemptId?: string;
+  branch?: string;
+  headSha?: string;
+} {
+  const gate = task.execution.reviewGate;
+  const artifact = gate?.artifacts.find((candidate) =>
+    candidate.generation === gate.activeGeneration
+    && candidate.status !== 'discarded'
+    && !candidate.discardedAt
+    && candidate.providerId === reviewId,
+  );
+  return {
+    reviewId: artifact?.providerId ?? task.execution.reviewId,
+    generation: task.execution.generation ?? 0,
+    selectedAttemptId: task.execution.selectedAttemptId,
+    branch: task.execution.branch,
+    headSha: artifact?.headSha,
+  };
+}
+
+function loadSourceTask(
+  sourceWorkflowId: string,
+  sourceTaskId: string,
+  deps: SpawnReviewGateCiRepairWorkflowDeps,
+): TaskState | undefined {
+  const direct = deps.persistence.loadTask?.(sourceTaskId);
+  if (direct) {
+    return direct;
+  }
+  return deps.persistence.loadTasks(sourceWorkflowId).find((task) => task.id === sourceTaskId);
+}
+
+function assertSourceReviewGateLineage(task: TaskState, args: ReviewGateCiRepairWorkflowMutationArgs): void {
+  if (task.config.workflowId !== args.sourceWorkflowId) {
+    throw new Error(
+      `Review-gate CI repair workflow is stale: source workflow changed (${args.sourceWorkflowId} → ${task.config.workflowId ?? 'missing'}).`,
+    );
+  }
+  if (task.status !== 'review_ready' && task.status !== 'awaiting_approval') {
+    throw new Error(
+      `Review-gate CI repair workflow is stale: source task ${args.sourceTaskId} is ${task.status}.`,
+    );
+  }
+  const current = currentReviewGateLineage(task, args.reviewId);
+  if (current.reviewId !== args.reviewId) {
+    throw new Error(
+      `Review-gate CI repair workflow is stale: review changed (${args.reviewId} → ${current.reviewId ?? 'missing'}).`,
+    );
+  }
+  if (current.generation !== args.generation) {
+    throw new Error(
+      `Review-gate CI repair workflow is stale: generation changed (${args.generation} → ${current.generation}).`,
+    );
+  }
+  if (args.selectedAttemptId !== undefined && current.selectedAttemptId !== args.selectedAttemptId) {
+    throw new Error(
+      `Review-gate CI repair workflow is stale: selected attempt changed (${args.selectedAttemptId} → ${current.selectedAttemptId ?? 'missing'}).`,
+    );
+  }
+  if (args.branch !== undefined && current.branch !== args.branch) {
+    throw new Error(
+      `Review-gate CI repair workflow is stale: branch changed (${args.branch} → ${current.branch ?? 'missing'}).`,
+    );
+  }
+  if (args.headSha !== undefined && current.headSha !== args.headSha) {
+    throw new Error(
+      `Review-gate CI repair workflow is stale: head SHA changed (${args.headSha} → ${current.headSha ?? 'missing'}).`,
+    );
+  }
+}
+
+function resolveBranch(task: TaskState, featureBranch: string | undefined, args: ReviewGateCiRepairWorkflowMutationArgs): string {
+  const branch = args.branch?.trim() || task.execution.branch?.trim() || featureBranch?.trim();
+  if (!branch) {
+    throw new Error('Review-gate CI repair requires a branch to checkout.');
+  }
+  return branch;
+}
+
+function resolveBaseBranch(baseBranch: string | undefined): string {
+  const resolved = baseBranch?.trim();
+  if (!resolved) {
+    throw new Error('Review-gate CI repair requires source workflow baseBranch.');
+  }
+  return resolved;
+}
+
+function buildFailedCheckBullet(check: ReviewGateCiRepairWorkflowMutationArgs['failedChecks'][number]): string {
+  const conclusion = check.conclusion ? ` (${check.conclusion})` : '';
+  const detailsUrl = check.detailsUrl ? ` — ${check.detailsUrl}` : '';
+  return `- ${check.name}${conclusion}${detailsUrl}`;
+}
+
+function buildRepairPrompt(
+  args: ReviewGateCiRepairWorkflowMutationArgs,
+  branch: string,
+  baseBranch: string,
+): string {
+  const failedChecks = args.failedChecks.map(buildFailedCheckBullet).join('\n');
+  return [
+    `Repair the existing pull request #${args.reviewId}.`,
+    `PR URL: ${args.reviewUrl}`,
+    `Head branch: ${branch}`,
+    `Head SHA: ${args.headSha ?? 'unknown'}`,
+    `Base branch: ${baseBranch}`,
+    '',
+    `Source workflow: ${args.sourceWorkflowId}`,
+    `Source merge task: ${args.sourceTaskId}`,
+    `Status: ${args.statusText}`,
+    '',
+    'Work directly on the review branch:',
+    `  git fetch origin ${branch} && git checkout ${branch}`,
+    '',
+    'Failed checks to clear:',
+    failedChecks,
+    '',
+    'Rules:',
+    '- Fix the failing checks on the same branch.',
+    `- Push your changes to the same branch (${branch}).`,
+    '- Never open a new PR.',
+    '- Do not recreate the source workflow.',
+  ].join('\n');
+}
+
+export async function spawnReviewGateCiRepairWorkflow(
+  args: ReviewGateCiRepairWorkflowMutationArgs,
+  deps: SpawnReviewGateCiRepairWorkflowDeps,
+): Promise<SpawnReviewGateCiRepairWorkflowResult> {
+  const sourceTask = loadSourceTask(args.sourceWorkflowId, args.sourceTaskId, deps);
+  if (!sourceTask) {
+    throw new Error(`Review-gate CI repair source task ${args.sourceTaskId} not found.`);
+  }
+  const sourceWorkflow = deps.persistence.loadWorkflow(args.sourceWorkflowId);
+  if (!sourceWorkflow) {
+    throw new Error(`Review-gate CI repair source workflow ${args.sourceWorkflowId} not found.`);
+  }
+
+  assertSourceReviewGateLineage(sourceTask, args);
+
+  const branch = resolveBranch(sourceTask, sourceWorkflow.featureBranch, args);
+  const baseBranch = resolveBaseBranch(sourceWorkflow.baseBranch);
+  const headShaOrNoHead = args.headSha ?? 'no-head';
+  const plan: PlanDefinition = {
+    name: `repair-review-gate-ci-${args.reviewId}-${headShaOrNoHead}`,
+    onFinish: 'none',
+    baseBranch,
+    ...(sourceWorkflow.repoUrl ? { repoUrl: sourceWorkflow.repoUrl } : {}),
+    ...(sourceWorkflow.intermediateRepoUrl ? { intermediateRepoUrl: sourceWorkflow.intermediateRepoUrl } : {}),
+    tasks: [
+      {
+        id: 'repair',
+        description: `Repair PR #${args.reviewId}: ${args.statusText}`,
+        prompt: buildRepairPrompt(args, branch, baseBranch),
+        ...(args.agentName ? { executionAgent: args.agentName } : {}),
+        ...(args.executionModel ? { executionModel: args.executionModel } : {}),
+      },
+    ],
+  };
+
+  const existingWorkflowIds = new Set(deps.persistence.listWorkflows().map((workflow) => workflow.id));
+  backupPlan(plan, undefined, deps.logger);
+  deps.orchestrator.loadPlan(plan, { allowGraphMutation: deps.allowGraphMutation });
+  const workflowId = deps.orchestrator.getWorkflowIds().find((id) => !existingWorkflowIds.has(id));
+  if (!workflowId) {
+    throw new Error('Loaded review-gate CI repair plan did not create a workflow.');
+  }
+  const started = deps.orchestrator
+    .startExecution()
+    .filter((task) => task.config.workflowId === workflowId);
+  return {
+    workflowId,
+    taskId: `${workflowId}/repair`,
+    started,
+  };
+}

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -284,6 +284,7 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       case 'invoker:set-merge-branch':
       case 'invoker:approve-merge':
       case 'invoker:fix-with-agent':
+      case 'invoker:spawn-review-gate-ci-repair':
       case 'invoker:edit-task-pool':
       case 'invoker:replace-task':
       case 'invoker:load-plan':

--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -4,6 +4,11 @@ import type { WorkerActionRecord, WorkerActionWrite, WorkflowMutationPriority } 
 import type { TaskState } from '@invoker/workflow-core';
 
 import {
+  buildReviewGateCiRepairWorkflowMutationArgs,
+  parseReviewGateCiRepairWorkflowMutationArgs,
+  SPAWN_REVIEW_GATE_CI_REPAIR_CHANNEL,
+} from '../review-gate-ci-repair.js';
+import {
   autoFixAttemptLedgerKeyFromLifecycleEvent,
   createAutoFixAttemptLedger,
 } from '../auto-fix-attempt-ledger.js';
@@ -118,9 +123,10 @@ function toRecord(write: WorkerActionWrite): WorkerActionRecord {
 function makeHarness(task = makeTask()) {
   const tasks = new Map<string, TaskState>([[task.id, task]]);
   const actions = new Map<string, WorkerActionRecord>();
-  const submit = vi.fn((workflowId: string, priority: WorkflowMutationPriority, _channel: string, args: unknown[]) => {
+  const submit = vi.fn((workflowId: string, priority: WorkflowMutationPriority, channel: string, args: unknown[]) => {
     expect(workflowId).toBe('wf-1');
     expect(priority).toBe('normal');
+    expect(channel).toBe(SPAWN_REVIEW_GATE_CI_REPAIR_CHANNEL);
     expect(args).toBeDefined();
     return 42;
   });
@@ -164,7 +170,7 @@ describe('PR status and CI failure workers', () => {
     await worker.stop();
   });
 
-  it.fails('queues a head-SHA guarded CI repair workflow intent and records its dedupe action', async () => {
+  it('queues a head-SHA guarded CI repair workflow intent and records its dedupe action', async () => {
     const event = makeEvent({
       failedChecks: [
         { name: 'unit', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/1' },
@@ -190,9 +196,9 @@ describe('PR status and CI failure workers', () => {
 
     expect(ciFailureActionKey(sameChecksDifferentOrder)).toBe(ciFailureActionKey(event));
     expect(harness.submit).toHaveBeenCalledTimes(1);
-    const [, , channel, args] = harness.submit.mock.calls[0];
-    expect(channel).toBe('invoker:spawn-review-gate-ci-repair');
-    expect(args[0]).toMatchObject({
+    const [, , , args] = harness.submit.mock.calls[0];
+    const parsed = parseReviewGateCiRepairWorkflowMutationArgs(args);
+    expect(parsed).toEqual(buildReviewGateCiRepairWorkflowMutationArgs({
       sourceWorkflowId: 'wf-1',
       sourceTaskId: 'wf-1/merge',
       reviewId: '123',
@@ -210,7 +216,7 @@ describe('PR status and CI failure workers', () => {
       taskStateVersion: 10,
       agentName: 'codex',
       executionModel: 'openai/gpt-5.2',
-    });
+    })[0]);
     expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toMatchObject({
       workerKind: CI_FAILURE_WORKER_KIND,
       actionType: 'fix-ci-failure',
@@ -219,7 +225,7 @@ describe('PR status and CI failure workers', () => {
       intentId: '42',
       externalKey: ciFailureActionKey(event),
       payload: expect.objectContaining({
-        channel: 'invoker:spawn-review-gate-ci-repair',
+        channel: SPAWN_REVIEW_GATE_CI_REPAIR_CHANNEL,
       }),
     });
   });

--- a/packages/execution-engine/src/__tests__/repro-ci-failure-action-stuck-queued.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-ci-failure-action-stuck-queued.test.ts
@@ -1,10 +1,10 @@
 /**
- * Repro: a review-gate CI repair stays "queued" forever after its fix intent
- * fails.
+ * Repro: a review-gate CI repair stays "queued" forever after its workflow
+ * spawn intent fails.
  *
  * Production failure (workflow "Prove Review Gate Fix No-op Root Cause"):
  * the ci-failure worker recorded its dedupe action as `queued` when it
- * submitted fix intent 27908. The intent failed 50ms later, but nothing wrote
+ * submitted repair intent 27908. The intent failed 50ms later, but nothing wrote
  * that outcome back to the worker action. From then on every tick logged
  *
  *   worker-ci-failure-skip reason=already-recorded existingStatus=queued
@@ -126,8 +126,8 @@ function makeIntent(id: number, status: WorkflowMutationIntentStatus, error?: st
   return {
     id,
     workflowId: 'wf-1',
-    channel: 'invoker:fix-with-agent',
-    args: ['wf-1/merge', 'codex', { autoFix: true }],
+    channel: 'invoker:spawn-review-gate-ci-repair',
+    args: [{ sourceWorkflowId: 'wf-1', sourceTaskId: 'wf-1/merge' }],
     priority: 'normal',
     status,
     error,
@@ -152,7 +152,7 @@ function makeHarness(opts: { intents: WorkflowMutationIntent[]; existingActionSt
     status: opts.existingActionStatus as WorkerActionRecord['status'],
     attemptCount: 1,
     intentId: opts.existingIntentId,
-    summary: 'Queued CI repair with agent',
+    summary: 'Queued CI repair workflow',
   }));
   const submit = vi.fn((_workflowId: string, _priority: WorkflowMutationPriority, _channel: string, _args: unknown[]) => 42);
   const store = {

--- a/packages/execution-engine/src/review-gate-ci-repair.ts
+++ b/packages/execution-engine/src/review-gate-ci-repair.ts
@@ -12,7 +12,6 @@ import type {
 import type { TaskState } from '@invoker/workflow-core';
 
 import {
-  buildFixWithAgentMutationArgs,
   isReviewGateCiContextStale,
   listOpenFixIntentsForTask,
   type ReviewGateCiContext,
@@ -35,7 +34,7 @@ import {
 import { recordWorkerDecisionRow } from './worker-decision-ledger.js';
 
 const CI_FAILURE_WORKER_KIND = 'ci-failure';
-const FIX_WITH_AGENT_CHANNEL = 'invoker:fix-with-agent';
+export const SPAWN_REVIEW_GATE_CI_REPAIR_CHANNEL = 'invoker:spawn-review-gate-ci-repair';
 const CI_FAILURE_ACTION_TYPE = 'fix-ci-failure';
 const NO_HEAD_SHA = 'no-head';
 
@@ -57,7 +56,7 @@ export interface ReviewGateCiRepairSubmitter {
   submit(
     workflowId: string,
     priority: WorkflowMutationPriority,
-    channel: typeof FIX_WITH_AGENT_CHANNEL,
+    channel: typeof SPAWN_REVIEW_GATE_CI_REPAIR_CHANNEL,
     args: unknown[],
     options?: { deferDrain?: boolean },
   ): number;
@@ -74,6 +73,83 @@ export interface ReviewGateCiRepairPolicyOptions {
   getRetryBudget?: (task: TaskState) => number;
   /** Optional failed-check log fetcher used to skip non-fixable infra failures. */
   fetchFailedCheckLogs?: FailedCheckLogFetcher;
+}
+
+export interface ReviewGateCiRepairWorkflowMutationArgs {
+  readonly sourceWorkflowId: string;
+  readonly sourceTaskId: string;
+  readonly reviewId: string;
+  readonly reviewUrl: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
+  readonly branch?: string;
+  readonly generation: number;
+  readonly selectedAttemptId?: string;
+  readonly failedChecks: readonly ReviewGateFailedCheck[];
+  readonly statusText: string;
+  readonly taskStateVersion: number;
+  readonly agentName?: string;
+  readonly executionModel?: string;
+}
+
+export function buildReviewGateCiRepairWorkflowMutationArgs(
+  payload: ReviewGateCiRepairWorkflowMutationArgs,
+): unknown[] {
+  return [payload];
+}
+
+export function parseReviewGateCiRepairWorkflowMutationArgs(args: unknown[]): ReviewGateCiRepairWorkflowMutationArgs {
+  const [raw] = args;
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('invoker:spawn-review-gate-ci-repair mutation requires an argument object');
+  }
+  const candidate = raw as Record<string, unknown>;
+  const {
+    sourceWorkflowId,
+    sourceTaskId,
+    reviewId,
+    reviewUrl,
+    headSha,
+    headRef,
+    branch,
+    generation,
+    selectedAttemptId,
+    failedChecks,
+    statusText,
+    taskStateVersion,
+    agentName,
+    executionModel,
+  } = candidate;
+  if (
+    typeof sourceWorkflowId !== 'string'
+    || typeof sourceTaskId !== 'string'
+    || typeof reviewId !== 'string'
+    || typeof reviewUrl !== 'string'
+    || typeof generation !== 'number'
+    || !Array.isArray(failedChecks)
+    || typeof statusText !== 'string'
+    || typeof taskStateVersion !== 'number'
+  ) {
+    throw new Error(
+      'invoker:spawn-review-gate-ci-repair mutation requires { sourceWorkflowId, sourceTaskId, reviewId, reviewUrl, generation, failedChecks, statusText, taskStateVersion }',
+    );
+  }
+  return {
+    sourceWorkflowId,
+    sourceTaskId,
+    reviewId,
+    reviewUrl,
+    ...(typeof headSha === 'string' ? { headSha } : {}),
+    ...(typeof headRef === 'string' ? { headRef } : {}),
+    ...(typeof branch === 'string' ? { branch } : {}),
+    generation,
+    ...(typeof selectedAttemptId === 'string' ? { selectedAttemptId } : {}),
+    failedChecks: failedChecks.map((check) => ({ ...(check as ReviewGateFailedCheck) })),
+    statusText,
+    taskStateVersion,
+    ...(typeof agentName === 'string' ? { agentName } : {}),
+    ...(typeof executionModel === 'string' ? { executionModel } : {}),
+  };
 }
 
 export function ciFailureChecksHash(failedChecks: readonly ReviewGateFailedCheck[]): string {
@@ -150,7 +226,6 @@ function reviewGateContextFromEvent(event: ReviewGateCiFailedLifecycleEvent): Re
     selectedAttemptId: event.attemptId,
     branch: event.branch,
     headSha: event.headSha,
-    fixContext: buildCiFailureFixContext(event),
   };
 }
 
@@ -288,22 +363,6 @@ function logCiFailureWorkerEvent(
 }
 
 
-function buildCiFailureFixContext(event: ReviewGateCiFailedLifecycleEvent): string {
-  const checks = event.failedChecks
-    .map((check) => {
-      const conclusion = check.conclusion ? ` (${check.conclusion})` : '';
-      const details = check.detailsUrl ? ` - ${check.detailsUrl}` : '';
-      return `- ${check.name}${conclusion}${details}`;
-    })
-    .join('\n');
-  return [
-    `Review-gate CI failed for ${event.reviewUrl}.`,
-    `Head SHA: ${event.headSha ?? 'unknown'}.`,
-    `Status: ${event.statusText}.`,
-    'Failed checks:',
-    checks,
-  ].join('\n');
-}
 
 function shouldSkipExistingAction(
   options: ReviewGateCiRepairPolicyOptions,
@@ -487,26 +546,35 @@ export async function queueReviewGateCiRepair(
   const executionModel = configuredExecutionModel && configuredExecutionModel.length > 0
     ? configuredExecutionModel
     : undefined;
-  const args = buildFixWithAgentMutationArgs(event.taskId, selectedAgent, {
-    autoFix: true,
-    reviewGateContext: {
-      reviewId: event.reviewId,
-      generation: event.generation,
-      selectedAttemptId: event.attemptId,
-      branch: event.branch,
-      headSha: event.headSha,
-      fixContext: buildCiFailureFixContext(event),
-    },
-    executionModel,
+  const args = buildReviewGateCiRepairWorkflowMutationArgs({
+    sourceWorkflowId: event.workflowId,
+    sourceTaskId: event.taskId,
+    reviewId: event.reviewId,
+    reviewUrl: event.reviewUrl,
+    ...(event.headSha ? { headSha: event.headSha } : {}),
+    ...(event.headRef ? { headRef: event.headRef } : {}),
+    ...(event.branch ? { branch: event.branch } : {}),
+    generation: event.generation,
+    ...(event.attemptId ? { selectedAttemptId: event.attemptId } : {}),
+    failedChecks: event.failedChecks.map((check) => ({ ...check })),
+    statusText: event.statusText,
+    taskStateVersion: event.taskStateVersion ?? task.taskStateVersion,
+    ...(selectedAgent ? { agentName: selectedAgent } : {}),
+    ...(executionModel ? { executionModel } : {}),
   });
-  const intentId = options.submitter.submit(event.workflowId, 'normal', FIX_WITH_AGENT_CHANNEL, args);
+  const intentId = options.submitter.submit(
+    event.workflowId,
+    'normal',
+    SPAWN_REVIEW_GATE_CI_REPAIR_CHANNEL,
+    args,
+  );
   recordCiFailureAction(
     options,
     event,
     'queued',
-    'Queued CI repair with agent',
+    'Queued CI repair workflow',
     {
-      channel: FIX_WITH_AGENT_CHANNEL,
+      channel: SPAWN_REVIEW_GATE_CI_REPAIR_CHANNEL,
       workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
     },
     intentId,
@@ -515,7 +583,7 @@ export async function queueReviewGateCiRepair(
   );
   logCiFailureWorkerEvent(options, event, 'worker-ci-failure-submitted', {
     intentId,
-    channel: FIX_WITH_AGENT_CHANNEL,
+    channel: SPAWN_REVIEW_GATE_CI_REPAIR_CHANNEL,
     agent: selectedAgent ?? null,
     executionModel: executionModel ?? null,
     workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),


### PR DESCRIPTION
## Summary

This sends worker-fired review-gate CI repair to a separate one-task workflow on the PR branch.

The bug was that red CI went straight into the merge-gate fix path. That changes gate state and disrupts the review flow.

The fix keeps the same worker checks, then sends the recovery work to a sibling workflow that works on the existing PR branch.

## Review Claim

Worker-triggered review-gate CI failures now start an independent repair workflow while the source merge gate stays in review.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The worker still decides when to act. Manual merge-gate fix, startup recreate, and retry or dedupe bookkeeping stay unchanged.

## Slice Rationale

The earlier proof slice established the expected worker outcome. This slice only changes where the red-CI recovery goes.

## Architectural Effect

The red-CI path now goes from the worker to a sibling repair workflow instead of entering the source merge gate's fix path.

## Alternative Considerations

Rejected reusing the merge-gate fix path or the workflow fork helpers because they move the source gate instead of leaving it in review.

## Non-goals

- No change to manual `fix` on a merge gate.
- No change to fresh-base recreate recovery.
- No new UI or operator workflow.

## Architecture

### Before

`review_gate.ci_failed` queued `invoker:fix-with-agent` on the merge gate itself.

### After

`review_gate.ci_failed` queues `invoker:spawn-review-gate-ci-repair`, which creates a sibling workflow with one `repair` task on the PR branch.

```mermaid
graph TD
    A["review_gate.ci_failed worker event"] --> B["invoker:spawn-review-gate-ci-repair"]
    B --> C["new repair workflow /repair task"]
    A -.-> D["source merge gate stays review_ready or awaiting_approval"]
```

## Visual Proof

1. Source workflow stays `review ready` while the sibling repair workflow exists in the graph.

![Source merge gate stays in review](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-4e66d2/review-gate-ci-source-proof.png)

2. Repair work runs as a separate workflow with its own running `repair` task.

![Sibling repair workflow runs independently](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-4e66d2/review-gate-ci-repair-proof.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/pr-ci-workers.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/review-gate-ci-repair-workflow.test.ts src/__tests__/review-gate-ci-repair-command.test.ts src/__tests__/repro-review-gate-ci-fix-review-ready.test.ts src/__tests__/no-autofix-outside-worker.test.ts`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/repro-ci-failure-action-stuck-queued.test.ts`
- [x] `pnpm --filter @invoker/app test:e2e -- e2e/tmp-review-gate-ci-proof.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 125f4d5c7`
- Post-revert steps: None.
- Data migration? No.

</details>
