### PR TITLE
[Delete planning terminals — UI](1) Add Planning Terminal rail controls

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
+import { Trash2 } from 'lucide-react';
 import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, PlanningConfirmationMode, ReviewGateQueryResponse, RuntimeStatus, StartReadyFreshBaseScope, StartReadyRequest, StartReadyResult, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus, WorkerActionSummary, WorkerLogEntry, WorkerStatusEntry } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
@@ -2981,23 +2982,98 @@ export function App() {
     workflows.size,
   ]);
 
-  const handleCreatePlanningSession = useCallback(() => {
+  const makeNextLocalPlanningSession = useCallback((): PlanningSessionView => {
     const index = nextPlanningSessionLocalIdRef.current;
     nextPlanningSessionLocalIdRef.current += 1;
     const now = new Date().toISOString();
     const localId = `local-planning-session-${index}`;
-    const session: PlanningSessionView = {
+    return {
       ...makeInitialPlanningSession(now, selectedPlanningConfirmationMode),
       id: localId,
       conversationKey: localId,
       presetKey: selectedPlanningPresetKey,
       confirmationMode: selectedPlanningConfirmationMode,
     };
+  }, [selectedPlanningConfirmationMode, selectedPlanningPresetKey]);
+
+  const removePlanningSessionsById = useCallback((sessionIds: string[]) => {
+    const removedIds = new Set(sessionIds.filter(Boolean));
+    if (removedIds.size === 0) return;
+
+    const removedIdList = [...removedIds];
+    clearPlanningStreamForSessionIds(removedIdList);
+    forgetPlanningStreamAliasesForSessionIds(removedIdList);
+    for (const sessionId of removedIds) {
+      pendingPlanningStreamSessionIdsRef.current.delete(sessionId);
+    }
+    setKeptPlanningDraftSessionIds((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const sessionId of removedIds) {
+        if (next.delete(sessionId)) changed = true;
+      }
+      return changed ? next : prev;
+    });
+    setReviewDraftSessionId((currentSessionId) => (
+      currentSessionId && removedIds.has(currentSessionId) ? null : currentSessionId
+    ));
+
+    const currentSessions = planningSessionsRef.current;
+    const remainingSessions = currentSessions.filter((session) => !removedIds.has(session.id));
+    if (remainingSessions.length === currentSessions.length) return;
+
+    let nextSessions = remainingSessions;
+    let nextActiveSessionId = activePlanningSessionIdRef.current;
+    const activeSessionRemoved = removedIds.has(nextActiveSessionId)
+      || !remainingSessions.some((session) => session.id === nextActiveSessionId);
+
+    if (remainingSessions.length === 0) {
+      const replacementSession = makeNextLocalPlanningSession();
+      nextSessions = [replacementSession];
+      nextActiveSessionId = replacementSession.id;
+    } else if (activeSessionRemoved) {
+      const firstRemovedIndex = currentSessions.findIndex((session) => removedIds.has(session.id));
+      const nextIndex = Math.min(firstRemovedIndex < 0 ? 0 : firstRemovedIndex, remainingSessions.length - 1);
+      nextActiveSessionId = remainingSessions[nextIndex]?.id ?? remainingSessions[0].id;
+    }
+
+    planningSessionsRef.current = nextSessions;
+    activePlanningSessionIdRef.current = nextActiveSessionId;
+    setPlanningSessions(nextSessions);
+    setActivePlanningSessionId(nextActiveSessionId);
+  }, [clearPlanningStreamForSessionIds, forgetPlanningStreamAliasesForSessionIds, makeNextLocalPlanningSession]);
+
+  const handleCreatePlanningSession = useCallback(() => {
+    const session = makeNextLocalPlanningSession();
     setPlanningSessions((prev) => [session, ...prev]);
     setActivePlanningSessionId(session.id);
     setSidebarSurface('home');
     focusKeyboardRegion('planning');
-  }, [focusKeyboardRegion, selectedPlanningConfirmationMode, selectedPlanningPresetKey]);
+  }, [focusKeyboardRegion, makeNextLocalPlanningSession]);
+
+  const handleDeletePlanningSession = useCallback((sessionId: string) => {
+    if (activePlanningReadOnly) return;
+    if (!sessionId.startsWith('local-')) {
+      void invoker?.planningChatDelete?.({ sessionId });
+    }
+    removePlanningSessionsById([sessionId]);
+  }, [activePlanningReadOnly, invoker, removePlanningSessionsById]);
+
+  const handleClearSubmittedPlanningSessions = useCallback(() => {
+    if (activePlanningReadOnly) return;
+    const confirmed = window.confirm(
+      'Clear all submitted planning chats? This cannot be undone.',
+    );
+    if (!confirmed) return;
+
+    const submittedSessionIds = planningSessionsRef.current
+      .filter((session) => session.status === 'submitted')
+      .map((session) => session.id);
+    if (submittedSessionIds.length === 0) return;
+
+    void invoker?.planningChatDeleteSubmitted?.();
+    removePlanningSessionsById(submittedSessionIds);
+  }, [activePlanningReadOnly, invoker, removePlanningSessionsById]);
 
   const handlePlanningModeChange = useCallback(async (mode: PlanningTerminalMode) => {
     const sourceSession = activePlanningSession;
@@ -4262,30 +4338,45 @@ export function App() {
           const selected = session.id === activePlanningSession.id;
           const preview = previewPlanningMessage(session);
           return (
-            <button
-              key={session.id}
-              type="button"
-              onClick={() => setActivePlanningSessionId(session.id)}
-              className={`flex w-full items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
-            >
-              <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-start justify-between gap-2">
-                  <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
-                    {session.title}
+            <div key={session.id} className="flex w-full items-stretch">
+              <button
+                type="button"
+                onClick={() => setActivePlanningSessionId(session.id)}
+                className={`flex min-w-0 flex-1 items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              >
+                <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
+                      {session.title}
+                    </div>
+                    <span className="shrink-0 text-[11px] text-muted-foreground">
+                      {relativePlanningUpdatedAt(session.updatedAt)}
+                    </span>
                   </div>
-                  <span className="shrink-0 text-[11px] text-muted-foreground">
-                    {relativePlanningUpdatedAt(session.updatedAt)}
-                  </span>
+                  <div
+                    className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
+                    title={preview}
+                  >
+                    {preview}
+                  </div>
                 </div>
-                <div
-                  className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
-                  title={preview}
+              </button>
+              {!activePlanningReadOnly && (
+                <button
+                  type="button"
+                  aria-label="Delete planning chat"
+                  title="Delete planning chat"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleDeletePlanningSession(session.id);
+                  }}
+                  className={`flex w-9 shrink-0 items-start justify-center px-2 py-2 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive ${selected ? 'bg-accent/40' : ''}`}
                 >
-                  {preview}
-                </div>
-              </div>
-            </button>
+                  <Trash2 className="mt-0.5 h-4 w-4" strokeWidth={1.75} aria-hidden="true" />
+                </button>
+              )}
+            </div>
           );
         })}
       </div>
