### PR TITLE
[Repair Workflow Step 3: rewire ci-failure worker](1) Route failed CI repair through workflows

### DIFF
--- a/packages/execution-engine/src/__tests__/ci-failure-tick-drops-events.test.ts
+++ b/packages/execution-engine/src/__tests__/ci-failure-tick-drops-events.test.ts
@@ -5,6 +5,7 @@ import type { TaskState } from '@invoker/workflow-core';
 
 import { createAutoFixAttemptLedger } from '../auto-fix-attempt-ledger.js';
 import type { ReviewGateCiFailedLifecycleEvent } from '../lifecycle-events.js';
+import { parseSpawnRepairWorkflowMutationArgs } from '../repair-workflow-spec.js';
 import {
   CI_FAILURE_WORKER_KIND,
   createCiFailureTick,
@@ -139,7 +140,9 @@ describe('createCiFailureTick resilience', () => {
       signal: new AbortController().signal,
     });
 
-    const submittedTaskIds = submit.mock.calls.map((call) => (call[3] as [string, ...unknown[]])[0]);
+    const submittedTaskIds = submit.mock.calls.map((call) =>
+      parseSpawnRepairWorkflowMutationArgs(call[3]).event.taskId,
+    );
     expect(submittedTaskIds).toContain('task-1');
     expect(submittedTaskIds).toContain('task-3');
     expect(submit).toHaveBeenCalledTimes(2);

--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -3,12 +3,15 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { WorkerActionRecord, WorkerActionWrite, WorkflowMutationPriority } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
 
-import { parseFixWithAgentMutationArgs } from '../auto-fix-intents.js';
 import {
   autoFixAttemptLedgerKeyFromLifecycleEvent,
   createAutoFixAttemptLedger,
 } from '../auto-fix-attempt-ledger.js';
 import type { ReviewGateCiFailedLifecycleEvent } from '../lifecycle-events.js';
+import {
+  buildRepairWorkflowSpec,
+  parseSpawnRepairWorkflowMutationArgs,
+} from '../repair-workflow-spec.js';
 import {
   CI_FAILURE_WORKER_KIND,
   ciFailureActionKey,
@@ -122,7 +125,7 @@ function makeHarness(task = makeTask()) {
   const submit = vi.fn((workflowId: string, priority: WorkflowMutationPriority, channel: string, args: unknown[]) => {
     expect(workflowId).toBe('wf-1');
     expect(priority).toBe('normal');
-    expect(channel).toBe('invoker:fix-with-agent');
+    expect(channel).toBe('invoker:spawn-repair-workflow');
     expect(args).toBeDefined();
     return 42;
   });
@@ -166,7 +169,7 @@ describe('PR status and CI failure workers', () => {
     await worker.stop();
   });
 
-  it('queues a head-SHA guarded CI repair intent and records its dedupe action', async () => {
+  it('queues a head-SHA guarded CI repair workflow spawn intent and records its dedupe action', async () => {
     const event = makeEvent({
       failedChecks: [
         { name: 'unit', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/1' },
@@ -193,31 +196,35 @@ describe('PR status and CI failure workers', () => {
     expect(ciFailureActionKey(sameChecksDifferentOrder)).toBe(ciFailureActionKey(event));
     expect(harness.submit).toHaveBeenCalledTimes(1);
     const [, , , args] = harness.submit.mock.calls[0];
-    const parsed = parseFixWithAgentMutationArgs(args);
+    const parsed = parseSpawnRepairWorkflowMutationArgs(args);
     expect(parsed).toMatchObject({
-      taskId: 'wf-1/merge',
-      agentName: 'codex',
-      context: {
-        autoFix: true,
-        executionModel: 'openai/gpt-5.2',
-        reviewGateContext: {
-          reviewId: '123',
-          generation: 2,
-          selectedAttemptId: 'attempt-1',
-          headSha: 'sha-1',
-        },
+      upstreamWorkflowId: 'wf-1',
+      upstreamFeatureBranch: 'feature/ci',
+      prHeadSha: 'sha-1',
+      failedCheckNames: ['unit', 'lint'],
+      source: 'worker',
+      queuedByRepairWorkflowGuard: true,
+      event: {
+        taskId: 'wf-1/merge',
+        reviewId: '123',
+        generation: 2,
+        attemptId: 'attempt-1',
+        headSha: 'sha-1',
       },
     });
     expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toMatchObject({
       workerKind: CI_FAILURE_WORKER_KIND,
-      actionType: 'fix-ci-failure',
+      actionType: 'spawn-repair-workflow',
       status: 'queued',
       intentId: '42',
       externalKey: ciFailureActionKey(event),
+      payload: expect.objectContaining({
+        channel: 'invoker:spawn-repair-workflow',
+      }),
     });
   });
 
-  it('queues CI repair while the in-memory retry budget allows it', async () => {
+  it('queues CI repair workflow spawn while the durable retry budget allows it', async () => {
     const event = makeEvent();
     const harness = makeHarness();
     const tick = createCiFailureTick({
@@ -234,16 +241,61 @@ describe('PR status and CI failure workers', () => {
     expect(harness.submit).toHaveBeenCalledTimes(1);
   });
 
-  it('skips CI repair once the in-memory retry budget is exhausted', async () => {
+  it('skips CI repair workflow spawn once the durable retry budget is exhausted', async () => {
     const event = makeEvent();
+    const nextEvent = makeEvent({
+      failedChecks: [
+        { name: 'types', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/3' },
+      ],
+    });
     const harness = makeHarness();
-    harness.attemptLedger.consume(autoFixAttemptLedgerKeyFromLifecycleEvent(event), 1);
     const tick = createCiFailureTick({
       store: harness.store,
       submitter: { submit: harness.submit },
       logger,
       attemptLedger: harness.attemptLedger,
       defaultAutoFixRetries: 1,
+      drainEvents: () => [event, nextEvent],
+    });
+
+    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(nextEvent)}`)).toMatchObject({
+      status: 'skipped',
+      payload: expect.objectContaining({
+        reason: 'worker-retry-budget-exhausted',
+        workerRetryBudget: 1,
+      }),
+    });
+  });
+
+  it('suppresses CI repair workflow spawn when the same review gate has a merge conflict', async () => {
+    const event = makeEvent();
+    const harness = makeHarness(makeTask({
+      execution: {
+        reviewGate: {
+          activeGeneration: 2,
+          completion: { required: 'all', status: 'approved' },
+          artifacts: [{
+            id: 'pr-123',
+            providerId: '123',
+            provider: 'github',
+            required: true,
+            status: 'open',
+            generation: 2,
+            headSha: 'sha-1',
+            mergeState: 'dirty',
+          }],
+        },
+      },
+    }));
+    const tick = createCiFailureTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 2,
       drainEvents: () => [event],
     });
 
@@ -251,12 +303,44 @@ describe('PR status and CI failure workers', () => {
 
     expect(harness.submit).not.toHaveBeenCalled();
     expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toMatchObject({
+      actionType: 'spawn-repair-workflow',
       status: 'skipped',
       payload: expect.objectContaining({
-        reason: 'worker-retry-budget-exhausted',
-        workerRetryBudget: 1,
+        reason: 'merge-conflict-present',
+        conflictOwner: 'review-gate-merge-conflict',
       }),
     });
+  });
+
+  it('queues the upstream workflow reference that repair-workflow cascade uses', async () => {
+    const event = makeEvent();
+    const harness = makeHarness();
+    const tick = createCiFailureTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 2,
+      drainEvents: () => [event],
+    });
+
+    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1, signal: new AbortController().signal });
+
+    const [, , , args] = harness.submit.mock.calls[0];
+    const payload = parseSpawnRepairWorkflowMutationArgs(args);
+    const spec = buildRepairWorkflowSpec({
+      event: payload.event,
+      upstreamWorkflowId: payload.upstreamWorkflowId,
+      upstreamFeatureBranch: payload.upstreamFeatureBranch,
+      prHeadSha: payload.prHeadSha,
+      failedCheckNames: payload.failedCheckNames,
+      repoUrl: 'git@github.com:owner/repo.git',
+    });
+    expect(spec.externalDependencies).toEqual([{
+      workflowId: 'wf-1',
+      taskId: '__merge__',
+      gatePolicy: 'ci_failed',
+    }]);
   });
 
   it('rejects stale CI failure events when the PR head changed before submit', async () => {
@@ -321,7 +405,7 @@ describe('PR status and CI failure workers', () => {
     expect(publish).not.toHaveBeenCalled();
   });
 
-  it('skips fix-with-agent for PR #5188-shaped infra checkout failures', async () => {
+  it('skips repair workflow spawn for PR #5188-shaped infra checkout failures', async () => {
     const event = makeEvent({
       failedChecks: [
         {
@@ -372,7 +456,7 @@ describe('PR status and CI failure workers', () => {
     });
   });
 
-  it('still queues fix-with-agent when fetched logs look like code failures', async () => {
+  it('still queues repair workflow spawn when fetched logs look like code failures', async () => {
     const event = makeEvent({
       failedChecks: [
         {

--- a/packages/execution-engine/src/workers/ci-failure-worker.ts
+++ b/packages/execution-engine/src/workers/ci-failure-worker.ts
@@ -1,22 +1,41 @@
 import type { Logger } from '@invoker/contracts';
 import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
+import type {
+  WorkerActionRecord,
+  WorkerActionStatus,
+  WorkflowMutationIntent,
+  WorkflowMutationIntentStatus,
+} from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
 
+import type { AutoFixAttemptLedger } from '../auto-fix-attempt-ledger.js';
 import {
-  createAutoFixAttemptLedger,
-  type AutoFixAttemptLedger,
-} from '../auto-fix-attempt-ledger.js';
-import { createFailedCheckLogFetcher } from '../ci-failure-infra-classifier.js';
+  classifyFailedChecks,
+  createFailedCheckLogFetcher,
+  type FailedCheckLogFetcher,
+} from '../ci-failure-infra-classifier.js';
+import {
+  isReviewGateCiContextStale,
+  type ReviewGateCiContext,
+  type ReviewGateLineageFields,
+} from '../auto-fix-intents.js';
 import type {
   ReviewGateCiFailedLifecycleEvent,
   WorkflowLifecycleEvent,
 } from '../lifecycle-events.js';
 import {
+  ciFailureChecksHash,
   ciFailureActionKey,
-  queueReviewGateCiRepair,
-  type ReviewGateCiRepairPolicyOptions,
-  type ReviewGateCiRepairStore,
-  type ReviewGateCiRepairSubmitter,
 } from '../review-gate-ci-repair.js';
+import {
+  queueRepairWorkflowSpawn,
+  repairWorkflowActionKey,
+  SPAWN_REPAIR_WORKFLOW_CHANNEL,
+  type QueueRepairWorkflowSpawnOptions,
+  type RepairWorkflowSpawnStore,
+  type RepairWorkflowSpawnSubmitter,
+} from '../repair-workflow-spec.js';
+import { recordWorkerDecisionRow } from '../worker-decision-ledger.js';
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import type { WorkerRegistry } from '../worker-registry.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
@@ -25,12 +44,23 @@ export const CI_FAILURE_WORKER_KIND = 'ci-failure';
 export const DEFAULT_CI_FAILURE_WORKER_INTERVAL_MS = 60_000;
 export { ciFailureActionKey };
 
-export type CiFailureWorkerStore = ReviewGateCiRepairStore;
+export interface CiFailureWorkerStore extends RepairWorkflowSpawnStore {
+  listWorkflowMutationIntents?(
+    workflowId?: string,
+    statuses?: WorkflowMutationIntentStatus[],
+  ): WorkflowMutationIntent[];
+}
 
-export type CiFailureWorkerSubmitter = ReviewGateCiRepairSubmitter;
+export type CiFailureWorkerSubmitter = RepairWorkflowSpawnSubmitter;
 
-export interface CiFailureWorkerPolicyOptions extends ReviewGateCiRepairPolicyOptions {
+export interface CiFailureWorkerPolicyOptions extends Omit<QueueRepairWorkflowSpawnOptions, 'logger' | 'store'> {
+  store: CiFailureWorkerStore;
+  logger: Logger;
   drainEvents?: () => ReviewGateCiFailedLifecycleEvent[];
+  /** Deprecated compatibility field; durable retry caps now live in worker_actions. */
+  attemptLedger?: AutoFixAttemptLedger;
+  /** Optional failed-check log fetcher used to skip non-fixable infra failures. */
+  fetchFailedCheckLogs?: FailedCheckLogFetcher;
 }
 
 export interface CiFailureWorkerOptions {
@@ -38,7 +68,7 @@ export interface CiFailureWorkerOptions {
   instanceId?: string;
   intervalMs?: number;
   installSignalHandlers?: boolean;
-  ciFailure?: Omit<CiFailureWorkerPolicyOptions, 'logger' | 'drainEvents' | 'attemptLedger'> & { readonly attemptLedger?: AutoFixAttemptLedger };
+  ciFailure?: Omit<CiFailureWorkerPolicyOptions, 'logger' | 'drainEvents'>;
   tickOnStart?: boolean;
   messageBus?: MessageBus;
   onTick?: WorkerTick;
@@ -81,7 +111,7 @@ export function createCiFailureTick(options: CiFailureWorkerPolicyOptions): Work
       if (seen.has(externalKey)) continue;
       seen.add(externalKey);
       try {
-        await queueReviewGateCiRepair(options, event);
+        await handleCiFailureEvent(options, event);
       } catch (error) {
         options.logger.error(`[worker:${CI_FAILURE_WORKER_KIND}] worker-ci-failure-tick-error`, {
           module: 'ci-failure-worker',
@@ -96,6 +126,299 @@ export function createCiFailureTick(options: CiFailureWorkerPolicyOptions): Work
   };
 }
 
+function loadTaskForEvent(
+  event: ReviewGateCiFailedLifecycleEvent,
+  options: CiFailureWorkerPolicyOptions,
+): TaskState | undefined {
+  const direct = options.store.loadTask?.(event.taskId);
+  if (direct) return direct;
+  return options.store.loadTasks(event.workflowId).find((task) => task.id === event.taskId);
+}
+
+function currentReviewGateArtifact(task: TaskState, reviewId: string) {
+  const gate = task.execution.reviewGate;
+  return gate?.artifacts.find((candidate) =>
+    candidate.generation === gate.activeGeneration
+    && candidate.status !== 'discarded'
+    && !candidate.discardedAt
+    && candidate.providerId === reviewId,
+  );
+}
+
+function currentReviewGateLineage(
+  task: TaskState,
+  reviewId: string,
+): ReviewGateLineageFields {
+  const artifact = currentReviewGateArtifact(task, reviewId);
+  return {
+    reviewId: artifact?.providerId ?? task.execution.reviewId,
+    generation: task.execution.generation ?? 0,
+    selectedAttemptId: task.execution.selectedAttemptId,
+    branch: task.execution.branch,
+    headSha: artifact?.headSha,
+  };
+}
+
+function reviewGateContextFromEvent(event: ReviewGateCiFailedLifecycleEvent): ReviewGateCiContext {
+  return {
+    reviewId: event.reviewId,
+    generation: event.generation,
+    selectedAttemptId: event.attemptId,
+    branch: event.branch,
+    headSha: event.headSha,
+  };
+}
+
+function staleReasonForEvent(
+  event: ReviewGateCiFailedLifecycleEvent,
+  task: TaskState,
+): { stale: false } | { stale: true; reason: string; details: Record<string, unknown> } {
+  if (task.config.workflowId !== event.workflowId) {
+    return {
+      stale: true,
+      reason: 'workflow-changed',
+      details: { currentWorkflowId: task.config.workflowId ?? null },
+    };
+  }
+  if (task.status !== 'review_ready' && task.status !== 'awaiting_approval') {
+    return {
+      stale: true,
+      reason: 'status-changed',
+      details: { currentStatus: task.status },
+    };
+  }
+
+  const context = reviewGateContextFromEvent(event);
+  const current = currentReviewGateLineage(task, event.reviewId);
+  if (!isReviewGateCiContextStale(context, current)) {
+    return { stale: false };
+  }
+
+  if (current.reviewId !== event.reviewId) {
+    return {
+      stale: true,
+      reason: 'review-changed',
+      details: { currentReviewId: current.reviewId ?? null },
+    };
+  }
+  if ((current.generation ?? 0) !== event.generation) {
+    return {
+      stale: true,
+      reason: 'generation-changed',
+      details: { currentGeneration: current.generation ?? 0 },
+    };
+  }
+  if (current.selectedAttemptId !== event.attemptId) {
+    return {
+      stale: true,
+      reason: 'selected-attempt-changed',
+      details: { currentSelectedAttemptId: current.selectedAttemptId ?? null },
+    };
+  }
+  if (current.headSha !== event.headSha) {
+    return {
+      stale: true,
+      reason: 'head-sha-changed',
+      details: { currentHeadSha: current.headSha ?? null },
+    };
+  }
+  return {
+    stale: true,
+    reason: 'branch-changed',
+    details: { currentBranch: current.branch ?? null },
+  };
+}
+
+function hasUnresolvedMergeConflictForEvent(
+  task: TaskState,
+  event: ReviewGateCiFailedLifecycleEvent,
+): boolean {
+  return currentReviewGateArtifact(task, event.reviewId)?.mergeState === 'dirty';
+}
+
+function recordCiFailureDecision(
+  options: CiFailureWorkerPolicyOptions,
+  event: ReviewGateCiFailedLifecycleEvent,
+  status: WorkerActionStatus,
+  summary: string,
+  payload: Record<string, unknown> = {},
+  intentId?: number | string,
+): WorkerActionRecord | undefined {
+  return recordWorkerDecisionRow(options.store, {
+    workerKind: CI_FAILURE_WORKER_KIND,
+    actionType: 'spawn-repair-workflow',
+    externalKey: repairWorkflowActionKey(event),
+    subjectType: 'review',
+    subjectId: event.reviewId,
+    workflowId: event.workflowId,
+    taskId: event.taskId,
+    status,
+    summary,
+    intentId,
+    payload: {
+      reviewUrl: event.reviewUrl,
+      headSha: event.headSha ?? null,
+      headRef: event.headRef ?? null,
+      branch: event.branch ?? null,
+      statusText: event.statusText,
+      generation: event.generation,
+      selectedAttemptId: event.attemptId ?? null,
+      taskStateVersion: event.taskStateVersion ?? null,
+      failedChecksHash: ciFailureChecksHash(event.failedChecks),
+      failedChecks: event.failedChecks.map((check) => ({ ...check })),
+      ...payload,
+    },
+  });
+}
+
+function logCiFailureWorkerEvent(
+  options: CiFailureWorkerPolicyOptions,
+  event: ReviewGateCiFailedLifecycleEvent,
+  phase: string,
+  details: Record<string, unknown>,
+): void {
+  const payload = {
+    reviewId: event.reviewId,
+    reviewUrl: event.reviewUrl,
+    workflowId: event.workflowId,
+    taskId: event.taskId,
+    generation: event.generation,
+    selectedAttemptId: event.attemptId ?? null,
+    failedChecksHash: ciFailureChecksHash(event.failedChecks),
+    ...details,
+  };
+  options.store.logEvent?.(event.taskId, 'debug.ci-failure-worker', payload);
+  options.logger.debug?.(`[worker:${CI_FAILURE_WORKER_KIND}] ${phase}`, {
+    module: 'ci-failure-worker',
+    ...payload,
+  });
+}
+
+function firstLine(text: string | undefined): string | undefined {
+  const trimmed = text?.trim();
+  if (!trimmed) return undefined;
+  return trimmed.split('\n', 1)[0];
+}
+
+function reconcileFinishedIntentAction(
+  options: CiFailureWorkerPolicyOptions,
+  event: ReviewGateCiFailedLifecycleEvent,
+): void {
+  const externalKey = repairWorkflowActionKey(event);
+  const existing = options.store.getWorkerAction?.(CI_FAILURE_WORKER_KIND, externalKey);
+  if (!existing || !existing.intentId) return;
+  if (existing.status !== 'queued' && existing.status !== 'pending' && existing.status !== 'running') return;
+
+  const terminalIntents = options.store.listWorkflowMutationIntents?.(event.workflowId, ['completed', 'failed']) ?? [];
+  const intent = terminalIntents.find((candidate) => String(candidate.id) === existing.intentId);
+  if (!intent) return;
+
+  const now = new Date().toISOString();
+  const status: WorkerActionStatus = intent.status === 'completed' ? 'completed' : 'failed';
+  const summary = status === 'completed'
+    ? 'CI repair intent completed'
+    : `CI repair intent failed: ${firstLine(intent.error) ?? 'unknown error'}`;
+  const payload = existing.payload && typeof existing.payload === 'object'
+    ? { ...(existing.payload as Record<string, unknown>) }
+    : {};
+  options.store.upsertWorkerAction?.({
+    ...existing,
+    status,
+    summary,
+    payload: {
+      ...payload,
+      reconciledIntentStatus: intent.status,
+      intentError: intent.error ?? null,
+    },
+    updatedAt: now,
+    completedAt: now,
+  });
+  logCiFailureWorkerEvent(options, event, 'worker-ci-failure-intent-reconciled', {
+    intentId: existing.intentId,
+    intentStatus: intent.status,
+    actionStatus: status,
+  });
+}
+
+async function handleCiFailureEvent(
+  options: CiFailureWorkerPolicyOptions,
+  event: ReviewGateCiFailedLifecycleEvent,
+): Promise<void> {
+  const task = loadTaskForEvent(event, options);
+  if (!task) {
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', { reason: 'task-missing' });
+    return;
+  }
+
+  reconcileFinishedIntentAction(options, event);
+
+  const stale = staleReasonForEvent(event, task);
+  if (stale.stale) {
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', { reason: stale.reason, ...stale.details });
+    return;
+  }
+
+  if (hasUnresolvedMergeConflictForEvent(task, event)) {
+    recordCiFailureDecision(
+      options,
+      event,
+      'skipped',
+      'Skipped CI repair workflow because review gate has an unresolved merge conflict',
+      {
+        reason: 'merge-conflict-present',
+        mergeState: 'dirty',
+        conflictOwner: 'review-gate-merge-conflict',
+      },
+    );
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
+      reason: 'merge-conflict-present',
+      mergeState: 'dirty',
+    });
+    return;
+  }
+
+  if (options.fetchFailedCheckLogs) {
+    let logsByDetailsUrl = new Map<string, string>();
+    try {
+      logsByDetailsUrl = await options.fetchFailedCheckLogs(event.failedChecks);
+    } catch (error) {
+      logCiFailureWorkerEvent(options, event, 'worker-ci-failure-infra-classify-error', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    const classified = classifyFailedChecks(event.failedChecks, logsByDetailsUrl);
+    if (classified.classification === 'infra') {
+      recordCiFailureDecision(
+        options,
+        event,
+        'skipped',
+        'Skipped CI repair workflow because failure looks like runner/infra',
+        {
+          reason: 'infra-failure',
+          matchedSignals: [...classified.matchedSignals],
+          classifiedCheckCount: classified.classifiedCheckCount,
+        },
+      );
+      logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
+        reason: 'infra-failure',
+        matchedSignals: [...classified.matchedSignals],
+        classifiedCheckCount: classified.classifiedCheckCount,
+      });
+      return;
+    }
+  }
+
+  const result = queueRepairWorkflowSpawn(options, event);
+  if (result.decision === 'queued') {
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-submitted', {
+      intentId: result.intentId,
+      channel: SPAWN_REPAIR_WORKFLOW_CHANNEL,
+    });
+  } else {
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', { reason: result.reason });
+  }
+}
+
 function isReviewGateCiFailedEvent(event: WorkflowLifecycleEvent): event is ReviewGateCiFailedLifecycleEvent {
   return event.kind === 'review_gate.ci_failed';
 }
@@ -103,14 +426,10 @@ function isReviewGateCiFailedEvent(event: WorkflowLifecycleEvent): event is Revi
 export function createCiFailureWorker(options: CiFailureWorkerOptions): WorkerRuntime {
   const pendingEvents: ReviewGateCiFailedLifecycleEvent[] = [];
   let lifecycleUnsubscribe: Unsubscribe | undefined;
-  const fallbackAttemptLedger = options.ciFailure && !options.ciFailure.attemptLedger
-    ? createAutoFixAttemptLedger()
-    : undefined;
   const onTick = options.onTick ?? (
     options.ciFailure
       ? createCiFailureTick({
         ...options.ciFailure,
-        attemptLedger: options.ciFailure.attemptLedger ?? fallbackAttemptLedger!,
         logger: options.logger,
         drainEvents: () => pendingEvents.splice(0),
       })


### PR DESCRIPTION
## Summary

Failed PR CI now routes through the repair workflow path instead of the legacy worker action path.

The worker records lifecycle outcomes and keeps merge-conflict handling from competing with CI repair.

Focused coverage locks the CI worker handoff, conflict worker handoff, and event draining behavior.

## Review Claim

Failed CI events route into repair workflow spawning while the worker lifecycle remains observable.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The slice stays inside the CI worker and its directly affected worker tests; existing pending-check and conflict flows stay covered.

## Slice Rationale

This slice owns only the CI repair path on top of the preceding branch.

## Non-goals

- No UI changes.
- No docs updates.
- No worker enablement surface changes.

## Architecture

### Before

```mermaid
graph TD
    A["CI failure event"] --> B["ci-failure worker"]
    B --> C["legacy worker action path"]
```

### After

```mermaid
graph TD
    A["CI failure event"] --> B["ci-failure worker"]
    B --> C["repair workflow spawn path"]
    C --> D["lifecycle result cascade"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/pr-ci-workers.test.ts src/__tests__/ci-failure-tick-drops-events.test.ts src/__tests__/review-gate-merge-conflict-worker.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, before dependent repair workflow steps land.
- Revert command: `git revert <published-sha>`
- Post-revert steps: Re-run the CI worker tests and typecheck.
- Data migration? No

</details>
