### PR TITLE
[Planning Terminal Tmux Blank Repro](2) Publish missing-main reviews on master

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -4222,6 +4222,110 @@ console.log(JSON.stringify(out));
       );
     });
 
+    it('publishes Invoker review stacks against master when saved baseBranch=main is missing', async () => {
+      const mergeTask = makeTask({
+        id: '__merge__wf-1',
+        status: 'running',
+        dependencies: ['t1'],
+        config: { isMergeNode: true, workflowId: 'wf-1' },
+      });
+      const allTasks = [
+        makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),
+        mergeTask,
+      ];
+      const orchestrator = {
+        getTask: (id: string) => allTasks.find(t => t.id === id),
+        getAllTasks: () => allTasks,
+        handleWorkerResponse: vi.fn(() => []),
+        setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
+      };
+      const persistence = {
+        loadWorkflow: () => ({
+          id: 'wf-1',
+          onFinish: 'none',
+          mergeMode: 'external_review',
+          baseBranch: 'main',
+          featureBranch: 'plan/empty',
+          name: 'Empty Invoker Workflow',
+          repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+        }),
+        updateTask: vi.fn(),
+      };
+      const mergeGateProvider = {
+        createReview: vi.fn(),
+      };
+      const onComplete = vi.fn();
+      const executor = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+        callbacks: { onComplete },
+        mergeGateProvider: mergeGateProvider as any,
+      });
+
+      const gitCalls: string[][] = [];
+      (executor as any).execGitReadonly = async () => '';
+      (executor as any).execGitIn = async (args: string[], _dir: string) => {
+        gitCalls.push([...args]);
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'base-sha';
+        if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2] === 'refs/remotes/origin/master^{commit}') {
+          return 'origin-master-sha';
+        }
+        if (args[0] === 'diff' && args[1] === '--name-only') return 'packages/app/src/reviewable.ts\n';
+        return '';
+      };
+      (executor as any).createMergeWorktree = vi.fn().mockResolvedValue('/tmp/mock-wt');
+      (executor as any).removeMergeWorktree = vi.fn();
+      (executor as any).publishReviewStackWithMakePrSkill = vi.fn().mockResolvedValue({
+        artifacts: [{
+          id: 'pr-1',
+          title: 'Empty Invoker Workflow',
+          url: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/123',
+          providerId: '123',
+          provider: 'github',
+          branch: 'plan/empty',
+          baseBranch: 'master',
+          required: true,
+          status: 'open',
+        }],
+        sessionId: 'sess-make-pr',
+        agentName: 'codex',
+      });
+      (executor as any).authorPrBodyWithSkill = vi.fn();
+
+      await (executor as any).executeMergeNode(mergeTask);
+
+      expect(gitCalls).toContainEqual(['diff', '--name-only', 'refs/remotes/origin/master...plan/empty', '--']);
+      expect((executor as any).publishReviewStackWithMakePrSkill).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseBranch: 'master',
+          featureBranch: 'plan/empty',
+        }),
+      );
+      expect(mergeGateProvider.createReview).not.toHaveBeenCalled();
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith(
+        '__merge__wf-1',
+        expect.objectContaining({
+          execution: expect.objectContaining({
+            reviewGate: expect.objectContaining({
+              artifacts: [
+                expect.objectContaining({
+                  baseBranch: 'master',
+                  branch: 'plan/empty',
+                }),
+              ],
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          generation: 0,
+        }),
+      );
+    });
+
     it('executeMergeNode anchors external_review gate worktrees on the origin-backed base branch', async () => {
       const allTasks = [
         makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -263,14 +263,28 @@ async function listReviewableChangedFiles(
   dir: string,
   baseBranch: string,
   featureBranch: string,
-): Promise<string[]> {
+): Promise<{ changedFiles: string[]; baseBranch: string }> {
   const normalizedBase = normalizeBranchForGithubCli(baseBranch);
-  let diffBaseRef = baseBranch;
-  for (const candidate of [
+  const alternateDefaultBranch = normalizedBase === 'main'
+    ? 'master'
+    : normalizedBase === 'master'
+      ? 'main'
+      : undefined;
+  const candidates = Array.from(new Set([
     `refs/remotes/origin/${normalizedBase}`,
     `origin/${normalizedBase}`,
     baseBranch,
-  ]) {
+    ...(alternateDefaultBranch
+      ? [
+          `refs/remotes/origin/${alternateDefaultBranch}`,
+          `origin/${alternateDefaultBranch}`,
+          alternateDefaultBranch,
+        ]
+      : []),
+  ]));
+  let diffBaseRef = baseBranch;
+  let resolvedBase = false;
+  for (const candidate of candidates) {
     try {
       const resolved = (await execGitInMergeSafe(
         host,
@@ -279,21 +293,31 @@ async function listReviewableChangedFiles(
       )).trim();
       if (resolved) {
         diffBaseRef = candidate;
+        resolvedBase = true;
         break;
       }
     } catch {
       // Try the next base spelling.
     }
   }
+  if (!resolvedBase) {
+    throw new Error(
+      `Unable to resolve review diff base "${baseBranch}" in merge gate workspace. ` +
+      `Tried: ${candidates.join(', ')}`,
+    );
+  }
   const out = await execGitInMergeSafe(
     host,
     ['diff', '--name-only', `${diffBaseRef}...${featureBranch}`, '--'],
     dir,
   );
-  return out
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean);
+  return {
+    changedFiles: out
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean),
+    baseBranch: normalizeBranchForGithubCli(diffBaseRef),
+  };
 }
 
 // ── Host interface ───────────────────────────────────────
@@ -886,22 +910,25 @@ export async function runMergeGateActionImpl(
         });
         await syncGateWorkspaceToFeatureBranch(host, gateWorkspacePath, featureBranch);
 
+        let reviewBaseBranch = baseBranch;
         if (isInvokerRepoUrl(workflow?.repoUrl)) {
-          const changedFiles = await listReviewableChangedFiles(
+          const reviewableChanges = await listReviewableChangedFiles(
             host,
             gateWorkspacePath!,
             baseBranch,
             featureBranch,
           );
+          reviewBaseBranch = reviewableChanges.baseBranch;
+          const changedFiles = reviewableChanges.changedFiles;
           if (changedFiles.length === 0) {
             logTaskProgress(host, task.id, 'info', 'Skipping review stack publication for empty Invoker branch', {
-              baseBranch,
+              baseBranch: reviewBaseBranch,
               featureBranch,
             });
             mergeTrace('GATE_WS_PATH_REVIEW_PUBLISH_NOOP', {
               taskId: task.id,
               gateWorkspacePath: gateWorkspacePath ?? null,
-              baseBranch,
+              baseBranch: reviewBaseBranch,
               featureBranch,
               onFinish,
               mergeMode,
@@ -934,7 +961,7 @@ export async function runMergeGateActionImpl(
         let fullSummary = summary;
         if (visualProof && host.runVisualProofCapture) {
           const slug = (featureBranch ?? 'workflow').replace(/\//g, '-');
-          const vpMarkdown = await host.runVisualProofCapture(baseBranch, featureBranch!, slug, workflow?.repoUrl);
+          const vpMarkdown = await host.runVisualProofCapture(reviewBaseBranch, featureBranch!, slug, workflow?.repoUrl);
           if (vpMarkdown) {
             fullSummary = (summary ?? '') + '\n\n' + vpMarkdown;
           }
@@ -944,7 +971,7 @@ export async function runMergeGateActionImpl(
           workflowId,
           mergeNodeTaskId: task.id,
           workflowName: workflow?.name ?? 'Workflow',
-          baseBranch,
+          baseBranch: reviewBaseBranch,
           featureBranch,
           workflowSummary: fullSummary ?? '',
           cwd: gateWorkspacePath!,


### PR DESCRIPTION
## Summary

This makes Invoker review publication resolve a missing saved `main` base to the repository's live `master` trunk.

Review gates now diff and publish against the resolved base, including visual proof capture and make-pr handoff.

## Review Claim

Merge-gate review publication uses `master` when an Invoker workflow saved `baseBranch: main` but the repository only has `master`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change only affects Invoker review publication after the requested base cannot be resolved; normal resolved bases keep their current path.

## Slice Rationale

This stays separate from the tmux repro so the review-base fallback can be checked as merge-gate routing behavior.

## Non-goals

- No default branch rename.
- No Mergify stack publication policy change.
- No terminal UI behavior change.

## Architecture

### Before

```mermaid
graph TD
    A["Workflow saved baseBranch: main"] --> B["Review diff tries origin/main"]
    B --> C["Missing base stops publication"]
```

### After

```mermaid
graph TD
    A["Workflow saved baseBranch: main"] --> B["Review diff tries origin/main"]
    B --> C["Fallback tries origin/master"]
    C --> D["make-pr receives resolved baseBranch: master"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/task-runner.test.ts -t "publishes Invoker review stacks against master when saved baseBranch=main is missing"`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-bodies/planning-terminal-tmux-blank-repro-2.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>
