### PR TITLE
[Continue babysit worker landing loop](5) Stop duplicate no-current-bottom blockers

### DIFF
--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -22,6 +22,7 @@ REPROS=(
   scripts/repro/repro-babysit-queue-repair-invalid-stop.sh
   scripts/repro/repro-babysit-no-current-bottom-comment.sh
   scripts/repro/repro-babysit-merged-pr-terminal.sh
+  scripts/repro/repro-babysit-merged-during-repair.sh
 )
 
 # repro-mergify-stack-dogfood.sh is deliberately excluded: it's an opt-in

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -301,6 +301,11 @@ def existing_split_stop_blocker(pr: PrSnapshot, blocker: Blocker) -> Blocker | N
     return None
 
 
+def has_exact_repair_stop_comment(pr: PrSnapshot, detail: str) -> bool:
+    expected = f"{REPAIR_STOP_PREFIX}{detail}".strip()
+    return any(comment.body.strip() == expected for comment in pr.repair_stop_comments)
+
+
 def latest_mergify_repair_invalid_blockers(
     pr: PrSnapshot,
     ledger: Ledger,
@@ -558,11 +563,18 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
         first = next((pr for pr in facts.stack.prs if pr.state == "OPEN"), None)
         if first is None:
             return None
+        detail = (
+            f"no current bottom on {facts.trunk}: lowest open stack PR #{first.number} "
+            f"is based on `{first.base_ref_name}`, not `{facts.trunk}`; land or retarget "
+            "that base before babysitting can queue this stack"
+        )
+        if has_exact_repair_stop_comment(first, detail):
+            return None
         return Action(
             "comment_blocked",
             first.number,
             "no-current-bottom",
-            f"no current bottom on {facts.trunk}: lowest open stack PR #{first.number} is based on `{first.base_ref_name}`, not `{facts.trunk}`; land or retarget that base before babysitting can queue this stack",
+            detail,
         )
 
     bottom = facts.bottom

--- a/scripts/repro/repro-babysit-merged-during-repair.sh
+++ b/scripts/repro/repro-babysit-merged-during-repair.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-merged-during-repair.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+mkdir -p "$HOME" "$TMP/state" "$TMP/bin"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+CALLS_PATH="$FAKE_GH_STATE_DIR/calls.log"
+LEDGER_PATH="$TMP/ledger.jsonl"
+ORIGIN="$TMP/origin.git"
+WORK_ROOT="$HOME/.invoker/mergify-admin-requeue-work/6111"
+export STATE_PATH LEDGER_PATH
+
+git init -q --bare "$ORIGIN"
+git init -q "$TMP/seed"
+git -C "$TMP/seed" config user.email repro@example.invalid
+git -C "$TMP/seed" config user.name Repro
+printf 'master\n' > "$TMP/seed/master.txt"
+git -C "$TMP/seed" add master.txt
+git -C "$TMP/seed" commit -q -m master
+git -C "$TMP/seed" branch -M master
+git -C "$TMP/seed" remote add origin "$ORIGIN"
+git -C "$TMP/seed" push -q origin master
+git -C "$TMP/seed" checkout -q --orphan stack/6111
+git -C "$TMP/seed" rm -qrf .
+printf 'head\n' > "$TMP/seed/head.txt"
+git -C "$TMP/seed" add head.txt
+git -C "$TMP/seed" commit -q -m head
+HEAD_SHA="$(git -C "$TMP/seed" rev-parse HEAD)"
+export HEAD_SHA
+git -C "$TMP/seed" push -q origin HEAD:refs/heads/stack/6111
+mkdir -p "$(dirname "$WORK_ROOT")"
+git clone -q "$ORIGIN" "$WORK_ROOT"
+
+cat > "$TMP/bin/claude" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+path = Path(os.environ["STATE_PATH"])
+state = json.loads(path.read_text(encoding="utf-8"))
+for pr in state["prs"]:
+    if int(pr["number"]) == 6111:
+        pr["state"] = "MERGED"
+        pr["mergeStateStatus"] = "UNKNOWN"
+path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+echo "fake repair: PR merged during repair"
+SH
+chmod +x "$TMP/bin/claude"
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = os.environ["HEAD_SHA"]
+state = {
+    "prs": [
+        {
+            "number": 6111,
+            "title": "Merged during repair",
+            "body": "## Summary\n\nMerged during repair repro.\n",
+            "url": "https://github.com/fake/repo/pull/6111",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "stack/6111",
+            "headRefOid": head,
+            "mergeStateStatus": "BLOCKED",
+            "mergeable": "MERGEABLE",
+            "labels": ["admin-bypass", "queued"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS", "PR Body": "FAILURE"},
+        }
+    ],
+    "issue_comments": {
+        "6111": [
+            {
+                "id": "m6111",
+                "user": {"login": "mergify"},
+                "updated_at": "2026-07-27T06:23:56Z",
+                "html_url": "https://github.com/fake/repo/pull/6111#m6111",
+                "body": "-*- Mergify Payload -*-\n{\"state\":\"queued\",\"queue_rule_name\":\"admin-bypass\"}\n-*- Mergify Payload End -*-\n# Merge Queue Status\n\n- Checks running",
+            }
+        ]
+    },
+    "job_logs": {"2": "Review Unit validation failed before merge."},
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+: > "$LEDGER_PATH"
+: > "$CALLS_PATH"
+
+if ! out="$(python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6111 2>&1)"; then
+  fail 'worker failed after PR merged during repair' "$out"
+fi
+case "$out" in
+  *'no merge base'*) fail 'worker retried local PR-body validation after terminal merge' "$out" ;;
+  *'Traceback'*) fail 'worker produced traceback after terminal merge' "$out" ;;
+esac
+grep -q 'repair-check PR #6111 check="PR Body"' <<<"$out" \
+  || fail 'expected repair-check action' "$out"
+grep -q '"kind": "repair-check"' "$LEDGER_PATH" \
+  || fail 'expected repair-check ledger row' "$(cat "$LEDGER_PATH")"
+grep -q '"kind": "repair-noop"' "$LEDGER_PATH" \
+  || fail 'expected repair-noop ledger row' "$(cat "$LEDGER_PATH")"
+
+echo '[repro] passed'

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -29,6 +29,7 @@ from scripts.mergify_admin_requeue import (
 from scripts.mergify_admin_requeue_gh_executor import ADMIN_BYPASS_NUDGE_LEDGER_KIND, AdminBypassGhExecutor
 from scripts.mergify_admin_requeue_loader import AdminBypassStackLoader
 from scripts.mergify_admin_requeue_logger import AdminBypassLogger
+from scripts.mergify_admin_requeue_model import RepairStopComment
 from scripts.mergify_admin_requeue_repairer import (
     NON_TRUNK_MANUAL_SPLIT_ERROR,
     NON_TRUNK_PREREQ_ERROR,
@@ -50,7 +51,7 @@ def mergify(state="dequeued", comment_id="m1", sha=HEAD):
     return MergifyQueueEvent(comment_id, state, "admin-bypass", "2026-07-03T00:00:00Z", sha, (), (), "https://example.invalid/comment")
 
 
-def pr(number, *, base="master", head=None, labels=None, checks=None, threads=(), latest=None, merge_state="CLEAN", mergeable="MERGEABLE", state="OPEN", draft=False, body=""):
+def pr(number, *, base="master", head=None, labels=None, checks=None, threads=(), latest=None, merge_state="CLEAN", mergeable="MERGEABLE", state="OPEN", draft=False, body="", repair_stop_comments=()):
     return PrSnapshot(
         number=number,
         title=f"PR {number}",
@@ -67,6 +68,7 @@ def pr(number, *, base="master", head=None, labels=None, checks=None, threads=()
         checks=checks if checks is not None else {name: check(name) for name in REQUIRED},
         review_threads=tuple(threads),
         latest_mergify=latest,
+        repair_stop_comments=tuple(repair_stop_comments),
     )
 
 PROOF_BODY = """## Summary
@@ -859,6 +861,31 @@ Failing checks
         executor.execute(action, item, 3)
         self.assertEqual([comment["body"] for comment in fake.comments].count(f"Mergify repair stopped: {detail}"), 1)
         self.assertEqual(ledger.count("comment-blocked", 2647, HEAD, "no-current-bottom:exact"), 1)
+
+    def test_no_current_bottom_exact_comment_stops_future_planning(self):
+        detail = "no current bottom on master: lowest open stack PR #2647 is based on `feature/base`, not `master`; land or retarget that base before babysitting can queue this stack"
+        bottom = pr(
+            2647,
+            base="feature/base",
+            head="stack/bottom",
+            labels={"admin-bypass"},
+            repair_stop_comments=(RepairStopComment(f"Mergify repair stopped: {detail}", "2026-07-27T00:00:00Z", "EdbertChan"),),
+        )
+        top = pr(2648, base="stack/bottom", labels={"admin-bypass"})
+        ledger = self.ledger()
+        ledger.record("comment-blocked", 2647, HEAD, "no-current-bottom", 1)
+        actions = plan_stack_actions(StackGroup("s", (bottom, top)), REQUIRED, ledger, 2)
+        self.assertEqual(actions, ())
+
+        legacy = pr(
+            2647,
+            base="feature/base",
+            head="stack/bottom",
+            labels={"admin-bypass"},
+            repair_stop_comments=(RepairStopComment("Mergify repair stopped: no current bottom on master", "2026-07-27T00:00:00Z", "EdbertChan"),),
+        )
+        actions = plan_stack_actions(StackGroup("s", (legacy, top)), REQUIRED, ledger, 3)
+        self.assertEqual([(a.kind, a.key, a.detail) for a in actions], [("comment_blocked", "no-current-bottom", detail)])
 
     def test_human_block_comment_records_once_then_waits(self):
         class FakeGh:


### PR DESCRIPTION
## Summary

Suppress a repeated no-current-bottom comment when the exact same blocker text is already posted on the current head commit.

Without this check, every worker tick re-posted the identical blocker each time it re-evaluated the same stuck PR.

## Review Claim

Approve that `mergify_admin_requeue_plan.py` checks the current head's existing comments before adding another no-current-bottom blocker.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change only adds a read-before-write comment comparison inside the existing plan script; it does not add a new GitHub write path.

## Slice Rationale

This is the standalone dedupe fix. Its matching shell repro, which replays a second worker tick against the same head, lands as the next PR in the stack.

## Non-goals

Does not change terminal-target classification or merge-during-repair handling (earlier slices). Does not change comment suppression for any blocker other than no-current-bottom.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 139fc339`
- Post-revert steps: None
- Data migration? No

</details>
