### PR TITLE
[Autofix Recreate Reset](2a) Reset durable recovery state

### DIFF
--- a/packages/app/src/__tests__/repro-autofix-recreate-reset.e2e.test.ts
+++ b/packages/app/src/__tests__/repro-autofix-recreate-reset.e2e.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  WorkerActionRecord,
+  WorkerActionWrite,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
+import {
+  createAutoFixAttemptLedger,
+  createAutoFixRecoveryTick,
+} from '@invoker/execution-engine';
+import { Orchestrator, type TaskState } from '@invoker/workflow-core';
+import { InMemoryBus, InMemoryPersistence } from '@invoker/test-kit';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+function resetAutoFixBudgetRows(
+  actions: Map<string, WorkerActionRecord>,
+  taskIds: readonly string[],
+): void {
+  for (const taskId of taskIds) {
+    for (const externalKey of [`retry-cap:${taskId}`, `autofix:retry:${taskId}`]) {
+      const key = `autofix:${externalKey}`;
+      const existing = actions.get(key);
+      if (existing) {
+        actions.set(key, { ...existing, attemptCount: 0 });
+      }
+    }
+  }
+}
+
+function makeFailedTask(task: TaskState, generation: number): void {
+  task.status = 'failed';
+  task.execution = {
+    generation,
+    selectedAttemptId: `attempt-${generation}`,
+    branch: 'feature/build',
+    error: 'Merge conflict merging experiment/wf-1/build',
+  };
+  task.taskStateVersion = generation;
+}
+
+describe('recreate-class auto-fix eligibility', () => {
+  it.fails('recreate and rebase-recreate restore exhausted auto-fix eligibility', async () => {
+    const persistence = new InMemoryPersistence();
+    const actions = new Map<string, WorkerActionRecord>();
+    const store = Object.assign(persistence, {
+      listWorkflowMutationIntents: () => [],
+      getWorkerAction: (workerKind: string, externalKey: string) =>
+        actions.get(`${workerKind}:${externalKey}`),
+      upsertWorkerAction: (write: WorkerActionWrite) => {
+        const key = `${write.workerKind}:${write.externalKey}`;
+        const existing = actions.get(key);
+        const saved: WorkerActionRecord = {
+          ...write,
+          id: existing?.id ?? write.id,
+          attemptCount: write.attemptCount ?? 0,
+          createdAt: existing?.createdAt ?? '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        };
+        actions.set(key, saved);
+        return saved;
+      },
+    });
+    const resetBudgets = (taskIds: readonly string[]) => resetAutoFixBudgetRows(actions, taskIds);
+    const orchestrator = new Orchestrator({
+      persistence: store,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 0,
+      onRecreateTasksReset: resetBudgets,
+    } as never);
+    orchestrator.loadPlan({
+      name: 'recreate resets auto-fix eligibility',
+      onFinish: 'none',
+      tasks: [{ id: 'build', description: 'build', command: 'pnpm build' }],
+    });
+    const workflowId = orchestrator.getWorkflowIds()[0]!;
+    const taskId = `${workflowId}/build`;
+    const submit = vi.fn((_workflowId: string, _priority: WorkflowMutationPriority) => 99);
+    const tick = createAutoFixRecoveryTick({
+      store,
+      submitter: { submit },
+      logger,
+      attemptLedger: createAutoFixAttemptLedger(),
+      defaultAutoFixRetries: 1,
+      getAutoFixAgent: () => 'codex',
+    });
+
+    for (let generation = 1; generation <= 2; generation += 1) {
+      const task = orchestrator.getTask(taskId)!;
+      makeFailedTask(task, generation);
+      persistence.updateTask(taskId, {
+        status: task.status,
+        execution: task.execution,
+        taskStateVersion: task.taskStateVersion,
+      });
+      await tick({ reason: 'poll' } as never);
+    }
+    expect(submit).toHaveBeenCalledTimes(1);
+
+    for (const recreate of [
+      () => orchestrator.recreateWorkflow(workflowId),
+      () => orchestrator.recreateWorkflowFromFreshBase(workflowId),
+    ]) {
+      await recreate();
+      const task = orchestrator.getTask(taskId)!;
+      makeFailedTask(task, (task.execution.generation ?? 0) + 1);
+      persistence.updateTask(taskId, {
+        status: task.status,
+        execution: task.execution,
+        taskStateVersion: task.taskStateVersion,
+      });
+      submit.mockClear();
+      await tick({ reason: 'poll' } as never);
+      expect(submit).toHaveBeenCalledTimes(1);
+    }
+  });
+});

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -25,6 +25,7 @@ import {
   isLivenessFailureTask,
 } from './auto-fix-gating.js';
 import {
+  autoFixBareRetryExternalKey,
   checkAutoFixRetryCap,
   recordAutoFixRetryConsumed,
 } from './auto-fix-retry-cap.js';
@@ -255,12 +256,6 @@ function autoFixDecisionExternalKey(candidate: AutoFixRecoveryCandidate): string
   return `${AUTO_FIX_WORKER_KIND}:${candidate.taskId}:${candidate.generation}:${candidate.attemptId ?? ''}`;
 }
 