@@ -4293,6 +4384,7 @@ export function App() {
   );
 
   const planningReadyCount = planningSessions.filter((session) => session.status === 'draft_ready').length;
+  const hasSubmittedPlanningSessions = planningSessions.some((session) => session.status === 'submitted');
   const connectedAgentLabels = (systemDiagnostics?.tools ?? [])
     .filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed)
     .map((tool) => tool.name.replace(/\s+CLI$/i, ''));
@@ -4450,18 +4542,15 @@ export function App() {
           </div>
         ) : (
           <>
-            <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2.5">
-              <div className="min-w-0">
-                <h2 className="text-sm font-medium text-foreground">Planning</h2>
-                <p className="mt-0.5 text-[11px] text-muted-foreground">
-                  {planningSessions.length} chat{planningSessions.length === 1 ? '' : 's'}
-                  {planningReadyCount > 0 ? ` · ${planningReadyCount} ready` : ''}
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                <Button variant="outline" size="sm" onClick={handleCreatePlanningSession}>
-                  New chat
-                </Button>
+            <div className="border-b border-border px-3 py-2.5">
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <h2 className="text-sm font-medium text-foreground">Planning</h2>
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">
+                    {planningSessions.length} chat{planningSessions.length === 1 ? '' : 's'}
+                    {planningReadyCount > 0 ? ` · ${planningReadyCount} ready` : ''}
+                  </p>
+                </div>
                 <button
                   type="button"
                   data-testid="planning-session-rail-toggle"
@@ -4471,6 +4560,20 @@ export function App() {
                 >
                   ‹
                 </button>
+              </div>
+              <div className="mt-2 grid grid-cols-2 gap-2">
+                <Button variant="outline" size="sm" onClick={handleCreatePlanningSession} className="px-2 text-[11px]">
+                  New chat
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleClearSubmittedPlanningSessions}
+                  disabled={activePlanningReadOnly || !hasSubmittedPlanningSessions}
+                  className="px-2 text-[11px]"
+                >
+                  Clear submitted
+                </Button>
               </div>
             </div>
             <div className={RAIL_LIST_FRAME_CLASS}>{renderPlanningSessionList()}</div>

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -224,6 +224,8 @@ export function createMockInvoker(
     })),
     planningChatDiscardDraft: vi.fn(async () => ({ ok: true })),
     planningChatReset: vi.fn(async () => ({ ok: true })),
