### PR TITLE
[Slack complaint scout loop](3) Bridge Slack complaints into the existing plan-draft approval flow

### DIFF
--- a/packages/slack-manager/src/__tests__/complaint-scout-bridge.test.ts
+++ b/packages/slack-manager/src/__tests__/complaint-scout-bridge.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const surfacesMock = vi.hoisted(() => ({
+  stageSlackPlanDraftForReview: vi.fn(async () => ({
+    draftId: 'draft-1',
+    version: 1,
+    messageTs: 'posted',
+    slackFileId: 'F1',
+    status: 'ready',
+    summary: { name: 'Scout bridge', steps: ['Inspect'], taskCount: 1, taskGroups: [{ workflow: null, tasks: ['Inspect'] }] },
+  })),
+  start: vi.fn(),
+  SlackSurface: vi.fn(),
+}));
+
+vi.mock('@invoker/surfaces', () => {
+  surfacesMock.SlackSurface.mockImplementation(() => ({
+    start: surfacesMock.start,
+    stageSlackPlanDraftForReview: surfacesMock.stageSlackPlanDraftForReview,
+  }));
+  return { SlackSurface: surfacesMock.SlackSurface };
+}, { virtual: true });
+
+describe('complaint scout bridge', () => {
+  const savedEnv = { ...process.env };
+  let managerDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...savedEnv };
+    managerDir = mkdtempSync(path.join(tmpdir(), 'invoker-slack-scout-'));
+    process.env.INVOKER_SLACK_MANAGER_DIR = managerDir;
+    process.env.INVOKER_REPO_ROOT = managerDir;
+    process.env.INVOKER_REPO_URL = 'https://github.com/acme/repo.git';
+    process.env.SLACK_BOT_TOKEN = 'xoxb-test';
+    process.env.SLACK_APP_TOKEN = 'xapp-test';
+    process.env.SLACK_SIGNING_SECRET = 'secret';
+    process.env.SLACK_CHANNEL_ID = 'C_DEFAULT';
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+    rmSync(managerDir, { recursive: true, force: true });
+  });
+
+  it('stages a plan draft through SlackSurface without starting Socket Mode', async () => {
+    const { stageComplaintScoutPlanDraft } = await import('../complaint-scout-bridge.js');
+    const planText = [
+      'name: Scout bridge',
+      'repoUrl: https://github.com/acme/repo.git',
+      'onFinish: none',
+      'tasks:',
+      '  - id: inspect',
+      '    description: Inspect the evidence-backed complaint',
+      '    command: printf inspect',
+      '    dependencies: []',
+      '',
+    ].join('\n');
+
+    const result = await stageComplaintScoutPlanDraft({
+      channelId: 'C_ALLOWED',
+      threadTs: '1700000000.000100',
+      planText,
+      requestedBy: 'U0ALGQ64HMF',
+    });
+
+    expect(result.status).toBe('ready');
+    expect(surfacesMock.start).not.toHaveBeenCalled();
+    expect(surfacesMock.SlackSurface).toHaveBeenCalledWith(expect.objectContaining({
+      botToken: 'xoxb-test',
+      channelId: 'C_DEFAULT',
+      slackPlanDraftRepo: expect.any(Object),
+    }));
+    expect(surfacesMock.stageSlackPlanDraftForReview).toHaveBeenCalledWith({
+      channelId: 'C_ALLOWED',
+      threadTs: '1700000000.000100',
+      planText,
+      repoUrl: 'https://github.com/acme/repo.git',
+      harnessPreset: 'codex',
+      workingDir: managerDir,
+      requestedBy: 'U0ALGQ64HMF',
+    });
+  });
+});

