### PR TITLE
[Authoritative task-graph snapshots](2) Sync app bridge snapshots

### DIFF
--- a/packages/app/src/__tests__/ipc-read-handlers.test.ts
+++ b/packages/app/src/__tests__/ipc-read-handlers.test.ts
@@ -33,7 +33,13 @@ describe('registerReadOnlyIpcHandlers', () => {
         handlers.set(channel, handler);
       }),
     };
-    const task = makeTask('wf-1/task-1');
+    const staleTask = makeTask('wf-1/stale-task');
+    const freshTask = makeTask('wf-1/fresh-task');
+    let syncedFromDb = false;
+    const syncAllFromDb = vi.fn(() => {
+      syncedFromDb = true;
+    });
+    const getAllTasks = vi.fn(() => (syncedFromDb ? [freshTask] : [staleTask]));
 
     registerReadOnlyIpcHandlers({
       ipcMain: ipcMain as never,
@@ -47,7 +53,8 @@ describe('registerReadOnlyIpcHandlers', () => {
         listWorkflows: vi.fn(() => [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }]),
       } as never,
       getOrchestrator: () => ({
-        getAllTasks: () => [task],
+        syncAllFromDb,
+        getAllTasks,
         getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 0, closed: 0, running: 0, pending: 1 }),
       }) as never,
       agentRegistry: {} as never,
