### PR TITLE
[Continue babysit worker landing loop](2) Reproduce merged target terminal handling

### DIFF
--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -21,6 +21,7 @@ REPROS=(
   scripts/repro/repro-babysit-targeted-scan-light.sh
   scripts/repro/repro-babysit-queue-repair-invalid-stop.sh
   scripts/repro/repro-babysit-no-current-bottom-comment.sh
+  scripts/repro/repro-babysit-merged-pr-terminal.sh
 )
 
 # repro-mergify-stack-dogfood.sh is deliberately excluded: it's an opt-in

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -72,6 +72,9 @@ def is_queue_only_required_check(name: str) -> bool:
 
 def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) -> tuple[Blocker, ...]:
     blockers: list[Blocker] = []
+    if pr.state == "MERGED":
+        blockers.append(Blocker("merged", "merged", pr.number, "state=MERGED"))
+        return tuple(blockers)
     if pr.state != "OPEN":
         blockers.append(Blocker("closed", "closed", pr.number, f"state={pr.state}"))
         return tuple(blockers)
@@ -552,7 +555,9 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
     if any(blocker.kind == "merge_hold" for blocker in facts.all_blockers):
         return None
     if not facts.bottom:
-        first = facts.stack.prs[0]
+        first = next((pr for pr in facts.stack.prs if pr.state == "OPEN"), None)
+        if first is None:
+            return None
         return Action(
             "comment_blocked",
             first.number,

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -185,8 +185,16 @@ def run_logged(args: Sequence[str], *, cwd: Path | str | None = None, capture: b
             print(exc.stdout, file=sys.stderr, end="" if exc.stdout.endswith("\n") else "\n")
         if exc.stderr:
             print(exc.stderr, file=sys.stderr, end="" if exc.stderr.endswith("\n") else "\n")
+        if is_github_rate_limit_error(exc):
+            raise RuntimeError("GitHub API rate limit exceeded while loading PR snapshots") from exc
         raise
     return completed.stdout or ""
+
+
+def is_github_rate_limit_error(exc: subprocess.CalledProcessError) -> bool:
+    text = "\n".join(str(part or "") for part in (exc.stdout, exc.stderr))
+    lowered = text.lower()
+    return "rate_limit" in text or "rate limit" in lowered
 
 
 def checkout_pr_head(repo: str, pr: PrSnapshot, work_root: Path) -> None:

--- a/scripts/repro/repro-babysit-merged-pr-terminal.sh
+++ b/scripts/repro/repro-babysit-merged-pr-terminal.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-merged-pr-terminal.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+mkdir -p "$HOME" "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+CALLS_PATH="$FAKE_GH_STATE_DIR/calls.log"
+LEDGER_PATH="$TMP/ledger.jsonl"
+export STATE_PATH LEDGER_PATH
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = "d01530d99b371fe79180cb9481007243bd808f93"
+state = {
+    "prs": [
+        {
+            "number": 6108,
+            "title": "Merged admin-bypass target",
+            "body": "## Summary\n\nMerged PR repro.\n",
+            "url": "https://github.com/fake/repo/pull/6108",
+            "state": "MERGED",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "stack/6108",
+            "headRefOid": head,
+            "mergeStateStatus": "UNKNOWN",
+            "mergeable": "UNKNOWN",
+            "labels": ["admin-bypass"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS"},
+        }
+    ],
+    "issue_comments": {
+        "6108": [
+            {
+                "id": "m6108",
+                "user": {"login": "mergify"},
+                "updated_at": "2026-07-27T06:05:00Z",
+                "html_url": "https://github.com/fake/repo/pull/6108#m6108",
+                "body": "-*- Mergify Payload -*-\n{\"state\":\"merged\",\"queue_rule_name\":\"admin-bypass\"}\n-*- Mergify Payload End -*-\nMerged at `" + head + "`.",
+            }
+        ]
+    },
+    "job_logs": {},
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+: > "$LEDGER_PATH"
+: > "$CALLS_PATH"
+
+if ! out="$(python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6108 2>&1)"; then
+  fail 'worker failed' "$out"
+fi
+case "$out" in
+  *'BLOCK PR #6108 state=MERGED'*) fail 'worker blocked an already merged PR' "$out" ;;
+esac
+if grep -q '^gh pr comment 6108 ' "$CALLS_PATH"; then
+  fail 'worker commented on an already merged PR' "$(cat "$CALLS_PATH")"
+fi
+if [ -s "$LEDGER_PATH" ]; then
+  fail 'worker recorded a retry/blocker row for an already merged PR' "$(cat "$LEDGER_PATH")"
+fi
+
+echo '[repro] passed'

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -945,6 +945,11 @@ The merge conditions cannot be satisfied due to failing checks
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2999, "state=CLOSED")])
 
