### PR TITLE
[Planning tmux output survives Home/Planning switches](2) Resolve main review diff fallback

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -4164,7 +4164,7 @@ console.log(JSON.stringify(out));
           id: 'wf-1',
           onFinish: 'none',
           mergeMode: 'external_review',
-          baseBranch: 'master',
+          baseBranch: 'main',
           featureBranch: 'plan/empty',
           name: 'Empty Invoker Workflow',
           repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
@@ -4189,8 +4189,14 @@ console.log(JSON.stringify(out));
       (executor as any).execGitIn = async (args: string[], _dir: string) => {
         gitCalls.push([...args]);
         if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'base-sha';
+        if (args[0] === 'fetch' && args[3] === '+refs/heads/main:refs/remotes/origin/main') {
+          throw new Error('could not fetch main');
+        }
         if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2] === 'refs/remotes/origin/master^{commit}') {
           return 'origin-base-sha';
+        }
+        if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2] === 'refs/remotes/origin/plan/empty^{commit}') {
+          return 'origin-feature-sha';
         }
         if (args[0] === 'diff' && args[1] === '--name-only') return '';
         return '';
@@ -4202,7 +4208,9 @@ console.log(JSON.stringify(out));
 
       await (executor as any).executeMergeNode(mergeTask);
 
-      expect(gitCalls).toContainEqual(['diff', '--name-only', 'refs/remotes/origin/master...plan/empty', '--']);
+      expect(gitCalls).toContainEqual(['fetch', '--', 'origin', '+refs/heads/main:refs/remotes/origin/main']);
+      expect(gitCalls).toContainEqual(['fetch', '--', 'origin', '+refs/heads/master:refs/remotes/origin/master']);
+      expect(gitCalls).toContainEqual(['diff', '--name-only', 'origin-base-sha...origin-feature-sha', '--']);
       expect((executor as any).publishReviewStackWithMakePrSkill).not.toHaveBeenCalled();
       expect((executor as any).authorPrBodyWithSkill).not.toHaveBeenCalled();
       expect(mergeGateProvider.createReview).not.toHaveBeenCalled();

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -258,42 +258,108 @@ async function syncGateWorkspaceToFeatureBranch(
   await execGitInMergeSafe(host, ['checkout', featureBranch], gateWorkspacePath);
 }
 
