### PR TITLE
[Continue babysit worker landing loop](6) Reproduce no-current-bottom replay suppression

### DIFF
--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -22,6 +22,7 @@ REPROS=(
   scripts/repro/repro-babysit-queue-repair-invalid-stop.sh
   scripts/repro/repro-babysit-no-current-bottom-comment.sh
   scripts/repro/repro-babysit-merged-pr-terminal.sh
+  scripts/repro/repro-babysit-merged-during-repair.sh
 )
 
 # repro-mergify-stack-dogfood.sh is deliberately excluded: it's an opt-in

--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -21,6 +21,7 @@ REPROS=(
   scripts/repro/repro-babysit-targeted-scan-light.sh
   scripts/repro/repro-babysit-queue-repair-invalid-stop.sh
   scripts/repro/repro-babysit-no-current-bottom-comment.sh
+  scripts/repro/repro-babysit-merged-pr-terminal.sh
 )
 
 # repro-mergify-stack-dogfood.sh is deliberately excluded: it's an opt-in

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -72,6 +72,9 @@ def is_queue_only_required_check(name: str) -> bool:
 
 def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) -> tuple[Blocker, ...]:
     blockers: list[Blocker] = []
+    if pr.state == "MERGED":
+        blockers.append(Blocker("merged", "merged", pr.number, "state=MERGED"))
+        return tuple(blockers)
     if pr.state != "OPEN":
         blockers.append(Blocker("closed", "closed", pr.number, f"state={pr.state}"))
         return tuple(blockers)
@@ -552,7 +555,9 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
     if any(blocker.kind == "merge_hold" for blocker in facts.all_blockers):
         return None
     if not facts.bottom:
