### PR TITLE
[Workflow Base Branch](2) Show base branch in merge gate UI

### DIFF
--- a/packages/app/e2e/pending-review-gate-target-repo.proof.spec.ts
+++ b/packages/app/e2e/pending-review-gate-target-repo.proof.spec.ts
@@ -40,8 +40,8 @@ test('pending review gate target repo row', async ({ page }) => {
   await mergeGateNode.click();
 
   await expect(page.getByTestId('workflow-inspector-title')).toBeVisible();
-  await expect(page.getByText('Target Branch')).toBeVisible();
-  await expect(page.getByTestId('target-branch-input')).toHaveValue('master');
+  await expect(page.getByText('Base Branch')).toBeVisible();
+  await expect(page.getByTestId('base-branch-display')).toHaveText('master');
   await expect(page.getByText('PR target repo')).toBeVisible();
   await expect(page.getByText('github.com/Neko-Catpital-Labs/Invoker')).toBeVisible();
 

--- a/packages/ui/src/__tests__/merge-branch.test.tsx
+++ b/packages/ui/src/__tests__/merge-branch.test.tsx
@@ -1,8 +1,8 @@
 /**
- * Component test: Merge gate branch selector in TaskPanel.
+ * Component test: Merge gate branch display in the inspector.
  *
  * Demoted from packages/app/e2e/merge-branch.spec.ts.
- * Tests clicking merge node shows Target Branch input, branch label, and blur persistence.
+ * Tests clicking a merge node shows the pinned base branch clearly.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -50,7 +50,7 @@ describe('workflow advanced metadata (component)', () => {
     mock.cleanup();
   });
 
-  it('shows base branch inside advanced metadata section', async () => {
+  it('shows the pinned base branch in the merge settings section', async () => {
     render(<App />);
     fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([taskA, mergeNode], workflows));
@@ -60,10 +60,14 @@ describe('workflow advanced metadata (component)', () => {
     });
 
     fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
-    fireEvent.click(screen.getByText(/Advanced metadata/i));
+    await waitFor(() => {
+      expect(screen.getByTestId('rf__node-__merge__wf-1')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('rf__node-__merge__wf-1'));
 
     await waitFor(() => {
-      expect(screen.getByText(/base branch: master/i)).toBeInTheDocument();
+      expect(screen.getByText('Base Branch')).toBeInTheDocument();
+      expect(screen.getByTestId('base-branch-display')).toHaveTextContent('master');
     });
   });
 });

--- a/packages/ui/src/__tests__/merge-gate-node.test.tsx
+++ b/packages/ui/src/__tests__/merge-gate-node.test.tsx
@@ -28,7 +28,7 @@ describe('MergeGateNode', () => {
     expect(screen.getByTestId('merge-gate-primary-label')).toHaveTextContent('Review');
   });
 
-  it('does not render branch, merge mode, or summary rows in DAG node', () => {
+  it('renders the base branch badge when DAG data includes it', () => {
     renderNode({
       status: 'awaiting_approval',
       label: 'Plan',
@@ -39,9 +39,7 @@ describe('MergeGateNode', () => {
       featureBranch: 'feature/x',
     });
 
-    expect(screen.queryByTestId('merge-branch-display')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('merge-branch-label')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('merge-mode-display')).not.toBeInTheDocument();
+    expect(screen.getByTestId('merge-gate-base-branch')).toHaveTextContent('base master');
     expect(screen.queryByTestId('merge-summary-preview')).not.toBeInTheDocument();
   });
 

--- a/packages/ui/src/components/MergeGateNode.tsx
+++ b/packages/ui/src/components/MergeGateNode.tsx
@@ -18,11 +18,11 @@ interface MergeGateNodeData {
   label: string;
   gateKind: MergeGateKind;
   mergeMode?: 'manual' | 'automatic' | 'external_review';
+  baseBranch?: string;
   /** Set when merge gate was fixed with Claude — first approve clears this (orchestrator). */
   pendingFixError?: string;
   dimmed?: boolean;
   selected?: boolean;
-  [key: string]: unknown;
 }
 
 interface MergeGateNodeProps {
@@ -42,6 +42,7 @@ export function MergeGateNode({ data }: MergeGateNodeProps) {
     label,
     gateKind,
     mergeMode = 'manual',
+    baseBranch,
     pendingFixError,
     dimmed: dataDimmed,
     selected: dataSelected,
@@ -103,6 +104,14 @@ export function MergeGateNode({ data }: MergeGateNodeProps) {
         />
         <span className={`text-[8px] tracking-wide ${colors.text}`}>{statusLabel}</span>
       </div>
+      {baseBranch ? (
+        <div
+          data-testid="merge-gate-base-branch"
+          className="mt-1 pl-2 font-mono text-[8px] tracking-wide text-muted-foreground"
+        >
+          base {baseBranch}
+        </div>
+      ) : null}
 
       <Handle
         type="source"

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -262,7 +262,6 @@ export function TaskPanel({
   onEditType,
   onEditAgent,
   onSetExternalGatePolicies,
-  onSetMergeBranch,
   mergeMode,
   onSetMergeMode,
   showApprovalActions = true,
@@ -271,7 +270,6 @@ export function TaskPanel({
   const [editCommandValue, setEditCommandValue] = useState('');
   const [isEditingPrompt, setIsEditingPrompt] = useState(false);
   const [editPromptValue, setEditPromptValue] = useState('');
-  const [branchValue, setBranchValue] = useState(baseBranch ?? '');
   const [showAdvanced, setShowAdvanced] = useState(true);
   const [isEditingGatePolicies, setIsEditingGatePolicies] = useState(false);
   const [isSavingGatePolicies, setIsSavingGatePolicies] = useState(false);
@@ -284,7 +282,6 @@ export function TaskPanel({
     setEditCommandValue(task?.config.command ?? '');
     setIsEditingPrompt(false);
     setEditPromptValue(task?.config.prompt ?? '');
-    setBranchValue(baseBranch ?? '');
     setIsEditingGatePolicies(false);
     setIsSavingGatePolicies(false);
     setIsSatisfiedListExpanded(false);
@@ -443,30 +440,16 @@ export function TaskPanel({
       </div>
 
 
-      {/* Target branch (merge gates only) */}
-      {task.config.isMergeNode && onSetMergeBranch && task.config.workflowId && (
-        <div className="flex items-center justify-between">
-          <span className="text-sm text-muted-foreground">Target Branch</span>
-          <input
-            data-testid="target-branch-input"
-            value={branchValue}
-            onChange={(e) => setBranchValue(e.target.value)}
-            onBlur={() => {
-              const trimmed = branchValue.trim();
-              if (trimmed && trimmed !== baseBranch) {
-                onSetMergeBranch(task.config.workflowId!, trimmed);
-              }
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                (e.target as HTMLInputElement).blur();
-              }
-              if (e.key === 'Escape') {
-                setBranchValue(baseBranch ?? '');
-              }
-            }}
-            className="bg-muted text-foreground text-xs font-mono rounded px-2 py-1 border border-border-strong focus:outline-none focus:border-border-strong w-28 text-right"
-          />
+      {/* Base branch (merge gates only) */}
+      {task.config.isMergeNode && (
+        <div className="flex items-start justify-between gap-3">
+          <span className="text-sm text-muted-foreground">Base Branch</span>
+          <div className="text-right">
+            <div data-testid="base-branch-display" className="font-mono text-xs text-foreground">
+              {baseBranch ?? 'n/a'}
+            </div>
+            <div className="text-[11px] text-muted-foreground">Task branches start from here.</div>
+          </div>
         </div>
       )}
 

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -311,7 +311,6 @@ export function WorkflowInspector({
   onReject,
   onRestartTask,
   onRecreateTask,
-  onSetMergeBranch,
   onSetMergeMode,
   onToggleCollapsed,
   onToggleAdvanced,
@@ -320,7 +319,6 @@ export function WorkflowInspector({
   const [editPromptValue, setEditPromptValue] = useState('');
   const [isEditingCommand, setIsEditingCommand] = useState(false);
   const [editCommandValue, setEditCommandValue] = useState('');
-  const [branchValue, setBranchValue] = useState('');
   const [taskLogEvents, setTaskLogEvents] = useState<TaskAuditEvent[]>([]);
   const [taskLogError, setTaskLogError] = useState<string | null>(null);
   const [showLogs, setShowLogs] = useState(true);
@@ -332,10 +330,6 @@ export function WorkflowInspector({
     setIsEditingCommand(false);
     setEditCommandValue(task?.config.command ?? '');
   }, [task?.id, task?.config.prompt, task?.config.command]);
-
-  useEffect(() => {
-    setBranchValue(workflow?.baseBranch ?? task?.config.featureBranch ?? '');
-  }, [workflow?.baseBranch, task?.config.featureBranch, task?.id]);
 
   useEffect(() => {
     if (!task) {
@@ -484,12 +478,6 @@ export function WorkflowInspector({
     }
   };
 
-  const saveBranch = () => {
-    const trimmed = branchValue.trim();
-    if (workflow?.id && trimmed && trimmed !== (workflow.baseBranch ?? '')) {
-      void onSetMergeBranch?.(workflow.id, trimmed);
-    }
-  };
 
   if (collapsed) {
     return (
@@ -761,27 +749,30 @@ export function WorkflowInspector({
           </section>
         )}
 
-        {isMergeNode && (onSetMergeBranch || onSetMergeMode) && (
+        {isMergeNode && (
           <section className="rounded border border-border bg-secondary/70 p-3 space-y-3">
-            {onSetMergeBranch && (
-              <label className="flex items-center justify-between gap-3">
-                <span className="text-xs uppercase tracking-wide text-muted-foreground">Target Branch</span>
-                <input
-                  data-testid="target-branch-input"
-                  value={branchValue}
-                  onChange={(event) => setBranchValue(event.target.value)}
-                  onBlur={saveBranch}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Enter') {
-                      (event.target as HTMLInputElement).blur();
-                    }
-                    if (event.key === 'Escape') {
-                      setBranchValue(workflow?.baseBranch ?? '');
-                    }
-                  }}
-                  className="min-w-0 max-w-[190px] rounded border border-border-strong bg-muted px-2 py-1 text-right font-mono text-xs text-foreground focus:border-border-strong focus:outline-none"
-                />
-              </label>
+            <div className="flex items-start justify-between gap-3">
+              <span className="text-xs uppercase tracking-wide text-muted-foreground">Base Branch</span>
+              <div className="max-w-[210px] text-right">
+                <div
+                  data-testid="base-branch-display"
+                  className="font-mono text-xs text-foreground"
+                >
+                  {workflow?.baseBranch ?? 'n/a'}
+                </div>
+                <div className="text-[11px] text-muted-foreground">Task branches start from here.</div>
+              </div>
+            </div>
+            {(workflow?.featureBranch ?? task?.config.featureBranch) && (
+              <div className="flex items-start justify-between gap-3">
+                <span className="text-xs uppercase tracking-wide text-muted-foreground">Feature Branch</span>
+                <span
+                  data-testid="feature-branch-display"
+                  className="max-w-[210px] break-all text-right font-mono text-xs text-foreground"
+                >
+                  {workflow?.featureBranch ?? task?.config.featureBranch}
+                </span>
+              </div>
             )}
             {onSetMergeMode && workflow?.id && (
               <label className="flex items-center justify-between gap-3">
@@ -1001,7 +992,7 @@ export function WorkflowInspector({
             <div className="border-t border-border px-3 py-2 space-y-1 text-xs text-muted-foreground">
               <div>workflow id: {workflow?.id ?? 'n/a'}</div>
               <div>task id: {task?.id ?? 'n/a'}</div>
-              <div>target branch: {workflow?.featureBranch ?? task?.config.featureBranch ?? 'n/a'}</div>
+              <div>feature branch: {workflow?.featureBranch ?? task?.config.featureBranch ?? 'n/a'}</div>
               <div>base branch: {workflow?.baseBranch ?? 'n/a'}</div>
               <div>heartbeat: {String(task?.execution.lastHeartbeatAt ?? 'n/a')}</div>
               <div>pool id: {task?.config.poolId ?? 'n/a'}</div>


### PR DESCRIPTION
## Summary

Merge gates now show the workflow base branch directly in the UI.

Before this, the inspector exposed an editable `Target Branch` input. That made the real rebase start point look like a normal branch choice.

This slice makes the base read-only, adds the derived feature branch, and labels merge-gate cards with their base branch.

## Review Claim

The merge-gate inspector and DAG now show the workflow base branch clearly enough for a user to see where recreate starts.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice is read-only UI exposure on top of the persisted workflow value from the previous slice. It does not change how workflow state is stored or migrated.

## Slice Rationale

Users need to see the rebase start point, but that explanation is a separate surface change from the persistence policy that fixes the wrong-base launch.

## Non-goals

- Changing how workflow base branches are chosen.
- Changing merge mode behavior.
- Updating docs or changelog copy.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm exec vitest run src/__tests__/merge-branch.test.tsx src/__tests__/merge-gate-node.test.tsx`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`
- [x] `bash scripts/ui-visual-proof.sh capture-after --spec pending-review-gate-target-repo.proof.spec.ts --output-dir /tmp/base-branch-ui-proof`

</details>

## Visual Proof

Before — the merge gate called this field `Target Branch` and exposed it as an editable input, so the real rebase start point was easy to misread.

![](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-f8a5e7/base-branch-before-target-branch.png)

After — the merge gate shows a read-only `Base Branch`, adds the derived `Feature Branch`, and explains that task branches start from the base shown here.

![](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-f8a5e7/base-branch-after-inspector.png)

Walkthrough video — same merge gate before and after.

Before: [base-branch-before-walkthrough.webm](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-f8a5e7/base-branch-before-walkthrough.webm)

After: [base-branch-after-walkthrough.webm](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-f8a5e7/base-branch-after-walkthrough.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert a07f7d82826e023dbf278717b56348a798933005`
- Post-revert steps: None.
- Data migration? No.

</details>
