### PR TITLE
[Remote Sync Step 1: Sync Schema and Change Journal](1) Add data-store sync schema and journal

### DIFF
--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createAttempt, createTaskState } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { Workflow } from '../adapter.js';
+import type { SqliteExecutor } from '../sqlite-executor.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  readJournalSince,
+  setSyncCursor,
+} from '../sync-journal.js';
+
+describe('sync journal', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function execOf(db: SQLiteAdapter): SqliteExecutor {
+    return (db as unknown as { executor: SqliteExecutor }).executor;
+  }
+
+  function workflow(id: string): Workflow {
+    return {
+      id,
+      name: id,
+      status: 'pending',
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+    };
+  }
+
+  it('rolls back a journal append with the mutation that created it', () => {
+    expect(() => {
+      adapter.runInTransaction(() => {
+        (adapter as any).db.run(
+          `INSERT INTO workflows (id, name, created_at, updated_at)
+           VALUES ('wf-rollback', 'Rollback', '2026-07-27T00:00:00.000Z', '2026-07-27T00:00:00.000Z')`,
+        );
+        appendJournalEntry(execOf(adapter), {
+          entityType: 'workflow',
+          entityId: 'wf-rollback',
+          op: 'upsert',
+          payload: { id: 'wf-rollback' },
+        });
+        throw new Error('rollback');
+      });
+    }).toThrow('rollback');
+
+    expect(adapter.loadWorkflow('wf-rollback', { includeDeleted: true })).toBeUndefined();
+    expect(readJournalSince(execOf(adapter), 0, 10)).toEqual([]);
+  });
+
+  it('assigns strictly monotonic journal sequence numbers', () => {
+    adapter.saveWorkflow(workflow('wf-seq'));
+    const task = createTaskState('task-seq', 'Task seq', [], { workflowId: 'wf-seq' });
+    adapter.saveTask('wf-seq', task);
+    adapter.updateTask('task-seq', { status: 'running' });
+    const attempt = createAttempt('task-seq', { status: 'pending' });
+    adapter.saveAttempt(attempt);
+    adapter.updateAttempt(attempt.id, { status: 'completed', completedAt: new Date('2026-07-27T00:00:01.000Z') });
+
+    const seqs = readJournalSince(execOf(adapter), 0, 20).map((entry) => entry.seq);
+    expect(seqs.length).toBeGreaterThanOrEqual(5);
+    for (let i = 1; i < seqs.length; i += 1) {
+      expect(seqs[i]).toBeGreaterThan(seqs[i - 1]);
+    }
+  });
+
+  it('reads journal entries after the stored peer cursor', () => {
+    adapter.saveWorkflow(workflow('wf-cursor'));
+    adapter.saveTask('wf-cursor', createTaskState('task-cursor', 'Task cursor', [], { workflowId: 'wf-cursor' }));
+    adapter.updateTask('task-cursor', { status: 'running' });
+
+    const all = readJournalSince(execOf(adapter), 0, 10);
+    const cursor = setSyncCursor(execOf(adapter), {
+      peerId: 'peer-a',
+      lastSentSeq: all[0].seq,
+      lastReceivedSeq: 7,
+      updatedAt: 1000,
+    });
+    expect(getSyncCursor(execOf(adapter), 'peer-a')).toEqual(cursor);
+
+    const unread = readJournalSince(execOf(adapter), cursor.lastSentSeq, 10);
+    expect(unread.map((entry) => entry.seq)).toEqual(all.slice(1).map((entry) => entry.seq));
+  });
+
+  it('excludes soft-deleted workflows from default listings and reads them with includeDeleted', () => {
+    adapter.saveWorkflow(workflow('wf-delete'));
+    adapter.saveWorkflow(workflow('wf-keep'));
+
+    adapter.deleteWorkflow('wf-delete');
+
+    expect(adapter.listWorkflows().map((entry) => entry.id)).toEqual(['wf-keep']);
+    expect(adapter.loadWorkflow('wf-delete')).toBeUndefined();
+
+    const deleted = adapter.listWorkflows({ includeDeleted: true }).find((entry) => entry.id === 'wf-delete');
+    expect(deleted?.deletedAt).toEqual(expect.any(Number));
+    expect(adapter.loadWorkflow('wf-delete', { includeDeleted: true })?.deletedAt).toEqual(expect.any(Number));
+  });
+
+  it('writes a tombstone journal entry when deleting a workflow', () => {
+    adapter.saveWorkflow(workflow('wf-tombstone'));
+
+    adapter.deleteWorkflow('wf-tombstone');
+
+    const tombstone = readJournalSince(execOf(adapter), 0, 20).find(
+      (entry) => entry.entityType === 'workflow' && entry.entityId === 'wf-tombstone' && entry.op === 'tombstone',
+    );
+    expect(tombstone).toBeDefined();
+    expect((tombstone!.payload as { id?: string }).id).toBe('wf-tombstone');
+    expect((tombstone!.payload as { deleted_at?: number }).deleted_at).toEqual(expect.any(Number));
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -126,8 +126,13 @@ export interface Workflow {
   generation?: number;
   createdAt: string;
   updatedAt: string;
+  deletedAt?: number;
 }
 export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup'>;
+
+export interface WorkflowListOptions {
+  includeDeleted?: boolean;
+}
 
 /**
  * Result of resolving a published PR back to its Invoker workflow via the merge
@@ -333,8 +338,8 @@ export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
-  loadWorkflow(workflowId: string): Workflow | undefined;
-  listWorkflows(): Workflow[];
+  loadWorkflow(workflowId: string, options?: WorkflowListOptions): Workflow | undefined;
+  listWorkflows(options?: WorkflowListOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
   /** Resolve a GitHub PR number back to its Invoker workflow via the merge node. */
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined;

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -1,6 +1,7 @@
 export * from './adapter.js';
 export * from './attempt-read-models.js';
 export * from './sqlite-adapter.js';
+export * from './sync-journal.js';
 export * from './slow-query-aggregator.js';
 export * from './conversation-repository.js';
 export * from './slack-session-repository.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -38,6 +38,7 @@ import type {
   PersistenceAdapter,
   ReviewGateLookup,
   Workflow,
+  WorkflowListOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
   TaskEvent,
@@ -78,6 +79,7 @@ import type { SqliteExecutor } from './sqlite-executor.js';
 import * as migrations from './sqlite-migrations.js';
 import { SqliteTaskAttemptRepository } from './sqlite-task-attempt-repository.js';
 import { SqliteWorkflowRepository, type WorkflowMetadataChanges } from './sqlite-workflow-repository.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 function normalizeWorkerActionStatus(status: string): string {
   return status === 'canceled' ? 'cancelled' : status;
@@ -1054,12 +1056,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.workflowRepo.updateWorkflow(workflowId, changes);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    return this.workflowRepo.loadWorkflow(workflowId);
+  loadWorkflow(workflowId: string, options?: WorkflowListOptions): Workflow | undefined {
+    return this.workflowRepo.loadWorkflow(workflowId, options);
   }
 
-  listWorkflows(): Workflow[] {
-    return this.workflowRepo.listWorkflows();
+  listWorkflows(options?: WorkflowListOptions): Workflow[] {
+    return this.workflowRepo.listWorkflows(options);
   }
 
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
@@ -1559,6 +1561,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
   deleteWorkflow(workflowId: string): void {
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
     this.runTransaction(() => {
+      const existingWorkflow = this.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+      if (!existingWorkflow) return;
+      const alreadyDeleted = existingWorkflow.deleted_at !== null && existingWorkflow.deleted_at !== undefined;
       this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM task_launch_dispatch WHERE workflow_id = ?', [workflowId]);
@@ -1598,7 +1603,21 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
+      if (!alreadyDeleted) {
+        this.db.run(
+          'UPDATE workflows SET deleted_at = ?, updated_at = ? WHERE id = ?',
+          [Date.now(), new Date().toISOString(), workflowId],
+        );
+        const tombstonePayload = this.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+        if (tombstonePayload) {
+          appendJournalEntry(this.executor, {
+            entityType: 'workflow',
+            entityId: workflowId,
+            op: 'tombstone',
+            payload: tombstonePayload,
+          });
+        }
+      }
     });
     this.removeOutputFiles(taskIds);
   }

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -49,6 +49,7 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
     generation: row.generation ?? 0,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+    deletedAt: row.deleted_at ?? undefined,
   };
 }
 

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -28,7 +28,28 @@ export const SCHEMA_DDL = `
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
         created_at TEXT DEFAULT (datetime('now')),
-        updated_at TEXT DEFAULT (datetime('now'))
+        updated_at TEXT DEFAULT (datetime('now')),
+        deleted_at INTEGER
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_journal (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+        entity_id TEXT NOT NULL,
+        op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+        payload TEXT NOT NULL CHECK (json_valid(payload)),
+        origin TEXT NOT NULL DEFAULT 'home',
+        created_at INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_sync_journal_entity
+        ON sync_journal(entity_type, entity_id, seq);
+
+      CREATE TABLE IF NOT EXISTS sync_cursors (
+        peer_id TEXT PRIMARY KEY,
+        last_sent_seq INTEGER NOT NULL DEFAULT 0,
+        last_received_seq INTEGER NOT NULL DEFAULT 0,
+        updated_at INTEGER NOT NULL
       );
 
       CREATE TABLE IF NOT EXISTS tasks (
@@ -597,6 +618,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
+  'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
 ];
 
 /**
@@ -628,6 +650,22 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  `CREATE TABLE IF NOT EXISTS sync_journal (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+    entity_id TEXT NOT NULL,
+    op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    origin TEXT NOT NULL DEFAULT 'home',
+    created_at INTEGER NOT NULL
+  )`,
+  'CREATE INDEX IF NOT EXISTS idx_sync_journal_entity ON sync_journal(entity_type, entity_id, seq)',
+  `CREATE TABLE IF NOT EXISTS sync_cursors (
+    peer_id TEXT PRIMARY KEY,
+    last_sent_seq INTEGER NOT NULL DEFAULT 0,
+    last_received_seq INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER NOT NULL
+  )`,
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */
@@ -652,7 +690,8 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
         created_at TEXT DEFAULT (datetime('now')),
-        updated_at TEXT DEFAULT (datetime('now'))
+        updated_at TEXT DEFAULT (datetime('now')),
+        deleted_at INTEGER
       )
     `;
 
@@ -662,12 +701,12 @@ export const WORKFLOWS_REBUILD_INSERT_DDL = `
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, created_at, updated_at, deleted_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, created_at, updated_at, deleted_at
       FROM workflows
     `;

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -17,8 +17,10 @@ import {
 import { mapRowToTask, mapRowToAttempt } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
+const TERMINAL_ATTEMPT_STATUSES = new Set<Attempt['status']>(['completed', 'failed', 'superseded']);
 
 /**
  * Adapter-side task/attempt mutators that {@link SqliteTaskAttemptRepository.failTaskAndAttempt}
@@ -43,6 +45,8 @@ export class SqliteTaskAttemptRepository {
   ) {}
 
   private hasCrashPreservationTableCache: boolean | null = null;
+  private journalWrappedTaskStatusUpdate = false;
+  private journalWrappedAttemptCompletionUpdate = false;
 
   private hasCrashPreservationTable(): boolean {
     if (this.hasCrashPreservationTableCache !== null) return this.hasCrashPreservationTableCache;
@@ -111,6 +115,7 @@ export class SqliteTaskAttemptRepository {
 
   saveTask(workflowId: string, task: TaskState): void {
     assertTaskConsistent(task);
+    this.exec.runTransaction(() => {
     const cfg = task.config;
     const exec = task.execution;
     this.exec.execRun(`
@@ -224,9 +229,20 @@ export class SqliteTaskAttemptRepository {
       task.taskStateVersion ?? 1,
     ]);
     this.syncCrashPreservationState(task.id, undefined, task.execution);
+    this.appendTaskJournalEntry(task.id);
+    });
   }
 
   updateTask(taskId: string, changes: TaskStateChanges): void {
+    if (changes.status !== undefined && !this.journalWrappedTaskStatusUpdate) {
+      this.journalWrappedTaskStatusUpdate = true;
+      try {
+        return this.exec.runTransaction(() => this.updateTask(taskId, changes));
+      } finally {
+        this.journalWrappedTaskStatusUpdate = false;
+      }
+    }
+
     const beforeTask = this.loadTask(taskId);
     if (!beforeTask) return;
 
@@ -418,6 +434,9 @@ export class SqliteTaskAttemptRepository {
       console.log(`[persist-sql] taskId=${taskId} columns=[${cols}]`);
     }
     this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    if (changes.status !== undefined) {
+      this.appendTaskJournalEntry(taskId);
+    }
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -594,6 +613,7 @@ export class SqliteTaskAttemptRepository {
   // ── Attempt CRUD ─────────────────────────────────────────
 
   saveAttempt(attempt: Attempt): void {
+    this.exec.runTransaction(() => {
     this.exec.execRun(`
       INSERT OR REPLACE INTO attempts (
         id, node_id, attempt_number, queue_priority, status,
@@ -628,6 +648,8 @@ export class SqliteTaskAttemptRepository {
       attempt.createdAt.toISOString(),
       attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
     ]);
+    this.appendAttemptJournalEntry(attempt.id);
+    });
   }
 
   loadAttempts(nodeId: string): Attempt[] {
@@ -689,6 +711,16 @@ export class SqliteTaskAttemptRepository {
   }
 
   updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void {
+    const shouldJournal = this.shouldJournalAttemptCompletion(changes);
+    if (shouldJournal && !this.journalWrappedAttemptCompletionUpdate) {
+      this.journalWrappedAttemptCompletionUpdate = true;
+      try {
+        return this.exec.runTransaction(() => this.updateAttempt(attemptId, changes));
+      } finally {
+        this.journalWrappedAttemptCompletionUpdate = false;
+      }
+    }
+
     const setClauses: string[] = [];
     const values: unknown[] = [];
 
@@ -712,6 +744,9 @@ export class SqliteTaskAttemptRepository {
     if (setClauses.length === 0) return;
     values.push(attemptId);
     this.exec.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    if (shouldJournal) {
+      this.appendAttemptJournalEntry(attemptId);
+    }
   }
 
   claimAttemptForLaunch(
@@ -888,5 +923,33 @@ export class SqliteTaskAttemptRepository {
       [nodeId, selected.createdAt.toISOString(), cappedLimit],
     );
     return rows.map((row) => mapRowToAttempt(row));
+  }
+
+  private shouldJournalAttemptCompletion(
+    changes: Partial<Pick<Attempt, 'status' | 'completedAt'>>,
+  ): boolean {
+    return changes.status !== undefined && TERMINAL_ATTEMPT_STATUSES.has(changes.status);
+  }
+
+  private appendTaskJournalEntry(taskId: string): void {
+    const row = this.exec.queryOne('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (!row) return;
+    appendJournalEntry(this.exec, {
+      entityType: 'task',
+      entityId: taskId,
+      op: 'upsert',
+      payload: row,
+    });
+  }
+
+  private appendAttemptJournalEntry(attemptId: string): void {
+    const row = this.exec.queryOne('SELECT * FROM attempts WHERE id = ?', [attemptId]);
+    if (!row) return;
+    appendJournalEntry(this.exec, {
+      entityType: 'attempt',
+      entityId: attemptId,
+      op: 'upsert',
+      payload: row,
+    });
   }
 }

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -27,11 +27,13 @@ import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ReviewGateLookup,
   Workflow,
+  WorkflowListOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
 } from './adapter.js';
 import { mapRowToWorkflow, mapRowToTask } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 export type WorkflowMetadataChanges = Partial<
   Pick<
@@ -88,23 +90,27 @@ export class SqliteWorkflowRepository {
 
   saveWorkflow(workflow: WorkflowSaveInput): void {
     assertWorkflowConsistent(workflow);
-    this.exec.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `, [
-      workflow.id, workflow.name,
-      workflow.description ?? null,
-      workflow.visualProof ? 1 : 0,
-      workflow.planFile ?? null, workflow.repoUrl ?? null, workflow.intermediateRepoUrl ?? null, workflow.branch ?? null,
-      workflow.onFinish ?? null, workflow.baseBranch ?? null, null, workflow.featureBranch ?? null,
-      workflow.mergeMode ?? null,
-      workflow.reviewProvider ?? null,
-      workflow.externalDependencies ? JSON.stringify(workflow.externalDependencies) : null,
-      workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
-      workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
-      workflow.generation ?? 0,
-      workflow.createdAt, workflow.updatedAt,
-    ]);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`
+        INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at, deleted_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `, [
+        workflow.id, workflow.name,
+        workflow.description ?? null,
+        workflow.visualProof ? 1 : 0,
+        workflow.planFile ?? null, workflow.repoUrl ?? null, workflow.intermediateRepoUrl ?? null, workflow.branch ?? null,
+        workflow.onFinish ?? null, workflow.baseBranch ?? null, null, workflow.featureBranch ?? null,
+        workflow.mergeMode ?? null,
+        workflow.reviewProvider ?? null,
+        workflow.externalDependencies ? JSON.stringify(workflow.externalDependencies) : null,
+        workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
+        workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
+        workflow.generation ?? 0,
+        workflow.createdAt, workflow.updatedAt,
+        workflow.deletedAt ?? null,
+      ]);
+      this.appendWorkflowJournalEntry(workflow.id, 'upsert');
+    });
   }
 
   updateWorkflow(workflowId: string, changes: WorkflowMetadataChanges): void {
@@ -165,25 +171,30 @@ export class SqliteWorkflowRepository {
     values.push(updatedAt);
     if (setClauses.length === 0) return;
 
-    const before = this.loadWorkflow(workflowId);
-    if (!before) return;
-    const after = this.buildWorkflowAfterChanges(before, changes, updatedAt);
-    assertWorkflowPatchConsistent(before, after, changes);
+    this.exec.runTransaction(() => {
+      const before = this.loadWorkflow(workflowId);
+      if (!before) return;
+      const after = this.buildWorkflowAfterChanges(before, changes, updatedAt);
+      assertWorkflowPatchConsistent(before, after, changes);
 
-    values.push(workflowId);
-    this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
+      this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, [...values, workflowId]);
+      this.appendWorkflowJournalEntry(workflowId, 'upsert');
+    });
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+  loadWorkflow(workflowId: string, options?: WorkflowListOptions): Workflow | undefined {
+    const row = this.exec.queryOne(
+      `SELECT * FROM workflows WHERE id = ?${options?.includeDeleted ? '' : ' AND deleted_at IS NULL'}`,
+      [workflowId],
+    );
     if (!row) return undefined;
     const rollup = this.loadWorkflowRollups([workflowId]).get(workflowId);
     return this.rowToWorkflow(row, rollup);
   }
 
-  listWorkflows(): Workflow[] {
+  listWorkflows(options?: WorkflowListOptions): Workflow[] {
     const rows = this.exec.queryAll(
-      'SELECT * FROM workflows ORDER BY created_at DESC',
+      `SELECT * FROM workflows${options?.includeDeleted ? '' : ' WHERE deleted_at IS NULL'} ORDER BY created_at DESC`,
     );
     const workflowIds = rows.map((row) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
@@ -205,7 +216,9 @@ export class SqliteWorkflowRepository {
               w.base_branch AS baseBranch
          FROM tasks t
          JOIN workflows w ON w.id = t.workflow_id
-        WHERE t.is_merge_node = 1 AND (t.review_id = ? OR t.review_url LIKE ?)`,
+        WHERE w.deleted_at IS NULL
+          AND t.is_merge_node = 1
+          AND (t.review_id = ? OR t.review_url LIKE ?)`,
       [pr, `%/pull/${pr}`],
     );
     if (rows.length === 0) return undefined;
@@ -257,7 +270,8 @@ export class SqliteWorkflowRepository {
     if (type === 'workflows' || type === 'all') {
       const workflows = this.exec.queryAll(
         `SELECT id, name, description, plan_file, repo_url, branch, created_at FROM workflows 
-         WHERE name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ? 
+         WHERE deleted_at IS NULL
+           AND (name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{ id: string; name?: string | null; created_at: string }>;
@@ -281,8 +295,11 @@ export class SqliteWorkflowRepository {
     
     if (type === 'tasks' || type === 'all') {
       const tasks = this.exec.queryAll(
-        `SELECT id, workflow_id, description, command, prompt, summary, problem, approach, test_plan, repro_command, status, created_at FROM tasks 
-         WHERE description LIKE ? OR command LIKE ? OR prompt LIKE ? OR summary LIKE ? OR problem LIKE ? OR approach LIKE ? OR test_plan LIKE ? OR repro_command LIKE ? 
+        `SELECT t.id, t.workflow_id, t.description, t.command, t.prompt, t.summary, t.problem, t.approach, t.test_plan, t.repro_command, t.status, t.created_at
+         FROM tasks t
+         JOIN workflows w ON w.id = t.workflow_id
+         WHERE w.deleted_at IS NULL
+           AND (t.description LIKE ? OR t.command LIKE ? OR t.prompt LIKE ? OR t.summary LIKE ? OR t.problem LIKE ? OR t.approach LIKE ? OR t.test_plan LIKE ? OR t.repro_command LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{
@@ -326,10 +343,16 @@ export class SqliteWorkflowRepository {
   loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
     const totalStartedAt = Date.now();
     const workflowQueryStartedAt = Date.now();
-    const workflowRows = this.exec.queryAll('SELECT * FROM workflows ORDER BY created_at DESC');
+    const workflowRows = this.exec.queryAll('SELECT * FROM workflows WHERE deleted_at IS NULL ORDER BY created_at DESC');
     const workflowMetadataQueryMs = Date.now() - workflowQueryStartedAt;
     const taskQueryStartedAt = Date.now();
-    const taskRows = this.exec.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC');
+    const taskRows = this.exec.queryAll(
+      `SELECT t.*
+         FROM tasks t
+         JOIN workflows w ON w.id = t.workflow_id
+        WHERE w.deleted_at IS NULL
+        ORDER BY t.workflow_id ASC, t.id ASC`,
+    );
     const taskQueryMs = Date.now() - taskQueryStartedAt;
     const tasksByWorkflowId = new Map<string, TaskState[]>();
     const workflowIds = workflowRows.map((row) => String(row.id));
@@ -465,5 +488,16 @@ export class SqliteWorkflowRepository {
 
   private rowToWorkflow(row: Record<string, unknown>, rollup?: WorkflowRollup): Workflow {
     return mapRowToWorkflow(row, rollup);
+  }
+
+  private appendWorkflowJournalEntry(workflowId: string, op: 'upsert' | 'tombstone'): void {
+    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+    if (!row) return;
+    appendJournalEntry(this.exec, {
+      entityType: 'workflow',
+      entityId: workflowId,
+      op,
+      payload: row,
+    });
   }
 }

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -1,0 +1,158 @@
+import type { SqliteExecutor } from './sqlite-executor.js';
+
+export type SyncEntityType = 'workflow' | 'task' | 'attempt' | 'event' | 'output';
+export type SyncJournalOp = 'upsert' | 'tombstone';
+
+export interface SyncJournalEntryInput {
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOp;
+  payload: unknown;
+  origin?: string;
+  createdAt?: number;
+}
+
+export interface SyncJournalEntry {
+  seq: number;
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOp;
+  payload: unknown;
+  origin: string;
+  createdAt: number;
+}
+
+export interface SyncCursor {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt: number;
+}
+
+export interface SyncCursorPatch {
+  peerId: string;
+  lastSentSeq?: number;
+  lastReceivedSeq?: number;
+  updatedAt?: number;
+}
+
+const DEFAULT_LOCAL_ORIGIN = 'home';
+
+// `output` is reserved in SyncEntityType for future output-spool snapshots.
+// High-volume output rows are intentionally not journaled by this foundation.
+
+export function appendJournalEntry(db: SqliteExecutor, entry: SyncJournalEntryInput): number {
+  const createdAt = normalizeIntegerTimestamp(entry.createdAt ?? Date.now(), 'createdAt');
+  const origin = entry.origin ?? DEFAULT_LOCAL_ORIGIN;
+  const payload = JSON.stringify(entry.payload);
+  if (payload === undefined) {
+    throw new Error('sync journal payload must be JSON-serializable');
+  }
+  db.execRun(
+    `INSERT INTO sync_journal (entity_type, entity_id, op, payload, origin, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [
+      entry.entityType,
+      entry.entityId,
+      entry.op,
+      payload,
+      origin,
+      createdAt,
+    ],
+  );
+  const row = db.queryOne('SELECT last_insert_rowid() AS seq') as { seq?: number | bigint } | undefined;
+  return Number(row?.seq ?? 0);
+}
+
+export function readJournalSince(
+  db: SqliteExecutor,
+  seq: number,
+  limit: number,
+): SyncJournalEntry[] {
+  const afterSeq = normalizeNonNegativeInteger(seq, 'seq');
+  const cappedLimit = normalizePositiveInteger(limit, 'limit');
+  const rows = db.queryAll(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq > ?
+      ORDER BY seq ASC
+      LIMIT ?`,
+    [afterSeq, cappedLimit],
+  );
+  return rows.map(rowToJournalEntry);
+}
+
+export function getSyncCursor(db: SqliteExecutor, peerId: string): SyncCursor | undefined {
+  const row = db.queryOne(
+    `SELECT peer_id, last_sent_seq, last_received_seq, updated_at
+       FROM sync_cursors
+      WHERE peer_id = ?`,
+    [peerId],
+  );
+  return row ? rowToCursor(row) : undefined;
+}
+
+export function setSyncCursor(db: SqliteExecutor, cursor: SyncCursorPatch): SyncCursor {
+  const existing = getSyncCursor(db, cursor.peerId);
+  const next: SyncCursor = {
+    peerId: cursor.peerId,
+    lastSentSeq: normalizeNonNegativeInteger(cursor.lastSentSeq ?? existing?.lastSentSeq ?? 0, 'lastSentSeq'),
+    lastReceivedSeq: normalizeNonNegativeInteger(
+      cursor.lastReceivedSeq ?? existing?.lastReceivedSeq ?? 0,
+      'lastReceivedSeq',
+    ),
+    updatedAt: normalizeIntegerTimestamp(cursor.updatedAt ?? Date.now(), 'updatedAt'),
+  };
+  db.execRun(
+    `INSERT INTO sync_cursors (peer_id, last_sent_seq, last_received_seq, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(peer_id) DO UPDATE SET
+       last_sent_seq = excluded.last_sent_seq,
+       last_received_seq = excluded.last_received_seq,
+       updated_at = excluded.updated_at`,
+    [next.peerId, next.lastSentSeq, next.lastReceivedSeq, next.updatedAt],
+  );
+  return next;
+}
+
+function rowToJournalEntry(row: Record<string, unknown>): SyncJournalEntry {
+  return {
+    seq: Number(row.seq),
+    entityType: row.entity_type as SyncEntityType,
+    entityId: String(row.entity_id),
+    op: row.op as SyncJournalOp,
+    payload: JSON.parse(String(row.payload)),
+    origin: String(row.origin),
+    createdAt: Number(row.created_at),
+  };
+}
+
+function rowToCursor(row: Record<string, unknown>): SyncCursor {
+  return {
+    peerId: String(row.peer_id),
+    lastSentSeq: Number(row.last_sent_seq),
+    lastReceivedSeq: Number(row.last_received_seq),
+    updatedAt: Number(row.updated_at),
+  };
+}
+
+function normalizePositiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function normalizeNonNegativeInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function normalizeIntegerTimestamp(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer timestamp`);
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Remote Sync Step 1: Sync Schema and Change Journal — 2 tasks completed, 0 failed, 0 closed, 0 ski&#112;ped

Remote sync now has data-store tables for journal entries, peer cursors, and workflow tombstones.

Workflow, task, and attempt writes append journal entries inside the same SQLite transaction.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926077035-3/implement-sync-schema | Add sync journal, cursor, and tombstone schema to data-store | completed |
| wf-1784926077035-3/verify-sync-schema | Run data-store package tests covering the new schema and journal | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784926077035-3/implement-sync-schema — Add sync journal, cursor, and tombstone schema to data-store

### wf-1784926077035-3/verify-sync-schema — Run data-store package tests covering the new schema and journal

</details>

## Review Claim

Approve the data-store sync schema contract: journal entries, peer cursors, and workflow tombstones are durable alongside existing persistence writes.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This slice stays inside data-store schema, repositories, mappers, adapter exports, and focused sync-journal tests.

## Slice Rationale

Remote sync needs durable change capture before later transport, replay, or conflict resolution slices can consume it.

## Non-goals

- No remote transport.
- No sync replay worker.
- No UI changes.

## Architecture

### Before

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["entity tables only"]
    C["Remote sync peers"] --> D["no durable cursor contract"]
```

### After

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["entity tables"]
    A --> C["sync_journal rows in the same transaction"]
    D["Remote sync peers"] --> E["sync_cursors record last sent and received sequence"]
    F["Workflow deletion"] --> G["deleted_at tombstone and journal row"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sync-journal.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8c2111917`
- Post-revert steps: None
- Data migration? No production migration has shipped yet.

</details>
