### PR TITLE
[Continue babysit worker landing loop](1) Treat merged targets as terminal

### DIFF
--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -72,6 +72,9 @@ def is_queue_only_required_check(name: str) -> bool:
 
 def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) -> tuple[Blocker, ...]:
     blockers: list[Blocker] = []
+    if pr.state == "MERGED":
+        blockers.append(Blocker("merged", "merged", pr.number, "state=MERGED"))
+        return tuple(blockers)
     if pr.state != "OPEN":
         blockers.append(Blocker("closed", "closed", pr.number, f"state={pr.state}"))
         return tuple(blockers)
@@ -552,7 +555,9 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
     if any(blocker.kind == "merge_hold" for blocker in facts.all_blockers):
         return None
     if not facts.bottom:
-        first = facts.stack.prs[0]
+        first = next((pr for pr in facts.stack.prs if pr.state == "OPEN"), None)
+        if first is None:
+            return None
         return Action(
             "comment_blocked",
             first.number,

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -185,8 +185,16 @@ def run_logged(args: Sequence[str], *, cwd: Path | str | None = None, capture: b
             print(exc.stdout, file=sys.stderr, end="" if exc.stdout.endswith("\n") else "\n")
         if exc.stderr:
             print(exc.stderr, file=sys.stderr, end="" if exc.stderr.endswith("\n") else "\n")
+        if is_github_rate_limit_error(exc):
+            raise RuntimeError("GitHub API rate limit exceeded while loading PR snapshots") from exc
         raise
     return completed.stdout or ""
+
+
+def is_github_rate_limit_error(exc: subprocess.CalledProcessError) -> bool:
+    text = "\n".join(str(part or "") for part in (exc.stdout, exc.stderr))
+    lowered = text.lower()
+    return "rate_limit" in text or "rate limit" in lowered
 
 
 def checkout_pr_head(repo: str, pr: PrSnapshot, work_root: Path) -> None:

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -945,6 +945,11 @@ The merge conditions cannot be satisfied due to failing checks
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2999, "state=CLOSED")])
 
+    def test_merged_pr_is_terminal_success_not_blocked(self):
+        stack = StackGroup("s", (pr(6108, state="MERGED", latest=mergify(state="merged")),))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual(actions, ())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -4,9 +4,8 @@ Documentation-by-test for the loader. This layer takes the *raw* shapes GitHub's
 `gh` CLI returns — issue comments, GraphQL PR detail, status-check rollups,
 review threads — and folds them into the typed ``PrSnapshot`` the planner reads.
 
-Each test feeds one realistic raw shape and pins what gets parsed out of it and
-why. The subprocess/`gh`-calling helpers are intentionally not exercised here;
-only the pure parse/transform functions are.
+Most tests feed one realistic raw shape and pin what gets parsed out of it and
+why. Subprocess coverage stays limited to GitHub CLI error classification.
 
 Run:  python3 scripts/test_mergify_admin_requeue_snapshot.py
 """
@@ -14,6 +13,7 @@ Run:  python3 scripts/test_mergify_admin_requeue_snapshot.py
 from __future__ import annotations
 
 import sys
+import subprocess
 import unittest
 from unittest import mock
 from pathlib import Path
@@ -80,6 +80,18 @@ class ParseMergifyQueueEvent(unittest.TestCase):
         self.assertEqual(event.failing_checks, ("build (ubuntu-latest)",))
         self.assertEqual(event.comment_id, "c-9001")
         self.assertEqual(event.queued_at, "2026-07-07T05:00:00Z")
+
+
+class GhCommandFailures(unittest.TestCase):
+    def test_graphql_rate_limit_becomes_controlled_runtime_error(self):
+        error = subprocess.CalledProcessError(
+            1,
+            ["gh", "api", "graphql"],
+            stderr='{"errors":[{"type":"RATE_LIMIT","code":"graphql_rate_limit","message":"API rate limit already exceeded"}]}',
+        )
+        with mock.patch("mergify_admin_requeue_snapshot.subprocess.run", side_effect=error):
+            with self.assertRaisesRegex(RuntimeError, "GitHub API rate limit exceeded"):
+                s.run_logged(["gh", "api", "graphql"])
 
 
 class ParseStackMetadata(unittest.TestCase):


### PR DESCRIPTION
## Summary

Classify an already-merged babysit target as terminal success instead of a pending target to fix.

Keep the no-current-bottom fallback pointed at the lowest open PR when a merged PR is briefly reported as the stack bottom.

## Review Claim

Approve that `mergify_admin_requeue_plan.py` and `mergify_admin_requeue_snapshot.py` stop treating a merged babysit target as unresolved work.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change is local classification logic inside the admin-requeue plan and snapshot scripts. It does not call any GitHub write API and does not touch a real PR.

## Slice Rationale

This is the standalone terminal-classification fix. The matching shell repro for this exact behavior lands as the next PR so the fix reads on its own before the repro is layered on top.

## Non-goals

Does not change repair-during-merge handling (a later slice). Does not change no-current-bottom duplicate-comment suppression (a later slice). No behavior change to unrelated requeue plan branches.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue`
- [x] `python3 -m unittest scripts.test_mergify_admin_requeue_snapshot`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 78a8ccf7`
- Post-revert steps: None
- Data migration? No

</details>