+    def test_merged_pr_is_terminal_success_not_blocked(self):
+        stack = StackGroup("s", (pr(6108, state="MERGED", latest=mergify(state="merged")),))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual(actions, ())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -4,9 +4,8 @@ Documentation-by-test for the loader. This layer takes the *raw* shapes GitHub's
 `gh` CLI returns — issue comments, GraphQL PR detail, status-check rollups,
 review threads — and folds them into the typed ``PrSnapshot`` the planner reads.
 
-Each test feeds one realistic raw shape and pins what gets parsed out of it and
-why. The subprocess/`gh`-calling helpers are intentionally not exercised here;
-only the pure parse/transform functions are.
+Most tests feed one realistic raw shape and pin what gets parsed out of it and
+why. Subprocess coverage stays limited to GitHub CLI error classification.
 
 Run:  python3 scripts/test_mergify_admin_requeue_snapshot.py
 """
@@ -14,6 +13,7 @@ Run:  python3 scripts/test_mergify_admin_requeue_snapshot.py
 from __future__ import annotations
 
 import sys
+import subprocess
 import unittest
 from unittest import mock
 from pathlib import Path
@@ -80,6 +80,18 @@ class ParseMergifyQueueEvent(unittest.TestCase):
         self.assertEqual(event.failing_checks, ("build (ubuntu-latest)",))
         self.assertEqual(event.comment_id, "c-9001")
         self.assertEqual(event.queued_at, "2026-07-07T05:00:00Z")
+
+
+class GhCommandFailures(unittest.TestCase):
+    def test_graphql_rate_limit_becomes_controlled_runtime_error(self):
+        error = subprocess.CalledProcessError(
+            1,
+            ["gh", "api", "graphql"],
+            stderr='{"errors":[{"type":"RATE_LIMIT","code":"graphql_rate_limit","message":"API rate limit already exceeded"}]}',
+        )
+        with mock.patch("mergify_admin_requeue_snapshot.subprocess.run", side_effect=error):
+            with self.assertRaisesRegex(RuntimeError, "GitHub API rate limit exceeded"):
+                s.run_logged(["gh", "api", "graphql"])
 
 
 class ParseStackMetadata(unittest.TestCase):


### PR DESCRIPTION
## Summary

Add a shell repro that fails if an already-merged babysit target still gets blocked, commented on, or logged as a retry.

The repro exercises the terminal-classification fix from the previous PR in this stack against a fake merged PR.

## Review Claim

Approve `scripts/repro/repro-babysit-merged-pr-terminal.sh` as the regression guard for merged-target terminal handling.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The repro only drives a local fake PR fixture through the existing admin-requeue scripts; it makes no GitHub network calls and touches no real PR.

## Slice Rationale

Landed as its own PR right after the fix so the fix and its regression proof are each a small, separately reviewable diff instead of one bundled change.

## Non-goals

Does not change any production script logic. Does not add coverage for repair-during-merge or no-current-bottom dedupe; those get their own repros later in this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-babysit-merged-pr-terminal.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8a590c77`
- Post-revert steps: None
- Data migration? No

</details>