--- a/packages/slack-manager/src/complaint-scout-bridge.ts
+++ b/packages/slack-manager/src/complaint-scout-bridge.ts
@@ -1,0 +1,109 @@
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import dotenv from 'dotenv';
+
+import { SlackSurface, type StageSlackPlanDraftResult } from '@invoker/surfaces';
+import { SlackPlanDraftRepository, SQLiteAdapter } from '@invoker/data-store';
+
+import { readSlackRuntimeConfig, resolveDefaultHarnessPreset } from './runtime-config.js';
+
+export const REQUIRED_SLACK_ENV = ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_SIGNING_SECRET', 'SLACK_CHANNEL_ID'];
+
+export interface ComplaintScoutPlanDraftPayload {
+  channelId: string;
+  threadTs: string;
+  planText: string;
+  repoUrl?: string;
+  workingDir?: string;
+  harnessPreset?: string;
+  requestedBy?: string;
+}
+
+export interface LoadSlackEnvResult {
+  ownerEnvPath: string;
+  missing: string[];
+}
+
+export function resolveSlackOwnerEnvPath(env: NodeJS.ProcessEnv = process.env): string {
+  const legacyOwnerEnvPath = path.join(homedir(), '.invoker', '.slack-owner.env');
+  const canonicalEnvPath = path.join(homedir(), '.invoker', '.env');
+  return env.INVOKER_SLACK_OWNER_ENV
+    ?? (existsSync(legacyOwnerEnvPath) ? legacyOwnerEnvPath : canonicalEnvPath);
+}
+
+export function loadSlackOwnerEnv(env: NodeJS.ProcessEnv = process.env): LoadSlackEnvResult {
+  const ownerEnvPath = resolveSlackOwnerEnvPath(env);
+  dotenv.config({ path: ownerEnvPath });
+  return {
+    ownerEnvPath,
+    missing: REQUIRED_SLACK_ENV.filter((key) => !env[key]),
+  };
+}
+
+export function readComplaintScoutPlanDraftPayload(filePath: string): ComplaintScoutPlanDraftPayload {
+  const payload = JSON.parse(readFileSync(filePath, 'utf8')) as Partial<ComplaintScoutPlanDraftPayload>;
+  for (const key of ['channelId', 'threadTs', 'planText'] as const) {
+    if (typeof payload[key] !== 'string' || !payload[key]?.trim()) {
+      throw new Error(`Missing required ${key} in scout plan draft payload.`);
+    }
+  }
+  return payload as ComplaintScoutPlanDraftPayload;
+}
+
+export async function stageComplaintScoutPlanDraft(payload: ComplaintScoutPlanDraftPayload): Promise<StageSlackPlanDraftResult> {
+  const repoRoot = process.env.INVOKER_REPO_ROOT ?? process.cwd();
+  const runtimeConfig = readSlackRuntimeConfig();
+  const repoUrl = payload.repoUrl ?? process.env.INVOKER_REPO_URL ?? runtimeConfig.defaultRepoUrl;
+  if (!repoUrl) throw new Error('Missing repoUrl for scout plan draft.');
+
+  const managerHome = process.env.INVOKER_SLACK_MANAGER_DIR ?? path.join(homedir(), '.invoker', 'slack-manager');
+  mkdirSync(managerHome, { recursive: true });
+  const adapter = await SQLiteAdapter.create(path.join(managerHome, 'slack-manager.db'), { ownerCapability: true });
+  try {
+    const slackPlanDraftRepo = new SlackPlanDraftRepository(adapter);
+    const defaultHarnessPreset = resolveDefaultHarnessPreset(process.env.INVOKER_SLACK_DEFAULT_PRESET, runtimeConfig.defaultHarnessPreset);
+    const slack = new SlackSurface({
+      botToken: process.env.SLACK_BOT_TOKEN!,
+      appToken: process.env.SLACK_APP_TOKEN!,
+      signingSecret: process.env.SLACK_SIGNING_SECRET!,
+      channelId: process.env.SLACK_CHANNEL_ID!,
+      lobbyChannelId: process.env.SLACK_LOBBY_CHANNEL_ID ?? process.env.SLACK_CHANNEL_ID,
+      slackPlanDraftRepo,
+      defaultRepoUrl: repoUrl,
+      repoUrl,
+      workingDir: payload.workingDir ?? repoRoot,
+      defaultHarnessPreset,
+      log: () => {},
+    });
+    return await slack.stageSlackPlanDraftForReview({
+      channelId: payload.channelId,
+      threadTs: payload.threadTs,
+      planText: payload.planText,
+      repoUrl,
+      harnessPreset: payload.harnessPreset ?? defaultHarnessPreset ?? 'codex',
+      workingDir: payload.workingDir ?? repoRoot,
+      requestedBy: payload.requestedBy ?? 'slack-complaint-scout',
+    });
+  } finally {
+    adapter.close();
+  }
+}
+
+export async function runComplaintScoutDraftCommand(payloadFile: string): Promise<void> {
+  const env = loadSlackOwnerEnv();
+  if (env.missing.length > 0) {
+    throw new Error(`Missing Slack credentials: ${env.missing.join(', ')} (looked in ${env.ownerEnvPath})`);
+  }
+  const payload = readComplaintScoutPlanDraftPayload(payloadFile);
+  const result = await stageComplaintScoutPlanDraft(payload);
+  console.log(JSON.stringify({
+    ok: true,
+    draftId: result.draftId,
+    version: result.version,
+    messageTs: result.messageTs,
+    slackFileId: result.slackFileId,
+    status: result.status,
+    summary: result.summary,
+  }));
+}

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -10,10 +10,9 @@
 
 import { execSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { existsSync, mkdirSync } from 'node:fs';
+import { mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
-import dotenv from 'dotenv';
 
 import { SlackSurface, type SlackSurfaceConfig } from '@invoker/surfaces';
 import { ConversationRepository, SlackPlanDraftRepository, SlackSessionRepository, SQLiteAdapter, WorkflowChannelRepository } from '@invoker/data-store';
@@ -28,24 +27,42 @@ import { createHarnessSessionDriverFactory, createPlanningCommandBuilder, create
 import { createWatchdog } from './watchdog.js';
 import { errMessage } from './util.js';
 import { acquireSlackConsumerLock } from './slack-consumer-lock.js';
+import { loadSlackOwnerEnv, runComplaintScoutDraftCommand } from './complaint-scout-bridge.js';
 const VERSION = '0.0.8';
-
-const REQUIRED_ENV = ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_SIGNING_SECRET', 'SLACK_CHANNEL_ID'];
+let runDaemon = true;
 
 if (process.argv.includes('--version') || process.argv.includes('-V')) {
   console.log(VERSION);
   process.exit(0);
 }
 
-if (process.argv.includes('--help') || process.argv.includes('-h')) {
+const stagePlanDraftArg = process.argv.indexOf('--stage-plan-draft');
+if (stagePlanDraftArg !== -1) {
+  const payloadFile = process.argv[stagePlanDraftArg + 1];
+  if (!payloadFile) {
+    console.error('[slack-manager] fatal: --stage-plan-draft requires a payload JSON file');
+    process.exit(1);
+  }
+  runDaemon = false;
+  void runComplaintScoutDraftCommand(payloadFile)
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error(`[slack-manager] fatal: ${errMessage(err)}`);
+      process.exit(1);
+    });
+} else if (process.argv.includes('--help') || process.argv.includes('-h')) {
   console.log(`invoker-slack ${VERSION}
 
-Usage: invoker-slack [--version] [--help]
+Usage: invoker-slack [--version] [--help] [--stage-plan-draft payload.json]
 
 Standalone Slack manager daemon. Loads credentials from
 ~/.invoker/.slack-owner.env, or ~/.invoker/.env when the legacy file is absent
 (or INVOKER_SLACK_OWNER_ENV), and drives Invoker
 over IPC. Install via: npm i -g @neko-catpital-labs/invoker-slack
+
+--stage-plan-draft is a bounded one-shot used by the Slack complaint scout. It
+posts an existing Approve/Cancel plan review draft and exits; it does not start
+Socket Mode or submit a workflow.
 `);
   process.exit(0);
 }
@@ -73,15 +90,9 @@ async function main(): Promise<void> {
   const instanceId = randomUUID();
   const { log, logFn } = makeLog(instanceId);
 
-  const legacyOwnerEnvPath = path.join(homedir(), '.invoker', '.slack-owner.env');
-  const canonicalEnvPath = path.join(homedir(), '.invoker', '.env');
-  const ownerEnvPath = process.env.INVOKER_SLACK_OWNER_ENV
-    ?? (existsSync(legacyOwnerEnvPath) ? legacyOwnerEnvPath : canonicalEnvPath);
-  dotenv.config({ path: ownerEnvPath });
-
-  const missing = REQUIRED_ENV.filter((key) => !process.env[key]);
-  if (missing.length > 0) {
-    log('error', `missing Slack credentials: ${missing.join(', ')} (looked in ${ownerEnvPath})`);
+  const env = loadSlackOwnerEnv();
+  if (env.missing.length > 0) {
+    log('error', `missing Slack credentials: ${env.missing.join(', ')} (looked in ${env.ownerEnvPath})`);
     process.exit(1);
   }
 
@@ -178,7 +189,9 @@ async function main(): Promise<void> {
   process.on('SIGTERM', () => void shutdown('SIGTERM'));
 }
 
-void main().catch((err) => {
-  console.error(`[slack-manager] fatal: ${errMessage(err)}`);
-  process.exit(1);
-});
+if (runDaemon) {
+  void main().catch((err) => {
+    console.error(`[slack-manager] fatal: ${errMessage(err)}`);
+    process.exit(1);
+  });
+}

--- a/packages/slack-manager/vitest.config.ts
+++ b/packages/slack-manager/vitest.config.ts
@@ -2,5 +2,10 @@ import { defineConfig, mergeConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.ts';
 
 export default mergeConfig(sharedConfig, defineConfig({
+  resolve: {
+    alias: {
+      '@invoker/surfaces': new URL('../surfaces/src/index.ts', import.meta.url).pathname,
+    },
+  },
   test: {},
 }));

--- a/packages/surfaces/src/__tests__/slack-plan-draft-approve.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-draft-approve.test.ts
@@ -19,6 +19,7 @@ vi.mock('@slack/bolt', () => {
     client = {
       auth: { test: vi.fn().mockResolvedValue({ user_id: 'U_BOT' }) },
       chat: { postMessage: vi.fn().mockResolvedValue({ ts: '1.1' }), update: vi.fn().mockResolvedValue({}) },
+      files: { uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F1' }] }) },
     };
   }
   return { App: MockApp };
@@ -106,5 +107,55 @@ describe('approveSlackPlanDraft', () => {
     const stored = repo.get(draft.draftId, draft.version);
     expect(stored?.status).toBe('submitted');
     expect(JSON.parse(stored?.workflowIdsJson ?? '[]')).toEqual([]);
+  });
+
+  it('stages a ready plan review without submitting the child workflow', async () => {
+    const surface = new SlackSurface({
+      botToken: 'xoxb', appToken: 'xapp', signingSecret: 's', channelId: 'CLOBBY',
+      slackPlanDraftRepo: repo, log: () => {},
+    });
+    const planText = [
+      'name: Scout draft',
+      'repoUrl: https://github.com/acme/repo.git',
+      'onFinish: none',
+      'tasks:',
+      '  - id: investigate',
+      '    description: Investigate the Slack complaint',
+      '    command: printf scout',
+      '    dependencies: []',
+      '',
+    ].join('\n');
+
+    const result = await surface.stageSlackPlanDraftForReview({
+      channelId: 'C1',
+      threadTs: 'T1',
+      planText,
+      repoUrl: 'https://github.com/acme/repo.git',
+      harnessPreset: 'codex',
+      workingDir: '/tmp/repo',
+      requestedBy: 'U1',
+    });
+
+    const app = surface.getApp() as any;
+    const stored = repo.get(result.draftId, result.version);
+    expect(stored?.status).toBe('ready');
+    expect(stored?.confirmationMode).toBe('require');
+    expect(stored?.planText).toBe(planText);
+    expect(result.status).toBe('ready');
+    expect(app.client.files.uploadV2).toHaveBeenCalledWith(expect.objectContaining({
+      channel_id: 'C1',
+      thread_ts: 'T1',
+    }));
+    expect(app.client.chat.update).toHaveBeenCalledWith(expect.objectContaining({
+      channel: 'C1',
+      blocks: expect.arrayContaining([
+        expect.objectContaining({
+          elements: expect.arrayContaining([
+            expect.objectContaining({ action_id: 'plan_draft_approve' }),
+            expect.objectContaining({ action_id: 'plan_draft_cancel' }),
+          ]),
+        }),
+      ]),
+    }));
   });
 });

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -140,6 +140,25 @@ export interface HarnessPreset {
   model?: string;
 }
 
+export interface StageSlackPlanDraftInput {
+  channelId: string;
+  threadTs: string;
+  planText: string;
+  repoUrl: string;
+  harnessPreset: string;
+  workingDir: string;
+  requestedBy: string;
+}
+
+export interface StageSlackPlanDraftResult {
+  draftId: string;
+  version: number;
+  messageTs?: string;
+  slackFileId?: string;
+  status: SlackPlanDraft['status'];
+  summary: PlanSummary;
+}
+
 export const BUILTIN_HARNESS_PRESETS: Record<string, HarnessPreset> = {
   'cursor+claude': { tool: 'cursor', model: 'claude' },
   'cursor+codex': { tool: 'cursor', model: 'codex' },
@@ -1168,6 +1187,46 @@ export class SlackSurface implements Surface {
         this.log('slack', 'error', `Auto-submit failed for draft ${draft.draftId}:${draft.version}: ${error instanceof Error ? error.message : String(error)}`);
       }
     }
+  }
+
+  async stageSlackPlanDraftForReview(input: StageSlackPlanDraftInput): Promise<StageSlackPlanDraftResult> {
+    if (!this.slackPlanDraftRepo) {
+      throw new Error('Slack plan reviews are not configured in this deployment.');
+    }
+    const summary = summarizePlanText(input.planText);
+    if (!summary) {
+      throw new Error('The supplied plan YAML could not be summarized for Slack review.');
+    }
+    const draft = this.slackPlanDraftRepo.create({
+      channelId: input.channelId,
+      threadTs: input.threadTs,
+      planText: input.planText,
+      summaryJson: JSON.stringify(summary),
+      repoUrl: input.repoUrl,
+      harnessPreset: input.harnessPreset,
+      workingDir: input.workingDir,
+      requestedBy: input.requestedBy,
+      confirmationMode: 'require',
+    });
+    const say: SayFn = async ({ text, thread_ts, blocks }) => {
+      const posted = await this.app.client.chat.postMessage({
+        channel: input.channelId,
+        text,
+        thread_ts,
+        ...(blocks ? { blocks: blocks as never } : {}),
+      });
+      return { ts: posted.ts as string | undefined };
+    };
+    await this.postSlackPlanDraft(draft, summary, say);
+    const ready = this.slackPlanDraftRepo.get(draft.draftId, draft.version) ?? draft;
+    return {
+      draftId: ready.draftId,
+      version: ready.version,
+      messageTs: ready.messageTs,
+      slackFileId: ready.slackFileId,
+      status: ready.status,
+      summary,
+    };
   }
 
   /** Post the immediate "received it" acknowledgment and track it for in-place replacement. */


### PR DESCRIPTION
## Summary

Wires the Slack complaint scout bridge into slack-manager and surfaces.

A live complaint now reaches the existing plan-draft Approve/Cancel flow instead of needing manual translation.

Each actionable target gets an approval-gated draft in its source thread. A human-only or insufficient-evidence target gets one exact blocker instead of being attempted again.

## Review Claim

Approve wiring an evidence-backed Slack complaint into the existing Approve/Cancel plan-draft flow, or producing one exact human-only blocker, without calling `start_plan` directly.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The bridge never calls `start_plan` and never sends child work to another workflow on its own; it never prints Slack tokens.

## Slice Rationale

This repo's PR-body rules keep product code separate from the plan write-up and the standalone script, so the bridge implementation and its tests ship alone in the behavior lane.

## Non-goals

- No config.json changes.
- No daemon worker or always-on process.
- No automatic child work submission.
- No reading of DM, all-channel, or other-author messages.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/slack-manager && pnpm test`
- [ ] `cd packages/surfaces && pnpm test src/__tests__/slack-plan-draft-approve.test.ts` (full-package `pnpm test` has 10 pre-existing failures on master, unrelated to this diff)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4c582d3b1`
- Post-revert steps: None
- Data migration? No

</details>
</content>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a bounded Slack complaint-scanning workflow that identifies actionable complaints and blockers from approved channels.
  * Added one-shot plan-draft staging for Slack review without starting the background service.
  * Plan drafts now include summaries, YAML attachments, required confirmation, and approve/cancel controls.
  * Added configurable repository, channel, author, time-window, and state options.

* **Bug Fixes**
  * Improved credential validation, retry handling, deduplication, and terminal-blocker reporting.

* **Tests**
  * Added coverage for complaint discovery, plan staging, Slack review controls, and safe one-shot execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->