-        first = facts.stack.prs[0]
+        first = next((pr for pr in facts.stack.prs if pr.state == "OPEN"), None)
+        if first is None:
+            return None
         return Action(
             "comment_blocked",
             first.number,

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -301,6 +301,11 @@ def existing_split_stop_blocker(pr: PrSnapshot, blocker: Blocker) -> Blocker | N
     return None
 
 
+def has_exact_repair_stop_comment(pr: PrSnapshot, detail: str) -> bool:
+    expected = f"{REPAIR_STOP_PREFIX}{detail}".strip()
+    return any(comment.body.strip() == expected for comment in pr.repair_stop_comments)
+
+
 def latest_mergify_repair_invalid_blockers(
     pr: PrSnapshot,
     ledger: Ledger,
@@ -558,11 +563,18 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
         first = next((pr for pr in facts.stack.prs if pr.state == "OPEN"), None)
         if first is None:
             return None
+        detail = (
+            f"no current bottom on {facts.trunk}: lowest open stack PR #{first.number} "
+            f"is based on `{first.base_ref_name}`, not `{facts.trunk}`; land or retarget "
+            "that base before babysitting can queue this stack"
+        )
+        if has_exact_repair_stop_comment(first, detail):
+            return None
         return Action(
             "comment_blocked",
             first.number,
             "no-current-bottom",
-            f"no current bottom on {facts.trunk}: lowest open stack PR #{first.number} is based on `{first.base_ref_name}`, not `{facts.trunk}`; land or retarget that base before babysitting can queue this stack",
+            detail,
         )
 
     bottom = facts.bottom

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -317,6 +317,32 @@ class AdminBypassRepairer:
     def push_branch(self, work_root: Path, branch_name: str) -> None:
         self.git_output(work_root, "push", "origin", f"HEAD:{branch_name}")
 
+    def terminal_repair_outcome(
+        self,
+        pr: PrSnapshot,
+        check_name: str,
+        start_head: str,
+        end_head: str,
+        work_root: Path,
+    ) -> RepairOutcome | None:
+        if not hasattr(self.gh, "pr_detail"):
+            return None
+        detail = self.gh.pr_detail(self.repo, pr.number)
+        state = str(detail.get("state") or pr.state)
+        if state == "OPEN":
+            return None
+        self.logger.trace(
+            "admin-bypass-repair-check-terminal",
+            repo=self.repo,
+            pr_number=pr.number,
+            check_name=check_name,
+            state=state,
+            start_head=start_head,
+            end_head=end_head,
+        )
+        self.hard_reset_work_root(work_root, start_head)
+        return self.blocked_outcome("noop", check_name, start_head, end_head)
+
     def create_repair_prerequisite(
         self,
         pr: PrSnapshot,
@@ -409,6 +435,9 @@ class AdminBypassRepairer:
             )
         log_path = self.executor.download_job_log(self.repo, details_url, pr.number, check_name) if details_url else ""
         if check_name == "PR Body" and self.job_log_is_empty(log_path):
+            terminal = self.terminal_repair_outcome(pr, check_name, start_head, start_head, work_root)
+            if terminal:
+                return terminal
             validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
             if validation.get("valid"):
                 self.logger.trace(
@@ -459,6 +488,9 @@ class AdminBypassRepairer:
         self.run_claude_repair(work_root, prompt)
         end_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
         status_lines = self.git_lines(work_root, "status", "--porcelain")
+        terminal = self.terminal_repair_outcome(pr, check_name, start_head, end_head, work_root)
+        if terminal:
+            return terminal
         if end_head == start_head and not status_lines:
             if not queue_only:
                 validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -185,8 +185,16 @@ def run_logged(args: Sequence[str], *, cwd: Path | str | None = None, capture: b
             print(exc.stdout, file=sys.stderr, end="" if exc.stdout.endswith("\n") else "\n")
         if exc.stderr:
             print(exc.stderr, file=sys.stderr, end="" if exc.stderr.endswith("\n") else "\n")
+        if is_github_rate_limit_error(exc):
+            raise RuntimeError("GitHub API rate limit exceeded while loading PR snapshots") from exc
         raise
     return completed.stdout or ""
+
+
+def is_github_rate_limit_error(exc: subprocess.CalledProcessError) -> bool:
+    text = "\n".join(str(part or "") for part in (exc.stdout, exc.stderr))
+    lowered = text.lower()
+    return "rate_limit" in text or "rate limit" in lowered
 
 
 def checkout_pr_head(repo: str, pr: PrSnapshot, work_root: Path) -> None:

--- a/scripts/repro/repro-babysit-merged-during-repair.sh
+++ b/scripts/repro/repro-babysit-merged-during-repair.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-merged-during-repair.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+mkdir -p "$HOME" "$TMP/state" "$TMP/bin"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+CALLS_PATH="$FAKE_GH_STATE_DIR/calls.log"
+LEDGER_PATH="$TMP/ledger.jsonl"
+ORIGIN="$TMP/origin.git"
+WORK_ROOT="$HOME/.invoker/mergify-admin-requeue-work/6111"
+export STATE_PATH LEDGER_PATH
+
+git init -q --bare "$ORIGIN"
+git init -q "$TMP/seed"
+git -C "$TMP/seed" config user.email repro@example.invalid
+git -C "$TMP/seed" config user.name Repro
+printf 'master\n' > "$TMP/seed/master.txt"
+git -C "$TMP/seed" add master.txt
+git -C "$TMP/seed" commit -q -m master
+git -C "$TMP/seed" branch -M master
+git -C "$TMP/seed" remote add origin "$ORIGIN"
+git -C "$TMP/seed" push -q origin master
+git -C "$TMP/seed" checkout -q --orphan stack/6111
+git -C "$TMP/seed" rm -qrf .
+printf 'head\n' > "$TMP/seed/head.txt"
+git -C "$TMP/seed" add head.txt
+git -C "$TMP/seed" commit -q -m head
+HEAD_SHA="$(git -C "$TMP/seed" rev-parse HEAD)"
+export HEAD_SHA
+git -C "$TMP/seed" push -q origin HEAD:refs/heads/stack/6111
+mkdir -p "$(dirname "$WORK_ROOT")"
+git clone -q "$ORIGIN" "$WORK_ROOT"
+
+cat > "$TMP/bin/claude" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+path = Path(os.environ["STATE_PATH"])
+state = json.loads(path.read_text(encoding="utf-8"))
+for pr in state["prs"]:
+    if int(pr["number"]) == 6111:
+        pr["state"] = "MERGED"
+        pr["mergeStateStatus"] = "UNKNOWN"
+path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+echo "fake repair: PR merged during repair"
+SH
+chmod +x "$TMP/bin/claude"
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = os.environ["HEAD_SHA"]
+state = {
+    "prs": [
+        {
+            "number": 6111,
+            "title": "Merged during repair",
+            "body": "## Summary\n\nMerged during repair repro.\n",
+            "url": "https://github.com/fake/repo/pull/6111",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "stack/6111",
+            "headRefOid": head,
+            "mergeStateStatus": "BLOCKED",
+            "mergeable": "MERGEABLE",
+            "labels": ["admin-bypass", "queued"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS", "PR Body": "FAILURE"},
+        }
+    ],
+    "issue_comments": {
+        "6111": [
+            {
+                "id": "m6111",
+                "user": {"login": "mergify"},
+                "updated_at": "2026-07-27T06:23:56Z",
+                "html_url": "https://github.com/fake/repo/pull/6111#m6111",
+                "body": "-*- Mergify Payload -*-\n{\"state\":\"queued\",\"queue_rule_name\":\"admin-bypass\"}\n-*- Mergify Payload End -*-\n# Merge Queue Status\n\n- Checks running",
+            }
+        ]
+    },
+    "job_logs": {"2": "Review Unit validation failed before merge."},
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+: > "$LEDGER_PATH"
+: > "$CALLS_PATH"
+
+if ! out="$(python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6111 2>&1)"; then
+  fail 'worker failed after PR merged during repair' "$out"
+fi
+case "$out" in
+  *'no merge base'*) fail 'worker retried local PR-body validation after terminal merge' "$out" ;;
+  *'Traceback'*) fail 'worker produced traceback after terminal merge' "$out" ;;
+esac
+grep -q 'repair-check PR #6111 check="PR Body"' <<<"$out" \
+  || fail 'expected repair-check action' "$out"
+grep -q '"kind": "repair-check"' "$LEDGER_PATH" \
+  || fail 'expected repair-check ledger row' "$(cat "$LEDGER_PATH")"
+grep -q '"kind": "repair-noop"' "$LEDGER_PATH" \
+  || fail 'expected repair-noop ledger row' "$(cat "$LEDGER_PATH")"
+
+echo '[repro] passed'

--- a/scripts/repro/repro-babysit-merged-pr-terminal.sh
+++ b/scripts/repro/repro-babysit-merged-pr-terminal.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-merged-pr-terminal.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+mkdir -p "$HOME" "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+CALLS_PATH="$FAKE_GH_STATE_DIR/calls.log"
+LEDGER_PATH="$TMP/ledger.jsonl"
+export STATE_PATH LEDGER_PATH
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = "d01530d99b371fe79180cb9481007243bd808f93"
+state = {
+    "prs": [
+        {
+            "number": 6108,
+            "title": "Merged admin-bypass target",
+            "body": "## Summary\n\nMerged PR repro.\n",
+            "url": "https://github.com/fake/repo/pull/6108",
+            "state": "MERGED",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "stack/6108",
+            "headRefOid": head,
+            "mergeStateStatus": "UNKNOWN",
+            "mergeable": "UNKNOWN",
+            "labels": ["admin-bypass"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS"},
+        }
+    ],
+    "issue_comments": {
+        "6108": [
+            {
+                "id": "m6108",
+                "user": {"login": "mergify"},
+                "updated_at": "2026-07-27T06:05:00Z",
+                "html_url": "https://github.com/fake/repo/pull/6108#m6108",
+                "body": "-*- Mergify Payload -*-\n{\"state\":\"merged\",\"queue_rule_name\":\"admin-bypass\"}\n-*- Mergify Payload End -*-\nMerged at `" + head + "`.",
+            }
+        ]
+    },
+    "job_logs": {},
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+: > "$LEDGER_PATH"
+: > "$CALLS_PATH"
+
+if ! out="$(python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6108 2>&1)"; then
+  fail 'worker failed' "$out"
+fi
+case "$out" in
+  *'BLOCK PR #6108 state=MERGED'*) fail 'worker blocked an already merged PR' "$out" ;;
+esac
+if grep -q '^gh pr comment 6108 ' "$CALLS_PATH"; then
+  fail 'worker commented on an already merged PR' "$(cat "$CALLS_PATH")"
+fi
+if [ -s "$LEDGER_PATH" ]; then
+  fail 'worker recorded a retry/blocker row for an already merged PR' "$(cat "$LEDGER_PATH")"
+fi
+
+echo '[repro] passed'

--- a/scripts/repro/repro-babysit-no-current-bottom-comment.sh
+++ b/scripts/repro/repro-babysit-no-current-bottom-comment.sh
@@ -131,5 +131,9 @@ if len(matches) != 1:
     raise SystemExit(f"expected 1 matching row, saw {len(matches)}")
 PY
 echo "$out1$out2" | grep -q 'no current bottom on master' || fail 'worker output did not name the blocker' "$out1$out2"
+echo "$out1" | grep -q 'BLOCK PR #5885 no current bottom on master' || fail 'tick 1 did not post blocker action' "$out1"
+if echo "$out2" | grep -q 'BLOCK PR #5885 no current bottom on master'; then
+  fail 'tick 2 retried no-current-bottom blocker action' "$out2"
+fi
 
 echo '[repro] passed'

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -419,6 +419,38 @@ Failing checks
         self.assertIn('"log_path": "/tmp/pr-body.log"', log)
         self.assertIn('"pr_number": 2647', log)
 
+    def test_repair_check_noop_skips_validation_when_pr_merges_during_repair(self):
+        class FakeGh:
+            def pr_detail(self, repo, number):
+                return {"number": number, "state": "MERGED"}
+
+        stderr = io.StringIO()
+        item = pr(6111, latest=mergify(state="queued"))
+        repairer = self.repairer(FakeGh(), self.ledger())
+        git_rev_parse = iter([HEAD, HEAD])
+        git_commands = []
+
+        def fake_git_output(_work_root, *args):
+            git_commands.append(args)
+            if args == ("rev-parse", "HEAD"):
+                return next(git_rev_parse)
+            return ""
+
+        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
+            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
+                with mock.patch.object(repairer, "git_output", side_effect=fake_git_output):
+                    with mock.patch.object(repairer, "git_lines", return_value=()):
+                        with mock.patch.object(repairer, "run_claude_repair"):
+                            with mock.patch.object(repairer, "validate_current_pr_body") as validate:
+                                with redirect_stderr(stderr):
+                                    result = repairer.repair_check(item, "PR Body")
+
+        validate.assert_not_called()
+        self.assertEqual(result.status, "noop")
+        self.assertIn(("reset", "--hard", HEAD), git_commands)
+        self.assertIn(("clean", "-fd"), git_commands)
+        self.assertIn('"event": "admin-bypass-repair-check-terminal"', stderr.getvalue())
+
 
     def test_repair_check_noop_invalid_non_trunk_blocks_human_split(self):
         item = pr(

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -29,6 +29,7 @@ from scripts.mergify_admin_requeue import (
 from scripts.mergify_admin_requeue_gh_executor import ADMIN_BYPASS_NUDGE_LEDGER_KIND, AdminBypassGhExecutor
 from scripts.mergify_admin_requeue_loader import AdminBypassStackLoader
 from scripts.mergify_admin_requeue_logger import AdminBypassLogger
+from scripts.mergify_admin_requeue_model import RepairStopComment
 from scripts.mergify_admin_requeue_repairer import (
     NON_TRUNK_MANUAL_SPLIT_ERROR,
     NON_TRUNK_PREREQ_ERROR,
@@ -50,7 +51,7 @@ def mergify(state="dequeued", comment_id="m1", sha=HEAD):
     return MergifyQueueEvent(comment_id, state, "admin-bypass", "2026-07-03T00:00:00Z", sha, (), (), "https://example.invalid/comment")
 
 
-def pr(number, *, base="master", head=None, labels=None, checks=None, threads=(), latest=None, merge_state="CLEAN", mergeable="MERGEABLE", state="OPEN", draft=False, body=""):
+def pr(number, *, base="master", head=None, labels=None, checks=None, threads=(), latest=None, merge_state="CLEAN", mergeable="MERGEABLE", state="OPEN", draft=False, body="", repair_stop_comments=()):
     return PrSnapshot(
         number=number,
         title=f"PR {number}",
@@ -67,6 +68,7 @@ def pr(number, *, base="master", head=None, labels=None, checks=None, threads=()
         checks=checks if checks is not None else {name: check(name) for name in REQUIRED},
         review_threads=tuple(threads),
         latest_mergify=latest,
+        repair_stop_comments=tuple(repair_stop_comments),
     )
 
 PROOF_BODY = """## Summary
@@ -859,6 +861,31 @@ Failing checks
         executor.execute(action, item, 3)
         self.assertEqual([comment["body"] for comment in fake.comments].count(f"Mergify repair stopped: {detail}"), 1)
         self.assertEqual(ledger.count("comment-blocked", 2647, HEAD, "no-current-bottom:exact"), 1)
+
+    def test_no_current_bottom_exact_comment_stops_future_planning(self):
+        detail = "no current bottom on master: lowest open stack PR #2647 is based on `feature/base`, not `master`; land or retarget that base before babysitting can queue this stack"
+        bottom = pr(
+            2647,
+            base="feature/base",
+            head="stack/bottom",
+            labels={"admin-bypass"},
+            repair_stop_comments=(RepairStopComment(f"Mergify repair stopped: {detail}", "2026-07-27T00:00:00Z", "EdbertChan"),),
+        )
+        top = pr(2648, base="stack/bottom", labels={"admin-bypass"})
+        ledger = self.ledger()
+        ledger.record("comment-blocked", 2647, HEAD, "no-current-bottom", 1)
+        actions = plan_stack_actions(StackGroup("s", (bottom, top)), REQUIRED, ledger, 2)
+        self.assertEqual(actions, ())
+
+        legacy = pr(
+            2647,
+            base="feature/base",
+            head="stack/bottom",
+            labels={"admin-bypass"},
+            repair_stop_comments=(RepairStopComment("Mergify repair stopped: no current bottom on master", "2026-07-27T00:00:00Z", "EdbertChan"),),
+        )
+        actions = plan_stack_actions(StackGroup("s", (legacy, top)), REQUIRED, ledger, 3)
+        self.assertEqual([(a.kind, a.key, a.detail) for a in actions], [("comment_blocked", "no-current-bottom", detail)])
 
     def test_human_block_comment_records_once_then_waits(self):
         class FakeGh:

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -945,6 +945,11 @@ The merge conditions cannot be satisfied due to failing checks
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2999, "state=CLOSED")])
 
+    def test_merged_pr_is_terminal_success_not_blocked(self):
+        stack = StackGroup("s", (pr(6108, state="MERGED", latest=mergify(state="merged")),))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual(actions, ())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -4,9 +4,8 @@ Documentation-by-test for the loader. This layer takes the *raw* shapes GitHub's
 `gh` CLI returns — issue comments, GraphQL PR detail, status-check rollups,
 review threads — and folds them into the typed ``PrSnapshot`` the planner reads.
 
-Each test feeds one realistic raw shape and pins what gets parsed out of it and
-why. The subprocess/`gh`-calling helpers are intentionally not exercised here;
-only the pure parse/transform functions are.
+Most tests feed one realistic raw shape and pin what gets parsed out of it and
+why. Subprocess coverage stays limited to GitHub CLI error classification.
 
 Run:  python3 scripts/test_mergify_admin_requeue_snapshot.py
 """
@@ -14,6 +13,7 @@ Run:  python3 scripts/test_mergify_admin_requeue_snapshot.py
 from __future__ import annotations
 
 import sys
+import subprocess
 import unittest
 from unittest import mock
 from pathlib import Path
@@ -80,6 +80,18 @@ class ParseMergifyQueueEvent(unittest.TestCase):
         self.assertEqual(event.failing_checks, ("build (ubuntu-latest)",))
         self.assertEqual(event.comment_id, "c-9001")
         self.assertEqual(event.queued_at, "2026-07-07T05:00:00Z")
+
+
+class GhCommandFailures(unittest.TestCase):
+    def test_graphql_rate_limit_becomes_controlled_runtime_error(self):
+        error = subprocess.CalledProcessError(
+            1,
+            ["gh", "api", "graphql"],
+            stderr='{"errors":[{"type":"RATE_LIMIT","code":"graphql_rate_limit","message":"API rate limit already exceeded"}]}',
+        )
+        with mock.patch("mergify_admin_requeue_snapshot.subprocess.run", side_effect=error):
+            with self.assertRaisesRegex(RuntimeError, "GitHub API rate limit exceeded"):
+                s.run_logged(["gh", "api", "graphql"])
 
 
 class ParseStackMetadata(unittest.TestCase):


### PR DESCRIPTION
## Summary

Extend the existing no-current-bottom shell repro so a second worker tick cannot post the same blocker again.

The extended repro fails unless the dedupe check from the previous PR keeps the second tick a no-op.

## Review Claim

Approve the extension to `scripts/repro/repro-babysit-no-current-bottom-comment.sh` as the regression guard for the replay-suppression fix added in the previous PR.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The repro only drives a local fake PR fixture through the existing plan script across two simulated ticks; it makes no GitHub network calls and touches no real PR.

## Slice Rationale

Landed as its own PR right after the fix so the fix and its regression proof are each a small, separately reviewable diff instead of one bundled change.

## Non-goals

Does not change any production script logic. Does not add coverage for terminal-target classification or merge-during-repair handling; those are covered by their own repros elsewhere in this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-babysit-no-current-bottom-comment.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 33a1f61e`
- Post-revert steps: None
- Data migration? No

</details>
