### PR TITLE
[Planning Terminal Tmux Blank Repro](2) Publish missing-main reviews on master

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -4222,6 +4222,114 @@ console.log(JSON.stringify(out));
       );
     });
 
+    it('publishes Invoker review stacks against master when persisted main is missing', async () => {
+      const featureBranch = 'plan/planning-terminal-tmux-blank-repro';
+      const mergeTask = makeTask({
+        id: '__merge__wf-1',
+        status: 'running',
+        dependencies: ['t1'],
+        config: { isMergeNode: true, workflowId: 'wf-1' },
+      });
+      const allTasks = [
+        makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),
+        mergeTask,
+      ];
+      const orchestrator = {
+        getTask: (id: string) => allTasks.find(t => t.id === id),
+        getAllTasks: () => allTasks,
+        handleWorkerResponse: vi.fn(() => []),
+        setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
+      };
+      const persistence = {
+        loadWorkflow: () => ({
+          id: 'wf-1',
+          onFinish: 'none',
+          mergeMode: 'external_review',
+          baseBranch: 'main',
+          featureBranch,
+          name: 'Planning Terminal Tmux Blank Repro',
+          repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+        }),
+        updateTask: vi.fn(),
+      };
+      const executor = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+        mergeGateProvider: { createReview: vi.fn() } as any,
+      });
+
+      const gitCalls: string[][] = [];
+      (executor as any).execGitReadonly = async () => '';
+      (executor as any).execGitIn = async (args: string[], _dir: string) => {
+        gitCalls.push([...args]);
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'base-sha';
+        if (args[0] === 'rev-parse' && args[1] === '--verify') {
+          const ref = args[2] ?? '';
+          if (ref.includes('main^{commit}')) {
+            throw new Error(`bad revision ${ref}`);
+          }
+          if (ref === 'refs/remotes/origin/master^{commit}') return 'origin-master-sha';
+          return 'sha';
+        }
+        if (args[0] === 'ls-remote' && args[1] === '--heads') {
+          return `sha\trefs/heads/${featureBranch}\n`;
+        }
+        if (args[0] === 'diff' && args[1] === '--name-only') {
+          return 'packages/app/e2e/planning-terminal-tmux-blank-repro.spec.ts\n';
+        }
+        return '';
+      };
+      (executor as any).createMergeWorktree = vi.fn().mockResolvedValue('/tmp/mock-wt');
+      (executor as any).removeMergeWorktree = vi.fn();
+      (executor as any).authorPrBodyWithSkill = vi.fn();
+      (executor as any).publishReviewStackWithMakePrSkill = vi.fn().mockResolvedValue({
+        artifacts: [{
+          id: 'pr-1',
+          title: 'Planning Terminal Tmux Blank Repro',
+          url: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/1',
+          providerId: '1',
+          provider: 'github',
+          branch: featureBranch,
+          baseBranch: 'master',
+          required: true,
+          status: 'open',
+        }],
+        sessionId: 'sess-make-pr',
+        agentName: 'codex',
+      });
+
+      await (executor as any).executeMergeNode(mergeTask);
+
+      expect(gitCalls).toContainEqual([
+        'diff',
+        '--name-only',
+        `refs/remotes/origin/master...${featureBranch}`,
+        '--',
+      ]);
+      expect((executor as any).publishReviewStackWithMakePrSkill).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseBranch: 'master',
+          featureBranch,
+          title: 'Planning Terminal Tmux Blank Repro',
+        }),
+      );
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith(
+        '__merge__wf-1',
+        expect.objectContaining({
+          execution: expect.objectContaining({
+            reviewGate: expect.objectContaining({
+              artifacts: [expect.objectContaining({ baseBranch: 'master' })],
+            }),
+          }),
+        }),
+        expect.objectContaining({ generation: 0 }),
+      );
+    });
+
     it('executeMergeNode anchors external_review gate worktrees on the origin-backed base branch', async () => {
       const allTasks = [
         makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -69,9 +69,72 @@ function canonicalMergeMode(mode: string | undefined): 'manual' | 'automatic' | 
 async function resolveBaseCheckoutRef(
   host: MergeRunnerHost,
   baseBranch: string,
-  _preferOriginTracking: boolean,
+  preferOriginTracking: boolean,
 ): Promise<string> {
-  return normalizeBranchForGithubCli(baseBranch);
+  const normalizedBase = normalizeBranchForGithubCli(baseBranch);
+  if (!preferOriginTracking) {
+    return normalizedBase;
+  }
+  for (const candidate of baseBranchResolutionCandidates(baseBranch)) {
+    for (const ref of candidate.refs) {
+      try {
+        const resolved = (await host.execGitReadonly(
+          ['rev-parse', '--verify', `${ref}^{commit}`],
+        )).trim();
+        if (resolved) {
+          return candidate.branchName;
+        }
+      } catch {
+        // Try the next base spelling.
+      }
+    }
+  }
+  return normalizedBase;
+}
+
+function baseBranchResolutionCandidates(baseBranch: string): Array<{ branchName: string; refs: string[] }> {
+  const normalizedBase = normalizeBranchForGithubCli(baseBranch);
+  const branchNames = [normalizedBase];
+  if (normalizedBase === 'main') {
+    branchNames.push('master');
+  } else if (normalizedBase === 'master') {
+    branchNames.push('main');
+  }
+
+  return branchNames.map((branchName, index) => ({
+    branchName,
+    refs: Array.from(new Set([
+      `refs/remotes/origin/${branchName}`,
+      `origin/${branchName}`,
+      ...(index === 0 ? [baseBranch] : []),
+      branchName,
+      `refs/heads/${branchName}`,
+    ])),
+  }));
+}
+
+async function resolveReviewBaseRef(
+  host: MergeRunnerHost,
+  dir: string,
+  baseBranch: string,
+): Promise<{ branchName: string; diffRef: string }> {
+  for (const candidate of baseBranchResolutionCandidates(baseBranch)) {
+    for (const ref of candidate.refs) {
+      try {
+        const resolved = (await execGitInMergeSafe(
+          host,
+          ['rev-parse', '--verify', `${ref}^{commit}`],
+          dir,
+        )).trim();
+        if (resolved) {
+          return { branchName: candidate.branchName, diffRef: ref };
+        }
+      } catch {
+        // Try the next base spelling.
+      }
+    }
+  }
+  return { branchName: normalizeBranchForGithubCli(baseBranch), diffRef: baseBranch };
 }
 
 /**
@@ -261,30 +324,9 @@ async function syncGateWorkspaceToFeatureBranch(
 async function listReviewableChangedFiles(
   host: MergeRunnerHost,
   dir: string,
-  baseBranch: string,
+  diffBaseRef: string,
   featureBranch: string,
 ): Promise<string[]> {
-  const normalizedBase = normalizeBranchForGithubCli(baseBranch);
-  let diffBaseRef = baseBranch;
-  for (const candidate of [
-    `refs/remotes/origin/${normalizedBase}`,
-    `origin/${normalizedBase}`,
-    baseBranch,
-  ]) {
-    try {
-      const resolved = (await execGitInMergeSafe(
-        host,
-        ['rev-parse', '--verify', `${candidate}^{commit}`],
-        dir,
-      )).trim();
-      if (resolved) {
-        diffBaseRef = candidate;
-        break;
-      }
-    } catch {
-      // Try the next base spelling.
-    }
-  }
   const out = await execGitInMergeSafe(
     host,
     ['diff', '--name-only', `${diffBaseRef}...${featureBranch}`, '--'],
@@ -886,22 +928,23 @@ export async function runMergeGateActionImpl(
         });
         await syncGateWorkspaceToFeatureBranch(host, gateWorkspacePath, featureBranch);
 
+        const reviewBase = await resolveReviewBaseRef(host, gateWorkspacePath!, baseBranch);
         if (isInvokerRepoUrl(workflow?.repoUrl)) {
           const changedFiles = await listReviewableChangedFiles(
             host,
             gateWorkspacePath!,
-            baseBranch,
+            reviewBase.diffRef,
             featureBranch,
           );
           if (changedFiles.length === 0) {
             logTaskProgress(host, task.id, 'info', 'Skipping review stack publication for empty Invoker branch', {
-              baseBranch,
+              baseBranch: reviewBase.branchName,
               featureBranch,
             });
             mergeTrace('GATE_WS_PATH_REVIEW_PUBLISH_NOOP', {
               taskId: task.id,
               gateWorkspacePath: gateWorkspacePath ?? null,
-              baseBranch,
+              baseBranch: reviewBase.branchName,
               featureBranch,
               onFinish,
               mergeMode,
@@ -934,7 +977,7 @@ export async function runMergeGateActionImpl(
         let fullSummary = summary;
         if (visualProof && host.runVisualProofCapture) {
           const slug = (featureBranch ?? 'workflow').replace(/\//g, '-');
-          const vpMarkdown = await host.runVisualProofCapture(baseBranch, featureBranch!, slug, workflow?.repoUrl);
+          const vpMarkdown = await host.runVisualProofCapture(reviewBase.branchName, featureBranch!, slug, workflow?.repoUrl);
           if (vpMarkdown) {
             fullSummary = (summary ?? '') + '\n\n' + vpMarkdown;
           }
@@ -944,7 +987,7 @@ export async function runMergeGateActionImpl(
           workflowId,
           mergeNodeTaskId: task.id,
           workflowName: workflow?.name ?? 'Workflow',
-          baseBranch,
+          baseBranch: reviewBase.branchName,
           featureBranch,
           workflowSummary: fullSummary ?? '',
           cwd: gateWorkspacePath!,
@@ -1437,21 +1480,29 @@ export async function publishAfterFixImpl(
     });
     await pushFeatureBranchWithRefLockRetry(host, consolidateDir, featureBranch);
 
+    let resolvedReviewBase: { branchName: string; diffRef: string } | undefined;
+    const getResolvedReviewBase = async (): Promise<{ branchName: string; diffRef: string }> => {
+      resolvedReviewBase ??= await resolveReviewBaseRef(host, consolidateDir, baseBranch);
+      return resolvedReviewBase;
+    };
+
     let fullSummary = summary;
     if (visualProof && host.runVisualProofCapture) {
       const slug = featureBranch.replace(/\//g, '-');
-      const vpMarkdown = await host.runVisualProofCapture(baseBranch, featureBranch, slug, workflow?.repoUrl);
+      const reviewBase = await getResolvedReviewBase();
+      const vpMarkdown = await host.runVisualProofCapture(reviewBase.branchName, featureBranch, slug, workflow?.repoUrl);
       if (vpMarkdown) {
         fullSummary = (summary ?? '') + '\n\n' + vpMarkdown;
       }
     }
 
     if (mergeMode === 'external_review' || onFinish === 'pull_request') {
+      const reviewBase = await getResolvedReviewBase();
       const published = await publishReviewArtifactsForMerge(host, {
         workflowId,
         mergeNodeTaskId: task.id,
         workflowName: workflow?.name ?? 'Workflow',
-        baseBranch,
+        baseBranch: reviewBase.branchName,
         featureBranch,
         workflowSummary: fullSummary ?? '',
         cwd: consolidateDir,


### PR DESCRIPTION
## Summary

This lets Invoker review publication fall back from a persisted `main` base to the repository's live `master` branch.

The review gate now diffs, captures visual proof, and publishes review artifacts against the resolved base branch.

## Review Claim

Approve resolving missing `main` review bases to `master` before publishing Invoker review stacks.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change stays inside merge-gate publication routing and focused tests; merge execution still uses the requested feature branch and existing review artifact flow.

## Slice Rationale

This follows the repro slice because it repairs the review-gate path needed to publish approved stacks when `main` is absent.

## Non-goals

This does not change merge conflict handling, review polling, approval policy, or non-Invoker PR publication.

## Architecture

### Before

```mermaid
graph TD
    A["workflow baseBranch is main"] --> B["diff and review publish use origin/main"]
    B --> C["publication fails when origin/main is absent"]
```

### After

```mermaid
graph TD
    A["workflow baseBranch is main"] --> B["resolveReviewBaseRef checks origin/main then origin/master"]
    B --> C["diff and review publish use master when main is absent"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/task-runner.test.ts -t "publishes Invoker review stacks against master when persisted main is missing"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 816bd1b07`
- Post-revert steps: None
- Data migration? No

</details>
