### PR TITLE
[Repro Planning Thinking Stream After Submit](1) Add focused planner-stream repro

### DIFF
--- a/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { InAppPlanningChatResponse } from '@invoker/contracts';
-import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
 
 vi.mock('@xyflow/react', async () => {
   // Dynamic import is required because Vitest hoists mock factories before test imports.
@@ -116,105 +116,6 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('invoker-terminal-planner-stream')).not.toBeInTheDocument();
       expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Final assistant reply for the new turn.');
-    });
-  });
-
-  it('opens a draft review sidebar before explicitly submitting the workflow', async () => {
-    mock.api.planningChatList = vi.fn(async () => ({
-      ok: true,
-      sessions: [makePlanningSessionSummary({
-        id: 'draft-1',
-        draftPlanSummary: {
-          name: 'Grouped plan',
-          taskCount: 3,
-          steps: ['Backend workflow', 'UI review'],
-          taskGroups: [
-            { workflow: 'Backend workflow', tasks: ['Add API endpoint'] },
-            { workflow: 'UI review', tasks: ['Add review sidebar', 'Wire ready bar actions'] },
-          ],
-        },
-        draftPlanText: 'name: Grouped plan\ntasks:\n  - id: review\n    description: Add review sidebar\n',
-      })],
-    }));
-    mock.api.planningChatSubmit = vi.fn(async () => ({
-      ok: true,
-      planName: 'Grouped plan',
-      workflowId: 'wf-created',
-    })) as any;
-
-    render(<App />);
-    await openPlanningTerminal();
-
-    fireEvent.click(await screen.findByTestId('invoker-terminal-review-draft'));
-
-    expect(await screen.findByRole('heading', { name: 'Review draft' })).toBeInTheDocument();
-    expect(mock.api.planningChatSubmit).not.toHaveBeenCalled();
-    expect(screen.getAllByTestId('draft-task-group')).toHaveLength(2);
-    expect(screen.getAllByTestId('draft-step-summary')).toHaveLength(3);
-    expect(screen.getByTestId('draft-raw-yaml')).toHaveTextContent('name: Grouped plan');
-
-    fireEvent.click(screen.getByTestId('planning-create-workflow'));
-
-    await waitFor(() => {
-      expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'draft-1' });
-    });
-  });
-  it('keeps the same draft after cancel and exposes discard on reopen', async () => {
-    mock.api.planningChatList = vi.fn(async () => ({
-      ok: true,
-      sessions: [makePlanningSessionSummary({
-        id: 'draft-keep',
-        draftPlanSummary: {
-          name: 'Kept draft',
-          taskCount: 2,
-          steps: ['Add API endpoint', 'Verify API endpoint'],
-          taskGroups: [{ workflow: 'Backend workflow', tasks: ['Add API endpoint', 'Verify API endpoint'] }],
-        },
-        draftPlanText: 'name: Kept draft\ntasks:\n  - id: keep\n    description: Add API endpoint\n',
-      })],
-    }));
-
-    render(<App />);
-    await openPlanningTerminal();
-
-    fireEvent.click(await screen.findByTestId('invoker-terminal-review-draft'));
-    fireEvent.click(await screen.findByTestId('planning-cancel-review'));
-
-    expect(await screen.findByText('Submission cancelled. Draft kept.')).toBeInTheDocument();
-    expect(screen.getByTestId('invoker-terminal-review-draft')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId('invoker-terminal-review-draft'));
-    expect(await screen.findByTestId('planning-discard-draft')).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('planning-discard-draft'));
-
-    await waitFor(() => {
-      expect(mock.api.planningChatDiscardDraft).toHaveBeenCalledWith({ sessionId: 'draft-keep' });
-    });
-  });
-
-  it('auto-submits after rendering a draft when review mode is auto-submit', async () => {
-    mock.api.planningChatSend = vi.fn(async () => ({
-      ok: true,
-      sessionId: 'session-auto',
-      reply: 'Here is the auto-submit plan.',
-      confirmationMode: 'auto_submit',
-      draftPlanAvailable: true,
-      draftPlanSummary: { name: 'Auto submit plan', taskCount: 1, steps: ['Ship it'] },
-      draftPlanText: 'name: Auto submit plan\ntasks:\n  - id: ship\n    description: Ship it\n',
-    })) as any;
-    mock.api.planningChatSubmit = vi.fn(async () => ({
-      ok: true,
-      planName: 'Auto submit plan',
-      workflowId: 'wf-auto',
-    })) as any;
-
-    render(<App />);
-    await openPlanningTerminal();
-
-    submitPlanningText('draft and submit');
-
-    await waitFor(() => {
-      expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-auto' });
     });
   });
 });


### PR DESCRIPTION
## Summary

This narrows the planning draft submit repro to the planner-stream visibility case after workflow creation.

The test covers a second planning turn while planningChatSend is pending, then checks that the stream clears after the final reply.

## Review Claim

Approve the focused proof for live planner-stream visibility during the next planning turn after draft workflow creation.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes only focused UI test coverage. It does not alter application behavior or planning APIs.

## Slice Rationale

This proof lands first so reviewers can inspect the stream regression independently from the verification wrapper.

## Non-goals

No application behavior change. No planning API change. No wrapper script in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx`

</details>

## Visual Proof

![Focused planning stream repro passing](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-27477e/planning-thinking-repro-pass.png)

The image captures the focused planner-stream repro passing for this proof slice.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c4b3ded49`
- Post-revert steps: None
- Data migration? No

</details>