@@ -62,10 +69,12 @@ describe('registerReadOnlyIpcHandlers', () => {
     const result = await handlers.get('invoker:get-tasks')?.({});
 
     expect(result).toEqual({
-      tasks: [task],
+      tasks: [freshTask],
       workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
       streamSequence: 42,
     });
+    expect(syncAllFromDb).toHaveBeenCalledTimes(1);
+    expect(getAllTasks).toHaveBeenCalledTimes(1);
   });
 
   it('get-review-gate returns the shared review gate shape', async () => {

--- a/packages/app/src/__tests__/task-graph-snapshot.test.ts
+++ b/packages/app/src/__tests__/task-graph-snapshot.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildTaskGraphSnapshot } from '../web/task-graph-snapshot.js';
+
+function makeTask(id: string) {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: {},
+    execution: {},
+  };
+}
+
+describe('buildTaskGraphSnapshot', () => {
+  it('returns tasks and workflows from one persistence snapshot when available', () => {
+    const task = makeTask('wf-1/task-1');
+    const workflow = { id: 'wf-1', name: 'Workflow 1', status: 'running' };
+    const syncAllFromDb = vi.fn();
+    const getAllTasks = vi.fn(() => {
+      throw new Error('getAllTasks fallback should not run when a persistence snapshot exists');
+    });
+    const listWorkflows = vi.fn(() => {
+      throw new Error('listWorkflows fallback should not run when a persistence snapshot exists');
+    });
+    const loadWorkflowTaskSnapshot = vi.fn(() => ({
+      workflows: [workflow],
+      tasks: [task],
+      tasksByWorkflowId: new Map([[workflow.id, [task]]]),
+    }));
+
+    const snapshot = buildTaskGraphSnapshot({
+      orchestrator: {
+        syncAllFromDb,
+        getAllTasks,
+      } as never,
+      persistence: {
+        listWorkflows,
+        loadWorkflowTaskSnapshot,
+      } as never,
+      getStreamSequence: () => 17,
+    });
+
+    expect(snapshot).toEqual({
+      tasks: [task],
+      workflows: [workflow],
+      streamSequence: 17,
+    });
+    expect(syncAllFromDb).toHaveBeenCalledTimes(1);
+    expect(loadWorkflowTaskSnapshot).toHaveBeenCalledTimes(1);
+    expect(getAllTasks).not.toHaveBeenCalled();
+    expect(listWorkflows).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -18,6 +18,7 @@ function makeDispatch(overrides: Record<string, unknown> = {}) {
   const approveTask = vi.fn(async () => ({ ok: true }));
   const deps = {
     orchestrator: {
+      syncAllFromDb: vi.fn(),
       getAllTasks: () => [makeTask('wf-1/task-1')],
       getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 0, closed: 0, running: 0, pending: 1 }),
       getTask: () => null,
@@ -58,12 +59,29 @@ describe('buildWebInvokerDispatch', () => {
   });
 
   it('get-tasks returns the { tasks, workflows, streamSequence } snapshot', async () => {
-    const { dispatch } = makeDispatch();
+    const staleTask = makeTask('wf-1/stale-task');
+    const freshTask = makeTask('wf-1/fresh-task');
+    let syncedFromDb = false;
+    const syncAllFromDb = vi.fn(() => {
+      syncedFromDb = true;
+    });
+    const getAllTasks = vi.fn(() => (syncedFromDb ? [freshTask] : [staleTask]));
+    const { dispatch } = makeDispatch({
+      orchestrator: {
+        syncAllFromDb,
+        getAllTasks,
+        getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 0, closed: 0, running: 0, pending: 1 }),
+        getTask: () => null,
+      },
+    });
+
     expect(await dispatch('invoker:get-tasks', [])).toEqual({
-      tasks: [makeTask('wf-1/task-1')],
+      tasks: [freshTask],
       workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
       streamSequence: 7,
     });
+    expect(syncAllFromDb).toHaveBeenCalledTimes(1);
+    expect(getAllTasks).toHaveBeenCalledTimes(1);
   });
 
   it('get-execution-harnesses returns harness metadata', async () => {

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -159,7 +159,10 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     }
 
     const { tasks, workflows, streamSequence } = buildTaskGraphSnapshot({
-      orchestrator,
+      orchestrator: {
+        syncAllFromDb: () => orchestrator.syncAllFromDb(),
+        getAllTasks: () => orchestrator.getAllTasks(),
+      },
       persistence,
       getStreamSequence: getTaskDeltaStreamSequence,
     });

--- a/packages/app/src/web/task-graph-snapshot.ts
+++ b/packages/app/src/web/task-graph-snapshot.ts
@@ -17,12 +17,13 @@ export interface TaskGraphSnapshot {
 }
 
 export interface BuildTaskGraphSnapshotDeps {
-  orchestrator: Pick<Orchestrator, 'getAllTasks'>;
+  orchestrator: Pick<Orchestrator, 'syncAllFromDb' | 'getAllTasks'>;
   persistence: Pick<SQLiteAdapter, 'listWorkflows'>;
   getStreamSequence: () => number;
 }
 
 export function buildTaskGraphSnapshot(deps: BuildTaskGraphSnapshotDeps): TaskGraphSnapshot {
+  deps.orchestrator.syncAllFromDb();
   return {
     tasks: deps.orchestrator.getAllTasks(),
     workflows: deps.persistence.listWorkflows() as WorkflowMeta[],

--- a/packages/app/src/web/task-graph-snapshot.ts
+++ b/packages/app/src/web/task-graph-snapshot.ts
@@ -18,15 +18,18 @@ export interface TaskGraphSnapshot {
 
 export interface BuildTaskGraphSnapshotDeps {
   orchestrator: Pick<Orchestrator, 'syncAllFromDb' | 'getAllTasks'>;
-  persistence: Pick<SQLiteAdapter, 'listWorkflows'>;
+  persistence: Pick<SQLiteAdapter, 'listWorkflows'> & {
+    loadWorkflowTaskSnapshot?: SQLiteAdapter['loadWorkflowTaskSnapshot'];
+  };
   getStreamSequence: () => number;
 }
 
 export function buildTaskGraphSnapshot(deps: BuildTaskGraphSnapshotDeps): TaskGraphSnapshot {
   deps.orchestrator.syncAllFromDb();
+  const snapshot = deps.persistence.loadWorkflowTaskSnapshot?.();
   return {
-    tasks: deps.orchestrator.getAllTasks(),
-    workflows: deps.persistence.listWorkflows() as WorkflowMeta[],
+    tasks: (snapshot?.tasks ?? deps.orchestrator.getAllTasks()) as TaskState[],
+    workflows: (snapshot?.workflows ?? deps.persistence.listWorkflows()) as WorkflowMeta[],
     streamSequence: deps.getStreamSequence(),
   };
 }

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -90,7 +90,10 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       // ── Reads ─────────────────────────────────────────────
       case 'invoker:get-tasks':
         return buildTaskGraphSnapshot({
-          orchestrator,
+          orchestrator: {
+            syncAllFromDb: () => orchestrator.syncAllFromDb(),
+            getAllTasks: () => orchestrator.getAllTasks(),
+          },
           persistence,
           getStreamSequence: deps.getStreamSequence,
         });


### PR DESCRIPTION
## Summary

The shared `invoker:get-tasks` bridge now calls `syncAllFromDb()` before building renderer task graph snapshots.

Electron and web callers use the same current snapshot behavior, so startup graph payloads include the full task set.

## Review Claim

Every plain `invoker:get-tasks` bridge route now syncs before building the renderer-facing task graph snapshot.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice stays inside the shared snapshot helper, its two bridge callsites, and focused regressions. Selected-workflow UI retention logic stays untouched.

## Slice Rationale

Electron and web both consume this shared builder, so the renderer-facing snapshot change is one reviewable slice after owner snapshots are fresh.

## Non-goals

- No edits to `packages/ui/src/App.tsx`.
- No edits to `packages/ui/src/hooks/useTasks.ts`.
- No refresh-event publisher changes.
- No review workflow changes.

## Architecture

### Before

```mermaid
graph TD
    A["Electron or web get-tasks route"] --> B["Build snapshot from cached tasks"]
    B --> C["Renderer consumes partial graph input"]
```

### After

```mermaid
graph TD
    A["Electron or web get-tasks route"] --> B["Call syncAllFromDb()"]
    B --> C["Build snapshot from current tasks"]
    C --> D["Renderer consumes complete graph input"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/ipc-read-handlers.test.ts -t "get-tasks"`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/web-invoker-dispatch.test.ts -t "get-tasks"`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/owner-read-query.test.ts src/__tests__/ipc-read-handlers.test.ts src/__tests__/web-invoker-dispatch.test.ts`
- [x] `cd packages/ui && pnpm test -- src/__tests__/selected-workflow-graph-disappears-repro.test.tsx src/__tests__/selected-workflow-selection-steal-repro.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, after accounting for any downstream branches based on this slice.
- Revert command: `git revert 88c9fd07d`
- Post-revert steps: Re-run the app bridge focused tests from the Test Plan.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task views now synchronize data before loading task information.
  * Task graph snapshots consistently display the latest available tasks.
  * Improved consistency across task retrieval channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->