-function autoFixBareRetryExternalKey(candidate: AutoFixRecoveryCandidate): string {
-  // Bare retry is once-per-task: after restart-task bumps generation, the next
-  // failure must escalate to fix-with-agent instead of another bare retry.
-  return `${AUTO_FIX_WORKER_KIND}:retry:${candidate.taskId}`;
-}
-
 function recordAutoFixDecisionRow(
   options: AutoFixRecoveryPolicyOptions,
   candidate: AutoFixRecoveryCandidate,
@@ -311,7 +306,7 @@ function recordAutoFixBareRetryRow(
   recordWorkerDecisionRow(options.store, {
     workerKind: AUTO_FIX_WORKER_KIND,
     actionType: AUTO_FIX_BARE_RETRY_ACTION_TYPE,
-    externalKey: autoFixBareRetryExternalKey(candidate),
+    externalKey: autoFixBareRetryExternalKey(candidate.taskId),
     subjectType: 'task',
     subjectId: candidate.taskId,
     workflowId: candidate.workflowId,
@@ -336,7 +331,7 @@ function hasBareRetryAlreadySubmitted(
 ): boolean {
   const existing = options.store.getWorkerAction?.(
     AUTO_FIX_WORKER_KIND,
-    autoFixBareRetryExternalKey(candidate),
+    autoFixBareRetryExternalKey(candidate.taskId),
   );
   if (!existing) return false;
   return existing.attemptCount > 0;

--- a/packages/execution-engine/src/auto-fix-retry-cap.ts
+++ b/packages/execution-engine/src/auto-fix-retry-cap.ts
@@ -19,8 +19,10 @@ import { recordWorkerDecisionRow, type WorkerDecisionStore } from './worker-deci
  * number of worker-initiated retries for a task can never exceed the config.
  * Both automatic retry kinds (bare `restart-task` and `fix-with-agent`) count,
  * and every worker shares the one counter so the cap is per-task, not
- * per-worker. It is a hard cap with no automatic reset; a human who wants more
- * attempts uses the explicit `fix` command, which bypasses the worker entirely.
+ * per-worker. It is a hard cap across restarts and generation bumps. Recreate-
+ * class lifecycle resets deliberately clear it for the affected task; a human
+ * who wants more attempts can also use the explicit `fix` command, which
+ * bypasses the worker entirely.
  */
 export const AUTO_FIX_RETRY_CAP_ACTION_TYPE = 'auto-retry-cap';
 
@@ -29,10 +31,16 @@ export const AUTO_FIX_RETRY_CAP_ACTION_TYPE = 'auto-retry-cap';
  * task's retries are counted together rather than once per worker kind.
  */
 const RETRY_CAP_WORKER_KIND = 'autofix';
+const BARE_RETRY_ACTION_TYPE = 'auto-retry';
 
 /** Stable per-task external key — deliberately free of generation/attempt. */
 export function autoFixRetryCapExternalKey(taskId: string): string {
   return `retry-cap:${taskId}`;
+}
+
+/** Stable per-task external key for the once-per-task bare retry marker. */
+export function autoFixBareRetryExternalKey(taskId: string): string {
+  return `${RETRY_CAP_WORKER_KIND}:retry:${taskId}`;
 }
 
 export interface AutoFixRetryCapDecision {
@@ -79,4 +87,52 @@ export function recordAutoFixRetryConsumed(
     summary: fields.summary ?? 'Durable per-task auto-fix retry counter',
     incrementAttempt: true,
   });
+}
+
+/** Clear the durable retry cap after a recreate-class task reset. */
+export function resetAutoFixRetryCap(store: WorkerDecisionStore, taskId: string): void {
+  const externalKey = autoFixRetryCapExternalKey(taskId);
+  const existing = store.getWorkerAction?.(RETRY_CAP_WORKER_KIND, externalKey);
+  store.upsertWorkerAction?.({
+    id: existing?.id ?? `${RETRY_CAP_WORKER_KIND}:${externalKey}`,
+    workerKind: RETRY_CAP_WORKER_KIND,
+    actionType: AUTO_FIX_RETRY_CAP_ACTION_TYPE,
+    ...(existing?.workflowId !== undefined ? { workflowId: existing.workflowId } : {}),
+    taskId,
+    subjectType: 'task',
+    subjectId: taskId,
+    externalKey,
+    status: 'queued',
+    attemptCount: 0,
+    summary: 'Durable per-task auto-fix retry counter',
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+/** Clear the once-per-task bare retry marker after a recreate-class task reset. */
+export function resetAutoFixBareRetry(store: WorkerDecisionStore, taskId: string): void {
+  const externalKey = autoFixBareRetryExternalKey(taskId);
+  const existing = store.getWorkerAction?.(RETRY_CAP_WORKER_KIND, externalKey);
+  store.upsertWorkerAction?.({
+    id: existing?.id ?? `${RETRY_CAP_WORKER_KIND}:${externalKey}`,
+    workerKind: RETRY_CAP_WORKER_KIND,
+    actionType: BARE_RETRY_ACTION_TYPE,
+    ...(existing?.workflowId !== undefined ? { workflowId: existing.workflowId } : {}),
+    taskId,
+    subjectType: 'task',
+    subjectId: taskId,
+    externalKey,
+    status: 'queued',
+    attemptCount: 0,
+    summary: 'Once-per-task auto-fix bare retry marker',
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+/** Reset all automatic recovery budget state for recreated tasks. */
+export function resetAutoFixBudgetForTasks(store: WorkerDecisionStore, taskIds: readonly string[]): void {
+  for (const taskId of taskIds) {
+    resetAutoFixRetryCap(store, taskId);
+    resetAutoFixBareRetry(store, taskId);
+  }
 }

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -77,6 +77,7 @@ export * from './reconcile-terminal-worker-actions.js';
 export * from './requeue-attempt-ledger.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-attempt-ledger.js';
+export * from './auto-fix-retry-cap.js';
 export * from './worker-decision-ledger.js';
 export * from './auto-fix-intents.js';
 export * from './lifecycle-events.js';


### PR DESCRIPTION
## Summary

Automatic recovery state now has one durable reset operation for recreated tasks.

It clears the cap and first-attempt marker without changing other worker state.

## Review Claim

The automatic recovery store can reset its two durable per-task counters.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The operation only writes the named automatic recovery rows for supplied task IDs.

## Slice Rationale

Durable-state mutation is separated from lifecycle dispatch and application construction.

## Non-goals

No lifecycle route, CLI surface, or GUI behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test src/__tests__/repro-auto-fix-retry-cap.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e8d777dfc`
- Post-revert steps: None
- Data migration? No

</details>
