### PR TITLE
[Camera-quiet background selection](1) Stop app-driven selection changes from recentering the graph camera

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1836,6 +1836,10 @@ export function App() {
     return command;
   }, []);
 
+  const recenterForSelection = useCallback((scope: GraphScope, target: string) => {
+    issueCameraCommand({ kind: 'centerSelection', scope, target, reason: 'selection' });
+  }, [issueCameraCommand]);
+
   const handleWorkflowGraphViewportSnapshot = useCallback((viewport: GraphCameraViewport) => {
     workflowGraphViewportRef.current = viewport;
   }, []);
@@ -1853,7 +1857,7 @@ export function App() {
     });
   }, []);
 
-  const selectWorkflowById = useCallback((workflowId: string) => {
+  const selectWorkflowById = useCallback((workflowId: string, options: { recenter?: boolean } = {}) => {
     armSuppressDagSurfaceDismiss();
     setWorkflowSelectionDismissed(false);
     setSelectedWorkflowId(workflowId);
@@ -1861,9 +1865,12 @@ export function App() {
     setContextMenu(null);
     setWorkflowContextMenu(null);
     focusKeyboardRegion('workflowGraph');
-  }, [armSuppressDagSurfaceDismiss, focusKeyboardRegion]);
+    if (options.recenter ?? true) {
+      recenterForSelection('workflow', workflowId);
+    }
+  }, [armSuppressDagSurfaceDismiss, focusKeyboardRegion, recenterForSelection]);
 
-  const selectTaskById = useCallback((taskId: string) => {
+  const selectTaskById = useCallback((taskId: string, options: { recenter?: boolean } = {}) => {
     const task = tasksRef.current.get(taskId);
     if (!task) return;
     setSelectedTaskId(task.id);
@@ -1876,19 +1883,35 @@ export function App() {
     setContextMenu(null);
     setWorkflowContextMenu(null);
     focusKeyboardRegion('taskGraph');
-  }, [focusKeyboardRegion]);
+    if (options.recenter ?? true) {
+      recenterForSelection('task', task.id);
+    }
+  }, [focusKeyboardRegion, recenterForSelection]);
 
   useEffect(() => {
     const unsubscribe = window.invoker?.onWorkflowMutationFailed?.((event) => {
       const failedTaskId = event.taskId;
       if (failedTaskId) {
         setMutationFailuresByTaskId((prev) => new Map(prev).set(failedTaskId, event));
+        const task = tasksRef.current.get(failedTaskId);
+        if (task) {
+          selectTaskById(task.id, { recenter: false });
+        } else {
+          setSelectedTaskId(failedTaskId);
+          setWorkflowSelectionDismissed(false);
+          setSelectedWorkflowId(event.workflowId);
+          setInspectorCollapsed(false);
+          setInspectorManualOpen(true);
+          setContextMenu(null);
+          setWorkflowContextMenu(null);
+          focusKeyboardRegion('taskGraph');
+        }
         return;
       }
       notifyMutationError('Mutation failed', event.message);
     });
     return () => { unsubscribe?.(); };
-  }, []);
+  }, [focusKeyboardRegion, selectTaskById]);
 
   const selectRelativeNode = useCallback((direction: 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight') => {
     const inTaskGraph = keyboardRegion === 'taskGraph';
@@ -2229,13 +2252,8 @@ export function App() {
   }, []);
 
   const handleWorkflowClick = useCallback((workflowId: string) => {
-    armSuppressDagSurfaceDismiss();
-    setWorkflowSelectionDismissed(false);
-    setSelectedWorkflowId(workflowId);
-    setSelectedTaskId(null);
-    setContextMenu(null);
-    setWorkflowContextMenu(null);
-  }, [armSuppressDagSurfaceDismiss]);
+    selectWorkflowById(workflowId);
+  }, [selectWorkflowById]);
 
   const handleWorkflowContextMenu = useCallback((event: React.MouseEvent<Element>, workflowId: string) => {
     event.preventDefault();
@@ -2262,7 +2280,7 @@ export function App() {
       if (activeWorkflowId !== null && !selectedWorkflowVanished) {
         return;
       }
-      selectWorkflowById(workflowEntries[0].workflow.id);
+      selectWorkflowById(workflowEntries[0].workflow.id, { recenter: false });
       return;
     }
 
@@ -2278,7 +2296,7 @@ export function App() {
       if (attentionEntries.some((entry) => entry.task.id === selectedTaskId)) {
         return;
       }
-      selectTaskById(attentionEntries[0].task.id);
+      selectTaskById(attentionEntries[0].task.id, { recenter: false });
       return;
     }
 

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { WorkflowMeta } from '../types.js';
 import type { GraphCameraCommand } from '../lib/graph-camera.js';
@@ -156,7 +156,7 @@ describe('Browser-surface camera (component)', () => {
     expect(fitViewMock).not.toHaveBeenCalled();
   }, 20000);
 
-  it('does not re-center or re-fit when the selected task changes while already on a browser surface', async () => {
+  it('re-centers when the selected task changes from a user click on a browser surface', async () => {
     mock.setTasks(tasks, workflows);
     render(<App />);
 
@@ -168,6 +168,72 @@ describe('Browser-surface camera (component)', () => {
     setCenterMock.mockClear();
 
     fireEvent.click(screen.getByTestId('rf__node-wf-a/two'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Task Two');
+    });
+    await flushFrames(6);
+
+    expect(setCenterMock).toHaveBeenCalled();
+    expect(fitViewMock).not.toHaveBeenCalled();
+  });
+
+  it('a background auto-select reshuffle changes selection but issues no camera command', async () => {
+    const reshuffleWorkflows: WorkflowMeta[] = [
+      { id: 'wf-a', name: 'Alpha Workflow', status: 'running' },
+      { id: 'wf-b', name: 'Beta Workflow', status: 'running' },
+    ];
+    mock.setTasks([], reshuffleWorkflows);
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId('sidebar-workflows'));
+    const list = await screen.findByTestId('workflows-rail-list');
+    fireEvent.click(within(list).getByRole('button', { name: /Beta Workflow/ }));
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Beta Workflow');
+    });
+    await settleCamera();
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+
+    act(() => {
+      mock.fireWorkflowsChanged([reshuffleWorkflows[0]]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Alpha Workflow');
+    }, { timeout: 3000 });
+    await flushFrames(6);
+
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(fitViewMock).not.toHaveBeenCalled();
+  });
+
+  it('a workflow-mutation-failed event selects the failed task but issues no camera command', async () => {
+    mock.setTasks(tasks, workflows);
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    fireEvent.click(await screen.findByTestId('workflow-node-wf-a'));
+    await screen.findByTestId('selected-workflow-mini-dag');
+    fireEvent.click(await screen.findByTestId('rf__node-wf-a/one'));
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Task One');
+    });
+    await settleCamera();
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+
+    act(() => {
+      mock.fireWorkflowMutationFailed({
+        intentId: 42,
+        workflowId: 'wf-a',
+        channel: 'invoker:approve',
+        taskId: 'wf-a/two',
+        message: 'approve failed',
+        failedAt: '2026-07-08T10:00:00.000Z',
+      });
+    });
 
     await waitFor(() => {
       expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Task Two');


### PR DESCRIPTION
## Summary

App-driven selection changes now keep the browser-surface graph camera quiet.

Background auto-selection and mutation-failure focus update the selected row without moving the viewport.

User clicks and keyboard navigation still recenter the selected workflow or task.

## Review Claim

Approve the camera command boundary: app-driven workflow and task selection updates inspector state without issuing graph movement, while user navigation still recenters.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change stays in UI selection and camera coordination plus focused component coverage. It does not alter selected task data, graph topology, or task execution.

## Slice Rationale

This activation-surface slice keeps the camera behavior and regression coverage together because they define one selection-to-camera command boundary.

The verification-only workflow task has no file diff, so it is represented in the test plan instead of an empty PR.

## Non-goals

- No graph layout, node position, or zoom math changes.
- No task execution, workflow mutation payload, or review-gate publication behavior changes.
- No worktree, SSH, or clone provisioning changes.

## Workflow Context

Camera-quiet background selection — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784181997868-1/quiet-background-camera | Stop app-driven selection changes from recentering the graph camera | completed |
| wf-1784181997868-1/verify-camera-quiet | Run the browser-surface camera regression suite | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784181997868-1/quiet-background-camera — Stop app-driven selection changes from recentering the graph camera

### wf-1784181997868-1/verify-camera-quiet — Run the browser-surface camera regression suite

</details>

## Architecture

### Before

```mermaid
graph TD
    A["Selection state changed"] --> B["centerSelection camera command"]
```

### After

```mermaid
graph TD
    A["User selection"] --> B["centerSelection camera command"]
    C["App-driven selection"] --> D["Selection state only"]
```

## Visual Proof

The screenshot shows the workflow and task graph surface where the camera command is consumed.

![Browser-surface graph context for the camera regression](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-146419/neutral-chrome-home-graph.png)

Static media cannot show a suppressed camera move. The focused Vitest spies in the test plan prove the no-movement condition.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/browser-surface-camera-resnap.test.tsx`
- [x] Invoker workflow task `wf-1784181997868-1/verify-camera-quiet` completed with the browser-surface camera regression suite passing.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c6e99d9f4fac490444e1bde16fa42ff76334b340`
- Post-revert steps: Rerun the focused UI camera regression suite.
- Data migration? No

</details>
