### PR TITLE
[Workflow Base Branch](3) Document master-pinned workflow base branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ All notable changes to Invoker will be documented in this file.
 - Stop manual Fix with Agent from starting when a failed task has no saved workspace. It now fails fast with a recreate-this-task message instead of entering a broken fix session.
 - Make the standalone Slack manager follow `~/.invoker/config.json` for its default harness preset before it falls back to `INVOKER_SLACK_DEFAULT_PRESET`. A stale owner-env preset could silently shadow the documented `defaultSlackHarnessPreset`, so `@Invoker` threads on remote hosts could still launch OMP after the UI and CLI had been switched to Codex. The manager now treats `config.json` as the source of truth, keeping `.slack-owner.env` for credentials and env-only fallback. Guarded by a dedicated slack-manager runtime-config regression test.
 
+
+- Pin every workflow base branch to `master`, including recreated/rebased runs and persisted workflows loaded at startup. The old UI labeled `workflow.baseBranch` as `Target Branch`, which made it easy to miss that a workflow was rebasing onto `main`, `release`, or a stale prereq branch. Plans/metadata writes now normalize to `master`, startup rewrites older persisted workflows to `master`, the inspector now shows a read-only `Base Branch` row plus `Feature Branch`, and merge-gate DAG nodes show their base branch inline.
 ## 0.0.7
 
 - Ship Slack as a separate npm-released SEA binary (`@neko-catpital-labs/invoker-slack` / `invoker-slack`), built and archived like the CLI, published from the release workflow, and always included in `scripts/local-macos-release-build.sh` maintainer cuts. The desktop app no longer embeds Slack; GUI relaunch from the manager resolves `INVOKER_GUI_COMMAND`, `invoker-ui`, macOS `open -a Invoker`, then the monorepo xvfb path.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -242,7 +242,7 @@ description: |
   Demonstrates a small AI implementation workflow with parallel code paths,
   an SSH-backed verification task, and a pull request review gate.
 repoUrl: git@github.com:your-org/your-repo.git
-baseBranch: main
+baseBranch: master
 onFinish: pull_request
 mergeMode: external_review
 tasks:
@@ -304,7 +304,7 @@ Package boundaries and runtime invariants live in [ARCHITECTURE.md](../ARCHITECT
 
 ## Core concepts
 
-- **Plan** — YAML: tasks, `dependencies`, defaults like `baseBranch`.
+- **Plan** — YAML: tasks, `dependencies`, and workflow defaults. `baseBranch` is pinned to `master` today.
 - **Workflow** — Persisted instance; generation and DB are source of truth.
 - **Task / attempt** — DAG node plus immutable execution records; **selected attempt** drives downstream validity and staleness.
 - **Executors** — `worktree`, `docker`, `ssh` (isolated workspaces).

--- a/docs/invoker-medium-article.md
+++ b/docs/invoker-medium-article.md
@@ -210,7 +210,7 @@ That is another consistent theme: if a claim about the system matters, there sho
 
 These are the words that keep showing up once you read the code. The definitions below are intentionally plain-language, but they track the runtime types in `packages/workflow-graph/src/types.ts`.
 
-- **Plan**: A YAML document describing a workflow: a name, defaults like `baseBranch` / `featureBranch`, and a list of tasks with ids, descriptions, and dependency edges. Plans are parsed into a `PlanDefinition` with validation on required fields.
+- **Plan**: A YAML document describing a workflow: a name, workflow defaults like `featureBranch`, a pinned `baseBranch: master`, and a list of tasks with ids, descriptions, and dependency edges. Plans are parsed into a `PlanDefinition` with validation on required fields.
 - **Workflow**: The persisted instance created from a plan. It has durable identity, stored tasks, and workflow-level fields (including a generation counter used to salt branch naming and invalidate stale work).
 - **Task (node)**: One unit of work in the DAG: a human-readable description, dependency ids, a `TaskConfig` (what to run and how), and `TaskExecution` (runtime fields like branch/commit/workspace metadata).
 - **Task status**: The workflow-visible lifecycle label (`pending`, `running`, `failed`, `needs_input`, `review_ready`, `awaiting_approval`, `stale`, and others).
@@ -236,7 +236,7 @@ You write a small DAG: task `deps` installs or updates dependencies, task `tests
 
 ```yaml
 name: ci-hardening
-baseBranch: main
+baseBranch: master
 tasks:
   - id: deps
     description: Refresh lockfile and install dependencies

--- a/docs/tutorial-first-agent-workflow.md
+++ b/docs/tutorial-first-agent-workflow.md
@@ -134,7 +134,7 @@ The generated YAML is intentionally small:
 ```yaml
 name: First agent workflow (codex)
 repoUrl: /tmp/invoker-first-agent-workflow
-baseBranch: HEAD
+baseBranch: master
 onFinish: none
 mergeMode: manual
 tasks:
@@ -155,7 +155,7 @@ tasks:
 To adapt it:
 
 - Change `repoUrl` to your repo URL or local repo path.
-- Change `baseBranch` to your target branch, such as `main`.
+- Leave `baseBranch: master`. Invoker pins workflow base branches to `master` today.
 - Replace the prompt with the concrete change you want.
 - Replace `npm test` with your real verification command.
 - Use `executionAgent: codex` or `executionAgent: claude`, depending on the agent you want.


### PR DESCRIPTION
## Summary

The workflow docs now say that Invoker pins workflow base branches to `master`.

Without this, the examples and help text still described older branch wording.

This slice updates the existing guides after the code stack lands.

## Review Claim

The user-facing docs and examples now describe the master-pinned workflow base branch correctly.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Docs only. No product code, tests, or build output changes.

## Slice Rationale

Repo policy keeps docs separate from product diffs. This follow-up makes the documentation easy to review on its own.

## Non-goals

- Changing workflow code.
- Changing merge-gate copy in product surfaces.
- Adding new guide sections beyond the existing base-branch references.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] No automated tests run. Docs-only slice.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 95e3b91ef2aa782cc4d2ede098591cd8944a6287`
- Post-revert steps: None.
- Data migration? No.

</details>