+type ReviewableChangedFiles = {
+  changedFiles: string[];
+  effectiveBaseBranch: string;
+};
+
+function reviewBaseBranchCandidates(baseBranch: string): string[] {
+  const normalizedBase = normalizeBranchForGithubCli(baseBranch);
+  const candidates = [normalizedBase];
+  if (normalizedBase === 'main') {
+    candidates.push('master');
+  } else if (normalizedBase === 'master') {
+    candidates.push('main');
+  }
+  return Array.from(new Set(candidates.filter(Boolean)));
+}
+
+async function fetchRemoteBranchIfExists(
+  host: MergeRunnerHost,
+  dir: string,
+  branch: string,
+): Promise<boolean> {
+  try {
+    await execGitInMergeSafe(
+      host,
+      ['fetch', '--', 'origin', `+refs/heads/${branch}:refs/remotes/origin/${branch}`],
+      dir,
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveCommit(
+  host: MergeRunnerHost,
+  dir: string,
+  ref: string,
+): Promise<string | undefined> {
+  try {
+    const resolved = (await execGitInMergeSafe(
+      host,
+      ['rev-parse', '--verify', `${ref}^{commit}`],
+      dir,
+    )).trim();
+    return resolved || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function listReviewableChangedFiles(
   host: MergeRunnerHost,
   dir: string,
   baseBranch: string,
   featureBranch: string,
-): Promise<string[]> {
-  const normalizedBase = normalizeBranchForGithubCli(baseBranch);
-  let diffBaseRef = baseBranch;
-  for (const candidate of [
-    `refs/remotes/origin/${normalizedBase}`,
-    `origin/${normalizedBase}`,
-    baseBranch,
-  ]) {
-    try {
-      const resolved = (await execGitInMergeSafe(
-        host,
-        ['rev-parse', '--verify', `${candidate}^{commit}`],
-        dir,
-      )).trim();
-      if (resolved) {
-        diffBaseRef = candidate;
-        break;
-      }
-    } catch {
-      // Try the next base spelling.
+): Promise<ReviewableChangedFiles> {
+  const baseCandidates = reviewBaseBranchCandidates(baseBranch);
+  let baseCommit: string | undefined;
+  let effectiveBaseBranch = normalizeBranchForGithubCli(baseBranch);
+
+  for (const candidate of baseCandidates) {
+    const fetched = await fetchRemoteBranchIfExists(host, dir, candidate);
+    if (!fetched) continue;
+
+    const resolved = await resolveCommit(host, dir, `refs/remotes/origin/${candidate}`);
+    if (resolved) {
+      baseCommit = resolved;
+      effectiveBaseBranch = candidate;
+      break;
     }
   }
+
+  if (!baseCommit) {
+    throw new Error(
+      `Unable to resolve review diff base "${baseBranch}" from origin ` +
+        `(tried ${baseCandidates.map((candidate) => `origin/${candidate}`).join(', ')})`,
+    );
+  }
+
+  const normalizedFeature = normalizeBranchForGithubCli(featureBranch);
+  await fetchRemoteBranchIfExists(host, dir, normalizedFeature);
+  const featureCommit =
+    await resolveCommit(host, dir, `refs/remotes/origin/${normalizedFeature}`) ??
+    await resolveCommit(host, dir, `refs/heads/${normalizedFeature}`) ??
+    await resolveCommit(host, dir, featureBranch);
+
+  if (!featureCommit) {
+    throw new Error(`Unable to resolve review diff feature branch "${featureBranch}"`);
+  }
+
   const out = await execGitInMergeSafe(
     host,
-    ['diff', '--name-only', `${diffBaseRef}...${featureBranch}`, '--'],
+    ['diff', '--name-only', `${baseCommit}...${featureCommit}`, '--'],
     dir,
   );
-  return out
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean);
+  return {
+    changedFiles: out
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean),
+    effectiveBaseBranch,
+  };
 }
 
 // ── Host interface ───────────────────────────────────────
@@ -886,22 +952,25 @@ export async function runMergeGateActionImpl(
         });
         await syncGateWorkspaceToFeatureBranch(host, gateWorkspacePath, featureBranch);
 
+        let reviewBaseBranch = baseBranch;
         if (isInvokerRepoUrl(workflow?.repoUrl)) {
-          const changedFiles = await listReviewableChangedFiles(
+          const reviewableChanges = await listReviewableChangedFiles(
             host,
             gateWorkspacePath!,
             baseBranch,
             featureBranch,
           );
+          const { changedFiles, effectiveBaseBranch } = reviewableChanges;
+          reviewBaseBranch = effectiveBaseBranch;
           if (changedFiles.length === 0) {
             logTaskProgress(host, task.id, 'info', 'Skipping review stack publication for empty Invoker branch', {
-              baseBranch,
+              baseBranch: reviewBaseBranch,
               featureBranch,
             });
             mergeTrace('GATE_WS_PATH_REVIEW_PUBLISH_NOOP', {
               taskId: task.id,
               gateWorkspacePath: gateWorkspacePath ?? null,
-              baseBranch,
+              baseBranch: reviewBaseBranch,
               featureBranch,
               onFinish,
               mergeMode,
@@ -934,7 +1003,12 @@ export async function runMergeGateActionImpl(
         let fullSummary = summary;
         if (visualProof && host.runVisualProofCapture) {
           const slug = (featureBranch ?? 'workflow').replace(/\//g, '-');
-          const vpMarkdown = await host.runVisualProofCapture(baseBranch, featureBranch!, slug, workflow?.repoUrl);
+          const vpMarkdown = await host.runVisualProofCapture(
+            reviewBaseBranch,
+            featureBranch!,
+            slug,
+            workflow?.repoUrl,
+          );
           if (vpMarkdown) {
             fullSummary = (summary ?? '') + '\n\n' + vpMarkdown;
           }
@@ -944,7 +1018,7 @@ export async function runMergeGateActionImpl(
           workflowId,
           mergeNodeTaskId: task.id,
           workflowName: workflow?.name ?? 'Workflow',
-          baseBranch,
+          baseBranch: reviewBaseBranch,
           featureBranch,
           workflowSummary: fullSummary ?? '',
           cwd: gateWorkspacePath!,

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
-import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, PlanningConfirmationMode, ReviewGateQueryResponse, RuntimeStatus, StartReadyFreshBaseScope, StartReadyRequest, StartReadyResult, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
+import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, PlanningConfirmationMode, ReviewGateQueryResponse, RuntimeStatus, StartReadyFreshBaseScope, StartReadyRequest, StartReadyResult, TerminalOutputEvent, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus, WorkerActionSummary, WorkerLogEntry, WorkerStatusEntry } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
 import { reportUiNavigation } from './lib/report-ui-navigation.js';
@@ -114,6 +114,7 @@ const EDITABLE_SELECTOR = [
 const SYSTEM_SETUP_AUTO_OPEN_DELAY_MS = 1200;
 const RAIL_LIST_FRAME_CLASS = 'flex min-h-0 flex-1 flex-col';
 const RAIL_SCROLL_BODY_CLASS = 'min-h-0 flex-1 overflow-y-auto';
+const TERMINAL_OUTPUT_SNAPSHOT_MAX_CHARS = 64 * 1024;
 
 function notifyMutationError(rawTitle: string, err: unknown): void {
   console.error(rawTitle, err);
@@ -124,6 +125,12 @@ function notifyMutationError(rawTitle: string, err: unknown): void {
 
 function formatCount(count: number, singular: string, plural = `${singular}s`): string {
   return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function appendTerminalOutputSnapshot(snapshot: string | undefined, chunk: string): string {
+  const next = `${snapshot ?? ''}${chunk}`;
+  if (next.length <= TERMINAL_OUTPUT_SNAPSHOT_MAX_CHARS) return next;
+  return next.slice(next.length - TERMINAL_OUTPUT_SNAPSHOT_MAX_CHARS);
 }
 
 type StartReadyRailModeId =
@@ -1305,6 +1312,64 @@ export function App() {
         )),
       );
     });
+    return () => { unsubscribe?.(); };
+  }, []);
+
+  useEffect(() => {
+    const updatePlanningTerminalSnapshot = (event: TerminalOutputEvent): void => {
+      if (event.kind !== 'planning' || event.data.length === 0) return;
+      const terminalUpdatedAt = new Date().toISOString();
+      setPlanningSessions((prev) => {
+        let changed = false;
+        const next = prev.map((session) => {
+          const matchesPlanningSession = event.planningSessionId
+            ? session.id === event.planningSessionId
+            : false;
+          const matchesTerminalSession = !event.planningSessionId
+            && session.terminalSession?.sessionId === event.sessionId;
+          if (!matchesPlanningSession && !matchesTerminalSession) return session;
+
+          const currentTerminalSession = session.terminalSession;
+          const outputSnapshot = appendTerminalOutputSnapshot(
+            currentTerminalSession?.outputSnapshot ?? session.terminalOutputSnapshot,
+            event.data,
+          );
+          const terminalSession: TerminalSessionDescriptor = currentTerminalSession
+            ? {
+                ...currentTerminalSession,
+                sessionId: event.sessionId,
+                taskId: event.taskId,
+                kind: 'planning',
+                planningSessionId: event.planningSessionId ?? currentTerminalSession.planningSessionId,
+                outputSnapshot,
+              }
+            : {
+                sessionId: event.sessionId,
+                taskId: event.taskId,
+                kind: 'planning',
+                planningSessionId: event.planningSessionId,
+                status: 'running',
+                mode: 'spawn',
+                attached: false,
+                createdAt: terminalUpdatedAt,
+                outputSnapshot,
+              };
+          changed = true;
+          return {
+            ...session,
+            terminalSession,
+            terminalSessionId: terminalSession.sessionId,
+            terminalStatus: terminalSession.status,
+            terminalExitCode: terminalSession.exitCode,
+            terminalOutputSnapshot: outputSnapshot,
+            terminalUpdatedAt,
+          };
+        });
+        return changed ? next : prev;
+      });
+    };
+
+    const unsubscribe = window.invoker?.onTerminalOutput?.(updatePlanningTerminalSnapshot);
     return () => { unsubscribe?.(); };
   }, []);
 

--- a/packages/ui/src/__tests__/planning-terminal-tmux.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-tmux.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const xtermMock = vi.hoisted(() => {
+  type DataHandler = (data: string) => void;
+
+  const instances: MockTerminal[] = [];
+  const fitInstances: MockFitAddon[] = [];
+  const writeLog: string[] = [];
+
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    dataHandler: DataHandler | null = null;
+    loadAddon = vi.fn();
+    open = vi.fn((host: HTMLElement) => {
+      const terminalElement = document.createElement('div');
+      terminalElement.className = 'xterm';
+      terminalElement.textContent = 'mock planning terminal';
+      host.appendChild(terminalElement);
+    });
+    write = vi.fn((data: string) => {
+      writeLog.push(data);
+    });
+    onData = vi.fn((cb: DataHandler) => {
+      this.dataHandler = cb;
+      return { dispose: vi.fn() };
+    });
+    focus = vi.fn();
+    dispose = vi.fn();
+
+    constructor() {
+      instances.push(this);
+    }
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+
+    constructor() {
+      fitInstances.push(this);
+    }
+  }
+
+  return {
+    Terminal: MockTerminal,
+    FitAddon: MockFitAddon,
+    instances,
+    fitInstances,
+    writeLog,
+    reset: () => {
+      instances.length = 0;
+      fitInstances.length = 0;
+      writeLog.length = 0;
+    },
+  };
+});
+
+vi.mock('xterm', () => ({ Terminal: xtermMock.Terminal }));
+vi.mock('xterm-addon-fit', () => ({ FitAddon: xtermMock.FitAddon }));
+
+const { App } = await import('../App.js');
+
+const PLANNING_SESSION_ID = 'saved-tmux';
+const PLANNING_TERMINAL_SESSION_ID = `mock-planning-terminal-${PLANNING_SESSION_ID}`;
+
+function planningTerminalOutput(data: string, planningSessionId: string | undefined = PLANNING_SESSION_ID) {
+  return {
+    sessionId: PLANNING_TERMINAL_SESSION_ID,
+    taskId: `planning:${PLANNING_SESSION_ID}`,
+    kind: 'planning' as const,
+    planningSessionId,
+    data,
+  };
+}
+
+describe('Planning terminal tmux persistence', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    xtermMock.reset();
+    mock = createMockInvoker();
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: PLANNING_SESSION_ID,
+          title: 'Saved tmux chat',
+          status: 'still_discussing',
+          messages: [],
+          draftPlanAvailable: false,
+          terminalMode: 'chat',
+        }),
+      ],
+    }));
+    mock.api.planningTerminalList = vi.fn(async () => []);
+    mock.install();
+  });
+
+  afterEach(() => {
+    cleanup();
+    mock.cleanup();
+    vi.restoreAllMocks();
+  });
+
+  async function renderSavedPlanningChat(): Promise<void> {
+    render(<App />);
+    await waitFor(() => {
+      expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('Saved tmux chat');
+    });
+  }
+
+  async function openPlanningTmux(): Promise<void> {
+    fireEvent.click(screen.getByRole('tab', { name: 'Tmux' }));
+    await waitFor(() => {
+      expect(mock.api.planningTerminalOpen).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('invoker-terminal-tmux-pane')).toHaveAttribute(
+        'data-session-id',
+        PLANNING_TERMINAL_SESSION_ID,
+      );
+    });
+  }
+
+  it('restores planning tmux output when switching between chat and tmux tabs', async () => {
+    await renderSavedPlanningChat();
+    await openPlanningTmux();
+
+    await act(async () => {
+      mock.fireTerminalOutput(planningTerminalOutput('visible tmux output\n'));
+    });
+
+    expect(xtermMock.instances.at(-1)?.write).toHaveBeenCalledWith('visible tmux output\n');
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Chat' }));
+    await waitFor(() => {
+      expect(screen.queryByTestId('invoker-terminal-tmux-pane')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Tmux' }));
+
+    await waitFor(() => {
+      expect(mock.api.planningTerminalOpen).toHaveBeenCalledTimes(1);
+      expect(xtermMock.instances.at(-1)?.write).toHaveBeenCalledWith(
+        expect.stringContaining('visible tmux output\n'),
+      );
+    });
+  });
+
+  it('restores planning tmux output emitted while the terminal surface is hidden', async () => {
+    await renderSavedPlanningChat();
+    await openPlanningTmux();
+
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+    expect(await screen.findByRole('heading', { name: 'Plan graph' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByTestId('invoker-terminal-tmux-pane')).not.toBeInTheDocument();
+    });
+
+    await act(async () => {
+      mock.fireTerminalOutput(planningTerminalOutput('hidden with planning id\n'));
+      mock.fireTerminalOutput(planningTerminalOutput('hidden with terminal id fallback\n', undefined));
+    });
+
+    expect(xtermMock.writeLog).not.toContain('hidden with planning id\n');
+    expect(xtermMock.writeLog).not.toContain('hidden with terminal id fallback\n');
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+
+    await waitFor(() => {
+      expect(mock.api.planningTerminalOpen).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('invoker-terminal-tmux-pane')).toHaveAttribute(
+        'data-session-id',
+        PLANNING_TERMINAL_SESSION_ID,
+      );
+      const latestTerminal = xtermMock.instances.at(-1);
+      expect(latestTerminal?.write).toHaveBeenCalledWith(
+        expect.stringContaining('hidden with planning id\nhidden with terminal id fallback\n'),
+      );
+    });
+  });
+});

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -26,6 +26,7 @@ interface PlanningPresetOptionView {
 }
 
 const TRANSCRIPT_BOTTOM_TOLERANCE_PX = 32;
+const TERMINAL_OUTPUT_SNAPSHOT_MAX_CHARS = 64 * 1024;
 
 function isTranscriptNearBottom(element: HTMLDivElement): boolean {
   return element.scrollHeight - element.scrollTop - element.clientHeight <= TRANSCRIPT_BOTTOM_TOLERANCE_PX;
@@ -37,6 +38,12 @@ function nowMs(): number {
 
 function roundMs(durationMs: number): number {
   return Math.max(0, Math.round(durationMs));
+}
+
+function appendTerminalOutputSnapshot(snapshot: string | undefined, chunk: string): string {
+  const next = `${snapshot ?? ''}${chunk}`;
+  if (next.length <= TERMINAL_OUTPUT_SNAPSHOT_MAX_CHARS) return next;
+  return next.slice(next.length - TERMINAL_OUTPUT_SNAPSHOT_MAX_CHARS);
 }
 
 function reportPlanningChatPerf(metric: string, data: Record<string, unknown>): void {
@@ -222,6 +229,15 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false }: PlanningTm
       if (event.sessionId !== session.sessionId) return;
       try {
         term.write(event.data);
+        const seededSnapshot = seededSnapshotRef.current;
+        const currentSnapshot = seededSnapshot?.sessionId === session.sessionId && seededSnapshot.term === term
+          ? seededSnapshot.snapshot
+          : '';
+        seededSnapshotRef.current = {
+          sessionId: session.sessionId,
+          snapshot: appendTerminalOutputSnapshot(currentSnapshot, event.data),
+          term,
+        };
       } catch {
         /* terminal disposed */
       }


### PR DESCRIPTION
## Summary

The completed workflow preserves planning tmux output across Home and Planning switches.

The merge gate now handles a requested `main` base in this repository.

It fetches the requested base, the default-branch fallback, and the feature branch before checking for an empty Invoker review branch.

When `main` is absent but `master` exists, the empty-branch check compares resolved SHAs instead of diffing an unresolved branch name.

## Review Claim

Approve resolving Invoker review diff refs before the merge gate decides whether a review branch has publishable changes.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change is limited to merge-gate branch resolution before review publication; it fetches refs and compares SHAs without changing workflow state or creating reviews.

## Slice Rationale

This slice is separate from the tmux UI behavior because it changes merge-gate routing around branch resolution, not terminal rendering.

## Non-goals

- Do not change planning tmux renderer behavior.
- Do not change GitHub write behavior for review creation.
- Do not change non-Invoker repository review handling.

## Architecture

### Before

```mermaid
graph TD
    A["workflow baseBranch is main"] --> B["empty-branch diff uses the branch name directly"]
    B --> C["missing refs can make review publication inspect the wrong range"]
```

### After

```mermaid
graph TD
    A["workflow baseBranch is main"] --> B["merge gate fetches main, master, and the feature branch"]
    B --> C["empty-branch diff compares resolved base and feature SHAs"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts -t "completes an empty Invoker external_review branch without publishing a make-pr stack"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f8e6243`
- Post-revert steps: rerun `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts -t "completes an empty Invoker external_review branch without publishing a make-pr stack"`
- Data migration? No

</details>

## Workflow Summary

Planning tmux output survives Home/Planning switches — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784340495515-7/implement-planning-tmux-history-sync | Keep planning tmux output snapshot in renderer state while the Planning surface is hidden, so remount restores scrollback/history | completed |
| wf-1784340495515-7/verify-planning-tmux-surface-switch-regression | Run focused UI regression test for planning tmux history across sidebar surface switches | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784340495515-7/implement-planning-tmux-history-sync — Keep planning tmux output snapshot in renderer state while the Planning surface is hidden, so remount restores scrollback/history

### wf-1784340495515-7/verify-planning-tmux-surface-switch-regression — Run focused UI regression test for planning tmux history across sidebar surface switches

</details>
