### PR TITLE
[Autofix Recreate Reset](2c) Activate recovery reset at startup

### DIFF
--- a/packages/app/src/__tests__/repro-autofix-recreate-reset.e2e.test.ts
+++ b/packages/app/src/__tests__/repro-autofix-recreate-reset.e2e.test.ts
@@ -48,7 +48,7 @@ function makeFailedTask(task: TaskState, generation: number): void {
 }
 
 describe('recreate-class auto-fix eligibility', () => {
-  it.fails('recreate and rebase-recreate restore exhausted auto-fix eligibility', async () => {
+  it('recreate and rebase-recreate restore exhausted auto-fix eligibility', async () => {
     const persistence = new InMemoryPersistence();
     const actions = new Map<string, WorkerActionRecord>();
     const store = Object.assign(persistence, {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -95,6 +95,7 @@ import {
   parseRequeueMutationArgs,
   parseRequeueEscalateMutationArgs,
   reconcileTerminalWorkerActionsOnStartup,
+  resetAutoFixBudgetForTasks,
   type AgentRegistry,
   type WorkerRegistry,
   type WorkerRuntimeDependencies,
@@ -811,6 +812,9 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     defaultPoolId: invokerConfig.defaultPoolId,
     availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
     deferRunningUntilLaunch: true,
+    onRecreateTasksReset: (taskIds) => {
+      resetAutoFixBudgetForTasks(persistence, taskIds);
+    },
   });
   commandService = new CommandService(
     orchestrator,
@@ -1108,6 +1112,9 @@ function startHeadlessMode(): void {
               defaultPoolId: invokerConfig.defaultPoolId,
               availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
               deferRunningUntilLaunch: true,
+              onRecreateTasksReset: (taskIds) => {
+                resetAutoFixBudgetForTasks(persistence, taskIds);
+              },
             });
             commandService = new CommandService(
               orchestrator,


### PR DESCRIPTION
## Summary

Application startup now routes recreated task IDs to the existing reset callback.

Existing recovery state remains unchanged outside recreated task lineages.

## Review Claim

The startup orchestrator routes task IDs to the existing reset callback and proves recovery resumes through the E2E regression.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This application route changes only the startup orchestrator configuration. Other task lineages retain their existing durable state.

## Slice Rationale

Application startup routing is separate from the GUI reconstruction surface, which follows in the next slice.

## Non-goals

This slice does not change configured limits, agent selection, or GUI clear behavior.

## Architecture

### Before

```mermaid
graph TD
    A["recreate lifecycle"] --> B["task state reset"]
```

### After

```mermaid
graph TD
    A["recreate lifecycle"] --> B["task state reset"]
    A --> C["durable recovery budget reset"]
```

## Visual Proof

![Worker activity showing an exhausted automatic recovery decision](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-2aec2c/worker-decisions-panel.png)

The worker decision panel visibly distinguishes queued automatic fixes from an exhausted recovery-budget skip. The reset itself is background-only and is covered by the focused E2E regression test.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core test src/__tests__/orchestrator.test.ts`
- [x] `pnpm --filter @invoker/app test src/__tests__/repro-autofix-recreate-reset.e2e.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2e6a2d13f`
- Post-revert steps: None
- Data migration? No

</details>
