### PR TITLE
[Continue babysit worker landing loop](3) Stop repair when PRs merge mid-run

### DIFF
--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -21,6 +21,7 @@ REPROS=(
   scripts/repro/repro-babysit-targeted-scan-light.sh
   scripts/repro/repro-babysit-queue-repair-invalid-stop.sh
   scripts/repro/repro-babysit-no-current-bottom-comment.sh
+  scripts/repro/repro-babysit-merged-pr-terminal.sh
 )
 
 # repro-mergify-stack-dogfood.sh is deliberately excluded: it's an opt-in

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -72,6 +72,9 @@ def is_queue_only_required_check(name: str) -> bool:
 
 def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) -> tuple[Blocker, ...]:
     blockers: list[Blocker] = []
+    if pr.state == "MERGED":
+        blockers.append(Blocker("merged", "merged", pr.number, "state=MERGED"))
+        return tuple(blockers)
     if pr.state != "OPEN":
         blockers.append(Blocker("closed", "closed", pr.number, f"state={pr.state}"))
         return tuple(blockers)
@@ -552,7 +555,9 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
     if any(blocker.kind == "merge_hold" for blocker in facts.all_blockers):
         return None
     if not facts.bottom:
-        first = facts.stack.prs[0]
+        first = next((pr for pr in facts.stack.prs if pr.state == "OPEN"), None)
+        if first is None:
+            return None
         return Action(
             "comment_blocked",
             first.number,

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -317,6 +317,32 @@ class AdminBypassRepairer:
     def push_branch(self, work_root: Path, branch_name: str) -> None:
         self.git_output(work_root, "push", "origin", f"HEAD:{branch_name}")
 
+    def terminal_repair_outcome(
+        self,
+        pr: PrSnapshot,
+        check_name: str,
+        start_head: str,
+        end_head: str,
+        work_root: Path,
+    ) -> RepairOutcome | None:
+        if not hasattr(self.gh, "pr_detail"):
+            return None
+        detail = self.gh.pr_detail(self.repo, pr.number)
+        state = str(detail.get("state") or pr.state)
+        if state == "OPEN":
+            return None
+        self.logger.trace(
+            "admin-bypass-repair-check-terminal",
+            repo=self.repo,
+            pr_number=pr.number,
+            check_name=check_name,
+            state=state,
+            start_head=start_head,
+            end_head=end_head,
+        )
+        self.hard_reset_work_root(work_root, start_head)
+        return self.blocked_outcome("noop", check_name, start_head, end_head)
+
     def create_repair_prerequisite(
         self,
         pr: PrSnapshot,
@@ -409,6 +435,9 @@ class AdminBypassRepairer:
             )
         log_path = self.executor.download_job_log(self.repo, details_url, pr.number, check_name) if details_url else ""
         if check_name == "PR Body" and self.job_log_is_empty(log_path):
+            terminal = self.terminal_repair_outcome(pr, check_name, start_head, start_head, work_root)
+            if terminal:
+                return terminal
             validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
             if validation.get("valid"):
                 self.logger.trace(
@@ -459,6 +488,9 @@ class AdminBypassRepairer:
         self.run_claude_repair(work_root, prompt)
         end_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
         status_lines = self.git_lines(work_root, "status", "--porcelain")
+        terminal = self.terminal_repair_outcome(pr, check_name, start_head, end_head, work_root)
+        if terminal:
+            return terminal
         if end_head == start_head and not status_lines:
             if not queue_only:
                 validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -185,8 +185,16 @@ def run_logged(args: Sequence[str], *, cwd: Path | str | None = None, capture: b
             print(exc.stdout, file=sys.stderr, end="" if exc.stdout.endswith("\n") else "\n")
         if exc.stderr:
             print(exc.stderr, file=sys.stderr, end="" if exc.stderr.endswith("\n") else "\n")
+        if is_github_rate_limit_error(exc):
+            raise RuntimeError("GitHub API rate limit exceeded while loading PR snapshots") from exc
         raise
     return completed.stdout or ""
+
+
+def is_github_rate_limit_error(exc: subprocess.CalledProcessError) -> bool:
+    text = "\n".join(str(part or "") for part in (exc.stdout, exc.stderr))
+    lowered = text.lower()
+    return "rate_limit" in text or "rate limit" in lowered
 
 
 def checkout_pr_head(repo: str, pr: PrSnapshot, work_root: Path) -> None:

--- a/scripts/repro/repro-babysit-merged-pr-terminal.sh
+++ b/scripts/repro/repro-babysit-merged-pr-terminal.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-merged-pr-terminal.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+mkdir -p "$HOME" "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+CALLS_PATH="$FAKE_GH_STATE_DIR/calls.log"
+LEDGER_PATH="$TMP/ledger.jsonl"
+export STATE_PATH LEDGER_PATH
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = "d01530d99b371fe79180cb9481007243bd808f93"
+state = {
+    "prs": [
+        {
+            "number": 6108,
+            "title": "Merged admin-bypass target",
+            "body": "## Summary\n\nMerged PR repro.\n",
+            "url": "https://github.com/fake/repo/pull/6108",
+            "state": "MERGED",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "stack/6108",
+            "headRefOid": head,
+            "mergeStateStatus": "UNKNOWN",
+            "mergeable": "UNKNOWN",
+            "labels": ["admin-bypass"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS"},
+        }
+    ],
+    "issue_comments": {
+        "6108": [
+            {
+                "id": "m6108",
+                "user": {"login": "mergify"},
+                "updated_at": "2026-07-27T06:05:00Z",
+                "html_url": "https://github.com/fake/repo/pull/6108#m6108",
+                "body": "-*- Mergify Payload -*-\n{\"state\":\"merged\",\"queue_rule_name\":\"admin-bypass\"}\n-*- Mergify Payload End -*-\nMerged at `" + head + "`.",
+            }
+        ]
+    },
+    "job_logs": {},
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+: > "$LEDGER_PATH"
+: > "$CALLS_PATH"
+
+if ! out="$(python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6108 2>&1)"; then
+  fail 'worker failed' "$out"
+fi
+case "$out" in
+  *'BLOCK PR #6108 state=MERGED'*) fail 'worker blocked an already merged PR' "$out" ;;
+esac
+if grep -q '^gh pr comment 6108 ' "$CALLS_PATH"; then
+  fail 'worker commented on an already merged PR' "$(cat "$CALLS_PATH")"
+fi
+if [ -s "$LEDGER_PATH" ]; then
+  fail 'worker recorded a retry/blocker row for an already merged PR' "$(cat "$LEDGER_PATH")"
+fi
+
+echo '[repro] passed'

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -419,6 +419,38 @@ Failing checks
         self.assertIn('"log_path": "/tmp/pr-body.log"', log)
         self.assertIn('"pr_number": 2647', log)
 
+    def test_repair_check_noop_skips_validation_when_pr_merges_during_repair(self):
+        class FakeGh:
+            def pr_detail(self, repo, number):
+                return {"number": number, "state": "MERGED"}
+
+        stderr = io.StringIO()
+        item = pr(6111, latest=mergify(state="queued"))
+        repairer = self.repairer(FakeGh(), self.ledger())
+        git_rev_parse = iter([HEAD, HEAD])
+        git_commands = []
+
+        def fake_git_output(_work_root, *args):
+            git_commands.append(args)
+            if args == ("rev-parse", "HEAD"):
+                return next(git_rev_parse)
+            return ""
+
+        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
+            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
+                with mock.patch.object(repairer, "git_output", side_effect=fake_git_output):
+                    with mock.patch.object(repairer, "git_lines", return_value=()):
+                        with mock.patch.object(repairer, "run_claude_repair"):
+                            with mock.patch.object(repairer, "validate_current_pr_body") as validate:
+                                with redirect_stderr(stderr):
+                                    result = repairer.repair_check(item, "PR Body")
+
+        validate.assert_not_called()
+        self.assertEqual(result.status, "noop")
+        self.assertIn(("reset", "--hard", HEAD), git_commands)
+        self.assertIn(("clean", "-fd"), git_commands)
+        self.assertIn('"event": "admin-bypass-repair-check-terminal"', stderr.getvalue())
+
 
     def test_repair_check_noop_invalid_non_trunk_blocks_human_split(self):
         item = pr(

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -945,6 +945,11 @@ The merge conditions cannot be satisfied due to failing checks
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2999, "state=CLOSED")])
 
+    def test_merged_pr_is_terminal_success_not_blocked(self):
+        stack = StackGroup("s", (pr(6108, state="MERGED", latest=mergify(state="merged")),))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual(actions, ())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -4,9 +4,8 @@ Documentation-by-test for the loader. This layer takes the *raw* shapes GitHub's
 `gh` CLI returns — issue comments, GraphQL PR detail, status-check rollups,
 review threads — and folds them into the typed ``PrSnapshot`` the planner reads.
 
-Each test feeds one realistic raw shape and pins what gets parsed out of it and
-why. The subprocess/`gh`-calling helpers are intentionally not exercised here;
-only the pure parse/transform functions are.
+Most tests feed one realistic raw shape and pin what gets parsed out of it and
+why. Subprocess coverage stays limited to GitHub CLI error classification.
 
 Run:  python3 scripts/test_mergify_admin_requeue_snapshot.py
 """
@@ -14,6 +13,7 @@ Run:  python3 scripts/test_mergify_admin_requeue_snapshot.py
 from __future__ import annotations
 
 import sys
+import subprocess
 import unittest
 from unittest import mock
 from pathlib import Path
@@ -80,6 +80,18 @@ class ParseMergifyQueueEvent(unittest.TestCase):
         self.assertEqual(event.failing_checks, ("build (ubuntu-latest)",))
         self.assertEqual(event.comment_id, "c-9001")
         self.assertEqual(event.queued_at, "2026-07-07T05:00:00Z")
+
+
+class GhCommandFailures(unittest.TestCase):
+    def test_graphql_rate_limit_becomes_controlled_runtime_error(self):
+        error = subprocess.CalledProcessError(
+            1,
+            ["gh", "api", "graphql"],
+            stderr='{"errors":[{"type":"RATE_LIMIT","code":"graphql_rate_limit","message":"API rate limit already exceeded"}]}',
+        )
+        with mock.patch("mergify_admin_requeue_snapshot.subprocess.run", side_effect=error):
+            with self.assertRaisesRegex(RuntimeError, "GitHub API rate limit exceeded"):
+                s.run_logged(["gh", "api", "graphql"])
 
 
 class ParseStackMetadata(unittest.TestCase):


### PR DESCRIPTION
## Summary

Teach PR Body repair to stop cleanly when the target PR merges while the repair attempt is still running.

Without this, the repairer could keep acting on a PR number that no longer represents open work.

## Review Claim

Approve that `mergify_admin_requeue_repairer.py` detects a mid-run merge and exits its repair attempt instead of continuing to act on the now-merged PR.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change only adds a merge check inside the existing repairer control flow; it does not add new GitHub write calls beyond the checks the repairer already performs.

## Slice Rationale

This is the standalone repair-stop fix. Its matching shell repro, which mutates a fake PR to merged mid-repair, lands as the next PR in the stack.

## Non-goals

Does not change terminal-target classification (an earlier slice). Does not change no-current-bottom duplicate-comment suppression (a later slice).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 094dbfc6`
- Post-revert steps: None
- Data migration? No

</details>