+    planningChatDelete: vi.fn(async () => ({ ok: true })),
+    planningChatDeleteSubmitted: vi.fn(async () => ({ ok: true, deletedSessionIds: [] })),
     onPlanningChatStream: vi.fn((cb: (event: InAppPlanningStreamEvent) => void) => {
       planningChatStreamCallbacks.add(cb);
       return () => { planningChatStreamCallbacks.delete(cb); };

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -29,10 +29,15 @@ describe('Invoker terminal (component)', () => {
     mock.cleanup();
   });
 
-  async function openPlanningTerminal() {
+  async function openPlanningRail() {
     fireEvent.click(await screen.findByTestId('sidebar-home'));
     const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
     if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+    await screen.findByTestId('planning-session-list');
+  }
+
+  async function openPlanningTerminal() {
+    await openPlanningRail();
     fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
@@ -271,8 +276,7 @@ describe('Invoker terminal (component)', () => {
     const secondPanel = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(secondPanel).toHaveTextContent('Drafting your plan…');
 
-    const sessionButtons = within(screen.getByTestId('planning-session-list')).getAllByRole('button');
-    fireEvent.click(sessionButtons[1]);
+    fireEvent.click(screen.getByText('first session request').closest('button')!);
 
     const firstPanel = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(firstPanel).toHaveTextContent('Drafting your plan…');
@@ -668,6 +672,178 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('2 chats'));
     expect(within(screen.getByTestId('sidebar-home')).queryByText('0')).not.toBeInTheDocument();
     expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('2 chats');
+  });
+
+  it('clicking a planning chat trash button removes that row and calls planningChatDelete', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'keep-chat',
+          title: 'Keep this planning chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+        makePlanningSessionSummary({
+          id: 'delete-chat',
+          title: 'Delete this planning chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningRail();
+    await screen.findByText('Delete this planning chat');
+
+    const rail = screen.getByTestId('planning-session-list');
+    fireEvent.click(within(rail).getAllByRole('button', { name: 'Delete planning chat' })[1]);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Delete this planning chat')).not.toBeInTheDocument();
+    });
+    expect(within(rail).getByText('Keep this planning chat')).toBeInTheDocument();
+    expect(mock.api.planningChatDelete).toHaveBeenCalledWith({ sessionId: 'delete-chat' });
+  });
+
+  it('deleting a local planning chat removes the row without calling planningChatDelete', async () => {
+    render(<App />);
+    await openPlanningRail();
+
+    fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('2 chats');
+    });
+
+    const rail = screen.getByTestId('planning-session-list');
+    fireEvent.click(within(rail).getAllByRole('button', { name: 'Delete planning chat' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('1 chat');
+    });
+    expect(mock.api.planningChatDelete).not.toHaveBeenCalled();
+  });
+
+  it('disables Clear submitted without submitted chats and clears submitted chats after confirmation', async () => {
+    const firstRender = render(<App />);
+    await openPlanningRail();
+
+    expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
+    firstRender.unmount();
+
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'idle-chat',
+          title: 'Idle planning chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+        makePlanningSessionSummary({
+          id: 'submitted-a',
+          title: 'Submitted planning chat A',
+          status: 'submitted',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+        makePlanningSessionSummary({
+          id: 'submitted-b',
+          title: 'Submitted planning chat B',
+          status: 'submitted',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+      ],
+    }));
+    vi.mocked(mock.api.planningChatDeleteSubmitted).mockClear();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    try {
+      render(<App />);
+      await openPlanningRail();
+      await screen.findByText('Submitted planning chat A');
+
+      const clearSubmittedButton = screen.getByRole('button', { name: 'Clear submitted' });
+      expect(clearSubmittedButton).toBeEnabled();
+      fireEvent.click(clearSubmittedButton);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Submitted planning chat A')).not.toBeInTheDocument();
+        expect(screen.queryByText('Submitted planning chat B')).not.toBeInTheDocument();
+      });
+      expect(within(screen.getByTestId('planning-session-list')).getByText('Idle planning chat')).toBeInTheDocument();
+      expect(mock.api.planningChatDeleteSubmitted).toHaveBeenCalledTimes(1);
+      expect(confirmSpy).toHaveBeenCalledWith('Clear all submitted planning chats? This cannot be undone.');
+    } finally {
+      confirmSpy.mockRestore();
+    }
+  });
+
+  it('deleting the last planning chat recreates a fresh empty chat', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'only-chat',
+          title: 'Only saved planning chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningRail();
+    await screen.findAllByText('Only saved planning chat');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete planning chat' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Only saved planning chat')).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('1 chat');
+    expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
+    expect(screen.getByText('What do you want to build?')).toBeInTheDocument();
+    expect(screen.getByTestId('invoker-terminal-input')).toBeEnabled();
+  });
+
+  it('hides planning chat trash buttons and disables Clear submitted in read-only mode', async () => {
+    mock.cleanup();
+    mock = createMockInvoker();
+    mock.setRuntimeStatus({ ownerMode: false, readOnly: true, mode: 'read-only' });
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'readonly-idle-chat',
+          title: 'Read-only idle planning chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+        makePlanningSessionSummary({
+          id: 'readonly-submitted-chat',
+          title: 'Read-only submitted planning chat',
+          status: 'submitted',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+        }),
+      ],
+    }));
+    mock.install();
+
+    render(<App />);
+    await openPlanningRail();
+    await screen.findByText('Read-only submitted planning chat');
+
+    const rail = screen.getByTestId('planning-session-list');
+    expect(within(rail).queryByRole('button', { name: 'Delete planning chat' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
   });
 
   it('continues the same planning session', async () => {


### PR DESCRIPTION
## Summary

Adds Planning Terminal rail controls for individual chat disposal and bulk clearing on the existing rail.

## Workflow Summary

Delete planning terminals — UI — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784313643126-2/ui-delete-planning-chat | Add per-row trash button (instant) + header Clear submitted button (confirm) to the Planning Terminal rail with reselection, empty-recreate, read-only gating, and stream cleanup | completed |
| wf-1784313643126-2/verify-ui-planning-terminal | Verify Planning Terminal rail delete + clear-submitted UI | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784313643126-2/ui-delete-planning-chat — Add per-row trash button (instant) + header Clear submitted button (confirm) to the Planning Terminal rail with reselection, empty-recreate, read-only gating, and stream cleanup

### wf-1784313643126-2/verify-ui-planning-terminal — Verify Planning Terminal rail delete + clear-submitted UI

</details>

## Review Claim

The Planning Terminal rail now offers per-chat trash controls and a bulk clearing action on the existing rail surface.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The slice stays in the Planning Terminal rail and focused renderer tests; backend bridges are invoked only through existing optional IPC methods.

## Slice Rationale

The rail controls, selection fallback, empty-session fallback, and stream-state reset stay together because reviewers can check one visible chat-management path.

## Non-goals

No backend storage changes.

No workflow graph changes.

No planning preset changes.

## Architecture

### Before

```mermaid
graph TD
    A["Planning session rail renders chat rows"]
    B["Rows only select active chat"]
    C["Submitted chats remain until backend refresh"]
    A --> B
    A --> C
```

### After

```mermaid
graph TD
    A["Planning session rail renders chat rows"]
    B["Rows select active chat"]
    C["Trash buttons prune individual chats"]
    D["Clear submitted prunes submitted chats after confirm"]
    E["Selection and stream state move to a remaining or fresh chat"]
    A --> B
    A --> C
    A --> D
    C --> E
    D --> E
```

## Visual Proof

Planning Terminal rail shows the new per-chat trash buttons and enabled Clear submitted action for submitted chats.

![Planning Terminal rail delete controls](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-76cd31/planning-terminal-delete-controls-25e4f1b26.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- --run src/__tests__/invoker-terminal.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 55760dc2f28f6cfc395a6e7c9890c71b1c20d512`
- Post-revert steps: None
- Data migration? No

</details>
